### PR TITLE
Move TIMG clock source defaults to metadata

### DIFF
--- a/esp-hal/src/clock/clocks_ll/esp32c6.rs
+++ b/esp-hal/src/clock/clocks_ll/esp32c6.rs
@@ -181,8 +181,9 @@ pub(crate) fn esp32c6_cpu_get_ls_divider() -> u8 {
 
 // clk_ll_cpu_get_hs_divider
 pub(crate) fn esp32c6_cpu_get_hs_divider() -> u8 {
-    let force_120m = PCR::regs().cpu_freq_conf().read().cpu_hs_120m_force().bit();
-    let cpu_hs_div = PCR::regs().cpu_freq_conf().read().cpu_hs_div_num().bits();
+    let cpu_freq_conf = PCR::regs().cpu_freq_conf().read();
+    let force_120m = cpu_freq_conf.cpu_hs_120m_force().bit();
+    let cpu_hs_div = cpu_freq_conf.cpu_hs_div_num().bits();
     if cpu_hs_div == 0 && force_120m {
         return 4;
     }

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -640,6 +640,8 @@ pub fn init(config: Config) -> Peripherals {
     // RTC domain must be enabled before we try to disable
     let mut rtc = crate::rtc_cntl::Rtc::new(peripherals.LPWR.reborrow());
 
+    Clocks::init(config.cpu_clock);
+
     // Handle watchdog configuration with defaults
     cfg_if::cfg_if! {
         if #[cfg(feature = "unstable")]
@@ -699,8 +701,6 @@ pub fn init(config: Config) -> Peripherals {
             crate::timer::timg::Wdt::<crate::peripherals::TIMG1<'static>>::new().disable();
         }
     }
-
-    Clocks::init(config.cpu_clock);
 
     #[cfg(esp32)]
     crate::time::time_init();

--- a/esp-hal/src/soc/esp32c6/mod.rs
+++ b/esp-hal/src/soc/esp32c6/mod.rs
@@ -29,9 +29,6 @@ pub(crate) mod registers {
 pub(crate) mod constants {
     use crate::time::Rate;
 
-    /// The default clock source for the timer group.
-    pub const TIMG_DEFAULT_CLK_SRC: u8 = 1;
-
     /// The clock frequency for the I2S peripheral in Hertz.
     pub const I2S_SCLK: u32 = 160_000_000;
     /// The default clock source for the I2S peripheral.

--- a/esp-hal/src/soc/esp32h2/mod.rs
+++ b/esp-hal/src/soc/esp32h2/mod.rs
@@ -28,9 +28,6 @@ pub(crate) mod registers {
 pub(crate) mod constants {
     use crate::time::Rate;
 
-    /// Default clock source for the timer group (TIMG) peripheral.
-    pub const TIMG_DEFAULT_CLK_SRC: u8 = 2;
-
     /// Default clock source for the I2S peripheral.
     pub const I2S_DEFAULT_CLK_SRC: u8 = 1;
     /// Clock frequency for the I2S peripheral, in Hertz.

--- a/esp-hal/src/timer/timg.rs
+++ b/esp-hal/src/timer/timg.rs
@@ -82,9 +82,9 @@ use crate::{
     time::{Duration, Instant, Rate},
 };
 
-#[cfg(soc_has_pcr)] // TODO: we should detect if `default_clock_source` itself is set.
+#[cfg(timergroup_default_clock_source_is_set)]
 const DEFAULT_CLK_SRC: u8 = property!("timergroup.default_clock_source");
-#[cfg(soc_has_pcr)] // TODO: we should detect if `default_wdt_clock_source` itself is set.
+#[cfg(timergroup_default_wdt_clock_source_is_set)]
 const DEFAULT_WDT_CLK_SRC: u8 = property!("timergroup.default_wdt_clock_source");
 const NUM_TIMG: usize = 1 + cfg!(timergroup_timg1) as usize;
 
@@ -145,19 +145,19 @@ impl TimerGroupInstance for TIMG0<'_> {
 
     fn configure_src_clk() {
         cfg_if::cfg_if! {
-            if #[cfg(esp32)] {
-                // ESP32 has only APB clock source, do nothing
-            } else if #[cfg(any(esp32c2, esp32c3, esp32s2, esp32s3))] {
-                unsafe {
-                    (*<Self as TimerGroupInstance>::register_block())
-                        .t(0)
-                        .config()
-                        .modify(|_, w| w.use_xtal().clear_bit());
-                }
+            if #[cfg(not(timergroup_default_clock_source_is_set))] {
+                // Clock source is not configurable
             } else if #[cfg(soc_has_pcr)] {
                 crate::peripherals::PCR::regs()
                     .timergroup0_timer_clk_conf()
                     .modify(|_, w| unsafe { w.tg0_timer_clk_sel().bits(DEFAULT_CLK_SRC) });
+            } else {
+                unsafe {
+                    (*<Self as TimerGroupInstance>::register_block())
+                        .t(0)
+                        .config()
+                        .modify(|_, w| w.use_xtal().bit(DEFAULT_CLK_SRC == 1));
+                }
             }
         }
     }
@@ -173,18 +173,18 @@ impl TimerGroupInstance for TIMG0<'_> {
 
     fn configure_wdt_src_clk() {
         cfg_if::cfg_if! {
-            if #[cfg(any(esp32, esp32s2, esp32s3))] {
-                // ESP32, ESP32-S2, and ESP32-S3 use only ABP, do nothing
-            } else if #[cfg(any(esp32c2, esp32c3))] {
-                unsafe {
-                    (*<Self as TimerGroupInstance>::register_block())
-                        .wdtconfig0()
-                        .modify(|_, w| w.wdt_use_xtal().clear_bit());
-                }
+            if #[cfg(not(timergroup_default_wdt_clock_source_is_set))] {
+                // Clock source is not configurable
             } else if #[cfg(soc_has_pcr)] {
                 crate::peripherals::PCR::regs()
                     .timergroup0_wdt_clk_conf()
                     .modify(|_, w| unsafe { w.tg0_wdt_clk_sel().bits(DEFAULT_WDT_CLK_SRC) });
+            } else {
+                unsafe {
+                    (*<Self as TimerGroupInstance>::register_block())
+                        .wdtconfig0()
+                        .modify(|_, w| w.wdt_use_xtal().bit(DEFAULT_WDT_CLK_SRC == 1));
+                }
             }
         }
     }
@@ -206,20 +206,19 @@ impl TimerGroupInstance for crate::peripherals::TIMG1<'_> {
     }
 
     fn configure_src_clk() {
-        // ESP32-C2 and ESP32-C3 don't have timg1, they don't get here
         cfg_if::cfg_if! {
-            if #[cfg(any(esp32))] {
-                // ESP32 has only APB clock source, do nothing
+            if #[cfg(not(timergroup_default_clock_source_is_set))] {
+                // Clock source is not configurable
             } else if #[cfg(soc_has_pcr)] {
                 crate::peripherals::PCR::regs()
                     .timergroup1_timer_clk_conf()
                     .modify(|_, w| unsafe { w.tg1_timer_clk_sel().bits(DEFAULT_CLK_SRC) });
-            } else if #[cfg(any(esp32s2, esp32s3))] {
+            } else {
                 unsafe {
                     (*<Self as TimerGroupInstance>::register_block())
                         .t(1)
                         .config()
-                        .modify(|_, w| w.use_xtal().clear_bit());
+                        .modify(|_, w| w.use_xtal().bit(DEFAULT_CLK_SRC == 1));
                 }
             }
         }
@@ -234,14 +233,19 @@ impl TimerGroupInstance for crate::peripherals::TIMG1<'_> {
     }
 
     fn configure_wdt_src_clk() {
-        // ESP32-C2 and ESP32-C3 don't have timg1, they don't get here
         cfg_if::cfg_if! {
-            if #[cfg(any(esp32, esp32s2, esp32s3))] {
-                // ESP32, ESP32-S2, and ESP32-S3 use only ABP, do nothing
+            if #[cfg(not(timergroup_default_wdt_clock_source_is_set))] {
+                // Clock source is not configurable
             } else if #[cfg(soc_has_pcr)] {
                 crate::peripherals::PCR::regs()
                     .timergroup1_wdt_clk_conf()
-                    .modify(|_, w| unsafe { w.tg1_wdt_clk_sel().bits(DEFAULT_CLK_SRC) });
+                    .modify(|_, w| unsafe { w.tg1_wdt_clk_sel().bits(DEFAULT_WDT_CLK_SRC) });
+            } else {
+                unsafe {
+                    (*<Self as TimerGroupInstance>::register_block())
+                        .wdtconfig0()
+                        .modify(|_, w| w.wdt_use_xtal().bit(DEFAULT_WDT_CLK_SRC == 1));
+                }
             }
         }
     }

--- a/esp-hal/src/timer/timg.rs
+++ b/esp-hal/src/timer/timg.rs
@@ -216,6 +216,11 @@ impl TimerGroupInstance for crate::peripherals::TIMG1<'_> {
             } else {
                 unsafe {
                     (*<Self as TimerGroupInstance>::register_block())
+                        .t(0)
+                        .config()
+                        .modify(|_, w| w.use_xtal().bit(DEFAULT_CLK_SRC == 1));
+                    #[cfg(timergroup_timg_has_timer1)]
+                    (*<Self as TimerGroupInstance>::register_block())
                         .t(1)
                         .config()
                         .modify(|_, w| w.use_xtal().bit(DEFAULT_CLK_SRC == 1));

--- a/esp-metadata-generated/src/_build_script_utils.rs
+++ b/esp-metadata-generated/src/_build_script_utils.rs
@@ -1122,6 +1122,8 @@ impl Chip {
                     "sha_algo_sha_224",
                     "sha_algo_sha_256",
                     "timergroup_timg_has_divcnt_rst",
+                    "timergroup_default_clock_source=\"1\"",
+                    "timergroup_default_wdt_clock_source=\"1\"",
                     "uart_ram_size=\"128\"",
                     "lp_uart_ram_size=\"32\"",
                     "wifi_has_wifi6",
@@ -1314,6 +1316,8 @@ impl Chip {
                     "cargo:rustc-cfg=sha_algo_sha_224",
                     "cargo:rustc-cfg=sha_algo_sha_256",
                     "cargo:rustc-cfg=timergroup_timg_has_divcnt_rst",
+                    "cargo:rustc-cfg=timergroup_default_clock_source=\"1\"",
+                    "cargo:rustc-cfg=timergroup_default_wdt_clock_source=\"1\"",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
                     "cargo:rustc-cfg=lp_uart_ram_size=\"32\"",
                     "cargo:rustc-cfg=wifi_has_wifi6",
@@ -1486,6 +1490,8 @@ impl Chip {
                     "sha_algo_sha_224",
                     "sha_algo_sha_256",
                     "timergroup_timg_has_divcnt_rst",
+                    "timergroup_default_clock_source=\"2\"",
+                    "timergroup_default_wdt_clock_source=\"1\"",
                     "uart_ram_size=\"128\"",
                     "has_dram_region",
                 ],
@@ -1652,6 +1658,8 @@ impl Chip {
                     "cargo:rustc-cfg=sha_algo_sha_224",
                     "cargo:rustc-cfg=sha_algo_sha_256",
                     "cargo:rustc-cfg=timergroup_timg_has_divcnt_rst",
+                    "cargo:rustc-cfg=timergroup_default_clock_source=\"2\"",
+                    "cargo:rustc-cfg=timergroup_default_wdt_clock_source=\"1\"",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
                     "cargo:rustc-cfg=has_dram_region",
                 ],
@@ -2656,6 +2664,8 @@ impl Config {
         println!("cargo:rustc-check-cfg=cfg(rng_apb_cycle_wait_num, values(\"16\"))");
         println!("cargo:rustc-check-cfg=cfg(uart_ram_size, values(\"128\"))");
         println!("cargo:rustc-check-cfg=cfg(lp_i2c_master_fifo_size, values(\"16\"))");
+        println!("cargo:rustc-check-cfg=cfg(timergroup_default_clock_source, values(\"1\",\"2\"))");
+        println!("cargo:rustc-check-cfg=cfg(timergroup_default_wdt_clock_source, values(\"1\"))");
         println!("cargo:rustc-check-cfg=cfg(lp_uart_ram_size, values(\"32\"))");
         for cfg in self.cfgs {
             println!("{cfg}");

--- a/esp-metadata-generated/src/_build_script_utils.rs
+++ b/esp-metadata-generated/src/_build_script_utils.rs
@@ -545,6 +545,10 @@ impl Chip {
                     "sha_algo_sha_224",
                     "sha_algo_sha_256",
                     "timergroup_timg_has_divcnt_rst",
+                    "timergroup_default_clock_source=\"0\"",
+                    "timergroup_default_clock_source_is_set",
+                    "timergroup_default_wdt_clock_source=\"0\"",
+                    "timergroup_default_wdt_clock_source_is_set",
                     "uart_ram_size=\"128\"",
                     "has_dram_region",
                 ],
@@ -654,6 +658,10 @@ impl Chip {
                     "cargo:rustc-cfg=sha_algo_sha_224",
                     "cargo:rustc-cfg=sha_algo_sha_256",
                     "cargo:rustc-cfg=timergroup_timg_has_divcnt_rst",
+                    "cargo:rustc-cfg=timergroup_default_clock_source=\"0\"",
+                    "cargo:rustc-cfg=timergroup_default_clock_source_is_set",
+                    "cargo:rustc-cfg=timergroup_default_wdt_clock_source=\"0\"",
+                    "cargo:rustc-cfg=timergroup_default_wdt_clock_source_is_set",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
                     "cargo:rustc-cfg=has_dram_region",
                 ],
@@ -794,6 +802,10 @@ impl Chip {
                     "sha_algo_sha_224",
                     "sha_algo_sha_256",
                     "timergroup_timg_has_divcnt_rst",
+                    "timergroup_default_clock_source=\"0\"",
+                    "timergroup_default_clock_source_is_set",
+                    "timergroup_default_wdt_clock_source=\"0\"",
+                    "timergroup_default_wdt_clock_source_is_set",
                     "uart_ram_size=\"128\"",
                     "has_dram_region",
                 ],
@@ -930,6 +942,10 @@ impl Chip {
                     "cargo:rustc-cfg=sha_algo_sha_224",
                     "cargo:rustc-cfg=sha_algo_sha_256",
                     "cargo:rustc-cfg=timergroup_timg_has_divcnt_rst",
+                    "cargo:rustc-cfg=timergroup_default_clock_source=\"0\"",
+                    "cargo:rustc-cfg=timergroup_default_clock_source_is_set",
+                    "cargo:rustc-cfg=timergroup_default_wdt_clock_source=\"0\"",
+                    "cargo:rustc-cfg=timergroup_default_wdt_clock_source_is_set",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
                     "cargo:rustc-cfg=has_dram_region",
                 ],
@@ -1498,7 +1514,7 @@ impl Chip {
                     "timergroup_timg_has_divcnt_rst",
                     "timergroup_default_clock_source=\"2\"",
                     "timergroup_default_clock_source_is_set",
-                    "timergroup_default_wdt_clock_source=\"1\"",
+                    "timergroup_default_wdt_clock_source=\"2\"",
                     "timergroup_default_wdt_clock_source_is_set",
                     "uart_ram_size=\"128\"",
                     "has_dram_region",
@@ -1668,7 +1684,7 @@ impl Chip {
                     "cargo:rustc-cfg=timergroup_timg_has_divcnt_rst",
                     "cargo:rustc-cfg=timergroup_default_clock_source=\"2\"",
                     "cargo:rustc-cfg=timergroup_default_clock_source_is_set",
-                    "cargo:rustc-cfg=timergroup_default_wdt_clock_source=\"1\"",
+                    "cargo:rustc-cfg=timergroup_default_wdt_clock_source=\"2\"",
                     "cargo:rustc-cfg=timergroup_default_wdt_clock_source_is_set",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
                     "cargo:rustc-cfg=has_dram_region",
@@ -1837,8 +1853,6 @@ impl Chip {
                     "timergroup_timg_has_timer1",
                     "timergroup_default_clock_source=\"0\"",
                     "timergroup_default_clock_source_is_set",
-                    "timergroup_default_wdt_clock_source=\"0\"",
-                    "timergroup_default_wdt_clock_source_is_set",
                     "uart_ram_size=\"128\"",
                     "has_dram_region",
                 ],
@@ -2002,8 +2016,6 @@ impl Chip {
                     "cargo:rustc-cfg=timergroup_timg_has_timer1",
                     "cargo:rustc-cfg=timergroup_default_clock_source=\"0\"",
                     "cargo:rustc-cfg=timergroup_default_clock_source_is_set",
-                    "cargo:rustc-cfg=timergroup_default_wdt_clock_source=\"0\"",
-                    "cargo:rustc-cfg=timergroup_default_wdt_clock_source_is_set",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
                     "cargo:rustc-cfg=has_dram_region",
                 ],
@@ -2189,8 +2201,6 @@ impl Chip {
                     "timergroup_timg_has_timer1",
                     "timergroup_default_clock_source=\"0\"",
                     "timergroup_default_clock_source_is_set",
-                    "timergroup_default_wdt_clock_source=\"0\"",
-                    "timergroup_default_wdt_clock_source_is_set",
                     "uart_ram_size=\"128\"",
                     "has_dram_region",
                 ],
@@ -2372,8 +2382,6 @@ impl Chip {
                     "cargo:rustc-cfg=timergroup_timg_has_timer1",
                     "cargo:rustc-cfg=timergroup_default_clock_source=\"0\"",
                     "cargo:rustc-cfg=timergroup_default_clock_source_is_set",
-                    "cargo:rustc-cfg=timergroup_default_wdt_clock_source=\"0\"",
-                    "cargo:rustc-cfg=timergroup_default_wdt_clock_source_is_set",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
                     "cargo:rustc-cfg=has_dram_region",
                 ],
@@ -2563,6 +2571,8 @@ impl Config {
         println!("cargo:rustc-check-cfg=cfg(i2c_master_bus_timeout_is_exponential)");
         println!("cargo:rustc-check-cfg=cfg(sha_algo_sha_224)");
         println!("cargo:rustc-check-cfg=cfg(timergroup_timg_has_divcnt_rst)");
+        println!("cargo:rustc-check-cfg=cfg(timergroup_default_clock_source_is_set)");
+        println!("cargo:rustc-check-cfg=cfg(timergroup_default_wdt_clock_source_is_set)");
         println!("cargo:rustc-check-cfg=cfg(esp32c3)");
         println!("cargo:rustc-check-cfg=cfg(soc_has_ds)");
         println!("cargo:rustc-check-cfg=cfg(soc_has_fe)");
@@ -2633,8 +2643,6 @@ impl Config {
         println!("cargo:rustc-check-cfg=cfg(soc_cpu_has_prv_mode)");
         println!("cargo:rustc-check-cfg=cfg(i2c_master_can_estimate_nack_reason)");
         println!("cargo:rustc-check-cfg=cfg(i2c_master_has_reliable_fsm_reset)");
-        println!("cargo:rustc-check-cfg=cfg(timergroup_default_clock_source_is_set)");
-        println!("cargo:rustc-check-cfg=cfg(timergroup_default_wdt_clock_source_is_set)");
         println!("cargo:rustc-check-cfg=cfg(wifi_has_wifi6)");
         println!("cargo:rustc-check-cfg=cfg(esp32h2)");
         println!("cargo:rustc-check-cfg=cfg(esp32s2)");
@@ -2694,13 +2702,13 @@ impl Config {
         println!("cargo:rustc-check-cfg=cfg(rmt_channel_ram_size, values(\"64\",\"48\"))");
         println!("cargo:rustc-check-cfg=cfg(rng_apb_cycle_wait_num, values(\"16\"))");
         println!("cargo:rustc-check-cfg=cfg(uart_ram_size, values(\"128\"))");
+        println!(
+            "cargo:rustc-check-cfg=cfg(timergroup_default_clock_source, values(\"0\",\"1\",\"2\"))"
+        );
+        println!(
+            "cargo:rustc-check-cfg=cfg(timergroup_default_wdt_clock_source, values(\"0\",\"1\",\"2\"))"
+        );
         println!("cargo:rustc-check-cfg=cfg(lp_i2c_master_fifo_size, values(\"16\"))");
-        println!(
-            "cargo:rustc-check-cfg=cfg(timergroup_default_clock_source, values(\"1\",\"2\",\"0\"))"
-        );
-        println!(
-            "cargo:rustc-check-cfg=cfg(timergroup_default_wdt_clock_source, values(\"1\",\"0\"))"
-        );
         println!("cargo:rustc-check-cfg=cfg(lp_uart_ram_size, values(\"32\"))");
         for cfg in self.cfgs {
             println!("{cfg}");

--- a/esp-metadata-generated/src/_build_script_utils.rs
+++ b/esp-metadata-generated/src/_build_script_utils.rs
@@ -271,6 +271,7 @@ impl Chip {
                     "gpio_output_signal_max=\"256\"",
                     "i2c_master_separate_filter_config_registers",
                     "i2c_master_i2c0_data_register_ahb_address=\"1610690588\"",
+                    "i2c_master_i2c0_data_register_ahb_address_is_set",
                     "i2c_master_max_bus_timeout=\"1048575\"",
                     "i2c_master_ll_intr_mask=\"262143\"",
                     "i2c_master_fifo_size=\"32\"",
@@ -418,6 +419,7 @@ impl Chip {
                     "cargo:rustc-cfg=gpio_output_signal_max=\"256\"",
                     "cargo:rustc-cfg=i2c_master_separate_filter_config_registers",
                     "cargo:rustc-cfg=i2c_master_i2c0_data_register_ahb_address=\"1610690588\"",
+                    "cargo:rustc-cfg=i2c_master_i2c0_data_register_ahb_address_is_set",
                     "cargo:rustc-cfg=i2c_master_max_bus_timeout=\"1048575\"",
                     "cargo:rustc-cfg=i2c_master_ll_intr_mask=\"262143\"",
                     "cargo:rustc-cfg=i2c_master_fifo_size=\"32\"",
@@ -1123,7 +1125,9 @@ impl Chip {
                     "sha_algo_sha_256",
                     "timergroup_timg_has_divcnt_rst",
                     "timergroup_default_clock_source=\"1\"",
+                    "timergroup_default_clock_source_is_set",
                     "timergroup_default_wdt_clock_source=\"1\"",
+                    "timergroup_default_wdt_clock_source_is_set",
                     "uart_ram_size=\"128\"",
                     "lp_uart_ram_size=\"32\"",
                     "wifi_has_wifi6",
@@ -1317,7 +1321,9 @@ impl Chip {
                     "cargo:rustc-cfg=sha_algo_sha_256",
                     "cargo:rustc-cfg=timergroup_timg_has_divcnt_rst",
                     "cargo:rustc-cfg=timergroup_default_clock_source=\"1\"",
+                    "cargo:rustc-cfg=timergroup_default_clock_source_is_set",
                     "cargo:rustc-cfg=timergroup_default_wdt_clock_source=\"1\"",
+                    "cargo:rustc-cfg=timergroup_default_wdt_clock_source_is_set",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
                     "cargo:rustc-cfg=lp_uart_ram_size=\"32\"",
                     "cargo:rustc-cfg=wifi_has_wifi6",
@@ -1491,7 +1497,9 @@ impl Chip {
                     "sha_algo_sha_256",
                     "timergroup_timg_has_divcnt_rst",
                     "timergroup_default_clock_source=\"2\"",
+                    "timergroup_default_clock_source_is_set",
                     "timergroup_default_wdt_clock_source=\"1\"",
+                    "timergroup_default_wdt_clock_source_is_set",
                     "uart_ram_size=\"128\"",
                     "has_dram_region",
                 ],
@@ -1659,7 +1667,9 @@ impl Chip {
                     "cargo:rustc-cfg=sha_algo_sha_256",
                     "cargo:rustc-cfg=timergroup_timg_has_divcnt_rst",
                     "cargo:rustc-cfg=timergroup_default_clock_source=\"2\"",
+                    "cargo:rustc-cfg=timergroup_default_clock_source_is_set",
                     "cargo:rustc-cfg=timergroup_default_wdt_clock_source=\"1\"",
+                    "cargo:rustc-cfg=timergroup_default_wdt_clock_source_is_set",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
                     "cargo:rustc-cfg=has_dram_region",
                 ],
@@ -1807,6 +1817,7 @@ impl Chip {
                     "i2c_master_separate_filter_config_registers",
                     "i2c_master_has_arbitration_en",
                     "i2c_master_i2c0_data_register_ahb_address=\"1610690588\"",
+                    "i2c_master_i2c0_data_register_ahb_address_is_set",
                     "i2c_master_max_bus_timeout=\"16777215\"",
                     "i2c_master_ll_intr_mask=\"131071\"",
                     "i2c_master_fifo_size=\"32\"",
@@ -1824,6 +1835,10 @@ impl Chip {
                     "sha_algo_sha_512_t",
                     "spi_master_has_octal",
                     "timergroup_timg_has_timer1",
+                    "timergroup_default_clock_source=\"0\"",
+                    "timergroup_default_clock_source_is_set",
+                    "timergroup_default_wdt_clock_source=\"0\"",
+                    "timergroup_default_wdt_clock_source_is_set",
                     "uart_ram_size=\"128\"",
                     "has_dram_region",
                 ],
@@ -1967,6 +1982,7 @@ impl Chip {
                     "cargo:rustc-cfg=i2c_master_separate_filter_config_registers",
                     "cargo:rustc-cfg=i2c_master_has_arbitration_en",
                     "cargo:rustc-cfg=i2c_master_i2c0_data_register_ahb_address=\"1610690588\"",
+                    "cargo:rustc-cfg=i2c_master_i2c0_data_register_ahb_address_is_set",
                     "cargo:rustc-cfg=i2c_master_max_bus_timeout=\"16777215\"",
                     "cargo:rustc-cfg=i2c_master_ll_intr_mask=\"131071\"",
                     "cargo:rustc-cfg=i2c_master_fifo_size=\"32\"",
@@ -1984,6 +2000,10 @@ impl Chip {
                     "cargo:rustc-cfg=sha_algo_sha_512_t",
                     "cargo:rustc-cfg=spi_master_has_octal",
                     "cargo:rustc-cfg=timergroup_timg_has_timer1",
+                    "cargo:rustc-cfg=timergroup_default_clock_source=\"0\"",
+                    "cargo:rustc-cfg=timergroup_default_clock_source_is_set",
+                    "cargo:rustc-cfg=timergroup_default_wdt_clock_source=\"0\"",
+                    "cargo:rustc-cfg=timergroup_default_wdt_clock_source_is_set",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
                     "cargo:rustc-cfg=has_dram_region",
                 ],
@@ -2167,6 +2187,10 @@ impl Chip {
                     "sha_algo_sha_512_t",
                     "spi_master_has_octal",
                     "timergroup_timg_has_timer1",
+                    "timergroup_default_clock_source=\"0\"",
+                    "timergroup_default_clock_source_is_set",
+                    "timergroup_default_wdt_clock_source=\"0\"",
+                    "timergroup_default_wdt_clock_source_is_set",
                     "uart_ram_size=\"128\"",
                     "has_dram_region",
                 ],
@@ -2346,6 +2370,10 @@ impl Chip {
                     "cargo:rustc-cfg=sha_algo_sha_512_t",
                     "cargo:rustc-cfg=spi_master_has_octal",
                     "cargo:rustc-cfg=timergroup_timg_has_timer1",
+                    "cargo:rustc-cfg=timergroup_default_clock_source=\"0\"",
+                    "cargo:rustc-cfg=timergroup_default_clock_source_is_set",
+                    "cargo:rustc-cfg=timergroup_default_wdt_clock_source=\"0\"",
+                    "cargo:rustc-cfg=timergroup_default_wdt_clock_source_is_set",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
                     "cargo:rustc-cfg=has_dram_region",
                 ],
@@ -2485,6 +2513,7 @@ impl Config {
         println!("cargo:rustc-check-cfg=cfg(gpio_has_bank_1)");
         println!("cargo:rustc-check-cfg=cfg(gpio_remap_iomux_pin_registers)");
         println!("cargo:rustc-check-cfg=cfg(i2c_master_separate_filter_config_registers)");
+        println!("cargo:rustc-check-cfg=cfg(i2c_master_i2c0_data_register_ahb_address_is_set)");
         println!("cargo:rustc-check-cfg=cfg(sha_algo_sha_1)");
         println!("cargo:rustc-check-cfg=cfg(sha_algo_sha_256)");
         println!("cargo:rustc-check-cfg=cfg(sha_algo_sha_384)");
@@ -2604,6 +2633,8 @@ impl Config {
         println!("cargo:rustc-check-cfg=cfg(soc_cpu_has_prv_mode)");
         println!("cargo:rustc-check-cfg=cfg(i2c_master_can_estimate_nack_reason)");
         println!("cargo:rustc-check-cfg=cfg(i2c_master_has_reliable_fsm_reset)");
+        println!("cargo:rustc-check-cfg=cfg(timergroup_default_clock_source_is_set)");
+        println!("cargo:rustc-check-cfg=cfg(timergroup_default_wdt_clock_source_is_set)");
         println!("cargo:rustc-check-cfg=cfg(wifi_has_wifi6)");
         println!("cargo:rustc-check-cfg=cfg(esp32h2)");
         println!("cargo:rustc-check-cfg=cfg(esp32s2)");
@@ -2664,8 +2695,12 @@ impl Config {
         println!("cargo:rustc-check-cfg=cfg(rng_apb_cycle_wait_num, values(\"16\"))");
         println!("cargo:rustc-check-cfg=cfg(uart_ram_size, values(\"128\"))");
         println!("cargo:rustc-check-cfg=cfg(lp_i2c_master_fifo_size, values(\"16\"))");
-        println!("cargo:rustc-check-cfg=cfg(timergroup_default_clock_source, values(\"1\",\"2\"))");
-        println!("cargo:rustc-check-cfg=cfg(timergroup_default_wdt_clock_source, values(\"1\"))");
+        println!(
+            "cargo:rustc-check-cfg=cfg(timergroup_default_clock_source, values(\"1\",\"2\",\"0\"))"
+        );
+        println!(
+            "cargo:rustc-check-cfg=cfg(timergroup_default_wdt_clock_source, values(\"1\",\"0\"))"
+        );
         println!("cargo:rustc-check-cfg=cfg(lp_uart_ram_size, values(\"32\"))");
         for cfg in self.cfgs {
             println!("{cfg}");

--- a/esp-metadata-generated/src/_generated_esp32c2.rs
+++ b/esp-metadata-generated/src/_generated_esp32c2.rs
@@ -159,6 +159,18 @@ macro_rules! property {
     ("timergroup.timg_has_divcnt_rst") => {
         true
     };
+    ("timergroup.default_clock_source") => {
+        0
+    };
+    ("timergroup.default_clock_source", str) => {
+        stringify!(0)
+    };
+    ("timergroup.default_wdt_clock_source") => {
+        0
+    };
+    ("timergroup.default_wdt_clock_source", str) => {
+        stringify!(0)
+    };
     ("uart.ram_size") => {
         128
     };

--- a/esp-metadata-generated/src/_generated_esp32c3.rs
+++ b/esp-metadata-generated/src/_generated_esp32c3.rs
@@ -174,6 +174,18 @@ macro_rules! property {
     ("timergroup.timg_has_divcnt_rst") => {
         true
     };
+    ("timergroup.default_clock_source") => {
+        0
+    };
+    ("timergroup.default_clock_source", str) => {
+        stringify!(0)
+    };
+    ("timergroup.default_wdt_clock_source") => {
+        0
+    };
+    ("timergroup.default_wdt_clock_source", str) => {
+        stringify!(0)
+    };
     ("uart.ram_size") => {
         128
     };

--- a/esp-metadata-generated/src/_generated_esp32c6.rs
+++ b/esp-metadata-generated/src/_generated_esp32c6.rs
@@ -180,6 +180,18 @@ macro_rules! property {
     ("timergroup.timg_has_divcnt_rst") => {
         true
     };
+    ("timergroup.default_clock_source") => {
+        1
+    };
+    ("timergroup.default_clock_source", str) => {
+        stringify!(1)
+    };
+    ("timergroup.default_wdt_clock_source") => {
+        1
+    };
+    ("timergroup.default_wdt_clock_source", str) => {
+        stringify!(1)
+    };
     ("uart.ram_size") => {
         128
     };

--- a/esp-metadata-generated/src/_generated_esp32h2.rs
+++ b/esp-metadata-generated/src/_generated_esp32h2.rs
@@ -174,6 +174,18 @@ macro_rules! property {
     ("timergroup.timg_has_divcnt_rst") => {
         true
     };
+    ("timergroup.default_clock_source") => {
+        2
+    };
+    ("timergroup.default_clock_source", str) => {
+        stringify!(2)
+    };
+    ("timergroup.default_wdt_clock_source") => {
+        1
+    };
+    ("timergroup.default_wdt_clock_source", str) => {
+        stringify!(1)
+    };
     ("uart.ram_size") => {
         128
     };

--- a/esp-metadata-generated/src/_generated_esp32h2.rs
+++ b/esp-metadata-generated/src/_generated_esp32h2.rs
@@ -181,10 +181,10 @@ macro_rules! property {
         stringify!(2)
     };
     ("timergroup.default_wdt_clock_source") => {
-        1
+        2
     };
     ("timergroup.default_wdt_clock_source", str) => {
-        stringify!(1)
+        stringify!(2)
     };
     ("uart.ram_size") => {
         128

--- a/esp-metadata-generated/src/_generated_esp32s2.rs
+++ b/esp-metadata-generated/src/_generated_esp32s2.rs
@@ -174,12 +174,6 @@ macro_rules! property {
     ("timergroup.default_clock_source", str) => {
         stringify!(0)
     };
-    ("timergroup.default_wdt_clock_source") => {
-        0
-    };
-    ("timergroup.default_wdt_clock_source", str) => {
-        stringify!(0)
-    };
     ("uart.ram_size") => {
         128
     };

--- a/esp-metadata-generated/src/_generated_esp32s2.rs
+++ b/esp-metadata-generated/src/_generated_esp32s2.rs
@@ -168,6 +168,18 @@ macro_rules! property {
     ("timergroup.timg_has_divcnt_rst") => {
         false
     };
+    ("timergroup.default_clock_source") => {
+        0
+    };
+    ("timergroup.default_clock_source", str) => {
+        stringify!(0)
+    };
+    ("timergroup.default_wdt_clock_source") => {
+        0
+    };
+    ("timergroup.default_wdt_clock_source", str) => {
+        stringify!(0)
+    };
     ("uart.ram_size") => {
         128
     };

--- a/esp-metadata-generated/src/_generated_esp32s3.rs
+++ b/esp-metadata-generated/src/_generated_esp32s3.rs
@@ -174,12 +174,6 @@ macro_rules! property {
     ("timergroup.default_clock_source", str) => {
         stringify!(0)
     };
-    ("timergroup.default_wdt_clock_source") => {
-        0
-    };
-    ("timergroup.default_wdt_clock_source", str) => {
-        stringify!(0)
-    };
     ("uart.ram_size") => {
         128
     };

--- a/esp-metadata-generated/src/_generated_esp32s3.rs
+++ b/esp-metadata-generated/src/_generated_esp32s3.rs
@@ -168,6 +168,18 @@ macro_rules! property {
     ("timergroup.timg_has_divcnt_rst") => {
         false
     };
+    ("timergroup.default_clock_source") => {
+        0
+    };
+    ("timergroup.default_clock_source", str) => {
+        stringify!(0)
+    };
+    ("timergroup.default_wdt_clock_source") => {
+        0
+    };
+    ("timergroup.default_wdt_clock_source", str) => {
+        stringify!(0)
+    };
     ("uart.ram_size") => {
         128
     };

--- a/esp-metadata/devices/esp32c2.toml
+++ b/esp-metadata/devices/esp32c2.toml
@@ -264,6 +264,8 @@ instances = [
 support_status = "partial"
 instances = [{ name = "timg0" }]
 timg_has_divcnt_rst = true
+default_clock_source = 0 # use_xtal = false
+default_wdt_clock_source = 0 # use_wdt_xtal = false
 
 [device.uart]
 support_status = "supported"

--- a/esp-metadata/devices/esp32c3.toml
+++ b/esp-metadata/devices/esp32c3.toml
@@ -324,6 +324,8 @@ instances = [
 support_status = "partial"
 instances = [{ name = "timg0" }, { name = "timg1" }]
 timg_has_divcnt_rst = true
+default_clock_source = 0 # use_xtal = false
+default_wdt_clock_source = 0 # use_wdt_xtal = false
 
 [device.uart]
 support_status = "supported"

--- a/esp-metadata/devices/esp32c6.toml
+++ b/esp-metadata/devices/esp32c6.toml
@@ -479,6 +479,8 @@ instances = [
 support_status = "partial"
 instances = [{ name = "timg0" }, { name = "timg1" }]
 timg_has_divcnt_rst = true
+default_clock_source = 1
+default_wdt_clock_source = 1
 
 [device.uart]
 support_status = "supported"

--- a/esp-metadata/devices/esp32h2.toml
+++ b/esp-metadata/devices/esp32h2.toml
@@ -396,6 +396,8 @@ instances = [
 support_status = "partial"
 instances = [{ name = "timg0" }, { name = "timg1" }]
 timg_has_divcnt_rst = true
+default_clock_source = 2
+default_wdt_clock_source = 1
 
 [device.uart]
 support_status = "supported"

--- a/esp-metadata/devices/esp32h2.toml
+++ b/esp-metadata/devices/esp32h2.toml
@@ -397,7 +397,7 @@ support_status = "partial"
 instances = [{ name = "timg0" }, { name = "timg1" }]
 timg_has_divcnt_rst = true
 default_clock_source = 2
-default_wdt_clock_source = 1
+default_wdt_clock_source = 2
 
 [device.uart]
 support_status = "supported"

--- a/esp-metadata/devices/esp32s2.toml
+++ b/esp-metadata/devices/esp32s2.toml
@@ -453,6 +453,7 @@ support_status = "partial"
 timg_has_timer1 = true
 timg_has_divcnt_rst = false
 instances = [{ name = "timg0" }, { name = "timg1" }]
+default_clock_source = 0 # use_xtal = false
 
 [device.uart]
 support_status = "supported"

--- a/esp-metadata/devices/esp32s3.toml
+++ b/esp-metadata/devices/esp32s3.toml
@@ -627,6 +627,7 @@ support_status = "partial"
 timg_has_timer1 = true
 timg_has_divcnt_rst = false
 instances = [{ name = "timg0" }, { name = "timg1" }]
+default_clock_source = 0 # use_xtal = false
 
 [device.uart]
 support_status = "supported"

--- a/esp-metadata/src/cfg.rs
+++ b/esp-metadata/src/cfg.rs
@@ -523,6 +523,10 @@ driver_configs![
             timg_has_timer1: bool,
             #[serde(default)]
             timg_has_divcnt_rst: bool,
+            #[serde(default)]
+            default_clock_source: Option<u32>,
+            #[serde(default)]
+            default_wdt_clock_source: Option<u32>,
         }
     },
     TouchProperties {

--- a/esp-metadata/src/cfg/gpio.rs
+++ b/esp-metadata/src/cfg/gpio.rs
@@ -186,7 +186,7 @@ pub(crate) struct IoMuxSignal {
 }
 
 impl super::GpioProperties {
-    pub(super) fn computed_properties(&self) -> impl Iterator<Item = (&str, Value)> {
+    pub(super) fn computed_properties(&self) -> impl Iterator<Item = (&str, bool, Value)> {
         let input_max = self
             .pins_and_signals
             .input_signals
@@ -203,8 +203,8 @@ impl super::GpioProperties {
             .unwrap_or(0) as u32;
 
         [
-            ("gpio.input_signal_max", Value::Number(input_max)),
-            ("gpio.output_signal_max", Value::Number(output_max)),
+            ("gpio.input_signal_max", false, Value::Number(input_max)),
+            ("gpio.output_signal_max", false, Value::Number(output_max)),
         ]
         .into_iter()
     }

--- a/esp-metadata/src/cfg/rsa.rs
+++ b/esp-metadata/src/cfg/rsa.rs
@@ -17,14 +17,16 @@ impl RsaLengths {
 impl GenericProperty for RsaLengths {}
 
 impl super::RsaProperties {
-    pub(super) fn computed_properties(&self) -> impl Iterator<Item = (&str, Value)> {
+    pub(super) fn computed_properties(&self) -> impl Iterator<Item = (&str, bool, Value)> {
         [
             (
                 "rsa.exponentiation",
+                false,
                 Value::NumberList(self.exponentiation.generate()),
             ),
             (
                 "rsa.multiplication",
+                false,
                 Value::NumberList(self.multiplication.generate()),
             ),
         ]


### PR DESCRIPTION
This PR isn't perfect, but at least we don't need to store constants in code.

Ideally, we'd describe the available options in metadata, too, and refer to them by name. We have 3 different ways for the defaults:
- ESP32 only uses APB, so "no choice" is one option
- C6/H2 configure clock sources via PCR (hopefully globally, but at least for the TIMG)
- The rest have peripheral-specific clock config options

This PR also fixes two issues with H2 WDT:
- The driver mistakenly selected clock source 1 (RTC_FAST_CLK) as the WDT clock source
- The timeout calculation assumed 80MHz clock source instead of 17.5 (old) or 48 (new).

The PR also makes sure we initialize the clocks before accessing them in WDT setup.