### PR TITLE
Make internals private

### DIFF
--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -1786,7 +1786,7 @@ mod private {
 
 /// Wi-Fi device operational modes.
 #[derive(Debug, Clone, Copy)]
-pub enum WifiDeviceMode {
+enum WifiDeviceMode {
     /// Station mode.
     Sta,
     /// Access Point mode.

--- a/esp-radio/src/wifi/state.rs
+++ b/esp-radio/src/wifi/state.rs
@@ -1,31 +1,36 @@
 use core::sync::atomic::Ordering;
 
-use portable_atomic_enum::atomic_enum;
+use private::AtomicWifiState;
+pub use private::WifiState;
 
 use super::WifiEvent;
 
-/// Wi-Fi interface state.
-#[atomic_enum]
-#[derive(PartialEq, Debug)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[non_exhaustive]
-pub enum WifiState {
-    /// Station started.
-    StaStarted,
-    /// Station connected.
-    StaConnected,
-    /// Station disconnected.
-    StaDisconnected,
-    /// Station stopped
-    StaStopped,
+mod private {
+    use portable_atomic_enum::atomic_enum;
 
-    /// Access point started.
-    ApStarted,
-    /// Access point stopped.
-    ApStopped,
+    /// Wi-Fi interface state.
+    #[atomic_enum]
+    #[derive(PartialEq, Debug)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+    #[non_exhaustive]
+    pub enum WifiState {
+        /// Station started.
+        StaStarted,
+        /// Station connected.
+        StaConnected,
+        /// Station disconnected.
+        StaDisconnected,
+        /// Station stopped
+        StaStopped,
 
-    /// Invalid Wi-Fi state.
-    Invalid,
+        /// Access point started.
+        ApStarted,
+        /// Access point stopped.
+        ApStopped,
+
+        /// Invalid Wi-Fi state.
+        Invalid,
+    }
 }
 
 impl From<WifiEvent> for WifiState {


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [ ] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

Shrink the wifi API surface by making internal types private

#### Testing
CI
