### PR TITLE
add embassy #[main] callback passing

### DIFF
--- a/esp-hal-procmacros/CHANGELOG.md
+++ b/esp-hal-procmacros/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `callback` arg to embassy::main macro (#3813)
 
 ### Changed
 

--- a/esp-hal-procmacros/src/lib.rs
+++ b/esp-hal-procmacros/src/lib.rs
@@ -213,6 +213,22 @@ pub fn entry(args: TokenStream, input: TokenStream) -> TokenStream {
 ///     // Function body
 /// }
 /// ```
+///
+/// You can also attach callbacks to the executor:
+/// ``` rust
+/// struct MyCallbacks;
+///
+/// impl Callbacks for MyCallbacks {
+///     fn before_poll(&mut self) {}
+///     fn on_idle(&mut self) {}
+/// }
+///
+/// #[main(callbacks = MyCallbacks)]
+/// async fn main(_s: embassy_executor::Spawner) {
+///     // Function body
+/// }
+/// ```
+
 #[cfg(feature = "embassy")]
 #[proc_macro_attribute]
 pub fn embassy_main(args: TokenStream, item: TokenStream) -> TokenStream {


### PR DESCRIPTION
### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

Thanks to "Allow hooking into the executor #3737" it is now easy to hook up extra functions for yielding wifi/measuring cpu usage. This PR adds callback argument to esp-hal-procmacro for `esp_hal_embassy::main`

#### Description
Now a callback struct can be passed to `main` macro by simply writing `#[esp_hal_embassy::main(callbacks = MyCallbacks)]` 

#### Testing
Currently I just edited an example to make sure it is passed. Not sure where and if a macro test is necessary. If yes I will add it after feedback. 
