### PR TITLE
Remove `scan_*_max` and `scan_n*` functions from `esp-radio`

### DIFF
--- a/esp-hal-procmacros/CHANGELOG.md
+++ b/esp-hal-procmacros/CHANGELOG.md
@@ -9,15 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added support for lifetimes and generics to `BuilderLite` derive macro (#3963)
 
 ### Changed
 
-
 ### Fixed
 
-
 ### Removed
-
 
 ## [v0.19.0] - 2025-07-16
 

--- a/esp-hal-procmacros/src/builder.rs
+++ b/esp-hal-procmacros/src/builder.rs
@@ -34,6 +34,7 @@ pub fn builder_lite_derive(item: TokenStream) -> TokenStream {
 
     let span = input.span();
     let ident = input.ident;
+    let generics = input.generics;
 
     let mut fns = Vec::new();
     let Data::Struct(DataStruct { fields, .. }) = &input.data else {
@@ -142,7 +143,7 @@ pub fn builder_lite_derive(item: TokenStream) -> TokenStream {
 
     let implementation = quote! {
         #[automatically_derived]
-        impl #ident {
+        impl #generics #ident #generics {
             #(#fns)*
         }
     };

--- a/esp-radio/CHANGELOG.md
+++ b/esp-radio/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `AccessPointInfo::country` to access the Country Code from the Wi-Fi scan results (#3837)
 - `unstable` feature to opt into `ble`, `esp-now`, `csi`, `sniffer`, `esp-ieee802154` and `smoltcp` APIs (#3865)
+- Optional `max` field in `ScanConfig` to allow limiting the number of returned results (#3963)
 
 ### Changed
 
@@ -31,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- `scan_with_config_sync_max`, `scan_with_config_sync_max`, `scan_n`, and `scan_n_async` functions (#3963)
 
 ## [v0.15.0] - 2025-07-16
 

--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -37,6 +37,7 @@ esp-wifi-sys = "0.7.1"
 num-derive = { version = "0.4.2" }
 num-traits = { version = "0.2.19", default-features = false }
 portable_atomic_enum = { version = "0.3.1", features = ["portable-atomic"] }
+procmacros = { version = "0.19.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
 xtensa-lx-rt = { version = "0.20.0", path = "../xtensa-lx-rt", optional = true }
 byte = { version = "0.2.7", optional = true }
 ieee802154 = { version = "0.6.1", optional = true }

--- a/esp-radio/MIGRATING-0.15.0.md
+++ b/esp-radio/MIGRATING-0.15.0.md
@@ -19,10 +19,10 @@ Furthermore, `esp_wifi::init` no longer requires `RNG` or a timer.
 
 `esp_wifi` crate has been renamed to `esp_radio`
 
-```diff 
+```diff
 - esp-wifi = "0.15.0"
 + esp-radio = "{{currentVersion}}"
-``` 
+```
 
 ## `EspWifi` prefix has been removed
 
@@ -49,3 +49,7 @@ Provide these symbols:
 + pub extern "C" fn realloc(ptr: *mut u8, new_size: usize) -> *mut u8 ...
 + pub extern "C" fn get_free_internal_heap_size() -> usize; ...
 ```
+
+## Scanning Functions
+
+The `scan_with_config_sync_max`, `scan_with_config_sync_max`, `scan_n`, and `scan_n_async` functions have been removed. You can instead use the `scan_with_config_async` or `scan_with_config_sync` funtions while specifying a `max` value in `ScanConfig`.

--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -56,6 +56,7 @@ use num_derive::FromPrimitive;
 #[doc(hidden)]
 pub(crate) use os_adapter::*;
 use portable_atomic::{AtomicUsize, Ordering};
+use procmacros::BuilderLite;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 #[cfg(all(feature = "smoltcp", feature = "unstable"))]
@@ -1617,7 +1618,7 @@ impl ScanTypeConfig {
 }
 
 /// Scan configuration
-#[derive(Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, BuilderLite)]
 pub struct ScanConfig<'a> {
     /// SSID to filter for.
     /// If [`None`] is passed, all SSIDs will be returned.

--- a/examples/wifi/bench/src/main.rs
+++ b/examples/wifi/bench/src/main.rs
@@ -28,7 +28,7 @@ use esp_hal::{
     timer::timg::TimerGroup,
 };
 use esp_println::println;
-use esp_radio::wifi::{ClientConfiguration, Configuration};
+use esp_radio::wifi::{ClientConfiguration, Configuration, ScanConfig};
 use smoltcp::{
     iface::{SocketSet, SocketStorage},
     wire::{DhcpOption, IpAddress},
@@ -99,7 +99,11 @@ fn main() -> ! {
     println!("is wifi started: {:?}", controller.is_started());
 
     println!("Start Wifi Scan");
-    let res = controller.scan_n(10).unwrap();
+    let scan_config = ScanConfig {
+        max: Some(10),
+        ..Default::default()
+    };
+    let res = controller.scan_with_config_sync(scan_config).unwrap();
     for ap in res {
         println!("{:?}", ap);
     }

--- a/examples/wifi/bench/src/main.rs
+++ b/examples/wifi/bench/src/main.rs
@@ -99,10 +99,7 @@ fn main() -> ! {
     println!("is wifi started: {:?}", controller.is_started());
 
     println!("Start Wifi Scan");
-    let scan_config = ScanConfig {
-        max: Some(10),
-        ..Default::default()
-    };
+    let scan_config = ScanConfig::default().with_max(10);
     let res = controller.scan_with_config_sync(scan_config).unwrap();
     for ap in res {
         println!("{:?}", ap);

--- a/examples/wifi/csi/src/main.rs
+++ b/examples/wifi/csi/src/main.rs
@@ -13,7 +13,7 @@ use esp_alloc as _;
 use esp_backtrace as _;
 use esp_hal::{clock::CpuClock, main, rng::Rng, time, timer::timg::TimerGroup};
 use esp_println::println;
-use esp_radio::wifi::{ClientConfiguration, Configuration, CsiConfig};
+use esp_radio::wifi::{ClientConfiguration, Configuration, CsiConfig, ScanConfig};
 use smoltcp::{
     iface::{SocketSet, SocketStorage},
     wire::DhcpOption,
@@ -84,7 +84,11 @@ fn main() -> ! {
 
     println!("Waiting for CSI data...");
     println!("Start Wifi Scan");
-    let res = controller.scan_n(10).unwrap();
+    let scan_config = ScanConfig {
+        max: Some(10),
+        ..Default::default()
+    };
+    let res = controller.scan_with_config_sync(scan_config).unwrap();
     for ap in res {
         println!("{:?}", ap);
     }

--- a/examples/wifi/csi/src/main.rs
+++ b/examples/wifi/csi/src/main.rs
@@ -84,10 +84,7 @@ fn main() -> ! {
 
     println!("Waiting for CSI data...");
     println!("Start Wifi Scan");
-    let scan_config = ScanConfig {
-        max: Some(10),
-        ..Default::default()
-    };
+    let scan_config = ScanConfig::default().with_max(10);
     let res = controller.scan_with_config_sync(scan_config).unwrap();
     for ap in res {
         println!("{:?}", ap);

--- a/examples/wifi/dhcp/src/main.rs
+++ b/examples/wifi/dhcp/src/main.rs
@@ -24,7 +24,7 @@ use esp_hal::{
     timer::timg::TimerGroup,
 };
 use esp_println::{print, println};
-use esp_radio::wifi::{ClientConfiguration, Configuration};
+use esp_radio::wifi::{ClientConfiguration, Configuration, ScanConfig};
 use smoltcp::{
     iface::{SocketSet, SocketStorage},
     wire::{DhcpOption, IpAddress},
@@ -84,7 +84,11 @@ fn main() -> ! {
     println!("is wifi started: {:?}", controller.is_started());
 
     println!("Start Wifi Scan");
-    let res = controller.scan_n(10).unwrap();
+    let scan_config = ScanConfig {
+        max: Some(10),
+        ..Default::default()
+    };
+    let res = controller.scan_with_config_sync(scan_config).unwrap();
     for ap in res {
         println!("{:?}", ap);
     }

--- a/examples/wifi/dhcp/src/main.rs
+++ b/examples/wifi/dhcp/src/main.rs
@@ -84,10 +84,7 @@ fn main() -> ! {
     println!("is wifi started: {:?}", controller.is_started());
 
     println!("Start Wifi Scan");
-    let scan_config = ScanConfig {
-        max: Some(10),
-        ..Default::default()
-    };
+    let scan_config = ScanConfig::default().with_max(10);
     let res = controller.scan_with_config_sync(scan_config).unwrap();
     for ap in res {
         println!("{:?}", ap);

--- a/examples/wifi/embassy_dhcp/src/main.rs
+++ b/examples/wifi/embassy_dhcp/src/main.rs
@@ -178,10 +178,7 @@ async fn connection(mut controller: WifiController<'static>) {
             println!("Wifi started!");
 
             println!("Scan");
-            let scan_config = ScanConfig {
-                max: Some(10),
-                ..Default::default()
-            };
+            let scan_config = ScanConfig::default().with_max(10);
             let result = controller
                 .scan_with_config_async(scan_config)
                 .await

--- a/examples/wifi/embassy_dhcp/src/main.rs
+++ b/examples/wifi/embassy_dhcp/src/main.rs
@@ -22,7 +22,15 @@ use esp_hal::{clock::CpuClock, rng::Rng, timer::timg::TimerGroup};
 use esp_println::println;
 use esp_radio::{
     Controller,
-    wifi::{ClientConfiguration, Configuration, WifiController, WifiDevice, WifiEvent, WifiState},
+    wifi::{
+        ClientConfiguration,
+        Configuration,
+        ScanConfig,
+        WifiController,
+        WifiDevice,
+        WifiEvent,
+        WifiState,
+    },
 };
 
 esp_bootloader_esp_idf::esp_app_desc!();
@@ -170,7 +178,14 @@ async fn connection(mut controller: WifiController<'static>) {
             println!("Wifi started!");
 
             println!("Scan");
-            let result = controller.scan_n_async(10).await.unwrap();
+            let scan_config = ScanConfig {
+                max: Some(10),
+                ..Default::default()
+            };
+            let result = controller
+                .scan_with_config_async(scan_config)
+                .await
+                .unwrap();
             for ap in result {
                 println!("{:?}", ap);
             }

--- a/examples/wifi/static_ip/src/main.rs
+++ b/examples/wifi/static_ip/src/main.rs
@@ -73,10 +73,7 @@ fn main() -> ! {
     println!("is wifi started: {:?}", controller.is_started());
 
     println!("Start Wifi Scan");
-    let scan_config = ScanConfig {
-        max: Some(10),
-        ..Default::default()
-    };
+    let scan_config = ScanConfig::default().with_max(10);
     let res = controller.scan_with_config_sync(scan_config).unwrap();
     for ap in res {
         println!("{:?}", ap);

--- a/examples/wifi/static_ip/src/main.rs
+++ b/examples/wifi/static_ip/src/main.rs
@@ -21,7 +21,7 @@ use esp_hal::{
     timer::timg::TimerGroup,
 };
 use esp_println::{print, println};
-use esp_radio::wifi::{ClientConfiguration, Configuration};
+use esp_radio::wifi::{ClientConfiguration, Configuration, ScanConfig};
 use smoltcp::iface::{SocketSet, SocketStorage};
 
 esp_bootloader_esp_idf::esp_app_desc!();
@@ -73,7 +73,11 @@ fn main() -> ! {
     println!("is wifi started: {:?}", controller.is_started());
 
     println!("Start Wifi Scan");
-    let res = controller.scan_n(10).unwrap();
+    let scan_config = ScanConfig {
+        max: Some(10),
+        ..Default::default()
+    };
+    let res = controller.scan_with_config_sync(scan_config).unwrap();
     for ap in res {
         println!("{:?}", ap);
     }


### PR DESCRIPTION
This removes the `scan_*_max` and `scan_n*` functions from `esp-radio`, and adds an optional `max` field to `ScanConfig` instead.

Additionally derives `BuilderLite` on `ScanConfig` to make instantiating the configuration a bit more pleasant.

Closes #3961