### PR TITLE
Move SHA driver operatoins into driver struct

### DIFF
--- a/esp-hal/src/sha.rs
+++ b/esp-hal/src/sha.rs
@@ -237,6 +237,7 @@ impl<'d> Sha<'d> {
         );
 
         state.first_run = true;
+        state.finished = true;
         state.cursor = 0;
         state.alignment_helper.reset();
 


### PR DESCRIPTION
This PR extract previously generic code into the SHA driver, allows for later reuse.