### PR TITLE
Prefix peripheral cfg symbols with `chip_has_*`

### DIFF
--- a/esp-hal/src/dma/gdma.rs
+++ b/esp-hal/src/dma/gdma.rs
@@ -726,28 +726,28 @@ cfg_if::cfg_if! {
 
 crate::dma::impl_dma_eligible! {
     AnyGdmaChannel {
-        #[cfg(spi2)]
+        #[cfg(soc_has_spi2)]
         SPI2 => Spi2,
 
-        #[cfg(spi3)]
+        #[cfg(soc_has_spi3)]
         SPI3 => Spi3,
 
-        #[cfg(uhci0)]
+        #[cfg(soc_has_uhci0)]
         UHCI0 => Uhci0,
 
-        #[cfg(i2s0)]
+        #[cfg(soc_has_i2s0)]
         I2S0 => I2s0,
 
-        #[cfg(i2s1)]
+        #[cfg(soc_has_i2s1)]
         I2S1 => I2s1,
 
         #[cfg(esp32s3)]
         LCD_CAM => LcdCam,
 
-        #[cfg(all(gdma, aes))]
+        #[cfg(all(gdma, soc_has_aes))]
         AES => Aes,
 
-        #[cfg(all(gdma, sha))]
+        #[cfg(all(gdma, soc_has_sha))]
         SHA => Sha,
 
         #[cfg(any(esp32c3, esp32c6, esp32h2, esp32s3))]
@@ -759,7 +759,7 @@ crate::dma::impl_dma_eligible! {
         #[cfg(esp32s3)]
         RMT => Rmt,
 
-        #[cfg(parl_io)]
+        #[cfg(soc_has_parl_io)]
         PARL_IO => ParlIo,
 
         #[cfg(any(esp32c2, esp32c6, esp32h2))]

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -2952,7 +2952,7 @@ pub(crate) mod asynch {
         }
     }
 
-    #[cfg(any(i2s0, i2s1))]
+    #[cfg(any(soc_has_i2s0, soc_has_i2s1))]
     pub struct DmaTxDoneChFuture<'a, CH>
     where
         CH: DmaTxChannel,
@@ -2961,7 +2961,7 @@ pub(crate) mod asynch {
         _a: (),
     }
 
-    #[cfg(any(i2s0, i2s1))]
+    #[cfg(any(soc_has_i2s0, soc_has_i2s1))]
     impl<'a, CH> DmaTxDoneChFuture<'a, CH>
     where
         CH: DmaTxChannel,
@@ -2971,7 +2971,7 @@ pub(crate) mod asynch {
         }
     }
 
-    #[cfg(any(i2s0, i2s1))]
+    #[cfg(any(soc_has_i2s0, soc_has_i2s1))]
     impl<CH> core::future::Future for DmaTxDoneChFuture<'_, CH>
     where
         CH: DmaTxChannel,
@@ -3005,7 +3005,7 @@ pub(crate) mod asynch {
         }
     }
 
-    #[cfg(any(i2s0, i2s1))]
+    #[cfg(any(soc_has_i2s0, soc_has_i2s1))]
     impl<CH> Drop for DmaTxDoneChFuture<'_, CH>
     where
         CH: DmaTxChannel,
@@ -3016,7 +3016,7 @@ pub(crate) mod asynch {
         }
     }
 
-    #[cfg(any(i2s0, i2s1))]
+    #[cfg(any(soc_has_i2s0, soc_has_i2s1))]
     pub struct DmaRxDoneChFuture<'a, CH>
     where
         CH: DmaRxChannel,
@@ -3025,7 +3025,7 @@ pub(crate) mod asynch {
         _a: (),
     }
 
-    #[cfg(any(i2s0, i2s1))]
+    #[cfg(any(soc_has_i2s0, soc_has_i2s1))]
     impl<'a, CH> DmaRxDoneChFuture<'a, CH>
     where
         CH: DmaRxChannel,
@@ -3035,7 +3035,7 @@ pub(crate) mod asynch {
         }
     }
 
-    #[cfg(any(i2s0, i2s1))]
+    #[cfg(any(soc_has_i2s0, soc_has_i2s1))]
     impl<CH> core::future::Future for DmaRxDoneChFuture<'_, CH>
     where
         CH: DmaRxChannel,
@@ -3073,7 +3073,7 @@ pub(crate) mod asynch {
         }
     }
 
-    #[cfg(any(i2s0, i2s1))]
+    #[cfg(any(soc_has_i2s0, soc_has_i2s1))]
     impl<CH> Drop for DmaRxDoneChFuture<'_, CH>
     where
         CH: DmaRxChannel,

--- a/esp-hal/src/dma/pdma/i2s.rs
+++ b/esp-hal/src/dma/pdma/i2s.rs
@@ -385,8 +385,9 @@ impl InterruptAccess<DmaRxInterrupt> for AnyI2sDmaRxChannel<'_> {
 crate::any_peripheral! {
     /// An I2S-compatible type-erased DMA channel.
     pub peripheral AnyI2sDmaChannel<'d> {
+        #[cfg(soc_has_i2s0)]
         I2s0(super::DMA_I2S0<'d>),
-        #[cfg(i2s1)]
+        #[cfg(soc_has_i2s1)]
         I2s1(super::DMA_I2S1<'d>),
     }
 }
@@ -408,8 +409,9 @@ impl PdmaChannel for AnyI2sDmaChannel<'_> {
 
     delegate::delegate! {
         to match &self.0 {
+            #[cfg(soc_has_i2s0)]
             AnyI2sDmaChannelInner::I2s0(channel) => channel,
-            #[cfg(i2s1)]
+            #[cfg(soc_has_i2s1)]
             AnyI2sDmaChannelInner::I2s1(channel) => channel,
         } {
             fn register_block(&self) -> &I2sRegisterBlock;

--- a/esp-hal/src/dma/pdma/mod.rs
+++ b/esp-hal/src/dma/pdma/mod.rs
@@ -136,17 +136,21 @@ macro_rules! impl_pdma_channel {
 impl_pdma_channel!(AnySpi, SpiRegisterBlock, DMA_SPI2, SPI2_DMA, [Spi2]);
 impl_pdma_channel!(AnySpi, SpiRegisterBlock, DMA_SPI3, SPI3_DMA, [Spi3]);
 
+#[cfg(soc_has_i2s0)]
 impl_pdma_channel!(AnyI2s, I2sRegisterBlock, DMA_I2S0, I2S0, [I2s0]);
-#[cfg(i2s1)]
+#[cfg(soc_has_i2s1)]
 impl_pdma_channel!(AnyI2s, I2sRegisterBlock, DMA_I2S1, I2S1, [I2s1]);
 
 // Specific peripherals use specific channels. Note that this may be overly
 // restrictive (ESP32 allows configuring 2 SPI DMA channels between 3 different
 // peripherals), but for the current set of restrictions this is sufficient.
+#[cfg(soc_has_spi2)]
 crate::dma::impl_dma_eligible!([DMA_SPI2] SPI2 => Spi2);
+#[cfg(soc_has_spi3)]
 crate::dma::impl_dma_eligible!([DMA_SPI3] SPI3 => Spi3);
+#[cfg(soc_has_i2s0)]
 crate::dma::impl_dma_eligible!([DMA_I2S0] I2S0 => I2s0);
-#[cfg(i2s1)]
+#[cfg(soc_has_i2s1)]
 crate::dma::impl_dma_eligible!([DMA_I2S1] I2S1 => I2s1);
 #[cfg(esp32s2)]
 use crate::peripherals::DMA_CRYPTO;

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -5,7 +5,7 @@
 //! Each pin can be used as a general-purpose I/O, or be connected to one or
 //! more internal peripheral signals.
 #![cfg_attr(
-    soc_etm,
+    soc_has_soc_etm,
     doc = "The GPIO pins also provide tasks and events via the ETM interconnect system. For more information, see the [etm] module."
 )]
 #![doc = ""]
@@ -54,13 +54,13 @@
 crate::unstable_module! {
     pub mod interconnect;
 
-    #[cfg(soc_etm)]
+    #[cfg(soc_has_soc_etm)]
     pub mod etm;
 
-    #[cfg(lp_io)]
+    #[cfg(soc_has_lp_io)]
     pub mod lp_io;
 
-    #[cfg(all(rtc_io, not(esp32)))]
+    #[cfg(all(soc_has_rtc_io, not(esp32)))]
     pub mod rtc_io;
 }
 
@@ -76,7 +76,7 @@ pub use placeholder::NoPin;
 use portable_atomic::AtomicU32;
 use strum::EnumCount;
 
-#[cfg(any(lp_io, rtc_cntl))]
+#[cfg(any(soc_has_lp_io, soc_has_rtc_cntl))]
 use crate::peripherals::{handle_rtcio, handle_rtcio_with_resistors};
 pub use crate::soc::gpio::*;
 use crate::{
@@ -354,7 +354,7 @@ pub trait RtcPin: Pin {
 /// Trait implemented by RTC pins which supporting internal pull-up / pull-down
 /// resistors.
 #[instability::unstable]
-#[cfg(any(lp_io, rtc_cntl))]
+#[cfg(any(soc_has_lp_io, soc_has_rtc_cntl))]
 pub trait RtcPinWithResistors: RtcPin {
     /// Enable/disable the internal pull-up resistor
     #[doc(hidden)]
@@ -588,7 +588,7 @@ pub struct AnyPin<'lt> {
 
 /// Workaround to make D+ and D- work on the ESP32-C3 and ESP32-S3, which by
 /// default are assigned to the `USB_SERIAL_JTAG` peripheral.
-#[cfg(usb_device)]
+#[cfg(soc_has_usb_device)]
 fn disable_usb_pads(gpionum: u8) {
     cfg_if::cfg_if! {
         if #[cfg(esp32c3)] {
@@ -937,7 +937,7 @@ macro_rules! gpio {
             pub(crate) use handle_gpio_input;
 
             cfg_if::cfg_if! {
-                if #[cfg(any(lp_io, rtc_cntl))] {
+                if #[cfg(any(soc_has_lp_io, soc_has_rtc_cntl))] {
                     #[doc(hidden)]
                     macro_rules! handle_rtcio {
                         ($this:expr, $inner:ident, $code:tt) => {
@@ -1792,7 +1792,7 @@ impl<'lt> AnyPin<'lt> {
     /// - Before converting it into signals
     /// - Before using it as an input or output
     pub(crate) fn init_gpio(&self) {
-        #[cfg(usb_device)]
+        #[cfg(soc_has_usb_device)]
         disable_usb_pads(self.number());
 
         self.set_output_enable(false);
@@ -2079,7 +2079,7 @@ impl Pin for AnyPin<'_> {
 impl InputPin for AnyPin<'_> {}
 impl OutputPin for AnyPin<'_> {}
 
-#[cfg(any(lp_io, rtc_cntl))]
+#[cfg(any(soc_has_lp_io, soc_has_rtc_cntl))]
 impl RtcPin for AnyPin<'_> {
     #[cfg(xtensa)]
     #[allow(unused_braces, reason = "False positive")]
@@ -2109,7 +2109,7 @@ impl RtcPin for AnyPin<'_> {
     }
 }
 
-#[cfg(any(lp_io, rtc_cntl))]
+#[cfg(any(soc_has_lp_io, soc_has_rtc_cntl))]
 impl RtcPinWithResistors for AnyPin<'_> {
     fn rtcio_pullup(&self, enable: bool) {
         handle_rtcio_with_resistors!(self, target, {

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -5,7 +5,7 @@
 //! Each pin can be used as a general-purpose I/O, or be connected to one or
 //! more internal peripheral signals.
 #![cfg_attr(
-    soc_has_soc_etm,
+    soc_has_etm,
     doc = "The GPIO pins also provide tasks and events via the ETM interconnect system. For more information, see the [etm] module."
 )]
 #![doc = ""]
@@ -54,7 +54,7 @@
 crate::unstable_module! {
     pub mod interconnect;
 
-    #[cfg(soc_has_soc_etm)]
+    #[cfg(soc_has_etm)]
     pub mod etm;
 
     #[cfg(soc_has_lp_io)]

--- a/esp-hal/src/i2c/mod.rs
+++ b/esp-hal/src/i2c/mod.rs
@@ -10,7 +10,7 @@
 
 pub mod master;
 
-#[cfg(lp_i2c0)]
+#[cfg(soc_has_lp_i2c0)]
 crate::unstable_module! {
     pub mod lp_i2c;
 }

--- a/esp-hal/src/i2s/master.rs
+++ b/esp-hal/src/i2s/master.rs
@@ -669,8 +669,9 @@ where
 
 /// A peripheral singleton compatible with the I2S master driver.
 pub trait Instance: RegisterAccessPrivate + super::IntoAnyI2s {}
+#[cfg(soc_has_i2s0)]
 impl Instance for crate::peripherals::I2S0<'_> {}
-#[cfg(i2s1)]
+#[cfg(soc_has_i2s1)]
 impl Instance for crate::peripherals::I2S1<'_> {}
 impl Instance for AnyI2s<'_> {}
 
@@ -678,7 +679,7 @@ mod private {
     use enumset::EnumSet;
 
     use super::*;
-    #[cfg(not(i2s1))]
+    #[cfg(not(soc_has_i2s1))]
     use crate::pac::i2s0::RegisterBlock;
     use crate::{
         DriverMode,
@@ -696,7 +697,7 @@ mod private {
     };
     // on ESP32-S3 I2S1 doesn't support all features - use that to avoid using those features
     // by accident
-    #[cfg(i2s1)]
+    #[cfg(soc_has_i2s1)]
     use crate::{pac::i2s1::RegisterBlock, peripherals::I2S1};
 
     pub struct TxCreator<'d, Dm>
@@ -1608,7 +1609,7 @@ mod private {
         }
     }
 
-    #[cfg(i2s1)]
+    #[cfg(soc_has_i2s1)]
     impl RegBlock for I2S1<'_> {
         fn regs(&self) -> &RegisterBlock {
             unsafe { &*I2S1::PTR.cast::<RegisterBlock>() }
@@ -1619,7 +1620,7 @@ mod private {
         }
     }
 
-    #[cfg(i2s1)]
+    #[cfg(soc_has_i2s1)]
     impl RegisterAccessPrivate for I2S1<'_> {
         fn set_interrupt_handler(&self, handler: InterruptHandler) {
             for core in crate::system::Cpu::other() {
@@ -1633,7 +1634,7 @@ mod private {
         }
     }
 
-    #[cfg(i2s1)]
+    #[cfg(soc_has_i2s1)]
     impl Signals for crate::peripherals::I2S1<'_> {
         fn mclk_signal(&self) -> OutputSignal {
             cfg_if::cfg_if! {
@@ -1685,16 +1686,18 @@ mod private {
     impl RegBlock for super::AnyI2s<'_> {
         fn regs(&self) -> &RegisterBlock {
             match &self.0 {
+                #[cfg(soc_has_i2s0)]
                 AnyI2sInner::I2s0(i2s) => RegBlock::regs(i2s),
-                #[cfg(i2s1)]
+                #[cfg(soc_has_i2s1)]
                 AnyI2sInner::I2s1(i2s) => RegBlock::regs(i2s),
             }
         }
 
         delegate::delegate! {
             to match &self.0 {
+                #[cfg(soc_has_i2s0)]
                 AnyI2sInner::I2s0(i2s) => i2s,
-                #[cfg(i2s1)]
+                #[cfg(soc_has_i2s1)]
                 AnyI2sInner::I2s1(i2s) => i2s,
             } {
                 fn peripheral(&self) -> crate::system::Peripheral;
@@ -1705,8 +1708,9 @@ mod private {
     impl RegisterAccessPrivate for super::AnyI2s<'_> {
         delegate::delegate! {
             to match &self.0 {
+                #[cfg(soc_has_i2s0)]
                 AnyI2sInner::I2s0(i2s) => i2s,
-                #[cfg(i2s1)]
+                #[cfg(soc_has_i2s1)]
                 AnyI2sInner::I2s1(i2s) => i2s,
             } {
                 fn set_interrupt_handler(&self, handler: InterruptHandler);
@@ -1717,8 +1721,9 @@ mod private {
     impl Signals for super::AnyI2s<'_> {
         delegate::delegate! {
             to match &self.0 {
+                #[cfg(soc_has_i2s0)]
                 AnyI2sInner::I2s0(i2s) => i2s,
-                #[cfg(i2s1)]
+                #[cfg(soc_has_i2s1)]
                 AnyI2sInner::I2s1(i2s) => i2s,
             } {
                 fn mclk_signal(&self) -> OutputSignal;

--- a/esp-hal/src/i2s/mod.rs
+++ b/esp-hal/src/i2s/mod.rs
@@ -10,9 +10,9 @@ pub mod parallel;
 crate::any_peripheral! {
     /// Any I2S peripheral.
     pub peripheral AnyI2s<'d> {
-        #[cfg(i2s0)]
+        #[cfg(soc_has_i2s0)]
         I2s0(crate::peripherals::I2S0<'d>),
-        #[cfg(i2s1)]
+        #[cfg(soc_has_i2s1)]
         I2s1(crate::peripherals::I2S1<'d>),
     }
 }
@@ -25,8 +25,9 @@ impl<'d> DmaEligible for AnyI2s<'d> {
 
     fn dma_peripheral(&self) -> crate::dma::DmaPeripheral {
         match &self.0 {
+            #[cfg(soc_has_i2s0)]
             AnyI2sInner::I2s0(_) => crate::dma::DmaPeripheral::I2s0,
-            #[cfg(i2s1)]
+            #[cfg(soc_has_i2s1)]
             AnyI2sInner::I2s1(_) => crate::dma::DmaPeripheral::I2s1,
         }
     }

--- a/esp-hal/src/i2s/parallel.rs
+++ b/esp-hal/src/i2s/parallel.rs
@@ -793,6 +793,6 @@ impl PrivateInstance for AnyI2s<'_> {
 pub trait Instance: PrivateInstance + super::IntoAnyI2s {}
 
 impl Instance for I2S0<'_> {}
-#[cfg(i2s1)]
+#[cfg(soc_has_i2s1)]
 impl Instance for I2S1<'_> {}
 impl Instance for AnyI2s<'_> {}

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -208,7 +208,7 @@ pub use esp_riscv_rt::{self, riscv};
 #[cfg_attr(not(feature = "unstable"), doc(hidden))]
 pub use xtensa_lx_rt::{self, xtensa_lx};
 
-#[cfg(efuse)]
+#[cfg(soc_has_efuse)]
 #[instability::unstable]
 #[cfg_attr(not(feature = "unstable"), allow(unused))]
 pub use self::soc::efuse;
@@ -226,20 +226,20 @@ pub use self::soc::psram;
 #[cfg_attr(not(feature = "unstable"), allow(unused))]
 pub use self::soc::ulp_core;
 
-#[cfg(any(dport, hp_sys, pcr, system))]
+#[cfg(any(soc_has_dport, soc_has_hp_sys, soc_has_pcr, soc_has_system))]
 pub mod clock;
-#[cfg(gpio)]
+#[cfg(soc_has_gpio)]
 pub mod gpio;
-#[cfg(any(i2c0, i2c1))]
+#[cfg(any(soc_has_i2c0, soc_has_i2c1))]
 pub mod i2c;
 pub mod peripheral;
-#[cfg(all(feature = "unstable", any(hmac, sha)))]
+#[cfg(all(feature = "unstable", any(soc_has_hmac, soc_has_sha)))]
 mod reg_access;
-#[cfg(any(spi0, spi1, spi2, spi3))]
+#[cfg(any(soc_has_spi0, soc_has_spi1, soc_has_spi2, soc_has_spi3))]
 pub mod spi;
 pub mod system;
 pub mod time;
-#[cfg(any(uart0, uart1, uart2))]
+#[cfg(any(soc_has_uart0, soc_has_uart1, soc_has_uart2))]
 pub mod uart;
 
 mod macros;
@@ -300,7 +300,7 @@ unstable_module! {
     pub mod asynch;
     pub mod config;
     pub mod debugger;
-    #[cfg(any(dport, interrupt_core0, interrupt_core1))]
+    #[cfg(any(soc_has_dport, soc_has_interrupt_core0, soc_has_interrupt_core1))]
     pub mod interrupt;
     pub mod rom;
     #[doc(hidden)]
@@ -310,55 +310,55 @@ unstable_module! {
     pub mod analog;
     #[cfg(any(systimer, timergroup))]
     pub mod timer;
-    #[cfg(any(lp_clkrst, rtc_cntl))]
+    #[cfg(any(soc_has_lp_clkrst, soc_has_rtc_cntl))]
     pub mod rtc_cntl;
     #[cfg(any(gdma, pdma))]
     pub mod dma;
-    #[cfg(soc_etm)]
+    #[cfg(soc_has_soc_etm)]
     pub mod etm;
-    #[cfg(usb0)]
+    #[cfg(soc_has_usb0)]
     pub mod otg_fs;
 }
 
 unstable_driver! {
-    #[cfg(aes)]
+    #[cfg(soc_has_aes)]
     pub mod aes;
-    #[cfg(assist_debug)]
+    #[cfg(soc_has_assist_debug)]
     pub mod assist_debug;
     pub mod delay;
-    #[cfg(ecc)]
+    #[cfg(soc_has_ecc)]
     pub mod ecc;
-    #[cfg(hmac)]
+    #[cfg(soc_has_hmac)]
     pub mod hmac;
-    #[cfg(any(i2s0, i2s1))]
+    #[cfg(any(soc_has_i2s0, soc_has_i2s1))]
     pub mod i2s;
-    #[cfg(lcd_cam)]
+    #[cfg(soc_has_lcd_cam)]
     pub mod lcd_cam;
-    #[cfg(ledc)]
+    #[cfg(soc_has_ledc)]
     pub mod ledc;
-    #[cfg(any(mcpwm0, mcpwm1))]
+    #[cfg(any(soc_has_mcpwm0, soc_has_mcpwm1))]
     pub mod mcpwm;
-    #[cfg(parl_io)]
+    #[cfg(soc_has_parl_io)]
     pub mod parl_io;
-    #[cfg(pcnt)]
+    #[cfg(soc_has_pcnt)]
     pub mod pcnt;
-    #[cfg(rmt)]
+    #[cfg(soc_has_rmt)]
     pub mod rmt;
-    #[cfg(rng)]
+    #[cfg(soc_has_rng)]
     pub mod rng;
-    #[cfg(rsa)]
+    #[cfg(soc_has_rsa)]
     pub mod rsa;
-    #[cfg(sha)]
+    #[cfg(soc_has_sha)]
     pub mod sha;
     #[cfg(touch)]
     pub mod touch;
-    #[cfg(trace0)]
+    #[cfg(soc_has_trace0)]
     pub mod trace;
     #[cfg(tsens)]
     pub mod tsens;
-    #[cfg(any(twai0, twai1))]
+    #[cfg(any(soc_has_twai0, soc_has_twai1))]
     pub mod twai;
-    #[cfg(usb_device)]
+    #[cfg(soc_has_usb_device)]
     pub mod usb_serial_jtag;
 }
 

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -314,7 +314,7 @@ unstable_module! {
     pub mod rtc_cntl;
     #[cfg(any(gdma, pdma))]
     pub mod dma;
-    #[cfg(soc_has_soc_etm)]
+    #[cfg(soc_has_etm)]
     pub mod etm;
     #[cfg(soc_has_usb0)]
     pub mod otg_fs;

--- a/esp-hal/src/mcpwm/mod.rs
+++ b/esp-hal/src/mcpwm/mod.rs
@@ -317,7 +317,7 @@ pub trait PwmPeripheral: crate::private::Sealed {
     fn peripheral() -> system::Peripheral;
 }
 
-#[cfg(mcpwm0)]
+#[cfg(soc_has_mcpwm0)]
 impl PwmPeripheral for crate::peripherals::MCPWM0<'_> {
     fn block() -> *const RegisterBlock {
         Self::regs()
@@ -340,7 +340,7 @@ impl PwmPeripheral for crate::peripherals::MCPWM0<'_> {
     }
 }
 
-#[cfg(mcpwm1)]
+#[cfg(soc_has_mcpwm1)]
 impl PwmPeripheral for crate::peripherals::MCPWM1<'_> {
     fn block() -> *const RegisterBlock {
         Self::regs()

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -1702,7 +1702,7 @@ mod chip_specific {
             return Err(Error::UnreachableTargetFrequency);
         };
 
-        #[cfg(not(pcr))]
+        #[cfg(not(soc_has_pcr))]
         {
             RMT::regs().sys_conf().modify(|_, w| unsafe {
                 w.clk_en().clear_bit();
@@ -1714,7 +1714,7 @@ mod chip_specific {
             });
         }
 
-        #[cfg(pcr)]
+        #[cfg(soc_has_pcr)]
         {
             use crate::peripherals::PCR;
             PCR::regs().rmt_sclk_conf().modify(|_, w| unsafe {

--- a/esp-hal/src/rtc_cntl/sleep/esp32c6.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c6.rs
@@ -1025,7 +1025,7 @@ impl RtcSleepConfig {
             // misc_modules_sleep_prepare
 
             // TODO: IDF-7370
-            #[cfg(not(pmu))]
+            #[cfg(not(soc_has_pmu))]
             if !(self.deep && wakeup_triggers.touch) {
                 let saradc = &*esp32c6::APB_SARADC::ptr();
                 saradc

--- a/esp-hal/src/rtc_cntl/sleep/mod.rs
+++ b/esp-hal/src/rtc_cntl/sleep/mod.rs
@@ -495,7 +495,7 @@ bitfield::bitfield! {
     pub bt, set_bt: 10;
 }
 
-#[cfg(pmu)]
+#[cfg(soc_has_pmu)]
 bitfield::bitfield! {
     /// Represents the wakeup triggers.
     #[derive(Default, Clone, Copy)]

--- a/esp-hal/src/spi/slave.rs
+++ b/esp-hal/src/spi/slave.rs
@@ -589,8 +589,9 @@ pub trait Instance: crate::private::Sealed + IntoAnySpi {
 #[allow(private_bounds)]
 pub trait InstanceDma: Instance + DmaEligible {}
 
+#[cfg(soc_has_spi2)]
 impl InstanceDma for crate::peripherals::SPI2<'_> {}
-#[cfg(spi3)]
+#[cfg(soc_has_spi3)]
 impl InstanceDma for crate::peripherals::SPI3<'_> {}
 
 /// Peripheral data describing a particular SPI instance.
@@ -836,7 +837,9 @@ impl<'d> DmaEligible for AnySpi<'d> {
 
 cfg_if::cfg_if! {
     if #[cfg(esp32)] {
+        #[cfg(spi_master_spi2)]
         spi_instance!(2, HSPICLK, HSPID, HSPIQ, HSPICS0);
+        #[cfg(spi_master_spi3)]
         spi_instance!(3, VSPICLK, VSPID, VSPIQ, VSPICS0);
     } else {
         #[cfg(spi_master_spi2)]

--- a/esp-hal/src/system.rs
+++ b/esp-hal/src/system.rs
@@ -106,7 +106,7 @@ pub enum Peripheral {
     #[cfg(soc_has_ecc)]
     Ecc,
     /// SOC ETM peripheral (Event Task Manager).
-    #[cfg(soc_has_soc_etm)]
+    #[cfg(soc_has_etm)]
     Etm,
     /// TRACE0 peripheral (Debug trace).
     #[cfg(soc_has_trace0)]
@@ -197,7 +197,7 @@ impl Peripheral {
         Self::Hmac,
         #[cfg(soc_has_ecc)]
         Self::Ecc,
-        #[cfg(soc_has_soc_etm)]
+        #[cfg(soc_has_etm)]
         Self::Etm,
         #[cfg(soc_has_trace0)]
         Self::Trace0,
@@ -858,7 +858,7 @@ impl PeripheralClockControl {
             Peripheral::Ecc => {
                 system.ecc_conf().modify(|_, w| w.ecc_clk_en().bit(enable));
             }
-            #[cfg(soc_has_soc_etm)]
+            #[cfg(soc_has_etm)]
             Peripheral::Etm => {
                 system.etm_conf().modify(|_, w| w.etm_clk_en().bit(enable));
             }
@@ -1052,7 +1052,7 @@ impl PeripheralClockControl {
                 system.ecc_conf().modify(|_, w| w.ecc_rst_en().set_bit());
                 system.ecc_conf().modify(|_, w| w.ecc_rst_en().clear_bit());
             }
-            #[cfg(soc_has_soc_etm)]
+            #[cfg(soc_has_etm)]
             Peripheral::Etm => {
                 system.etm_conf().modify(|_, w| w.etm_rst_en().set_bit());
                 system.etm_conf().modify(|_, w| w.etm_rst_en().clear_bit());

--- a/esp-hal/src/system.rs
+++ b/esp-hal/src/system.rs
@@ -19,34 +19,34 @@ use crate::peripherals::SYSTEM;
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Peripheral {
     /// SPI2 peripheral.
-    #[cfg(spi2)]
+    #[cfg(soc_has_spi2)]
     Spi2,
     /// SPI3 peripheral.
-    #[cfg(spi3)]
+    #[cfg(soc_has_spi3)]
     Spi3,
     /// External I2C0 peripheral.
-    #[cfg(i2c0)]
+    #[cfg(soc_has_i2c0)]
     I2cExt0,
     /// External I2C1 peripheral.
-    #[cfg(i2c1)]
+    #[cfg(soc_has_i2c1)]
     I2cExt1,
     /// RMT peripheral (Remote Control).
-    #[cfg(rmt)]
+    #[cfg(soc_has_rmt)]
     Rmt,
     /// LEDC peripheral (LED PWM Controller).
-    #[cfg(ledc)]
+    #[cfg(soc_has_ledc)]
     Ledc,
     /// MCPWM0 peripheral (Motor Control PWM 0).
-    #[cfg(mcpwm0)]
+    #[cfg(soc_has_mcpwm0)]
     Mcpwm0,
     /// MCPWM1 peripheral (Motor Control PWM 1).
-    #[cfg(mcpwm1)]
+    #[cfg(soc_has_mcpwm1)]
     Mcpwm1,
     /// PCNT peripheral (Pulse Counter).
-    #[cfg(pcnt)]
+    #[cfg(soc_has_pcnt)]
     Pcnt,
     /// APB SAR ADC peripheral.
-    #[cfg(apb_saradc)]
+    #[cfg(soc_has_apb_saradc)]
     ApbSarAdc,
     /// General DMA (GDMA) peripheral.
     #[cfg(gdma)]
@@ -55,67 +55,67 @@ pub enum Peripheral {
     #[cfg(pdma)]
     Dma,
     /// I2S0 peripheral (Inter-IC Sound).
-    #[cfg(i2s0)]
+    #[cfg(soc_has_i2s0)]
     I2s0,
     /// I2S1 peripheral (Inter-IC Sound).
-    #[cfg(i2s1)]
+    #[cfg(soc_has_i2s1)]
     I2s1,
     /// USB0 peripheral.
-    #[cfg(usb0)]
+    #[cfg(soc_has_usb0)]
     Usb,
     /// AES peripheral (Advanced Encryption Standard).
-    #[cfg(aes)]
+    #[cfg(soc_has_aes)]
     Aes,
     /// TWAI0 peripheral.
-    #[cfg(twai0)]
+    #[cfg(soc_has_twai0)]
     Twai0,
     /// TWAI1 peripheral.
-    #[cfg(twai1)]
+    #[cfg(soc_has_twai1)]
     Twai1,
     /// Timer Group 0 peripheral.
-    #[cfg(timg0)]
+    #[cfg(soc_has_timg0)]
     Timg0,
     /// Timer Group 1 peripheral.
-    #[cfg(timg1)]
+    #[cfg(soc_has_timg1)]
     Timg1,
     /// SHA peripheral (Secure Hash Algorithm).
-    #[cfg(sha)]
+    #[cfg(soc_has_sha)]
     Sha,
     /// USB Device peripheral.
-    #[cfg(usb_device)]
+    #[cfg(soc_has_usb_device)]
     UsbDevice,
     /// UART0 peripheral.
-    #[cfg(uart0)]
+    #[cfg(soc_has_uart0)]
     Uart0,
     /// UART1 peripheral.
-    #[cfg(uart1)]
+    #[cfg(soc_has_uart1)]
     Uart1,
     /// UART2 peripheral.
-    #[cfg(uart2)]
+    #[cfg(soc_has_uart2)]
     Uart2,
     /// RSA peripheral (Rivest-Shamir-Adleman encryption).
-    #[cfg(rsa)]
+    #[cfg(soc_has_rsa)]
     Rsa,
     /// Parallel IO peripheral.
-    #[cfg(parl_io)]
+    #[cfg(soc_has_parl_io)]
     ParlIo,
     /// HMAC peripheral (Hash-based Message Authentication Code).
-    #[cfg(hmac)]
+    #[cfg(soc_has_hmac)]
     Hmac,
     /// ECC peripheral (Elliptic Curve Cryptography).
-    #[cfg(ecc)]
+    #[cfg(soc_has_ecc)]
     Ecc,
     /// SOC ETM peripheral (Event Task Manager).
-    #[cfg(soc_etm)]
+    #[cfg(soc_has_soc_etm)]
     Etm,
     /// TRACE0 peripheral (Debug trace).
-    #[cfg(trace0)]
+    #[cfg(soc_has_trace0)]
     Trace0,
     /// LCD Camera peripheral.
-    #[cfg(lcd_cam)]
+    #[cfg(soc_has_lcd_cam)]
     LcdCam,
     /// Systimer peripheral.
-    #[cfg(systimer)]
+    #[cfg(soc_has_systimer)]
     Systimer,
     /// Temperature sensor peripheral.
     #[cfg(tsens)]
@@ -125,11 +125,11 @@ pub enum Peripheral {
 impl Peripheral {
     const KEEP_ENABLED: &[Peripheral] = &[
         Peripheral::Uart0,
-        #[cfg(usb_device)]
+        #[cfg(soc_has_usb_device)]
         Peripheral::UsbDevice,
-        #[cfg(systimer)]
+        #[cfg(soc_has_systimer)]
         Peripheral::Systimer,
-        #[cfg(timg0)]
+        #[cfg(soc_has_timg0)]
         Peripheral::Timg0,
         #[cfg(esp32c6)] // used by some wifi calibration steps.
         // TODO: We should probably automatically enable this when needed.
@@ -139,71 +139,71 @@ impl Peripheral {
     const COUNT: usize = Self::ALL.len();
 
     const ALL: &[Self] = &[
-        #[cfg(spi2)]
+        #[cfg(soc_has_spi2)]
         Self::Spi2,
-        #[cfg(spi3)]
+        #[cfg(soc_has_spi3)]
         Self::Spi3,
-        #[cfg(i2c0)]
+        #[cfg(soc_has_i2c0)]
         Self::I2cExt0,
-        #[cfg(i2c1)]
+        #[cfg(soc_has_i2c1)]
         Self::I2cExt1,
-        #[cfg(rmt)]
+        #[cfg(soc_has_rmt)]
         Self::Rmt,
-        #[cfg(ledc)]
+        #[cfg(soc_has_ledc)]
         Self::Ledc,
-        #[cfg(mcpwm0)]
+        #[cfg(soc_has_mcpwm0)]
         Self::Mcpwm0,
-        #[cfg(mcpwm1)]
+        #[cfg(soc_has_mcpwm1)]
         Self::Mcpwm1,
-        #[cfg(pcnt)]
+        #[cfg(soc_has_pcnt)]
         Self::Pcnt,
-        #[cfg(apb_saradc)]
+        #[cfg(soc_has_apb_saradc)]
         Self::ApbSarAdc,
         #[cfg(gdma)]
         Self::Gdma,
         #[cfg(pdma)]
         Self::Dma,
-        #[cfg(i2s0)]
+        #[cfg(soc_has_i2s0)]
         Self::I2s0,
-        #[cfg(i2s1)]
+        #[cfg(soc_has_i2s1)]
         Self::I2s1,
-        #[cfg(usb0)]
+        #[cfg(soc_has_usb0)]
         Self::Usb,
-        #[cfg(aes)]
+        #[cfg(soc_has_aes)]
         Self::Aes,
-        #[cfg(twai0)]
+        #[cfg(soc_has_twai0)]
         Self::Twai0,
-        #[cfg(twai1)]
+        #[cfg(soc_has_twai1)]
         Self::Twai1,
-        #[cfg(timg0)]
+        #[cfg(soc_has_timg0)]
         Self::Timg0,
-        #[cfg(timg1)]
+        #[cfg(soc_has_timg1)]
         Self::Timg1,
-        #[cfg(sha)]
+        #[cfg(soc_has_sha)]
         Self::Sha,
-        #[cfg(usb_device)]
+        #[cfg(soc_has_usb_device)]
         Self::UsbDevice,
-        #[cfg(uart0)]
+        #[cfg(soc_has_uart0)]
         Self::Uart0,
-        #[cfg(uart1)]
+        #[cfg(soc_has_uart1)]
         Self::Uart1,
-        #[cfg(uart2)]
+        #[cfg(soc_has_uart2)]
         Self::Uart2,
-        #[cfg(rsa)]
+        #[cfg(soc_has_rsa)]
         Self::Rsa,
-        #[cfg(parl_io)]
+        #[cfg(soc_has_parl_io)]
         Self::ParlIo,
-        #[cfg(hmac)]
+        #[cfg(soc_has_hmac)]
         Self::Hmac,
-        #[cfg(ecc)]
+        #[cfg(soc_has_ecc)]
         Self::Ecc,
-        #[cfg(soc_etm)]
+        #[cfg(soc_has_soc_etm)]
         Self::Etm,
-        #[cfg(trace0)]
+        #[cfg(soc_has_trace0)]
         Self::Trace0,
-        #[cfg(lcd_cam)]
+        #[cfg(soc_has_lcd_cam)]
         Self::LcdCam,
-        #[cfg(systimer)]
+        #[cfg(soc_has_systimer)]
         Self::Systimer,
         #[cfg(tsens)]
         Self::Tsens,
@@ -329,47 +329,47 @@ impl PeripheralClockControl {
         let perip_clk_en1 = &system.perip_clk_en1();
 
         match peripheral {
-            #[cfg(spi2)]
+            #[cfg(soc_has_spi2)]
             Peripheral::Spi2 => {
                 perip_clk_en0.modify(|_, w| w.spi2_clk_en().bit(enable));
             }
-            #[cfg(spi3)]
+            #[cfg(soc_has_spi3)]
             Peripheral::Spi3 => {
                 perip_clk_en0.modify(|_, w| w.spi3_clk_en().bit(enable));
             }
-            #[cfg(all(i2c0, esp32))]
+            #[cfg(all(soc_has_i2c0, esp32))]
             Peripheral::I2cExt0 => {
                 perip_clk_en0.modify(|_, w| w.i2c0_ext0_clk_en().bit(enable));
             }
-            #[cfg(all(i2c0, not(esp32)))]
+            #[cfg(all(soc_has_i2c0, not(esp32)))]
             Peripheral::I2cExt0 => {
                 perip_clk_en0.modify(|_, w| w.i2c_ext0_clk_en().bit(enable));
             }
-            #[cfg(i2c1)]
+            #[cfg(soc_has_i2c1)]
             Peripheral::I2cExt1 => {
                 perip_clk_en0.modify(|_, w| w.i2c_ext1_clk_en().bit(enable));
             }
-            #[cfg(rmt)]
+            #[cfg(soc_has_rmt)]
             Peripheral::Rmt => {
                 perip_clk_en0.modify(|_, w| w.rmt_clk_en().bit(enable));
             }
-            #[cfg(ledc)]
+            #[cfg(soc_has_ledc)]
             Peripheral::Ledc => {
                 perip_clk_en0.modify(|_, w| w.ledc_clk_en().bit(enable));
             }
-            #[cfg(mcpwm0)]
+            #[cfg(soc_has_mcpwm0)]
             Peripheral::Mcpwm0 => {
                 perip_clk_en0.modify(|_, w| w.pwm0_clk_en().bit(enable));
             }
-            #[cfg(mcpwm1)]
+            #[cfg(soc_has_mcpwm1)]
             Peripheral::Mcpwm1 => {
                 perip_clk_en0.modify(|_, w| w.pwm1_clk_en().bit(enable));
             }
-            #[cfg(pcnt)]
+            #[cfg(soc_has_pcnt)]
             Peripheral::Pcnt => {
                 perip_clk_en0.modify(|_, w| w.pcnt_clk_en().bit(enable));
             }
-            #[cfg(apb_saradc)]
+            #[cfg(soc_has_apb_saradc)]
             Peripheral::ApbSarAdc => {
                 perip_clk_en0.modify(|_, w| w.apb_saradc_clk_en().bit(enable));
             }
@@ -400,11 +400,11 @@ impl PeripheralClockControl {
             Peripheral::I2s1 => {
                 perip_clk_en0.modify(|_, w| w.i2s1_clk_en().bit(enable));
             }
-            #[cfg(usb0)]
+            #[cfg(soc_has_usb0)]
             Peripheral::Usb => {
                 perip_clk_en0.modify(|_, w| w.usb_clk_en().bit(enable));
             }
-            #[cfg(twai0)]
+            #[cfg(soc_has_twai0)]
             Peripheral::Twai0 => {
                 perip_clk_en0.modify(|_, w| w.twai_clk_en().bit(enable));
             }
@@ -416,19 +416,19 @@ impl PeripheralClockControl {
             Peripheral::Aes => {
                 perip_clk_en1.modify(|_, w| w.crypto_aes_clk_en().bit(enable));
             }
-            #[cfg(timg0)]
+            #[cfg(soc_has_timg0)]
             Peripheral::Timg0 => {
                 #[cfg(any(esp32c3, esp32s2, esp32s3))]
                 perip_clk_en0.modify(|_, w| w.timers_clk_en().bit(enable));
                 perip_clk_en0.modify(|_, w| w.timergroup_clk_en().bit(enable));
             }
-            #[cfg(timg1)]
+            #[cfg(soc_has_timg1)]
             Peripheral::Timg1 => {
                 #[cfg(any(esp32c3, esp32s2, esp32s3))]
                 perip_clk_en0.modify(|_, w| w.timers_clk_en().bit(enable));
                 perip_clk_en0.modify(|_, w| w.timergroup1_clk_en().bit(enable));
             }
-            #[cfg(sha)]
+            #[cfg(soc_has_sha)]
             Peripheral::Sha => {
                 #[cfg(not(esp32))]
                 perip_clk_en1.modify(|_, w| w.crypto_sha_clk_en().bit(enable));
@@ -441,19 +441,19 @@ impl PeripheralClockControl {
             Peripheral::UsbDevice => {
                 perip_clk_en1.modify(|_, w| w.usb_device_clk_en().bit(enable));
             }
-            #[cfg(uart0)]
+            #[cfg(soc_has_uart0)]
             Peripheral::Uart0 => {
                 perip_clk_en0.modify(|_, w| w.uart_clk_en().bit(enable));
             }
-            #[cfg(uart1)]
+            #[cfg(soc_has_uart1)]
             Peripheral::Uart1 => {
                 perip_clk_en0.modify(|_, w| w.uart1_clk_en().bit(enable));
             }
-            #[cfg(all(uart2, esp32s3))]
+            #[cfg(all(soc_has_uart2, esp32s3))]
             Peripheral::Uart2 => {
                 perip_clk_en1.modify(|_, w| w.uart2_clk_en().set_bit());
             }
-            #[cfg(all(uart2, esp32))]
+            #[cfg(all(soc_has_uart2, esp32))]
             Peripheral::Uart2 => {
                 perip_clk_en0.modify(|_, w| w.uart2_clk_en().bit(enable));
             }
@@ -468,19 +468,19 @@ impl PeripheralClockControl {
                     .rsa_pd_ctrl()
                     .modify(|_, w| w.rsa_mem_pd().bit(!enable));
             }
-            #[cfg(hmac)]
+            #[cfg(soc_has_hmac)]
             Peripheral::Hmac => {
                 perip_clk_en1.modify(|_, w| w.crypto_hmac_clk_en().bit(enable));
             }
-            #[cfg(ecc)]
+            #[cfg(soc_has_ecc)]
             Peripheral::Ecc => {
                 perip_clk_en1.modify(|_, w| w.crypto_ecc_clk_en().bit(enable));
             }
-            #[cfg(lcd_cam)]
+            #[cfg(soc_has_lcd_cam)]
             Peripheral::LcdCam => {
                 perip_clk_en1.modify(|_, w| w.lcd_cam_clk_en().bit(enable));
             }
-            #[cfg(systimer)]
+            #[cfg(soc_has_systimer)]
             Peripheral::Systimer => {
                 perip_clk_en0.modify(|_, w| w.systimer_clk_en().bit(enable));
             }
@@ -505,57 +505,57 @@ impl PeripheralClockControl {
         let perip_rst_en1 = system.perip_rst_en1();
 
         critical_section::with(|_cs| match peripheral {
-            #[cfg(spi2)]
+            #[cfg(soc_has_spi2)]
             Peripheral::Spi2 => {
                 perip_rst_en0.modify(|_, w| w.spi2_rst().set_bit());
                 perip_rst_en0.modify(|_, w| w.spi2_rst().clear_bit());
             }
-            #[cfg(spi3)]
+            #[cfg(soc_has_spi3)]
             Peripheral::Spi3 => {
                 perip_rst_en0.modify(|_, w| w.spi3_rst().set_bit());
                 perip_rst_en0.modify(|_, w| w.spi3_rst().clear_bit());
             }
-            #[cfg(all(i2c0, esp32))]
+            #[cfg(all(soc_has_i2c0, esp32))]
             Peripheral::I2cExt0 => {
                 perip_rst_en0.modify(|_, w| w.i2c0_ext0_rst().set_bit());
                 perip_rst_en0.modify(|_, w| w.i2c0_ext0_rst().clear_bit());
             }
-            #[cfg(all(i2c0, not(esp32)))]
+            #[cfg(all(soc_has_i2c0, not(esp32)))]
             Peripheral::I2cExt0 => {
                 perip_rst_en0.modify(|_, w| w.i2c_ext0_rst().set_bit());
                 perip_rst_en0.modify(|_, w| w.i2c_ext0_rst().clear_bit());
             }
-            #[cfg(i2c1)]
+            #[cfg(soc_has_i2c1)]
             Peripheral::I2cExt1 => {
                 perip_rst_en0.modify(|_, w| w.i2c_ext1_rst().set_bit());
                 perip_rst_en0.modify(|_, w| w.i2c_ext1_rst().clear_bit());
             }
-            #[cfg(rmt)]
+            #[cfg(soc_has_rmt)]
             Peripheral::Rmt => {
                 perip_rst_en0.modify(|_, w| w.rmt_rst().set_bit());
                 perip_rst_en0.modify(|_, w| w.rmt_rst().clear_bit());
             }
-            #[cfg(ledc)]
+            #[cfg(soc_has_ledc)]
             Peripheral::Ledc => {
                 perip_rst_en0.modify(|_, w| w.ledc_rst().set_bit());
                 perip_rst_en0.modify(|_, w| w.ledc_rst().clear_bit());
             }
-            #[cfg(mcpwm0)]
+            #[cfg(soc_has_mcpwm0)]
             Peripheral::Mcpwm0 => {
                 perip_rst_en0.modify(|_, w| w.pwm0_rst().set_bit());
                 perip_rst_en0.modify(|_, w| w.pwm0_rst().clear_bit());
             }
-            #[cfg(mcpwm1)]
+            #[cfg(soc_has_mcpwm1)]
             Peripheral::Mcpwm1 => {
                 perip_rst_en0.modify(|_, w| w.pwm1_rst().set_bit());
                 perip_rst_en0.modify(|_, w| w.pwm1_rst().clear_bit());
             }
-            #[cfg(pcnt)]
+            #[cfg(soc_has_pcnt)]
             Peripheral::Pcnt => {
                 perip_rst_en0.modify(|_, w| w.pcnt_rst().set_bit());
                 perip_rst_en0.modify(|_, w| w.pcnt_rst().clear_bit());
             }
-            #[cfg(apb_saradc)]
+            #[cfg(soc_has_apb_saradc)]
             Peripheral::ApbSarAdc => {
                 perip_rst_en0.modify(|_, w| w.apb_saradc_rst().set_bit());
                 perip_rst_en0.modify(|_, w| w.apb_saradc_rst().clear_bit());
@@ -595,12 +595,12 @@ impl PeripheralClockControl {
                 perip_rst_en0.modify(|_, w| w.i2s1_rst().set_bit());
                 perip_rst_en0.modify(|_, w| w.i2s1_rst().clear_bit());
             }
-            #[cfg(usb0)]
+            #[cfg(soc_has_usb0)]
             Peripheral::Usb => {
                 perip_rst_en0.modify(|_, w| w.usb_rst().set_bit());
                 perip_rst_en0.modify(|_, w| w.usb_rst().clear_bit());
             }
-            #[cfg(twai0)]
+            #[cfg(soc_has_twai0)]
             Peripheral::Twai0 => {
                 perip_rst_en0.modify(|_, w| w.twai_rst().set_bit());
                 perip_rst_en0.modify(|_, w| w.twai_rst().clear_bit());
@@ -615,7 +615,7 @@ impl PeripheralClockControl {
                 perip_rst_en1.modify(|_, w| w.crypto_aes_rst().set_bit());
                 perip_rst_en1.modify(|_, w| w.crypto_aes_rst().clear_bit());
             }
-            #[cfg(timg0)]
+            #[cfg(soc_has_timg0)]
             Peripheral::Timg0 => {
                 #[cfg(any(esp32c3, esp32s2, esp32s3))]
                 perip_rst_en0.modify(|_, w| w.timers_rst().set_bit());
@@ -624,7 +624,7 @@ impl PeripheralClockControl {
                 perip_rst_en0.modify(|_, w| w.timers_rst().clear_bit());
                 perip_rst_en0.modify(|_, w| w.timergroup_rst().clear_bit());
             }
-            #[cfg(timg1)]
+            #[cfg(soc_has_timg1)]
             Peripheral::Timg1 => {
                 #[cfg(any(esp32c3, esp32s2, esp32s3))]
                 perip_rst_en0.modify(|_, w| w.timers_rst().set_bit());
@@ -633,7 +633,7 @@ impl PeripheralClockControl {
                 perip_rst_en0.modify(|_, w| w.timers_rst().clear_bit());
                 perip_rst_en0.modify(|_, w| w.timergroup1_rst().clear_bit());
             }
-            #[cfg(sha)]
+            #[cfg(soc_has_sha)]
             Peripheral::Sha => {
                 #[cfg(not(esp32))]
                 perip_rst_en1.modify(|_, w| w.crypto_sha_rst().set_bit());
@@ -650,22 +650,22 @@ impl PeripheralClockControl {
                 perip_rst_en1.modify(|_, w| w.usb_device_rst().set_bit());
                 perip_rst_en1.modify(|_, w| w.usb_device_rst().clear_bit());
             }
-            #[cfg(uart0)]
+            #[cfg(soc_has_uart0)]
             Peripheral::Uart0 => {
                 perip_rst_en0.modify(|_, w| w.uart_rst().set_bit());
                 perip_rst_en0.modify(|_, w| w.uart_rst().clear_bit());
             }
-            #[cfg(uart1)]
+            #[cfg(soc_has_uart1)]
             Peripheral::Uart1 => {
                 perip_rst_en0.modify(|_, w| w.uart1_rst().set_bit());
                 perip_rst_en0.modify(|_, w| w.uart1_rst().clear_bit());
             }
-            #[cfg(all(uart2, esp32s3))]
+            #[cfg(all(soc_has_uart2, esp32s3))]
             Peripheral::Uart2 => {
                 perip_rst_en1.modify(|_, w| w.uart2_rst().set_bit());
                 perip_rst_en1.modify(|_, w| w.uart2_rst().clear_bit());
             }
-            #[cfg(all(uart2, esp32))]
+            #[cfg(all(soc_has_uart2, esp32))]
             Peripheral::Uart2 => {
                 perip_rst_en0.modify(|_, w| w.uart2_rst().set_bit());
                 perip_rst_en0.modify(|_, w| w.uart2_rst().clear_bit());
@@ -680,22 +680,22 @@ impl PeripheralClockControl {
                 perip_rst_en1.modify(|_, w| w.crypto_rsa_rst().set_bit());
                 perip_rst_en1.modify(|_, w| w.crypto_rsa_rst().clear_bit());
             }
-            #[cfg(hmac)]
+            #[cfg(soc_has_hmac)]
             Peripheral::Hmac => {
                 perip_rst_en1.modify(|_, w| w.crypto_hmac_rst().set_bit());
                 perip_rst_en1.modify(|_, w| w.crypto_hmac_rst().clear_bit());
             }
-            #[cfg(ecc)]
+            #[cfg(soc_has_ecc)]
             Peripheral::Ecc => {
                 perip_rst_en1.modify(|_, w| w.crypto_ecc_rst().set_bit());
                 perip_rst_en1.modify(|_, w| w.crypto_ecc_rst().clear_bit());
             }
-            #[cfg(lcd_cam)]
+            #[cfg(soc_has_lcd_cam)]
             Peripheral::LcdCam => {
                 perip_rst_en1.modify(|_, w| w.lcd_cam_rst().set_bit());
                 perip_rst_en1.modify(|_, w| w.lcd_cam_rst().clear_bit());
             }
-            #[cfg(systimer)]
+            #[cfg(soc_has_systimer)]
             Peripheral::Systimer => {
                 perip_rst_en0.modify(|_, w| w.systimer_rst().set_bit());
                 perip_rst_en0.modify(|_, w| w.systimer_rst().clear_bit());
@@ -721,43 +721,43 @@ impl PeripheralClockControl {
         let system = SYSTEM::regs();
 
         match peripheral {
-            #[cfg(spi2)]
+            #[cfg(soc_has_spi2)]
             Peripheral::Spi2 => {
                 system
                     .spi2_conf()
                     .modify(|_, w| w.spi2_clk_en().bit(enable));
             }
-            #[cfg(i2c0)]
+            #[cfg(soc_has_i2c0)]
             Peripheral::I2cExt0 => {
                 system
                     .i2c0_conf()
                     .modify(|_, w| w.i2c0_clk_en().bit(enable));
             }
-            #[cfg(i2c1)]
+            #[cfg(soc_has_i2c1)]
             Peripheral::I2cExt1 => {
                 system
                     .i2c1_conf()
                     .modify(|_, w| w.i2c1_clk_en().bit(enable));
             }
-            #[cfg(rmt)]
+            #[cfg(soc_has_rmt)]
             Peripheral::Rmt => {
                 system.rmt_conf().modify(|_, w| w.rmt_clk_en().bit(enable));
             }
-            #[cfg(ledc)]
+            #[cfg(soc_has_ledc)]
             Peripheral::Ledc => {
                 system
                     .ledc_conf()
                     .modify(|_, w| w.ledc_clk_en().bit(enable));
             }
-            #[cfg(mcpwm0)]
+            #[cfg(soc_has_mcpwm0)]
             Peripheral::Mcpwm0 => {
                 system.pwm_conf().modify(|_, w| w.pwm_clk_en().bit(enable));
             }
-            #[cfg(mcpwm1)]
+            #[cfg(soc_has_mcpwm1)]
             Peripheral::Mcpwm1 => {
                 system.pwm_conf.modify(|_, w| w.pwm_clk_en().bit(enable));
             }
-            #[cfg(apb_saradc)]
+            #[cfg(soc_has_apb_saradc)]
             Peripheral::ApbSarAdc => {
                 system
                     .saradc_conf()
@@ -769,11 +769,11 @@ impl PeripheralClockControl {
                     .gdma_conf()
                     .modify(|_, w| w.gdma_clk_en().bit(enable));
             }
-            #[cfg(i2s0)]
+            #[cfg(soc_has_i2s0)]
             Peripheral::I2s0 => {
                 system.i2s_conf().modify(|_, w| w.i2s_clk_en().bit(enable));
             }
-            #[cfg(twai0)]
+            #[cfg(soc_has_twai0)]
             Peripheral::Twai0 => {
                 system
                     .twai0_conf()
@@ -789,86 +789,86 @@ impl PeripheralClockControl {
                     });
                 }
             }
-            #[cfg(twai1)]
+            #[cfg(soc_has_twai1)]
             Peripheral::Twai1 => {
                 system
                     .twai1_conf()
                     .modify(|_, w| w.twai1_clk_en().bit(enable));
             }
-            #[cfg(aes)]
+            #[cfg(soc_has_aes)]
             Peripheral::Aes => {
                 system.aes_conf().modify(|_, w| w.aes_clk_en().bit(enable));
             }
-            #[cfg(pcnt)]
+            #[cfg(soc_has_pcnt)]
             Peripheral::Pcnt => {
                 system
                     .pcnt_conf()
                     .modify(|_, w| w.pcnt_clk_en().bit(enable));
             }
-            #[cfg(timg0)]
+            #[cfg(soc_has_timg0)]
             Peripheral::Timg0 => {
                 system
                     .timergroup0_timer_clk_conf()
                     .modify(|_, w| w.tg0_timer_clk_en().bit(enable));
             }
-            #[cfg(timg1)]
+            #[cfg(soc_has_timg1)]
             Peripheral::Timg1 => {
                 system
                     .timergroup1_timer_clk_conf()
                     .modify(|_, w| w.tg1_timer_clk_en().bit(enable));
             }
-            #[cfg(sha)]
+            #[cfg(soc_has_sha)]
             Peripheral::Sha => {
                 system.sha_conf().modify(|_, w| w.sha_clk_en().bit(enable));
             }
-            #[cfg(usb_device)]
+            #[cfg(soc_has_usb_device)]
             Peripheral::UsbDevice => {
                 system
                     .usb_device_conf()
                     .modify(|_, w| w.usb_device_clk_en().bit(enable));
             }
-            #[cfg(uart0)]
+            #[cfg(soc_has_uart0)]
             Peripheral::Uart0 => {
                 system.uart(0).conf().modify(|_, w| w.clk_en().bit(enable));
             }
-            #[cfg(uart1)]
+            #[cfg(soc_has_uart1)]
             Peripheral::Uart1 => {
                 system.uart(1).conf().modify(|_, w| w.clk_en().bit(enable));
             }
-            #[cfg(rsa)]
+            #[cfg(soc_has_rsa)]
             Peripheral::Rsa => {
                 system.rsa_conf().modify(|_, w| w.rsa_clk_en().bit(enable));
                 system
                     .rsa_pd_ctrl()
                     .modify(|_, w| w.rsa_mem_pd().clear_bit());
             }
-            #[cfg(parl_io)]
+            #[cfg(soc_has_parl_io)]
             Peripheral::ParlIo => {
                 system
                     .parl_io_conf()
                     .modify(|_, w| w.parl_clk_en().bit(enable));
             }
-            #[cfg(hmac)]
+            #[cfg(soc_has_hmac)]
             Peripheral::Hmac => {
                 system
                     .hmac_conf()
                     .modify(|_, w| w.hmac_clk_en().bit(enable));
             }
-            #[cfg(ecc)]
+            #[cfg(soc_has_ecc)]
             Peripheral::Ecc => {
                 system.ecc_conf().modify(|_, w| w.ecc_clk_en().bit(enable));
             }
-            #[cfg(soc_etm)]
+            #[cfg(soc_has_soc_etm)]
             Peripheral::Etm => {
                 system.etm_conf().modify(|_, w| w.etm_clk_en().bit(enable));
             }
-            #[cfg(trace0)]
+            #[cfg(soc_has_trace0)]
             Peripheral::Trace0 => {
                 system
                     .trace_conf()
                     .modify(|_, w| w.trace_clk_en().bit(enable));
             }
-            #[cfg(systimer)]
+            #[cfg(soc_has_systimer)]
             Peripheral::Systimer => {
                 system
                     .systimer_conf()
@@ -894,14 +894,14 @@ impl PeripheralClockControl {
         let system = SYSTEM::regs();
 
         match peripheral {
-            #[cfg(spi2)]
+            #[cfg(soc_has_spi2)]
             Peripheral::Spi2 => {
                 system.spi2_conf().modify(|_, w| w.spi2_rst_en().set_bit());
                 system
                     .spi2_conf()
                     .modify(|_, w| w.spi2_rst_en().clear_bit());
             }
-            #[cfg(i2c0)]
+            #[cfg(soc_has_i2c0)]
             Peripheral::I2cExt0 => {
                 #[cfg(any(esp32c6, esp32h2))]
                 {
@@ -911,7 +911,7 @@ impl PeripheralClockControl {
                         .modify(|_, w| w.i2c0_rst_en().clear_bit());
                 }
             }
-            #[cfg(i2c1)]
+            #[cfg(soc_has_i2c1)]
             Peripheral::I2cExt1 => {
                 #[cfg(esp32h2)]
                 {
@@ -921,29 +921,29 @@ impl PeripheralClockControl {
                         .modify(|_, w| w.i2c1_rst_en().clear_bit());
                 }
             }
-            #[cfg(rmt)]
+            #[cfg(soc_has_rmt)]
             Peripheral::Rmt => {
                 system.rmt_conf().modify(|_, w| w.rmt_rst_en().set_bit());
                 system.rmt_conf().modify(|_, w| w.rmt_rst_en().clear_bit());
             }
-            #[cfg(ledc)]
+            #[cfg(soc_has_ledc)]
             Peripheral::Ledc => {
                 system.ledc_conf().modify(|_, w| w.ledc_rst_en().set_bit());
                 system
                     .ledc_conf()
                     .modify(|_, w| w.ledc_rst_en().clear_bit());
             }
-            #[cfg(mcpwm0)]
+            #[cfg(soc_has_mcpwm0)]
             Peripheral::Mcpwm0 => {
                 system.pwm_conf().modify(|_, w| w.pwm_rst_en().set_bit());
                 system.pwm_conf().modify(|_, w| w.pwm_rst_en().clear_bit());
             }
-            #[cfg(mcpwm1)]
+            #[cfg(soc_has_mcpwm1)]
             Peripheral::Mcpwm1 => {
                 system.pwm_conf.modify(|_, w| w.pwm_rst_en().set_bit());
                 system.pwm_conf.modify(|_, w| w.pwm_rst_en().clear_bit());
             }
-            #[cfg(apb_saradc)]
+            #[cfg(soc_has_apb_saradc)]
             Peripheral::ApbSarAdc => {
                 system
                     .saradc_conf()
@@ -959,12 +959,12 @@ impl PeripheralClockControl {
                     .gdma_conf()
                     .modify(|_, w| w.gdma_rst_en().clear_bit());
             }
-            #[cfg(i2s0)]
+            #[cfg(soc_has_i2s0)]
             Peripheral::I2s0 => {
                 system.i2s_conf().modify(|_, w| w.i2s_rst_en().set_bit());
                 system.i2s_conf().modify(|_, w| w.i2s_rst_en().clear_bit());
             }
-            #[cfg(twai0)]
+            #[cfg(soc_has_twai0)]
             Peripheral::Twai0 => {
                 system
                     .twai0_conf()
@@ -973,7 +973,7 @@ impl PeripheralClockControl {
                     .twai0_conf()
                     .modify(|_, w| w.twai0_rst_en().clear_bit());
             }
-            #[cfg(twai1)]
+            #[cfg(soc_has_twai1)]
             Peripheral::Twai1 => {
                 system
                     .twai1_conf()
@@ -982,32 +982,32 @@ impl PeripheralClockControl {
                     .twai1_conf()
                     .modify(|_, w| w.twai1_rst_en().clear_bit());
             }
-            #[cfg(aes)]
+            #[cfg(soc_has_aes)]
             Peripheral::Aes => {
                 system.aes_conf().modify(|_, w| w.aes_rst_en().set_bit());
                 system.aes_conf().modify(|_, w| w.aes_rst_en().clear_bit());
             }
-            #[cfg(pcnt)]
+            #[cfg(soc_has_pcnt)]
             Peripheral::Pcnt => {
                 system.pcnt_conf().modify(|_, w| w.pcnt_rst_en().set_bit());
                 system
                     .pcnt_conf()
                     .modify(|_, w| w.pcnt_rst_en().clear_bit());
             }
-            #[cfg(timg0)]
+            #[cfg(soc_has_timg0)]
             Peripheral::Timg0 => {
                 // no reset?
             }
-            #[cfg(timg1)]
+            #[cfg(soc_has_timg1)]
             Peripheral::Timg1 => {
                 // no reset?
             }
-            #[cfg(sha)]
+            #[cfg(soc_has_sha)]
             Peripheral::Sha => {
                 system.sha_conf().modify(|_, w| w.sha_rst_en().set_bit());
                 system.sha_conf().modify(|_, w| w.sha_rst_en().clear_bit());
             }
-            #[cfg(usb_device)]
+            #[cfg(soc_has_usb_device)]
             Peripheral::UsbDevice => {
                 system
                     .usb_device_conf()
@@ -1016,22 +1016,22 @@ impl PeripheralClockControl {
                     .usb_device_conf()
                     .modify(|_, w| w.usb_device_rst_en().clear_bit());
             }
-            #[cfg(uart0)]
+            #[cfg(soc_has_uart0)]
             Peripheral::Uart0 => {
                 system.uart(0).conf().modify(|_, w| w.rst_en().set_bit());
                 system.uart(0).conf().modify(|_, w| w.rst_en().clear_bit());
             }
-            #[cfg(uart1)]
+            #[cfg(soc_has_uart1)]
             Peripheral::Uart1 => {
                 system.uart(1).conf().modify(|_, w| w.rst_en().set_bit());
                 system.uart(1).conf().modify(|_, w| w.rst_en().clear_bit());
             }
-            #[cfg(rsa)]
+            #[cfg(soc_has_rsa)]
             Peripheral::Rsa => {
                 system.rsa_conf().modify(|_, w| w.rsa_rst_en().set_bit());
                 system.rsa_conf().modify(|_, w| w.rsa_rst_en().clear_bit());
             }
-            #[cfg(parl_io)]
+            #[cfg(soc_has_parl_io)]
             Peripheral::ParlIo => {
                 system
                     .parl_io_conf()
@@ -1040,24 +1040,24 @@ impl PeripheralClockControl {
                     .parl_io_conf()
                     .modify(|_, w| w.parl_rst_en().clear_bit());
             }
-            #[cfg(hmac)]
+            #[cfg(soc_has_hmac)]
             Peripheral::Hmac => {
                 system.hmac_conf().modify(|_, w| w.hmac_rst_en().set_bit());
                 system
                     .hmac_conf()
                     .modify(|_, w| w.hmac_rst_en().clear_bit());
             }
-            #[cfg(ecc)]
+            #[cfg(soc_has_ecc)]
             Peripheral::Ecc => {
                 system.ecc_conf().modify(|_, w| w.ecc_rst_en().set_bit());
                 system.ecc_conf().modify(|_, w| w.ecc_rst_en().clear_bit());
             }
-            #[cfg(soc_etm)]
+            #[cfg(soc_has_soc_etm)]
             Peripheral::Etm => {
                 system.etm_conf().modify(|_, w| w.etm_rst_en().set_bit());
                 system.etm_conf().modify(|_, w| w.etm_rst_en().clear_bit());
             }
-            #[cfg(trace0)]
+            #[cfg(soc_has_trace0)]
             Peripheral::Trace0 => {
                 system
                     .trace_conf()
@@ -1066,7 +1066,7 @@ impl PeripheralClockControl {
                     .trace_conf()
                     .modify(|_, w| w.trace_rst_en().clear_bit());
             }
-            #[cfg(systimer)]
+            #[cfg(soc_has_systimer)]
             Peripheral::Systimer => {
                 system
                     .systimer_conf()

--- a/esp-hal/src/timer/systimer.rs
+++ b/esp-hal/src/timer/systimer.rs
@@ -99,7 +99,7 @@ impl<'d> SystemTimer<'d> {
         // Don't reset Systimer as it will break `time::Instant::now`, only enable it
         PeripheralClockControl::enable(PeripheralEnable::Systimer);
 
-        #[cfg(soc_has_soc_etm)]
+        #[cfg(soc_has_etm)]
         etm::enable_etm();
 
         Self {
@@ -661,7 +661,7 @@ mod asynch {
     }
 }
 
-#[cfg(soc_has_soc_etm)]
+#[cfg(soc_has_etm)]
 pub mod etm {
     //! # Event Task Matrix Function
     //!

--- a/esp-hal/src/timer/systimer.rs
+++ b/esp-hal/src/timer/systimer.rs
@@ -99,7 +99,7 @@ impl<'d> SystemTimer<'d> {
         // Don't reset Systimer as it will break `time::Instant::now`, only enable it
         PeripheralClockControl::enable(PeripheralEnable::Systimer);
 
-        #[cfg(soc_etm)]
+        #[cfg(soc_has_soc_etm)]
         etm::enable_etm();
 
         Self {
@@ -661,7 +661,7 @@ mod asynch {
     }
 }
 
-#[cfg(soc_etm)]
+#[cfg(soc_has_soc_etm)]
 pub mod etm {
     //! # Event Task Matrix Function
     //!

--- a/esp-hal/src/timer/timg.rs
+++ b/esp-hal/src/timer/timg.rs
@@ -895,7 +895,7 @@ mod asynch {
 }
 
 /// Event Task Matrix
-#[cfg(soc_etm)]
+#[cfg(soc_has_soc_etm)]
 pub mod etm {
     use super::*;
     use crate::etm::{EtmEvent, EtmTask};

--- a/esp-hal/src/timer/timg.rs
+++ b/esp-hal/src/timer/timg.rs
@@ -895,7 +895,7 @@ mod asynch {
 }
 
 /// Event Task Matrix
-#[cfg(soc_has_soc_etm)]
+#[cfg(soc_has_etm)]
 pub mod etm {
     use super::*;
     use crate::etm::{EtmEvent, EtmTask};

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -1530,7 +1530,7 @@ impl PrivateInstance for crate::peripherals::TWAI0<'_> {
     }
 }
 
-#[cfg(twai1)]
+#[cfg(soc_has_twai1)]
 impl PrivateInstance for crate::peripherals::TWAI1<'_> {
     fn number(&self) -> usize {
         1
@@ -1570,9 +1570,9 @@ impl PrivateInstance for crate::peripherals::TWAI1<'_> {
 crate::any_peripheral! {
     /// Any TWAI peripheral.
     pub peripheral AnyTwai<'d> {
-        #[cfg(twai0)]
+        #[cfg(soc_has_twai0)]
         Twai0(crate::peripherals::TWAI0<'d>),
-        #[cfg(twai1)]
+        #[cfg(soc_has_twai1)]
         Twai1(crate::peripherals::TWAI1<'d>),
     }
 }
@@ -1580,9 +1580,9 @@ crate::any_peripheral! {
 impl PrivateInstance for AnyTwai<'_> {
     delegate::delegate! {
         to match &self.0 {
-            #[cfg(twai0)]
+            #[cfg(soc_has_twai0)]
             AnyTwaiInner::Twai0(twai) => twai,
-            #[cfg(twai1)]
+            #[cfg(soc_has_twai1)]
             AnyTwaiInner::Twai1(twai) => twai,
         } {
             fn number(&self) -> usize;
@@ -1600,8 +1600,9 @@ impl PrivateInstance for AnyTwai<'_> {
 /// A peripheral singleton compatible with the TWAI driver.
 pub trait Instance: PrivateInstance + IntoAnyTwai {}
 
+#[cfg(soc_has_twai0)]
 impl Instance for crate::peripherals::TWAI0<'_> {}
-#[cfg(twai1)]
+#[cfg(soc_has_twai1)]
 impl Instance for crate::peripherals::TWAI1<'_> {}
 impl Instance for AnyTwai<'_> {}
 
@@ -1616,8 +1617,9 @@ mod asynch {
     use procmacros::handler;
 
     use super::*;
+    #[cfg(soc_has_twai0)]
     use crate::peripherals::TWAI0;
-    #[cfg(twai1)]
+    #[cfg(soc_has_twai1)]
     use crate::peripherals::TWAI1;
 
     pub struct TwaiAsyncState {
@@ -1828,13 +1830,14 @@ mod asynch {
         }
     }
 
+    #[cfg(soc_has_twai0)]
     #[handler]
     pub(super) fn twai0() {
         let twai = unsafe { TWAI0::steal() };
         handle_interrupt(twai.register_block(), twai.async_state());
     }
 
-    #[cfg(twai1)]
+    #[cfg(soc_has_twai1)]
     #[handler]
     pub(super) fn twai1() {
         let twai = unsafe { TWAI1::steal() };

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -3,7 +3,7 @@
 //! ## Overview
 //!
 //! The UART is a hardware peripheral which handles communication using serial
-//! communication interfaces, such as RS232 and RS485. This peripheral provides
+//! communication interfaces, such as RS232 and RS485. This peripheral provides!
 //! a cheap and ubiquitous method for full- and half-duplex communication
 //! between devices.
 //!
@@ -149,14 +149,14 @@ impl embedded_io::Error for TxError {
 #[instability::unstable]
 pub enum ClockSource {
     /// APB_CLK clock source
-    #[cfg_attr(not(any(esp32c6, esp32h2, lp_uart)), default)]
+    #[cfg_attr(not(any(esp32c6, esp32h2, soc_has_lp_uart)), default)]
     Apb,
     /// RC_FAST_CLK clock source (17.5 MHz)
     #[cfg(not(any(esp32, esp32s2)))]
     RcFast,
     /// XTAL_CLK clock source
     #[cfg(not(any(esp32, esp32s2)))]
-    #[cfg_attr(any(esp32c6, esp32h2, lp_uart), default)]
+    #[cfg_attr(any(esp32c6, esp32h2, soc_has_lp_uart), default)]
     Xtal,
     /// REF_TICK clock source (derived from XTAL or RC_FAST, 1MHz)
     #[cfg(any(esp32, esp32s2))]
@@ -2201,7 +2201,7 @@ pub(super) fn intr_handler(uart: &Info, state: &State) {
 }
 
 /// Low-power UART
-#[cfg(lp_uart)]
+#[cfg(soc_has_lp_uart)]
 #[instability::unstable]
 pub mod lp_uart {
     use crate::{
@@ -3257,19 +3257,21 @@ macro_rules! impl_instance {
     };
 }
 
+#[cfg(soc_has_uart0)]
 impl_instance!(UART0, Uart0, U0TXD, U0RXD, U0CTS, U0RTS);
+#[cfg(soc_has_uart1)]
 impl_instance!(UART1, Uart1, U1TXD, U1RXD, U1CTS, U1RTS);
-#[cfg(uart2)]
+#[cfg(soc_has_uart2)]
 impl_instance!(UART2, Uart2, U2TXD, U2RXD, U2CTS, U2RTS);
 
 crate::any_peripheral! {
     /// Any UART peripheral.
     pub peripheral AnyUart<'d> {
-        #[cfg(uart0)]
+        #[cfg(soc_has_uart0)]
         Uart0(crate::peripherals::UART0<'d>),
-        #[cfg(uart1)]
+        #[cfg(soc_has_uart1)]
         Uart1(crate::peripherals::UART1<'d>),
-        #[cfg(uart2)]
+        #[cfg(soc_has_uart2)]
         Uart2(crate::peripherals::UART2<'d>),
     }
 }
@@ -3278,11 +3280,11 @@ impl Instance for AnyUart<'_> {
     #[inline]
     fn parts(&self) -> (&'static Info, &'static State) {
         match &self.0 {
-            #[cfg(uart0)]
+            #[cfg(soc_has_uart0)]
             AnyUartInner::Uart0(uart) => uart.parts(),
-            #[cfg(uart1)]
+            #[cfg(soc_has_uart1)]
             AnyUartInner::Uart1(uart) => uart.parts(),
-            #[cfg(uart2)]
+            #[cfg(soc_has_uart2)]
             AnyUartInner::Uart2(uart) => uart.parts(),
         }
     }

--- a/esp-metadata/devices/esp32c6.toml
+++ b/esp-metadata/devices/esp32c6.toml
@@ -60,7 +60,7 @@ peripherals = [
     "rsa",
     "sha",
     "slchost",
-    "soc_etm",
+    "etm",
     "spi0",
     "spi1",
     "spi2",

--- a/esp-metadata/devices/esp32h2.toml
+++ b/esp-metadata/devices/esp32h2.toml
@@ -53,7 +53,7 @@ peripherals = [
     "rng",
     "rsa",
     "sha",
-    "soc_etm",
+    "etm",
     "spi0",
     "spi1",
     "spi2",

--- a/esp-metadata/src/generate_cfg.rs
+++ b/esp-metadata/src/generate_cfg.rs
@@ -457,7 +457,7 @@ driver_configs![
     EtmProperties {
         driver: etm,
         name: "ETM",
-        peripherals: &["soc_etm"],
+        peripherals: &["etm"],
         properties: {}
     },
     GpioProperties {

--- a/esp-metadata/src/generate_cfg.rs
+++ b/esp-metadata/src/generate_cfg.rs
@@ -820,7 +820,12 @@ impl Config {
             },
         ]
         .into_iter()
-        .chain(self.device.peripherals.iter().cloned())
+        .chain(
+            self.device
+                .peripherals
+                .iter()
+                .map(|p| format!("soc_has_{p}")),
+        )
         .chain(self.device.symbols.iter().cloned())
         .chain(
             self.device


### PR DESCRIPTION
cc https://github.com/esp-rs/esp-hal/pull/3626#discussion_r2139958256

I have intentionally not touched `symbols =` symbols, even though Copilot sometimes tried to.