### PR TITLE
Disable I2C arbitration

### DIFF
--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -1331,6 +1331,8 @@ impl Driver<'_> {
             // Use Most Significant Bit first for sending and receiving data
             w.tx_lsb_first().clear_bit();
             w.rx_lsb_first().clear_bit();
+            #[cfg(not(esp32))]
+            w.arbitration_en().clear_bit();
             // Ensure that clock is enabled
             w.clk_en().set_bit()
         });


### PR DESCRIPTION
esp-idf doesn't use this, and we see random ArbitrationLost errors even with a single master, so let's try to be safe.