### PR TITLE
Ensure the plan phase accounts for perma-unstable packages

### DIFF
--- a/xtask/src/commands/release/bump_version.rs
+++ b/xtask/src/commands/release/bump_version.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 use toml_edit::{Item, TableLike, Value};
 
-use crate::{cargo::CargoToml, changelog::Changelog, commands::PLACEHOLDER, Package, Version};
+use crate::{Package, Version, cargo::CargoToml, changelog::Changelog, commands::PLACEHOLDER};
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub enum VersionBump {
@@ -65,18 +65,6 @@ pub fn update_package(
     version: &VersionBump,
     dry_run: bool,
 ) -> Result<semver::Version> {
-    let version = {
-        if package.package() == Package::EspRomSys && version != &VersionBump::Patch {
-            log::warn!(
-                "Bump '{:?}' is not acceptable for package esp-rom-sys - using 'Patch'",
-                version
-            );
-            &VersionBump::Patch
-        } else {
-            version
-        }
-    };
-
     check_crate_before_bumping(package)?;
     let new_version = bump_crate_version(package, version, dry_run)?;
     finalize_changelog(package, &new_version, dry_run)?;

--- a/xtask/src/commands/release/plan.rs
+++ b/xtask/src/commands/release/plan.rs
@@ -120,6 +120,20 @@ pub fn plan(workspace: &Path, args: PlanArgs) -> Result<()> {
             } else {
                 ReleaseType::Minor
             };
+
+            // Special case: some packages are perma-unstable, meaning they won't ever have a stable
+            // release. For these packages, we always use a patch release.
+            let amount = match package {
+                Package::EspRomSys if amount != ReleaseType::Patch => {
+                    log::debug!(
+                        "Bump '{:?}' is not acceptable for package esp-rom-sys - using 'Patch'",
+                        amount
+                    );
+                    ReleaseType::Patch
+                }
+                _ => amount,
+            };
+
             log::debug!("{} needs {:?} version bump", package, amount);
             Some(amount)
         } else {


### PR DESCRIPTION
The idea here is the the plan should _never_ suggest bumping these perma unstable packages (we may however wish to bump a package manually ourselves in the future). So instread of extracting into a function and checking twice, we're now only checking (and normalizing) in the planning phase.