### PR TITLE
Read from Cargo.toml whether a crate is published

### DIFF
--- a/xtask/src/commands/release/tag_releases.rs
+++ b/xtask/src/commands/release/tag_releases.rs
@@ -31,7 +31,7 @@ pub fn tag_releases(workspace: &Path, mut args: TagReleasesArgs) -> Result<()> {
         // If a package does not require documentation, this also means that it is not
         // published (maybe this function needs a better name), so we can skip tagging
         // it:
-        if !package.is_published() {
+        if !package.is_published(workspace) {
             continue;
         }
 

--- a/xtask/src/documentation.rs
+++ b/xtask/src/documentation.rs
@@ -38,7 +38,7 @@ pub fn build_documentation(
 
     for package in packages {
         // Not all packages need documentation built:
-        if !package.is_published() {
+        if !package.is_published(workspace) {
             continue;
         }
 
@@ -308,7 +308,7 @@ pub fn build_documentation_index(workspace: &Path, packages: &mut [Package]) -> 
 
     for package in packages {
         // Not all packages have documentation built:
-        if !package.is_published() {
+        if !package.is_published(workspace) {
             continue;
         }
 
@@ -431,7 +431,7 @@ fn generate_documentation_meta_for_index(workspace: &Path) -> Result<Vec<Value>>
 
     for package in Package::iter() {
         // Not all packages have documentation built:
-        if !package.is_published() {
+        if !package.is_published(workspace) {
             continue;
         }
 

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -87,9 +87,14 @@ impl Package {
         matches!(self, EspHal | EspLpHal | EspWifi | EspHalEmbassy)
     }
 
-    /// Should documentation be built for the package?
-    pub fn is_published(&self) -> bool {
-        !matches!(self, Package::Examples | Package::HilTest | Package::QaTest)
+    /// Should documentation be built for the package, and should the package be
+    /// published?
+    pub fn is_published(&self, workspace: &Path) -> bool {
+        // TODO: we should use some sort of cache instead of parsing the TOML every
+        // time, but for now this should be good enough.
+        let toml =
+            crate::cargo::CargoToml::new(workspace, *self).expect("Failed to parse Cargo.toml");
+        toml.is_published()
     }
 
     /// Build on host

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -184,7 +184,7 @@ fn lint_packages(workspace: &Path, args: LintPackagesArgs) -> Result<()> {
     let mut packages = args.packages;
     packages.sort();
 
-    for package in packages.iter().filter(|p| p.is_published()) {
+    for package in packages.iter().filter(|p| p.is_published(workspace)) {
         // Unfortunately each package has its own unique requirements for
         // building, so we need to handle each individually (though there
         // is *some* overlap)


### PR DESCRIPTION
This PR is a bit inefficient but hopefully it doesn't make the xtask too slow. Use Cargo.toml data instead of hardcoding whether a package is published. (And also cleans up --no-verify)