### PR TITLE
Resolve `C-EXAMPLE`: Spi

### DIFF
--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -997,8 +997,7 @@ where
     #[doc = crate::before_snippet!()]
     /// # use esp_hal::spi::Mode;
     /// # use esp_hal::spi::master::{Config, Spi};
-    /// let mut spi = Spi::new(peripherals.SPI2, Config::default())?
-    /// .with_mosi(peripherals.GPIO1);
+    /// let mut spi = Spi::new(peripherals.SPI2, Config::default())?.with_mosi(peripherals.GPIO1);
     ///
     /// # Ok(())
     /// # }
@@ -1023,8 +1022,7 @@ where
     #[doc = crate::before_snippet!()]
     /// # use esp_hal::spi::Mode;
     /// # use esp_hal::spi::master::{Config, Spi};
-    /// let mut spi = Spi::new(peripherals.SPI2, Config::default())?
-    /// .with_miso(peripherals.GPIO2);
+    /// let mut spi = Spi::new(peripherals.SPI2, Config::default())?.with_miso(peripherals.GPIO2);
     ///
     /// # Ok(())
     /// # }
@@ -1130,8 +1128,7 @@ where
     /// # use esp_hal::spi::master::{Config, Spi};
     /// let mut spi = Spi::new(peripherals.SPI2, Config::default())?;
     ///
-    /// spi.apply_config(&Config::default()
-    /// .with_frequency(Rate::from_khz(100)));
+    /// spi.apply_config(&Config::default().with_frequency(Rate::from_khz(100)));
     ///
     /// # Ok(())
     /// # }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [X] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Added doc examples for Spi. Second PR related to https://github.com/esp-rs/esp-hal/issues/2623

#### Testing
`cargo xtask run doc-tests esp-hal esp32c6`

#3736 was closed due to the "fix" keyword in https://github.com/esp-rs/esp-hal/pull/3739 :facepalm: 