### PR TITLE
Multi-core: Lower the probability of a multi-core executor lockup

### DIFF
--- a/esp-hal-embassy/CHANGELOG.md
+++ b/esp-hal-embassy/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a potential lockup issue (#3589)
 
 ### Removed
 

--- a/esp-hal-embassy/src/executor/thread.rs
+++ b/esp-hal-embassy/src/executor/thread.rs
@@ -116,6 +116,10 @@ This will use software-interrupt 3 which isn't available for anything else to wa
     }
 
     #[cfg(all(xtensa, low_power_wait))]
+    // This function must be in RAM. Loading parts of it from flash can cause a race
+    // that results in the core not waking up. Placing `wait_impl` in RAM ensures that
+    // it is shorter than the interrupt handler that would clear the interrupt source.
+    #[macros::ram]
     fn wait_impl(cpu: usize) {
         // Manual critical section implementation that only masks interrupts handlers.
         // We must not acquire the cross-core on dual-core systems because that would

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -270,7 +270,7 @@ esp-metadata = { path = "../esp-metadata" }
 default = []
 unstable = ["esp-hal/unstable"]
 
-defmt = ["dep:defmt-rtt", "esp-hal/defmt", "embedded-test/defmt", "esp-wifi/defmt"]
+defmt = ["dep:defmt-rtt", "esp-hal/defmt", "embedded-test/defmt", "esp-wifi/defmt", "esp-hal-embassy/defmt"]
 
 # Device support (required!):
 esp32 = [


### PR DESCRIPTION
This should fix HIL. Ideally we'd turn FROM_CPU3 into an edge-triggered interrupt but I couldn't figure out how to make it work.

How the bug can be triggered:

- The software interrupt that wakes the cores is handled on both cores, and both cores clear the interrupt
- `wait_impl` is a very short interrupt-free context
- So there's a chance core 1 tries to clear core 0 but it just triggers and clears the interrupt, and because it's level triggered, the CPU forgets it happened before `wait_impl` got to the `waiti` instructions
- which can happen if `rsil` is in the cache and gets executed, but `waiti` isn't and we have to load from flash