### PR TITLE
RMT: Refactor state checks, support non-blocking poll on blocking transactions

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `aes::Key` variants have been renamed from bytes to bits (e.g. `Key16 -> Key128`) (#3845)
 - `aes::Mode` has been replaced by `Operation`. The key length is now solely determined by the key. (#3882)
 - `Aes::process` has been split into `Aes::encrypt` and `Aes::decrypt` (#3882)
+- Blocking RMT transactions can now be `poll`ed without blocking, returning whether they have completed. (#3716)
 
 ### Fixed
 

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -1073,16 +1073,12 @@ impl<Raw: TxChannelInternal> ContinuousTxTransaction<Raw> {
         raw.update();
 
         loop {
-            if raw.is_error() {
-                return Err((Error::TransmissionError, self.channel));
-            }
-
-            if raw.is_tx_done() {
-                break;
+            match raw.get_tx_status() {
+                Some(Event::Error) => break Err((Error::TransmissionError, self.channel)),
+                Some(Event::End) => break Ok(self.channel),
+                _ => continue,
             }
         }
-
-        Ok(self.channel)
     }
 
     /// Stop transaction as soon as possible.
@@ -1101,16 +1097,12 @@ impl<Raw: TxChannelInternal> ContinuousTxTransaction<Raw> {
         }
 
         loop {
-            if raw.is_error() {
-                return Err((Error::TransmissionError, self.channel));
-            }
-
-            if raw.is_tx_done() {
-                break;
+            match raw.get_tx_status() {
+                Some(Event::Error) => break Err((Error::TransmissionError, self.channel)),
+                Some(Event::End) => break Ok(self.channel),
+                _ => continue,
             }
         }
-
-        Ok(self.channel)
     }
 
     /// Check if the `loopcount` interrupt bit is set

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -1005,48 +1005,48 @@ where
         let memsize = raw.memsize().codes();
 
         loop {
-            // wait for TX-THR
-            while !raw.is_tx_threshold_set() {
-                if raw.is_tx_done() {
+            // Not sure that all the error cases below can happen. However, it's best to
+            // handle them to be sure that we don't lock up here in case they can happen.
+            match raw.get_tx_status() {
+                Some(Event::Error) => break Err((Error::TransmissionError, self.channel)),
+                Some(Event::End) => {
                     if !self.remaining_data.is_empty() {
                         // Unexpectedly done, even though we have data left: For example, this could
                         // happen if there is a stop code inside the data and not just at the end.
-                        return Err((Error::TransmissionError, self.channel));
+                        break Err((Error::TransmissionError, self.channel));
                     } else {
-                        return Ok(self.channel);
+                        break Ok(self.channel);
                     }
                 }
-                if raw.is_error() {
-                    // Not sure that this can happen? In any case, be sure that we don't lock up
-                    // here in case it can.
-                    return Err((Error::TransmissionError, self.channel));
-                }
-            }
-            raw.reset_tx_threshold_set();
+                Some(Event::Threshold) => {
+                    raw.reset_tx_threshold_set();
 
-            if !self.remaining_data.is_empty() {
-                // re-fill TX RAM
-                let ptr = unsafe { raw.channel_ram_start().add(self.ram_index) };
-                let count = self.remaining_data.len().min(memsize / 2);
-                let (chunk, remaining) = self.remaining_data.split_at(count);
-                for (idx, entry) in chunk.iter().enumerate() {
-                    unsafe {
-                        ptr.add(idx).write_volatile(*entry);
+                    if !self.remaining_data.is_empty() {
+                        // re-fill TX RAM
+                        let ptr = unsafe { raw.channel_ram_start().add(self.ram_index) };
+                        let count = self.remaining_data.len().min(memsize / 2);
+                        let (chunk, remaining) = self.remaining_data.split_at(count);
+                        for (idx, entry) in chunk.iter().enumerate() {
+                            unsafe {
+                                ptr.add(idx).write_volatile(*entry);
+                            }
+                        }
+
+                        // If count == memsize / 2 codes were written, update ram_index as
+                        // - 0 -> memsize / 2
+                        // - memsize / 2 -> 0
+                        // Otherwise, for count < memsize / 2, the new position is invalid but the new
+                        // slice is empty and we won't use ram_index again.
+                        self.ram_index = memsize / 2 - self.ram_index;
+                        self.remaining_data = remaining;
+                        debug_assert!(
+                            self.ram_index == 0
+                                || self.ram_index == memsize / 2
+                                || self.remaining_data.is_empty()
+                        );
                     }
                 }
-
-                // If count == memsize / 2 codes were written, update ram_index as
-                // - 0 -> memsize / 2
-                // - memsize / 2 -> 0
-                // Otherwise, for count < memsize / 2, the new position is invalid but the new
-                // slice is empty and we won't use ram_index again.
-                self.ram_index = memsize / 2 - self.ram_index;
-                self.remaining_data = remaining;
-                debug_assert!(
-                    self.ram_index == 0
-                        || self.ram_index == memsize / 2
-                        || self.remaining_data.is_empty()
-                );
+                _ => continue,
             }
         }
     }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖
This refactors accesses to hardware state flags to avoid unnecessarily repeated volatile reads. Additionally, by using `match` statements, the resulting code becomes more idiomatic and better exposes the similarities of blocking and async code. Finally, this PR add non-blocking `poll` methods to blocking transactions, which are quite similar to their async equivalent. They enable proper interleaving of such transactions with other work. This is currently only relevant for tx due to the lack of wrapping rx support, but the latter will also be added as part of #3509.

Except for the new methods, there should be no user-facing changes, hence no need for adding to the migration guide.

This should be easiest to review commit-by-commit while ignoring whitespace changes; see individual commit messages for more details on the rationale for some changes.

In the last commit, I removed the now unused low-level state getters. Does this seem reasonable to you, or should they be kept in case they'll be needed again? (FWIW, I'm not using them anywhere in #3509.)

Part of #3509.

Closes #3184
Closes #1749
(Not completely sure about both of these issues since they don't describe their use case in a lot of detail, but this does enable non-blocking operations.)

#### Testing
HIL tests on esp32c3, in addition to testing as part of #3509.
