### PR TITLE
output as json doc helper with single quotes

### DIFF
--- a/xtask/src/commands/release/tag_releases.rs
+++ b/xtask/src/commands/release/tag_releases.rs
@@ -67,6 +67,7 @@ pub fn tag_releases(workspace: &Path, mut args: TagReleasesArgs) -> Result<()> {
     }
 
     let workflow_input = serde_json::to_string(&created)?;
+    let workflow_input = workflow_input.replace("\"", "'");
 
     log::info!("Documentation workflow input for these packages:\r\n\r\n{workflow_input}\r\n\r\n");
 


### PR DESCRIPTION
Required for the new workflow input.

Closes #3563 