### PR TITLE
Split the `wifi` feature into `wifi-ap`, `wifi-sta` and `wifi-eap`

### DIFF
--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -126,8 +126,11 @@ sys-logs = ["esp-wifi-sys/sys-logs"]
 #! ### Wireless Feature Flags
 
 ## Enable WiFi support
-wifi = ["dep:enumset", "dep:embassy-net-driver"]
+wifi = ["wifi-sta", "wifi-ap", "wifi-eap"]
 
+wifi-sta = ["dep:enumset", "dep:embassy-net-driver"]
+wifi-ap  = ["dep:enumset", "dep:embassy-net-driver"]
+wifi-eap = ["dep:enumset", "dep:embassy-net-driver"]
 ## Enable esp-now support
 esp-now = ["wifi"]
 

--- a/esp-radio/build.rs
+++ b/esp-radio/build.rs
@@ -68,7 +68,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         "#
     );
     assert!(
-        !cfg!(feature = "wifi") || chip.contains("wifi"),
+        !(cfg!(feature = "wifi-ap") || cfg!(feature = "wifi-sta") || cfg!(feature = "wifi-eap"))
+            || chip.contains("wifi"),
         r#"
 
         WiFi is not supported on this target.
@@ -108,10 +109,13 @@ fn main() -> Result<(), Box<dyn Error>> {
             "#
         );
 
-        #[cfg(all(feature = "wifi", feature = "ble"))]
+        #[cfg(all(
+            any(feature = "wifi-ap", feature = "wifi-sta", feature = "wifi-eap"),
+            feature = "ble"
+        ))]
         println!("cargo:rustc-cfg=coex");
 
-        #[cfg(not(feature = "wifi"))]
+        #[cfg(not(any(feature = "wifi-sta", feature = "wifi-ap", feature = "wifi-eap")))]
         println!("cargo:warning=coex is enabled but wifi is not");
 
         #[cfg(not(feature = "ble"))]
@@ -131,7 +135,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rustc-link-search={}", out.display());
     println!("cargo:rerun-if-changed=./ld/");
     let config = [
-        #[cfg(feature = "wifi")]
+        #[cfg(any(feature = "wifi-ap", feature = "wifi-sta", feature = "wifi-eap"))]
         "wifi",
         #[cfg(feature = "ble")]
         "ble",

--- a/esp-radio/src/common_adapter/mod.rs
+++ b/esp-radio/src/common_adapter/mod.rs
@@ -219,17 +219,17 @@ pub unsafe extern "C" fn puts(s: *const c_char) {
 #[unsafe(no_mangle)]
 static mut __ESP_RADIO_WIFI_EVENT: esp_event_base_t = c"WIFI_EVENT".as_ptr();
 
-#[cfg(feature = "wifi")]
+#[cfg(any(feature = "wifi-ap", feature = "wifi-sta"))]
 pub unsafe extern "C" fn ets_timer_disarm(timer: *mut crate::binary::c_types::c_void) {
     crate::compat::timer_compat::compat_timer_disarm(timer.cast());
 }
 
-#[cfg(feature = "wifi")]
+#[cfg(any(feature = "wifi-ap", feature = "wifi-sta"))]
 pub unsafe extern "C" fn ets_timer_done(timer: *mut crate::binary::c_types::c_void) {
     crate::compat::timer_compat::compat_timer_done(timer.cast());
 }
 
-#[cfg(feature = "wifi")]
+#[cfg(any(feature = "wifi-ap", feature = "wifi-sta"))]
 pub unsafe extern "C" fn ets_timer_setfn(
     ptimer: *mut crate::binary::c_types::c_void,
     pfunction: *mut crate::binary::c_types::c_void,
@@ -247,7 +247,7 @@ pub unsafe extern "C" fn ets_timer_setfn(
     }
 }
 
-#[cfg(feature = "wifi")]
+#[cfg(any(feature = "wifi-ap", feature = "wifi-sta"))]
 pub unsafe extern "C" fn ets_timer_arm(
     timer: *mut crate::binary::c_types::c_void,
     tmout: u32,
@@ -256,7 +256,7 @@ pub unsafe extern "C" fn ets_timer_arm(
     crate::compat::timer_compat::compat_timer_arm(timer.cast(), tmout, repeat);
 }
 
-#[cfg(feature = "wifi")]
+#[cfg(any(feature = "wifi-ap", feature = "wifi-sta"))]
 pub unsafe extern "C" fn ets_timer_arm_us(
     timer: *mut crate::binary::c_types::c_void,
     tmout: u32,

--- a/esp-radio/src/compat/malloc.rs
+++ b/esp-radio/src/compat/malloc.rs
@@ -6,20 +6,20 @@
 unsafe extern "C" {
     pub fn malloc(size: usize) -> *mut u8;
 
-    #[cfg(any(feature = "wifi", not(npl)))]
+    #[cfg(any(feature = "wifi-ap", feature = "wifi-sta", not(npl)))]
     pub fn malloc_internal(size: usize) -> *mut u8;
 
     pub fn free(ptr: *mut u8);
 
-    #[cfg(feature = "wifi")]
+    #[cfg(any(feature = "wifi-ap", feature = "wifi-sta"))]
     pub fn realloc_internal(ptr: *mut u8, size: usize) -> *mut u8;
 
-    #[cfg(any(feature = "wifi", all(feature = "ble", npl)))]
+    #[cfg(any(feature = "wifi-sta", feature = "wifi-ap", all(feature = "ble", npl)))]
     pub fn calloc(number: u32, size: usize) -> *mut u8;
 
-    #[cfg(feature = "wifi")]
+    #[cfg(any(feature = "wifi-ap", feature = "wifi-sta"))]
     pub fn calloc_internal(number: u32, size: usize) -> *mut u8;
 
-    #[cfg(feature = "wifi")]
+    #[cfg(any(feature = "wifi-ap", feature = "wifi-sta"))]
     pub fn get_free_internal_heap_size() -> usize;
 }

--- a/esp-radio/src/compat/timer_compat.rs
+++ b/esp-radio/src/compat/timer_compat.rs
@@ -42,7 +42,7 @@ pub(crate) struct Timer {
     next: Option<Box<Timer>>,
 }
 
-#[cfg(any(feature = "wifi", all(feature = "ble", npl)))]
+#[cfg(any(feature = "wifi-sta", feature = "wifi-ap", all(feature = "ble", npl)))]
 impl Timer {
     pub(crate) fn id(&self) -> usize {
         self.ets_timer as usize
@@ -76,7 +76,7 @@ impl TimerQueue {
     }
 }
 
-#[cfg(any(feature = "wifi", all(feature = "ble", npl)))]
+#[cfg(any(feature = "wifi-sta", feature = "wifi-ap", all(feature = "ble", npl)))]
 impl TimerQueue {
     fn find(&mut self, ets_timer: *mut ets_timer) -> Option<&mut Box<Timer>> {
         let mut current = self.head.as_mut();
@@ -90,7 +90,7 @@ impl TimerQueue {
         None
     }
 
-    #[cfg(feature = "wifi")]
+    #[cfg(any(feature = "wifi-sta", feature = "wifi-ap"))]
     fn remove(&mut self, ets_timer: *mut ets_timer) {
         if let Some(head) = self.head.as_mut()
             && core::ptr::eq(head.ets_timer, ets_timer)
@@ -149,12 +149,12 @@ unsafe impl Send for TimerQueue {}
 
 pub(crate) static TIMERS: Locked<TimerQueue> = Locked::new(TimerQueue::new());
 
-#[cfg(any(feature = "wifi", all(feature = "ble", npl)))]
+#[cfg(any(feature = "wifi-sta", feature = "wifi-ap", all(feature = "ble", npl)))]
 pub(crate) fn compat_timer_arm(ets_timer: *mut ets_timer, tmout: u32, repeat: bool) {
     compat_timer_arm_us(ets_timer, tmout * 1000, repeat);
 }
 
-#[cfg(any(feature = "wifi", all(feature = "ble", npl)))]
+#[cfg(any(feature = "wifi-sta", feature = "wifi-ap", all(feature = "ble", npl)))]
 pub(crate) fn compat_timer_arm_us(ets_timer: *mut ets_timer, us: u32, repeat: bool) {
     let systick = crate::time::systimer_count();
     let ticks = crate::time::micros_to_ticks(us as u64);
@@ -176,7 +176,7 @@ pub(crate) fn compat_timer_arm_us(ets_timer: *mut ets_timer, us: u32, repeat: bo
     })
 }
 
-#[cfg(any(feature = "wifi", all(feature = "ble", npl)))]
+#[cfg(any(feature = "wifi-sta", feature = "wifi-ap", all(feature = "ble", npl)))]
 pub fn compat_timer_disarm(ets_timer: *mut ets_timer) {
     trace!("timer disarm");
     TIMERS.with(|timers| {
@@ -189,7 +189,7 @@ pub fn compat_timer_disarm(ets_timer: *mut ets_timer) {
     })
 }
 
-#[cfg(feature = "wifi")]
+#[cfg(any(feature = "wifi-ap", feature = "wifi-sta"))]
 pub fn compat_timer_done(ets_timer: *mut ets_timer) {
     trace!("timer done");
     TIMERS.with(|timers| {
@@ -209,7 +209,7 @@ pub fn compat_timer_done(ets_timer: *mut ets_timer) {
     })
 }
 
-#[cfg(any(feature = "wifi", all(feature = "ble", npl)))]
+#[cfg(any(feature = "wifi-sta", feature = "wifi-ap", all(feature = "ble", npl)))]
 pub(crate) fn compat_timer_setfn(
     ets_timer: *mut ets_timer,
     pfunction: unsafe extern "C" fn(*mut c_types::c_void),

--- a/esp-radio/src/lib.rs
+++ b/esp-radio/src/lib.rs
@@ -90,7 +90,10 @@
 #![allow(unknown_lints)]
 #![allow(non_local_definitions)]
 #![cfg_attr(
-    not(any(feature = "wifi", feature = "ble")),
+    not(any(
+        any(feature = "wifi-sta", feature = "wifi-ap", feature = "wifi-eap"),
+        feature = "ble"
+    )),
     allow(
         unused,
         reason = "There are a number of places where code is needed for either wifi or ble,
@@ -122,7 +125,7 @@ use hal::{
     time::Rate,
 };
 
-#[cfg(feature = "wifi")]
+#[cfg(any(feature = "wifi-sta", feature = "wifi-ap", feature = "wifi-eap"))]
 use crate::wifi::WifiError;
 use crate::{
     preempt::yield_task,
@@ -162,7 +165,7 @@ mod time;
 
 pub(crate) use unstable_module;
 
-#[cfg(feature = "wifi")]
+#[cfg(any(feature = "wifi-sta", feature = "wifi-ap", feature = "wifi-eap"))]
 pub mod wifi;
 
 unstable_module! {
@@ -321,7 +324,7 @@ pub enum InitializationError {
     /// The internal error code is reported.
     General(i32),
     /// An error from the WiFi driver.
-    #[cfg(feature = "wifi")]
+    #[cfg(any(feature = "wifi-sta", feature = "wifi-ap", feature = "wifi-eap"))]
     WifiError(WifiError),
     /// The current CPU clock frequency is too low.
     WrongClockConfig,
@@ -335,7 +338,7 @@ pub enum InitializationError {
     Adc2IsUsed,
 }
 
-#[cfg(feature = "wifi")]
+#[cfg(any(feature = "wifi-sta", feature = "wifi-ap", feature = "wifi-eap"))]
 impl From<WifiError> for InitializationError {
     fn from(value: WifiError) -> Self {
         InitializationError::WifiError(value)

--- a/esp-radio/src/radio/radio_esp32.rs
+++ b/esp-radio/src/radio/radio_esp32.rs
@@ -1,4 +1,9 @@
-#[cfg(any(feature = "wifi", feature = "ble"))]
+#[cfg(any(
+    feature = "wifi-ap",
+    feature = "wifi-sta",
+    feature = "wifi-eap",
+    feature = "ble"
+))]
 #[allow(unused_imports)]
 use crate::hal::{interrupt, peripherals};
 
@@ -47,7 +52,7 @@ fn Software0() {
     }
 }
 
-#[cfg(feature = "wifi")]
+#[cfg(any(feature = "wifi-ap", feature = "wifi-sta", feature = "wifi-eap"))]
 #[unsafe(no_mangle)]
 extern "C" fn WIFI_MAC() {
     unsafe {

--- a/esp-radio/src/radio/radio_esp32c2.rs
+++ b/esp-radio/src/radio/radio_esp32c2.rs
@@ -1,4 +1,9 @@
-#[cfg(any(feature = "wifi", feature = "ble"))]
+#[cfg(any(
+    feature = "wifi-ap",
+    feature = "wifi-sta",
+    feature = "wifi-eap",
+    feature = "ble"
+))]
 #[allow(unused_imports)]
 use crate::{
     binary,
@@ -17,7 +22,7 @@ pub(crate) fn shutdown_radio_isr() {
     }
 }
 
-#[cfg(feature = "wifi")]
+#[cfg(any(feature = "wifi-ap", feature = "wifi-sta", feature = "wifi-eap"))]
 #[unsafe(no_mangle)]
 extern "C" fn WIFI_MAC() {
     unsafe {
@@ -34,7 +39,7 @@ extern "C" fn WIFI_MAC() {
     };
 }
 
-#[cfg(feature = "wifi")]
+#[cfg(any(feature = "wifi-ap", feature = "wifi-sta", feature = "wifi-eap"))]
 #[unsafe(no_mangle)]
 extern "C" fn WIFI_PWR() {
     unsafe {

--- a/esp-radio/src/radio/radio_esp32c3.rs
+++ b/esp-radio/src/radio/radio_esp32c3.rs
@@ -1,4 +1,9 @@
-#[cfg(any(feature = "wifi", feature = "ble"))]
+#[cfg(any(
+    feature = "wifi-ap",
+    feature = "wifi-sta",
+    feature = "wifi-eap",
+    feature = "ble"
+))]
 #[allow(unused_imports)]
 use crate::{
     binary,
@@ -18,7 +23,7 @@ pub(crate) fn shutdown_radio_isr() {
     }
 }
 
-#[cfg(feature = "wifi")]
+#[cfg(any(feature = "wifi-ap", feature = "wifi-sta", feature = "wifi-eap"))]
 #[unsafe(no_mangle)]
 extern "C" fn WIFI_MAC() {
     unsafe {
@@ -35,7 +40,7 @@ extern "C" fn WIFI_MAC() {
     };
 }
 
-#[cfg(feature = "wifi")]
+#[cfg(any(feature = "wifi-ap", feature = "wifi-sta", feature = "wifi-eap"))]
 #[unsafe(no_mangle)]
 extern "C" fn WIFI_PWR() {
     unsafe {

--- a/esp-radio/src/radio/radio_esp32c6.rs
+++ b/esp-radio/src/radio/radio_esp32c6.rs
@@ -1,5 +1,10 @@
 use crate::hal::peripherals::{INTERRUPT_CORE0, Interrupt};
-#[cfg(any(feature = "wifi", feature = "ble"))]
+#[cfg(any(
+    feature = "wifi-ap",
+    feature = "wifi-sta",
+    feature = "wifi-eap",
+    feature = "ble"
+))]
 #[allow(unused_imports)]
 use crate::{binary, hal::interrupt};
 
@@ -23,7 +28,7 @@ pub(crate) fn shutdown_radio_isr() {
     }
 }
 
-#[cfg(feature = "wifi")]
+#[cfg(any(feature = "wifi-ap", feature = "wifi-sta", feature = "wifi-eap"))]
 #[unsafe(no_mangle)]
 extern "C" fn WIFI_MAC() {
     unsafe {
@@ -40,7 +45,7 @@ extern "C" fn WIFI_MAC() {
     };
 }
 
-#[cfg(feature = "wifi")]
+#[cfg(any(feature = "wifi-ap", feature = "wifi-sta", feature = "wifi-eap"))]
 #[unsafe(no_mangle)]
 extern "C" fn WIFI_PWR() {
     unsafe {

--- a/esp-radio/src/radio/radio_esp32s2.rs
+++ b/esp-radio/src/radio/radio_esp32s2.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "wifi")]
+#[cfg(any(feature = "wifi-ap", feature = "wifi-sta", feature = "wifi-eap"))]
 #[allow(unused_imports)]
 use crate::hal::{interrupt, peripherals};
 
@@ -11,7 +11,7 @@ pub(crate) fn shutdown_radio_isr() {
     // ble not supported
 }
 
-#[cfg(feature = "wifi")]
+#[cfg(any(feature = "wifi-ap", feature = "wifi-sta", feature = "wifi-eap"))]
 #[unsafe(no_mangle)]
 extern "C" fn WIFI_MAC() {
     unsafe {
@@ -25,7 +25,7 @@ extern "C" fn WIFI_MAC() {
     }
 }
 
-#[cfg(feature = "wifi")]
+#[cfg(any(feature = "wifi-ap", feature = "wifi-sta", feature = "wifi-eap"))]
 #[unsafe(no_mangle)]
 extern "C" fn WIFI_PWR() {
     unsafe {

--- a/esp-radio/src/radio/radio_esp32s3.rs
+++ b/esp-radio/src/radio/radio_esp32s3.rs
@@ -1,4 +1,9 @@
-#[cfg(any(feature = "wifi", feature = "ble"))]
+#[cfg(any(
+    feature = "wifi-ap",
+    feature = "wifi-sta",
+    feature = "wifi-eap",
+    feature = "ble"
+))]
 #[allow(unused_imports)]
 use crate::hal::{interrupt, peripherals::Interrupt};
 
@@ -14,7 +19,7 @@ pub(crate) fn shutdown_radio_isr() {
     }
 }
 
-#[cfg(feature = "wifi")]
+#[cfg(any(feature = "wifi-ap", feature = "wifi-sta", feature = "wifi-eap"))]
 #[unsafe(no_mangle)]
 extern "C" fn WIFI_MAC() {
     unsafe {
@@ -28,7 +33,7 @@ extern "C" fn WIFI_MAC() {
     }
 }
 
-#[cfg(feature = "wifi")]
+#[cfg(any(feature = "wifi-ap", feature = "wifi-sta", feature = "wifi-eap"))]
 #[unsafe(no_mangle)]
 extern "C" fn WIFI_PWR() {
     unsafe {

--- a/esp-radio/src/wifi/os_adapter_esp32.rs
+++ b/esp-radio/src/wifi/os_adapter_esp32.rs
@@ -65,7 +65,7 @@ pub unsafe extern "C" fn set_isr(
         },
         _ => panic!("set_isr - unsupported interrupt number {}", n),
     }
-    #[cfg(feature = "wifi")]
+    #[cfg(any(feature = "wifi-ap", feature = "wifi-sta", feature = "wifi-eap"))]
     {
         unwrap!(interrupt::enable(
             peripherals::Interrupt::WIFI_MAC,

--- a/esp-radio/src/wifi/os_adapter_esp32c2.rs
+++ b/esp-radio/src/wifi/os_adapter_esp32c2.rs
@@ -61,7 +61,7 @@ pub unsafe extern "C" fn set_isr(
         },
         _ => panic!("set_isr - unsupported interrupt number {}", n),
     }
-    #[cfg(feature = "wifi")]
+    #[cfg(any(feature = "wifi-ap", feature = "wifi-sta", feature = "wifi-eap"))]
     {
         unwrap!(interrupt::enable(
             peripherals::Interrupt::WIFI_MAC,

--- a/esp-radio/src/wifi/os_adapter_esp32c3.rs
+++ b/esp-radio/src/wifi/os_adapter_esp32c3.rs
@@ -62,7 +62,7 @@ pub unsafe extern "C" fn set_isr(
         _ => panic!("set_isr - unsupported interrupt number {}", n),
     }
 
-    #[cfg(feature = "wifi")]
+    #[cfg(any(feature = "wifi-ap", feature = "wifi-sta", feature = "wifi-eap"))]
     {
         unwrap!(interrupt::enable(
             peripherals::Interrupt::WIFI_MAC,

--- a/esp-radio/src/wifi/os_adapter_esp32c6.rs
+++ b/esp-radio/src/wifi/os_adapter_esp32c6.rs
@@ -76,7 +76,7 @@ pub unsafe extern "C" fn set_isr(
         },
         _ => panic!("set_isr - unsupported interrupt number {}", n),
     }
-    #[cfg(feature = "wifi")]
+    #[cfg(any(feature = "wifi-sta", feature = "wifi-ap", feature = "wifi-eap"))]
     {
         unwrap!(interrupt::enable(
             peripherals::Interrupt::WIFI_MAC,

--- a/esp-radio/src/wifi/os_adapter_esp32s2.rs
+++ b/esp-radio/src/wifi/os_adapter_esp32s2.rs
@@ -67,7 +67,7 @@ pub unsafe extern "C" fn set_isr(
         _ => panic!("set_isr - unsupported interrupt number {}", n),
     }
 
-    #[cfg(feature = "wifi")]
+    #[cfg(any(feature = "wifi-ap", feature = "wifi-sta", feature = "wifi-eap"))]
     {
         unwrap!(interrupt::enable(
             peripherals::Interrupt::WIFI_MAC,

--- a/esp-radio/src/wifi/os_adapter_esp32s3.rs
+++ b/esp-radio/src/wifi/os_adapter_esp32s3.rs
@@ -54,7 +54,7 @@ pub unsafe extern "C" fn set_isr(
         },
         _ => panic!("set_isr - unsupported interrupt number {}", n),
     }
-    #[cfg(feature = "wifi")]
+    #[cfg(any(feature = "wifi-ap", feature = "wifi-sta", feature = "wifi-eap"))]
     {
         unwrap!(interrupt::enable(
             peripherals::Interrupt::WIFI_MAC,

--- a/examples/esp-now/esp_now/Cargo.toml
+++ b/examples/esp-now/esp_now/Cargo.toml
@@ -20,7 +20,7 @@ esp-radio = { path = "../../../esp-radio", features = [
     "esp-now",
     "log-04",
     "unstable",
-    "wifi",
+    "wifi-sta",
 ] }
 
 [features]

--- a/examples/wifi/80211_tx/Cargo.toml
+++ b/examples/wifi/80211_tx/Cargo.toml
@@ -20,7 +20,7 @@ esp-radio = { path = "../../../esp-radio", features = [
     "log-04",
     "sniffer",
     "unstable",
-    "wifi",
+    "wifi-sta",
 ] }
 ieee80211 = { version = "0.4.0", default-features = false }
 

--- a/examples/wifi/access_point/Cargo.toml
+++ b/examples/wifi/access_point/Cargo.toml
@@ -22,7 +22,7 @@ esp-radio = { path = "../../../esp-radio", features = [
     "log-04",
     "smoltcp",
     "unstable",
-    "wifi",
+    "wifi-ap",
 ] }
 smoltcp = { version = "0.12.0", default-features = false, features = [
     "medium-ethernet",

--- a/examples/wifi/access_point_with_sta/Cargo.toml
+++ b/examples/wifi/access_point_with_sta/Cargo.toml
@@ -22,7 +22,8 @@ esp-radio = { path = "../../../esp-radio", features = [
     "log-04",
     "smoltcp",
     "unstable",
-    "wifi",
+    "wifi-ap",
+    "wifi-sta"
 ] }
 log = "0.4.27"
 smoltcp = { version = "0.12.0", default-features = false, features = [

--- a/examples/wifi/bench/Cargo.toml
+++ b/examples/wifi/bench/Cargo.toml
@@ -22,7 +22,7 @@ esp-radio = { path = "../../../esp-radio", features = [
     "log-04",
     "smoltcp",
     "unstable",
-    "wifi",
+    "wifi-sta",
 ] }
 smoltcp = { version = "0.12.0", default-features = false, features = [
     "medium-ethernet",

--- a/examples/wifi/coex/Cargo.toml
+++ b/examples/wifi/coex/Cargo.toml
@@ -28,7 +28,7 @@ esp-radio = { path = "../../../esp-radio", features = [
     "log-04",
     "smoltcp",
     "unstable",
-    "wifi",
+    "wifi-sta",
 ] }
 smoltcp = { version = "0.12.0", default-features = false, features = [
     "medium-ethernet",

--- a/examples/wifi/csi/Cargo.toml
+++ b/examples/wifi/csi/Cargo.toml
@@ -22,7 +22,7 @@ esp-radio = { path = "../../../esp-radio", features = [
     "log-04",
     "smoltcp",
     "unstable",
-    "wifi",
+    "wifi-sta",
 ] }
 smoltcp = { version = "0.12.0", default-features = false, features = [
     "medium-ethernet",

--- a/examples/wifi/dhcp/Cargo.toml
+++ b/examples/wifi/dhcp/Cargo.toml
@@ -22,7 +22,7 @@ esp-radio = { path = "../../../esp-radio", features = [
     "log-04",
     "smoltcp",
     "unstable",
-    "wifi",
+    "wifi-sta",
 ] }
 smoltcp = { version = "0.12.0", default-features = false, features = [
     "medium-ethernet",

--- a/examples/wifi/embassy_access_point/Cargo.toml
+++ b/examples/wifi/embassy_access_point/Cargo.toml
@@ -33,7 +33,7 @@ esp-radio-preempt-baremetal = { path = "../../../esp-radio-preempt-baremetal", f
 esp-radio = { path = "../../../esp-radio", features = [
     "log-04",
     "unstable",
-    "wifi",
+    "wifi-ap",
 ] }
 log = "0.4.27"
 static_cell = "2.1.0"

--- a/examples/wifi/embassy_access_point_with_sta/Cargo.toml
+++ b/examples/wifi/embassy_access_point_with_sta/Cargo.toml
@@ -31,7 +31,8 @@ esp-radio-preempt-baremetal = { path = "../../../esp-radio-preempt-baremetal", f
 esp-radio = { path = "../../../esp-radio", features = [
     "log-04",
     "unstable",
-    "wifi",
+    "wifi-ap",
+    "wifi-sta"
 ] }
 static_cell = "2.1.0"
 

--- a/examples/wifi/embassy_bench/Cargo.toml
+++ b/examples/wifi/embassy_bench/Cargo.toml
@@ -30,7 +30,7 @@ esp-radio-preempt-baremetal = { path = "../../../esp-radio-preempt-baremetal", f
 esp-radio = { path = "../../../esp-radio", features = [
     "log-04",
     "unstable",
-    "wifi",
+    "wifi-sta",
 ] }
 static_cell = "2.1.0"
 

--- a/examples/wifi/embassy_dhcp/Cargo.toml
+++ b/examples/wifi/embassy_dhcp/Cargo.toml
@@ -30,7 +30,7 @@ esp-radio-preempt-baremetal = { path = "../../../esp-radio-preempt-baremetal", f
 esp-radio = { path = "../../../esp-radio", features = [
     "log-04",
     "unstable",
-    "wifi",
+    "wifi-sta",
 ] }
 static_cell = "2.1.0"
 

--- a/examples/wifi/sniffer/Cargo.toml
+++ b/examples/wifi/sniffer/Cargo.toml
@@ -21,7 +21,7 @@ esp-radio = { path = "../../../esp-radio", features = [
     "log-04",
     "sniffer",
     "unstable",
-    "wifi",
+    "wifi-sta",
 ] }
 ieee80211 = { version = "0.4.0", default-features = false }
 

--- a/examples/wifi/static_ip/Cargo.toml
+++ b/examples/wifi/static_ip/Cargo.toml
@@ -22,7 +22,7 @@ esp-radio = { path = "../../../esp-radio", features = [
     "log-04",
     "smoltcp",
     "unstable",
-    "wifi",
+    "wifi-sta",
 ] }
 smoltcp = { version = "0.12.0", default-features = false, features = [
     "medium-ethernet",


### PR DESCRIPTION
This implements https://github.com/esp-rs/esp-hal/issues/3700#issuecomment-3008283070
I compared the `embassy_dhcp` example size with only `wifi-sta` and `wifi` features:

```text    data     bss     dec     hex filename
1594448    6848  113040 1714336  1a28a0 embassy-dhcp
```

```
text    data     bss     dec     hex filename
1692010    6856  113168 1812034  1ba642 embassy-dhcp
```

using `wifi` instead of `wifi-sta` (for this example results in:
```
text: +97,562 bytes  
data: +8 bytes  
bss:  +128 bytes  
dec:  +97,698 bytes
```

closes https://github.com/esp-rs/esp-hal/issues/3820, https://github.com/esp-rs/esp-hal/issues/3700