### PR TITLE
Fix ESP32 crash

### DIFF
--- a/esp-hal/src/clock/mod.rs
+++ b/esp-hal/src/clock/mod.rs
@@ -331,6 +331,8 @@ static mut ACTIVE_CLOCKS: Option<Clocks> = None;
 impl Clocks {
     pub(crate) fn init(cpu_clock_speed: CpuClock) {
         critical_section::with(|_| {
+            crate::rtc_cntl::rtc::init();
+
             let config = Self::configure(cpu_clock_speed);
             crate::rtc_cntl::RtcClock::update_xtal_freq_mhz(config.xtal_clock.as_mhz());
             unsafe { ACTIVE_CLOCKS = Some(config) };

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -637,8 +637,6 @@ pub fn init(config: Config) -> Peripherals {
 
     let mut peripherals = Peripherals::take();
 
-    crate::rtc_cntl::rtc::init();
-
     Clocks::init(config.cpu_clock);
 
     crate::rtc_cntl::rtc::configure_clock();

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -637,7 +637,11 @@ pub fn init(config: Config) -> Peripherals {
 
     let mut peripherals = Peripherals::take();
 
+    crate::rtc_cntl::rtc::init();
+
     Clocks::init(config.cpu_clock);
+
+    crate::rtc_cntl::rtc::configure_clock();
 
     // RTC domain must be enabled before we try to disable
     let mut rtc = crate::rtc_cntl::Rtc::new(peripherals.LPWR.reborrow());

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -642,6 +642,9 @@ pub fn init(config: Config) -> Peripherals {
     // RTC domain must be enabled before we try to disable
     let mut rtc = crate::rtc_cntl::Rtc::new(peripherals.LPWR.reborrow());
 
+    #[cfg(any(esp32, esp32s2, esp32s3, esp32c3, esp32c6, esp32c2))]
+    crate::rtc_cntl::sleep::RtcSleepConfig::base_settings(&rtc);
+
     // Handle watchdog configuration with defaults
     #[cfg(not(any(esp32, esp32s2)))]
     rtc.swd.disable();

--- a/esp-hal/src/rtc_cntl/mod.rs
+++ b/esp-hal/src/rtc_cntl/mod.rs
@@ -328,17 +328,12 @@ impl<'d> Rtc<'d> {
         rtc::init();
         rtc::configure_clock();
 
-        let this = Self {
+        Self {
             _inner: rtc_cntl,
             rwdt: Rwdt::new(),
             #[cfg(any(esp32c2, esp32c3, esp32c6, esp32h2, esp32s3))]
             swd: Swd::new(),
-        };
-
-        #[cfg(any(esp32, esp32s2, esp32s3, esp32c3, esp32c6, esp32c2))]
-        RtcSleepConfig::base_settings(&this);
-
-        this
+        }
     }
 
     /// Return estimated XTAL frequency in MHz.

--- a/esp-hal/src/rtc_cntl/mod.rs
+++ b/esp-hal/src/rtc_cntl/mod.rs
@@ -325,9 +325,6 @@ impl<'d> Rtc<'d> {
     ///
     /// Optionally an interrupt handler can be bound.
     pub fn new(rtc_cntl: crate::peripherals::LPWR<'d>) -> Self {
-        rtc::init();
-        rtc::configure_clock();
-
         Self {
             _inner: rtc_cntl,
             rwdt: Rwdt::new(),

--- a/esp-hal/src/rtc_cntl/mod.rs
+++ b/esp-hal/src/rtc_cntl/mod.rs
@@ -809,7 +809,10 @@ impl RtcClock {
         // Start calibration
         timg0
             .rtccalicfg()
-            .modify(|_, w| w.rtc_cali_start().clear_bit().rtc_cali_start().set_bit());
+            .modify(|_, w| w.rtc_cali_start().clear_bit());
+        timg0
+            .rtccalicfg()
+            .modify(|_, w| w.rtc_cali_start().set_bit());
 
         // Wait for calibration to finish up to another us_time_estimate
         crate::rom::ets_delay_us(us_time_estimate);
@@ -841,6 +844,7 @@ impl RtcClock {
         timg0
             .rtccalicfg()
             .modify(|_, w| w.rtc_cali_start().clear_bit());
+
         rtc_cntl.clk_conf().modify(|_, w| {
             w.dig_xtal32k_en().bit(dig_32k_xtal_enabled);
             w.dig_clk8m_d256_en().bit(dig_clk8m_d256_enabled)
@@ -1200,6 +1204,10 @@ impl RtcClock {
         #[cfg(not(esp32))]
         TIMG0::regs().rtccalicfg2().reset();
 
+        TIMG0::regs()
+            .rtccalicfg()
+            .modify(|_, w| w.rtc_cali_start().clear_bit());
+
         TIMG0::regs().rtccalicfg().write(|w| unsafe {
             w.rtc_cali_clk_sel().bits(calibration_clock as u8);
             w.rtc_cali_max().bits(SLOW_CLOCK_CYCLES as u16);
@@ -1220,6 +1228,10 @@ impl RtcClock {
         {}
 
         let cali_value = TIMG0::regs().rtccalicfg1().read().rtc_cali_value().bits();
+
+        TIMG0::regs()
+            .rtccalicfg()
+            .modify(|_, w| w.rtc_cali_start().clear_bit());
 
         (cali_value * (calibration_clock.frequency().as_hz() / SLOW_CLOCK_CYCLES)) / 1_000_000
     }

--- a/esp-hal/src/rtc_cntl/rtc/esp32.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32.rs
@@ -5,14 +5,13 @@ use crate::{
     rtc_cntl::{RtcCalSel, RtcClock, RtcFastClock, RtcSlowClock},
 };
 
-pub(crate) fn init() {}
+pub(crate) fn init() {
+    RtcClock::set_fast_freq(RtcFastClock::RtcFastClockRcFast);
+    RtcClock::set_slow_freq(RtcSlowClock::RtcSlowClockRcSlow);
+}
 
 pub(crate) fn configure_clock() {
-    RtcClock::set_fast_freq(RtcFastClock::RtcFastClockRcFast);
-
     let cal_val = loop {
-        RtcClock::set_slow_freq(RtcSlowClock::RtcSlowClockRcSlow);
-
         let res = RtcClock::calibrate(RtcCalSel::RtcCalRtcMux, 1024);
         if res != 0 {
             break res;

--- a/esp-hal/src/rtc_cntl/rtc/esp32c2.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32c2.rs
@@ -34,24 +34,22 @@ pub(crate) fn init() {
     }
 
     regi2c::I2C_ULP_IR_FORCE_XPD_CK.write_field(0);
+
+    // from esp_clk_init:
+    // clk_ll_rc_fast_enable();
+    rtc_cntl.clk_conf().modify(|_, w| w.enb_ck8m().clear_bit());
+    rtc_cntl
+        .timer1()
+        .modify(|_, w| unsafe { w.ck8m_wait().bits(5) });
+    // esp_rom_delay_us(SOC_DELAY_RC_FAST_ENABLE);
+    crate::rom::ets_delay_us(50);
+
+    RtcClock::set_fast_freq(RtcFastClock::RtcFastClockRcFast);
+    RtcClock::set_slow_freq(RtcSlowClock::RtcSlowClockRcSlow);
 }
 
 pub(crate) fn configure_clock() {
-    unsafe {
-        // from esp_clk_init:
-        // clk_ll_rc_fast_enable();
-        LPWR::regs()
-            .clk_conf()
-            .modify(|_, w| w.enb_ck8m().clear_bit());
-        LPWR::regs().timer1().modify(|_, w| w.ck8m_wait().bits(5));
-        // esp_rom_delay_us(SOC_DELAY_RC_FAST_ENABLE);
-        crate::rom::ets_delay_us(50);
-    }
-    RtcClock::set_fast_freq(RtcFastClock::RtcFastClockRcFast);
-
     let cal_val = loop {
-        RtcClock::set_slow_freq(RtcSlowClock::RtcSlowClockRcSlow);
-
         let res = RtcClock::calibrate(RtcCalSel::RtcCalRtcMux, 1024);
         if res != 0 {
             break res;

--- a/esp-hal/src/rtc_cntl/rtc/esp32c6.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32c6.rs
@@ -1054,14 +1054,13 @@ pub(crate) fn init() {
     let modem_lpclk_src = ModemClockLpclkSource::from(RtcSlowClockSource::current());
 
     modem_clock_select_lp_clock_source_wifi(modem_lpclk_src, 0);
+
+    RtcClock::set_fast_freq(RtcFastClock::RtcFastClockRcFast);
+    RtcClock::set_slow_freq(RtcSlowClock::RtcSlowClockRcSlow);
 }
 
 pub(crate) fn configure_clock() {
-    RtcClock::set_fast_freq(RtcFastClock::RtcFastClockRcFast);
-
     let cal_val = loop {
-        RtcClock::set_slow_freq(RtcSlowClock::RtcSlowClockRcSlow);
-
         let res = RtcClock::calibrate(RtcCalSel::RtcCalRtcMux, 1024);
         if res != 0 {
             break res;

--- a/esp-hal/src/rtc_cntl/rtc/esp32h2.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32h2.rs
@@ -39,66 +39,65 @@ const I2C_PMU_OR_XPD_TRX_LSB: u8 = 2;
 
 pub(crate) fn init() {
     // * No peripheral reg i2c power up required on the target */
+    regi2c_write_mask(
+        I2C_PMU,
+        I2C_PMU_HOSTID,
+        I2C_PMU_EN_I2C_RTC_DREG,
+        I2C_PMU_EN_I2C_RTC_DREG_MSB,
+        I2C_PMU_EN_I2C_RTC_DREG_LSB,
+        0,
+    );
+    regi2c_write_mask(
+        I2C_PMU,
+        I2C_PMU_HOSTID,
+        I2C_PMU_EN_I2C_DIG_DREG,
+        I2C_PMU_EN_I2C_DIG_DREG_MSB,
+        I2C_PMU_EN_I2C_DIG_DREG_LSB,
+        0,
+    );
+    regi2c_write_mask(
+        I2C_PMU,
+        I2C_PMU_HOSTID,
+        I2C_PMU_EN_I2C_RTC_DREG_SLP,
+        I2C_PMU_EN_I2C_RTC_DREG_SLP_MSB,
+        I2C_PMU_EN_I2C_RTC_DREG_SLP_LSB,
+        0,
+    );
+    regi2c_write_mask(
+        I2C_PMU,
+        I2C_PMU_HOSTID,
+        I2C_PMU_EN_I2C_DIG_DREG_SLP,
+        I2C_PMU_EN_I2C_DIG_DREG_SLP_MSB,
+        I2C_PMU_EN_I2C_DIG_DREG_SLP_LSB,
+        0,
+    );
+    regi2c_write_mask(
+        I2C_PMU,
+        I2C_PMU_HOSTID,
+        I2C_PMU_OR_XPD_RTC_REG,
+        I2C_PMU_OR_XPD_RTC_REG_MSB,
+        I2C_PMU_OR_XPD_RTC_REG_LSB,
+        0,
+    );
+    regi2c_write_mask(
+        I2C_PMU,
+        I2C_PMU_HOSTID,
+        I2C_PMU_OR_XPD_DIG_REG,
+        I2C_PMU_OR_XPD_DIG_REG_MSB,
+        I2C_PMU_OR_XPD_DIG_REG_LSB,
+        0,
+    );
+    regi2c_write_mask(
+        I2C_PMU,
+        I2C_PMU_HOSTID,
+        I2C_PMU_OR_XPD_TRX,
+        I2C_PMU_OR_XPD_TRX_MSB,
+        I2C_PMU_OR_XPD_TRX_LSB,
+        0,
+    );
+
+    let pmu = PMU::regs();
     unsafe {
-        regi2c_write_mask(
-            I2C_PMU,
-            I2C_PMU_HOSTID,
-            I2C_PMU_EN_I2C_RTC_DREG,
-            I2C_PMU_EN_I2C_RTC_DREG_MSB,
-            I2C_PMU_EN_I2C_RTC_DREG_LSB,
-            0,
-        );
-        regi2c_write_mask(
-            I2C_PMU,
-            I2C_PMU_HOSTID,
-            I2C_PMU_EN_I2C_DIG_DREG,
-            I2C_PMU_EN_I2C_DIG_DREG_MSB,
-            I2C_PMU_EN_I2C_DIG_DREG_LSB,
-            0,
-        );
-        regi2c_write_mask(
-            I2C_PMU,
-            I2C_PMU_HOSTID,
-            I2C_PMU_EN_I2C_RTC_DREG_SLP,
-            I2C_PMU_EN_I2C_RTC_DREG_SLP_MSB,
-            I2C_PMU_EN_I2C_RTC_DREG_SLP_LSB,
-            0,
-        );
-        regi2c_write_mask(
-            I2C_PMU,
-            I2C_PMU_HOSTID,
-            I2C_PMU_EN_I2C_DIG_DREG_SLP,
-            I2C_PMU_EN_I2C_DIG_DREG_SLP_MSB,
-            I2C_PMU_EN_I2C_DIG_DREG_SLP_LSB,
-            0,
-        );
-        regi2c_write_mask(
-            I2C_PMU,
-            I2C_PMU_HOSTID,
-            I2C_PMU_OR_XPD_RTC_REG,
-            I2C_PMU_OR_XPD_RTC_REG_MSB,
-            I2C_PMU_OR_XPD_RTC_REG_LSB,
-            0,
-        );
-        regi2c_write_mask(
-            I2C_PMU,
-            I2C_PMU_HOSTID,
-            I2C_PMU_OR_XPD_DIG_REG,
-            I2C_PMU_OR_XPD_DIG_REG_MSB,
-            I2C_PMU_OR_XPD_DIG_REG_LSB,
-            0,
-        );
-        regi2c_write_mask(
-            I2C_PMU,
-            I2C_PMU_HOSTID,
-            I2C_PMU_OR_XPD_TRX,
-            I2C_PMU_OR_XPD_TRX_MSB,
-            I2C_PMU_OR_XPD_TRX_LSB,
-            0,
-        );
-
-        let pmu = PMU::regs();
-
         pmu.power_pd_top_cntl().write(|w| w.bits(0));
         pmu.power_pd_hpaon_cntl().write(|w| w.bits(0));
         pmu.power_pd_hpcpu_cntl().write(|w| w.bits(0));
@@ -116,14 +115,13 @@ pub(crate) fn init() {
         pmu.slp_wakeup_cntl7()
             .modify(|_, w| w.ana_wait_target().bits(1700));
     }
+
+    RtcClock::set_fast_freq(RtcFastClock::RtcFastClockRcFast);
+    RtcClock::set_slow_freq(RtcSlowClock::RtcSlowClockRcSlow);
 }
 
 pub(crate) fn configure_clock() {
-    RtcClock::set_fast_freq(RtcFastClock::RtcFastClockRcFast);
-
     let cal_val = loop {
-        RtcClock::set_slow_freq(RtcSlowClock::RtcSlowClockRcSlow);
-
         let res = RtcClock::calibrate(RtcCalSel::RtcCalRtcMux, 1024);
         if res != 0 {
             break res;

--- a/esp-hal/src/rtc_cntl/rtc/esp32s2.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32s2.rs
@@ -5,14 +5,13 @@ use crate::{
     rtc_cntl::{RtcCalSel, RtcClock, RtcFastClock, RtcSlowClock},
 };
 
-pub(crate) fn init() {}
+pub(crate) fn init() {
+    RtcClock::set_fast_freq(RtcFastClock::RtcFastClockRcFast);
+    RtcClock::set_slow_freq(RtcSlowClock::RtcSlowClockRcSlow);
+}
 
 pub(crate) fn configure_clock() {
-    RtcClock::set_fast_freq(RtcFastClock::RtcFastClockRcFast);
-
     let cal_val = loop {
-        RtcClock::set_slow_freq(RtcSlowClock::RtcSlowClockRcSlow);
-
         let res = RtcClock::calibrate(RtcCalSel::RtcCalRtcMux, 1024);
         if res != 0 {
             break res;

--- a/esp-hal/src/rtc_cntl/rtc/esp32s3.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32s3.rs
@@ -5,14 +5,13 @@ use crate::{
     rtc_cntl::{RtcCalSel, RtcClock, RtcFastClock, RtcSlowClock},
 };
 
-pub(crate) fn init() {}
+pub(crate) fn init() {
+    RtcClock::set_fast_freq(RtcFastClock::RtcFastClockRcFast);
+    RtcClock::set_slow_freq(RtcSlowClock::RtcSlowClockRcSlow);
+}
 
 pub(crate) fn configure_clock() {
-    RtcClock::set_fast_freq(RtcFastClock::RtcFastClockRcFast);
-
     let cal_val = loop {
-        RtcClock::set_slow_freq(RtcSlowClock::RtcSlowClockRcSlow);
-
         let res = RtcClock::calibrate(RtcCalSel::RtcCalRtcMux, 1024);
         if res != 0 {
             break res;


### PR DESCRIPTION
This PR makes changes to sort out the dependency between internal oscillator calibration and XTAL measurement. The PR moves RC clock calibration into HAL init, so that subsequent calls to the Rtc constructor no longer go through the calibration process. RC clocks are configured before initializing (and potentially measuring) XTAL, and the measured XTAL is now used to more accurately calibrate the RTC clock.

The PR also fixes the root cause of the crash: XTAL calibration failed to clear the `rtc_cali_start` bit. The running theory is that this has previously caused the XTAL clock measurement to return the value that the RTC clock measurement produced, likely accidentally overclocking the chip.

Closes #2105 
Closes #3756
