### PR TITLE
xtask: Tweak dependency updates

### DIFF
--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -9,6 +9,7 @@ use clap::ValueEnum;
 use esp_metadata::{Chip, Config};
 use semver::Prerelease;
 use strum::{Display, EnumIter, IntoEnumIterator as _};
+use toml_edit::{Item, Value};
 
 use crate::{cargo::CargoArgsBuilder, firmware::Metadata};
 
@@ -400,6 +401,8 @@ pub fn bump_version(
     manifest["package"]["version"] = toml_edit::value(version.to_string());
     fs::write(manifest_path, manifest.to_string())?;
 
+    let dependency_kinds = ["dependencies", "dev-dependencies", "build-dependencies"];
+
     for pkg in Package::iter() {
         let manifest_path = workspace.join(pkg.to_string()).join("Cargo.toml");
         let manifest = fs::read_to_string(&manifest_path)
@@ -407,23 +410,33 @@ pub fn bump_version(
 
         let mut manifest = manifest.parse::<toml_edit::DocumentMut>()?;
 
-        if manifest["dependencies"]
-            .as_table()
-            .unwrap()
-            .contains_key(&package.to_string())
-        {
-            log::info!(
-                "  Bumping {package} version for package {pkg}: ({prev_version} -> {version})"
-            );
+        let mut changed = false;
+        let package_name = package.to_string();
+        for dependency_kind in dependency_kinds {
+            let Some(table) = manifest[dependency_kind].as_table_mut() else {
+                continue;
+            };
+
+            let dependency = &mut table[package_name.as_str()];
 
             // Update dependencies which specify a version:
-            if let Some(table) = manifest["dependencies"].as_table_mut() {
-                if let Some(table) = table[&package.to_string()].as_table_mut() {
-                    if table.contains_key("version") {
-                        table["version"] = toml_edit::value(version.to_string());
-                    }
+            match dependency {
+                Item::Table(table) if table.contains_key("version") => {
+                    table["version"] = toml_edit::value(version.to_string());
+                    changed = true;
                 }
+                Item::Value(Value::InlineTable(table)) if table.contains_key("version") => {
+                    table["version"] = version.to_string().into();
+                    changed = true;
+                }
+                _ => continue,
             }
+        }
+
+        if changed {
+            log::info!(
+                "  Bumping {package_name} version for package {pkg}: ({prev_version} -> {version})"
+            );
 
             fs::write(&manifest_path, manifest.to_string())
                 .with_context(|| format!("Could not write {}", manifest_path.display()))?;

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -400,9 +400,7 @@ pub fn bump_version(
     manifest["package"]["version"] = toml_edit::value(version.to_string());
     fs::write(manifest_path, manifest.to_string())?;
 
-    for pkg in
-        Package::iter().filter(|p| ![package, Package::Examples, Package::HilTest].contains(p))
-    {
+    for pkg in Package::iter() {
         let manifest_path = workspace.join(pkg.to_string()).join("Cargo.toml");
         let manifest = fs::read_to_string(&manifest_path)
             .with_context(|| format!("Could not read {}", manifest_path.display()))?;

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -418,8 +418,13 @@ pub fn bump_version(
                 "  Bumping {package} version for package {pkg}: ({prev_version} -> {version})"
             );
 
+            // Update dependencies which specify a version:
             if let Some(table) = manifest["dependencies"].as_table_mut() {
-                table[&package.to_string()]["version"] = toml_edit::value(version.to_string());
+                if let Some(table) = table[&package.to_string()].as_table_mut() {
+                    if table.contains_key("version") {
+                        table["version"] = toml_edit::value(version.to_string());
+                    }
+                }
             }
 
             fs::write(&manifest_path, manifest.to_string())


### PR DESCRIPTION
This PR skips adding `version = ...` to dependencies that don't already specify a version. For example, bumping `esp-hal-embassy` will not add a version to qa-test's line: `esp-hal-embassy    = { path = "../esp-hal-embassy" }`

Also, this pr removes the filtering so that we bump versions for hil tests and examples, if relevant. The PR also implements bumping dev/build dependencies.