### PR TITLE
esp-config tui

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       # Run tests in esp-config
-      - run: cd esp-config && cargo test --features build
+      - run: cd esp-config && cargo test --features build,tui
 
       # Run tests in esp-bootloader-esp-idf
       - run: cd esp-bootloader-esp-idf && cargo test --features=std

--- a/esp-config/Cargo.toml
+++ b/esp-config/Cargo.toml
@@ -12,10 +12,26 @@ license       = "MIT OR Apache-2.0"
 bench = false
 test  = true
 
+[[bin]]
+name = "esp-config"
+required-features = ["tui"]
+
 [dependencies]
 document-features = "0.2.11"
+
+# used by the `build` and `tui` feature
 serde = { version = "1.0.197", features = ["derive"], optional = true }
-serde_json = { version = "1.0.0", optional = true }
+serde_json = { version = "1.0.0", features = ["arbitrary_precision"], optional = true }
+
+# used by the `tui` feature
+clap            = { version = "4.5.32", features = ["derive"], optional = true }
+crossterm       = { version = "0.28.1", optional = true }
+env_logger      = { version = "0.11.7", optional = true }
+log             = { version = "0.4.26", optional = true }
+ratatui         = { version = "0.29.0", features = ["crossterm", "unstable"], optional = true }
+toml_edit       = { version = "0.22.26", optional = true }
+tui-textarea    = { version = "0.7.0", optional = true }
+walkdir         = { version = "2.5.0", optional = true }
 
 [dev-dependencies]
 temp-env = "0.3.6"
@@ -24,3 +40,18 @@ pretty_assertions = "1.4.1"
 [features]
 ## Enable the generation and parsing of a config
 build = ["dep:serde","dep:serde_json"]
+
+## The TUI
+tui = [
+    "dep:clap",
+    "dep:crossterm",
+    "dep:env_logger",
+    "dep:log",
+    "dep:ratatui",
+    "dep:toml_edit",
+    "dep:tui-textarea",
+    "dep:walkdir",
+    "dep:serde",
+    "dep:serde_json",
+    "build",
+]

--- a/esp-config/src/bin/esp-config/main.rs
+++ b/esp-config/src/bin/esp-config/main.rs
@@ -1,0 +1,249 @@
+use std::{
+    collections::HashMap,
+    error::Error,
+    path::{Path, PathBuf},
+};
+
+use clap::Parser;
+use env_logger::{Builder, Env};
+use esp_config::{ConfigOption, Value};
+use serde::Deserialize;
+use toml_edit::{DocumentMut, Formatted, Item, Table};
+use walkdir::WalkDir;
+
+mod tui;
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Root of the project
+    #[arg(short = 'P', long)]
+    path: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CrateConfig {
+    name: String,
+    options: Vec<ConfigItem>,
+}
+
+#[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
+struct ConfigItem {
+    option: ConfigOption,
+    actual_value: Value,
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    Builder::from_env(Env::default().default_filter_or(log::LevelFilter::Info.as_str()))
+        .format_target(false)
+        .init();
+
+    let args = Args::parse();
+
+    let work_dir = args.path.clone().unwrap_or(".".into());
+
+    ensure_fresh_build(&work_dir)?;
+
+    let mut configs = parse_configs(&work_dir)?;
+    let initial_configs = configs.clone();
+    let mut previous_config = initial_configs.clone();
+
+    let mut errors_to_show = None;
+
+    loop {
+        let repository = tui::Repository::new(configs.clone());
+
+        // TUI stuff ahead
+        let terminal = tui::init_terminal()?;
+
+        // create app and run it
+        let updated_cfg = tui::App::new(errors_to_show, repository).run(terminal)?;
+
+        tui::restore_terminal()?;
+
+        // done with the TUI
+        if let Some(updated_cfg) = updated_cfg {
+            configs = updated_cfg.clone();
+            apply_config(&work_dir, updated_cfg.clone(), previous_config.clone())?;
+            previous_config = updated_cfg;
+        } else {
+            println!("Reverted configuration...");
+            apply_config(&work_dir, initial_configs, vec![])?;
+            break;
+        }
+
+        if let Some(errors) = check_build_after_changes(&work_dir) {
+            errors_to_show = Some(errors);
+        } else {
+            println!("Updated configuration...");
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+fn apply_config(
+    path: &Path,
+    updated_cfg: Vec<CrateConfig>,
+    previous_cfg: Vec<CrateConfig>,
+) -> Result<(), Box<dyn Error>> {
+    let config_toml = path.join(".cargo/config.toml");
+
+    let mut config = std::fs::read_to_string(&config_toml)?
+        .as_str()
+        .parse::<DocumentMut>()?;
+
+    if !config.contains_key("env") {
+        config.insert("env", Item::Table(Table::new()));
+    }
+
+    let envs = config.get_mut("env").unwrap().as_table_mut().unwrap();
+
+    for cfg in updated_cfg {
+        let prefix = cfg.name.to_ascii_uppercase().replace("-", "_");
+        let previous_crate_cfg = previous_cfg.iter().find(|c| c.name == cfg.name);
+
+        for option in cfg.options {
+            let previous_option = previous_crate_cfg.and_then(|c| {
+                c.options
+                    .iter()
+                    .find(|o| o.option.name == option.option.name)
+            });
+
+            let key = format!(
+                "{prefix}_CONFIG_{}",
+                option.option.name.to_ascii_uppercase().replace("-", "_")
+            );
+
+            // avoid updating unchanged options to keep the comments (if any)
+            if Some(&option.actual_value) != previous_option.map(|option| &option.actual_value) {
+                if option.actual_value != option.option.default_value {
+                    let value = toml_edit::Value::String(Formatted::new(format!(
+                        "{}",
+                        option.actual_value
+                    )));
+
+                    envs.insert(&key, Item::Value(value));
+                } else {
+                    envs.remove(&key);
+                }
+            }
+        }
+    }
+
+    std::fs::write(&config_toml, config.to_string().as_bytes())?;
+
+    Ok(())
+}
+
+fn parse_configs(path: &Path) -> Result<Vec<CrateConfig>, Box<dyn Error>> {
+    // we cheat by just trying to find the latest version of the config files
+    // this should be fine since we force a fresh build before
+    let mut candidates: Vec<_> = WalkDir::new(path.join("target"))
+        .into_iter()
+        .filter_entry(|entry| {
+            entry.file_type().is_dir() || {
+                if let Some(name) = entry.file_name().to_str() {
+                    name.ends_with("_config_data.json")
+                } else {
+                    false
+                }
+            }
+        })
+        .filter(|entry| !entry.as_ref().unwrap().file_type().is_dir())
+        .map(|entry| entry.unwrap())
+        .collect();
+    candidates.sort_by_key(|entry| entry.metadata().unwrap().modified().unwrap());
+
+    let mut crate_config_table_to_json: HashMap<String, PathBuf> = HashMap::new();
+
+    for e in candidates {
+        if e.file_name()
+            .to_str()
+            .unwrap()
+            .ends_with("_config_data.json")
+        {
+            let crate_name = e
+                .file_name()
+                .to_str()
+                .unwrap()
+                .replace("_config_data.json", "")
+                .replace("_", "-");
+            crate_config_table_to_json.insert(crate_name.clone(), e.path().to_path_buf());
+        }
+    }
+
+    let mut configs = Vec::new();
+
+    for (crate_name, path) in crate_config_table_to_json {
+        let options =
+            serde_json::from_str::<Vec<ConfigItem>>(std::fs::read_to_string(&path)?.as_str())
+                .map_err(|e| {
+                    format!(
+                        "Unable to read config file {:?} - try `cargo clean` first ({e:?})",
+                        path
+                    )
+                })?
+                .iter()
+                .filter(|option| option.option.active)
+                .cloned()
+                .collect();
+
+        configs.push(CrateConfig {
+            name: crate_name,
+            options,
+        });
+    }
+    configs.sort_by_key(|entry| entry.name.clone());
+
+    if configs.is_empty() {
+        return Err("No config files found.".into());
+    }
+
+    Ok(configs)
+}
+
+fn ensure_fresh_build(path: &PathBuf) -> Result<(), Box<dyn Error>> {
+    let status = std::process::Command::new("cargo")
+        .arg("build")
+        .current_dir(path)
+        .status()?;
+
+    if !status.success() {
+        return Err("Your project doesn't build. Fix the errors first.".into());
+    }
+
+    Ok(())
+}
+
+fn check_build_after_changes(path: &PathBuf) -> Option<String> {
+    println!("Check configuration...");
+
+    let status = std::process::Command::new("cargo")
+        .arg("build")
+        .current_dir(path)
+        .stdout(std::process::Stdio::inherit())
+        .output();
+
+    if let Ok(status) = &status {
+        if status.status.success() {
+            return None;
+        }
+    }
+
+    let mut errors = String::new();
+
+    for line in String::from_utf8(status.unwrap().stderr)
+        .unwrap_or_default()
+        .lines()
+    {
+        if line.contains("the evaluated program panicked at '") {
+            let error = line[line.find('\'').unwrap() + 1..].to_string();
+            let error = error[..error.find("',").unwrap_or(error.len())].to_string();
+            errors.push_str(&format!("{error}\n"));
+        }
+    }
+
+    Some(errors)
+}

--- a/esp-config/src/bin/esp-config/tui.rs
+++ b/esp-config/src/bin/esp-config/tui.rs
@@ -1,0 +1,734 @@
+use std::{error::Error, io};
+
+use crossterm::{
+    ExecutableCommand,
+    event::{self, Event, KeyCode, KeyEventKind},
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
+use esp_config::{DisplayHint, Stability, Validator, Value};
+use ratatui::{prelude::*, style::palette::tailwind, widgets::*};
+use tui_textarea::{CursorMove, TextArea};
+
+type AppResult<T> = Result<T, Box<dyn Error>>;
+
+pub struct Repository {
+    configs: Vec<crate::CrateConfig>,
+    current_crate: Option<usize>,
+}
+
+enum Item {
+    TopLevel(String),
+    CrateLevel(crate::ConfigItem),
+}
+
+impl Item {
+    fn title(&self, _width: u16, ui_elements: &UiElements) -> String {
+        match self {
+            Item::TopLevel(crate_name) => crate_name.clone(),
+            Item::CrateLevel(config_option) => {
+                let display_value = match &config_option.actual_value {
+                    Value::Bool(b) => b.to_string(),
+                    Value::Integer(i) => match config_option.option.display_hint {
+                        DisplayHint::None => format!("{}", i),
+                        DisplayHint::Binary => format!("0b{:0b}", i),
+                        DisplayHint::Hex => format!("0x{:x}", i),
+                    },
+                    Value::String(s) => s.clone(),
+                };
+
+                format!(
+                    "{} ({}{}){}",
+                    config_option.option.name,
+                    display_value,
+                    if config_option.actual_value == config_option.option.default_value {
+                        ui_elements.default_value
+                    } else {
+                        ""
+                    },
+                    if config_option.option.stability == Stability::Unstable {
+                        ui_elements.unstable
+                    } else {
+                        ""
+                    }
+                )
+                .to_string()
+            }
+        }
+    }
+
+    fn help_text(&self) -> String {
+        match self {
+            Item::TopLevel(crate_name) => format!("The `{crate_name}` crate").to_string(),
+            Item::CrateLevel(config_option) => config_option.option.description.clone(),
+        }
+        .replace("<p>", "")
+        .replace("</p>", "\n")
+        .to_string()
+    }
+
+    fn value(&self) -> Value {
+        match self {
+            Item::TopLevel(_) => unreachable!(),
+            Item::CrateLevel(config_option) => config_option.actual_value.clone(),
+        }
+    }
+
+    fn constraint(&self) -> Option<Validator> {
+        match self {
+            Item::TopLevel(_) => unreachable!(),
+            Item::CrateLevel(config_option) => config_option.option.constraint.clone(),
+        }
+    }
+
+    fn display_hint(&self) -> DisplayHint {
+        match self {
+            Item::TopLevel(_) => unreachable!(),
+            Item::CrateLevel(config_option) => config_option.option.display_hint.clone(),
+        }
+    }
+}
+
+impl Repository {
+    pub fn new(options: Vec<crate::CrateConfig>) -> Self {
+        Self {
+            configs: options,
+            current_crate: None,
+        }
+    }
+
+    fn current_level(&self) -> Vec<Item> {
+        if self.current_crate.is_none() {
+            Vec::from_iter(
+                self.configs
+                    .iter()
+                    .map(|config| Item::TopLevel(config.name.clone())),
+            )
+        } else {
+            Vec::from_iter(
+                self.configs[self.current_crate.unwrap()]
+                    .options
+                    .iter()
+                    .map(|option| Item::CrateLevel(option.clone())),
+            )
+        }
+    }
+
+    fn enter_group(&mut self, index: usize) {
+        if self.current_crate.is_none() {
+            self.current_crate = Some(index);
+        }
+    }
+
+    fn up(&mut self) {
+        if self.current_crate.is_some() {
+            self.current_crate = None;
+        }
+    }
+
+    fn set_current(&mut self, index: usize, new_value: Value) {
+        if self.current_crate.is_none() {
+            return;
+        }
+
+        self.configs[self.current_crate.unwrap()].options[index].actual_value = new_value;
+    }
+
+    // true if this is a configurable option
+    fn is_option(&self, _index: usize) -> bool {
+        self.current_crate.is_some()
+    }
+
+    // What to show in the list
+    fn current_level_desc(&self, width: u16, ui_elements: &UiElements) -> Vec<String> {
+        let level = self.current_level();
+
+        level.iter().map(|v| v.title(width, ui_elements)).collect()
+    }
+}
+
+pub fn init_terminal() -> AppResult<Terminal<impl Backend>> {
+    enable_raw_mode()?;
+    io::stdout().execute(EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(io::stdout());
+    let terminal = Terminal::new(backend)?;
+    Ok(terminal)
+}
+
+pub fn restore_terminal() -> AppResult<()> {
+    disable_raw_mode()?;
+    io::stdout().execute(LeaveAlternateScreen)?;
+    Ok(())
+}
+
+struct UiElements {
+    default_value: &'static str,
+    unstable: &'static str,
+    popup_highlight_symbol: &'static str,
+}
+
+struct Colors {
+    header_bg: Color,
+    normal_row_color: Color,
+    help_row_color: Color,
+    text_color: Color,
+
+    selected_active_style: Style,
+    edit_invalid_style: Style,
+    edit_valid_style: Style,
+    border_style: Style,
+    border_error_style: Style,
+}
+
+impl Colors {
+    const RGB: Self = Self {
+        header_bg: tailwind::BLUE.c950,
+        normal_row_color: tailwind::SLATE.c950,
+        help_row_color: tailwind::SLATE.c800,
+        text_color: tailwind::SLATE.c200,
+
+        selected_active_style: Style::new()
+            .add_modifier(Modifier::BOLD)
+            .fg(tailwind::SLATE.c200)
+            .bg(tailwind::BLUE.c950),
+        edit_invalid_style: Style::new().add_modifier(Modifier::BOLD).fg(Color::Red),
+        edit_valid_style: Style::new()
+            .add_modifier(Modifier::BOLD)
+            .fg(tailwind::SLATE.c200),
+        border_style: Style::new()
+            .add_modifier(Modifier::BOLD)
+            .fg(Color::LightBlue),
+        border_error_style: Style::new().add_modifier(Modifier::BOLD).fg(Color::Red),
+    };
+    const ANSI: Self = Self {
+        header_bg: Color::DarkGray,
+        normal_row_color: Color::Black,
+        help_row_color: Color::DarkGray,
+        text_color: Color::Gray,
+
+        selected_active_style: Style::new()
+            .add_modifier(Modifier::BOLD)
+            .fg(Color::White)
+            .bg(Color::Blue),
+        edit_invalid_style: Style::new().add_modifier(Modifier::BOLD).fg(Color::Red),
+        edit_valid_style: Style::new().add_modifier(Modifier::BOLD).fg(Color::Gray),
+        border_style: Style::new()
+            .add_modifier(Modifier::BOLD)
+            .fg(Color::LightBlue),
+        border_error_style: Style::new().add_modifier(Modifier::BOLD).fg(Color::Red),
+    };
+}
+
+impl UiElements {
+    const FANCY: Self = Self {
+        default_value: " 📌",
+        unstable: " 🚧",
+        popup_highlight_symbol: "▶️ ",
+    };
+    const FALLBACK: Self = Self {
+        default_value: " *",
+        unstable: " !",
+        popup_highlight_symbol: "> ",
+    };
+}
+
+pub struct App<'a> {
+    repository: Repository,
+
+    state: Vec<ListState>,
+
+    confirm_quit: bool,
+
+    editing: bool,
+    textarea: TextArea<'a>,
+    editing_constraints: Option<Validator>,
+    input_valid: bool,
+
+    showing_selection_popup: bool,
+    list_popup: List<'a>,
+    list_popup_state: ListState,
+
+    show_initial_message: bool,
+    initial_message: Option<String>,
+
+    ui_elements: UiElements,
+    colors: Colors,
+}
+
+impl App<'_> {
+    pub fn new(errors_to_show: Option<String>, repository: Repository) -> Self {
+        let (ui_elements, colors) = match std::env::var("TERM_PROGRAM").as_deref() {
+            Ok("vscode") => (UiElements::FALLBACK, Colors::RGB),
+            Ok("Apple_Terminal") => (UiElements::FALLBACK, Colors::ANSI),
+            _ => (UiElements::FANCY, Colors::RGB),
+        };
+
+        let mut initial_state = ListState::default();
+        initial_state.select(Some(0));
+
+        Self {
+            repository,
+            state: vec![initial_state],
+            confirm_quit: false,
+            editing: false,
+            textarea: TextArea::default(),
+            editing_constraints: None,
+            input_valid: true,
+            showing_selection_popup: false,
+            list_popup: List::default(),
+            list_popup_state: ListState::default(),
+            show_initial_message: errors_to_show.is_some(),
+            initial_message: errors_to_show,
+            ui_elements,
+            colors,
+        }
+    }
+
+    pub fn selected(&self) -> usize {
+        if let Some(current) = self.state.last() {
+            current.selected().unwrap_or_default()
+        } else {
+            0
+        }
+    }
+
+    pub fn select_next(&mut self) {
+        if let Some(current) = self.state.last_mut() {
+            current.select_next();
+        }
+    }
+    pub fn select_previous(&mut self) {
+        if let Some(current) = self.state.last_mut() {
+            current.select_previous();
+        }
+    }
+    pub fn enter_menu(&mut self) {
+        let mut new_state = ListState::default();
+        new_state.select(Some(0));
+        self.state.push(new_state);
+    }
+    pub fn exit_menu(&mut self) {
+        if self.state.len() > 1 {
+            self.state.pop();
+        }
+    }
+}
+
+impl App<'_> {
+    pub fn run(
+        &mut self,
+        mut terminal: Terminal<impl Backend>,
+    ) -> AppResult<Option<Vec<crate::CrateConfig>>> {
+        loop {
+            self.draw(&mut terminal)?;
+
+            if let Event::Key(key) = event::read()? {
+                if self.editing {
+                    match key.code {
+                        KeyCode::Enter if key.kind == KeyEventKind::Press => {
+                            if !self.input_valid {
+                                continue;
+                            }
+
+                            let selected = self.selected();
+                            if self.repository.is_option(selected) {
+                                let current = self.repository.current_level()[selected].value();
+                                let text = self.textarea.lines().join("");
+
+                                if let Some(value) = match current {
+                                    Value::Bool(_) => Some(Value::Bool(text.parse().unwrap())),
+                                    Value::Integer(_) => match parse_i128(&text) {
+                                        Ok(value) => Some(Value::Integer(value)),
+                                        Err(_) => None,
+                                    },
+                                    Value::String(_) => Some(Value::String(text)),
+                                } {
+                                    self.repository.set_current(selected, value)
+                                };
+                            }
+
+                            self.editing = false;
+                        }
+                        KeyCode::Esc => {
+                            self.editing = false;
+                        }
+                        _ => {
+                            if self.textarea.input(key) {
+                                let selected = self.selected();
+                                if self.repository.is_option(selected) {
+                                    let current = self.repository.current_level()[selected].value();
+                                    let text = self.textarea.lines().join("");
+
+                                    let parsed_value = match current {
+                                        Value::Bool(_) => Some(Value::Bool(text.parse().unwrap())),
+                                        Value::Integer(_) => match parse_i128(&text) {
+                                            Ok(value) => Some(Value::Integer(value)),
+                                            Err(_) => None,
+                                        },
+                                        Value::String(_) => Some(Value::String(text)),
+                                    };
+
+                                    let validator_failed =
+                                        if let Some(constraint) = &self.editing_constraints {
+                                            match &parsed_value {
+                                                Some(value) => constraint.validate(value).is_err(),
+                                                None => false,
+                                            }
+                                        } else {
+                                            false
+                                        };
+
+                                    let invalid = parsed_value.is_none() || validator_failed;
+
+                                    self.textarea.set_style(if invalid {
+                                        self.colors.edit_invalid_style
+                                    } else {
+                                        self.colors.edit_valid_style
+                                    });
+                                    self.input_valid = !invalid;
+                                }
+                            }
+                        }
+                    }
+                } else if self.showing_selection_popup && key.kind == KeyEventKind::Press {
+                    match key.code {
+                        KeyCode::Char('q') | KeyCode::Esc => {
+                            self.showing_selection_popup = false;
+                        }
+                        KeyCode::Down | KeyCode::Char('j') => self.list_popup_state.select_next(),
+                        KeyCode::Up | KeyCode::Char('k') => self.list_popup_state.select_previous(),
+                        KeyCode::Enter if key.kind == KeyEventKind::Press => {
+                            let selected = self.selected();
+                            if let Some(Validator::Enumeration(items)) = &self.repository.configs
+                                [self.repository.current_crate.unwrap()]
+                            .options[selected]
+                                .option
+                                .constraint
+                            {
+                                self.repository.set_current(
+                                    selected,
+                                    Value::String(
+                                        items[self.list_popup_state.selected().unwrap()].clone(),
+                                    ),
+                                );
+                            }
+                            self.showing_selection_popup = false;
+                        }
+                        _ => (),
+                    }
+                } else if self.show_initial_message {
+                    match key.code {
+                        KeyCode::Enter if key.kind == KeyEventKind::Press => {
+                            self.show_initial_message = false;
+                        }
+                        _ => (),
+                    }
+                } else if key.kind == KeyEventKind::Press {
+                    use KeyCode::*;
+
+                    if self.confirm_quit {
+                        match key.code {
+                            Char('y') | Char('Y') => return Ok(None),
+                            _ => self.confirm_quit = false,
+                        }
+                        continue;
+                    }
+
+                    match key.code {
+                        Char('q') => self.confirm_quit = true,
+                        Char('s') | Char('S') => return Ok(Some(self.repository.configs.clone())),
+                        Esc => {
+                            if self.state.len() == 1 {
+                                self.confirm_quit = true;
+                            } else {
+                                self.repository.up();
+                                self.exit_menu();
+                            }
+                        }
+                        Char('h') | Left => {
+                            self.repository.up();
+                            self.exit_menu();
+                        }
+                        Char('l') | Char(' ') | Right | Enter => {
+                            let selected = self.selected();
+                            if self.repository.is_option(selected) {
+                                let current = self.repository.current_level()[selected].value();
+                                let constraint =
+                                    self.repository.current_level()[selected].constraint();
+
+                                match current {
+                                    Value::Bool(value) => {
+                                        self.repository.set_current(selected, Value::Bool(!value))
+                                    }
+                                    Value::Integer(value) => {
+                                        let display_value = match self.repository.current_level()
+                                            [selected]
+                                            .display_hint()
+                                        {
+                                            DisplayHint::None => format!("{value}"),
+                                            DisplayHint::Binary => format!("0b{value:0b}"),
+                                            DisplayHint::Hex => format!("0x{value:x}"),
+                                        };
+                                        self.textarea =
+                                            make_text_area(&display_value, &self.colors);
+                                        self.editing_constraints = constraint;
+                                        self.editing = true;
+                                    }
+                                    Value::String(s) => match constraint {
+                                        Some(Validator::Enumeration(items)) => {
+                                            let selected_option =
+                                                items.iter().position(|v| *v == s);
+                                            self.list_popup =
+                                                make_popup(items, &self.ui_elements, &self.colors);
+                                            self.list_popup_state = ListState::default();
+                                            self.list_popup_state.select(selected_option);
+                                            self.showing_selection_popup = true;
+                                        }
+                                        _ => {
+                                            self.textarea = make_text_area(&s, &self.colors);
+                                            self.editing_constraints = None;
+                                            self.editing = true;
+                                        }
+                                    },
+                                }
+                            } else {
+                                self.repository.enter_group(self.selected());
+                                self.enter_menu();
+                            }
+                        }
+                        Char('j') | Down => {
+                            self.select_next();
+                        }
+                        Char('k') | Up => {
+                            self.select_previous();
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+
+    fn draw(&mut self, terminal: &mut Terminal<impl Backend>) -> AppResult<()> {
+        terminal.draw(|f| {
+            f.render_widget(self, f.area());
+        })?;
+
+        Ok(())
+    }
+}
+
+fn make_text_area<'a>(s: &str, colors: &Colors) -> TextArea<'a> {
+    let mut text_area = TextArea::new(vec![s.to_string()]);
+    text_area.set_block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(colors.border_style)
+            .title("Input"),
+    );
+    text_area.set_style(colors.edit_valid_style);
+    text_area.set_cursor_line_style(Style::default());
+    text_area.move_cursor(CursorMove::End);
+    text_area
+}
+
+fn make_popup<'a>(items: Vec<String>, ui_elements: &UiElements, colors: &Colors) -> List<'a> {
+    List::new(items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(colors.border_style)
+                .title("Choose"),
+        )
+        .highlight_style(colors.selected_active_style)
+        .highlight_symbol(ui_elements.popup_highlight_symbol)
+        .repeat_highlight_symbol(true)
+}
+
+impl Widget for &mut App<'_> {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let vertical = Layout::vertical([
+            Constraint::Length(2),
+            Constraint::Fill(1),
+            Constraint::Length(self.help_lines(area)),
+            Constraint::Length(self.footer_lines(area)),
+        ]);
+        let [header_area, rest_area, help_area, footer_area] = vertical.areas(area);
+
+        self.render_title(header_area, buf);
+        self.render_item(rest_area, buf);
+        self.render_help(help_area, buf);
+        self.render_footer(footer_area, buf);
+
+        if self.editing {
+            let area = Rect {
+                x: 5,
+                y: area.height / 2 - 2,
+                width: area.width - 10,
+                height: 3,
+            };
+
+            ratatui::widgets::Clear.render(area, buf);
+            self.textarea.render(area, buf);
+        }
+
+        if self.showing_selection_popup {
+            let area = Rect {
+                x: 5,
+                y: area.height / 2 - 3,
+                width: area.width - 10,
+                height: 6,
+            };
+
+            ratatui::widgets::Clear.render(area, buf);
+            StatefulWidget::render(&self.list_popup, area, buf, &mut self.list_popup_state);
+        }
+
+        if self.show_initial_message {
+            let area = Rect {
+                x: 5,
+                y: area.height / 2 - 5,
+                width: area.width - 10,
+                height: 5,
+            };
+
+            let block = Paragraph::new(self.initial_message.as_ref().unwrap().clone())
+                .style(self.colors.edit_invalid_style)
+                .block(
+                    Block::bordered()
+                        .title("The project generated errors")
+                        .style(self.colors.border_error_style)
+                        .padding(Padding::uniform(1)),
+                );
+            block.render(area, buf);
+        }
+    }
+}
+
+impl App<'_> {
+    fn render_title(&self, area: Rect, buf: &mut Buffer) {
+        Paragraph::new("esp-config")
+            .bold()
+            .centered()
+            .render(area, buf);
+    }
+
+    fn render_item(&mut self, area: Rect, buf: &mut Buffer) {
+        // We create two blocks, one is for the header (outer) and the other is for the
+        // list (inner).
+        let outer_block = Block::default()
+            .borders(Borders::NONE)
+            .fg(self.colors.text_color)
+            .bg(self.colors.header_bg)
+            .title_alignment(Alignment::Center);
+        let inner_block = Block::default()
+            .borders(Borders::NONE)
+            .fg(self.colors.text_color)
+            .bg(self.colors.normal_row_color);
+
+        // We get the inner area from outer_block. We'll use this area later to render
+        // the table.
+        let outer_area = area;
+        let inner_area = outer_block.inner(outer_area);
+
+        // We can render the header in outer_area.
+        outer_block.render(outer_area, buf);
+
+        // Iterate through all elements in the `items` and stylize them.
+        let items: Vec<ListItem> = self
+            .repository
+            .current_level_desc(area.width, &self.ui_elements)
+            .into_iter()
+            .map(|value| ListItem::new(value).style(Style::default()))
+            .collect();
+
+        // We can now render the item list
+        // (look carefully, we are using StatefulWidget's render.)
+        // ratatui::widgets::StatefulWidget::render as stateful_render
+        if let Some(current_state) = self.state.last_mut() {
+            // Create a List from all list items and highlight the currently selected one
+            let items = List::new(items)
+                .block(inner_block)
+                .highlight_style(self.colors.selected_active_style)
+                .highlight_spacing(HighlightSpacing::Always);
+            StatefulWidget::render(items, inner_area, buf, current_state);
+        } else {
+            ratatui::restore();
+            panic!("menu state not found!")
+        }
+    }
+
+    fn help_paragraph(&self) -> Option<Paragraph<'_>> {
+        let selected = self
+            .selected()
+            .min(self.repository.current_level().len() - 1);
+        let option = &self.repository.current_level()[selected];
+        let help_text = option.help_text();
+        if help_text.is_empty() {
+            return None;
+        }
+
+        let help_block = Block::default()
+            .borders(Borders::NONE)
+            .fg(self.colors.text_color)
+            .bg(self.colors.help_row_color);
+
+        Some(
+            Paragraph::new(help_text)
+                .centered()
+                .wrap(Wrap { trim: false })
+                .block(help_block),
+        )
+    }
+
+    fn help_lines(&self, area: Rect) -> u16 {
+        if let Some(paragraph) = self.help_paragraph() {
+            paragraph.line_count(area.width) as u16
+        } else {
+            0
+        }
+    }
+
+    fn render_help(&self, area: Rect, buf: &mut Buffer) {
+        if let Some(paragraph) = self.help_paragraph() {
+            paragraph.render(area, buf);
+        }
+    }
+
+    fn footer_paragraph(&self) -> Paragraph<'_> {
+        let text = if self.confirm_quit {
+            "Are you sure you want to quit? (y/N)"
+        } else if self.editing {
+            "ENTER to confirm, ESC to cancel"
+        } else if self.showing_selection_popup {
+            "Use ↓↑ to move, ENTER to confirm, ESC to cancel"
+        } else if self.show_initial_message {
+            "ENTER to confirm"
+        } else {
+            "Use ↓↑ to move, ESC/← to go up, → to go deeper or change the value, s/S to save and generate, ESC/q to cancel"
+        };
+
+        Paragraph::new(text).centered().wrap(Wrap { trim: false })
+    }
+
+    fn footer_lines(&self, area: Rect) -> u16 {
+        self.footer_paragraph().line_count(area.width) as u16
+    }
+
+    fn render_footer(&self, area: Rect, buf: &mut Buffer) {
+        self.footer_paragraph().render(area, buf);
+    }
+}
+
+fn parse_i128(str: &str) -> Result<i128, std::num::ParseIntError> {
+    let str = str.trim();
+
+    if let Some(stripped) = str.strip_prefix("0x") {
+        return i128::from_str_radix(stripped, 16);
+    }
+
+    if let Some(stripped) = str.strip_prefix("0b") {
+        return i128::from_str_radix(stripped, 2);
+    }
+
+    str.parse::<i128>()
+}

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -101,7 +101,10 @@ impl Package {
         let mut features = vec![];
         match self {
             Package::EspBacktrace => features.push("defmt".to_owned()),
-            Package::EspConfig => features.push("build".to_owned()),
+            Package::EspConfig => {
+                features.push("build".to_owned());
+                features.push("tui".to_owned());
+            },
             Package::EspHal => {
                 features.push("unstable".to_owned());
                 if config.contains("psram") {


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
This supercedes https://github.com/esp-rs/esp-generate/pull/149 

TL;DR this adds a TUI to edit config options

![image](https://github.com/user-attachments/assets/2afc89e3-bc05-4be9-8fe9-78915fa41d01)

I guess in this case `skip-changelog` is fine

#### Testing

Testing:

- generate a project via esp-generate, patch all esp-* dependencies, e.g. `esp-config = { git = "https://github.com/esp-rs/esp-hal/" }` etc.
- install the binary: e.g. inside the esp-config directory `cargo install --features=tui --path .`
- inside your generated project: `esp-config`
