### PR TITLE
Reduce disk space used when running `xtask ci`

### DIFF
--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -15,7 +15,7 @@ use crate::{Package, windows_safe_path};
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum CargoAction {
-    Build(PathBuf),
+    Build(Option<PathBuf>),
     Run,
 }
 

--- a/xtask/src/commands/build.rs
+++ b/xtask/src/commands/build.rs
@@ -124,7 +124,7 @@ pub fn build_examples(
     args: ExamplesArgs,
     examples: Vec<Metadata>,
     package_path: &Path,
-    out_path: &Path,
+    out_path: Option<&Path>,
 ) -> Result<()> {
     let chip = args.chip.unwrap();
 
@@ -160,7 +160,7 @@ pub fn build_examples(
                 chip,
                 &target,
                 example,
-                CargoAction::Build(out_path.to_path_buf()),
+                CargoAction::Build(out_path.map(|p| p.to_path_buf())),
                 1,
                 args.debug,
                 args.toolchain.as_deref(),
@@ -177,7 +177,7 @@ pub fn build_examples(
                 chip,
                 &target,
                 example,
-                CargoAction::Build(out_path.to_path_buf()),
+                CargoAction::Build(out_path.map(|p| p.to_path_buf())),
                 1,
                 args.debug,
                 args.toolchain.as_deref(),

--- a/xtask/src/commands/mod.rs
+++ b/xtask/src/commands/mod.rs
@@ -129,7 +129,7 @@ pub fn examples(workspace: &Path, mut args: ExamplesArgs, action: CargoAction) -
 
     // Execute the specified action:
     match action {
-        CargoAction::Build(out_path) => build_examples(args, examples, &package_path, &out_path),
+        CargoAction::Build(out_path) => build_examples(args, examples, &package_path, out_path.as_ref().map(|p| p.as_path())),
         CargoAction::Run => run_examples(args, examples, &package_path),
     }
 }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -130,13 +130,13 @@ fn main() -> Result<()> {
             Build::Examples(args) => examples(
                 &workspace,
                 args,
-                CargoAction::Build(target_path.join("examples")),
+                CargoAction::Build(Some(target_path.join("examples"))),
             ),
             Build::Package(args) => build_package(&workspace, args),
             Build::Tests(args) => tests(
                 &workspace,
                 args,
-                CargoAction::Build(target_path.join("tests")),
+                CargoAction::Build(Some(target_path.join("tests"))),
             ),
         },
 
@@ -382,10 +382,10 @@ fn run_ci_checks(workspace: &Path, args: CiArgs) -> Result<()> {
                 toolchain: args.toolchain.clone(),
                 timings: false,
             },
-            CargoAction::Build(PathBuf::from(format!(
+            CargoAction::Build(Some(PathBuf::from(format!(
                 "./esp-lp-hal/target/{}/release/examples",
                 args.chip.target()
-            ))),
+            )))),
         )
         .inspect_err(|_| failed.push("Build LP-HAL Examples"))
         .and_then(|_| {
@@ -407,6 +407,13 @@ fn run_ci_checks(workspace: &Path, args: CiArgs) -> Result<()> {
             Ok(())
         })
         .ok();
+
+        // remove the (now) obsolete duplicates
+        std::fs::remove_dir_all(PathBuf::from(format!(
+            "./esp-lp-hal/target/{}/release/examples/{}",
+            args.chip.target(),
+            args.chip
+        )))?;
         println!("::endgroup");
 
         // Check documentation
@@ -458,7 +465,7 @@ fn run_ci_checks(workspace: &Path, args: CiArgs) -> Result<()> {
             toolchain: args.toolchain.clone(),
             timings: false,
         },
-        CargoAction::Build(PathBuf::from("./examples/target/")),
+        CargoAction::Build(None),
     )
     .inspect_err(|_| failed.push("Build examples"))
     .ok();
@@ -476,7 +483,7 @@ fn run_ci_checks(workspace: &Path, args: CiArgs) -> Result<()> {
             toolchain: args.toolchain.clone(),
             timings: false,
         },
-        CargoAction::Build(PathBuf::from("./qa-test/target/")),
+        CargoAction::Build(None),
     )
     .inspect_err(|_| failed.push("Build qa-test"))
     .ok();


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [ ] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

This tries to reduce disk space used when running `xtask ci` by avoiding unnecessarily copying the ELF files to a "random" location - this might mitigate the failing CI (which fails because the runner runs out of disk space)

#### Testing
We'll see
