### PR TITLE
RMT: Some internal refactorings

### DIFF
--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -862,21 +862,12 @@ cfg_if::cfg_if! {
     }
 }
 
-impl<'d, Dm> Rmt<'d, Dm>
-where
-    Dm: crate::DriverMode,
-{
-    pub(crate) fn new_internal(peripheral: RMT<'d>, frequency: Rate) -> Result<Self, Error> {
-        let me = Rmt::create(peripheral);
-        self::chip_specific::configure_clock(frequency)?;
-        Ok(me)
-    }
-}
-
 impl<'d> Rmt<'d, Blocking> {
     /// Create a new RMT instance
     pub fn new(peripheral: RMT<'d>, frequency: Rate) -> Result<Self, Error> {
-        Self::new_internal(peripheral, frequency)
+        let this = Rmt::create(peripheral);
+        self::chip_specific::configure_clock(frequency)?;
+        Ok(this)
     }
 
     /// Reconfigures the driver for asynchronous operation.

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -709,7 +709,7 @@ impl Default for RxChannelConfig {
 // Declare input/output signals in a const array.
 macro_rules! declare_signals {
     ($name:ident, $type:ident, [$($entry:ident $(,)?)*; $count:expr]) => {
-        pub(crate) const $name: [crate::gpio::$type; $count] = [
+        const $name: [crate::gpio::$type; $count] = [
             $(crate::gpio::$type::$entry,)*
         ];
     };

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -1953,10 +1953,12 @@ pub trait TxChannelInternal: ChannelInternal {
 
     fn set_tx_interrupt(&self, event: EnumSet<Event>, enable: bool);
 
+    #[inline]
     fn listen_tx_interrupt(&self, event: impl Into<EnumSet<Event>>) {
         self.set_tx_interrupt(event.into(), true);
     }
 
+    #[inline]
     fn unlisten_tx_interrupt(&self, event: impl Into<EnumSet<Event>>) {
         self.set_tx_interrupt(event.into(), false);
     }
@@ -1995,10 +1997,12 @@ pub trait RxChannelInternal: ChannelInternal {
 
     fn set_rx_interrupt(&self, event: EnumSet<Event>, enable: bool);
 
+    #[inline]
     fn listen_rx_interrupt(&self, event: impl Into<EnumSet<Event>>) {
         self.set_rx_interrupt(event.into(), true);
     }
 
+    #[inline]
     fn unlisten_rx_interrupt(&self, event: impl Into<EnumSet<Event>>) {
         self.set_rx_interrupt(event.into(), false);
     }

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -213,6 +213,7 @@ use crate::{
     Blocking,
     asynch::AtomicWaker,
     gpio::{
+        self,
         InputConfig,
         Level,
         OutputConfig,
@@ -754,9 +755,9 @@ macro_rules! declare_tx_channels {
             #[allow(clippy::no_effect)]
             const CHANNEL_INDEX_COUNT: u8 = const { 0 $( + {$idx; 1} )+ };
 
-            const OUTPUT_SIGNALS: [crate::gpio::OutputSignal; CHANNEL_INDEX_COUNT as usize] = [
+            const OUTPUT_SIGNALS: [gpio::OutputSignal; CHANNEL_INDEX_COUNT as usize] = [
                 $(
-                    crate::gpio::OutputSignal::[< RMT_SIG_ $idx >],
+                    gpio::OutputSignal::[< RMT_SIG_ $idx >],
                 )+
             ];
 
@@ -776,9 +777,9 @@ macro_rules! declare_tx_channels {
 macro_rules! declare_rx_channels {
     ($([$num:literal, $idx:literal]),+ $(,)?) => {
         paste::paste! {
-            const INPUT_SIGNALS: [crate::gpio::InputSignal; CHANNEL_INDEX_COUNT as usize] = [
+            const INPUT_SIGNALS: [gpio::InputSignal; CHANNEL_INDEX_COUNT as usize] = [
                 $(
-                    crate::gpio::InputSignal::[< RMT_SIG_ $idx >],
+                    gpio::InputSignal::[< RMT_SIG_ $idx >],
                 )+
             ];
 
@@ -1800,7 +1801,7 @@ pub trait ChannelInternal: RawChannelAccess {
 
 #[doc(hidden)]
 pub trait TxChannelInternal: ChannelInternal {
-    fn output_signal(&self) -> crate::gpio::OutputSignal {
+    fn output_signal(&self) -> gpio::OutputSignal {
         OUTPUT_SIGNALS[self.channel() as usize]
     }
 
@@ -1879,7 +1880,7 @@ pub trait TxChannelInternal: ChannelInternal {
 
 #[doc(hidden)]
 pub trait RxChannelInternal: ChannelInternal {
-    fn input_signal(&self) -> crate::gpio::InputSignal {
+    fn input_signal(&self) -> gpio::InputSignal {
         INPUT_SIGNALS[self.channel() as usize]
     }
 
@@ -1939,7 +1940,7 @@ mod chip_specific {
         Tx,
         TxChannelInternal,
     };
-    use crate::{peripherals::RMT, time::Rate};
+    use crate::{gpio, peripherals::RMT, time::Rate};
 
     pub(super) fn configure_clock(frequency: Rate) -> Result<(), Error> {
         let src_clock = crate::soc::constants::RMT_CLOCK_SRC_FREQ;
@@ -2233,7 +2234,7 @@ mod chip_specific {
     where
         A: RawChannelAccess<Dir = Rx>,
     {
-        fn input_signal(&self) -> crate::gpio::InputSignal {
+        fn input_signal(&self) -> gpio::InputSignal {
             let ch_idx = ch_idx(self) as usize;
             super::INPUT_SIGNALS[ch_idx]
         }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖
Miscellaneous internal refactorings and cleanups of the RMT driver as well as a new HIL test. There should be no user-facing changes (thus no changelog entry).

This should be easiest to review commit-by-commit. The commit messages provide rationale for each of the changes.

This is part of/preparation for #3509.

#### Testing
Ran HIL tests on esp32c3 and as part of #3509.