### PR TITLE
Move semaphore implementation to esp-preempt

### DIFF
--- a/esp-preempt/src/semaphore.rs
+++ b/esp-preempt/src/semaphore.rs
@@ -1,0 +1,122 @@
+use alloc::boxed::Box;
+use core::ptr::NonNull;
+
+use esp_hal::time::{Duration, Instant};
+use esp_radio_preempt_driver::{
+    register_semaphore_implementation,
+    semaphore::{SemaphoreImplementation, SemaphorePtr},
+    yield_task,
+};
+use esp_sync::NonReentrantMutex;
+
+struct SemaphoreInner {
+    current: u32,
+    max: u32,
+}
+
+impl SemaphoreInner {
+    fn try_take(&mut self) -> bool {
+        if self.current > 0 {
+            self.current -= 1;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn try_give(&mut self) -> bool {
+        if self.current < self.max {
+            self.current += 1;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+pub struct Semaphore {
+    inner: NonReentrantMutex<SemaphoreInner>,
+}
+
+impl Semaphore {
+    pub fn new(max: u32, initial: u32) -> Self {
+        Semaphore {
+            inner: NonReentrantMutex::new(SemaphoreInner {
+                current: initial,
+                max,
+            }),
+        }
+    }
+
+    unsafe fn from_ptr<'a>(ptr: SemaphorePtr) -> &'a Self {
+        unsafe { ptr.cast::<Self>().as_ref() }
+    }
+
+    pub fn try_take(&self) -> bool {
+        self.inner.with(|sem| sem.try_take())
+    }
+
+    fn yield_loop_with_timeout(timeout_us: Option<u32>, cb: impl Fn() -> bool) -> bool {
+        let start = if timeout_us.is_some() {
+            Instant::now()
+        } else {
+            Instant::EPOCH
+        };
+
+        let timeout = timeout_us
+            .map(|us| Duration::from_micros(us as u64))
+            .unwrap_or(Duration::MAX);
+
+        loop {
+            if cb() {
+                return true;
+            }
+
+            if timeout_us.is_some() && start.elapsed() > timeout {
+                return false;
+            }
+
+            yield_task();
+        }
+    }
+
+    pub fn take(&self, timeout_us: Option<u32>) -> bool {
+        Self::yield_loop_with_timeout(timeout_us, || self.try_take())
+    }
+
+    pub fn give(&self) -> bool {
+        self.inner.with(|sem| sem.try_give())
+    }
+}
+
+impl SemaphoreImplementation for Semaphore {
+    fn create(max: u32, initial: u32) -> SemaphorePtr {
+        let sem = Box::new(Semaphore::new(max, initial));
+        NonNull::from(Box::leak(sem)).cast()
+    }
+
+    unsafe fn delete(semaphore: SemaphorePtr) {
+        let sem = unsafe { Box::from_raw(semaphore.cast::<Semaphore>().as_ptr()) };
+        core::mem::drop(sem);
+    }
+
+    unsafe fn take(semaphore: SemaphorePtr, timeout_us: Option<u32>) -> bool {
+        let semaphore = unsafe { Semaphore::from_ptr(semaphore) };
+
+        semaphore.take(timeout_us)
+    }
+
+    unsafe fn give(semaphore: SemaphorePtr) -> bool {
+        let semaphore = unsafe { Semaphore::from_ptr(semaphore) };
+
+        semaphore.give()
+    }
+
+    unsafe fn try_take(semaphore: SemaphorePtr) -> bool {
+        let semaphore = unsafe { Semaphore::from_ptr(semaphore) };
+
+        semaphore.try_take()
+    }
+}
+
+register_semaphore_implementation!(Semaphore);

--- a/esp-preempt/src/task/mod.rs
+++ b/esp-preempt/src/task/mod.rs
@@ -10,6 +10,7 @@ use arch_specific::Registers;
 pub(crate) use arch_specific::*;
 #[cfg(xtensa)]
 use esp_hal::trapframe::TrapFrame;
+use esp_radio_preempt_driver::semaphore::{SemaphoreHandle, SemaphorePtr};
 
 use crate::{InternalMemory, SCHEDULER_STATE, task, timer};
 
@@ -19,7 +20,7 @@ pub(crate) struct Context {
     pub trap_frame: Registers,
     #[cfg(xtensa)]
     pub trap_frame: TrapFrame,
-    pub thread_semaphore: u32,
+    pub thread_semaphore: Option<SemaphorePtr>,
     pub next: *mut Context,
     pub _allocated_stack: Box<[MaybeUninit<u8>], InternalMemory>,
 }
@@ -38,9 +39,18 @@ impl Context {
 
         Context {
             trap_frame: task::new_task_context(task_fn, param, stack_top),
-            thread_semaphore: 0,
+            thread_semaphore: None,
             next: core::ptr::null_mut(),
             _allocated_stack: stack,
+        }
+    }
+}
+
+impl Drop for Context {
+    fn drop(&mut self) {
+        if let Some(sem) = self.thread_semaphore {
+            let sem = unsafe { SemaphoreHandle::from_ptr(sem) };
+            core::mem::drop(sem)
         }
     }
 }
@@ -53,7 +63,7 @@ pub(super) fn allocate_main_task() {
             trap_frame: Registers::default(),
             #[cfg(xtensa)]
             trap_frame: TrapFrame::default(),
-            thread_semaphore: 0,
+            thread_semaphore: None,
             next: core::ptr::null_mut(),
             _allocated_stack: Box::<[u8], _>::new_uninit_slice_in(0, InternalMemory),
         },
@@ -107,8 +117,12 @@ pub(super) fn delete_all_tasks() {
     }
 }
 
+pub(super) fn with_current_task<R>(mut cb: impl FnMut(&mut Context) -> R) -> R {
+    SCHEDULER_STATE.with(|state| cb(unsafe { &mut *state.current_task }))
+}
+
 pub(super) fn current_task() -> *mut Context {
-    SCHEDULER_STATE.with(|state| state.current_task)
+    with_current_task(|task| task as *mut Context)
 }
 
 pub(super) fn schedule_task_deletion(task: *mut Context) {

--- a/esp-radio-preempt-driver/src/lib.rs
+++ b/esp-radio-preempt-driver/src/lib.rs
@@ -28,7 +28,11 @@
 
 #![no_std]
 
+pub mod semaphore;
+
 use core::ffi::c_void;
+
+use crate::semaphore::SemaphorePtr;
 
 unsafe extern "Rust" {
     fn esp_preempt_initialized() -> bool;
@@ -43,7 +47,7 @@ unsafe extern "Rust" {
         task_stack_size: usize,
     ) -> *mut c_void;
     fn esp_preempt_schedule_task_deletion(task_handle: *mut c_void);
-    fn esp_preempt_current_task_thread_semaphore() -> *mut c_void;
+    fn esp_preempt_current_task_thread_semaphore() -> SemaphorePtr;
 }
 
 /// Set the Scheduler implementation.
@@ -71,21 +75,25 @@ macro_rules! scheduler_impl {
         fn esp_preempt_enable() {
             <$t as $crate::Scheduler>::enable(&$name)
         }
+
         #[unsafe(no_mangle)]
         #[inline]
         fn esp_preempt_disable() {
             <$t as $crate::Scheduler>::disable(&$name)
         }
+
         #[unsafe(no_mangle)]
         #[inline]
         fn esp_preempt_yield_task() {
             <$t as $crate::Scheduler>::yield_task(&$name)
         }
+
         #[unsafe(no_mangle)]
         #[inline]
         fn esp_preempt_current_task() -> *mut c_void {
             <$t as $crate::Scheduler>::current_task(&$name)
         }
+
         #[unsafe(no_mangle)]
         #[inline]
         fn esp_preempt_task_create(
@@ -95,14 +103,16 @@ macro_rules! scheduler_impl {
         ) -> *mut c_void {
             <$t as $crate::Scheduler>::task_create(&$name, task, param, task_stack_size)
         }
+
         #[unsafe(no_mangle)]
         #[inline]
         fn esp_preempt_schedule_task_deletion(task_handle: *mut c_void) {
             <$t as $crate::Scheduler>::schedule_task_deletion(&$name, task_handle)
         }
+
         #[unsafe(no_mangle)]
         #[inline]
-        fn esp_preempt_current_task_thread_semaphore() -> *mut c_void {
+        fn esp_preempt_current_task_thread_semaphore() -> SemaphorePtr {
             <$t as $crate::Scheduler>::current_task_thread_semaphore(&$name)
         }
     };
@@ -153,7 +163,7 @@ pub trait Scheduler: Send + Sync + 'static {
     /// This function should return an opaque per-thread pointer to an
     /// usize-sized memory location, which will be used to store a pointer
     /// to a semaphore for this thread.
-    fn current_task_thread_semaphore(&self) -> *mut c_void;
+    fn current_task_thread_semaphore(&self) -> SemaphorePtr;
 }
 
 // API used (mostly) by esp-radio
@@ -224,6 +234,6 @@ pub unsafe fn schedule_task_deletion(task_handle: *mut c_void) {
 
 /// Returns a pointer to the current thread's semaphore.
 #[inline]
-pub fn current_task_thread_semaphore() -> *mut c_void {
+pub fn current_task_thread_semaphore() -> SemaphorePtr {
     unsafe { esp_preempt_current_task_thread_semaphore() }
 }

--- a/esp-radio-preempt-driver/src/semaphore.rs
+++ b/esp-radio-preempt-driver/src/semaphore.rs
@@ -1,0 +1,172 @@
+//! Semaphores
+
+use core::ptr::NonNull;
+
+/// Pointer to an opaque semaphore created by the driver implementation.
+pub type SemaphorePtr = NonNull<()>;
+
+unsafe extern "Rust" {
+    fn esp_preempt_semaphore_create(max: u32, initial: u32) -> SemaphorePtr;
+    fn esp_preempt_semaphore_delete(semaphore: SemaphorePtr);
+
+    fn esp_preempt_semaphore_take(semaphore: SemaphorePtr, timeout_us: Option<u32>) -> bool;
+    fn esp_preempt_semaphore_give(semaphore: SemaphorePtr) -> bool;
+
+    fn esp_preempt_semaphore_try_take(semaphore: SemaphorePtr) -> bool;
+}
+
+pub trait SemaphoreImplementation {
+    /// Creates a new semaphore instance.
+    fn create(max: u32, initial: u32) -> SemaphorePtr;
+
+    /// Deletes a semaphore instance.
+    ///
+    /// # Safety
+    ///
+    /// `semaphore` must be a pointer returned from [`Self::create`].
+    unsafe fn delete(semaphore: SemaphorePtr);
+
+    /// Increments the semaphore's counter.
+    ///
+    /// If a timeout is given, this function should block until either a semaphore could be taken,
+    /// or the timeout has been reached. If no timeout is specified, the function should block
+    /// indefinitely.
+    ///
+    /// The timeout is specified in microseconds.
+    ///
+    /// This function returns `true` if the semaphore was taken, `false` if the timeout was reached.
+    ///
+    /// # Safety
+    ///
+    /// `semaphore` must be a pointer returned from [`Self::create`].
+    unsafe fn take(semaphore: SemaphorePtr, timeout_us: Option<u32>) -> bool;
+
+    /// Increments the semaphore's counter.
+    ///
+    /// This function returns `true` if the semaphore was given, `false` if the counter is at
+    /// its maximum.
+    ///
+    /// # Safety
+    ///
+    /// `semaphore` must be a pointer returned from [`Self::create`].
+    unsafe fn give(semaphore: SemaphorePtr) -> bool;
+
+    /// Attempts to decrement the semaphore's counter.
+    ///
+    /// If the counter is zero, this function must immediately return `false`.
+    ///
+    /// # Safety
+    ///
+    /// `semaphore` must be a pointer returned from [`Self::create`].
+    unsafe fn try_take(semaphore: SemaphorePtr) -> bool;
+}
+
+#[macro_export]
+macro_rules! register_semaphore_implementation {
+    ($t: ty) => {
+        #[unsafe(no_mangle)]
+        #[inline]
+        fn esp_preempt_semaphore_create(max: u32, initial: u32) -> $crate::semaphore::SemaphorePtr {
+            <$t as $crate::semaphore::SemaphoreImplementation>::create(max, initial)
+        }
+
+        #[unsafe(no_mangle)]
+        #[inline]
+        fn esp_preempt_semaphore_delete(semaphore: $crate::semaphore::SemaphorePtr) {
+            unsafe { <$t as $crate::semaphore::SemaphoreImplementation>::delete(semaphore) }
+        }
+
+        #[unsafe(no_mangle)]
+        #[inline]
+        fn esp_preempt_semaphore_take(
+            semaphore: $crate::semaphore::SemaphorePtr,
+            timeout_us: Option<u32>,
+        ) -> bool {
+            unsafe {
+                <$t as $crate::semaphore::SemaphoreImplementation>::take(semaphore, timeout_us)
+            }
+        }
+
+        #[unsafe(no_mangle)]
+        #[inline]
+        fn esp_preempt_semaphore_give(semaphore: $crate::semaphore::SemaphorePtr) -> bool {
+            unsafe { <$t as $crate::semaphore::SemaphoreImplementation>::give(semaphore) }
+        }
+
+        #[unsafe(no_mangle)]
+        #[inline]
+        fn esp_preempt_semaphore_try_take(semaphore: $crate::semaphore::SemaphorePtr) -> bool {
+            unsafe { <$t as $crate::semaphore::SemaphoreImplementation>::try_take(semaphore) }
+        }
+    };
+}
+
+#[repr(transparent)]
+pub struct SemaphoreHandle(SemaphorePtr);
+impl SemaphoreHandle {
+    /// Creates a new semaphore instance.
+    pub fn new(initial: u32, max: u32) -> Self {
+        let ptr = unsafe { esp_preempt_semaphore_create(initial, max) };
+        Self(ptr)
+    }
+
+    /// Converts this object into a pointer without dropping it.
+    pub fn leak(self) -> SemaphorePtr {
+        let ptr = self.0;
+        core::mem::forget(self);
+        ptr
+    }
+
+    /// Recovers the object from a leaked pointer.
+    ///
+    /// # Safety
+    ///
+    /// - The caller must only use pointers created using [`Self::leak`].
+    /// - The caller must ensure the pointer is not shared.
+    pub unsafe fn from_ptr(ptr: SemaphorePtr) -> Self {
+        Self(ptr)
+    }
+
+    /// Creates a reference to this object from a leaked pointer.
+    ///
+    /// This function is used in the esp-radio code to interact with the semaphore.
+    ///
+    /// # Safety
+    ///
+    /// - The caller must only use pointers created using [`Self::leak`].
+    pub unsafe fn ref_from_ptr(ptr: &SemaphorePtr) -> &Self {
+        unsafe { core::mem::transmute(ptr) }
+    }
+
+    /// Increments the semaphore's counter.
+    ///
+    /// If a timeout is given, this function blocks until either a semaphore could be taken, or the
+    /// timeout has been reached. If no timeout is given, this function blocks until the operation
+    /// succeeds.
+    ///
+    /// This function returns `true` if the semaphore was taken, `false` if the timeout was reached.
+    pub fn take(&self, timeout_us: Option<u32>) -> bool {
+        unsafe { esp_preempt_semaphore_take(self.0, timeout_us) }
+    }
+
+    /// Increments the semaphore's counter.
+    ///
+    /// This function returns `true` if the semaphore was given, `false` if the counter is at its
+    /// maximum.
+    pub fn give(&self) -> bool {
+        unsafe { esp_preempt_semaphore_give(self.0) }
+    }
+
+    /// Attempts to decrement the semaphore's counter.
+    ///
+    /// If the counter is zero, this function returns `false`.
+    pub fn try_take(&self) -> bool {
+        unsafe { esp_preempt_semaphore_try_take(self.0) }
+    }
+}
+
+impl Drop for SemaphoreHandle {
+    fn drop(&mut self) {
+        unsafe { esp_preempt_semaphore_delete(self.0) };
+    }
+}

--- a/esp-radio/src/ble/btdm.rs
+++ b/esp-radio/src/ble/btdm.rs
@@ -2,7 +2,7 @@ use alloc::boxed::Box;
 use core::ptr::{addr_of, addr_of_mut};
 
 use esp_sync::RawMutex;
-use esp_wifi_sys::c_types::{c_char, c_void};
+use esp_wifi_sys::c_types::*;
 use portable_atomic::{AtomicBool, Ordering};
 
 use super::ReceivedPacket;
@@ -122,30 +122,9 @@ unsafe extern "C" fn task_yield() {
 }
 
 unsafe extern "C" fn task_yield_from_isr() {
+    // This is not called because we never set xHigherPriorityTaskWoken = true in the `_from_isr`
+    // functions. This should be revisited if a scheduler needs it.
     todo!();
-}
-
-unsafe extern "C" fn semphr_create(max: u32, init: u32) -> *const () {
-    unsafe { crate::common_adapter::semphr_create(max, init) as *const () }
-}
-
-unsafe extern "C" fn semphr_delete(sem: *const ()) {
-    unsafe {
-        crate::common_adapter::semphr_delete(sem as *mut crate::binary::c_types::c_void);
-    }
-}
-
-unsafe extern "C" fn semphr_take(sem: *const (), block_time_ms: u32) -> i32 {
-    unsafe {
-        crate::common_adapter::semphr_take(
-            sem as *mut crate::binary::c_types::c_void,
-            block_time_ms,
-        )
-    }
-}
-
-unsafe extern "C" fn semphr_give(sem: *const ()) -> i32 {
-    unsafe { crate::common_adapter::semphr_give(sem as *mut crate::binary::c_types::c_void) }
 }
 
 unsafe extern "C" fn mutex_create() -> *const () {

--- a/esp-radio/src/ble/npl.rs
+++ b/esp-radio/src/ble/npl.rs
@@ -8,10 +8,7 @@ use esp_hal::time::{Duration, Instant};
 
 use super::*;
 use crate::{
-    binary::{
-        c_types::{c_char, c_void},
-        include::*,
-    },
+    binary::{c_types::*, include::*},
     compat::{
         self,
         common::{ConcurrentQueue, str_from_c},
@@ -26,7 +23,7 @@ pub(crate) mod ble_os_adapter_chip_specific;
 
 const EVENT_QUEUE_SIZE: usize = 16;
 
-const TIME_FOREVER: u32 = crate::compat::common::OSI_FUNCS_TIME_BLOCKING;
+const TIME_FOREVER: u32 = crate::compat::OSI_FUNCS_TIME_BLOCKING;
 
 #[cfg(esp32c2)]
 const OS_MSYS_1_BLOCK_COUNT: i32 = 24;

--- a/esp-radio/src/ble/os_adapter_esp32.rs
+++ b/esp-radio/src/ble/os_adapter_esp32.rs
@@ -2,34 +2,26 @@ use core::ptr::addr_of_mut;
 
 use super::*;
 use crate::{
-    binary::{
-        c_types,
-        include::{
-            esp_bt_controller_config_t,
-            esp_bt_mode_t,
-            esp_bt_mode_t_ESP_BT_MODE_BLE,
-            esp_bt_mode_t_ESP_BT_MODE_BTDM,
-            esp_bt_mode_t_ESP_BT_MODE_CLASSIC_BT,
-            esp_bt_mode_t_ESP_BT_MODE_IDLE,
-        },
+    binary::include::{
+        esp_bt_controller_config_t,
+        esp_bt_mode_t,
+        esp_bt_mode_t_ESP_BT_MODE_BLE,
+        esp_bt_mode_t_ESP_BT_MODE_BTDM,
+        esp_bt_mode_t_ESP_BT_MODE_CLASSIC_BT,
+        esp_bt_mode_t_ESP_BT_MODE_IDLE,
     },
+    common_adapter::*,
     hal::{interrupt, peripherals::Interrupt},
 };
 
-pub(crate) static mut ISR_INTERRUPT_5: (
-    *mut crate::binary::c_types::c_void,
-    *mut crate::binary::c_types::c_void,
-) = (core::ptr::null_mut(), core::ptr::null_mut());
+pub(crate) static mut ISR_INTERRUPT_5: (*mut c_void, *mut c_void) =
+    (core::ptr::null_mut(), core::ptr::null_mut());
 
-pub(crate) static mut ISR_INTERRUPT_8: (
-    *mut crate::binary::c_types::c_void,
-    *mut crate::binary::c_types::c_void,
-) = (core::ptr::null_mut(), core::ptr::null_mut());
+pub(crate) static mut ISR_INTERRUPT_8: (*mut c_void, *mut c_void) =
+    (core::ptr::null_mut(), core::ptr::null_mut());
 
-pub(crate) static mut ISR_INTERRUPT_7: (
-    *mut crate::binary::c_types::c_void,
-    *mut crate::binary::c_types::c_void,
-) = (core::ptr::null_mut(), core::ptr::null_mut());
+pub(crate) static mut ISR_INTERRUPT_7: (*mut c_void, *mut c_void) =
+    (core::ptr::null_mut(), core::ptr::null_mut());
 
 #[repr(C)]
 pub(super) struct osi_funcs_s {
@@ -40,12 +32,12 @@ pub(super) struct osi_funcs_s {
     interrupt_restore: Option<unsafe extern "C" fn()>,
     task_yield: Option<unsafe extern "C" fn()>,
     task_yield_from_isr: Option<unsafe extern "C" fn()>,
-    semphr_create: Option<unsafe extern "C" fn(u32, u32) -> *const ()>,
-    semphr_delete: Option<unsafe extern "C" fn(*const ())>,
-    semphr_take_from_isr: Option<unsafe extern "C" fn(*const (), *const ()) -> i32>,
-    semphr_give_from_isr: Option<unsafe extern "C" fn(*const (), *const ()) -> i32>,
-    semphr_take: Option<unsafe extern "C" fn(*const (), u32) -> i32>,
-    semphr_give: Option<unsafe extern "C" fn(*const ()) -> i32>,
+    semphr_create: Option<unsafe extern "C" fn(u32, u32) -> *mut c_void>,
+    semphr_delete: Option<unsafe extern "C" fn(*mut c_void)>,
+    semphr_take_from_isr: Option<unsafe extern "C" fn(*mut c_void, *mut bool) -> i32>,
+    semphr_give_from_isr: Option<unsafe extern "C" fn(*mut c_void, *mut bool) -> i32>,
+    semphr_take: Option<unsafe extern "C" fn(*mut c_void, u32) -> i32>,
+    semphr_give: Option<unsafe extern "C" fn(*mut c_void) -> i32>,
     mutex_create: Option<unsafe extern "C" fn() -> *const ()>,
     mutex_delete: Option<unsafe extern "C" fn(*const ())>,
     mutex_lock: Option<unsafe extern "C" fn(*const ()) -> i32>,
@@ -58,21 +50,21 @@ pub(super) struct osi_funcs_s {
     queue_recv_from_isr: Option<unsafe extern "C" fn(*const (), *const (), *const ()) -> i32>,
     task_create: Option<
         unsafe extern "C" fn(
-            *mut crate::binary::c_types::c_void,
-            *const crate::binary::c_types::c_char,
+            *mut c_void,
+            *const c_char,
             u32,
-            *mut crate::binary::c_types::c_void,
+            *mut c_void,
             u32,
-            *mut crate::binary::c_types::c_void,
+            *mut c_void,
             u32,
         ) -> i32,
     >,
     task_delete: Option<unsafe extern "C" fn(*mut ())>,
     is_in_isr: Option<unsafe extern "C" fn() -> i32>,
     cause_sw_intr_to_core: Option<unsafe extern "C" fn(i32, i32) -> i32>,
-    malloc: Option<unsafe extern "C" fn(u32) -> *mut crate::binary::c_types::c_void>,
-    malloc_internal: Option<unsafe extern "C" fn(u32) -> *mut crate::binary::c_types::c_void>,
-    free: Option<unsafe extern "C" fn(*mut crate::binary::c_types::c_void)>,
+    malloc: Option<unsafe extern "C" fn(u32) -> *mut c_void>,
+    malloc_internal: Option<unsafe extern "C" fn(u32) -> *mut c_void>,
+    free: Option<unsafe extern "C" fn(*mut c_void)>,
     read_efuse_mac: Option<unsafe extern "C" fn(*const ()) -> i32>,
     srand: Option<unsafe extern "C" fn(u32)>,
     rand: Option<unsafe extern "C" fn() -> i32>,
@@ -103,15 +95,8 @@ pub(super) struct osi_funcs_s {
     set_isr13: Option<unsafe extern "C" fn(i32, unsafe extern "C" fn(), *const ()) -> i32>,
     interrupt_l3_disable: Option<unsafe extern "C" fn()>,
     interrupt_l3_restore: Option<unsafe extern "C" fn()>,
-    custom_queue_create:
-        Option<unsafe extern "C" fn(u32, u32) -> *mut crate::binary::c_types::c_void>,
-    coex_version_get: Option<
-        unsafe extern "C" fn(
-            *mut crate::binary::c_types::c_uint,
-            *mut crate::binary::c_types::c_uint,
-            *mut crate::binary::c_types::c_uint,
-        ) -> crate::binary::c_types::c_int,
-    >,
+    custom_queue_create: Option<unsafe extern "C" fn(u32, u32) -> *mut c_void>,
+    coex_version_get: Option<unsafe extern "C" fn(*mut c_uint, *mut c_uint, *mut c_uint) -> c_int>,
     patch_apply: Option<unsafe extern "C" fn()>,
     magic: u32,
 }
@@ -126,8 +111,8 @@ pub(super) static G_OSI_FUNCS: osi_funcs_s = osi_funcs_s {
     task_yield_from_isr: Some(task_yield_from_isr),
     semphr_create: Some(semphr_create),
     semphr_delete: Some(semphr_delete),
-    semphr_take_from_isr: Some(crate::common_adapter::semphr_take_from_isr),
-    semphr_give_from_isr: Some(crate::common_adapter::semphr_give_from_isr),
+    semphr_take_from_isr: Some(semphr_take_from_isr),
+    semphr_give_from_isr: Some(semphr_give_from_isr),
     semphr_take: Some(semphr_take),
     semphr_give: Some(semphr_give),
     mutex_create: Some(mutex_create),
@@ -574,7 +559,7 @@ pub(crate) unsafe extern "C" fn set_isr(n: i32, f: unsafe extern "C" fn(), arg: 
     match n {
         5 => {
             unsafe {
-                ISR_INTERRUPT_5 = (f as *mut c_types::c_void, arg as *mut c_types::c_void);
+                ISR_INTERRUPT_5 = (f as *mut c_void, arg as *mut c_void);
             }
             unwrap!(interrupt::enable(
                 Interrupt::RWBT,
@@ -586,11 +571,11 @@ pub(crate) unsafe extern "C" fn set_isr(n: i32, f: unsafe extern "C" fn(), arg: 
             ));
         }
         7 => unsafe {
-            ISR_INTERRUPT_7 = (f as *mut c_types::c_void, arg as *mut c_types::c_void);
+            ISR_INTERRUPT_7 = (f as *mut c_void, arg as *mut c_void);
         },
         8 => {
             unsafe {
-                ISR_INTERRUPT_8 = (f as *mut c_types::c_void, arg as *mut c_types::c_void);
+                ISR_INTERRUPT_8 = (f as *mut c_void, arg as *mut c_void);
             }
             unwrap!(interrupt::enable(
                 Interrupt::BT_BB,

--- a/esp-radio/src/ble/os_adapter_esp32c2.rs
+++ b/esp-radio/src/ble/os_adapter_esp32c2.rs
@@ -1,3 +1,4 @@
+use super::*;
 use crate::{
     binary::include::esp_bt_controller_config_t,
     hal::{
@@ -6,15 +7,11 @@ use crate::{
     },
 };
 
-pub(crate) static mut ISR_INTERRUPT_4: (
-    *mut crate::binary::c_types::c_void,
-    *mut crate::binary::c_types::c_void,
-) = (core::ptr::null_mut(), core::ptr::null_mut());
+pub(crate) static mut ISR_INTERRUPT_4: (*mut c_void, *mut c_void) =
+    (core::ptr::null_mut(), core::ptr::null_mut());
 
-pub(crate) static mut ISR_INTERRUPT_7: (
-    *mut crate::binary::c_types::c_void,
-    *mut crate::binary::c_types::c_void,
-) = (core::ptr::null_mut(), core::ptr::null_mut());
+pub(crate) static mut ISR_INTERRUPT_7: (*mut c_void, *mut c_void) =
+    (core::ptr::null_mut(), core::ptr::null_mut());
 
 // keep them aligned with BT_CONTROLLER_INIT_CONFIG_DEFAULT in ESP-IDF
 // ideally _some_ of these values should be configurable
@@ -84,9 +81,9 @@ pub(crate) fn disable_sleep_mode() {
 pub(super) unsafe extern "C" fn esp_intr_alloc(
     source: u32,
     flags: u32,
-    handler: *mut crate::binary::c_types::c_void,
-    arg: *mut crate::binary::c_types::c_void,
-    ret_handle: *mut *mut crate::binary::c_types::c_void,
+    handler: *mut c_void,
+    arg: *mut c_void,
+    ret_handle: *mut *mut c_void,
 ) -> i32 {
     trace!(
         "esp_intr_alloc {} {} {:?} {:?} {:?}",

--- a/esp-radio/src/ble/os_adapter_esp32c3.rs
+++ b/esp-radio/src/ble/os_adapter_esp32c3.rs
@@ -1,18 +1,14 @@
 use super::*;
 use crate::{
-    binary::c_types::c_char,
+    common_adapter::*,
     hal::{interrupt, peripherals::Interrupt},
 };
 
-pub(crate) static mut BT_INTERRUPT_FUNCTION5: (
-    *mut crate::binary::c_types::c_void,
-    *mut crate::binary::c_types::c_void,
-) = (core::ptr::null_mut(), core::ptr::null_mut());
+pub(crate) static mut BT_INTERRUPT_FUNCTION5: (*mut c_void, *mut c_void) =
+    (core::ptr::null_mut(), core::ptr::null_mut());
 
-pub(crate) static mut BT_INTERRUPT_FUNCTION8: (
-    *mut crate::binary::c_types::c_void,
-    *mut crate::binary::c_types::c_void,
-) = (core::ptr::null_mut(), core::ptr::null_mut());
+pub(crate) static mut BT_INTERRUPT_FUNCTION8: (*mut c_void, *mut c_void) =
+    (core::ptr::null_mut(), core::ptr::null_mut());
 
 #[repr(C)]
 pub(super) struct osi_funcs_s {
@@ -27,12 +23,12 @@ pub(super) struct osi_funcs_s {
     interrupt_restore: Option<unsafe extern "C" fn()>,
     task_yield: Option<unsafe extern "C" fn()>,
     task_yield_from_isr: Option<unsafe extern "C" fn()>,
-    semphr_create: Option<unsafe extern "C" fn(u32, u32) -> *const ()>,
-    semphr_delete: Option<unsafe extern "C" fn(*const ())>,
-    semphr_take_from_isr: Option<unsafe extern "C" fn(*const (), *const ()) -> i32>,
-    semphr_give_from_isr: Option<unsafe extern "C" fn(*const (), *const ()) -> i32>,
-    semphr_take: Option<unsafe extern "C" fn(*const (), u32) -> i32>,
-    semphr_give: Option<unsafe extern "C" fn(*const ()) -> i32>,
+    semphr_create: Option<unsafe extern "C" fn(u32, u32) -> *mut c_void>,
+    semphr_delete: Option<unsafe extern "C" fn(*mut c_void)>,
+    semphr_take_from_isr: Option<unsafe extern "C" fn(*mut c_void, *mut bool) -> i32>,
+    semphr_give_from_isr: Option<unsafe extern "C" fn(*mut c_void, *mut bool) -> i32>,
+    semphr_take: Option<unsafe extern "C" fn(*mut c_void, u32) -> i32>,
+    semphr_give: Option<unsafe extern "C" fn(*mut c_void) -> i32>,
     mutex_create: Option<unsafe extern "C" fn() -> *const ()>,
     mutex_delete: Option<unsafe extern "C" fn(*const ())>,
     mutex_lock: Option<unsafe extern "C" fn(*const ()) -> i32>,
@@ -45,21 +41,21 @@ pub(super) struct osi_funcs_s {
     queue_recv_from_isr: Option<unsafe extern "C" fn(*const (), *const (), *const ()) -> i32>,
     task_create: Option<
         unsafe extern "C" fn(
-            *mut crate::binary::c_types::c_void,
+            *mut c_void,
             *const c_char,
             u32,
-            *mut crate::binary::c_types::c_void,
+            *mut c_void,
             u32,
-            *mut crate::binary::c_types::c_void,
+            *mut c_void,
             u32,
         ) -> i32,
     >,
     task_delete: Option<unsafe extern "C" fn(*mut ())>,
     is_in_isr: Option<unsafe extern "C" fn() -> i32>,
     cause_sw_intr_to_core: Option<unsafe extern "C" fn(i32, i32) -> i32>,
-    malloc: Option<unsafe extern "C" fn(u32) -> *mut crate::binary::c_types::c_void>,
-    malloc_internal: Option<unsafe extern "C" fn(u32) -> *mut crate::binary::c_types::c_void>,
-    free: Option<unsafe extern "C" fn(*mut crate::binary::c_types::c_void)>,
+    malloc: Option<unsafe extern "C" fn(u32) -> *mut c_void>,
+    malloc_internal: Option<unsafe extern "C" fn(u32) -> *mut c_void>,
+    free: Option<unsafe extern "C" fn(*mut c_void)>,
     read_efuse_mac: Option<unsafe extern "C" fn(*const ()) -> i32>,
     srand: Option<unsafe extern "C" fn(u32)>,
     rand: Option<unsafe extern "C" fn() -> i32>,
@@ -102,8 +98,8 @@ pub(super) static G_OSI_FUNCS: osi_funcs_s = osi_funcs_s {
     task_yield_from_isr: Some(task_yield_from_isr),
     semphr_create: Some(semphr_create),
     semphr_delete: Some(semphr_delete),
-    semphr_take_from_isr: Some(crate::common_adapter::semphr_take_from_isr),
-    semphr_give_from_isr: Some(crate::common_adapter::semphr_give_from_isr),
+    semphr_take_from_isr: Some(semphr_take_from_isr),
+    semphr_give_from_isr: Some(semphr_give_from_isr),
     semphr_take: Some(semphr_take),
     semphr_give: Some(semphr_give),
     mutex_create: Some(mutex_create),
@@ -357,10 +353,7 @@ pub(crate) unsafe extern "C" fn interrupt_handler_set(
     unsafe {
         match interrupt_no {
             5 => {
-                BT_INTERRUPT_FUNCTION5 = (
-                    func as *mut crate::binary::c_types::c_void,
-                    arg as *mut crate::binary::c_types::c_void,
-                );
+                BT_INTERRUPT_FUNCTION5 = (func as *mut c_void, arg as *mut c_void);
                 unwrap!(interrupt::enable(
                     Interrupt::RWBT,
                     interrupt::Priority::Priority1
@@ -371,10 +364,7 @@ pub(crate) unsafe extern "C" fn interrupt_handler_set(
                 ));
             }
             8 => {
-                BT_INTERRUPT_FUNCTION8 = (
-                    func as *mut crate::binary::c_types::c_void,
-                    arg as *mut crate::binary::c_types::c_void,
-                );
+                BT_INTERRUPT_FUNCTION8 = (func as *mut c_void, arg as *mut c_void);
                 unwrap!(interrupt::enable(
                     Interrupt::RWBLE,
                     interrupt::Priority::Priority1

--- a/esp-radio/src/ble/os_adapter_esp32c6.rs
+++ b/esp-radio/src/ble/os_adapter_esp32c6.rs
@@ -1,3 +1,4 @@
+use super::*;
 use crate::{
     binary::include::esp_bt_controller_config_t,
     hal::{
@@ -7,15 +8,11 @@ use crate::{
     },
 };
 
-pub(crate) static mut ISR_INTERRUPT_4: (
-    *mut crate::binary::c_types::c_void,
-    *mut crate::binary::c_types::c_void,
-) = (core::ptr::null_mut(), core::ptr::null_mut());
+pub(crate) static mut ISR_INTERRUPT_4: (*mut c_void, *mut c_void) =
+    (core::ptr::null_mut(), core::ptr::null_mut());
 
-pub(crate) static mut ISR_INTERRUPT_7: (
-    *mut crate::binary::c_types::c_void,
-    *mut crate::binary::c_types::c_void,
-) = (core::ptr::null_mut(), core::ptr::null_mut());
+pub(crate) static mut ISR_INTERRUPT_7: (*mut c_void, *mut c_void) =
+    (core::ptr::null_mut(), core::ptr::null_mut());
 
 // keep them aligned with BT_CONTROLLER_INIT_CONFIG_DEFAULT in ESP-IDF
 // ideally _some_ of these values should be configurable
@@ -84,9 +81,9 @@ pub(crate) fn disable_sleep_mode() {
 pub(super) unsafe extern "C" fn esp_intr_alloc(
     source: u32,
     flags: u32,
-    handler: *mut crate::binary::c_types::c_void,
-    arg: *mut crate::binary::c_types::c_void,
-    ret_handle: *mut *mut crate::binary::c_types::c_void,
+    handler: *mut c_void,
+    arg: *mut c_void,
+    ret_handle: *mut *mut c_void,
 ) -> i32 {
     trace!(
         "esp_intr_alloc {} {} {:?} {:?} {:?}",

--- a/esp-radio/src/ble/os_adapter_esp32h2.rs
+++ b/esp-radio/src/ble/os_adapter_esp32h2.rs
@@ -1,3 +1,4 @@
+use super::*;
 use crate::{
     binary::include::esp_bt_controller_config_t,
     hal::{
@@ -7,15 +8,11 @@ use crate::{
     },
 };
 
-pub(crate) static mut ISR_INTERRUPT_15: (
-    *mut crate::binary::c_types::c_void,
-    *mut crate::binary::c_types::c_void,
-) = (core::ptr::null_mut(), core::ptr::null_mut());
+pub(crate) static mut ISR_INTERRUPT_15: (*mut c_void, *mut c_void) =
+    (core::ptr::null_mut(), core::ptr::null_mut());
 
-pub(crate) static mut ISR_INTERRUPT_3: (
-    *mut crate::binary::c_types::c_void,
-    *mut crate::binary::c_types::c_void,
-) = (core::ptr::null_mut(), core::ptr::null_mut());
+pub(crate) static mut ISR_INTERRUPT_3: (*mut c_void, *mut c_void) =
+    (core::ptr::null_mut(), core::ptr::null_mut());
 
 // keep them aligned with BT_CONTROLLER_INIT_CONFIG_DEFAULT in ESP-IDF
 // ideally _some_ of these values should be configurable
@@ -84,9 +81,9 @@ pub(crate) fn disable_sleep_mode() {
 pub(super) unsafe extern "C" fn esp_intr_alloc(
     source: u32,
     flags: u32,
-    handler: *mut crate::binary::c_types::c_void,
-    arg: *mut crate::binary::c_types::c_void,
-    ret_handle: *mut *mut crate::binary::c_types::c_void,
+    handler: *mut c_void,
+    arg: *mut c_void,
+    ret_handle: *mut *mut c_void,
 ) -> i32 {
     trace!(
         "esp_intr_alloc {} {} {:?} {:?} {:?}",

--- a/esp-radio/src/compat/mod.rs
+++ b/esp-radio/src/compat/mod.rs
@@ -1,7 +1,12 @@
+#![allow(dead_code)]
+
 pub mod common;
 pub mod malloc;
 pub mod misc;
+pub mod semaphore;
 pub mod timer_compat;
+
+pub(crate) const OSI_FUNCS_TIME_BLOCKING: u32 = u32::MAX;
 
 #[unsafe(no_mangle)]
 unsafe extern "C" fn __esp_radio_putchar(_c: u8) {

--- a/esp-radio/src/compat/semaphore.rs
+++ b/esp-radio/src/compat/semaphore.rs
@@ -1,0 +1,53 @@
+use esp_radio_preempt_driver::semaphore::{SemaphoreHandle, SemaphorePtr};
+use esp_wifi_sys::c_types::c_void;
+
+use crate::compat::OSI_FUNCS_TIME_BLOCKING;
+
+pub(crate) fn sem_create(max: u32, init: u32) -> *mut c_void {
+    SemaphoreHandle::new(max, init).leak().as_ptr().cast()
+}
+
+pub(crate) fn sem_delete(semphr: *mut c_void) {
+    let ptr = unwrap!(SemaphorePtr::new(semphr.cast()), "semphr is null");
+
+    let handle = unsafe { SemaphoreHandle::from_ptr(ptr) };
+    core::mem::drop(handle);
+}
+
+pub(crate) fn sem_take(semphr: *mut c_void, tick: u32) -> i32 {
+    let ptr = unwrap!(SemaphorePtr::new(semphr.cast()), "semphr is null");
+
+    let handle = unsafe { SemaphoreHandle::ref_from_ptr(&ptr) };
+    // Assuming `tick` is in microseconds
+    let timeout = if tick == OSI_FUNCS_TIME_BLOCKING {
+        None
+    } else {
+        Some(tick)
+    };
+
+    handle.take(timeout) as i32
+}
+
+pub(crate) fn sem_take_from_isr(semphr: *mut c_void, _higher_prio_task_waken: *mut bool) -> i32 {
+    let ptr = unwrap!(SemaphorePtr::new(semphr.cast()), "semphr is null");
+
+    let handle = unsafe { SemaphoreHandle::ref_from_ptr(&ptr) };
+
+    handle.try_take() as i32
+}
+
+pub(crate) fn sem_give(semphr: *mut c_void) -> i32 {
+    let ptr = unwrap!(SemaphorePtr::new(semphr.cast()), "semphr is null");
+
+    let handle = unsafe { SemaphoreHandle::ref_from_ptr(&ptr) };
+
+    handle.give() as i32
+}
+
+pub(crate) fn sem_give_from_isr(semphr: *mut c_void, _higher_prio_task_waken: *mut bool) -> i32 {
+    let ptr = unwrap!(SemaphorePtr::new(semphr.cast()), "semphr is null");
+
+    let handle = unsafe { SemaphoreHandle::ref_from_ptr(&ptr) };
+
+    handle.give() as i32
+}

--- a/esp-radio/src/wifi/internal.rs
+++ b/esp-radio/src/wifi/internal.rs
@@ -9,6 +9,8 @@ use esp_wifi_sys::include::{
 
 use super::os_adapter::{self, *};
 use crate::common_adapter::*;
+#[cfg(coex)]
+use crate::{binary::c_types::c_void, hal::ram};
 
 #[cfg(all(coex, any(esp32, esp32c2, esp32c3, esp32c6, esp32s3)))]
 pub(super) static mut G_COEX_ADAPTER_FUNCS: crate::binary::include::coex_adapter_funcs_t =
@@ -46,19 +48,15 @@ pub(super) static mut G_COEX_ADAPTER_FUNCS: crate::binary::include::coex_adapter
     };
 
 #[cfg(coex)]
-unsafe extern "C" fn semphr_take_from_isr_wrapper(
-    semphr: *mut crate::binary::c_types::c_void,
-    hptw: *mut crate::binary::c_types::c_void,
-) -> i32 {
-    unsafe { crate::common_adapter::semphr_take_from_isr(semphr as *const (), hptw as *const ()) }
+#[ram]
+unsafe extern "C" fn semphr_take_from_isr_wrapper(semphr: *mut c_void, hptw: *mut c_void) -> i32 {
+    unsafe { crate::common_adapter::semphr_take_from_isr(semphr, hptw as *mut bool) }
 }
 
 #[cfg(coex)]
-unsafe extern "C" fn semphr_give_from_isr_wrapper(
-    semphr: *mut crate::binary::c_types::c_void,
-    hptw: *mut crate::binary::c_types::c_void,
-) -> i32 {
-    unsafe { crate::common_adapter::semphr_give_from_isr(semphr as *const (), hptw as *const ()) }
+#[ram]
+unsafe extern "C" fn semphr_give_from_isr_wrapper(semphr: *mut c_void, hptw: *mut c_void) -> i32 {
+    unsafe { crate::common_adapter::semphr_give_from_isr(semphr, hptw as *mut bool) }
 }
 
 #[cfg(coex)]

--- a/esp-radio/src/wifi/os_adapter/mod.rs
+++ b/esp-radio/src/wifi/os_adapter/mod.rs
@@ -175,7 +175,7 @@ pub unsafe extern "C" fn is_from_isr() -> bool {
 ///
 /// *************************************************************************
 pub unsafe extern "C" fn spin_lock_create() -> *mut crate::binary::c_types::c_void {
-    let ptr = crate::compat::common::sem_create(1, 1);
+    let ptr = crate::compat::semaphore::sem_create(1, 1);
 
     trace!("spin_lock_create {:?}", ptr);
     ptr as *mut crate::binary::c_types::c_void
@@ -197,7 +197,7 @@ pub unsafe extern "C" fn spin_lock_create() -> *mut crate::binary::c_types::c_vo
 pub unsafe extern "C" fn spin_lock_delete(lock: *mut crate::binary::c_types::c_void) {
     trace!("spin_lock_delete {:?}", lock);
 
-    crate::compat::common::sem_delete(lock);
+    crate::compat::semaphore::sem_delete(lock);
 }
 
 /// **************************************************************************


### PR DESCRIPTION
Proof of concept for #4025. The implementation is still the yield loop we have (without a few bugs we have, like unbounded `give`, and overwriting the previous value of hptw), but the yield loop is now a detail of esp-preempt, not esp-radio.