### PR TITLE
Fix an I2C race condition

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -94,7 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GPIO interrupt handling no longer causes infinite looping if a task at higher priority is awaiting on a pin event (#3408)
 - `esp_hal::gpio::Input::is_interrupt_set` can now return true (#3408)
 - `Uart::write_str` (both core::fmt and uWrite implementations) no longer stops writing when the internal buffer fills up (#3452)
-- Fixed I2C `Timeout` errors experienced during high CPU load (#3458)
+- Fixed I2C `Timeout` errors experienced during high CPU load (#3458, #3555)
 - Fix a problem where reading/writing flash didn't work when using PSRAM on ESP32 (#3524)
 
 ### Removed


### PR DESCRIPTION
This PR fixes an error that can cause I2C to report a timeout even if the transmission completes successfully. The cause and the fix are both similar to https://github.com/esp-rs/esp-hal/pull/3458

I'm also removing some reset-on-error calls which seem redundant, because we're resetting the whole peripheral anyway shortly after.