### PR TITLE
WDT cleanup and fix tests

### DIFF
--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -643,62 +643,42 @@ pub fn init(config: Config) -> Peripherals {
     let mut rtc = crate::rtc_cntl::Rtc::new(peripherals.LPWR.reborrow());
 
     // Handle watchdog configuration with defaults
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "unstable")]
-        {
-            #[cfg(not(any(esp32, esp32s2)))]
-            if config.watchdog.swd() {
-                rtc.swd.enable();
-            } else {
-                rtc.swd.disable();
-            }
+    #[cfg(not(any(esp32, esp32s2)))]
+    rtc.swd.disable();
 
-            match config.watchdog.rwdt() {
-                WatchdogStatus::Enabled(duration) => {
-                    rtc.rwdt.set_timeout(crate::rtc_cntl::RwdtStage::Stage0, duration);
-                    rtc.rwdt.enable();
-                }
-                WatchdogStatus::Disabled => {
-                    rtc.rwdt.disable();
-                }
-            }
+    rtc.rwdt.disable();
 
-            #[cfg(timergroup_timg0)]
-            match config.watchdog.timg0() {
-                WatchdogStatus::Enabled(duration) => {
-                    let mut timg0_wd = crate::timer::timg::Wdt::<crate::peripherals::TIMG0<'static>>::new();
-                    timg0_wd.set_timeout(crate::timer::timg::MwdtStage::Stage0, duration);
-                    timg0_wd.enable();
-                }
-                WatchdogStatus::Disabled => {
-                    crate::timer::timg::Wdt::<crate::peripherals::TIMG0<'static>>::new().disable();
-                }
-            }
+    #[cfg(timergroup_timg0)]
+    crate::timer::timg::Wdt::<crate::peripherals::TIMG0<'static>>::new().disable();
 
-            #[cfg(timergroup_timg1)]
-            match config.watchdog.timg1() {
-                WatchdogStatus::Enabled(duration) => {
-                    let mut timg1_wd = crate::timer::timg::Wdt::<crate::peripherals::TIMG1<'static>>::new();
-                    timg1_wd.set_timeout(crate::timer::timg::MwdtStage::Stage0, duration);
-                    timg1_wd.enable();
-                }
-                WatchdogStatus::Disabled => {
-                    crate::timer::timg::Wdt::<crate::peripherals::TIMG1<'static>>::new().disable();
-                }
-            }
+    #[cfg(timergroup_timg1)]
+    crate::timer::timg::Wdt::<crate::peripherals::TIMG1<'static>>::new().disable();
+
+    #[cfg(feature = "unstable")]
+    {
+        #[cfg(not(any(esp32, esp32s2)))]
+        if config.watchdog.swd() {
+            rtc.swd.enable();
         }
-        else
-        {
-            #[cfg(not(any(esp32, esp32s2)))]
-            rtc.swd.disable();
 
-            rtc.rwdt.disable();
+        if let WatchdogStatus::Enabled(duration) = config.watchdog.rwdt() {
+            rtc.rwdt
+                .set_timeout(crate::rtc_cntl::RwdtStage::Stage0, duration);
+            rtc.rwdt.enable();
+        }
 
-            #[cfg(timergroup_timg0)]
-            crate::timer::timg::Wdt::<crate::peripherals::TIMG0<'static>>::new().disable();
+        #[cfg(timergroup_timg0)]
+        if let WatchdogStatus::Enabled(duration) = config.watchdog.timg0() {
+            let mut timg0_wd = crate::timer::timg::Wdt::<crate::peripherals::TIMG0<'static>>::new();
+            timg0_wd.set_timeout(crate::timer::timg::MwdtStage::Stage0, duration);
+            timg0_wd.enable();
+        }
 
-            #[cfg(timergroup_timg1)]
-            crate::timer::timg::Wdt::<crate::peripherals::TIMG1<'static>>::new().disable();
+        #[cfg(timergroup_timg1)]
+        if let WatchdogStatus::Enabled(duration) = config.watchdog.timg1() {
+            let mut timg1_wd = crate::timer::timg::Wdt::<crate::peripherals::TIMG1<'static>>::new();
+            timg1_wd.set_timeout(crate::timer::timg::MwdtStage::Stage0, duration);
+            timg1_wd.enable();
         }
     }
 

--- a/esp-hal/src/rtc_cntl/mod.rs
+++ b/esp-hal/src/rtc_cntl/mod.rs
@@ -144,6 +144,8 @@ cfg_if::cfg_if! {
         use crate::peripherals::LP_WDT;
         use crate::peripherals::LP_TIMER;
         use crate::peripherals::LP_AON;
+
+        use rtc::{RtcSlowClock, RtcCalSel}; // TODO: bring the types into this module
     } else {
         use crate::peripherals::LPWR as LP_WDT;
         use crate::peripherals::LPWR as LP_TIMER;
@@ -781,7 +783,7 @@ impl RtcClock {
             // The Fosc CLK of calibration circuit is divided by 32 for ECO1.
             // So we need to divide the calibrate cycles of the FOSC for ECO1 and above
             // chips by 32 to avoid excessive calibration time.
-            slowclk_cycles >>= 5;
+            slowclk_cycles >> 5
         } else {
             slowclk_cycles
         };

--- a/esp-hal/src/rtc_cntl/rtc/esp32h2.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32h2.rs
@@ -300,7 +300,7 @@ impl RtcClock {
     /// Calibration of RTC_SLOW_CLK is performed using a special feature of
     /// TIMG0. This feature counts the number of XTAL clock cycles within a
     /// given number of RTC_SLOW_CLK cycles.
-    fn calibrate_internal(mut cal_clk: RtcCalSel, slowclk_cycles: u32) -> u32 {
+    pub(crate) fn calibrate_internal(mut cal_clk: RtcCalSel, slowclk_cycles: u32) -> u32 {
         const SOC_CLK_RC_FAST_FREQ_APPROX: u32 = 17_500_000;
         const SOC_CLK_RC_SLOW_FREQ_APPROX: u32 = 136_000;
         const SOC_CLK_XTAL32K_FREQ_APPROX: u32 = 32768;

--- a/esp-hal/src/rtc_cntl/rtc/esp32h2.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32h2.rs
@@ -297,15 +297,6 @@ impl RtcClock {
         }
     }
 
-    fn calibrate(cal_clk: RtcCalSel, slowclk_cycles: u32) -> u32 {
-        let xtal_freq = RtcClock::xtal_freq();
-        let xtal_cycles = RtcClock::calibrate_internal(cal_clk, slowclk_cycles) as u64;
-        let divider = xtal_freq.mhz() as u64 * slowclk_cycles as u64;
-        let period_64 = ((xtal_cycles << RtcClock::CAL_FRACT) + divider / 2u64 - 1u64) / divider;
-
-        (period_64 & u32::MAX as u64) as u32
-    }
-
     /// Calibration of RTC_SLOW_CLK is performed using a special feature of
     /// TIMG0. This feature counts the number of XTAL clock cycles within a
     /// given number of RTC_SLOW_CLK cycles.
@@ -564,23 +555,5 @@ impl RtcClock {
         }
 
         cal_val
-    }
-
-    pub(crate) fn cycles_to_1ms() -> u16 {
-        let period_13q19 = RtcClock::calibrate(
-            match RtcClock::slow_freq() {
-                RtcSlowClock::RtcSlowClockRcSlow => RtcCalSel::RtcCalRtcMux,
-                RtcSlowClock::RtcSlowClock32kXtal => RtcCalSel::RtcCal32kXtal,
-                RtcSlowClock::RtcSlowClock32kRc => RtcCalSel::RtcCal32kRc,
-                RtcSlowClock::RtcSlowOscSlow => RtcCalSel::RtcCal32kOscSlow,
-                // RtcSlowClock::RtcCalRcFast => RtcCalSel::RtcCalRcFast,
-            },
-            1024,
-        );
-
-        // 100_000_000 is used to get rid of `float` calculations
-        let period = (100_000_000 * period_13q19 as u64) / (1 << RtcClock::CAL_FRACT);
-
-        (100_000_000 * 1000 / period) as u16
     }
 }

--- a/hil-test/tests/init.rs
+++ b/hil-test/tests/init.rs
@@ -36,10 +36,14 @@ mod tests {
         let mut wdt0 = timg0.wdt;
         let delay = Delay::new();
 
-        for _ in 0..4 {
+        // Loop for more than the timeout of the watchdog.
+        for _ in 0..6 {
             wdt0.feed();
-            delay.delay(Duration::from_millis(250));
+            delay.delay(Duration::from_millis(100));
         }
+        // Disable the watchdog, to prevent accidentally resetting the MCU while the host is setting
+        // up the next test.
+        wdt0.disable();
     }
 
     #[test]
@@ -70,10 +74,14 @@ mod tests {
         let mut wdt1 = timg1.wdt;
         let delay = Delay::new();
 
-        for _ in 0..4 {
+        // Loop for more than the timeout of the watchdog.
+        for _ in 0..6 {
             wdt1.feed();
-            delay.delay(Duration::from_millis(250));
+            delay.delay(Duration::from_millis(100));
         }
+        // Disable the watchdog, to prevent accidentally resetting the MCU while the host is setting
+        // up the next test.
+        wdt1.disable();
     }
 
     #[test]
@@ -92,27 +100,36 @@ mod tests {
         let mut wdt0 = timg0.wdt;
         let delay = Delay::new();
 
-        for _ in 0..4 {
+        // Loop for more than the timeout of the watchdog.
+        for _ in 0..6 {
             wdt0.feed();
-            delay.delay(Duration::from_millis(250));
+            delay.delay(Duration::from_millis(100));
         }
+        // Disable the watchdog, to prevent accidentally resetting the MCU while the host is setting
+        // up the next test.
+        wdt0.disable();
     }
 
     #[test]
-    #[timeout(4)]
     fn test_feeding_rtc_wdt() {
         let peripherals = esp_hal::init(
             Config::default().with_watchdog(
                 WatchdogConfig::default()
-                    .with_rwdt(WatchdogStatus::Enabled(Duration::from_millis(3000))),
+                    .with_rwdt(WatchdogStatus::Enabled(Duration::from_millis(500))),
             ),
         );
 
         let mut rtc = Rtc::new(peripherals.LPWR);
         let delay = Delay::new();
 
-        rtc.rwdt.feed();
-        delay.delay(Duration::from_millis(2500));
+        // Loop for more than the timeout of the watchdog.
+        for _ in 0..6 {
+            rtc.rwdt.feed();
+            delay.delay(Duration::from_millis(100));
+        }
+        // Disable the watchdog, to prevent accidentally resetting the MCU while the host is setting
+        // up the next test.
+        rtc.rwdt.disable();
     }
 
     #[test]
@@ -120,6 +137,6 @@ mod tests {
         esp_hal::init(Config::default());
 
         let delay = Delay::new();
-        delay.delay(Duration::from_millis(2000));
+        delay.delay(Duration::from_millis(1000));
     }
 }


### PR DESCRIPTION
The main point of this PR is to disable WDTs after a test has finished. The WDT can trigger after a test has finished, but before the next is started.

The PR also cleans up lib.rs a bit by disabling WDTs unconditionally first, and also merges some functions that were separately copied for C6/H2.

The PR also reduces the delays used in the `init` test suite, just to save a bit of time.