### PR TITLE
Integrate pre-releases into bump-version

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -46,8 +46,18 @@ enum Cli {
 #[derive(Debug, Args)]
 struct BumpVersionArgs {
     /// How much to bump the version by.
+    ///
+    /// If the version is a pre-release, this will just remove the pre-release
+    /// version tag.
     #[arg(value_enum)]
     amount: Version,
+    /// Pre-release version to append to the version.
+    ///
+    /// If the package is already a pre-release, this will ignore `amount`. If
+    /// the package is not a pre-release, this will bump the version by
+    /// `amount` and append the pre-release version as `<pre>.0`.
+    #[arg(long)]
+    pre: Option<String>,
     /// Package(s) to target.
     #[arg(value_enum, default_values_t = Package::iter())]
     packages: Vec<Package>,
@@ -157,7 +167,7 @@ fn main() -> Result<()> {
 fn bump_version(workspace: &Path, args: BumpVersionArgs) -> Result<()> {
     // Bump the version by the specified amount for each given package:
     for package in args.packages {
-        xtask::bump_version(workspace, package, args.amount)?;
+        xtask::bump_version(workspace, package, args.amount, args.pre.as_deref())?;
     }
 
     Ok(())


### PR DESCRIPTION
cc #3438

With this PR we'll have the option to specify `--pre beta` (or any other dev tag, really) for the version bumps. The script matches the version and does the following:
- If the current version is not a pre-release, it'll bump version and add the tag (1.0.0 -> 1.1.0-dev.0)
- If the current version is a pre-release:
  - If `--pre` is set, it bumps the pre version, ignoring `amount`: (1.1.0-dev.0 -> 1.1.0-dev.1)
  - If `--pre` is not set, it ignores `amount` and just removes the pre-release tag: (1.1.0-dev.1 -> 1.1.0)