### PR TITLE
Minor linker script touchups.

### DIFF
--- a/esp-hal/ld/esp32/esp32.x
+++ b/esp-hal/ld/esp32/esp32.x
@@ -16,7 +16,6 @@ INCLUDE "fixups/rtc_fast_rwdata_dummy.x"
 
 /* Shared sections - ordering matters */
 SECTIONS {
-  INCLUDE "rodata_desc.x"
   INCLUDE "rwtext.x"
   INCLUDE "rwdata.x"
 }

--- a/esp-hal/ld/esp32c2/esp32c2.x
+++ b/esp-hal/ld/esp32c2/esp32c2.x
@@ -52,7 +52,6 @@ INSERT BEFORE .data;
 
 /* Shared sections - ordering matters */
 SECTIONS {
-  INCLUDE "rodata_desc.x"
   INCLUDE "rwtext.x"
   INCLUDE "rwdata.x"
 }

--- a/esp-hal/ld/esp32c2/esp32c2.x
+++ b/esp-hal/ld/esp32c2/esp32c2.x
@@ -1,15 +1,6 @@
 /* esp32c2 fixups */
 
 SECTIONS {
-  .trap : ALIGN(4)
-  {
-    KEEP(*(.trap));
-    *(.trap.*);
-  } > RWTEXT
-}
-INSERT BEFORE .rwtext;
-
-SECTIONS {
   .rotext_dummy (NOLOAD) :
   {
     /* This dummy section represents the .rodata section within ROTEXT.

--- a/esp-hal/ld/esp32c3/esp32c3.x
+++ b/esp-hal/ld/esp32c3/esp32c3.x
@@ -52,7 +52,6 @@ INSERT BEFORE .data;
 
 /* Shared sections - ordering matters */
 SECTIONS {
-  INCLUDE "rodata_desc.x"
   INCLUDE "rwtext.x"
   INCLUDE "rwdata.x"
 }

--- a/esp-hal/ld/esp32c3/esp32c3.x
+++ b/esp-hal/ld/esp32c3/esp32c3.x
@@ -1,15 +1,6 @@
 /* esp32c3 fixups */
 
 SECTIONS {
-  .trap : ALIGN(4)
-  {
-    KEEP(*(.trap));
-    *(.trap.*);
-  } > RWTEXT
-}
-INSERT BEFORE .rwtext;
-
-SECTIONS {
   .rotext_dummy (NOLOAD) :
   {
     /* This dummy section represents the .rodata section within ROTEXT.

--- a/esp-hal/ld/esp32c6/esp32c6.x
+++ b/esp-hal/ld/esp32c6/esp32c6.x
@@ -36,10 +36,6 @@ INSERT BEFORE .text;
 /* end of esp32c6 fixups */
 
 /* Shared sections #2 - ordering matters */
-SECTIONS {
-  INCLUDE "rodata_desc.x"
-}
-
 INCLUDE "rodata.x"
 INCLUDE "text.x"
 INCLUDE "rtc_fast.x"

--- a/esp-hal/ld/esp32c6/esp32c6.x
+++ b/esp-hal/ld/esp32c6/esp32c6.x
@@ -5,12 +5,6 @@
 PROVIDE(interrupt0 = DefaultHandler);
 
 SECTIONS {
-  .trap : ALIGN(4)
-  {
-    KEEP(*(.trap));
-    *(.trap.*);
-  } > RWTEXT
-
   /* Shared sections - ordering matters */
   INCLUDE "rwtext.x"
   INCLUDE "rwdata.x"

--- a/esp-hal/ld/esp32h2/esp32h2.x
+++ b/esp-hal/ld/esp32h2/esp32h2.x
@@ -34,9 +34,6 @@ SECTIONS {
 INSERT BEFORE .text;
 
 /* Shared sections #2 - ordering matters */
-SECTIONS {
-  INCLUDE "rodata_desc.x"
-}
 INCLUDE "rodata.x"
 INCLUDE "text.x"
 INCLUDE "rtc_fast.x"

--- a/esp-hal/ld/esp32h2/esp32h2.x
+++ b/esp-hal/ld/esp32h2/esp32h2.x
@@ -4,12 +4,6 @@
 PROVIDE(interrupt0 = DefaultHandler);
 
 SECTIONS {
-  .trap : ALIGN(4)
-  {
-    KEEP(*(.trap));
-    *(.trap.*);
-  } > RWTEXT
-
   /* Shared sections - ordering matters */
   INCLUDE "rwtext.x"
   INCLUDE "rwdata.x"

--- a/esp-hal/ld/esp32s2/esp32s2.x
+++ b/esp-hal/ld/esp32s2/esp32s2.x
@@ -24,7 +24,6 @@ INCLUDE "fixups/rtc_fast_rwdata_dummy.x"
 
 /* Shared sections - ordering matters */
 SECTIONS {
-  INCLUDE "rodata_desc.x"
   INCLUDE "rwtext.x"
   INCLUDE "rwdata.x"
 }

--- a/esp-hal/ld/esp32s3/esp32s3.x
+++ b/esp-hal/ld/esp32s3/esp32s3.x
@@ -50,7 +50,6 @@ INSERT BEFORE .data;
 
 /* Shared sections - ordering matters */
 SECTIONS {
-  INCLUDE "rodata_desc.x"
   INCLUDE "rwtext.x"
   INCLUDE "rwdata.x"
 }

--- a/esp-hal/ld/sections/rodata.x
+++ b/esp-hal/ld/sections/rodata.x
@@ -1,6 +1,11 @@
-
-
 SECTIONS {
+  /* For ESP App Description, must be placed first in image */
+  .rodata_desc : ALIGN(4)
+  {
+      KEEP(*(.rodata_desc));
+      KEEP(*(.rodata_desc.*));
+  } > RODATA
+
   .rodata : ALIGN(4)
   {
     . = ALIGN (4);

--- a/esp-hal/ld/sections/rodata_desc.x
+++ b/esp-hal/ld/sections/rodata_desc.x
@@ -1,5 +1,0 @@
-.rodata_desc : ALIGN(4)
-{
-    KEEP(*(.rodata_desc));
-    KEEP(*(.rodata_desc.*));
-} > RODATA

--- a/esp-hal/ld/sections/rwtext.x
+++ b/esp-hal/ld/sections/rwtext.x
@@ -1,3 +1,11 @@
+#IF riscv
+.trap : ALIGN(4)
+{
+  KEEP(*(.trap));
+  *(.trap.*);
+} > RWTEXT
+#ENDIF
+
 .rwtext : ALIGN(4)
 {
   . = ALIGN (4);


### PR DESCRIPTION
Inlines `rodata_desc.x` and consolidates `.trap` output section definitions. Changes aren't necessarily impactful. Mostly something that I noticed when trying to understand this project's section ordering.