### PR TITLE
Use the ram macro instead of assuming the .rwtext section

### DIFF
--- a/esp-storage/Cargo.toml
+++ b/esp-storage/Cargo.toml
@@ -19,6 +19,7 @@ bench = false
 
 [dependencies]
 embedded-storage = "0.3.1"
+procmacros       = { version = "0.19.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
 
 # Optional dependencies
 critical-section = { version = "1.2.0", optional = true }

--- a/esp-storage/src/hardware.rs
+++ b/esp-storage/src/hardware.rs
@@ -1,28 +1,25 @@
 use esp_rom_sys as _;
 use esp_rom_sys::rom::spiflash::*;
+use procmacros::ram;
 
 use crate::maybe_with_critical_section;
 
-#[inline(never)]
-#[unsafe(link_section = ".rwtext")]
+#[ram]
 pub(crate) fn spiflash_read(src_addr: u32, data: *const u32, len: u32) -> i32 {
     maybe_with_critical_section(|| unsafe { esp_rom_spiflash_read(src_addr, data, len) })
 }
 
-#[inline(never)]
-#[unsafe(link_section = ".rwtext")]
+#[ram]
 pub(crate) fn spiflash_unlock() -> i32 {
     maybe_with_critical_section(|| unsafe { esp_rom_spiflash_unlock() })
 }
 
-#[inline(never)]
-#[unsafe(link_section = ".rwtext")]
+#[ram]
 pub(crate) fn spiflash_erase_sector(sector_number: u32) -> i32 {
     maybe_with_critical_section(|| unsafe { esp_rom_spiflash_erase_sector(sector_number) })
 }
 
-#[inline(never)]
-#[unsafe(link_section = ".rwtext")]
+#[ram]
 pub(crate) fn spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 {
     maybe_with_critical_section(|| unsafe { esp_rom_spiflash_write(dest_addr, data, len) })
 }

--- a/esp-storage/src/lib.rs
+++ b/esp-storage/src/lib.rs
@@ -17,7 +17,6 @@ mod storage;
 
 #[cfg(not(feature = "emulation"))]
 #[inline(always)]
-#[cfg_attr(not(target_os = "macos"), unsafe(link_section = ".rwtext"))]
 fn maybe_with_critical_section<R>(f: impl FnOnce() -> R) -> R {
     #[cfg(feature = "critical-section")]
     return critical_section::with(|_| f());


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

Closes #3954

#### Testing

Running examples locally, CI
