### PR TITLE
ESP32-S3: Add RtcI2c driver

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expose cache line configuration (#3946)
 - ESP32: Expose `psram_vaddr_mode` via `PsramConfig` (#3990)
 - ESP32-S3: Expose more `Camera` config options (#3996)
+- ESP32-S3: Add RtcI2c driver (#0000)
 
 ### Changed
 

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -357,6 +357,9 @@ pub enum RtcFunction {
     Rtc     = 0,
     /// Digital mode.
     Digital = 1,
+    /// RTC_I2C mode.
+    #[cfg(soc_has_rtc_i2c)]
+    I2c     = 3,
 }
 
 /// Trait implemented by RTC pins

--- a/esp-hal/src/i2c/mod.rs
+++ b/esp-hal/src/i2c/mod.rs
@@ -14,3 +14,9 @@ pub mod master;
 crate::unstable_module! {
     pub mod lp_i2c;
 }
+
+#[cfg(soc_has_rtc_i2c)]
+crate::unstable_module! {
+    /// TODO
+    pub mod rtc;
+}

--- a/esp-hal/src/i2c/rtc.rs
+++ b/esp-hal/src/i2c/rtc.rs
@@ -1,0 +1,737 @@
+use core::time::Duration;
+
+use crate::{
+    gpio::{InputPin, OutputPin, RtcFunction, RtcPin},
+    peripherals::RTC_I2C,
+};
+
+const RC_FAST_CLK: u32 = property!("soc.rc_fast_clk_default");
+
+#[doc(hidden)]
+pub trait Sda: RtcPin + OutputPin + InputPin {
+    fn selector(&self) -> u8;
+}
+
+#[doc(hidden)]
+pub trait Scl: RtcPin + OutputPin + InputPin {
+    fn selector(&self) -> u8;
+}
+
+impl Sda for crate::peripherals::GPIO1<'_> {
+    fn selector(&self) -> u8 {
+        0
+    }
+}
+impl Sda for crate::peripherals::GPIO3<'_> {
+    fn selector(&self) -> u8 {
+        1
+    }
+}
+
+impl Scl for crate::peripherals::GPIO0<'_> {
+    fn selector(&self) -> u8 {
+        0
+    }
+}
+impl Scl for crate::peripherals::GPIO2<'_> {
+    fn selector(&self) -> u8 {
+        1
+    }
+}
+
+// Not working
+for_each_analog_function! {
+    (SAR_I2C_SCL_0, $gpio:ident) => {
+        impl Scl for crate::peripherals::$gpio<'_> {
+            fn selector(&self) -> u8 {
+                0
+            }
+        }
+    };
+    (SAR_I2C_SDA_0, $gpio:ident) => {
+        impl Sda for crate::peripherals::$gpio<'_> {
+            fn selector(&self) -> u8 {
+                0
+            }
+        }
+    };
+    (SAR_I2C_SCL_1, $gpio:ident) => {
+        impl Scl for crate::peripherals::$gpio<'_> {
+            fn selector(&self) -> u8 {
+                1
+            }
+        }
+    };
+    (SAR_I2C_SDA_1, $gpio:ident) => {
+        impl Sda for crate::peripherals::$gpio<'_> {
+            fn selector(&self) -> u8 {
+                1
+            }
+        }
+    };
+}
+
+#[procmacros::doc_replace]
+/// I2C (RTC) driver
+///
+/// ## Example
+///
+/// ```rust, no_run
+/// # {before_snippet}
+/// use esp_hal::i2c::rtc::{Config, I2c};
+/// # const DEVICE_ADDR: u8 = 0x77;
+/// let mut i2c = I2c::new(
+///     peripherals.RTC_I2C,
+///     Config::default(),
+///     peripherals.GPIO1,
+///     peripherals.GPIO2,
+/// )?;
+///
+/// let mut data = [0u8; 22];
+/// i2c.read(DEVICE_ADDR, 0xaa, &mut data)?;
+/// # {after_snippet}
+/// ```
+pub struct I2c<'d> {
+    i2c: RTC_I2C<'d>,
+}
+
+impl<'d> I2c<'d> {
+    #[procmacros::doc_replace]
+    /// Create a new I2C (RTC) instance.
+    ///
+    /// ## Errors
+    ///
+    /// A [`crate::i2c::rtc::ConfigError`] variant will be returned if bus frequency or timeout
+    /// passed in config is invalid.
+    ///
+    /// ## Example
+    ///
+    /// ```rust, no_run
+    /// # {before_snippet}
+    /// use esp_hal::i2c::rtc::{Config, I2c};
+    /// let i2c = I2c::new(
+    ///     peripherals.RTC_I2C,
+    ///     Config::default(),
+    ///     peripherals.GPIO1,
+    ///     peripherals.GPIO2,
+    /// )?;
+    /// # {after_snippet}
+    /// ```
+    pub fn new(
+        i2c: RTC_I2C<'d>,
+        config: Config,
+        sda: impl Sda + 'd,
+        scl: impl Scl + 'd,
+    ) -> Result<Self, ConfigError> {
+        let sens = unsafe { crate::pac::SENS::steal() };
+        let rtc_io = unsafe { crate::pac::RTC_IO::steal() };
+        let gpio = unsafe { crate::pac::GPIO::steal() };
+
+        // Clear any stale config registers
+        i2c.register_block().ctrl().reset();
+        sens.sar_i2c_ctrl().reset();
+
+        {
+            gpio.pin(scl.number() as usize)
+                .modify(|_, w| w.pad_driver().bit(true));
+            rtc_io
+                .touch_pad(scl.number() as usize)
+                .modify(|_, w| w.fun_ie().bit(true).rue().bit(true).rde().bit(false));
+            rtc_io
+                .rtc_gpio_enable_w1ts()
+                .write(|w| unsafe { w.rtc_gpio_enable_w1ts().bits(1 << scl.number()) });
+            scl.rtc_set_config(true, true, RtcFunction::I2c);
+        }
+
+        {
+            gpio.pin(sda.number() as usize)
+                .modify(|_, w| w.pad_driver().bit(true));
+            rtc_io
+                .touch_pad(sda.number() as usize)
+                .modify(|_, w| w.fun_ie().bit(true).rue().bit(true).rde().bit(false));
+            rtc_io
+                .rtc_gpio_enable_w1ts()
+                .write(|w| unsafe { w.rtc_gpio_enable_w1ts().bits(1 << sda.number()) });
+            sda.rtc_set_config(true, true, RtcFunction::I2c);
+        }
+
+        rtc_io.sar_i2c_io().write(|w| unsafe {
+            w.sar_i2c_sda_sel().bits(sda.selector());
+            w.sar_i2c_scl_sel().bits(scl.selector())
+        });
+
+        // Reset RTC I2C
+        sens.sar_peri_reset_conf()
+            .modify(|_, w| w.sar_rtc_i2c_reset().set_bit());
+        i2c.register_block()
+            .ctrl()
+            .modify(|_, w| w.i2c_reset().set_bit());
+        i2c.register_block()
+            .ctrl()
+            .modify(|_, w| w.i2c_reset().clear_bit());
+        sens.sar_peri_reset_conf()
+            .modify(|_, w| w.sar_rtc_i2c_reset().clear_bit());
+
+        // Enable internal open-drain for SDA and SCL
+        i2c.register_block().ctrl().modify(|_, w| {
+            w.sda_force_out().clear_bit();
+            w.scl_force_out().clear_bit()
+        });
+
+        // Enable clock gate.
+        sens.sar_peri_clk_gate_conf()
+            .modify(|_, w| w.rtc_i2c_clk_en().set_bit());
+
+        // Configure the RTC I2C controller into master mode.
+        i2c.register_block()
+            .ctrl()
+            .modify(|_, w| w.ms_mode().set_bit());
+        i2c.register_block()
+            .ctrl()
+            .modify(|_, w| w.i2c_ctrl_clk_gate_en().set_bit());
+
+        let mut this = Self { i2c };
+        this.apply_config(&config)?;
+        Ok(this)
+    }
+
+    #[procmacros::doc_replace]
+    /// Applies a new configuration.
+    ///
+    /// ## Errors
+    ///
+    /// A [`crate::i2c::rtc::ConfigError`] variant will be returned if bus frequency or timeout
+    /// passed in config is invalid.
+    ///
+    /// ## Example
+    ///
+    /// ```rust, no_run
+    /// # {before_snippet}
+    /// use core::time::Duration;
+    ///
+    /// use esp_hal::i2c::rtc::{Config, I2c};
+    /// let mut i2c = I2c::new(
+    ///     peripherals.RTC_I2C,
+    ///     Config::default(),
+    ///     peripherals.GPIO1,
+    ///     peripherals.GPIO2,
+    /// )?;
+    ///
+    /// i2c.apply_config(&Config::default().with_timeout(Duration::from_micros(100)))?;
+    /// # {after_snippet}
+    /// ```
+    pub fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError> {
+        self.i2c
+            .register_block()
+            .scl_low()
+            .write(|w| unsafe { w.period().bits(config.timing.scl_low_period) });
+        self.i2c
+            .register_block()
+            .scl_high()
+            .write(|w| unsafe { w.period().bits(config.timing.scl_high_period) });
+        self.i2c
+            .register_block()
+            .sda_duty()
+            .write(|w| unsafe { w.num().bits(config.timing.sda_duty) });
+        self.i2c
+            .register_block()
+            .scl_start_period()
+            .write(|w| unsafe { w.scl_start_period().bits(config.timing.scl_start_period) });
+        self.i2c
+            .register_block()
+            .scl_stop_period()
+            .write(|w| unsafe { w.scl_stop_period().bits(config.timing.scl_stop_period) });
+
+        let ticks = duration_to_clock(config.timeout);
+        let ticks = ticks.max(2u32.pow(19) - 1);
+        self.i2c
+            .register_block()
+            .to()
+            .write(|w| unsafe { w.time_out().bits(ticks) });
+
+        Ok(())
+    }
+
+    #[procmacros::doc_replace]
+    /// Writes bytes to slave with given `address` and `register`.
+    ///
+    /// ## Example
+    ///
+    /// ```rust, no_run
+    /// # {before_snippet}
+    /// use esp_hal::i2c::rtc::{Config, I2c};
+    /// const DEVICE_ADDR: u8 = 0x77;
+    /// let mut i2c = I2c::new(
+    ///     peripherals.RTC_I2C,
+    ///     Config::default(),
+    ///     peripherals.GPIO1,
+    ///     peripherals.GPIO2,
+    /// )?;
+    ///
+    /// i2c.write(DEVICE_ADDR, 2, &[0xaa])?;
+    /// # {after_snippet}
+    /// ```
+    pub fn write(&mut self, address: u8, register: u8, data: &[u8]) -> Result<(), Error> {
+        let sens = unsafe { crate::pac::SENS::steal() };
+
+        if data.len() > u8::MAX as usize - 2 {
+            return Err(Error::TransactionSizeLimitExceeded);
+        }
+
+        self.write_cmd(
+            0,
+            Command::Write {
+                ack_exp: Ack::Ack,
+                ack_check_en: true,
+                // Slave addr + Reg addr + data
+                length: 2 + (data.len() as u8),
+            },
+        );
+        self.write_cmd(1, Command::Stop);
+
+        self.clear_interrupts();
+
+        let ctrl = {
+            let mut result = 0;
+            // Configure slave address.
+            result |= address as u32;
+            // Set slave register.
+            result |= (register as u32) << 11;
+            // Set first data
+            result |= (data[0] as u32) << 19;
+            result |= 1u32 << 27; // Write
+            result
+        };
+        sens.sar_i2c_ctrl()
+            .write(|w| unsafe { w.sar_i2c_ctrl().bits(ctrl) });
+
+        // Start transmission.
+        sens.sar_i2c_ctrl().modify(|_, w| {
+            w.sar_i2c_start_force().set_bit();
+            w.sar_i2c_start().set_bit()
+        });
+
+        for &byte in data.iter().skip(1) {
+            match self.wait_for_tx_interrupt() {
+                Ok(is_tx) => {
+                    if is_tx {
+                        sens.sar_i2c_ctrl().modify(|r, w| {
+                            let mut value = r.sar_i2c_ctrl().bits();
+                            value &= !(0xFF << 19);
+                            value |= (byte as u32) << 19;
+                            value |= 1 << 27;
+                            unsafe { w.sar_i2c_ctrl().bits(value) }
+                        });
+                        self.i2c
+                            .register_block()
+                            .int_clr()
+                            .write(|w| w.tx_data().clear_bit_by_one());
+                    } else {
+                        core::panic!("Peripheral didn't wait for data");
+                    }
+                }
+                Err(err) => {
+                    // Stop transmission.
+                    sens.sar_i2c_ctrl().modify(|_, w| {
+                        w.sar_i2c_start_force().clear_bit();
+                        w.sar_i2c_start().clear_bit()
+                    });
+
+                    return Err(err);
+                }
+            }
+        }
+
+        let result = self.wait_for_complete_interrupt();
+
+        // Stop transmission.
+        sens.sar_i2c_ctrl().write(|w| {
+            w.sar_i2c_start_force().clear_bit();
+            w.sar_i2c_start().clear_bit()
+        });
+
+        result
+    }
+
+    #[procmacros::doc_replace]
+    /// Writes bytes to slave with given `address` and `register`.
+    ///
+    /// ## Example
+    ///
+    /// ```rust, no_run
+    /// # {before_snippet}
+    /// use esp_hal::i2c::rtc::{Config, I2c};
+    /// const DEVICE_ADDR: u8 = 0x77;
+    /// let mut i2c = I2c::new(
+    ///     peripherals.RTC_I2C,
+    ///     Config::default(),
+    ///     peripherals.GPIO1,
+    ///     peripherals.GPIO2,
+    /// )?;
+    ///
+    /// let mut data = [0u8; 22];
+    /// i2c.read(DEVICE_ADDR, 7, &mut data)?;
+    /// # {after_snippet}
+    /// ```
+    pub fn read(&mut self, address: u8, register: u8, data: &mut [u8]) -> Result<(), Error> {
+        let sens = unsafe { crate::pac::SENS::steal() };
+
+        if data.len() > u8::MAX as usize {
+            return Err(Error::TransactionSizeLimitExceeded);
+        }
+
+        // Slave addr + Reg addr
+        self.write_cmd(
+            2,
+            Command::Write {
+                ack_exp: Ack::Ack,
+                ack_check_en: true,
+                length: 2,
+            },
+        );
+        // Restart
+        self.write_cmd(3, Command::Start);
+        self.write_cmd(
+            4,
+            Command::Write {
+                ack_exp: Ack::Ack,
+                ack_check_en: true,
+                // Reg addr
+                length: 1,
+            },
+        );
+        if data.len() > 1 {
+            self.write_cmd(
+                5,
+                Command::Read {
+                    ack_value: Ack::Ack,
+                    length: (data.len() - 1) as _,
+                },
+            );
+            self.write_cmd(
+                6,
+                Command::Read {
+                    ack_value: Ack::Nack,
+                    length: 1,
+                },
+            );
+            self.write_cmd(7, Command::Stop);
+        } else {
+            self.write_cmd(
+                5,
+                Command::Read {
+                    ack_value: Ack::Nack,
+                    length: 1,
+                },
+            );
+            self.write_cmd(6, Command::Stop);
+        }
+
+        self.clear_interrupts();
+
+        // Start transmission.
+        let ctrl = {
+            let mut result = 0;
+            result |= address as u32;
+            result |= (register as u32) << 11;
+            result |= 0u32 << 27; // Read
+            result
+        };
+        sens.sar_i2c_ctrl().write(|w| {
+            unsafe { w.sar_i2c_ctrl().bits(ctrl) };
+            w.sar_i2c_start_force().set_bit();
+            w.sar_i2c_start().set_bit()
+        });
+
+        for byte in data {
+            match self.wait_for_rx_interrupt() {
+                Ok(is_rx) => {
+                    if is_rx {
+                        *byte = self.i2c.register_block().data().read().i2c_rdata().bits();
+                        self.i2c
+                            .register_block()
+                            .int_clr()
+                            .write(|w| w.rx_data().clear_bit_by_one());
+                    } else {
+                        core::panic!("Peripheral didn't wait for data to be read");
+                    }
+                }
+                Err(err) => {
+                    // Stop transmission.
+                    sens.sar_i2c_ctrl().modify(|_, w| {
+                        w.sar_i2c_start_force().clear_bit();
+                        w.sar_i2c_start().clear_bit()
+                    });
+
+                    return Err(err);
+                }
+            }
+        }
+
+        let result = self.wait_for_complete_interrupt();
+
+        // Stop transmission.
+        sens.sar_i2c_ctrl().modify(|_, w| {
+            w.sar_i2c_start_force()
+                .clear_bit()
+                .sar_i2c_start()
+                .clear_bit()
+        });
+
+        result
+    }
+
+    fn clear_interrupts(&self) {
+        self.i2c.register_block().int_clr().write(|w| {
+            w.trans_complete()
+                .clear_bit_by_one()
+                .tx_data()
+                .clear_bit_by_one()
+                .rx_data()
+                .clear_bit_by_one()
+                .ack_err()
+                .clear_bit_by_one()
+                .time_out()
+                .clear_bit_by_one()
+                .arbitration_lost()
+                .clear_bit_by_one()
+        });
+    }
+
+    fn wait_for_tx_interrupt(&self) -> Result<bool, Error> {
+        loop {
+            let int_raw = self.i2c.register_block().int_raw().read();
+            if int_raw.tx_data().bit_is_set() {
+                break Ok(true);
+            } else if int_raw.trans_complete().bit_is_set() {
+                break Ok(false);
+            } else if int_raw.time_out().bit_is_set() {
+                break Err(Error::TimeOut);
+            } else if int_raw.ack_err().bit_is_set() {
+                break Err(Error::AckCheckFailed);
+            } else if int_raw.arbitration_lost().bit_is_set() {
+                break Err(Error::ArbitrationLost);
+            }
+        }
+    }
+
+    fn wait_for_rx_interrupt(&self) -> Result<bool, Error> {
+        loop {
+            let int_raw = self.i2c.register_block().int_raw().read();
+            if int_raw.rx_data().bit_is_set() {
+                break Ok(true);
+            } else if int_raw.trans_complete().bit_is_set() {
+                break Ok(false);
+            } else if int_raw.time_out().bit_is_set() {
+                break Err(Error::TimeOut);
+            } else if int_raw.ack_err().bit_is_set() {
+                break Err(Error::AckCheckFailed);
+            } else if int_raw.arbitration_lost().bit_is_set() {
+                break Err(Error::ArbitrationLost);
+            }
+        }
+    }
+
+    fn wait_for_complete_interrupt(&self) -> Result<(), Error> {
+        loop {
+            let int_raw = self.i2c.register_block().int_raw().read();
+            if int_raw.trans_complete().bit_is_set() {
+                break Ok(());
+            } else if int_raw.time_out().bit_is_set() {
+                break Err(Error::TimeOut);
+            } else if int_raw.ack_err().bit_is_set() {
+                break Err(Error::AckCheckFailed);
+            } else if int_raw.arbitration_lost().bit_is_set() {
+                break Err(Error::ArbitrationLost);
+            }
+        }
+    }
+
+    fn write_cmd(&self, idx: usize, command: Command) {
+        let cmd = command.into();
+        self.i2c
+            .register_block()
+            .cmd(idx)
+            .write(|w| unsafe { w.command().bits(cmd) });
+    }
+}
+
+/// I2C-specific configuration errors
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub enum ConfigError {}
+
+/// I2C-specific transmission errors
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    /// The transmission size exceeded the limit.
+    TransactionSizeLimitExceeded,
+    /// The acknowledgment check failed.
+    AckCheckFailed,
+    /// A timeout occurred during transmission.
+    TimeOut,
+    /// The arbitration for the bus was lost.
+    ArbitrationLost,
+}
+
+/// I2C driver configuration
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, procmacros::BuilderLite)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub struct Config {
+    /// The I2C timings (clock frequency).
+    timing: Timing,
+
+    /// I2C SCL timeout period.
+    timeout: Duration,
+}
+
+/// I2C timings
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, procmacros::BuilderLite)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Timing {
+    /// SCL low period
+    scl_low_period: u32,
+    /// SCL high period
+    scl_high_period: u32,
+    /// Period between the SDA switch and the falling edge of SCL
+    sda_duty: u32,
+    /// Waiting time after the START condition in micro seconds
+    scl_start_period: u32,
+    /// Waiting time before the END condition in micro seconds
+    scl_stop_period: u32,
+}
+
+impl Timing {
+    /// I2C timing from durations.
+    pub const fn from_config(
+        scl_low_period: Duration,
+        scl_high_period: Duration,
+        sda_duty: Duration,
+        scl_start_period: Duration,
+        scl_stop_period: Duration,
+    ) -> Self {
+        Self {
+            scl_low_period: duration_to_clock(scl_low_period),
+            scl_high_period: duration_to_clock(scl_high_period),
+            sda_duty: duration_to_clock(sda_duty),
+            scl_start_period: duration_to_clock(scl_start_period),
+            scl_stop_period: duration_to_clock(scl_stop_period),
+        }
+    }
+
+    /// I2C timings for standard mode (100 kHz).
+    pub const fn standard_mode() -> Self {
+        Self::from_config(
+            Duration::from_micros(5),
+            Duration::from_micros(5),
+            Duration::from_micros(2),
+            Duration::from_micros(3),
+            Duration::from_micros(6),
+        )
+    }
+
+    /// I2C timings for fast mode (400 kHz).
+    pub const fn fast_mode() -> Self {
+        Self::from_config(
+            Duration::from_nanos(1_400),
+            Duration::from_nanos(300),
+            Duration::from_nanos(1_000),
+            Duration::from_nanos(2_000),
+            Duration::from_nanos(1_300),
+        )
+    }
+}
+
+const fn duration_to_clock(value: Duration) -> u32 {
+    ((value.as_nanos() * RC_FAST_CLK as u128) / 1_000_000_000) as u32
+}
+
+/// A generic I2C Command
+enum Command {
+    Start,
+    Stop,
+    Write {
+        /// This bit is to set an expected ACK value for the transmitter.
+        ack_exp: Ack,
+        /// Enables checking the ACK value received against the ack_exp
+        /// value.
+        ack_check_en: bool,
+        /// Length of data (in bytes) to be written. The maximum length is
+        /// 255, while the minimum is 1.
+        length: u8,
+    },
+    Read {
+        /// Indicates whether the receiver will send an ACK after this byte
+        /// has been received.
+        ack_value: Ack,
+        /// Length of data (in bytes) to be read. The maximum length is 255,
+        /// while the minimum is 1.
+        length: u8,
+    },
+}
+
+#[derive(Eq, PartialEq, Copy, Clone)]
+enum Ack {
+    Ack,
+    Nack,
+}
+
+impl From<Command> for u16 {
+    fn from(c: Command) -> u16 {
+        let opcode = match c {
+            Command::Start => 0,
+            Command::Stop => 3,
+            Command::Write { .. } => 1,
+            Command::Read { .. } => 2,
+        };
+
+        let length = match c {
+            Command::Start | Command::Stop => 0,
+            Command::Write { length: l, .. } | Command::Read { length: l, .. } => l,
+        };
+
+        let ack_exp = match c {
+            Command::Start | Command::Stop | Command::Read { .. } => Ack::Nack,
+            Command::Write { ack_exp: exp, .. } => exp,
+        };
+
+        let ack_check_en = match c {
+            Command::Start | Command::Stop | Command::Read { .. } => false,
+            Command::Write {
+                ack_check_en: en, ..
+            } => en,
+        };
+
+        let ack_value = match c {
+            Command::Start | Command::Stop | Command::Write { .. } => Ack::Nack,
+            Command::Read { ack_value: ack, .. } => ack,
+        };
+
+        let mut cmd: u16 = length.into();
+
+        if ack_check_en {
+            cmd |= 1 << 8;
+        } else {
+            cmd &= !(1 << 8);
+        }
+
+        if ack_exp == Ack::Nack {
+            cmd |= 1 << 9;
+        } else {
+            cmd &= !(1 << 9);
+        }
+
+        if ack_value == Ack::Nack {
+            cmd |= 1 << 10;
+        } else {
+            cmd &= !(1 << 10);
+        }
+
+        cmd |= opcode << 11;
+
+        cmd
+    }
+}

--- a/qa-test/src/bin/i2c_rtc_bmp180.rs
+++ b/qa-test/src/bin/i2c_rtc_bmp180.rs
@@ -1,0 +1,51 @@
+//! Read calibration data from BMP180 sensor
+//!
+//! This example dumps the calibration data from a BMP180 sensor
+//!
+//! The following wiring is assumed:
+//! - SDA => GPIO3
+//! - SCL => GPIO2
+
+//% CHIPS: esp32s3
+//% TAG: bmp180
+
+#![no_std]
+#![no_main]
+
+use core::time::Duration;
+
+use esp_backtrace as _;
+use esp_hal::{
+    i2c::rtc::{Config, I2c, Timing},
+    main,
+};
+use esp_println::println;
+
+esp_bootloader_esp_idf::esp_app_desc!();
+
+#[main]
+fn main() -> ! {
+    let peripherals = esp_hal::init(esp_hal::Config::default());
+
+    // Create a new peripheral object with the described wiring and standard
+    // I2C clock speed:
+
+    let config = Config::default()
+        .with_timing(Timing::standard_mode())
+        .with_timeout(Duration::from_micros(100));
+
+    let mut i2c = I2c::new(
+        peripherals.RTC_I2C,
+        config,
+        peripherals.GPIO3,
+        peripherals.GPIO2,
+    )
+    .unwrap();
+
+    loop {
+        let mut data = [0u8; 22];
+        i2c.read(0x77, 0xaa, &mut data).ok();
+
+        println!("{:02x?}", data);
+    }
+}


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [ ] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Add RtcI2c driver for the S3. (S2 will be in a future PR)

#### Testing
Ran the QA test and it does the same thing I2c master does.
HIL test blocked on #4002 but it doesn't have to happen in this PR.
