### PR TITLE
Simplify i2c future

### DIFF
--- a/hil-test/tests/i2c.rs
+++ b/hil-test/tests/i2c.rs
@@ -69,23 +69,16 @@ mod tests {
     fn empty_write_returns_ack_error_for_unknown_address(mut ctx: Context) {
         // on some chips we can determine the ack-check-failed reason but not on all
         // chips
-        cfg_if::cfg_if! {
-            if #[cfg(any(esp32,esp32s2,esp32c2,esp32c3))] {
-                assert_eq!(
-                    ctx.i2c.write(NON_EXISTENT_ADDRESS, &[]),
-                    Err(Error::AcknowledgeCheckFailed(
-                        AcknowledgeCheckFailedReason::Unknown
-                    ))
-                );
-            } else {
-                assert_eq!(
-                    ctx.i2c.write(NON_EXISTENT_ADDRESS, &[]),
-                    Err(Error::AcknowledgeCheckFailed(
-                        AcknowledgeCheckFailedReason::Address
-                    ))
-                );
-            }
-        }
+        let reason = if cfg!(any(esp32, esp32s2, esp32c2, esp32c3)) {
+            AcknowledgeCheckFailedReason::Unknown
+        } else {
+            AcknowledgeCheckFailedReason::Address
+        };
+
+        assert_eq!(
+            ctx.i2c.write(NON_EXISTENT_ADDRESS, &[]),
+            Err(Error::AcknowledgeCheckFailed(reason))
+        );
 
         assert_eq!(ctx.i2c.write(DUT_ADDRESS, &[]), Ok(()));
     }
@@ -129,23 +122,14 @@ mod tests {
 
         // on some chips we can determine the ack-check-failed reason but not on all
         // chips
-        cfg_if::cfg_if! {
-            if #[cfg(any(esp32,esp32s2,esp32c2,esp32c3))] {
-                assert_eq!(
-                    i2c.write_async(NON_EXISTENT_ADDRESS, &[]).await,
-                    Err(Error::AcknowledgeCheckFailed(
-                        AcknowledgeCheckFailedReason::Unknown
-                    ))
-                );
-            } else {
-                assert_eq!(
-                    i2c.write_async(NON_EXISTENT_ADDRESS, &[]).await,
-                    Err(Error::AcknowledgeCheckFailed(
-                        AcknowledgeCheckFailedReason::Address
-                    ))
-                );
-            }
-        }
+        let reason = if cfg!(any(esp32, esp32s2, esp32c2, esp32c3)) {
+            AcknowledgeCheckFailedReason::Unknown
+        } else {
+            AcknowledgeCheckFailedReason::Address
+        };
+
+        let should_fail = i2c.write_async(NON_EXISTENT_ADDRESS, &[]).await;
+        assert_eq!(should_fail, Err(Error::AcknowledgeCheckFailed(reason)));
 
         assert_eq!(i2c.write_async(DUT_ADDRESS, &[]).await, Ok(()));
     }


### PR DESCRIPTION
I2cFuture enabled a single event bit, and listened for a single event bit to be disabled. However, in some places we are waiting for any one of two bits - but the way it's implemented, both of those futures get resolved at the same time, likely making the code less efficient by having 3 different futures.

This PR refactors the Future to use an EventSet to be more in line with other implementations.