### PR TITLE
Apply release plan

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -112,13 +112,9 @@ jobs:
           path: ~/.cargo/bin/
 
       - name: Build documentation
-        # For release PRs, we want to skip the generating documentation if the version is already
-        # present in the manifest. This is meant to ensure only the released packages are built.
-        # For manual run we don't do such filtering, as we want to build the documentation for
-        # all packages specified by the user.
         run: |
           chmod +x ~/.cargo/bin/xtask
-          ~/.cargo/bin/xtask build documentation --packages=${{ matrix.packages.name }} --base-url https://docs.espressif.com/projects/rust/
+          ~/.cargo/bin/xtask build documentation --packages=${{ matrix.packages.name }} --base-url ${{ fromJSON('["https://preview-docs.espressif.com/projects/rust/", "https://docs.espressif.com/projects/rust/"]')[github.event.inputs.server == 'production'] }}
 
       # https://github.com/actions/deploy-pages/issues/303#issuecomment-1951207879
       - name: Remove problematic '.lock' files

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -137,6 +137,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
 
       - name: Prepare
         run: mkdir docs && mkdir docs/esp-hal && mkdir docs/esp-wifi && mkdir docs/esp-lp-hal
@@ -145,6 +148,18 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: "docs/"
+
+      - name: Download xtask
+        uses: actions/download-artifact@v4
+        with:
+          name: xtask
+          path: ~/.cargo/bin/
+
+      # Create an index for _all_ packages. Per-package workflows don't upload the landing page.
+      - name: Create index.html
+        run: |
+          chmod +x ~/.cargo/bin/xtask
+          ~/.cargo/bin/xtask build documentation-index
 
       - if: ${{ github.event.inputs.server == 'preview' || github.event_name == 'pull_request' }}
         name: Deploy to preview server

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -46,14 +46,14 @@ jobs:
           repository: esp-rs/esp-hal
       - name: Build xtask
         run: |
-          cargo build --release --package=xtask --features=deploy-docs
-          cp target/release/xtask ~/.cargo/bin/hal-xtask
+          cargo build --package=xtask --features=deploy-docs
+          cp target/debug/xtask ~/.cargo/bin/hal-xtask
 
       - name: Cache xtask for all jobs
         uses: actions/upload-artifact@v4
         with:
           name: xtask
-          path: target/release/xtask
+          path: target/debug/xtask
 
       - id: setup_manual
         name: Set up [manual run with specific packages]
@@ -63,6 +63,7 @@ jobs:
       - id: setup_pr
         name: Set up [pull request or all packages]
         if: ${{ github.event_name == 'pull_request' || github.event.inputs.packages == '' }}
+        # Release PRs will ignore the tag values and just check out the latest commit
         run: |
           output=$(hal-xtask release tag-releases)
           echo "packages=${output}" >> "$GITHUB_OUTPUT"
@@ -90,25 +91,34 @@ jobs:
       - name: rust-src
         run: rustup component add rust-src --toolchain nightly
 
+      # Checkout the tag we need to start building the docs
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        with:
+          repository: esp-rs/esp-hal
+          ref: ${{ matrix.packages.tag }}
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        if: ${{ github.event_name != 'workflow_dispatch' }}
+        with:
+          repository: esp-rs/esp-hal
+
       - name: Download xtask
         uses: actions/download-artifact@v4
         with:
           name: xtask
-          path: ~/.cargo/bin/hal-xtask
-
-      # Checkout the tag we need to start building the docs
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          repository: esp-rs/esp-hal
-          ref: ${{ matrix.packages.tag }}
+          path: ~/.cargo/bin/
 
       - name: Build documentation
         # For release PRs, we want to skip the generating documentation if the version is already
         # present in the manifest. This is meant to ensure only the released packages are built.
         # For manual run we don't do such filtering, as we want to build the documentation for
         # all packages specified by the user.
-        run: hal-xtask build documentation --packages=${{ matrix.packages.name }} ${{ fromJSON('["", "--skip-if-up-to-date"]')[ github.event_name == 'pull_request' ] }} --base-url /projects/rust/
+        run: |
+          chmod +x ~/.cargo/bin/xtask
+          ~/.cargo/bin/xtask build documentation --packages=${{ matrix.packages.name }} ${{ fromJSON('["", "--skip-if-up-to-date"]')[ github.event_name == 'pull_request' ] }} --base-url /projects/rust/
 
       # https://github.com/actions/deploy-pages/issues/303#issuecomment-1951207879
       - name: Remove problematic '.lock' files

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -118,7 +118,7 @@ jobs:
         # all packages specified by the user.
         run: |
           chmod +x ~/.cargo/bin/xtask
-          ~/.cargo/bin/xtask build documentation --packages=${{ matrix.packages.name }} ${{ fromJSON('["", "--skip-if-up-to-date"]')[ github.event_name == 'pull_request' ] }} --base-url /projects/rust/
+          ~/.cargo/bin/xtask build documentation --packages=${{ matrix.packages.name }} ${{ fromJSON('["", "--skip-if-up-to-date"]')[ github.event_name == 'pull_request' ] }} --base-url https://docs.espressif.com/projects/rust/
 
       # https://github.com/actions/deploy-pages/issues/303#issuecomment-1951207879
       - name: Remove problematic '.lock' files

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -99,6 +99,7 @@ jobs:
           repository: esp-rs/esp-hal
           ref: ${{ matrix.packages.tag }}
 
+      # If running a release PR, we want to build docs for the latest commit on the released branch.
       - name: Checkout repository
         uses: actions/checkout@v4
         if: ${{ github.event_name != 'workflow_dispatch' }}
@@ -132,30 +133,20 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'release-pr')) }}
 
     steps:
+      # Check out the sources, the xtask reads package versions from the Cargo.toml files
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: stable
 
-      - name: Prepare
-        run: mkdir docs && mkdir docs/esp-hal && mkdir docs/esp-wifi && mkdir docs/esp-lp-hal
-
-      - name: Download all docs
+      - name: Download all docs and xtask
         uses: actions/download-artifact@v4
         with:
           path: "docs/"
 
-      - name: Download xtask
-        uses: actions/download-artifact@v4
-        with:
-          name: xtask
-          path: ~/.cargo/bin/
-
       # Create an index for _all_ packages. Per-package workflows don't upload the landing page.
       - name: Create index.html
         run: |
-          chmod +x ~/.cargo/bin/xtask
-          ~/.cargo/bin/xtask build documentation-index
+          chmod +x docs/xtask/xtask
+          docs/xtask/xtask build documentation-index
+          rm -rf docs/xtask
 
       - if: ${{ github.event.inputs.server == 'preview' || github.event_name == 'pull_request' }}
         name: Deploy to preview server

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -118,7 +118,7 @@ jobs:
         # all packages specified by the user.
         run: |
           chmod +x ~/.cargo/bin/xtask
-          ~/.cargo/bin/xtask build documentation --packages=${{ matrix.packages.name }} ${{ fromJSON('["", "--skip-if-up-to-date"]')[ github.event_name == 'pull_request' ] }} --base-url https://docs.espressif.com/projects/rust/
+          ~/.cargo/bin/xtask build documentation --packages=${{ matrix.packages.name }} --base-url https://docs.espressif.com/projects/rust/
 
       # https://github.com/actions/deploy-pages/issues/303#issuecomment-1951207879
       - name: Remove problematic '.lock' files

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,6 +1,8 @@
 name: Documentation
 
 on:
+  pull_request:
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
     inputs:
       packages:
@@ -8,8 +10,10 @@ on:
           A JSON structure describing the packages to build.
           E.g: [{"name":"esp-hal","tag":"v0.23.1"},{"name":"esp-wifi","tag":"esp-wifi-v0.12"}]
 
-          NOTE: You can run `cargo xtask tag-releases` to get the json output generated for this workflow.
-        required: true
+          NOTE: You can run `cargo xtask release tag-releases` to get the json output generated for this workflow.
+
+          If you want to build all packages, leave this field empty.
+        required: false
       server:
         type: choice
         description: Which server to deploy to
@@ -24,12 +28,51 @@ env:
 jobs:
   setup:
     runs-on: ubuntu-latest
-    outputs:
-      packages: "${{ github.event.inputs.packages }}"
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'release-pr')) }}
     steps:
-      - run: echo "Setup complete!"
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      # Build the `xtask` package using the latest commit, and copy the
+      # resulting binary to the `~/.cargo/bin/` directory. We do this to
+      # avoid having to rebuild different versions of the package for
+      # different tags if they do not fall on the same commit, and to
+      # make sure that we take advantage of any subsequent updates to
+      # the xtask which may have happened after a release was tagged.
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          repository: esp-rs/esp-hal
+      - name: Build xtask
+        run: |
+          cargo build --release --package=xtask --features=deploy-docs
+          cp target/release/xtask ~/.cargo/bin/hal-xtask
+
+      - name: Cache xtask for all jobs
+        uses: actions/upload-artifact@v4
+        with:
+          name: xtask
+          path: target/release/xtask
+
+      - id: setup_manual
+        name: Set up [manual run with specific packages]
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.packages != '' }}
+        run: echo "packages=${{ github.event.inputs.packages }}" >> "$GITHUB_OUTPUT"
+
+      - id: setup_pr
+        name: Set up [pull request or all packages]
+        if: ${{ github.event_name == 'pull_request' || github.event.inputs.packages == '' }}
+        run: |
+          output=$(hal-xtask release tag-releases)
+          echo "packages=${output}" >> "$GITHUB_OUTPUT"
+
+    outputs:
+      packages: "${{ steps.setup_manual.outputs.packages || steps.setup_pr.outputs.packages }}"
+
   build:
     needs: setup
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'release-pr')) }}
     strategy:
       fail-fast: true
       matrix:
@@ -47,21 +90,11 @@ jobs:
       - name: rust-src
         run: rustup component add rust-src --toolchain nightly
 
-      # TODO: we could build this once and download onto each runner
-      # Build the `xtask` package using the latest commit, and copy the
-      # resulting binary to the `~/.cargo/bin/` directory. We do this to
-      # avoid having to rebuild different versions of the package for
-      # different tags if they do not fall on the same commit, and to
-      # make sure that we take advantage of any subsequent updates to
-      # the xtask which may have happened after a release was tagged.
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - name: Download xtask
+        uses: actions/download-artifact@v4
         with:
-          repository: esp-rs/esp-hal
-      - name: Build xtask
-        run: |
-          cargo build --release --package=xtask --features=deploy-docs
-          cp target/release/xtask ~/.cargo/bin/hal-xtask
+          name: xtask
+          path: ~/.cargo/bin/hal-xtask
 
       # Checkout the tag we need to start building the docs
       - name: Checkout repository
@@ -71,7 +104,11 @@ jobs:
           ref: ${{ matrix.packages.tag }}
 
       - name: Build documentation
-        run: hal-xtask build documentation --packages=${{ matrix.packages.name }} --base-url /projects/rust/
+        # For release PRs, we want to skip the generating documentation if the version is already
+        # present in the manifest. This is meant to ensure only the released packages are built.
+        # For manual run we don't do such filtering, as we want to build the documentation for
+        # all packages specified by the user.
+        run: hal-xtask build documentation --packages=${{ matrix.packages.name }} ${{ fromJSON('["", "--skip-if-up-to-date"]')[ github.event_name == 'pull_request' ] }} --base-url /projects/rust/
 
       # https://github.com/actions/deploy-pages/issues/303#issuecomment-1951207879
       - name: Remove problematic '.lock' files
@@ -86,19 +123,20 @@ jobs:
   assemble:
     needs: [setup, build]
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'release-pr')) }}
+
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: stable
+
       - name: Prepare
         run: mkdir docs && mkdir docs/esp-hal && mkdir docs/esp-wifi && mkdir docs/esp-lp-hal
+
       - name: Download all docs
         uses: actions/download-artifact@v4
         with:
           path: "docs/"
 
-      - if: ${{ github.event.inputs.server == 'preview' }}
+      - if: ${{ github.event.inputs.server == 'preview' || github.event_name == 'pull_request' }}
         name: Deploy to preview server
         uses: appleboy/scp-action@v0.1.7
         with:
@@ -110,7 +148,8 @@ jobs:
           strip_components: 1 # remove the docs prefix
           overwrite: true
 
-      - if: ${{ github.event.inputs.server == 'production' }}
+      # Deploying to production server is only allowed for manual runs
+      - if: ${{ github.event.inputs.server == 'production' && github.event_name == 'workflow_dispatch' }}
         name: Deploy to production server
         uses: appleboy/scp-action@v0.1.7
         with:

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -39,6 +39,7 @@ rustdoc-types = { version = "0.35.0", optional = true }
 
 flate2 = { version = "1.1.1", optional = true }
 temp-file = { version = "0.1.9", optional = true }
+urlencoding = { version = "2.1.3", optional = true }
 
 [dev-dependencies]
 pretty_assertions = "1.2.0"
@@ -47,4 +48,4 @@ pretty_assertions = "1.2.0"
 deploy-docs  = ["dep:reqwest"]
 preview-docs = ["dep:opener", "dep:rocket"]
 semver-checks = [ "dep:cargo-semver-checks", "dep:rustdoc-types", "dep:flate2", "dep:temp-file" ]
-release = ["semver-checks"]
+release = ["semver-checks", "dep:opener", "dep:urlencoding"]

--- a/xtask/src/commands/build.rs
+++ b/xtask/src/commands/build.rs
@@ -19,6 +19,8 @@ use crate::{
 pub enum Build {
     /// Build documentation for the specified chip.
     Documentation(BuildDocumentationArgs),
+    /// Build documentation index.
+    DocumentationIndex,
     /// Build all examples for the specified chip.
     Examples(ExamplesArgs),
     /// Build the specified package with the given options.
@@ -105,6 +107,13 @@ pub fn build_documentation(workspace: &Path, mut args: BuildDocumentationArgs) -
             .launch(),
         )?;
     }
+
+    Ok(())
+}
+
+pub fn build_documentation_index(workspace: &Path) -> Result<()> {
+    let mut packages = Package::iter().collect::<Vec<_>>();
+    crate::documentation::build_documentation_index(workspace, &mut packages)?;
 
     Ok(())
 }

--- a/xtask/src/commands/build.rs
+++ b/xtask/src/commands/build.rs
@@ -20,6 +20,7 @@ pub enum Build {
     /// Build documentation for the specified chip.
     Documentation(BuildDocumentationArgs),
     /// Build documentation index.
+    #[cfg(feature = "deploy-docs")]
     DocumentationIndex,
     /// Build all examples for the specified chip.
     Examples(ExamplesArgs),
@@ -111,6 +112,7 @@ pub fn build_documentation(workspace: &Path, mut args: BuildDocumentationArgs) -
     Ok(())
 }
 
+#[cfg(feature = "deploy-docs")]
 pub fn build_documentation_index(workspace: &Path) -> Result<()> {
     let mut packages = Package::iter().collect::<Vec<_>>();
     crate::documentation::build_documentation_index(workspace, &mut packages)?;

--- a/xtask/src/commands/build.rs
+++ b/xtask/src/commands/build.rs
@@ -41,11 +41,6 @@ pub struct BuildDocumentationArgs {
     /// Base URL of the deployed documentation.
     #[arg(long)]
     pub base_url: Option<String>,
-    /// Don't build the documentation for packages that are in the manifest.
-    ///
-    /// This option is meant for CI, to skip building packages for no reason.
-    #[arg(long)]
-    pub skip_if_up_to_date: bool,
     #[cfg(feature = "preview-docs")]
     #[arg(long)]
     pub serve: bool,
@@ -74,20 +69,12 @@ pub struct BuildPackageArgs {
 // Subcommand Actions
 
 pub fn build_documentation(workspace: &Path, mut args: BuildDocumentationArgs) -> Result<()> {
-    let anything_built = crate::documentation::build_documentation(
+    crate::documentation::build_documentation(
         workspace,
         &mut args.packages,
         &mut args.chips,
         args.base_url,
-        args.skip_if_up_to_date,
     )?;
-
-    if !anything_built {
-        // We don't deal with the preview-docs edge case because skip_if_up_to_date is
-        // intended to be set by CI only.
-        log::info!("No new documentation was built.");
-        return Ok(());
-    }
 
     crate::documentation::build_documentation_index(workspace, &mut args.packages)?;
 

--- a/xtask/src/commands/release.rs
+++ b/xtask/src/commands/release.rs
@@ -2,12 +2,16 @@ use clap::Subcommand;
 
 pub mod bump_version;
 #[cfg(feature = "release")]
+pub mod execute_plan;
+#[cfg(feature = "release")]
 pub mod plan;
 pub mod publish;
 pub mod semver_check;
 pub mod tag_releases;
 
 pub use bump_version::*;
+#[cfg(feature = "release")]
+pub use execute_plan::*;
 #[cfg(feature = "release")]
 pub use plan::*;
 pub use publish::*;
@@ -27,6 +31,10 @@ pub enum Release {
     /// control what and how gets released.
     #[cfg(feature = "release")]
     Plan(PlanArgs),
+    /// Execute a release plan. This command will update versions, changelogs,
+    /// and opens a pull request with the changes.
+    #[cfg(feature = "release")]
+    ExecutePlan(ApplyPlanArgs),
     /// Bump the version of the specified package(s).
     ///
     /// This command will, for each specified package:

--- a/xtask/src/commands/release/execute_plan.rs
+++ b/xtask/src/commands/release/execute_plan.rs
@@ -60,9 +60,8 @@ pub fn execute_plan(workspace: &Path, args: ApplyPlanArgs) -> Result<()> {
             );
         }
 
-        update_package(&mut package, &step.bump)?;
+        let new_version = update_package(&mut package, &step.bump, !args.no_dry_run)?;
 
-        let new_version = package.package_version();
         step.tag_name = package.package.tag(&new_version);
         step.new_version = new_version;
     }
@@ -89,10 +88,7 @@ pub fn execute_plan(workspace: &Path, args: ApplyPlanArgs) -> Result<()> {
 
     if !args.no_dry_run {
         println!(
-            "Dry run completed. No permanent changes were made, but code has been updated. \
-            You can review the changes. If you are satisfied, clean the workspace with \
-            `git reset --hard` and run `cargo xrelease execute-plan --no-dry-run` to make \
-            the changes permanent."
+            "Dry run completed. To make changes, run `cargo xrelease execute-plan --no-dry-run`."
         );
     }
 

--- a/xtask/src/commands/release/execute_plan.rs
+++ b/xtask/src/commands/release/execute_plan.rs
@@ -1,0 +1,284 @@
+use std::{path::Path, process::Command};
+
+use anyhow::{Context, Result, bail, ensure};
+use clap::Args;
+
+use crate::{
+    cargo::CargoToml,
+    commands::{release::plan::Plan, update_package},
+    git::current_branch,
+};
+
+#[derive(Debug, Args)]
+pub struct ApplyPlanArgs {
+    /// Only make code changes, do not commit or push.
+    #[arg(long)]
+    dry_run: bool,
+}
+
+pub fn execute_plan(workspace: &Path, args: ApplyPlanArgs) -> Result<()> {
+    ensure_workspace_clean(workspace)?;
+
+    let plan_path = workspace.join("release_plan.jsonc");
+    let plan_path = crate::windows_safe_path(&plan_path);
+
+    let plan_source = std::fs::read_to_string(&plan_path)
+        .with_context(|| format!("Failed to read release plan from {}", plan_path.display()))?;
+
+    if plan_source.lines().any(|line| line.starts_with("//")) {
+        bail!(
+            "The release plan has not been finalized. Please open the plan and follow the instructions in it."
+        );
+    }
+
+    let plan = serde_json::from_str::<Plan>(&plan_source)
+        .with_context(|| format!("Failed to parse release plan from {}", plan_path.display()))?;
+
+    ensure!(
+        current_branch()? == plan.base,
+        "The release plan must be executed on the same branch it was created on. \
+        Please switch to the {} branch and try again.",
+        plan.base
+    );
+
+    // Make code changes
+    for step in plan.packages.iter() {
+        let mut package = CargoToml::new(workspace, step.package)?;
+
+        if package.package_version() != step.current_version {
+            if package.package_version() == step.new_version {
+                println!(
+                    "Package {} is already at version {}. Skipping.",
+                    step.package, step.new_version
+                );
+                continue;
+            }
+            bail!(
+                "The version of package {} has changed in an unexpected way. Cannot continue.",
+                step.package
+            );
+        }
+
+        update_package(&mut package, &step.bump)?;
+    }
+
+    make_git_changes(args.dry_run, &plan_source, &plan)?;
+
+    Ok(())
+}
+
+fn ensure_workspace_clean(workspace: &Path) -> Result<()> {
+    std::env::set_current_dir(workspace)
+        .with_context(|| format!("Failed to change directory to {}", workspace.display()))?;
+
+    let status = Command::new("git")
+        .arg("status")
+        .arg("--porcelain")
+        .output()
+        .context("Failed to check git status")?;
+
+    ensure!(
+        String::from_utf8_lossy(&status.stdout).trim().is_empty(),
+        "The workspace is not clean. Please commit or stash your changes before running this command."
+    );
+
+    Ok(())
+}
+
+fn make_git_changes(dry_run: bool, release_plan_str: &str, release_plan: &Plan) -> Result<()> {
+    // Find an available branch name
+    let branch_name = format!(
+        "{branch_name}-{}",
+        jiff::Timestamp::now().strftime("%Y-%m-%d"),
+        branch_name = "release-branch",
+    );
+
+    // Switch to the new branch
+    if dry_run {
+        println!("Dry run: would create a new branch: {branch_name}");
+    } else {
+        // Create a new branch
+        let status = Command::new("git")
+            .arg("switch")
+            .arg("-c")
+            .arg(&branch_name)
+            .status()
+            .context("Failed to create new branch")?;
+
+        if !status.success() {
+            bail!("Failed to create new branch: {branch_name}");
+        }
+    }
+
+    // Commit the changes
+    if dry_run {
+        println!("Dry run: would commit changes to branch: {branch_name}");
+    } else {
+        Command::new("git")
+            .arg("commit")
+            .arg("-am")
+            .arg("Finalize crates for release")
+            .status()
+            .context("Failed to commit changes")?;
+    }
+
+    // Push the branch
+    let url = if dry_run {
+        println!("Dry run: would push branch: {branch_name}");
+        String::from("<dry_run_url>")
+    } else {
+        // git push origin <branch_name>
+        let message = Command::new("git")
+            .arg("push")
+            .arg("origin")
+            .arg(&branch_name)
+            .output()
+            .context("Failed to push branch")?;
+
+        if !message.status.success() {
+            bail!(
+                "Failed to push branch: {}",
+                String::from_utf8_lossy(&message.stderr)
+            );
+        }
+
+        // Extract the URL from the output
+        extract_url_from_push(&String::from_utf8_lossy(&message.stderr)) // git outputs to stderr
+    };
+
+    // Open a pull request
+
+    let packages_to_release = release_plan
+        .packages
+        .iter()
+        .map(|step| format!("- {}: {}", step.package, step.new_version))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let mut body = format!(
+        r#"This pull request prepares the following packages for release:
+
+{packages_to_release}
+
+The release plan used for this release:
+
+```json
+{release_plan_str}
+```
+
+Please review the changes and merge them into the main branch.
+Once merged, the packages will be ready to be published and tagged.
+"#
+    );
+
+    if release_plan.base != "main" {
+        body = format!(
+            "⚠️ This pull request was branched off from `{current_branch}`. ⚠️\n\n{body}",
+            current_branch = release_plan.base
+        );
+    }
+
+    // TODO: don't forget to update the PR text once we have the `publish` command
+    // updated.
+
+    let pr_url_base = comparison_url(&release_plan.base, &url, &branch_name)?;
+
+    // Query string options are documented at: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request
+    let open_pr_url = format!(
+        "{pr_url_base}?quick_pull=1&title=Prepare+release&labels={label}&body={body}",
+        body = urlencoding::encode(&body),
+        label = "release-pr",
+    );
+
+    if opener::open(&open_pr_url).is_err() {
+        println!("Open the following URL to create a pull request:");
+        println!("{open_pr_url}");
+    }
+
+    println!("Once you create and merge the pull request, check out current main.");
+    println!("Make sure you have the release_plan.jsonc file in the root of the workspace.");
+    // TODO: uncomment this once we have the `publish` command updated
+    // println!("Next, run `cargo xrelease publish` to tag the release and publish
+    // the packages.");
+
+    Ok(())
+}
+
+fn extract_url_from_push(output: &str) -> String {
+    output
+        .lines()
+        .map(|s| s.trim_start_matches("remote:"))
+        .map(|s| s.trim())
+        .find(|&s| s.starts_with("https://"))
+        .unwrap_or("")
+        .to_string()
+}
+
+fn comparison_url(base: &str, url: &str, branch_name: &str) -> Result<String> {
+    let url = if url.starts_with("https://github.com/esp-rs/") {
+        format!("https://github.com/esp-rs/esp-hal/compare/{base}...{branch_name}")
+    } else {
+        let Some(user) = url.split('/').nth(3) else {
+            bail!("Failed to extract user from URL: {url}");
+        };
+        format!("https://github.com/esp-rs/esp-hal/compare/{base}...{user}:esp-hal:{branch_name}")
+    };
+
+    Ok(url)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn extract_url() {
+        let message = "Enumerating objects: 20, done.
+Counting objects: 100% (20/20), done.
+Delta compression using up to 16 threads
+Compressing objects: 100% (14/14), done.
+Writing objects: 100% (14/14), 2.61 KiB | 2.61 MiB/s, done.
+Total 14 (delta 13), reused 0 (delta 0), pack-reused 0 (from 0)
+remote: Resolving deltas: 100% (13/13), completed with 6 local objects.
+remote: 
+remote: Create a pull request for 'foo' on GitHub by visiting:
+remote:      https://github.com/bugadani/esp-hal/pull/new/foo
+remote:
+To https://github.com/bugadani/esp-hal.git
+ * [new branch]          foo -> foo
+branch 'foo' set up to track 'origin/foo'.
+";
+
+        let url = extract_url_from_push(message);
+        assert_eq!(url, "https://github.com/bugadani/esp-hal/pull/new/foo");
+    }
+
+    #[test]
+    fn create_comparison_url() {
+        let cases = [
+            // From forked repo
+            (
+                "https://github.com/bugadani/esp-hal/pull/new/foo",
+                ("main", "foo"),
+                "https://github.com/esp-rs/esp-hal/compare/main...bugadani:esp-hal:foo",
+            ),
+            (
+                "https://github.com/bugadani/esp-hal/pull/new/foo",
+                ("backport", "foo"),
+                "https://github.com/esp-rs/esp-hal/compare/backport...bugadani:esp-hal:foo",
+            ),
+            // From upstream
+            (
+                "https://github.com/esp-rs/esp-hal/pull/new/foo",
+                ("main", "foo"),
+                "https://github.com/esp-rs/esp-hal/compare/main...foo",
+            ),
+        ];
+
+        for (input_url, (current_branch, release_branch), expected_url) in cases {
+            let url = comparison_url(current_branch, input_url, release_branch)
+                .expect("Failed to create PR URL");
+            assert_eq!(url, expected_url);
+        }
+    }
+}

--- a/xtask/src/commands/release/execute_plan.rs
+++ b/xtask/src/commands/release/execute_plan.rs
@@ -213,9 +213,9 @@ Once merged, the packages will be ready to be published and tagged.
 
     // Query string options are documented at: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request
     let open_pr_url = format!(
-        "{pr_url_base}?quick_pull=1&title=Prepare+release&labels={label}&body={body}",
+        "{pr_url_base}?quick_pull=1&title=Prepare+release&labels={labels}&body={body}",
         body = urlencoding::encode(&body),
-        label = "release-pr",
+        labels = "release-pr,skip-changelog",
     );
 
     if dry_run {

--- a/xtask/src/commands/release/execute_plan.rs
+++ b/xtask/src/commands/release/execute_plan.rs
@@ -221,11 +221,9 @@ Once merged, the packages will be ready to be published and tagged.
     if dry_run {
         println!("Dry run: would open the following URL to create a pull request:");
         println!("{open_pr_url}");
-    } else {
-        if opener::open(&open_pr_url).is_err() {
-            println!("Open the following URL to create a pull request:");
-            println!("{open_pr_url}");
-        }
+    } else if opener::open(&open_pr_url).is_err() {
+        println!("Open the following URL to create a pull request:");
+        println!("{open_pr_url}");
     }
 
     println!("Once you create and merge the pull request, check out current main.");

--- a/xtask/src/commands/release/tag_releases.rs
+++ b/xtask/src/commands/release/tag_releases.rs
@@ -66,10 +66,12 @@ pub fn tag_releases(workspace: &Path, mut args: TagReleasesArgs) -> Result<()> {
         log::info!("IMPORTANT: Don't forget to push the tags to the correct remote!");
     }
 
-    log::info!(
-        "Documentation workflow input for these packages:\r\n\r\n {:#}",
-        serde_json::to_string(&created)?
-    );
+    let workflow_input = serde_json::to_string(&created)?;
+
+    log::info!("Documentation workflow input for these packages:\r\n\r\n{workflow_input}\r\n\r\n");
+
+    // Print to stdout for GitHub Actions
+    print!("{workflow_input}");
 
     Ok(())
 }

--- a/xtask/src/documentation.rs
+++ b/xtask/src/documentation.rs
@@ -227,7 +227,7 @@ fn cargo_doc(workspace: &Path, package: Package, chip: Option<Chip>) -> Result<P
 
     // Special case: `esp-metadata` requires `std`, and we get some really confusing
     // errors if we try to pass `-Zbuild-std=core`:
-    if package != Package::EspMetadata {
+    if package.needs_build_std() {
         builder = builder.arg("-Zbuild-std=alloc,core");
     }
 

--- a/xtask/src/documentation.rs
+++ b/xtask/src/documentation.rs
@@ -28,16 +28,13 @@ pub fn build_documentation(
     packages: &mut [Package],
     chips: &mut [Chip],
     base_url: Option<String>,
-    skip_if_up_to_date: bool,
-) -> Result<bool> {
+) -> Result<()> {
     let output_path = workspace.join("docs");
 
     fs::create_dir_all(&output_path)
         .with_context(|| format!("Failed to create {}", output_path.display()))?;
 
     packages.sort();
-
-    let mut any_built = false;
 
     for package in packages {
         // Not all packages need documentation built:
@@ -67,15 +64,7 @@ pub fn build_documentation(
 
         // Update the package manifest to include the latest version:
         let version = crate::package_version(workspace, *package)?;
-        if skip_if_up_to_date && manifest.versions.contains(&version) {
-            log::info!(
-                "Skipping documentation for '{package}' version '{version}' as it is already up to date"
-            );
-            continue;
-        }
         manifest.versions.insert(version.clone());
-
-        any_built = true;
 
         // Build the documentation for the package:
         if chips.is_empty() {
@@ -96,7 +85,7 @@ pub fn build_documentation(
         patch_documentation_index_for_package(workspace, package, &version, &base_url)?;
     }
 
-    Ok(any_built)
+    Ok(())
 }
 
 fn build_documentation_for_package(

--- a/xtask/src/documentation.rs
+++ b/xtask/src/documentation.rs
@@ -478,7 +478,11 @@ fn fetch_manifest(base_url: &Option<String>, package: &Package) -> Result<Manife
 
     #[cfg(feature = "deploy-docs")]
     let manifest = match reqwest::blocking::get(manifest_url) {
-        Ok(resp) => resp.json::<Manifest>()?,
+        Ok(resp) if resp.status().is_success() => resp.json::<Manifest>()?,
+        Ok(resp) => {
+            log::warn!("Unable to fetch package manifest: {}", resp.status());
+            Manifest::default()
+        }
         Err(err) => {
             log::warn!("Unable to fetch package manifest: {err}");
             Manifest::default()

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -85,6 +85,12 @@ impl Package {
         )
     }
 
+    pub fn needs_build_std(&self) -> bool {
+        use Package::*;
+
+        !matches!(self, EspConfig | EspMetadata)
+    }
+
     /// Do the package's chip-specific cargo features affect the public API?
     pub fn chip_features_matter(&self) -> bool {
         use Package::*;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -127,6 +127,8 @@ fn main() -> Result<()> {
             Release::Publish(args) => publish(&workspace, args),
             #[cfg(feature = "release")]
             Release::Plan(args) => plan(&workspace, args),
+            #[cfg(feature = "release")]
+            Release::ExecutePlan(args) => execute_plan(&workspace, args),
         },
 
         Cli::Ci(args) => run_ci_checks(&workspace, args),

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -99,6 +99,7 @@ fn main() -> Result<()> {
         // Build-related subcommands:
         Cli::Build(build) => match build {
             Build::Documentation(args) => build_documentation(&workspace, args),
+            Build::DocumentationIndex => build_documentation_index(&workspace),
             Build::Examples(args) => examples(
                 &workspace,
                 args,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -99,6 +99,7 @@ fn main() -> Result<()> {
         // Build-related subcommands:
         Cli::Build(build) => match build {
             Build::Documentation(args) => build_documentation(&workspace, args),
+            #[cfg(feature = "deploy-docs")]
             Build::DocumentationIndex => build_documentation_index(&workspace),
             Build::Examples(args) => examples(
                 &workspace,


### PR DESCRIPTION
This PR build on top of #3506 to implement the second part of the release process: the PR applies the version bumps from the release plan, commits and pushes to a new branch and opens a browser window to open the release prep PR.

This part, and the last (`publish`) part are expected to be somewhat staright-forward scripting steps. What needs to be done is already implemented in bits and pieces, it just needs to be tied together - although there are edge cases.

The PR also modifies (and fixes) the documentation workflow, so that a release PR deploys an updated documentation to the preview server.

Closes #3070