### PR TITLE
Allow running specific tests

### DIFF
--- a/xtask/src/commands/build.rs
+++ b/xtask/src/commands/build.rs
@@ -147,7 +147,8 @@ pub fn build_examples(
             let example_idx = inquire::Select::new(
                 "Select the example:",
                 examples.iter().map(|ex| ex.binary_name()).collect(),
-            ).prompt()?;
+            )
+            .prompt()?;
 
             if let Some(selected) = examples.iter().find(|ex| ex.binary_name() == example_idx) {
                 filtered.push(selected);
@@ -165,6 +166,7 @@ pub fn build_examples(
                 args.debug,
                 args.toolchain.as_deref(),
                 args.timings,
+                &[],
             )?;
         }
 
@@ -182,6 +184,7 @@ pub fn build_examples(
                 args.debug,
                 args.toolchain.as_deref(),
                 args.timings,
+                &[],
             )
         })
     }

--- a/xtask/src/commands/run.rs
+++ b/xtask/src/commands/run.rs
@@ -8,7 +8,7 @@ use anyhow::{Context as _, Result, bail};
 use clap::{Args, Subcommand};
 use esp_metadata::Chip;
 
-use super::{ExamplesArgs, TestsArgs, DocTestArgs};
+use super::{DocTestArgs, ExamplesArgs, TestsArgs};
 use crate::{
     cargo::{CargoAction, CargoArgsBuilder},
     firmware::Metadata,
@@ -162,14 +162,16 @@ pub fn run_examples(
             )
             .prompt()?;
 
-            if let Some(selected) = examples.into_iter().find(|ex| ex.binary_name() == example_idx) {
+            if let Some(selected) = examples
+                .into_iter()
+                .find(|ex| ex.binary_name() == example_idx)
+            {
                 filtered.push(selected);
             }
         }
 
         examples = filtered;
     }
-
 
     examples.sort_by_key(|ex| ex.tag());
 
@@ -213,6 +215,7 @@ pub fn run_examples(
                     args.debug,
                     args.toolchain.as_deref(),
                     args.timings,
+                    &[],
                 )
                 .is_err()
             {

--- a/xtask/src/firmware.rs
+++ b/xtask/src/firmware.rs
@@ -93,8 +93,8 @@ impl Metadata {
         self.description.clone()
     }
 
-    pub fn matches(&self, filter: &Option<String>) -> bool {
-        let Some(filter) = filter.as_deref() else {
+    pub fn matches(&self, filter: Option<&str>) -> bool {
+        let Some(filter) = filter else {
             return false;
         };
 

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -371,6 +371,7 @@ pub fn execute_app(
     debug: bool,
     toolchain: Option<&str>,
     timings: bool,
+    extra_args: &[&str],
 ) -> Result<()> {
     let package = app.example_path().strip_prefix(package_path)?;
     log::info!("Building example '{}' for '{}'", package.display(), chip);
@@ -446,6 +447,8 @@ pub fn execute_app(
         }
         builder = builder.toolchain(toolchain);
     }
+
+    builder = builder.args(extra_args);
 
     let args = builder.build();
     log::debug!("{args:#?}");


### PR DESCRIPTION
probe-rs supports filtering tests. This PR exposes this to us via the xtask, so that I don't keep accidentally committing trimming down test files...

example: `cargo xtask run tests esp32 --test sha::test_for_digest_rolling` will skip running the 10s+ 1-to-200 test case.