### PR TITLE
Fix, simplify and ignore PSRAM doc example

### DIFF
--- a/esp-hal/src/soc/esp32/psram.rs
+++ b/esp-hal/src/soc/esp32/psram.rs
@@ -18,28 +18,13 @@
 //! You need an ESP32 with at least 2 MB of PSRAM memory.
 //! Notice that PSRAM example **must** be built in release mode!
 //!
-//! ```rust, no_run
+//! ```rust, ignore
 //! # {before_snippet}
 //! # extern crate alloc;
 //! # use alloc::{string::String, vec::Vec};
-//! # use esp_alloc as _;
-//! # use esp_hal::psram;
-//!
-//! // Initialize PSRAM and add it as a heap memory region
-//! fn init_psram_heap(start: *mut u8, size: usize) {
-//!     unsafe {
-//!         esp_alloc::HEAP.add_region(esp_alloc::HeapRegion::new(
-//!             start,
-//!             size,
-//!             esp_alloc::MemoryCapability::External.into(),
-//!         ));
-//!     }
-//! }
-//!
-//! // Initialize PSRAM and add it to the heap
-//! let (start, size) = psram::init_psram(peripherals.PSRAM, psram::PsramConfig::default());
-//!
-//! init_psram_heap(start, size);
+//! #
+//! // Add PSRAM to the heap.
+//! esp_alloc::psram_allocator!(&peripherals.PSRAM, esp_hal::psram);
 //!
 //! let mut large_vec: Vec<u32> = Vec::with_capacity(500 * 1024 / 4);
 //!
@@ -48,7 +33,7 @@
 //! }
 //!
 //! let string = String::from("A string allocated in PSRAM");
-//! # }
+//! # {after_snippet}
 //! ```
 
 pub use crate::soc::psram_common::*;

--- a/esp-hal/src/soc/esp32s2/psram.rs
+++ b/esp-hal/src/soc/esp32s2/psram.rs
@@ -18,26 +18,13 @@
 //! You need an ESP32S2 with at least 2 MB of PSRAM memory.
 //! Notice that PSRAM example **must** be built in release mode!
 //!
-//! ```rust, no_run
+//! ```rust, ignore
 //! # {before_snippet}
 //! # extern crate alloc;
 //! # use alloc::{string::String, vec::Vec};
-//! # use esp_alloc as _;
-//! # use esp_hal::psram;
-//!
-//! // Initialize PSRAM and add it as a heap memory region
-//! fn init_psram_heap(start: *mut u8, size: usize) {
-//!     unsafe {
-//!         esp_alloc::HEAP.add_region(esp_alloc::HeapRegion::new(
-//!             start,
-//!             size,
-//!             esp_alloc::MemoryCapability::External.into(),
-//!         ));
-//!     }
-//! }
-//!
-//! // Initialize PSRAM and add it to the heap
-//! let (start, size) = psram::init_psram(peripherals.PSRAM, psram::PsramConfig::default());
+//! #
+//! // Add PSRAM to the heap.
+//! esp_alloc::psram_allocator!(&peripherals.PSRAM, esp_hal::psram);
 //!
 //! init_psram_heap(start, size);
 //!
@@ -48,7 +35,7 @@
 //! }
 //!
 //! let string = String::from("A string allocated in PSRAM");
-//! # }
+//! # {after_snippet}
 //! ```
 
 use crate::peripherals::{EXTMEM, SPI0, SPI1};

--- a/esp-hal/src/soc/esp32s3/psram.rs
+++ b/esp-hal/src/soc/esp32s3/psram.rs
@@ -24,28 +24,13 @@
 //!
 //! Notice that PSRAM example **must** be built in release mode!
 //!
-//! ```rust, no_run
+//! ```rust, ignore
 //! # {before_snippet}
 //! # extern crate alloc;
 //! # use alloc::{string::String, vec::Vec};
-//! # use esp_alloc as _;
-//! # use esp_hal::psram;
-//!
-//! // Initialize PSRAM and add it as a heap memory region
-//! fn init_psram_heap(start: *mut u8, size: usize) {
-//!     unsafe {
-//!         esp_alloc::HEAP.add_region(esp_alloc::HeapRegion::new(
-//!             start,
-//!             size,
-//!             esp_alloc::MemoryCapability::External.into(),
-//!         ));
-//!     }
-//! }
-//!
-//! // Initialize PSRAM and add it to the heap
-//! let (start, size) = psram::init_psram(peripherals.PSRAM, psram::PsramConfig::default());
-//!
-//! init_psram_heap(start, size);
+//! #
+//! // Add PSRAM to the heap.
+//! esp_alloc::psram_allocator!(&peripherals.PSRAM, esp_hal::psram);
 //!
 //! let mut large_vec: Vec<u32> = Vec::with_capacity(500 * 1024 / 4);
 //!
@@ -54,7 +39,7 @@
 //! }
 //!
 //! let string = String::from("A string allocated in PSRAM");
-//! # }
+//! # {after_snippet}
 //! ```
 
 use crate::peripherals::{EXTMEM, IO_MUX, SPI0, SPI1};

--- a/xtask/src/commands/run.rs
+++ b/xtask/src/commands/run.rs
@@ -53,7 +53,10 @@ pub fn run_doc_tests(workspace: &Path, args: ExamplesArgs) -> Result<()> {
     // Determine the appropriate build target, and cargo features for the given
     // package and chip:
     let target = args.package.target_triple(&chip)?;
-    let features = vec![chip.to_string(), "unstable".to_string()];
+    let mut features = args
+        .package
+        .feature_rules(&esp_metadata::Config::for_chip(&chip));
+    features.push(chip.to_string());
 
     // We need `nightly` for building the doc tests, unfortunately:
     let toolchain = if chip.is_xtensa() { "esp" } else { "nightly" };


### PR DESCRIPTION
These examples failed to compile, so I've taken the opportunity to rewrite them to use the `esp_alloc::psram_allocator` macro. Since esp_alloc is not available in doc tests, the examples are now ignored.