### PR TITLE
ESP32-S2: Go into hibernation if there's only Ext1 WakeupSource

### DIFF
--- a/esp-hal/src/rtc_cntl/sleep/esp32s2.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32s2.rs
@@ -159,9 +159,8 @@ impl WakeSource for Ext1WakeupSource<'_, '_> {
         &self,
         _rtc: &Rtc<'_>,
         triggers: &mut WakeTriggers,
-        sleep_config: &mut RtcSleepConfig,
+        _sleep_config: &mut RtcSleepConfig,
     ) {
-        sleep_config.set_rtc_peri_pd_en(false);
         triggers.set_ext1(true);
 
         // TODO: disable clock when not in use
@@ -174,6 +173,7 @@ impl WakeSource for Ext1WakeupSource<'_, '_> {
         let mut bits = 0u32;
         for pin in pins.iter_mut() {
             pin.rtc_set_config(true, true, RtcFunction::Rtc);
+            pin.rtcio_pad_hold(true);
             bits |= 1 << pin.rtc_number();
         }
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖
Don't request rtc_periph power up in ext1 and enable hold for pad in case of rtc_peri power down. Hibernation is defined in the datasheet as the deep sleep condition where the RTC peripheral power domain is also powered down.
The previous code requested the RTC peripheral domain to stay powered on, presumably due to copy-pasting from the Ext0 WakeupSource. Ext1 is special in that it can power down this domain, so best to take advantage of this.
The esp32s3 code might benefit from a similar change.
This took my power consumption during deep sleep down from 1.3mA to <0.1mA (as measured with a cheap multi-meter).

#### Description
I removed the call to `sleep_config.set_rtc_peri_pd_en` in `Ext1WakeupSource::apply` because its idf analog is never called in case of only the Ext1WakupSource. The RtcSleepConfig powers down the rtc_periph demain by default and the power-down is disabled if by other sources if necessary.
Because the rtc_periph power domain is powered-down, the `rtcio_pad_hold(true)` call had to be added to preserve the internal wiring from the pad to the RTc peripheral for the actual wake up.  Without this, it does not wake up upon a trigger. This is also what IDF does: [`sleep_modes.c`](https://github.com/espressif/esp-idf/blob/60d9ca995cece90b25bb719e7466b54669109057/components/esp_hw_support/sleep_modes.c#L2067)

#### Testing
Checked the current consumption with a multi-meter for non-trivial project that enters deep sleep after some WiFi work. Am able to leave deep-sleep when the Rtc pin of the Ext1WakeupSource becomes HIGH.
