### PR TITLE
parl io: Reset TX fifo before each transfer

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -81,6 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `OneShot` timer now returns an InvalidTimeout from `schedule` instead of panicking (#3433)
 - GPIO interrupt handling no longer causes infinite looping if a task at higher priority is awaiting on a pin event (#3408)
 - `esp_hal::gpio::Input::is_interrupt_set` can now return true (#3408)
+- PARL_IO: Reset TX fifo before each transfer (#3448)
 
 ### Removed
 

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -1232,7 +1232,15 @@ where
         PCR::regs()
             .parl_clk_tx_conf()
             .modify(|_, w| w.parl_tx_rst_en().set_bit());
+        PCR::regs()
+            .parl_clk_tx_conf()
+            .modify(|_, w| w.parl_tx_rst_en().clear_bit());
 
+        PCR::regs()
+            .parl_clk_tx_conf()
+            .modify(|_, w| w.parl_clk_tx_en().clear_bit());
+
+        Instance::reset_tx_fifo();
         Instance::clear_tx_interrupts();
         Instance::set_tx_bytes(number_of_bytes as u16);
 
@@ -1251,7 +1259,7 @@ where
 
         PCR::regs()
             .parl_clk_tx_conf()
-            .modify(|_, w| w.parl_tx_rst_en().clear_bit());
+            .modify(|_, w| w.parl_clk_tx_en().set_bit());
 
         Ok(ParlIoTxTransfer {
             parl_io: ManuallyDrop::new(self),
@@ -1727,6 +1735,17 @@ mod private {
             });
         }
 
+        pub fn reset_tx_fifo() {
+            let reg_block = PARL_IO::regs();
+
+            reg_block
+                .tx_cfg0()
+                .modify(|_, w| w.tx_fifo_srst().set_bit());
+            reg_block
+                .tx_cfg0()
+                .modify(|_, w| w.tx_fifo_srst().clear_bit());
+        }
+
         pub fn set_tx_bytes(len: u16) {
             let reg_block = PARL_IO::regs();
 
@@ -1939,6 +1958,17 @@ mod private {
                     .tx_eof()
                     .clear_bit_by_one()
             });
+        }
+
+        pub fn reset_tx_fifo() {
+            let reg_block = PARL_IO::regs();
+
+            reg_block
+                .tx_cfg0()
+                .modify(|_, w| w.tx_fifo_srst().set_bit());
+            reg_block
+                .tx_cfg0()
+                .modify(|_, w| w.tx_fifo_srst().clear_bit());
         }
 
         pub fn set_tx_bytes(len: u16) {

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -1964,10 +1964,10 @@ mod private {
             let reg_block = PARL_IO::regs();
 
             reg_block
-                .tx_cfg0()
+                .fifo_cfg()
                 .modify(|_, w| w.tx_fifo_srst().set_bit());
             reg_block
-                .tx_cfg0()
+                .fifo_cfg()
                 .modify(|_, w| w.tx_fifo_srst().clear_bit());
         }
 

--- a/hil-test/tests/parl_io.rs
+++ b/hil-test/tests/parl_io.rs
@@ -117,7 +117,7 @@ mod tests {
 
         let pio = ParlIo::new(ctx.parl_io, ctx.dma_channel).unwrap();
 
-        let pio_tx = pio
+        let mut pio_tx = pio
             .tx
             .with_config(
                 tx_pins,
@@ -128,7 +128,7 @@ mod tests {
                     .with_bit_order(BitPackOrder::Lsb),
             )
             .unwrap();
-        let pio_rx = pio
+        let mut pio_rx = pio
             .rx
             .with_config(
                 rx_pins,
@@ -139,22 +139,25 @@ mod tests {
             )
             .unwrap();
 
-        for (i, b) in dma_tx_buf.as_mut_slice().iter_mut().enumerate() {
-            *b = i as u8;
+        for _ in 0..2 {
+            dma_rx_buf.as_mut_slice().fill(0);
+            for (i, b) in dma_tx_buf.as_mut_slice().iter_mut().enumerate() {
+                *b = i as u8;
+            }
+
+            let rx_transfer = pio_rx
+                .read(Some(dma_rx_buf.len()), dma_rx_buf)
+                .map_err(|e| e.0)
+                .unwrap();
+            let tx_transfer = pio_tx
+                .write(dma_tx_buf.len(), dma_tx_buf)
+                .map_err(|e| e.0)
+                .unwrap();
+            (_, pio_tx, dma_tx_buf) = tx_transfer.wait();
+            (_, pio_rx, dma_rx_buf) = rx_transfer.wait();
+
+            assert_eq!(dma_rx_buf.as_slice(), dma_tx_buf.as_slice());
         }
-
-        let rx_transfer = pio_rx
-            .read(Some(dma_rx_buf.len()), dma_rx_buf)
-            .map_err(|e| e.0)
-            .unwrap();
-        let tx_transfer = pio_tx
-            .write(dma_tx_buf.len(), dma_tx_buf)
-            .map_err(|e| e.0)
-            .unwrap();
-        (_, _, dma_tx_buf) = tx_transfer.wait();
-        (_, _, dma_rx_buf) = rx_transfer.wait();
-
-        assert_eq!(dma_rx_buf.as_slice(), dma_tx_buf.as_slice());
     }
 
     #[test]
@@ -180,7 +183,7 @@ mod tests {
 
         let pio = ParlIo::new(ctx.parl_io, ctx.dma_channel).unwrap();
 
-        let pio_tx = pio
+        let mut pio_tx = pio
             .tx
             .with_config(
                 tx_pins,
@@ -191,7 +194,7 @@ mod tests {
                     .with_bit_order(BitPackOrder::Lsb),
             )
             .unwrap();
-        let pio_rx = pio
+        let mut pio_rx = pio
             .rx
             .with_config(
                 rx_pins,
@@ -202,22 +205,25 @@ mod tests {
             )
             .unwrap();
 
-        for (i, b) in dma_tx_buf.as_mut_slice().iter_mut().enumerate() {
-            *b = i as u8;
+        for _ in 0..2 {
+            dma_rx_buf.as_mut_slice().fill(0);
+            for (i, b) in dma_tx_buf.as_mut_slice().iter_mut().enumerate() {
+                *b = i as u8;
+            }
+
+            let rx_transfer = pio_rx
+                .read(Some(dma_rx_buf.len()), dma_rx_buf)
+                .map_err(|e| e.0)
+                .unwrap();
+            let tx_transfer = pio_tx
+                .write(dma_tx_buf.len(), dma_tx_buf)
+                .map_err(|e| e.0)
+                .unwrap();
+            (_, pio_tx, dma_tx_buf) = tx_transfer.wait();
+            (_, pio_rx, dma_rx_buf) = rx_transfer.wait();
+
+            assert_eq!(dma_rx_buf.as_slice(), dma_tx_buf.as_slice());
         }
-
-        let rx_transfer = pio_rx
-            .read(Some(dma_rx_buf.len()), dma_rx_buf)
-            .map_err(|e| e.0)
-            .unwrap();
-        let tx_transfer = pio_tx
-            .write(dma_tx_buf.len(), dma_tx_buf)
-            .map_err(|e| e.0)
-            .unwrap();
-        (_, _, dma_tx_buf) = tx_transfer.wait();
-        (_, _, dma_rx_buf) = rx_transfer.wait();
-
-        assert_eq!(dma_rx_buf.as_slice(), dma_tx_buf.as_slice());
     }
 
     #[test]
@@ -249,7 +255,7 @@ mod tests {
 
         let pio = ParlIo::new(ctx.parl_io, ctx.dma_channel).unwrap();
 
-        let pio_tx = pio
+        let mut pio_tx = pio
             .tx
             .with_config(
                 tx_pins,
@@ -260,7 +266,7 @@ mod tests {
                     .with_bit_order(BitPackOrder::Lsb),
             )
             .unwrap();
-        let pio_rx = pio
+        let mut pio_rx = pio
             .rx
             .with_config(
                 rx_pins,
@@ -271,22 +277,25 @@ mod tests {
             )
             .unwrap();
 
-        for (i, b) in dma_tx_buf.as_mut_slice().iter_mut().enumerate() {
-            *b = i as u8;
+        for _ in 0..2 {
+            dma_rx_buf.as_mut_slice().fill(0);
+            for (i, b) in dma_tx_buf.as_mut_slice().iter_mut().enumerate() {
+                *b = i as u8;
+            }
+
+            let rx_transfer = pio_rx
+                .read(Some(dma_rx_buf.len()), dma_rx_buf)
+                .map_err(|e| e.0)
+                .unwrap();
+            let tx_transfer = pio_tx
+                .write(dma_tx_buf.len(), dma_tx_buf)
+                .map_err(|e| e.0)
+                .unwrap();
+            (_, pio_tx, dma_tx_buf) = tx_transfer.wait();
+            (_, pio_rx, dma_rx_buf) = rx_transfer.wait();
+
+            assert_eq!(dma_rx_buf.as_slice(), dma_tx_buf.as_slice());
         }
-
-        let rx_transfer = pio_rx
-            .read(Some(dma_rx_buf.len()), dma_rx_buf)
-            .map_err(|e| e.0)
-            .unwrap();
-        let tx_transfer = pio_tx
-            .write(dma_tx_buf.len(), dma_tx_buf)
-            .map_err(|e| e.0)
-            .unwrap();
-        (_, _, dma_tx_buf) = tx_transfer.wait();
-        (_, _, dma_rx_buf) = rx_transfer.wait();
-
-        assert_eq!(dma_rx_buf.as_slice(), dma_tx_buf.as_slice());
     }
 
     // This test is disabled on the H2 because in 8-bit mode, there's no external
@@ -296,7 +305,7 @@ mod tests {
     #[cfg(not(esp32h2))]
     #[test]
     fn test_parl_io_rx_can_read_tx_in_8_bit_mode(ctx: Context) {
-        const BUFFER_SIZE: usize = 250;
+        const BUFFER_SIZE: usize = 252;
 
         let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(BUFFER_SIZE);
         let mut dma_rx_buf = DmaRxBuf::new(rx_descriptors, rx_buffer).unwrap();
@@ -326,7 +335,7 @@ mod tests {
 
         let pio = ParlIo::new(ctx.parl_io, ctx.dma_channel).unwrap();
 
-        let pio_tx = pio
+        let mut pio_tx = pio
             .tx
             .with_config(
                 tx_pins,
@@ -337,7 +346,7 @@ mod tests {
                     .with_bit_order(BitPackOrder::Msb),
             )
             .unwrap();
-        let pio_rx = pio
+        let mut pio_rx = pio
             .rx
             .with_config(
                 rx_pins,
@@ -348,21 +357,24 @@ mod tests {
             )
             .unwrap();
 
-        for (i, b) in dma_tx_buf.as_mut_slice().iter_mut().enumerate() {
-            *b = i as u8;
+        for _ in 0..2 {
+            dma_rx_buf.as_mut_slice().fill(0);
+            for (i, b) in dma_tx_buf.as_mut_slice().iter_mut().enumerate() {
+                *b = i as u8;
+            }
+
+            let rx_transfer = pio_rx
+                .read(Some(dma_rx_buf.len()), dma_rx_buf)
+                .map_err(|e| e.0)
+                .unwrap();
+            let tx_transfer = pio_tx
+                .write(dma_tx_buf.len(), dma_tx_buf)
+                .map_err(|e| e.0)
+                .unwrap();
+            (_, pio_tx, dma_tx_buf) = tx_transfer.wait();
+            (_, pio_rx, dma_rx_buf) = rx_transfer.wait();
+
+            assert_eq!(dma_rx_buf.as_slice(), dma_tx_buf.as_slice());
         }
-
-        let rx_transfer = pio_rx
-            .read(Some(dma_rx_buf.len()), dma_rx_buf)
-            .map_err(|e| e.0)
-            .unwrap();
-        let tx_transfer = pio_tx
-            .write(dma_tx_buf.len(), dma_tx_buf)
-            .map_err(|e| e.0)
-            .unwrap();
-        (_, _, dma_tx_buf) = tx_transfer.wait();
-        (_, _, dma_rx_buf) = rx_transfer.wait();
-
-        assert_eq!(dma_rx_buf.as_slice(), dma_tx_buf.as_slice());
     }
 }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Fixes the behaviour reported in https://github.com/esp-rs/esp-hal/issues/3400#issuecomment-2823078132

#### Testing
HIL
