### PR TITLE
RMT: Minor cleanups, simplify address calculations, extend HIL test

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -67,6 +67,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- RMT: Return an error when trying create a channel with `memsize: 0` (#3477)
+- RMT: fix a potential hang on transmitting data with an embedded stop code (#3477)
 - RMT channel drop implementation bugfix where the channel was not released properly (#3496)
 - RMT now uses correct max filter threshold of 255 instead of 127 (#3192)
 - Full-duplex SPI works when mixed with half-duplex SPI (#3176)

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -1471,13 +1471,13 @@ fn async_interrupt_handler() {
         2 => Channel::<Async, 2>::unlisten_interrupt(Event::End | Event::Error),
         3 => Channel::<Async, 3>::unlisten_interrupt(Event::End | Event::Error),
 
-        #[cfg(any(esp32, esp32s3))]
+        #[cfg(esp32s3)]
         4 => Channel::<Async, 4>::unlisten_interrupt(Event::End | Event::Error),
-        #[cfg(any(esp32, esp32s3))]
+        #[cfg(esp32s3)]
         5 => Channel::<Async, 5>::unlisten_interrupt(Event::End | Event::Error),
-        #[cfg(any(esp32, esp32s3))]
+        #[cfg(esp32s3)]
         6 => Channel::<Async, 6>::unlisten_interrupt(Event::End | Event::Error),
-        #[cfg(any(esp32, esp32s3))]
+        #[cfg(esp32s3)]
         7 => Channel::<Async, 7>::unlisten_interrupt(Event::End | Event::Error),
 
         _ => unreachable!(),
@@ -1514,17 +1514,17 @@ fn async_interrupt_handler() {
             <Channel<Async, 4> as TxChannelInternal>::unlisten_interrupt(Event::End | Event::Error);
             <Channel<Async, 4> as RxChannelInternal>::unlisten_interrupt(Event::End | Event::Error);
         }
-        #[cfg(any(esp32, esp32s3))]
+        #[cfg(esp32)]
         5 => {
             <Channel<Async, 5> as TxChannelInternal>::unlisten_interrupt(Event::End | Event::Error);
             <Channel<Async, 5> as RxChannelInternal>::unlisten_interrupt(Event::End | Event::Error);
         }
-        #[cfg(any(esp32, esp32s3))]
+        #[cfg(esp32)]
         6 => {
             <Channel<Async, 6> as TxChannelInternal>::unlisten_interrupt(Event::End | Event::Error);
             <Channel<Async, 6> as RxChannelInternal>::unlisten_interrupt(Event::End | Event::Error);
         }
-        #[cfg(any(esp32, esp32s3))]
+        #[cfg(esp32)]
         7 => {
             <Channel<Async, 7> as TxChannelInternal>::unlisten_interrupt(Event::End | Event::Error);
             <Channel<Async, 7> as RxChannelInternal>::unlisten_interrupt(Event::End | Event::Error);

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -2358,6 +2358,11 @@ mod chip_specific {
                 fn start_tx() {
                     let rmt = crate::peripherals::RMT::regs();
 
+                    for i in 0..Self::memsize() {
+                        rmt.chconf1(($ch_num + i).into())
+                            .modify(|_, w| w.mem_owner().clear_bit());
+                    }
+
                     rmt.chconf1($ch_num).modify(|_, w| {
                         w.mem_rd_rst().set_bit();
                         w.apb_mem_rst().set_bit();

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -460,7 +460,7 @@ impl crate::interrupt::InterruptConfigurable for Rmt<'_, Blocking> {
 // because subsequent channels are in use so that we can't reserve the RAM),
 // restore all state and return with an error.
 fn reserve_channel(channel: u8, state: RmtState, memsize: u8) -> Result<(), Error> {
-    if memsize > NUM_CHANNELS as u8 - channel {
+    if memsize == 0 || memsize > NUM_CHANNELS as u8 - channel {
         return Err(Error::InvalidMemsize);
     }
 

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -1600,11 +1600,12 @@ pub trait TxChannelInternal {
 
         let ptr = channel_ram_start(Self::CHANNEL);
         let memsize = constants::RMT_CHANNEL_RAM_SIZE * Self::memsize() as usize;
-        for (idx, entry) in data.iter().take(memsize).enumerate() {
-            unsafe {
-                ptr.add(idx).write_volatile(*entry);
-            }
-        }
+        let written = data
+            .iter()
+            .take(memsize)
+            .enumerate()
+            .map(|(idx, entry)| unsafe { ptr.add(idx).write_volatile(*entry) })
+            .count();
 
         Self::set_threshold((memsize / 2) as u8);
         Self::set_continuous(continuous);
@@ -1614,11 +1615,7 @@ pub trait TxChannelInternal {
         Self::start_tx();
         Self::update();
 
-        if data.len() >= memsize {
-            Ok(memsize)
-        } else {
-            Ok(data.len())
-        }
+        Ok(written)
     }
 
     fn stop();

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -2134,11 +2134,12 @@ mod chip_specific {
                 fn start_rx() {
                     let rmt = crate::peripherals::RMT::regs();
 
-                    for i in 0..Self::memsize() {
+                    for i in 1..Self::memsize() {
                         rmt.ch_rx_conf1(($ch_index + i).into())
                             .modify(|_, w| w.mem_owner().set_bit());
                     }
                     rmt.ch_rx_conf1($ch_index).modify(|_, w| {
+                        w.mem_owner().set_bit();
                         w.mem_wr_rst().set_bit();
                         w.apb_mem_rst().set_bit();
                         w.rx_en().set_bit()
@@ -2359,12 +2360,13 @@ mod chip_specific {
                 fn start_tx() {
                     let rmt = crate::peripherals::RMT::regs();
 
-                    for i in 0..Self::memsize() {
+                    for i in 1..Self::memsize() {
                         rmt.chconf1(($ch_num + i).into())
                             .modify(|_, w| w.mem_owner().clear_bit());
                     }
 
                     rmt.chconf1($ch_num).modify(|_, w| {
+                        w.mem_owner().clear_bit();
                         w.mem_rd_rst().set_bit();
                         w.apb_mem_rst().set_bit();
                         w.tx_start().set_bit()
@@ -2506,12 +2508,13 @@ mod chip_specific {
                 fn start_rx() {
                     let rmt = crate::peripherals::RMT::regs();
 
-                    for i in 0..Self::memsize() {
+                    for i in 1..Self::memsize() {
                         rmt.chconf1(($ch_num + i).into())
                             .modify(|_, w| w.mem_owner().set_bit());
                     }
 
                     rmt.chconf1($ch_num).modify(|_, w| {
+                        w.mem_owner().set_bit();
                         w.mem_wr_rst().set_bit();
                         w.apb_mem_rst().set_bit();
                         w.rx_en().set_bit()

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -364,7 +364,7 @@ impl Default for TxChannelConfig {
             carrier_high: Default::default(),
             carrier_low: Default::default(),
             carrier_level: Level::Low,
-            memsize: 1u8,
+            memsize: 1,
         }
     }
 }

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -2460,14 +2460,6 @@ mod chip_specific {
                 fn clear_interrupts() {
                     let rmt = crate::peripherals::RMT::regs();
 
-                    rmt.chconf1($ch_num).modify(|_, w| {
-                        w.mem_wr_rst().set_bit();
-                        w.apb_mem_rst().set_bit();
-                        w.mem_owner().set_bit();
-                        w.rx_en().clear_bit()
-                    });
-                    Self::update();
-
                     rmt.int_clr().write(|w| {
                         w.ch_rx_end($ch_num).set_bit();
                         w.ch_err($ch_num).set_bit();

--- a/hil-test/tests/rmt.rs
+++ b/hil-test/tests/rmt.rs
@@ -6,120 +6,204 @@
 #![no_std]
 #![no_main]
 
+use core::fmt::Debug;
+
 use esp_hal::{
-    gpio::Level,
-    rmt::{PulseCode, Rmt, RxChannel, RxChannelConfig, TxChannel, TxChannelConfig},
+    gpio::{Level, NoPin},
+    rmt::{Error, PulseCode, Rmt, RxChannel, RxChannelConfig, TxChannel, TxChannelConfig},
     time::Rate,
 };
 use hil_test as _;
 
+cfg_if::cfg_if! {
+    if #[cfg(esp32h2)] {
+        const FREQ: Rate = Rate::from_mhz(32);
+        const DIV: u8 = 64;
+    } else {
+        const FREQ: Rate = Rate::from_mhz(80);
+        const DIV: u8 = 160;
+    }
+}
+
+fn setup(
+    tx_config: TxChannelConfig,
+    rx_config: RxChannelConfig,
+) -> (impl TxChannel + Debug, impl RxChannel + Debug) {
+    let peripherals = esp_hal::init(esp_hal::Config::default());
+
+    let rmt = Rmt::new(peripherals.RMT, FREQ).unwrap();
+
+    let (rx, tx) = hil_test::common_test_pins!(peripherals);
+
+    let tx_channel = {
+        use esp_hal::rmt::TxChannelCreator;
+        rmt.channel0
+            .configure(tx, tx_config.with_clk_divider(DIV))
+            .unwrap()
+    };
+
+    cfg_if::cfg_if! {
+        if #[cfg(any(esp32, esp32s3))] {
+            let rx_channel_creator = rmt.channel4;
+        } else {
+            let rx_channel_creator = rmt.channel2;
+        }
+    };
+    let rx_channel = {
+        use esp_hal::rmt::RxChannelCreator;
+        rx_channel_creator
+            .configure(rx, rx_config.with_clk_divider(DIV))
+            .unwrap()
+    };
+
+    (tx_channel, rx_channel)
+}
+
+fn generate_tx_data<const TX_LEN: usize>(write_end_marker: bool) -> [u32; TX_LEN] {
+    let mut tx_data: [_; TX_LEN] = core::array::from_fn(|i| {
+        PulseCode::new(Level::High, (100 + (i * 10) % 200) as u16, Level::Low, 50)
+    });
+
+    if write_end_marker {
+        tx_data[TX_LEN - 2] = PulseCode::new(Level::High, 3000, Level::Low, 500);
+        tx_data[TX_LEN - 1] = PulseCode::empty();
+    }
+
+    tx_data
+}
+
+// Run a test where some data is sent from one channel and looped back to
+// another one for receive, and verify that the data matches.
+fn do_rmt_loopback<const TX_LEN: usize>(tx_memsize: u8, rx_memsize: u8, wait_tx_first: bool) {
+    let tx_config = TxChannelConfig::default().with_memsize(tx_memsize);
+    let rx_config = RxChannelConfig::default()
+        .with_idle_threshold(1000)
+        .with_memsize(rx_memsize);
+
+    let (tx_channel, rx_channel) = setup(tx_config, rx_config);
+
+    let tx_data: [_; TX_LEN] = generate_tx_data(true);
+    let mut rcv_data: [u32; TX_LEN] = [PulseCode::empty(); TX_LEN];
+
+    let rx_transaction = rx_channel.receive(&mut rcv_data).unwrap();
+    let tx_transaction = tx_channel.transmit(&tx_data).unwrap();
+
+    if wait_tx_first {
+        tx_transaction.wait().unwrap();
+        rx_transaction.wait().unwrap();
+    } else {
+        rx_transaction.wait().unwrap();
+        tx_transaction.wait().unwrap();
+    }
+
+    // the last two pulse-codes are the ones which wait for the timeout so
+    // they can't be equal
+    assert_eq!(&tx_data[..TX_LEN - 2], &rcv_data[..TX_LEN - 2]);
+}
+
+// Run a test that just sends some data, without trying to recive it.
+#[must_use = "Tests should fail on errors"]
+fn do_rmt_single_shot<const TX_LEN: usize>(
+    tx_memsize: u8,
+    write_end_marker: bool,
+) -> Result<(), Error> {
+    let tx_config = TxChannelConfig::default()
+        .with_clk_divider(DIV)
+        .with_memsize(tx_memsize);
+    let (tx_channel, _) = setup(tx_config, Default::default());
+
+    let tx_data: [_; TX_LEN] = generate_tx_data(write_end_marker);
+
+    tx_channel.transmit(&tx_data)?.wait().map_err(|(e, _)| e)?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 #[embedded_test::tests(default_timeout = 1)]
 mod tests {
-    use esp_hal::rmt::Error;
-
     use super::*;
 
     #[init]
     fn init() {}
 
     #[test]
-    fn rmt_loopback() {
-        let peripherals = esp_hal::init(esp_hal::Config::default());
+    fn rmt_loopback_simple() {
+        // 20 codes fit a single RAM block
+        do_rmt_loopback::<20>(1, 1, false);
+    }
 
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "esp32h2")] {
-                let freq = Rate::from_mhz(32);
-            } else {
-                let freq = Rate::from_mhz(80);
-            }
-        };
+    #[test]
+    fn rmt_loopback_extended_ram() {
+        // 80 codes require two RAM blocks
+        do_rmt_loopback::<80>(2, 2, false);
+    }
 
-        let rmt = Rmt::new(peripherals.RMT, freq).unwrap();
+    // FIXME: This test currently fails on esp32 with an rmt::Error::ReceiverError,
+    // which should imply a receiver overrun, which is unexpected (the buffer
+    // should hold 2 * 64 codes, which is sufficient).
+    // However, the problem already exists exists in the original code that added
+    // support for extended channel RAM, so we can't bisect to find a
+    // regression. Skip the test for now.
+    #[cfg(not(esp32))]
+    #[test]
+    fn rmt_loopback_tx_wrap() {
+        // 80 codes require two RAM blocks; thus a tx channel with only 1 block requires
+        // wrapping. We need to .wait() on the tx transaction first to handle
+        // this.
+        do_rmt_loopback::<80>(1, 2, true);
+    }
 
-        let (rx, tx) = hil_test::common_test_pins!(peripherals);
+    // FIXME: This test can't work right now, because wrapping rx is not
+    // implemented.
+    //
+    // #[test]
+    // fn rmt_loopback_rx_wrap() {
+    //     // 80 codes require two RAM blocks; thus an rx channel with only 1 block
+    //     // requires wrapping
+    //     do_rmt_loopback<80>(2, 1, false);
+    // }
 
-        let tx_config = TxChannelConfig::default().with_clk_divider(255);
+    #[test]
+    fn rmt_single_shot_wrap() {
+        // Single RAM block (48 or 64 codes), requires wrapping
+        do_rmt_single_shot::<80>(1, true).unwrap();
+    }
 
-        let tx_channel = {
-            use esp_hal::rmt::TxChannelCreator;
-            rmt.channel0.configure(tx, tx_config).unwrap()
-        };
+    #[test]
+    fn rmt_single_shot_extended() {
+        // Two RAM blocks (96 or 128 codes), no wrapping
+        do_rmt_single_shot::<80>(2, true).unwrap();
+    }
 
-        let rx_config = RxChannelConfig::default()
-            .with_clk_divider(255)
-            .with_idle_threshold(1000);
-
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "esp32")] {
-                let  rx_channel = {
-                    use esp_hal::rmt::RxChannelCreator;
-                    rmt.channel1.configure(rx, rx_config).unwrap()
-                };
-            } else if #[cfg(feature = "esp32s2")] {
-                let rx_channel = {
-                    use esp_hal::rmt::RxChannelCreator;
-                    rmt.channel1.configure(rx, rx_config).unwrap()
-                };
-            } else if #[cfg(feature = "esp32s3")] {
-                let  rx_channel = {
-                    use esp_hal::rmt::RxChannelCreator;
-                    rmt.channel7.configure(rx, rx_config).unwrap()
-                };
-            } else {
-                let  rx_channel = {
-                    use esp_hal::rmt::RxChannelCreator;
-                    rmt.channel2.configure(rx, rx_config).unwrap()
-                };
-            }
-        }
-
-        let mut tx_data = [PulseCode::new(Level::High, 200, Level::Low, 50); 20];
-
-        tx_data[tx_data.len() - 2] = PulseCode::new(Level::High, 3000, Level::Low, 500);
-        tx_data[tx_data.len() - 1] = PulseCode::empty();
-
-        let mut rcv_data: [u32; 20] = [PulseCode::empty(); 20];
-
-        let rx_transaction = rx_channel.receive(&mut rcv_data).unwrap();
-        let tx_transaction = tx_channel.transmit(&tx_data).unwrap();
-
-        rx_transaction.wait().unwrap();
-        tx_transaction.wait().unwrap();
-
-        // the last two pulse-codes are the ones which wait for the timeout so
-        // they can't be equal
-        assert_eq!(&tx_data[..18], &rcv_data[..18]);
+    #[test]
+    fn rmt_single_shot_extended_wrap() {
+        // Two RAM blocks (96 or 128 codes), requires wrapping
+        do_rmt_single_shot::<150>(2, true).unwrap();
     }
 
     #[test]
     fn rmt_single_shot_fails_without_end_marker() {
+        let result = do_rmt_single_shot::<20>(1, false);
+
+        assert!(matches!(result, Err(Error::EndMarkerMissing)));
+    }
+
+    #[test]
+    fn rmt_overlapping_ram_fails() {
+        use esp_hal::rmt::TxChannelCreator;
+
         let peripherals = esp_hal::init(esp_hal::Config::default());
 
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "esp32h2")] {
-                let freq = Rate::from_mhz(32);
-            } else {
-                let freq = Rate::from_mhz(80);
-            }
-        };
+        let rmt = Rmt::new(peripherals.RMT, FREQ).unwrap();
 
-        let rmt = Rmt::new(peripherals.RMT, freq).unwrap();
+        let ch0 = rmt
+            .channel0
+            .configure(NoPin, TxChannelConfig::default().with_memsize(2));
 
-        let (_, tx) = hil_test::common_test_pins!(peripherals);
+        let ch1 = rmt.channel1.configure(NoPin, TxChannelConfig::default());
 
-        let tx_config = TxChannelConfig::default().with_clk_divider(255);
-
-        let tx_channel = {
-            use esp_hal::rmt::TxChannelCreator;
-            rmt.channel0.configure(tx, tx_config).unwrap()
-        };
-
-        let tx_data = [PulseCode::new(Level::High, 200, Level::Low, 50); 20];
-
-        let tx_transaction = tx_channel.transmit(&tx_data);
-
-        assert!(tx_transaction.is_err());
-        assert!(matches!(tx_transaction, Err(Error::EndMarkerMissing)));
+        assert!(ch0.is_ok());
+        assert!(matches!(ch1, Err(Error::MemoryBlockNotAvailable)));
     }
 }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖
Various refactorings of the RMT driver that make it more readable (in my opinion) or improve error handling in edge cases.

This touches quite a bit of code, but it should be fairly easy to review commit-by-commit. Let me know if I should split this into several PRs.

#### Description
This contains
- A few minor cleanups (mostly related to `cfg` attributes).
- Simplifications to address calculations: This should make the code much more readable.
- Fixes to a few edge cases of the code.
- Extensions to the HIL test such that they should cover more code paths of the RMT driver, in particular regarding wrapping of the buffer and the recently introduced extended channel RAM support.

For details, see the individual commit messages.

Note that I disabled one of the newly added HIL tests on `esp32`: It fails in CI, and I couldn't easily figure out why (from a quick glance at the idf code and the TRM). However, it appears that this failure is not a result of any change in this PR: In https://github.com/esp-rs/esp-hal/pull/3484, I pushed a branch which contains `main` just before merging https://github.com/esp-rs/esp-hal/pull/3453 with a single additional commit which adds the tests from this PR, but leaves the driver untouched. Thus, the failure already existed after https://github.com/esp-rs/esp-hal/pull/3292. (Since it involves using a channel with more than 1 block of the RAM, the test can't be run before that PR. The underlying issue might have been around before.)

There should be no user-visible changes.

#### Testing
Build-tested esp32c3, no tests on real hardware except for CI.
