### PR TITLE
Generate i2c instances from metadata

### DIFF
--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -3114,7 +3114,7 @@ fn estimate_ack_failed_reason(_register_block: &RegisterBlock) -> AcknowledgeChe
     }
 }
 
-macro_rules! instance {
+crate::peripherals::for_each_i2c_master!(
     ($inst:ident, $peri:ident, $scl:ident, $sda:ident, $interrupt:ident) => {
         impl Instance for crate::peripherals::$inst<'_> {
             fn parts(&self) -> (&Info, &State) {
@@ -3141,12 +3141,7 @@ macro_rules! instance {
             }
         }
     };
-}
-
-#[cfg(i2c_master_i2c0)]
-instance!(I2C0, I2cExt0, I2CEXT0_SCL, I2CEXT0_SDA, I2C_EXT0);
-#[cfg(i2c_master_i2c1)]
-instance!(I2C1, I2cExt1, I2CEXT1_SCL, I2CEXT1_SDA, I2C_EXT1);
+);
 
 crate::any_peripheral! {
     /// Any I2C peripheral.

--- a/esp-hal/src/soc/esp32/peripherals.rs
+++ b/esp-hal/src/soc/esp32/peripherals.rs
@@ -122,4 +122,5 @@ crate::peripherals! {
     ]
 }
 
+include!(concat!(env!("OUT_DIR"), "/_generated_peris.rs"));
 include!(concat!(env!("OUT_DIR"), "/_generated_gpio.rs"));

--- a/esp-hal/src/soc/esp32c2/peripherals.rs
+++ b/esp-hal/src/soc/esp32c2/peripherals.rs
@@ -82,4 +82,5 @@ crate::peripherals! {
     ]
 }
 
+include!(concat!(env!("OUT_DIR"), "/_generated_peris.rs"));
 include!(concat!(env!("OUT_DIR"), "/_generated_gpio.rs"));

--- a/esp-hal/src/soc/esp32c3/peripherals.rs
+++ b/esp-hal/src/soc/esp32c3/peripherals.rs
@@ -100,4 +100,5 @@ crate::peripherals! {
     ]
 }
 
+include!(concat!(env!("OUT_DIR"), "/_generated_peris.rs"));
 include!(concat!(env!("OUT_DIR"), "/_generated_gpio.rs"));

--- a/esp-hal/src/soc/esp32c6/peripherals.rs
+++ b/esp-hal/src/soc/esp32c6/peripherals.rs
@@ -145,4 +145,5 @@ crate::peripherals! {
     ]
 }
 
+include!(concat!(env!("OUT_DIR"), "/_generated_peris.rs"));
 include!(concat!(env!("OUT_DIR"), "/_generated_gpio.rs"));

--- a/esp-hal/src/soc/esp32h2/peripherals.rs
+++ b/esp-hal/src/soc/esp32h2/peripherals.rs
@@ -130,4 +130,5 @@ crate::peripherals! {
     ]
 }
 
+include!(concat!(env!("OUT_DIR"), "/_generated_peris.rs"));
 include!(concat!(env!("OUT_DIR"), "/_generated_gpio.rs"));

--- a/esp-hal/src/soc/esp32s2/peripherals.rs
+++ b/esp-hal/src/soc/esp32s2/peripherals.rs
@@ -129,4 +129,5 @@ crate::peripherals! {
     ]
 }
 
+include!(concat!(env!("OUT_DIR"), "/_generated_peris.rs"));
 include!(concat!(env!("OUT_DIR"), "/_generated_gpio.rs"));

--- a/esp-hal/src/soc/esp32s3/peripherals.rs
+++ b/esp-hal/src/soc/esp32s3/peripherals.rs
@@ -138,4 +138,5 @@ crate::peripherals! {
     ]
 }
 
+include!(concat!(env!("OUT_DIR"), "/_generated_peris.rs"));
 include!(concat!(env!("OUT_DIR"), "/_generated_gpio.rs"));

--- a/esp-metadata/devices/esp32.toml
+++ b/esp-metadata/devices/esp32.toml
@@ -551,7 +551,10 @@ output_signals = [
 
 [device.i2c_master]
 support_status = "supported"
-instances = [{ name = "i2c0" }, { name = "i2c1" }]
+instances = [
+    { name = "i2c0", sys_instance = "I2cExt0", scl = "I2CEXT0_SCL", sda = "I2CEXT0_SDA", interrupt = "I2C_EXT0" },
+    { name = "i2c1", sys_instance = "I2cExt1", scl = "I2CEXT1_SCL", sda = "I2CEXT1_SDA", interrupt = "I2C_EXT1" },
+]
 ll_intr_mask = 0x3ffff
 fifo_size = 32
 max_bus_timeout = 0xFFFFF

--- a/esp-metadata/devices/esp32c2.toml
+++ b/esp-metadata/devices/esp32c2.toml
@@ -195,7 +195,9 @@ output_signals = [
 
 [device.i2c_master]
 support_status = "supported"
-instances = [{ name = "i2c0" }]
+instances = [
+    { name = "i2c0", sys_instance = "I2cExt0", scl = "I2CEXT0_SCL", sda = "I2CEXT0_SDA", interrupt = "I2C_EXT0" },
+]
 has_fsm_timeouts = true
 has_hw_bus_clear = true
 ll_intr_mask = 0x3ffff

--- a/esp-metadata/devices/esp32c3.toml
+++ b/esp-metadata/devices/esp32c3.toml
@@ -244,7 +244,9 @@ output_signals = [
 
 [device.i2c_master]
 support_status = "supported"
-instances = [{ name = "i2c0" }]
+instances = [
+    { name = "i2c0", sys_instance = "I2cExt0", scl = "I2CEXT0_SCL", sda = "I2CEXT0_SDA", interrupt = "I2C_EXT0" },
+]
 has_fsm_timeouts = true
 has_hw_bus_clear = true
 ll_intr_mask = 0x3ffff

--- a/esp-metadata/devices/esp32c6.toml
+++ b/esp-metadata/devices/esp32c6.toml
@@ -367,7 +367,9 @@ output_signals = [
 
 [device.i2c_master]
 support_status = "supported"
-instances = [{ name = "i2c0" }]
+instances = [
+    { name = "i2c0", sys_instance = "I2cExt0", scl = "I2CEXT0_SCL", sda = "I2CEXT0_SDA", interrupt = "I2C_EXT0" },
+]
 has_fsm_timeouts = true
 has_hw_bus_clear = true
 ll_intr_mask = 0x3ffff

--- a/esp-metadata/devices/esp32h2.toml
+++ b/esp-metadata/devices/esp32h2.toml
@@ -311,7 +311,10 @@ output_signals = [
 
 [device.i2c_master]
 support_status = "supported"
-instances = [{ name = "i2c0" }, { name = "i2c1" }]
+instances = [
+    { name = "i2c0", sys_instance = "I2cExt0", scl = "I2CEXT0_SCL", sda = "I2CEXT0_SDA", interrupt = "I2C_EXT0" },
+    { name = "i2c1", sys_instance = "I2cExt1", scl = "I2CEXT1_SCL", sda = "I2CEXT1_SDA", interrupt = "I2C_EXT1" },
+]
 has_fsm_timeouts = true
 has_hw_bus_clear = true
 ll_intr_mask = 0x3ffff

--- a/esp-metadata/devices/esp32s2.toml
+++ b/esp-metadata/devices/esp32s2.toml
@@ -337,7 +337,10 @@ output_signals = [
 ]
 [device.i2c_master]
 support_status = "supported"
-instances = [{ name = "i2c0" }, { name = "i2c1" }]
+instances = [
+    { name = "i2c0", sys_instance = "I2cExt0", scl = "I2CEXT0_SCL", sda = "I2CEXT0_SDA", interrupt = "I2C_EXT0" },
+    { name = "i2c1", sys_instance = "I2cExt1", scl = "I2CEXT1_SCL", sda = "I2CEXT1_SDA", interrupt = "I2C_EXT1" },
+]
 ll_intr_mask = 0x1ffff
 fifo_size = 32
 has_bus_timeout_enable = true

--- a/esp-metadata/devices/esp32s3.toml
+++ b/esp-metadata/devices/esp32s3.toml
@@ -485,7 +485,10 @@ output_signals = [
 
 [device.i2c_master]
 support_status = "supported"
-instances = [{ name = "i2c0" }, { name = "i2c1" }]
+instances = [
+    { name = "i2c0", sys_instance = "I2cExt0", scl = "I2CEXT0_SCL", sda = "I2CEXT0_SDA", interrupt = "I2C_EXT0" },
+    { name = "i2c1", sys_instance = "I2cExt1", scl = "I2CEXT1_SCL", sda = "I2CEXT1_SDA", interrupt = "I2C_EXT1" },
+]
 has_fsm_timeouts = true
 has_hw_bus_clear = true
 ll_intr_mask = 0x3ffff

--- a/esp-metadata/src/cfg.rs
+++ b/esp-metadata/src/cfg.rs
@@ -49,6 +49,14 @@ impl SupportStatus {
 #[derive(Debug, Default, Clone, serde::Deserialize, serde::Serialize)]
 pub(crate) struct EmptyInstanceConfig {}
 
+#[derive(Debug, Default, Clone, serde::Deserialize, serde::Serialize)]
+pub(crate) struct I2cMasterInstanceConfig {
+    pub sys_instance: String,
+    pub scl: String,
+    pub sda: String,
+    pub interrupt: String,
+}
+
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum PinCapability {
@@ -349,7 +357,7 @@ driver_configs![
         peripherals: &["hmac"],
         properties: {}
     },
-    I2cMasterProperties {
+    I2cMasterProperties<I2cMasterInstanceConfig> {
         driver: i2c_master,
         name: "I2C master",
         peripherals: &["i2c0", "i2c1"],


### PR DESCRIPTION
This PR takes the embassy-stm32's `for_each!` macro and adapts it for our purposes. As a demo, I've extracted I2C master instance configurations to esp-metadata.

I was considering generating `AnyI2c`, too, but I think that would move way too many assumptions into esp-metadata (the availability of delegate and/or what functions need to be delegated, for example).