### PR TITLE
Use indexmap to ensure stable iteration order

### DIFF
--- a/esp-metadata-generated/src/_build_script_utils.rs
+++ b/esp-metadata-generated/src/_build_script_utils.rs
@@ -2383,31 +2383,31 @@ impl Config {
         println!("cargo:rustc-check-cfg=cfg(soc_has_dma_ch4)");
         println!("cargo:rustc-check-cfg=cfg(octal_psram)");
         println!("cargo:rustc-check-cfg=cfg(camera)");
-        println!("cargo:rustc-check-cfg=cfg(gpio_constant_0_input, values(\"48\",\"31\",\"60\"))");
-        println!(
-            "cargo:rustc-check-cfg=cfg(i2c_master_max_bus_timeout, values(\"1048575\",\"31\",\"16777215\"))"
-        );
-        println!("cargo:rustc-check-cfg=cfg(gpio_constant_1_input, values(\"56\",\"30\"))");
-        println!(
-            "cargo:rustc-check-cfg=cfg(rmt_ram_start, values(\"1073047552\",\"1610703872\",\"1610638336\",\"1610642432\",\"1061250048\",\"1610704896\"))"
-        );
-        println!("cargo:rustc-check-cfg=cfg(rmt_channel_ram_size, values(\"64\",\"48\"))");
-        println!("cargo:rustc-check-cfg=cfg(gpio_func_in_sel_offset, values(\"0\"))");
-        println!("cargo:rustc-check-cfg=cfg(i2c_master_fifo_size, values(\"32\",\"16\"))");
         println!("cargo:rustc-check-cfg=cfg(gpio_gpio_function, values(\"2\",\"1\"))");
         println!(
-            "cargo:rustc-check-cfg=cfg(interrupts_status_registers, values(\"3\",\"2\",\"4\"))"
+            "cargo:rustc-check-cfg=cfg(gpio_input_signal_max, values(\"206\",\"100\",\"124\",\"204\",\"189\"))"
         );
         println!("cargo:rustc-check-cfg=cfg(gpio_output_signal_max, values(\"256\",\"128\"))");
+        println!("cargo:rustc-check-cfg=cfg(gpio_constant_0_input, values(\"48\",\"31\",\"60\"))");
+        println!("cargo:rustc-check-cfg=cfg(gpio_constant_1_input, values(\"56\",\"30\"))");
+        println!("cargo:rustc-check-cfg=cfg(gpio_func_in_sel_offset, values(\"0\"))");
         println!(
             "cargo:rustc-check-cfg=cfg(i2c_master_i2c0_data_register_ahb_address, values(\"1610690588\"))"
         );
         println!(
-            "cargo:rustc-check-cfg=cfg(i2c_master_ll_intr_mask, values(\"262143\",\"131071\"))"
+            "cargo:rustc-check-cfg=cfg(i2c_master_max_bus_timeout, values(\"1048575\",\"31\",\"16777215\"))"
         );
         println!(
-            "cargo:rustc-check-cfg=cfg(gpio_input_signal_max, values(\"206\",\"100\",\"124\",\"204\",\"189\"))"
+            "cargo:rustc-check-cfg=cfg(i2c_master_ll_intr_mask, values(\"262143\",\"131071\"))"
         );
+        println!("cargo:rustc-check-cfg=cfg(i2c_master_fifo_size, values(\"32\",\"16\"))");
+        println!(
+            "cargo:rustc-check-cfg=cfg(interrupts_status_registers, values(\"3\",\"2\",\"4\"))"
+        );
+        println!(
+            "cargo:rustc-check-cfg=cfg(rmt_ram_start, values(\"1073047552\",\"1610703872\",\"1610638336\",\"1610642432\",\"1061250048\",\"1610704896\"))"
+        );
+        println!("cargo:rustc-check-cfg=cfg(rmt_channel_ram_size, values(\"64\",\"48\"))");
         for cfg in self.cfgs {
             println!("{cfg}");
         }

--- a/esp-metadata/Cargo.toml
+++ b/esp-metadata/Cargo.toml
@@ -9,13 +9,14 @@ repository    = "https://github.com/esp-rs/esp-hal"
 license       = "MIT OR Apache-2.0"
 
 [dependencies]
-anyhow     = { version = "1.0.98" }
-clap       = { version = "4.5.37", features = ["derive"], optional = true }
-basic-toml = { version = "0.1.10" }
-serde      = { version = "1.0.219", default-features = false, features = ["derive"] }
-strum      = { version = "0.27.1", features = ["derive"] }
-proc-macro2 = { version = "1.0.36" }
-quote      = { version = "1.0.15" }
+anyhow     = "1.0"
+clap       = { version = "4.5", features = ["derive"], optional = true }
+basic-toml = "0.1"
+serde      = { version = "1.0", default-features = false, features = ["derive"] }
+strum      = { version = "0.27", features = ["derive"] }
+proc-macro2 = "1"
+quote      = "1"
+indexmap = { version = "2", features = ["serde"] }
 
 [features]
 default = []

--- a/esp-metadata/src/lib.rs
+++ b/esp-metadata/src/lib.rs
@@ -2,10 +2,11 @@
 mod cfg;
 
 use core::str::FromStr;
-use std::{collections::HashMap, fmt::Write, sync::OnceLock};
+use std::{fmt::Write, sync::OnceLock};
 
 use anyhow::{Result, bail, ensure};
 use cfg::PeriConfig;
+use indexmap::IndexMap;
 pub use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use strum::IntoEnumIterator;
@@ -197,7 +198,7 @@ impl Chip {
         // Used by our documentation builds to prevent the huge red warning banner.
         cfgs.push(String::from("cargo:rustc-check-cfg=cfg(not_really_docsrs)"));
 
-        let mut cfg_values: HashMap<String, Vec<String>> = HashMap::new();
+        let mut cfg_values: IndexMap<String, Vec<String>> = IndexMap::new();
 
         for chip in Chip::iter() {
             let config = Config::for_chip(&chip);
@@ -253,7 +254,7 @@ pub struct PeripheralDef {
     is_virtual: bool,
     /// List of related interrupt signals
     #[serde(default)]
-    interrupts: HashMap<String, String>,
+    interrupts: IndexMap<String, String>,
 }
 
 impl PeripheralDef {


### PR DESCRIPTION
This PR should ensure that the output of `cargo xtask update-metadata` is stable (i.e. running it multiple times doesn't give different results). Using std HashMap, this is not ensured and no metadata changes can still cause some files to change, which isn't ideal.