### PR TITLE
[demo PR] Prepare release

### DIFF
--- a/esp-backtrace/Cargo.toml
+++ b/esp-backtrace/Cargo.toml
@@ -22,14 +22,14 @@ test  = false
 cfg-if      = "1.0.0"
 defmt       = { version = "1.0.1", optional = true }
 esp-config  = { version = "0.3.0", path = "../esp-config" }
-esp-println = { version = "0.13.0", optional = true, default-features = false, path = "../esp-println" }
+esp-println = { version = "0.14.0", optional = true, default-features = false, path = "../esp-println" }
 heapless    = "0.8"
 semihosting = { version = "0.1.20", optional = true }
 
 [build-dependencies]
-esp-build = { version = "0.2.0", path = "../esp-build" }
+esp-build = { version = "0.3.0", path = "../esp-build" }
 esp-config   = { version = "0.3.0", path = "../esp-config", features = ["build"] }
-esp-metadata = { version = "0.6.0", path = "../esp-metadata" }
+esp-metadata = { version = "0.7.0", path = "../esp-metadata" }
 
 [features]
 default = ["colors"]

--- a/esp-build/CHANGELOG.md
+++ b/esp-build/CHANGELOG.md
@@ -12,13 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bump Rust edition to 2024, bump MSRV to 1.85. (#3391)
 
 ### Fixed
 
 
 ### Removed
 
+
+## [v0.3.0] - 2025-05-21
+
+### Changed
+
+- Bump Rust edition to 2024, bump MSRV to 1.85. (#3391)
 
 ## [0.2.0] - 2025-01-15
 
@@ -34,4 +39,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release (#2518)
 
 [0.2.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-build-v0.2.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-build-v0.2.0...HEAD
+[v0.3.0]: https://github.com/esp-rs/esp-hal/compare/esp-build-v0.2.0...esp-build-v0.3.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-build-v0.3.0...HEAD

--- a/esp-build/Cargo.toml
+++ b/esp-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-build"
-version       = "0.2.0"
+version       = "0.3.0"
 edition       = "2024"
 rust-version  = "1.85.0"
 description   = "Build utilities for esp-hal"

--- a/esp-hal-embassy/Cargo.toml
+++ b/esp-hal-embassy/Cargo.toml
@@ -42,9 +42,9 @@ defmt                     = { version = "1.0.1", optional = true }
 log-04                    = { package = "log", version = "0.4.27", optional = true }
 
 [build-dependencies]
-esp-build    = { version = "0.2.0", path = "../esp-build" }
+esp-build    = { version = "0.3.0", path = "../esp-build" }
 esp-config   = { version = "0.3.0", path = "../esp-config", features = ["build"] }
-esp-metadata = { version = "0.6.0", path = "../esp-metadata" }
+esp-metadata = { version = "0.7.0", path = "../esp-metadata" }
 
 [features]
 default = ["executors"]

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -43,9 +43,9 @@ fugit                    = "0.3.7"
 instability              = "0.3.7"
 strum                    = { version = "0.27.1", default-features = false, features = ["derive"] }
 
-esp-build                = { version = "0.2.0", path = "../esp-build" }
+esp-build                = { version = "0.3.0", path = "../esp-build" }
 esp-config               = { version = "0.3.0", path = "../esp-config" }
-esp-metadata             = { version = "0.6.0", path = "../esp-metadata", default-features = false }
+esp-metadata             = { version = "0.7.0", path = "../esp-metadata", default-features = false }
 procmacros               = { version = "0.17.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
 
 # Dependencies that are optional because they are used by unstable drivers.
@@ -93,8 +93,8 @@ xtensa-lx-rt     = { version = "0.18.0", path = "../xtensa-lx-rt" }
 [build-dependencies]
 basic-toml   = "0.1.10"
 cfg-if       = "1.0.0"
-esp-build    = { version = "0.2.0", path = "../esp-build" }
-esp-metadata = { version = "0.6.0", path = "../esp-metadata" }
+esp-build    = { version = "0.3.0", path = "../esp-build" }
+esp-metadata = { version = "0.7.0", path = "../esp-metadata" }
 esp-config   = { version = "0.3.0", path = "../esp-config", features = ["build"] }
 serde        = { version = "1.0.219", features = ["derive"] }
 

--- a/esp-lp-hal/Cargo.toml
+++ b/esp-lp-hal/Cargo.toml
@@ -31,7 +31,7 @@ riscv             = { version = "0.11.1", features = ["critical-section-single-h
 panic-halt = "0.2.0"
 
 [build-dependencies]
-esp-build = { version = "0.2.0", path = "../esp-build" }
+esp-build = { version = "0.3.0", path = "../esp-build" }
 
 [features]
 default = ["embedded-hal"]

--- a/esp-metadata/CHANGELOG.md
+++ b/esp-metadata/CHANGELOG.md
@@ -9,18 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add ability to define memory regions, have DRAM defined there (#3300)
-- Provide macros to get the start/end of a memory region, make it possible to use the macros in a no-std project (#3300)
 
 ### Changed
 
-- Bump Rust edition to 2024, bump MSRV to 1.85. (#3391)
 
 ### Fixed
 
 
 ### Removed
 
+
+## [v0.7.0] - 2025-05-21
+
+### Added
+
+- Add ability to define memory regions, have DRAM defined there (#3300)
+- Provide macros to get the start/end of a memory region, make it possible to use the macros in a no-std project (#3300)
+
+### Changed
+
+- Bump Rust edition to 2024, bump MSRV to 1.85. (#3391)
 
 ## [0.6.0] - 2025-02-24
 
@@ -58,4 +66,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release (#2518)
 
 [0.6.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-metadata-v0.6.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-metadata-v0.6.0...HEAD
+[v0.7.0]: https://github.com/esp-rs/esp-hal/compare/esp-metadata-v0.6.0...esp-metadata-v0.7.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-metadata-v0.7.0...HEAD

--- a/esp-metadata/Cargo.toml
+++ b/esp-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-metadata"
-version       = "0.6.0"
+version       = "0.7.0"
 edition       = "2024"
 rust-version  = "1.85.0"
 description   = "Metadata for Espressif devices"

--- a/esp-println/CHANGELOG.md
+++ b/esp-println/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+
+### Changed
+
+
+### Fixed
+
+
+### Removed
+
+
+## [v0.14.0] - 2025-05-21
+
+### Added
+
 - Added new `_esp_println_timestamp()` hook, gated by the `timestamp` feature to provide timestamp for logging (#3194)
 - Added metadata for espflash to help setting log format (#3276)
 
@@ -23,9 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Manually setting a log level now correctly ignores `ESP_LOG`. (#3240)
 - Fixed logging rules being order-dependent. (#3240)
-
-### Removed
-
 
 ## [0.13.1] - 2025-02-24
 
@@ -85,4 +96,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove RTT and defmt-raw support (#1658)
 
 [0.13.1]: https://github.com/esp-rs/esp-hal/releases/tag/esp-println-v0.13.1
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-println-v0.13.1...HEAD
+[v0.14.0]: https://github.com/esp-rs/esp-hal/compare/esp-println-v0.13.1...esp-println-v0.14.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-println-v0.14.0...HEAD

--- a/esp-println/Cargo.toml
+++ b/esp-println/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-println"
-version       = "0.13.1"
+version       = "0.14.0"
 edition       = "2024"
 rust-version  = "1.85.0"
 description   = "Provides `print!` and `println!` implementations various Espressif devices"
@@ -32,8 +32,8 @@ defmt            = { version = "1.0.1", optional = true }
 log-04           = { package = "log", version = "0.4.27", optional = true }
 
 [build-dependencies]
-esp-build    = { version = "0.2.0", path = "../esp-build" }
-esp-metadata = { version = "0.6.0", path = "../esp-metadata" }
+esp-build    = { version = "0.3.0", path = "../esp-build" }
+esp-metadata = { version = "0.7.0", path = "../esp-metadata" }
 log-04       = { package = "log", version = "0.4.27" }
 
 [features]

--- a/esp-storage/Cargo.toml
+++ b/esp-storage/Cargo.toml
@@ -28,8 +28,8 @@ critical-section = { version = "1.2.0", optional = true }
 document-features = "0.2.11"
 
 [build-dependencies]
-esp-build    = { version = "0.2.0", path = "../esp-build" }
-esp-metadata = { version = "0.6.0", path = "../esp-metadata" }
+esp-build    = { version = "0.3.0", path = "../esp-build" }
+esp-metadata = { version = "0.7.0", path = "../esp-metadata" }
 
 [features]
 default = ["critical-section"]

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -51,9 +51,9 @@ defmt            = { version = "1.0.1", optional = true }
 log-04           = { package = "log", version = "0.4.27", optional = true }
 
 [build-dependencies]
-esp-build    = { version = "0.2.0", path = "../esp-build" }
+esp-build    = { version = "0.3.0", path = "../esp-build" }
 esp-config   = { version = "0.3.0", path = "../esp-config", features = ["build"] }
-esp-metadata = { version = "0.6.0", path = "../esp-metadata" }
+esp-metadata = { version = "0.7.0", path = "../esp-metadata" }
 
 [features]
 default = ["builtin-scheduler", "esp-alloc"]


### PR DESCRIPTION
This PR showcases the output of `cargo xrelease apply-plan`. Original output starts below the line:

---

This pull request prepares the following packages for release:

- esp-build: 0.3.0
- esp-metadata: 0.7.0
- esp-println: 0.14.0

The release plan used for this release:

```json
{
  "packages": [
    {
      "package": "esp-build",
      "semver_checked": false,
      "current_version": "0.2.0",
      "new_version": "0.3.0",
      "tag_name": "esp-build-v0.3.0",
      "bump": "Minor"
    },
    {
      "package": "esp-metadata",
      "semver_checked": false,
      "current_version": "0.6.0",
      "new_version": "0.7.0",
      "tag_name": "esp-metadata-v0.7.0",
      "bump": "Minor"
    },
    {
      "package": "esp-println",
      "semver_checked": false,
      "current_version": "0.13.1",
      "new_version": "0.14.0",
      "tag_name": "esp-println-v0.14.0",
      "bump": "Minor"
    }
  ]
}
```
        