### PR TITLE
Fix `wifi` examples

### DIFF
--- a/esp-radio/src/common_adapter/mod.rs
+++ b/esp-radio/src/common_adapter/mod.rs
@@ -347,13 +347,6 @@ pub(crate) unsafe fn phy_disable_clock() {
 }
 
 pub(crate) fn phy_calibrate() {
-    // Set PHY whether in combo module
-    // For comode mode, phy enable will be not in WiFi RX state
-    #[cfg(not(any(esp32s2, esp32h2)))]
-    unsafe {
-        esp_wifi_sys::include::phy_init_param_set(1);
-    }
-
     let phy_version = unsafe { get_phy_version_str() };
     trace!("phy_version {}", unsafe { str_from_c(phy_version) });
 


### PR DESCRIPTION
[#4003](https://github.com/esp-rs/esp-hal/pull/4003/files#diff-6b9d424b8ab8e83098ac6dca1a112df2ebc7df06f0ce0f81aad78cf65b046dedR350-R355) broke `wifi` examples (they couldn't connect). This reverts problematic addition. `802.15.4` examples should be still working fine