### PR TITLE
Add wifi init test case, fix logic bug in wifi::new

### DIFF
--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -2740,10 +2740,6 @@ pub fn new<'d>(
         return Err(WifiError::Unsupported);
     }
 
-    let mut controller = WifiController {
-        _phantom: Default::default(),
-    };
-
     crate::wifi::wifi_init()?;
 
     let mut cntry_code = [0u8; 3];
@@ -2764,6 +2760,12 @@ pub fn new<'d>(
 
     // At some point the "High-speed ADC" entropy source became available.
     unsafe { esp_hal::rng::TrngSource::increase_entropy_source_counter() };
+
+    // Only create WifiController after we've enabled TRNG - otherwise returning an error from this
+    // function will cause panic because WifiController::drop tries to disable the TRNG.
+    let mut controller = WifiController {
+        _phantom: Default::default(),
+    };
 
     controller.set_power_saving(PowerSaveMode::default())?;
 

--- a/hil-test/tests/esp_radio_init.rs
+++ b/hil-test/tests/esp_radio_init.rs
@@ -108,4 +108,15 @@ mod tests {
             Some(esp_radio::InitializationError::InterruptsDisabled),
         ));
     }
+
+    #[test]
+    #[cfg(soc_has_wifi)]
+    fn test_wifi_can_be_initialized(peripherals: Peripherals) {
+        let timg0 = TimerGroup::new(peripherals.TIMG0);
+        esp_preempt::init(timg0.timer0);
+
+        let esp_radio_ctrl = esp_radio::init().unwrap();
+
+        _ = esp_radio::wifi::new(&esp_radio_ctrl, peripherals.WIFI).unwrap();
+    }
 }


### PR DESCRIPTION
Discovered by https://github.com/esp-rs/esp-hal/pull/4043#issuecomment-3252833274, this is half of the problem.