### PR TITLE
Fix ble crash

### DIFF
--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed a BLE panic caused by unimplemented functions (#3762)
+- Fixed the BLE stack crashing in certain cases (#3854)
 
 
 ### Removed

--- a/esp-wifi/CHANGELOG.md
+++ b/esp-wifi/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a BLE panic caused by unimplemented functions (#3762)
+
 
 ### Removed
 

--- a/esp-wifi/src/compat/common.rs
+++ b/esp-wifi/src/compat/common.rs
@@ -413,12 +413,12 @@ pub(crate) fn number_of_messages_in_queue(queue: *const ConcurrentQueue) -> u32 
 /// components/newlib/time.c
 #[unsafe(no_mangle)]
 pub(crate) unsafe extern "C" fn sleep(
-    seconds: crate::binary::c_types::c_uint,
+    millis: crate::binary::c_types::c_uint,
 ) -> crate::binary::c_types::c_uint {
     trace!("sleep");
 
     unsafe {
-        usleep(seconds * 1_000);
+        usleep(millis * 1_000);
     }
     0
 }

--- a/hil-test/tests/esp_wifi_ble_controller.rs
+++ b/hil-test/tests/esp_wifi_ble_controller.rs
@@ -11,7 +11,7 @@
 //! THIS DOESN'T ACTUALLY TEST THE RADIO HOWEVER.
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s3
-//% FEATURES: unstable esp-wifi esp-alloc esp-wifi/ble
+//% FEATURES: unstable esp-wifi esp-alloc esp-wifi/ble defmt
 
 #![no_std]
 #![no_main]


### PR DESCRIPTION
This PR fixes the second problem reported in #3760 by inserting a short sleep before deinitializing the BLE stack.

As far as I can see, the problem is that the BLE tasks are still working when we are deinitializing the stack. I'm not sure how we could wait for them to finish before we turn the lights off, but a short wait seems to be enough for now.

Closes #3760
Closes #3762