### PR TITLE
Requesting feedback: Improve async wifi performance

### DIFF
--- a/esp-hal-embassy/esp_config.yml
+++ b/esp-hal-embassy/esp_config.yml
@@ -8,6 +8,17 @@ options:
   default:
     - value: true
 
+- name: low-power-wait-wifi-perf-opt
+  description: "If using wifi, this improves async ping times and may improve async throughput.
+               Enables running the wifi stack just before going into low power sleep.
+               This should cause any outbound packets to be sent earlier as we run the wifi stack before going to sleep.
+               This should also cause inbound packets to be processed earlier since if waiting for an interrupt,
+               and a radio interrupt occurs, then before going back to sleep we run the wifi stack which processes the incoming packet.
+               Enabling this option allows setting esp-wifi tick_rate_hz to 1 which helps further reduce power consumption,
+               as the wifi stack will run at a variable tick rate as needed rather than at a fixed rate."
+  default:
+    - value: true
+
 - name: timer-queue
   description: "The flavour of the timer queue provided by this crate. Integrated
                queues require the `executors` feature to be enabled.</p><p>If you use


### PR DESCRIPTION
This change seems to increase async wifi performance quite nicely. It helps with http response times and with ping times. I do not know of any adverse effects. I'm requesting that someone test this on xtensa. It would be very interesting to hear what results others get with this. If it seems promising we could refine this further. Think of this as a request for testing and comments on the approach for now. It could probably be improved if we could know:

1. Size of the TX queue.
2. If the interrupt that woke us from waiti needs to be serviced by the wifi task.

Test program:
```Rust

controller
    .set_power_saving(esp_wifi::config::PowerSaveMode::None)
    .unwrap();
    
loop {
    let mut socket = TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer);
    let mut buf = [0; 512];

    let local_endpoint = (config.address.address(), 80);
    socket.accept(local_endpoint).await.unwrap();
    socket.read(&mut buf).await.unwrap();

    socket
        .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 6\r\nConnection: close\r\n\r\nhi m8\n")
        .await
        .unwrap();
    socket.flush().await.unwrap();
}
```

All tests performed on esp32s3. All tests with 1m between AP and esp32s3 in STA mode.

.cargo/config.toml esp32s3
```
[env]
ESP_WIFI_CONFIG_TICK_RATE_HZ = "1"
ESP_HAL_EMBASSY_CONFIG_LOW_POWER_WAIT = "true"
ESP_HAL_EMBASSY_CONFIG_LOW_POWER_WAIT_WIFI_PERF_OPT = "true"
ESP_WIFI_CONFIG_PHY_ENABLE_USB = "false"
```

Results:
```
64 bytes from 10.42.0.226: icmp_seq=2 ttl=64 time=0.640 ms
64 bytes from 10.42.0.226: icmp_seq=3 ttl=64 time=0.525 ms
64 bytes from 10.42.0.226: icmp_seq=4 ttl=64 time=0.737 ms
64 bytes from 10.42.0.226: icmp_seq=5 ttl=64 time=1.19 ms
64 bytes from 10.42.0.226: icmp_seq=6 ttl=64 time=1.15 ms
64 bytes from 10.42.0.226: icmp_seq=7 ttl=64 time=1.17 ms
64 bytes from 10.42.0.226: icmp_seq=8 ttl=64 time=0.654 ms
64 bytes from 10.42.0.226: icmp_seq=9 ttl=64 time=0.999 ms
64 bytes from 10.42.0.226: icmp_seq=10 ttl=64 time=0.591 ms

curl http://10.42.0.226  0,00s user 0,00s system 44% cpu 0,009 total
curl http://10.42.0.226  0,00s user 0,00s system 41% cpu 0,009 total
curl http://10.42.0.226  0,00s user 0,00s system 51% cpu 0,006 total
curl http://10.42.0.226  0,00s user 0,00s system 48% cpu 0,008 total
```

.cargo/config.toml esp32s3 1KHz optimization disabled for comparison
```
[env]
ESP_WIFI_CONFIG_TICK_RATE_HZ = "1000"
ESP_HAL_EMBASSY_CONFIG_LOW_POWER_WAIT = "true"
ESP_HAL_EMBASSY_CONFIG_LOW_POWER_WAIT_WIFI_PERF_OPT = "false"
ESP_WIFI_CONFIG_PHY_ENABLE_USB = "false"
```

Results:
```
64 bytes from 10.42.0.226: icmp_seq=1 ttl=64 time=2.45 ms
64 bytes from 10.42.0.226: icmp_seq=2 ttl=64 time=1.85 ms
64 bytes from 10.42.0.226: icmp_seq=3 ttl=64 time=1.53 ms
64 bytes from 10.42.0.226: icmp_seq=4 ttl=64 time=1.25 ms
64 bytes from 10.42.0.226: icmp_seq=5 ttl=64 time=0.968 ms
64 bytes from 10.42.0.226: icmp_seq=6 ttl=64 time=0.851 ms
64 bytes from 10.42.0.226: icmp_seq=7 ttl=64 time=2.31 ms
64 bytes from 10.42.0.226: icmp_seq=8 ttl=64 time=1.46 ms
64 bytes from 10.42.0.226: icmp_seq=9 ttl=64 time=1.64 ms
64 bytes from 10.42.0.226: icmp_seq=10 ttl=64 time=9.85 ms
64 bytes from 10.42.0.226: icmp_seq=11 ttl=64 time=0.831 ms

curl http://10.42.0.226  0,00s user 0,00s system 33% cpu 0,010 total
curl http://10.42.0.226  0,00s user 0,00s system 32% cpu 0,011 total
curl http://10.42.0.226  0,00s user 0,00s system 30% cpu 0,011 total
curl http://10.42.0.226  0,00s user 0,00s system 36% cpu 0,010 total
```

Keep in mind that tie curl timing includes loading the curl executable so the improvement is bigger than it might seem.


## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [ ] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Please provide a clear and concise description of your changes, including the motivation behind these changes. The context is crucial for the reviewers.

#### Testing
Describe how you tested your changes.
