### PR TITLE
Move `rtc_clk_xtal_freq_get` impl to esp-rom-sys

### DIFF
--- a/esp-hal/src/rtc_cntl/mod.rs
+++ b/esp-hal/src/rtc_cntl/mod.rs
@@ -1274,11 +1274,3 @@ pub fn wakeup_cause() -> SleepSource {
 
     SleepSource::Undefined
 }
-
-// libphy.a can pull this in on some chips, we provide it here in the hal
-// so that either ieee or esp-wifi gets it for free without duplicating in both
-#[unsafe(no_mangle)]
-extern "C" fn rtc_clk_xtal_freq_get() -> i32 {
-    let xtal = RtcClock::xtal_freq();
-    xtal.mhz() as i32
-}

--- a/esp-rom-sys/Cargo.toml
+++ b/esp-rom-sys/Cargo.toml
@@ -21,6 +21,7 @@ bench = false
 test  = false
 
 [dependencies]
+cfg-if              = "1.0.1"
 defmt               = { version = "1.0.1", optional = true }
 document-features   = "0.2.11"
 log-04              = { package = "log", version = "0.4.26", optional = true }

--- a/esp-rom-sys/src/rom/mod.rs
+++ b/esp-rom-sys/src/rom/mod.rs
@@ -72,7 +72,7 @@ pub fn ets_set_appcpu_boot_addr(boot_addr: u32) {
     unsafe { ets_set_appcpu_boot_addr(boot_addr) };
 }
 
-// libphy.a can pull this in on some chips, we provide it here in the hal
+// libphy.a can pull this in on some chips, we provide it here
 // so that either ieee or esp-wifi gets it for free without duplicating in both
 #[unsafe(no_mangle)]
 extern "C" fn rtc_clk_xtal_freq_get() -> i32 {

--- a/esp-rom-sys/src/rom/mod.rs
+++ b/esp-rom-sys/src/rom/mod.rs
@@ -71,3 +71,34 @@ pub fn ets_set_appcpu_boot_addr(boot_addr: u32) {
 
     unsafe { ets_set_appcpu_boot_addr(boot_addr) };
 }
+
+// libphy.a can pull this in on some chips, we provide it here in the hal
+// so that either ieee or esp-wifi gets it for free without duplicating in both
+#[unsafe(no_mangle)]
+extern "C" fn rtc_clk_xtal_freq_get() -> i32 {
+    cfg_if::cfg_if! {
+        if #[cfg(any(esp32c6, esp32h2))] {
+            unsafe extern "C" {
+                fn ets_clk_get_xtal_freq() -> i32;
+            }
+            (unsafe { ets_clk_get_xtal_freq() }) / 1_000_000
+        } else if #[cfg(any(esp32s2, esp32s3, esp32c3))] {
+            unsafe extern "C" {
+                fn ets_get_xtal_freq() -> i32;
+            }
+            (unsafe { ets_get_xtal_freq() }) / 1_000_000
+        } else if #[cfg(esp32)] {
+            // the ROM function returns something close to 80_000_000
+            // just rely on RTC_CNTL_STORE4
+            let rtc_cntl_store4: *const u32 = 0x3FF480B0 as *const u32;
+            ((unsafe { rtc_cntl_store4.read_volatile() })  & 0xff) as i32
+        } else if #[cfg(esp32c2)] {
+            // the ROM function returns 40 also for a 26 MHz xtal
+            // just rely on RTC_CNTL_STORE4
+            let rtc_cntl_store4: *const u32 = 0x600080AC  as *const u32;
+            ((unsafe { rtc_cntl_store4.read_volatile() })  & 0xff) as i32
+        } else {
+            compile_error!("rtc_clk_xtal_freq_get not implemented for this chip");
+        }
+    }
+}


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

Closes #3763 

skip-changelog - no user visible change

#### Testing

Used the function in some test code, CI, running esp-wifi examples
