### PR TITLE
Disable USB pads before connecting a function

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prevent bootloops when DRAM is close to being full. (#3635)
 - Fix PSRAM mapping on ESP32-S3 when the bootloader used the last page to access flash (#3637)
 - `ESP_HAL_CONFIG_STACK_GUARD_OFFSET` and `ESP_HAL_CONFIG_STACK_GUARD_VALUE` are now unstable config options (#3711)
+- Fixed MCPWM output when using USB pins (#3795)
 
 ### Removed
 

--- a/esp-hal/src/gpio/interconnect.rs
+++ b/esp-hal/src/gpio/interconnect.rs
@@ -417,6 +417,7 @@ impl Signal<'_> {
                         .map(|(af, _)| *af)
                         .unwrap_or(AlternateFunction::GPIO)
                 };
+                pin.disable_usb_pads();
                 pin.set_alternate_function(af);
                 af == AlternateFunction::GPIO
             }
@@ -466,6 +467,7 @@ impl Signal<'_> {
                 .map(|(af, _)| *af)
                 .unwrap_or(AlternateFunction::GPIO)
         };
+        pin.disable_usb_pads();
         pin.set_alternate_function(af);
 
         let use_gpio_matrix = af == AlternateFunction::GPIO;

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -1806,13 +1806,7 @@ impl<'lt> AnyPin<'lt> {
         GpioBank::_0
     }
 
-    #[inline]
-    /// Resets the GPIO to a known state.
-    ///
-    /// This function needs to be called before using the GPIO pin:
-    /// - Before converting it into signals
-    /// - Before using it as an input or output
-    pub(crate) fn init_gpio(&self) {
+    pub(crate) fn disable_usb_pads(&self) {
         #[cfg(soc_has_usb_device)]
         {
             /// Workaround to make D+ and D- work when the pin is assigned to
@@ -1842,8 +1836,17 @@ impl<'lt> AnyPin<'lt> {
                 (USB_DP, $gpio:ident) => { disable_usb_pads!($gpio) };
             }
         }
+    }
 
+    #[inline]
+    /// Resets the GPIO to a known state.
+    ///
+    /// This function needs to be called before using the GPIO pin:
+    /// - Before converting it into signals
+    /// - Before using it as an input or output
+    pub(crate) fn init_gpio(&self) {
         self.set_output_enable(false);
+        self.disable_usb_pads();
 
         GPIO::regs()
             .func_out_sel_cfg(self.number() as usize)


### PR DESCRIPTION
Fixes #3792

This PR disables USB pads before configuring any alternate function. This is safe to do even when configuring the pins to USB later, as USB is an analog function and needs to be initialized differently.

Unfortunately since we're using USB JTAG to run the HIL tests, this change can't be tested.