### PR TITLE
Esp32: ensure wifi data comes before bss

### DIFF
--- a/esp-hal/ld/esp32/memory.x
+++ b/esp-hal/ld/esp32/memory.x
@@ -1,6 +1,6 @@
-/* This memory map assumes the flash cache is on; 
-   the blocks used are excluded from the various memory ranges 
-   
+/* This memory map assumes the flash cache is on;
+   the blocks used are excluded from the various memory ranges
+
    see: https://github.com/espressif/esp-idf/blob/5b1189570025ba027f2ff6c2d91f6ffff3809cc2/components/heap/port/esp32/memory_layout.c
    for details
    */
@@ -19,8 +19,8 @@ MEMORY
 
   reserved_for_rom_seg   : ORIGIN = 0x3FFAE000, len = 8k /* SRAM2; reserved for usage by the ROM */
   dram_seg ( RW )        : ORIGIN = 0x3FFB0000 + RESERVE_DRAM, len = 176k - RESERVE_DRAM /* SRAM2+1; first 64kB used by BT if enable */
-  
-  /* 
+
+  /*
   * The following values come from the heap allocator in esp-idf: https://github.com/espressif/esp-idf/blob/ab63aaa4a24a05904da2862d627f3987ecbeafd0/components/heap/port/esp32/memory_layout.c#L137-L157
   * The segment dram2_seg after the rom data space is not mentioned in the esp32 linker scripts in esp-idf, instead the space after is used as heap space.
   * It seems not all rom data space is reserved, but only "core"/"important" ROM functions that may be called after booting from ROM.
@@ -30,7 +30,7 @@ MEMORY
 
   /*
   *   The following values are derived from the __stack and _stack_sentry values from ROM.
-  *   They represent the stacks used for each core setup by ROM code. In theory both of these 
+  *   They represent the stacks used for each core setup by ROM code. In theory both of these
   *   can be reclaimed once both cores are running, but for now we play it safe and reserve them both.
   */
   reserved_rom_stack_pro  : ORIGIN = 0x3ffe1320, len = 11264
@@ -38,7 +38,7 @@ MEMORY
 
   dram2_seg              : ORIGIN = 0x3ffe7e30, len = 98767  /* the rest of DRAM after the rom data segments and rom stacks in the middle */
 
-  /* external flash 
+  /* external flash
      The 0x20 offset is a convenience for the app binary image generation.
      Flash cache has 64KB pages. The .bin file which is flashed to the chip
      has a 0x18 byte file header, and each segment has a 0x08 byte segment

--- a/esp-hal/ld/sections/rwdata.x
+++ b/esp-hal/ld/sections/rwdata.x
@@ -23,6 +23,13 @@
 /* LMA of .data */
 _sidata = LOADADDR(.data);
 
+.data.wifi :
+{
+  . = ALIGN(4);
+  *( .dram1 .dram1.*)
+  . = ALIGN(4);
+} > RWDATA
+
 .bss (NOLOAD) : ALIGN(4)
 {
   _bss_start = ABSOLUTE(.);
@@ -49,12 +56,5 @@ _sidata = LOADADDR(.data);
   . = ALIGN(4);
   *(.noinit .noinit.*)
   *(.uninit .uninit.*)
-  . = ALIGN(4);
-} > RWDATA
-
-.data.wifi :
-{
-  . = ALIGN(4);
-  *( .dram1 .dram1.*)
   . = ALIGN(4);
 } > RWDATA

--- a/esp-wifi/src/wifi/os_adapter.rs
+++ b/esp-wifi/src/wifi/os_adapter.rs
@@ -1495,11 +1495,15 @@ pub unsafe extern "C" fn log_writev(
     format: *const crate::binary::c_types::c_char,
     args: crate::binary::include::va_list,
 ) {
-    crate::binary::log::syslog(
-        level,
-        format as _,
-        core::mem::transmute::<crate::binary::include::va_list, core::ffi::VaListImpl<'_>>(args),
-    );
+    unsafe {
+        crate::binary::log::syslog(
+            level,
+            format as _,
+            core::mem::transmute::<crate::binary::include::va_list, core::ffi::VaListImpl<'_>>(
+                args,
+            ),
+        );
+    }
 }
 
 /// **************************************************************************

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -270,7 +270,7 @@ esp-metadata = { path = "../esp-metadata" }
 default = []
 unstable = ["esp-hal/unstable"]
 
-defmt = ["dep:defmt-rtt", "esp-hal/defmt", "embedded-test/defmt", "esp-wifi/defmt", "esp-hal-embassy/defmt"]
+defmt = ["dep:defmt-rtt", "esp-hal/defmt", "embedded-test/defmt", "esp-wifi?/defmt", "esp-hal-embassy?/defmt"]
 
 # Device support (required!):
 esp32 = [


### PR DESCRIPTION
This PR is aimed to fix the bootloop in https://github.com/esp-rs/esp-generate/issues/194. Due to some very specific circumstances, we ended up with initialized memory in the bootloader's stack region, which caused a non-bootable firmware. This PR ensures that the initialized memory is placed before anything uninitialized, reducing the chance of a similar issue. If we end up with a similar conflict in the future, it means the user pretty much has no stack anyway.

I tried writing a test but I had to rely on esp_wifi::init calling coex_init, and use some very specific heap sizes to bet right on the point between a linker error and a booting firmware. Given this fragility, let's say I wasn't able to come up with an effective test.