### PR TITLE
Alarm

### DIFF
--- a/esp-hal-embassy/src/lib.rs
+++ b/esp-hal-embassy/src/lib.rs
@@ -52,8 +52,6 @@
 // MUST be the first module
 mod fmt;
 
-#[cfg(not(feature = "esp32"))]
-use esp_hal::timer::systimer::Alarm;
 use esp_hal::timer::{AnyTimer, timg::Timer as TimgTimer};
 pub use macros::embassy_main as main;
 
@@ -91,11 +89,9 @@ pub trait TimerCollection {
 trait IntoAnyTimer: Into<AnyTimer<'static>> {}
 
 impl IntoAnyTimer for AnyTimer<'static> {}
-
-impl IntoAnyTimer for TimgTimer<'static> where Self: Into<AnyTimer<'static>> {}
-
-#[cfg(not(feature = "esp32"))]
-impl IntoAnyTimer for Alarm<'static> where Self: Into<AnyTimer<'static>> {}
+impl IntoAnyTimer for TimgTimer<'static> {}
+#[cfg(systimer)]
+impl IntoAnyTimer for esp_hal::timer::systimer::Alarm<'static> {}
 
 impl<T> TimerCollection for T
 where

--- a/esp-hal-embassy/src/time_driver.rs
+++ b/esp-hal-embassy/src/time_driver.rs
@@ -159,9 +159,13 @@ impl EmbassyTimer {
         });
 
         // Store the available timers
-        DRIVER
-            .available_timers
-            .with(|available_timers| *available_timers = Some(timers));
+        DRIVER.available_timers.with(|available_timers| {
+            assert!(
+                available_timers.is_none(),
+                "The timers have already been initialized."
+            );
+            *available_timers = Some(timers);
+        });
     }
 
     #[cfg(not(single_queue))]

--- a/esp-hal/src/timer/mod.rs
+++ b/esp-hal/src/timer/mod.rs
@@ -6,10 +6,10 @@
 //! can be used to interact with different hardware timers, like the `TIMG` and
 //! SYSTIMER.
 #![cfg_attr(
-    not(feature = "esp32"),
+    systimer,
     doc = "See the [timg] and [systimer] modules for more information."
 )]
-#![cfg_attr(feature = "esp32", doc = "See the [timg] module for more information.")]
+#![cfg_attr(not(systimer), doc = "See the [timg] module for more information.")]
 //! ## Examples
 //!
 //! ### One-shot Timer

--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -114,8 +114,6 @@ use core::marker::PhantomData;
 
 use common_adapter::chip_specific::phy_mem_init;
 use esp_config::*;
-#[cfg(not(feature = "esp32"))]
-use esp_hal::timer::systimer::Alarm;
 use esp_hal::{self as hal, clock::RadioClockController, peripherals::RADIO_CLK};
 use hal::{
     Blocking,
@@ -318,8 +316,8 @@ pub trait EspWifiTimerSource: private::Sealed {
 impl private::Sealed for TimeBase {}
 impl private::Sealed for AnyTimer<'_> {}
 impl private::Sealed for TimgTimer<'_> {}
-#[cfg(not(feature = "esp32"))]
-impl private::Sealed for Alarm<'_> {}
+#[cfg(systimer)]
+impl private::Sealed for esp_hal::timer::systimer::Alarm<'_> {}
 
 impl<T> EspWifiTimerSource for T
 where


### PR DESCRIPTION
With this PR, although probably not in the easiest to parse way, the rustdoc contains what types can be passed to `init`:

![image](https://github.com/user-attachments/assets/dcf3692c-67e3-4333-bf92-1e749ae38c5d)

![image](https://github.com/user-attachments/assets/56e31c08-3ae7-4732-a47f-3938c4f67605)

The TimeBase trait is now sealed, its method is private so it's impossible to call multiple times - without calling `esp_hal_embassy::init` multiple times, at least (in which case the crate panics anyway).