### PR TITLE
Check unique chip feature in esp-metadata

### DIFF
--- a/esp-backtrace/Cargo.toml
+++ b/esp-backtrace/Cargo.toml
@@ -29,6 +29,7 @@ semihosting = { version = "0.1.20", optional = true }
 [build-dependencies]
 esp-build = { version = "0.2.0", path = "../esp-build" }
 esp-config   = { version = "0.3.0", path = "../esp-config", features = ["build"] }
+esp-metadata = { version = "0.6.0", path = "../esp-metadata" }
 
 [features]
 default = ["colors"]

--- a/esp-backtrace/build.rs
+++ b/esp-backtrace/build.rs
@@ -3,9 +3,7 @@ use esp_config::{ConfigOption, Stability, Value, generate_config};
 
 fn main() {
     // Ensure that only a single chip is specified:
-    assert_unique_used_features!(
-        "esp32", "esp32c2", "esp32c3", "esp32c6", "esp32h2", "esp32p4", "esp32s2", "esp32s3"
-    );
+    let _ = esp_metadata::Chip::from_cargo_feature().unwrap();
 
     // Ensure that exactly a backend is selected:
     assert_unique_used_features!("defmt", "println");

--- a/esp-hal-embassy/build.rs
+++ b/esp-hal-embassy/build.rs
@@ -1,38 +1,11 @@
-use std::{error::Error as StdError, str::FromStr};
+use std::error::Error as StdError;
 
-use esp_build::assert_unique_used_features;
 use esp_config::{ConfigOption, Stability, Validator, Value, generate_config};
 use esp_metadata::{Chip, Config};
 
 fn main() -> Result<(), Box<dyn StdError>> {
-    // NOTE: update when adding new device support!
-    // Ensure that exactly one chip has been specified:
-    assert_unique_used_features!(
-        "esp32", "esp32c2", "esp32c3", "esp32c6", "esp32h2", "esp32s2", "esp32s3"
-    );
-
-    // NOTE: update when adding new device support!
-    // Determine the name of the configured device:
-    let device_name = if cfg!(feature = "esp32") {
-        "esp32"
-    } else if cfg!(feature = "esp32c2") {
-        "esp32c2"
-    } else if cfg!(feature = "esp32c3") {
-        "esp32c3"
-    } else if cfg!(feature = "esp32c6") {
-        "esp32c6"
-    } else if cfg!(feature = "esp32h2") {
-        "esp32h2"
-    } else if cfg!(feature = "esp32s2") {
-        "esp32s2"
-    } else if cfg!(feature = "esp32s3") {
-        "esp32s3"
-    } else {
-        unreachable!() // We've confirmed exactly one known device was selected
-    };
-
     // Load the configuration file for the configured device:
-    let chip = Chip::from_str(device_name)?;
+    let chip = Chip::from_cargo_feature()?;
     let config = Config::for_chip(&chip);
 
     // Define all necessary configuration symbols for the configured device:

--- a/esp-println/Cargo.toml
+++ b/esp-println/Cargo.toml
@@ -32,8 +32,9 @@ defmt            = { version = "1.0.1", optional = true }
 log-04           = { package = "log", version = "0.4.27", optional = true }
 
 [build-dependencies]
-esp-build = { version = "0.2.0", path = "../esp-build" }
-log-04    = { package = "log", version = "0.4.27" }
+esp-build    = { version = "0.2.0", path = "../esp-build" }
+esp-metadata = { version = "0.6.0", path = "../esp-metadata" }
+log-04       = { package = "log", version = "0.4.27" }
 
 [features]
 default          = ["auto", "colors", "critical-section"]

--- a/esp-println/build.rs
+++ b/esp-println/build.rs
@@ -1,26 +1,32 @@
 use std::{env, path::Path};
 
 use esp_build::assert_unique_used_features;
+use esp_metadata::Chip;
 use log_04::LevelFilter;
 
 fn main() {
     // Ensure that only a single chip is specified
-    assert_unique_used_features!(
-        "esp32", "esp32c2", "esp32c3", "esp32c6", "esp32h2", "esp32p4", "esp32s2", "esp32s3"
-    );
+    let chip = if cfg!(feature = "esp32p4") {
+        None
+    } else {
+        Some(Chip::from_cargo_feature().unwrap())
+    };
 
     // Ensure that only a single communication method is specified
     assert_unique_used_features!("jtag-serial", "uart", "auto");
 
     // Ensure that, if the `jtag-serial` communication method feature is enabled,
     // a compatible chip feature is also enabled.
-    if cfg!(feature = "jtag-serial")
-        && !(cfg!(feature = "esp32c3")
-            || cfg!(feature = "esp32c6")
-            || cfg!(feature = "esp32h2")
-            || cfg!(feature = "esp32p4")
-            || cfg!(feature = "esp32s3"))
-    {
+
+    // TODO: replace with Config once the P4 is supported by esp-hal (we're using
+    // Config::for_chip to reject P4 currently)
+    let has_jtag_serial = cfg!(feature = "esp32p4")
+        || matches!(
+            chip,
+            Some(Chip::Esp32c3 | Chip::Esp32c6 | Chip::Esp32h2 | Chip::Esp32s3)
+        );
+
+    if cfg!(feature = "jtag-serial") && !has_jtag_serial {
         panic!(
             "The `jtag-serial` feature is only supported by the ESP32-C3, ESP32-C6, ESP32-H2, ESP32-P4, and ESP32-S3"
         );

--- a/esp-storage/Cargo.toml
+++ b/esp-storage/Cargo.toml
@@ -28,7 +28,8 @@ critical-section = { version = "1.2.0", optional = true }
 document-features = "0.2.11"
 
 [build-dependencies]
-esp-build = { version = "0.2.0", path = "../esp-build" }
+esp-build    = { version = "0.2.0", path = "../esp-build" }
+esp-metadata = { version = "0.6.0", path = "../esp-metadata" }
 
 [features]
 default = ["critical-section"]

--- a/esp-storage/build.rs
+++ b/esp-storage/build.rs
@@ -1,8 +1,8 @@
 fn main() -> Result<(), String> {
     // Ensure that only a single chip is specified
-    esp_build::assert_unique_used_features!(
-        "esp32", "esp32c2", "esp32c3", "esp32c6", "esp32h2", "esp32s2", "esp32s3"
-    );
+    if !cfg!(feature = "emulation") {
+        let _ = esp_metadata::Chip::from_cargo_feature().map_err(|e| format!("{e:?}"))?;
+    }
 
     if cfg!(feature = "esp32") {
         match std::env::var("OPT_LEVEL") {

--- a/esp-wifi/build.rs
+++ b/esp-wifi/build.rs
@@ -1,37 +1,11 @@
-use std::{error::Error, str::FromStr};
+use std::error::Error;
 
-use esp_build::assert_unique_used_features;
 use esp_config::{ConfigOption, Stability, Validator, Value, generate_config};
 use esp_metadata::{Chip, Config};
 
 fn main() -> Result<(), Box<dyn Error>> {
-    // Ensure that only a single chip is specified:
-    assert_unique_used_features!(
-        "esp32", "esp32c2", "esp32c3", "esp32c6", "esp32h2", "esp32s2", "esp32s3"
-    );
-
-    // NOTE: update when adding new device support!
-    // Determine the name of the configured device:
-    let device_name = if cfg!(feature = "esp32") {
-        "esp32"
-    } else if cfg!(feature = "esp32c2") {
-        "esp32c2"
-    } else if cfg!(feature = "esp32c3") {
-        "esp32c3"
-    } else if cfg!(feature = "esp32c6") {
-        "esp32c6"
-    } else if cfg!(feature = "esp32h2") {
-        "esp32h2"
-    } else if cfg!(feature = "esp32s2") {
-        "esp32s2"
-    } else if cfg!(feature = "esp32s3") {
-        "esp32s3"
-    } else {
-        unreachable!() // We've confirmed exactly one known device was selected
-    };
-
     // Load the configuration file for the configured device:
-    let chip = Chip::from_str(device_name)?;
+    let chip = Chip::from_cargo_feature()?;
     let config = Config::for_chip(&chip);
 
     // Define all necessary configuration symbols for the configured device:

--- a/hil-test/build.rs
+++ b/hil-test/build.rs
@@ -1,37 +1,10 @@
-use std::{error::Error, str::FromStr};
+use std::error::Error;
 
-use esp_build::assert_unique_used_features;
 use esp_metadata::{Chip, Config};
 
 fn main() -> Result<(), Box<dyn Error>> {
-    // NOTE: update when adding new device support!
-    // Ensure that exactly one chip has been specified:
-    assert_unique_used_features!(
-        "esp32", "esp32c2", "esp32c3", "esp32c6", "esp32h2", "esp32s2", "esp32s3"
-    );
-
-    // NOTE: update when adding new device support!
-    // Determine the name of the configured device:
-    let device_name = if cfg!(feature = "esp32") {
-        "esp32"
-    } else if cfg!(feature = "esp32c2") {
-        "esp32c2"
-    } else if cfg!(feature = "esp32c3") {
-        "esp32c3"
-    } else if cfg!(feature = "esp32c6") {
-        "esp32c6"
-    } else if cfg!(feature = "esp32h2") {
-        "esp32h2"
-    } else if cfg!(feature = "esp32s2") {
-        "esp32s2"
-    } else if cfg!(feature = "esp32s3") {
-        "esp32s3"
-    } else {
-        unreachable!() // We've confirmed exactly one known device was selected
-    };
-
     // Load the configuration file for the configured device:
-    let chip = Chip::from_str(device_name)?;
+    let chip = Chip::from_cargo_feature()?;
     let config = Config::for_chip(&chip);
 
     // Define all necessary configuration symbols for the configured device:


### PR DESCRIPTION
In general we're not relying on esp-metadata enough. This PR removes the many ad-hoc chip list checks (and adds an ugly hack to esp-println because P4 is supported there...)