### PR TITLE
Add toolchain arg to more xtask commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,11 +94,12 @@ jobs:
 
       - name: Build and Check
         shell: bash
-        run: cargo +${{ matrix.device.toolchain }} xtask ci ${{ matrix.device.soc }}
+        run: cargo xcheck ci ${{ matrix.device.soc }} --toolchain ${{ matrix.device.toolchain }}
 
       - name: Semver-Check
         shell: bash
-        run: cargo +${{ matrix.device.toolchain }} xcheck semver-check --chips ${{ matrix.device.soc }} check
+        # always invokes +esp internally
+        run: cargo xcheck semver-check --chips ${{ matrix.device.soc }} check
 
   extras:
     runs-on: macos-m1-self-hosted

--- a/.github/workflows/ci_nightly.yml
+++ b/.github/workflows/ci_nightly.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        device: [ "esp32c2", "esp32c3", "esp32c6", "esp32h2" ]
+        device: ["esp32c2", "esp32c3", "esp32c6", "esp32h2"]
     steps:
       - uses: actions/checkout@v4
 
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build and Check
         shell: bash
-        run: cargo +nightly xtask ci ${{ matrix.device }}
+        run: cargo xtask ci ${{ matrix.device }} --toolchain nightly
 
       - if: failure()
         name: Create or Update GitHub Issue

--- a/xtask/src/commands/build.rs
+++ b/xtask/src/commands/build.rs
@@ -140,6 +140,7 @@ pub fn build_examples(
                 CargoAction::Build(out_path.to_path_buf()),
                 1,
                 args.debug,
+                args.toolchain.as_deref(),
             )?;
         }
         Ok(())
@@ -157,6 +158,7 @@ pub fn build_examples(
                 CargoAction::Build(out_path.to_path_buf()),
                 1,
                 args.debug,
+                args.toolchain.as_deref(),
             )
         })
     }

--- a/xtask/src/commands/mod.rs
+++ b/xtask/src/commands/mod.rs
@@ -30,6 +30,10 @@ pub struct ExamplesArgs {
     /// Optional example to act on (all examples used if omitted)
     #[arg(long)]
     pub example: Option<String>,
+
+    /// The toolchain used to build the examples
+    #[arg(long)]
+    pub toolchain: Option<String>,
 }
 
 #[derive(Debug, Args)]
@@ -44,6 +48,10 @@ pub struct TestsArgs {
     /// Optional test to act on (all tests used if omitted)
     #[arg(long, short = 't')]
     pub test: Option<String>,
+
+    /// The toolchain used to build the tests
+    #[arg(long)]
+    pub toolchain: Option<String>,
 }
 
 // ----------------------------------------------------------------------------
@@ -116,6 +124,7 @@ pub fn tests(workspace: &Path, args: TestsArgs, action: CargoAction) -> Result<(
                 action.clone(),
                 args.repeat,
                 false,
+                args.toolchain.as_deref(),
             )?;
         }
         Ok(())
@@ -132,6 +141,7 @@ pub fn tests(workspace: &Path, args: TestsArgs, action: CargoAction) -> Result<(
                 action.clone(),
                 args.repeat,
                 false,
+                args.toolchain.as_deref(),
             )
             .is_err()
             {

--- a/xtask/src/commands/run.rs
+++ b/xtask/src/commands/run.rs
@@ -184,6 +184,7 @@ pub fn run_examples(
                     CargoAction::Run,
                     1,
                     args.debug,
+                    args.toolchain.as_deref(),
                 )
                 .is_err()
             {

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -3,7 +3,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use cargo::CargoAction;
 use clap::ValueEnum;
 use esp_metadata::{Chip, Config};
@@ -305,6 +305,7 @@ pub fn execute_app(
     action: CargoAction,
     repeat: usize,
     debug: bool,
+    toolchain: Option<&str>,
 ) -> Result<()> {
     let package = app.example_path().strip_prefix(package_path)?;
     log::info!("Building example '{}' for '{}'", package.display(), chip);
@@ -358,10 +359,9 @@ pub fn execute_app(
         builder.add_arg("--release");
     }
 
-    let tc = std::env::var("RUSTUP_TOOLCHAIN");
-    let toolchain = match tc {
+    let toolchain = match toolchain {
         // Preserve user choice
-        Ok(ref tc) => Some(tc.as_str()),
+        Some(tc) => Some(tc),
         // If targeting an Xtensa device, we must use the '+esp' toolchain modifier:
         _ if target.starts_with("xtensa") => Some("esp"),
         _ => None,


### PR DESCRIPTION
Why? Because I screwed up the previous change, that relied on `RUSTUP_TOOLCHAIN`. Obviously that env var always exists, so building tests/examples for Xtensa needed `cargo +esp xtask`. But the toolchain used to build the xtask, and the toolchain invoked BY the xtask are, conceptually, separate. This allows reusing the same xtask binary to run checks on any chips without rebuilding, at the cost of another CLI argument.