### PR TITLE
Fix GPIO matrix typo

### DIFF
--- a/esp-hal/src/gpio/interconnect.rs
+++ b/esp-hal/src/gpio/interconnect.rs
@@ -473,7 +473,7 @@ impl Signal<'_> {
         let use_gpio_matrix = af == AlternateFunction::GPIO;
 
         assert!(
-            signal.can_use_gpio_matrix() || use_gpio_matrix,
+            signal.can_use_gpio_matrix() || !use_gpio_matrix,
             "{:?} cannot be routed through the GPIO matrix",
             signal
         );


### PR DESCRIPTION
This PR fixes an issue where trying to use signals that can't be routed through the GPIO matrix causes a panic.