### PR TITLE
Add clean and build timings to xtask

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,6 @@
 [alias]
 xtask    = "run --package xtask --"
+xclean   = "xtask clean"
 xdoc     = "run --package xtask --features=deploy-docs,preview-docs --"
 xfmt     = "xtask fmt-packages"
 qa       = "xtask run example qa-test"

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -8,15 +8,17 @@ Automation using [cargo-xtask](https://github.com/matklad/cargo-xtask).
 Usage: xtask <COMMAND>
 
 Commands:
-  build            Build-related subcommands
-  run              Run-related subcommands
-  release          Release-related subcommands
-  ci               Perform (parts of) the checks done in CI
-  fmt-packages     Format all packages in the workspace with rustfmt
-  lint-packages    Lint all packages in the workspace with clippy
-  semver-check     Semver Checks
-  check-changelog  Check the changelog for packages
-  help             Print this message or the help of the given subcommand(s)
+  build                      Build-related subcommands
+  run                        Run-related subcommands
+  release                    Release-related subcommands
+  ci                         Perform (parts of) the checks done in CI
+  fmt-packages               Format all packages in the workspace with rustfmt
+  clean                      Run cargo clean
+  lint-packages              Lint all packages in the workspace with clippy
+  semver-check               Semver Checks
+  check-changelog            Check the changelog for packages
+  update-chip-support-table  Re-generate the chip support table in the esp-hal README
+  help                       Print this message or the help of the given subcommand(s)
 
 Options:
   -h, --help  Print help

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -6,12 +6,12 @@ use std::{
     process::{Command, Stdio},
 };
 
-use anyhow::{bail, Context as _, Result};
+use anyhow::{Context as _, Result, bail};
 use clap::ValueEnum as _;
 use serde::{Deserialize, Serialize};
 use toml_edit::{DocumentMut, Formatted, Item, Value};
 
-use crate::{windows_safe_path, Package};
+use crate::{Package, windows_safe_path};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum CargoAction {
@@ -294,8 +294,7 @@ impl<'a> CargoToml<'a> {
     ///
     /// Callback arguments:
     /// - `path`: The path to the table (e.g. `dependencies.package`)
-    /// - `dependency_kind`: The kind of dependency (e.g. `dependencies`,
-    ///   `dev-dependencies`)
+    /// - `dependency_kind`: The kind of dependency (e.g. `dependencies`, `dev-dependencies`)
     /// - `table`: The table itself
     pub fn visit_dependencies(
         &mut self,

--- a/xtask/src/commands/build.rs
+++ b/xtask/src/commands/build.rs
@@ -141,6 +141,7 @@ pub fn build_examples(
                 1,
                 args.debug,
                 args.toolchain.as_deref(),
+                args.timings,
             )?;
         }
         Ok(())
@@ -159,6 +160,7 @@ pub fn build_examples(
                 1,
                 args.debug,
                 args.toolchain.as_deref(),
+                args.timings,
             )
         })
     }

--- a/xtask/src/commands/mod.rs
+++ b/xtask/src/commands/mod.rs
@@ -34,6 +34,10 @@ pub struct ExamplesArgs {
     /// The toolchain used to build the examples
     #[arg(long)]
     pub toolchain: Option<String>,
+
+    /// Emit crate build timings
+    #[arg(long)]
+    pub timings: bool,
 }
 
 #[derive(Debug, Args)]
@@ -52,6 +56,10 @@ pub struct TestsArgs {
     /// The toolchain used to build the tests
     #[arg(long)]
     pub toolchain: Option<String>,
+
+    /// Emit crate build timings
+    #[arg(long)]
+    pub timings: bool,
 }
 
 // ----------------------------------------------------------------------------
@@ -125,6 +133,7 @@ pub fn tests(workspace: &Path, args: TestsArgs, action: CargoAction) -> Result<(
                 args.repeat,
                 false,
                 args.toolchain.as_deref(),
+                args.timings,
             )?;
         }
         Ok(())
@@ -142,6 +151,7 @@ pub fn tests(workspace: &Path, args: TestsArgs, action: CargoAction) -> Result<(
                 args.repeat,
                 false,
                 args.toolchain.as_deref(),
+                args.timings,
             )
             .is_err()
             {

--- a/xtask/src/commands/run.rs
+++ b/xtask/src/commands/run.rs
@@ -185,6 +185,7 @@ pub fn run_examples(
                     1,
                     args.debug,
                     args.toolchain.as_deref(),
+                    args.timings,
                 )
                 .is_err()
             {

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -138,7 +138,10 @@ impl Package {
     pub fn chip_features_matter(&self) -> bool {
         use Package::*;
 
-        matches!(self, EspHal | EspLpHal | EspWifi | EspHalEmbassy | EspRomSys | EspBootloaderEspIdf)
+        matches!(
+            self,
+            EspHal | EspLpHal | EspWifi | EspHalEmbassy | EspRomSys | EspBootloaderEspIdf
+        )
     }
 
     /// Should documentation be built for the package, and should the package be
@@ -309,6 +312,7 @@ pub fn execute_app(
     repeat: usize,
     debug: bool,
     toolchain: Option<&str>,
+    timings: bool,
 ) -> Result<()> {
     let package = app.example_path().strip_prefix(package_path)?;
     log::info!("Building example '{}' for '{}'", package.display(), chip);
@@ -360,6 +364,9 @@ pub fn execute_app(
 
     if !debug {
         builder.add_arg("--release");
+    }
+    if timings {
+        builder.add_arg("--timings");
     }
 
     let toolchain = match toolchain {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -351,6 +351,7 @@ fn run_ci_checks(workspace: &Path, args: CiArgs) -> Result<()> {
             example: None,
             debug: true,
             toolchain: args.toolchain.clone(),
+            timings: false,
         },
     )
     .inspect_err(|_| failed.push("Doc Test"))
@@ -387,6 +388,7 @@ fn run_ci_checks(workspace: &Path, args: CiArgs) -> Result<()> {
                 example: None,
                 debug: false,
                 toolchain: args.toolchain.clone(),
+                timings: false,
             },
             CargoAction::Build(PathBuf::from(format!(
                 "./esp-lp-hal/target/{}/release/examples",
@@ -462,6 +464,7 @@ fn run_ci_checks(workspace: &Path, args: CiArgs) -> Result<()> {
             example: None,
             debug: true,
             toolchain: args.toolchain.clone(),
+            timings: false,
         },
         CargoAction::Build(PathBuf::from("./examples/target/")),
     )
@@ -479,6 +482,7 @@ fn run_ci_checks(workspace: &Path, args: CiArgs) -> Result<()> {
             example: None,
             debug: true,
             toolchain: args.toolchain.clone(),
+            timings: false,
         },
         CargoAction::Build(PathBuf::from("./qa-test/target/")),
     )


### PR DESCRIPTION
This PR implements two new xtask features:

- `cargo xtask clean` runs cargo clean in all packages
- `cargo build --timings`: for example/test builds, this new option generates an HTML with crate build times