### PR TITLE
Make BLE work on ESP32-C2 with 26 MHz Xtal

### DIFF
--- a/esp-hal/src/clock/clocks_ll/esp32c2.rs
+++ b/esp-hal/src/clock/clocks_ll/esp32c2.rs
@@ -188,10 +188,14 @@ pub(super) fn ble_rtc_clk_init() {
         w.lp_timer_sel_rtc_slow().clear_bit()
     });
 
-    // assume 40MHz xtal
+    let divider = match crate::rtc_cntl::RtcClock::xtal_freq() {
+        XtalClock::_26M => 129,
+        XtalClock::_40M => 249,
+    };
+
     MODEM_CLKRST::regs()
         .modem_lp_timer_conf()
-        .modify(|_, w| unsafe { w.lp_timer_clk_div_num().bits(249) });
+        .modify(|_, w| unsafe { w.lp_timer_clk_div_num().bits(divider) });
 
     MODEM_CLKRST::regs().etm_clk_conf().modify(|_, w| {
         w.etm_clk_active().set_bit();

--- a/esp-radio/src/ble/npl.rs
+++ b/esp-radio/src/ble/npl.rs
@@ -1081,7 +1081,26 @@ pub(crate) fn ble_init() {
 
         self::ble_os_adapter_chip_specific::ble_rtc_clk_init();
 
+        #[cfg(esp32c2)]
+        let mut cfg = ble_os_adapter_chip_specific::BLE_CONFIG;
+
+        #[cfg(not(esp32c2))]
         let cfg = ble_os_adapter_chip_specific::BLE_CONFIG;
+
+        #[cfg(esp32c2)]
+        {
+            use esp_hal::clock::Clock;
+
+            let xtal = crate::hal::rtc_cntl::RtcClock::xtal_freq();
+            let mhz = xtal.mhz() as u8;
+
+            cfg.main_xtal_freq = mhz;
+
+            if mhz == 26 {
+                cfg.rtc_freq = 40000;
+                cfg.main_xtal_freq = 26;
+            }
+        }
 
         let res = esp_register_ext_funcs(&G_OSI_FUNCS as *const ExtFuncsT);
         if res != 0 {


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [ ] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

BLE never really worked on ESP32-C2 with 26MHz xtal. It was able to scan and advertise but connecting never worked.

#### Testing
Running the bas_peripheral example
