### PR TITLE
Fix bound checking in the NorFlash::erase implementation of FlashRegion

### DIFF
--- a/esp-bootloader-esp-idf/CHANGELOG.md
+++ b/esp-bootloader-esp-idf/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - FlashRegion: The `capacity` methods implemented for `embedded_storage::ReadStorage` and `embedded_storage::nor_flash::ReadNorFlash` now return the same value (#3902)
 - Don't fail the build on long project names (#3905)
 - FlashRegion: Fix off-by-one bug when bounds checking (#3977)
+- FlashRegion: Fix exclusive upper bound checking when erasing (#4055)
 
 ### Removed
 

--- a/esp-bootloader-esp-idf/src/partitions.rs
+++ b/esp-bootloader-esp-idf/src/partitions.rs
@@ -649,7 +649,7 @@ where
             return Err(Error::OutOfBounds);
         }
 
-        if !self.range().contains(&address_to) {
+        if address_to > self.range().end {
             return Err(Error::OutOfBounds);
         }
 


### PR DESCRIPTION
### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones.
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
`address_to` could be just past the range, being exactly equal to the end that is exclusive.

#### Testing
I configured littlefs to use `partition size / erase size` blocks, and got an `OutOfBounds` error when it tried to erase the last block. 