### PR TITLE
[esp-backtrace]: Only halt cores when using the halt-core feature

### DIFF
--- a/esp-backtrace/CHANGELOG.md
+++ b/esp-backtrace/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `exception-handler` now panics. (#3838)
+- Only halt cores in panics when `halt-cores` feature is enabled. (#4010)
 
 ### Fixed
 

--- a/esp-backtrace/Cargo.toml
+++ b/esp-backtrace/Cargo.toml
@@ -20,6 +20,7 @@ test  = false
 
 [dependencies]
 cfg-if      = "1.0.0"
+critical-section = "1.1.2"
 defmt       = { version = "1", optional = true }
 esp-config  = { version = "0.5.0", path = "../esp-config" }
 esp-println = { version = "0.15.0", optional = true, default-features = false, path = "../esp-println" }
@@ -53,7 +54,7 @@ print-float-registers = [] # TODO support esp32p4
 # additional functionality:
 ## Print messages in red
 colors               = []
-## Invoke the extern function `custom_halt()` instead of doing a loop {} in case of a panic
+## Invoke the extern function `custom_halt()` instead of doing a loop {} in case of a panic. This feature does not implies `halt-cores` feature.
 custom-halt          = []
 ## Invoke the extern function `custom_pre_backtrace()` before handling a panic
 custom-pre-backtrace = []

--- a/esp-backtrace/Cargo.toml
+++ b/esp-backtrace/Cargo.toml
@@ -54,7 +54,7 @@ print-float-registers = [] # TODO support esp32p4
 # additional functionality:
 ## Print messages in red
 colors               = []
-## Invoke the extern function `custom_halt()` instead of doing a loop {} in case of a panic. This feature does not implies `halt-cores` feature.
+## Invoke the extern function `custom_halt()` instead of doing a loop {} in case of a panic. This feature does not imply the `halt-cores` feature.
 custom-halt          = []
 ## Invoke the extern function `custom_pre_backtrace()` before handling a panic
 custom-pre-backtrace = []

--- a/esp-backtrace/src/lib.rs
+++ b/esp-backtrace/src/lib.rs
@@ -157,11 +157,6 @@ fn is_valid_ram_address(address: u32) -> bool {
         return false;
     }
 
-    #[cfg(feature = "esp32p4")]
-    if !(0x4FF0_0000..=0x4FFC_0000).contains(&address) {
-        return false;
-    }
-
     #[cfg(feature = "esp32s2")]
     if !(0x3FFB_0000..=0x4000_0000).contains(&address) {
         return false;
@@ -184,18 +179,13 @@ fn halt() -> ! {
                 fn custom_halt() -> !;
             }
             unsafe { custom_halt() }
-        } else if #[cfg(any(feature = "esp32", /*feature = "esp32p4",*/ feature = "esp32s3"))] {
+        } else if #[cfg(any(feature = "esp32", feature = "esp32s3"))] {
             // multi-core
             #[cfg(feature = "esp32")]
             mod registers {
                 pub(crate) const OPTIONS0: u32 = 0x3ff48000;
                 pub(crate) const SW_CPU_STALL: u32 = 0x3ff480ac;
             }
-
-            // #[cfg(feature = "esp32p4")]
-            // mod registers {
-            //     pub(crate) const SW_CPU_STALL: u32 = 0x50115200;
-            // }
 
             #[cfg(feature = "esp32s3")]
             mod registers {

--- a/esp-backtrace/src/lib.rs
+++ b/esp-backtrace/src/lib.rs
@@ -170,7 +170,7 @@ fn is_valid_ram_address(address: u32) -> bool {
     true
 }
 
-#[cfg(feature = "panic-handler")]
+#[cfg(feature = "halt-cores")]
 fn halt() -> ! {
     cfg_if::cfg_if! {
         if #[cfg(feature = "custom-halt")] {

--- a/esp-backtrace/src/lib.rs
+++ b/esp-backtrace/src/lib.rs
@@ -240,7 +240,9 @@ fn abort() -> ! {
         } else if #[cfg(feature = "halt-cores")] {
             halt();
         } else {
-            loop {}
+            critical_section::with(|_| {
+                loop {}
+            })
         }
     }
 }

--- a/esp-backtrace/src/lib.rs
+++ b/esp-backtrace/src/lib.rs
@@ -192,10 +192,10 @@ fn halt() -> ! {
                 pub(crate) const SW_CPU_STALL: u32 = 0x3ff480ac;
             }
 
-            #[cfg(feature = "esp32p4")]
-            mod registers {
-                pub(crate) const SW_CPU_STALL: u32 = 0x50115200;
-            }
+            // #[cfg(feature = "esp32p4")]
+            // mod registers {
+            //     pub(crate) const SW_CPU_STALL: u32 = 0x50115200;
+            // }
 
             #[cfg(feature = "esp32s3")]
             mod registers {
@@ -247,8 +247,10 @@ fn abort() -> ! {
     cfg_if::cfg_if! {
         if #[cfg(feature = "semihosting")] {
             semihosting::process::abort();
-        } else {
+        } else if #[cfg(feature = "halt-cores")] {
             halt();
+        } else {
+            loop {}
         }
     }
 }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Only halt cores when using the `halt-core` feature.

#### Testing
Local example and CI.