### PR TITLE
Implement suspending the work queue

### DIFF
--- a/esp-hal/src/aes/mod.rs
+++ b/esp-hal/src/aes/mod.rs
@@ -829,7 +829,7 @@ impl<'d> AesBackend<'d> {
     /// ```
     pub fn start(&mut self) -> AesWorkQueueDriver<'_, 'd> {
         AesWorkQueueDriver {
-            _inner: WorkQueueDriver::new(self, BLOCKING_AES_VTABLE, &AES_WORK_QUEUE),
+            inner: WorkQueueDriver::new(self, BLOCKING_AES_VTABLE, &AES_WORK_QUEUE),
         }
     }
 
@@ -871,7 +871,14 @@ pub enum Error {
 ///
 /// This object must be kept around, otherwise AES operations will never complete.
 pub struct AesWorkQueueDriver<'t, 'd> {
-    _inner: WorkQueueDriver<'t, AesBackend<'d>, AesOperation>,
+    inner: WorkQueueDriver<'t, AesBackend<'d>, AesOperation>,
+}
+
+impl<'t, 'd> AesWorkQueueDriver<'t, 'd> {
+    /// Finishes processing the current work queue item, then stops the driver.
+    pub fn stop(self) -> impl Future<Output = ()> {
+        self.inner.stop()
+    }
 }
 
 /// An AES work queue user.

--- a/esp-hal/src/work_queue.rs
+++ b/esp-hal/src/work_queue.rs
@@ -636,7 +636,7 @@ where
     T: Sync + Send,
 {
     fn drop(&mut self) {
-        let suspended = self.queue.inner.with(|inner| {
+        let suspend_started = self.queue.inner.with(|inner| {
             if inner.is_active() {
                 inner.suspend(None);
                 true
@@ -645,7 +645,7 @@ where
             }
         });
 
-        if suspended {
+        if suspend_started {
             loop {
                 let done = self.queue.inner.with(|inner| {
                     if inner.is_active() {

--- a/hil-test/tests/aes.rs
+++ b/hil-test/tests/aes.rs
@@ -6,6 +6,8 @@
 #![no_std]
 #![no_main]
 
+use embassy_executor::Spawner;
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
 use esp_hal::{
     Config,
     aes::{
@@ -19,7 +21,7 @@ use esp_hal::{
     },
     clock::CpuClock,
 };
-use hil_test as _;
+use hil_test::mk_static;
 
 const KEY: &[u8] = b"SUp4SeCp@sSw0rd";
 const KEY_128: [u8; 16] = pad_to::<16>(KEY);
@@ -307,10 +309,6 @@ fn run_cipher_tests(buffer: &mut [u8]) {
 #[cfg(test)]
 #[embedded_test::tests(default_timeout = 3, executor = hil_test::Executor::new())]
 mod tests {
-    use embassy_executor::Spawner;
-    use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
-    use hil_test::mk_static;
-
     use super::*;
 
     #[test]


### PR DESCRIPTION
This PR adds an async way to stop the work queue if needed. This may be useful for entering sleep, for example, without blocking for the last operations to finish.

This will also allow us to implement HMAC/DSA/ECDSA work queues. We still need a way to share a peripheral with multiple backends, but the more complex peripherals (HMAC/DSA/ECDSA) can suspend the queue, do their thing and let the queue resume processing when they are done. The algorithm will suspend once, try locking the required peripherals in a loop, and do work when everything is available. I think this should succeed even if these peripherals are different work queues, but we may end up implementing a single sign/authenticate work queue because in the vast majority of MCUs these peripehrals are mutually exclusive. (ECDSA may be somewhat special after C5 as it won't need RSA, so we can split that out into a second queue on those MCUs if it makes a difference down the line).