### PR TITLE
Generate a trait for each signal that requires direct IO MUX function

### DIFF
--- a/esp-hal/src/gpio/interconnect.rs
+++ b/esp-hal/src/gpio/interconnect.rs
@@ -941,3 +941,5 @@ impl NoOp {
 /// # }
 /// ```
 fn _compile_tests() {}
+
+implement_alternate_function_markers!();

--- a/esp-metadata-generated/src/_generated_esp32.rs
+++ b/esp-metadata-generated/src/_generated_esp32.rs
@@ -1518,3 +1518,284 @@ macro_rules! define_io_mux_reg {
         }
     };
 }
+#[macro_export]
+#[doc(hidden)]
+macro_rules! implement_alternate_function_markers {
+    () => {
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SD_CMD input function"]
+        pub trait InputFunction_SD_CMD {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SD_DATA0 input function"]
+        pub trait InputFunction_SD_DATA0 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SD_DATA1 input function"]
+        pub trait InputFunction_SD_DATA1 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SD_DATA2 input function"]
+        pub trait InputFunction_SD_DATA2 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SD_DATA3 input function"]
+        pub trait InputFunction_SD_DATA3 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS1_DATA0 input function"]
+        pub trait InputFunction_HS1_DATA0 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS1_DATA1 input function"]
+        pub trait InputFunction_HS1_DATA1 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS1_DATA2 input function"]
+        pub trait InputFunction_HS1_DATA2 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS1_DATA3 input function"]
+        pub trait InputFunction_HS1_DATA3 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS1_DATA4 input function"]
+        pub trait InputFunction_HS1_DATA4 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS1_DATA5 input function"]
+        pub trait InputFunction_HS1_DATA5 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS1_DATA6 input function"]
+        pub trait InputFunction_HS1_DATA6 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS1_DATA7 input function"]
+        pub trait InputFunction_HS1_DATA7 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS2_DATA0 input function"]
+        pub trait InputFunction_HS2_DATA0 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS2_DATA1 input function"]
+        pub trait InputFunction_HS2_DATA1 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS2_DATA2 input function"]
+        pub trait InputFunction_HS2_DATA2 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS2_DATA3 input function"]
+        pub trait InputFunction_HS2_DATA3 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the EMAC_TX_CLK input function"]
+        pub trait InputFunction_EMAC_TX_CLK {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the EMAC_RXD2 input function"]
+        pub trait InputFunction_EMAC_RXD2 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the EMAC_TX_ER input function"]
+        pub trait InputFunction_EMAC_TX_ER {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the EMAC_RX_CLK input function"]
+        pub trait InputFunction_EMAC_RX_CLK {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the EMAC_RX_ER input function"]
+        pub trait InputFunction_EMAC_RX_ER {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the EMAC_RXD3 input function"]
+        pub trait InputFunction_EMAC_RXD3 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the EMAC_RXD0 input function"]
+        pub trait InputFunction_EMAC_RXD0 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the EMAC_RXD1 input function"]
+        pub trait InputFunction_EMAC_RXD1 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the EMAC_RX_DV input function"]
+        pub trait InputFunction_EMAC_RX_DV {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the MTDI input function"]
+        pub trait InputFunction_MTDI {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the MTCK input function"]
+        pub trait InputFunction_MTCK {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the MTMS input function"]
+        pub trait InputFunction_MTMS {}
+        impl InputFunction_EMAC_TX_CLK for crate::peripherals::GPIO0<'_> {}
+        impl InputFunction_EMAC_RXD2 for crate::peripherals::GPIO1<'_> {}
+        impl InputFunction_HS2_DATA0 for crate::peripherals::GPIO2<'_> {}
+        impl InputFunction_SD_DATA0 for crate::peripherals::GPIO2<'_> {}
+        impl InputFunction_HS2_DATA1 for crate::peripherals::GPIO4<'_> {}
+        impl InputFunction_SD_DATA1 for crate::peripherals::GPIO4<'_> {}
+        impl InputFunction_EMAC_TX_ER for crate::peripherals::GPIO4<'_> {}
+        impl InputFunction_HS1_DATA6 for crate::peripherals::GPIO5<'_> {}
+        impl InputFunction_EMAC_RX_CLK for crate::peripherals::GPIO5<'_> {}
+        impl InputFunction_SD_DATA0 for crate::peripherals::GPIO7<'_> {}
+        impl InputFunction_HS1_DATA0 for crate::peripherals::GPIO7<'_> {}
+        impl InputFunction_SD_DATA1 for crate::peripherals::GPIO8<'_> {}
+        impl InputFunction_HS1_DATA1 for crate::peripherals::GPIO8<'_> {}
+        impl InputFunction_SD_DATA2 for crate::peripherals::GPIO9<'_> {}
+        impl InputFunction_HS1_DATA2 for crate::peripherals::GPIO9<'_> {}
+        impl InputFunction_SD_DATA3 for crate::peripherals::GPIO10<'_> {}
+        impl InputFunction_HS1_DATA3 for crate::peripherals::GPIO10<'_> {}
+        impl InputFunction_SD_CMD for crate::peripherals::GPIO11<'_> {}
+        impl InputFunction_MTDI for crate::peripherals::GPIO12<'_> {}
+        impl InputFunction_HS2_DATA2 for crate::peripherals::GPIO12<'_> {}
+        impl InputFunction_SD_DATA2 for crate::peripherals::GPIO12<'_> {}
+        impl InputFunction_MTCK for crate::peripherals::GPIO13<'_> {}
+        impl InputFunction_HS2_DATA3 for crate::peripherals::GPIO13<'_> {}
+        impl InputFunction_SD_DATA3 for crate::peripherals::GPIO13<'_> {}
+        impl InputFunction_EMAC_RX_ER for crate::peripherals::GPIO13<'_> {}
+        impl InputFunction_MTMS for crate::peripherals::GPIO14<'_> {}
+        impl InputFunction_SD_CMD for crate::peripherals::GPIO15<'_> {}
+        impl InputFunction_EMAC_RXD3 for crate::peripherals::GPIO15<'_> {}
+        impl InputFunction_HS1_DATA4 for crate::peripherals::GPIO16<'_> {}
+        impl InputFunction_HS1_DATA5 for crate::peripherals::GPIO17<'_> {}
+        impl InputFunction_HS1_DATA7 for crate::peripherals::GPIO18<'_> {}
+        impl InputFunction_EMAC_RXD0 for crate::peripherals::GPIO25<'_> {}
+        impl InputFunction_EMAC_RXD1 for crate::peripherals::GPIO26<'_> {}
+        impl InputFunction_EMAC_RX_DV for crate::peripherals::GPIO27<'_> {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the CLK_OUT1 output function"]
+        pub trait OutputFunction_CLK_OUT1 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the CLK_OUT2 output function"]
+        pub trait OutputFunction_CLK_OUT2 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the CLK_OUT3 output function"]
+        pub trait OutputFunction_CLK_OUT3 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SD_CLK output function"]
+        pub trait OutputFunction_SD_CLK {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SD_CMD output function"]
+        pub trait OutputFunction_SD_CMD {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SD_DATA0 output function"]
+        pub trait OutputFunction_SD_DATA0 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SD_DATA1 output function"]
+        pub trait OutputFunction_SD_DATA1 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SD_DATA2 output function"]
+        pub trait OutputFunction_SD_DATA2 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SD_DATA3 output function"]
+        pub trait OutputFunction_SD_DATA3 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS1_CLK output function"]
+        pub trait OutputFunction_HS1_CLK {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS1_CMD output function"]
+        pub trait OutputFunction_HS1_CMD {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS1_DATA0 output function"]
+        pub trait OutputFunction_HS1_DATA0 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS1_DATA1 output function"]
+        pub trait OutputFunction_HS1_DATA1 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS1_DATA2 output function"]
+        pub trait OutputFunction_HS1_DATA2 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS1_DATA3 output function"]
+        pub trait OutputFunction_HS1_DATA3 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS1_DATA4 output function"]
+        pub trait OutputFunction_HS1_DATA4 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS1_DATA5 output function"]
+        pub trait OutputFunction_HS1_DATA5 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS1_DATA6 output function"]
+        pub trait OutputFunction_HS1_DATA6 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS1_DATA7 output function"]
+        pub trait OutputFunction_HS1_DATA7 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS1_STROBE output function"]
+        pub trait OutputFunction_HS1_STROBE {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS2_CLK output function"]
+        pub trait OutputFunction_HS2_CLK {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS2_CMD output function"]
+        pub trait OutputFunction_HS2_CMD {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS2_DATA0 output function"]
+        pub trait OutputFunction_HS2_DATA0 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS2_DATA1 output function"]
+        pub trait OutputFunction_HS2_DATA1 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS2_DATA2 output function"]
+        pub trait OutputFunction_HS2_DATA2 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS2_DATA3 output function"]
+        pub trait OutputFunction_HS2_DATA3 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the EMAC_TX_CLK output function"]
+        pub trait OutputFunction_EMAC_TX_CLK {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the EMAC_TX_ER output function"]
+        pub trait OutputFunction_EMAC_TX_ER {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the EMAC_TXD3 output function"]
+        pub trait OutputFunction_EMAC_TXD3 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the EMAC_RX_ER output function"]
+        pub trait OutputFunction_EMAC_RX_ER {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the EMAC_TXD2 output function"]
+        pub trait OutputFunction_EMAC_TXD2 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the EMAC_CLK_OUT output function"]
+        pub trait OutputFunction_EMAC_CLK_OUT {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the EMAC_CLK_180 output function"]
+        pub trait OutputFunction_EMAC_CLK_180 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the EMAC_TXD0 output function"]
+        pub trait OutputFunction_EMAC_TXD0 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the EMAC_TX_EN output function"]
+        pub trait OutputFunction_EMAC_TX_EN {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the EMAC_TXD1 output function"]
+        pub trait OutputFunction_EMAC_TXD1 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the MTDO output function"]
+        pub trait OutputFunction_MTDO {}
+        impl OutputFunction_CLK_OUT1 for crate::peripherals::GPIO0<'_> {}
+        impl OutputFunction_EMAC_TX_CLK for crate::peripherals::GPIO0<'_> {}
+        impl OutputFunction_CLK_OUT3 for crate::peripherals::GPIO1<'_> {}
+        impl OutputFunction_HS2_DATA0 for crate::peripherals::GPIO2<'_> {}
+        impl OutputFunction_SD_DATA0 for crate::peripherals::GPIO2<'_> {}
+        impl OutputFunction_CLK_OUT2 for crate::peripherals::GPIO3<'_> {}
+        impl OutputFunction_HS2_DATA1 for crate::peripherals::GPIO4<'_> {}
+        impl OutputFunction_SD_DATA1 for crate::peripherals::GPIO4<'_> {}
+        impl OutputFunction_EMAC_TX_ER for crate::peripherals::GPIO4<'_> {}
+        impl OutputFunction_HS1_DATA6 for crate::peripherals::GPIO5<'_> {}
+        impl OutputFunction_SD_CLK for crate::peripherals::GPIO6<'_> {}
+        impl OutputFunction_HS1_CLK for crate::peripherals::GPIO6<'_> {}
+        impl OutputFunction_SD_DATA0 for crate::peripherals::GPIO7<'_> {}
+        impl OutputFunction_HS1_DATA0 for crate::peripherals::GPIO7<'_> {}
+        impl OutputFunction_SD_DATA1 for crate::peripherals::GPIO8<'_> {}
+        impl OutputFunction_HS1_DATA1 for crate::peripherals::GPIO8<'_> {}
+        impl OutputFunction_SD_DATA2 for crate::peripherals::GPIO9<'_> {}
+        impl OutputFunction_HS1_DATA2 for crate::peripherals::GPIO9<'_> {}
+        impl OutputFunction_SD_DATA3 for crate::peripherals::GPIO10<'_> {}
+        impl OutputFunction_HS1_DATA3 for crate::peripherals::GPIO10<'_> {}
+        impl OutputFunction_SD_CMD for crate::peripherals::GPIO11<'_> {}
+        impl OutputFunction_HS1_CMD for crate::peripherals::GPIO11<'_> {}
+        impl OutputFunction_HS2_DATA2 for crate::peripherals::GPIO12<'_> {}
+        impl OutputFunction_SD_DATA2 for crate::peripherals::GPIO12<'_> {}
+        impl OutputFunction_EMAC_TXD3 for crate::peripherals::GPIO12<'_> {}
+        impl OutputFunction_HS2_DATA3 for crate::peripherals::GPIO13<'_> {}
+        impl OutputFunction_SD_DATA3 for crate::peripherals::GPIO13<'_> {}
+        impl OutputFunction_EMAC_RX_ER for crate::peripherals::GPIO13<'_> {}
+        impl OutputFunction_HS2_CLK for crate::peripherals::GPIO14<'_> {}
+        impl OutputFunction_SD_CLK for crate::peripherals::GPIO14<'_> {}
+        impl OutputFunction_EMAC_TXD2 for crate::peripherals::GPIO14<'_> {}
+        impl OutputFunction_MTDO for crate::peripherals::GPIO15<'_> {}
+        impl OutputFunction_HS2_CMD for crate::peripherals::GPIO15<'_> {}
+        impl OutputFunction_SD_CMD for crate::peripherals::GPIO15<'_> {}
+        impl OutputFunction_HS1_DATA4 for crate::peripherals::GPIO16<'_> {}
+        impl OutputFunction_EMAC_CLK_OUT for crate::peripherals::GPIO16<'_> {}
+        impl OutputFunction_HS1_DATA5 for crate::peripherals::GPIO17<'_> {}
+        impl OutputFunction_EMAC_CLK_180 for crate::peripherals::GPIO17<'_> {}
+        impl OutputFunction_HS1_DATA7 for crate::peripherals::GPIO18<'_> {}
+        impl OutputFunction_EMAC_TXD0 for crate::peripherals::GPIO19<'_> {}
+        impl OutputFunction_EMAC_TX_EN for crate::peripherals::GPIO21<'_> {}
+        impl OutputFunction_EMAC_TXD1 for crate::peripherals::GPIO22<'_> {}
+        impl OutputFunction_HS1_STROBE for crate::peripherals::GPIO23<'_> {}
+    };
+}

--- a/esp-metadata-generated/src/_generated_esp32.rs
+++ b/esp-metadata-generated/src/_generated_esp32.rs
@@ -1523,279 +1523,251 @@ macro_rules! define_io_mux_reg {
 macro_rules! implement_alternate_function_markers {
     () => {
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the SD_CMD input function"]
-        pub trait InputFunction_SD_CMD {}
+        #[doc = "Marker trait for pins that have the SD_CMD function"]
+        pub trait AlternateFunction_SD_CMD: crate::gpio::InputPin + crate::gpio::OutputPin {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SD_DATA0 function"]
+        pub trait AlternateFunction_SD_DATA0:
+            crate::gpio::InputPin + crate::gpio::OutputPin
+        {
+        }
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SD_DATA1 function"]
+        pub trait AlternateFunction_SD_DATA1:
+            crate::gpio::InputPin + crate::gpio::OutputPin
+        {
+        }
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SD_DATA2 function"]
+        pub trait AlternateFunction_SD_DATA2:
+            crate::gpio::InputPin + crate::gpio::OutputPin
+        {
+        }
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SD_DATA3 function"]
+        pub trait AlternateFunction_SD_DATA3:
+            crate::gpio::InputPin + crate::gpio::OutputPin
+        {
+        }
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS1_DATA0 function"]
+        pub trait AlternateFunction_HS1_DATA0:
+            crate::gpio::InputPin + crate::gpio::OutputPin
+        {
+        }
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS1_DATA1 function"]
+        pub trait AlternateFunction_HS1_DATA1:
+            crate::gpio::InputPin + crate::gpio::OutputPin
+        {
+        }
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS1_DATA2 function"]
+        pub trait AlternateFunction_HS1_DATA2:
+            crate::gpio::InputPin + crate::gpio::OutputPin
+        {
+        }
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS1_DATA3 function"]
+        pub trait AlternateFunction_HS1_DATA3:
+            crate::gpio::InputPin + crate::gpio::OutputPin
+        {
+        }
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS1_DATA4 function"]
+        pub trait AlternateFunction_HS1_DATA4:
+            crate::gpio::InputPin + crate::gpio::OutputPin
+        {
+        }
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS1_DATA5 function"]
+        pub trait AlternateFunction_HS1_DATA5:
+            crate::gpio::InputPin + crate::gpio::OutputPin
+        {
+        }
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS1_DATA6 function"]
+        pub trait AlternateFunction_HS1_DATA6:
+            crate::gpio::InputPin + crate::gpio::OutputPin
+        {
+        }
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS1_DATA7 function"]
+        pub trait AlternateFunction_HS1_DATA7:
+            crate::gpio::InputPin + crate::gpio::OutputPin
+        {
+        }
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS2_DATA0 function"]
+        pub trait AlternateFunction_HS2_DATA0:
+            crate::gpio::InputPin + crate::gpio::OutputPin
+        {
+        }
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS2_DATA1 function"]
+        pub trait AlternateFunction_HS2_DATA1:
+            crate::gpio::InputPin + crate::gpio::OutputPin
+        {
+        }
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS2_DATA2 function"]
+        pub trait AlternateFunction_HS2_DATA2:
+            crate::gpio::InputPin + crate::gpio::OutputPin
+        {
+        }
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS2_DATA3 function"]
+        pub trait AlternateFunction_HS2_DATA3:
+            crate::gpio::InputPin + crate::gpio::OutputPin
+        {
+        }
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the EMAC_TX_CLK function"]
+        pub trait AlternateFunction_EMAC_TX_CLK:
+            crate::gpio::InputPin + crate::gpio::OutputPin
+        {
+        }
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the SD_DATA0 input function"]
-        pub trait InputFunction_SD_DATA0 {}
+        #[doc = "Marker trait for pins that have the EMAC_RXD2 function"]
+        pub trait AlternateFunction_EMAC_RXD2: crate::gpio::InputPin {}
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the SD_DATA1 input function"]
-        pub trait InputFunction_SD_DATA1 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the SD_DATA2 input function"]
-        pub trait InputFunction_SD_DATA2 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the SD_DATA3 input function"]
-        pub trait InputFunction_SD_DATA3 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the HS1_DATA0 input function"]
-        pub trait InputFunction_HS1_DATA0 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the HS1_DATA1 input function"]
-        pub trait InputFunction_HS1_DATA1 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the HS1_DATA2 input function"]
-        pub trait InputFunction_HS1_DATA2 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the HS1_DATA3 input function"]
-        pub trait InputFunction_HS1_DATA3 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the HS1_DATA4 input function"]
-        pub trait InputFunction_HS1_DATA4 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the HS1_DATA5 input function"]
-        pub trait InputFunction_HS1_DATA5 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the HS1_DATA6 input function"]
-        pub trait InputFunction_HS1_DATA6 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the HS1_DATA7 input function"]
-        pub trait InputFunction_HS1_DATA7 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the HS2_DATA0 input function"]
-        pub trait InputFunction_HS2_DATA0 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the HS2_DATA1 input function"]
-        pub trait InputFunction_HS2_DATA1 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the HS2_DATA2 input function"]
-        pub trait InputFunction_HS2_DATA2 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the HS2_DATA3 input function"]
-        pub trait InputFunction_HS2_DATA3 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the EMAC_TX_CLK input function"]
-        pub trait InputFunction_EMAC_TX_CLK {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the EMAC_RXD2 input function"]
-        pub trait InputFunction_EMAC_RXD2 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the EMAC_TX_ER input function"]
-        pub trait InputFunction_EMAC_TX_ER {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the EMAC_RX_CLK input function"]
-        pub trait InputFunction_EMAC_RX_CLK {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the EMAC_RX_ER input function"]
-        pub trait InputFunction_EMAC_RX_ER {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the EMAC_RXD3 input function"]
-        pub trait InputFunction_EMAC_RXD3 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the EMAC_RXD0 input function"]
-        pub trait InputFunction_EMAC_RXD0 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the EMAC_RXD1 input function"]
-        pub trait InputFunction_EMAC_RXD1 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the EMAC_RX_DV input function"]
-        pub trait InputFunction_EMAC_RX_DV {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the MTDI input function"]
-        pub trait InputFunction_MTDI {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the MTCK input function"]
-        pub trait InputFunction_MTCK {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the MTMS input function"]
-        pub trait InputFunction_MTMS {}
-        impl InputFunction_EMAC_TX_CLK for crate::peripherals::GPIO0<'_> {}
-        impl InputFunction_EMAC_RXD2 for crate::peripherals::GPIO1<'_> {}
-        impl InputFunction_HS2_DATA0 for crate::peripherals::GPIO2<'_> {}
-        impl InputFunction_SD_DATA0 for crate::peripherals::GPIO2<'_> {}
-        impl InputFunction_HS2_DATA1 for crate::peripherals::GPIO4<'_> {}
-        impl InputFunction_SD_DATA1 for crate::peripherals::GPIO4<'_> {}
-        impl InputFunction_EMAC_TX_ER for crate::peripherals::GPIO4<'_> {}
-        impl InputFunction_HS1_DATA6 for crate::peripherals::GPIO5<'_> {}
-        impl InputFunction_EMAC_RX_CLK for crate::peripherals::GPIO5<'_> {}
-        impl InputFunction_SD_DATA0 for crate::peripherals::GPIO7<'_> {}
-        impl InputFunction_HS1_DATA0 for crate::peripherals::GPIO7<'_> {}
-        impl InputFunction_SD_DATA1 for crate::peripherals::GPIO8<'_> {}
-        impl InputFunction_HS1_DATA1 for crate::peripherals::GPIO8<'_> {}
-        impl InputFunction_SD_DATA2 for crate::peripherals::GPIO9<'_> {}
-        impl InputFunction_HS1_DATA2 for crate::peripherals::GPIO9<'_> {}
-        impl InputFunction_SD_DATA3 for crate::peripherals::GPIO10<'_> {}
-        impl InputFunction_HS1_DATA3 for crate::peripherals::GPIO10<'_> {}
-        impl InputFunction_SD_CMD for crate::peripherals::GPIO11<'_> {}
-        impl InputFunction_MTDI for crate::peripherals::GPIO12<'_> {}
-        impl InputFunction_HS2_DATA2 for crate::peripherals::GPIO12<'_> {}
-        impl InputFunction_SD_DATA2 for crate::peripherals::GPIO12<'_> {}
-        impl InputFunction_MTCK for crate::peripherals::GPIO13<'_> {}
-        impl InputFunction_HS2_DATA3 for crate::peripherals::GPIO13<'_> {}
-        impl InputFunction_SD_DATA3 for crate::peripherals::GPIO13<'_> {}
-        impl InputFunction_EMAC_RX_ER for crate::peripherals::GPIO13<'_> {}
-        impl InputFunction_MTMS for crate::peripherals::GPIO14<'_> {}
-        impl InputFunction_SD_CMD for crate::peripherals::GPIO15<'_> {}
-        impl InputFunction_EMAC_RXD3 for crate::peripherals::GPIO15<'_> {}
-        impl InputFunction_HS1_DATA4 for crate::peripherals::GPIO16<'_> {}
-        impl InputFunction_HS1_DATA5 for crate::peripherals::GPIO17<'_> {}
-        impl InputFunction_HS1_DATA7 for crate::peripherals::GPIO18<'_> {}
-        impl InputFunction_EMAC_RXD0 for crate::peripherals::GPIO25<'_> {}
-        impl InputFunction_EMAC_RXD1 for crate::peripherals::GPIO26<'_> {}
-        impl InputFunction_EMAC_RX_DV for crate::peripherals::GPIO27<'_> {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the CLK_OUT1 output function"]
-        pub trait OutputFunction_CLK_OUT1 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the CLK_OUT2 output function"]
-        pub trait OutputFunction_CLK_OUT2 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the CLK_OUT3 output function"]
-        pub trait OutputFunction_CLK_OUT3 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the SD_CLK output function"]
-        pub trait OutputFunction_SD_CLK {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the SD_CMD output function"]
-        pub trait OutputFunction_SD_CMD {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the SD_DATA0 output function"]
-        pub trait OutputFunction_SD_DATA0 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the SD_DATA1 output function"]
-        pub trait OutputFunction_SD_DATA1 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the SD_DATA2 output function"]
-        pub trait OutputFunction_SD_DATA2 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the SD_DATA3 output function"]
-        pub trait OutputFunction_SD_DATA3 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the HS1_CLK output function"]
-        pub trait OutputFunction_HS1_CLK {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the HS1_CMD output function"]
-        pub trait OutputFunction_HS1_CMD {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the HS1_DATA0 output function"]
-        pub trait OutputFunction_HS1_DATA0 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the HS1_DATA1 output function"]
-        pub trait OutputFunction_HS1_DATA1 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the HS1_DATA2 output function"]
-        pub trait OutputFunction_HS1_DATA2 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the HS1_DATA3 output function"]
-        pub trait OutputFunction_HS1_DATA3 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the HS1_DATA4 output function"]
-        pub trait OutputFunction_HS1_DATA4 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the HS1_DATA5 output function"]
-        pub trait OutputFunction_HS1_DATA5 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the HS1_DATA6 output function"]
-        pub trait OutputFunction_HS1_DATA6 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the HS1_DATA7 output function"]
-        pub trait OutputFunction_HS1_DATA7 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the HS1_STROBE output function"]
-        pub trait OutputFunction_HS1_STROBE {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the HS2_CLK output function"]
-        pub trait OutputFunction_HS2_CLK {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the HS2_CMD output function"]
-        pub trait OutputFunction_HS2_CMD {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the HS2_DATA0 output function"]
-        pub trait OutputFunction_HS2_DATA0 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the HS2_DATA1 output function"]
-        pub trait OutputFunction_HS2_DATA1 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the HS2_DATA2 output function"]
-        pub trait OutputFunction_HS2_DATA2 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the HS2_DATA3 output function"]
-        pub trait OutputFunction_HS2_DATA3 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the EMAC_TX_CLK output function"]
-        pub trait OutputFunction_EMAC_TX_CLK {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the EMAC_TX_ER output function"]
-        pub trait OutputFunction_EMAC_TX_ER {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the EMAC_TXD3 output function"]
-        pub trait OutputFunction_EMAC_TXD3 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the EMAC_RX_ER output function"]
-        pub trait OutputFunction_EMAC_RX_ER {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the EMAC_TXD2 output function"]
-        pub trait OutputFunction_EMAC_TXD2 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the EMAC_CLK_OUT output function"]
-        pub trait OutputFunction_EMAC_CLK_OUT {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the EMAC_CLK_180 output function"]
-        pub trait OutputFunction_EMAC_CLK_180 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the EMAC_TXD0 output function"]
-        pub trait OutputFunction_EMAC_TXD0 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the EMAC_TX_EN output function"]
-        pub trait OutputFunction_EMAC_TX_EN {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the EMAC_TXD1 output function"]
-        pub trait OutputFunction_EMAC_TXD1 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the MTDO output function"]
-        pub trait OutputFunction_MTDO {}
-        impl OutputFunction_CLK_OUT1 for crate::peripherals::GPIO0<'_> {}
-        impl OutputFunction_EMAC_TX_CLK for crate::peripherals::GPIO0<'_> {}
-        impl OutputFunction_CLK_OUT3 for crate::peripherals::GPIO1<'_> {}
-        impl OutputFunction_HS2_DATA0 for crate::peripherals::GPIO2<'_> {}
-        impl OutputFunction_SD_DATA0 for crate::peripherals::GPIO2<'_> {}
-        impl OutputFunction_CLK_OUT2 for crate::peripherals::GPIO3<'_> {}
-        impl OutputFunction_HS2_DATA1 for crate::peripherals::GPIO4<'_> {}
-        impl OutputFunction_SD_DATA1 for crate::peripherals::GPIO4<'_> {}
-        impl OutputFunction_EMAC_TX_ER for crate::peripherals::GPIO4<'_> {}
-        impl OutputFunction_HS1_DATA6 for crate::peripherals::GPIO5<'_> {}
-        impl OutputFunction_SD_CLK for crate::peripherals::GPIO6<'_> {}
-        impl OutputFunction_HS1_CLK for crate::peripherals::GPIO6<'_> {}
-        impl OutputFunction_SD_DATA0 for crate::peripherals::GPIO7<'_> {}
-        impl OutputFunction_HS1_DATA0 for crate::peripherals::GPIO7<'_> {}
-        impl OutputFunction_SD_DATA1 for crate::peripherals::GPIO8<'_> {}
-        impl OutputFunction_HS1_DATA1 for crate::peripherals::GPIO8<'_> {}
-        impl OutputFunction_SD_DATA2 for crate::peripherals::GPIO9<'_> {}
-        impl OutputFunction_HS1_DATA2 for crate::peripherals::GPIO9<'_> {}
-        impl OutputFunction_SD_DATA3 for crate::peripherals::GPIO10<'_> {}
-        impl OutputFunction_HS1_DATA3 for crate::peripherals::GPIO10<'_> {}
-        impl OutputFunction_SD_CMD for crate::peripherals::GPIO11<'_> {}
-        impl OutputFunction_HS1_CMD for crate::peripherals::GPIO11<'_> {}
-        impl OutputFunction_HS2_DATA2 for crate::peripherals::GPIO12<'_> {}
-        impl OutputFunction_SD_DATA2 for crate::peripherals::GPIO12<'_> {}
-        impl OutputFunction_EMAC_TXD3 for crate::peripherals::GPIO12<'_> {}
-        impl OutputFunction_HS2_DATA3 for crate::peripherals::GPIO13<'_> {}
-        impl OutputFunction_SD_DATA3 for crate::peripherals::GPIO13<'_> {}
-        impl OutputFunction_EMAC_RX_ER for crate::peripherals::GPIO13<'_> {}
-        impl OutputFunction_HS2_CLK for crate::peripherals::GPIO14<'_> {}
-        impl OutputFunction_SD_CLK for crate::peripherals::GPIO14<'_> {}
-        impl OutputFunction_EMAC_TXD2 for crate::peripherals::GPIO14<'_> {}
-        impl OutputFunction_MTDO for crate::peripherals::GPIO15<'_> {}
-        impl OutputFunction_HS2_CMD for crate::peripherals::GPIO15<'_> {}
-        impl OutputFunction_SD_CMD for crate::peripherals::GPIO15<'_> {}
-        impl OutputFunction_HS1_DATA4 for crate::peripherals::GPIO16<'_> {}
-        impl OutputFunction_EMAC_CLK_OUT for crate::peripherals::GPIO16<'_> {}
-        impl OutputFunction_HS1_DATA5 for crate::peripherals::GPIO17<'_> {}
-        impl OutputFunction_EMAC_CLK_180 for crate::peripherals::GPIO17<'_> {}
-        impl OutputFunction_HS1_DATA7 for crate::peripherals::GPIO18<'_> {}
-        impl OutputFunction_EMAC_TXD0 for crate::peripherals::GPIO19<'_> {}
-        impl OutputFunction_EMAC_TX_EN for crate::peripherals::GPIO21<'_> {}
-        impl OutputFunction_EMAC_TXD1 for crate::peripherals::GPIO22<'_> {}
-        impl OutputFunction_HS1_STROBE for crate::peripherals::GPIO23<'_> {}
+        #[doc = "Marker trait for pins that have the EMAC_TX_ER function"]
+        pub trait AlternateFunction_EMAC_TX_ER:
+            crate::gpio::InputPin + crate::gpio::OutputPin
+        {
+        }
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the EMAC_RX_CLK function"]
+        pub trait AlternateFunction_EMAC_RX_CLK: crate::gpio::InputPin {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the EMAC_RX_ER function"]
+        pub trait AlternateFunction_EMAC_RX_ER:
+            crate::gpio::InputPin + crate::gpio::OutputPin
+        {
+        }
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the EMAC_RXD3 function"]
+        pub trait AlternateFunction_EMAC_RXD3: crate::gpio::InputPin {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the EMAC_RXD0 function"]
+        pub trait AlternateFunction_EMAC_RXD0: crate::gpio::InputPin {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the EMAC_RXD1 function"]
+        pub trait AlternateFunction_EMAC_RXD1: crate::gpio::InputPin {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the EMAC_RX_DV function"]
+        pub trait AlternateFunction_EMAC_RX_DV: crate::gpio::InputPin {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the MTDI function"]
+        pub trait AlternateFunction_MTDI: crate::gpio::InputPin {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the MTCK function"]
+        pub trait AlternateFunction_MTCK: crate::gpio::InputPin {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the MTMS function"]
+        pub trait AlternateFunction_MTMS: crate::gpio::InputPin {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the CLK_OUT1 function"]
+        pub trait AlternateFunction_CLK_OUT1: crate::gpio::OutputPin {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the CLK_OUT2 function"]
+        pub trait AlternateFunction_CLK_OUT2: crate::gpio::OutputPin {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the CLK_OUT3 function"]
+        pub trait AlternateFunction_CLK_OUT3: crate::gpio::OutputPin {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SD_CLK function"]
+        pub trait AlternateFunction_SD_CLK: crate::gpio::OutputPin {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS1_CLK function"]
+        pub trait AlternateFunction_HS1_CLK: crate::gpio::OutputPin {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS1_CMD function"]
+        pub trait AlternateFunction_HS1_CMD: crate::gpio::OutputPin {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS1_STROBE function"]
+        pub trait AlternateFunction_HS1_STROBE: crate::gpio::OutputPin {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS2_CLK function"]
+        pub trait AlternateFunction_HS2_CLK: crate::gpio::OutputPin {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the HS2_CMD function"]
+        pub trait AlternateFunction_HS2_CMD: crate::gpio::OutputPin {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the EMAC_TXD3 function"]
+        pub trait AlternateFunction_EMAC_TXD3: crate::gpio::OutputPin {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the EMAC_TXD2 function"]
+        pub trait AlternateFunction_EMAC_TXD2: crate::gpio::OutputPin {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the EMAC_CLK_OUT function"]
+        pub trait AlternateFunction_EMAC_CLK_OUT: crate::gpio::OutputPin {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the EMAC_CLK_180 function"]
+        pub trait AlternateFunction_EMAC_CLK_180: crate::gpio::OutputPin {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the EMAC_TXD0 function"]
+        pub trait AlternateFunction_EMAC_TXD0: crate::gpio::OutputPin {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the EMAC_TX_EN function"]
+        pub trait AlternateFunction_EMAC_TX_EN: crate::gpio::OutputPin {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the EMAC_TXD1 function"]
+        pub trait AlternateFunction_EMAC_TXD1: crate::gpio::OutputPin {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the MTDO function"]
+        pub trait AlternateFunction_MTDO: crate::gpio::OutputPin {}
+        impl AlternateFunction_CLK_OUT1 for crate::peripherals::GPIO0<'_> {}
+        impl AlternateFunction_EMAC_TX_CLK for crate::peripherals::GPIO0<'_> {}
+        impl AlternateFunction_CLK_OUT3 for crate::peripherals::GPIO1<'_> {}
+        impl AlternateFunction_EMAC_RXD2 for crate::peripherals::GPIO1<'_> {}
+        impl AlternateFunction_HS2_DATA0 for crate::peripherals::GPIO2<'_> {}
+        impl AlternateFunction_SD_DATA0 for crate::peripherals::GPIO2<'_> {}
+        impl AlternateFunction_CLK_OUT2 for crate::peripherals::GPIO3<'_> {}
+        impl AlternateFunction_HS2_DATA1 for crate::peripherals::GPIO4<'_> {}
+        impl AlternateFunction_SD_DATA1 for crate::peripherals::GPIO4<'_> {}
+        impl AlternateFunction_EMAC_TX_ER for crate::peripherals::GPIO4<'_> {}
+        impl AlternateFunction_HS1_DATA6 for crate::peripherals::GPIO5<'_> {}
+        impl AlternateFunction_EMAC_RX_CLK for crate::peripherals::GPIO5<'_> {}
+        impl AlternateFunction_SD_CLK for crate::peripherals::GPIO6<'_> {}
+        impl AlternateFunction_HS1_CLK for crate::peripherals::GPIO6<'_> {}
+        impl AlternateFunction_SD_DATA0 for crate::peripherals::GPIO7<'_> {}
+        impl AlternateFunction_HS1_DATA0 for crate::peripherals::GPIO7<'_> {}
+        impl AlternateFunction_SD_DATA1 for crate::peripherals::GPIO8<'_> {}
+        impl AlternateFunction_HS1_DATA1 for crate::peripherals::GPIO8<'_> {}
+        impl AlternateFunction_SD_DATA2 for crate::peripherals::GPIO9<'_> {}
+        impl AlternateFunction_HS1_DATA2 for crate::peripherals::GPIO9<'_> {}
+        impl AlternateFunction_SD_DATA3 for crate::peripherals::GPIO10<'_> {}
+        impl AlternateFunction_HS1_DATA3 for crate::peripherals::GPIO10<'_> {}
+        impl AlternateFunction_SD_CMD for crate::peripherals::GPIO11<'_> {}
+        impl AlternateFunction_HS1_CMD for crate::peripherals::GPIO11<'_> {}
+        impl AlternateFunction_MTDI for crate::peripherals::GPIO12<'_> {}
+        impl AlternateFunction_HS2_DATA2 for crate::peripherals::GPIO12<'_> {}
+        impl AlternateFunction_SD_DATA2 for crate::peripherals::GPIO12<'_> {}
+        impl AlternateFunction_EMAC_TXD3 for crate::peripherals::GPIO12<'_> {}
+        impl AlternateFunction_MTCK for crate::peripherals::GPIO13<'_> {}
+        impl AlternateFunction_HS2_DATA3 for crate::peripherals::GPIO13<'_> {}
+        impl AlternateFunction_SD_DATA3 for crate::peripherals::GPIO13<'_> {}
+        impl AlternateFunction_EMAC_RX_ER for crate::peripherals::GPIO13<'_> {}
+        impl AlternateFunction_MTMS for crate::peripherals::GPIO14<'_> {}
+        impl AlternateFunction_HS2_CLK for crate::peripherals::GPIO14<'_> {}
+        impl AlternateFunction_SD_CLK for crate::peripherals::GPIO14<'_> {}
+        impl AlternateFunction_EMAC_TXD2 for crate::peripherals::GPIO14<'_> {}
+        impl AlternateFunction_MTDO for crate::peripherals::GPIO15<'_> {}
+        impl AlternateFunction_HS2_CMD for crate::peripherals::GPIO15<'_> {}
+        impl AlternateFunction_SD_CMD for crate::peripherals::GPIO15<'_> {}
+        impl AlternateFunction_EMAC_RXD3 for crate::peripherals::GPIO15<'_> {}
+        impl AlternateFunction_HS1_DATA4 for crate::peripherals::GPIO16<'_> {}
+        impl AlternateFunction_EMAC_CLK_OUT for crate::peripherals::GPIO16<'_> {}
+        impl AlternateFunction_HS1_DATA5 for crate::peripherals::GPIO17<'_> {}
+        impl AlternateFunction_EMAC_CLK_180 for crate::peripherals::GPIO17<'_> {}
+        impl AlternateFunction_HS1_DATA7 for crate::peripherals::GPIO18<'_> {}
+        impl AlternateFunction_EMAC_TXD0 for crate::peripherals::GPIO19<'_> {}
+        impl AlternateFunction_EMAC_TX_EN for crate::peripherals::GPIO21<'_> {}
+        impl AlternateFunction_EMAC_TXD1 for crate::peripherals::GPIO22<'_> {}
+        impl AlternateFunction_HS1_STROBE for crate::peripherals::GPIO23<'_> {}
+        impl AlternateFunction_EMAC_RXD0 for crate::peripherals::GPIO25<'_> {}
+        impl AlternateFunction_EMAC_RXD1 for crate::peripherals::GPIO26<'_> {}
+        impl AlternateFunction_EMAC_RX_DV for crate::peripherals::GPIO27<'_> {}
     };
 }

--- a/esp-metadata-generated/src/_generated_esp32c2.rs
+++ b/esp-metadata-generated/src/_generated_esp32c2.rs
@@ -742,3 +742,25 @@ macro_rules! define_io_mux_reg {
         }
     };
 }
+#[macro_export]
+#[doc(hidden)]
+macro_rules! implement_alternate_function_markers {
+    () => {
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the MTCK input function"]
+        pub trait InputFunction_MTCK {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the MTMS input function"]
+        pub trait InputFunction_MTMS {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the MTDI input function"]
+        pub trait InputFunction_MTDI {}
+        impl InputFunction_MTMS for crate::peripherals::GPIO4<'_> {}
+        impl InputFunction_MTDI for crate::peripherals::GPIO5<'_> {}
+        impl InputFunction_MTCK for crate::peripherals::GPIO6<'_> {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the MTDO output function"]
+        pub trait OutputFunction_MTDO {}
+        impl OutputFunction_MTDO for crate::peripherals::GPIO7<'_> {}
+    };
+}

--- a/esp-metadata-generated/src/_generated_esp32c2.rs
+++ b/esp-metadata-generated/src/_generated_esp32c2.rs
@@ -747,20 +747,20 @@ macro_rules! define_io_mux_reg {
 macro_rules! implement_alternate_function_markers {
     () => {
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the MTCK input function"]
-        pub trait InputFunction_MTCK {}
+        #[doc = "Marker trait for pins that have the MTCK function"]
+        pub trait AlternateFunction_MTCK: crate::gpio::InputPin {}
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the MTMS input function"]
-        pub trait InputFunction_MTMS {}
+        #[doc = "Marker trait for pins that have the MTMS function"]
+        pub trait AlternateFunction_MTMS: crate::gpio::InputPin {}
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the MTDI input function"]
-        pub trait InputFunction_MTDI {}
-        impl InputFunction_MTMS for crate::peripherals::GPIO4<'_> {}
-        impl InputFunction_MTDI for crate::peripherals::GPIO5<'_> {}
-        impl InputFunction_MTCK for crate::peripherals::GPIO6<'_> {}
+        #[doc = "Marker trait for pins that have the MTDI function"]
+        pub trait AlternateFunction_MTDI: crate::gpio::InputPin {}
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the MTDO output function"]
-        pub trait OutputFunction_MTDO {}
-        impl OutputFunction_MTDO for crate::peripherals::GPIO7<'_> {}
+        #[doc = "Marker trait for pins that have the MTDO function"]
+        pub trait AlternateFunction_MTDO: crate::gpio::OutputPin {}
+        impl AlternateFunction_MTMS for crate::peripherals::GPIO4<'_> {}
+        impl AlternateFunction_MTDI for crate::peripherals::GPIO5<'_> {}
+        impl AlternateFunction_MTCK for crate::peripherals::GPIO6<'_> {}
+        impl AlternateFunction_MTDO for crate::peripherals::GPIO7<'_> {}
     };
 }

--- a/esp-metadata-generated/src/_generated_esp32c3.rs
+++ b/esp-metadata-generated/src/_generated_esp32c3.rs
@@ -819,20 +819,20 @@ macro_rules! define_io_mux_reg {
 macro_rules! implement_alternate_function_markers {
     () => {
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the MTCK input function"]
-        pub trait InputFunction_MTCK {}
+        #[doc = "Marker trait for pins that have the MTCK function"]
+        pub trait AlternateFunction_MTCK: crate::gpio::InputPin {}
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the MTMS input function"]
-        pub trait InputFunction_MTMS {}
+        #[doc = "Marker trait for pins that have the MTMS function"]
+        pub trait AlternateFunction_MTMS: crate::gpio::InputPin {}
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the MTDI input function"]
-        pub trait InputFunction_MTDI {}
-        impl InputFunction_MTMS for crate::peripherals::GPIO4<'_> {}
-        impl InputFunction_MTDI for crate::peripherals::GPIO5<'_> {}
-        impl InputFunction_MTCK for crate::peripherals::GPIO6<'_> {}
+        #[doc = "Marker trait for pins that have the MTDI function"]
+        pub trait AlternateFunction_MTDI: crate::gpio::InputPin {}
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the MTDO output function"]
-        pub trait OutputFunction_MTDO {}
-        impl OutputFunction_MTDO for crate::peripherals::GPIO7<'_> {}
+        #[doc = "Marker trait for pins that have the MTDO function"]
+        pub trait AlternateFunction_MTDO: crate::gpio::OutputPin {}
+        impl AlternateFunction_MTMS for crate::peripherals::GPIO4<'_> {}
+        impl AlternateFunction_MTDI for crate::peripherals::GPIO5<'_> {}
+        impl AlternateFunction_MTCK for crate::peripherals::GPIO6<'_> {}
+        impl AlternateFunction_MTDO for crate::peripherals::GPIO7<'_> {}
     };
 }

--- a/esp-metadata-generated/src/_generated_esp32c3.rs
+++ b/esp-metadata-generated/src/_generated_esp32c3.rs
@@ -814,3 +814,25 @@ macro_rules! define_io_mux_reg {
         }
     };
 }
+#[macro_export]
+#[doc(hidden)]
+macro_rules! implement_alternate_function_markers {
+    () => {
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the MTCK input function"]
+        pub trait InputFunction_MTCK {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the MTMS input function"]
+        pub trait InputFunction_MTMS {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the MTDI input function"]
+        pub trait InputFunction_MTDI {}
+        impl InputFunction_MTMS for crate::peripherals::GPIO4<'_> {}
+        impl InputFunction_MTDI for crate::peripherals::GPIO5<'_> {}
+        impl InputFunction_MTCK for crate::peripherals::GPIO6<'_> {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the MTDO output function"]
+        pub trait OutputFunction_MTDO {}
+        impl OutputFunction_MTDO for crate::peripherals::GPIO7<'_> {}
+    };
+}

--- a/esp-metadata-generated/src/_generated_esp32c6.rs
+++ b/esp-metadata-generated/src/_generated_esp32c6.rs
@@ -1112,64 +1112,59 @@ macro_rules! define_io_mux_reg {
 macro_rules! implement_alternate_function_markers {
     () => {
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the SDIO_CMD input function"]
-        pub trait InputFunction_SDIO_CMD {}
+        #[doc = "Marker trait for pins that have the SDIO_CMD function"]
+        pub trait AlternateFunction_SDIO_CMD:
+            crate::gpio::InputPin + crate::gpio::OutputPin
+        {
+        }
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the SDIO_DATA0 input function"]
-        pub trait InputFunction_SDIO_DATA0 {}
+        #[doc = "Marker trait for pins that have the SDIO_DATA0 function"]
+        pub trait AlternateFunction_SDIO_DATA0:
+            crate::gpio::InputPin + crate::gpio::OutputPin
+        {
+        }
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the SDIO_DATA1 input function"]
-        pub trait InputFunction_SDIO_DATA1 {}
+        #[doc = "Marker trait for pins that have the SDIO_DATA1 function"]
+        pub trait AlternateFunction_SDIO_DATA1:
+            crate::gpio::InputPin + crate::gpio::OutputPin
+        {
+        }
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the SDIO_DATA2 input function"]
-        pub trait InputFunction_SDIO_DATA2 {}
+        #[doc = "Marker trait for pins that have the SDIO_DATA2 function"]
+        pub trait AlternateFunction_SDIO_DATA2:
+            crate::gpio::InputPin + crate::gpio::OutputPin
+        {
+        }
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the SDIO_DATA3 input function"]
-        pub trait InputFunction_SDIO_DATA3 {}
+        #[doc = "Marker trait for pins that have the SDIO_DATA3 function"]
+        pub trait AlternateFunction_SDIO_DATA3:
+            crate::gpio::InputPin + crate::gpio::OutputPin
+        {
+        }
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the MTDI input function"]
-        pub trait InputFunction_MTDI {}
+        #[doc = "Marker trait for pins that have the MTDI function"]
+        pub trait AlternateFunction_MTDI: crate::gpio::InputPin {}
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the MTCK input function"]
-        pub trait InputFunction_MTCK {}
+        #[doc = "Marker trait for pins that have the MTCK function"]
+        pub trait AlternateFunction_MTCK: crate::gpio::InputPin {}
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the MTMS input function"]
-        pub trait InputFunction_MTMS {}
-        impl InputFunction_MTMS for crate::peripherals::GPIO4<'_> {}
-        impl InputFunction_MTDI for crate::peripherals::GPIO5<'_> {}
-        impl InputFunction_MTCK for crate::peripherals::GPIO6<'_> {}
-        impl InputFunction_SDIO_CMD for crate::peripherals::GPIO18<'_> {}
-        impl InputFunction_SDIO_DATA0 for crate::peripherals::GPIO20<'_> {}
-        impl InputFunction_SDIO_DATA1 for crate::peripherals::GPIO21<'_> {}
-        impl InputFunction_SDIO_DATA2 for crate::peripherals::GPIO22<'_> {}
-        impl InputFunction_SDIO_DATA3 for crate::peripherals::GPIO23<'_> {}
+        #[doc = "Marker trait for pins that have the MTMS function"]
+        pub trait AlternateFunction_MTMS: crate::gpio::InputPin {}
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the SDIO_CLK output function"]
-        pub trait OutputFunction_SDIO_CLK {}
+        #[doc = "Marker trait for pins that have the SDIO_CLK function"]
+        pub trait AlternateFunction_SDIO_CLK: crate::gpio::OutputPin {}
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the SDIO_CMD output function"]
-        pub trait OutputFunction_SDIO_CMD {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the SDIO_DATA0 output function"]
-        pub trait OutputFunction_SDIO_DATA0 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the SDIO_DATA1 output function"]
-        pub trait OutputFunction_SDIO_DATA1 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the SDIO_DATA2 output function"]
-        pub trait OutputFunction_SDIO_DATA2 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the SDIO_DATA3 output function"]
-        pub trait OutputFunction_SDIO_DATA3 {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the MTDO output function"]
-        pub trait OutputFunction_MTDO {}
-        impl OutputFunction_MTDO for crate::peripherals::GPIO7<'_> {}
-        impl OutputFunction_SDIO_CMD for crate::peripherals::GPIO18<'_> {}
-        impl OutputFunction_SDIO_CLK for crate::peripherals::GPIO19<'_> {}
-        impl OutputFunction_SDIO_DATA0 for crate::peripherals::GPIO20<'_> {}
-        impl OutputFunction_SDIO_DATA1 for crate::peripherals::GPIO21<'_> {}
-        impl OutputFunction_SDIO_DATA2 for crate::peripherals::GPIO22<'_> {}
-        impl OutputFunction_SDIO_DATA3 for crate::peripherals::GPIO23<'_> {}
+        #[doc = "Marker trait for pins that have the MTDO function"]
+        pub trait AlternateFunction_MTDO: crate::gpio::OutputPin {}
+        impl AlternateFunction_MTMS for crate::peripherals::GPIO4<'_> {}
+        impl AlternateFunction_MTDI for crate::peripherals::GPIO5<'_> {}
+        impl AlternateFunction_MTCK for crate::peripherals::GPIO6<'_> {}
+        impl AlternateFunction_MTDO for crate::peripherals::GPIO7<'_> {}
+        impl AlternateFunction_SDIO_CMD for crate::peripherals::GPIO18<'_> {}
+        impl AlternateFunction_SDIO_CLK for crate::peripherals::GPIO19<'_> {}
+        impl AlternateFunction_SDIO_DATA0 for crate::peripherals::GPIO20<'_> {}
+        impl AlternateFunction_SDIO_DATA1 for crate::peripherals::GPIO21<'_> {}
+        impl AlternateFunction_SDIO_DATA2 for crate::peripherals::GPIO22<'_> {}
+        impl AlternateFunction_SDIO_DATA3 for crate::peripherals::GPIO23<'_> {}
     };
 }

--- a/esp-metadata-generated/src/_generated_esp32c6.rs
+++ b/esp-metadata-generated/src/_generated_esp32c6.rs
@@ -1107,3 +1107,69 @@ macro_rules! define_io_mux_reg {
         }
     };
 }
+#[macro_export]
+#[doc(hidden)]
+macro_rules! implement_alternate_function_markers {
+    () => {
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SDIO_CMD input function"]
+        pub trait InputFunction_SDIO_CMD {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SDIO_DATA0 input function"]
+        pub trait InputFunction_SDIO_DATA0 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SDIO_DATA1 input function"]
+        pub trait InputFunction_SDIO_DATA1 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SDIO_DATA2 input function"]
+        pub trait InputFunction_SDIO_DATA2 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SDIO_DATA3 input function"]
+        pub trait InputFunction_SDIO_DATA3 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the MTDI input function"]
+        pub trait InputFunction_MTDI {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the MTCK input function"]
+        pub trait InputFunction_MTCK {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the MTMS input function"]
+        pub trait InputFunction_MTMS {}
+        impl InputFunction_MTMS for crate::peripherals::GPIO4<'_> {}
+        impl InputFunction_MTDI for crate::peripherals::GPIO5<'_> {}
+        impl InputFunction_MTCK for crate::peripherals::GPIO6<'_> {}
+        impl InputFunction_SDIO_CMD for crate::peripherals::GPIO18<'_> {}
+        impl InputFunction_SDIO_DATA0 for crate::peripherals::GPIO20<'_> {}
+        impl InputFunction_SDIO_DATA1 for crate::peripherals::GPIO21<'_> {}
+        impl InputFunction_SDIO_DATA2 for crate::peripherals::GPIO22<'_> {}
+        impl InputFunction_SDIO_DATA3 for crate::peripherals::GPIO23<'_> {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SDIO_CLK output function"]
+        pub trait OutputFunction_SDIO_CLK {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SDIO_CMD output function"]
+        pub trait OutputFunction_SDIO_CMD {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SDIO_DATA0 output function"]
+        pub trait OutputFunction_SDIO_DATA0 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SDIO_DATA1 output function"]
+        pub trait OutputFunction_SDIO_DATA1 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SDIO_DATA2 output function"]
+        pub trait OutputFunction_SDIO_DATA2 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SDIO_DATA3 output function"]
+        pub trait OutputFunction_SDIO_DATA3 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the MTDO output function"]
+        pub trait OutputFunction_MTDO {}
+        impl OutputFunction_MTDO for crate::peripherals::GPIO7<'_> {}
+        impl OutputFunction_SDIO_CMD for crate::peripherals::GPIO18<'_> {}
+        impl OutputFunction_SDIO_CLK for crate::peripherals::GPIO19<'_> {}
+        impl OutputFunction_SDIO_DATA0 for crate::peripherals::GPIO20<'_> {}
+        impl OutputFunction_SDIO_DATA1 for crate::peripherals::GPIO21<'_> {}
+        impl OutputFunction_SDIO_DATA2 for crate::peripherals::GPIO22<'_> {}
+        impl OutputFunction_SDIO_DATA3 for crate::peripherals::GPIO23<'_> {}
+    };
+}

--- a/esp-metadata-generated/src/_generated_esp32h2.rs
+++ b/esp-metadata-generated/src/_generated_esp32h2.rs
@@ -851,20 +851,20 @@ macro_rules! define_io_mux_reg {
 macro_rules! implement_alternate_function_markers {
     () => {
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the MTDI input function"]
-        pub trait InputFunction_MTDI {}
+        #[doc = "Marker trait for pins that have the MTDI function"]
+        pub trait AlternateFunction_MTDI: crate::gpio::InputPin {}
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the MTCK input function"]
-        pub trait InputFunction_MTCK {}
+        #[doc = "Marker trait for pins that have the MTCK function"]
+        pub trait AlternateFunction_MTCK: crate::gpio::InputPin {}
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the MTMS input function"]
-        pub trait InputFunction_MTMS {}
-        impl InputFunction_MTMS for crate::peripherals::GPIO2<'_> {}
-        impl InputFunction_MTDI for crate::peripherals::GPIO3<'_> {}
-        impl InputFunction_MTCK for crate::peripherals::GPIO4<'_> {}
+        #[doc = "Marker trait for pins that have the MTMS function"]
+        pub trait AlternateFunction_MTMS: crate::gpio::InputPin {}
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the MTDO output function"]
-        pub trait OutputFunction_MTDO {}
-        impl OutputFunction_MTDO for crate::peripherals::GPIO5<'_> {}
+        #[doc = "Marker trait for pins that have the MTDO function"]
+        pub trait AlternateFunction_MTDO: crate::gpio::OutputPin {}
+        impl AlternateFunction_MTMS for crate::peripherals::GPIO2<'_> {}
+        impl AlternateFunction_MTDI for crate::peripherals::GPIO3<'_> {}
+        impl AlternateFunction_MTCK for crate::peripherals::GPIO4<'_> {}
+        impl AlternateFunction_MTDO for crate::peripherals::GPIO5<'_> {}
     };
 }

--- a/esp-metadata-generated/src/_generated_esp32h2.rs
+++ b/esp-metadata-generated/src/_generated_esp32h2.rs
@@ -846,3 +846,25 @@ macro_rules! define_io_mux_reg {
         }
     };
 }
+#[macro_export]
+#[doc(hidden)]
+macro_rules! implement_alternate_function_markers {
+    () => {
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the MTDI input function"]
+        pub trait InputFunction_MTDI {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the MTCK input function"]
+        pub trait InputFunction_MTCK {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the MTMS input function"]
+        pub trait InputFunction_MTMS {}
+        impl InputFunction_MTMS for crate::peripherals::GPIO2<'_> {}
+        impl InputFunction_MTDI for crate::peripherals::GPIO3<'_> {}
+        impl InputFunction_MTCK for crate::peripherals::GPIO4<'_> {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the MTDO output function"]
+        pub trait OutputFunction_MTDO {}
+        impl OutputFunction_MTDO for crate::peripherals::GPIO5<'_> {}
+    };
+}

--- a/esp-metadata-generated/src/_generated_esp32s2.rs
+++ b/esp-metadata-generated/src/_generated_esp32s2.rs
@@ -1382,37 +1382,37 @@ macro_rules! define_io_mux_reg {
 macro_rules! implement_alternate_function_markers {
     () => {
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the MTDI input function"]
-        pub trait InputFunction_MTDI {}
+        #[doc = "Marker trait for pins that have the MTDI function"]
+        pub trait AlternateFunction_MTDI: crate::gpio::InputPin {}
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the MTCK input function"]
-        pub trait InputFunction_MTCK {}
+        #[doc = "Marker trait for pins that have the MTCK function"]
+        pub trait AlternateFunction_MTCK: crate::gpio::InputPin {}
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the MTMS input function"]
-        pub trait InputFunction_MTMS {}
-        impl InputFunction_MTCK for crate::peripherals::GPIO39<'_> {}
-        impl InputFunction_MTDI for crate::peripherals::GPIO41<'_> {}
-        impl InputFunction_MTMS for crate::peripherals::GPIO42<'_> {}
+        #[doc = "Marker trait for pins that have the MTMS function"]
+        pub trait AlternateFunction_MTMS: crate::gpio::InputPin {}
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the CLK_OUT1 output function"]
-        pub trait OutputFunction_CLK_OUT1 {}
+        #[doc = "Marker trait for pins that have the CLK_OUT1 function"]
+        pub trait AlternateFunction_CLK_OUT1: crate::gpio::OutputPin {}
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the CLK_OUT2 output function"]
-        pub trait OutputFunction_CLK_OUT2 {}
+        #[doc = "Marker trait for pins that have the CLK_OUT2 function"]
+        pub trait AlternateFunction_CLK_OUT2: crate::gpio::OutputPin {}
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the CLK_OUT3 output function"]
-        pub trait OutputFunction_CLK_OUT3 {}
+        #[doc = "Marker trait for pins that have the CLK_OUT3 function"]
+        pub trait AlternateFunction_CLK_OUT3: crate::gpio::OutputPin {}
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the MTDO output function"]
-        pub trait OutputFunction_MTDO {}
-        impl OutputFunction_CLK_OUT3 for crate::peripherals::GPIO18<'_> {}
-        impl OutputFunction_CLK_OUT2 for crate::peripherals::GPIO19<'_> {}
-        impl OutputFunction_CLK_OUT1 for crate::peripherals::GPIO20<'_> {}
-        impl OutputFunction_CLK_OUT3 for crate::peripherals::GPIO39<'_> {}
-        impl OutputFunction_MTDO for crate::peripherals::GPIO40<'_> {}
-        impl OutputFunction_CLK_OUT2 for crate::peripherals::GPIO40<'_> {}
-        impl OutputFunction_CLK_OUT1 for crate::peripherals::GPIO41<'_> {}
-        impl OutputFunction_CLK_OUT1 for crate::peripherals::GPIO43<'_> {}
-        impl OutputFunction_CLK_OUT2 for crate::peripherals::GPIO44<'_> {}
+        #[doc = "Marker trait for pins that have the MTDO function"]
+        pub trait AlternateFunction_MTDO: crate::gpio::OutputPin {}
+        impl AlternateFunction_CLK_OUT3 for crate::peripherals::GPIO18<'_> {}
+        impl AlternateFunction_CLK_OUT2 for crate::peripherals::GPIO19<'_> {}
+        impl AlternateFunction_CLK_OUT1 for crate::peripherals::GPIO20<'_> {}
+        impl AlternateFunction_MTCK for crate::peripherals::GPIO39<'_> {}
+        impl AlternateFunction_CLK_OUT3 for crate::peripherals::GPIO39<'_> {}
+        impl AlternateFunction_MTDO for crate::peripherals::GPIO40<'_> {}
+        impl AlternateFunction_CLK_OUT2 for crate::peripherals::GPIO40<'_> {}
+        impl AlternateFunction_MTDI for crate::peripherals::GPIO41<'_> {}
+        impl AlternateFunction_CLK_OUT1 for crate::peripherals::GPIO41<'_> {}
+        impl AlternateFunction_MTMS for crate::peripherals::GPIO42<'_> {}
+        impl AlternateFunction_CLK_OUT1 for crate::peripherals::GPIO43<'_> {}
+        impl AlternateFunction_CLK_OUT2 for crate::peripherals::GPIO44<'_> {}
     };
 }

--- a/esp-metadata-generated/src/_generated_esp32s2.rs
+++ b/esp-metadata-generated/src/_generated_esp32s2.rs
@@ -1377,3 +1377,42 @@ macro_rules! define_io_mux_reg {
         }
     };
 }
+#[macro_export]
+#[doc(hidden)]
+macro_rules! implement_alternate_function_markers {
+    () => {
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the MTDI input function"]
+        pub trait InputFunction_MTDI {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the MTCK input function"]
+        pub trait InputFunction_MTCK {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the MTMS input function"]
+        pub trait InputFunction_MTMS {}
+        impl InputFunction_MTCK for crate::peripherals::GPIO39<'_> {}
+        impl InputFunction_MTDI for crate::peripherals::GPIO41<'_> {}
+        impl InputFunction_MTMS for crate::peripherals::GPIO42<'_> {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the CLK_OUT1 output function"]
+        pub trait OutputFunction_CLK_OUT1 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the CLK_OUT2 output function"]
+        pub trait OutputFunction_CLK_OUT2 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the CLK_OUT3 output function"]
+        pub trait OutputFunction_CLK_OUT3 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the MTDO output function"]
+        pub trait OutputFunction_MTDO {}
+        impl OutputFunction_CLK_OUT3 for crate::peripherals::GPIO18<'_> {}
+        impl OutputFunction_CLK_OUT2 for crate::peripherals::GPIO19<'_> {}
+        impl OutputFunction_CLK_OUT1 for crate::peripherals::GPIO20<'_> {}
+        impl OutputFunction_CLK_OUT3 for crate::peripherals::GPIO39<'_> {}
+        impl OutputFunction_MTDO for crate::peripherals::GPIO40<'_> {}
+        impl OutputFunction_CLK_OUT2 for crate::peripherals::GPIO40<'_> {}
+        impl OutputFunction_CLK_OUT1 for crate::peripherals::GPIO41<'_> {}
+        impl OutputFunction_CLK_OUT1 for crate::peripherals::GPIO43<'_> {}
+        impl OutputFunction_CLK_OUT2 for crate::peripherals::GPIO44<'_> {}
+    };
+}

--- a/esp-metadata-generated/src/_generated_esp32s3.rs
+++ b/esp-metadata-generated/src/_generated_esp32s3.rs
@@ -1589,3 +1589,86 @@ macro_rules! define_io_mux_reg {
         }
     };
 }
+#[macro_export]
+#[doc(hidden)]
+macro_rules! implement_alternate_function_markers {
+    () => {
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SPIIO4 input function"]
+        pub trait InputFunction_SPIIO4 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SPIIO5 input function"]
+        pub trait InputFunction_SPIIO5 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SPIIO6 input function"]
+        pub trait InputFunction_SPIIO6 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SPIIO7 input function"]
+        pub trait InputFunction_SPIIO7 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the MTDI input function"]
+        pub trait InputFunction_MTDI {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the MTCK input function"]
+        pub trait InputFunction_MTCK {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the MTMS input function"]
+        pub trait InputFunction_MTMS {}
+        impl InputFunction_SPIIO4 for crate::peripherals::GPIO33<'_> {}
+        impl InputFunction_SPIIO5 for crate::peripherals::GPIO34<'_> {}
+        impl InputFunction_SPIIO6 for crate::peripherals::GPIO35<'_> {}
+        impl InputFunction_SPIIO7 for crate::peripherals::GPIO36<'_> {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SPIIO4 output function"]
+        pub trait OutputFunction_SPIIO4 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SPIIO5 output function"]
+        pub trait OutputFunction_SPIIO5 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SPIIO6 output function"]
+        pub trait OutputFunction_SPIIO6 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SPIIO7 output function"]
+        pub trait OutputFunction_SPIIO7 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the CLK_OUT1 output function"]
+        pub trait OutputFunction_CLK_OUT1 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the CLK_OUT2 output function"]
+        pub trait OutputFunction_CLK_OUT2 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the CLK_OUT3 output function"]
+        pub trait OutputFunction_CLK_OUT3 {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SPICLK_P_DIFF output function"]
+        pub trait OutputFunction_SPICLK_P_DIFF {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SPICLK_N_DIFF output function"]
+        pub trait OutputFunction_SPICLK_N_DIFF {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SUBSPICLK_P_DIFF output function"]
+        pub trait OutputFunction_SUBSPICLK_P_DIFF {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the SUBSPICLK_N_DIFF output function"]
+        pub trait OutputFunction_SUBSPICLK_N_DIFF {}
+        #[instability::unstable]
+        #[doc = "Marker trait for pins that have the MTDO output function"]
+        pub trait OutputFunction_MTDO {}
+        impl OutputFunction_CLK_OUT3 for crate::peripherals::GPIO18<'_> {}
+        impl OutputFunction_CLK_OUT2 for crate::peripherals::GPIO19<'_> {}
+        impl OutputFunction_CLK_OUT1 for crate::peripherals::GPIO20<'_> {}
+        impl OutputFunction_SPIIO4 for crate::peripherals::GPIO33<'_> {}
+        impl OutputFunction_SPIIO5 for crate::peripherals::GPIO34<'_> {}
+        impl OutputFunction_SPIIO6 for crate::peripherals::GPIO35<'_> {}
+        impl OutputFunction_SPIIO7 for crate::peripherals::GPIO36<'_> {}
+        impl OutputFunction_CLK_OUT3 for crate::peripherals::GPIO39<'_> {}
+        impl OutputFunction_CLK_OUT2 for crate::peripherals::GPIO40<'_> {}
+        impl OutputFunction_CLK_OUT1 for crate::peripherals::GPIO41<'_> {}
+        impl OutputFunction_CLK_OUT1 for crate::peripherals::GPIO43<'_> {}
+        impl OutputFunction_CLK_OUT2 for crate::peripherals::GPIO44<'_> {}
+        impl OutputFunction_SPICLK_P_DIFF for crate::peripherals::GPIO47<'_> {}
+        impl OutputFunction_SUBSPICLK_P_DIFF for crate::peripherals::GPIO47<'_> {}
+        impl OutputFunction_SPICLK_N_DIFF for crate::peripherals::GPIO48<'_> {}
+        impl OutputFunction_SUBSPICLK_N_DIFF for crate::peripherals::GPIO48<'_> {}
+    };
+}

--- a/esp-metadata-generated/src/_generated_esp32s3.rs
+++ b/esp-metadata-generated/src/_generated_esp32s3.rs
@@ -1594,81 +1594,65 @@ macro_rules! define_io_mux_reg {
 macro_rules! implement_alternate_function_markers {
     () => {
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the SPIIO4 input function"]
-        pub trait InputFunction_SPIIO4 {}
+        #[doc = "Marker trait for pins that have the SPIIO4 function"]
+        pub trait AlternateFunction_SPIIO4: crate::gpio::InputPin + crate::gpio::OutputPin {}
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the SPIIO5 input function"]
-        pub trait InputFunction_SPIIO5 {}
+        #[doc = "Marker trait for pins that have the SPIIO5 function"]
+        pub trait AlternateFunction_SPIIO5: crate::gpio::InputPin + crate::gpio::OutputPin {}
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the SPIIO6 input function"]
-        pub trait InputFunction_SPIIO6 {}
+        #[doc = "Marker trait for pins that have the SPIIO6 function"]
+        pub trait AlternateFunction_SPIIO6: crate::gpio::InputPin + crate::gpio::OutputPin {}
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the SPIIO7 input function"]
-        pub trait InputFunction_SPIIO7 {}
+        #[doc = "Marker trait for pins that have the SPIIO7 function"]
+        pub trait AlternateFunction_SPIIO7: crate::gpio::InputPin + crate::gpio::OutputPin {}
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the MTDI input function"]
-        pub trait InputFunction_MTDI {}
+        #[doc = "Marker trait for pins that have the MTDI function"]
+        pub trait AlternateFunction_MTDI: crate::gpio::InputPin {}
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the MTCK input function"]
-        pub trait InputFunction_MTCK {}
+        #[doc = "Marker trait for pins that have the MTCK function"]
+        pub trait AlternateFunction_MTCK: crate::gpio::InputPin {}
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the MTMS input function"]
-        pub trait InputFunction_MTMS {}
-        impl InputFunction_SPIIO4 for crate::peripherals::GPIO33<'_> {}
-        impl InputFunction_SPIIO5 for crate::peripherals::GPIO34<'_> {}
-        impl InputFunction_SPIIO6 for crate::peripherals::GPIO35<'_> {}
-        impl InputFunction_SPIIO7 for crate::peripherals::GPIO36<'_> {}
+        #[doc = "Marker trait for pins that have the MTMS function"]
+        pub trait AlternateFunction_MTMS: crate::gpio::InputPin {}
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the SPIIO4 output function"]
-        pub trait OutputFunction_SPIIO4 {}
+        #[doc = "Marker trait for pins that have the CLK_OUT1 function"]
+        pub trait AlternateFunction_CLK_OUT1: crate::gpio::OutputPin {}
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the SPIIO5 output function"]
-        pub trait OutputFunction_SPIIO5 {}
+        #[doc = "Marker trait for pins that have the CLK_OUT2 function"]
+        pub trait AlternateFunction_CLK_OUT2: crate::gpio::OutputPin {}
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the SPIIO6 output function"]
-        pub trait OutputFunction_SPIIO6 {}
+        #[doc = "Marker trait for pins that have the CLK_OUT3 function"]
+        pub trait AlternateFunction_CLK_OUT3: crate::gpio::OutputPin {}
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the SPIIO7 output function"]
-        pub trait OutputFunction_SPIIO7 {}
+        #[doc = "Marker trait for pins that have the SPICLK_P_DIFF function"]
+        pub trait AlternateFunction_SPICLK_P_DIFF: crate::gpio::OutputPin {}
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the CLK_OUT1 output function"]
-        pub trait OutputFunction_CLK_OUT1 {}
+        #[doc = "Marker trait for pins that have the SPICLK_N_DIFF function"]
+        pub trait AlternateFunction_SPICLK_N_DIFF: crate::gpio::OutputPin {}
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the CLK_OUT2 output function"]
-        pub trait OutputFunction_CLK_OUT2 {}
+        #[doc = "Marker trait for pins that have the SUBSPICLK_P_DIFF function"]
+        pub trait AlternateFunction_SUBSPICLK_P_DIFF: crate::gpio::OutputPin {}
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the CLK_OUT3 output function"]
-        pub trait OutputFunction_CLK_OUT3 {}
+        #[doc = "Marker trait for pins that have the SUBSPICLK_N_DIFF function"]
+        pub trait AlternateFunction_SUBSPICLK_N_DIFF: crate::gpio::OutputPin {}
         #[instability::unstable]
-        #[doc = "Marker trait for pins that have the SPICLK_P_DIFF output function"]
-        pub trait OutputFunction_SPICLK_P_DIFF {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the SPICLK_N_DIFF output function"]
-        pub trait OutputFunction_SPICLK_N_DIFF {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the SUBSPICLK_P_DIFF output function"]
-        pub trait OutputFunction_SUBSPICLK_P_DIFF {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the SUBSPICLK_N_DIFF output function"]
-        pub trait OutputFunction_SUBSPICLK_N_DIFF {}
-        #[instability::unstable]
-        #[doc = "Marker trait for pins that have the MTDO output function"]
-        pub trait OutputFunction_MTDO {}
-        impl OutputFunction_CLK_OUT3 for crate::peripherals::GPIO18<'_> {}
-        impl OutputFunction_CLK_OUT2 for crate::peripherals::GPIO19<'_> {}
-        impl OutputFunction_CLK_OUT1 for crate::peripherals::GPIO20<'_> {}
-        impl OutputFunction_SPIIO4 for crate::peripherals::GPIO33<'_> {}
-        impl OutputFunction_SPIIO5 for crate::peripherals::GPIO34<'_> {}
-        impl OutputFunction_SPIIO6 for crate::peripherals::GPIO35<'_> {}
-        impl OutputFunction_SPIIO7 for crate::peripherals::GPIO36<'_> {}
-        impl OutputFunction_CLK_OUT3 for crate::peripherals::GPIO39<'_> {}
-        impl OutputFunction_CLK_OUT2 for crate::peripherals::GPIO40<'_> {}
-        impl OutputFunction_CLK_OUT1 for crate::peripherals::GPIO41<'_> {}
-        impl OutputFunction_CLK_OUT1 for crate::peripherals::GPIO43<'_> {}
-        impl OutputFunction_CLK_OUT2 for crate::peripherals::GPIO44<'_> {}
-        impl OutputFunction_SPICLK_P_DIFF for crate::peripherals::GPIO47<'_> {}
-        impl OutputFunction_SUBSPICLK_P_DIFF for crate::peripherals::GPIO47<'_> {}
-        impl OutputFunction_SPICLK_N_DIFF for crate::peripherals::GPIO48<'_> {}
-        impl OutputFunction_SUBSPICLK_N_DIFF for crate::peripherals::GPIO48<'_> {}
+        #[doc = "Marker trait for pins that have the MTDO function"]
+        pub trait AlternateFunction_MTDO: crate::gpio::OutputPin {}
+        impl AlternateFunction_CLK_OUT3 for crate::peripherals::GPIO18<'_> {}
+        impl AlternateFunction_CLK_OUT2 for crate::peripherals::GPIO19<'_> {}
+        impl AlternateFunction_CLK_OUT1 for crate::peripherals::GPIO20<'_> {}
+        impl AlternateFunction_SPIIO4 for crate::peripherals::GPIO33<'_> {}
+        impl AlternateFunction_SPIIO5 for crate::peripherals::GPIO34<'_> {}
+        impl AlternateFunction_SPIIO6 for crate::peripherals::GPIO35<'_> {}
+        impl AlternateFunction_SPIIO7 for crate::peripherals::GPIO36<'_> {}
+        impl AlternateFunction_CLK_OUT3 for crate::peripherals::GPIO39<'_> {}
+        impl AlternateFunction_CLK_OUT2 for crate::peripherals::GPIO40<'_> {}
+        impl AlternateFunction_CLK_OUT1 for crate::peripherals::GPIO41<'_> {}
+        impl AlternateFunction_CLK_OUT1 for crate::peripherals::GPIO43<'_> {}
+        impl AlternateFunction_CLK_OUT2 for crate::peripherals::GPIO44<'_> {}
+        impl AlternateFunction_SPICLK_P_DIFF for crate::peripherals::GPIO47<'_> {}
+        impl AlternateFunction_SUBSPICLK_P_DIFF for crate::peripherals::GPIO47<'_> {}
+        impl AlternateFunction_SPICLK_N_DIFF for crate::peripherals::GPIO48<'_> {}
+        impl AlternateFunction_SUBSPICLK_N_DIFF for crate::peripherals::GPIO48<'_> {}
     };
 }


### PR DESCRIPTION
Some signals, like the ones related to SDIO, can not be routed through the GPIO matrix. They are constrainted to (usually) one GPIO only, so APIs that work with them shouldn't really accept a generic GPIO (or AnyPin). While in the current implementation using a wrong pin would panic, we can do better: we can define a trait for each relevant signal, and implement it for each compatible pin - as done in this PR. This allows drivers to only accept the correct pin (or maybe AnyPin that would still panic when the wrong one is passed).

Downsides:
- Signals have different names between devices. Drivers can define macros in metadata to map them (import-alias), but that may be somewhat hard to read.
- Later MCUs may choose to allow routing the signal through the GPIO matric. The import-alias macro could be used to allow any GPIO in this case for the relevant MCU, making the import-alias macro a bit more attractive.
- Some signals (`CLK_OUTn`) may not need to be differentiated, but this approach forces them to be distinct.