### PR TITLE
Add a way to get/set calibration data

### DIFF
--- a/esp-radio/CHANGELOG.md
+++ b/esp-radio/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `unstable` feature to opt into `ble`, `esp-now`, `csi`, `sniffer`, `esp-ieee802154` and `smoltcp` APIs (#3865)
 - Added unstable `wifi-eap` feature (#3924)
 - Optional `max` field in `ScanConfig` to allow limiting the number of returned results (#3963)
+- `set_calibration_data` and `calibration_data` (#4001)
 
 ### Changed
 

--- a/esp-radio/CHANGELOG.md
+++ b/esp-radio/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `unstable` feature to opt into `ble`, `esp-now`, `csi`, `sniffer`, `esp-ieee802154` and `smoltcp` APIs (#3865)
 - Added unstable `wifi-eap` feature (#3924)
 - Optional `max` field in `ScanConfig` to allow limiting the number of returned results (#3963)
-- `set_calibration_data` and `calibration_data` (#4001)
+- `set_phy_calibration_data` and `phy_calibration_data` (#4001)
 
 ### Changed
 

--- a/esp-radio/esp_config.yml
+++ b/esp-radio/esp_config.yml
@@ -214,7 +214,7 @@ options:
     description: "Use PHY_RF_CAL_FULL instead of PHY_RF_CAL_PARTIAL."
     default:
       - value: true
-      
+
   - name: ieee802154_rx_queue_size
     description: Size of the RX queue in frames
     default:

--- a/esp-radio/src/common_adapter/mod.rs
+++ b/esp-radio/src/common_adapter/mod.rs
@@ -393,14 +393,14 @@ pub(crate) fn phy_calibrate() {
 ///
 /// If you see the data is different than what was persisted before, consider persisting the new
 /// data.
-pub fn calibration_data() -> [u8; core::mem::size_of::<esp_phy_calibration_data_t>()] {
+pub fn phy_calibration_data() -> [u8; core::mem::size_of::<esp_phy_calibration_data_t>()] {
     CAL_DATA.with(|cal_data| *cal_data)
 }
 
 /// Set calibration data.
 ///
 /// This will be used next time the phy gets initialized.
-pub fn set_calibration_data(data: &[u8; core::mem::size_of::<esp_phy_calibration_data_t>()]) {
+pub fn set_phy_calibration_data(data: &[u8; core::mem::size_of::<esp_phy_calibration_data_t>()]) {
     CAL_DATA.with(|cal_data| {
         *cal_data = *data;
     });

--- a/esp-radio/src/lib.rs
+++ b/esp-radio/src/lib.rs
@@ -112,6 +112,7 @@ mod fmt;
 use core::marker::PhantomData;
 
 use common_adapter::chip_specific::phy_mem_init;
+pub use common_adapter::{calibration_data, set_calibration_data};
 use esp_config::*;
 use esp_hal::{self as hal};
 use esp_radio_preempt_driver as preempt;

--- a/esp-radio/src/lib.rs
+++ b/esp-radio/src/lib.rs
@@ -112,7 +112,7 @@ mod fmt;
 use core::marker::PhantomData;
 
 use common_adapter::chip_specific::phy_mem_init;
-pub use common_adapter::{calibration_data, set_calibration_data};
+pub use common_adapter::{phy_calibration_data, set_phy_calibration_data};
 use esp_config::*;
 use esp_hal::{self as hal};
 use esp_radio_preempt_driver as preempt;


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Closes #2720

Users can retrieve and set calibration data

#### Testing
Locally modified example

