### PR TITLE
Resolve `C-EXAMPLE`: Uart

### DIFF
--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -397,6 +397,25 @@ pub trait DriverMode: crate::private::Sealed {}
 /// Drivers are constructed in blocking mode by default. To learn about the
 /// differences between blocking and async drivers, see the [`Async`] mode
 /// documentation.
+///
+/// [`Async`] drivers can be converted to a [`Blocking`] driver using the
+/// `into_blocking` method, for example:
+///
+/// ```rust, no_run
+#[doc = crate::before_snippet!()]
+/// # use esp_hal::uart::{Config, Uart};
+/// let uart = Uart::new(
+///     peripherals.UART0,
+///     Config::default())?
+/// .with_rx(peripherals.GPIO1)
+/// .with_tx(peripherals.GPIO2)
+/// .into_async();
+///
+/// let blocking_uart = uart.into_blocking();
+///
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct Blocking;
@@ -405,8 +424,24 @@ pub struct Blocking;
 ///
 /// Drivers are constructed in blocking mode by default. To set up an async
 /// driver, a [`Blocking`] driver must be converted to an `Async` driver using
-/// the `into_async` method. Drivers can be converted back to blocking mode
-/// using the `into_blocking` method.
+/// the `into_async` method, for example:
+///
+/// ```rust, no_run
+#[doc = crate::before_snippet!()]
+/// # use esp_hal::uart::{Config, Uart};
+/// let uart = Uart::new(
+///     peripherals.UART0,
+///     Config::default())?
+/// .with_rx(peripherals.GPIO1)
+/// .with_tx(peripherals.GPIO2)
+/// .into_async();
+///
+/// # Ok(())
+/// # }
+/// ```
+/// 
+/// Drivers can be converted back to blocking mode using the `into_blocking`
+/// method, see [`Blocking`] documentation for more details.
 ///
 /// Async mode drivers offer most of the same features as blocking drivers, but
 /// with the addition of async APIs. Interrupt-related functions are not

--- a/esp-hal/src/uart.rs
+++ b/esp-hal/src/uart.rs
@@ -1256,21 +1256,8 @@ impl<'d> Uart<'d, Blocking> {
 
     /// Reconfigures the driver to operate in [`Async`] mode.
     ///
-    /// ## Example
-    ///
-    /// ```rust, no_run
-    #[doc = crate::before_snippet!()]
-    /// # use esp_hal::uart::{Config, Uart};
-    /// let uart = Uart::new(
-    ///     peripherals.UART0,
-    ///     Config::default())?
-    /// .with_rx(peripherals.GPIO1)
-    /// .with_tx(peripherals.GPIO2)
-    /// .into_async();
-    ///
-    /// # Ok(())
-    /// # }
-    /// ```
+    /// See the [`Async`] documentation for an example on how to use this
+    /// method.
     pub fn into_async(self) -> Uart<'d, Async> {
         Uart {
             rx: self.rx.into_async(),
@@ -1390,22 +1377,8 @@ impl<'d> Uart<'d, Blocking> {
 impl<'d> Uart<'d, Async> {
     /// Reconfigures the driver to operate in [`Blocking`] mode.
     ///
-    /// ## Example
-    ///
-    /// ```rust, no_run
-    #[doc = crate::before_snippet!()]
-    /// # use esp_hal::uart::{Config, Uart};
-    /// let uart = Uart::new(
-    ///     peripherals.UART0,
-    ///     Config::default())?
-    /// .with_rx(peripherals.GPIO1)
-    /// .with_tx(peripherals.GPIO2)
-    /// .into_async();
-    ///
-    /// let blocking_uart = uart.into_blocking();
-    /// # Ok(())
-    /// # }
-    /// ```
+    /// See the [`Blocking`] documentation for an example on how to use this
+    /// method.
     pub fn into_blocking(self) -> Uart<'d, Blocking> {
         Uart {
             rx: self.rx.into_blocking(),
@@ -1519,7 +1492,6 @@ impl<'d> Uart<'d, Async> {
     ///
     /// let mut buf = [0u8; MESSAGE.len()];
     /// uart.read_async(&mut buf[..]).await.unwrap();
-
     /// # Ok(())
     /// # }
     /// ```


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Added doc examples for Uart. First PR related to #2623 

#### Testing
`cargo xtask run doc-tests esp-hal esp32c6`
