### PR TITLE
chore(esp-hal/ld): remove riscv `debug.x`

### DIFF
--- a/esp-hal/build.rs
+++ b/esp-hal/build.rs
@@ -111,12 +111,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         preprocess_file(
             &config_symbols,
             &cfg,
-            "ld/riscv/debug.x",
-            out.join("debug.x"),
-        )?;
-        preprocess_file(
-            &config_symbols,
-            &cfg,
             "ld/riscv/hal-defaults.x",
             out.join("hal-defaults.x"),
         )?;

--- a/esp-hal/ld/esp32c2/esp32c2.x
+++ b/esp-hal/ld/esp32c2/esp32c2.x
@@ -101,6 +101,4 @@ INCLUDE "stack.x"
 INCLUDE "dram2.x"
 /* End of Shared sections */
 
-INCLUDE "debug.x"
-
 _dram_origin = ORIGIN( DRAM );

--- a/esp-hal/ld/esp32c3/esp32c3.x
+++ b/esp-hal/ld/esp32c3/esp32c3.x
@@ -102,6 +102,4 @@ INCLUDE "stack.x"
 INCLUDE "dram2.x"
 /* End of Shared sections */
 
-INCLUDE "debug.x"
-
 _dram_origin = ORIGIN( DRAM );

--- a/esp-hal/ld/esp32c6/esp32c6.x
+++ b/esp-hal/ld/esp32c6/esp32c6.x
@@ -92,6 +92,4 @@ INCLUDE "stack.x"
 INCLUDE "dram2.x"
 /* End of Shared sections #2 */
 
-INCLUDE "debug.x"
-
 _dram_origin = ORIGIN( RAM );

--- a/esp-hal/ld/esp32h2/esp32h2.x
+++ b/esp-hal/ld/esp32h2/esp32h2.x
@@ -85,6 +85,4 @@ INCLUDE "stack.x"
 INCLUDE "dram2.x"
 /* End of Shared sections #2 */
 
-INCLUDE "debug.x"
-
 _dram_origin = ORIGIN( RAM );

--- a/esp-hal/ld/riscv/debug.x
+++ b/esp-hal/ld/riscv/debug.x
@@ -1,6 +1,0 @@
-
-
-SECTIONS {
-  .eh_frame (INFO) : { KEEP(*(.eh_frame)) }
-  .eh_frame_hdr (INFO) : { *(.eh_frame_hdr) }
-}


### PR DESCRIPTION
Believe that this is a remnant of forking riscv-rt. Upstream removed it, and I think esp-hal should too.

See: https://github.com/rust-embedded/riscv/issues/196

Relates to #2390