### PR TITLE
Update allocator_api2

### DIFF
--- a/esp-alloc/CHANGELOG.md
+++ b/esp-alloc/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `allocator_api2` to support allocator APIs on stable Rust. (#3318)
+- `allocator_api2` to support allocator APIs on stable Rust. (#3318, #3487)
 - `AnyMemory`, `InternalMemory`, `ExternalMemory` allocators. (#3318)
 
 ### Changed

--- a/esp-alloc/Cargo.toml
+++ b/esp-alloc/Cargo.toml
@@ -19,7 +19,7 @@ bench = false
 test = false
 
 [dependencies]
-allocator-api2        = { version = "0.2.0", default-features = false }
+allocator-api2        = { version = "0.3.0", default-features = false }
 defmt                 = { version = "1.0.1", optional = true }
 cfg-if                = "1.0.0"
 critical-section      = "1.2.0"
@@ -29,7 +29,9 @@ document-features     = "0.2.11"
 
 [features]
 default = []
-nightly = ["allocator-api2/nightly"]
+
+## Enable nightly rustc-only features, like `feature(allocator_api)`.
+nightly = []
 
 ## Implement `defmt::Format` on certain types.
 defmt = ["dep:defmt"]

--- a/esp-alloc/src/allocators.rs
+++ b/esp-alloc/src/allocators.rs
@@ -1,6 +1,11 @@
-use core::{alloc::GlobalAlloc, ptr::NonNull};
+#[cfg(feature = "nightly")]
+use core::alloc::{AllocError as CoreAllocError, Allocator as CoreAllocator};
+use core::{
+    alloc::{GlobalAlloc, Layout},
+    ptr::NonNull,
+};
 
-use allocator_api2::alloc::{AllocError, Allocator, Layout};
+use allocator_api2::alloc::{AllocError, Allocator};
 use enumset::EnumSet;
 
 use crate::MemoryCapability;
@@ -30,12 +35,40 @@ unsafe impl Allocator for EspHeap {
     }
 }
 
+#[cfg(feature = "nightly")]
+unsafe impl CoreAllocator for EspHeap {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, CoreAllocError> {
+        let raw_ptr = unsafe { self.alloc(layout) };
+        let ptr = NonNull::new(raw_ptr).ok_or(CoreAllocError)?;
+        Ok(NonNull::slice_from_raw_parts(ptr, layout.size()))
+    }
+
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        unsafe {
+            crate::HEAP.dealloc(ptr.as_ptr(), layout);
+        }
+    }
+}
+
 /// An allocator that uses all configured, available memory.
 pub struct AnyMemory;
 
 unsafe impl Allocator for AnyMemory {
     fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
         allocate_caps(EnumSet::empty(), layout)
+    }
+
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        unsafe {
+            crate::HEAP.dealloc(ptr.as_ptr(), layout);
+        }
+    }
+}
+
+#[cfg(feature = "nightly")]
+unsafe impl CoreAllocator for AnyMemory {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, CoreAllocError> {
+        allocate_caps(EnumSet::empty(), layout).map_err(|_| CoreAllocError)
     }
 
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
@@ -60,12 +93,38 @@ unsafe impl Allocator for InternalMemory {
     }
 }
 
+#[cfg(feature = "nightly")]
+unsafe impl CoreAllocator for InternalMemory {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, CoreAllocError> {
+        allocate_caps(EnumSet::from(MemoryCapability::Internal), layout).map_err(|_| CoreAllocError)
+    }
+
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        unsafe {
+            crate::HEAP.dealloc(ptr.as_ptr(), layout);
+        }
+    }
+}
+
 /// An allocator that uses external (PSRAM) memory only.
 pub struct ExternalMemory;
 
 unsafe impl Allocator for ExternalMemory {
     fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
         allocate_caps(EnumSet::from(MemoryCapability::External), layout)
+    }
+
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        unsafe {
+            crate::HEAP.dealloc(ptr.as_ptr(), layout);
+        }
+    }
+}
+
+#[cfg(feature = "nightly")]
+unsafe impl CoreAllocator for ExternalMemory {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, CoreAllocError> {
+        allocate_caps(EnumSet::from(MemoryCapability::External), layout).map_err(|_| CoreAllocError)
     }
 
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {

--- a/esp-alloc/src/lib.rs
+++ b/esp-alloc/src/lib.rs
@@ -91,7 +91,7 @@
 //! you will need it for the `Box` and `Vec` types.
 //!
 //! ```toml
-//! allocator-api2 = { version = "0.2", default-features = false, features = ["alloc"] }
+//! allocator-api2 = { version = "0.3", default-features = false, features = ["alloc"] }
 //! ```
 //!
 //! With this, you can use the `Box` and `Vec` types from `allocator_api2`, with
@@ -107,6 +107,11 @@
 //! vec.push(0xabcd1234);
 //! assert_eq!(vec[0], 0xabcd1234);
 //! ```
+//!
+//! Note that if you use the nightly `allocator_api` feature, you can use the
+//! `Box` and `Vec` types from `alloc`. `allocator_api2` is still available as
+//! an option, but types from `allocator_api2` are not compatible with the
+//! standard library types.
 //!
 //! # Heap stats
 //!

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -27,7 +27,7 @@ embedded-io-async = { version = "0.6.1" }
 rand_core = "0.9.3"
 
 # Unstable dependencies that are not (strictly) part of the public API
-allocator-api2 = { version = "0.2.0", default-features = false, features = ["alloc"] }
+allocator-api2 = { version = "0.3.0", default-features = false, features = ["alloc"] }
 document-features  = "0.2.11"
 esp-alloc = { version = "0.7.0", path = "../esp-alloc", optional = true }
 esp-config = { version = "0.3.0", path = "../esp-config" }

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -220,7 +220,7 @@ harness           = false
 required-features = ["esp-wifi", "esp-alloc"]
 
 [dependencies]
-allocator-api2    = { version = "0.2.0", default-features = false, features = ["alloc"] }
+allocator-api2    = { version = "0.3.0", default-features = false, features = ["alloc"] }
 cfg-if             = "1.0.0"
 critical-section   = "1.1.3"
 defmt              = "1.0.1"

--- a/hil-test/tests/alloc_psram.rs
+++ b/hil-test/tests/alloc_psram.rs
@@ -4,10 +4,13 @@
 // The S3 dev kit in the HIL-tester has octal PSRAM.
 //% CHIPS(octal): esp32s3
 //% ENV(octal): ESP_HAL_CONFIG_PSRAM_MODE=octal
-//% FEATURES: unstable psram
+//% FEATURES: unstable psram esp-alloc/nightly
 
 #![no_std]
 #![no_main]
+// TODO: this test is Xtensa-only, so we can enable allocator_api unconditionally. This will not
+// always be the case. Will this need a //% TOOLCHAIN?
+#![feature(allocator_api)]
 
 use hil_test as _;
 
@@ -16,6 +19,8 @@ extern crate alloc;
 #[cfg(test)]
 #[embedded_test::tests]
 mod tests {
+    use alloc::vec::Vec as AllocVec;
+
     use allocator_api2::vec::Vec;
     use esp_alloc::{AnyMemory, ExternalMemory, InternalMemory};
 
@@ -29,7 +34,7 @@ mod tests {
 
     #[test]
     fn test_simple() {
-        let mut vec = alloc::vec::Vec::new();
+        let mut vec = AllocVec::new();
 
         for i in 0..10000 {
             vec.push(i);
@@ -44,7 +49,7 @@ mod tests {
     fn all_psram_is_usable() {
         let free = esp_alloc::HEAP.free();
         defmt::info!("Free: {}", free);
-        let mut vec = alloc::vec::Vec::with_capacity(free);
+        let mut vec = AllocVec::with_capacity(free);
 
         for i in 0..free {
             vec.push((i % 256) as u8);


### PR DESCRIPTION
A new update to `allocator_api2` removed the `nightly` feature, so that they always duplicate the alloc types. Previously the nightly feature required `#[feature(allocator_api)]` which we did not enable in esp-wifi, so it wasn't compatible with allocator_api2/nightly. This is no longer an issue.