### PR TITLE
Allow renaming esp-hal

### DIFF
--- a/esp-hal-procmacros/src/blocking.rs
+++ b/esp-hal-procmacros/src/blocking.rs
@@ -23,8 +23,13 @@ pub fn main(args: TokenStream, input: TokenStream) -> TokenStream {
             .into();
     }
 
+    let root = match proc_macro_crate::crate_name("esp-hal") {
+        Ok(proc_macro_crate::FoundCrate::Name(ref name)) => quote::format_ident!("{name}"),
+        _ => quote::format_ident!("esp_hal"),
+    };
+
     quote::quote!(
-        #[esp_hal::__macro_implementation::__entry]
+        #[#root::__macro_implementation::__entry]
         #f
     )
     .into()

--- a/esp-hal-procmacros/src/embassy.rs
+++ b/esp-hal-procmacros/src/embassy.rs
@@ -157,8 +157,13 @@ impl Drop for Ctxt {
 }
 
 pub fn main_fn() -> TokenStream2 {
+    let root = match proc_macro_crate::crate_name("esp-hal") {
+        Ok(proc_macro_crate::FoundCrate::Name(ref name)) => quote::format_ident!("{name}"),
+        _ => quote::format_ident!("esp_hal"),
+    };
+
     quote! {
-        #[esp_hal::main]
+        #[#root::main]
         fn main() -> ! {
             let mut executor = ::esp_hal_embassy::Executor::new();
             let executor = unsafe { __make_static(&mut executor) };


### PR DESCRIPTION
This PR allows aliasing the package (`hal = { package = "esp-hal" ...`). I'm not sure this is worth calling out in any changelog, especially that I'm not confident we'll not accidentally break it...