### PR TITLE
RISCV: Don't pass TrapFrame into interrupt handlers

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `aes::Mode` has been replaced by `Operation`. The key length is now solely determined by the key. (#3882)
 - `Aes::process` has been split into `Aes::encrypt` and `Aes::decrypt` (#3882)
 - Blocking RMT transactions can now be `poll`ed without blocking, returning whether they have completed. (#3716)
+- RISC-V: Interrupt handler don't get a TrapFrame passed in anymore (#3903)
 
 ### Fixed
 

--- a/esp-hal/src/interrupt/riscv.rs
+++ b/esp-hal/src/interrupt/riscv.rs
@@ -777,7 +777,7 @@ mod rt {
                 unsafe {
                     let level =
                         change_current_runlevel(unwrap!(Priority::try_from(elevated as u32)));
-                    riscv::interrupt::nested(|| handler());
+                    riscv::interrupt::nested(handler);
                     change_current_runlevel(level);
                 }
             }

--- a/esp-hal/src/interrupt/riscv.rs
+++ b/esp-hal/src/interrupt/riscv.rs
@@ -751,7 +751,7 @@ mod rt {
 
     #[unsafe(no_mangle)]
     #[ram]
-    unsafe fn handle_interrupts(cpu_intr: CpuInterrupt, context: &mut TrapFrame) {
+    unsafe fn handle_interrupts(cpu_intr: CpuInterrupt) {
         let core = Cpu::current();
         let status = status(core);
 
@@ -768,17 +768,16 @@ mod rt {
             let not_nested = (handler & 1) == 1;
             let handler = handler & !1;
 
-            let handler: fn(&mut TrapFrame) =
-                unsafe { core::mem::transmute::<usize, fn(&mut TrapFrame)>(handler) };
+            let handler: fn() = unsafe { core::mem::transmute::<usize, fn()>(handler) };
 
             if not_nested || prio == Priority::Priority15 {
-                handler(context);
+                handler();
             } else {
                 let elevated = prio as u8;
                 unsafe {
                     let level =
                         change_current_runlevel(unwrap!(Priority::try_from(elevated as u32)));
-                    riscv::interrupt::nested(|| handler(context));
+                    riscv::interrupt::nested(|| handler());
                     change_current_runlevel(level);
                 }
             }
@@ -820,7 +819,6 @@ mod rt {
                     .global interrupt"#,$num,r#"
 
                 interrupt"#,$num,r#":
-                    mv a1, a0
                     li a0,"#,$num,r#"
                     j handle_interrupts
                 "#

--- a/esp-radio-preempt-baremetal/src/lib.rs
+++ b/esp-radio-preempt-baremetal/src/lib.rs
@@ -33,7 +33,6 @@ use esp_hal::{
     sync::Locked,
     time::{Duration, Instant, Rate},
     timer::{AnyTimer, PeriodicTimer},
-    trapframe::TrapFrame,
 };
 
 use crate::{task::Context, timer::TIMER};
@@ -154,7 +153,7 @@ impl SchedulerState {
     }
 
     #[cfg(xtensa)]
-    fn switch_task(&mut self, trap_frame: &mut TrapFrame) {
+    fn switch_task(&mut self, trap_frame: &mut esp_hal::trapframe::TrapFrame) {
         task::save_task_context(unsafe { &mut *self.current_task }, trap_frame);
 
         if !self.to_delete.is_null() {
@@ -168,7 +167,7 @@ impl SchedulerState {
     }
 
     #[cfg(riscv)]
-    fn switch_task(&mut self, _trap_frame: &mut TrapFrame) {
+    fn switch_task(&mut self) {
         if !self.to_delete.is_null() {
             let task_to_delete = core::mem::take(&mut self.to_delete);
             self.delete_task(task_to_delete);

--- a/esp-radio-preempt-baremetal/src/task/mod.rs
+++ b/esp-radio-preempt-baremetal/src/task/mod.rs
@@ -8,6 +8,7 @@ use allocator_api2::boxed::Box;
 #[cfg(riscv)]
 use arch_specific::Registers;
 pub(crate) use arch_specific::*;
+#[cfg(xtensa)]
 use esp_hal::trapframe::TrapFrame;
 
 use crate::{InternalMemory, SCHEDULER_STATE, task, timer};
@@ -122,6 +123,12 @@ pub(super) fn schedule_task_deletion(task: *mut Context) {
     }
 }
 
+#[cfg(riscv)]
+pub(crate) fn task_switch() {
+    SCHEDULER_STATE.with(|state| state.switch_task());
+}
+
+#[cfg(xtensa)]
 pub(crate) fn task_switch(trap_frame: &mut TrapFrame) {
     SCHEDULER_STATE.with(|state| state.switch_task(trap_frame));
 }

--- a/esp-radio-preempt-baremetal/src/timer/riscv.rs
+++ b/esp-radio-preempt-baremetal/src/timer/riscv.rs
@@ -1,30 +1,9 @@
-use core::ptr::addr_of_mut;
-
 use esp_hal::{
     interrupt::{self, software::SoftwareInterrupt},
     peripherals::Interrupt,
 };
 
 use crate::task::task_switch;
-
-static mut FAKE_TRAP_FRAME: esp_hal::interrupt::TrapFrame = esp_hal::interrupt::TrapFrame {
-    ra: 0xdeadbeef,
-    t0: 0xdeadbeef,
-    t1: 0xdeadbeef,
-    t2: 0xdeadbeef,
-    t3: 0xdeadbeef,
-    t4: 0xdeadbeef,
-    t5: 0xdeadbeef,
-    t6: 0xdeadbeef,
-    a0: 0xdeadbeef,
-    a1: 0xdeadbeef,
-    a2: 0xdeadbeef,
-    a3: 0xdeadbeef,
-    a4: 0xdeadbeef,
-    a5: 0xdeadbeef,
-    a6: 0xdeadbeef,
-    a7: 0xdeadbeef,
-};
 
 pub(crate) fn setup_multitasking() {
     // Register the interrupt handler without nesting to satisfy the requirements of the task
@@ -47,7 +26,7 @@ extern "C" fn swint2_handler() {
     let swi = unsafe { SoftwareInterrupt::<2>::steal() };
     swi.reset();
 
-    task_switch(unsafe { &mut *addr_of_mut!(FAKE_TRAP_FRAME) });
+    task_switch();
 }
 
 #[inline]
@@ -60,5 +39,5 @@ pub(crate) fn yield_task() {
 #[esp_hal::ram]
 pub(crate) extern "C" fn timer_tick_handler() {
     super::clear_timer_interrupt();
-    crate::task::task_switch(unsafe { &mut *addr_of_mut!(FAKE_TRAP_FRAME) });
+    crate::task::task_switch();
 }

--- a/esp-radio/src/radio/radio_esp32c3.rs
+++ b/esp-radio/src/radio/radio_esp32c3.rs
@@ -88,7 +88,7 @@ extern "C" fn RWBLE() {
 
 #[cfg(feature = "ble")]
 #[unsafe(no_mangle)]
-extern "C" fn BT_BB(_trap_frame: &mut crate::hal::interrupt::TrapFrame) {
+extern "C" fn BT_BB() {
     unsafe {
         let (fnc, arg) = crate::ble::btdm::ble_os_adapter_chip_specific::BT_INTERRUPT_FUNCTION5;
 

--- a/esp-riscv-rt/src/lib.rs
+++ b/esp-riscv-rt/src/lib.rs
@@ -652,7 +652,7 @@ r#"
     sw a7, 15*4(sp)
 
     # jump to handler loaded in direct handler
-    add a0, sp, zero # load trap-frame address in a0
+    add a0, sp, zero # load trap-frame address in a0 - we only _need_ this only for trap-0 / exceptions
     jalr ra, ra # jump to label loaded in _start_trapX
 
     lw ra, 0*4(sp)


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

This prepares us to switch to the riscv-rt's trap-handling code eventually. In any case we don't need the TrapFrame for interrupts anymore, so we shouldn't  pass it in

No migration-guide entry for this: this behavior was never documented and never encouraged to use

`skip-changelog` because of internal changes in esp-riscv-rt and esp-radio-preempt-baremetal

#### Testing
Manual checking examples, CI
