### PR TITLE
Change alignment helper functions to take bytes, not words

### DIFF
--- a/esp-hal/src/ecc.rs
+++ b/esp-hal/src/ecc.rs
@@ -167,19 +167,22 @@ impl<Dm: DriverMode> Ecc<'_, Dm> {
 
         let mut tmp = [0_u8; 32];
         self.reverse_words(k, &mut tmp);
-        self.alignment_helper
-            .volatile_write_regset(self.regs().k_mem(0).as_ptr(), tmp.as_ref(), 8);
+        self.alignment_helper.volatile_write_regset(
+            self.regs().k_mem(0).as_ptr(),
+            tmp.as_ref(),
+            32,
+        );
         self.reverse_words(x, &mut tmp);
         self.alignment_helper.volatile_write_regset(
             self.regs().px_mem(0).as_ptr(),
             tmp.as_ref(),
-            8,
+            32,
         );
         self.reverse_words(y, &mut tmp);
         self.alignment_helper.volatile_write_regset(
             self.regs().py_mem(0).as_ptr(),
             tmp.as_ref(),
-            8,
+            32,
         );
 
         self.regs().mult_conf().write(|w| unsafe {
@@ -195,10 +198,10 @@ impl<Dm: DriverMode> Ecc<'_, Dm> {
         while self.is_busy() {}
 
         self.alignment_helper
-            .volatile_read_regset(self.regs().px_mem(0).as_ptr(), &mut tmp, 8);
+            .volatile_read_regset(self.regs().px_mem(0).as_ptr(), &mut tmp, 32);
         self.reverse_words(tmp.as_ref(), x);
         self.alignment_helper
-            .volatile_read_regset(self.regs().py_mem(0).as_ptr(), &mut tmp, 8);
+            .volatile_read_regset(self.regs().py_mem(0).as_ptr(), &mut tmp, 32);
         self.reverse_words(tmp.as_ref(), y);
 
         Ok(())
@@ -240,13 +243,16 @@ impl<Dm: DriverMode> Ecc<'_, Dm> {
 
         let mut tmp = [0_u8; 32];
         self.reverse_words(k, &mut tmp);
-        self.alignment_helper
-            .volatile_write_regset(self.regs().k_mem(0).as_ptr(), tmp.as_ref(), 8);
+        self.alignment_helper.volatile_write_regset(
+            self.regs().k_mem(0).as_ptr(),
+            tmp.as_ref(),
+            32,
+        );
         self.reverse_words(y, &mut tmp);
         self.alignment_helper.volatile_write_regset(
             self.regs().py_mem(0).as_ptr(),
             tmp.as_ref(),
-            8,
+            32,
         );
 
         self.regs().mult_conf().write(|w| unsafe {
@@ -262,7 +268,7 @@ impl<Dm: DriverMode> Ecc<'_, Dm> {
         while self.is_busy() {}
 
         self.alignment_helper
-            .volatile_read_regset(self.regs().py_mem(0).as_ptr(), &mut tmp, 8);
+            .volatile_read_regset(self.regs().py_mem(0).as_ptr(), &mut tmp, 32);
         self.reverse_words(tmp.as_ref(), y);
 
         Ok(())
@@ -307,13 +313,13 @@ impl<Dm: DriverMode> Ecc<'_, Dm> {
         self.alignment_helper.volatile_write_regset(
             self.regs().px_mem(0).as_ptr(),
             tmp.as_ref(),
-            8,
+            32,
         );
         self.reverse_words(y, &mut tmp);
         self.alignment_helper.volatile_write_regset(
             self.regs().py_mem(0).as_ptr(),
             tmp.as_ref(),
-            8,
+            32,
         );
 
         self.regs().mult_conf().write(|w| unsafe {
@@ -377,19 +383,22 @@ impl<Dm: DriverMode> Ecc<'_, Dm> {
 
         let mut tmp = [0_u8; 32];
         self.reverse_words(k, &mut tmp);
-        self.alignment_helper
-            .volatile_write_regset(self.regs().k_mem(0).as_ptr(), tmp.as_ref(), 8);
+        self.alignment_helper.volatile_write_regset(
+            self.regs().k_mem(0).as_ptr(),
+            tmp.as_ref(),
+            32,
+        );
         self.reverse_words(x, &mut tmp);
         self.alignment_helper.volatile_write_regset(
             self.regs().px_mem(0).as_ptr(),
             tmp.as_ref(),
-            8,
+            32,
         );
         self.reverse_words(y, &mut tmp);
         self.alignment_helper.volatile_write_regset(
             self.regs().py_mem(0).as_ptr(),
             tmp.as_ref(),
-            8,
+            32,
         );
 
         self.regs().mult_conf().write(|w| unsafe {
@@ -410,10 +419,10 @@ impl<Dm: DriverMode> Ecc<'_, Dm> {
         }
 
         self.alignment_helper
-            .volatile_read_regset(self.regs().px_mem(0).as_ptr(), &mut tmp, 8);
+            .volatile_read_regset(self.regs().px_mem(0).as_ptr(), &mut tmp, 32);
         self.reverse_words(tmp.as_ref(), x);
         self.alignment_helper
-            .volatile_read_regset(self.regs().py_mem(0).as_ptr(), &mut tmp, 8);
+            .volatile_read_regset(self.regs().py_mem(0).as_ptr(), &mut tmp, 32);
         self.reverse_words(tmp.as_ref(), y);
 
         Ok(())
@@ -466,28 +475,28 @@ impl<Dm: DriverMode> Ecc<'_, Dm> {
 
         let mut tmp = [0_u8; 32];
         self.reverse_words(k, &mut tmp);
-        self.alignment_helper
-            .volatile_write_regset(self.regs().k_mem(0).as_ptr(), tmp.as_ref(), 8);
+        self.alignment_helper.volatile_write_regset(
+            self.regs().k_mem(0).as_ptr(),
+            tmp.as_ref(),
+            32,
+        );
         self.reverse_words(px, &mut tmp);
         self.alignment_helper.volatile_write_regset(
             self.regs().px_mem(0).as_ptr(),
             tmp.as_ref(),
-            8,
+            32,
         );
         self.reverse_words(py, &mut tmp);
         self.alignment_helper.volatile_write_regset(
             self.regs().py_mem(0).as_ptr(),
             tmp.as_ref(),
-            8,
+            32,
         );
 
         self.regs().mult_conf().write(|w| unsafe {
-            w.work_mode()
-                .bits(mode as u8)
-                .key_length()
-                .bit(curve)
-                .start()
-                .set_bit()
+            w.work_mode().bits(mode as u8);
+            w.key_length().bit(curve);
+            w.start().set_bit()
         });
 
         // wait for interrupt
@@ -499,19 +508,19 @@ impl<Dm: DriverMode> Ecc<'_, Dm> {
         }
 
         self.alignment_helper
-            .volatile_read_regset(self.regs().px_mem(0).as_ptr(), &mut tmp, 8);
+            .volatile_read_regset(self.regs().px_mem(0).as_ptr(), &mut tmp, 32);
         self.reverse_words(tmp.as_ref(), px);
         self.alignment_helper
-            .volatile_read_regset(self.regs().py_mem(0).as_ptr(), &mut tmp, 8);
+            .volatile_read_regset(self.regs().py_mem(0).as_ptr(), &mut tmp, 32);
         self.reverse_words(tmp.as_ref(), py);
         self.alignment_helper
-            .volatile_read_regset(self.regs().qx_mem(0).as_ptr(), &mut tmp, 8);
+            .volatile_read_regset(self.regs().qx_mem(0).as_ptr(), &mut tmp, 32);
         self.reverse_words(tmp.as_ref(), qx);
         self.alignment_helper
-            .volatile_read_regset(self.regs().qy_mem(0).as_ptr(), &mut tmp, 8);
+            .volatile_read_regset(self.regs().qy_mem(0).as_ptr(), &mut tmp, 32);
         self.reverse_words(tmp.as_ref(), qy);
         self.alignment_helper
-            .volatile_read_regset(self.regs().qz_mem(0).as_ptr(), &mut tmp, 8);
+            .volatile_read_regset(self.regs().qz_mem(0).as_ptr(), &mut tmp, 32);
         self.reverse_words(tmp.as_ref(), qz);
 
         Ok(())
@@ -553,28 +562,28 @@ impl<Dm: DriverMode> Ecc<'_, Dm> {
 
         let mut tmp = [0_u8; 32];
         self.reverse_words(k, &mut tmp);
-        self.alignment_helper
-            .volatile_write_regset(self.regs().k_mem(0).as_ptr(), tmp.as_ref(), 8);
+        self.alignment_helper.volatile_write_regset(
+            self.regs().k_mem(0).as_ptr(),
+            tmp.as_ref(),
+            32,
+        );
         self.reverse_words(x, &mut tmp);
         self.alignment_helper.volatile_write_regset(
             self.regs().px_mem(0).as_ptr(),
             tmp.as_ref(),
-            8,
+            32,
         );
         self.reverse_words(y, &mut tmp);
         self.alignment_helper.volatile_write_regset(
             self.regs().py_mem(0).as_ptr(),
             tmp.as_ref(),
-            8,
+            32,
         );
 
         self.regs().mult_conf().write(|w| unsafe {
-            w.work_mode()
-                .bits(mode as u8)
-                .key_length()
-                .bit(curve)
-                .start()
-                .set_bit()
+            w.work_mode().bits(mode as u8);
+            w.key_length().bit(curve);
+            w.start().set_bit()
         });
 
         while self.is_busy() {}
@@ -582,23 +591,23 @@ impl<Dm: DriverMode> Ecc<'_, Dm> {
         cfg_if::cfg_if! {
             if #[cfg(not(esp32h2))] {
             self.alignment_helper
-                .volatile_read_regset(self.regs().px_mem(0).as_ptr(), &mut tmp, 8);
+                .volatile_read_regset(self.regs().px_mem(0).as_ptr(), &mut tmp, 32);
             self.reverse_words(tmp.as_ref(), x);
             self.alignment_helper
-                .volatile_read_regset(self.regs().py_mem(0).as_ptr(), &mut tmp, 8);
+                .volatile_read_regset(self.regs().py_mem(0).as_ptr(), &mut tmp, 32);
             self.reverse_words(tmp.as_ref(), y);
             self.alignment_helper
-                .volatile_read_regset(self.regs().k_mem(0).as_ptr(), &mut tmp, 8);
+                .volatile_read_regset(self.regs().k_mem(0).as_ptr(), &mut tmp, 32);
             self.reverse_words(tmp.as_ref(), k);
             } else {
             self.alignment_helper
-                .volatile_read_regset(self.regs().qx_mem(0).as_ptr(), &mut tmp, 8);
+                .volatile_read_regset(self.regs().qx_mem(0).as_ptr(), &mut tmp, 32);
             self.reverse_words(tmp.as_ref(), x);
             self.alignment_helper
-                .volatile_read_regset(self.regs().qy_mem(0).as_ptr(), &mut tmp, 8);
+                .volatile_read_regset(self.regs().qy_mem(0).as_ptr(), &mut tmp, 32);
             self.reverse_words(tmp.as_ref(), y);
             self.alignment_helper
-                .volatile_read_regset(self.regs().qz_mem(0).as_ptr(), &mut tmp, 8);
+                .volatile_read_regset(self.regs().qz_mem(0).as_ptr(), &mut tmp, 32);
             self.reverse_words(tmp.as_ref(), k);
             }
         }
@@ -647,22 +656,22 @@ impl<Dm: DriverMode> Ecc<'_, Dm> {
         cfg_if::cfg_if! {
             if #[cfg(not(esp32h2))] {
                 self.alignment_helper
-                    .volatile_write_regset(self.regs().px_mem(0).as_ptr(), tmp.as_ref(), 8);
+                    .volatile_write_regset(self.regs().px_mem(0).as_ptr(), tmp.as_ref(), 32);
                 self.reverse_words(y, &mut tmp);
                 self.alignment_helper
-                    .volatile_write_regset(self.regs().py_mem(0).as_ptr(), tmp.as_ref(), 8);
+                    .volatile_write_regset(self.regs().py_mem(0).as_ptr(), tmp.as_ref(), 32);
                 self.reverse_words(z, &mut tmp);
                 self.alignment_helper
-                    .volatile_write_regset(self.regs().k_mem(0).as_ptr(), tmp.as_ref(), 8);
+                    .volatile_write_regset(self.regs().k_mem(0).as_ptr(), tmp.as_ref(), 32);
             } else {
                 self.alignment_helper
-                    .volatile_write_regset(self.regs().qx_mem(0).as_ptr(), tmp.as_ref(), 8);
+                    .volatile_write_regset(self.regs().qx_mem(0).as_ptr(), tmp.as_ref(), 32);
                 self.reverse_words(y, &mut tmp);
                 self.alignment_helper
-                    .volatile_write_regset(self.regs().qy_mem(0).as_ptr(), tmp.as_ref(), 8);
+                    .volatile_write_regset(self.regs().qy_mem(0).as_ptr(), tmp.as_ref(), 32);
                 self.reverse_words(z, &mut tmp);
                 self.alignment_helper
-                    .volatile_write_regset(self.regs().qz_mem(0).as_ptr(), tmp.as_ref(), 8);
+                    .volatile_write_regset(self.regs().qz_mem(0).as_ptr(), tmp.as_ref(), 32);
             }
         }
 
@@ -726,28 +735,28 @@ impl<Dm: DriverMode> Ecc<'_, Dm> {
 
         let mut tmp = [0_u8; 32];
         self.reverse_words(k, &mut tmp);
-        self.alignment_helper
-            .volatile_write_regset(self.regs().k_mem(0).as_ptr(), tmp.as_ref(), 8);
+        self.alignment_helper.volatile_write_regset(
+            self.regs().k_mem(0).as_ptr(),
+            tmp.as_ref(),
+            32,
+        );
         self.reverse_words(x, &mut tmp);
         self.alignment_helper.volatile_write_regset(
             self.regs().px_mem(0).as_ptr(),
             tmp.as_ref(),
-            8,
+            32,
         );
         self.reverse_words(y, &mut tmp);
         self.alignment_helper.volatile_write_regset(
             self.regs().py_mem(0).as_ptr(),
             tmp.as_ref(),
-            8,
+            32,
         );
 
         self.regs().mult_conf().write(|w| unsafe {
-            w.work_mode()
-                .bits(mode as u8)
-                .key_length()
-                .bit(curve)
-                .start()
-                .set_bit()
+            w.work_mode().bits(mode as u8);
+            w.key_length().bit(curve);
+            w.start().set_bit()
         });
 
         // wait for interrupt
@@ -766,23 +775,23 @@ impl<Dm: DriverMode> Ecc<'_, Dm> {
         cfg_if::cfg_if! {
             if #[cfg(not(esp32h2))] {
                 self.alignment_helper
-                    .volatile_read_regset(self.regs().px_mem(0).as_ptr(), &mut tmp, 8);
+                    .volatile_read_regset(self.regs().px_mem(0).as_ptr(), &mut tmp, 32);
                 self.reverse_words(tmp.as_ref(), x);
                 self.alignment_helper
-                    .volatile_read_regset(self.regs().py_mem(0).as_ptr(), &mut tmp, 8);
+                    .volatile_read_regset(self.regs().py_mem(0).as_ptr(), &mut tmp, 32);
                 self.reverse_words(tmp.as_ref(), y);
                 self.alignment_helper
-                    .volatile_read_regset(self.regs().k_mem(0).as_ptr(), &mut tmp, 8);
+                    .volatile_read_regset(self.regs().k_mem(0).as_ptr(), &mut tmp, 32);
                 self.reverse_words(tmp.as_ref(), k);
             } else {
                 self.alignment_helper
-                    .volatile_read_regset(self.regs().qx_mem(0).as_ptr(), &mut tmp, 8);
+                    .volatile_read_regset(self.regs().qx_mem(0).as_ptr(), &mut tmp, 32);
                 self.reverse_words(tmp.as_ref(), x);
                 self.alignment_helper
-                    .volatile_read_regset(self.regs().qy_mem(0).as_ptr(), &mut tmp, 8);
+                    .volatile_read_regset(self.regs().qy_mem(0).as_ptr(), &mut tmp, 32);
                 self.reverse_words(tmp.as_ref(), y);
                 self.alignment_helper
-                    .volatile_read_regset(self.regs().qz_mem(0).as_ptr(), &mut tmp, 8);
+                    .volatile_read_regset(self.regs().qz_mem(0).as_ptr(), &mut tmp, 32);
                 self.reverse_words(tmp.as_ref(), k);
             }
         }
@@ -848,19 +857,19 @@ impl<Dm: DriverMode> Ecc<'_, Dm> {
 
         tmp[0..px.len()].copy_from_slice(px);
         self.alignment_helper
-            .volatile_write_regset(self.regs().px_mem(0).as_ptr(), &tmp, 8);
+            .volatile_write_regset(self.regs().px_mem(0).as_ptr(), &tmp, 32);
         tmp[0..py.len()].copy_from_slice(py);
         self.alignment_helper
-            .volatile_write_regset(self.regs().py_mem(0).as_ptr(), &tmp, 8);
+            .volatile_write_regset(self.regs().py_mem(0).as_ptr(), &tmp, 32);
         tmp[0..qx.len()].copy_from_slice(qx);
         self.alignment_helper
-            .volatile_write_regset(self.regs().qx_mem(0).as_ptr(), &tmp, 8);
+            .volatile_write_regset(self.regs().qx_mem(0).as_ptr(), &tmp, 32);
         tmp[0..qy.len()].copy_from_slice(qy);
         self.alignment_helper
-            .volatile_write_regset(self.regs().qy_mem(0).as_ptr(), &tmp, 8);
+            .volatile_write_regset(self.regs().qy_mem(0).as_ptr(), &tmp, 32);
         tmp[0..qz.len()].copy_from_slice(qz);
         self.alignment_helper
-            .volatile_write_regset(self.regs().qz_mem(0).as_ptr(), &tmp, 8);
+            .volatile_write_regset(self.regs().qz_mem(0).as_ptr(), &tmp, 32);
 
         self.regs().mult_conf().write(|w| unsafe {
             w.work_mode()
@@ -875,23 +884,23 @@ impl<Dm: DriverMode> Ecc<'_, Dm> {
         while self.is_busy() {}
 
         self.alignment_helper
-            .volatile_read_regset(self.regs().px_mem(0).as_ptr(), &mut tmp, 8);
+            .volatile_read_regset(self.regs().px_mem(0).as_ptr(), &mut tmp, 32);
         let mut tmp_len = px.len();
         px[..].copy_from_slice(&tmp[..tmp_len]);
         self.alignment_helper
-            .volatile_read_regset(self.regs().py_mem(0).as_ptr(), &mut tmp, 8);
+            .volatile_read_regset(self.regs().py_mem(0).as_ptr(), &mut tmp, 32);
         tmp_len = py.len();
         py[..].copy_from_slice(&tmp[..tmp_len]);
         self.alignment_helper
-            .volatile_read_regset(self.regs().qx_mem(0).as_ptr(), &mut tmp, 8);
+            .volatile_read_regset(self.regs().qx_mem(0).as_ptr(), &mut tmp, 32);
         tmp_len = qx.len();
         qx[..].copy_from_slice(&tmp[..tmp_len]);
         self.alignment_helper
-            .volatile_read_regset(self.regs().qy_mem(0).as_ptr(), &mut tmp, 8);
+            .volatile_read_regset(self.regs().qy_mem(0).as_ptr(), &mut tmp, 32);
         tmp_len = qy.len();
         qy[..].copy_from_slice(&tmp[..tmp_len]);
         self.alignment_helper
-            .volatile_read_regset(self.regs().qz_mem(0).as_ptr(), &mut tmp, 8);
+            .volatile_read_regset(self.regs().qz_mem(0).as_ptr(), &mut tmp, 32);
         tmp_len = qz.len();
         qz[..].copy_from_slice(&tmp[..tmp_len]);
 
@@ -940,10 +949,10 @@ impl<Dm: DriverMode> Ecc<'_, Dm> {
         let mut tmp = [0_u8; 32];
         tmp[0..a.len()].copy_from_slice(a);
         self.alignment_helper
-            .volatile_write_regset(self.regs().px_mem(0).as_ptr(), &tmp, 8);
+            .volatile_write_regset(self.regs().px_mem(0).as_ptr(), &tmp, 32);
         tmp[0..b.len()].copy_from_slice(b);
         self.alignment_helper
-            .volatile_write_regset(self.regs().py_mem(0).as_ptr(), &tmp, 8);
+            .volatile_write_regset(self.regs().py_mem(0).as_ptr(), &tmp, 32);
 
         self.regs().mult_conf().write(|w| unsafe {
             w.work_mode()
@@ -962,7 +971,7 @@ impl<Dm: DriverMode> Ecc<'_, Dm> {
                 self.alignment_helper.volatile_read_regset(
                     self.regs().px_mem(0).as_ptr(),
                     &mut tmp,
-                    8,
+                    32,
                 );
                 let tmp_len = a.len();
                 a[..].copy_from_slice(&tmp[..tmp_len]);
@@ -971,7 +980,7 @@ impl<Dm: DriverMode> Ecc<'_, Dm> {
                 self.alignment_helper.volatile_read_regset(
                     self.regs().py_mem(0).as_ptr(),
                     &mut tmp,
-                    8,
+                    32,
                 );
                 let tmp_len = b.len();
                 b[..].copy_from_slice(&tmp[..tmp_len]);

--- a/esp-hal/src/reg_access.rs
+++ b/esp-hal/src/reg_access.rs
@@ -84,15 +84,12 @@ impl<E: EndianessConverter> AlignmentHelper<E> {
         self.buf_fill = 0;
     }
 
-    pub const fn align_size(&self) -> usize {
-        U32_ALIGN_SIZE
-    }
-
     // This function will write any remaining buffer to dst and return the
     // amount of *bytes* written (0 means no write). If the buffer is not
     // aligned to the size of the register destination, it will append the '0'
     // value.
     pub fn flush_to(&mut self, dst_ptr: *mut u32, offset: usize) -> usize {
+        let offset = offset / U32_ALIGN_SIZE;
         if self.buf_fill != 0 {
             for i in self.buf_fill..U32_ALIGN_SIZE {
                 self.buf[i] = 0;
@@ -104,7 +101,7 @@ impl<E: EndianessConverter> AlignmentHelper<E> {
                     .write_volatile(E::u32_from_bytes(self.buf));
             }
 
-            let ret = self.align_size() - self.buf_fill;
+            let ret = U32_ALIGN_SIZE - self.buf_fill;
             self.buf_fill = 0;
 
             ret
@@ -116,6 +113,9 @@ impl<E: EndianessConverter> AlignmentHelper<E> {
     // This function is similar to `volatile_set_memory` but will prepend data that
     // was previously ingested and ensure aligned (u32) writes.
     pub fn volatile_write(&mut self, dst_ptr: *mut u32, val: u8, count: usize, offset: usize) {
+        let count = count / U32_ALIGN_SIZE;
+        let offset = offset / U32_ALIGN_SIZE;
+
         let dst_ptr = unsafe { dst_ptr.add(offset) };
 
         let mut cursor = if self.buf_fill != 0 {
@@ -157,6 +157,9 @@ impl<E: EndianessConverter> AlignmentHelper<E> {
         dst_bound: usize,
         offset: usize,
     ) -> (&'a [u8], bool) {
+        let dst_bound = dst_bound / U32_ALIGN_SIZE;
+        let offset = offset / U32_ALIGN_SIZE;
+
         assert!(dst_bound > 0);
 
         let dst_ptr = unsafe { dst_ptr.add(offset) };
@@ -223,6 +226,7 @@ impl<E: EndianessConverter> AlignmentHelper<E> {
 
     #[allow(dead_code)]
     pub fn volatile_write_regset(&mut self, dst_ptr: *mut u32, src: &[u8], dst_bound: usize) {
+        let dst_bound = dst_bound / U32_ALIGN_SIZE;
         assert!(dst_bound > 0);
         assert!(src.len() <= dst_bound * 4);
 
@@ -238,6 +242,7 @@ impl<E: EndianessConverter> AlignmentHelper<E> {
     }
 
     pub fn volatile_read_regset(&self, src_ptr: *const u32, dst: &mut [u8], dst_bound: usize) {
+        let dst_bound = dst_bound / U32_ALIGN_SIZE;
         assert!(dst.len() >= dst_bound * 4);
 
         let chunks = dst.chunks_exact_mut(U32_ALIGN_SIZE);


### PR DESCRIPTION
This is a small cleanup to reduce noise around AlignmentHelper. Since this is a helper that consumes bytes to spit out words, it makes little sense for it to take parameter counts as words. There is at least one usage site where already a number of bytes was passed in by accident, it seems.