### PR TITLE
fix(esp-hal/esp32): Fix switched ADC channel numbers on esp32

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PSRAM on ESP32-S2 (#3811)
 - WDT now allows configuring longer timeouts (#3816)
 - `ADC2` now cannot be used simultaneously with `radio` on ESP32 (#3876)
+- Switched GPIO32 and GPIO33 ADC channel numbers (#3908)
 
 ### Removed
 

--- a/esp-hal/src/analog/adc/esp32.rs
+++ b/esp-hal/src/analog/adc/esp32.rs
@@ -404,8 +404,8 @@ mod adc_implementation {
             (GPIO37<'_>, 1), // Alt. name: SENSOR_CAPP
             (GPIO38<'_>, 2), // Alt. name: SENSOR_CAPN
             (GPIO39<'_>, 3), // Alt. name: SENSOR_VN
-            (GPIO32<'_>, 4), // Alt. name: 32K_XN
-            (GPIO33<'_>, 5), // Alt. name: 32K_XP
+            (GPIO32<'_>, 4), // Alt. name: 32K_XP
+            (GPIO33<'_>, 5), // Alt. name: 32K_XN
             (GPIO34<'_>, 6), // Alt. name: VDET_1
             (GPIO35<'_>, 7), // Alt. name: VDET_2
         ]

--- a/esp-hal/src/analog/adc/esp32.rs
+++ b/esp-hal/src/analog/adc/esp32.rs
@@ -404,8 +404,8 @@ mod adc_implementation {
             (GPIO37<'_>, 1), // Alt. name: SENSOR_CAPP
             (GPIO38<'_>, 2), // Alt. name: SENSOR_CAPN
             (GPIO39<'_>, 3), // Alt. name: SENSOR_VN
-            (GPIO33<'_>, 4), // Alt. name: 32K_XP
-            (GPIO32<'_>, 5), // Alt. name: 32K_XN
+            (GPIO32<'_>, 4), // Alt. name: 32K_XN
+            (GPIO33<'_>, 5), // Alt. name: 32K_XP
             (GPIO34<'_>, 6), // Alt. name: VDET_1
             (GPIO35<'_>, 7), // Alt. name: VDET_2
         ]


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

The analog-to-digital adc1 channel numbers were switched for GPIO32 and GPIO33 pins.

#### Testing

Connected a potentiometer to both pins to check which one is reading the correct values when enabling one of GPIO33 and GPIO32.
