### PR TITLE
Remove proc-macro-error2

### DIFF
--- a/esp-hal-procmacros/Cargo.toml
+++ b/esp-hal-procmacros/Cargo.toml
@@ -20,7 +20,6 @@ document-features = "0.2.11"
 litrs             = "0.4.1"
 object            = { version = "0.36.7", default-features = false, features = ["read_core", "elf"], optional = true }
 proc-macro-crate  = "3.3.0"
-proc-macro-error2 = "2.0.1"
 proc-macro2       = "1.0.95"
 quote             = "1.0.40"
 syn               = { version = "2.0.100", features = ["extra-traits", "full"] }

--- a/esp-hal-procmacros/src/lib.rs
+++ b/esp-hal-procmacros/src/lib.rs
@@ -116,7 +116,6 @@ mod switch;
 /// [`bytemuck::AnyBitPattern`]: https://docs.rs/bytemuck/1.9.0/bytemuck/trait.AnyBitPattern.html
 /// [`bytemuck::Zeroable`]: https://docs.rs/bytemuck/1.9.0/bytemuck/trait.Zeroable.html
 #[proc_macro_attribute]
-#[proc_macro_error2::proc_macro_error]
 pub fn ram(args: TokenStream, input: TokenStream) -> TokenStream {
     ram::ram(args, input)
 }
@@ -142,7 +141,6 @@ pub fn ram(args: TokenStream, input: TokenStream) -> TokenStream {
 /// fn my_function() {}
 /// ```
 #[proc_macro_attribute]
-#[proc_macro_error2::proc_macro_error]
 pub fn enable_doc_switch(args: TokenStream, input: TokenStream) -> TokenStream {
     switch::enable_doc_switch(args, input)
 }
@@ -154,7 +152,6 @@ pub fn enable_doc_switch(args: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// If no priority is given, `Priority::min()` is assumed
 #[proc_macro_attribute]
-#[proc_macro_error2::proc_macro_error]
 pub fn handler(args: TokenStream, input: TokenStream) -> TokenStream {
     interrupt::handler(args, input)
 }
@@ -175,7 +172,6 @@ pub fn load_lp_code(input: TokenStream) -> TokenStream {
 /// Marks the entry function of a LP core / ULP program.
 #[cfg(any(feature = "is-lp-core", feature = "is-ulp-core"))]
 #[proc_macro_attribute]
-#[proc_macro_error2::proc_macro_error]
 pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
     lp_core::entry(args, input)
 }


### PR DESCRIPTION
Not a significant win, but we don't really need the dependency.