### PR TITLE
Tweak I2cFuture

### DIFF
--- a/hil-test/tests/i2c.rs
+++ b/hil-test/tests/i2c.rs
@@ -196,8 +196,6 @@ mod tests {
         assert_ne!(read_data, [0u8; 22])
     }
 
-    // This is still an issue on ESP32-S2
-    #[cfg(not(esp32s2))]
     #[test]
     async fn test_timeout_when_scl_kept_low(ctx: Context) {
         let mut i2c = ctx.i2c.into_async();
@@ -210,8 +208,6 @@ mod tests {
             .expect_err("Expected timeout error");
     }
 
-    // This is still an issue on ESP32-S2
-    #[cfg(not(esp32s2))]
     #[test]
     async fn async_test_timeout_when_scl_kept_low(ctx: Context) {
         let mut i2c = ctx.i2c.into_async();


### PR DESCRIPTION
This PR refactors ESP32 to use the I2cFuture code, and adds soft timeout for ESP32-S2. This allows re-enabling the disabled tests.