### PR TITLE
Enable problem-matchers in CI

### DIFF
--- a/.github/rust-matchers.json
+++ b/.github/rust-matchers.json
@@ -1,0 +1,44 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "rust-compiler",
+            "pattern": [
+                {
+                    "regexp": "^(?:\\x1B\\[[0-9;]*[a-zA-Z])*(warning|warn|error)(\\[(\\S*)\\])?(?:\\x1B\\[[0-9;]*[a-zA-Z])*: (.*?)(?:\\x1B\\[[0-9;]*[a-zA-Z])*$",
+                    "severity": 1,
+                    "message": 4,
+                    "code": 3
+                },
+                {
+                    "regexp": "^(?:\\x1B\\[[0-9;]*[a-zA-Z])*\\s+(?:\\x1B\\[[0-9;]*[a-zA-Z])*-->\\s(?:\\x1B\\[[0-9;]*[a-zA-Z])*(\\S+):(\\d+):(\\d+)(?:\\x1B\\[[0-9;]*[a-zA-Z])*$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3
+                }
+            ]
+        },
+        {
+            "owner": "rust-formatter",
+            "pattern": [
+                {
+                    "regexp": "^(Diff in (\\S+)) at line (\\d+):",
+                    "message": 1,
+                    "file": 2,
+                    "line": 3
+                }
+            ]
+        },
+        {
+            "owner": "rust-panic",
+            "pattern": [
+                {
+                    "regexp": "^.*panicked\\s+at\\s+'(.*)',\\s+(.*):(\\d+):(\\d+)$",
+                    "message": 1,
+                    "file": 2,
+                    "line": 3,
+                    "column": 4
+                }
+            ]
+        }
+    ]
+}

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -334,6 +334,8 @@ fn publish(workspace: &Path, args: PublishArgs) -> Result<()> {
 }
 
 fn run_ci_checks(workspace: &Path, args: CiArgs) -> Result<()> {
+    println!("::add-matcher::.github/rust-matchers.json");
+
     let mut failure = false;
     let started_at = Instant::now();
 


### PR DESCRIPTION
Not sure if we want this or not - it was easy enough to add so no tears if we don't :) 

This enables problem matchers while running the xtask's CI command. That will annotate errors from CI in the PR.

See https://github.com/esp-rs/esp-hal/pull/3479/files#diff-89657a062476ae9e54680a8c5befcc236f12563c18e339e72a08c046ae5da276 for how this looks like
