### PR TITLE
chore: remove unused `esp-build` dependency listings

### DIFF
--- a/esp-hal-embassy/Cargo.toml
+++ b/esp-hal-embassy/Cargo.toml
@@ -42,7 +42,6 @@ defmt                     = { version = "1.0.1", optional = true }
 log-04                    = { package = "log", version = "0.4.27", optional = true }
 
 [build-dependencies]
-esp-build    = { version = "0.3.0", path = "../esp-build" }
 esp-config   = { version = "0.4.0", path = "../esp-config", features = ["build"] }
 esp-metadata = { version = "0.7.0", path = "../esp-metadata" }
 

--- a/esp-storage/Cargo.toml
+++ b/esp-storage/Cargo.toml
@@ -28,7 +28,6 @@ critical-section = { version = "1.2.0", optional = true }
 document-features = "0.2.11"
 
 [build-dependencies]
-esp-build    = { version = "0.3.0", path = "../esp-build" }
 esp-metadata = { version = "0.7.0", path = "../esp-metadata" }
 
 [features]

--- a/esp-wifi/Cargo.toml
+++ b/esp-wifi/Cargo.toml
@@ -51,7 +51,6 @@ defmt            = { version = "1.0.1", optional = true }
 log-04           = { package = "log", version = "0.4.27", optional = true }
 
 [build-dependencies]
-esp-build    = { version = "0.3.0", path = "../esp-build" }
 esp-config   = { version = "0.4.0", path = "../esp-config", features = ["build"] }
 esp-metadata = { version = "0.7.0", path = "../esp-metadata" }
 

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -263,7 +263,6 @@ sha1                = { version = "0.10.6", default-features = false }
 sha2                = { version = "0.10.8", default-features = false }
 
 [build-dependencies]
-esp-build    = { path = "../esp-build" }
 esp-metadata = { path = "../esp-metadata" }
 
 [features]


### PR DESCRIPTION
A bit unsure about if and how changelog entries should be added for this. Under `#Fixed` for each crate?

### Submission Checklist 📝
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

Hoping that it may unblock compile time improvements.

#### Testing

PR CI 😈
