### PR TITLE
Allow stealing RMT channel creator and fix RMT channel Drop

### DIFF
--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -1234,11 +1234,12 @@ where
     Dm: crate::DriverMode,
 {
     fn drop(&mut self) {
+        let memsize = chip_specific::channel_mem_size(CHANNEL);
+
         // This isn't really necessary, but be extra sure that this channel can't
         // interfere with others.
         chip_specific::set_channel_mem_size(CHANNEL, 0);
 
-        let memsize = chip_specific::channel_mem_size(CHANNEL);
         for s in STATE[usize::from(CHANNEL)..usize::from(CHANNEL + memsize)]
             .iter()
             .rev()

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -75,7 +75,7 @@
 //! # Ok(())
 //! # }
 //! ```
-//! 
+//!
 //! ### TX operation
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
@@ -107,7 +107,7 @@
 //! }
 //! # }
 //! ```
-//! 
+//!
 //! ### RX operation
 //! ```rust, no_run
 #![doc = crate::before_snippet!()]
@@ -216,7 +216,7 @@
 //! }
 //! # }
 //! ```
-//! 
+//!
 //! > Note: on ESP32 and ESP32-S2 you cannot specify a base frequency other than 80 MHz
 
 use core::{
@@ -230,20 +230,17 @@ use enumset::{EnumSet, EnumSetType};
 use portable_atomic::{AtomicU8, Ordering};
 
 use crate::{
-    Async,
-    Blocking,
     asynch::AtomicWaker,
     gpio::{
-        InputConfig,
-        Level,
-        OutputConfig,
         interconnect::{PeripheralInput, PeripheralOutput},
+        InputConfig, Level, OutputConfig,
     },
     handler,
     peripherals::{Interrupt, RMT},
     soc::constants,
     system::{self, GenericPeripheralGuard},
     time::Rate,
+    Async, Blocking,
 };
 
 /// Errors
@@ -841,6 +838,21 @@ mod impl_for_chip {
         _guard: GenericPeripheralGuard<{ crate::system::Peripheral::Rmt as u8 }>,
     }
 
+    impl<Dm: crate::DriverMode, const CHANNEL: u8> ChannelCreator<Dm, CHANNEL> {
+        /// Unsafely steal a channel creator instance.
+        ///
+        /// # Safety
+        ///
+        /// Circumvents HAL ownership and safety guarantees and allows creating multiple
+        /// handles to the same peripheral structure.
+        pub unsafe fn steal() -> ChannelCreator<Dm, CHANNEL> {
+            ChannelCreator {
+                phantom: PhantomData,
+                _guard: GenericPeripheralGuard::new(),
+            }
+        }
+    }
+
     impl_tx_channel_creator!(0);
     impl_tx_channel_creator!(1);
 
@@ -938,6 +950,21 @@ mod impl_for_chip {
         _guard: GenericPeripheralGuard<{ crate::system::Peripheral::Rmt as u8 }>,
     }
 
+    impl<Dm: crate::DriverMode, const CHANNEL: u8> ChannelCreator<Dm, CHANNEL> {
+        /// Unsafely steal a channel creator instance.
+        ///
+        /// # Safety
+        ///
+        /// Circumvents HAL ownership and safety guarantees and allows creating multiple
+        /// handles to the same peripheral structure.
+        pub unsafe fn steal() -> ChannelCreator<Dm, CHANNEL> {
+            ChannelCreator {
+                phantom: PhantomData,
+                _guard: GenericPeripheralGuard::new(),
+            }
+        }
+    }
+
     impl_tx_channel_creator!(0);
     impl_tx_channel_creator!(1);
     impl_tx_channel_creator!(2);
@@ -1033,6 +1060,21 @@ mod impl_for_chip {
     {
         phantom: PhantomData<Dm>,
         _guard: GenericPeripheralGuard<{ crate::system::Peripheral::Rmt as u8 }>,
+    }
+
+    impl<Dm: crate::DriverMode, const CHANNEL: u8> ChannelCreator<Dm, CHANNEL> {
+        /// Unsafely steal a channel creator instance.
+        ///
+        /// # Safety
+        ///
+        /// Circumvents HAL ownership and safety guarantees and allows creating multiple
+        /// handles to the same peripheral structure.
+        pub unsafe fn steal() -> ChannelCreator<Dm, CHANNEL> {
+            ChannelCreator {
+                phantom: PhantomData,
+                _guard: GenericPeripheralGuard::new(),
+            }
+        }
     }
 
     impl_tx_channel_creator!(0);
@@ -1138,6 +1180,21 @@ mod impl_for_chip {
     {
         phantom: PhantomData<Dm>,
         _guard: GenericPeripheralGuard<{ crate::system::Peripheral::Rmt as u8 }>,
+    }
+
+    impl<Dm, const CHANNEL: u8> ChannelCreator<Dm, CHANNEL> {
+        /// Unsafely steal a channel creator instance.
+        ///
+        /// # Safety
+        ///
+        /// Circumvents HAL ownership and safety guarantees and allows creating multiple
+        /// handles to the same peripheral structure.
+        pub unsafe fn steal() -> ChannelCreator<Dm, CHANNEL> {
+            ChannelCreator {
+                phantom: PhantomData,
+                _guard: GenericPeripheralGuard::new(),
+            }
+        }
     }
 
     impl_tx_channel_creator!(0);


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [ ] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

Allow stealing RMT channels to allow re-configuration and re-creation. Fix Drop impl for this to work properly

#### Testing

I tested this on hardware, dropping a channel and then later re-creating it, which lead to a panic because the memory was not released properly.
