### PR TITLE
Add missing `frequency` and `timeout` setters for `i2c::master::Config`

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `frequency` and `timeout` setters for `I2C::Config`
 - RMT channel creator `steal` function (#3496)
 - Support for RMT extended memory (#3182)
 - Support for `rand_core` 0.9 (#3211)

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -518,7 +518,7 @@ impl Config {
 /// # const DEVICE_ADDR: u8 = 0x77;
 /// let mut i2c = I2c::new(
 ///     peripherals.I2C0,
-///     Config::default(),
+///     Config::default().with_frequency(400.khz()),
 /// )?
 /// .with_sda(peripherals.GPIO1)
 /// .with_scl(peripherals.GPIO2);

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -495,6 +495,20 @@ impl Default for Config {
     }
 }
 
+impl Config {
+    /// Set the frequency of the I2C bus clock.
+    pub fn with_frequency(mut self, frequency: Rate) -> Self {
+        self.frequency = frequency;
+        self
+    }
+
+    /// Set the timeout period for the I2C bus.
+    pub fn with_timeout(mut self, timeout: BusTimeout) -> Self {
+        self.timeout = timeout;
+        self
+    }
+}
+
 /// I2C driver
 ///
 /// ### I2C initialization and communication with the device


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
The `frequency` and `timeout` fields where changed to private but not setters were provided, this PR is to add these missing setters.

#### Testing
I can now use non-default config to create I2c bus instance.