### PR TITLE
Always show example description before compiling it

### DIFF
--- a/examples/src/bin/lp_core_basic.rs
+++ b/examples/src/bin/lp_core_basic.rs
@@ -3,7 +3,7 @@
 //! Code on LP core increments a counter and continuously toggles LED. The
 //! current value is printed by the HP core.
 //!
-//! Make sure to first compile the `esp-lp-hal/examples/blinky.rs` example
+//! ⚠️ Make sure to first compile the `esp-lp-hal/examples/blinky.rs` example ⚠️
 //!
 //! The following wiring is assumed:
 //! - LED => GPIO1

--- a/xtask/src/commands/mod.rs
+++ b/xtask/src/commands/mod.rs
@@ -85,7 +85,6 @@ pub fn examples(workspace: &Path, mut args: ExamplesArgs, action: CargoAction) -
     // Execute the specified action:
     match action {
         CargoAction::Build(out_path) => build_examples(args, examples, &package_path, &out_path),
-        CargoAction::Run if args.example.is_some() => run_example(args, examples, &package_path),
         CargoAction::Run => run_examples(args, examples, &package_path),
     }
 }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
When running multiple examples, we show the description of the example. This changes the xtask to do that also for a single example.

This would mitigate what is described in #3544 since the user will see the prerequisites before anything else.

(And we will have a similar situation for #3609 - but there some additional steps are needed)

We could even add a check for defined pre-conditions (while pre-conditions for now would just mean a file is present or not) - not sure if that would be worth it however

#### Testing
Run a single example
