### PR TITLE
Fix CI example checks

### DIFF
--- a/examples/wifi/access_point/src/main.rs
+++ b/examples/wifi/access_point/src/main.rs
@@ -78,9 +78,10 @@ fn main() -> ! {
     let socket_set = SocketSet::new(&mut socket_set_entries[..]);
     let mut stack = Stack::new(iface, device, socket_set, now, rng.random());
 
-    let client_config = Configuration::AccessPoint(AccessPointConfiguration {
-        ssid: "esp-radio".into(),
-        ..Default::default()
+    let client_config = Configuration::AccessPoint({
+        let mut config = AccessPointConfiguration::default();
+        config.ssid = "esp-radio".into();
+        config
     });
     let res = controller.set_configuration(&client_config);
     println!("wifi_set_configuration returned {:?}", res);

--- a/examples/wifi/access_point_with_sta/src/main.rs
+++ b/examples/wifi/access_point_with_sta/src/main.rs
@@ -72,14 +72,16 @@ fn main() -> ! {
     let sta_stack = Stack::new(sta_interface, sta_device, sta_socket_set, now, rng.random());
 
     let client_config = Configuration::Mixed(
-        ClientConfiguration {
-            ssid: SSID.into(),
-            password: PASSWORD.into(),
-            ..Default::default()
+        {
+            let mut client_config = ClientConfiguration::default();
+            client_config.ssid = SSID.into();
+            client_config.password = PASSWORD.into();
+            client_config
         },
-        AccessPointConfiguration {
-            ssid: "esp-radio".into(),
-            ..Default::default()
+        {
+            let mut ap_config = AccessPointConfiguration::default();
+            ap_config.ssid = "esp-radio".into();
+            ap_config
         },
     );
     let res = controller.set_configuration(&client_config);

--- a/examples/wifi/bench/src/main.rs
+++ b/examples/wifi/bench/src/main.rs
@@ -87,10 +87,11 @@ fn main() -> ! {
     let now = || time::Instant::now().duration_since_epoch().as_millis();
     let stack = Stack::new(iface, device, socket_set, now, rng.random());
 
-    let client_config = Configuration::Client(ClientConfiguration {
-        ssid: SSID.into(),
-        password: PASSWORD.into(),
-        ..Default::default()
+    let client_config = Configuration::Client({
+        let mut config = ClientConfiguration::default();
+        config.ssid = SSID.into();
+        config.password = PASSWORD.into();
+        config
     });
     let res = controller.set_configuration(&client_config);
     println!("wifi_set_configuration returned {:?}", res);

--- a/examples/wifi/coex/src/main.rs
+++ b/examples/wifi/coex/src/main.rs
@@ -121,10 +121,11 @@ fn main() -> ! {
     let rng = Rng::new();
     let stack = Stack::new(iface, device, socket_set, now, rng.random());
 
-    let client_config = Configuration::Client(ClientConfiguration {
-        ssid: SSID.into(),
-        password: PASSWORD.into(),
-        ..Default::default()
+    let client_config = Configuration::Client({
+        let mut config = ClientConfiguration::default();
+        config.ssid = SSID.into();
+        config.password = PASSWORD.into();
+        config
     });
     let res = controller.set_configuration(&client_config);
     println!("wifi_set_configuration returned {:?}", res);

--- a/examples/wifi/csi/src/main.rs
+++ b/examples/wifi/csi/src/main.rs
@@ -57,10 +57,11 @@ fn main() -> ! {
     let now = || time::Instant::now().duration_since_epoch().as_millis();
     let stack = Stack::new(iface, device, socket_set, now, rng.random());
 
-    let client_config = Configuration::Client(ClientConfiguration {
-        ssid: SSID.into(),
-        password: PASSWORD.into(),
-        ..Default::default()
+    let client_config = Configuration::Client({
+        let mut config = ClientConfiguration::default();
+        config.ssid = SSID.into();
+        config.password = PASSWORD.into();
+        config
     });
     let res = controller.set_configuration(&client_config);
     println!("wifi_set_configuration returned {:?}", res);

--- a/examples/wifi/dhcp/src/main.rs
+++ b/examples/wifi/dhcp/src/main.rs
@@ -72,10 +72,11 @@ fn main() -> ! {
         .set_power_saving(esp_radio::config::PowerSaveMode::None)
         .unwrap();
 
-    let client_config = Configuration::Client(ClientConfiguration {
-        ssid: SSID.into(),
-        password: PASSWORD.into(),
-        ..Default::default()
+    let client_config = Configuration::Client({
+        let mut config = ClientConfiguration::default();
+        config.ssid = SSID.into();
+        config.password = PASSWORD.into();
+        config
     });
     let res = controller.set_configuration(&client_config);
     println!("wifi_set_configuration returned {:?}", res);

--- a/examples/wifi/embassy_access_point/src/main.rs
+++ b/examples/wifi/embassy_access_point/src/main.rs
@@ -256,9 +256,10 @@ async fn connection(mut controller: WifiController<'static>) {
             _ => {}
         }
         if !matches!(controller.is_started(), Ok(true)) {
-            let client_config = Configuration::AccessPoint(AccessPointConfiguration {
-                ssid: "esp-radio".try_into().unwrap(),
-                ..Default::default()
+            let client_config = Configuration::AccessPoint({
+                let mut config = AccessPointConfiguration::default();
+                config.ssid = "esp-radio".into();
+                config
             });
             controller.set_configuration(&client_config).unwrap();
             println!("Starting wifi");

--- a/examples/wifi/embassy_access_point_with_sta/src/main.rs
+++ b/examples/wifi/embassy_access_point_with_sta/src/main.rs
@@ -119,14 +119,16 @@ async fn main(spawner: Spawner) -> ! {
     );
 
     let client_config = Configuration::Mixed(
-        ClientConfiguration {
-            ssid: SSID.into(),
-            password: PASSWORD.into(),
-            ..Default::default()
+        {
+            let mut client_config = ClientConfiguration::default();
+            client_config.ssid = SSID.into();
+            client_config.password = PASSWORD.into();
+            client_config
         },
-        AccessPointConfiguration {
-            ssid: "esp-radio".into(),
-            ..Default::default()
+        {
+            let mut ap_config = AccessPointConfiguration::default();
+            ap_config.ssid = "esp-radio".into();
+            ap_config
         },
     );
     controller.set_configuration(&client_config).unwrap();

--- a/examples/wifi/embassy_bench/src/main.rs
+++ b/examples/wifi/embassy_bench/src/main.rs
@@ -158,10 +158,11 @@ async fn connection(mut controller: WifiController<'static>) {
             _ => {}
         }
         if !matches!(controller.is_started(), Ok(true)) {
-            let client_config = Configuration::Client(ClientConfiguration {
-                ssid: SSID.into(),
-                password: PASSWORD.into(),
-                ..Default::default()
+            let client_config = Configuration::Client({
+                let mut config = ClientConfiguration::default();
+                config.ssid = SSID.into();
+                config.password = PASSWORD.into();
+                config
             });
             controller.set_configuration(&client_config).unwrap();
             println!("Starting wifi");

--- a/examples/wifi/embassy_dhcp/src/main.rs
+++ b/examples/wifi/embassy_dhcp/src/main.rs
@@ -167,10 +167,11 @@ async fn connection(mut controller: WifiController<'static>) {
             _ => {}
         }
         if !matches!(controller.is_started(), Ok(true)) {
-            let client_config = Configuration::Client(ClientConfiguration {
-                ssid: SSID.into(),
-                password: PASSWORD.into(),
-                ..Default::default()
+            let client_config = Configuration::Client({
+                let mut config = ClientConfiguration::default();
+                config.ssid = SSID.into();
+                config.password = PASSWORD.into();
+                config
             });
             controller.set_configuration(&client_config).unwrap();
             println!("Starting wifi");

--- a/examples/wifi/static_ip/src/main.rs
+++ b/examples/wifi/static_ip/src/main.rs
@@ -61,10 +61,11 @@ fn main() -> ! {
     let now = || time::Instant::now().duration_since_epoch().as_millis();
     let mut stack = Stack::new(iface, device, socket_set, now, rng.random());
 
-    let client_config = Configuration::Client(ClientConfiguration {
-        ssid: SSID.into(),
-        password: PASSWORD.into(),
-        ..Default::default()
+    let client_config = Configuration::Client({
+        let mut config = ClientConfiguration::default();
+        config.ssid = SSID.into();
+        config.password = PASSWORD.into();
+        config
     });
     let res = controller.set_configuration(&client_config);
     println!("wifi_set_configuration returned {:?}", res);

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -452,9 +452,9 @@ pub fn execute_app(
     };
 
     if let CargoAction::Build(out_dir) = action {
-        if let Some(out_dir) = out_dir {
-            cargo::run_with_env(&args, &cwd, env_vars, false)?;
+        cargo::run_with_env(&args, &cwd, env_vars, false)?;
 
+        if let Some(out_dir) = out_dir {
             // Now that the build has succeeded and we printed the output, we can
             // rerun the build again quickly enough to capture JSON. We'll use this to
             // copy the binary to the output directory.


### PR DESCRIPTION
There was a subtle bug in our `xtask` which, after some recent changes, resulted in the examples not actually being built in CI but passing regardless. This resolves that issue, and updates the necessary examples to get CI green again.

Somewhat unrelated, this makes the `wifi` examples a bit ugly, however #3964 recommends deriving `BuilderLite` for these configuration types, so this can be cleaned up by @JurajSadel (or somebody else) whenever those changes are PR'd. Focus here was just to get CI working correctly again