### PR TITLE
Remove global wifi/ble init state tracking

### DIFF
--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump Rust edition to 2024, bump MSRV to 1.85. (#3391)
 - Update `defmt` to 1.0 (#3416)
 - The `log` feature has been replaced by `log-04`. (#3425)
+- Removed `esp_wifi::deinit_unchecked` and `esp_wifi::EspWifiController::deinit` - you can just drop `EspWifiController` instead
 
 ### Fixed
 

--- a/esp-wifi/MIGRATING-0.13.md
+++ b/esp-wifi/MIGRATING-0.13.md
@@ -46,3 +46,14 @@ Some code can be simplified now.
 ## `AccessPointInfo` doesn't include the `protocols` field anymore
 
 That field was never populated and has been removed.
+
+## Deinitialization
+
+`esp_wifi::EspWifiController::deinit` got removed and you should just drop the `EspWifiController` instead.
+
+```diff
+- esp_wifi_ctrl.deinit();
++ core::mem::drop(esp_wifi_ctrl);
+```
+Since `esp_wifi::deinit_unchecked` is now removed there is no unsafe way to forcefully deinit the controller.
+Drop the instance of `EspWifiController` instead (see above).

--- a/esp-wifi/src/ble/btdm.rs
+++ b/esp-wifi/src/ble/btdm.rs
@@ -452,7 +452,6 @@ pub(crate) fn ble_init() {
 
         API_vhci_host_register_callback(&VHCI_HOST_CALLBACK);
     }
-    crate::flags::BLE.store(true, Ordering::Release);
 }
 
 pub(crate) fn ble_deinit() {
@@ -464,7 +463,6 @@ pub(crate) fn ble_deinit() {
         btdm_controller_deinit();
         crate::common_adapter::chip_specific::phy_disable();
     }
-    crate::flags::BLE.store(false, Ordering::Release);
 }
 
 pub fn send_hci(data: &[u8]) {

--- a/esp-wifi/src/ble/npl.rs
+++ b/esp-wifi/src/ble/npl.rs
@@ -1221,7 +1221,6 @@ pub(crate) fn ble_init() {
 
         debug!("The ble_controller_init was initialized");
     }
-    crate::flags::BLE.store(true, Ordering::Release);
 }
 
 pub(crate) fn ble_deinit() {
@@ -1248,7 +1247,6 @@ pub(crate) fn ble_deinit() {
 
         crate::common_adapter::chip_specific::phy_disable();
     }
-    crate::flags::BLE.store(false, Ordering::Release);
 }
 
 #[cfg(esp32c2)]

--- a/esp-wifi/src/lib.rs
+++ b/esp-wifi/src/lib.rs
@@ -122,7 +122,6 @@ use hal::{
     time::Rate,
     timer::{AnyTimer, PeriodicTimer, timg::Timer as TimgTimer},
 };
-use portable_atomic::Ordering;
 
 #[cfg(feature = "wifi")]
 use crate::wifi::WifiError;
@@ -250,54 +249,28 @@ const _: () = {
 
 type TimeBase = PeriodicTimer<'static, Blocking>;
 
-pub(crate) mod flags {
-    use portable_atomic::AtomicBool;
-
-    pub(crate) static ESP_WIFI_INITIALIZED: AtomicBool = AtomicBool::new(false);
-    pub(crate) static WIFI: AtomicBool = AtomicBool::new(false);
-    pub(crate) static BLE: AtomicBool = AtomicBool::new(false);
-}
-
 #[derive(Debug, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct EspWifiController<'d> {
     _inner: PhantomData<&'d ()>,
 }
 
-impl EspWifiController<'_> {
-    /// Is the WiFi part of the radio running
-    pub fn wifi(&self) -> bool {
-        crate::flags::WIFI.load(Ordering::Acquire)
-    }
-
-    /// Is the BLE part of the radio running
-    pub fn ble(&self) -> bool {
-        crate::flags::BLE.load(Ordering::Acquire)
-    }
-
-    /// De-initialize the radio
-    pub fn deinit(self) -> Result<(), InitializationError> {
-        if crate::flags::ESP_WIFI_INITIALIZED.load(Ordering::Acquire) {
-            // safety: no other driver can be using this if this is callable
-            unsafe { deinit_unchecked() }
-        } else {
-            Ok(())
-        }
-    }
-
-    pub(crate) unsafe fn conjure() -> Self {
-        Self {
-            _inner: PhantomData,
-        }
-    }
-}
-
 impl Drop for EspWifiController<'_> {
     fn drop(&mut self) {
-        if crate::flags::ESP_WIFI_INITIALIZED.load(Ordering::Acquire) {
-            // safety: no other driver can be using this if this is callable
-            unsafe { deinit_unchecked().ok() };
+        // Disable coexistence
+        #[cfg(coex)]
+        {
+            unsafe { crate::wifi::os_adapter::coex_disable() };
+            unsafe { crate::wifi::os_adapter::coex_deinit() };
         }
+
+        shutdown_radio_isr();
+
+        #[cfg(feature = "builtin-scheduler")]
+        preempt_builtin::disable_timer();
+
+        // This shuts down the task switcher and timer tick interrupt.
+        preempt::disable();
     }
 }
 
@@ -417,58 +390,9 @@ pub fn init<'d>(
         error => return Err(InitializationError::General(error)),
     }
 
-    crate::flags::ESP_WIFI_INITIALIZED.store(true, Ordering::Release);
-
     Ok(EspWifiController {
         _inner: PhantomData,
     })
-}
-
-/// Deinitializes the entire radio stack
-///
-/// This can be useful to shutdown the stack before going to sleep for example.
-///
-/// # Safety
-///
-/// The user must ensure that any use of the radio via the WIFI/BLE/ESP-NOW
-/// drivers are complete, else undefined behaviour may occur within those
-/// drivers.
-pub unsafe fn deinit_unchecked() -> Result<(), InitializationError> {
-    // Disable coexistence
-    #[cfg(coex)]
-    {
-        unsafe { crate::wifi::os_adapter::coex_disable() };
-        unsafe { crate::wifi::os_adapter::coex_deinit() };
-    }
-
-    let controller = unsafe { EspWifiController::conjure() };
-
-    // Peripheral drivers should already take care of shutting these down
-    // we have to check this in the case where a user calls `deinit_unchecked`
-    // directly.
-    if controller.wifi() {
-        #[cfg(feature = "wifi")]
-        crate::wifi::wifi_deinit()?;
-        crate::flags::WIFI.store(false, Ordering::Release);
-    }
-
-    if controller.ble() {
-        #[cfg(feature = "ble")]
-        crate::ble::ble_deinit();
-        crate::flags::BLE.store(false, Ordering::Release);
-    }
-
-    shutdown_radio_isr();
-
-    #[cfg(feature = "builtin-scheduler")]
-    preempt_builtin::disable_timer();
-
-    // This shuts down the task switcher and timer tick interrupt.
-    preempt::disable();
-
-    crate::flags::ESP_WIFI_INITIALIZED.store(false, Ordering::Release);
-
-    Ok(())
 }
 
 /// Returns true if at least some interrupt levels are disabled.

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -1359,8 +1359,6 @@ pub(crate) fn wifi_init() -> Result<(), WifiError> {
             chip_specific::g_misc_nvs = addr_of!(NVS_STRUCT) as u32;
         }
 
-        crate::flags::WIFI.store(true, Ordering::SeqCst);
-
         Ok(())
     }
 }
@@ -1397,11 +1395,10 @@ pub(crate) unsafe extern "C" fn coex_init() -> i32 {
     0
 }
 
-pub(crate) fn wifi_deinit() -> Result<(), crate::InitializationError> {
+fn wifi_deinit() -> Result<(), crate::InitializationError> {
     esp_wifi_result!(unsafe { esp_wifi_stop() })?;
     esp_wifi_result!(unsafe { esp_wifi_deinit_internal() })?;
     esp_wifi_result!(unsafe { esp_supplicant_deinit() })?;
-    crate::flags::WIFI.store(false, Ordering::Release);
     Ok(())
 }
 
@@ -2612,7 +2609,7 @@ pub struct Interfaces<'d> {
 ///
 /// Make sure to **not** call this function while interrupts are disabled.
 pub fn new<'d>(
-    inited: &'d EspWifiController<'d>,
+    _inited: &'d EspWifiController<'d>,
     _device: crate::hal::peripherals::WIFI<'d>,
 ) -> Result<(WifiController<'d>, Interfaces<'d>), WifiError> {
     if crate::is_interrupts_disabled() {
@@ -2623,30 +2620,26 @@ pub fn new<'d>(
         _phantom: Default::default(),
     };
 
-    if !inited.wifi() {
-        crate::wifi::wifi_init()?;
+    crate::wifi::wifi_init()?;
 
-        let mut cntry_code = [0u8; 3];
-        cntry_code[..crate::CONFIG.country_code.len()]
-            .copy_from_slice(crate::CONFIG.country_code.as_bytes());
-        cntry_code[2] = crate::CONFIG.country_code_operating_class;
+    let mut cntry_code = [0u8; 3];
+    cntry_code[..crate::CONFIG.country_code.len()]
+        .copy_from_slice(crate::CONFIG.country_code.as_bytes());
+    cntry_code[2] = crate::CONFIG.country_code_operating_class;
 
-        #[allow(clippy::useless_transmute)]
-        unsafe {
-            let country = wifi_country_t {
-                // FIXME once we bumped the MSRV accordingly (see https://github.com/esp-rs/esp-hal/pull/3027#discussion_r1944718266)
-                #[allow(clippy::useless_transmute)]
-                cc: core::mem::transmute::<[u8; 3], [core::ffi::c_char; 3]>(cntry_code),
-                schan: 1,
-                nchan: 13,
-                max_tx_power: 20,
-                policy: wifi_country_policy_t_WIFI_COUNTRY_POLICY_MANUAL,
-            };
-            esp_wifi_result!(esp_wifi_set_country(&country))?;
-        }
-
-        controller.set_power_saving(PowerSaveMode::default())?;
+    #[allow(clippy::useless_transmute)]
+    unsafe {
+        let country = wifi_country_t {
+            cc: cntry_code,
+            schan: 1,
+            nchan: 13,
+            max_tx_power: 20,
+            policy: wifi_country_policy_t_WIFI_COUNTRY_POLICY_MANUAL,
+        };
+        esp_wifi_result!(esp_wifi_set_country(&country))?;
     }
+
+    controller.set_power_saving(PowerSaveMode::default())?;
 
     Ok((
         controller,


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [ ] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Please provide a clear and concise description of your changes, including the motivation behind these changes. The context is crucial for the reviewers.

#### Testing
Describe how you tested your changes.
