### PR TITLE
Make mutexes reentrant by default

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - WDT now allows configuring longer timeouts (#3816)
 - `ADC2` now cannot be used simultaneously with `radio` on ESP32 (#3876)
 - Switched GPIO32 and GPIO33 ADC channel numbers (#3908, #3911)
+- Switched GPIO32 and GPIO33 ADC channel numbers (#3908)
+- Calling `Input::unlisten` in a GPIO interrupt handler no longer panics (#3913)
 
 ### Removed
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -35,7 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - WDT now allows configuring longer timeouts (#3816)
 - `ADC2` now cannot be used simultaneously with `radio` on ESP32 (#3876)
 - Switched GPIO32 and GPIO33 ADC channel numbers (#3908, #3911)
-- Switched GPIO32 and GPIO33 ADC channel numbers (#3908)
 - Calling `Input::unlisten` in a GPIO interrupt handler no longer panics (#3913)
 
 ### Removed

--- a/esp-hal/src/sync.rs
+++ b/esp-hal/src/sync.rs
@@ -437,13 +437,6 @@ unsafe impl embassy_sync::blocking_mutex::raw::RawMutex for RawPriorityLimitedMu
     }
 }
 
-// Prefer this over a critical-section as this allows you to have multiple
-// locks active at the same time rather than using the global mutex that is
-// critical-section.
-pub(crate) fn lock<T>(lock: &RawMutex, f: impl FnOnce() -> T) -> T {
-    lock.lock(f)
-}
-
 /// Data protected by a [RawMutex].
 ///
 /// This is largely equivalent to a `Mutex<RefCell<T>>`, but accessing the inner

--- a/esp-hal/src/timer/timg.rs
+++ b/esp-hal/src/timer/timg.rs
@@ -93,7 +93,7 @@ cfg_if::cfg_if! {
     // and S2 where the effective interrupt enable register (config) is not shared between
     // the timers.
     if #[cfg(all(timergroup_timg_has_timer1, not(any(esp32, esp32s2))))] {
-        use crate::sync::{lock, RawMutex};
+        use crate::sync::RawMutex;
         static INT_ENA_LOCK: [RawMutex; NUM_TIMG] = [const { RawMutex::new() }; NUM_TIMG];
     }
 }
@@ -582,7 +582,7 @@ impl Timer<'_> {
                     .config()
                     .modify(|_, w| w.level_int_en().bit(state));
             } else if #[cfg(timergroup_timg_has_timer1)] {
-                lock(&INT_ENA_LOCK[self.timer_group() as usize], || {
+                INT_ENA_LOCK[self.timer_group() as usize].lock(|| {
                     self.register_block()
                         .int_ena()
                         .modify(|_, w| w.t(self.timer_number()).bit(state));


### PR DESCRIPTION
Fixes #3909

This doesn't change the semantics of `Locked` which still panics on reentry - changing that would be unsound. That means `Locked<()>` can still be used a non-reentrant critical section.