### PR TITLE
(re-)introduce the rt feature on esp-hal

### DIFF
--- a/documentation/DEVELOPER-GUIDELINES.md
+++ b/documentation/DEVELOPER-GUIDELINES.md
@@ -61,6 +61,7 @@ In general, the [Rust API Guidelines](https://rust-lang.github.io/api-guidelines
     - see [this example](https://github.com/esp-rs/esp-hal/blob/df2b7bd8472cc1d18db0d9441156575570f59bb3/esp-hal/src/spi/mod.rs#L15)
     - e.g. `#[cfg_attr(feature = "defmt", derive(defmt::Format))]`
   - Implementations of common, but unstable traits (e.g. `embassy_embedded_hal::SetConfig`) need to be gated with the `unstable` feature.
+- Libraries depending on esp-hal, should disable the `rt` feature to avoid future compatibility concerns.
 
 ## API Surface
 

--- a/esp-hal-embassy/Cargo.toml
+++ b/esp-hal-embassy/Cargo.toml
@@ -21,7 +21,7 @@ test  = false
 [dependencies]
 cfg-if                    = "1.0.0"
 critical-section          = "1.2.0"
-esp-hal                   = { version = "1.0.0-beta.1", path = "../esp-hal", features = ["requires-unstable"] }
+esp-hal                   = { version = "1.0.0-beta.1", path = "../esp-hal", default-features = false, features = ["requires-unstable"] }
 portable-atomic           = "1.11.0"
 static_cell               = "2.1.0"
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the feature `requires-unstable` (#3772)
 - `AnyPin::downcast`/`AnyPeripheral::downcast` to allow retrieving the original GPIO/peripheral type (#3783, #3784)
 - Add `ESP_HAL_CONFIG_PLACE_RMT_DRIVER_IN_RAM` configuration option to pin the RMT driver in RAM (#3778).
+- The `rt` feature (#3706)
 
 ### Changed
 
@@ -35,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adjusted ESP32-S2 and ESP-S3 memory region lengths to reflect those defined in ESP-IDF. (#3709)
 - Changed the various `ConfigError` variant names to use a consistent word order. (#3782)
 - Adjusted ESP32-S2 deep-sleep to hibernate for the Ext1WakeupSource (#3785)
+- Libraries depending on esp-hal should now disable default features, so that only the final binary crate enables the `rt` feature (#3706)
 
 ### Fixed
 

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -83,11 +83,11 @@ esp32s3 = { version = "0.32.0", features = ["critical-section", "rt"], git = "ht
 
 [target.'cfg(target_arch = "riscv32")'.dependencies]
 riscv            = { version = "0.12.1" }
-esp-riscv-rt     = { version = "0.11.0", path = "../esp-riscv-rt" }
+esp-riscv-rt     = { version = "0.11.0", path = "../esp-riscv-rt", optional = true }
 
 [target.'cfg(target_arch = "xtensa")'.dependencies]
 xtensa-lx        = { version = "0.11.0", path = "../xtensa-lx" }
-xtensa-lx-rt     = { version = "0.19.0", path = "../xtensa-lx-rt" }
+xtensa-lx-rt     = { version = "0.19.0", path = "../xtensa-lx-rt", optional = true }
 
 [build-dependencies]
 cfg-if       = "1.0.0"
@@ -99,7 +99,7 @@ serde        = { version = "1.0.219", default-features = false, features = ["der
 jiff = { version = "0.2.10", default-features = false, features = ["static"] }
 
 [features]
-default = []
+default = ["rt"]
 
 # These features are considered private and unstable. They are not covered by
 # semver guarantees and may change or be removed without notice.
@@ -172,6 +172,21 @@ esp32s3 = [
     "__usb_otg",
     "esp-rom-sys/esp32s3",
     "esp-metadata-generated/esp32s3",
+]
+
+## Runtime support
+##
+## If you are depending on `esp-hal` as a library, you should *not* enable the `rt` feature under any circumstance.
+rt = [
+    "dep:xtensa-lx-rt",
+    "dep:esp-riscv-rt",
+    "esp32?/rt",
+    "esp32c2?/rt",
+    "esp32c3?/rt",
+    "esp32c6?/rt",
+    "esp32h2?/rt",
+    "esp32s2?/rt",
+    "esp32s3?/rt",
 ]
 
 

--- a/esp-hal/src/clock/mod.rs
+++ b/esp-hal/src/clock/mod.rs
@@ -43,6 +43,7 @@
 //! let peripherals = esp_hal::init(config);
 //! # {after_snippet}
 //! ```
+#![cfg_attr(not(feature = "rt"), expect(unused))]
 
 use core::{cell::Cell, marker::PhantomData};
 

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -68,11 +68,12 @@ crate::unstable_module! {
 mod asynch;
 mod embedded_hal_impls;
 pub(crate) mod interrupt;
+use interrupt::*;
+
 mod placeholder;
 
 use core::fmt::Display;
 
-use interrupt::*;
 pub use placeholder::NoPin;
 use portable_atomic::AtomicU32;
 use strum::EnumCount;
@@ -82,9 +83,12 @@ use crate::{
     interrupt::{InterruptHandler, Priority},
     peripherals::{GPIO, IO_MUX, Interrupt},
     private::{self, Sealed},
+    sync::RawMutex,
 };
 
 define_io_mux_signals!();
+
+pub(crate) static GPIO_LOCK: RawMutex = RawMutex::new();
 
 /// Represents a pin-peripheral connection that, when dropped, disconnects the
 /// peripheral from the pin.

--- a/esp-hal/src/macros.rs
+++ b/esp-hal/src/macros.rs
@@ -299,6 +299,7 @@ macro_rules! ignore {
 #[doc(hidden)]
 macro_rules! metadata {
     ($category:literal, $key:ident, $value:expr) => {
+        #[cfg(feature = "rt")]
         #[unsafe(link_section = concat!(".espressif.metadata"))]
         #[used]
         #[unsafe(export_name = concat!($category, ".", stringify!($key)))]

--- a/esp-hal/src/peripherals.rs
+++ b/esp-hal/src/peripherals.rs
@@ -190,6 +190,7 @@ for_each_peripheral! {
         impl Peripherals {
             /// Returns all the peripherals *once*
             #[inline]
+            #[cfg_attr(not(feature = "rt"), expect(dead_code))]
             pub(crate) fn take() -> Self {
                 #[unsafe(no_mangle)]
                 static mut _ESP_HAL_DEVICE_PERIPHERALS: bool = false;

--- a/esp-hal/src/soc/mod.rs
+++ b/esp-hal/src/soc/mod.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "rt"), expect(unused))]
+
 use core::ops::Range;
 
 use portable_atomic::{AtomicU8, Ordering};
@@ -142,6 +144,7 @@ pub(crate) fn addr_in_range(addr: usize, range: Range<usize>) -> bool {
     range.contains(&addr)
 }
 
+#[cfg(feature = "rt")]
 #[cfg(riscv)]
 #[unsafe(export_name = "hal_main")]
 fn hal_main(a0: usize, a1: usize, a2: usize) -> ! {
@@ -158,6 +161,7 @@ fn hal_main(a0: usize, a1: usize, a2: usize) -> ! {
 }
 
 #[cfg(xtensa)]
+#[cfg(feature = "rt")]
 #[unsafe(no_mangle)]
 #[cfg_attr(esp32s3, unsafe(link_section = ".rwtext"))]
 unsafe extern "C" fn ESP32Reset() -> ! {
@@ -234,11 +238,13 @@ unsafe extern "C" fn ESP32Reset() -> ! {
     unsafe { xtensa_lx_rt::Reset() }
 }
 
+#[cfg(feature = "rt")]
 #[unsafe(export_name = "__stack_chk_fail")]
 unsafe extern "C" fn stack_chk_fail() {
     panic!("Stack corruption detected");
 }
 
+#[cfg(feature = "rt")]
 fn setup_stack_guard() {
     unsafe extern "C" {
         static mut __stack_chk_guard: u32;

--- a/esp-hal/src/sync.rs
+++ b/esp-hal/src/sync.rs
@@ -146,7 +146,7 @@ mod single_core {
                 if #[cfg(riscv)] {
                     if token != 0 {
                         unsafe {
-                            esp_riscv_rt::riscv::interrupt::enable();
+                            riscv::interrupt::enable();
                         }
                     }
                 } else if #[cfg(xtensa)] {

--- a/esp-hal/src/system.rs
+++ b/esp-hal/src/system.rs
@@ -226,6 +226,7 @@ static PERIPHERAL_REF_COUNT: Mutex<RefCell<[usize; Peripheral::COUNT]>> =
 /// Disable all peripherals.
 ///
 /// Peripherals listed in [KEEP_ENABLED] are NOT disabled.
+#[cfg_attr(not(feature = "rt"), expect(dead_code))]
 pub(crate) fn disable_peripherals() {
     // Take the critical section up front to avoid taking it multiple times.
     critical_section::with(|cs| {

--- a/esp-hal/src/time.rs
+++ b/esp-hal/src/time.rs
@@ -746,7 +746,7 @@ fn now() -> Instant {
     Instant::from_ticks(ticks / div)
 }
 
-#[cfg(esp32)]
+#[cfg(all(esp32, feature = "rt"))]
 pub(crate) fn time_init() {
     let apb = crate::Clocks::get().apb_clock.as_hz();
     // we assume 80MHz APB clock source - there is no way to configure it in a

--- a/esp-ieee802154/Cargo.toml
+++ b/esp-ieee802154/Cargo.toml
@@ -21,7 +21,7 @@ test  = false
 [dependencies]
 cfg-if            = "1.0.0"
 critical-section  = "1.2.0"
-esp-hal           = { version = "1.0.0-beta.1", path = "../esp-hal", features = ["requires-unstable"] }
+esp-hal           = { version = "1.0.0-beta.1", path = "../esp-hal", default-features = false, features = ["requires-unstable"] }
 
 # ⚠️ Unstable dependencies that are part of the public API
 heapless          = "0.8.0"

--- a/esp-wifi/src/preempt_builtin/preempt_riscv.rs
+++ b/esp-wifi/src/preempt_builtin/preempt_riscv.rs
@@ -1,7 +1,7 @@
+pub use esp_hal::trapframe::TrapFrame;
 use esp_wifi_sys::c_types;
 
 use super::*;
-pub use crate::hal::interrupt::TrapFrame;
 
 pub(crate) fn new_task_context(
     task: extern "C" fn(*mut c_types::c_void),

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -179,6 +179,7 @@ impl Package {
             Package::EspConfig => features.push("build".to_owned()),
             Package::EspHal => {
                 features.push("unstable".to_owned());
+                features.push("rt".to_owned());
                 if config.contains("psram") {
                     // TODO this doesn't test octal psram (since `ESP_HAL_CONFIG_PSRAM_MODE`
                     // defaults to `quad`) as it would require a separate build
@@ -193,6 +194,7 @@ impl Package {
             }
             Package::EspWifi => {
                 features.push("esp-hal/unstable".to_owned());
+                features.push("esp-hal/rt".to_owned());
                 features.push("defmt".to_owned());
                 if config.contains("wifi") {
                     features.push("wifi".to_owned());
@@ -213,12 +215,14 @@ impl Package {
             }
             Package::EspHalEmbassy => {
                 features.push("esp-hal/unstable".to_owned());
+                features.push("esp-hal/rt".to_owned());
                 features.push("defmt".to_owned());
                 features.push("executors".to_owned());
             }
             Package::EspIeee802154 => {
                 features.push("defmt".to_owned());
                 features.push("esp-hal/unstable".to_owned());
+                features.push("esp-hal/rt".to_owned());
             }
             Package::EspLpHal => {
                 if config.contains("lp_core") {
@@ -251,12 +255,19 @@ impl Package {
 
         match self {
             Package::EspHal => {
-                // Make sure no additional features (e.g. no "unstable") still compiles:
+                // This checks if the `esp-hal` crate compiles with the no features (other than the
+                // chip selection)
+                
+                // This tests that disabling the `rt` feature works
                 cases.push(vec![]);
+                // This checks if the `esp-hal` crate compiles _without_ the `unstable` feature
+                // enabled
+                cases.push(vec!["rt".to_owned()]);
             }
             Package::EspWifi => {
                 // Minimal set of features that when enabled _should_ still compile:
                 cases.push(vec![
+                    "esp-hal/rt".to_owned(),
                     "esp-hal/unstable".to_owned(),
                     "builtin-scheduler".to_owned(),
                 ]);

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -279,7 +279,9 @@ fn lint_package(
         builder = builder.arg(arg.to_string());
     }
 
-    builder = builder.arg(format!("--features={}", features.join(",")));
+    if !features.is_empty() {
+        builder = builder.arg(format!("--features={}", features.join(",")));
+    }
 
     let builder = if fix {
         builder.arg("--fix").arg("--lib").arg("--allow-dirty")


### PR DESCRIPTION
cc: https://github.com/esp-rs/esp-hal/issues/2589

Adds the `rt` feature which disables `esp_hal::init` and removes runtime symbols from the global name space. Disabling the `rt` feature is the recommended way to use esp-hal as a library, so I have added it to the dev guidelines.


## Unresolved questions

* ~~CI checks for non-rt builds~~
* ~~Fix unused warnings in the soc modules (this place is a bit of a mess, not sure how to tackle this just yet)~~
* ~~Checks to ensure we don't introduce new global symbols whilst `rt` isn't enabled.~~ Follow up task in https://github.com/esp-rs/esp-hal/issues/3738
* ~~build.rs checks should be reduced~~
* ~~Should configs still be checked in non-rt mode? Or should only the esp-hal version that has `rt` enabled do the config checking?~~ Yes, config is versioned by major version (as only one major version can exist in a crate graph, the config is supplied with the crate)
* ~~Document library usage~~


Opening for early feedback, and also to know if there are other places I should check for rt assumptions.