### PR TITLE
Update enumset dependency to enable defmt

### DIFF
--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -19,7 +19,7 @@ esp-hal = { version = "1.0.0-beta.0", path = "../esp-hal", default-features = fa
 critical-section = "1.2.0"
 cfg-if = "1.0.0"
 portable-atomic = { version = "1.11.0", default-features = false }
-enumset   = { version = "1.1.5", default-features = false, optional = true }
+enumset   = { version = "1.1.6", default-features = false, optional = true }
 
 # ⚠️ Unstable dependencies
 embedded-io = { version = "0.6.1", default-features = false }
@@ -145,7 +145,7 @@ serde = ["dep:serde", "enumset?/serde"]
 log-04 = ["dep:log-04", "esp-hal/log-04", "esp-wifi-sys/log"]
 
 ## Enable logging output using `defmt` and implement `defmt::Format` on certain types.
-defmt = ["dep:defmt", "smoltcp?/defmt", "esp-hal/defmt", "bt-hci?/defmt", "esp-wifi-sys/defmt"]
+defmt = ["dep:defmt", "smoltcp?/defmt", "esp-hal/defmt", "bt-hci?/defmt", "esp-wifi-sys/defmt", "enumset/defmt"]
 
 [package.metadata.docs.rs]
 features = [


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
  **Not applicable**: This enables new functionality that would not be covered by examples yet (nor does it need to).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
  **Not applicable**: No code was changed.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
  **Unsure if needed**: A minor bump in a dependency would probably not be worth mentioning, and neither is the feature forwarding (we wouldn't mention other new features of a dependency either, this just needs a tad more work to become usable).
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
  **Not applicable**: No changes needed downstream.
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)
   **Does not really apply, that is about APIs and code and not about **


#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

  Note that editing is sadly not possible due to GitHub's limitations; I'll try to be quick about applying any suggestions.

### Pull Request Details 📖

#### Description

`enumset::EnumSet` is part of this crate's [public API](https://docs.esp-rs.org/esp-hal/esp-wifi/0.12.0/esp32/esp_wifi/wifi/struct.WifiController.html#method.capabilities), but did not implement defmt even though this crate has a flag for it.

Updating enumset by a minor revision enables cross-linking the defmt features to gain an implementation of `Format` on the capabilities.

#### Testing

I think that CI passing should suffice (but don't know this project's CI coverage to be sure).