### PR TITLE
Tweak preempt API - expose `hptw`, rename functions, add `yield_task_from_isr`

### DIFF
--- a/esp-preempt/src/lib.rs
+++ b/esp-preempt/src/lib.rs
@@ -321,6 +321,10 @@ impl esp_radio_preempt_driver::Scheduler for Scheduler {
         timer::yield_task()
     }
 
+    fn yield_task_from_isr(&self) {
+        self.yield_task();
+    }
+
     fn max_task_priority(&self) -> u32 {
         255
     }

--- a/esp-preempt/src/queue.rs
+++ b/esp-preempt/src/queue.rs
@@ -187,7 +187,11 @@ impl QueueImplementation for Queue {
         unsafe { queue.send_to_back(item, timeout_us) }
     }
 
-    unsafe fn try_send_to_back(queue: QueuePtr, item: *const u8) -> bool {
+    unsafe fn try_send_to_back_from_isr(
+        queue: QueuePtr,
+        item: *const u8,
+        _higher_prio_task_waken: Option<&mut bool>,
+    ) -> bool {
         let queue = unsafe { Queue::from_ptr(queue) };
 
         unsafe { queue.try_send_to_back(item) }
@@ -199,7 +203,11 @@ impl QueueImplementation for Queue {
         unsafe { queue.receive(item, timeout_us) }
     }
 
-    unsafe fn try_receive(queue: QueuePtr, item: *mut u8) -> bool {
+    unsafe fn try_receive_from_isr(
+        queue: QueuePtr,
+        item: *mut u8,
+        _higher_prio_task_waken: Option<&mut bool>,
+    ) -> bool {
         let queue = unsafe { Queue::from_ptr(queue) };
 
         unsafe { queue.try_receive(item) }

--- a/esp-preempt/src/semaphore.rs
+++ b/esp-preempt/src/semaphore.rs
@@ -131,6 +131,14 @@ impl SemaphoreImplementation for Semaphore {
 
         semaphore.try_take()
     }
+
+    unsafe fn try_give_from_isr(semaphore: SemaphorePtr, _hptw: Option<&mut bool>) -> bool {
+        unsafe { <Self as SemaphoreImplementation>::give(semaphore) }
+    }
+
+    unsafe fn try_take_from_isr(semaphore: SemaphorePtr, _hptw: Option<&mut bool>) -> bool {
+        unsafe { <Self as SemaphoreImplementation>::try_take(semaphore) }
+    }
 }
 
 register_semaphore_implementation!(Semaphore);

--- a/esp-radio-preempt-driver/src/semaphore.rs
+++ b/esp-radio-preempt-driver/src/semaphore.rs
@@ -11,9 +11,17 @@ unsafe extern "Rust" {
 
     fn esp_preempt_semaphore_take(semaphore: SemaphorePtr, timeout_us: Option<u32>) -> bool;
     fn esp_preempt_semaphore_give(semaphore: SemaphorePtr) -> bool;
+    fn esp_preempt_semaphore_try_give_from_isr(
+        semaphore: SemaphorePtr,
+        higher_prio_task_waken: Option<&mut bool>,
+    ) -> bool;
     fn esp_preempt_semaphore_current_count(semaphore: SemaphorePtr) -> u32;
 
     fn esp_preempt_semaphore_try_take(semaphore: SemaphorePtr) -> bool;
+    fn esp_preempt_semaphore_try_take_from_isr(
+        semaphore: SemaphorePtr,
+        higher_prio_task_waken: Option<&mut bool>,
+    ) -> bool;
 }
 
 pub trait SemaphoreImplementation {
@@ -52,6 +60,22 @@ pub trait SemaphoreImplementation {
     /// `semaphore` must be a pointer returned from [`Self::create`].
     unsafe fn give(semaphore: SemaphorePtr) -> bool;
 
+    /// Attempts to increment the semaphore's counter from an ISR.
+    ///
+    /// This function returns `true` if the semaphore was given, `false` if the counter is at
+    /// its maximum.
+    ///
+    /// The `higher_prio_task_waken` parameter is an optional mutable reference to a boolean flag.
+    /// If the flag is `Some`, the implementation may set it to `true` to request a context switch.
+    ///
+    /// # Safety
+    ///
+    /// `semaphore` must be a pointer returned from [`Self::create`].
+    unsafe fn try_give_from_isr(
+        semaphore: SemaphorePtr,
+        higher_prio_task_waken: Option<&mut bool>,
+    ) -> bool;
+
     /// Returns the semaphore's current counter value.
     ///
     /// # Safety
@@ -67,6 +91,21 @@ pub trait SemaphoreImplementation {
     ///
     /// `semaphore` must be a pointer returned from [`Self::create`].
     unsafe fn try_take(semaphore: SemaphorePtr) -> bool;
+
+    /// Attempts to decrement the semaphore's counter from an ISR.
+    ///
+    /// If the counter is zero, this function must immediately return `false`.
+    ///
+    /// The `higher_prio_task_waken` parameter is an optional mutable reference to a boolean flag.
+    /// If the flag is `Some`, the implementation may set it to `true` to request a context switch.
+    ///
+    /// # Safety
+    ///
+    /// `semaphore` must be a pointer returned from [`Self::create`].
+    unsafe fn try_take_from_isr(
+        semaphore: SemaphorePtr,
+        higher_prio_task_waken: Option<&mut bool>,
+    ) -> bool;
 }
 
 #[macro_export]
@@ -103,6 +142,20 @@ macro_rules! register_semaphore_implementation {
 
         #[unsafe(no_mangle)]
         #[inline]
+        fn esp_preempt_semaphore_try_give_from_isr(
+            semaphore: $crate::semaphore::SemaphorePtr,
+            higher_prio_task_waken: Option<&mut bool>,
+        ) -> bool {
+            unsafe {
+                <$t as $crate::semaphore::SemaphoreImplementation>::try_give_from_isr(
+                    semaphore,
+                    higher_prio_task_waken,
+                )
+            }
+        }
+
+        #[unsafe(no_mangle)]
+        #[inline]
         fn esp_preempt_semaphore_current_count(semaphore: $crate::semaphore::SemaphorePtr) -> u32 {
             unsafe { <$t as $crate::semaphore::SemaphoreImplementation>::current_count(semaphore) }
         }
@@ -111,6 +164,20 @@ macro_rules! register_semaphore_implementation {
         #[inline]
         fn esp_preempt_semaphore_try_take(semaphore: $crate::semaphore::SemaphorePtr) -> bool {
             unsafe { <$t as $crate::semaphore::SemaphoreImplementation>::try_take(semaphore) }
+        }
+
+        #[unsafe(no_mangle)]
+        #[inline]
+        fn esp_preempt_semaphore_try_take_from_isr(
+            semaphore: $crate::semaphore::SemaphorePtr,
+            higher_prio_task_waken: Option<&mut bool>,
+        ) -> bool {
+            unsafe {
+                <$t as $crate::semaphore::SemaphoreImplementation>::try_take_from_isr(
+                    semaphore,
+                    higher_prio_task_waken,
+                )
+            }
         }
     };
 }
@@ -171,6 +238,15 @@ impl SemaphoreHandle {
         unsafe { esp_preempt_semaphore_give(self.0) }
     }
 
+    /// Attempts to increment the semaphore's counter from an ISR.
+    ///
+    /// If the counter is at its maximum, this function returns `false`.
+    ///
+    /// If the flag is `Some`, the implementation may set it to `true` to request a context switch.
+    pub fn try_give_from_isr(&self, higher_prio_task_waken: Option<&mut bool>) -> bool {
+        unsafe { esp_preempt_semaphore_try_give_from_isr(self.0, higher_prio_task_waken) }
+    }
+
     /// Returns the current counter value.
     pub fn current_count(&self) -> u32 {
         unsafe { esp_preempt_semaphore_current_count(self.0) }
@@ -181,6 +257,16 @@ impl SemaphoreHandle {
     /// If the counter is zero, this function returns `false`.
     pub fn try_take(&self) -> bool {
         unsafe { esp_preempt_semaphore_try_take(self.0) }
+    }
+
+    /// Attempts to decrement the semaphore's counter from an ISR.
+    ///
+    /// If the counter is zero, this function returns `false`.
+    ///
+    /// If a higher priority task is woken up by this operation, the `higher_prio_task_waken` flag
+    /// is set to `true`.
+    pub fn try_take_from_isr(&self, higher_prio_task_waken: Option<&mut bool>) -> bool {
+        unsafe { esp_preempt_semaphore_try_take_from_isr(self.0, higher_prio_task_waken) }
     }
 }
 

--- a/esp-radio-preempt-driver/src/timer.rs
+++ b/esp-radio-preempt-driver/src/timer.rs
@@ -1,13 +1,15 @@
 //! Timers
 
-use alloc::boxed::Box;
-use core::ptr::NonNull;
+use core::{ffi::c_void, ptr::NonNull};
 
 /// Pointer to an opaque timer created by the driver implementation.
 pub type TimerPtr = NonNull<()>;
 
 unsafe extern "Rust" {
-    fn esp_preempt_timer_create(callback: Box<dyn FnMut() + Send>) -> TimerPtr;
+    fn esp_preempt_timer_create(
+        function: unsafe extern "C" fn(*mut c_void),
+        data: *mut c_void,
+    ) -> TimerPtr;
     fn esp_preempt_timer_delete(timer: TimerPtr);
 
     fn esp_preempt_timer_arm(timer: TimerPtr, timeout: u64, periodic: bool);
@@ -16,7 +18,7 @@ unsafe extern "Rust" {
 
 pub trait TimerImplementation {
     /// Creates a new timer instance from the given callback.
-    fn create(callback: Box<dyn FnMut() + Send>) -> TimerPtr;
+    fn create(function: unsafe extern "C" fn(*mut c_void), data: *mut c_void) -> TimerPtr;
 
     /// Deletes a timer instance.
     ///
@@ -48,8 +50,11 @@ macro_rules! register_timer_implementation {
     ($t: ty) => {
         #[unsafe(no_mangle)]
         #[inline]
-        fn esp_preempt_timer_create(callback: Box<dyn FnMut() + Send>) -> $crate::timer::TimerPtr {
-            <$t as $crate::timer::TimerImplementation>::create(callback)
+        fn esp_preempt_timer_create(
+            function: unsafe extern "C" fn(*mut ::core::ffi::c_void),
+            data: *mut ::core::ffi::c_void,
+        ) -> $crate::timer::TimerPtr {
+            <$t as $crate::timer::TimerImplementation>::create(function, data)
         }
 
         #[unsafe(no_mangle)]
@@ -76,9 +81,13 @@ macro_rules! register_timer_implementation {
 pub struct TimerHandle(TimerPtr);
 impl TimerHandle {
     /// Creates a new timer instance from the given callback.
-    pub fn new(callback: Box<dyn FnMut() + Send>) -> Self {
-        let ptr = unsafe { esp_preempt_timer_create(callback) };
-        Self(ptr)
+    ///
+    /// # Safety
+    ///
+    /// - The callback and its data must be valid for the lifetime of the timer.
+    /// - The callback and its data need to be able to be sent across threads.
+    pub unsafe fn new(function: unsafe extern "C" fn(*mut c_void), data: *mut c_void) -> Self {
+        Self(unsafe { esp_preempt_timer_create(function, data) })
     }
 
     /// Converts this object into a pointer without dropping it.

--- a/esp-radio/src/ble/btdm.rs
+++ b/esp-radio/src/ble/btdm.rs
@@ -124,7 +124,7 @@ unsafe extern "C" fn task_yield() {
 unsafe extern "C" fn task_yield_from_isr() {
     // This is not called because we never set xHigherPriorityTaskWoken = true in the `_from_isr`
     // functions. This should be revisited if a scheduler needs it.
-    todo!();
+    crate::preempt::yield_task_from_isr();
 }
 
 unsafe extern "C" fn mutex_create() -> *const () {

--- a/esp-radio/src/common_adapter/mod.rs
+++ b/esp-radio/src/common_adapter/mod.rs
@@ -131,7 +131,7 @@ pub unsafe extern "C" fn semphr_take_from_isr(
     higher_priority_task_waken: *mut bool,
 ) -> i32 {
     trace!(">>>> semphr_take_from_isr {:?}", semphr);
-    sem_take_from_isr(semphr, higher_priority_task_waken)
+    sem_try_take_from_isr(semphr, higher_priority_task_waken)
 }
 
 /// **************************************************************************
@@ -159,7 +159,7 @@ pub unsafe extern "C" fn semphr_give_from_isr(
     higher_priority_task_waken: *mut bool,
 ) -> i32 {
     trace!(">>>> semphr_give_from_isr {:?}", semphr);
-    sem_give_from_isr(semphr, higher_priority_task_waken)
+    sem_try_give_from_isr(semphr, higher_priority_task_waken)
 }
 
 /// **************************************************************************
@@ -521,9 +521,13 @@ pub unsafe extern "C" fn queue_send(
 pub unsafe extern "C" fn queue_send_from_isr(
     queue: *mut c_void,
     item: *mut c_void,
-    _higher_priority_task_waken: *mut c_void,
+    higher_priority_task_waken: *mut c_void,
 ) -> i32 {
-    crate::compat::queue::queue_try_send_to_back(queue.cast(), item.cast_const())
+    crate::compat::queue::queue_try_send_to_back_from_isr(
+        queue.cast(),
+        item.cast_const(),
+        higher_priority_task_waken.cast(),
+    )
 }
 
 /// **************************************************************************
@@ -606,9 +610,13 @@ pub unsafe extern "C" fn queue_recv(
 pub unsafe extern "C" fn queue_recv_from_isr(
     queue: *mut c_void,
     item: *mut c_void,
-    _higher_priority_task_waken: *mut c_void,
+    higher_priority_task_waken: *mut c_void,
 ) -> i32 {
-    crate::compat::queue::queue_try_receive(queue.cast(), item)
+    crate::compat::queue::queue_try_receive_from_isr(
+        queue.cast(),
+        item,
+        higher_priority_task_waken.cast(),
+    )
 }
 
 /// **************************************************************************

--- a/esp-radio/src/compat/semaphore.rs
+++ b/esp-radio/src/compat/semaphore.rs
@@ -30,12 +30,12 @@ pub(crate) fn sem_take(semphr: *mut c_void, tick: u32) -> i32 {
     handle.take(timeout) as i32
 }
 
-pub(crate) fn sem_take_from_isr(semphr: *mut c_void, _higher_prio_task_waken: *mut bool) -> i32 {
+pub(crate) fn sem_try_take_from_isr(semphr: *mut c_void, higher_prio_task_waken: *mut bool) -> i32 {
     let ptr = unwrap!(SemaphorePtr::new(semphr.cast()), "semphr is null");
 
     let handle = unsafe { SemaphoreHandle::ref_from_ptr(&ptr) };
 
-    handle.try_take() as i32
+    handle.try_take_from_isr(unsafe { higher_prio_task_waken.as_mut() }) as i32
 }
 
 pub(crate) fn sem_give(semphr: *mut c_void) -> i32 {
@@ -44,6 +44,14 @@ pub(crate) fn sem_give(semphr: *mut c_void) -> i32 {
     let handle = unsafe { SemaphoreHandle::ref_from_ptr(&ptr) };
 
     handle.give() as i32
+}
+
+pub(crate) fn sem_try_give_from_isr(semphr: *mut c_void, higher_prio_task_waken: *mut bool) -> i32 {
+    let ptr = unwrap!(SemaphorePtr::new(semphr.cast()), "semphr is null");
+
+    let handle = unsafe { SemaphoreHandle::ref_from_ptr(&ptr) };
+
+    handle.try_give_from_isr(unsafe { higher_prio_task_waken.as_mut() }) as i32
 }
 
 pub(crate) fn sem_give_from_isr(semphr: *mut c_void, _higher_prio_task_waken: *mut bool) -> i32 {

--- a/esp-radio/src/wifi/os_adapter/mod.rs
+++ b/esp-radio/src/wifi/os_adapter/mod.rs
@@ -20,7 +20,6 @@ use crate::{
     },
     hal::{clock::ModemClockController, peripherals::WIFI},
     memory_fence::memory_fence,
-    preempt::yield_task,
     time::{blob_ticks_to_micros, millis_to_blob_ticks},
 };
 
@@ -242,7 +241,7 @@ pub unsafe extern "C" fn wifi_int_restore(_wifi_int_mux: *mut c_void, tmp: u32) 
 /// *************************************************************************
 pub unsafe extern "C" fn task_yield_from_isr() {
     trace!("task_yield_from_isr");
-    yield_task();
+    crate::preempt::yield_task_from_isr();
 }
 
 /// **************************************************************************


### PR DESCRIPTION
This PR should bring the driver crate closer to FreeRTOS's APIs. The job of the driver crate isn't to provide a good general Rust OS API, it is to interface with esp-radio, which was designed for FreeRTOS. The implementors can then pick and choose how they want to implement the `_from_isr` functions and whether they require the `higher_prio_task_waken` flag to trigger a context switch.

cc #4025