### PR TITLE
Use TLSF by default

### DIFF
--- a/esp-alloc/CHANGELOG.md
+++ b/esp-alloc/CHANGELOG.md
@@ -10,9 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - New default feature (`compat`) enables implementations for `malloc`, `free`, `calloc`, `realloc` (#3890)
+- `ESP_ALLOC_CONFIG_HEAP_ALGORITHM` to select the heap algorithm for a particular region (#3950)
+- `EspHeap::max_new_allocation(_caps)` (#3948)
 
 ### Changed
 - Make stats structs fields public (#3828)
+- The default heap allocator is now TLSF, implemented by the `rlsf` crate (#3950)
 
 ### Fixed
 

--- a/esp-alloc/Cargo.toml
+++ b/esp-alloc/Cargo.toml
@@ -24,8 +24,13 @@ defmt                 = { version = "1.0.1", optional = true }
 cfg-if                = "1.0.0"
 critical-section      = "1.2.0"
 enumset               = "1.1.6"
-linked_list_allocator = { version = "0.10.5", default-features = false, features = ["const_mut_refs"] }
 document-features     = "0.2.11"
+
+linked_list_allocator = { version = "0.10.5", default-features = false, features = ["const_mut_refs"] }
+rlsf = { version = "0.2", features = ["unstable"] }
+
+[build-dependencies]
+esp-config   = { version = "0.5.0", path = "../esp-config", features = ["build"] }
 
 [features]
 default = ["compat"]

--- a/esp-alloc/build.rs
+++ b/esp-alloc/build.rs
@@ -1,0 +1,20 @@
+use esp_config::generate_config_from_yaml_definition;
+
+#[macro_export]
+macro_rules! assert_unique_used_features {
+    ($($feature:literal),+ $(,)?) => {
+        assert!(
+            (0 $(+ cfg!(feature = $feature) as usize)+ ) == 1,
+            "Exactly one of the following features must be enabled: {}",
+            [$($feature),+].join(", ")
+        );
+    };
+}
+
+fn main() {
+    // emit config
+    println!("cargo:rerun-if-changed=./esp_config.yml");
+    let cfg_yaml = std::fs::read_to_string("./esp_config.yml")
+        .expect("Failed to read esp_config.yml for esp-alloc");
+    generate_config_from_yaml_definition(&cfg_yaml, true, true, None).unwrap();
+}

--- a/esp-alloc/esp_config.yml
+++ b/esp-alloc/esp_config.yml
@@ -1,0 +1,14 @@
+crate: esp-alloc
+
+options:
+  - name: heap_algorithm
+    description: "The heap algorithm to use. TLSF offers higher performance
+      and bounded allocation time, but uses more memory."
+    default:
+      - value: '"TLSF"'
+    constraints:
+      - type:
+          validator: enumeration
+          value:
+            - "LLFF"
+            - "TLSF"

--- a/esp-alloc/src/heap/llff.rs
+++ b/esp-alloc/src/heap/llff.rs
@@ -1,0 +1,44 @@
+use core::{alloc::Layout, ptr::NonNull};
+
+use linked_list_allocator::Heap;
+
+pub(crate) struct LlffHeap {
+    heap: Heap,
+}
+
+impl LlffHeap {
+    pub unsafe fn new(heap_bottom: *mut u8, size: usize) -> Self {
+        let mut heap = Heap::empty();
+        unsafe { heap.init(heap_bottom, size) };
+        Self { heap }
+    }
+
+    pub fn size(&self) -> usize {
+        self.heap.size()
+    }
+
+    pub fn used(&self) -> usize {
+        self.heap.used()
+    }
+
+    pub fn free(&self) -> usize {
+        self.heap.free()
+    }
+
+    pub fn max_new_allocation(&self) -> usize {
+        self.free()
+    }
+
+    pub fn allocate(&mut self, layout: Layout) -> Option<NonNull<u8>> {
+        self.heap.allocate_first_fit(layout).ok()
+    }
+
+    pub(crate) unsafe fn try_deallocate(&mut self, ptr: NonNull<u8>, layout: Layout) -> bool {
+        if self.heap.bottom() <= ptr.as_ptr() && self.heap.top() >= ptr.as_ptr() {
+            unsafe { self.heap.deallocate(ptr, layout) };
+            true
+        } else {
+            false
+        }
+    }
+}

--- a/esp-alloc/src/heap/mod.rs
+++ b/esp-alloc/src/heap/mod.rs
@@ -1,0 +1,9 @@
+#[cfg(heap_algorithm_llff)]
+mod llff;
+#[cfg(heap_algorithm_tlsf)]
+mod tlsf;
+
+#[cfg(heap_algorithm_llff)]
+pub(crate) use llff::LlffHeap as Heap;
+#[cfg(heap_algorithm_tlsf)]
+pub(crate) use tlsf::TlsfHeap as Heap;

--- a/esp-alloc/src/heap/tlsf.rs
+++ b/esp-alloc/src/heap/tlsf.rs
@@ -1,0 +1,81 @@
+use core::{alloc::Layout, ptr::NonNull};
+
+use rlsf::Tlsf;
+
+// TODO: make this configurable
+type Heap = Tlsf<'static, usize, usize, { usize::BITS as usize }, { usize::BITS as usize }>;
+
+pub(crate) struct TlsfHeap {
+    heap: Heap,
+    pool_start: usize,
+    pool_end: usize,
+}
+
+impl TlsfHeap {
+    pub unsafe fn new(heap_bottom: *mut u8, size: usize) -> Self {
+        let mut heap = Heap::new();
+
+        let block = unsafe { core::slice::from_raw_parts(heap_bottom, size) };
+        let actual_size = unsafe { heap.insert_free_block_ptr(block.into()).unwrap() };
+
+        Self {
+            heap,
+            pool_start: heap_bottom as usize,
+            pool_end: heap_bottom as usize + actual_size.get(),
+        }
+    }
+
+    pub fn size(&self) -> usize {
+        self.pool_end - self.pool_start
+    }
+
+    pub fn used(&self) -> usize {
+        let mut used = 0;
+        let pool =
+            unsafe { core::slice::from_raw_parts(self.pool_start as *const u8, self.size()) };
+        for block in unsafe { self.heap.iter_blocks(NonNull::from(pool)) } {
+            if block.is_occupied() {
+                used += block.size();
+            }
+        }
+        used
+    }
+
+    pub fn free(&self) -> usize {
+        let mut free = 0;
+        let pool =
+            unsafe { core::slice::from_raw_parts(self.pool_start as *const u8, self.size()) };
+        for block in unsafe { self.heap.iter_blocks(NonNull::from(pool)) } {
+            if !block.is_occupied() {
+                free += block.max_payload_size();
+            }
+        }
+        free
+    }
+
+    pub fn max_new_allocation(&self) -> usize {
+        let mut allocable = 0;
+        let pool =
+            unsafe { core::slice::from_raw_parts(self.pool_start as *const u8, self.size()) };
+        for block in unsafe { self.heap.iter_blocks(NonNull::from(pool)) } {
+            if !block.is_occupied() {
+                allocable = allocable.max(block.max_payload_size());
+            }
+        }
+        allocable
+    }
+
+    pub fn allocate(&mut self, layout: Layout) -> Option<NonNull<u8>> {
+        self.heap.allocate(layout)
+    }
+
+    pub(crate) unsafe fn try_deallocate(&mut self, ptr: NonNull<u8>, layout: Layout) -> bool {
+        let addr = ptr.addr().get();
+        if self.pool_start <= addr && self.pool_end > addr {
+            unsafe { self.heap.deallocate(ptr, layout.align()) };
+            true
+        } else {
+            false
+        }
+    }
+}

--- a/examples/wifi/embassy_access_point/Cargo.toml
+++ b/examples/wifi/embassy_access_point/Cargo.toml
@@ -9,7 +9,7 @@ cfg-if = "1.0.0"
 edge-dhcp = "0.5.0"
 edge-nal = "0.5.0"
 edge-nal-embassy = "0.5.0"
-embassy-executor = { version = "0.7.0", features = ["task-arena-size-20480"] }
+embassy-executor = { version = "0.7.0", features = ["task-arena-size-8192"] }
 embassy-net = { version = "0.6.0", features = [
     "dhcpv4",
     "medium-ethernet",

--- a/examples/wifi/embassy_access_point_with_sta/Cargo.toml
+++ b/examples/wifi/embassy_access_point_with_sta/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 cfg-if = "1.0.0"
-embassy-executor = { version = "0.7.0", features = ["task-arena-size-20480"] }
+embassy-executor = { version = "0.7.0", features = ["task-arena-size-8192"] }
 embassy-futures = "0.1.1"
 embassy-net = { version = "0.6.0", features = [
     "dhcpv4",

--- a/examples/wifi/embassy_bench/Cargo.toml
+++ b/examples/wifi/embassy_bench/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 cfg-if = "1.0.0"
-embassy-executor = { version = "0.7.0", features = ["task-arena-size-20480"] }
+embassy-executor = { version = "0.7.0", features = ["task-arena-size-8192"] }
 embassy-futures = "0.1.1"
 embassy-net = { version = "0.6.0", features = [
     "dhcpv4",

--- a/examples/wifi/embassy_dhcp/Cargo.toml
+++ b/examples/wifi/embassy_dhcp/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 cfg-if = "1.0.0"
-embassy-executor = { version = "0.7.0", features = ["task-arena-size-20480"] }
+embassy-executor = { version = "0.7.0", features = ["task-arena-size-8192"] }
 embassy-net = { version = "0.6.0", features = [
     "dhcpv4",
     "medium-ethernet",

--- a/hil-test/tests/alloc_psram.rs
+++ b/hil-test/tests/alloc_psram.rs
@@ -52,16 +52,24 @@ mod tests {
 
     #[test]
     fn all_psram_is_usable() {
-        let free = esp_alloc::HEAP.free();
-        defmt::info!("Free: {}", free);
-        let mut vec = AllocVec::with_capacity(free);
+        loop {
+            let available = esp_alloc::HEAP.max_new_allocation();
+            if available == 0 {
+                break;
+            }
+            defmt::info!("Available: {}", available);
+            let mut vec = AllocVec::with_capacity(available);
 
-        for i in 0..free {
-            vec.push((i % 256) as u8);
-        }
+            for i in 0..available {
+                vec.push((i % 256) as u8);
+            }
 
-        for i in 0..free {
-            assert_eq!(vec[i], (i % 256) as u8);
+            for i in 0..available {
+                assert_eq!(vec[i], (i % 256) as u8);
+            }
+
+            // Do not deallocate vec, so that the next iteration will use some other memory.
+            core::mem::forget(vec);
         }
     }
 
@@ -126,16 +134,24 @@ mod tests {
 
     #[test]
     fn all_psram_is_usable_with_any_mem_allocator() {
-        let free = esp_alloc::HEAP.free();
-        defmt::info!("Free: {}", free);
-        let mut vec = Vec::with_capacity_in(free, AnyMemory);
+        loop {
+            let available = esp_alloc::HEAP.max_new_allocation();
+            if available == 0 {
+                break;
+            }
+            defmt::info!("Available: {}", available);
+            let mut vec = Vec::with_capacity_in(available, AnyMemory);
 
-        for i in 0..free {
-            vec.push((i % 256) as u8);
-        }
+            for i in 0..available {
+                vec.push((i % 256) as u8);
+            }
 
-        for i in 0..free {
-            assert_eq!(vec[i], (i % 256) as u8);
+            for i in 0..available {
+                assert_eq!(vec[i], (i % 256) as u8);
+            }
+
+            // Do not deallocate vec, so that the next iteration will use some other memory.
+            core::mem::forget(vec);
         }
     }
 


### PR DESCRIPTION
Closes #3376

I chose not to use embedded-alloc as it internally uses critical_section::Mutex and [we should do better](#3937). Also we could provide configuration options to tune the TLSF allocator, and we use features (heap stats) that are not provided by embedded-alloc.

Unconfident PR for HIL results, then I'll document this a bit better.

We could also offer per-region configurability - but we need to be smart about that, the TLSF struct is ~4K, compared to LLFF being 24 bytes.