### PR TITLE
Change common test pins for esp32

### DIFF
--- a/hil-test/README.md
+++ b/hil-test/README.md
@@ -101,7 +101,7 @@ Our self-hosted runners have the following setup:
 - ESP32 (`esp32-jtag`):
   - Devkit: `ESP32-DevKitC-V4` connected via UART.
     - `GPIO32` and `GPIO33` are I2C pins.
-    - `GPIO26` and `GPIO27` are connected.
+    - `GPIO2` and `GPIO4` are connected.
   - Probe: `ESP-Prog` connected with the [following connections][connection_esp32]
   - RPi: Raspbian 12 configured with the following [setup]
 

--- a/hil-test/src/lib.rs
+++ b/hil-test/src/lib.rs
@@ -54,7 +54,7 @@ macro_rules! common_test_pins {
             if #[cfg(any(esp32s2, esp32s3))] {
                 ($peripherals.GPIO9, $peripherals.GPIO10)
             } else if #[cfg(esp32)] {
-                ($peripherals.GPIO26, $peripherals.GPIO27)
+                ($peripherals.GPIO2, $peripherals.GPIO4)
             } else {
                 ($peripherals.GPIO2, $peripherals.GPIO3)
             }


### PR DESCRIPTION
Context: @bugadani asked us to change the pins used in esp32 HIL runner, because previous GPIO26-GPIO27 was impossible to use on his `esp32-ethernet-kit`. Changing it to GPIO2-GPIO4 instead causes 0 discomfort for us, but makes Daniel's life a bit more pleasant