### PR TITLE
More SHA tweaks

### DIFF
--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -73,13 +73,13 @@ ufmt-write               = { version = "0.1.0", optional = true }
 # IMPORTANT:
 # Each supported device MUST have its PAC included below along with a
 # corresponding feature.
-esp32   = { version = "0.38.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "c6257509fab5a584a5b6b49855bdde5cd0adee87" }
-esp32c2 = { version = "0.27.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "c6257509fab5a584a5b6b49855bdde5cd0adee87" }
-esp32c3 = { version = "0.30.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "c6257509fab5a584a5b6b49855bdde5cd0adee87" }
-esp32c6 = { version = "0.21.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "c6257509fab5a584a5b6b49855bdde5cd0adee87" }
-esp32h2 = { version = "0.17.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "c6257509fab5a584a5b6b49855bdde5cd0adee87" }
-esp32s2 = { version = "0.29.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "c6257509fab5a584a5b6b49855bdde5cd0adee87" }
-esp32s3 = { version = "0.33.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "c6257509fab5a584a5b6b49855bdde5cd0adee87" }
+esp32   = { version = "0.38.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "aa2c01b835dfe8dbaee881d044004d3bd326b460" }
+esp32c2 = { version = "0.27.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "aa2c01b835dfe8dbaee881d044004d3bd326b460" }
+esp32c3 = { version = "0.30.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "aa2c01b835dfe8dbaee881d044004d3bd326b460" }
+esp32c6 = { version = "0.21.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "aa2c01b835dfe8dbaee881d044004d3bd326b460" }
+esp32h2 = { version = "0.17.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "aa2c01b835dfe8dbaee881d044004d3bd326b460" }
+esp32s2 = { version = "0.29.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "aa2c01b835dfe8dbaee881d044004d3bd326b460" }
+esp32s3 = { version = "0.33.0", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "aa2c01b835dfe8dbaee881d044004d3bd326b460" }
 
 [target.'cfg(target_arch = "riscv32")'.dependencies]
 riscv            = { version = "0.14.0", optional = true }


### PR DESCRIPTION
This PR groups some of the overly generic operations needed for ESP32 behind a `ShaAlgorithmKind` enum. It also updates the PAC to remove some raw register bit manupulation.

The new enum is visible, but mostly useless to users I think, so I'll not add a changelog entry for it.