### PR TITLE
Clean up NPL a bit

### DIFF
--- a/esp-wifi/src/ble/btdm.rs
+++ b/esp-wifi/src/ble/btdm.rs
@@ -1,6 +1,6 @@
-use alloc::boxed::Box;
 use core::ptr::{addr_of, addr_of_mut};
 
+use allocator_api2::boxed::Box;
 use esp_wifi_sys::c_types::{c_char, c_void};
 use portable_atomic::{AtomicBool, Ordering};
 

--- a/esp-wifi/src/ble/mod.rs
+++ b/esp-wifi/src/ble/mod.rs
@@ -8,9 +8,10 @@ pub(crate) mod btdm;
 #[cfg(any(esp32c2, esp32c6, esp32h2))]
 pub(crate) mod npl;
 
-use alloc::{boxed::Box, collections::vec_deque::VecDeque, vec::Vec};
+use alloc::{collections::vec_deque::VecDeque, vec::Vec};
 use core::{cell::RefCell, mem::MaybeUninit};
 
+use allocator_api2::boxed::Box;
 pub(crate) use ble::{ble_deinit, ble_init, send_hci};
 use critical_section::Mutex;
 


### PR DESCRIPTION
This PR attempts to clean up NPL a bit by making the following changes:

- Take `mut` pointers where applicable. The C api doesn't care, in Rust a `*const -> *mut` cast can be UB, but we know the pointers are in memory so we can just remove the casts.
- Use `Box` more. Typed allocation does not have to prepend the size of the object to the allocated memory, and we don't have to write manual malloc/free. We do need to leak and restore the boxes, though, which still sucks.
- Extract the double pointer deref code into unsafe fns. This means we no longer forget to null-check the inputs, we don't paper over const-mut casts, and we're working with a reference to our heap-allocated object, instead of unsafe pointer meddling.
