### PR TITLE
Compare functions by their address

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- `InterruptHandler` no longer implements `PartialEq`, `Eq` or `Hash`. (#3650)
 
 ## [v1.0.0-beta.1] - 2025-06-03
 

--- a/esp-hal/src/gpio/interrupt.rs
+++ b/esp-hal/src/gpio/interrupt.rs
@@ -94,11 +94,9 @@ impl CFnPtr {
 pub(crate) fn bind_default_interrupt_handler() {
     // We first check if a handler is set in the vector table.
     if let Some(handler) = interrupt::bound_handler(Interrupt::GPIO) {
-        let handler = handler as *const unsafe extern "C" fn();
-
         // We only allow binding the default handler if nothing else is bound.
         // This prevents silently overwriting RTIC's interrupt handler, if using GPIO.
-        if !core::ptr::eq(handler, DEFAULT_INTERRUPT_HANDLER.handler() as _) {
+        if !core::ptr::fn_addr_eq(handler, DEFAULT_INTERRUPT_HANDLER.handler()) {
             // The user has configured an interrupt handler they wish to use.
             info!("Not using default GPIO interrupt handler: already bound in vector table");
             return;

--- a/esp-hal/src/interrupt/mod.rs
+++ b/esp-hal/src/interrupt/mod.rs
@@ -122,17 +122,11 @@ pub trait InterruptConfigurable: crate::private::Sealed {
     multi_core,
     doc = "**Note**: Interrupts are handled on the core they were setup on, if a driver is initialized on core 0, and moved to core 1, core 0 will still handle the interrupt."
 )]
-#[derive(Copy, Clone, Debug, Eq, Hash)]
+#[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct InterruptHandler {
     f: extern "C" fn(),
     prio: Priority,
-}
-
-impl PartialEq for InterruptHandler {
-    fn eq(&self, other: &Self) -> bool {
-        core::ptr::fn_addr_eq(self.f, other.f) && self.prio == other.prio
-    }
 }
 
 impl InterruptHandler {

--- a/esp-hal/src/interrupt/mod.rs
+++ b/esp-hal/src/interrupt/mod.rs
@@ -122,11 +122,17 @@ pub trait InterruptConfigurable: crate::private::Sealed {
     multi_core,
     doc = "**Note**: Interrupts are handled on the core they were setup on, if a driver is initialized on core 0, and moved to core 1, core 0 will still handle the interrupt."
 )]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Debug, Eq, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct InterruptHandler {
     f: extern "C" fn(),
     prio: Priority,
+}
+
+impl PartialEq for InterruptHandler {
+    fn eq(&self, other: &Self) -> bool {
+        core::ptr::fn_addr_eq(self.f, other.f) && self.prio == other.prio
+    }
 }
 
 impl InterruptHandler {


### PR DESCRIPTION
Closes #3648 

I think the only affected piece of code is GPIO interrupts, where we've been lucky so far with the "potentially surprising semantics". I guess we'll see if we continue to be lucky.