### PR TITLE
chore: update esp-radio dependency on bt-hci

### DIFF
--- a/esp-radio/CHANGELOG.md
+++ b/esp-radio/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rename `esp-wifi` to `esp-radio`. (#3858)
 - `esp-ieee802154` package has been folded into `esp-radio`, it's now alloc. (#3861, #3890)
 - `ble`, `esp-now`, `csi`, `sniffer`, `esp-ieee802154` and `smoltcp` features and APIs marked as unstable (#3865)
-- Update bt-hci version to add additional HCI commands
+- Update bt-hci version to add additional HCI commands (#3920)
 
 ### Fixed
 

--- a/esp-radio/CHANGELOG.md
+++ b/esp-radio/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rename `esp-wifi` to `esp-radio`. (#3858)
 - `esp-ieee802154` package has been folded into `esp-radio`, it's now alloc. (#3861, #3890)
 - `ble`, `esp-now`, `csi`, `sniffer`, `esp-ieee802154` and `smoltcp` features and APIs marked as unstable (#3865)
+- Update bt-hci version to add additional HCI commands
 
 ### Fixed
 

--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -48,7 +48,7 @@ smoltcp = { version = "0.12.0", default-features = false, features = [
   "socket-raw",
 ], optional = true }
 embassy-net-driver = { version = "0.2.0", optional = true }
-bt-hci = { version = "0.3.0", optional = true }
+bt-hci = { version = "0.4.0", optional = true }
 
 # Logging interfaces, they are mutually exclusive so they need to be behind separate features.
 defmt            = { version = "1.0.1", optional = true }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [ ] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

Update the bt-hci dependency.

#### Testing
Verified by patching the esp32 example in the trouble repository.
