### PR TITLE
Peripheral support table

### DIFF
--- a/esp-hal/README.md
+++ b/esp-hal/README.md
@@ -46,6 +46,64 @@ For help getting started with this HAL, please refer to [The Rust on ESP Book] a
 [s2-trm]: https://www.espressif.com/sites/default/files/documentation/esp32-s2_technical_reference_manual_en.pdf
 [s3-trm]: https://www.espressif.com/sites/default/files/documentation/esp32-s3_technical_reference_manual_en.pdf
 
+## Peripheral support
+
+<!-- The following table is machine generated. Do not edit the comments and the table by hand! -->
+<!-- start chip support table -->
+| Driver             | ESP32 | ESP32-C2 | ESP32-C3 | ESP32-C6 | ESP32-H2 | ESP32-S2 | ESP32-S3 |
+| ------------------ |:-----:|:--------:|:--------:|:--------:|:--------:|:--------:|:--------:|
+| ADC                | ⚒️   | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      |
+| AES                | ⚒️   |          | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      |
+| ASSIST_DEBUG       |       | ⚒️      | ⚒️      | ⚒️      | ⚒️      |          | ⚒️      |
+| DAC                | ⚒️   |          |          |          |          | ⚒️      |          |
+| DMA                | ⚒️   | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      |
+| DS                 |       |          | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      |
+| ECC                |       | ⚒️      |          | ⚒️      | ⚒️      |          |          |
+| Ethernet           | ❌    |          |          |          |          |          |          |
+| ETM                |       |          |          | ⚒️      | ⚒️      |          |          |
+| GPIO               | ✔️   | ✔️      | ✔️      | ✔️      | ✔️      | ✔️      | ✔️      |
+| HMAC               |       |          | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      |
+| I2C master         | ✔️   | ✔️      | ✔️      | ✔️      | ✔️      | ✔️      | ✔️      |
+| I2C slave          | ❌    | ❌       | ❌       | ❌       | ❌       | ❌       | ❌       |
+| I2S                | ⚒️   |          | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      |
+| Interrupts         | ⚒️   | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      |
+| IOMUX              | ⚒️   | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      |
+| Camera interface   | ❌    |          |          |          |          |          | ⚒️      |
+| RGB display        | ⚒️   |          |          |          |          | ❌       | ⚒️      |
+| LEDC               | ⚒️   | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      |
+| MCPWM              | ⚒️   |          |          | ⚒️      | ⚒️      |          | ⚒️      |
+| PARL_IO            |       |          |          | ⚒️      | ⚒️      |          |          |
+| PCNT               | ⚒️   |          |          | ⚒️      | ⚒️      | ⚒️      | ⚒️      |
+| PSRAM              | ⚒️   |          |          |          |          | ⚒️      | ⚒️      |
+| RMT                | ⚒️   |          | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      |
+| RNG                | ⚒️   | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      |
+| RSA                | ⚒️   |          | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      |
+| SDIO host          | ⚒️   |          |          |          |          |          | ⚒️      |
+| SDIO slave         | ⚒️   |          |          | ⚒️      |          |          |          |
+| Light/deep sleep   | ⚒️   | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      |
+| SHA                | ⚒️   | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      |
+| SPI master         | ✔️   | ✔️      | ✔️      | ✔️      | ✔️      | ✔️      | ✔️      |
+| SPI slave          | ⚒️   | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      |
+| SYSTIMER           |       | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      |
+| Temperature sensor | ⚒️   | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      |
+| Timers             | ⚒️   | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      |
+| Touch              | ⚒️   |          |          |          |          | ❌       | ❌       |
+| TWAI               | ⚒️   |          | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      |
+| UART               | ✔️   | ✔️      | ✔️      | ✔️      | ✔️      | ✔️      | ✔️      |
+| ULP (FSM)          | ⚒️   |          |          |          |          | ⚒️      | ⚒️      |
+| ULP (RISC-V)       |       |          |          | ⚒️      |          | ⚒️      | ⚒️      |
+| USB OTG FS         |       |          |          |          |          | ⚒️      | ⚒️      |
+| USB Serial/JTAG    |       |          | ⚒️      | ⚒️      | ⚒️      |          | ⚒️      |
+| WIFI               | ⚒️   | ⚒️      | ⚒️      | ⚒️      |          | ⚒️      | ⚒️      |
+| Bluetooth          | ⚒️   | ⚒️      | ⚒️      | ⚒️      | ⚒️      |          | ⚒️      |
+| IEEE 802.15.4      |       |          |          | ⚒️      | ⚒️      |          |          |
+
+ * Empty cell: not available
+ * ❌: Not supported
+ * ⚒️: Partial support
+ * ✔️: Supported
+<!-- end chip support table -->
+
 ## `unstable` feature
 
 The stable feature set is designed to remain consistent and reliable. Other parts guarded by the `unstable` feature, however, are still under active development and may undergo breaking changes and are disabled by default.

--- a/esp-metadata/devices/esp32.toml
+++ b/esp-metadata/devices/esp32.toml
@@ -1,3 +1,10 @@
+# ESP32 Device Metadata
+#
+# Empty [`device.driver`] tables imply `partial` support status.
+#
+# If you modify a driver support status, run `cargo xtask update-chip-support-table` to
+# update the table in the esp-hal README.
+
 [device]
 name  = "esp32"
 arch  = "xtensa"
@@ -11,6 +18,7 @@ peripherals = [
     "bb",
     "dport",
     "efuse",
+    "emac",
     "flash_encryption",
     "frc_timer",
     "gpio",
@@ -80,6 +88,64 @@ symbols = [
 
 memory = [{ name = "dram", start = 0x3FFA_E000, end = 0x4000_0000 }]
 
+[device.gpio]
+status = "supported"
+
+[device.i2c_master]
+status = "supported"
+
+[device.i2c_slave]
+status = "not_supported"
+
 [device.rmt]
+status = "partial"
 ram_start = 0x3ff56800
 channel_ram_size = 64
+
+[device.spi_master]
+status = "supported"
+
+[device.uart]
+status = "supported"
+
+[device.ethernet]
+status = "not_supported"
+
+[device.camera]
+status = "not_supported"
+[device.rgb_display]
+
+# Other drivers which are partially supported but have no other configuration:
+
+## Crypto
+[device.aes]
+[device.rsa]
+[device.sha]
+[device.rng]
+
+## Interfaces
+[device.i2s]
+[device.ledc]
+[device.mcpwm]
+[device.pcnt]
+[device.sd_host]
+[device.sd_slave]
+[device.spi_slave]
+[device.touch]
+[device.twai]
+
+## Miscellaneous
+[device.adc]
+[device.dac]
+[device.dma]
+[device.interrupts]
+[device.io_mux]
+[device.psram]
+[device.temp_sensor]
+[device.sleep]
+[device.timers]
+[device.ulp_fsm]
+
+## Radio
+[device.wifi]
+[device.bt]

--- a/esp-metadata/devices/esp32c2.toml
+++ b/esp-metadata/devices/esp32c2.toml
@@ -1,3 +1,10 @@
+# ESP32-C2 Device Metadata
+#
+# Empty [`device.driver`] tables imply `partial` support status.
+#
+# If you modify a driver support status, run `cargo xtask update-chip-support-table` to
+# update the table in the esp-hal README.
+
 [device]
 name  = "esp32c2"
 arch  = "riscv"
@@ -56,6 +63,43 @@ symbols = [
 
 memory = [{ name = "dram", start = 0x3FCA_0000, end = 0x3FCE_0000 }]
 
+[device.gpio]
+status = "supported"
+
 [device.i2c_master]
+status = "supported"
 has_fsm_timeouts = true
 has_hw_bus_clear = true
+
+[device.spi_master]
+status = "supported"
+
+[device.uart]
+status = "supported"
+
+# Other drivers which are partially supported but have no other configuration:
+
+## Crypto
+# [device.aes] Product portfolio lists AES, but TRM only has XTS_AES?
+[device.ecc]
+[device.sha]
+[device.rng]
+
+## Interfaces
+[device.ledc]
+[device.spi_slave]
+
+## Miscellaneous
+[device.assist_debug]
+[device.adc]
+[device.dma]
+[device.interrupts]
+[device.io_mux]
+[device.temp_sensor]
+[device.sleep]
+[device.timers]
+[device.systimer]
+
+## Radio
+[device.wifi]
+[device.bt]

--- a/esp-metadata/devices/esp32c3.toml
+++ b/esp-metadata/devices/esp32c3.toml
@@ -1,3 +1,10 @@
+# ESP32-C3 Device Metadata
+#
+# Empty [`device.driver`] tables imply `partial` support status.
+#
+# If you modify a driver support status, run `cargo xtask update-chip-support-table` to
+# update the table in the esp-hal README.
+
 [device]
 name  = "esp32c3"
 arch  = "riscv"
@@ -70,10 +77,54 @@ symbols = [
 
 memory = [{ name = "dram", start = 0x3FC8_0000, end = 0x3FCE_0000 }]
 
+
+[device.gpio]
+status = "supported"
+
+[device.i2c_master]
+status = "supported"
+has_fsm_timeouts = true
+has_hw_bus_clear = true
+
 [device.rmt]
+status = "partial"
 ram_start = 0x60016400
 channel_ram_size = 48
 
-[device.i2c_master]
-has_fsm_timeouts = true
-has_hw_bus_clear = true
+[device.spi_master]
+status = "supported"
+
+[device.uart]
+status = "supported"
+
+# Other drivers which are partially supported but have no other configuration:
+
+## Crypto
+[device.aes]
+[device.ds]
+[device.rsa]
+[device.sha]
+[device.hmac]
+[device.rng]
+
+## Interfaces
+[device.i2s]
+[device.ledc]
+[device.spi_slave]
+[device.twai]
+[device.usb_serial_jtag]
+
+## Miscellaneous
+[device.adc]
+[device.assist_debug]
+[device.dma]
+[device.interrupts]
+[device.io_mux]
+[device.temp_sensor]
+[device.timers]
+[device.sleep]
+[device.systimer]
+
+## Radio
+[device.wifi]
+[device.bt]

--- a/esp-metadata/devices/esp32c6.toml
+++ b/esp-metadata/devices/esp32c6.toml
@@ -1,3 +1,10 @@
+# ESP32-C6 Device Metadata
+#
+# Empty [`device.driver`] tables imply `partial` support status.
+#
+# If you modify a driver support status, run `cargo xtask update-chip-support-table` to
+# update the table in the esp-hal README.
+
 [device]
 name  = "esp32c6"
 arch  = "riscv"
@@ -102,10 +109,61 @@ symbols = [
 
 memory = [{ name = "dram", start = 0x4080_0000, end = 0x4088_0000 }]
 
+[device.gpio]
+status = "supported"
+
+[device.i2c_master]
+status = "supported"
+has_fsm_timeouts = true
+has_hw_bus_clear = true
+
 [device.rmt]
+status = "partial"
 ram_start = 0x60006400
 channel_ram_size = 48
 
-[device.i2c_master]
-has_fsm_timeouts = true
-has_hw_bus_clear = true
+[device.spi_master]
+status = "supported"
+
+[device.uart]
+status = "supported"
+
+# Other drivers which are partially supported but have no other configuration:
+
+## Crypto
+[device.aes]
+[device.ds]
+[device.ecc]
+[device.rsa]
+[device.sha]
+[device.hmac]
+[device.rng]
+
+## Interfaces
+[device.i2s]
+[device.ledc]
+[device.mcpwm]
+[device.parl_io]
+[device.pcnt]
+[device.spi_slave]
+[device.sd_slave]
+[device.twai]
+[device.usb_serial_jtag]
+
+## Miscellaneous
+[device.adc]
+[device.assist_debug]
+[device.dma]
+[device.etm]
+[device.interrupts]
+[device.io_mux]
+[device.sleep]
+[device.temp_sensor]
+[device.systimer]
+[device.timers]
+[device.ulp_riscv]
+
+## Radio
+[device.wifi]
+[device.bt]
+[device.ieee802154]

--- a/esp-metadata/devices/esp32h2.toml
+++ b/esp-metadata/devices/esp32h2.toml
@@ -1,3 +1,10 @@
+# ESP32-H2 Device Metadata
+#
+# Empty [`device.driver`] tables imply `partial` support status.
+#
+# If you modify a driver support status, run `cargo xtask update-chip-support-table` to
+# update the table in the esp-hal README.
+
 [device]
 name  = "esp32h2"
 arch  = "riscv"
@@ -81,10 +88,58 @@ symbols = [
 
 memory = [{ name = "dram", start = 0x4080_0000, end = 0x4085_0000 }]
 
+[device.gpio]
+status = "supported"
+
+[device.i2c_master]
+status = "supported"
+has_fsm_timeouts = true
+has_hw_bus_clear = true
+
 [device.rmt]
+status = "partial"
 ram_start = 0x60007400
 channel_ram_size = 48
 
-[device.i2c_master]
-has_fsm_timeouts = true
-has_hw_bus_clear = true
+[device.spi_master]
+status = "supported"
+
+[device.uart]
+status = "supported"
+
+# Other drivers which are partially supported but have no other configuration:
+
+## Crypto
+[device.aes]
+[device.ds]
+[device.ecc]
+[device.rsa]
+[device.sha]
+[device.hmac]
+[device.rng]
+
+## Interfaces
+[device.i2s]
+[device.ledc]
+[device.mcpwm]
+[device.parl_io]
+[device.pcnt]
+[device.spi_slave]
+[device.twai]
+[device.usb_serial_jtag]
+
+## Miscellaneous
+[device.adc]
+[device.assist_debug]
+[device.dma]
+[device.etm]
+[device.interrupts]
+[device.io_mux]
+[device.sleep]
+[device.systimer]
+[device.temp_sensor]
+[device.timers]
+
+## Radio
+[device.bt]
+[device.ieee802154]

--- a/esp-metadata/devices/esp32p4.toml
+++ b/esp-metadata/devices/esp32p4.toml
@@ -1,3 +1,10 @@
+# ESP32-P4 Device Metadata
+#
+# Empty [`device.driver`] tables imply `partial` support status.
+#
+# If you modify a driver support status, run `cargo xtask update-chip-support-table` to
+# update the table in the esp-hal README.
+
 [device]
 name  = "esp32p4"
 arch  = "riscv"

--- a/esp-metadata/devices/esp32s2.toml
+++ b/esp-metadata/devices/esp32s2.toml
@@ -1,3 +1,10 @@
+# ESP32-S2 Device Metadata
+#
+# Empty [`device.driver`] tables imply `partial` support status.
+#
+# If you modify a driver support status, run `cargo xtask update-chip-support-table` to
+# update the table in the esp-hal README.
+
 [device]
 name  = "esp32s2"
 arch  = "xtensa"
@@ -57,6 +64,7 @@ symbols = [
     "phy",
     "wifi",
     "psram",
+    "psram_dma",
     "ulp_riscv_core",
     "timg_timer1",
     "large_intr_status",
@@ -75,13 +83,64 @@ symbols = [
     "uart_support_wakeup_int",
     "ulp_supported",
     "riscv_coproc_supported",
-
-    # Other capabilities
-    "psram_dma",
 ]
 
 memory = [{ name = "dram", start = 0x3FFB_0000, end = 0x4000_0000 }]
 
+[device.gpio]
+status = "supported"
+
+[device.i2c_master]
+status = "supported"
+
 [device.rmt]
+status = "partial"
 ram_start = 0x3f416400
 channel_ram_size = 64
+
+[device.spi_master]
+status = "supported"
+
+[device.uart]
+status = "supported"
+
+[device.rgb_display]
+status = "not_supported"
+
+[device.touch]
+status = "not_supported"
+
+# Other drivers which are partially supported but have no other configuration:
+
+## Crypto
+[device.aes]
+[device.ds]
+[device.rsa]
+[device.hmac]
+[device.sha]
+[device.rng]
+
+## Interfaces
+[device.i2s]
+[device.ledc]
+[device.spi_slave]
+[device.pcnt]
+[device.twai]
+[device.usb_otg]
+
+## Miscellaneous
+[device.adc]
+[device.dac]
+[device.dma]
+[device.interrupts]
+[device.io_mux]
+[device.psram]
+[device.sleep]
+[device.systimer]
+[device.timers]
+[device.temp_sensor]
+[device.ulp_fsm]
+[device.ulp_riscv]
+
+## Radio
+[device.wifi]

--- a/esp-metadata/devices/esp32s3.toml
+++ b/esp-metadata/devices/esp32s3.toml
@@ -1,3 +1,10 @@
+# ESP32-S3 Device Metadata
+#
+# Empty [`device.driver`] tables imply `partial` support status.
+#
+# If you modify a driver support status, run `cargo xtask update-chip-support-table` to
+# update the table in the esp-hal README.
+
 [device]
 name  = "esp32s3"
 arch  = "xtensa"
@@ -36,6 +43,7 @@ peripherals = [
     "rtc_cntl",
     "rtc_i2c",
     "rtc_io",
+    "sdhost",
     "sens",
     "sensitive",
     "sha",
@@ -92,17 +100,69 @@ symbols = [
     "uart_support_wakeup_int",
     "ulp_supported",
     "riscv_coproc_supported",
-
-    # Other capabilities
-    "psram_dma",
 ]
 
 memory = [{ name = "dram", start = 0x3FC8_8000, end = 0x3FD0_0000 }]
 
+[device.gpio]
+status = "supported"
+
+[device.i2c_master]
+status = "supported"
+has_fsm_timeouts = true
+has_hw_bus_clear = true
+
 [device.rmt]
+status = "partial"
 ram_start = 0x60016800
 channel_ram_size = 48
 
-[device.i2c_master]
-has_fsm_timeouts = true
-has_hw_bus_clear = true
+[device.spi_master]
+status = "supported"
+
+[device.uart]
+status = "supported"
+
+[device.touch]
+status = "not_supported"
+
+# Other drivers which are partially supported but have no other configuration:
+
+## Crypto
+[device.aes]
+[device.ds]
+[device.rsa]
+[device.hmac]
+[device.sha]
+[device.rng]
+
+## Interfaces
+[device.i2s]
+[device.camera]
+[device.rgb_display]
+[device.ledc]
+[device.mcpwm]
+[device.pcnt]
+[device.sd_host]
+[device.spi_slave]
+[device.twai]
+[device.usb_otg]
+[device.usb_serial_jtag]
+
+## Miscellaneous
+[device.adc]
+[device.assist_debug]
+[device.dma]
+[device.interrupts]
+[device.io_mux]
+[device.psram]
+[device.sleep]
+[device.systimer]
+[device.temp_sensor]
+[device.timers]
+[device.ulp_fsm]
+[device.ulp_riscv]
+
+## Radio
+[device.wifi]
+[device.bt]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -40,6 +40,8 @@ enum Cli {
     SemverCheck(SemverCheckArgs),
     /// Check the changelog for packages.
     CheckChangelog(CheckChangelogArgs),
+    /// Re-generate the chip support table in the esp-hal README.
+    UpdateChipSupportTable,
 }
 
 #[derive(Debug, Args)]
@@ -142,6 +144,12 @@ fn main() -> Result<()> {
         Cli::LintPackages(args) => lint_packages(&workspace, args),
         Cli::SemverCheck(args) => semver_checks(&workspace, args),
         Cli::CheckChangelog(args) => check_changelog(&workspace, &args.packages, args.normalize),
+        Cli::UpdateChipSupportTable => {
+            // Re-generate the chip support table in the esp-hal README.
+            // This is a no-op if the table is already up-to-date.
+            xtask::update_chip_support_table(&workspace)?;
+            Ok(())
+        }
     }
 }
 


### PR DESCRIPTION
- I'm sure I've missed a peripheral or two somewhere
- The concept is a bit backwards, we probably will want to generate the peripheral instance cfgs (e.g. (`spi2`) based on the driver config. Right now the symbols are instead used to somewhat double-check the configs. This will be tidied up later.

Closes #2584