### PR TITLE
Add app desc macro examples

### DIFF
--- a/esp-bootloader-esp-idf/src/lib.rs
+++ b/esp-bootloader-esp-idf/src/lib.rs
@@ -9,6 +9,69 @@
 //! - read the partition table
 //! - conveniently use a partition to read and write flash contents
 //!
+//! ## Examples
+//!
+//! ### Populating the Application Descriptor
+//!
+//! To use the default values:
+//!
+//! ```rust, ignore
+//! #![no_std]
+//! #![no_main]
+//!
+//! #[panic_handler]
+//! fn panic(_: &core::panic::PanicInfo) -> ! {
+//!     loop {}
+//! }
+//!
+//! esp_bootloader_esp_idf::esp_app_desc!();
+//!
+//! #[esp_hal::main]
+//! fn main() -> ! {
+//!     let _peripherals = esp_hal::init(esp_hal::Config::default());
+//!
+//!     loop {}
+//! }
+//! ```
+//!
+//! If you want to customize the application descriptor:
+//!
+//! ```rust, ignore
+//! #![no_std]
+//! #![no_main]
+//!
+//! #[panic_handler]
+//! fn panic(_: &core::panic::PanicInfo) -> ! {
+//!     loop {}
+//! }
+//!
+//! esp_bootloader_esp_idf::esp_app_desc!(
+//!     // Version
+//!     "1.0.0",
+//!     // Project name
+//!     "my_project",
+//!     // Build time
+//!     "12:00:00",
+//!     // Build date
+//!     "2021-01-01",
+//!     // ESP-IDF version
+//!     "4.4",
+//!     // MMU page size
+//!     8 * 1024,
+//!     // Minimal eFuse block revision supported by image. Format: major * 100 + minor
+//!     0,
+//!     // Maximum eFuse block revision supported by image. Format: major * 100 + minor
+//!     u16::MAX
+//! );
+//!
+//! #[esp_hal::main]
+//! fn main() -> ! {
+//!     let _peripherals = esp_hal::init(esp_hal::Config::default());
+//!
+//!     loop {}
+//! }
+//! ```
+//!
 //! ## Additional configuration
 //!
 //! We've exposed some configuration options that don't fit into cargo


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [X] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
The idea is to improve the errors on app description errors on `espflash` see https://github.com/esp-rs/espflash/issues/919#issuecomment-3026933343, for that I think we should just point to the lib docs where some examples should live. 

#### Testing
`cargo xtask build documentation --packages esp-bootloader-esp-idf`