### PR TITLE
Run rustfmt as part of the host tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,9 +151,9 @@ jobs:
           cargo +esp xtask lint-packages --chips esp32,esp32s2,esp32s3
 
   # --------------------------------------------------------------------------
-  # Format
+  # host tests
 
-  rustfmt:
+  host-tests:
     runs-on: macos-m1-self-hosted
 
     steps:
@@ -168,19 +168,6 @@ jobs:
 
       # Check the formatting of all packages:
       - run: cargo xtask fmt-packages --check
-
-  # --------------------------------------------------------------------------
-  # host tests
-
-  host-tests:
-    runs-on: macos-m1-self-hosted
-
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: stable
-      - uses: Swatinem/rust-cache@v2
 
       # Run tests in esp-config
       - run: cd esp-config && cargo test --features build


### PR DESCRIPTION
There is no good reason to treat these separately, and merging the two jobs gives gha fewer chances to schedule work for the wrong PR in the queue. If the format check fails, we'll still see it with about the same delay as before as it's the first check.