### PR TITLE
Update `embassy-futures`

### DIFF
--- a/examples/async/embassy_usb_serial/Cargo.toml
+++ b/examples/async/embassy_usb_serial/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 embassy-executor = "0.9.0"
-embassy-futures = "0.1.1"
+embassy-futures = "0.1"
 embassy-usb = { version = "0.5.0", default-features = false }
 esp-backtrace = { path = "../../../esp-backtrace", features = [
     "panic-handler",

--- a/examples/ble/bas_peripheral/Cargo.toml
+++ b/examples/ble/bas_peripheral/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 bt-hci = "0.4.0"
 embassy-executor = "0.9.0"
-embassy-futures = "0.1.1"
+embassy-futures = "0.1"
 embassy-sync = "0.7.2"
 embassy-time = "0.5.0"
 esp-alloc = { path = "../../../esp-alloc" }

--- a/examples/ble/scanner/Cargo.toml
+++ b/examples/ble/scanner/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 bt-hci = "0.4.0"
 embassy-executor = "0.9.0"
-embassy-futures = "0.1.1"
+embassy-futures = "0.1"
 embassy-time = "0.5.0"
 esp-alloc = { path = "../../../esp-alloc" }
 esp-backtrace = { path = "../../../esp-backtrace", features = [

--- a/examples/esp-now/embassy_esp_now/Cargo.toml
+++ b/examples/esp-now/embassy_esp_now/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 cfg-if = "1.0.0"
 embassy-executor = "0.9.0"
-embassy-futures = "0.1.1"
+embassy-futures = "0.1"
 embassy-time = "0.5.0"
 esp-alloc = { path = "../../../esp-alloc" }
 esp-backtrace = { path = "../../../esp-backtrace", features = [

--- a/examples/wifi/embassy_access_point_with_sta/Cargo.toml
+++ b/examples/wifi/embassy_access_point_with_sta/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 cfg-if = "1.0.0"
 embassy-executor = "0.9.0"
-embassy-futures = "0.1.1"
+embassy-futures = "0.1"
 embassy-net = { version = "0.7.0", features = [
     "dhcpv4",
     "medium-ethernet",

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -219,7 +219,7 @@ critical-section   = "1.1.3"
 defmt              = "1.0.1"
 defmt-rtt          = { version = "1.0.0", optional = true }
 embassy-executor   = { version = "0.9.0", default-features = false }
-embassy-futures    = "0.1.1"
+embassy-futures    = "0.1"
 embedded-storage   = "0.3.1"
 embassy-sync       = "0.6.0"
 embassy-time       = "0.5.0"

--- a/qa-test/Cargo.toml
+++ b/qa-test/Cargo.toml
@@ -10,7 +10,7 @@ blocking-network-stack = { git = "https://github.com/bjoernQ/blocking-network-st
 cfg-if = "1.0.0"
 embassy-executor = "0.9.0"
 embassy-time = "0.5.0"
-embassy-futures = "0.1.1"
+embassy-futures = "0.1"
 embassy-net = { version = "0.7.0", features = [ "tcp", "udp", "dhcpv4", "medium-ethernet"] }
 embassy-sync = "0.6.1"
 embedded-graphics = "0.8.1"


### PR DESCRIPTION
I've started to see:
```rust
error: failed to select a version for `embassy-futures`.
    ... required by package `embassy-embedded-hal v0.5.0`
    ... which satisfies dependency `embassy-embedded-hal = "^0.5.0"` of package `esp-hal v1.0.0-rc.0 (/Users/jurajsadel/esp-rs/esp-hal/esp-hal)`
    ... which satisfies path dependency `esp-hal` (locked to 1.0.0-rc.0) of package `esp-radio v0.15.0 (/Users/jurajsadel/esp-rs/esp-hal/esp-radio)`
versions that meet the requirements `^0.1.2` are: 0.1.2

all possible versions conflict with previously selected packages.

  previously selected package `embassy-futures v0.1.1`
    ... which satisfies dependency `embassy-futures = "^0.1"` (locked to 0.1.1) of package `esp-hal v1.0.0-rc.0 (/Users/jurajsadel/esp-rs/esp-hal/esp-hal)`
    ... which satisfies path dependency `esp-hal` (locked to 1.0.0-rc.0) of package `esp-radio v0.15.0 (/Users/jurajsadel/esp-rs/esp-hal/esp-radio)`

failed to select a version for `embassy-futures` which could resolve this conflict
Error: Failed to execute cargo subcommand `cargo +esp clippy --target=xtensa-esp32-none-elf -Zbuild-std=core,alloc --no-default-features --features=esp-hal/unstable,esp-hal/rt,defmt,wifi,wifi-eap,esp-now,sniffer,smoltcp/proto-ipv4,smoltcp/proto-ipv6,ble,coex,unstable,esp32 -- -D warnings --no-deps`
```