### PR TITLE
Allow configuring longer WDT periods

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - PSRAM on ESP32-S2 (#3811)
+- WDT now allows configuring longer timeouts (#3816)
 
 ### Removed
 

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -73,13 +73,13 @@ ufmt-write               = { version = "0.1.0", optional = true }
 # IMPORTANT:
 # Each supported device MUST have its PAC included below along with a
 # corresponding feature.
-esp32   = { version = "0.38.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "5eae169" }
-esp32c2 = { version = "0.27.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "5eae169" }
-esp32c3 = { version = "0.30.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "5eae169" }
-esp32c6 = { version = "0.21.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "5eae169" }
-esp32h2 = { version = "0.17.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "5eae169" }
-esp32s2 = { version = "0.29.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "5eae169" }
-esp32s3 = { version = "0.33.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "5eae169" }
+esp32   = { version = "0.38.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "848dc3a89" }
+esp32c2 = { version = "0.27.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "848dc3a89" }
+esp32c3 = { version = "0.30.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "848dc3a89" }
+esp32c6 = { version = "0.21.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "848dc3a89" }
+esp32h2 = { version = "0.17.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "848dc3a89" }
+esp32s2 = { version = "0.29.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "848dc3a89" }
+esp32s3 = { version = "0.33.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "848dc3a89" }
 
 [target.'cfg(target_arch = "riscv32")'.dependencies]
 riscv            = { version = "0.12.1" }

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -73,13 +73,13 @@ ufmt-write               = { version = "0.1.0", optional = true }
 # IMPORTANT:
 # Each supported device MUST have its PAC included below along with a
 # corresponding feature.
-esp32   = { version = "0.38.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "848dc3a89" }
-esp32c2 = { version = "0.27.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "848dc3a89" }
-esp32c3 = { version = "0.30.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "848dc3a89" }
-esp32c6 = { version = "0.21.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "848dc3a89" }
-esp32h2 = { version = "0.17.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "848dc3a89" }
-esp32s2 = { version = "0.29.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "848dc3a89" }
-esp32s3 = { version = "0.33.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "848dc3a89" }
+esp32   = { version = "0.38.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "7232b3e" }
+esp32c2 = { version = "0.27.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "7232b3e" }
+esp32c3 = { version = "0.30.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "7232b3e" }
+esp32c6 = { version = "0.21.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "7232b3e" }
+esp32h2 = { version = "0.17.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "7232b3e" }
+esp32s2 = { version = "0.29.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "7232b3e" }
+esp32s3 = { version = "0.33.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "7232b3e" }
 
 [target.'cfg(target_arch = "riscv32")'.dependencies]
 riscv            = { version = "0.12.1" }

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -649,9 +649,8 @@ pub fn init(config: Config) -> Peripherals {
 
             match config.watchdog.rwdt() {
                 WatchdogStatus::Enabled(duration) => {
+                    rtc.rwdt.set_timeout(crate::rtc_cntl::RwdtStage::Stage0, duration);
                     rtc.rwdt.enable();
-                    rtc.rwdt
-                        .set_timeout(crate::rtc_cntl::RwdtStage::Stage0, duration);
                 }
                 WatchdogStatus::Disabled => {
                     rtc.rwdt.disable();
@@ -662,8 +661,8 @@ pub fn init(config: Config) -> Peripherals {
             match config.watchdog.timg0() {
                 WatchdogStatus::Enabled(duration) => {
                     let mut timg0_wd = crate::timer::timg::Wdt::<crate::peripherals::TIMG0<'static>>::new();
-                    timg0_wd.enable();
                     timg0_wd.set_timeout(crate::timer::timg::MwdtStage::Stage0, duration);
+                    timg0_wd.enable();
                 }
                 WatchdogStatus::Disabled => {
                     crate::timer::timg::Wdt::<crate::peripherals::TIMG0<'static>>::new().disable();
@@ -674,8 +673,8 @@ pub fn init(config: Config) -> Peripherals {
             match config.watchdog.timg1() {
                 WatchdogStatus::Enabled(duration) => {
                     let mut timg1_wd = crate::timer::timg::Wdt::<crate::peripherals::TIMG1<'static>>::new();
-                    timg1_wd.enable();
                     timg1_wd.set_timeout(crate::timer::timg::MwdtStage::Stage0, duration);
+                    timg1_wd.enable();
                 }
                 WatchdogStatus::Disabled => {
                     crate::timer::timg::Wdt::<crate::peripherals::TIMG1<'static>>::new().disable();

--- a/esp-metadata-generated/src/_build_script_utils.rs
+++ b/esp-metadata-generated/src/_build_script_utils.rs
@@ -526,6 +526,7 @@ impl Chip {
                     "i2c_master_ll_intr_mask=\"262143\"",
                     "i2c_master_fifo_size=\"16\"",
                     "interrupts_status_registers=\"2\"",
+                    "timergroup_timg_has_divcnt_rst",
                     "uart_ram_size=\"128\"",
                     "has_dram_region",
                 ],
@@ -628,6 +629,7 @@ impl Chip {
                     "cargo:rustc-cfg=i2c_master_ll_intr_mask=\"262143\"",
                     "cargo:rustc-cfg=i2c_master_fifo_size=\"16\"",
                     "cargo:rustc-cfg=interrupts_status_registers=\"2\"",
+                    "cargo:rustc-cfg=timergroup_timg_has_divcnt_rst",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
                     "cargo:rustc-cfg=has_dram_region",
                 ],
@@ -754,6 +756,7 @@ impl Chip {
                     "interrupts_status_registers=\"2\"",
                     "rmt_ram_start=\"1610703872\"",
                     "rmt_channel_ram_size=\"48\"",
+                    "timergroup_timg_has_divcnt_rst",
                     "uart_ram_size=\"128\"",
                     "has_dram_region",
                 ],
@@ -876,6 +879,7 @@ impl Chip {
                     "cargo:rustc-cfg=interrupts_status_registers=\"2\"",
                     "cargo:rustc-cfg=rmt_ram_start=\"1610703872\"",
                     "cargo:rustc-cfg=rmt_channel_ram_size=\"48\"",
+                    "cargo:rustc-cfg=timergroup_timg_has_divcnt_rst",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
                     "cargo:rustc-cfg=has_dram_region",
                 ],
@@ -1055,6 +1059,7 @@ impl Chip {
                     "interrupts_status_registers=\"3\"",
                     "rmt_ram_start=\"1610638336\"",
                     "rmt_channel_ram_size=\"48\"",
+                    "timergroup_timg_has_divcnt_rst",
                     "uart_ram_size=\"128\"",
                     "lp_uart_ram_size=\"32\"",
                     "wifi_has_wifi6",
@@ -1232,6 +1237,7 @@ impl Chip {
                     "cargo:rustc-cfg=interrupts_status_registers=\"3\"",
                     "cargo:rustc-cfg=rmt_ram_start=\"1610638336\"",
                     "cargo:rustc-cfg=rmt_channel_ram_size=\"48\"",
+                    "cargo:rustc-cfg=timergroup_timg_has_divcnt_rst",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
                     "cargo:rustc-cfg=lp_uart_ram_size=\"32\"",
                     "cargo:rustc-cfg=wifi_has_wifi6",
@@ -1389,6 +1395,7 @@ impl Chip {
                     "interrupts_status_registers=\"2\"",
                     "rmt_ram_start=\"1610642432\"",
                     "rmt_channel_ram_size=\"48\"",
+                    "timergroup_timg_has_divcnt_rst",
                     "uart_ram_size=\"128\"",
                     "has_dram_region",
                 ],
@@ -1540,6 +1547,7 @@ impl Chip {
                     "cargo:rustc-cfg=interrupts_status_registers=\"2\"",
                     "cargo:rustc-cfg=rmt_ram_start=\"1610642432\"",
                     "cargo:rustc-cfg=rmt_channel_ram_size=\"48\"",
+                    "cargo:rustc-cfg=timergroup_timg_has_divcnt_rst",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
                     "cargo:rustc-cfg=has_dram_region",
                 ],
@@ -2339,6 +2347,7 @@ impl Config {
         println!("cargo:rustc-check-cfg=cfg(i2c_master_has_arbitration_en)");
         println!("cargo:rustc-check-cfg=cfg(i2c_master_has_tx_fifo_watermark)");
         println!("cargo:rustc-check-cfg=cfg(i2c_master_bus_timeout_is_exponential)");
+        println!("cargo:rustc-check-cfg=cfg(timergroup_timg_has_divcnt_rst)");
         println!("cargo:rustc-check-cfg=cfg(esp32c3)");
         println!("cargo:rustc-check-cfg=cfg(soc_has_ds)");
         println!("cargo:rustc-check-cfg=cfg(soc_has_fe)");

--- a/esp-metadata-generated/src/_generated_esp32.rs
+++ b/esp-metadata-generated/src/_generated_esp32.rs
@@ -156,6 +156,9 @@ macro_rules! property {
     ("timergroup.timg_has_timer1") => {
         true
     };
+    ("timergroup.timg_has_divcnt_rst") => {
+        false
+    };
     ("uart.ram_size") => {
         128
     };

--- a/esp-metadata-generated/src/_generated_esp32c2.rs
+++ b/esp-metadata-generated/src/_generated_esp32c2.rs
@@ -144,6 +144,9 @@ macro_rules! property {
     ("timergroup.timg_has_timer1") => {
         false
     };
+    ("timergroup.timg_has_divcnt_rst") => {
+        true
+    };
     ("uart.ram_size") => {
         128
     };

--- a/esp-metadata-generated/src/_generated_esp32c3.rs
+++ b/esp-metadata-generated/src/_generated_esp32c3.rs
@@ -156,6 +156,9 @@ macro_rules! property {
     ("timergroup.timg_has_timer1") => {
         false
     };
+    ("timergroup.timg_has_divcnt_rst") => {
+        true
+    };
     ("uart.ram_size") => {
         128
     };

--- a/esp-metadata-generated/src/_generated_esp32c6.rs
+++ b/esp-metadata-generated/src/_generated_esp32c6.rs
@@ -162,6 +162,9 @@ macro_rules! property {
     ("timergroup.timg_has_timer1") => {
         false
     };
+    ("timergroup.timg_has_divcnt_rst") => {
+        true
+    };
     ("uart.ram_size") => {
         128
     };

--- a/esp-metadata-generated/src/_generated_esp32h2.rs
+++ b/esp-metadata-generated/src/_generated_esp32h2.rs
@@ -156,6 +156,9 @@ macro_rules! property {
     ("timergroup.timg_has_timer1") => {
         false
     };
+    ("timergroup.timg_has_divcnt_rst") => {
+        true
+    };
     ("uart.ram_size") => {
         128
     };

--- a/esp-metadata-generated/src/_generated_esp32s2.rs
+++ b/esp-metadata-generated/src/_generated_esp32s2.rs
@@ -156,6 +156,9 @@ macro_rules! property {
     ("timergroup.timg_has_timer1") => {
         true
     };
+    ("timergroup.timg_has_divcnt_rst") => {
+        false
+    };
     ("uart.ram_size") => {
         128
     };

--- a/esp-metadata-generated/src/_generated_esp32s3.rs
+++ b/esp-metadata-generated/src/_generated_esp32s3.rs
@@ -156,6 +156,9 @@ macro_rules! property {
     ("timergroup.timg_has_timer1") => {
         true
     };
+    ("timergroup.timg_has_divcnt_rst") => {
+        false
+    };
     ("uart.ram_size") => {
         128
     };

--- a/esp-metadata/devices/esp32.toml
+++ b/esp-metadata/devices/esp32.toml
@@ -598,6 +598,7 @@ instances = [
 
 [device.timergroup]
 timg_has_timer1 = true
+timg_has_divcnt_rst = false
 instances = [{ name = "timg0" }, { name = "timg1" }]
 
 [device.uart]

--- a/esp-metadata/devices/esp32c2.toml
+++ b/esp-metadata/devices/esp32c2.toml
@@ -254,6 +254,7 @@ instances = [
 
 [device.timergroup]
 instances = [{ name = "timg0" }]
+timg_has_divcnt_rst = true
 
 [device.uart]
 support_status = "supported"

--- a/esp-metadata/devices/esp32c3.toml
+++ b/esp-metadata/devices/esp32c3.toml
@@ -300,6 +300,7 @@ instances = [
 
 [device.timergroup]
 instances = [{ name = "timg0" }, { name = "timg1" }]
+timg_has_divcnt_rst = true
 
 [device.uart]
 support_status = "supported"

--- a/esp-metadata/devices/esp32c6.toml
+++ b/esp-metadata/devices/esp32c6.toml
@@ -454,6 +454,7 @@ instances = [
 
 [device.timergroup]
 instances = [{ name = "timg0" }, { name = "timg1" }]
+timg_has_divcnt_rst = true
 
 [device.uart]
 support_status = "supported"

--- a/esp-metadata/devices/esp32h2.toml
+++ b/esp-metadata/devices/esp32h2.toml
@@ -371,6 +371,7 @@ instances = [
 
 [device.timergroup]
 instances = [{ name = "timg0" }, { name = "timg1" }]
+timg_has_divcnt_rst = true
 
 [device.uart]
 support_status = "supported"

--- a/esp-metadata/devices/esp32s2.toml
+++ b/esp-metadata/devices/esp32s2.toml
@@ -421,6 +421,7 @@ instances = [
 
 [device.timergroup]
 timg_has_timer1 = true
+timg_has_divcnt_rst = false
 instances = [{ name = "timg0" }, { name = "timg1" }]
 
 [device.uart]

--- a/esp-metadata/devices/esp32s3.toml
+++ b/esp-metadata/devices/esp32s3.toml
@@ -596,6 +596,7 @@ instances = [
 
 [device.timergroup]
 timg_has_timer1 = true
+timg_has_divcnt_rst = false
 instances = [{ name = "timg0" }, { name = "timg1" }]
 
 [device.uart]

--- a/esp-metadata/src/cfg.rs
+++ b/esp-metadata/src/cfg.rs
@@ -460,6 +460,8 @@ driver_configs![
         properties: {
             #[serde(default)]
             timg_has_timer1: bool,
+            #[serde(default)]
+            timg_has_divcnt_rst: bool,
         }
     },
     TouchProperties {

--- a/hil-test/tests/init.rs
+++ b/hil-test/tests/init.rs
@@ -45,6 +45,20 @@ mod tests {
     }
 
     #[test]
+    #[cfg(timergroup_timg0)]
+    fn test_wdt0_uses_prescaler() {
+        esp_hal::init(
+            Config::default().with_watchdog(
+                WatchdogConfig::default()
+                    .with_timg0(WatchdogStatus::Enabled(Duration::from_micros(53_687_092))), // multiplied by 80 (for the default clock source), then taking the 32 lower bits this is 0x40
+            ),
+        );
+
+        let delay = Delay::new();
+        delay.delay(Duration::from_millis(250));
+    }
+
+    #[test]
     #[cfg(timergroup_timg1)]
     fn test_feeding_timg1_wdt() {
         let peripherals = esp_hal::init(


### PR DESCRIPTION
Closes #3779

# Testing

Since probe-rs disables WDTs, we need to manually test this change. This can be done by updating e.g. the `embassy_hello_world` example with the following esp_hal init call:

```rust
    let peripherals = esp_hal::init(esp_hal::Config::default().with_watchdog(
        esp_hal::config::WatchdogConfig::default().with_timg0(
            // multiplied by 80 (for the default clock source), then taking the 32 lower bits
            // this is 0x40
            esp_hal::config::WatchdogStatus::Enabled(esp_hal::time::Duration::from_micros(
                53_687_092,
            )),
        ),
    ));
```

If the PR works, the MCU reboots after ~53.6 seconds. If the PR does not work, the MCU reboots immediately.