### PR TITLE
Add a version placeholder and replace on version bump

### DIFF
--- a/esp-hal/MIGRATING-1.0.0-beta.0.md
+++ b/esp-hal/MIGRATING-1.0.0-beta.0.md
@@ -1,4 +1,4 @@
-# Migration Guide from v1.0.0-beta.0 to ?
+# Migration Guide from v1.0.0-beta.0 to {{currentVersion}}
 
 ## Peripheral singleton changes
 

--- a/esp-wifi/MIGRATING-0.13.md
+++ b/esp-wifi/MIGRATING-0.13.md
@@ -1,4 +1,4 @@
-# Migration Guide from 0.13.x to 0.14.x
+# Migration Guide from 0.13.x to {{currentVersion}}
 
 ## Initializing esp-wifi
 

--- a/xtask/src/changelog.rs
+++ b/xtask/src/changelog.rs
@@ -47,7 +47,7 @@ impl Changelog {
     pub fn finalize(
         &mut self,
         package: Package,
-        version: semver::Version,
+        version: &semver::Version,
         timestamp: jiff::Timestamp,
     ) {
         // Find the entry for the version

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -222,7 +222,7 @@ impl Package {
         }
     }
 
-    pub fn tag(&self, version: semver::Version) -> String {
+    pub fn tag(&self, version: &semver::Version) -> String {
         format!("{self}-v{version}")
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -516,7 +516,7 @@ fn tag_releases(workspace: &Path, mut args: TagReleasesArgs) -> Result<()> {
         }
 
         let version = xtask::package_version(workspace, package)?;
-        let tag = package.tag(version);
+        let tag = package.tag(&version);
 
         if args.no_dry_run {
             let output = Command::new("git")

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -28,6 +28,16 @@ enum Cli {
     Run(Run),
 
     /// Bump the version of the specified package(s).
+    ///
+    /// This command will, for each specified package:
+    /// - Verify that the crate can be released (e.g. it doesn't refer to git
+    ///   dependencies)
+    /// - Update the version in `Cargo.toml` files
+    /// - Update the version in dependencies' `Cargo.toml` files
+    /// - Check if the changelog can be finalized
+    /// - Update the version in the changelog
+    /// - Replaces `{{currentVersion}}` markers in source files and the
+    ///   migration guide.
     BumpVersion(BumpVersionArgs),
     /// Perform (parts of) the checks done in CI
     Ci(CiArgs),


### PR DESCRIPTION
This PR will let us add `{{currentVersion}}` into our files and teaches bump-version to replace them with the proper version. This is meant for:

- migration guides
- stabilized config options
- API stabilization

cc #3438