### PR TITLE
Remove some unnecessary caches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@v1
         with:
           toolchain: stable
-      - uses: Swatinem/rust-cache@v2
 
       # Build the extra crates
       - name: Build the bench-server
@@ -134,7 +133,6 @@ jobs:
           target: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf
           toolchain: ${{ env.MSRV }}
           components: rust-src,clippy
-      - uses: Swatinem/rust-cache@v2
 
       - name: Stable toolchain checks
         run: rustc +${{ env.MSRV }} --version --verbose
@@ -163,7 +161,6 @@ jobs:
         with:
           toolchain: nightly
           components: rustfmt,miri
-      - uses: Swatinem/rust-cache@v2
 
       # Check the formatting of all packages:
       - run: cargo xtask fmt-packages --check

--- a/.github/workflows/ci_nightly.yml
+++ b/.github/workflows/ci_nightly.yml
@@ -37,8 +37,6 @@ jobs:
           toolchain: nightly
           components: rust-src, clippy, rustfmt
 
-      - uses: Swatinem/rust-cache@v2
-
       - name: Build and Check
         shell: bash
         run: cargo xtask ci ${{ matrix.device }} --toolchain nightly


### PR DESCRIPTION
This PR removes caches from the CI where they are not necessary.

- On the macOS runner, downloading and uploading the cache itself takes up more time than it saves
- The runtime of the nightly CI check does not matter at all

Even in other places, the cache is largely ineffective currently, but let's go one step a time.