### PR TITLE
Stop using `ok` in esp-wifi/esp-ieee802154 crates codebase.

### DIFF
--- a/esp-wifi/src/esp_now/mod.rs
+++ b/esp-wifi/src/esp_now/mod.rs
@@ -635,8 +635,14 @@ impl<'d> EspNow<'d> {
         };
 
         check_error_expect!({ esp_now_init() }, "esp-now-init failed");
-        check_error_expect!({ esp_now_register_recv_cb(Some(rcv_cb)) }, "receiving callback failed");
-        check_error_expect!({ esp_now_register_send_cb(Some(send_cb)) }, "sending callback failed");
+        check_error_expect!(
+            { esp_now_register_recv_cb(Some(rcv_cb)) },
+            "receiving callback failed"
+        );
+        check_error_expect!(
+            { esp_now_register_send_cb(Some(send_cb)) },
+            "sending callback failed"
+        );
 
         esp_now
             .add_peer(PeerInfo {

--- a/esp-wifi/src/esp_now/mod.rs
+++ b/esp-wifi/src/esp_now/mod.rs
@@ -622,8 +622,8 @@ impl<'d> EspNow<'d> {
         };
 
         check_error!({ esp_now_init() }).expect("esp-now-init failed");
-        check_error!({ esp_now_register_recv_cb(Some(rcv_cb)) }).ok();
-        check_error!({ esp_now_register_send_cb(Some(send_cb)) }).ok();
+        check_error!({ esp_now_register_recv_cb(Some(rcv_cb)) }).unwrap();
+        check_error!({ esp_now_register_send_cb(Some(send_cb)) }).unwrap();
 
         esp_now
             .add_peer(PeerInfo {
@@ -633,7 +633,7 @@ impl<'d> EspNow<'d> {
                 channel: None,
                 encrypt: false,
             })
-            .ok();
+            .unwrap();
 
         esp_now
     }

--- a/esp-wifi/src/esp_now/mod.rs
+++ b/esp-wifi/src/esp_now/mod.rs
@@ -622,8 +622,8 @@ impl<'d> EspNow<'d> {
         };
 
         check_error!({ esp_now_init() }).expect("esp-now-init failed");
-        check_error!({ esp_now_register_recv_cb(Some(rcv_cb)) }).unwrap();
-        check_error!({ esp_now_register_send_cb(Some(send_cb)) }).unwrap();
+        check_error!({ esp_now_register_recv_cb(Some(rcv_cb)) }).expect("receiving callback failed");
+        check_error!({ esp_now_register_send_cb(Some(send_cb)) }).expect("sending callback failed");
 
         esp_now
             .add_peer(PeerInfo {
@@ -633,7 +633,7 @@ impl<'d> EspNow<'d> {
                 channel: None,
                 encrypt: false,
             })
-            .unwrap();
+            .expect("adding peer failed");
 
         esp_now
     }

--- a/esp-wifi/src/esp_now/mod.rs
+++ b/esp-wifi/src/esp_now/mod.rs
@@ -52,6 +52,19 @@ macro_rules! check_error {
     };
 }
 
+macro_rules! check_error_expect {
+    ($block:block, $msg:literal) => {
+        match unsafe { $block } {
+            0 => (),
+            res => panic!(
+                "{}: {:?}",
+                $msg,
+                EspNowError::Error(Error::from_code(res as u32))
+            ),
+        }
+    };
+}
+
 /// Internal errors that can occur with ESP-NOW.
 #[repr(u32)]
 #[derive(Debug)]
@@ -621,9 +634,9 @@ impl<'d> EspNow<'d> {
             _phantom: PhantomData,
         };
 
-        check_error!({ esp_now_init() }).expect("esp-now-init failed");
-        check_error!({ esp_now_register_recv_cb(Some(rcv_cb)) }).expect("receiving callback failed");
-        check_error!({ esp_now_register_send_cb(Some(send_cb)) }).expect("sending callback failed");
+        check_error_expect!({ esp_now_init() }, "esp-now-init failed");
+        check_error_expect!({ esp_now_register_recv_cb(Some(rcv_cb)) }, "receiving callback failed");
+        check_error_expect!({ esp_now_register_send_cb(Some(send_cb)) }, "sending callback failed");
 
         esp_now
             .add_peer(PeerInfo {


### PR DESCRIPTION
closes https://github.com/esp-rs/esp-hal/issues/2755

I'm not entirely sure if that's it for resolving the issue though. 

there's another [usage of `.ok()` in esp-ieee802154](https://github.com/esp-rs/esp-hal/blob/main/esp-ieee802154/src/raw.rs#L399), but I think there it's okay, as it seems to be an interrupt part, so we can't actually handle a potential error there. The rest are examples, which, as mention in the original issue, will be refactored. 


Lemme know if you want to see something else here