### PR TITLE
feat(esp-wifi): add Country Code

### DIFF
--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Country Code is returned from the Wi-Fi scan results
+
 
 ### Changed
 

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -4,7 +4,10 @@ pub mod event;
 mod internal;
 pub(crate) mod os_adapter;
 pub(crate) mod state;
-use alloc::{collections::vec_deque::VecDeque, string::{String, ToString}};
+use alloc::{
+    collections::vec_deque::VecDeque,
+    string::{String, ToString},
+};
 use core::{
     fmt::Debug,
     marker::PhantomData,
@@ -1846,13 +1849,15 @@ fn convert_ap_info(record: &include::wifi_ap_record_t) -> AccessPointInfo {
 
     // Extract country code from ESP-IDF structure
     let country_code = {
-        let cc_bytes = unsafe {
-            core::slice::from_raw_parts(record.country.cc.as_ptr() as *const u8, 3)
-        };
-        
+        let cc_bytes =
+            unsafe { core::slice::from_raw_parts(record.country.cc.as_ptr() as *const u8, 3) };
+
         // Find the null terminator or end of array
-        let cc_len = cc_bytes.iter().position(|&b| b == 0).unwrap_or(cc_bytes.len());
-        
+        let cc_len = cc_bytes
+            .iter()
+            .position(|&b| b == 0)
+            .unwrap_or(cc_bytes.len());
+
         if cc_len >= 2 {
             // Validate that we have at least 2 valid ASCII characters
             let cc_slice = &cc_bytes[..cc_len.min(2)];
@@ -3193,4 +3198,3 @@ impl core::future::Future for MultiWifiEventFuture {
         }
     }
 }
-

--- a/esp-wifi/src/wifi/mod.rs
+++ b/esp-wifi/src/wifi/mod.rs
@@ -4,7 +4,7 @@ pub mod event;
 mod internal;
 pub(crate) mod os_adapter;
 pub(crate) mod state;
-use alloc::{collections::vec_deque::VecDeque, string::String};
+use alloc::{collections::vec_deque::VecDeque, string::{String, ToString}};
 use core::{
     fmt::Debug,
     marker::PhantomData,
@@ -241,6 +241,11 @@ pub struct AccessPointInfo {
 
     /// The authentication method used by the access point.
     pub auth_method: Option<AuthMethod>,
+
+    /// The country code of the access point (if available from beacon frames).
+    /// This is a 2-character ISO country code (e.g., "US", "DE", "JP").
+    #[cfg_attr(feature = "defmt", defmt(Debug2Format))]
+    pub country_code: Option<String>,
 }
 
 /// Configuration for a Wi-Fi access point.
@@ -1839,6 +1844,28 @@ fn convert_ap_info(record: &include::wifi_ap_record_t) -> AccessPointInfo {
     let mut ssid = String::new();
     ssid.push_str(ssid_ref);
 
+    // Extract country code from ESP-IDF structure
+    let country_code = {
+        let cc_bytes = unsafe {
+            core::slice::from_raw_parts(record.country.cc.as_ptr() as *const u8, 3)
+        };
+        
+        // Find the null terminator or end of array
+        let cc_len = cc_bytes.iter().position(|&b| b == 0).unwrap_or(cc_bytes.len());
+        
+        if cc_len >= 2 {
+            // Validate that we have at least 2 valid ASCII characters
+            let cc_slice = &cc_bytes[..cc_len.min(2)];
+            if cc_slice.iter().all(|&b| b.is_ascii_uppercase()) {
+                core::str::from_utf8(cc_slice).ok().map(|s| s.to_string())
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    };
+
     AccessPointInfo {
         ssid,
         bssid: record.bssid,
@@ -1851,6 +1878,7 @@ fn convert_ap_info(record: &include::wifi_ap_record_t) -> AccessPointInfo {
         },
         signal_strength: record.rssi,
         auth_method: Some(AuthMethod::from_raw(record.authmode)),
+        country_code,
     }
 }
 
@@ -3165,3 +3193,4 @@ impl core::future::Future for MultiWifiEventFuture {
         }
     }
 }
+

--- a/examples/src/bin/wifi_scan_with_country_codes.rs
+++ b/examples/src/bin/wifi_scan_with_country_codes.rs
@@ -1,0 +1,79 @@
+//! WiFi scanning example with country code display
+//!
+//! This example demonstrates how to scan for WiFi access points and display
+//! their country codes, which are now available directly from ESP-IDF.
+
+//% FEATURES: esp-wifi esp-wifi/wifi esp-hal/unstable
+//% CHIPS: esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c6
+
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use alloc::{collections::BTreeSet, string::String, vec::Vec};
+use esp_backtrace as _;
+use esp_hal::{clock::CpuClock, main, rng::Rng, timer::timg::TimerGroup};
+use esp_println::println;
+use esp_wifi::{init, wifi::WifiMode};
+
+esp_bootloader_esp_idf::esp_app_desc!();
+
+#[main]
+fn main() -> ! {
+    esp_println::logger::init_logger_from_env();
+    let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
+    let peripherals = esp_hal::init(config);
+
+    esp_alloc::heap_allocator!(size: 72 * 1024);
+
+    let timg0 = TimerGroup::new(peripherals.TIMG0);
+    let esp_wifi_ctrl = init(timg0.timer0, Rng::new(peripherals.RNG)).unwrap();
+
+    let (mut controller, _interfaces) = 
+        esp_wifi::wifi::new(&esp_wifi_ctrl, peripherals.WIFI).unwrap();
+
+    controller.set_mode(WifiMode::Sta).unwrap();
+    controller.start().unwrap();
+
+    println!("Starting WiFi scan with country code display...");
+
+    // Perform WiFi scan
+    let scan_results = controller.scan_n(20).unwrap();
+
+    println!("Found {} access points:\n", scan_results.len());
+    println!("{:<25} | {:<8} | {:<5} | {:<8}", "SSID", "Channel", "RSSI", "Country");
+    println!("{:-<50}", "");
+    
+    // Display scan results with country codes
+    for ap in &scan_results {
+        let country_display = ap.country_code.as_deref().unwrap_or("Unknown");
+        println!(
+            "{:<25} | {:<8} | {:<5} | {:<8}",
+            if ap.ssid.len() > 24 { &ap.ssid[..24] } else { &ap.ssid },
+            ap.channel,
+            ap.signal_strength,
+            country_display
+        );
+    }
+
+    // Show unique country codes found
+    let unique_countries: Vec<String> = {
+        let mut countries: BTreeSet<String> = BTreeSet::new();
+        for ap in &scan_results {
+            if let Some(ref country) = ap.country_code {
+                countries.insert(country.clone());
+            }
+        }
+        countries.into_iter().collect()
+    };
+
+    println!("\nUnique country codes detected: {:?}", unique_countries);
+    println!("Total APs with country info: {}", 
+        scan_results.iter().filter(|ap| ap.country_code.is_some()).count());
+
+    loop {
+        let mut delay = esp_hal::delay::Delay::new();
+        delay.delay_millis(1000u32);
+    }
+}


### PR DESCRIPTION
### Submission Checklist 📝
- [X] I have updated existing examples or added new ones (if applicable).
- [X] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [X] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [X] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [X] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [X] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

This PR adds support to return the country code of the access points scanned by esp-wifi.

#### Testing

Tested by using the feature - most of the APs around me either return a country code (e.g: `US`) or `None`
