### PR TITLE
Use riscv-rt's startup code

### DIFF
--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -128,6 +128,7 @@ esp32   = [
 esp32c2 = [
     "dep:esp32c2",
     "dep:riscv",
+    "esp-riscv-rt/no-mie-mip",
     "portable-atomic/unsafe-assume-single-core",
     "esp-rom-sys/esp32c2",
     "esp-metadata-generated/esp32c2",
@@ -136,6 +137,7 @@ esp32c2 = [
 esp32c3 = [
     "dep:esp32c3",
     "dep:riscv",
+    "esp-riscv-rt/no-mie-mip",
     "esp-riscv-rt/rtc-ram",
     "portable-atomic/unsafe-assume-single-core",
     "esp-rom-sys/esp32c3",
@@ -146,7 +148,6 @@ esp32c6 = [
     "dep:esp32c6",
     "dep:riscv",
     "esp-riscv-rt/rtc-ram",
-    "esp-riscv-rt/has-mie-mip",
     "procmacros/has-lp-core",
     "esp-rom-sys/esp32c6",
     "esp-metadata-generated/esp32c6",
@@ -156,7 +157,6 @@ esp32h2 = [
     "dep:esp32h2",
     "dep:riscv",
     "esp-riscv-rt/rtc-ram",
-    "esp-riscv-rt/has-mie-mip",
     "esp-rom-sys/esp32h2",
     "esp-metadata-generated/esp32h2",
 ]

--- a/esp-hal/ld/esp32/esp32.x
+++ b/esp-hal/ld/esp32/esp32.x
@@ -27,9 +27,3 @@ INCLUDE "stack.x"
 INCLUDE "dram2.x"
 INCLUDE "metadata.x"
 /* End of Shared sections */
-
-EXTERN(DefaultHandler);
-
-EXTERN(WIFI_EVENT); /* Force inclusion of WiFi libraries */
-
-INCLUDE "device.x"

--- a/esp-hal/ld/esp32s2/esp32s2.x
+++ b/esp-hal/ld/esp32s2/esp32s2.x
@@ -35,7 +35,3 @@ INCLUDE "stack.x"
 INCLUDE "dram2.x"
 INCLUDE "metadata.x"
 /* End of Shared sections */
-
-EXTERN(DefaultHandler);
-
-INCLUDE "device.x"

--- a/esp-hal/ld/esp32s3/esp32s3.x
+++ b/esp-hal/ld/esp32s3/esp32s3.x
@@ -61,7 +61,3 @@ INCLUDE "stack.x"
 INCLUDE "dram2.x"
 INCLUDE "metadata.x"
 /* End of Shared sections */
-
-EXTERN(DefaultHandler);
-
-INCLUDE "device.x"

--- a/esp-hal/ld/riscv/hal-defaults.x
+++ b/esp-hal/ld/riscv/hal-defaults.x
@@ -1,44 +1,62 @@
 ENTRY(_start)
 
+/*
+We don't use the linker scripts defined in riscv-rt (since we have special needs) but we need to define some symbols to satisfy riscv-rt
+*/
+
 PROVIDE(_stext = ORIGIN(ROTEXT));
+
+/* Default abort entry point. If no abort symbol is provided, then abort maps to _default_abort. */
+EXTERN(_default_abort);
+PROVIDE(abort = _default_abort);
+
+/* Trap for exceptions triggered during initialization. If the execution reaches this point, it
+   means that there is a bug in the boot code. If no _pre_init_trap symbol is provided, then
+  _pre_init_trap defaults to _default_abort. Note that _pre_init_trap must be 4-byte aligned */
+PROVIDE(_pre_init_trap = _default_abort);
+
+/* Default trap entry point. If not _start_trap symbol is provided, then _start_trap maps to
+   _default_start_trap, which saves caller saved registers, calls _start_trap_rust, restores
+   caller saved registers and then returns. Note that _start_trap must be 4-byte aligned */
+EXTERN(_default_start_trap);
+PROVIDE(_start_trap = _default_start_trap);
+
+/* Default interrupt setup entry point. If not _setup_interrupts symbol is provided, then
+   _setup_interrupts maps to _default_setup_interrupts, which in direct mode sets the value
+   of the xtvec register to _start_trap and, in vectored mode, sets its value to
+   _vector_table and enables vectored mode. */
+EXTERN(_default_setup_interrupts);
+PROVIDE(_setup_interrupts = _default_setup_interrupts);
+
+/* Default main routine. If no hal_main symbol is provided, then hal_main maps to main, which
+   is usually defined by final users via the #[riscv_rt::entry] attribute. Using hal_main
+   instead of main directly allow HALs to inject code before jumping to user main. */
+PROVIDE(hal_main = main);
+
+/* Default exception handler. By default, the exception handler is abort.
+   Users can override this alias by defining the symbol themselves */
+PROVIDE(ExceptionHandler = abort);
+
+/* Default interrupt trap entry point. When vectored trap mode is enabled,
+   the riscv-rt crate provides an implementation of this function, which saves caller saved
+   registers, calls the the DefaultHandler ISR, restores caller saved registers and returns.
+   Note, however, that this provided implementation cannot be overwritten. We use PROVIDE
+   to avoid compilation errors in direct mode, not to allow users to overwrite the symbol. */
+PROVIDE(_start_DefaultHandler_trap = _start_trap);
+
+/* Default interrupt handler. */
+PROVIDE(DefaultHandler = EspDefaultHandler);
+
 PROVIDE(_max_hart_id = 0);
 
-/* Must be called __global_pointer$ for linker relaxations to work. */
-PROVIDE(__global_pointer$ = _data_start + 0x800);
+/* don't init data - expect the bootloader to do it */
+__sdata = 0;
+__edata = 0;
+__sidata = 0;
 
-/* # Start trap function override
-  By default uses the riscv crates default trap handler
-  but by providing the `_start_trap` symbol external crates can override.
-*/
-PROVIDE(_start_trap = default_start_trap);
-
-/* # Multi-processing hook function
-   fn _mp_hook() -> bool;
-
-   This function is called from all the harts and must return true only for one hart,
-   which will perform memory initialization. For other harts it must return false
-   and implement wake-up in platform-dependent way (e.g. after waiting for a user interrupt).
-*/
-PROVIDE(_mp_hook = default_mp_hook);
-
-/* A PAC/HAL defined routine that should initialize custom interrupt controller if needed. */
-PROVIDE(_setup_interrupts = default_setup_interrupts);
-
-PROVIDE(__post_init = default_post_init);
-
-PROVIDE(UserSoft = DefaultHandler);
-PROVIDE(SupervisorSoft = DefaultHandler);
-PROVIDE(MachineSoft = DefaultHandler);
-PROVIDE(UserTimer = DefaultHandler);
-PROVIDE(SupervisorTimer = DefaultHandler);
-PROVIDE(MachineTimer = DefaultHandler);
-PROVIDE(UserExternal = DefaultHandler);
-PROVIDE(SupervisorExternal = DefaultHandler);
-PROVIDE(MachineExternal = DefaultHandler);
-
-PROVIDE(ExceptionHandler = DefaultExceptionHandler);
-
-PROVIDE(DefaultHandler = EspDefaultHandler);
+/* alias bss start + end as expected by riscv-rt */
+__sbss = _bss_start;
+__ebss = _bss_end;
 
 PROVIDE(interrupt1 = DefaultHandler);
 PROVIDE(interrupt2 = DefaultHandler);
@@ -72,5 +90,5 @@ PROVIDE(interrupt29 = DefaultHandler);
 PROVIDE(interrupt30 = DefaultHandler);
 PROVIDE(interrupt31 = DefaultHandler);
 
-/* not included by esp-hal? */
+/* external interrupts (from PAC) */
 INCLUDE "device.x"

--- a/esp-hal/ld/xtensa/hal-defaults.x
+++ b/esp-hal/ld/xtensa/hal-defaults.x
@@ -7,3 +7,6 @@ PROVIDE(level4_interrupt = DefaultHandler);
 PROVIDE(level5_interrupt = DefaultHandler);
 PROVIDE(level6_interrupt = DefaultHandler);
 PROVIDE(level7_interrupt = DefaultHandler);
+
+/* external interrupts (from PAC) */
+INCLUDE "device.x"

--- a/esp-riscv-rt/Cargo.toml
+++ b/esp-riscv-rt/Cargo.toml
@@ -18,13 +18,14 @@ test  = false
 [dependencies]
 document-features = "0.2.11"
 riscv             = "0.14.0"
-riscv-rt-macros   = "0.5.0"
+# TODO wait for a release
+riscv-rt          = {version = "0.15.0", git = "https://github.com/rust-embedded/riscv.git", rev = "f81db37f67829161f5c58e29140fa7f073e4c7e3", features = ["pre-init", "no-exceptions", "no-interrupts", "single-hart"]}
 
 [features]
-## Indicate that the device supports `mie` and `mip` CSRs.
-has-mie-mip = []
+## Indicate that the device does NOT support `mie` and `mip` CSRs.
+no-mie-mip = ["riscv-rt/no-xie-xip"]
 ## Indicate that the device has RTC RAM.
 rtc-ram = []
 
 # This feature is intended for testing; you probably don't want to enable it:
-ci = ["has-mie-mip", "rtc-ram"]
+ci = ["rtc-ram"]

--- a/esp-riscv-rt/README.md
+++ b/esp-riscv-rt/README.md
@@ -8,7 +8,9 @@
 
 Minimal runtime / startup for RISC-V devices from Espressif.
 
-Much of the code in this package originated in the [rust-embedded/riscv] repository.
+This is using [rust-embedded/riscv] under the hood as much as possible and uses custom implementation where needed.
+
+We use the `single-hart` feature since starting up harts != 0 is handled by the HAL, not the runtime.
 
 [rust-embedded/riscv]: https://github.com/rust-embedded/riscv
 

--- a/esp-riscv-rt/src/lib.rs
+++ b/esp-riscv-rt/src/lib.rs
@@ -16,56 +16,20 @@
 use core::arch::global_asm;
 
 pub use riscv;
-use riscv::register::{mcause, mtvec};
-pub use riscv_rt_macros::{entry, pre_init};
+pub use riscv_rt::entry;
 
-pub use self::Interrupt as interrupt;
-
-#[unsafe(export_name = "error: esp-riscv-rt appears more than once in the dependency graph")]
 #[doc(hidden)]
-pub static __ONCE__: () = ();
-
-unsafe extern "C" {
-    // Boundaries of the .bss section
-    static mut _bss_end: u32;
-    static mut _bss_start: u32;
-
-    // Boundaries of the .data section
-    static mut _data_end: u32;
-    static mut _data_start: u32;
-
-    // Initial values of the .data section (stored in Flash)
-    static _sidata: u32;
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn _dispatch_exception() {
+    // never called but needed for riscv-rt to link
+    panic!();
 }
 
-/// Rust entry point (_start_rust)
-///
-/// Zeros bss section, initializes data section and calls main. This function
-/// never returns.
-///
-/// # Safety
-///
-/// This function should not be called directly by the user, and should instead
-/// be invoked by the runtime implicitly.
-#[unsafe(link_section = ".init.rust")]
-#[unsafe(export_name = "_start_rust")]
-pub unsafe extern "C" fn start_rust(a0: usize, a1: usize, a2: usize) -> ! {
-    unsafe {
-        unsafe extern "Rust" {
-            fn hal_main(a0: usize, a1: usize, a2: usize) -> !;
-
-            fn __post_init();
-
-            fn _setup_interrupts();
-
-        }
-
-        __post_init();
-
-        _setup_interrupts();
-
-        hal_main(a0, a1, a2);
-    }
+#[doc(hidden)]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn _dispatch_core_interrupt() {
+    // never called but needed for riscv-rt to link
+    panic!();
 }
 
 /// Registers saved in trap handler
@@ -158,152 +122,6 @@ pub struct TrapFrame {
     pub mtval: usize,
 }
 
-/// Trap entry point rust (_start_trap_rust)
-///
-/// `scause`/`mcause` is read to determine the cause of the trap. XLEN-1 bit
-/// indicates if it's an interrupt or an exception. The result is examined and
-/// ExceptionHandler or one of the core interrupt handlers is called.
-///
-/// # Safety
-///
-/// This function should not be called directly by the user, and should instead
-/// be invoked by the runtime implicitly.
-#[unsafe(link_section = ".trap.rust")]
-#[unsafe(export_name = "_start_trap_rust")]
-pub unsafe extern "C" fn start_trap_rust(trap_frame: *const TrapFrame) {
-    unsafe extern "C" {
-        fn ExceptionHandler(trap_frame: &TrapFrame);
-        fn DefaultHandler();
-    }
-
-    unsafe {
-        let cause = mcause::read();
-
-        if cause.is_exception() {
-            ExceptionHandler(&*trap_frame)
-        } else if cause.code() < __INTERRUPTS.len() {
-            let h = &__INTERRUPTS[cause.code()];
-            if h.reserved == 0 {
-                DefaultHandler();
-            } else {
-                (h.handler)();
-            }
-        } else {
-            DefaultHandler();
-        }
-    }
-}
-
-#[doc(hidden)]
-#[unsafe(no_mangle)]
-#[allow(unused_variables, non_snake_case)]
-pub fn DefaultExceptionHandler(trap_frame: &TrapFrame) -> ! {
-    loop {
-        // Prevent this from turning into a UDF instruction
-        // see rust-lang/rust#28728 for details
-        continue;
-    }
-}
-
-#[doc(hidden)]
-#[unsafe(no_mangle)]
-#[allow(unused_variables, non_snake_case)]
-pub fn DefaultInterruptHandler() {
-    loop {
-        // Prevent this from turning into a UDF instruction
-        // see rust-lang/rust#28728 for details
-        continue;
-    }
-}
-
-// Interrupts
-#[doc(hidden)]
-pub enum Interrupt {
-    UserSoft,
-    SupervisorSoft,
-    MachineSoft,
-    UserTimer,
-    SupervisorTimer,
-    MachineTimer,
-    UserExternal,
-    SupervisorExternal,
-    MachineExternal,
-}
-
-unsafe extern "C" {
-    fn UserSoft();
-    fn SupervisorSoft();
-    fn MachineSoft();
-    fn UserTimer();
-    fn SupervisorTimer();
-    fn MachineTimer();
-    fn UserExternal();
-    fn SupervisorExternal();
-    fn MachineExternal();
-}
-
-#[doc(hidden)]
-pub union Vector {
-    pub handler: unsafe extern "C" fn(),
-    pub reserved: usize,
-}
-
-#[doc(hidden)]
-#[unsafe(no_mangle)]
-pub static __INTERRUPTS: [Vector; 12] = [
-    Vector { handler: UserSoft },
-    Vector {
-        handler: SupervisorSoft,
-    },
-    Vector { reserved: 0 },
-    Vector {
-        handler: MachineSoft,
-    },
-    Vector { handler: UserTimer },
-    Vector {
-        handler: SupervisorTimer,
-    },
-    Vector { reserved: 0 },
-    Vector {
-        handler: MachineTimer,
-    },
-    Vector {
-        handler: UserExternal,
-    },
-    Vector {
-        handler: SupervisorExternal,
-    },
-    Vector { reserved: 0 },
-    Vector {
-        handler: MachineExternal,
-    },
-];
-
-#[doc(hidden)]
-#[unsafe(no_mangle)]
-#[rustfmt::skip]
-pub unsafe extern "Rust" fn default_post_init() {}
-
-/// Default implementation of `_setup_interrupts` that sets `mtvec`/`stvec` to a
-/// trap handler address.
-#[doc(hidden)]
-#[unsafe(no_mangle)]
-#[rustfmt::skip]
-pub unsafe extern "Rust" fn default_setup_interrupts() { unsafe {
-    unsafe extern "C" {
-        fn _start_trap();
-    }
-
-    mtvec::write(
-        {
-            let mut mtvec = mtvec::Mtvec::from_bits(0);
-            mtvec.set_trap_mode(mtvec::TrapMode::Vectored);
-            mtvec.set_address(_start_trap as usize);
-            mtvec
-        }
-    );
-}}
-
 /// Parse cfg attributes inside a global_asm call.
 macro_rules! cfg_global_asm {
     {@inner, [$($x:tt)*], } => {
@@ -325,43 +143,10 @@ macro_rules! cfg_global_asm {
 
 cfg_global_asm! {
     r#"
-/*
-    Entry point of all programs (_start).
-
-    It initializes DWARF call frame information, the stack pointer, the
-    frame pointer (needed for closures to work in start_rust) and the global
-    pointer. Then it calls _start_rust.
-*/
-
 .section .init, "ax"
-.global _start
-
-_start:
-    /* Jump to the absolute address defined by the linker script. */
-    lui ra, %hi(_abs_start)
-    jr %lo(_abs_start)(ra)
-
-_abs_start:
-    .option norelax
-    .cfi_startproc
-    .cfi_undefined ra
-"#,
-#[cfg(feature = "has-mie-mip")]
-    r#"
-    csrw mie, 0
-    csrw mip, 0
-"#,
-    r#"
-    la a0, _bss_start
-    la a1, _bss_end
-    bge a0, a1, 2f
-    mv a3, x0
-    1:
-    sw a3, 0(a0)
-    addi a0, a0, 4
-    blt a0, a1, 1b
-    2:
-"#,
+.weak __pre_init
+__pre_init:"#,
+    // Zero .rtc_fast.bss
 #[cfg(feature = "rtc-ram")]
     r#"
     la a0, _rtc_fast_bss_start
@@ -374,11 +159,13 @@ _abs_start:
     blt a0, a1, 1b
     2:
 "#,
-    // Zero .rtc_fast.persistent iff the chip just powered on
-#[cfg(feature = "rtc-ram")]
+     // Zero .rtc_fast.persistent if the chip just powered on
+ #[cfg(feature = "rtc-ram")]
     r#"
     mv a0, zero
+    mv t0, ra
     call rtc_get_reset_reason
+    mv ra, t0
     addi a1, zero, 1
     bne a0, a1, 2f
     la a0, _rtc_fast_persistent_start
@@ -391,62 +178,10 @@ _abs_start:
     blt a0, a1, 1b
     2:
 "#,
-    r#"
-    li  x1, 0
-    li  x2, 0
-    li  x3, 0
-    li  x4, 0
-    li  x5, 0
-    li  x6, 0
-    li  x7, 0
-    li  x8, 0
-    li  x9, 0
-    li  x10,0
-    li  x11,0
-    li  x12,0
-    li  x13,0
-    li  x14,0
-    li  x15,0
-    li  x16,0
-    li  x17,0
-    li  x18,0
-    li  x19,0
-    li  x20,0
-    li  x21,0
-    li  x22,0
-    li  x23,0
-    li  x24,0
-    li  x25,0
-    li  x26,0
-    li  x27,0
-    li  x28,0
-    li  x29,0
-    li  x30,0
-    li  x31,0
-
-    .option push
-    .option norelax
-    la gp, __global_pointer$
-    .option pop
-
-    // Check hart ID
-    csrr t2, mhartid
-    lui t0, %hi(_max_hart_id)
-    add t0, t0, %lo(_max_hart_id)
-    bgtu t2, t0, abort
-
-    // Allocate stack
-    la sp, _stack_start
-    li t0, 4 // make sure stack start is in RAM
-    sub sp, sp, t0
-    andi sp, sp, -16 // Force 16-byte alignment
-
-    // Set frame pointer
-    add s0, sp, zero
-
-    jal zero, _start_rust
-
-    .cfi_endproc
+r#"
+    ret
+"#,
+r#"
 
 /*
     Trap entry points (_start_trap, _start_trapN for N in 1..=31)
@@ -489,7 +224,8 @@ _abs_start:
 .weak _start_trap31
 "#,
 r#"
-_start_trap: // Handle exceptions in vectored mode
+_start_trap:
+    // Handle exceptions in vectored mode
     // move SP to some save place if it's pointing below the RAM
     // otherwise we won't be able to do anything reasonable
     // (since we don't have a working stack)
@@ -516,7 +252,7 @@ _start_trap: // Handle exceptions in vectored mode
 
     addi sp, sp, -40*4
     sw ra, 0(sp)
-    la ra, _start_trap_rust_hal /* Load the HAL trap handler */
+    la ra, _start_trap_rust_hal /* this runs on exception, use regular fault handler */
     j _start_trap_direct
 _start_trap1:
     addi sp, sp, -40*4
@@ -672,8 +408,6 @@ _start_trap31:
     addi sp, sp, -40*4
     sw ra, 0(sp)
     la ra, interrupt31
-    j _start_trap_direct
-la ra, _start_trap_rust_hal /* this runs on exception, use regular fault handler */
 _start_trap_direct:
 "#,
 r#"
@@ -780,12 +514,6 @@ r#"
 
     # SP was restored from the original SP
     mret
-
-/* Make sure there is an abort when linking */
-.section .text.abort
-.globl abort
-abort:
-    j abort
 
 /*
     Interrupt vector table (_vector_table)


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [ ] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

First step to resolve #2390

Use the riscv-rt startup code at least. This is still using our own trap-handler etc. - not sure how to fit the "1 peripheral interrupt" to "1 CPU interrupt" approach into our way to handle interrupts but at least we can align things a bit more in upcoming PRs

DRAFT since we would need a release of riscv-rt containing https://github.com/rust-embedded/riscv/pull/332 first

#### Testing
CI, manually running examples
