### PR TITLE
Move some more peripherals to metadata

### DIFF
--- a/esp-hal/src/analog/dac.rs
+++ b/esp-hal/src/analog/dac.rs
@@ -121,12 +121,14 @@ pub trait Instance: crate::private::Sealed {
     }
 }
 
+#[cfg(dac_dac1)]
 impl<'d> Instance for crate::peripherals::DAC1<'d> {
     const INDEX: usize = 0;
 
     type Pin = Dac1Gpio<'d>;
 }
 
+#[cfg(dac_dac2)]
 impl<'d> Instance for crate::peripherals::DAC2<'d> {
     const INDEX: usize = 1;
 

--- a/esp-hal/src/analog/mod.rs
+++ b/esp-hal/src/analog/mod.rs
@@ -5,7 +5,7 @@
 //! available on the device. For more information about a peripheral driver,
 //! please refer to the relevant module documentation.
 
-#[cfg(any(adc1, adc2))]
+#[cfg(adc)]
 pub mod adc;
 #[cfg(dac)]
 pub mod dac;

--- a/esp-hal/src/gpio/interrupt.rs
+++ b/esp-hal/src/gpio/interrupt.rs
@@ -207,12 +207,12 @@ pub(super) extern "C" fn user_gpio_interrupt_handler() {
 fn interrupt_status() -> [(GpioBank, u32); GpioBank::COUNT] {
     let intrs_bank0 = InterruptStatusRegisterAccess::Bank0.interrupt_status_read();
 
-    #[cfg(gpio_bank_1)]
+    #[cfg(gpio_has_bank_1)]
     let intrs_bank1 = InterruptStatusRegisterAccess::Bank1.interrupt_status_read();
 
     [
         (GpioBank::_0, intrs_bank0),
-        #[cfg(gpio_bank_1)]
+        #[cfg(gpio_has_bank_1)]
         (GpioBank::_1, intrs_bank1),
     ]
 }

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -466,7 +466,7 @@ pub trait TouchPin: Pin {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum GpioBank {
     _0,
-    #[cfg(gpio_bank_1)]
+    #[cfg(gpio_has_bank_1)]
     _1,
 }
 
@@ -480,7 +480,7 @@ impl GpioBank {
     fn offset(self) -> u8 {
         match self {
             Self::_0 => 0,
-            #[cfg(gpio_bank_1)]
+            #[cfg(gpio_has_bank_1)]
             Self::_1 => 32,
         }
     }
@@ -498,7 +498,7 @@ impl GpioBank {
             Self::_0 => GPIO::regs()
                 .enable_w1tc()
                 .write(|w| unsafe { w.bits(word) }),
-            #[cfg(gpio_bank_1)]
+            #[cfg(gpio_has_bank_1)]
             Self::_1 => GPIO::regs()
                 .enable1_w1tc()
                 .write(|w| unsafe { w.bits(word) }),
@@ -510,7 +510,7 @@ impl GpioBank {
             Self::_0 => GPIO::regs()
                 .enable_w1ts()
                 .write(|w| unsafe { w.bits(word) }),
-            #[cfg(gpio_bank_1)]
+            #[cfg(gpio_has_bank_1)]
             Self::_1 => GPIO::regs()
                 .enable1_w1ts()
                 .write(|w| unsafe { w.bits(word) }),
@@ -520,7 +520,7 @@ impl GpioBank {
     fn read_input(self) -> u32 {
         match self {
             Self::_0 => GPIO::regs().in_().read().bits(),
-            #[cfg(gpio_bank_1)]
+            #[cfg(gpio_has_bank_1)]
             Self::_1 => GPIO::regs().in1().read().bits(),
         }
     }
@@ -528,7 +528,7 @@ impl GpioBank {
     fn read_output(self) -> u32 {
         match self {
             Self::_0 => GPIO::regs().out().read().bits(),
-            #[cfg(gpio_bank_1)]
+            #[cfg(gpio_has_bank_1)]
             Self::_1 => GPIO::regs().out1().read().bits(),
         }
     }
@@ -536,7 +536,7 @@ impl GpioBank {
     fn read_interrupt_status(self) -> u32 {
         match self {
             Self::_0 => GPIO::regs().status().read().bits(),
-            #[cfg(gpio_bank_1)]
+            #[cfg(gpio_has_bank_1)]
             Self::_1 => GPIO::regs().status1().read().bits(),
         }
     }
@@ -546,7 +546,7 @@ impl GpioBank {
             Self::_0 => GPIO::regs()
                 .status_w1tc()
                 .write(|w| unsafe { w.bits(word) }),
-            #[cfg(gpio_bank_1)]
+            #[cfg(gpio_has_bank_1)]
             Self::_1 => GPIO::regs()
                 .status1_w1tc()
                 .write(|w| unsafe { w.bits(word) }),
@@ -564,7 +564,7 @@ impl GpioBank {
     fn write_output_set(self, word: u32) {
         match self {
             Self::_0 => GPIO::regs().out_w1ts().write(|w| unsafe { w.bits(word) }),
-            #[cfg(gpio_bank_1)]
+            #[cfg(gpio_has_bank_1)]
             Self::_1 => GPIO::regs().out1_w1ts().write(|w| unsafe { w.bits(word) }),
         };
     }
@@ -572,7 +572,7 @@ impl GpioBank {
     fn write_output_clear(self, word: u32) {
         match self {
             Self::_0 => GPIO::regs().out_w1tc().write(|w| unsafe { w.bits(word) }),
-            #[cfg(gpio_bank_1)]
+            #[cfg(gpio_has_bank_1)]
             Self::_1 => GPIO::regs().out1_w1tc().write(|w| unsafe { w.bits(word) }),
         };
     }
@@ -1777,7 +1777,7 @@ impl private::Sealed for AnyPin<'_> {}
 
 impl<'lt> AnyPin<'lt> {
     fn bank(&self) -> GpioBank {
-        #[cfg(gpio_bank_1)]
+        #[cfg(gpio_has_bank_1)]
         if self.number() >= 32 {
             return GpioBank::_1;
         }

--- a/esp-hal/src/interrupt/mod.rs
+++ b/esp-hal/src/interrupt/mod.rs
@@ -149,14 +149,7 @@ impl InterruptHandler {
     }
 }
 
-#[cfg(large_intr_status)]
-const STATUS_WORDS: usize = 3;
-
-#[cfg(very_large_intr_status)]
-const STATUS_WORDS: usize = 4;
-
-#[cfg(not(any(large_intr_status, very_large_intr_status)))]
-const STATUS_WORDS: usize = 2;
+const STATUS_WORDS: usize = property!("interrupts.status_registers");
 
 /// Representation of peripheral-interrupt status bits.
 #[derive(Clone, Copy, Default, Debug)]
@@ -171,21 +164,21 @@ impl InterruptStatus {
         }
     }
 
-    #[cfg(large_intr_status)]
+    #[cfg(interrupts_status_registers = "3")]
     const fn from(w0: u32, w1: u32, w2: u32) -> Self {
         Self {
             status: [w0, w1, w2],
         }
     }
 
-    #[cfg(very_large_intr_status)]
+    #[cfg(interrupts_status_registers = "4")]
     const fn from(w0: u32, w1: u32, w2: u32, w3: u32) -> Self {
         Self {
             status: [w0, w1, w2, w3],
         }
     }
 
-    #[cfg(not(any(large_intr_status, very_large_intr_status)))]
+    #[cfg(interrupts_status_registers = "2")]
     const fn from(w0: u32, w1: u32) -> Self {
         Self { status: [w0, w1] }
     }
@@ -213,7 +206,7 @@ impl BitAnd for InterruptStatus {
     type Output = InterruptStatus;
 
     fn bitand(self, rhs: Self) -> Self::Output {
-        #[cfg(large_intr_status)]
+        #[cfg(interrupts_status_registers = "3")]
         return Self::Output {
             status: [
                 self.status[0] & rhs.status[0],
@@ -222,7 +215,7 @@ impl BitAnd for InterruptStatus {
             ],
         };
 
-        #[cfg(very_large_intr_status)]
+        #[cfg(interrupts_status_registers = "4")]
         return Self::Output {
             status: [
                 self.status[0] & rhs.status[0],
@@ -232,7 +225,7 @@ impl BitAnd for InterruptStatus {
             ],
         };
 
-        #[cfg(not(any(large_intr_status, very_large_intr_status)))]
+        #[cfg(interrupts_status_registers = "2")]
         return Self::Output {
             status: [
                 self.status[0] & rhs.status[0],

--- a/esp-hal/src/interrupt/riscv.rs
+++ b/esp-hal/src/interrupt/riscv.rs
@@ -301,13 +301,13 @@ pub fn disable(_core: Cpu, interrupt: Interrupt) {
 #[inline]
 pub fn status(_core: Cpu) -> InterruptStatus {
     cfg_if::cfg_if! {
-        if #[cfg(large_intr_status)] {
+        if #[cfg(interrupts_status_registers = "3")] {
             InterruptStatus::from(
                 INTERRUPT_CORE0::regs().intr_status_reg_0().read().bits(),
                 INTERRUPT_CORE0::regs().intr_status_reg_1().read().bits(),
                 INTERRUPT_CORE0::regs().int_status_reg_2().read().bits(),
             )
-        } else if #[cfg(very_large_intr_status)] {
+        } else if #[cfg(interrupts_status_registers = "4")] {
             InterruptStatus::from(
                 INTERRUPT_CORE0::regs().intr_status_reg_0().read().bits(),
                 INTERRUPT_CORE0::regs().intr_status_reg_1().read().bits(),

--- a/esp-hal/src/interrupt/xtensa.rs
+++ b/esp-hal/src/interrupt/xtensa.rs
@@ -230,7 +230,7 @@ pub fn clear(_core: Cpu, which: CpuInterrupt) {
 }
 
 /// Get status of peripheral interrupts
-#[cfg(large_intr_status)]
+#[cfg(interrupts_status_registers = "3")]
 pub fn status(core: Cpu) -> InterruptStatus {
     unsafe {
         match core {
@@ -268,7 +268,7 @@ pub fn status(core: Cpu) -> InterruptStatus {
 }
 
 /// Get status of peripheral interrupts
-#[cfg(very_large_intr_status)]
+#[cfg(interrupts_status_registers = "4")]
 pub fn status(core: Cpu) -> InterruptStatus {
     unsafe {
         match core {

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -306,7 +306,7 @@ unstable_module! {
     #[doc(hidden)]
     pub mod sync;
     // Drivers needed for initialization or they are tightly coupled to something else.
-    #[cfg(any(adc1, adc2, dac))]
+    #[cfg(any(adc, dac))]
     pub mod analog;
     #[cfg(any(systimer, timergroup))]
     pub mod timer;

--- a/esp-metadata/devices/esp32.toml
+++ b/esp-metadata/devices/esp32.toml
@@ -59,11 +59,15 @@ peripherals = [
     "uhci1",
 ]
 
-symbols = [
-    # Additional peripherals defined by us (the developers):
+virtual_peripherals = [
     "adc1",
     "adc2",
-    "dac",
+    "dac1",
+    "dac2",
+]
+
+symbols = [
+    # Additional peripherals defined by us (the developers):
     "pdma",
     "phy",
     "psram",
@@ -82,6 +86,20 @@ symbols = [
 ]
 
 memory = [{ name = "dram", start = 0x3FFA_E000, end = 0x4000_0000 }]
+
+[device.adc]
+status = "partial"
+instances = [
+    { name = "adc1" },
+    { name = "adc2" },
+]
+
+[device.dac]
+status = "partial"
+instances = [
+    { name = "dac1" },
+    { name = "dac2" },
+]
 
 [device.gpio]
 status = "supported"
@@ -146,8 +164,6 @@ status = "not_supported"
 [device.twai]
 
 ## Miscellaneous
-[device.adc]
-[device.dac]
 [device.dma]
 [device.io_mux]
 [device.psram]

--- a/esp-metadata/devices/esp32.toml
+++ b/esp-metadata/devices/esp32.toml
@@ -68,7 +68,6 @@ symbols = [
     "phy",
     "psram",
     "touch",
-    "large_intr_status",
 
     # ROM capabilities
     "rom_crc_le",
@@ -99,6 +98,10 @@ i2c0_data_register_ahb_address = 0x6001301c
 
 [device.i2c_slave]
 status = "not_supported"
+
+[device.interrupts]
+status = "partial"
+status_registers = 3
 
 [device.rmt]
 status = "partial"
@@ -146,7 +149,6 @@ status = "not_supported"
 [device.adc]
 [device.dac]
 [device.dma]
-[device.interrupts]
 [device.io_mux]
 [device.psram]
 [device.temp_sensor]

--- a/esp-metadata/devices/esp32.toml
+++ b/esp-metadata/devices/esp32.toml
@@ -69,7 +69,6 @@ symbols = [
     "psram",
     "touch",
     "large_intr_status",
-    "gpio_bank_1",
 
     # ROM capabilities
     "rom_crc_le",
@@ -87,6 +86,7 @@ memory = [{ name = "dram", start = 0x3FFA_E000, end = 0x4000_0000 }]
 
 [device.gpio]
 status = "supported"
+has_bank_1 = true
 
 [device.i2c_master]
 status = "supported"

--- a/esp-metadata/devices/esp32c2.toml
+++ b/esp-metadata/devices/esp32c2.toml
@@ -40,9 +40,12 @@ peripherals = [
     "xts_aes",
 ]
 
+virtual_peripherals = [
+    "adc1",
+]
+
 symbols = [
     # Additional peripherals defined by us (the developers):
-    "adc1",
     "assist_debug_sp_monitor",
     "gdma",
     "phy",
@@ -60,6 +63,12 @@ symbols = [
 ]
 
 memory = [{ name = "dram", start = 0x3FCA_0000, end = 0x3FCE_0000 }]
+
+[device.adc]
+status = "partial"
+instances = [
+    { name = "adc1" },
+]
 
 [device.gpio]
 status = "supported"
@@ -106,7 +115,6 @@ status = "supported"
 
 ## Miscellaneous
 [device.assist_debug]
-[device.adc]
 [device.dma]
 [device.io_mux]
 [device.temp_sensor]

--- a/esp-metadata/devices/esp32c2.toml
+++ b/esp-metadata/devices/esp32c2.toml
@@ -78,6 +78,10 @@ has_arbitration_en = true
 has_tx_fifo_watermark = true
 bus_timeout_is_exponential = true
 
+[device.interrupts]
+status = "partial"
+status_registers = 2
+
 [device.spi_master]
 status = "supported"
 instances = [{ name = "spi2" }]
@@ -104,7 +108,6 @@ status = "supported"
 [device.assist_debug]
 [device.adc]
 [device.dma]
-[device.interrupts]
 [device.io_mux]
 [device.temp_sensor]
 [device.sleep]

--- a/esp-metadata/devices/esp32c3.toml
+++ b/esp-metadata/devices/esp32c3.toml
@@ -51,10 +51,13 @@ peripherals = [
     "xts_aes",
 ]
 
-symbols = [
-    # Additional peripherals defined by us (the developers):
+virtual_peripherals = [
     "adc1",
     "adc2",
+]
+
+symbols = [
+    # Additional peripherals defined by us (the developers):
     "assist_debug_sp_monitor",
     "assist_debug_region_monitor",
     "gdma",
@@ -75,6 +78,12 @@ symbols = [
 
 memory = [{ name = "dram", start = 0x3FC8_0000, end = 0x3FCE_0000 }]
 
+[device.adc]
+status = "partial"
+instances = [
+    { name = "adc1" },
+    { name = "adc2" },
+]
 
 [device.gpio]
 status = "supported"
@@ -132,7 +141,6 @@ status = "not_supported"
 [device.usb_serial_jtag]
 
 ## Miscellaneous
-[device.adc]
 [device.assist_debug]
 [device.dma]
 [device.io_mux]

--- a/esp-metadata/devices/esp32c3.toml
+++ b/esp-metadata/devices/esp32c3.toml
@@ -93,6 +93,10 @@ has_arbitration_en = true
 has_tx_fifo_watermark = true
 bus_timeout_is_exponential = true
 
+[device.interrupts]
+status = "partial"
+status_registers = 2
+
 [device.rmt]
 status = "partial"
 ram_start = 0x60016400
@@ -131,7 +135,6 @@ status = "not_supported"
 [device.adc]
 [device.assist_debug]
 [device.dma]
-[device.interrupts]
 [device.io_mux]
 [device.temp_sensor]
 [device.sleep]

--- a/esp-metadata/devices/esp32c6.toml
+++ b/esp-metadata/devices/esp32c6.toml
@@ -77,9 +77,12 @@ peripherals = [
     "usb_device",
 ]
 
+virtual_peripherals = [
+    "adc1",
+]
+
 symbols = [
     # Additional peripherals defined by us (the developers):
-    "adc1",
     "assist_debug_sp_monitor",
     "assist_debug_region_monitor",
     "gdma",
@@ -103,6 +106,12 @@ symbols = [
 ]
 
 memory = [{ name = "dram", start = 0x4080_0000, end = 0x4088_0000 }]
+
+[device.adc]
+status = "partial"
+instances = [
+    { name = "adc1" },
+]
 
 [device.gpio]
 status = "supported"
@@ -171,7 +180,6 @@ has_wifi6 = true
 [device.usb_serial_jtag]
 
 ## Miscellaneous
-[device.adc]
 [device.assist_debug]
 [device.dma]
 [device.etm]

--- a/esp-metadata/devices/esp32c6.toml
+++ b/esp-metadata/devices/esp32c6.toml
@@ -83,7 +83,6 @@ symbols = [
     "assist_debug_sp_monitor",
     "assist_debug_region_monitor",
     "gdma",
-    "large_intr_status",
     "plic",
     "phy",
     "lp_core",
@@ -123,6 +122,10 @@ has_reliable_fsm_reset = true
 has_arbitration_en = true
 has_tx_fifo_watermark = true
 bus_timeout_is_exponential = true
+
+[device.interrupts]
+status = "partial"
+status_registers = 3
 
 [device.rmt]
 status = "partial"
@@ -172,7 +175,6 @@ has_wifi6 = true
 [device.assist_debug]
 [device.dma]
 [device.etm]
-[device.interrupts]
 [device.io_mux]
 [device.sleep]
 [device.temp_sensor]

--- a/esp-metadata/devices/esp32h2.toml
+++ b/esp-metadata/devices/esp32h2.toml
@@ -69,9 +69,12 @@ peripherals = [
     "usb_device",
 ]
 
+virtual_peripherals = [
+    "adc1",
+]
+
 symbols = [
     # Additional peripherals defined by us (the developers):
-    "adc1",
     "assist_debug_sp_monitor",
     "assist_debug_region_monitor",
     "gdma",
@@ -86,6 +89,12 @@ symbols = [
 ]
 
 memory = [{ name = "dram", start = 0x4080_0000, end = 0x4085_0000 }]
+
+[device.adc]
+status = "partial"
+instances = [
+    { name = "adc1" },
+]
 
 [device.gpio]
 status = "supported"
@@ -149,7 +158,6 @@ status = "not_supported"
 [device.usb_serial_jtag]
 
 ## Miscellaneous
-[device.adc]
 [device.assist_debug]
 [device.dma]
 [device.etm]

--- a/esp-metadata/devices/esp32h2.toml
+++ b/esp-metadata/devices/esp32h2.toml
@@ -106,6 +106,10 @@ has_arbitration_en = true
 has_tx_fifo_watermark = true
 bus_timeout_is_exponential = true
 
+[device.interrupts]
+status = "partial"
+status_registers = 2
+
 [device.rmt]
 status = "partial"
 ram_start = 0x60007400
@@ -149,7 +153,6 @@ status = "not_supported"
 [device.assist_debug]
 [device.dma]
 [device.etm]
-[device.interrupts]
 [device.io_mux]
 [device.sleep]
 [device.systimer]

--- a/esp-metadata/devices/esp32s2.toml
+++ b/esp-metadata/devices/esp32s2.toml
@@ -55,11 +55,15 @@ peripherals = [
     "xts_aes",
 ]
 
-symbols = [
-    # Additional peripherals defined by us (the developers):
+virtual_peripherals = [
     "adc1",
     "adc2",
-    "dac",
+    "dac1",
+    "dac2",
+]
+
+symbols = [
+    # Additional peripherals defined by us (the developers):
     "pdma",
     "phy",
     "psram",
@@ -82,6 +86,20 @@ symbols = [
 ]
 
 memory = [{ name = "dram", start = 0x3FFB_0000, end = 0x4000_0000 }]
+
+[device.adc]
+status = "partial"
+instances = [
+    { name = "adc1" },
+    { name = "adc2" },
+]
+
+[device.dac]
+status = "partial"
+instances = [
+    { name = "dac1" },
+    { name = "dac2" },
+]
 
 [device.gpio]
 status = "supported"
@@ -148,8 +166,6 @@ status = "not_supported"
 [device.usb_otg]
 
 ## Miscellaneous
-[device.adc]
-[device.dac]
 [device.dma]
 [device.io_mux]
 [device.psram]

--- a/esp-metadata/devices/esp32s2.toml
+++ b/esp-metadata/devices/esp32s2.toml
@@ -65,7 +65,6 @@ symbols = [
     "psram",
     "psram_dma",
     "ulp_riscv_core",
-    "large_intr_status",
     "spi_octal",
 
     # ROM capabilities
@@ -98,6 +97,10 @@ max_bus_timeout = 0xFFFFFF
 separate_filter_config_registers = true
 has_arbitration_en = true
 i2c0_data_register_ahb_address = 0x6001301c
+
+[device.interrupts]
+status = "partial"
+status_registers = 3
 
 [device.rmt]
 status = "partial"
@@ -148,7 +151,6 @@ status = "not_supported"
 [device.adc]
 [device.dac]
 [device.dma]
-[device.interrupts]
 [device.io_mux]
 [device.psram]
 [device.sleep]

--- a/esp-metadata/devices/esp32s2.toml
+++ b/esp-metadata/devices/esp32s2.toml
@@ -66,7 +66,6 @@ symbols = [
     "psram_dma",
     "ulp_riscv_core",
     "large_intr_status",
-    "gpio_bank_1",
     "spi_octal",
 
     # ROM capabilities
@@ -87,6 +86,7 @@ memory = [{ name = "dram", start = 0x3FFB_0000, end = 0x4000_0000 }]
 
 [device.gpio]
 status = "supported"
+has_bank_1 = true
 
 [device.i2c_master]
 status = "supported"

--- a/esp-metadata/devices/esp32s3.toml
+++ b/esp-metadata/devices/esp32s3.toml
@@ -79,7 +79,6 @@ symbols = [
     "psram_dma",
     "octal_psram",
     "ulp_riscv_core",
-    "very_large_intr_status",
     "spi_octal",
 
     # ROM capabilities
@@ -118,6 +117,10 @@ has_conf_update = true
 has_arbitration_en = true
 has_tx_fifo_watermark = true
 bus_timeout_is_exponential = true
+
+[device.interrupts]
+status = "partial"
+status_registers = 4
 
 [device.rmt]
 status = "partial"
@@ -167,7 +170,6 @@ status = "not_supported"
 [device.adc]
 [device.assist_debug]
 [device.dma]
-[device.interrupts]
 [device.io_mux]
 [device.psram]
 [device.sleep]

--- a/esp-metadata/devices/esp32s3.toml
+++ b/esp-metadata/devices/esp32s3.toml
@@ -68,10 +68,13 @@ peripherals = [
     "xts_aes",
 ]
 
-symbols = [
-    # Additional peripherals defined by us (the developers):
+virtual_peripherals = [
     "adc1",
     "adc2",
+]
+
+symbols = [
+    # Additional peripherals defined by us (the developers):
     "assist_debug_region_monitor",
     "gdma",
     "phy",
@@ -98,6 +101,13 @@ symbols = [
 ]
 
 memory = [{ name = "dram", start = 0x3FC8_8000, end = 0x3FD0_0000 }]
+
+[device.adc]
+status = "partial"
+instances = [
+    { name = "adc1" },
+    { name = "adc2" },
+]
 
 [device.gpio]
 status = "supported"
@@ -167,7 +177,6 @@ status = "not_supported"
 [device.usb_serial_jtag]
 
 ## Miscellaneous
-[device.adc]
 [device.assist_debug]
 [device.dma]
 [device.io_mux]

--- a/esp-metadata/devices/esp32s3.toml
+++ b/esp-metadata/devices/esp32s3.toml
@@ -80,7 +80,6 @@ symbols = [
     "octal_psram",
     "ulp_riscv_core",
     "very_large_intr_status",
-    "gpio_bank_1",
     "spi_octal",
 
     # ROM capabilities
@@ -103,6 +102,7 @@ memory = [{ name = "dram", start = 0x3FC8_8000, end = 0x3FD0_0000 }]
 
 [device.gpio]
 status = "supported"
+has_bank_1 = true
 
 [device.i2c_master]
 status = "supported"

--- a/esp-metadata/src/generate_cfg.rs
+++ b/esp-metadata/src/generate_cfg.rs
@@ -192,6 +192,8 @@ struct Device {
     trm: String,
 
     peripherals: Vec<String>,
+    // For now, this is only used to double-check the configuration.
+    virtual_peripherals: Vec<String>,
     symbols: Vec<String>,
     memory: Vec<MemoryRegion>,
 
@@ -409,7 +411,7 @@ driver_configs![
     AdcProperties {
         driver: adc,
         name: "ADC",
-        peripherals: &["adc1", "adc2"],
+        peripherals: &[],
         properties: {}
     },
     AesProperties {
@@ -757,6 +759,7 @@ impl Config {
                 cores: 1,
                 trm: "".to_owned(),
                 peripherals: Vec::new(),
+                virtual_peripherals: Vec::new(),
                 symbols: Vec::new(),
                 memory: Vec::new(),
                 peri_config: PeriConfig::default(),
@@ -768,7 +771,8 @@ impl Config {
         for instance in self.device.peri_config.driver_instances() {
             let (driver, peri) = instance.split_once('.').unwrap();
             ensure!(
-                self.device.peripherals.iter().any(|p| p == peri),
+                self.device.peripherals.iter().any(|p| p == peri)
+                    || self.device.virtual_peripherals.iter().any(|p| p == peri),
                 "Driver {driver} marks an implementation for '{peri}' but this peripheral is not defined for '{}'",
                 self.device.name
             );

--- a/esp-metadata/src/generate_cfg.rs
+++ b/esp-metadata/src/generate_cfg.rs
@@ -464,7 +464,10 @@ driver_configs![
         driver: gpio,
         name: "GPIO",
         peripherals: &["gpio"],
-        properties: {}
+        properties: {
+            #[serde(default)]
+            has_bank_1: bool,
+        }
     },
     HmacProperties {
         driver: hmac,
@@ -955,8 +958,15 @@ fn define_all_possible_symbols() {
     for chip in Chip::iter() {
         let config = Config::for_chip(&chip);
         for symbol in config.all() {
+            let symbol_name = symbol
+                .split('=')
+                .next()
+                .expect("The first split can't fail");
             // https://doc.rust-lang.org/cargo/reference/build-scripts.html#rustc-check-cfg
-            println!("cargo:rustc-check-cfg=cfg({})", symbol.replace('.', "_"));
+            println!(
+                "cargo:rustc-check-cfg=cfg({})",
+                symbol_name.replace('.', "_")
+            );
         }
     }
 }


### PR DESCRIPTION
This PR required me to define `virtual_peripherals` for ADC/DAC.