### PR TITLE
Fix ESP32 PSRAM (in combination with esp-storage)

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -95,6 +95,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `esp_hal::gpio::Input::is_interrupt_set` can now return true (#3408)
 - `Uart::write_str` (both core::fmt and uWrite implementations) no longer stops writing when the internal buffer fills up (#3452)
 - Fixed I2C `Timeout` errors experienced during high CPU load (#3458)
+- Fix a problem where reading/writing flash didn't work when using PSRAM on ESP32 (#3524)
 
 ### Removed
 

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -238,6 +238,7 @@ embedded-hal-async = "1.0.0"
 embedded-hal-nb    = "1.0.0"
 esp-alloc          = { path = "../esp-alloc", optional = true }
 esp-backtrace      = { path = "../esp-backtrace", default-features = false, features = ["exception-handler", "defmt", "semihosting"] }
+esp-bootloader-esp-idf = { path = "../esp-bootloader-esp-idf" }
 esp-hal            = { path = "../esp-hal", optional = true }
 esp-hal-embassy    = { path = "../esp-hal-embassy", optional = true }
 esp-storage        = { path = "../esp-storage", optional = true }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Fixes #3229

#### Testing
Added CI test - additionally you can use this code (modified read_write_flash example)

```rust
//! Writes and reads flash memory.
//!
//! See https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/partition-tables.html#built-in-partition-tables

//% FEATURES: esp-storage esp-hal/unstable  esp-alloc/internal-heap-stats esp-hal/psram
//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3

#![no_std]
#![no_main]

use embedded_storage::{ReadStorage, Storage};
use esp_backtrace as _;
use esp_bootloader_esp_idf::partitions;
use esp_hal::main;
use esp_println::println;
use esp_storage::FlashStorage;

extern crate alloc;

use alloc::{string::String, vec::Vec};

use esp_alloc as _;

esp_bootloader_esp_idf::esp_app_desc!();
use esp_hal::psram;

fn init_psram_heap(start: *mut u8, size: usize) {
    unsafe {
        esp_alloc::HEAP.add_region(esp_alloc::HeapRegion::new(
            start,
            size,
            esp_alloc::MemoryCapability::External.into(),
        ));
    }
}

#[main]
fn main() -> ! {
    esp_println::logger::init_logger_from_env();

    let peripherals = esp_hal::init(esp_hal::Config::default());

    let (start, size) = psram::psram_raw_parts(&peripherals.PSRAM);
    init_psram_heap(start, size);

    println!("Going to access PSRAM");
    let mut large_vec = Vec::<u32>::with_capacity(500 * 1024 / 4);

    for i in 0..(500 * 1024 / 4) {
        large_vec.push((i & 0xff) as u32);
    }

    println!("vec size = {} bytes", large_vec.len() * 4);
    println!("vec address = {:p}", large_vec.as_ptr());
    println!("vec[..100] = {:?}", &large_vec[..100]);

    let string = String::from("A string allocated in PSRAM");
    println!("'{}' allocated at {:p}", &string, string.as_ptr());

    println!("{}", esp_alloc::HEAP.stats());

    let mut flash = FlashStorage::new();
    println!("Flash size = {}", flash.capacity());

    let mut pt_mem = [0u8; partitions::PARTITION_TABLE_MAX_LEN];
    let pt = partitions::read_partition_table(&mut flash, &mut pt_mem).unwrap();

    for i in 0..pt.len() {
        let raw = pt.get_partition(i).unwrap();
        println!("{:?}", raw);
    }
    println!();

    // The app descriptor (if present) is contained in the first 256 bytes
    // of an app image, right after the image header (24 bytes) and the first section header (8 bytes)
    let mut app_desc = [0u8; 256];
    pt.find_partition(partitions::PartitionType::App(
        partitions::AppPartitionSubType::Factory,
    ))
    .unwrap()
    .unwrap()
    .as_embedded_storage(&mut flash)
    .read(32, &mut app_desc)
    .unwrap();
    println!("App descriptor dump {:02x?}", app_desc);
    println!();

    let nvs = pt
        .find_partition(partitions::PartitionType::Data(
            partitions::DataPartitionSubType::Nvs,
        ))
        .unwrap()
        .unwrap();
    let mut nvs_partition = nvs.as_embedded_storage(&mut flash);

    let mut bytes = [0u8; 32];
    println!("NVS partition size = {}", nvs_partition.capacity());
    println!();

    let offset_in_nvs_partition = 0;

    nvs_partition
        .read(offset_in_nvs_partition, &mut bytes)
        .unwrap();
    println!(
        "Read from {:x}:  {:02x?}",
        offset_in_nvs_partition,
        &bytes[..32]
    );

    bytes[0x00] = bytes[0x00].wrapping_add(1);
    bytes[0x01] = bytes[0x01].wrapping_add(2);
    bytes[0x02] = bytes[0x02].wrapping_add(3);
    bytes[0x03] = bytes[0x03].wrapping_add(4);
    bytes[0x04] = bytes[0x04].wrapping_add(1);
    bytes[0x05] = bytes[0x05].wrapping_add(2);
    bytes[0x06] = bytes[0x06].wrapping_add(3);
    bytes[0x07] = bytes[0x07].wrapping_add(4);

    nvs_partition
        .write(offset_in_nvs_partition, &bytes)
        .unwrap();
    println!(
        "Written to {:x}: {:02x?}",
        offset_in_nvs_partition,
        &bytes[..32]
    );

    let mut reread_bytes = [0u8; 32];
    nvs_partition.read(0, &mut reread_bytes).unwrap();
    println!(
        "Read from {:x}:  {:02x?}",
        offset_in_nvs_partition,
        &reread_bytes[..32]
    );

    println!();
    println!("Reset (CTRL-R in espflash) to re-read the persisted data.");

    loop {}
}

```