### PR TITLE
Make esp-config structs de-serialization friendly

### DIFF
--- a/esp-backtrace/build.rs
+++ b/esp-backtrace/build.rs
@@ -1,5 +1,5 @@
 use esp_build::assert_unique_used_features;
-use esp_config::{ConfigOption, Stability, Value, generate_config};
+use esp_config::{ConfigOption, generate_config};
 
 fn main() {
     // Ensure that only a single chip is specified:
@@ -15,14 +15,11 @@ fn main() {
     // emit config
     generate_config(
         "esp_backtrace",
-        &[ConfigOption {
-            name: "backtrace-frames",
-            description: "The maximum number of frames that will be printed in a backtrace",
-            default_value: Value::Integer(10),
-            constraint: None,
-            stability: Stability::Unstable,
-            active: true,
-        }],
+        &[ConfigOption::integer(
+            "backtrace-frames",
+            "The maximum number of frames that will be printed in a backtrace",
+            10,
+        )],
         true,
         true,
     );

--- a/esp-backtrace/build.rs
+++ b/esp-backtrace/build.rs
@@ -15,7 +15,7 @@ fn main() {
     // emit config
     generate_config(
         "esp_backtrace",
-        &[ConfigOption::integer(
+        &[ConfigOption::new(
             "backtrace-frames",
             "The maximum number of frames that will be printed in a backtrace",
             10,

--- a/esp-bootloader-esp-idf/Cargo.toml
+++ b/esp-bootloader-esp-idf/Cargo.toml
@@ -15,7 +15,7 @@ default-target = "riscv32imac-unknown-none-elf"
 
 [lib]
 bench = false
-test  = false
+test  = true
 
 [dependencies]
 defmt = { version = "1.0.1", optional = true }

--- a/esp-bootloader-esp-idf/build.rs
+++ b/esp-bootloader-esp-idf/build.rs
@@ -41,7 +41,7 @@ fn main() {
                 "partition-table-offset",
                 "The address of partition table (by default 0x8000). Allows you to \
                 move the partition table, it gives more space for the bootloader. Note that the \
-                bootloader and app will both need to be compiled with the same |
+                bootloader and app will both need to be compiled with the same \
                 PARTITION_TABLE_OFFSET value.",
                 0x8000,
             )

--- a/esp-bootloader-esp-idf/build.rs
+++ b/esp-bootloader-esp-idf/build.rs
@@ -19,7 +19,7 @@ fn main() {
     generate_config(
         "esp-bootloader-esp-idf",
         &[
-            ConfigOption::string(
+            ConfigOption::new(
                 "mmu_page_size",
                 "ESP32-C2, ESP32-C6 and ESP32-H2 support configurable page sizes. \
                 This is currently only used to populate the app descriptor.",
@@ -31,13 +31,13 @@ fn main() {
                 String::from("32k"),
                 String::from("64k"),
             ])), // .active(true) TODO we need to know the device here
-            ConfigOption::string(
+            ConfigOption::new(
                 "esp_idf_version",
                 "ESP-IDF version used in the application descriptor. Currently it's \
                 not checked by the bootloader.",
                 "0.0.0",
             ),
-            ConfigOption::integer(
+            ConfigOption::new(
                 "partition-table-offset",
                 "The address of partition table (by default 0x8000). Allows you to \
                 move the partition table, it gives more space for the bootloader. Note that the \

--- a/esp-bootloader-esp-idf/build.rs
+++ b/esp-bootloader-esp-idf/build.rs
@@ -1,7 +1,7 @@
 use std::env;
 
 use chrono::{TimeZone, Utc};
-use esp_config::{ConfigOption, Stability, Validator, Value, generate_config};
+use esp_config::{ConfigOption, Validator, generate_config};
 
 fn main() {
     let build_time = match env::var("SOURCE_DATE_EPOCH") {
@@ -19,40 +19,33 @@ fn main() {
     generate_config(
         "esp-bootloader-esp-idf",
         &[
-            ConfigOption {
-                name: "mmu_page_size",
-                description: "ESP32-C2, ESP32-C6 and ESP32-H2 support configurable page sizes. \
+            ConfigOption::string(
+                "mmu_page_size",
+                "ESP32-C2, ESP32-C6 and ESP32-H2 support configurable page sizes. \
                 This is currently only used to populate the app descriptor.",
-                default_value: Value::String(String::from("64k")),
-                constraint: Some(Validator::Enumeration(vec![
-                    String::from("8k"),
-                    String::from("16k"),
-                    String::from("32k"),
-                    String::from("64k"),
-                ])),
-                stability: Stability::Unstable,
-                active: true, // TODO we need to know the device here
-            },
-            ConfigOption {
-                name: "esp_idf_version",
-                description: "ESP-IDF version used in the application descriptor. Currently it's \
+                "64k",
+            )
+            .constraint(Validator::Enumeration(vec![
+                String::from("8k"),
+                String::from("16k"),
+                String::from("32k"),
+                String::from("64k"),
+            ])), // .active(true) TODO we need to know the device here
+            ConfigOption::string(
+                "esp_idf_version",
+                "ESP-IDF version used in the application descriptor. Currently it's \
                 not checked by the bootloader.",
-                default_value: Value::String(String::from("0.0.0")),
-                constraint: None,
-                stability: Stability::Unstable,
-                active: true,
-            },
-            ConfigOption {
-                name: "partition-table-offset",
-                description: "The address of partition table (by default 0x8000). Allows you to \
+                "0.0.0",
+            ),
+            ConfigOption::integer(
+                "partition-table-offset",
+                "The address of partition table (by default 0x8000). Allows you to \
                 move the partition table, it gives more space for the bootloader. Note that the \
                 bootloader and app will both need to be compiled with the same |
                 PARTITION_TABLE_OFFSET value.",
-                default_value: Value::Integer(0x8000),
-                constraint: Some(Validator::PositiveInteger),
-                stability: Stability::Unstable,
-                active: true,
-            },
+                0x8000,
+            )
+            .constraint(Validator::PositiveInteger),
         ],
         true,
         true,

--- a/esp-config/CHANGELOG.md
+++ b/esp-config/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `generate_config` now takes a slice of `ConfigOption`s instead of tuples. (#3362)
 - Bump Rust edition to 2024, bump MSRV to 1.85. (#3391)
+- `ConfigOption` favors `String` over `&str` (#3455)
+- Removed the `Custom` validator (#3455)
 
 ### Fixed
 

--- a/esp-config/Cargo.toml
+++ b/esp-config/Cargo.toml
@@ -10,7 +10,7 @@ license       = "MIT OR Apache-2.0"
 
 [lib]
 bench = false
-test  = false
+test  = true
 
 [dependencies]
 document-features = "0.2.11"

--- a/esp-config/src/generate/mod.rs
+++ b/esp-config/src/generate/mod.rs
@@ -264,14 +264,14 @@ pub struct ConfigOption {
 }
 
 impl ConfigOption {
-    /// An integer config option
+    /// Create a new config option.
     ///
-    /// Unstable and active by default.
-    pub fn integer(name: &str, description: &str, default_value: i128) -> Self {
+    /// Unstable, active, no display-hint and not constrained by default.
+    pub fn new(name: &str, description: &str, default_value: impl Into<Value>) -> Self {
         Self {
             name: name.to_string(),
             description: description.to_string(),
-            default_value: Value::Integer(default_value),
+            default_value: default_value.into(),
             constraint: None,
             stability: Stability::Unstable,
             active: true,
@@ -279,43 +279,13 @@ impl ConfigOption {
         }
     }
 
-    /// An string config option
-    ///
-    /// Unstable and active by default.
-    pub fn string(name: &str, description: &str, default_value: &str) -> Self {
-        Self {
-            name: name.to_string(),
-            description: description.to_string(),
-            default_value: Value::String(default_value.to_string()),
-            constraint: None,
-            stability: Stability::Unstable,
-            active: true,
-            display_hint: DisplayHint::None,
-        }
-    }
-
-    /// An boolean config option
-    ///
-    /// Unstable and active by default.
-    pub fn boolean(name: &str, description: &str, default_value: bool) -> Self {
-        Self {
-            name: name.to_string(),
-            description: description.to_string(),
-            default_value: Value::Bool(default_value),
-            constraint: None,
-            stability: Stability::Unstable,
-            active: true,
-            display_hint: DisplayHint::None,
-        }
-    }
-
-    /// Constraint the config option
+    /// Constrain the config option
     pub fn constraint(mut self, validator: Validator) -> Self {
         self.constraint = Some(validator);
         self
     }
 
-    /// Constraint the config option
+    /// Constrain the config option
     pub fn constraint_by(mut self, validator: Option<Validator>) -> Self {
         self.constraint = validator;
         self

--- a/esp-config/src/generate/value.rs
+++ b/esp-config/src/generate/value.rs
@@ -1,11 +1,11 @@
 use std::fmt;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::Error;
 
 /// Supported configuration value types.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Value {
     /// Booleans.
     Bool(bool),

--- a/esp-config/src/generate/value.rs
+++ b/esp-config/src/generate/value.rs
@@ -94,3 +94,27 @@ impl fmt::Display for Value {
         }
     }
 }
+
+impl From<bool> for Value {
+    fn from(value: bool) -> Self {
+        Value::Bool(value)
+    }
+}
+
+impl From<i128> for Value {
+    fn from(value: i128) -> Self {
+        Value::Integer(value)
+    }
+}
+
+impl From<&str> for Value {
+    fn from(value: &str) -> Self {
+        Value::String(value.to_string())
+    }
+}
+
+impl From<String> for Value {
+    fn from(value: String) -> Self {
+        Value::String(value)
+    }
+}

--- a/esp-config/src/lib.rs
+++ b/esp-config/src/lib.rs
@@ -10,6 +10,7 @@ mod generate;
 #[cfg(feature = "build")]
 pub use generate::{
     ConfigOption,
+    DisplayHint,
     Error,
     Stability,
     generate_config,

--- a/esp-hal-embassy/build.rs
+++ b/esp-hal-embassy/build.rs
@@ -15,14 +15,14 @@ fn main() -> Result<(), Box<dyn StdError>> {
     let crate_config = generate_config(
         "esp_hal_embassy",
         &[
-            ConfigOption::boolean(
+            ConfigOption::new(
                 "low-power-wait",
                 "Enables the lower-power wait if no tasks are ready to run on the \
                 thread-mode executor. This allows the MCU to use less power if the workload allows. \
                 Recommended for battery-powered systems. May impact analog performance.",
                 true,
             ),
-            ConfigOption::string(
+            ConfigOption::new(
                 "timer-queue",
                 "The flavour of the timer queue provided by this crate. Integrated \
                 queues require the `executors` feature to be enabled.</p><p>If you use \
@@ -46,7 +46,7 @@ fn main() -> Result<(), Box<dyn StdError>> {
                 Validator::Enumeration(vec![String::from("generic")])
             })
             .active(cfg!(feature = "executors")),
-            ConfigOption::integer(
+            ConfigOption::new(
                 "generic-queue-size",
                 "The capacity of the queue when the `generic` timer \
                 queue flavour is selected.",

--- a/esp-hal-embassy/build.rs
+++ b/esp-hal-embassy/build.rs
@@ -1,6 +1,6 @@
 use std::error::Error as StdError;
 
-use esp_config::{ConfigOption, Stability, Validator, Value, generate_config};
+use esp_config::{ConfigOption, Validator, Value, generate_config};
 use esp_metadata::{Chip, Config};
 
 fn main() -> Result<(), Box<dyn StdError>> {
@@ -15,50 +15,44 @@ fn main() -> Result<(), Box<dyn StdError>> {
     let crate_config = generate_config(
         "esp_hal_embassy",
         &[
-            ConfigOption {
-                name: "low-power-wait",
-                description: "Enables the lower-power wait if no tasks are ready to run on the \
+            ConfigOption::boolean(
+                "low-power-wait",
+                "Enables the lower-power wait if no tasks are ready to run on the \
                 thread-mode executor. This allows the MCU to use less power if the workload allows. \
                 Recommended for battery-powered systems. May impact analog performance.",
-                default_value: Value::Bool(true),
-                constraint: None,
-                stability: Stability::Unstable,
-                active: true,
-            },
-            ConfigOption {
-                name: "timer-queue",
-                description: "The flavour of the timer queue provided by this crate. Integrated \
+                true,
+            ),
+            ConfigOption::string(
+                "timer-queue",
+                "The flavour of the timer queue provided by this crate. Integrated \
                 queues require the `executors` feature to be enabled.</p><p>If you use \
                 embassy-executor, the `single-integrated` queue is recommended for ease of use, \
                 while the `multiple-integrated` queue is recommended for performance. The \
                 `multiple-integrated` option needs one timer per executor.</p><p>The `generic` \
                 queue allows using embassy-time without the embassy executors.",
-                default_value: Value::String(if cfg!(feature = "executors") {
-                    String::from("single-integrated")
+                if cfg!(feature = "executors") {
+                    "single-integrated"
                 } else {
-                    String::from("generic")
-                }),
-                constraint: Some(if cfg!(feature = "executors") {
-                    Validator::Enumeration(vec![
-                        String::from("generic"),
-                        String::from("single-integrated"),
-                        String::from("multiple-integrated"),
-                    ])
-                } else {
-                    Validator::Enumeration(vec![String::from("generic")])
-                }),
-                stability: Stability::Unstable,
-                active: cfg!(feature = "executors"),
-            },
-            ConfigOption {
-                name: "generic-queue-size",
-                description: "The capacity of the queue when the `generic` timer \
+                    "generic"
+                },
+            )
+            .constraint(if cfg!(feature = "executors") {
+                Validator::Enumeration(vec![
+                    String::from("generic"),
+                    String::from("single-integrated"),
+                    String::from("multiple-integrated"),
+                ])
+            } else {
+                Validator::Enumeration(vec![String::from("generic")])
+            })
+            .active(cfg!(feature = "executors")),
+            ConfigOption::integer(
+                "generic-queue-size",
+                "The capacity of the queue when the `generic` timer \
                 queue flavour is selected.",
-                default_value: Value::Integer(64),
-                constraint: Some(Validator::PositiveInteger),
-                stability: Stability::Unstable,
-                active: true,
-            },
+                64,
+            )
+            .constraint(Validator::PositiveInteger),
         ],
         true,
         true,

--- a/esp-hal/build.rs
+++ b/esp-hal/build.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use esp_build::assert_unique_features;
-use esp_config::{ConfigOption, Stability, Validator, Value, generate_config};
+use esp_config::{ConfigOption, DisplayHint, Validator, Value, generate_config};
 use esp_metadata::{Chip, Config};
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -51,88 +51,71 @@ fn main() -> Result<(), Box<dyn Error>> {
     let cfg = generate_config(
         "esp_hal",
         &[
-            ConfigOption {
-                name: "place-spi-master-driver-in-ram",
-                description: "Places the SPI master driver in RAM for better performance",
-                default_value: Value::Bool(false),
-                constraint: None,
-                stability: Stability::Unstable,
-                active: true,
-            },
-            ConfigOption {
-                name: "place-switch-tables-in-ram",
-                description: "Places switch-tables, some lookup tables and constants related to \
+            ConfigOption::boolean(
+                "place-spi-master-driver-in-ram",
+                "Places the SPI master driver in RAM for better performance",
+                false,
+            ),
+            ConfigOption::boolean(
+                "place-switch-tables-in-ram",
+                "Places switch-tables, some lookup tables and constants related to \
                 interrupt handling into RAM - resulting in better performance but slightly more \
                 RAM consumption.",
-                default_value: Value::Bool(true),
-                constraint: None,
-                stability: Stability::Stable("1.0.0-beta.0"),
-                active: true,
-            },
-            ConfigOption {
-                name: "place-anon-in-ram",
-                description: "Places anonymous symbols into RAM - resulting in better performance \
+                true,
+            )
+            .stable("1.0.0-beta.0"),
+            ConfigOption::boolean(
+                "place-anon-in-ram",
+                "Places anonymous symbols into RAM - resulting in better performance \
                 at the cost of significant more RAM consumption. Best to be combined with \
                 `place-switch-tables-in-ram`.",
-                default_value: Value::Bool(false),
-                constraint: None,
-                stability: Stability::Stable("1.0.0-beta.0"),
-                active: true,
-            },
+                false,
+            )
+            .stable("1.0.0-beta.0"),
             // Ideally, we should be able to set any clock frequency for any chip. However,
             // currently only the 32 and C2 implements any sort of configurability, and
             // the rest have a fixed clock frequeny.
-            ConfigOption {
-                name: "xtal-frequency",
-                description: "The frequency of the crystal oscillator, in MHz. Set to `auto` to \
+            ConfigOption::string(
+                "xtal-frequency",
+                "The frequency of the crystal oscillator, in MHz. Set to `auto` to \
                 automatically detect the frequency. `auto` may not be able to identify the clock \
                 frequency in some cases. Also, configuring a specific frequency may increase \
                 performance slightly.",
-                default_value: Value::String(match chip {
-                    Chip::Esp32 | Chip::Esp32c2 => String::from("auto"),
+                match chip {
+                    Chip::Esp32 | Chip::Esp32c2 => "auto",
                     // The rest has only one option
-                    Chip::Esp32c3 | Chip::Esp32c6 | Chip::Esp32s2 | Chip::Esp32s3 => {
-                        String::from("40")
-                    }
-                    Chip::Esp32h2 => String::from("32"),
-                }),
-                constraint: match chip {
-                    Chip::Esp32 | Chip::Esp32c2 => Some(Validator::Enumeration(vec![
-                        String::from("auto"),
-                        String::from("26"),
-                        String::from("40"),
-                    ])),
-                    // The rest has only one option
-                    _ => None,
+                    Chip::Esp32c3 | Chip::Esp32c6 | Chip::Esp32s2 | Chip::Esp32s3 => "40",
+                    Chip::Esp32h2 => "32",
                 },
-                stability: Stability::Unstable,
-                active: [Chip::Esp32, Chip::Esp32c2].contains(&chip),
-            },
-            ConfigOption {
-                name: "spi-address-workaround",
-                description: "Enables a workaround for the issue where SPI in \
+            )
+            .constraint_by(match chip {
+                Chip::Esp32 | Chip::Esp32c2 => Some(Validator::Enumeration(vec![
+                    String::from("auto"),
+                    String::from("26"),
+                    String::from("40"),
+                ])),
+                // The rest has only one option
+                _ => None,
+            })
+            .active([Chip::Esp32, Chip::Esp32c2].contains(&chip)),
+            ConfigOption::boolean(
+                "spi-address-workaround",
+                "Enables a workaround for the issue where SPI in \
                 half-duplex mode incorrectly transmits the address on a single line if the \
                 data buffer is empty.",
-                default_value: Value::Bool(true),
-                constraint: None,
-                stability: Stability::Unstable,
-                active: chip == Chip::Esp32,
-            },
-            ConfigOption {
-                name: "flip-link",
-                description: "Move the stack to start of RAM to get zero-cost stack overflow protection.",
-                default_value: Value::Bool(false),
-                constraint: None,
-                stability: Stability::Unstable,
-                active: [Chip::Esp32c6, Chip::Esp32h2].contains(&chip),
-            },
+                true,
+            )
+            .active(chip == Chip::Esp32),
+            ConfigOption::boolean(
+                "flip-link",
+                "Move the stack to start of RAM to get zero-cost stack overflow protection.",
+                false,
+            )
+            .active([Chip::Esp32c6, Chip::Esp32h2].contains(&chip)),
             // TODO: automate "enum of single choice" handling - they don't need
             // to be presented to the user
-            ConfigOption {
-                name: "psram-mode",
-                description: "SPIRAM chip mode",
-                default_value: Value::String(String::from("quad")),
-                constraint: Some(Validator::Enumeration(
+            ConfigOption::string("psram-mode", "SPIRAM chip mode", "quad")
+                .constraint(Validator::Enumeration(
                     if config
                         .symbols()
                         .iter()
@@ -142,41 +125,35 @@ fn main() -> Result<(), Box<dyn Error>> {
                     } else {
                         vec![String::from("quad")]
                     },
-                )),
-                stability: Stability::Unstable,
-                active: config
-                    .symbols()
-                    .iter()
-                    .any(|s| s.eq_ignore_ascii_case("psram")),
-            },
+                ))
+                .active(
+                    config
+                        .symbols()
+                        .iter()
+                        .any(|s| s.eq_ignore_ascii_case("psram")),
+                ),
             // Rust's stack smashing protection configuration
-            ConfigOption {
-                name: "stack-guard-offset",
-                description: "The stack guard variable will be placed this many bytes from \
+            ConfigOption::integer(
+                "stack-guard-offset",
+                "The stack guard variable will be placed this many bytes from \
                 the stack's end.",
-                default_value: Value::Integer(4096),
-                constraint: None,
-                stability: Stability::Stable("1.0.0-beta.0"),
-                active: true,
-            },
-            ConfigOption {
-                name: "stack-guard-value",
-                description: "The value to be written to the stack guard variable.",
-                default_value: Value::Integer(0xDEED_BAAD),
-                constraint: None,
-                stability: Stability::Stable("1.0.0-beta.0"),
-                active: true,
-            },
-            ConfigOption {
-                name: "impl-critical-section",
-                description: "Provide a `critical-section` implementation. Note that if disabled, \
+                4096,
+            )
+            .stable("1.0.0-beta.0"),
+            ConfigOption::integer(
+                "stack-guard-value",
+                "The value to be written to the stack guard variable.",
+                0xDEED_BAAD,
+            )
+            .stable("1.0.0-beta.0")
+            .display_hint(DisplayHint::Hex),
+            ConfigOption::boolean(
+                "impl-critical-section",
+                "Provide a `critical-section` implementation. Note that if disabled, \
                 you will need to provide a `critical-section` implementation which is \
                 using `restore-state-u32`.",
-                default_value: Value::Bool(true),
-                constraint: None,
-                stability: Stability::Unstable,
-                active: true,
-            },
+                true,
+            ),
         ],
         cfg!(feature = "unstable"),
         true,

--- a/esp-hal/build.rs
+++ b/esp-hal/build.rs
@@ -51,12 +51,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     let cfg = generate_config(
         "esp_hal",
         &[
-            ConfigOption::boolean(
+            ConfigOption::new(
                 "place-spi-master-driver-in-ram",
                 "Places the SPI master driver in RAM for better performance",
                 false,
             ),
-            ConfigOption::boolean(
+            ConfigOption::new(
                 "place-switch-tables-in-ram",
                 "Places switch-tables, some lookup tables and constants related to \
                 interrupt handling into RAM - resulting in better performance but slightly more \
@@ -64,7 +64,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 true,
             )
             .stable("1.0.0-beta.0"),
-            ConfigOption::boolean(
+            ConfigOption::new(
                 "place-anon-in-ram",
                 "Places anonymous symbols into RAM - resulting in better performance \
                 at the cost of significant more RAM consumption. Best to be combined with \
@@ -75,7 +75,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             // Ideally, we should be able to set any clock frequency for any chip. However,
             // currently only the 32 and C2 implements any sort of configurability, and
             // the rest have a fixed clock frequeny.
-            ConfigOption::string(
+            ConfigOption::new(
                 "xtal-frequency",
                 "The frequency of the crystal oscillator, in MHz. Set to `auto` to \
                 automatically detect the frequency. `auto` may not be able to identify the clock \
@@ -98,7 +98,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 _ => None,
             })
             .active([Chip::Esp32, Chip::Esp32c2].contains(&chip)),
-            ConfigOption::boolean(
+            ConfigOption::new(
                 "spi-address-workaround",
                 "Enables a workaround for the issue where SPI in \
                 half-duplex mode incorrectly transmits the address on a single line if the \
@@ -106,7 +106,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 true,
             )
             .active(chip == Chip::Esp32),
-            ConfigOption::boolean(
+            ConfigOption::new(
                 "flip-link",
                 "Move the stack to start of RAM to get zero-cost stack overflow protection.",
                 false,
@@ -114,7 +114,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             .active([Chip::Esp32c6, Chip::Esp32h2].contains(&chip)),
             // TODO: automate "enum of single choice" handling - they don't need
             // to be presented to the user
-            ConfigOption::string("psram-mode", "SPIRAM chip mode", "quad")
+            ConfigOption::new("psram-mode", "SPIRAM chip mode", "quad")
                 .constraint(Validator::Enumeration(
                     if config
                         .symbols()
@@ -133,21 +133,21 @@ fn main() -> Result<(), Box<dyn Error>> {
                         .any(|s| s.eq_ignore_ascii_case("psram")),
                 ),
             // Rust's stack smashing protection configuration
-            ConfigOption::integer(
+            ConfigOption::new(
                 "stack-guard-offset",
                 "The stack guard variable will be placed this many bytes from \
                 the stack's end.",
                 4096,
             )
             .stable("1.0.0-beta.0"),
-            ConfigOption::integer(
+            ConfigOption::new(
                 "stack-guard-value",
                 "The value to be written to the stack guard variable.",
                 0xDEED_BAAD,
             )
             .stable("1.0.0-beta.0")
             .display_hint(DisplayHint::Hex),
-            ConfigOption::boolean(
+            ConfigOption::new(
                 "impl-critical-section",
                 "Provide a `critical-section` implementation. Note that if disabled, \
                 you will need to provide a `critical-section` implementation which is \

--- a/esp-ieee802154/build.rs
+++ b/esp-ieee802154/build.rs
@@ -1,6 +1,6 @@
 use std::{env, path::PathBuf};
 
-use esp_config::{ConfigOption, Stability, Validator, Value, generate_config};
+use esp_config::{ConfigOption, Validator, generate_config};
 
 fn main() {
     let out = PathBuf::from(env::var_os("OUT_DIR").unwrap());
@@ -9,14 +9,10 @@ fn main() {
     // emit config
     generate_config(
         "esp_ieee802154",
-        &[ConfigOption {
-            name: "rx_queue_size",
-            description: "Size of the RX queue in frames",
-            default_value: Value::Integer(50),
-            constraint: Some(Validator::PositiveInteger),
-            stability: Stability::Unstable,
-            active: true,
-        }],
+        &[
+            ConfigOption::integer("rx_queue_size", "Size of the RX queue in frames", 50)
+                .constraint(Validator::PositiveInteger),
+        ],
         true,
         true,
     );

--- a/esp-ieee802154/build.rs
+++ b/esp-ieee802154/build.rs
@@ -10,7 +10,7 @@ fn main() {
     generate_config(
         "esp_ieee802154",
         &[
-            ConfigOption::integer("rx_queue_size", "Size of the RX queue in frames", 50)
+            ConfigOption::new("rx_queue_size", "Size of the RX queue in frames", 50)
                 .constraint(Validator::PositiveInteger),
         ],
         true,

--- a/esp-wifi/build.rs
+++ b/esp-wifi/build.rs
@@ -78,93 +78,157 @@ fn main() -> Result<(), Box<dyn Error>> {
             ConfigOption::new("tx_queue_size", "Size of the TX queue in frames", 3)
                 .constraint(Validator::PositiveInteger),
             ConfigOption::new(
-                 "static_rx_buf_num",
-                 "WiFi static RX buffer number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
-                10).constraint(Validator::PositiveInteger),
+                "static_rx_buf_num",
+                "WiFi static RX buffer number. See [ESP-IDF Programming Guide]\
+                 (https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/\
+                 network/esp_wifi.html#_CPPv418wifi_init_config_t)",
+                10,
+            )
+            .constraint(Validator::PositiveInteger),
             ConfigOption::new(
                 "dynamic_rx_buf_num",
-                 "WiFi dynamic RX buffer number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
-                32).constraint(Validator::PositiveInteger),
+                "WiFi dynamic RX buffer number. See [ESP-IDF Programming Guide]\
+                 (https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/\
+                 network/esp_wifi.html#_CPPv418wifi_init_config_t)",
+                32,
+            )
+            .constraint(Validator::PositiveInteger),
             ConfigOption::new(
                 "static_tx_buf_num",
-                 "WiFi static TX buffer number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
-                0),
+                "WiFi static TX buffer number. See [ESP-IDF Programming Guide]\
+                 (https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/\
+                 network/esp_wifi.html#_CPPv418wifi_init_config_t)",
+                0,
+            ),
             ConfigOption::new(
-                 "dynamic_tx_buf_num",
-                 "WiFi dynamic TX buffer number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
-                32),
+                "dynamic_tx_buf_num",
+                "WiFi dynamic TX buffer number. See [ESP-IDF Programming Guide]\
+                 (https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/\
+                 network/esp_wifi.html#_CPPv418wifi_init_config_t)",
+                32,
+            ),
             ConfigOption::new(
-                 "ampdu_rx_enable",
-                 "WiFi AMPDU RX feature enable flag. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
-                true),
+                "ampdu_rx_enable",
+                "WiFi AMPDU RX feature enable flag. See [ESP-IDF Programming Guide]\
+                 (https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/\
+                 network/esp_wifi.html#_CPPv418wifi_init_config_t)",
+                true,
+            ),
             ConfigOption::new(
                 "ampdu_tx_enable",
-                 "WiFi AMPDU TX feature enable flag. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
-                true),
+                "WiFi AMPDU TX feature enable flag. See [ESP-IDF Programming Guide]\
+                 (https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/\
+                 network/esp_wifi.html#_CPPv418wifi_init_config_t)",
+                true,
+            ),
             ConfigOption::new(
-                 "amsdu_tx_enable",
-                 "WiFi AMSDU TX feature enable flag. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
-                false),
+                "amsdu_tx_enable",
+                "WiFi AMSDU TX feature enable flag. See [ESP-IDF Programming Guide]\
+                 (https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/\
+                 network/esp_wifi.html#_CPPv418wifi_init_config_t)",
+                false,
+            ),
             ConfigOption::new(
-                 "rx_ba_win",
-                 "WiFi Block Ack RX window size. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
-                6),
+                "rx_ba_win",
+                "WiFi Block Ack RX window size. See [ESP-IDF Programming Guide]\
+                 (https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/\
+                 network/esp_wifi.html#_CPPv418wifi_init_config_t)",
+                6,
+            ),
             ConfigOption::new(
-                 "max_burst_size",
-                 "See [smoltcp's documentation](https://docs.rs/smoltcp/0.10.0/smoltcp/phy/struct.DeviceCapabilities.html#structfield.max_burst_size)",
-                1),
+                "max_burst_size",
+                "See [smoltcp's documentation]\
+                 (https://docs.rs/smoltcp/0.10.0/smoltcp/phy/struct.DeviceCapabilities.html\
+                 #structfield.max_burst_size)",
+                1,
+            ),
             ConfigOption::new(
-                 "country_code",
-                 "Country code. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/wifi.html#wi-fi-country-code)",
-                "CN"),
+                "country_code",
+                "Country code. See [ESP-IDF Programming Guide]\
+                 (https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/\
+                 wifi.html#wi-fi-country-code)",
+                "CN",
+            ),
             ConfigOption::new(
-                 "country_code_operating_class",
-                 "If not 0: Operating Class table number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/wifi.html#wi-fi-country-code)",
-                0),
+                "country_code_operating_class",
+                "If not 0: Operating Class table number. See [ESP-IDF Programming Guide]\
+                 (https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/\
+                 wifi.html#wi-fi-country-code)",
+                0,
+            ),
             ConfigOption::new(
-                 "mtu",
-                 "MTU, see [smoltcp's documentation](https://docs.rs/smoltcp/0.10.0/smoltcp/phy/struct.DeviceCapabilities.html#structfield.max_transmission_unit)",
-                1492).constraint(Validator::PositiveInteger),
+                "mtu",
+                "MTU, see [smoltcp's documentation]\
+                 (https://docs.rs/smoltcp/0.10.0/smoltcp/phy/struct.DeviceCapabilities.html\
+                 #structfield.max_transmission_unit)",
+                1492,
+            )
+            .constraint(Validator::PositiveInteger),
             ConfigOption::new(
-                 "tick_rate_hz",
-                 "Tick rate of the internal task scheduler in hertz",
-                100).constraint(Validator::PositiveInteger),
+                "tick_rate_hz",
+                "Tick rate of the internal task scheduler in hertz",
+                100,
+            )
+            .constraint(Validator::PositiveInteger),
             ConfigOption::new(
-                 "listen_interval",
-                 "Interval for station to listen to beacon from AP. The unit of listen interval is one beacon interval. For example, if beacon interval is 100 ms and listen interval is 3, the interval for station to listen to beacon is 300 ms",
-                3),
+                "listen_interval",
+                "Interval for station to listen to beacon from AP.
+                 The unit of listen interval is one beacon interval.
+                 For example, if beacon interval is 100 ms and listen interval is 3,
+                 the interval for station to listen to beacon is 300 ms",
+                3,
+            ),
             ConfigOption::new(
                 "beacon_timeout",
-                 "For Station, If the station does not receive a beacon frame from the connected SoftAP during the  inactive time, disconnect from SoftAP. Default 6s. Range 6-30",
-                6).constraint(Validator::IntegerInRange(6..30)),
+                "For Station, If the station does not receive a beacon frame
+                 from the connected SoftAP during the  inactive time, disconnect from SoftAP.
+                 Default 6s. Range 6-30",
+                6,
+            )
+            .constraint(Validator::IntegerInRange(6..30)),
             ConfigOption::new(
-                 "ap_beacon_timeout",
-                 "For SoftAP, If the SoftAP doesn't receive any data from the connected STA during inactive time, the SoftAP will force deauth the STA. Default is 300s",
-                300),
+                "ap_beacon_timeout",
+                "For SoftAP, If the SoftAP doesn't receive any data from the connected STA
+                 during inactive time, the SoftAP will force deauth the STA. Default is 300s",
+                300,
+            ),
             ConfigOption::new(
-                 "failure_retry_cnt",
-                "Number of connection retries station will do before moving to next AP. scan_method should be set as WIFI_ALL_CHANNEL_SCAN to use this config. Note: Enabling this may cause connection time to increase incase best AP doesn't behave properly. Defaults to 1",
-                1).constraint(Validator::PositiveInteger),
+                "failure_retry_cnt",
+                "Number of connection retries station will do before moving to next AP.
+                scan_method should be set as WIFI_ALL_CHANNEL_SCAN to use this config.
+                Note: Enabling this may cause connection time to increase incase best AP
+                doesn't behave properly. Defaults to 1",
+                1,
+            )
+            .constraint(Validator::PositiveInteger),
             ConfigOption::new(
                 "scan_method",
-                 "0 = WIFI_FAST_SCAN, 1 = WIFI_ALL_CHANNEL_SCAN, defaults to 0",
-                0).constraint(Validator::IntegerInRange(0..2)),
+                "0 = WIFI_FAST_SCAN, 1 = WIFI_ALL_CHANNEL_SCAN, defaults to 0",
+                0,
+            )
+            .constraint(Validator::IntegerInRange(0..2)),
             ConfigOption::new(
                 "dump_packets",
-                 "Dump packets via an info log statement",
-                false),
+                "Dump packets via an info log statement",
+                false,
+            ),
             ConfigOption::new(
                 "phy_enable_usb",
-                 "Keeps USB running when using WiFi. This allows debugging and log messages via USB Serial JTAG. Turn off for best WiFi performance.",
-                true),
+                "Keeps USB running when using WiFi.
+                 This allows debugging and log messages via USB Serial JTAG.
+                 Turn off for best WiFi performance.",
+                true,
+            ),
             ConfigOption::new(
                 "phy_skip_calibration_after_deep_sleep",
-                 "Use PHY_RF_CAL_NONE after deep sleep.",
-                false),
+                "Use PHY_RF_CAL_NONE after deep sleep.",
+                false,
+            ),
             ConfigOption::new(
                 "phy_full_calibration",
-                 "Use PHY_RF_CAL_FULL instead of PHY_RF_CAL_PARTIAL.",
-                true),
+                "Use PHY_RF_CAL_FULL instead of PHY_RF_CAL_PARTIAL.",
+                true,
+            ),
         ],
         true,
         true,

--- a/esp-wifi/build.rs
+++ b/esp-wifi/build.rs
@@ -1,6 +1,6 @@
 use std::error::Error;
 
-use esp_config::{ConfigOption, Stability, Validator, Value, generate_config};
+use esp_config::{ConfigOption, Validator, generate_config};
 use esp_metadata::{Chip, Config};
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -73,198 +73,98 @@ fn main() -> Result<(), Box<dyn Error>> {
     generate_config(
         "esp_wifi",
         &[
-            ConfigOption {
-                name: "rx_queue_size",
-                description: "Size of the RX queue in frames",
-                default_value: Value::Integer(5),
-                constraint: Some(Validator::PositiveInteger),
-                stability: Stability::Unstable,
-                active: true,
-            },
-            ConfigOption {
-                name: "tx_queue_size",
-                description: "Size of the TX queue in frames",
-                default_value: Value::Integer(3),
-                constraint: Some(Validator::PositiveInteger),
-                stability: Stability::Unstable,
-                active: true,
-            },
-            ConfigOption {
-                name: "static_rx_buf_num",
-                description: "WiFi static RX buffer number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
-                default_value: Value::Integer(10),
-                constraint: None,
-                stability: Stability::Unstable,
-                active: true,
-            },
-            ConfigOption {
-                name: "dynamic_rx_buf_num",
-                description: "WiFi dynamic RX buffer number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
-                default_value: Value::Integer(32),
-                constraint: None,
-                stability: Stability::Unstable,
-                active: true,
-            },
-            ConfigOption {
-                name: "static_tx_buf_num",
-                description: "WiFi static TX buffer number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
-                default_value: Value::Integer(0),
-                constraint: None,
-                stability: Stability::Unstable,
-                active: true,
-            },
-            ConfigOption {
-                name: "dynamic_tx_buf_num",
-                description: "WiFi dynamic TX buffer number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
-                default_value: Value::Integer(32),
-                constraint: None,
-                stability: Stability::Unstable,
-                active: true,
-            },
-            ConfigOption {
-                name: "ampdu_rx_enable",
-                description: "WiFi AMPDU RX feature enable flag. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
-                default_value: Value::Bool(true),
-                constraint: None,
-                stability: Stability::Unstable,
-                active: true,
-            },
-            ConfigOption {
-                name: "ampdu_tx_enable",
-                description: "WiFi AMPDU TX feature enable flag. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
-                default_value: Value::Bool(true),
-                constraint: None,
-                stability: Stability::Unstable,
-                active: true,
-            },
-            ConfigOption {
-                name: "amsdu_tx_enable",
-                description: "WiFi AMSDU TX feature enable flag. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
-                default_value: Value::Bool(false),
-                constraint: None,
-                stability: Stability::Unstable,
-                active: true,
-            },
-            ConfigOption {
-                name: "rx_ba_win",
-                description: "WiFi Block Ack RX window size. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
-                default_value: Value::Integer(6),
-                constraint: None,
-                stability: Stability::Unstable,
-                active: true,
-            },
-            ConfigOption {
-                name: "max_burst_size",
-                description: "See [smoltcp's documentation](https://docs.rs/smoltcp/0.10.0/smoltcp/phy/struct.DeviceCapabilities.html#structfield.max_burst_size)",
-                default_value: Value::Integer(1),
-                constraint: None,
-                stability: Stability::Unstable,
-                active: true,
-            },
-            ConfigOption {
-                name: "country_code",
-                description: "Country code. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/wifi.html#wi-fi-country-code)",
-                default_value: Value::String("CN".to_owned()),
-                constraint: None,
-                stability: Stability::Unstable,
-                active: true,
-            },
-            ConfigOption {
-                name: "country_code_operating_class",
-                description: "If not 0: Operating Class table number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/wifi.html#wi-fi-country-code)",
-                default_value: Value::Integer(0),
-                constraint: None,
-                stability: Stability::Unstable,
-                active: true,
-            },
-            ConfigOption {
-                name: "mtu",
-                description: "MTU, see [smoltcp's documentation](https://docs.rs/smoltcp/0.10.0/smoltcp/phy/struct.DeviceCapabilities.html#structfield.max_transmission_unit)",
-                default_value: Value::Integer(1492),
-                constraint: None,
-                stability: Stability::Unstable,
-                active: true,
-            },
-            ConfigOption {
-                name: "tick_rate_hz",
-                description: "Tick rate of the internal task scheduler in hertz",
-                default_value: Value::Integer(100),
-                constraint: None,
-                stability: Stability::Unstable,
-                active: true,
-            },
-            ConfigOption {
-                name: "listen_interval",
-                description: "Interval for station to listen to beacon from AP. The unit of listen interval is one beacon interval. For example, if beacon interval is 100 ms and listen interval is 3, the interval for station to listen to beacon is 300 ms",
-                default_value: Value::Integer(3),
-                constraint: None,
-                stability: Stability::Unstable,
-                active: true,
-            },
-            ConfigOption {
-                name: "beacon_timeout",
-                description: "For Station, If the station does not receive a beacon frame from the connected SoftAP during the  inactive time, disconnect from SoftAP. Default 6s. Range 6-30",
-                default_value: Value::Integer(6),
-                constraint: None,
-                stability: Stability::Unstable,
-                active: true,
-            },
-            ConfigOption {
-                name: "ap_beacon_timeout",
-                description: "For SoftAP, If the SoftAP doesn't receive any data from the connected STA during inactive time, the SoftAP will force deauth the STA. Default is 300s",
-                default_value: Value::Integer(300),
-                constraint: None,
-                stability: Stability::Unstable,
-                active: true,
-            },
-            ConfigOption {
-                name: "failure_retry_cnt",
-                description: "Number of connection retries station will do before moving to next AP. scan_method should be set as WIFI_ALL_CHANNEL_SCAN to use this config. Note: Enabling this may cause connection time to increase incase best AP doesn't behave properly. Defaults to 1",
-                default_value: Value::Integer(1),
-                constraint: None,
-                stability: Stability::Unstable,
-                active: true,
-            },
-            ConfigOption {
-                name: "scan_method",
-                description: "0 = WIFI_FAST_SCAN, 1 = WIFI_ALL_CHANNEL_SCAN, defaults to 0",
-                default_value: Value::Integer(0),
-                constraint: None,
-                stability: Stability::Unstable,
-                active: true,
-            },
-            ConfigOption {
-                name: "dump_packets",
-                description: "Dump packets via an info log statement",
-                default_value: Value::Bool(false),
-                constraint: None,
-                stability: Stability::Unstable,
-                active: true,
-            },
-            ConfigOption {
-                name: "phy_enable_usb",
-                description: "Keeps USB running when using WiFi. This allows debugging and log messages via USB Serial JTAG. Turn off for best WiFi performance.",
-                default_value: Value::Bool(true),
-                constraint: None,
-                stability: Stability::Unstable,
-                active: true,
-            },
-            ConfigOption {
-                name: "phy_skip_calibration_after_deep_sleep",
-                description: "Use PHY_RF_CAL_NONE after deep sleep.",
-                default_value: Value::Bool(false),
-                constraint: None,
-                stability: Stability::Unstable,
-                active: true,
-            },
-            ConfigOption {
-                name: "phy_full_calibration",
-                description: "Use PHY_RF_CAL_FULL instead of PHY_RF_CAL_PARTIAL.",
-                default_value: Value::Bool(true),
-                constraint: None,
-                stability: Stability::Unstable,
-                active: true,
-            },
+            ConfigOption::integer("rx_queue_size", "Size of the RX queue in frames", 5)
+                .constraint(Validator::PositiveInteger),
+            ConfigOption::integer("tx_queue_size", "Size of the TX queue in frames", 3)
+                .constraint(Validator::PositiveInteger),
+            ConfigOption::integer(
+                 "static_rx_buf_num",
+                 "WiFi static RX buffer number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
+                10).constraint(Validator::PositiveInteger),
+            ConfigOption::integer(
+                "dynamic_rx_buf_num",
+                 "WiFi dynamic RX buffer number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
+                32).constraint(Validator::PositiveInteger),
+            ConfigOption::integer(
+                "static_tx_buf_num",
+                 "WiFi static TX buffer number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
+                0),
+            ConfigOption::integer(
+                 "dynamic_tx_buf_num",
+                 "WiFi dynamic TX buffer number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
+                32),
+            ConfigOption::boolean(
+                 "ampdu_rx_enable",
+                 "WiFi AMPDU RX feature enable flag. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
+                true),
+            ConfigOption::boolean(
+                "ampdu_tx_enable",
+                 "WiFi AMPDU TX feature enable flag. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
+                true),
+            ConfigOption::boolean(
+                 "amsdu_tx_enable",
+                 "WiFi AMSDU TX feature enable flag. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
+                false),
+            ConfigOption::integer(
+                 "rx_ba_win",
+                 "WiFi Block Ack RX window size. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
+                6),
+            ConfigOption::integer(
+                 "max_burst_size",
+                 "See [smoltcp's documentation](https://docs.rs/smoltcp/0.10.0/smoltcp/phy/struct.DeviceCapabilities.html#structfield.max_burst_size)",
+                1),
+            ConfigOption::string(
+                 "country_code",
+                 "Country code. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/wifi.html#wi-fi-country-code)",
+                "CN"),
+            ConfigOption::integer(
+                 "country_code_operating_class",
+                 "If not 0: Operating Class table number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/wifi.html#wi-fi-country-code)",
+                0),
+            ConfigOption::integer(
+                 "mtu",
+                 "MTU, see [smoltcp's documentation](https://docs.rs/smoltcp/0.10.0/smoltcp/phy/struct.DeviceCapabilities.html#structfield.max_transmission_unit)",
+                1492).constraint(Validator::PositiveInteger),
+            ConfigOption::integer(
+                 "tick_rate_hz",
+                 "Tick rate of the internal task scheduler in hertz",
+                100).constraint(Validator::PositiveInteger),
+            ConfigOption::integer(
+                 "listen_interval",
+                 "Interval for station to listen to beacon from AP. The unit of listen interval is one beacon interval. For example, if beacon interval is 100 ms and listen interval is 3, the interval for station to listen to beacon is 300 ms",
+                3),
+            ConfigOption::integer(
+                "beacon_timeout",
+                 "For Station, If the station does not receive a beacon frame from the connected SoftAP during the  inactive time, disconnect from SoftAP. Default 6s. Range 6-30",
+                6).constraint(Validator::IntegerInRange(6..30)),
+            ConfigOption::integer(
+                 "ap_beacon_timeout",
+                 "For SoftAP, If the SoftAP doesn't receive any data from the connected STA during inactive time, the SoftAP will force deauth the STA. Default is 300s",
+                300),
+            ConfigOption::integer(
+                 "failure_retry_cnt",
+                "Number of connection retries station will do before moving to next AP. scan_method should be set as WIFI_ALL_CHANNEL_SCAN to use this config. Note: Enabling this may cause connection time to increase incase best AP doesn't behave properly. Defaults to 1",
+                1).constraint(Validator::PositiveInteger),
+            ConfigOption::integer(
+                "scan_method",
+                 "0 = WIFI_FAST_SCAN, 1 = WIFI_ALL_CHANNEL_SCAN, defaults to 0",
+                0).constraint(Validator::IntegerInRange(0..2)),
+            ConfigOption::boolean(
+                "dump_packets",
+                 "Dump packets via an info log statement",
+                false),
+            ConfigOption::boolean(
+                "phy_enable_usb",
+                 "Keeps USB running when using WiFi. This allows debugging and log messages via USB Serial JTAG. Turn off for best WiFi performance.",
+                true),
+            ConfigOption::boolean(
+                "phy_skip_calibration_after_deep_sleep",
+                 "Use PHY_RF_CAL_NONE after deep sleep.",
+                false),
+            ConfigOption::boolean(
+                "phy_full_calibration",
+                 "Use PHY_RF_CAL_FULL instead of PHY_RF_CAL_PARTIAL.",
+                true),
         ],
         true,
         true,

--- a/esp-wifi/build.rs
+++ b/esp-wifi/build.rs
@@ -73,95 +73,95 @@ fn main() -> Result<(), Box<dyn Error>> {
     generate_config(
         "esp_wifi",
         &[
-            ConfigOption::integer("rx_queue_size", "Size of the RX queue in frames", 5)
+            ConfigOption::new("rx_queue_size", "Size of the RX queue in frames", 5)
                 .constraint(Validator::PositiveInteger),
-            ConfigOption::integer("tx_queue_size", "Size of the TX queue in frames", 3)
+            ConfigOption::new("tx_queue_size", "Size of the TX queue in frames", 3)
                 .constraint(Validator::PositiveInteger),
-            ConfigOption::integer(
+            ConfigOption::new(
                  "static_rx_buf_num",
                  "WiFi static RX buffer number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
                 10).constraint(Validator::PositiveInteger),
-            ConfigOption::integer(
+            ConfigOption::new(
                 "dynamic_rx_buf_num",
                  "WiFi dynamic RX buffer number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
                 32).constraint(Validator::PositiveInteger),
-            ConfigOption::integer(
+            ConfigOption::new(
                 "static_tx_buf_num",
                  "WiFi static TX buffer number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
                 0),
-            ConfigOption::integer(
+            ConfigOption::new(
                  "dynamic_tx_buf_num",
                  "WiFi dynamic TX buffer number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
                 32),
-            ConfigOption::boolean(
+            ConfigOption::new(
                  "ampdu_rx_enable",
                  "WiFi AMPDU RX feature enable flag. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
                 true),
-            ConfigOption::boolean(
+            ConfigOption::new(
                 "ampdu_tx_enable",
                  "WiFi AMPDU TX feature enable flag. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
                 true),
-            ConfigOption::boolean(
+            ConfigOption::new(
                  "amsdu_tx_enable",
                  "WiFi AMSDU TX feature enable flag. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
                 false),
-            ConfigOption::integer(
+            ConfigOption::new(
                  "rx_ba_win",
                  "WiFi Block Ack RX window size. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_wifi.html#_CPPv418wifi_init_config_t)",
                 6),
-            ConfigOption::integer(
+            ConfigOption::new(
                  "max_burst_size",
                  "See [smoltcp's documentation](https://docs.rs/smoltcp/0.10.0/smoltcp/phy/struct.DeviceCapabilities.html#structfield.max_burst_size)",
                 1),
-            ConfigOption::string(
+            ConfigOption::new(
                  "country_code",
                  "Country code. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/wifi.html#wi-fi-country-code)",
                 "CN"),
-            ConfigOption::integer(
+            ConfigOption::new(
                  "country_code_operating_class",
                  "If not 0: Operating Class table number. See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/wifi.html#wi-fi-country-code)",
                 0),
-            ConfigOption::integer(
+            ConfigOption::new(
                  "mtu",
                  "MTU, see [smoltcp's documentation](https://docs.rs/smoltcp/0.10.0/smoltcp/phy/struct.DeviceCapabilities.html#structfield.max_transmission_unit)",
                 1492).constraint(Validator::PositiveInteger),
-            ConfigOption::integer(
+            ConfigOption::new(
                  "tick_rate_hz",
                  "Tick rate of the internal task scheduler in hertz",
                 100).constraint(Validator::PositiveInteger),
-            ConfigOption::integer(
+            ConfigOption::new(
                  "listen_interval",
                  "Interval for station to listen to beacon from AP. The unit of listen interval is one beacon interval. For example, if beacon interval is 100 ms and listen interval is 3, the interval for station to listen to beacon is 300 ms",
                 3),
-            ConfigOption::integer(
+            ConfigOption::new(
                 "beacon_timeout",
                  "For Station, If the station does not receive a beacon frame from the connected SoftAP during the  inactive time, disconnect from SoftAP. Default 6s. Range 6-30",
                 6).constraint(Validator::IntegerInRange(6..30)),
-            ConfigOption::integer(
+            ConfigOption::new(
                  "ap_beacon_timeout",
                  "For SoftAP, If the SoftAP doesn't receive any data from the connected STA during inactive time, the SoftAP will force deauth the STA. Default is 300s",
                 300),
-            ConfigOption::integer(
+            ConfigOption::new(
                  "failure_retry_cnt",
                 "Number of connection retries station will do before moving to next AP. scan_method should be set as WIFI_ALL_CHANNEL_SCAN to use this config. Note: Enabling this may cause connection time to increase incase best AP doesn't behave properly. Defaults to 1",
                 1).constraint(Validator::PositiveInteger),
-            ConfigOption::integer(
+            ConfigOption::new(
                 "scan_method",
                  "0 = WIFI_FAST_SCAN, 1 = WIFI_ALL_CHANNEL_SCAN, defaults to 0",
                 0).constraint(Validator::IntegerInRange(0..2)),
-            ConfigOption::boolean(
+            ConfigOption::new(
                 "dump_packets",
                  "Dump packets via an info log statement",
                 false),
-            ConfigOption::boolean(
+            ConfigOption::new(
                 "phy_enable_usb",
                  "Keeps USB running when using WiFi. This allows debugging and log messages via USB Serial JTAG. Turn off for best WiFi performance.",
                 true),
-            ConfigOption::boolean(
+            ConfigOption::new(
                 "phy_skip_calibration_after_deep_sleep",
                  "Use PHY_RF_CAL_NONE after deep sleep.",
                 false),
-            ConfigOption::boolean(
+            ConfigOption::new(
                 "phy_full_calibration",
                  "Use PHY_RF_CAL_FULL instead of PHY_RF_CAL_PARTIAL.",
                 true),


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

In preparation of #3442 this makes the esp-config structs more de-serialization friendly.

- remove the unused `Custom` validator
- use `String` in favor of `&str`
- convenience constructors

`skip-changelog` because of the changes in the crates using it (in `build.rs`)

#### Testing
CI

