### PR TITLE
Prepare release

### DIFF
--- a/esp-hal-embassy/CHANGELOG.md
+++ b/esp-hal-embassy/CHANGELOG.md
@@ -15,10 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed a potential lockup issue (#3589)
 
 ### Removed
 
+
+## [v0.9.0] - 2025-06-05
+
+### Fixed
+
+- Fixed a potential lockup issue (#3589)
 
 ## [v0.8.0] - 2025-06-03
 
@@ -122,4 +127,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [0.7.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-hal-embassy-v0.7.0
 [v0.8.0]: https://github.com/esp-rs/esp-hal/compare/esp-hal-embassy-v0.7.0...esp-hal-embassy-v0.8.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-hal-embassy-v0.8.0...HEAD
+[v0.9.0]: https://github.com/esp-rs/esp-hal/compare/esp-hal-embassy-v0.8.0...esp-hal-embassy-v0.9.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-hal-embassy-v0.9.0...HEAD

--- a/esp-hal-embassy/Cargo.toml
+++ b/esp-hal-embassy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-hal-embassy"
-version       = "0.8.0"
+version       = "0.9.0"
 edition       = "2024"
 rust-version  = "1.86.0"
 description   = "Embassy support for esp-hal"

--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -9,17 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- It's now possible to obtain the RSSI of the currently connected AP, by using `WifiController::rssi(&self)` (#3593)
 
 ### Changed
 
 
 ### Fixed
 
-- Fix a compilation error for ESP32 + coex + ble + defmt (#3596)
 
 ### Removed
 
+
+## [v0.15.0] - 2025-06-05
+
+### Added
+
+- It's now possible to obtain the RSSI of the currently connected AP, by using `WifiController::rssi(&self)` (#3593)
+
+### Fixed
+
+- Fix a compilation error for ESP32 + coex + ble + defmt (#3596)
 
 ## [v0.14.0] - 2025-06-03
 
@@ -256,4 +264,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [0.13.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-wifi-v0.13.0
 [v0.14.0]: https://github.com/esp-rs/esp-hal/compare/esp-wifi-v0.13.0...esp-wifi-v0.14.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-wifi-v0.14.0...HEAD
+[v0.15.0]: https://github.com/esp-rs/esp-hal/compare/esp-wifi-v0.14.0...esp-wifi-v0.15.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-wifi-v0.15.0...HEAD

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "esp-wifi"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2024"
 rust-version  = "1.86.0"
 description = "A WiFi, Bluetooth and ESP-NOW driver for use with Espressif chips and bare-metal Rust"


### PR DESCRIPTION
This pull request prepares the following packages for release:

- esp-wifi: 0.14.1
- esp-hal-embassy: 0.8.1

The release plan used for this release:

```json
{
  "base": "main",
  "packages": [
    {
      "package": "esp-wifi",
      "semver_checked": false,
      "current_version": "0.14.0",
      "new_version": "0.14.1",
      "tag_name": "esp-wifi-v0.14.1",
      "bump": "Patch"
    },
    {
      "package": "esp-hal-embassy",
      "semver_checked": false,
      "current_version": "0.8.0",
      "new_version": "0.8.1",
      "tag_name": "esp-hal-embassy-v0.8.1",
      "bump": "Patch"
    }
  ]
}
```

Please review the changes and merge them into the `main` branch.

After merging, please make sure you have this release plan in the repo root,
then run the following command on the `main` branch to tag and publish the packages:

```
cargo xrelease publish-plan --no-dry-run
```
