### PR TITLE
Add `additional configuration` section to docs in packages that lacked this

### DIFF
--- a/esp-backtrace/Cargo.toml
+++ b/esp-backtrace/Cargo.toml
@@ -25,6 +25,7 @@ esp-config  = { version = "0.5.0", path = "../esp-config" }
 esp-println = { version = "0.15.0", optional = true, default-features = false, path = "../esp-println" }
 heapless    = "0.8"
 semihosting = { version = "0.1.20", optional = true }
+document-features = "0.2.11"
 
 [build-dependencies]
 esp-config   = { version = "0.5.0", path = "../esp-config", features = ["build"] }
@@ -40,21 +41,27 @@ esp32h2 = ["esp-println?/esp32h2"]
 esp32s2 = ["esp-println?/esp32s2", "semihosting?/openocd-semihosting"]
 esp32s3 = ["esp-println?/esp32s3", "semihosting?/openocd-semihosting", "print-float-registers"]
 
-# Use esp-println
+## Use `esp-println`
 println = ["dep:esp-println"]
 
-# Use defmt
+## Use `defmt`
 defmt = ["dep:defmt"]
 
 print-float-registers = [] # TODO support esp32p4
 
 # You may optionally enable one or more of the below features to provide
 # additional functionality:
+## Print messages in red (only used for panic and exception handlers)
 colors               = []
+## Invoke the extern function custom_halt() instead of doing a loop {} in case of a panic or exception
 custom-halt          = []
+## Invoke the extern function `custom_pre_backtrace()` before handling a panic or exception
 custom-pre-backtrace = []
+## Include an exception handler, will add `esp-println` as a dependency
 exception-handler    = []
+## Halt both CPUs on ESP32 / ESP32-S3 instead of doing a `loop {}` in case of a panic or exception
 halt-cores           = []
+## Include a panic handler, will add `esp-println` as a dependency
 panic-handler        = []
 
 [lints.rust]

--- a/esp-backtrace/src/lib.rs
+++ b/esp-backtrace/src/lib.rs
@@ -1,14 +1,16 @@
 #![allow(rustdoc::bare_urls, unused_macros)]
 #![cfg_attr(target_arch = "xtensa", feature(asm_experimental_arch))]
-//! Supports the ESP32, ESP32-C2/C3/C6, ESP32-H2, ESP32-P4, and ESP32-S2/S3. Optional exception and
-//! panic handlers are included, both of which can be enabled via their respective features.
+//! This is a lightweight crate for obtaining backtraces during panics, exceptions, and hard faults
+//! on Espressif devices. It provides optional panic and exception handlers and supports a range of
+//! output options, all configurable through feature flags.
 //!
 //! Please note that when targeting a RISC-V device, you **need** to force frame pointers (i.e.
 //! `"-C", "force-frame-pointers",` in your `.cargo/config.toml`); this is **not** required for
 //! Xtensa.
 //!
-//! You can get an array of backtrace addresses (limited to 10 entries by default) via `arch::backtrace()` if
-//! you want to create a backtrace yourself (i.e. not using the panic or exception handler).
+//! You can get an array of backtrace addresses (limited to 10 entries by default) via
+//! `arch::backtrace()` if you want to create a backtrace yourself (i.e. not using the panic or
+//! exception handler).
 //!
 //! ## Features
 #![doc = document_features::document_features!()]

--- a/esp-backtrace/src/lib.rs
+++ b/esp-backtrace/src/lib.rs
@@ -2,6 +2,14 @@
 #![cfg_attr(target_arch = "xtensa", feature(asm_experimental_arch))]
 #![doc = include_str!("../README.md")]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
+//! ## Additional configuration
+//!
+//! We've exposed some configuration options that don't fit into cargo
+//! features. These can be set via environment variables, or via cargo's `[env]`
+//! section inside `.cargo/config.toml`. Below is a table of tunable parameters
+//! for this crate:
+#![doc = ""]
+#![doc = include_str!(concat!(env!("OUT_DIR"), "/esp_backtrace_config_table.md"))]
 #![no_std]
 
 #[cfg(feature = "defmt")]

--- a/esp-backtrace/src/lib.rs
+++ b/esp-backtrace/src/lib.rs
@@ -1,7 +1,17 @@
 #![allow(rustdoc::bare_urls, unused_macros)]
 #![cfg_attr(target_arch = "xtensa", feature(asm_experimental_arch))]
-#![doc = include_str!("../README.md")]
-#![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
+//! Supports the ESP32, ESP32-C2/C3/C6, ESP32-H2, ESP32-P4, and ESP32-S2/S3. Optional exception and
+//! panic handlers are included, both of which can be enabled via their respective features.
+//!
+//! Please note that when targeting a RISC-V device, you **need** to force frame pointers (i.e.
+//! `"-C", "force-frame-pointers",` in your `.cargo/config.toml`); this is **not** required for
+//! Xtensa.
+//!
+//! You can get an array of backtrace addresses (currently limited to 10) via `arch::backtrace()` if
+//! you want to create a backtrace yourself (i.e. not using the panic or exception handler).
+//!
+//! ## Features
+#![doc = document_features::document_features!()]
 //! ## Additional configuration
 //!
 //! We've exposed some configuration options that don't fit into cargo
@@ -10,6 +20,7 @@
 //! for this crate:
 #![doc = ""]
 #![doc = include_str!(concat!(env!("OUT_DIR"), "/esp_backtrace_config_table.md"))]
+#![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 #![no_std]
 
 #[cfg(feature = "defmt")]

--- a/esp-backtrace/src/lib.rs
+++ b/esp-backtrace/src/lib.rs
@@ -7,7 +7,7 @@
 //! `"-C", "force-frame-pointers",` in your `.cargo/config.toml`); this is **not** required for
 //! Xtensa.
 //!
-//! You can get an array of backtrace addresses (currently limited to 10) via `arch::backtrace()` if
+//! You can get an array of backtrace addresses (limited to 10 entries by default) via `arch::backtrace()` if
 //! you want to create a backtrace yourself (i.e. not using the panic or exception handler).
 //!
 //! ## Features

--- a/esp-backtrace/src/lib.rs
+++ b/esp-backtrace/src/lib.rs
@@ -4,9 +4,10 @@
 //! on Espressif devices. It provides optional panic and exception handlers and supports a range of
 //! output options, all configurable through feature flags.
 //!
-//! Please note that when targeting a RISC-V device, you **need** to force frame pointers (i.e.
-//! `"-C", "force-frame-pointers",` in your `.cargo/config.toml`); this is **not** required for
-//! Xtensa.
+#![cfg_attr(
+    target_arch = "riscv32",
+    doc = "Please note that you **need** to force frame pointers (i.e. `\"-C\", \"force-frame-pointers\",` in your `.cargo/config.toml`)"
+)]
 //!
 //! You can get an array of backtrace addresses (limited to 10 entries by default) via
 //! `arch::backtrace()` if you want to create a backtrace yourself (i.e. not using the panic or

--- a/esp-backtrace/src/lib.rs
+++ b/esp-backtrace/src/lib.rs
@@ -3,12 +3,10 @@
 //! This is a lightweight crate for obtaining backtraces during panics, exceptions, and hard faults
 //! on Espressif devices. It provides optional panic and exception handlers and supports a range of
 //! output options, all configurable through feature flags.
-//!
 #![cfg_attr(
     target_arch = "riscv32",
     doc = "Please note that you **need** to force frame pointers (i.e. `\"-C\", \"force-frame-pointers\",` in your `.cargo/config.toml`)"
 )]
-//!
 //! You can get an array of backtrace addresses (limited to 10 entries by default) via
 //! `arch::backtrace()` if you want to create a backtrace yourself (i.e. not using the panic or
 //! exception handler).

--- a/esp-hal-embassy/src/lib.rs
+++ b/esp-hal-embassy/src/lib.rs
@@ -35,7 +35,7 @@
 //! queue flavour, then you need to pass as many timers as you start executors.
 //! In other cases, you can pass a single timer.
 //!
-//! ## Configuration
+//! ## Additional Configuration
 //!
 //! You can configure the behaviour of the embassy runtime by using the
 //! following environment variables:

--- a/esp-ieee802154/src/lib.rs
+++ b/esp-ieee802154/src/lib.rs
@@ -17,6 +17,14 @@
 //!
 //! ## Feature Flags
 #![doc = document_features::document_features!()]
+//! ## Additional configuration
+//!
+//! We've exposed some configuration options that don't fit into cargo
+//! features. These can be set via environment variables, or via cargo's `[env]`
+//! section inside `.cargo/config.toml`. Below is a table of tunable parameters
+//! for this crate:
+#![doc = ""]
+#![doc = include_str!(concat!(env!("OUT_DIR"), "/esp_ieee802154_config_table.md"))]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 #![no_std]
 


### PR DESCRIPTION
Draft as I want some opinions on `esp-backtrace` one....

as we're just importing the `readme` for docs page, we can just append this section. I'm okay with copy-pasting the `readme` text itself and just pasting this section in it, but maybe it's fine as it is or there's another way around

<img width="1164" height="957" alt="image" src="https://github.com/user-attachments/assets/baf19366-2946-4ff4-9e9e-4381cc019325" />
