### PR TITLE
I2C tweaks

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -94,7 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GPIO interrupt handling no longer causes infinite looping if a task at higher priority is awaiting on a pin event (#3408)
 - `esp_hal::gpio::Input::is_interrupt_set` can now return true (#3408)
 - `Uart::write_str` (both core::fmt and uWrite implementations) no longer stops writing when the internal buffer fills up (#3452)
-- Fixed I2C `Timeout` errors experienced during high CPU load (#3458)
+- Fixed I2C `Timeout` errors experienced during high CPU load (#3458, #3555)
 - Fix a problem where reading/writing flash didn't work when using PSRAM on ESP32 (#3524)
 
 ### Removed

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -95,6 +95,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `esp_hal::gpio::Input::is_interrupt_set` can now return true (#3408)
 - `Uart::write_str` (both core::fmt and uWrite implementations) no longer stops writing when the internal buffer fills up (#3452)
 - Fixed I2C `Timeout` errors experienced during high CPU load (#3458, #3555)
+- Fixed I2C `Timeout` errors experienced during high CPU load (#3458, #3552)
 - Fix a problem where reading/writing flash didn't work when using PSRAM on ESP32 (#3524)
 
 ### Removed

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -121,7 +121,7 @@ pub enum BusTimeout {
     Maximum,
 
     /// Disable timeout control.
-    #[cfg(not(any(esp32, esp32s2)))]
+    #[cfg(not(esp32))]
     Disabled,
 
     /// Timeout in bus clock cycles.
@@ -141,7 +141,7 @@ impl BusTimeout {
                 }
             }
 
-            #[cfg(not(any(esp32, esp32s2)))]
+            #[cfg(not(esp32))]
             BusTimeout::Disabled => 1,
 
             BusTimeout::BusCycles(cycles) => *cycles,
@@ -1539,8 +1539,8 @@ impl Driver<'_> {
         let scl_stop_hold_time = hold;
 
         let timeout = BusTimeout::BusCycles(match timeout {
-            BusTimeout::Maximum => 0xFF_FFFF,
             BusTimeout::BusCycles(cycles) => check_timeout(cycles * 2 * half_cycle, 0xFF_FFFF)?,
+            other => other.cycles(),
         });
 
         configure_clock(

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -1922,6 +1922,13 @@ impl Driver<'_> {
     }
 
     fn is_completed(&self, end_only: bool) -> Result<bool, Error> {
+        // Read errors _before_ checking for completion. This is important because we
+        // may be interrupted, which can cause an error to be detected, even if
+        // the transmission was successful.
+        // TODO: we should refactor `check_errors` to work on the already read interrupt
+        // bits.
+        let errors = self.check_errors();
+
         let interrupts = self.regs().int_raw().read();
 
         if (!end_only && interrupts.trans_complete().bit_is_set())
@@ -1933,9 +1940,7 @@ impl Driver<'_> {
             return Ok(true);
         }
 
-        self.check_errors()?;
-
-        Ok(false)
+        errors.map(|_| false)
     }
 
     fn all_commands_done(&self) -> bool {

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -1884,9 +1884,7 @@ impl Driver<'_> {
         } else {
             Event::TxComplete | Event::EndDetect
         };
-        I2cFuture::new(event, self.info, self.state)
-            .await
-            .inspect_err(|_| self.reset())?;
+        I2cFuture::new(event, self.info, self.state).await?;
         self.check_all_commands_done().await
     }
 
@@ -1929,7 +1927,7 @@ impl Driver<'_> {
             return Ok(true);
         }
 
-        self.check_errors().inspect_err(|_| self.reset())?;
+        self.check_errors()?;
 
         Ok(false)
     }
@@ -2238,7 +2236,7 @@ impl Driver<'_> {
             // wait for STOP - apparently on ESP32 we otherwise miss the ACK error for an
             // empty write
             if self.regs().sr().read().scl_state_last() == 0b110 {
-                self.check_errors().inspect_err(|_| self.reset())?;
+                self.check_errors()?;
                 break;
             }
         }
@@ -2330,7 +2328,7 @@ impl Driver<'_> {
             // wait for STOP - apparently on ESP32 we otherwise miss the ACK error for an
             // empty write
             if self.regs().sr().read().scl_state_last() == 0b110 {
-                self.check_errors().inspect_err(|_| self.reset())?;
+                self.check_errors()?;
                 embassy_futures::yield_now().await;
                 break;
             }

--- a/hil-test/tests/i2c.rs
+++ b/hil-test/tests/i2c.rs
@@ -190,7 +190,6 @@ mod tests {
     }
 
     // This is still an issue on ESP32-S2
-    #[cfg(not(esp32s2))]
     #[test]
     async fn async_test_timeout_when_scl_kept_low(ctx: Context) {
         let mut i2c = ctx.i2c.into_async();

--- a/hil-test/tests/i2c.rs
+++ b/hil-test/tests/i2c.rs
@@ -190,6 +190,17 @@ mod tests {
     }
 
     #[test]
+    async fn test_timeout_when_scl_kept_low(ctx: Context) {
+        let mut i2c = ctx.i2c.into_async();
+
+        esp_hal::gpio::InputSignal::I2CEXT0_SCL.connect_to(&esp_hal::gpio::Level::Low);
+
+        let mut read_data = [0u8; 22];
+        // will run into an error but it should return at least
+        i2c.write_read(DUT_ADDRESS, &[0xaa], &mut read_data).ok();
+    }
+
+    #[test]
     async fn async_test_timeout_when_scl_kept_low(ctx: Context) {
         let mut i2c = ctx.i2c.into_async();
 

--- a/hil-test/tests/i2c.rs
+++ b/hil-test/tests/i2c.rs
@@ -189,7 +189,6 @@ mod tests {
         assert_ne!(read_data, [0u8; 22])
     }
 
-    // This is still an issue on ESP32-S2
     #[test]
     async fn async_test_timeout_when_scl_kept_low(ctx: Context) {
         let mut i2c = ctx.i2c.into_async();


### PR DESCRIPTION
This PR tweaks the I2C driver in the following ways:

- I2cFuture is now implemented for ESP32, although it busy-wakes the CPU and contains a software timeout.
- ESP32S2 uses the same I2cFuture implementation as ESP32. This allows us to re-enable the SCL timeout test.
- The FSM timeouts are ignored by default. This should mask the random timeout errors we have. As we don't really know why these occur or how to work around them (just resetting the FSM before starting a transfer is not a workaround), this is probably a better default than the 2^16 clock cycles the hardware wants.
- A bunch of redundant `inspect_err(reset)`s have been removed. We end up reconfiguring the whole peripheral on error, so they shouldn't be necessary.

Closes #2771 as there's not much reason to keep that open.