### PR TITLE
Peri support fixes

### DIFF
--- a/esp-hal/README.md
+++ b/esp-hal/README.md
@@ -57,7 +57,7 @@ For help getting started with this HAL, please refer to [The Rust on ESP Book] a
 | ASSIST_DEBUG       |       | ⚒️      | ⚒️      | ⚒️      | ⚒️      |          | ⚒️      |
 | DAC                | ⚒️   |          |          |          |          | ⚒️      |          |
 | DMA                | ⚒️   | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      |
-| DS                 |       |          | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      |
+| DS                 |       |          | ❌       | ❌       | ❌       | ❌       | ❌       |
 | ECC                |       | ⚒️      |          | ⚒️      | ⚒️      |          |          |
 | Ethernet           | ❌    |          |          |          |          |          |          |
 | ETM                |       |          |          | ⚒️      | ⚒️      |          |          |
@@ -68,7 +68,7 @@ For help getting started with this HAL, please refer to [The Rust on ESP Book] a
 | I2S                | ⚒️   |          | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      |
 | Interrupts         | ⚒️   | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      |
 | IOMUX              | ⚒️   | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      |
-| Camera interface   | ❌    |          |          |          |          |          | ⚒️      |
+| Camera interface   | ❌    |          |          |          |          | ❌       | ⚒️      |
 | RGB display        | ⚒️   |          |          |          |          | ❌       | ⚒️      |
 | LEDC               | ⚒️   | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️      |
 | MCPWM              | ⚒️   |          |          | ⚒️      | ⚒️      |          | ⚒️      |

--- a/esp-metadata/devices/esp32c3.toml
+++ b/esp-metadata/devices/esp32c3.toml
@@ -97,11 +97,13 @@ status = "supported"
 [device.uart]
 status = "supported"
 
+[device.ds]
+status = "not_supported"
+
 # Other drivers which are partially supported but have no other configuration:
 
 ## Crypto
 [device.aes]
-[device.ds]
 [device.rsa]
 [device.sha]
 [device.hmac]

--- a/esp-metadata/devices/esp32c6.toml
+++ b/esp-metadata/devices/esp32c6.toml
@@ -128,11 +128,13 @@ status = "supported"
 [device.uart]
 status = "supported"
 
+[device.ds]
+status = "not_supported"
+
 # Other drivers which are partially supported but have no other configuration:
 
 ## Crypto
 [device.aes]
-[device.ds]
 [device.ecc]
 [device.rsa]
 [device.sha]

--- a/esp-metadata/devices/esp32h2.toml
+++ b/esp-metadata/devices/esp32h2.toml
@@ -107,11 +107,13 @@ status = "supported"
 [device.uart]
 status = "supported"
 
+[device.ds]
+status = "not_supported"
+
 # Other drivers which are partially supported but have no other configuration:
 
 ## Crypto
 [device.aes]
-[device.ds]
 [device.ecc]
 [device.rsa]
 [device.sha]

--- a/esp-metadata/devices/esp32s2.toml
+++ b/esp-metadata/devices/esp32s2.toml
@@ -104,17 +104,22 @@ status = "supported"
 [device.uart]
 status = "supported"
 
-[device.rgb_display]
+[device.rgb_display] # via SPI and I2S
+status = "not_supported"
+
+[device.camera] # via I2S
 status = "not_supported"
 
 [device.touch]
+status = "not_supported"
+
+[device.ds]
 status = "not_supported"
 
 # Other drivers which are partially supported but have no other configuration:
 
 ## Crypto
 [device.aes]
-[device.ds]
 [device.rsa]
 [device.hmac]
 [device.sha]

--- a/esp-metadata/devices/esp32s3.toml
+++ b/esp-metadata/devices/esp32s3.toml
@@ -126,11 +126,13 @@ status = "supported"
 [device.touch]
 status = "not_supported"
 
+[device.ds]
+status = "not_supported"
+
 # Other drivers which are partially supported but have no other configuration:
 
 ## Crypto
 [device.aes]
-[device.ds]
 [device.rsa]
 [device.hmac]
 [device.sha]


### PR DESCRIPTION
Marking DS as not supported (#884)
Marking S2 Camera as not supported instead of not available, as LCD/CAM can be supported via I2S