### PR TITLE
Docs landing page

### DIFF
--- a/resources/index.html.jinja
+++ b/resources/index.html.jinja
@@ -26,15 +26,15 @@
 
     .logo {
       text-align: center;
-      margin-bottom: 50px;
-      font-size: 1em;
-      font-weight: 500;
+      margin-bottom: 42px;
+      font-size: 0.8em;
+      font-weight: 100;
     }
 
     .logo img {
       width: 100px;
       height: auto;
-      margin-bottom: 20px;
+      margin-bottom: 12px;
     }
 
     .content {
@@ -112,7 +112,9 @@
   <div class="content">
     <div class="logo">
       <img src="esp-rs.svg" alt="esp-rs logo" />
-      <div>esp-hal enables Rust embedded developers to build safe, high-level, and efficient firmware for a wide range of ESP32 chips.
+      <div>
+      <h2>esp-rs Documentation and Resources</h2>
+      esp-hal enables Rust embedded developers to build safe, high-level, and efficient firmware for a wide range of ESP32 chips.
       It supports both blocking and async APIs, with additional crates for Wi-Fi, Bluetooth, flash storage, logging, and more.</div>
     </div>
 

--- a/resources/index.html.jinja
+++ b/resources/index.html.jinja
@@ -37,6 +37,10 @@
       margin-bottom: 12px;
     }
 
+    .logo h2 {
+      margin-top: 0.5rem;
+    }
+
     .content {
       width: 900px;
     }

--- a/resources/index.html.jinja
+++ b/resources/index.html.jinja
@@ -62,7 +62,7 @@
 
     .crate-name {
       color: #d6991d;
-      width: 120px;
+      width: 220px;
     }
 
     /* Ensure the link color does not change after being clicked */
@@ -89,7 +89,7 @@
 
     .resource-name {
       color: #d6991d;
-      width: 240px;
+      width: 400px;
     }
 
     /* Ensure the link color does not change after being clicked */

--- a/resources/index.html.jinja
+++ b/resources/index.html.jinja
@@ -20,7 +20,6 @@
       margin: 0;
       padding: 40px 20px;
       display: flex;
-      width: 100vw;
       justify-content: center;
       box-sizing: border-box;
     }

--- a/resources/index.html.jinja
+++ b/resources/index.html.jinja
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>esp-rs Documentation</title>
+  <title>esp-rs Documentation and Resources</title>
 
   <link rel="icon" href="esp-rs.svg" />
   <link href="https://fonts.googleapis.com/css2?family=Fira+Sans:wght@400;500&display=swap" rel="stylesheet" />
@@ -20,7 +20,6 @@
       margin: 0;
       padding: 40px 20px;
       display: flex;
-      height: 100vh;
       width: 100vw;
       justify-content: center;
       box-sizing: border-box;
@@ -29,7 +28,7 @@
     .logo {
       text-align: center;
       margin-bottom: 50px;
-      font-size: 2em;
+      font-size: 1em;
       font-weight: 500;
     }
 
@@ -81,6 +80,27 @@
       width: 120px;
     }
 
+    .resource {
+      display: flex;
+      align-items: center;
+      padding: 10px;
+      border-bottom: 2px solid #454444;
+    }
+
+    .resource-name {
+      color: #d6991d;
+      width: 240px;
+    }
+
+    /* Ensure the link color does not change after being clicked */
+    .resource-name a:link,
+    .resource-name a:visited,
+    .resource-name a:hover,
+    .resource-name a:active,
+    .resource-name a:focus {
+      color: #d6991d;
+    }
+
     @media screen and (min-height: 650px) {
       body {
         align-items: center;
@@ -93,10 +113,11 @@
   <div class="content">
     <div class="logo">
       <img src="esp-rs.svg" alt="esp-rs logo" />
-      <div>esp-rs Documentation</div>
+      <div>esp-hal enables Rust embedded developers to build safe, high-level, and efficient firmware for a wide range of ESP32 chips.
+      It supports both blocking and async APIs, with additional crates for Wi-Fi, Bluetooth, flash storage, logging, and more.</div>
     </div>
 
-    <h2>Packages</h2>
+    <h2>Package Documentation</h2>
 
     {%- for meta in metadata %}
     <div class="crate">
@@ -107,6 +128,11 @@
       <span class="crate-version">{{ meta.version }}</span>
     </div>
     {%- endfor %}
+
+    <h2>Resources</h2>
+    <div class="resource"><span class="resource-name"><a href="https://docs.espressif.com/projects/rust/book/">The Rust on ESP Book</a></span></div>
+    <div class="resource"><span class="resource-name"><a href="https://docs.espressif.com/projects/rust/no_std-training/">Embedded Rust (no_std) on Espressif Training</a></span></div>
+
   </div>
 </body>
 

--- a/resources/index.html.jinja
+++ b/resources/index.html.jinja
@@ -116,11 +116,15 @@
   <div class="content">
     <div class="logo">
       <img src="esp-rs.svg" alt="esp-rs logo" />
-      <div>
       <h2>esp-rs Documentation and Resources</h2>
-      esp-hal enables Rust embedded developers to build safe, high-level, and efficient firmware for a wide range of ESP32 chips.
-      It supports both blocking and async APIs, with additional crates for Wi-Fi, Bluetooth, flash storage, logging, and more.</div>
+      Bare-metal (no_std) hardware abstraction layer for Espressif devices.
     </div>
+
+    <h2>Resources</h2>
+
+    <div class="resource"><span class="resource-name"><a href="https://docs.espressif.com/projects/rust/book/">The Rust on ESP Book</a></span></div>
+    <div class="resource"><span class="resource-name"><a href="https://docs.espressif.com/projects/rust/no_std-training/">Embedded Rust (no_std) on Espressif Training</a></span></div>
+
 
     <h2>Package Documentation</h2>
 
@@ -133,10 +137,6 @@
       <span class="crate-version">{{ meta.version }}</span>
     </div>
     {%- endfor %}
-
-    <h2>Resources</h2>
-    <div class="resource"><span class="resource-name"><a href="https://docs.espressif.com/projects/rust/book/">The Rust on ESP Book</a></span></div>
-    <div class="resource"><span class="resource-name"><a href="https://docs.espressif.com/projects/rust/no_std-training/">Embedded Rust (no_std) on Espressif Training</a></span></div>
 
   </div>
 </body>


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

Fixes #3634

![image](https://github.com/user-attachments/assets/983469ec-1cd2-4bbd-b62d-f43133fe6837)

Can't think of more resources to add - open to suggestions.

The "blurb about the project" is a bit brief but
- I'd expect most people to get here already know they want to use esp-hal - don't think a lot of people will see this by casually roaming the internet
- more text here means they need to scroll
- happy to get suggestions for rephrasing it

Resources come after the docs because most users will get here to find docs (my assumption at least)

When doing this I started to wonder how useful the "Documentation for esp-alloc crate" etc. half-sentences are. Probably we could do better but that is outside the scope of this PR

#### Testing

Build the doc-index and have a look

