### PR TITLE
Remove the Unused section for esp-alloc stats

### DIFF
--- a/esp-alloc/CHANGELOG.md
+++ b/esp-alloc/CHANGELOG.md
@@ -11,8 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `allocator_api2` to support allocator APIs on stable Rust. (#3318)
 - `AnyMemory`, `InternalMemory`, `ExternalMemory` allocators. (#3318)
+- Removed the `Unused` section for `stats()` to make the output cleaner (#3486)
 
 ### Changed
+
 - Bump Rust edition to 2024, bump MSRV to 1.85. (#3391)
 - Update `defmt` to 1.0 (#3416)
 

--- a/esp-alloc/src/lib.rs
+++ b/esp-alloc/src/lib.rs
@@ -130,8 +130,6 @@
 //! Total allocated: 46148
 //! Memory Layout:
 //! Internal | ████████████░░░░░░░░░░░░░░░░░░░░░░░ | Used: 35% (Used 46148 of 131068, free: 84920)
-//! Unused   | ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ |
-//! Unused   | ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ |
 //! ```
 //! ## Feature Flags
 #![doc = document_features::document_features!()]
@@ -338,11 +336,6 @@ impl Display for HeapStats {
             if let Some(region) = region.as_ref() {
                 region.fmt(f)?;
                 writeln!(f)?;
-            } else {
-                // Display unused memory regions
-                write!(f, "Unused   | ")?;
-                write_bar(f, 0)?;
-                writeln!(f, " |")?;
             }
         }
         Ok(())
@@ -365,10 +358,6 @@ impl defmt::Format for HeapStats {
         for region in self.region_stats.iter() {
             if let Some(region) = region.as_ref() {
                 defmt::write!(fmt, "{}\n", region);
-            } else {
-                defmt::write!(fmt, "Unused   | ");
-                write_bar_defmt(fmt, 0);
-                defmt::write!(fmt, " |\n");
             }
         }
     }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

Removed extra code, making output cleaner.
Before:
```
INFO - Global heap stats: HEAP INFO
Size: 217600
Current usage: 2048
Max usage: 2048
Total freed: 0
Total allocated: 2048
Memory Layout: 
Internal | █░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ | Used: 3% (Used 2048 of 64000, free: 61952)
Internal | ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ | Used: 0% (Used 0 of 153600, free: 153600)
Unused   | ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ |

INFO - PSRAM heap stats: HEAP INFO
Size: 8388608
Current usage: 0
Max usage: 0
Total freed: 0
Total allocated: 0
Memory Layout: 
External | ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ | Used: 0% (Used 0 of 8388608, free: 8388608)
Unused   | ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ |
Unused   | ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ |
```

After:
```
INFO - Global heap stats: HEAP INFO
Size: 217600
Current usage: 2048
Max usage: 2048
Total freed: 0
Total allocated: 2048
Memory Layout: 
Internal | █░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ | Used: 3% (Used 2048 of 64000, free: 61952)
Internal | ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ | Used: 0% (Used 0 of 153600, free: 153600)

INFO - PSRAM heap stats: HEAP INFO
Size: 8388608
Current usage: 0
Max usage: 0
Total freed: 0
Total allocated: 0
Memory Layout: 
External | ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░ | Used: 0% (Used 0 of 8388608, free: 8388608)
```