### PR TITLE
Move smaller GPIO properties to metadata

### DIFF
--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -72,13 +72,13 @@ ufmt-write               = { version = "0.1.0", optional = true }
 # IMPORTANT:
 # Each supported device MUST have its PAC included below along with a
 # corresponding feature.
-esp32   = { version = "0.37.0", features = ["critical-section", "rt"], optional = true }
-esp32c2 = { version = "0.26.0", features = ["critical-section", "rt"], optional = true }
-esp32c3 = { version = "0.29.0", features = ["critical-section", "rt"], optional = true }
-esp32c6 = { version = "0.20.0", features = ["critical-section", "rt"], optional = true }
-esp32h2 = { version = "0.16.0", features = ["critical-section", "rt"], optional = true }
-esp32s2 = { version = "0.28.0", features = ["critical-section", "rt"], optional = true }
-esp32s3 = { version = "0.32.0", features = ["critical-section", "rt"], optional = true }
+esp32   = { version = "0.37.0", features = ["critical-section", "rt"], git = "https://github.com/esp-rs/esp-pacs", rev = "7707ae7", optional = true }
+esp32c2 = { version = "0.26.0", features = ["critical-section", "rt"], git = "https://github.com/esp-rs/esp-pacs", rev = "7707ae7", optional = true }
+esp32c3 = { version = "0.29.0", features = ["critical-section", "rt"], git = "https://github.com/esp-rs/esp-pacs", rev = "7707ae7", optional = true }
+esp32c6 = { version = "0.20.0", features = ["critical-section", "rt"], git = "https://github.com/esp-rs/esp-pacs", rev = "7707ae7", optional = true }
+esp32h2 = { version = "0.16.0", features = ["critical-section", "rt"], git = "https://github.com/esp-rs/esp-pacs", rev = "7707ae7", optional = true }
+esp32s2 = { version = "0.28.0", features = ["critical-section", "rt"], git = "https://github.com/esp-rs/esp-pacs", rev = "7707ae7", optional = true }
+esp32s3 = { version = "0.32.0", features = ["critical-section", "rt"], git = "https://github.com/esp-rs/esp-pacs", rev = "7707ae7", optional = true }
 
 [target.'cfg(target_arch = "riscv32")'.dependencies]
 riscv            = { version = "0.12.1" }

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -82,7 +82,7 @@ pub use crate::soc::gpio::*;
 use crate::{
     asynch::AtomicWaker,
     interrupt::{InterruptHandler, Priority},
-    peripherals::{GPIO, IO_MUX, Interrupt, handle_gpio_input, handle_gpio_output},
+    peripherals::{GPIO, IO_MUX, Interrupt, handle_gpio_input, handle_gpio_output, io_mux_reg},
     private::{self, Sealed},
 };
 
@@ -765,7 +765,7 @@ macro_rules! io_type {
             fn set_analog(&self, _: $crate::private::Internal) {
                 use $crate::peripherals::GPIO;
 
-                $crate::gpio::io_mux_reg($gpionum).modify(|_, w| unsafe {
+                $crate::peripherals::io_mux_reg($gpionum).modify(|_, w| unsafe {
                     w.mcu_sel().bits(1);
                     w.fun_ie().clear_bit();
                     w.fun_wpu().clear_bit();

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -778,6 +778,12 @@ macro_rules! io_type {
             }
         }
     };
+    (UsbDm, $gpionum:literal) => {
+        impl $crate::otg_fs::UsbDm for paste::paste!( [<GPIO $gpionum>]<'_> ) {}
+    };
+    (UsbDp, $gpionum:literal) => {
+        impl $crate::otg_fs::UsbDp for paste::paste!( [<GPIO $gpionum>]<'_> ) {}
+    };
     ($other:ident, $gpionum:literal) => {
         // TODO
     };

--- a/esp-hal/src/pcnt/channel.rs
+++ b/esp-hal/src/pcnt/channel.rs
@@ -120,7 +120,7 @@ impl<const UNIT: usize, const NUM: usize> Channel<'_, UNIT, NUM> {
             _ => unreachable!(),
         };
 
-        if (signal as usize) <= crate::gpio::INPUT_SIGNAL_MAX as usize {
+        if signal as usize <= property!("gpio.input_signal_max") {
             let source = source.into();
             source.set_input_enable(true);
             signal.connect_to(&source);
@@ -178,7 +178,7 @@ impl<const UNIT: usize, const NUM: usize> Channel<'_, UNIT, NUM> {
             _ => unreachable!(),
         };
 
-        if (signal as usize) <= crate::gpio::INPUT_SIGNAL_MAX as usize {
+        if signal as usize <= property!("gpio.input_signal_max") {
             let source = source.into();
             source.set_input_enable(true);
             signal.connect_to(&source);

--- a/esp-hal/src/soc/esp32/gpio.rs
+++ b/esp-hal/src/soc/esp32/gpio.rs
@@ -8,10 +8,6 @@
 //!
 //! Let's get through the functionality and configurations provided by this GPIO
 //! module:
-//!   - `io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO0:`:
-//!       * This function returns a reference to the GPIO register associated
-//!         with the given GPIO number. It uses unsafe code and transmutation to
-//!         access the GPIO registers based on the provided GPIO number.
 //!   - `errata36(pin_num: u8, pull_up: bool, pull_down: bool)`:
 //!       * Handles the configuration of pull-up and pull-down resistors for
 //!         specific GPIO pins
@@ -33,56 +29,6 @@
 //! This trait provides functions to read the interrupt status and NMI status
 //! registers for both the `PRO CPU` and `APP CPU`. The implementation uses the
 //! `gpio` peripheral to access the appropriate registers.
-
-use core::mem::transmute;
-
-use crate::{pac::io_mux, peripherals::IO_MUX};
-
-pub(crate) fn io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO0 {
-    let iomux = IO_MUX::regs();
-
-    unsafe {
-        match gpio_num {
-            0 => transmute::<&'static io_mux::GPIO0, &'static io_mux::GPIO0>(iomux.gpio0()),
-            1 => transmute::<&'static io_mux::GPIO1, &'static io_mux::GPIO0>(iomux.gpio1()),
-            2 => transmute::<&'static io_mux::GPIO2, &'static io_mux::GPIO0>(iomux.gpio2()),
-            3 => transmute::<&'static io_mux::GPIO3, &'static io_mux::GPIO0>(iomux.gpio3()),
-            4 => transmute::<&'static io_mux::GPIO4, &'static io_mux::GPIO0>(iomux.gpio4()),
-            5 => transmute::<&'static io_mux::GPIO5, &'static io_mux::GPIO0>(iomux.gpio5()),
-            6 => transmute::<&'static io_mux::GPIO6, &'static io_mux::GPIO0>(iomux.gpio6()),
-            7 => transmute::<&'static io_mux::GPIO7, &'static io_mux::GPIO0>(iomux.gpio7()),
-            8 => transmute::<&'static io_mux::GPIO8, &'static io_mux::GPIO0>(iomux.gpio8()),
-            9 => transmute::<&'static io_mux::GPIO9, &'static io_mux::GPIO0>(iomux.gpio9()),
-            10 => transmute::<&'static io_mux::GPIO10, &'static io_mux::GPIO0>(iomux.gpio10()),
-            11 => transmute::<&'static io_mux::GPIO11, &'static io_mux::GPIO0>(iomux.gpio11()),
-            12 => transmute::<&'static io_mux::GPIO12, &'static io_mux::GPIO0>(iomux.gpio12()),
-            13 => transmute::<&'static io_mux::GPIO13, &'static io_mux::GPIO0>(iomux.gpio13()),
-            14 => transmute::<&'static io_mux::GPIO14, &'static io_mux::GPIO0>(iomux.gpio14()),
-            15 => transmute::<&'static io_mux::GPIO15, &'static io_mux::GPIO0>(iomux.gpio15()),
-            16 => transmute::<&'static io_mux::GPIO16, &'static io_mux::GPIO0>(iomux.gpio16()),
-            17 => transmute::<&'static io_mux::GPIO17, &'static io_mux::GPIO0>(iomux.gpio17()),
-            18 => transmute::<&'static io_mux::GPIO18, &'static io_mux::GPIO0>(iomux.gpio18()),
-            19 => transmute::<&'static io_mux::GPIO19, &'static io_mux::GPIO0>(iomux.gpio19()),
-            20 => transmute::<&'static io_mux::GPIO20, &'static io_mux::GPIO0>(iomux.gpio20()),
-            21 => transmute::<&'static io_mux::GPIO21, &'static io_mux::GPIO0>(iomux.gpio21()),
-            22 => transmute::<&'static io_mux::GPIO22, &'static io_mux::GPIO0>(iomux.gpio22()),
-            23 => transmute::<&'static io_mux::GPIO23, &'static io_mux::GPIO0>(iomux.gpio23()),
-            24 => transmute::<&'static io_mux::GPIO24, &'static io_mux::GPIO0>(iomux.gpio24()),
-            25 => transmute::<&'static io_mux::GPIO25, &'static io_mux::GPIO0>(iomux.gpio25()),
-            26 => transmute::<&'static io_mux::GPIO26, &'static io_mux::GPIO0>(iomux.gpio26()),
-            27 => transmute::<&'static io_mux::GPIO27, &'static io_mux::GPIO0>(iomux.gpio27()),
-            32 => transmute::<&'static io_mux::GPIO32, &'static io_mux::GPIO0>(iomux.gpio32()),
-            33 => transmute::<&'static io_mux::GPIO33, &'static io_mux::GPIO0>(iomux.gpio33()),
-            34 => transmute::<&'static io_mux::GPIO34, &'static io_mux::GPIO0>(iomux.gpio34()),
-            35 => transmute::<&'static io_mux::GPIO35, &'static io_mux::GPIO0>(iomux.gpio35()),
-            36 => transmute::<&'static io_mux::GPIO36, &'static io_mux::GPIO0>(iomux.gpio36()),
-            37 => transmute::<&'static io_mux::GPIO37, &'static io_mux::GPIO0>(iomux.gpio37()),
-            38 => transmute::<&'static io_mux::GPIO38, &'static io_mux::GPIO0>(iomux.gpio38()),
-            39 => transmute::<&'static io_mux::GPIO39, &'static io_mux::GPIO0>(iomux.gpio39()),
-            other => panic!("GPIO {} does not exist", other),
-        }
-    }
-}
 
 /// Peripheral input signals for the GPIO mux
 #[allow(non_camel_case_types, clippy::upper_case_acronyms)]

--- a/esp-hal/src/soc/esp32/gpio.rs
+++ b/esp-hal/src/soc/esp32/gpio.rs
@@ -43,23 +43,10 @@
 use core::mem::transmute;
 
 use crate::{
-    gpio::AlternateFunction,
     pac::io_mux,
     peripherals::{GPIO, IO_MUX},
     system::Cpu,
 };
-
-pub(crate) const FUNC_IN_SEL_OFFSET: usize = 0;
-
-pub(crate) type InputSignalType = u16;
-pub(crate) type OutputSignalType = u16;
-pub(crate) const OUTPUT_SIGNAL_MAX: u16 = 548;
-pub(crate) const INPUT_SIGNAL_MAX: u16 = 539;
-
-pub(crate) const ONE_INPUT: u8 = 0x38;
-pub(crate) const ZERO_INPUT: u8 = 0x30;
-
-pub(crate) const GPIO_FUNCTION: AlternateFunction = AlternateFunction::_2;
 
 pub(crate) fn io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO0 {
     let iomux = IO_MUX::regs();

--- a/esp-hal/src/soc/esp32/gpio.rs
+++ b/esp-hal/src/soc/esp32/gpio.rs
@@ -12,12 +12,6 @@
 //!       * This function returns a reference to the GPIO register associated
 //!         with the given GPIO number. It uses unsafe code and transmutation to
 //!         access the GPIO registers based on the provided GPIO number.
-//!   - `gpio_intr_enable(int_enable: bool, nmi_enable: bool) -> u8`:
-//!       * This function enables or disables GPIO interrupts and Non-Maskable
-//!         Interrupts (NMI). It takes two boolean arguments int_enable and
-//!         nmi_enable to control the interrupt and NMI enable settings. The
-//!         function returns an u8 value representing the interrupt enable
-//!         settings.
 //!   - `errata36(pin_num: u8, pull_up: bool, pull_down: bool)`:
 //!       * Handles the configuration of pull-up and pull-down resistors for
 //!         specific GPIO pins
@@ -42,7 +36,7 @@
 
 use core::mem::transmute;
 
-use crate::{pac::io_mux, peripherals::IO_MUX, system::Cpu};
+use crate::{pac::io_mux, peripherals::IO_MUX};
 
 pub(crate) fn io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO0 {
     let iomux = IO_MUX::regs();
@@ -87,13 +81,6 @@ pub(crate) fn io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO0 {
             39 => transmute::<&'static io_mux::GPIO39, &'static io_mux::GPIO0>(iomux.gpio39()),
             other => panic!("GPIO {} does not exist", other),
         }
-    }
-}
-
-pub(crate) fn gpio_intr_enable(int_enable: bool, nmi_enable: bool) -> u8 {
-    match Cpu::current() {
-        Cpu::AppCpu => int_enable as u8 | ((nmi_enable as u8) << 1),
-        Cpu::ProCpu => ((int_enable as u8) << 2) | ((nmi_enable as u8) << 3),
     }
 }
 

--- a/esp-hal/src/soc/esp32/gpio.rs
+++ b/esp-hal/src/soc/esp32/gpio.rs
@@ -42,11 +42,7 @@
 
 use core::mem::transmute;
 
-use crate::{
-    pac::io_mux,
-    peripherals::{GPIO, IO_MUX},
-    system::Cpu,
-};
+use crate::{pac::io_mux, peripherals::IO_MUX, system::Cpu};
 
 pub(crate) fn io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO0 {
     let iomux = IO_MUX::regs();
@@ -748,19 +744,4 @@ touch! {
     // ---
     (8, 33, sar_touch_out5, sar_touch_thres5, false)
     (9, 32, sar_touch_out5, sar_touch_thres5, false)
-}
-
-#[derive(Clone, Copy)]
-pub(crate) enum InterruptStatusRegisterAccess {
-    Bank0,
-    Bank1,
-}
-
-impl InterruptStatusRegisterAccess {
-    pub(crate) fn interrupt_status_read(self) -> u32 {
-        match self {
-            Self::Bank0 => GPIO::regs().status().read().bits(),
-            Self::Bank1 => GPIO::regs().status1().read().bits(),
-        }
-    }
 }

--- a/esp-hal/src/soc/esp32/psram.rs
+++ b/esp-hal/src/soc/esp32/psram.rs
@@ -1060,7 +1060,7 @@ pub(crate) mod utils {
 
             fn configure_gpio(gpio: u8, field: Field, bits: u8) {
                 unsafe {
-                    let ptr = crate::gpio::io_mux_reg(gpio);
+                    let ptr = crate::peripherals::io_mux_reg(gpio);
                     ptr.modify(|_, w| apply_to_field!(w, field, bits));
                 }
             }

--- a/esp-hal/src/soc/esp32c2/gpio.rs
+++ b/esp-hal/src/soc/esp32c2/gpio.rs
@@ -34,10 +34,7 @@
 //! This trait provides functions to read the interrupt status and NMI status
 //! registers for both the `PRO CPU` and `APP CPU`. The implementation uses the
 //! `gpio` peripheral to access the appropriate registers.
-use crate::{
-    pac::io_mux,
-    peripherals::{GPIO, IO_MUX},
-};
+use crate::{pac::io_mux, peripherals::IO_MUX};
 
 pub(crate) fn io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO {
     IO_MUX::regs().gpio(gpio_num as usize)
@@ -204,15 +201,4 @@ rtc_pins! {
     3
     4
     5
-}
-
-#[derive(Clone, Copy)]
-pub(crate) enum InterruptStatusRegisterAccess {
-    Bank0,
-}
-
-impl InterruptStatusRegisterAccess {
-    pub(crate) fn interrupt_status_read(self) -> u32 {
-        GPIO::regs().pcpu_int().read().bits()
-    }
 }

--- a/esp-hal/src/soc/esp32c2/gpio.rs
+++ b/esp-hal/src/soc/esp32c2/gpio.rs
@@ -10,12 +10,6 @@
 //! module:
 //!   - `io_mux_reg(gpio_num: u8) -> &'static crate::peripherals::io_mux::GPIO`:
 //!       * Returns the IO_MUX register for the specified GPIO pin number.
-//!   - `gpio_intr_enable(int_enable: bool, nmi_enable: bool) -> u8`:
-//!       * This function enables or disables GPIO interrupts and Non-Maskable
-//!         Interrupts (NMI). It takes two boolean arguments int_enable and
-//!         nmi_enable to control the interrupt and NMI enable settings. The
-//!         function returns an u8 value representing the interrupt enable
-//!         settings.
 //!   - `gpio` block:
 //!       * Defines the pin configurations for various GPIO pins. Each line
 //!         represents a pin and its associated options such as input/output
@@ -38,10 +32,6 @@ use crate::{pac::io_mux, peripherals::IO_MUX};
 
 pub(crate) fn io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO {
     IO_MUX::regs().gpio(gpio_num as usize)
-}
-
-pub(crate) fn gpio_intr_enable(int_enable: bool, nmi_enable: bool) -> u8 {
-    int_enable as u8 | ((nmi_enable as u8) << 1)
 }
 
 /// Peripheral input signals for the GPIO mux

--- a/esp-hal/src/soc/esp32c2/gpio.rs
+++ b/esp-hal/src/soc/esp32c2/gpio.rs
@@ -35,22 +35,9 @@
 //! registers for both the `PRO CPU` and `APP CPU`. The implementation uses the
 //! `gpio` peripheral to access the appropriate registers.
 use crate::{
-    gpio::AlternateFunction,
     pac::io_mux,
     peripherals::{GPIO, IO_MUX},
 };
-
-pub(crate) const FUNC_IN_SEL_OFFSET: usize = 0;
-
-pub(crate) type InputSignalType = u8;
-pub(crate) type OutputSignalType = u8;
-pub(crate) const OUTPUT_SIGNAL_MAX: u8 = 128;
-pub(crate) const INPUT_SIGNAL_MAX: u8 = 100;
-
-pub(crate) const ONE_INPUT: u8 = 0x1e;
-pub(crate) const ZERO_INPUT: u8 = 0x1f;
-
-pub(crate) const GPIO_FUNCTION: AlternateFunction = AlternateFunction::_1;
 
 pub(crate) fn io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO {
     IO_MUX::regs().gpio(gpio_num as usize)

--- a/esp-hal/src/soc/esp32c2/gpio.rs
+++ b/esp-hal/src/soc/esp32c2/gpio.rs
@@ -8,8 +8,6 @@
 //!
 //! Let's get through the functionality and configurations provided by this GPIO
 //! module:
-//!   - `io_mux_reg(gpio_num: u8) -> &'static crate::peripherals::io_mux::GPIO`:
-//!       * Returns the IO_MUX register for the specified GPIO pin number.
 //!   - `gpio` block:
 //!       * Defines the pin configurations for various GPIO pins. Each line
 //!         represents a pin and its associated options such as input/output
@@ -28,11 +26,6 @@
 //! This trait provides functions to read the interrupt status and NMI status
 //! registers for both the `PRO CPU` and `APP CPU`. The implementation uses the
 //! `gpio` peripheral to access the appropriate registers.
-use crate::{pac::io_mux, peripherals::IO_MUX};
-
-pub(crate) fn io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO {
-    IO_MUX::regs().gpio(gpio_num as usize)
-}
 
 /// Peripheral input signals for the GPIO mux
 #[allow(non_camel_case_types, clippy::upper_case_acronyms)]
@@ -169,13 +162,13 @@ macro_rules! rtc_pins {
 
             impl crate::gpio::RtcPinWithResistors for paste::paste!($crate::peripherals::[<GPIO $pin_num>]<'_>) {
                 fn rtcio_pullup(&self, enable: bool) {
-                    IO_MUX::regs()
+                    $crate::peripherals::IO_MUX::regs()
                         .gpio($pin_num)
                         .modify(|_, w| w.fun_wpu().bit(enable));
                 }
 
                 fn rtcio_pulldown(&self, enable: bool) {
-                    IO_MUX::regs()
+                    $crate::peripherals::IO_MUX::regs()
                         .gpio($pin_num)
                         .modify(|_, w| w.fun_wpd().bit(enable));
                 }

--- a/esp-hal/src/soc/esp32c3/gpio.rs
+++ b/esp-hal/src/soc/esp32c3/gpio.rs
@@ -8,9 +8,6 @@
 //!
 //! Let's get through the functionality and configurations provided by this GPIO
 //! module:
-//!   - `io_mux_reg(gpio_num: u8) -> &'static
-//!     crate::peripherals::io_mux::GPIO0:`:
-//!       * Returns the IO_MUX register for the specified GPIO pin number.
 //!   - `gpio` block:
 //!       * Defines the pin configurations for various GPIO pins. Each line
 //!         represents a pin and its associated options such as input/output
@@ -29,12 +26,6 @@
 //! This trait provides functions to read the interrupt status and NMI status
 //! registers for both the `PRO CPU` and `APP CPU`. The implementation uses the
 //! `gpio` peripheral to access the appropriate registers.
-
-use crate::{pac::io_mux, peripherals::IO_MUX};
-
-pub(crate) fn io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO {
-    IO_MUX::regs().gpio(gpio_num as usize)
-}
 
 /// Peripheral input signals for the GPIO mux
 #[allow(non_camel_case_types, clippy::upper_case_acronyms)]
@@ -196,13 +187,13 @@ macro_rules! rtc_pins {
 
                 impl crate::gpio::RtcPinWithResistors for $crate::peripherals::[<GPIO $pin_num>]<'_> {
                     fn rtcio_pullup(&self, enable: bool) {
-                        IO_MUX::regs()
+                        $crate::peripherals::IO_MUX::regs()
                             .gpio($pin_num)
                             .modify(|_, w| w.fun_wpu().bit(enable));
                     }
 
                     fn rtcio_pulldown(&self, enable: bool) {
-                        IO_MUX::regs()
+                        $crate::peripherals::IO_MUX::regs()
                             .gpio($pin_num)
                             .modify(|_, w| w.fun_wpd().bit(enable));
                     }

--- a/esp-hal/src/soc/esp32c3/gpio.rs
+++ b/esp-hal/src/soc/esp32c3/gpio.rs
@@ -36,10 +36,7 @@
 //! registers for both the `PRO CPU` and `APP CPU`. The implementation uses the
 //! `gpio` peripheral to access the appropriate registers.
 
-use crate::{
-    pac::io_mux,
-    peripherals::{GPIO, IO_MUX},
-};
+use crate::{pac::io_mux, peripherals::IO_MUX};
 
 pub(crate) fn io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO {
     IO_MUX::regs().gpio(gpio_num as usize)
@@ -233,15 +230,4 @@ rtc_pins! {
     3
     4
     5
-}
-
-#[derive(Clone, Copy)]
-pub(crate) enum InterruptStatusRegisterAccess {
-    Bank0,
-}
-
-impl InterruptStatusRegisterAccess {
-    pub(crate) fn interrupt_status_read(self) -> u32 {
-        GPIO::regs().pcpu_int().read().bits()
-    }
 }

--- a/esp-hal/src/soc/esp32c3/gpio.rs
+++ b/esp-hal/src/soc/esp32c3/gpio.rs
@@ -37,22 +37,9 @@
 //! `gpio` peripheral to access the appropriate registers.
 
 use crate::{
-    gpio::AlternateFunction,
     pac::io_mux,
     peripherals::{GPIO, IO_MUX},
 };
-
-pub(crate) const FUNC_IN_SEL_OFFSET: usize = 0;
-
-pub(crate) type InputSignalType = u8;
-pub(crate) type OutputSignalType = u8;
-pub(crate) const OUTPUT_SIGNAL_MAX: u8 = 128;
-pub(crate) const INPUT_SIGNAL_MAX: u8 = 100;
-
-pub(crate) const ONE_INPUT: u8 = 0x1e;
-pub(crate) const ZERO_INPUT: u8 = 0x1f;
-
-pub(crate) const GPIO_FUNCTION: AlternateFunction = AlternateFunction::_1;
 
 pub(crate) fn io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO {
     IO_MUX::regs().gpio(gpio_num as usize)

--- a/esp-hal/src/soc/esp32c3/gpio.rs
+++ b/esp-hal/src/soc/esp32c3/gpio.rs
@@ -11,12 +11,6 @@
 //!   - `io_mux_reg(gpio_num: u8) -> &'static
 //!     crate::peripherals::io_mux::GPIO0:`:
 //!       * Returns the IO_MUX register for the specified GPIO pin number.
-//!   - `gpio_intr_enable(int_enable: bool, nmi_enable: bool) -> u8`:
-//!       * This function enables or disables GPIO interrupts and Non-Maskable
-//!         Interrupts (NMI). It takes two boolean arguments int_enable and
-//!         nmi_enable to control the interrupt and NMI enable settings. The
-//!         function returns an u8 value representing the interrupt enable
-//!         settings.
 //!   - `gpio` block:
 //!       * Defines the pin configurations for various GPIO pins. Each line
 //!         represents a pin and its associated options such as input/output
@@ -40,10 +34,6 @@ use crate::{pac::io_mux, peripherals::IO_MUX};
 
 pub(crate) fn io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO {
     IO_MUX::regs().gpio(gpio_num as usize)
-}
-
-pub(crate) fn gpio_intr_enable(int_enable: bool, nmi_enable: bool) -> u8 {
-    int_enable as u8 | ((nmi_enable as u8) << 1)
 }
 
 /// Peripheral input signals for the GPIO mux

--- a/esp-hal/src/soc/esp32c6/gpio.rs
+++ b/esp-hal/src/soc/esp32c6/gpio.rs
@@ -36,10 +36,7 @@
 //! registers for both the `PRO CPU` and `APP CPU`. The implementation uses the
 //! `gpio` peripheral to access the appropriate registers.
 
-use crate::{
-    pac::io_mux,
-    peripherals::{GPIO, IO_MUX},
-};
+use crate::{pac::io_mux, peripherals::IO_MUX};
 
 pub(crate) fn io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO {
     IO_MUX::regs().gpio(gpio_num as usize)
@@ -281,15 +278,4 @@ crate::gpio::lp_io::lp_gpio! {
     5
     6
     7
-}
-
-#[derive(Clone, Copy)]
-pub(crate) enum InterruptStatusRegisterAccess {
-    Bank0,
-}
-
-impl InterruptStatusRegisterAccess {
-    pub(crate) fn interrupt_status_read(self) -> u32 {
-        GPIO::regs().pcpu_int().read().bits()
-    }
 }

--- a/esp-hal/src/soc/esp32c6/gpio.rs
+++ b/esp-hal/src/soc/esp32c6/gpio.rs
@@ -8,9 +8,6 @@
 //!
 //! Let's get through the functionality and configurations provided by this GPIO
 //! module:
-//!   - `io_mux_reg(gpio_num: u8) -> &'static
-//!     crate::peripherals::io_mux::GPIO0:`:
-//!       * Returns the IO_MUX register for the specified GPIO pin number.
 //!   - `gpio` block:
 //!       * Defines the pin configurations for various GPIO pins. Each line
 //!         represents a pin and its associated options such as input/output
@@ -29,12 +26,6 @@
 //! This trait provides functions to read the interrupt status and NMI status
 //! registers for both the `PRO CPU` and `APP CPU`. The implementation uses the
 //! `gpio` peripheral to access the appropriate registers.
-
-use crate::{pac::io_mux, peripherals::IO_MUX};
-
-pub(crate) fn io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO {
-    IO_MUX::regs().gpio(gpio_num as usize)
-}
 
 /// Peripheral input signals for the GPIO mux
 #[allow(non_camel_case_types, clippy::upper_case_acronyms)]

--- a/esp-hal/src/soc/esp32c6/gpio.rs
+++ b/esp-hal/src/soc/esp32c6/gpio.rs
@@ -37,22 +37,9 @@
 //! `gpio` peripheral to access the appropriate registers.
 
 use crate::{
-    gpio::AlternateFunction,
     pac::io_mux,
     peripherals::{GPIO, IO_MUX},
 };
-
-pub(crate) const FUNC_IN_SEL_OFFSET: usize = 0;
-
-pub(crate) type InputSignalType = u8;
-pub(crate) type OutputSignalType = u8;
-pub(crate) const OUTPUT_SIGNAL_MAX: u8 = 128;
-pub(crate) const INPUT_SIGNAL_MAX: u8 = 124;
-
-pub(crate) const ONE_INPUT: u8 = 0x38;
-pub(crate) const ZERO_INPUT: u8 = 0x3c;
-
-pub(crate) const GPIO_FUNCTION: AlternateFunction = AlternateFunction::_1;
 
 pub(crate) fn io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO {
     IO_MUX::regs().gpio(gpio_num as usize)

--- a/esp-hal/src/soc/esp32c6/gpio.rs
+++ b/esp-hal/src/soc/esp32c6/gpio.rs
@@ -11,12 +11,6 @@
 //!   - `io_mux_reg(gpio_num: u8) -> &'static
 //!     crate::peripherals::io_mux::GPIO0:`:
 //!       * Returns the IO_MUX register for the specified GPIO pin number.
-//!   - `gpio_intr_enable(int_enable: bool, nmi_enable: bool) -> u8`:
-//!       * This function enables or disables GPIO interrupts and Non-Maskable
-//!         Interrupts (NMI). It takes two boolean arguments int_enable and
-//!         nmi_enable to control the interrupt and NMI enable settings. The
-//!         function returns an u8 value representing the interrupt enable
-//!         settings.
 //!   - `gpio` block:
 //!       * Defines the pin configurations for various GPIO pins. Each line
 //!         represents a pin and its associated options such as input/output
@@ -40,10 +34,6 @@ use crate::{pac::io_mux, peripherals::IO_MUX};
 
 pub(crate) fn io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO {
     IO_MUX::regs().gpio(gpio_num as usize)
-}
-
-pub(crate) fn gpio_intr_enable(int_enable: bool, nmi_enable: bool) -> u8 {
-    int_enable as u8 | ((nmi_enable as u8) << 1)
 }
 
 /// Peripheral input signals for the GPIO mux

--- a/esp-hal/src/soc/esp32h2/gpio.rs
+++ b/esp-hal/src/soc/esp32h2/gpio.rs
@@ -36,10 +36,7 @@
 //! registers for both the `PRO CPU` and `APP CPU`. The implementation uses the
 //! `gpio` peripheral to access the appropriate registers.
 
-use crate::{
-    pac::io_mux,
-    peripherals::{GPIO, IO_MUX},
-};
+use crate::{pac::io_mux, peripherals::IO_MUX};
 
 pub(crate) fn io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO {
     IO_MUX::regs().gpio(gpio_num as usize)
@@ -234,15 +231,4 @@ pub enum OutputSignal {
     CLK_OUT_OUT2     = 126,
     CLK_OUT_OUT3     = 127,
     GPIO             = 128,
-}
-
-#[derive(Clone, Copy)]
-pub(crate) enum InterruptStatusRegisterAccess {
-    Bank0,
-}
-
-impl InterruptStatusRegisterAccess {
-    pub(crate) fn interrupt_status_read(self) -> u32 {
-        GPIO::regs().pcpu_int().read().bits()
-    }
 }

--- a/esp-hal/src/soc/esp32h2/gpio.rs
+++ b/esp-hal/src/soc/esp32h2/gpio.rs
@@ -8,9 +8,6 @@
 //!
 //! Let's get through the functionality and configurations provided by this GPIO
 //! module:
-//!   - `io_mux_reg(gpio_num: u8) -> &'static
-//!     crate::peripherals::io_mux::GPIO0:`:
-//!       * Returns the IO_MUX register for the specified GPIO pin number.
 //!   - `gpio` block:
 //!       * Defines the pin configurations for various GPIO pins. Each line
 //!         represents a pin and its associated options such as input/output
@@ -29,12 +26,6 @@
 //! This trait provides functions to read the interrupt status and NMI status
 //! registers for both the `PRO CPU` and `APP CPU`. The implementation uses the
 //! `gpio` peripheral to access the appropriate registers.
-
-use crate::{pac::io_mux, peripherals::IO_MUX};
-
-pub(crate) fn io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO {
-    IO_MUX::regs().gpio(gpio_num as usize)
-}
 
 /// Peripheral input signals for the GPIO mux
 #[allow(non_camel_case_types, clippy::upper_case_acronyms)]

--- a/esp-hal/src/soc/esp32h2/gpio.rs
+++ b/esp-hal/src/soc/esp32h2/gpio.rs
@@ -37,22 +37,9 @@
 //! `gpio` peripheral to access the appropriate registers.
 
 use crate::{
-    gpio::AlternateFunction,
     pac::io_mux,
     peripherals::{GPIO, IO_MUX},
 };
-
-pub(crate) const FUNC_IN_SEL_OFFSET: usize = 0;
-
-pub(crate) type InputSignalType = u8;
-pub(crate) type OutputSignalType = u8;
-pub(crate) const OUTPUT_SIGNAL_MAX: u8 = 128;
-pub(crate) const INPUT_SIGNAL_MAX: u8 = 124;
-
-pub(crate) const ONE_INPUT: u8 = 0x38;
-pub(crate) const ZERO_INPUT: u8 = 0x3c;
-
-pub(crate) const GPIO_FUNCTION: AlternateFunction = AlternateFunction::_1;
 
 pub(crate) fn io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO {
     IO_MUX::regs().gpio(gpio_num as usize)

--- a/esp-hal/src/soc/esp32h2/gpio.rs
+++ b/esp-hal/src/soc/esp32h2/gpio.rs
@@ -11,12 +11,6 @@
 //!   - `io_mux_reg(gpio_num: u8) -> &'static
 //!     crate::peripherals::io_mux::GPIO0:`:
 //!       * Returns the IO_MUX register for the specified GPIO pin number.
-//!   - `gpio_intr_enable(int_enable: bool, nmi_enable: bool) -> u8`:
-//!       * This function enables or disables GPIO interrupts and Non-Maskable
-//!         Interrupts (NMI). It takes two boolean arguments int_enable and
-//!         nmi_enable to control the interrupt and NMI enable settings. The
-//!         function returns an u8 value representing the interrupt enable
-//!         settings.
 //!   - `gpio` block:
 //!       * Defines the pin configurations for various GPIO pins. Each line
 //!         represents a pin and its associated options such as input/output
@@ -40,10 +34,6 @@ use crate::{pac::io_mux, peripherals::IO_MUX};
 
 pub(crate) fn io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO {
     IO_MUX::regs().gpio(gpio_num as usize)
-}
-
-pub(crate) fn gpio_intr_enable(int_enable: bool, nmi_enable: bool) -> u8 {
-    int_enable as u8 | ((nmi_enable as u8) << 1)
 }
 
 /// Peripheral input signals for the GPIO mux

--- a/esp-hal/src/soc/esp32s2/gpio.rs
+++ b/esp-hal/src/soc/esp32s2/gpio.rs
@@ -8,10 +8,6 @@
 //!
 //! Let's get through the functionality and configurations provided by this GPIO
 //! module:
-//!   - `io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO0:`:
-//!       * This function returns a reference to the GPIO register associated
-//!         with the given GPIO number. It uses unsafe code and transmutation to
-//!         access the GPIO registers based on the provided GPIO number.
 //!   - `impl_get_rtc_pad`:
 //!       * This macro_rule generates a function to get a specific RTC pad. It
 //!         takes a single argument `$pad_name`, which is an identifier
@@ -40,15 +36,6 @@
 //! This trait provides functions to read the interrupt status and NMI status
 //! registers for both the `PRO CPU` and `APP CPU`. The implementation uses the
 //! `gpio` peripheral to access the appropriate registers.
-
-use crate::{
-    pac::io_mux,
-    peripherals::{IO_MUX, SENS},
-};
-
-pub(crate) fn io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO {
-    IO_MUX::regs().gpio(gpio_num as usize)
-}
 
 /// Peripheral input signals for the GPIO mux
 #[allow(non_camel_case_types, clippy::upper_case_acronyms)]
@@ -353,7 +340,7 @@ rtcio_analog! {
 }
 
 fn enable_iomux_clk_gate() {
-    SENS::regs()
+    crate::peripherals::SENS::regs()
         .sar_io_mux_conf()
         .modify(|_, w| w.iomux_clk_gate_en().set_bit());
 }

--- a/esp-hal/src/soc/esp32s2/gpio.rs
+++ b/esp-hal/src/soc/esp32s2/gpio.rs
@@ -426,10 +426,6 @@ impl InterruptStatusRegisterAccess {
     }
 }
 
-// implement marker traits on USB pins
-impl crate::otg_fs::UsbDm for crate::peripherals::GPIO19<'_> {}
-impl crate::otg_fs::UsbDp for crate::peripherals::GPIO20<'_> {}
-
 fn enable_iomux_clk_gate() {
     SENS::regs()
         .sar_io_mux_conf()

--- a/esp-hal/src/soc/esp32s2/gpio.rs
+++ b/esp-hal/src/soc/esp32s2/gpio.rs
@@ -50,22 +50,9 @@
 use core::mem::transmute;
 
 use crate::{
-    gpio::AlternateFunction,
     pac::io_mux,
     peripherals::{GPIO, IO_MUX, SENS},
 };
-
-pub(crate) const FUNC_IN_SEL_OFFSET: usize = 0;
-
-pub(crate) type InputSignalType = u16;
-pub(crate) type OutputSignalType = u16;
-pub(crate) const OUTPUT_SIGNAL_MAX: u16 = 256;
-pub(crate) const INPUT_SIGNAL_MAX: u16 = 204;
-
-pub(crate) const ONE_INPUT: u8 = 0x38;
-pub(crate) const ZERO_INPUT: u8 = 0x3c;
-
-pub(crate) const GPIO_FUNCTION: AlternateFunction = AlternateFunction::_1;
 
 pub(crate) fn io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO0 {
     let iomux = IO_MUX::regs();

--- a/esp-hal/src/soc/esp32s2/gpio.rs
+++ b/esp-hal/src/soc/esp32s2/gpio.rs
@@ -51,7 +51,7 @@ use core::mem::transmute;
 
 use crate::{
     pac::io_mux,
-    peripherals::{GPIO, IO_MUX, SENS},
+    peripherals::{IO_MUX, SENS},
 };
 
 pub(crate) fn io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO0 {
@@ -409,21 +409,6 @@ rtcio_analog! {
     (19, rtc_pad19(),    pad19      )
     (20, rtc_pad20(),    pad20      )
     (21, rtc_pad21(),    pad21      )
-}
-
-#[derive(Clone, Copy)]
-pub(crate) enum InterruptStatusRegisterAccess {
-    Bank0,
-    Bank1,
-}
-
-impl InterruptStatusRegisterAccess {
-    pub(crate) fn interrupt_status_read(self) -> u32 {
-        match self {
-            Self::Bank0 => GPIO::regs().pcpu_int().read().bits(),
-            Self::Bank1 => GPIO::regs().pcpu_int1().read().bits(),
-        }
-    }
 }
 
 fn enable_iomux_clk_gate() {

--- a/esp-hal/src/soc/esp32s2/gpio.rs
+++ b/esp-hal/src/soc/esp32s2/gpio.rs
@@ -41,59 +41,13 @@
 //! registers for both the `PRO CPU` and `APP CPU`. The implementation uses the
 //! `gpio` peripheral to access the appropriate registers.
 
-use core::mem::transmute;
-
 use crate::{
     pac::io_mux,
     peripherals::{IO_MUX, SENS},
 };
 
-pub(crate) fn io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO0 {
-    let iomux = IO_MUX::regs();
-    unsafe {
-        match gpio_num {
-            0 => transmute::<&'static io_mux::GPIO0, &'static io_mux::GPIO0>(iomux.gpio0()),
-            1 => transmute::<&'static io_mux::GPIO1, &'static io_mux::GPIO0>(iomux.gpio1()),
-            2 => transmute::<&'static io_mux::GPIO2, &'static io_mux::GPIO0>(iomux.gpio2()),
-            3 => transmute::<&'static io_mux::GPIO3, &'static io_mux::GPIO0>(iomux.gpio3()),
-            4 => transmute::<&'static io_mux::GPIO4, &'static io_mux::GPIO0>(iomux.gpio4()),
-            5 => transmute::<&'static io_mux::GPIO5, &'static io_mux::GPIO0>(iomux.gpio5()),
-            6 => transmute::<&'static io_mux::GPIO6, &'static io_mux::GPIO0>(iomux.gpio6()),
-            7 => transmute::<&'static io_mux::GPIO7, &'static io_mux::GPIO0>(iomux.gpio7()),
-            8 => transmute::<&'static io_mux::GPIO8, &'static io_mux::GPIO0>(iomux.gpio8()),
-            9 => transmute::<&'static io_mux::GPIO9, &'static io_mux::GPIO0>(iomux.gpio9()),
-            10 => transmute::<&'static io_mux::GPIO10, &'static io_mux::GPIO0>(iomux.gpio10()),
-            11 => transmute::<&'static io_mux::GPIO11, &'static io_mux::GPIO0>(iomux.gpio11()),
-            12 => transmute::<&'static io_mux::GPIO12, &'static io_mux::GPIO0>(iomux.gpio12()),
-            13 => transmute::<&'static io_mux::GPIO13, &'static io_mux::GPIO0>(iomux.gpio13()),
-            14 => transmute::<&'static io_mux::GPIO14, &'static io_mux::GPIO0>(iomux.gpio14()),
-            15 => transmute::<&'static io_mux::GPIO15, &'static io_mux::GPIO0>(iomux.gpio15()),
-            16 => transmute::<&'static io_mux::GPIO16, &'static io_mux::GPIO0>(iomux.gpio16()),
-            17 => transmute::<&'static io_mux::GPIO17, &'static io_mux::GPIO0>(iomux.gpio17()),
-            18 => transmute::<&'static io_mux::GPIO18, &'static io_mux::GPIO0>(iomux.gpio18()),
-            19 => transmute::<&'static io_mux::GPIO19, &'static io_mux::GPIO0>(iomux.gpio19()),
-            20 => transmute::<&'static io_mux::GPIO20, &'static io_mux::GPIO0>(iomux.gpio20()),
-            21 => transmute::<&'static io_mux::GPIO21, &'static io_mux::GPIO0>(iomux.gpio21()),
-            26 => transmute::<&'static io_mux::GPIO26, &'static io_mux::GPIO0>(iomux.gpio26()),
-            27 => transmute::<&'static io_mux::GPIO27, &'static io_mux::GPIO0>(iomux.gpio27()),
-            32 => transmute::<&'static io_mux::GPIO32, &'static io_mux::GPIO0>(iomux.gpio32()),
-            33 => transmute::<&'static io_mux::GPIO33, &'static io_mux::GPIO0>(iomux.gpio33()),
-            34 => transmute::<&'static io_mux::GPIO34, &'static io_mux::GPIO0>(iomux.gpio34()),
-            35 => transmute::<&'static io_mux::GPIO35, &'static io_mux::GPIO0>(iomux.gpio35()),
-            36 => transmute::<&'static io_mux::GPIO36, &'static io_mux::GPIO0>(iomux.gpio36()),
-            37 => transmute::<&'static io_mux::GPIO37, &'static io_mux::GPIO0>(iomux.gpio37()),
-            38 => transmute::<&'static io_mux::GPIO38, &'static io_mux::GPIO0>(iomux.gpio38()),
-            39 => transmute::<&'static io_mux::GPIO39, &'static io_mux::GPIO0>(iomux.gpio39()),
-            40 => transmute::<&'static io_mux::GPIO40, &'static io_mux::GPIO0>(iomux.gpio40()),
-            41 => transmute::<&'static io_mux::GPIO41, &'static io_mux::GPIO0>(iomux.gpio41()),
-            42 => transmute::<&'static io_mux::GPIO42, &'static io_mux::GPIO0>(iomux.gpio42()),
-            43 => transmute::<&'static io_mux::GPIO43, &'static io_mux::GPIO0>(iomux.gpio43()),
-            44 => transmute::<&'static io_mux::GPIO44, &'static io_mux::GPIO0>(iomux.gpio44()),
-            45 => transmute::<&'static io_mux::GPIO45, &'static io_mux::GPIO0>(iomux.gpio45()),
-            46 => transmute::<&'static io_mux::GPIO46, &'static io_mux::GPIO0>(iomux.gpio46()),
-            _ => ::core::unreachable!(),
-        }
-    }
+pub(crate) fn io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO {
+    IO_MUX::regs().gpio(gpio_num as usize)
 }
 
 /// Peripheral input signals for the GPIO mux

--- a/esp-hal/src/soc/esp32s2/gpio.rs
+++ b/esp-hal/src/soc/esp32s2/gpio.rs
@@ -12,12 +12,6 @@
 //!       * This function returns a reference to the GPIO register associated
 //!         with the given GPIO number. It uses unsafe code and transmutation to
 //!         access the GPIO registers based on the provided GPIO number.
-//!   - `gpio_intr_enable(int_enable: bool, nmi_enable: bool) -> u8`:
-//!       * This function enables or disables GPIO interrupts and Non-Maskable
-//!         Interrupts (NMI). It takes two boolean arguments int_enable and
-//!         nmi_enable to control the interrupt and NMI enable settings. The
-//!         function returns an u8 value representing the interrupt enable
-//!         settings.
 //!   - `impl_get_rtc_pad`:
 //!       * This macro_rule generates a function to get a specific RTC pad. It
 //!         takes a single argument `$pad_name`, which is an identifier
@@ -100,13 +94,6 @@ pub(crate) fn io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO0 {
             _ => ::core::unreachable!(),
         }
     }
-}
-
-pub(crate) fn gpio_intr_enable(int_enable: bool, nmi_enable: bool) -> u8 {
-    int_enable as u8
-        | ((nmi_enable as u8) << 1)
-        | ((int_enable as u8) << 2)
-        | ((nmi_enable as u8) << 3)
 }
 
 /// Peripheral input signals for the GPIO mux

--- a/esp-hal/src/soc/esp32s3/gpio.rs
+++ b/esp-hal/src/soc/esp32s3/gpio.rs
@@ -506,10 +506,6 @@ impl InterruptStatusRegisterAccess {
     }
 }
 
-// implement marker traits on USB pins
-impl crate::otg_fs::UsbDm for crate::peripherals::GPIO19<'_> {}
-impl crate::otg_fs::UsbDp for crate::peripherals::GPIO20<'_> {}
-
 fn enable_iomux_clk_gate() {
     crate::peripherals::SENS::regs()
         .sar_peri_clk_gate_conf()

--- a/esp-hal/src/soc/esp32s3/gpio.rs
+++ b/esp-hal/src/soc/esp32s3/gpio.rs
@@ -8,9 +8,6 @@
 //!
 //! Let's get through the functionality and configurations provided by this GPIO
 //! module:
-//!   - `io_mux_reg(gpio_num: u8) -> &'static
-//!     crate::peripherals::io_mux::GPIO0:`:
-//!       * Returns the IO_MUX register for the specified GPIO pin number.
 //!   - `gpio` block:
 //!       * Defines the pin configurations for various GPIO pins. Each line
 //!         represents a pin and its associated options such as input/output
@@ -29,12 +26,6 @@
 //! This trait provides functions to read the interrupt status and NMI status
 //! registers for both the `PRO CPU` and `APP CPU`. The implementation uses the
 //! `gpio` peripheral to access the appropriate registers.
-
-use crate::{pac::io_mux, peripherals::IO_MUX};
-
-pub(crate) fn io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO {
-    IO_MUX::regs().gpio(gpio_num as usize)
-}
 
 /// Peripheral input signals for the GPIO mux
 #[allow(non_camel_case_types, clippy::upper_case_acronyms)]

--- a/esp-hal/src/soc/esp32s3/gpio.rs
+++ b/esp-hal/src/soc/esp32s3/gpio.rs
@@ -36,10 +36,7 @@
 //! registers for both the `PRO CPU` and `APP CPU`. The implementation uses the
 //! `gpio` peripheral to access the appropriate registers.
 
-use crate::{
-    pac::io_mux,
-    peripherals::{GPIO, IO_MUX},
-};
+use crate::{pac::io_mux, peripherals::IO_MUX};
 
 pub(crate) fn io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO {
     IO_MUX::regs().gpio(gpio_num as usize)
@@ -487,23 +484,6 @@ rtcio_analog! {
     (19, rtc_pad19(),    pad19      )
     (20, rtc_pad20(),    pad20      )
     (21, rtc_pad21(),    pad21      )
-}
-
-// Whilst the S3 is a dual core chip, it shares the enable registers between
-// cores so treat it as a single core device
-#[derive(Clone, Copy)]
-pub(crate) enum InterruptStatusRegisterAccess {
-    Bank0,
-    Bank1,
-}
-
-impl InterruptStatusRegisterAccess {
-    pub(crate) fn interrupt_status_read(self) -> u32 {
-        match self {
-            Self::Bank0 => GPIO::regs().pcpu_int().read().bits(),
-            Self::Bank1 => GPIO::regs().pcpu_int1().read().bits(),
-        }
-    }
 }
 
 fn enable_iomux_clk_gate() {

--- a/esp-hal/src/soc/esp32s3/gpio.rs
+++ b/esp-hal/src/soc/esp32s3/gpio.rs
@@ -37,22 +37,9 @@
 //! `gpio` peripheral to access the appropriate registers.
 
 use crate::{
-    gpio::AlternateFunction,
     pac::io_mux,
     peripherals::{GPIO, IO_MUX},
 };
-
-pub(crate) const FUNC_IN_SEL_OFFSET: usize = 0;
-
-pub(crate) type InputSignalType = u16;
-pub(crate) type OutputSignalType = u16;
-pub(crate) const OUTPUT_SIGNAL_MAX: u16 = 256;
-pub(crate) const INPUT_SIGNAL_MAX: u16 = 189;
-
-pub(crate) const ONE_INPUT: u8 = 0x38;
-pub(crate) const ZERO_INPUT: u8 = 0x3c;
-
-pub(crate) const GPIO_FUNCTION: AlternateFunction = AlternateFunction::_1;
 
 pub(crate) fn io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO {
     IO_MUX::regs().gpio(gpio_num as usize)

--- a/esp-hal/src/soc/esp32s3/gpio.rs
+++ b/esp-hal/src/soc/esp32s3/gpio.rs
@@ -11,12 +11,6 @@
 //!   - `io_mux_reg(gpio_num: u8) -> &'static
 //!     crate::peripherals::io_mux::GPIO0:`:
 //!       * Returns the IO_MUX register for the specified GPIO pin number.
-//!   - `gpio_intr_enable(int_enable: bool, nmi_enable: bool) -> u8`:
-//!       * This function enables or disables GPIO interrupts and Non-Maskable
-//!         Interrupts (NMI). It takes two boolean arguments int_enable and
-//!         nmi_enable to control the interrupt and NMI enable settings. The
-//!         function returns an u8 value representing the interrupt enable
-//!         settings.
 //!   - `gpio` block:
 //!       * Defines the pin configurations for various GPIO pins. Each line
 //!         represents a pin and its associated options such as input/output
@@ -40,10 +34,6 @@ use crate::{pac::io_mux, peripherals::IO_MUX};
 
 pub(crate) fn io_mux_reg(gpio_num: u8) -> &'static io_mux::GPIO {
     IO_MUX::regs().gpio(gpio_num as usize)
-}
-
-pub(crate) fn gpio_intr_enable(int_enable: bool, nmi_enable: bool) -> u8 {
-    int_enable as u8 | ((nmi_enable as u8) << 1)
 }
 
 /// Peripheral input signals for the GPIO mux

--- a/esp-metadata/devices/esp32.toml
+++ b/esp-metadata/devices/esp32.toml
@@ -109,6 +109,7 @@ input_signal_max = 255
 output_signal_max = 256
 constant_0_input = 0x30
 constant_1_input = 0x38
+remap_iomux_pin_registers = true
 instances = [
     { name = "gpio", pins = [
         { pin =  0, kind = ["input", "output", "analog", "rtc", "touch"], af_input = { 5 = "EMAC_TX_CLK" },                                               af_output = { 1 = "CLK_OUT1" } },

--- a/esp-metadata/devices/esp32.toml
+++ b/esp-metadata/devices/esp32.toml
@@ -104,6 +104,11 @@ instances = [
 [device.gpio]
 support_status = "supported"
 has_bank_1 = true
+gpio_function = 2
+input_signal_max = 255
+output_signal_max = 256
+constant_0_input = 0x30
+constant_1_input = 0x38
 instances = [
     { name = "gpio", pins = [
         { pin =  0, kind = ["input", "output", "analog", "rtc", "touch"], af_input = { 5 = "EMAC_TX_CLK" },                                               af_output = { 1 = "CLK_OUT1" } },

--- a/esp-metadata/devices/esp32c2.toml
+++ b/esp-metadata/devices/esp32c2.toml
@@ -72,6 +72,11 @@ instances = [
 
 [device.gpio]
 support_status = "supported"
+gpio_function = 1
+input_signal_max = 100
+output_signal_max = 128
+constant_0_input = 0x1f
+constant_1_input = 0x1e
 instances = [
     { name = "gpio", pins = [
         { pin =  0, kind = ["input", "output", "analog", "rtc"] },

--- a/esp-metadata/devices/esp32c3.toml
+++ b/esp-metadata/devices/esp32c3.toml
@@ -87,6 +87,11 @@ instances = [
 
 [device.gpio]
 support_status = "supported"
+gpio_function = 1
+input_signal_max = 100
+output_signal_max = 128
+constant_0_input = 0x1f
+constant_1_input = 0x1e
 instances = [
     { name = "gpio", pins = [
         { pin =  0, kind = ["input", "output", "analog", "rtc"] },

--- a/esp-metadata/devices/esp32c6.toml
+++ b/esp-metadata/devices/esp32c6.toml
@@ -115,6 +115,11 @@ instances = [
 
 [device.gpio]
 support_status = "supported"
+gpio_function = 1
+input_signal_max = 124
+output_signal_max = 128
+constant_0_input = 0x3c
+constant_1_input = 0x38
 instances = [
     { name = "gpio", pins = [
         { pin =  0, kind = ["input", "output", "analog", "rtc"] },

--- a/esp-metadata/devices/esp32h2.toml
+++ b/esp-metadata/devices/esp32h2.toml
@@ -98,6 +98,11 @@ instances = [
 
 [device.gpio]
 support_status = "supported"
+gpio_function = 1
+input_signal_max = 124
+output_signal_max = 128
+constant_0_input = 0x3c
+constant_1_input = 0x38
 instances = [
     { name = "gpio", pins = [
         { pin =  0, kind = ["input", "output", "analog"], af_input = { 2 = "FSPIQ" },   af_output = { 2 = "FSPIQ" } },

--- a/esp-metadata/devices/esp32s2.toml
+++ b/esp-metadata/devices/esp32s2.toml
@@ -130,8 +130,8 @@ instances = [
         { pin = 16, kind = ["input", "output", "analog", "rtc"], af_input = { 2 = "U0CTS" } },
         { pin = 17, kind = ["input", "output", "analog", "rtc"],                                                              af_output = { 2 = "U1TXD" } },
         { pin = 18, kind = ["input", "output", "analog", "rtc"], af_input = { 2 = "U1RXD" } },
-        { pin = 19, kind = ["input", "output", "analog", "rtc"],                                                              af_output = { 2 = "U1RTS" } },
-        { pin = 20, kind = ["input", "output", "analog", "rtc"], af_input = { 2 = "U1CTS" } },
+        { pin = 19, kind = ["input", "output", "analog", "rtc", "usb_dm"],                                                    af_output = { 2 = "U1RTS" } },
+        { pin = 20, kind = ["input", "output", "analog", "rtc", "usb_dp"], af_input = { 2 = "U1CTS" } },
         { pin = 21, kind = ["input", "output", "analog", "rtc"] },
 
         { pin = 26, kind = ["input", "output"] },

--- a/esp-metadata/devices/esp32s2.toml
+++ b/esp-metadata/devices/esp32s2.toml
@@ -104,6 +104,11 @@ instances = [
 [device.gpio]
 support_status = "supported"
 has_bank_1 = true
+gpio_function = 1
+input_signal_max = 204
+output_signal_max = 256
+constant_0_input = 0x3c
+constant_1_input = 0x38
 instances = [
     { name = "gpio", pins = [
         { pin =  0, kind = ["input", "output", "analog", "rtc"] },

--- a/esp-metadata/devices/esp32s3.toml
+++ b/esp-metadata/devices/esp32s3.toml
@@ -138,8 +138,8 @@ instances = [
         { pin = 16, kind = ["input", "output", "analog", "rtc"], af_input = { 2 = "U0CTS" } },
         { pin = 17, kind = ["input", "output", "analog", "rtc"],                                                              af_output = { 2 = "U1TXD" } },
         { pin = 18, kind = ["input", "output", "analog", "rtc"], af_input = { 2 = "U1RXD" } },
-        { pin = 19, kind = ["input", "output", "analog", "rtc"],                                                              af_output = { 2 = "U1RTS" } },
-        { pin = 20, kind = ["input", "output", "analog", "rtc"], af_input = { 2 = "U1CTS" } },
+        { pin = 19, kind = ["input", "output", "analog", "rtc", "usb_dm"],                                                    af_output = { 2 = "U1RTS" } },
+        { pin = 20, kind = ["input", "output", "analog", "rtc", "usb_dp"], af_input = { 2 = "U1CTS" } },
         { pin = 21, kind = ["input", "output", "analog", "rtc"] },
 
         { pin = 26, kind = ["input", "output"] },

--- a/esp-metadata/devices/esp32s3.toml
+++ b/esp-metadata/devices/esp32s3.toml
@@ -112,6 +112,11 @@ instances = [
 [device.gpio]
 support_status = "supported"
 has_bank_1 = true
+gpio_function = 1
+input_signal_max = 189
+output_signal_max = 256
+constant_0_input = 0x3c
+constant_1_input = 0x38
 instances = [
     { name = "gpio", pins = [
         { pin =  0, kind = ["input", "output", "analog", "rtc"] },

--- a/esp-metadata/src/cfg.rs
+++ b/esp-metadata/src/cfg.rs
@@ -67,6 +67,8 @@ pub(crate) enum PinCapability {
     Analog,
     Rtc,
     Touch,
+    UsbDm,
+    UsbDp,
 }
 
 #[derive(Debug, Default, Clone, serde::Deserialize, serde::Serialize)]

--- a/esp-metadata/src/cfg.rs
+++ b/esp-metadata/src/cfg.rs
@@ -325,6 +325,13 @@ driver_configs![
         properties: {
             #[serde(default)]
             has_bank_1: bool,
+            gpio_function: u32,
+            input_signal_max: u32,
+            output_signal_max: u32,
+            constant_0_input: u32,
+            constant_1_input: u32,
+            #[serde(default)] // currently 0 in all devices
+            func_in_sel_offset:u32,
         }
     },
     HmacProperties {

--- a/esp-metadata/src/cfg.rs
+++ b/esp-metadata/src/cfg.rs
@@ -332,6 +332,8 @@ driver_configs![
             output_signal_max: u32,
             constant_0_input: u32,
             constant_1_input: u32,
+            #[serde(default)]
+            remap_iomux_pin_registers: bool,
             #[serde(default)] // currently 0 in all devices
             func_in_sel_offset:u32,
         }

--- a/esp-metadata/src/lib.rs
+++ b/esp-metadata/src/lib.rs
@@ -468,6 +468,8 @@ impl Config {
                     analog: bool,
                     rtc_io: bool,
                     touch: bool,
+                    usb_dm: bool,
+                    usb_dp: bool,
                 }
 
                 let mut pin_attrs = PinAttrs {
@@ -476,6 +478,8 @@ impl Config {
                     analog: false,
                     rtc_io: false,
                     touch: false,
+                    usb_dm: false,
+                    usb_dp: false,
                 };
                 pin.kind.iter().for_each(|kind| match kind {
                     cfg::PinCapability::Input => pin_attrs.input = true,
@@ -483,6 +487,8 @@ impl Config {
                     cfg::PinCapability::Analog => pin_attrs.analog = true,
                     cfg::PinCapability::Rtc => pin_attrs.rtc_io = true,
                     cfg::PinCapability::Touch => pin_attrs.touch = true,
+                    cfg::PinCapability::UsbDm => pin_attrs.usb_dm = true,
+                    cfg::PinCapability::UsbDp => pin_attrs.usb_dp = true,
                 });
 
                 let mut attrs = vec![];
@@ -505,6 +511,12 @@ impl Config {
                 }
                 if pin_attrs.touch {
                     attrs.push(quote::quote! { Touch });
+                }
+                if pin_attrs.usb_dm {
+                    attrs.push(quote::quote! { UsbDm });
+                }
+                if pin_attrs.usb_dp {
+                    attrs.push(quote::quote! { UsbDp });
                 }
 
                 let mut input_afs = vec![];

--- a/esp-metadata/src/lib.rs
+++ b/esp-metadata/src/lib.rs
@@ -453,97 +453,133 @@ impl Config {
     }
 
     fn generate_gpios(&self, out_dir: &Path, file_name: &str) {
+        let Some(gpio) = self.device.peri_config.gpio.as_ref() else {
+            // No GPIOs defined, nothing to do.
+            return;
+        };
+
         let out_file = out_dir.join(file_name).to_string_lossy().to_string();
 
-        let pins = self.device.peri_config.gpio.as_ref().unwrap().instances[0]
-            .instance_config
-            .pins
-            .iter()
-            .map(|pin| {
-                let pin_number = number(pin.pin);
+        let pins = gpio.instances[0].instance_config.pins.iter().map(|pin| {
+            let pin_number = number(pin.pin);
 
-                struct PinAttrs {
-                    input: bool,
-                    output: bool,
-                    analog: bool,
-                    rtc_io: bool,
-                    touch: bool,
-                    usb_dm: bool,
-                    usb_dp: bool,
-                }
+            struct PinAttrs {
+                input: bool,
+                output: bool,
+                analog: bool,
+                rtc_io: bool,
+                touch: bool,
+                usb_dm: bool,
+                usb_dp: bool,
+            }
 
-                let mut pin_attrs = PinAttrs {
-                    input: false,
-                    output: false,
-                    analog: false,
-                    rtc_io: false,
-                    touch: false,
-                    usb_dm: false,
-                    usb_dp: false,
-                };
-                pin.kind.iter().for_each(|kind| match kind {
-                    cfg::PinCapability::Input => pin_attrs.input = true,
-                    cfg::PinCapability::Output => pin_attrs.output = true,
-                    cfg::PinCapability::Analog => pin_attrs.analog = true,
-                    cfg::PinCapability::Rtc => pin_attrs.rtc_io = true,
-                    cfg::PinCapability::Touch => pin_attrs.touch = true,
-                    cfg::PinCapability::UsbDm => pin_attrs.usb_dm = true,
-                    cfg::PinCapability::UsbDp => pin_attrs.usb_dp = true,
-                });
-
-                let mut attrs = vec![];
-
-                if pin_attrs.input {
-                    attrs.push(quote::quote! { Input });
-                }
-                if pin_attrs.output {
-                    attrs.push(quote::quote! { Output });
-                }
-                if pin_attrs.analog {
-                    attrs.push(quote::quote! { Analog });
-                }
-                if pin_attrs.rtc_io {
-                    if !pin_attrs.output {
-                        attrs.push(quote::quote! { RtcIo });
-                    } else {
-                        attrs.push(quote::quote! { RtcIoInput });
-                    }
-                }
-                if pin_attrs.touch {
-                    attrs.push(quote::quote! { Touch });
-                }
-                if pin_attrs.usb_dm {
-                    attrs.push(quote::quote! { UsbDm });
-                }
-                if pin_attrs.usb_dp {
-                    attrs.push(quote::quote! { UsbDp });
-                }
-
-                let mut input_afs = vec![];
-                let mut output_afs = vec![];
-
-                for af in 0..6 {
-                    if let Some(signal) = pin.af_input.get(af) {
-                        let af = quote::format_ident!("_{af}");
-                        let signal = TokenStream::from_str(signal).unwrap();
-                        input_afs.push(quote::quote! { #af => #signal });
-                    }
-                    if let Some(signal) = pin.af_output.get(af) {
-                        let af = quote::format_ident!("_{af}");
-                        let signal = TokenStream::from_str(signal).unwrap();
-                        output_afs.push(quote::quote! { #af => #signal });
-                    }
-                }
-
-                quote::quote! {
-                    ( #pin_number, [#(#attrs),*] ( #(#input_afs)* ) ( #(#output_afs)* ) )
-                }
+            let mut pin_attrs = PinAttrs {
+                input: false,
+                output: false,
+                analog: false,
+                rtc_io: false,
+                touch: false,
+                usb_dm: false,
+                usb_dp: false,
+            };
+            pin.kind.iter().for_each(|kind| match kind {
+                cfg::PinCapability::Input => pin_attrs.input = true,
+                cfg::PinCapability::Output => pin_attrs.output = true,
+                cfg::PinCapability::Analog => pin_attrs.analog = true,
+                cfg::PinCapability::Rtc => pin_attrs.rtc_io = true,
+                cfg::PinCapability::Touch => pin_attrs.touch = true,
+                cfg::PinCapability::UsbDm => pin_attrs.usb_dm = true,
+                cfg::PinCapability::UsbDp => pin_attrs.usb_dp = true,
             });
+
+            let mut attrs = vec![];
+
+            if pin_attrs.input {
+                attrs.push(quote::quote! { Input });
+            }
+            if pin_attrs.output {
+                attrs.push(quote::quote! { Output });
+            }
+            if pin_attrs.analog {
+                attrs.push(quote::quote! { Analog });
+            }
+            if pin_attrs.rtc_io {
+                if !pin_attrs.output {
+                    attrs.push(quote::quote! { RtcIo });
+                } else {
+                    attrs.push(quote::quote! { RtcIoInput });
+                }
+            }
+            if pin_attrs.touch {
+                attrs.push(quote::quote! { Touch });
+            }
+            if pin_attrs.usb_dm {
+                attrs.push(quote::quote! { UsbDm });
+            }
+            if pin_attrs.usb_dp {
+                attrs.push(quote::quote! { UsbDp });
+            }
+
+            let mut input_afs = vec![];
+            let mut output_afs = vec![];
+
+            for af in 0..6 {
+                if let Some(signal) = pin.af_input.get(af) {
+                    let af = quote::format_ident!("_{af}");
+                    let signal = TokenStream::from_str(signal).unwrap();
+                    input_afs.push(quote::quote! { #af => #signal });
+                }
+                if let Some(signal) = pin.af_output.get(af) {
+                    let af = quote::format_ident!("_{af}");
+                    let signal = TokenStream::from_str(signal).unwrap();
+                    output_afs.push(quote::quote! { #af => #signal });
+                }
+            }
+
+            quote::quote! {
+                ( #pin_number, [#(#attrs),*] ( #(#input_afs)* ) ( #(#output_afs)* ) )
+            }
+        });
+
+        let io_mux_accessor = if gpio.remap_iomux_pin_registers {
+            let iomux_pin_regs = gpio.instances[0].instance_config.pins.iter().map(|pin| {
+                let pin = number(pin.pin);
+                let reg = quote::format_ident!("GPIO{pin}");
+                let accessor = quote::format_ident!("gpio{pin}");
+
+                quote::quote! { #pin => transmute::<&'static io_mux::#reg, &'static io_mux::GPIO0>(iomux.#accessor()), }
+            });
+
+            quote::quote! {
+                pub(crate) fn io_mux_reg(gpio_num: u8) -> &'static crate::pac::io_mux::GPIO0 {
+                    use core::mem::transmute;
+
+                    use crate::{pac::io_mux, peripherals::IO_MUX};
+
+                    let iomux = IO_MUX::regs();
+                    unsafe {
+                        match gpio_num {
+                            #(#iomux_pin_regs)*
+                            other => panic!("GPIO {} does not exist", other),
+                        }
+                    }
+                }
+
+            }
+        } else {
+            quote::quote! {
+                pub(crate) fn io_mux_reg(gpio_num: u8) -> &'static crate::pac::io_mux::GPIO {
+                    crate::peripherals::IO_MUX::regs().gpio(gpio_num as usize)
+                }
+            }
+        };
 
         let g = quote::quote! {
             crate::gpio! {
                 #(#pins)*
             }
+
+            #io_mux_accessor
         };
 
         std::fs::write(&out_file, g.to_string()).unwrap();


### PR DESCRIPTION
After this PR, only the input/output signal enums, and a bunch of implementation remains in the soc/gpio module.