### PR TITLE
Add docsrs metadata and warning for esp-lp-hal

### DIFF
--- a/esp-lp-hal/Cargo.toml
+++ b/esp-lp-hal/Cargo.toml
@@ -10,6 +10,11 @@ categories    = ["embedded", "hardware-support", "no-std"]
 repository    = "https://github.com/esp-rs/esp-hal"
 license       = "MIT OR Apache-2.0"
 
+[package.metadata.docs.rs]
+default-target = "riscv32imac-unknown-none-elf"
+features       = ["esp32c6"]
+rustdoc-args   = ["--cfg", "docsrs"]
+
 [lib]
 bench = false
 test  = false

--- a/esp-lp-hal/src/lib.rs
+++ b/esp-lp-hal/src/lib.rs
@@ -1,3 +1,7 @@
+#![cfg_attr(
+    all(docsrs, not(not_really_docsrs)),
+    doc = "<div style='padding:30px;background:#810;color:#fff;text-align:center;'><p>You might want to <a href='https://docs.espressif.com/projects/rust/'>browse the <code>esp-lp-hal</code> documentation on the esp-rs website</a> instead.</p><p>The documentation here on <a href='https://docs.rs'>docs.rs</a> is built for a single chip only (ESP32-C6, in particular), while on the esp-rs website you can select your exact chip from the list of supported devices. Available peripherals and their APIs change depending on the chip.</p></div>\n\n<br/>\n\n"
+)]
 //! Bare-metal (`no_std`) HAL for the low power and ultra-low power cores found
 //! in some Espressif devices. Where applicable, drivers implement the
 //! [embedded-hal] traits.


### PR DESCRIPTION
#### Testing

I built once with `cargo docs-rs --open` to show the notice, then again with our xtask tooling to prove the notice was hidden.
