### PR TITLE
Add HW DTR support (port of #2994)

### DIFF
--- a/esp-hal/src/uart/mod.rs
+++ b/esp-hal/src/uart/mod.rs
@@ -471,6 +471,7 @@ where
 
         let rts_pin = PinGuard::new_unconnected();
         let tx_pin = PinGuard::new_unconnected();
+        let dtr_pin = PinGuard::new_unconnected();
 
         let mut serial = Uart {
             rx: UartRx {
@@ -486,6 +487,7 @@ where
                 mem_guard,
                 rts_pin,
                 tx_pin,
+                dtr_pin,
                 baudrate: config.baudrate,
             },
         };
@@ -524,6 +526,7 @@ pub struct UartTx<'d, Dm: DriverMode> {
     mem_guard: MemoryGuard<'d>,
     rts_pin: PinGuard,
     tx_pin: PinGuard,
+    dtr_pin: PinGuard,
     baudrate: u32,
 }
 
@@ -670,6 +673,7 @@ impl<'d> UartTx<'d, Blocking> {
             mem_guard: self.mem_guard,
             rts_pin: self.rts_pin,
             tx_pin: self.tx_pin,
+            dtr_pin: self.dtr_pin,
             baudrate: self.baudrate,
         }
     }
@@ -694,6 +698,7 @@ impl<'d> UartTx<'d, Async> {
             mem_guard: self.mem_guard,
             rts_pin: self.rts_pin,
             tx_pin: self.tx_pin,
+            dtr_pin: self.dtr_pin,
             baudrate: self.baudrate,
         }
     }
@@ -775,6 +780,25 @@ where
 
         self.rts_pin = rts.connect_with_guard(self.uart.info().rts_signal);
 
+        self
+    }
+
+    /// Configure DTR pin
+    #[instability::unstable]
+    pub fn with_dtr(mut self, dtr: impl PeripheralOutput<'d>) -> Self {
+        let dtr = dtr.into();
+
+        dtr.apply_output_config(&OutputConfig::default());
+        dtr.set_output_enable(true);
+
+        self.dtr_pin = dtr.connect_with_guard(self.uart.info().dtr_signal);
+
+        self
+    }
+
+    /// Enable RS485 mode
+    pub fn with_rs485(self) -> Self {
+        self.regs().rs485_conf().write(|w| w.rs485_en().set_bit());
         self
     }
 
@@ -1790,6 +1814,20 @@ where
     /// ```
     pub fn with_rts(mut self, rts: impl PeripheralOutput<'d>) -> Self {
         self.tx = self.tx.with_rts(rts);
+        self
+    }
+
+    /// Configure DTR pin
+    #[instability::unstable]
+    pub fn with_dtr(mut self, dtr: impl PeripheralOutput<'d>) -> Self {
+        self.tx = self.tx.with_dtr(dtr);
+        self
+    }
+
+    /// Enable RS485 mode
+    #[instability::unstable]
+    pub fn with_rs485(mut self) -> Self {
+        self.tx = self.tx.with_rs485();
         self
     }
 
@@ -2925,6 +2963,9 @@ pub struct Info {
 
     /// RTS (Request to Send) pin
     pub rts_signal: OutputSignal,
+
+    /// DTR (Data Terminal Ready) pin
+    pub dtr_signal: OutputSignal,
 }
 
 /// Peripheral state for a UART instance.
@@ -3679,7 +3720,7 @@ impl PartialEq for Info {
 unsafe impl Sync for Info {}
 
 for_each_uart! {
-    ($inst:ident, $peri:ident, $rxd:ident, $txd:ident, $cts:ident, $rts:ident) => {
+    ($inst:ident, $peri:ident, $rxd:ident, $txd:ident, $cts:ident, $rts:ident, $dtr:ident) => {
         impl Instance for crate::peripherals::$inst<'_> {
             fn parts(&self) -> (&'static Info, &'static State) {
                 #[crate::handler]
@@ -3704,6 +3745,7 @@ for_each_uart! {
                     rx_signal: InputSignal::$rxd,
                     cts_signal: InputSignal::$cts,
                     rts_signal: OutputSignal::$rts,
+                    dtr_signal: OutputSignal::$dtr,
                 };
                 (&PERIPHERAL, &STATE)
             }

--- a/esp-hal/src/uart/mod.rs
+++ b/esp-hal/src/uart/mod.rs
@@ -1285,6 +1285,18 @@ where
         sync_regs(self.regs());
     }
 
+    /// Inverts polarity of RX signal if `invertedd`
+    #[instability::unstable]
+    pub fn with_polarity(self, inverted: bool) -> Self {
+        self.uart
+            .info()
+            .regs()
+            .conf0()
+            .modify(|_, w| w.rxd_inv().bit(inverted));
+
+        self
+    }
+
     /// Change the configuration.
     ///
     /// ## Errors

--- a/esp-lp-hal/CHANGELOG.md
+++ b/esp-lp-hal/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed size of LP_UART's RAM block (#3812)
 
 ### Removed
 

--- a/esp-metadata-generated/src/_generated_esp32.rs
+++ b/esp-metadata-generated/src/_generated_esp32.rs
@@ -2208,17 +2208,18 @@ macro_rules! for_each_i2c_master {
 /// - `$sys`: the name of the instance as it is in the `esp_hal::system::Peripheral` enum.
 /// - `$rx`, `$tx`, `$cts`, `$rts`: signal names.
 ///
-/// Example data: `(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS)`
+/// Example data: `(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS, U0DTR)`
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_uart {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS));
-        _for_each_inner!((UART1, Uart1, U1RXD, U1TXD, U1CTS, U1RTS));
-        _for_each_inner!((UART2, Uart2, U2RXD, U2TXD, U2CTS, U2RTS));
-        _for_each_inner!((all(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS), (UART1, Uart1,
-        U1RXD, U1TXD, U1CTS, U1RTS), (UART2, Uart2, U2RXD, U2TXD, U2CTS, U2RTS)));
+        _for_each_inner!((UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS, U0DTR));
+        _for_each_inner!((UART1, Uart1, U1RXD, U1TXD, U1CTS, U1RTS, U1DTR));
+        _for_each_inner!((UART2, Uart2, U2RXD, U2TXD, U2CTS, U2RTS, U2DTR));
+        _for_each_inner!((all(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS, U0DTR), (UART1,
+        Uart1, U1RXD, U1TXD, U1CTS, U1RTS, U1DTR), (UART2, Uart2, U2RXD, U2TXD, U2CTS,
+        U2RTS, U2DTR)));
     };
 }
 /// This macro can be used to generate code for each peripheral instance of the SPI master driver.

--- a/esp-metadata-generated/src/_generated_esp32c2.rs
+++ b/esp-metadata-generated/src/_generated_esp32c2.rs
@@ -1766,16 +1766,16 @@ macro_rules! for_each_i2c_master {
 /// - `$sys`: the name of the instance as it is in the `esp_hal::system::Peripheral` enum.
 /// - `$rx`, `$tx`, `$cts`, `$rts`: signal names.
 ///
-/// Example data: `(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS)`
+/// Example data: `(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS, U0DTR)`
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_uart {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS));
-        _for_each_inner!((UART1, Uart1, U1RXD, U1TXD, U1CTS, U1RTS));
-        _for_each_inner!((all(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS), (UART1, Uart1,
-        U1RXD, U1TXD, U1CTS, U1RTS)));
+        _for_each_inner!((UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS, U0DTR));
+        _for_each_inner!((UART1, Uart1, U1RXD, U1TXD, U1CTS, U1RTS, U1DTR));
+        _for_each_inner!((all(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS, U0DTR), (UART1,
+        Uart1, U1RXD, U1TXD, U1CTS, U1RTS, U1DTR)));
     };
 }
 /// This macro can be used to generate code for each peripheral instance of the SPI master driver.

--- a/esp-metadata-generated/src/_generated_esp32c3.rs
+++ b/esp-metadata-generated/src/_generated_esp32c3.rs
@@ -2139,16 +2139,16 @@ macro_rules! for_each_i2c_master {
 /// - `$sys`: the name of the instance as it is in the `esp_hal::system::Peripheral` enum.
 /// - `$rx`, `$tx`, `$cts`, `$rts`: signal names.
 ///
-/// Example data: `(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS)`
+/// Example data: `(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS, U0DTR)`
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_uart {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS));
-        _for_each_inner!((UART1, Uart1, U1RXD, U1TXD, U1CTS, U1RTS));
-        _for_each_inner!((all(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS), (UART1, Uart1,
-        U1RXD, U1TXD, U1CTS, U1RTS)));
+        _for_each_inner!((UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS, U0DTR));
+        _for_each_inner!((UART1, Uart1, U1RXD, U1TXD, U1CTS, U1RTS, U1DTR));
+        _for_each_inner!((all(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS, U0DTR), (UART1,
+        Uart1, U1RXD, U1TXD, U1CTS, U1RTS, U1DTR)));
     };
 }
 /// This macro can be used to generate code for each peripheral instance of the SPI master driver.

--- a/esp-metadata-generated/src/_generated_esp32c6.rs
+++ b/esp-metadata-generated/src/_generated_esp32c6.rs
@@ -2717,16 +2717,16 @@ macro_rules! for_each_i2c_master {
 /// - `$sys`: the name of the instance as it is in the `esp_hal::system::Peripheral` enum.
 /// - `$rx`, `$tx`, `$cts`, `$rts`: signal names.
 ///
-/// Example data: `(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS)`
+/// Example data: `(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS, U0DTR)`
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_uart {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS));
-        _for_each_inner!((UART1, Uart1, U1RXD, U1TXD, U1CTS, U1RTS));
-        _for_each_inner!((all(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS), (UART1, Uart1,
-        U1RXD, U1TXD, U1CTS, U1RTS)));
+        _for_each_inner!((UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS, U0DTR));
+        _for_each_inner!((UART1, Uart1, U1RXD, U1TXD, U1CTS, U1RTS, U1DTR));
+        _for_each_inner!((all(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS, U0DTR), (UART1,
+        Uart1, U1RXD, U1TXD, U1CTS, U1RTS, U1DTR)));
     };
 }
 /// This macro can be used to generate code for each peripheral instance of the SPI master driver.

--- a/esp-metadata-generated/src/_generated_esp32h2.rs
+++ b/esp-metadata-generated/src/_generated_esp32h2.rs
@@ -950,16 +950,16 @@ macro_rules! for_each_i2c_master {
 /// - `$sys`: the name of the instance as it is in the `esp_hal::system::Peripheral` enum.
 /// - `$rx`, `$tx`, `$cts`, `$rts`: signal names.
 ///
-/// Example data: `(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS)`
+/// Example data: `(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS, U0DTR)`
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_uart {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS));
-        _for_each_inner!((UART1, Uart1, U1RXD, U1TXD, U1CTS, U1RTS));
-        _for_each_inner!((all(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS), (UART1, Uart1,
-        U1RXD, U1TXD, U1CTS, U1RTS)));
+        _for_each_inner!((UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS, U0DTR));
+        _for_each_inner!((UART1, Uart1, U1RXD, U1TXD, U1CTS, U1RTS, U1DTR));
+        _for_each_inner!((all(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS, U0DTR), (UART1,
+        Uart1, U1RXD, U1TXD, U1CTS, U1RTS, U1DTR)));
     };
 }
 /// This macro can be used to generate code for each peripheral instance of the SPI master driver.

--- a/esp-metadata-generated/src/_generated_esp32s2.rs
+++ b/esp-metadata-generated/src/_generated_esp32s2.rs
@@ -1002,16 +1002,16 @@ macro_rules! for_each_i2c_master {
 /// - `$sys`: the name of the instance as it is in the `esp_hal::system::Peripheral` enum.
 /// - `$rx`, `$tx`, `$cts`, `$rts`: signal names.
 ///
-/// Example data: `(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS)`
+/// Example data: `(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS, U0DTR)`
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_uart {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS));
-        _for_each_inner!((UART1, Uart1, U1RXD, U1TXD, U1CTS, U1RTS));
-        _for_each_inner!((all(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS), (UART1, Uart1,
-        U1RXD, U1TXD, U1CTS, U1RTS)));
+        _for_each_inner!((UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS, U0DTR));
+        _for_each_inner!((UART1, Uart1, U1RXD, U1TXD, U1CTS, U1RTS, U1DTR));
+        _for_each_inner!((all(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS, U0DTR), (UART1,
+        Uart1, U1RXD, U1TXD, U1CTS, U1RTS, U1DTR)));
     };
 }
 /// This macro can be used to generate code for each peripheral instance of the SPI master driver.

--- a/esp-metadata-generated/src/_generated_esp32s3.rs
+++ b/esp-metadata-generated/src/_generated_esp32s3.rs
@@ -1017,17 +1017,18 @@ macro_rules! for_each_i2c_master {
 /// - `$sys`: the name of the instance as it is in the `esp_hal::system::Peripheral` enum.
 /// - `$rx`, `$tx`, `$cts`, `$rts`: signal names.
 ///
-/// Example data: `(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS)`
+/// Example data: `(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS, U0DTR)`
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_uart {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS));
-        _for_each_inner!((UART1, Uart1, U1RXD, U1TXD, U1CTS, U1RTS));
-        _for_each_inner!((UART2, Uart2, U2RXD, U2TXD, U2CTS, U2RTS));
-        _for_each_inner!((all(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS), (UART1, Uart1,
-        U1RXD, U1TXD, U1CTS, U1RTS), (UART2, Uart2, U2RXD, U2TXD, U2CTS, U2RTS)));
+        _for_each_inner!((UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS, U0DTR));
+        _for_each_inner!((UART1, Uart1, U1RXD, U1TXD, U1CTS, U1RTS, U1DTR));
+        _for_each_inner!((UART2, Uart2, U2RXD, U2TXD, U2CTS, U2RTS, U2DTR));
+        _for_each_inner!((all(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS, U0DTR), (UART1,
+        Uart1, U1RXD, U1TXD, U1CTS, U1RTS, U1DTR), (UART2, Uart2, U2RXD, U2TXD, U2CTS,
+        U2RTS, U2DTR)));
     };
 }
 /// This macro can be used to generate code for each peripheral instance of the SPI master driver.

--- a/esp-metadata/devices/esp32.toml
+++ b/esp-metadata/devices/esp32.toml
@@ -820,9 +820,9 @@ instances = [{ name = "timg0" }, { name = "timg1" }]
 [device.uart]
 support_status = "supported"
 instances = [
-    { name = "uart0", sys_instance = "Uart0", tx = "U0TXD", rx = "U0RXD", cts = "U0CTS", rts = "U0RTS" },
-    { name = "uart1", sys_instance = "Uart1", tx = "U1TXD", rx = "U1RXD", cts = "U1CTS", rts = "U1RTS" },
-    { name = "uart2", sys_instance = "Uart2", tx = "U2TXD", rx = "U2RXD", cts = "U2CTS", rts = "U2RTS" },
+    { name = "uart0", sys_instance = "Uart0", tx = "U0TXD", rx = "U0RXD", cts = "U0CTS", rts = "U0RTS", dtr = "U0DTR"  },
+    { name = "uart1", sys_instance = "Uart1", tx = "U1TXD", rx = "U1RXD", cts = "U1CTS", rts = "U1RTS", dtr = "U1DTR"  },
+    { name = "uart2", sys_instance = "Uart2", tx = "U2TXD", rx = "U2RXD", cts = "U2CTS", rts = "U2RTS", dtr = "U2DTR"  },
 ]
 ram_size = 128
 

--- a/esp-metadata/devices/esp32c2.toml
+++ b/esp-metadata/devices/esp32c2.toml
@@ -390,8 +390,8 @@ default_wdt_clock_source = 0 # use_wdt_xtal = false
 [device.uart]
 support_status = "supported"
 instances = [
-    { name = "uart0", sys_instance = "Uart0", tx = "U0TXD", rx = "U0RXD", cts = "U0CTS", rts = "U0RTS" },
-    { name = "uart1", sys_instance = "Uart1", tx = "U1TXD", rx = "U1RXD", cts = "U1CTS", rts = "U1RTS" },
+    { name = "uart0", sys_instance = "Uart0", tx = "U0TXD", rx = "U0RXD", cts = "U0CTS", rts = "U0RTS", dtr = "U0DTR"  },
+    { name = "uart1", sys_instance = "Uart1", tx = "U1TXD", rx = "U1RXD", cts = "U1CTS", rts = "U1RTS", dtr = "U1DTR"  },
 ]
 ram_size = 128
 

--- a/esp-metadata/devices/esp32c3.toml
+++ b/esp-metadata/devices/esp32c3.toml
@@ -463,8 +463,8 @@ default_wdt_clock_source = 0 # use_wdt_xtal = false
 [device.uart]
 support_status = "supported"
 instances = [
-    { name = "uart0", sys_instance = "Uart0", tx = "U0TXD", rx = "U0RXD", cts = "U0CTS", rts = "U0RTS" },
-    { name = "uart1", sys_instance = "Uart1", tx = "U1TXD", rx = "U1RXD", cts = "U1CTS", rts = "U1RTS" },
+    { name = "uart0", sys_instance = "Uart0", tx = "U0TXD", rx = "U0RXD", cts = "U0CTS", rts = "U0RTS", dtr = "U0DTR"  },
+    { name = "uart1", sys_instance = "Uart1", tx = "U1TXD", rx = "U1RXD", cts = "U1CTS", rts = "U1RTS", dtr = "U1DTR"  },
 ]
 ram_size = 128
 

--- a/esp-metadata/devices/esp32c6.toml
+++ b/esp-metadata/devices/esp32c6.toml
@@ -644,8 +644,8 @@ default_wdt_clock_source = 1
 [device.uart]
 support_status = "supported"
 instances = [
-    { name = "uart0", sys_instance = "Uart0", tx = "U0TXD", rx = "U0RXD", cts = "U0CTS", rts = "U0RTS" },
-    { name = "uart1", sys_instance = "Uart1", tx = "U1TXD", rx = "U1RXD", cts = "U1CTS", rts = "U1RTS" },
+    { name = "uart0", sys_instance = "Uart0", tx = "U0TXD", rx = "U0RXD", cts = "U0CTS", rts = "U0RTS", dtr = "U0DTR"  },
+    { name = "uart1", sys_instance = "Uart1", tx = "U1TXD", rx = "U1RXD", cts = "U1CTS", rts = "U1RTS", dtr = "U1DTR"  },
 ]
 ram_size = 128
 peripheral_controls_mem_clk = true

--- a/esp-metadata/devices/esp32h2.toml
+++ b/esp-metadata/devices/esp32h2.toml
@@ -477,8 +477,8 @@ default_wdt_clock_source = 2
 [device.uart]
 support_status = "supported"
 instances = [
-    { name = "uart0", sys_instance = "Uart0", tx = "U0TXD", rx = "U0RXD", cts = "U0CTS", rts = "U0RTS" },
-    { name = "uart1", sys_instance = "Uart1", tx = "U1TXD", rx = "U1RXD", cts = "U1CTS", rts = "U1RTS" },
+    { name = "uart0", sys_instance = "Uart0", tx = "U0TXD", rx = "U0RXD", cts = "U0CTS", rts = "U0RTS", dtr = "U0DTR"  },
+    { name = "uart1", sys_instance = "Uart1", tx = "U1TXD", rx = "U1RXD", cts = "U1CTS", rts = "U1RTS", dtr = "U1DTR"  },
 ]
 ram_size = 128
 peripheral_controls_mem_clk = true

--- a/esp-metadata/devices/esp32s2.toml
+++ b/esp-metadata/devices/esp32s2.toml
@@ -529,8 +529,8 @@ default_clock_source = 0 # use_xtal = false
 [device.uart]
 support_status = "supported"
 instances = [
-    { name = "uart0", sys_instance = "Uart0", tx = "U0TXD", rx = "U0RXD", cts = "U0CTS", rts = "U0RTS" },
-    { name = "uart1", sys_instance = "Uart1", tx = "U1TXD", rx = "U1RXD", cts = "U1CTS", rts = "U1RTS" },
+    { name = "uart0", sys_instance = "Uart0", tx = "U0TXD", rx = "U0RXD", cts = "U0CTS", rts = "U0RTS", dtr = "U0DTR"  },
+    { name = "uart1", sys_instance = "Uart1", tx = "U1TXD", rx = "U1RXD", cts = "U1CTS", rts = "U1RTS", dtr = "U1DTR"  },
 ]
 ram_size = 128
 

--- a/esp-metadata/devices/esp32s3.toml
+++ b/esp-metadata/devices/esp32s3.toml
@@ -698,9 +698,9 @@ default_clock_source = 0 # use_xtal = false
 [device.uart]
 support_status = "supported"
 instances = [
-    { name = "uart0", sys_instance = "Uart0", tx = "U0TXD", rx = "U0RXD", cts = "U0CTS", rts = "U0RTS" },
-    { name = "uart1", sys_instance = "Uart1", tx = "U1TXD", rx = "U1RXD", cts = "U1CTS", rts = "U1RTS" },
-    { name = "uart2", sys_instance = "Uart2", tx = "U2TXD", rx = "U2RXD", cts = "U2CTS", rts = "U2RTS" },
+    { name = "uart0", sys_instance = "Uart0", tx = "U0TXD", rx = "U0RXD", cts = "U0CTS", rts = "U0RTS", dtr = "U0DTR" },
+    { name = "uart1", sys_instance = "Uart1", tx = "U1TXD", rx = "U1RXD", cts = "U1CTS", rts = "U1RTS", dtr = "U1DTR" },
+    { name = "uart2", sys_instance = "Uart2", tx = "U2TXD", rx = "U2RXD", cts = "U2CTS", rts = "U2RTS", dtr = "U2DTR" },
 ]
 ram_size = 128
 

--- a/esp-metadata/src/cfg/uart.rs
+++ b/esp-metadata/src/cfg/uart.rs
@@ -20,6 +20,9 @@ pub(crate) struct UartInstanceConfig {
 
     /// IOMUX signal name of the instance's RTS signal.
     pub rts: String,
+
+    /// IOMUX signal name of the instance's DTR signal.
+    pub dtr: String,
 }
 
 /// Generates `for_each_uart!` which can be used to implement the UART
@@ -39,11 +42,12 @@ pub(crate) fn generate_uart_peripherals(uart: &UartProperties) -> TokenStream {
             let tx = format_ident!("{}", instance_config.tx);
             let cts = format_ident!("{}", instance_config.cts);
             let rts = format_ident!("{}", instance_config.rts);
+            let dtr = format_ident!("{}", instance_config.dtr);
 
             // The order and meaning of these tokens must match their use in the
             // `for_each_uart!` call.
             quote! {
-                #instance, #sys, #rx, #tx, #cts, #rts
+                #instance, #sys, #rx, #tx, #cts, #rts, #dtr
             }
         })
         .collect::<Vec<_>>();
@@ -65,7 +69,7 @@ pub(crate) fn generate_uart_peripherals(uart: &UartProperties) -> TokenStream {
         /// - `$sys`: the name of the instance as it is in the `esp_hal::system::Peripheral` enum.
         /// - `$rx`, `$tx`, `$cts`, `$rts`: signal names.
         ///
-        /// Example data: `(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS)`
+        /// Example data: `(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS, U0DTR)`
         #for_each
     }
 }


### PR DESCRIPTION
### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [ ] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖
#### Description
This is a port of #2994 for mainline (1.0.0-beta1).

#### Testing
Currently test it on a board to control an RS485 transceiver chip
