### PR TITLE
Use div_ceil for buffer size calculation

### DIFF
--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -551,7 +551,7 @@ macro_rules! declare_aligned_dma_buffer {
         // ESP32-S2 technically supports byte-aligned DMA buffers, but the
         // transfer ends up writing out of bounds.
         // if the buffer's length is 2 or 3 (mod 4).
-        static mut $name: [u32; ($size + 3) / 4] = [0; ($size + 3) / 4];
+        static mut $name: [u32; $size.div_ceil(4)] = [0; $size.div_ceil(4)];
     };
 }
 


### PR DESCRIPTION
### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Replace manual ceiling division with Rust's built-in div_ceil method for improved readability and standard library usage in DMA buffer allocation macro.

#### Testing
Using this macro.
