### PR TITLE
xtask: Only run the selected example, not all of them

### DIFF
--- a/xtask/src/commands/mod.rs
+++ b/xtask/src/commands/mod.rs
@@ -135,9 +135,10 @@ pub fn examples(workspace: &Path, mut args: ExamplesArgs, action: CargoAction) -
     // Sort all examples by name:
     examples.sort_by_key(|a| a.binary_name());
 
-    let mut filtered = examples.clone();
+    let mut filtered = vec![];
 
     if let Some(example) = args.example.as_deref() {
+        filtered.clone_from(&examples);
         if !example.eq_ignore_ascii_case("all") {
             // Only keep the example the user wants
             filtered.retain(|ex| ex.matches_name(example));


### PR DESCRIPTION
Should be straight forward - `cargo xtask run example --chip esp32` appended the selected example to the complete list, so it ended up wanting to run everything.