### PR TITLE
Give more time to ECC tests

### DIFF
--- a/hil-test/tests/ecc.rs
+++ b/hil-test/tests/ecc.rs
@@ -65,7 +65,6 @@ mod tests {
     }
 
     #[test]
-    #[timeout(5)]
     fn test_ecc_affine_point_multiplication(mut ctx: Context<'static>) {
         for &prime_field in TEST_PARAMS_VECTOR.prime_fields {
             match prime_field.len() {


### PR DESCRIPTION
Looks like the test just became slower for some reason, and that caused HIL to start failing.