### PR TITLE
Refactor `xtask` subcommands to be group by common functionality

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [alias]
 xtask = "run --package xtask --"
-xdoc = "run --package xtask --features=deploy-docs,preview-docs --"
-xfmt = "xtask fmt-packages"
-qa = "xtask run-example qa-test"
+xdoc  = "run --package xtask --features=deploy-docs,preview-docs --"
+xfmt  = "xtask fmt-packages"
+qa    = "xtask run example qa-test"

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -25,7 +25,7 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     outputs:
-      packages: '${{ github.event.inputs.packages }}'
+      packages: "${{ github.event.inputs.packages }}"
     steps:
       - run: echo "Setup complete!"
   build:
@@ -71,7 +71,7 @@ jobs:
           ref: ${{ matrix.packages.tag }}
 
       - name: Build documentation
-        run: hal-xtask build-documentation --packages=${{ matrix.packages.name }} --base-url /projects/rust/
+        run: hal-xtask build documentation --packages=${{ matrix.packages.name }} --base-url /projects/rust/
 
       # https://github.com/actions/deploy-pages/issues/303#issuecomment-1951207879
       - name: Remove problematic '.lock' files
@@ -97,11 +97,6 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: "docs/"
-
-      # Create an index for _all_ packages.
-      - name: Create index.html
-        run: cargo xtask build-documentation-index
-
 
       - if: ${{ github.event.inputs.server == 'preview' }}
         name: Deploy to preview server

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -9,7 +9,7 @@ on:
       repository:
         description: "Owner and repository to test"
         required: true
-        default: 'esp-rs/esp-hal'
+        default: "esp-rs/esp-hal"
       branch:
         description: "Branch, tag or SHA to checkout."
         required: true
@@ -118,7 +118,7 @@ jobs:
           version: 1.85.0.0
 
       - name: Build tests
-        run: cargo xtask build-tests ${{ matrix.target.soc }}
+        run: cargo xtask build tests ${{ matrix.target.soc }}
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -176,7 +176,7 @@ jobs:
 
           export PATH=$PATH:/home/espressif/.cargo/bin
           chmod +x xtask
-          ./xtask run-elfs ${{ matrix.target.soc }} tests-${{ matrix.target.soc }}
+          ./xtask run elfs ${{ matrix.target.soc }} tests-${{ matrix.target.soc }}
 
       - name: Clean up
         if: always()

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -8,22 +8,15 @@ Automation using [cargo-xtask](https://github.com/matklad/cargo-xtask).
 Usage: xtask <COMMAND>
 
 Commands:
-  build-documentation        Build documentation for the specified chip
-  build-documentation-index  Build documentation index including the specified packages
-  build-examples             Build all examples for the specified chip
-  build-package              Build the specified package with the given options
-  build-tests                Build all applicable tests or the specified test for a specified chip
-  bump-version               Bump the version of the specified package(s)
-  fmt-packages               Format all packages in the workspace with rustfmt
-  lint-packages              Lint all packages in the workspace with clippy
-  publish                    Attempt to publish the specified package
-  run-doc-tests              Run doctests for specified chip and package
-  run-example                Run the given example for the specified chip
-  run-tests                  Run all applicable tests or the specified test for a specified chip
-  run-elfs                   Run all ELFs in a folder
-  ci                         Perform (parts of) the checks done in CI
-  tag-releases               Generate git tags for all new package releases
-  help                       Print this message or the help of the given subcommand(s)
+  build          Build-related subcommands
+  run            Run-related subcommands
+  bump-version   Bump the version of the specified package(s)
+  ci             Perform (parts of) the checks done in CI
+  fmt-packages   Format all packages in the workspace with rustfmt
+  lint-packages  Lint all packages in the workspace with clippy
+  publish        Attempt to publish the specified package
+  tag-releases   Generate git tags for all new package releases
+  help           Print this message or the help of the given subcommand(s)
 
 Options:
   -h, --help  Print help
@@ -32,14 +25,15 @@ Options:
 You can get help for subcommands, too!
 
 ```text
-cargo xtask build-examples --help
-    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.21s
-     Running `target\debug\xtask.exe build-examples --help`
+cargo xtask build examples --help
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.11s
+     Running `[...]/target/debug/xtask build examples --help`
+
 Build all examples for the specified chip
 
-Usage: xtask.exe build-examples [OPTIONS] <PACKAGE> <CHIP> [EXAMPLE]
+Usage: xtask build examples [OPTIONS] <CHIP> <PACKAGE>
 
-...
+[...]
 ```
 
 ## Test/example metadata use

--- a/xtask/src/commands/build.rs
+++ b/xtask/src/commands/build.rs
@@ -26,7 +26,7 @@ pub enum Build {
 // ----------------------------------------------------------------------------
 // Subcommand Arguments
 
-#[derive(Debug, Args)]
+#[derive(Debug, Default, Args)]
 pub struct BuildDocumentationArgs {
     /// Package(s) to document.
     #[arg(long, value_enum, value_delimiter = ',', default_values_t = Package::iter())]
@@ -114,11 +114,7 @@ pub fn build_examples(
     // Determine the appropriate build target for the given package and chip:
     let target = args.package.target_triple(&args.chip)?;
 
-    if examples
-        .iter()
-        .find(|ex| ex.matches(&args.example))
-        .is_some()
-    {
+    if examples.iter().any(|ex| ex.matches(&args.example)) {
         // Attempt to build only the specified example:
         for example in examples.iter().filter(|ex| ex.matches(&args.example)) {
             crate::execute_app(

--- a/xtask/src/commands/build.rs
+++ b/xtask/src/commands/build.rs
@@ -5,6 +5,7 @@ use clap::{Args, Subcommand};
 use esp_metadata::Chip;
 use strum::IntoEnumIterator as _;
 
+use super::{ExamplesArgs, TestsArgs};
 use crate::{Package, cargo::CargoAction, firmware::Metadata};
 
 // ----------------------------------------------------------------------------
@@ -15,11 +16,11 @@ pub enum Build {
     /// Build documentation for the specified chip.
     Documentation(BuildDocumentationArgs),
     /// Build all examples for the specified chip.
-    Examples(BuildExamplesArgs),
+    Examples(ExamplesArgs),
     /// Build the specified package with the given options.
     Package(BuildPackageArgs),
     /// Build all applicable tests or the specified test for a specified chip.
-    Tests(BuildTestsArgs),
+    Tests(TestsArgs),
 }
 
 // ----------------------------------------------------------------------------
@@ -42,21 +43,6 @@ pub struct BuildDocumentationArgs {
 }
 
 #[derive(Debug, Args)]
-pub struct BuildExamplesArgs {
-    /// Package whose examples we which to act on.
-    #[arg(value_enum)]
-    pub package: Package,
-    /// Chip to target.
-    #[arg(value_enum)]
-    pub chip: Chip,
-    /// Optional example to act on (all examples used if omitted)
-    pub example: Option<String>,
-    /// Build examples in debug mode only
-    #[arg(long)]
-    pub debug: bool,
-}
-
-#[derive(Debug, Args)]
 pub struct BuildPackageArgs {
     /// Package to build.
     #[arg(value_enum)]
@@ -73,19 +59,6 @@ pub struct BuildPackageArgs {
     /// Don't enabled the default features.
     #[arg(long)]
     pub no_default_features: bool,
-}
-
-#[derive(Debug, Args)]
-pub struct BuildTestsArgs {
-    /// Chip to target.
-    #[arg(value_enum)]
-    pub chip: Chip,
-    /// Optional test to act on (all tests used if omitted)
-    #[arg(short = 't', long)]
-    pub test: Option<String>,
-    /// Repeat the tests for a specific number of times.
-    #[arg(long)]
-    pub repeat: Option<usize>,
 }
 
 // ----------------------------------------------------------------------------
@@ -133,7 +106,7 @@ pub fn build_documentation(workspace: &Path, mut args: BuildDocumentationArgs) -
 }
 
 pub fn build_examples(
-    args: BuildExamplesArgs,
+    args: ExamplesArgs,
     examples: Vec<Metadata>,
     package_path: &Path,
     out_path: &Path,

--- a/xtask/src/commands/build.rs
+++ b/xtask/src/commands/build.rs
@@ -1,0 +1,193 @@
+use std::path::Path;
+
+use anyhow::{Result, bail};
+use clap::{Args, Subcommand};
+use esp_metadata::Chip;
+use strum::IntoEnumIterator as _;
+
+use crate::{Package, cargo::CargoAction, firmware::Metadata};
+
+// ----------------------------------------------------------------------------
+// Subcommands
+
+#[derive(Debug, Subcommand)]
+pub enum Build {
+    /// Build documentation for the specified chip.
+    Documentation(BuildDocumentationArgs),
+    /// Build all examples for the specified chip.
+    Examples(BuildExamplesArgs),
+    /// Build the specified package with the given options.
+    Package(BuildPackageArgs),
+    /// Build all applicable tests or the specified test for a specified chip.
+    Tests(BuildTestsArgs),
+}
+
+// ----------------------------------------------------------------------------
+// Subcommand Arguments
+
+#[derive(Debug, Args)]
+pub struct BuildDocumentationArgs {
+    /// Package(s) to document.
+    #[arg(long, value_enum, value_delimiter = ',', default_values_t = Package::iter())]
+    pub packages: Vec<Package>,
+    /// Chip(s) to build documentation for.
+    #[arg(long, value_enum, value_delimiter = ',', default_values_t = Chip::iter())]
+    pub chips: Vec<Chip>,
+    /// Base URL of the deployed documentation.
+    #[arg(long)]
+    pub base_url: Option<String>,
+    #[cfg(feature = "preview-docs")]
+    #[arg(long)]
+    pub serve: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct BuildExamplesArgs {
+    /// Package whose examples we which to act on.
+    #[arg(value_enum)]
+    pub package: Package,
+    /// Chip to target.
+    #[arg(value_enum)]
+    pub chip: Chip,
+    /// Optional example to act on (all examples used if omitted)
+    pub example: Option<String>,
+    /// Build examples in debug mode only
+    #[arg(long)]
+    pub debug: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct BuildPackageArgs {
+    /// Package to build.
+    #[arg(value_enum)]
+    pub package: Package,
+    /// Target to build for.
+    #[arg(long)]
+    pub target: Option<String>,
+    /// Features to build with.
+    #[arg(long, value_delimiter = ',')]
+    pub features: Vec<String>,
+    /// Toolchain to build with.
+    #[arg(long)]
+    pub toolchain: Option<String>,
+    /// Don't enabled the default features.
+    #[arg(long)]
+    pub no_default_features: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct BuildTestsArgs {
+    /// Chip to target.
+    #[arg(value_enum)]
+    pub chip: Chip,
+    /// Optional test to act on (all tests used if omitted)
+    #[arg(short = 't', long)]
+    pub test: Option<String>,
+    /// Repeat the tests for a specific number of times.
+    #[arg(long)]
+    pub repeat: Option<usize>,
+}
+
+// ----------------------------------------------------------------------------
+// Subcommand Actions
+
+pub fn build_documentation(workspace: &Path, mut args: BuildDocumentationArgs) -> Result<()> {
+    crate::documentation::build_documentation(
+        workspace,
+        &mut args.packages,
+        &mut args.chips,
+        args.base_url,
+    )?;
+
+    crate::documentation::build_documentation_index(workspace, &mut args.packages)?;
+
+    #[cfg(feature = "preview-docs")]
+    if args.serve {
+        use std::{
+            thread::{sleep, spawn},
+            time::Duration,
+        };
+
+        use rocket::fs::{FileServer, Options};
+
+        spawn(|| {
+            sleep(Duration::from_millis(1000));
+            opener::open_browser("http://127.0.0.1:8000/").ok();
+        });
+
+        rocket::async_main(
+            {
+                rocket::build().mount(
+                    "/",
+                    FileServer::new(
+                        "docs",
+                        Options::Index | Options::IndexFile | Options::DotFiles,
+                    ),
+                )
+            }
+            .launch(),
+        )?;
+    }
+
+    Ok(())
+}
+
+pub fn build_examples(
+    args: BuildExamplesArgs,
+    examples: Vec<Metadata>,
+    package_path: &Path,
+    out_path: &Path,
+) -> Result<()> {
+    // Determine the appropriate build target for the given package and chip:
+    let target = args.package.target_triple(&args.chip)?;
+
+    if examples
+        .iter()
+        .find(|ex| ex.matches(&args.example))
+        .is_some()
+    {
+        // Attempt to build only the specified example:
+        for example in examples.iter().filter(|ex| ex.matches(&args.example)) {
+            crate::execute_app(
+                package_path,
+                args.chip,
+                target,
+                example,
+                CargoAction::Build(out_path.to_path_buf()),
+                1,
+                args.debug,
+            )?;
+        }
+        Ok(())
+    } else if args.example.is_some() {
+        // An invalid argument was provided:
+        bail!("Example not found or unsupported for the given chip")
+    } else {
+        // Attempt to build each supported example, with all required features enabled:
+        examples.iter().try_for_each(|example| {
+            crate::execute_app(
+                package_path,
+                args.chip,
+                target,
+                example,
+                CargoAction::Build(out_path.to_path_buf()),
+                1,
+                args.debug,
+            )
+        })
+    }
+}
+
+pub fn build_package(workspace: &Path, args: BuildPackageArgs) -> Result<()> {
+    // Absolute path of the package's root:
+    let package_path = crate::windows_safe_path(&workspace.join(args.package.to_string()));
+
+    // Build the package using the provided features and/or target, if any:
+    crate::build_package(
+        &package_path,
+        args.features,
+        args.no_default_features,
+        args.toolchain,
+        args.target,
+    )
+}

--- a/xtask/src/commands/mod.rs
+++ b/xtask/src/commands/mod.rs
@@ -1,3 +1,153 @@
-pub use self::build::*;
+use std::path::Path;
+
+use anyhow::{Result, bail};
+use clap::Args;
+use esp_metadata::Chip;
+
+pub use self::{build::*, run::*};
+use crate::{Package, cargo::CargoAction};
 
 mod build;
+mod run;
+
+// ----------------------------------------------------------------------------
+// Subcommand Arguments
+
+#[derive(Debug, Args)]
+pub struct ExamplesArgs {
+    /// Chip to target.
+    #[arg(value_enum)]
+    pub chip: Chip,
+    /// Package whose examples we which to act on.
+    #[arg(value_enum)]
+    pub package: Package,
+
+    /// Build examples in debug mode only
+    #[arg(long)]
+    pub debug: bool,
+    /// Optional example to act on (all examples used if omitted)
+    #[arg(long)]
+    pub example: Option<String>,
+}
+
+#[derive(Debug, Args)]
+pub struct TestsArgs {
+    /// Chip to target.
+    #[arg(value_enum)]
+    pub chip: Chip,
+
+    /// Repeat the tests for a specific number of times.
+    #[arg(long)]
+    pub repeat: Option<usize>,
+    /// Optional test to act on (all tests used if omitted)
+    #[arg(long, short = 't')]
+    pub test: Option<String>,
+}
+
+// ----------------------------------------------------------------------------
+// Subcommand Actions
+
+pub fn examples(workspace: &Path, mut args: ExamplesArgs, action: CargoAction) -> Result<()> {
+    // Ensure that the package/chip combination provided are valid:
+    args.package.validate_package_chip(&args.chip)?;
+
+    // If the 'esp-hal' package is specified, what we *really* want is the
+    // 'examples' package instead:
+    if args.package == Package::EspHal {
+        log::warn!(
+            "Package '{}' specified, using '{}' instead",
+            Package::EspHal,
+            Package::Examples
+        );
+        args.package = Package::Examples;
+    }
+
+    // Absolute path of the package's root:
+    let package_path = crate::windows_safe_path(&workspace.join(args.package.to_string()));
+
+    let example_path = match args.package {
+        Package::Examples | Package::QaTest => package_path.join("src").join("bin"),
+        Package::HilTest => package_path.join("tests"),
+        _ => package_path.join("examples"),
+    };
+
+    // Load all examples which support the specified chip and parse their metadata:
+    let mut examples = crate::firmware::load(&example_path)?
+        .iter()
+        .filter_map(|example| {
+            if example.supports_chip(args.chip) {
+                Some(example.clone())
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+
+    // Sort all examples by name:
+    examples.sort_by_key(|a| a.binary_name());
+
+    // Execute the specified action:
+    match action {
+        CargoAction::Build(out_path) => build_examples(args, examples, &package_path, &out_path),
+        CargoAction::Run if args.example.is_some() => run_example(args, examples, &package_path),
+        CargoAction::Run => run_examples(args, examples, &package_path),
+    }
+}
+
+pub fn tests(workspace: &Path, args: TestsArgs, action: CargoAction) -> Result<()> {
+    // Absolute path of the 'hil-test' package's root:
+    let package_path = crate::windows_safe_path(&workspace.join("hil-test"));
+
+    // Determine the appropriate build target for the given package and chip:
+    let target = Package::HilTest.target_triple(&args.chip)?;
+
+    // Load all tests which support the specified chip and parse their metadata:
+    let mut tests = crate::firmware::load(&package_path.join("tests"))?
+        .into_iter()
+        .filter(|example| example.supports_chip(args.chip))
+        .collect::<Vec<_>>();
+
+    // Sort all tests by name:
+    tests.sort_by_key(|a| a.binary_name());
+
+    // Execute the specified action:
+    if tests.iter().find(|test| test.matches(&args.test)).is_some() {
+        for test in tests.iter().filter(|test| test.matches(&args.test)) {
+            crate::execute_app(
+                &package_path,
+                args.chip,
+                target,
+                test,
+                action.clone(),
+                args.repeat.unwrap_or(1),
+                false,
+            )?;
+        }
+        Ok(())
+    } else if args.test.is_some() {
+        bail!("Test not found or unsupported for the given chip")
+    } else {
+        let mut failed = Vec::new();
+        for test in tests {
+            if crate::execute_app(
+                &package_path,
+                args.chip,
+                target,
+                &test,
+                action.clone(),
+                args.repeat.unwrap_or(1),
+                false,
+            )
+            .is_err()
+            {
+                failed.push(test.name_with_configuration());
+            }
+        }
+
+        if !failed.is_empty() {
+            bail!("Failed tests: {:#?}", failed);
+        }
+
+        Ok(())
+    }
+}

--- a/xtask/src/commands/mod.rs
+++ b/xtask/src/commands/mod.rs
@@ -15,12 +15,12 @@ mod run;
 
 #[derive(Debug, Args)]
 pub struct ExamplesArgs {
-    /// Chip to target.
-    #[arg(value_enum)]
-    pub chip: Chip,
     /// Package whose examples we which to act on.
     #[arg(value_enum)]
     pub package: Package,
+    /// Chip to target.
+    #[arg(value_enum)]
+    pub chip: Chip,
 
     /// Build examples in debug mode only
     #[arg(long)]

--- a/xtask/src/commands/mod.rs
+++ b/xtask/src/commands/mod.rs
@@ -1,0 +1,3 @@
+pub use self::build::*;
+
+mod build;

--- a/xtask/src/commands/run.rs
+++ b/xtask/src/commands/run.rs
@@ -1,0 +1,228 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use anyhow::{Context as _, Result, bail, ensure};
+use clap::{Args, Subcommand};
+use esp_metadata::Chip;
+
+use super::{ExamplesArgs, TestsArgs};
+use crate::{
+    cargo::{CargoAction, CargoArgsBuilder},
+    firmware::Metadata,
+};
+
+// ----------------------------------------------------------------------------
+// Subcommands
+
+#[derive(Debug, Subcommand)]
+pub enum Run {
+    /// Run doctests for specified chip and package.
+    DocTests(ExamplesArgs),
+    /// Run all ELFs in a folder.
+    Elfs(RunElfsArgs),
+    /// Run the given example for the specified chip.
+    Example(ExamplesArgs),
+    /// Run all applicable tests or the specified test for a specified chip.
+    Tests(TestsArgs),
+}
+
+// ----------------------------------------------------------------------------
+// Subcommand Arguments
+
+#[derive(Debug, Args)]
+pub struct RunElfsArgs {
+    /// Which chip to run the tests for.
+    #[arg(value_enum)]
+    pub chip: Chip,
+    /// Path to the ELFs.
+    pub path: PathBuf,
+}
+
+// ----------------------------------------------------------------------------
+// Subcommand Actions
+
+pub fn run_doc_tests(workspace: &Path, args: ExamplesArgs) -> Result<()> {
+    let chip = args.chip;
+
+    let package_name = args.package.to_string();
+    let package_path = crate::windows_safe_path(&workspace.join(&package_name));
+
+    // Determine the appropriate build target, and cargo features for the given
+    // package and chip:
+    let target = args.package.target_triple(&chip)?;
+    let features = vec![chip.to_string(), "unstable".to_string()];
+
+    // We need `nightly` for building the doc tests, unfortunately:
+    let toolchain = if chip.is_xtensa() { "esp" } else { "nightly" };
+
+    // Build up an array of command-line arguments to pass to `cargo`:
+    let builder = CargoArgsBuilder::default()
+        .toolchain(toolchain)
+        .subcommand("test")
+        .arg("--doc")
+        .arg("-Zdoctest-xcompile")
+        .arg("-Zbuild-std=core,panic_abort")
+        .target(target)
+        .features(&features)
+        .arg("--release");
+
+    let args = builder.build();
+    log::debug!("{args:#?}");
+
+    // Execute `cargo doc` from the package root:
+    crate::cargo::run(&args, &package_path)?;
+
+    Ok(())
+}
+
+pub fn run_elfs(args: RunElfsArgs) -> Result<()> {
+    let mut failed: Vec<String> = Vec::new();
+    for elf in fs::read_dir(&args.path)? {
+        let entry = elf?;
+
+        let elf_path = entry.path();
+        let elf_name = elf_path
+            .with_extension("")
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
+
+        log::info!("Running test '{}' for '{}'", elf_name, args.chip);
+
+        let mut command = Command::new("probe-rs");
+        command.arg("run").arg(elf_path);
+
+        if args.chip == Chip::Esp32c2 {
+            command.arg("--speed").arg("15000");
+        };
+
+        command.arg("--verify");
+
+        let mut command = command.spawn().context("Failed to execute probe-rs")?;
+        let status = command
+            .wait()
+            .context("Error while waiting for probe-rs to exit")?;
+
+        log::info!("'{elf_name}' done");
+
+        if !status.success() {
+            failed.push(elf_name);
+        }
+    }
+
+    if !failed.is_empty() {
+        bail!("Failed tests: {:?}", failed);
+    }
+
+    Ok(())
+}
+
+pub fn run_example(args: ExamplesArgs, examples: Vec<Metadata>, package_path: &Path) -> Result<()> {
+    // Determine the appropriate build target for the given package and chip:
+    let target = args.package.target_triple(&args.chip)?;
+
+    // Filter the examples down to only the binary we're interested in, assuming it
+    // actually supports the specified chip:
+    let mut found_one = false;
+    for example in examples.iter().filter(|ex| ex.matches(&args.example)) {
+        found_one = true;
+        crate::execute_app(
+            package_path,
+            args.chip,
+            target,
+            example,
+            CargoAction::Run,
+            1,
+            args.debug,
+        )?;
+    }
+
+    ensure!(
+        found_one,
+        "Example not found or unsupported for {}",
+        args.chip
+    );
+
+    Ok(())
+}
+
+pub fn run_examples(
+    args: ExamplesArgs,
+    examples: Vec<Metadata>,
+    package_path: &Path,
+) -> Result<()> {
+    // Determine the appropriate build target for the given package and chip:
+    let target = args.package.target_triple(&args.chip)?;
+
+    // Filter the examples down to only the binaries we're interested in
+    let mut examples: Vec<Metadata> = examples
+        .iter()
+        .filter(|ex| ex.supports_chip(args.chip))
+        .cloned()
+        .collect();
+    examples.sort_by_key(|ex| ex.tag());
+
+    let console = console::Term::stdout();
+
+    for example in examples {
+        let mut skip = false;
+
+        log::info!("Running example '{}'", example.output_file_name());
+        if let Some(description) = example.description() {
+            log::info!(
+                "\n\n{}\n\nPress ENTER to run example, `s` to skip",
+                description.trim()
+            );
+        } else {
+            log::info!("\n\nPress ENTER to run example, `s` to skip");
+        }
+
+        loop {
+            let key = console.read_key();
+
+            match key {
+                Ok(console::Key::Enter) => break,
+                Ok(console::Key::Char('s')) => {
+                    skip = true;
+                    break;
+                }
+                _ => (),
+            }
+        }
+
+        if !skip {
+            while !skip
+                && crate::execute_app(
+                    package_path,
+                    args.chip,
+                    target,
+                    &example,
+                    CargoAction::Run,
+                    1,
+                    args.debug,
+                )
+                .is_err()
+            {
+                log::info!("Failed to run example. Retry or skip? (r/s)");
+                loop {
+                    let key = console.read_key();
+
+                    match key {
+                        Ok(console::Key::Char('r')) => break,
+                        Ok(console::Key::Char('s')) => {
+                            skip = true;
+                            break;
+                        }
+                        _ => (),
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -12,6 +12,7 @@ use strum::{Display, EnumIter, IntoEnumIterator as _};
 use crate::{cargo::CargoArgsBuilder, firmware::Metadata};
 
 pub mod cargo;
+pub mod commands;
 pub mod documentation;
 pub mod firmware;
 

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -325,56 +325,6 @@ pub fn execute_app(
     Ok(())
 }
 
-/// Build the specified package, using the given toolchain/target/features if
-/// provided.
-pub fn build_package(
-    package_path: &Path,
-    features: Vec<String>,
-    no_default_features: bool,
-    toolchain: Option<String>,
-    target: Option<String>,
-) -> Result<()> {
-    log::info!("Building package '{}'", package_path.display());
-    if !features.is_empty() {
-        log::info!("  Features: {}", features.join(","));
-    }
-    if let Some(ref target) = target {
-        log::info!("  Target:   {}", target);
-    }
-
-    let mut builder = CargoArgsBuilder::default()
-        .subcommand("build")
-        .arg("--release");
-
-    if let Some(toolchain) = toolchain {
-        builder = builder.toolchain(toolchain);
-    }
-
-    if let Some(target) = target {
-        // If targeting an Xtensa device, we must use the '+esp' toolchain modifier:
-        if target.starts_with("xtensa") {
-            builder = builder.toolchain("esp");
-            builder = builder.arg("-Zbuild-std=core,alloc")
-        }
-        builder = builder.target(target);
-    }
-
-    if !features.is_empty() {
-        builder = builder.features(&features);
-    }
-
-    if no_default_features {
-        builder = builder.arg("--no-default-features");
-    }
-
-    let args = builder.build();
-    log::debug!("{args:#?}");
-
-    cargo::run(&args, package_path)?;
-
-    Ok(())
-}
-
 /// Bump the version of the specified package by the specified amount.
 pub fn bump_version(workspace: &Path, package: Package, amount: Version) -> Result<()> {
     let manifest_path = workspace.join(package.to_string()).join("Cargo.toml");

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -216,7 +216,7 @@ fn lint_packages(workspace: &Path, args: LintPackagesArgs) -> Result<()> {
         for chip in &args.chips {
             let device = Config::for_chip(chip);
 
-            if let Err(_) = package.validate_package_chip(chip) {
+            if package.validate_package_chip(chip).is_err() {
                 continue;
             }
 
@@ -370,8 +370,7 @@ fn run_ci_checks(workspace: &Path, args: CiArgs) -> Result<()> {
         BuildDocumentationArgs {
             packages: vec![Package::EspHal, Package::EspWifi, Package::EspHalEmbassy],
             chips: vec![args.chip],
-            base_url: None,
-            serve: false,
+            ..Default::default()
         },
     )
     .inspect_err(|_| failure = true)
@@ -402,7 +401,7 @@ fn run_ci_checks(workspace: &Path, args: CiArgs) -> Result<()> {
             let from_dir = PathBuf::from(format!(
                 "./esp-lp-hal/target/{}/release/examples/{}",
                 args.chip.target(),
-                args.chip.to_string()
+                args.chip
             ));
             let to_dir = PathBuf::from(format!(
                 "./esp-lp-hal/target/{}/release/examples",
@@ -424,8 +423,7 @@ fn run_ci_checks(workspace: &Path, args: CiArgs) -> Result<()> {
             BuildDocumentationArgs {
                 packages: vec![Package::EspLpHal],
                 chips: vec![args.chip],
-                base_url: None,
-                serve: false,
+                ..Default::default()
             },
         )
         .inspect_err(|_| failure = true)
@@ -455,7 +453,7 @@ fn run_ci_checks(workspace: &Path, args: CiArgs) -> Result<()> {
             example: None,
             debug: true,
         },
-        CargoAction::Build(PathBuf::from(format!("./examples/target/"))),
+        CargoAction::Build(PathBuf::from("./examples/target/")),
     )
     .inspect_err(|_| failure = true)
     .ok();
@@ -469,7 +467,7 @@ fn run_ci_checks(workspace: &Path, args: CiArgs) -> Result<()> {
             example: None,
             debug: true,
         },
-        CargoAction::Build(PathBuf::from(format!("./qa-test/target/"))),
+        CargoAction::Build(PathBuf::from("./qa-test/target/")),
     )
     .inspect_err(|_| failure = true)
     .ok();

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -5,7 +5,7 @@ use std::{
     time::Instant,
 };
 
-use anyhow::{Context as _, Result, bail, ensure};
+use anyhow::{Result, bail};
 use clap::{Args, Parser};
 use esp_metadata::{Chip, Config};
 use strum::IntoEnumIterator;
@@ -14,7 +14,6 @@ use xtask::{
     Version,
     cargo::{CargoAction, CargoArgsBuilder},
     commands::*,
-    firmware::Metadata,
 };
 
 // ----------------------------------------------------------------------------
@@ -25,9 +24,14 @@ enum Cli {
     /// Build-related subcommands
     #[clap(subcommand)]
     Build(Build),
+    /// Run-related subcommands
+    #[clap(subcommand)]
+    Run(Run),
 
     /// Bump the version of the specified package(s).
     BumpVersion(BumpVersionArgs),
+    /// Perform (parts of) the checks done in CI
+    Ci(CiArgs),
     /// Format all packages in the workspace with rustfmt
     #[clap(alias = "format-packages")]
     FmtPackages(FmtPackagesArgs),
@@ -35,47 +39,8 @@ enum Cli {
     LintPackages(LintPackagesArgs),
     /// Attempt to publish the specified package.
     Publish(PublishArgs),
-    /// Run doctests for specified chip and package.
-    #[clap(alias = "run-doc-test")]
-    RunDocTests(ExampleArgs),
-    /// Run the given example for the specified chip.
-    RunExample(BuildExamplesArgs),
-    /// Run all applicable tests or the specified test for a specified chip.
-    RunTests(BuildTestsArgs),
-    /// Run all ELFs in a folder.
-    RunElfs(RunElfArgs),
-    /// Perform (parts of) the checks done in CI
-    Ci(CiArgs),
     /// Generate git tags for all new package releases.
     TagReleases(TagReleasesArgs),
-}
-
-#[derive(Debug, Args)]
-struct ExampleArgs {
-    /// Package whose examples we which to act on.
-    #[arg(value_enum)]
-    package: Package,
-    /// Chip to target.
-    #[arg(value_enum)]
-    chip: Chip,
-    /// Optional example to act on (all examples used if omitted)
-    example: Option<String>,
-    /// Build examples in debug mode only
-    #[arg(long)]
-    debug: bool,
-}
-
-#[derive(Debug, Args)]
-struct TestArgs {
-    /// Chip to target.
-    #[arg(value_enum)]
-    chip: Chip,
-    /// Optional test to act on (all tests used if omitted)
-    #[arg(short = 't', long)]
-    test: Option<String>,
-    /// Repeat the tests for a specific number of times.
-    #[arg(long)]
-    repeat: Option<usize>,
 }
 
 #[derive(Debug, Args)]
@@ -89,6 +54,13 @@ struct BumpVersionArgs {
 }
 
 #[derive(Debug, Args)]
+struct CiArgs {
+    /// Chip to target.
+    #[arg(value_enum)]
+    chip: Chip,
+}
+
+#[derive(Debug, Args)]
 struct FmtPackagesArgs {
     /// Run in 'check' mode; exists with 0 if formatted correctly, 1 otherwise
     #[arg(long)]
@@ -97,15 +69,6 @@ struct FmtPackagesArgs {
     /// Package(s) to target.
     #[arg(value_enum, default_values_t = Package::iter())]
     packages: Vec<Package>,
-}
-
-#[derive(Debug, Args)]
-struct GenerateEfuseFieldsArgs {
-    /// Path to the local ESP-IDF repository.
-    idf_path: PathBuf,
-    /// Chip to build eFuse fields table for.
-    #[arg(value_enum)]
-    chip: Chip,
 }
 
 #[derive(Debug, Args)]
@@ -132,22 +95,6 @@ struct PublishArgs {
     /// Do not pass the `--dry-run` argument, actually try to publish.
     #[arg(long)]
     no_dry_run: bool,
-}
-
-#[derive(Debug, Args)]
-struct RunElfArgs {
-    /// Which chip to run the tests for.
-    #[arg(value_enum)]
-    chip: Chip,
-    /// Path to the ELFs.
-    path: PathBuf,
-}
-
-#[derive(Debug, Args)]
-struct CiArgs {
-    /// Chip to target.
-    #[arg(value_enum)]
-    chip: Chip,
 }
 
 #[derive(Debug, Args)]
@@ -187,236 +134,25 @@ fn main() -> Result<()> {
             ),
         },
 
+        // Run-related subcommands:
+        Cli::Run(run) => match run {
+            Run::DocTests(args) => run_doc_tests(&workspace, args),
+            Run::Elfs(args) => run_elfs(args),
+            Run::Example(args) => examples(&workspace, args, CargoAction::Run),
+            Run::Tests(args) => tests(&workspace, args, CargoAction::Run),
+        },
+
         Cli::BumpVersion(args) => bump_version(&workspace, args),
+        Cli::Ci(args) => run_ci_checks(&workspace, args),
         Cli::FmtPackages(args) => fmt_packages(&workspace, args),
         Cli::LintPackages(args) => lint_packages(&workspace, args),
         Cli::Publish(args) => publish(&workspace, args),
-        Cli::RunDocTests(args) => run_doc_tests(&workspace, args),
-        Cli::RunElfs(args) => run_elfs(args),
-        Cli::RunExample(args) => examples(&workspace, args, CargoAction::Run),
-        Cli::RunTests(args) => tests(&workspace, args, CargoAction::Run),
-        Cli::Ci(args) => run_ci_checks(&workspace, args),
         Cli::TagReleases(args) => tag_releases(&workspace, args),
     }
 }
 
 // ----------------------------------------------------------------------------
 // Subcommands
-
-pub fn examples(workspace: &Path, mut args: BuildExamplesArgs, action: CargoAction) -> Result<()> {
-    // Ensure that the package/chip combination provided are valid:
-    args.package.validate_package_chip(&args.chip)?;
-
-    // If the 'esp-hal' package is specified, what we *really* want is the
-    // 'examples' package instead:
-    if args.package == Package::EspHal {
-        log::warn!(
-            "Package '{}' specified, using '{}' instead",
-            Package::EspHal,
-            Package::Examples
-        );
-        args.package = Package::Examples;
-    }
-
-    // Absolute path of the package's root:
-    let package_path = xtask::windows_safe_path(&workspace.join(args.package.to_string()));
-
-    let example_path = match args.package {
-        Package::Examples | Package::QaTest => package_path.join("src").join("bin"),
-        Package::HilTest => package_path.join("tests"),
-        _ => package_path.join("examples"),
-    };
-
-    // Load all examples which support the specified chip and parse their metadata:
-    let mut examples = xtask::firmware::load(&example_path)?
-        .iter()
-        .filter_map(|example| {
-            if example.supports_chip(args.chip) {
-                Some(example.clone())
-            } else {
-                None
-            }
-        })
-        .collect::<Vec<_>>();
-
-    // Sort all examples by name:
-    examples.sort_by_key(|a| a.binary_name());
-
-    // Execute the specified action:
-    match action {
-        CargoAction::Build(out_path) => build_examples(args, examples, &package_path, &out_path),
-        CargoAction::Run if args.example.is_some() => run_example(args, examples, &package_path),
-        CargoAction::Run => run_examples(args, examples, &package_path),
-    }
-}
-
-pub fn tests(workspace: &Path, args: BuildTestsArgs, action: CargoAction) -> Result<()> {
-    // Absolute path of the 'hil-test' package's root:
-    let package_path = xtask::windows_safe_path(&workspace.join("hil-test"));
-
-    // Determine the appropriate build target for the given package and chip:
-    let target = Package::HilTest.target_triple(&args.chip)?;
-
-    // Load all tests which support the specified chip and parse their metadata:
-    let mut tests = xtask::firmware::load(&package_path.join("tests"))?
-        .into_iter()
-        .filter(|example| example.supports_chip(args.chip))
-        .collect::<Vec<_>>();
-
-    // Sort all tests by name:
-    tests.sort_by_key(|a| a.binary_name());
-
-    // Execute the specified action:
-    if tests.iter().find(|test| test.matches(&args.test)).is_some() {
-        for test in tests.iter().filter(|test| test.matches(&args.test)) {
-            xtask::execute_app(
-                &package_path,
-                args.chip,
-                target,
-                test,
-                action.clone(),
-                args.repeat.unwrap_or(1),
-                false,
-            )?;
-        }
-        Ok(())
-    } else if args.test.is_some() {
-        bail!("Test not found or unsupported for the given chip")
-    } else {
-        let mut failed = Vec::new();
-        for test in tests {
-            if xtask::execute_app(
-                &package_path,
-                args.chip,
-                target,
-                &test,
-                action.clone(),
-                args.repeat.unwrap_or(1),
-                false,
-            )
-            .is_err()
-            {
-                failed.push(test.name_with_configuration());
-            }
-        }
-
-        if !failed.is_empty() {
-            bail!("Failed tests: {:#?}", failed);
-        }
-
-        Ok(())
-    }
-}
-
-fn run_example(
-    args: BuildExamplesArgs,
-    examples: Vec<Metadata>,
-    package_path: &Path,
-) -> Result<()> {
-    // Determine the appropriate build target for the given package and chip:
-    let target = args.package.target_triple(&args.chip)?;
-
-    // Filter the examples down to only the binary we're interested in, assuming it
-    // actually supports the specified chip:
-    let mut found_one = false;
-    for example in examples.iter().filter(|ex| ex.matches(&args.example)) {
-        found_one = true;
-        xtask::execute_app(
-            package_path,
-            args.chip,
-            target,
-            example,
-            CargoAction::Run,
-            1,
-            args.debug,
-        )?;
-    }
-
-    ensure!(
-        found_one,
-        "Example not found or unsupported for {}",
-        args.chip
-    );
-
-    Ok(())
-}
-
-fn run_examples(
-    args: BuildExamplesArgs,
-    examples: Vec<Metadata>,
-    package_path: &Path,
-) -> Result<()> {
-    // Determine the appropriate build target for the given package and chip:
-    let target = args.package.target_triple(&args.chip)?;
-
-    // Filter the examples down to only the binaries we're interested in
-    let mut examples: Vec<Metadata> = examples
-        .iter()
-        .filter(|ex| ex.supports_chip(args.chip))
-        .cloned()
-        .collect();
-    examples.sort_by_key(|ex| ex.tag());
-
-    let console = console::Term::stdout();
-
-    for example in examples {
-        let mut skip = false;
-
-        log::info!("Running example '{}'", example.output_file_name());
-        if let Some(description) = example.description() {
-            log::info!(
-                "\n\n{}\n\nPress ENTER to run example, `s` to skip",
-                description.trim()
-            );
-        } else {
-            log::info!("\n\nPress ENTER to run example, `s` to skip");
-        }
-
-        loop {
-            let key = console.read_key();
-
-            match key {
-                Ok(console::Key::Enter) => break,
-                Ok(console::Key::Char('s')) => {
-                    skip = true;
-                    break;
-                }
-                _ => (),
-            }
-        }
-
-        if !skip {
-            while !skip
-                && xtask::execute_app(
-                    package_path,
-                    args.chip,
-                    target,
-                    &example,
-                    CargoAction::Run,
-                    1,
-                    args.debug,
-                )
-                .is_err()
-            {
-                log::info!("Failed to run example. Retry or skip? (r/s)");
-                loop {
-                    let key = console.read_key();
-
-                    match key {
-                        Ok(console::Key::Char('r')) => break,
-                        Ok(console::Key::Char('s')) => {
-                            skip = true;
-                            break;
-                        }
-                        _ => (),
-                    }
-                }
-            }
-        }
-    }
-
-    Ok(())
-}
 
 fn bump_version(workspace: &Path, args: BumpVersionArgs) -> Result<()> {
     // Bump the version by the specified amount for each given package:
@@ -597,83 +333,6 @@ fn publish(workspace: &Path, args: PublishArgs) -> Result<()> {
     Ok(())
 }
 
-fn run_elfs(args: RunElfArgs) -> Result<()> {
-    let mut failed: Vec<String> = Vec::new();
-    for elf in fs::read_dir(&args.path)? {
-        let entry = elf?;
-
-        let elf_path = entry.path();
-        let elf_name = elf_path
-            .with_extension("")
-            .file_name()
-            .unwrap()
-            .to_string_lossy()
-            .to_string();
-
-        log::info!("Running test '{}' for '{}'", elf_name, args.chip);
-
-        let mut command = Command::new("probe-rs");
-        command.arg("run").arg(elf_path);
-
-        if args.chip == Chip::Esp32c2 {
-            command.arg("--speed").arg("15000");
-        };
-
-        command.arg("--verify");
-
-        let mut command = command.spawn().context("Failed to execute probe-rs")?;
-        let status = command
-            .wait()
-            .context("Error while waiting for probe-rs to exit")?;
-
-        log::info!("'{elf_name}' done");
-
-        if !status.success() {
-            failed.push(elf_name);
-        }
-    }
-
-    if !failed.is_empty() {
-        bail!("Failed tests: {:?}", failed);
-    }
-
-    Ok(())
-}
-
-fn run_doc_tests(workspace: &Path, args: ExampleArgs) -> Result<()> {
-    let chip = args.chip;
-
-    let package_name = args.package.to_string();
-    let package_path = xtask::windows_safe_path(&workspace.join(&package_name));
-
-    // Determine the appropriate build target, and cargo features for the given
-    // package and chip:
-    let target = args.package.target_triple(&chip)?;
-    let features = vec![chip.to_string(), "unstable".to_string()];
-
-    // We need `nightly` for building the doc tests, unfortunately:
-    let toolchain = if chip.is_xtensa() { "esp" } else { "nightly" };
-
-    // Build up an array of command-line arguments to pass to `cargo`:
-    let builder = CargoArgsBuilder::default()
-        .toolchain(toolchain)
-        .subcommand("test")
-        .arg("--doc")
-        .arg("-Zdoctest-xcompile")
-        .arg("-Zbuild-std=core,panic_abort")
-        .target(target)
-        .features(&features)
-        .arg("--release");
-
-    let args = builder.build();
-    log::debug!("{args:#?}");
-
-    // Execute `cargo doc` from the package root:
-    xtask::cargo::run(&args, &package_path)?;
-
-    Ok(())
-}
-
 fn run_ci_checks(workspace: &Path, args: CiArgs) -> Result<()> {
     let mut failure = false;
     let started_at = Instant::now();
@@ -695,7 +354,7 @@ fn run_ci_checks(workspace: &Path, args: CiArgs) -> Result<()> {
     // Check doc-tests
     run_doc_tests(
         workspace,
-        ExampleArgs {
+        ExamplesArgs {
             package: Package::EspHal,
             chip: args.chip,
             example: None,
@@ -727,7 +386,7 @@ fn run_ci_checks(workspace: &Path, args: CiArgs) -> Result<()> {
         // expects it
         examples(
             workspace,
-            BuildExamplesArgs {
+            ExamplesArgs {
                 package: Package::EspLpHal,
                 chip: args.chip,
                 example: None,
@@ -790,7 +449,7 @@ fn run_ci_checks(workspace: &Path, args: CiArgs) -> Result<()> {
     // Build (examples)
     examples(
         workspace,
-        BuildExamplesArgs {
+        ExamplesArgs {
             package: Package::Examples,
             chip: args.chip,
             example: None,
@@ -804,7 +463,7 @@ fn run_ci_checks(workspace: &Path, args: CiArgs) -> Result<()> {
     // Build (qa-test)
     examples(
         workspace,
-        BuildExamplesArgs {
+        ExamplesArgs {
             package: Package::QaTest,
             chip: args.chip,
             example: None,


### PR DESCRIPTION
This groups some `xtask` subcommands together which accomplish similar tasks. There were a number of `build` and `run` related subcommands, and upcoming work from @MabezDev will add `release` subcommands as well. The primary goals here are just organization and code deduplication.

There is likely still some additional deduplication/refactoring of code which can be performed, however I intend to have more PRs working on the xtask and this is quite large already, so I have not done more than necessary here.

I've additionally combined the `build-documentation` and `build-documentation-index` subcommands into just `build documentation`, as requested.

I have done some testing locally, hopefully nothing has been broken.

Sort of progress towards #3170