### PR TITLE
Remove esp-backtrace from hil tests

### DIFF
--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -245,7 +245,6 @@ embedded-io-async  = "0.6.1"
 embedded-can       = "0.4.1"
 embedded-hal-async = "1.0.0"
 esp-alloc          = { path = "../esp-alloc", optional = true }
-esp-backtrace      = { path = "../esp-backtrace", default-features = false, features = ["defmt", "semihosting"] }
 esp-bootloader-esp-idf = { path = "../esp-bootloader-esp-idf" }
 esp-hal            = { path = "../esp-hal" }
 esp-hal-embassy    = { path = "../esp-hal-embassy", optional = true }
@@ -283,7 +282,6 @@ esp-radio = ["dep:esp-radio", "dep:esp-preempt"]
 # Device support (required!):
 esp32 = [
     "embedded-test/xtensa-semihosting",
-    "esp-backtrace/esp32",
     "esp-hal/esp32",
     "esp-hal-embassy?/esp32",
     "esp-radio?/esp32",
@@ -293,7 +291,6 @@ esp32 = [
     "esp-preempt?/esp32",
 ]
 esp32c2 = [
-    "esp-backtrace/esp32c2",
     "esp-hal/esp32c2",
     "esp-hal-embassy?/esp32c2",
     "esp-radio?/esp32c2",
@@ -303,7 +300,6 @@ esp32c2 = [
     "esp-preempt?/esp32c2"
 ]
 esp32c3 = [
-    "esp-backtrace/esp32c3",
     "esp-hal/esp32c3",
     "esp-hal-embassy?/esp32c3",
     "esp-radio?/esp32c3",
@@ -313,7 +309,6 @@ esp32c3 = [
     "esp-preempt?/esp32c3",
 ]
 esp32c6 = [
-    "esp-backtrace/esp32c6",
     "esp-hal/esp32c6",
     "esp-hal-embassy?/esp32c6",
     "esp-radio?/esp32c6",
@@ -323,7 +318,6 @@ esp32c6 = [
     "esp-preempt?/esp32c6",
 ]
 esp32h2 = [
-    "esp-backtrace/esp32h2",
     "esp-hal/esp32h2",
     "esp-hal-embassy?/esp32h2",
     "esp-radio?/esp32h2",
@@ -334,7 +328,6 @@ esp32h2 = [
 ]
 esp32s2 = [
     "embedded-test/xtensa-semihosting",
-    "esp-backtrace/esp32s2",
     "esp-hal/esp32s2",
     "esp-hal-embassy?/esp32s2",
     "esp-radio?/esp32s2",
@@ -345,7 +338,6 @@ esp32s2 = [
 ]
 esp32s3 = [
     "embedded-test/xtensa-semihosting",
-    "esp-backtrace/esp32s3",
     "esp-hal/esp32s3",
     "esp-hal-embassy?/esp32s3",
     "esp-radio?/esp32s3",

--- a/hil-test/src/lib.rs
+++ b/hil-test/src/lib.rs
@@ -24,8 +24,6 @@ unsafe impl defmt::Logger for Logger {
 
 #[cfg(feature = "defmt")]
 use defmt_rtt as _;
-// Make sure esp_backtrace is not removed.
-use esp_backtrace as _;
 
 #[cfg(feature = "defmt")]
 #[macro_export]


### PR DESCRIPTION
In the HIL tests, embedded-test acts as the panic handler. Since we no longer need esp-backtrace to handle exceptions, I think we can safely remove it from the test suite.