### PR TITLE
xtask: Bump version in changelog, add check-changelog

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -188,3 +188,6 @@ jobs:
           changeLogPath: xtensa-lx-rt/CHANGELOG.md
           skipLabels: "skip-changelog"
           missingUpdateErrorMessage: "Please add a changelog entry in the xtensa-lx-rt/CHANGELOG.md file."
+
+      - name: Changelog format check
+        run: cargo xtask check-changelog

--- a/esp-alloc/CHANGELOG.md
+++ b/esp-alloc/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
 
 ### Added
 
@@ -13,12 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `AnyMemory`, `InternalMemory`, `ExternalMemory` allocators. (#3318)
 
 ### Changed
+
 - Bump Rust edition to 2024, bump MSRV to 1.85. (#3391)
 - Update `defmt` to 1.0 (#3416)
 
 ### Fixed
 
+
 ### Removed
+
 
 ## [0.7.0] - 2025-02-24
 
@@ -57,3 +60,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.1.0 - 2022-07-25
 
 [0.7.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-alloc-v0.7.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-alloc-v0.7.0...HEAD

--- a/esp-backtrace/CHANGELOG.md
+++ b/esp-backtrace/CHANGELOG.md
@@ -46,18 +46,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.14.1 - 2024-09-06
 
-### Added
-
-
 ### Changed
 
 - Print a more helpful message in case of a `Cp0Disabled` exception (#2061)
-
-### Fixed
-
-
-### Removed
-
 
 ## 0.14.0 - 2024-08-29
 

--- a/esp-backtrace/CHANGELOG.md
+++ b/esp-backtrace/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
 
 ### Added
 
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ESP32/S2/S3: Fixed an issue where the backtrace wasn't correctly captured in some cases (#3272)
 
 ### Removed
+
 
 ## [0.15.1] - 2025-02-24
 
@@ -47,13 +48,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+
 ### Changed
 
 - Print a more helpful message in case of a `Cp0Disabled` exception (#2061)
 
 ### Fixed
 
+
 ### Removed
+
 
 ## 0.14.0 - 2024-08-29
 
@@ -66,8 +70,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve panic message printing (#1823)
 
 ## 0.13.0 - 2024-07-16
-
-No changes - published to avoid conflicts with `esp-println`
 
 ## 0.12.2 - 2024-07-15
 
@@ -83,3 +85,4 @@ No changes - published to avoid conflicts with `esp-println`
 - Only prints float registers on targets which have them. (#1690)
 
 [0.15.1]: https://github.com/esp-rs/esp-hal/releases/tag/esp-backtrace-v0.15.1
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-backtrace-v0.15.1...HEAD

--- a/esp-bootloader-esp-idf/CHANGELOG.md
+++ b/esp-bootloader-esp-idf/CHANGELOG.md
@@ -5,14 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
 
 ### Added
 
 - Support ESP-IDF app descriptor (#3281)
-
 - Support reading partition tables and conveniently read/write partition content (#3316)
-
 - OTA-DATA partition support (#3354)
 
 ### Changed
@@ -22,5 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+
 ### Removed
+
 

--- a/esp-build/CHANGELOG.md
+++ b/esp-build/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
 ### Added
+
 
 ### Changed
 
@@ -15,17 +16,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+
 ### Removed
 
-## 0.2.0 - 2025-01-15
+
+## [0.2.0] - 2025-01-15
 
 ### Changed
 
-- Use `panic` instead of `process::exit` in esp-build (#2402 )
+- Use `panic` instead of `process::exit` in esp-build (#2402)
 - Bump MSRV to 1.84 (#2951)
 
-## [0.1.0] - 2024-04-17
+## 0.1.0 - 2024-04-17
 
-- Initial release
+### Added
 
-[Unreleased]: https://github.com/esp-rs/esp-hal/commits/main/esp-build?since=2025-01-15
+- Initial release (#2518)
+
+[0.2.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-build-v0.2.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-build-v0.2.0...HEAD

--- a/esp-config/CHANGELOG.md
+++ b/esp-config/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
 
 ### Added
 
@@ -21,11 +21,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+
 ### Removed
+
 
 ## [0.3.1] - 2025-02-24
 
-- `Enumeration` validator added
+### Added
+
+- `Enumeration` validator added (#3172)
 
 ## 0.3.0 - 2025-01-15
 
@@ -46,6 +50,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.1.0 - 2024-10-10
 
-- Initial release
+### Added
+
+- Initial release (#2518)
 
 [0.3.1]: https://github.com/esp-rs/esp-hal/releases/tag/esp-config-v0.3.1
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-config-v0.3.1...HEAD

--- a/esp-hal-embassy/CHANGELOG.md
+++ b/esp-hal-embassy/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
 
 ### Added
 
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a panic on very long wakeup times (#3433)
 
 ### Removed
+
 
 ## [0.7.0] - 2025-02-24
 
@@ -66,7 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Reduce memory footprint by 4 bytes on multi-core MCUs.
+- Reduce memory footprint by 4 bytes on multi-core MCUs. (#2377)
 - The time driver no longer uses cross-core critical sections. (#2559)
 
 ### Fixed
@@ -74,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Alarm interrupts are now handled on the core that allocated them. (For executors created on the second core after calling `esp_hal_embassy::init`) (#2451)
 
 ### Removed
+
 
 ## 0.4.0 - 2024-10-10
 
@@ -110,3 +112,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.1.0 - 2024-06-04
 
 [0.7.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-hal-embassy-v0.7.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-hal-embassy-v0.7.0...HEAD

--- a/esp-hal-embassy/CHANGELOG.md
+++ b/esp-hal-embassy/CHANGELOG.md
@@ -74,9 +74,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Alarm interrupts are now handled on the core that allocated them. (For executors created on the second core after calling `esp_hal_embassy::init`) (#2451)
 
-### Removed
-
-
 ## 0.4.0 - 2024-10-10
 
 ### Changed

--- a/esp-hal-procmacros/CHANGELOG.md
+++ b/esp-hal-procmacros/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
 
 ### Added
+
 
 ### Changed
 
@@ -16,7 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+
 ### Removed
+
 
 ## [0.17.0] - 2025-02-24
 
@@ -28,9 +31,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+
 ### Fixed
 
+
 ### Removed
+
 
 ## 0.16.0 - 2025-01-15
 
@@ -81,6 +87,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.1.0 - 2022-08-25
 
-- Initial release
+### Added
+
+- Initial release (#2518)
 
 [0.17.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-hal-procmacros-v0.17.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-hal-procmacros-v0.17.0...HEAD

--- a/esp-hal-procmacros/CHANGELOG.md
+++ b/esp-hal-procmacros/CHANGELOG.md
@@ -29,15 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `#[builder_lite(skip_setter)]` and `#[builder_lite(skip_getter)]` attribute to skip generating setters or getters (#3011)
 - Added `#[builder_lite(skip)]` to ignore a field completely (#3011)
 
-### Changed
-
-
-### Fixed
-
-
-### Removed
-
-
 ## 0.16.0 - 2025-01-15
 
 ### Added

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -878,9 +878,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ESP32/ESP32-S2/ESP32-S3: Fix embassy-time-timg0 driver (#1091)
 - ESP32: ADC readings are no longer inverted (#1093)
 
-### Removed
-
-
 ## [0.14.1] - 2023-12-13
 
 ### Fixed

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -98,7 +98,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `Flex::{set_as_input, set_as_output, set_drive_strength, set_as_open_drain, pull_direction}` functions (#3387)
 - The `Efuse::read_field_be` function has been removed (#3440)
 
-## v1.0.0-beta.0 - 2025-02-24
+## [v1.0.0-beta.0] - 2025-02-24
 
 ### Added
 
@@ -417,7 +417,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Io::new_with_priority` and `Io::new_no_bind_interrupt`. (#2486)
 - `parl_io::{no_clk_pin(), NoClkPin}` (#2531)
 - Removed `get_core` function in favour of `Cpu::current` (#2533)
-
 - Removed `uart::Config` setters and `symbol_length`. (#2847)
 
 ## [0.21.1]
@@ -480,7 +479,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `NO_PIN` constant has been removed. (#2133)
 - MSRV bump to 1.79 (#2156)
 - Allow handling interrupts while trying to lock critical section on multi-core chips. (#2197)
-- Migrate `Camera` to a move based API (#2242).
+- Migrate `Camera` to a move based API (#2242)
 - Removed the PS-RAM related features, replaced by `quad-psram`/`octal-psram`, `init_psram` takes a configuration parameter, it's now possible to auto-detect PS-RAM size (#2178)
 - `EspTwaiFrame` constructors now accept any type that converts into `esp_hal::twai::Id` (#2207)
 - Change `DmaTxBuf` to support PSRAM on `esp32s3` (#2161)
@@ -557,7 +556,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `debugger::debugger_connected`. (#1961)
 - DMA: don't require `Sealed` to implement `ReadBuffer` and `WriteBuffer` (#1921)
 - Allow DMA to/from psram for esp32s3 (#1827)
-- Added missing methods to `SpiDmaBus` (#2016).
+- Added missing methods to `SpiDmaBus` (#2016)
 - PARL_IO use ReadBuffer and WriteBuffer for Async DMA (#1996)
 
 ### Changed
@@ -723,7 +722,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Reserve `esp32` ROM stacks to prevent the trashing of dram2 section (#1289)
 - Fixing `esp-wifi` + `TRNG` issue on `ESP32-S2` (#1272)
-- Fixed core1 startup using the wrong stack on the esp32 and esp32s3 (#1286).
+- Fixed core1 startup using the wrong stack on the esp32 and esp32s3 (#1286)
 - ESP32: Apply fix for Errata 3.6 in all the places necessary. (#1315)
 - ESP32 & ESP32-S2: Fix I²C frequency (#1306)
 - UART's TX/RX FIFOs are now cleared during initialization (#1344)
@@ -834,20 +833,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ESP32-S3: Configure 32k ICACHE (#1169)
 - Lift the minimal buffer size requirement for I2S (#1189)
 - Replaced `SystemTimer::TICKS_PER_SEC` with `SystemTimer::ticks_per_sec()` (#1981)
-
-### Removed
-
-- Remove `xtal-26mhz` and `xtal-40mhz` features (#1165)
-- All chip-specific HAL packages have been removed (#1196)
-
-### Breaking
-
 - `ADC` and `DAC` drivers now take virtual peripherals in their constructors, instead of splitting `APB_SARADC`/`SENS` (#1100)
 - The `DAC` driver's constructor is now `new` instead of `dac`, to be more consistent with other APIs (#1100)
 - The DMA peripheral is now called `Dma` for devices with both PDMA and GDMA controllers (#1125)
 - The `ADC` driver's constructor is now `new` instead of `adc`, to be more consistent with other APIs (#1133)
 - `embassy-executor`'s `integrated-timers` is no longer enabled by default. (#1196)
 - Renamed `embassy-time-systick` to `embassy-time-systick-16mhz` for use with all chips with a systimer, except `esp32s2`. Added `embassy-time-systick-80mhz` specifically for the `esp32s2`. (#1247)
+
+### Removed
+
+- Remove `xtal-26mhz` and `xtal-40mhz` features (#1165)
+- All chip-specific HAL packages have been removed (#1196)
 
 ## [0.15.0] - 2024-01-19
 
@@ -860,7 +856,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `embedded-io` feature to each chip-specific HAL (#1072)
 - Add `embassy-time-driver` to `esp-hal-common` due to updating `embassy-time` to `v0.3.0` (#1075)
 - ESP32-S3: Added support for 80Mhz PSRAM (#1069)
-- ESP32-C3/S3: Add workaround for USB pin exchange on usb-serial-jtag (#1104).
+- ESP32-C3/S3: Add workaround for USB pin exchange on usb-serial-jtag (#1104)
 - ESP32C6: Added LP_UART initialization (#1113)
 - Add `place-spi-driver-in-ram` feature to `esp-hal-common` (#1096)
 
@@ -871,6 +867,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `embassy-time` to `0.3.0` and embassy-executor to `0.5.0` release due to the release of the `embedded-hal-*` packages (#1075)
 - No longer depend on `embassy-time` (#1092)
 - Update to latest `smart-leds-trait` and `smart-leds` packages (#1094)
+- Unify the low-power peripheral names (`RTC_CNTL` and `LP_CLKRST` to `LPWR`) (#1064)
 
 ### Fixed
 
@@ -883,9 +880,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-### Breaking
-
-- Unify the low-power peripheral names (`RTC_CNTL` and `LP_CLKRST` to `LPWR`) (#1064)
 
 ## [0.14.1] - 2023-12-13
 
@@ -921,7 +915,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ESP32-S2/S3: Don't require GPIO 18 to create a USB peripheral driver instance (#990)
 - Updated to latest release candidate (`1.0.0-rc.2`) for `embedded-hal{-async,-nb}` (#994)
 - Explicit panic when hitting the `DefaultHandler` (#1005)
-- Relevant interrupts are now auto enabled in `embassy::init` (#1014).
+- Relevant interrupts are now auto enabled in `embassy::init` (#1014)
+- `Spi::new`/`Spi::new_half_duplex` takes no gpio pin now, instead you need to call `with_pins` to setup those (#901)
+- ESP32-C2, ESP32-C3, ESP32-S2: atomic emulation trap has been removed. (#904, #985)
 
 ### Fixed
 
@@ -940,17 +936,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Direct boot support has been removed (#903).
+- Direct boot support has been removed (#903)
 - Removed the `mcu-boot` feature from `esp32c3-hal` (#938)
 - Removed SpiBusController and SpiBusDevice in favour of embedded-hal-bus and embassy-embedded-hal implementataions. (#978)
-
-### Breaking
-
-- `Spi::new`/`Spi::new_half_duplex` takes no gpio pin now, instead you need to call `with_pins` to setup those (#901).
-- ESP32-C2, ESP32-C3, ESP32-S2: atomic emulation trap has been removed. (#904, #985)
-  - When upgrading you must either remove [these lines](https://github.com/esp-rs/riscv-atomic-emulation-trap#usage) from your `.cargo/config.toml`.
-  - Usage of `core::sync::atomic::*` in dependent crates should be replaced with [portable-atomic](https://github.com/taiki-e/portable-atomic).
-- RSA driver now takes `u32` words instead of `u8` bytes. The expected slice length is now 4 times shorter. (#981)
 
 ## [0.13.1] - 2023-11-02
 
@@ -975,7 +963,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ETM driver, GPIO ETM (#819)
 - (G)DMA AES support (#821)
 - SYSTIMER ETM functionality (#828)
-- Adding async support for RSA peripheral(doesn't work properly for `esp32` chip - issue will be created)(#790)
+- Adding async support for RSA peripheral(doesn't work properly for `esp32` chip - issue will be created) (#790)
 - Added sleep support for ESP32-C3 with timer and GPIO wakeups (#795)
 - Support for ULP-RISCV including Delay and GPIO (#840, #845)
 - Add bare-bones SPI slave support, DMA only (#580, #843)
@@ -990,6 +978,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bumped MSRV to 1.67 (#798)
 - Optimised multi-core critical section implementation (#797)
 - Changed linear- and curve-calibrated ADC to provide readings in mV (#836)
+- `Uart::new` now takes the `&Clocks` struct to ensure baudrate is correct for CPU/APB speed. (#808)
+- `Uart::new_with_config` takes an `Config` instead of `Option<Config>`. (#808)
+- `Alarm::set_period` takes a period (duration) instead of a frequency (#812)
+- `Alarm::interrupt_clear` is now `Alarm::clear_interrupt` to be consistent (#812)
+- The `PeripheralClockControl` struct is no longer public, drivers no longer take this as a parameter (#817)
+- Unify the system peripheral, `SYSTEM`, `DPORT` and `PCR` are now all exposed as `SYSTEM` (#832)
+- Unified the ESP32's and ESP32-C2's xtal frequency features (#831)
+- Replace any underscores in feature names with dashes (#833)
+- The `spi` and `spi_slave` modules have been refactored into the `spi`, `spi::master`, and `spi::slave` modules (#843)
+- The `WithDmaSpi2`/`WithDmaSpi3` structs are no longer generic around the inner peripheral type (#853)
+- The `SarAdcExt`/`SensExt` traits are now collectively named `AnalogExt` instead (#857)
+- Replace the `radio` module with peripheral singleton structs (#852)
+- The SPI traits are no longer re-exported in the main prelude, but from preludes in `spi::master`/`spi::slave` instead (#860)
+- The `embedded-hal-1` and `embedded-hal-async` traits are no longer re-exported in the prelude (#860)
 
 ### Fixed
 
@@ -998,7 +1000,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Xtensa targets: Use ESP32Reset - not Reset (#823)
 - Examples should now work with the `defmt` feature (#810)
 - Fixed a race condition causing SpiDma to stop working unexpectedly (#869)
-- Fixed async uart serial, and updated the embassy_serial examples (#871).
+- Fixed async uart serial, and updated the embassy_serial examples (#871)
 - Fix ESP32-S3 direct-boot (#873)
 - Fix ESP32-C6 ADC (#876)
 - Fix ADC Calibration not being used on ESP32-S2 and ESP32-S3 (#1000)
@@ -1012,23 +1014,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Pin::enable_hold` (#793)
 - Removed the generic return type for ADC reads (#792)
 
-### Breaking
-
-- `Uart::new` now takes the `&Clocks` struct to ensure baudrate is correct for CPU/APB speed. (#808)
-- `Uart::new_with_config` takes an `Config` instead of `Option<Config>`. (#808)
-- `Alarm::set_period` takes a period (duration) instead of a frequency (#812)
-- `Alarm::interrupt_clear` is now `Alarm::clear_interrupt` to be consistent (#812)
-- The `PeripheralClockControl` struct is no longer public, drivers no longer take this as a parameter (#817)
-- Unify the system peripheral, `SYSTEM`, `DPORT` and `PCR` are now all exposed as `SYSTEM` (#832).
-- Unified the ESP32's and ESP32-C2's xtal frequency features (#831)
-- Replace any underscores in feature names with dashes (#833)
-- The `spi` and `spi_slave` modules have been refactored into the `spi`, `spi::master`, and `spi::slave` modules (#843)
-- The `WithDmaSpi2`/`WithDmaSpi3` structs are no longer generic around the inner peripheral type (#853)
-- The `SarAdcExt`/`SensExt` traits are now collectively named `AnalogExt` instead (#857)
-- Replace the `radio` module with peripheral singleton structs (#852)
-- The SPI traits are no longer re-exported in the main prelude, but from preludes in `spi::master`/`spi::slave` instead (#860)
-- The `embedded-hal-1` and `embedded-hal-async` traits are no longer re-exported in the prelude (#860)
-
 ## [0.12.0] - 2023-09-05
 
 ### Added
@@ -1038,15 +1023,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add PARL_IO driver for ESP32-C6 / ESP32-H2 (#733, #760)
 - Implement `ufmt_write::uWrite` trait for USB Serial JTAG (#751)
 - Add HMAC peripheral support (#755)
-- Add multicore-aware embassy executor for Xtensa MCUs (#723, #756).
-- Add interrupt-executor for Xtensa MCUs (#723, #756).
+- Add multicore-aware embassy executor for Xtensa MCUs (#723, #756)
+- Add interrupt-executor for Xtensa MCUs (#723, #756)
 - Add missing `Into<Gpio<Analog, GPIONUN>>` conversion (#764)
 - Updated `clock` module documentation (#774)
 - Add `log` feature to enable log output (#773)
 - Add `defmt` feature to enable log output (#773)
 - A new macro to load LP core code on ESP32-C6 (#779)
 - Add `ECC`` peripheral driver (#785)
-- Initial LLD support for Xtensa chips (#861).
+- Initial LLD support for Xtensa chips (#861)
 
 ### Changed
 
@@ -1054,6 +1039,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Moved AlignmentHelper to its own module (#753)
 - Disable all watchdog timers by default at startup (#763)
 - `log` crate is now opt-in (#773)
+- `CpuControl::start_app_core()` now takes an `FnOnce` closure (#739)
 
 ### Fixed
 
@@ -1063,10 +1049,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `Instant::now()` not counting in some cases when using TIMG0 as the timebase (#737)
 - Fix number of ADC attenuations for ESP32-C6 (#771)
 - Fix SHA registers access (#805)
-
-### Breaking
-
-- `CpuControl::start_app_core()` now takes an `FnOnce` closure (#739)
 
 ## [0.11.0] - 2023-08-10
 
@@ -1089,6 +1071,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `embedded-hal-*` alpha packages to their latest versions (#640)
 - Implement the `Clone` and `Copy` traits for the `Rng` driver (#650)
 - Use all remaining memory as core-0's stack (#716)
+- `DmaTransfer::wait` and `I2sReadDmaTransfer::wait_receive` now return `Result` (#665)
+- `gpio::Pin` is now object-safe (#687)
 
 ### Fixed
 
@@ -1105,11 +1089,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Remove the `allow-opt-level-z` feature from `esp32c3-hal` (#654)
 - Remove the old `pulse_control` driver (#694)
-
-### Breaking
-
-- `DmaTransfer::wait` and `I2sReadDmaTransfer::wait_receive` now return `Result` (#665)
-- `gpio::Pin` is now object-safe (#687)
 
 ## [0.10.0] - 2023-06-04
 
@@ -1134,7 +1113,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add embassy async `read` support for `uart` (#620)
 - Add bare-bones support to run code on ULP-RISCV / LP core (#631)
 - Add ADC calibration implementation for a riscv chips (#555)
-- Add `async` implementation for `USB Serial/JTAG`(#632)
+- Add `async` implementation for `USB Serial/JTAG` (#632)
 
 ### Changed
 
@@ -1148,6 +1127,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve examples documentation (#533)
 - esp32h2-hal: added README (#585)
 - Update `esp-hal-procmacros` package dependencies and features (#628)
+- Simplified user-facing SpiDma and I2s types (#626)
+- Significantly simplified user-facing GPIO pin types. (#553)
+- No longer re-export the `soc` module and the contents of the `interrupt` module at the package level (#607)
 
 ### Fixed
 
@@ -1170,12 +1152,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix rom::crc docs (#611)
 - Fixed a possible overlap of `.data` and `.rwtext` (#616)
 - Avoid SDA/SCL being low while configuring pins for I2C (#619)
-
-### Breaking
-
-- Simplified user-facing SpiDma and I2s types (#626)
-- Significantly simplified user-facing GPIO pin types. (#553)
-- No longer re-export the `soc` module and the contents of the `interrupt` module at the package level (#607)
 
 ## [0.9.0] - 2023-05-02
 
@@ -1228,34 +1204,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.0] - 2022-08-05
 
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.0.0-beta.0...HEAD
-[v1.0.0-beta.0]: https://github.com/esp-rs/esp-hal/compare/v0.23.1..esp-hal-v1.0.0-beta.0
-[0.23.1]: https://github.com/esp-rs/esp-hal/compare/v0.23.0..v0.23.1
-[0.23.0]: https://github.com/esp-rs/esp-hal/compare/v0.22.0..v0.23.0
-[0.22.0]: https://github.com/esp-rs/esp-hal/compare/v0.21.1...v0.22.0
-[0.21.1]: https://github.com/esp-rs/esp-hal/compare/v0.21.0...v0.21.1
-[0.21.0]: https://github.com/esp-rs/esp-hal/compare/v0.20.1...v0.21.0
-[0.20.1]: https://github.com/esp-rs/esp-hal/compare/v0.20.0...v0.20.1
-[0.20.0]: https://github.com/esp-rs/esp-hal/compare/v0.19.0...v0.20.0
-[0.19.0]: https://github.com/esp-rs/esp-hal/compare/v0.18.0...v0.19.0
-[0.18.0]: https://github.com/esp-rs/esp-hal/compare/v0.17.0...v0.18.0
-[0.17.0]: https://github.com/esp-rs/esp-hal/compare/v0.16.1...v0.17.0
-[0.16.1]: https://github.com/esp-rs/esp-hal/compare/v0.16.0...v0.16.1
-[0.16.0]: https://github.com/esp-rs/esp-hal/compare/v0.15.0...v0.16.0
-[0.15.0]: https://github.com/esp-rs/esp-hal/compare/v0.14.1...v0.15.0
-[0.14.1]: https://github.com/esp-rs/esp-hal/compare/v0.14.0...v0.14.1
-[0.14.0]: https://github.com/esp-rs/esp-hal/compare/v0.13.1...v0.14.0
-[0.13.1]: https://github.com/esp-rs/esp-hal/compare/v0.13.0...v0.13.1
-[0.13.0]: https://github.com/esp-rs/esp-hal/compare/v0.12.0...v0.13.0
-[0.12.0]: https://github.com/esp-rs/esp-hal/compare/v0.11.0...v0.12.0
-[0.11.0]: https://github.com/esp-rs/esp-hal/compare/v0.10.0...v0.11.0
-[0.10.0]: https://github.com/esp-rs/esp-hal/compare/v0.9.0...v0.10.0
-[0.9.0]: https://github.com/esp-rs/esp-hal/compare/v0.8.0...v0.9.0
-[0.8.0]: https://github.com/esp-rs/esp-hal/compare/v0.7.1...v0.8.0
-[0.7.1]: https://github.com/esp-rs/esp-hal/compare/v0.7.0...v0.7.1
-[0.7.0]: https://github.com/esp-rs/esp-hal/compare/v0.5.0...v0.7.0
-[0.5.0]: https://github.com/esp-rs/esp-hal/compare/v0.4.0...v0.5.0
-[0.4.0]: https://github.com/esp-rs/esp-hal/compare/v0.3.0...v0.4.0
-[0.3.0]: https://github.com/esp-rs/esp-hal/compare/v0.2.0...v0.3.0
-[0.2.0]: https://github.com/esp-rs/esp-hal/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/esp-rs/esp-hal/releases/tag/v0.1.0
+[0.2.0]: https://github.com/esp-rs/esp-hal/compare/v0.1.0...v0.2.0
+[0.3.0]: https://github.com/esp-rs/esp-hal/compare/v0.2.0...v0.3.0
+[0.4.0]: https://github.com/esp-rs/esp-hal/compare/v0.3.0...v0.4.0
+[0.5.0]: https://github.com/esp-rs/esp-hal/compare/v0.4.0...v0.5.0
+[0.7.0]: https://github.com/esp-rs/esp-hal/compare/v0.5.0...v0.7.0
+[0.7.1]: https://github.com/esp-rs/esp-hal/compare/v0.7.0...v0.7.1
+[0.8.0]: https://github.com/esp-rs/esp-hal/compare/v0.7.1...v0.8.0
+[0.9.0]: https://github.com/esp-rs/esp-hal/compare/v0.8.0...v0.9.0
+[0.10.0]: https://github.com/esp-rs/esp-hal/compare/v0.9.0...v0.10.0
+[0.11.0]: https://github.com/esp-rs/esp-hal/compare/v0.10.0...v0.11.0
+[0.12.0]: https://github.com/esp-rs/esp-hal/compare/v0.11.0...v0.12.0
+[0.13.0]: https://github.com/esp-rs/esp-hal/compare/v0.12.0...v0.13.0
+[0.13.1]: https://github.com/esp-rs/esp-hal/compare/v0.13.0...v0.13.1
+[0.14.0]: https://github.com/esp-rs/esp-hal/compare/v0.13.1...v0.14.0
+[0.14.1]: https://github.com/esp-rs/esp-hal/compare/v0.14.0...v0.14.1
+[0.15.0]: https://github.com/esp-rs/esp-hal/compare/v0.14.1...v0.15.0
+[0.16.0]: https://github.com/esp-rs/esp-hal/compare/v0.15.0...v0.16.0
+[0.16.1]: https://github.com/esp-rs/esp-hal/compare/v0.16.0...v0.16.1
+[0.17.0]: https://github.com/esp-rs/esp-hal/compare/v0.16.1...v0.17.0
+[0.18.0]: https://github.com/esp-rs/esp-hal/compare/v0.17.0...v0.18.0
+[0.19.0]: https://github.com/esp-rs/esp-hal/compare/v0.18.0...v0.19.0
+[0.20.0]: https://github.com/esp-rs/esp-hal/compare/v0.19.0...v0.20.0
+[0.20.1]: https://github.com/esp-rs/esp-hal/compare/v0.20.0...v0.20.1
+[0.21.0]: https://github.com/esp-rs/esp-hal/compare/v0.20.1...v0.21.0
+[0.21.1]: https://github.com/esp-rs/esp-hal/compare/v0.21.0...v0.21.1
+[0.22.0]: https://github.com/esp-rs/esp-hal/compare/v0.21.1...v0.22.0
+[0.23.0]: https://github.com/esp-rs/esp-hal/compare/v0.22.0...v0.23.0
+[0.23.1]: https://github.com/esp-rs/esp-hal/compare/v0.23.0...v0.23.1
+[v1.0.0-beta.0]: https://github.com/esp-rs/esp-hal/compare/v0.23.1...esp-hal-v1.0.0-beta.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.0.0-beta.0...HEAD

--- a/esp-ieee802154/CHANGELOG.md
+++ b/esp-ieee802154/CHANGELOG.md
@@ -5,9 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
 
 ### Added
+
 
 ### Changed
 
@@ -20,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed compatibility with `defmt` (#3374)
 
 ### Removed
+
 
 ## [0.6.0] - 2025-02-24
 
@@ -38,7 +40,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.3.1 - 2024-10-10
 
-- Bumped esp-wifi-sys to `v0.6.0`
+### Changed
+
+- Bumped esp-wifi-sys to `v0.6.0` (#2328)
 
 ## 0.3.0 - 2024-10-10 - YANKED
 
@@ -71,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Initial release
+- Initial release (#1800)
 
 [0.6.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-ieee802154-v0.6.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-ieee802154-v0.6.0...HEAD

--- a/esp-lp-hal/CHANGELOG.md
+++ b/esp-lp-hal/CHANGELOG.md
@@ -5,9 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
 
 ### Added
+
 
 ### Changed
 
@@ -16,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump Rust edition to 2024, bump MSRV to 1.85. (#3391)
 
 ### Fixed
+
 
 ### Removed
 
@@ -27,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add the `esp32c6-lp-hal` package (#714)
 - Add GPIO (output) and delay functionality to `esp32c6-lp-hal` (#715)
-- Add GPIO input support and implement additional `embedded-hal` output traits for the C6's LP core [#720]
+- Add GPIO input support and implement additional `embedded-hal` output traits for the C6's LP core (#720)
 - Add the `ulp-riscv-hal` package (#840)
 - Add LP_UART basic driver (#1113)
 - Added basic `LP-I2C` driver for C6 (#1185)
@@ -43,3 +45,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed to `esp-ulp-riscv-hal` (#916)
 - Remove 2nd level generics from GPIO pin (#1526)
 - GPIO Input/Output types have been converted to unit structs (#1754)
+

--- a/esp-metadata/CHANGELOG.md
+++ b/esp-metadata/CHANGELOG.md
@@ -2,15 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
 
 ### Added
 
 - Add ability to define memory regions, have DRAM defined there (#3300)
-
 - Provide macros to get the start/end of a memory region, make it possible to use the macros in a no-std project (#3300)
 
 ### Changed
@@ -19,7 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+
 ### Removed
+
 
 ## [0.6.0] - 2025-02-24
 
@@ -42,16 +43,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump MSRV to 1.84 (#2951)
 
-## [0.4.0] - 2024-10-10
+## 0.4.0 - 2024-10-10
 
-## [0.3.0] - 2024-08-29
+## 0.3.0 - 2024-08-29
 
-## [0.2.0] - 2024-07-15
+## 0.2.0 - 2024-07-15
 
-## [0.1.1] - 2024-06-04
+## 0.1.1 - 2024-06-04
 
-## [0.1.0] - 2024-04-17
+## 0.1.0 - 2024-04-17
 
-- Initial release
+### Added
+
+- Initial release (#2518)
 
 [0.6.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-metadata-v0.6.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-metadata-v0.6.0...HEAD

--- a/esp-println/CHANGELOG.md
+++ b/esp-println/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
 
 ### Added
 
@@ -26,11 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+
 ## [0.13.1] - 2025-02-24
 
 ### Fixed
 
-- Fix build failure when `critical-section` feature is disabled
+- Fix build failure when `critical-section` feature is disabled (#3163)
 
 ## 0.13.0 - 2025-01-15
 
@@ -65,22 +66,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Un-pinned the defmt package's version number
+- Un-pinned the defmt package's version number (#1658)
 
 ## 0.9.0 - 2024-02-07
 
 ### Added
 
-- Add support for ESP32-P4
+- Add support for ESP32-P4 (#1658)
 
 ### Removed
 
-- Remove ESP 8266 support
+- Remove ESP 8266 support (#1658)
 
 ## 0.8.0 - 2023-12-21
 
 ### Removed
 
-- Remove RTT and defmt-raw support
+- Remove RTT and defmt-raw support (#1658)
 
 [0.13.1]: https://github.com/esp-rs/esp-hal/releases/tag/esp-println-v0.13.1
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-println-v0.13.1...HEAD

--- a/esp-riscv-rt/CHANGELOG.md
+++ b/esp-riscv-rt/CHANGELOG.md
@@ -74,9 +74,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix RISC-V stack allocation (#988)
 - ESP32-C6/ESP32-H2: Add `fix-sp` feature to support `flip-link` in `esp-hal-common` (#1008)
 
-### Removed
-
-
 ## 0.5.0 - 2023-09-05
 
 ### Changed

--- a/esp-riscv-rt/CHANGELOG.md
+++ b/esp-riscv-rt/CHANGELOG.md
@@ -5,9 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
 
 ### Added
+
 
 ### Changed
 
@@ -15,7 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+
 ### Removed
+
 
 ## [0.10.0] - 2025-02-24
 
@@ -26,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.9.1 - 2024-11-20
 
-## Fixed
+### Fixed
 
 - Fix interrupt stack alignment (#2425)
 
@@ -38,10 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- All existing features controlling ram initialization. Most (`init-data`, `init-rw-text`,
-  `init-rtc-fast-data`, and `init-rtc-fast-text`) were only used for the (already removed) direct
-  boot support. `zero-bss` is now enabled unconditionally. `zero-rtc-fast-bss` was merged into the
-  new `rtc-ram` feature. (#1677)
+- All existing features controlling ram initialization. (#1677)
 
 ## 0.8.0 - 2024-04-18
 
@@ -64,7 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated to latest version of `riscv` and `riscv-rt-macros` dependencies
+- Updated to latest version of `riscv` and `riscv-rt-macros` dependencies (#1098)
 
 ## 0.6.0 - 2023-12-12
 
@@ -75,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ESP32-C6/ESP32-H2: Add `fix-sp` feature to support `flip-link` in `esp-hal-common` (#1008)
 
 ### Removed
+
 
 ## 0.5.0 - 2023-09-05
 
@@ -95,3 +96,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.1.0 - 2023-01-26
 
 [0.10.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-riscv-rt-v0.10.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-riscv-rt-v0.10.0...HEAD

--- a/esp-storage/CHANGELOG.md
+++ b/esp-storage/CHANGELOG.md
@@ -35,15 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added trait MultiwriteNorFlash to FlashStorage (#2478)
 
-### Changed
-
-
-### Fixed
-
-
-### Removed
-
-
 ## 0.3.1 - 2024-10-10
 
 ## 0.3.0 - 2023-08-16

--- a/esp-storage/CHANGELOG.md
+++ b/esp-storage/CHANGELOG.md
@@ -5,9 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
 
 ### Added
+
 
 ### Changed
 
@@ -15,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `low-level` feature has been removed, the gated API is always available (#3425)
 
 ### Fixed
+
 
 ### Removed
 
@@ -25,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump MSRV to 1.84 (#2951)
-- Add support for 32MB flash
+- Add support for 32MB flash (#3163)
 
 ## 0.4.0 - 2024-11-20
 
@@ -35,9 +37,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+
 ### Fixed
 
+
 ### Removed
+
 
 ## 0.3.1 - 2024-10-10
 
@@ -48,3 +53,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.1.0 - 2022-09-26
 
 [0.5.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-storage-v0.5.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-storage-v0.5.0...HEAD

--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
 
 ### Added
 
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - COEX on ESP32 is now working (#3403)
 
 ### Removed
+
 
 ## [0.13.0] - 2025-02-24
 
@@ -73,18 +74,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `esp_wifi::init` no longer requires `EspWifiInitFor`, and now returns `EspWifiController`, see the migration guide for more details (#2301)
 - No need to add `rom_functions.x` manually anymore (#2374)
-- esp-now: Data is now private in `ReceivedData` - use `data()`(#2396)
+- esp-now: Data is now private in `ReceivedData` - use `data()` (#2396)
 - Changed the async APIs to have a `_async` postfix to avoid name collisions (#2446)
 - `phy_enable_usb` is enabled by default (#2446)
 - Removed `get_` prefixes from functions (#2528)
 - Opting out of `esp-alloc` now requires implementing `esp_wifi_deallocate_internal_ram` (#3320)
-
 - Config: Crate prefixes and configuration keys are now separated by `_CONFIG_` (#2848)
 
 ### Fixed
 
 - Fixed a possible crash when parsing results from a radius server (#2380)
-- Fixed `async fn WifiController::disconnect` hanging forever when awaited if not connected when called (#2392).
+- Fixed `async fn WifiController::disconnect` hanging forever when awaited if not connected when called (#2392)
 - Fixed building esp-wifi without either `ble` or `wifi` enabled (#3336)
 
 ### Removed
@@ -99,7 +99,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bumped esp-wifi-sys to `v0.6.0`
+- Bumped esp-wifi-sys to `v0.6.0` (#2328)
 
 ## 0.10.0 - 2024-10-10 - YANKED
 
@@ -135,13 +135,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+
 ### Changed
+
 
 ### Fixed
 
 - Builds on stable, again (#2067)
 
 ### Removed
+
 
 ## 0.9.0 - 2024-09-03
 
@@ -151,9 +154,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+
 ### Fixed
 
+
 ### Removed
+
 
 ## 0.8.0 - 2024-08-29
 
@@ -176,7 +182,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Check no password is set when using `AuthMethod::None`(#1806)
+- Check no password is set when using `AuthMethod::None` (#1806)
 
 ### Fixed
 
@@ -202,17 +208,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Removed embedded-hal v0.2 dependency
+- Removed embedded-hal v0.2 dependency (#1582)
 
 ## 0.5.1 - 2024-04-22
 
-Patch release to fix docs.rs build
+### Fixed
+
+- Patch release to fix docs.rs build (#1582)
 
 ## 0.5.0 - 2024-04-19
 
 ### Fixed
 
-- Fix compile error when using smoltcp `DNS_MAX_RESULT_COUNT` values other than 1
+- Fix compile error when using smoltcp `DNS_MAX_RESULT_COUNT` values other than 1 (#1654)
 
 ## 0.4.0 - 2024-03-12
 
@@ -220,7 +228,7 @@ Patch release to fix docs.rs build
 
 - Users don't need embedded-svc to control wifi anymore. The wifi trait is optionally implemented now. (#429)
 - Better network performance by forced yielding of the task when buffers are full / empty. (#430)
-- Depend on esp-hal 0.16.1, update other dependencies
+- Depend on esp-hal 0.16.1, update other dependencies (#1582)
 
 ## 0.3.0 - 2024-01-29
 
@@ -236,16 +244,22 @@ Patch release to fix docs.rs build
 ### Changed
 
 - Update driver blobs (#410)
-- Update dependencies to fit `embedded-hal` `1.0`
+- Update dependencies to fit `embedded-hal` `1.0` (#1582)
 
 ### Removed
 
+
 ## 0.2.0 - 2024-01-05
 
-Initial release supporting WiFi on ESP32, ESP32-S2, ESP32-S3, ESP32-C3, ESP32-C2, ESP32-C6, supporting BLE on WiFi on ESP32, ESP32-S3, ESP32-C3, ESP32-C2, ESP32-C6, ESP32-H2
+### Added
+
+- Initial release supporting WiFi on ESP32, ESP32-S2, ESP32-S3, ESP32-C3, ESP32-C2, ESP32-C6, supporting BLE on WiFi on ESP32, ESP32-S3, ESP32-C3, ESP32-C2, ESP32-C6, ESP32-H2 (#1582)
 
 ## 0.1.0 - 2023-11-27
 
-Initial release supporting WiFi on ESP32, ESP32-S2, ESP32-S3, ESP32-C3, ESP32-C2, ESP32-C6, supporting BLE on WiFi on ESP32, ESP32-S3, ESP32-C3, ESP32-C2, ESP32-C6
+### Added
+
+- Initial release supporting WiFi on ESP32, ESP32-S2, ESP32-S3, ESP32-C3, ESP32-C2, ESP32-C6, supporting BLE on WiFi on ESP32, ESP32-S3, ESP32-C3, ESP32-C2, ESP32-C6 (#1582)
 
 [0.13.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-wifi-v0.13.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-wifi-v0.13.0...HEAD

--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -133,33 +133,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.9.1 - 2024-09-03
 
-### Added
-
-
-### Changed
-
-
 ### Fixed
 
 - Builds on stable, again (#2067)
-
-### Removed
-
 
 ## 0.9.0 - 2024-09-03
 
 ### Added
 
 - Added support for WPA2-ENTERPRISE (#2004)
-
-### Changed
-
-
-### Fixed
-
-
-### Removed
-
 
 ## 0.8.0 - 2024-08-29
 
@@ -245,9 +227,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update driver blobs (#410)
 - Update dependencies to fit `embedded-hal` `1.0` (#1582)
-
-### Removed
-
 
 ## 0.2.0 - 2024-01-05
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -40,6 +40,9 @@ rustdoc-types = { version = "0.35.0", optional = true }
 flate2 = { version = "1.1.1", optional = true }
 temp-file = { version = "0.1.9", optional = true }
 
+[dev-dependencies]
+pretty_assertions = "1.2.0"
+
 [features]
 deploy-docs  = ["dep:reqwest"]
 preview-docs = ["dep:opener", "dep:rocket"]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -11,6 +11,7 @@ clap         = { version = "4.5.20", features = ["derive", "wrap_help"] }
 console      = "0.15.10"
 env_logger   = "0.11.5"
 esp-metadata = { path = "../esp-metadata", features = ["clap"] }
+jiff         = { version = "0.2.13" }
 kuchikiki    = "0.8.2"
 log          = "0.4.22"
 minijinja    = "2.5.0"

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -8,15 +8,16 @@ Automation using [cargo-xtask](https://github.com/matklad/cargo-xtask).
 Usage: xtask <COMMAND>
 
 Commands:
-  build          Build-related subcommands
-  run            Run-related subcommands
-  bump-version   Bump the version of the specified package(s)
-  ci             Perform (parts of) the checks done in CI
-  fmt-packages   Format all packages in the workspace with rustfmt
-  lint-packages  Lint all packages in the workspace with clippy
-  publish        Attempt to publish the specified package
-  tag-releases   Generate git tags for all new package releases
-  help           Print this message or the help of the given subcommand(s)
+  build            Build-related subcommands
+  run              Run-related subcommands
+  bump-version     Bump the version of the specified package(s)
+  ci               Perform (parts of) the checks done in CI
+  fmt-packages     Format all packages in the workspace with rustfmt
+  lint-packages    Lint all packages in the workspace with clippy
+  publish          Attempt to publish the specified package
+  tag-releases     Generate git tags for all new package releases
+  check-changelog  Check the changelog for packages
+  help             Print this message or the help of the given subcommand(s)
 
 Options:
   -h, --help  Print help

--- a/xtask/src/changelog.rs
+++ b/xtask/src/changelog.rs
@@ -1,0 +1,334 @@
+use std::{fmt::Display, iter::Peekable, str::Lines};
+
+use anyhow::{Context, Result, bail};
+
+use crate::Package;
+
+#[derive(Debug)]
+pub(crate) struct Changelog {
+    entries: Vec<ChangelogForVersion>,
+}
+
+impl Changelog {
+    pub fn parse(changelog: &str) -> Result<Self> {
+        let mut lines = changelog.lines().peekable();
+
+        let mut this = Self {
+            entries: Vec::new(),
+        };
+
+        // Remove header
+        let mut parsed_changelog = false;
+        while let Some(line) = lines.peek() {
+            if line.starts_with("## ") {
+                let version = ChangelogForVersion::parse(&mut lines)?;
+                // Add the version to the changelog
+                this.entries.push(version);
+                parsed_changelog = true;
+            } else if parsed_changelog {
+                if line.starts_with('[') {
+                    let (version, tag) = parse_tag_link(line)?;
+                    let entry = this
+                        .entries
+                        .iter_mut()
+                        .find(|e| e.version == version)
+                        .unwrap();
+                    entry.tag = Some(tag.to_string());
+                }
+                lines.next();
+            } else {
+                lines.next();
+            }
+        }
+
+        Ok(this)
+    }
+
+    pub fn finalize(&mut self, package: Package, version: semver::Version) {
+        // Find the entry for the version
+        let Some(unreleased_entry) = self.entries.iter_mut().find(|e| e.version == "Unreleased")
+        else {
+            // No unreleased changes.
+            return;
+        };
+
+        unreleased_entry.version = format!("v{version}");
+        unreleased_entry.tag = Some(package.tag(version));
+        unreleased_entry.date = Some(jiff::Timestamp::now().strftime("%Y-%m-%d").to_string());
+
+        self.entries.insert(
+            0,
+            ChangelogForVersion {
+                version: "Unreleased".to_string(),
+                date: None,
+                tag: None,
+                groups: vec![
+                    ChangelogGroup::new("Added"),
+                    ChangelogGroup::new("Changed"),
+                    ChangelogGroup::new("Fixed"),
+                    ChangelogGroup::new("Removed"),
+                ],
+            },
+        );
+    }
+}
+
+impl Display for Changelog {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            r#"# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+"#
+        )?;
+        for entry in &self.entries {
+            write!(f, "{entry}")?;
+        }
+
+        let mut previous = None;
+        for entry in self.entries.iter().rev() {
+            let version_tag = if let Some(tag) = entry.tag.as_ref() {
+                tag
+            } else if entry.version == "Unreleased" {
+                "HEAD"
+            } else {
+                continue;
+            };
+
+            if let Some(previous) = previous {
+                writeln!(
+                    f,
+                    "[{}]: https://github.com/esp-rs/esp-hal/compare/{previous}...{version_tag}",
+                    entry.version
+                )?;
+            } else if entry.version != "Unreleased" {
+                writeln!(
+                    f,
+                    "[{}]: https://github.com/esp-rs/esp-hal/releases/tag/{version_tag}",
+                    entry.version
+                )?;
+            }
+
+            previous = Some(version_tag);
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct ChangelogForVersion {
+    version: String,
+    date: Option<String>,
+    tag: Option<String>,
+    /// The changelog groups
+    groups: Vec<ChangelogGroup>,
+}
+impl ChangelogForVersion {
+    fn parse(lines: &mut Peekable<Lines<'_>>) -> Result<Self> {
+        let header = lines.next().unwrap();
+
+        let mut parts = header.trim_start_matches("## ").splitn(2, " - ");
+
+        let version = parts.next().unwrap().trim_matches(['[', ']', ' ']);
+        log::debug!("Parsing changelog for version: {version}");
+        let date = parts.next().map(|date| date.trim().to_string());
+
+        let mut this = Self {
+            version: version.to_string(),
+            date,
+            tag: None,
+            groups: Vec::new(),
+        };
+        let mut current_group = None;
+
+        while let Some(line) = lines.peek() {
+            if line.starts_with("## ") {
+                break;
+            } else if let Some(group_header) = line.strip_prefix("### ") {
+                let group_header = match group_header {
+                    "Fixed" => "Fixed",
+                    "Added" => "Added",
+                    "Breaking" | "Changed" => "Changed",
+                    "Removed" => "Removed",
+                    _ => bail!("Unknown group found in changelog for {version}: {group_header}"),
+                };
+
+                if this.groups.iter().any(|g| g.name == group_header) {
+                    current_group = this.groups.iter_mut().find(|g| g.name == group_header);
+                } else {
+                    // Create a new group
+                    let group = ChangelogGroup::new(group_header);
+                    this.groups.push(group);
+                    current_group = this.groups.last_mut();
+                }
+            } else if line.starts_with("- ") {
+                let line = line.trim_start_matches("- ");
+                let Some(current_group) = current_group.as_deref_mut() else {
+                    bail!("No group found for changelog entry in {version}: {line}");
+                };
+
+                // Add the entry to the current group
+                let line = ChangelogLine::parse(line).with_context(|| {
+                    format!("Could not parse changelog line for {version}: {line}")
+                })?;
+
+                current_group.lines.push(line);
+            } else if line.trim().is_empty() {
+                // Empty line, just skip
+            } else {
+                // Not ours any more.
+                break;
+            }
+            lines.next();
+        }
+
+        Ok(this)
+    }
+}
+impl Display for ChangelogForVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.tag.is_some() || self.version == "Unreleased" {
+            write!(f, "## [{}]", self.version)?;
+        } else {
+            write!(f, "## {}", self.version)?;
+        }
+        if let Some(date) = &self.date {
+            writeln!(f, " - {}", date)?;
+        } else {
+            writeln!(f)?;
+        }
+        writeln!(f)?;
+
+        for group in self.groups.iter() {
+            write!(f, "{group}")?;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct ChangelogGroup {
+    name: &'static str,
+    lines: Vec<ChangelogLine>,
+}
+impl ChangelogGroup {
+    fn new(name: &'static str) -> Self {
+        Self {
+            name,
+            lines: Vec::new(),
+        }
+    }
+}
+
+impl Display for ChangelogGroup {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "### {}", self.name)?;
+        writeln!(f)?;
+        for line in &self.lines {
+            writeln!(f, "{line}")?;
+        }
+        writeln!(f)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct ChangelogLine {
+    indentation: usize,
+    line: String,
+    prs: Vec<usize>,
+}
+impl ChangelogLine {
+    fn parse(line: &str) -> Result<Self> {
+        // Format is: `- <description> (#<pr>[, #<pr>...])`
+        let indentation = line.chars().take_while(|c| c.is_whitespace()).count();
+        let line = line.trim();
+        let (description, prs) = if let Some(pr_start) = line.rfind("(#") {
+            let (description, prs) = line.split_at(pr_start);
+            (description.trim(), Some(prs))
+        } else {
+            (line, None)
+        };
+        let description = description.trim_start_matches("- ").trim();
+
+        let prs = if let Some(prs) = prs {
+            prs.trim_start_matches('(')
+                .trim_end_matches('.') // normalize "(#pr)."
+                .trim_end_matches(')')
+                .split(',')
+                .map(|pr| pr.trim().trim_start_matches('#').parse::<usize>())
+                .collect::<Result<Vec<_>, _>>()
+                .with_context(|| format!("Could not parse PR number {prs}"))?
+        } else if indentation == 0 {
+            bail!("Missing PR number");
+        } else {
+            vec![]
+        };
+
+        Ok(Self {
+            indentation,
+            line: description.to_string(),
+            prs,
+        })
+    }
+}
+
+impl Display for ChangelogLine {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let indentation = " ".repeat(self.indentation);
+        write!(f, "{indentation}- {}", self.line)?;
+        if !self.prs.is_empty() {
+            write!(f, " (")?;
+            for (i, pr) in self.prs.iter().enumerate() {
+                if i > 0 {
+                    write!(f, ", ")?;
+                }
+                write!(f, "#{pr}")?;
+            }
+            write!(f, ")")?;
+        }
+
+        Ok(())
+    }
+}
+
+fn parse_tag_link(line: &str) -> Result<(&str, &str)> {
+    let mut parts = line.split(']');
+    let version = parts
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("Could not parse tag link"))?
+        .trim_start_matches('[');
+
+    let link = parts
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("Could not parse tag link"))?
+        .trim_start_matches(':')
+        .trim();
+
+    let tag = if let Some(compare_link) =
+        link.strip_prefix("https://github.com/esp-rs/esp-hal/compare/")
+    {
+        let mut parts = compare_link.split("..");
+        parts.next(); // Skip the previous tag
+        parts
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("Could not parse tag link"))?
+            .trim_start_matches('.') // normalize .. vs ...
+            .trim()
+    } else if let Some(release_link) =
+        link.strip_prefix("https://github.com/esp-rs/esp-hal/releases/tag/")
+    {
+        release_link.trim()
+    } else {
+        bail!("Could not parse link {line}");
+    };
+
+    Ok((version, tag))
+}

--- a/xtask/src/commands/bump_version.rs
+++ b/xtask/src/commands/bump_version.rs
@@ -6,7 +6,7 @@ use semver::Prerelease;
 use strum::IntoEnumIterator;
 use toml_edit::{Item, Value};
 
-use crate::{Package, Version};
+use crate::{Package, Version, changelog::Changelog};
 
 #[derive(Debug, Args)]
 pub struct BumpVersionArgs {
@@ -31,7 +31,8 @@ pub struct BumpVersionArgs {
 pub fn bump_version(workspace: &Path, args: BumpVersionArgs) -> Result<()> {
     // Bump the version by the specified amount for each given package:
     for package in args.packages {
-        bump_crate_version(workspace, package, args.amount, args.pre.as_deref())?;
+        let new_version = bump_crate_version(workspace, package, args.amount, args.pre.as_deref())?;
+        finalize_changelog(workspace, package, new_version)?;
     }
 
     Ok(())
@@ -43,7 +44,7 @@ fn bump_crate_version(
     package: Package,
     amount: Version,
     pre: Option<&str>,
-) -> Result<()> {
+) -> Result<semver::Version> {
     let manifest_path = workspace.join(package.to_string()).join("Cargo.toml");
     let manifest = fs::read_to_string(&manifest_path)
         .with_context(|| format!("Could not read {}", manifest_path.display()))?;
@@ -106,7 +107,7 @@ fn bump_crate_version(
         }
     }
 
-    Ok(())
+    Ok(version)
 }
 
 fn do_version_bump(
@@ -154,6 +155,34 @@ fn do_version_bump(
     }
 
     Ok(version)
+}
+
+fn finalize_changelog(
+    workspace: &Path,
+    package: Package,
+    new_version: semver::Version,
+) -> Result<()> {
+    let changelog_path = workspace.join(package.to_string()).join("CHANGELOG.md");
+
+    if !changelog_path.exists() {
+        // No changelog exists for this package
+        return Ok(());
+    }
+
+    log::info!("  Updating changelog for package: {package}");
+
+    // Let's parse the old changelog first
+    let changelog_str = fs::read_to_string(&changelog_path)
+        .with_context(|| format!("Could not read {}", changelog_path.display()))?;
+
+    let mut changelog = Changelog::parse(&changelog_str)
+        .with_context(|| format!("Could not parse {}", changelog_path.display()))?;
+
+    changelog.finalize(package, new_version);
+
+    std::fs::write(&changelog_path, changelog.to_string())?;
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/xtask/src/commands/bump_version.rs
+++ b/xtask/src/commands/bump_version.rs
@@ -178,7 +178,7 @@ fn finalize_changelog(
     let mut changelog = Changelog::parse(&changelog_str)
         .with_context(|| format!("Could not parse {}", changelog_path.display()))?;
 
-    changelog.finalize(package, new_version);
+    changelog.finalize(package, new_version, jiff::Timestamp::now());
 
     std::fs::write(&changelog_path, changelog.to_string())?;
 

--- a/xtask/src/commands/check_changelog.rs
+++ b/xtask/src/commands/check_changelog.rs
@@ -1,0 +1,45 @@
+use std::path::Path;
+
+use anyhow::{Context, Result, bail};
+
+use crate::{Package, changelog::Changelog};
+
+pub fn check_changelog(workspace: &Path, packages: &[Package], normalize: bool) -> Result<()> {
+    let mut failed = false;
+    for package in packages {
+        if let Err(e) = check_changelog_for_package(workspace, *package, normalize) {
+            eprintln!("Error checking changelog for package {}: {:?}", package, e);
+            failed = true;
+        }
+    }
+
+    if failed {
+        bail!("One or more changelogs failed to check.");
+    }
+
+    Ok(())
+}
+
+fn check_changelog_for_package(workspace: &Path, package: Package, normalize: bool) -> Result<()> {
+    let changelog_path = workspace.join(package.to_string()).join("CHANGELOG.md");
+
+    if !changelog_path.exists() {
+        // No changelog exists for this package
+        return Ok(());
+    }
+
+    log::info!("  Updating changelog for package: {package}");
+
+    // Let's parse the old changelog first
+    let changelog_str = std::fs::read_to_string(&changelog_path)
+        .with_context(|| format!("Could not read {}", changelog_path.display()))?;
+
+    let changelog = Changelog::parse(&changelog_str)
+        .with_context(|| format!("Could not parse {}", changelog_path.display()))?;
+
+    if normalize {
+        std::fs::write(&changelog_path, changelog.to_string())?;
+    }
+
+    Ok(())
+}

--- a/xtask/src/commands/check_changelog.rs
+++ b/xtask/src/commands/check_changelog.rs
@@ -28,7 +28,7 @@ fn check_changelog_for_package(workspace: &Path, package: Package, normalize: bo
         return Ok(());
     }
 
-    log::info!("  Updating changelog for package: {package}");
+    log::info!("  Checking changelog for package: {package}");
 
     // Let's parse the old changelog first
     let changelog_str = std::fs::read_to_string(&changelog_path)

--- a/xtask/src/commands/mod.rs
+++ b/xtask/src/commands/mod.rs
@@ -1,14 +1,15 @@
 use std::path::Path;
 
-use anyhow::{Result, bail};
+use anyhow::{bail, Result};
 use clap::Args;
 use esp_metadata::Chip;
 
-pub use self::{build::*, bump_version::*, run::*, semver_check::*};
-use crate::{Package, cargo::CargoAction};
+pub use self::{build::*, bump_version::*, check_changelog::*, run::*, semver_check::*};
+use crate::{cargo::CargoAction, Package};
 
 mod build;
 mod bump_version;
+mod check_changelog;
 mod run;
 mod semver_check;
 

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -12,6 +12,7 @@ use strum::{Display, EnumIter};
 use crate::{cargo::CargoArgsBuilder, firmware::Metadata};
 
 pub mod cargo;
+pub mod changelog;
 pub mod commands;
 pub mod documentation;
 pub mod firmware;
@@ -219,6 +220,10 @@ impl Package {
                 chip
             ))
         }
+    }
+
+    pub fn tag(&self, version: semver::Version) -> String {
+        format!("{self}-v{version}")
     }
 }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -504,7 +504,7 @@ fn tag_releases(workspace: &Path, mut args: TagReleasesArgs) -> Result<()> {
         }
 
         let version = xtask::package_version(workspace, package)?;
-        let tag = format!("{package}-v{version}");
+        let tag = package.tag(version);
 
         if args.no_dry_run {
             let output = Command::new("git")

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -5,17 +5,15 @@ use std::{
     time::Instant,
 };
 
-use anyhow::{Result, bail};
+use anyhow::{bail, Result};
 use clap::{Args, Parser};
 use esp_metadata::{Chip, Config};
 use strum::IntoEnumIterator;
 use xtask::{
-    Package,
     cargo::{CargoAction, CargoArgsBuilder},
     commands::*,
+    Package,
 };
-
-
 
 // ----------------------------------------------------------------------------
 // Command-line Interface
@@ -44,6 +42,8 @@ enum Cli {
     TagReleases(TagReleasesArgs),
     /// Semver Checks
     SemverCheck(SemverCheckArgs),
+    /// Check the changelog for packages.
+    CheckChangelog(CheckChangelogArgs),
 }
 
 #[derive(Debug, Args)]
@@ -101,6 +101,17 @@ struct TagReleasesArgs {
     no_dry_run: bool,
 }
 
+#[derive(Debug, Args)]
+struct CheckChangelogArgs {
+    /// Package(s) to tag.
+    #[arg(long, value_enum, value_delimiter = ',', default_values_t = Package::iter())]
+    packages: Vec<Package>,
+
+    /// Re-generate the changelog with consistent formatting.
+    #[arg(long)]
+    normalize: bool,
+}
+
 // ----------------------------------------------------------------------------
 // Application
 
@@ -142,6 +153,7 @@ fn main() -> Result<()> {
         Cli::Publish(args) => publish(&workspace, args),
         Cli::TagReleases(args) => tag_releases(&workspace, args),
         Cli::SemverCheck(args) => semver_checks(&workspace, args),
+        Cli::CheckChangelog(args) => check_changelog(&workspace, &args.packages, args.normalize),
     }
 }
 

--- a/xtensa-lx-rt/CHANGELOG.md
+++ b/xtensa-lx-rt/CHANGELOG.md
@@ -9,15 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+
 ### Changed
 
 - Bump Rust edition to 2024, bump MSRV to 1.85. (#3391)
 
 ### Fixed
 
+
 ### Removed
 
-## 0.18.0 - 2025-01-15
+
+## [0.18.0] - 2025-01-15
 
 ### Changed
 
@@ -31,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+
 ## 0.17.1 - 2024-09-02
 
 ### Added
@@ -43,4 +47,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Initial releases
 
-[Unreleased]: https://github.com/esp-rs/esp-hal/commits/main/xtensa-lx?since=2025-01-15
+[0.18.0]: https://github.com/esp-rs/esp-hal/releases/tag/xtensa-lx-rt-v0.18.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/xtensa-lx-rt-v0.18.0...HEAD

--- a/xtensa-lx-rt/CHANGELOG.md
+++ b/xtensa-lx-rt/CHANGELOG.md
@@ -32,9 +32,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed saving the state of the FPU co-processor. (#2311)
 
-### Removed
-
-
 ## 0.17.1 - 2024-09-02
 
 ### Added

--- a/xtensa-lx/CHANGELOG.md
+++ b/xtensa-lx/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
 ### Added
+
 
 ### Changed
 
@@ -15,9 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+
 ### Removed
 
-## 0.10.0 - 2025-01-15
+
+## [0.10.0] - 2025-01-15
 
 ### Fixed
 
@@ -33,18 +36,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `spin` feature and `mutex` module has been removed. (#2537)
 - The `InterruptNumber` trait has been removed. (#2537)
 
-## [0.9.0] - 2024-02-21
+## 0.9.0 - 2024-02-21
 
-## [0.8.0] - 2023-02-23
+## 0.8.0 - 2023-02-23
 
-## [0.7.0] - 2022-04-20
+## 0.7.0 - 2022-04-20
 
-## [0.6.0] - 2022-01-16
+## 0.6.0 - 2022-01-16
 
-## [0.5.0] - 2022-01-15
+## 0.5.0 - 2022-01-15
 
-## [0.4.0] - 2021-08-11
+## 0.4.0 - 2021-08-11
 
-## [0.3.0] - 2020-09-19
+## 0.3.0 - 2020-09-19
 
-[Unreleased]: https://github.com/esp-rs/esp-hal/commits/main/xtensa-lx?since=2025-01-15
+[0.10.0]: https://github.com/esp-rs/esp-hal/releases/tag/xtensa-lx-v0.10.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/xtensa-lx-v0.10.0...HEAD


### PR DESCRIPTION
This PR implements parsing the changelog, reformatting in, and adds a finalization step to bump-version. The PR also adds the parsing (and consequently, format checking) to the changelog CI workflow.

cc #3438