### PR TITLE
xtask: Rework example command structure

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -10,6 +10,7 @@ clap         = { version = "4.5.20", features = ["derive", "wrap_help"] }
 console      = "0.15.10"
 env_logger   = { version = "0.11.5", default-features = false, features = ["auto-color", "humantime"] }
 esp-metadata = { path = "../esp-metadata", features = ["clap"] }
+inquire         = "0.7.5"
 jiff         = { version = "0.2.13", default-features = false, features = ["std"] }
 kuchikiki    = { version = "0.8.2", optional = true }
 log          = "0.4.22"

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -33,7 +33,7 @@ cargo xtask build examples --help
 
 Build all examples for the specified chip
 
-Usage: xtask build examples [OPTIONS] <CHIP> <PACKAGE>
+Usage: xtask build examples [OPTIONS] <EXAMPLE>
 
 [...]
 ```

--- a/xtask/src/commands/build.rs
+++ b/xtask/src/commands/build.rs
@@ -131,11 +131,11 @@ pub fn build_examples(
     // Determine the appropriate build target for the given package and chip:
     let target = args.package.unwrap().target_triple(&chip)?;
 
-    if args.example.to_lowercase() != "all" {
+    if !args.example.eq_ignore_ascii_case("all") {
         // Attempt to build only the specified example:
         let filtered = examples
             .iter()
-            .filter(|ex| ex.matches(&Some(args.example.to_lowercase().clone())))
+            .filter(|ex| ex.matches_name(&args.example))
             .collect::<Vec<_>>();
 
         if filtered.is_empty() {

--- a/xtask/src/commands/build.rs
+++ b/xtask/src/commands/build.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use anyhow::{Result, bail};
+use anyhow::Result;
 use clap::{Args, Subcommand};
 use esp_metadata::Chip;
 use strum::IntoEnumIterator as _;
@@ -129,20 +129,29 @@ pub fn build_examples(
     let chip = args.chip.unwrap();
 
     // Determine the appropriate build target for the given package and chip:
-    let target = args.package.unwrap().target_triple(&chip)?;
+    let target = args.package.target_triple(&chip)?;
 
     if !args.example.eq_ignore_ascii_case("all") {
         // Attempt to build only the specified example:
-        let filtered = examples
+        let mut filtered = examples
             .iter()
             .filter(|ex| ex.matches_name(&args.example))
             .collect::<Vec<_>>();
 
         if filtered.is_empty() {
-            bail!(
-                "Example '{}' not found or unsupported for the given chip",
+            log::warn!(
+                "Example '{}' not found or unsupported for the given chip. Please select one of the existing examples in the desired package.",
                 args.example
             );
+
+            let example_idx = inquire::Select::new(
+                "Select the example:",
+                examples.iter().map(|ex| ex.binary_name()).collect(),
+            ).prompt()?;
+
+            if let Some(selected) = examples.iter().find(|ex| ex.binary_name() == example_idx) {
+                filtered.push(selected);
+            }
         }
 
         for example in filtered {

--- a/xtask/src/commands/mod.rs
+++ b/xtask/src/commands/mod.rs
@@ -23,7 +23,7 @@ pub struct ExamplesArgs {
     /// Chip to target.
     #[arg(value_enum, long)]
     pub chip: Option<Chip>,
-    /// Package whose examples we which to act on.
+    /// Package whose examples we wish to act on.
     #[arg(value_enum, long)]
     pub package: Option<Package>,
     /// Build examples in debug mode only

--- a/xtask/src/commands/mod.rs
+++ b/xtask/src/commands/mod.rs
@@ -6,7 +6,8 @@ use esp_metadata::Chip;
 
 pub use self::{build::*, check_changelog::*, release::*, run::*};
 use crate::{Package, cargo::CargoAction};
-
+use inquire::Select;
+use strum::IntoEnumIterator;
 mod build;
 mod check_changelog;
 mod release;
@@ -17,19 +18,17 @@ mod run;
 
 #[derive(Debug, Args)]
 pub struct ExamplesArgs {
-    /// Package whose examples we which to act on.
-    #[arg(value_enum)]
-    pub package: Package,
+    /// Example to act on ("all" will execute every example).
+    pub example: String,
     /// Chip to target.
-    #[arg(value_enum)]
-    pub chip: Chip,
-
+    #[arg(value_enum, long)]
+    pub chip: Option<Chip>,
+    /// Package whose examples we which to act on.
+    #[arg(value_enum, long)]
+    pub package: Option<Package>,
     /// Build examples in debug mode only
     #[arg(long)]
     pub debug: bool,
-    /// Optional example to act on (all examples used if omitted)
-    #[arg(long)]
-    pub example: Option<String>,
 
     /// The toolchain used to build the examples
     #[arg(long)]
@@ -38,6 +37,16 @@ pub struct ExamplesArgs {
     /// Emit crate build timings
     #[arg(long)]
     pub timings: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct DocTestArgs {
+    /// Package where we wish to run doc tests.
+    #[arg(value_enum)]
+    pub package: Package,
+    /// Chip to target.
+    #[arg(value_enum)]
+    pub chip: Chip,
 }
 
 #[derive(Debug, Args)]
@@ -66,32 +75,48 @@ pub struct TestsArgs {
 // Subcommand Actions
 
 pub fn examples(workspace: &Path, mut args: ExamplesArgs, action: CargoAction) -> Result<()> {
+    if args.chip.is_none() {
+        let chip_variants = Chip::iter().collect::<Vec<_>>();
+
+        let chip = Select::new("Select your target chip:", chip_variants).prompt()?;
+
+        args.chip = Some(chip);
+    }
+
+    let chip = args.chip.unwrap();
+
+    // If no package was provided, default to `examples`
+    if args.package.is_none() {
+        args.package = Some(Package::Examples);
+    }
     // Ensure that the package/chip combination provided are valid:
-    args.package.validate_package_chip(&args.chip)?;
+    args.package.unwrap().validate_package_chip(&chip)?;
 
     // If the 'esp-hal' package is specified, what we *really* want is the
     // 'examples' package instead:
-    if args.package == Package::EspHal {
+    if let Some(Package::EspHal) = args.package {
         log::warn!(
             "Package '{}' specified, using '{}' instead",
             Package::EspHal,
             Package::Examples
         );
-        args.package = Package::Examples;
+        args.package = Some(Package::Examples);
     }
 
+    let package = args.package.unwrap();
+
     // Absolute path of the package's root:
-    let package_path = crate::windows_safe_path(&workspace.join(args.package.to_string()));
+    let package_path = crate::windows_safe_path(&workspace.join(package.to_string()));
 
     // Load all examples which support the specified chip and parse their metadata.
     //
     // The `examples` directory contains a number of individual projects, and does not rely on
     // metadata comments in the source files. As such, it needs to load its metadata differently
     // than other packages.
-    let examples = if args.package == Package::Examples {
+    let examples = if package == Package::Examples {
         crate::firmware::load_cargo_toml(&package_path)?
     } else {
-        let example_path = match args.package {
+        let example_path = match package {
             Package::QaTest => package_path.join("src").join("bin"),
             Package::HilTest => package_path.join("tests"),
             _ => package_path.join("examples"),
@@ -102,7 +127,7 @@ pub fn examples(workspace: &Path, mut args: ExamplesArgs, action: CargoAction) -
 
     let mut examples = examples
         .into_iter()
-        .filter(|example| example.supports_chip(args.chip))
+        .filter(|example| example.supports_chip(chip))
         .collect::<Vec<_>>();
 
     // Sort all examples by name:

--- a/xtask/src/commands/run.rs
+++ b/xtask/src/commands/run.rs
@@ -8,7 +8,7 @@ use anyhow::{Context as _, Result, bail, ensure};
 use clap::{Args, Subcommand};
 use esp_metadata::Chip;
 
-use super::{ExamplesArgs, TestsArgs};
+use super::{ExamplesArgs, TestsArgs, DocTestArgs};
 use crate::{
     cargo::{CargoAction, CargoArgsBuilder},
     firmware::Metadata,
@@ -20,7 +20,7 @@ use crate::{
 #[derive(Debug, Subcommand)]
 pub enum Run {
     /// Run doctests for specified chip and package.
-    DocTests(ExamplesArgs),
+    DocTests(DocTestArgs),
     /// Run all ELFs in a folder.
     Elfs(RunElfsArgs),
     /// Run the given example for the specified chip.
@@ -44,7 +44,7 @@ pub struct RunElfsArgs {
 // ----------------------------------------------------------------------------
 // Subcommand Actions
 
-pub fn run_doc_tests(workspace: &Path, args: ExamplesArgs) -> Result<()> {
+pub fn run_doc_tests(workspace: &Path, args: DocTestArgs) -> Result<()> {
     let chip = args.chip;
 
     let package_name = args.package.to_string();
@@ -132,23 +132,25 @@ pub fn run_examples(
 ) -> Result<()> {
     let mut examples = examples;
 
-    // Determine the appropriate build target for the given package and chip:
-    let target = args.package.target_triple(&args.chip)?;
+    // At this point, package can never be `None`, so we can safely unwrap it.
+    let package = args.package.unwrap();
+    // At this point, chip can never be `None`, so we can safely unwrap it.
+    let chip = args.chip.unwrap();
 
-    let single_example = args.example.is_some();
+    // Determine the appropriate build target for the given package and chip:
+    let target = package.target_triple(&chip)?;
 
     // Filter the examples down to only the binaries supported by the given chip
-    examples.retain(|ex| ex.supports_chip(args.chip));
+    examples.retain(|ex| ex.supports_chip(chip));
 
-    // User requested to run exactly one example
-    if single_example {
-        // Filter the examples down to only the binary we're interested in
-        examples.retain(|ex| ex.matches(&args.example));
-
+    // Handle "all" examples and specific example
+    if args.example.to_lowercase() != "all" {
+        examples.retain(|ex| ex.matches(&Some(args.example.to_lowercase().clone())));
         ensure!(
             examples.len() == 1,
-            "Example not found or unsupported for {}",
-            args.chip
+            "Example '{}' not found or unsupported for {}",
+            args.example,
+            chip
         );
     }
 
@@ -186,7 +188,7 @@ pub fn run_examples(
             while !skip
                 && crate::execute_app(
                     package_path,
-                    args.chip,
+                    chip,
                     &target,
                     &example,
                     CargoAction::Run,

--- a/xtask/src/commands/run.rs
+++ b/xtask/src/commands/run.rs
@@ -144,8 +144,8 @@ pub fn run_examples(
     examples.retain(|ex| ex.supports_chip(chip));
 
     // Handle "all" examples and specific example
-    if args.example.to_lowercase() != "all" {
-        examples.retain(|ex| ex.matches(&Some(args.example.to_lowercase().clone())));
+    if !args.example.eq_ignore_ascii_case("all") {
+        examples.retain(|ex| ex.matches_name(&args.example));
         ensure!(
             examples.len() == 1,
             "Example '{}' not found or unsupported for {}",

--- a/xtask/src/firmware.rs
+++ b/xtask/src/firmware.rs
@@ -100,6 +100,10 @@ impl Metadata {
 
         filter == self.binary_name() || filter == self.output_file_name()
     }
+
+    pub fn matches_name(&self, name: &str) -> bool {
+        name.to_lowercase() == self.binary_name() || name.to_lowercase() == self.output_file_name()
+    }
 }
 
 #[derive(Debug, Default, Clone)]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -375,7 +375,7 @@ fn run_ci_checks(workspace: &Path, args: CiArgs) -> Result<()> {
         examples(
             workspace,
             ExamplesArgs {
-                package: Some(Package::EspLpHal),
+                package: Package::EspLpHal,
                 chip: Some(args.chip),
                 example: "all".to_string(),
                 debug: false,
@@ -451,7 +451,7 @@ fn run_ci_checks(workspace: &Path, args: CiArgs) -> Result<()> {
     examples(
         workspace,
         ExamplesArgs {
-            package: Some(Package::Examples),
+            package: Package::Examples,
             chip: Some(args.chip),
             example: "all".to_string(),
             debug: true,
@@ -469,7 +469,7 @@ fn run_ci_checks(workspace: &Path, args: CiArgs) -> Result<()> {
     examples(
         workspace,
         ExamplesArgs {
-            package: Some(Package::QaTest),
+            package: Package::QaTest,
             chip: Some(args.chip),
             example: "all".to_string(),
             debug: true,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -341,13 +341,9 @@ fn run_ci_checks(workspace: &Path, args: CiArgs) -> Result<()> {
     println!("::group::Doc Test");
     run_doc_tests(
         workspace,
-        ExamplesArgs {
+        DocTestArgs {
             package: Package::EspHal,
             chip: args.chip,
-            example: None,
-            debug: true,
-            toolchain: args.toolchain.clone(),
-            timings: false,
         },
     )
     .inspect_err(|_| failed.push("Doc Test"))
@@ -379,9 +375,9 @@ fn run_ci_checks(workspace: &Path, args: CiArgs) -> Result<()> {
         examples(
             workspace,
             ExamplesArgs {
-                package: Package::EspLpHal,
-                chip: args.chip,
-                example: None,
+                package: Some(Package::EspLpHal),
+                chip: Some(args.chip),
+                example: "all".to_string(),
                 debug: false,
                 toolchain: args.toolchain.clone(),
                 timings: false,
@@ -455,9 +451,9 @@ fn run_ci_checks(workspace: &Path, args: CiArgs) -> Result<()> {
     examples(
         workspace,
         ExamplesArgs {
-            package: Package::Examples,
-            chip: args.chip,
-            example: None,
+            package: Some(Package::Examples),
+            chip: Some(args.chip),
+            example: "all".to_string(),
             debug: true,
             toolchain: args.toolchain.clone(),
             timings: false,
@@ -473,9 +469,9 @@ fn run_ci_checks(workspace: &Path, args: CiArgs) -> Result<()> {
     examples(
         workspace,
         ExamplesArgs {
-            package: Package::QaTest,
-            chip: args.chip,
-            example: None,
+            package: Some(Package::QaTest),
+            chip: Some(args.chip),
+            example: "all".to_string(),
             debug: true,
             toolchain: args.toolchain.clone(),
             timings: false,


### PR DESCRIPTION
closes https://github.com/esp-rs/esp-hal/issues/3832

This will just work now:
```
cargo xtask run example gpio
```

The "bonus point" item from the initial release has been completed: chip selection menu will appear if user hasn't specified the desired chip. 

Just pass "all" instead of example name to execute/build all the examples (discussable?). This parameter is case-insensitive now

@MabezDev, I do not agree that we should only run examples `examples` directory, at least I ran examples/test from multiple directories with this command. Instead, we now have ‘examples’ as the default repository, but the user is free to change the desired package using the `--package` parameter (e.g., `--package hil-test`).


UPD: If filtered is empty, so doesn't match any of the examples, user is prompted to choose one of existing. So we're not just saying "Sorry, it's unsupported", but something like interactive flow in case of wrong/misspelled example. I'll drop a video of that in main PR comment

https://github.com/user-attachments/assets/cf5555ea-18d8-4610-ad31-ccf97d87ca3f