### PR TITLE
Make metadata macros available even for build scripts

### DIFF
--- a/esp-metadata-generated/src/lib.rs
+++ b/esp-metadata-generated/src/lib.rs
@@ -99,19 +99,19 @@
 //! ```
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(not(feature = "build-script"), no_std)]
-#[cfg(all(not(feature = "build-script"), feature = "esp32"))]
+#[cfg(feature = "esp32")]
 include!("_generated_esp32.rs");
-#[cfg(all(not(feature = "build-script"), feature = "esp32c2"))]
+#[cfg(feature = "esp32c2")]
 include!("_generated_esp32c2.rs");
-#[cfg(all(not(feature = "build-script"), feature = "esp32c3"))]
+#[cfg(feature = "esp32c3")]
 include!("_generated_esp32c3.rs");
-#[cfg(all(not(feature = "build-script"), feature = "esp32c6"))]
+#[cfg(feature = "esp32c6")]
 include!("_generated_esp32c6.rs");
-#[cfg(all(not(feature = "build-script"), feature = "esp32h2"))]
+#[cfg(feature = "esp32h2")]
 include!("_generated_esp32h2.rs");
-#[cfg(all(not(feature = "build-script"), feature = "esp32s2"))]
+#[cfg(feature = "esp32s2")]
 include!("_generated_esp32s2.rs");
-#[cfg(all(not(feature = "build-script"), feature = "esp32s3"))]
+#[cfg(feature = "esp32s3")]
 include!("_generated_esp32s3.rs");
 #[cfg(any(feature = "build-script", docsrs))]
 include!("_build_script_utils.rs");

--- a/esp-metadata/CHANGELOG.md
+++ b/esp-metadata/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Output: Include firmware-side metadata macros even if the build-script feature is set. (#3906)
 
 ### Removed
 

--- a/esp-metadata/src/lib.rs
+++ b/esp-metadata/src/lib.rs
@@ -910,7 +910,7 @@ pub fn generate_lib_rs() -> TokenStream {
         let feature = format!("{c}");
         let file = format!("_generated_{c}.rs");
         quote! {
-            #[cfg(all(not(feature = "build-script"), feature = #feature))]
+            #[cfg(feature = #feature)]
             include!(#file);
         }
     });


### PR DESCRIPTION
Rust-analyzer seems to analyze crates once, with both the build-script and the device feature enabled. This prevented macros from being resolved, causing a regression in user experience. This PR should remedy that by making the macros available even in build scripts.