### PR TITLE
examples/README.md: clarify xtask subcommand usage and arguments

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -13,7 +13,7 @@ For more information regarding the examples, refer to the `README.md` file in an
 You can build all examples for a given device using the `build examples` subcommand:
 
 ```shell
-cargo xtask build examples esp-hal esp32
+cargo xtask build examples esp-hal --chip esp32 all
 ```
 
 Note that we must specify which package to build the examples for, since this repository contains multiple packages. Specifying `esp-hal` will build the examples in the `examples/` directory instead.
@@ -23,7 +23,7 @@ Note that we must specify which package to build the examples for, since this re
 You can also build and then subsequently flash and run an example using the `run example` subcommand. With a target device connected to your host system, run:
 
 ```shell
-cargo xtask run example esp-hal esp32c6 --example embassy_hello_world
+cargo xtask run example embassy_hello_world --chip=esp32c6
 ```
 
 Again, note that we must specify which package to build the example from, plus which example to build and flash to the target device.


### PR DESCRIPTION
- Update example commands to use the new `--chip` argument format for `build examples` and `run example` subcommands.
- Improve clarity by showing explicit argument order and usage.
- Reflect recent changes in xtask interface for building and running examples.

## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (README.md only).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/MIGRATING-0.21.md).
- [ ] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Please provide a clear and concise description of your changes, including the motivation behind these changes. The context is crucial for the reviewers.

#### Testing
Describe how you tested your changes.
