### PR TITLE
Add wait queues to semaphore/queue

### DIFF
--- a/esp-hal/src/timer/systimer.rs
+++ b/esp-hal/src/timer/systimer.rs
@@ -111,6 +111,7 @@ impl<'d> SystemTimer<'d> {
     }
 
     /// Get the current count of the given unit in the System Timer.
+    #[inline]
     pub fn unit_value(unit: Unit) -> u64 {
         // This should be safe to access from multiple contexts
         // worst case scenario the second accessor ends up reading
@@ -233,6 +234,7 @@ impl Unit {
         }
     }
 
+    #[inline]
     fn read_count(&self) -> u64 {
         // This can be a shared reference as long as this type isn't Sync.
 

--- a/esp-preempt/src/lib.rs
+++ b/esp-preempt/src/lib.rs
@@ -30,6 +30,7 @@ mod semaphore;
 mod task;
 mod timer;
 mod timer_queue;
+mod wait_queue;
 
 pub(crate) use esp_alloc::InternalMemory;
 use esp_hal::{

--- a/esp-preempt/src/queue.rs
+++ b/esp-preempt/src/queue.rs
@@ -1,6 +1,6 @@
+use alloc::{boxed::Box, vec};
 use core::ptr::NonNull;
 
-use allocator_api2::boxed::Box;
 use esp_hal::time::{Duration, Instant};
 use esp_radio_preempt_driver::{
     queue::{QueueImplementation, QueuePtr},
@@ -27,7 +27,7 @@ impl QueueInner {
             capacity,
             current_read: 0,
             current_write: 0,
-            storage: unsafe { Box::new_zeroed_slice(capacity * item_size).assume_init() },
+            storage: vec![0; capacity * item_size].into_boxed_slice(),
             waiting_for_space: WaitQueue::new(),
             waiting_for_item: WaitQueue::new(),
         }
@@ -83,7 +83,7 @@ impl QueueInner {
         // good enough for now
         let count = self.len();
 
-        let mut tmp_item = unsafe { Box::<[u8]>::new_zeroed_slice(self.item_size).assume_init() };
+        let mut tmp_item = vec![0; self.item_size];
 
         let item_slice = unsafe { core::slice::from_raw_parts(item, self.item_size) };
         for _ in 0..count {

--- a/esp-preempt/src/queue.rs
+++ b/esp-preempt/src/queue.rs
@@ -1,6 +1,6 @@
-use alloc::{boxed::Box, vec};
 use core::ptr::NonNull;
 
+use allocator_api2::boxed::Box;
 use esp_hal::time::{Duration, Instant};
 use esp_radio_preempt_driver::{
     queue::{QueueImplementation, QueuePtr},
@@ -27,7 +27,7 @@ impl QueueInner {
             capacity,
             current_read: 0,
             current_write: 0,
-            storage: vec![0; capacity * item_size].into_boxed_slice(),
+            storage: unsafe { Box::new_zeroed_slice(capacity * item_size).assume_init() },
             waiting_for_space: WaitQueue::new(),
             waiting_for_item: WaitQueue::new(),
         }
@@ -83,7 +83,7 @@ impl QueueInner {
         // good enough for now
         let count = self.len();
 
-        let mut tmp_item = vec![0; self.item_size];
+        let mut tmp_item = unsafe { Box::<[u8]>::new_zeroed_slice(self.item_size).assume_init() };
 
         let item_slice = unsafe { core::slice::from_raw_parts(item, self.item_size) };
         for _ in 0..count {

--- a/esp-preempt/src/queue.rs
+++ b/esp-preempt/src/queue.rs
@@ -5,9 +5,10 @@ use esp_hal::time::{Duration, Instant};
 use esp_radio_preempt_driver::{
     queue::{QueueImplementation, QueuePtr},
     register_queue_implementation,
-    yield_task,
 };
 use esp_sync::NonReentrantMutex;
+
+use crate::{SCHEDULER, task::WaitQueue};
 
 struct QueueInner {
     storage: Box<[u8]>,
@@ -15,6 +16,8 @@ struct QueueInner {
     capacity: usize,
     current_read: usize,
     current_write: usize,
+    waiting_for_space: WaitQueue,
+    waiting_for_item: WaitQueue,
 }
 
 impl QueueInner {
@@ -25,6 +28,8 @@ impl QueueInner {
             current_read: 0,
             current_write: 0,
             storage: vec![0; capacity * item_size].into_boxed_slice(),
+            waiting_for_space: WaitQueue::new(),
+            waiting_for_item: WaitQueue::new(),
         }
     }
 
@@ -39,7 +44,7 @@ impl QueueInner {
     }
 
     unsafe fn try_enqueue(&mut self, item: *const u8) -> bool {
-        if self.len() == self.capacity {
+        if self.full() {
             return false;
         }
 
@@ -54,7 +59,7 @@ impl QueueInner {
     }
 
     unsafe fn try_dequeue(&mut self, dst: *mut u8) -> bool {
-        if self.len() == 0 {
+        if self.empty() {
             return false;
         }
 
@@ -69,14 +74,14 @@ impl QueueInner {
     }
 
     unsafe fn remove(&mut self, item: *const u8) {
+        if self.empty() {
+            return;
+        }
+
         // do what the ESP-IDF implementations does...
         // just remove all elements and add them back except the one we need to remove -
         // good enough for now
         let count = self.len();
-
-        if count == 0 {
-            return;
-        }
 
         let mut tmp_item = vec![0; self.item_size];
 
@@ -100,6 +105,14 @@ impl QueueInner {
             self.capacity - self.current_read + self.current_write
         }
     }
+
+    fn empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    fn full(&self) -> bool {
+        self.len() == self.capacity
+    }
 }
 
 pub struct Queue {
@@ -117,48 +130,143 @@ impl Queue {
         unsafe { ptr.cast::<Self>().as_ref() }
     }
 
-    fn yield_loop_with_timeout(timeout_us: Option<u32>, mut cb: impl FnMut() -> bool) -> bool {
-        let start = if timeout_us.is_some() {
-            Instant::now()
-        } else {
-            Instant::EPOCH
-        };
-
-        let timeout = timeout_us
-            .map(|us| Duration::from_micros(us as u64))
-            .unwrap_or(Duration::MAX);
+    unsafe fn send_to_back(&self, item: *const u8, timeout_us: Option<u32>) -> bool {
+        let deadline = timeout_us.map(|us| Instant::now() + Duration::from_micros(us as u64));
 
         loop {
-            if cb() {
+            let enqueued = self.inner.with(|queue| {
+                if unsafe { queue.try_enqueue(item) } {
+                    // WaitQueue::notify_one
+                    if let Some(waken_task) = queue.waiting_for_item.pop() {
+                        SCHEDULER.with(|scheduler| scheduler.resume_task(waken_task));
+                    }
+                    true
+                } else {
+                    // The task will go to sleep when the above critical section is released.
+                    // WaitQueue::wait_with_deadline
+                    SCHEDULER.with(|scheduler| {
+                        queue
+                            .waiting_for_space
+                            .push(unwrap!(scheduler.current_task));
+
+                        let wake_at = if let Some(deadline) = deadline {
+                            deadline
+                        } else {
+                            Instant::EPOCH + Duration::MAX
+                        };
+                        scheduler.sleep_until(wake_at);
+                    });
+                    false
+                }
+            });
+
+            if enqueued {
                 return true;
             }
 
-            if timeout_us.is_some() && start.elapsed() > timeout {
+            // We are here because the queue was full. Now we've either timed out, or an item has
+            // been removed from the queue. However, any higher priority task can wake up
+            // and preempt us still. Let's just check for the timeout, and try the whole process
+            // again.
+
+            if let Some(deadline) = deadline
+                && deadline < Instant::now()
+            {
+                // We have a deadline and we've timed out.
                 return false;
             }
-
-            yield_task();
+            // We can block more, so let's attempt to enqueue again.
         }
     }
 
-    unsafe fn send_to_back(&self, item: *const u8, timeout_us: Option<u32>) -> bool {
-        Self::yield_loop_with_timeout(timeout_us, || unsafe { self.try_send_to_back(item) })
-    }
-
     unsafe fn try_send_to_back(&self, item: *const u8) -> bool {
-        self.inner.with(|queue| unsafe { queue.try_enqueue(item) })
+        self.inner.with(|queue| {
+            if unsafe { queue.try_enqueue(item) } {
+                // WaitQueue::notify_one
+                if let Some(waken_task) = queue.waiting_for_item.pop() {
+                    SCHEDULER.with(|scheduler| scheduler.resume_task(waken_task));
+                }
+                true
+            } else {
+                false
+            }
+        })
     }
 
     unsafe fn receive(&self, item: *mut u8, timeout_us: Option<u32>) -> bool {
-        Self::yield_loop_with_timeout(timeout_us, || unsafe { self.try_receive(item) })
+        let deadline = timeout_us.map(|us| Instant::now() + Duration::from_micros(us as u64));
+
+        loop {
+            // Attempt to dequeue an item from the queue
+            let dequeued = self.inner.with(|queue| {
+                if unsafe { queue.try_dequeue(item) } {
+                    if let Some(waken_task) = queue.waiting_for_space.pop() {
+                        SCHEDULER.with(|scheduler| scheduler.resume_task(waken_task));
+                    }
+                    true
+                } else {
+                    // The task will go to sleep when the above critical section is released.
+                    // WaitQueue::wait_with_deadline
+                    SCHEDULER.with(|scheduler| {
+                        queue.waiting_for_item.push(unwrap!(scheduler.current_task));
+
+                        let wake_at = if let Some(deadline) = deadline {
+                            deadline
+                        } else {
+                            Instant::EPOCH + Duration::MAX
+                        };
+                        scheduler.sleep_until(wake_at);
+                    });
+                    false
+                }
+            });
+
+            if dequeued {
+                return true;
+            }
+
+            // We are here because we weren't able to dequeue from the queue previously. We've
+            // either timed out, or the queue has an item. However, any higher priority
+            // task can wake up and preempt us still. Let's just check for the timeout,
+            // and try the whole process again.
+
+            if let Some(deadline) = deadline
+                && deadline < Instant::now()
+            {
+                // We have a deadline and we've timed out.
+                return false;
+            }
+            // We can block more, so let's attempt to dequeue again.
+        }
     }
 
     unsafe fn try_receive(&self, item: *mut u8) -> bool {
-        self.inner.with(|queue| unsafe { queue.try_dequeue(item) })
+        self.inner.with(|queue| {
+            let dequeued = unsafe { queue.try_dequeue(item) };
+
+            if dequeued && let Some(waken_task) = queue.waiting_for_space.pop() {
+                SCHEDULER.with(|scheduler| scheduler.resume_task(waken_task));
+            }
+
+            dequeued
+        })
     }
 
     unsafe fn remove(&self, item: *const u8) {
-        self.inner.with(|queue| unsafe { queue.remove(item) })
+        self.inner.with(|queue| {
+            let was_full = queue.full();
+
+            unsafe {
+                queue.remove(item);
+            }
+
+            if was_full
+                && !queue.full()
+                && let Some(waken_task) = queue.waiting_for_space.pop()
+            {
+                SCHEDULER.with(|scheduler| scheduler.resume_task(waken_task));
+            }
+        })
     }
 
     fn messages_waiting(&self) -> usize {

--- a/esp-preempt/src/run_queue.rs
+++ b/esp-preempt/src/run_queue.rs
@@ -21,6 +21,11 @@ impl RunQueue {
     pub(crate) fn mark_task_ready(&mut self, mut ready_task: TaskPtr) {
         // TODO: this will need to track max ready priority.
         unsafe { ready_task.as_mut().state = TaskState::Ready };
+        if let Some(mut containing_queue) = unsafe { ready_task.as_mut().current_queue.take() } {
+            unsafe {
+                containing_queue.as_mut().remove(ready_task);
+            }
+        }
         self.ready_tasks.push(ready_task);
     }
 

--- a/esp-preempt/src/scheduler.rs
+++ b/esp-preempt/src/scheduler.rs
@@ -225,10 +225,6 @@ impl Scheduler {
         self.inner.with(cb)
     }
 
-    pub(crate) fn yield_task(&self) {
-        task::yield_task();
-    }
-
     pub(crate) fn current_task(&self) -> TaskPtr {
         task::current_task()
     }
@@ -284,11 +280,11 @@ impl esp_radio_preempt_driver::Scheduler for Scheduler {
     }
 
     fn yield_task(&self) {
-        self.yield_task();
+        task::yield_task();
     }
 
     fn yield_task_from_isr(&self) {
-        self.yield_task();
+        task::yield_task();
     }
 
     fn max_task_priority(&self) -> u32 {

--- a/esp-preempt/src/semaphore.rs
+++ b/esp-preempt/src/semaphore.rs
@@ -5,20 +5,24 @@ use esp_hal::time::{Duration, Instant};
 use esp_radio_preempt_driver::{
     register_semaphore_implementation,
     semaphore::{SemaphoreImplementation, SemaphoreKind, SemaphorePtr},
-    yield_task,
 };
 use esp_sync::NonReentrantMutex;
 
-use crate::task::{TaskPtr, current_task};
+use crate::{
+    SCHEDULER,
+    task::{TaskPtr, WaitQueue, current_task},
+};
 
 enum SemaphoreInner {
     Counting {
         current: u32,
         max: u32,
+        waiting: WaitQueue,
     },
     RecursiveMutex {
         owner: Option<TaskPtr>,
         lock_counter: u32,
+        waiting: WaitQueue,
     },
 }
 
@@ -36,6 +40,7 @@ impl SemaphoreInner {
             SemaphoreInner::RecursiveMutex {
                 owner,
                 lock_counter,
+                ..
             } => {
                 let current = current_task();
                 if owner.is_none() || owner.unwrap() == current {
@@ -50,7 +55,7 @@ impl SemaphoreInner {
 
     fn try_give(&mut self) -> bool {
         match self {
-            SemaphoreInner::Counting { current, max } => {
+            SemaphoreInner::Counting { current, max, .. } => {
                 if *current < *max {
                     *current += 1;
                     true
@@ -61,6 +66,7 @@ impl SemaphoreInner {
             SemaphoreInner::RecursiveMutex {
                 owner,
                 lock_counter,
+                ..
             } => {
                 let current = current_task();
 
@@ -85,6 +91,20 @@ impl SemaphoreInner {
             }
         }
     }
+
+    fn push_waiting_task(&mut self, task: TaskPtr) {
+        match self {
+            SemaphoreInner::Counting { waiting, .. } => waiting.push(task),
+            SemaphoreInner::RecursiveMutex { waiting, .. } => waiting.push(task),
+        }
+    }
+
+    fn pop_waiting(&mut self) -> Option<TaskPtr> {
+        match self {
+            SemaphoreInner::Counting { waiting, .. } => waiting.pop(),
+            SemaphoreInner::RecursiveMutex { waiting, .. } => waiting.pop(),
+        }
+    }
 }
 
 pub struct Semaphore {
@@ -97,10 +117,12 @@ impl Semaphore {
             SemaphoreKind::Counting { initial, max } => SemaphoreInner::Counting {
                 current: initial,
                 max,
+                waiting: WaitQueue::new(),
             },
             SemaphoreKind::RecursiveMutex => SemaphoreInner::RecursiveMutex {
                 owner: None,
                 lock_counter: 0,
+                waiting: WaitQueue::new(),
             },
         };
         Semaphore {
@@ -116,32 +138,45 @@ impl Semaphore {
         self.inner.with(|sem| sem.try_take())
     }
 
-    fn yield_loop_with_timeout(timeout_us: Option<u32>, cb: impl Fn() -> bool) -> bool {
-        let start = if timeout_us.is_some() {
-            Instant::now()
-        } else {
-            Instant::EPOCH
-        };
-
-        let timeout = timeout_us
-            .map(|us| Duration::from_micros(us as u64))
-            .unwrap_or(Duration::MAX);
-
+    pub fn take(&self, timeout_us: Option<u32>) -> bool {
+        let deadline = timeout_us.map(|us| Instant::now() + Duration::from_micros(us as u64));
         loop {
-            if cb() {
+            let taken = self.inner.with(|sem| {
+                if sem.try_take() {
+                    true
+                } else {
+                    // The task will go to sleep when the above critical section is released.
+                    SCHEDULER.with(|scheduler| {
+                        sem.push_waiting_task(unwrap!(scheduler.current_task));
+
+                        let wake_at = if let Some(deadline) = deadline {
+                            deadline
+                        } else {
+                            Instant::EPOCH + Duration::MAX
+                        };
+                        scheduler.sleep_until(wake_at);
+                    });
+                    false
+                }
+            });
+
+            if taken {
                 return true;
             }
 
-            if timeout_us.is_some() && start.elapsed() > timeout {
+            // We are here because we weren't able to take the semaphore previously. We've either
+            // timed out, or the semaphore is ready for taking. However, any higher priority task
+            // can wake up and preempt us still. Let's just check for the timeout, and
+            // try the whole process again.
+
+            if let Some(deadline) = deadline
+                && deadline < Instant::now()
+            {
+                // We have a deadline and we've timed out.
                 return false;
             }
-
-            yield_task();
+            // We can block more, so let's attempt to take the semaphore again.
         }
-    }
-
-    pub fn take(&self, timeout_us: Option<u32>) -> bool {
-        Self::yield_loop_with_timeout(timeout_us, || self.try_take())
     }
 
     pub fn current_count(&self) -> u32 {
@@ -149,7 +184,16 @@ impl Semaphore {
     }
 
     pub fn give(&self) -> bool {
-        self.inner.with(|sem| sem.try_give())
+        self.inner.with(|sem| {
+            if sem.try_give() {
+                if let Some(waken_task) = sem.pop_waiting() {
+                    SCHEDULER.with(|scheduler| scheduler.resume_task(waken_task));
+                }
+                true
+            } else {
+                false
+            }
+        })
     }
 }
 

--- a/esp-preempt/src/semaphore.rs
+++ b/esp-preempt/src/semaphore.rs
@@ -1,7 +1,6 @@
+use alloc::boxed::Box;
 use core::ptr::NonNull;
 
-use allocator_api2::boxed::Box;
-use esp_alloc::InternalMemory;
 use esp_hal::time::{Duration, Instant};
 use esp_radio_preempt_driver::{
     register_semaphore_implementation,
@@ -190,13 +189,12 @@ impl Semaphore {
 
 impl SemaphoreImplementation for Semaphore {
     fn create(kind: SemaphoreKind) -> SemaphorePtr {
-        let sem = Box::new_in(Semaphore::new(kind), InternalMemory);
+        let sem = Box::new(Semaphore::new(kind));
         NonNull::from(Box::leak(sem)).cast()
     }
 
     unsafe fn delete(semaphore: SemaphorePtr) {
-        let sem =
-            unsafe { Box::from_raw_in(semaphore.cast::<Semaphore>().as_ptr(), InternalMemory) };
+        let sem = unsafe { Box::from_raw(semaphore.cast::<Semaphore>().as_ptr()) };
         core::mem::drop(sem);
     }
 

--- a/esp-preempt/src/semaphore.rs
+++ b/esp-preempt/src/semaphore.rs
@@ -146,6 +146,7 @@ impl Semaphore {
                     true
                 } else {
                     // The task will go to sleep when the above critical section is released.
+                    // WaitQueue::wait_with_deadline
                     SCHEDULER.with(|scheduler| {
                         sem.push_waiting_task(unwrap!(scheduler.current_task));
 

--- a/esp-preempt/src/task/mod.rs
+++ b/esp-preempt/src/task/mod.rs
@@ -284,7 +284,7 @@ pub(crate) fn spawn_idle_task() {
 
 pub(crate) extern "C" fn idle_task(_: *mut c_void) {
     loop {
-        SCHEDULER.yield_task();
+        yield_task();
         // TODO: once we have priorities, we can waiti:
         // #[cfg(xtensa)]
         // unsafe {
@@ -335,8 +335,11 @@ pub(super) fn schedule_task_deletion(task: *mut Context) {
     // Tasks are deleted during context switches, so we need to yield if we are
     // deleting the current task.
     if deleting_current {
-        loop {
-            SCHEDULER.yield_task();
-        }
+        SCHEDULER.with(|scheduler| {
+            // We won't be re-scheduled.
+            scheduler.event.set_blocked();
+            yield_task();
+        });
+        unreachable!();
     }
 }

--- a/esp-preempt/src/task/mod.rs
+++ b/esp-preempt/src/task/mod.rs
@@ -296,7 +296,7 @@ pub(super) fn allocate_main_task() {
 }
 
 pub(crate) fn spawn_idle_task() {
-    let ptr = SCHEDULER.create_task(idle_task, core::ptr::null_mut(), 8192);
+    let ptr = SCHEDULER.create_task(idle_task, core::ptr::null_mut(), 4096);
     debug!("Idle task created: {:?}", ptr);
 }
 

--- a/esp-preempt/src/task/mod.rs
+++ b/esp-preempt/src/task/mod.rs
@@ -169,6 +169,10 @@ impl<E: TaskListElement> TaskQueue<E> {
     }
 }
 
+// A task is either blocked, or ready. Since it can't be both, we can reuse the ready queue element.
+// Note however, that a task can simultaneously be in the timer queue and a wait queue!
+pub(crate) type WaitQueue = TaskQueue<TaskReadyQueueElement>;
+
 #[repr(C)]
 pub(crate) struct Context {
     #[cfg(riscv)]

--- a/esp-preempt/src/task/mod.rs
+++ b/esp-preempt/src/task/mod.rs
@@ -172,10 +172,6 @@ impl<E: TaskListElement> TaskQueue<E> {
     }
 }
 
-// A task is either blocked, or ready. Since it can't be both, we can reuse the ready queue element.
-// Note however, that a task can simultaneously be in the timer queue and a wait queue!
-pub(crate) type WaitQueue = TaskQueue<TaskReadyQueueElement>;
-
 #[repr(C)]
 pub(crate) struct Context {
     #[cfg(riscv)]
@@ -192,7 +188,7 @@ pub(crate) struct Context {
     /// The list of all allocated tasks
     pub alloc_list_item: TaskListItem,
 
-    /// The list of ready tasks
+    /// Either the RunQueue or the WaitQueue
     pub ready_queue_item: TaskListItem,
 
     /// The timer queue

--- a/esp-preempt/src/timer/mod.rs
+++ b/esp-preempt/src/timer/mod.rs
@@ -135,13 +135,20 @@ impl TimeDriver {
         }
     }
 
-    pub(crate) fn schedule_wakeup(&mut self, mut current_task: TaskPtr, at: Instant) {
+    pub(crate) fn schedule_wakeup(&mut self, mut current_task: TaskPtr, at: Instant) -> bool {
         unsafe { debug_assert_eq!(current_task.as_mut().state, TaskState::Ready) };
+
+        // Target time is in the past, don't sleep.
+        if at <= Instant::now() {
+            return false;
+        }
+
         unsafe { current_task.as_mut().state = TaskState::Sleeping };
 
+        // Target time is infinite, suspend task without waking up via timer.
         if at == Instant::EPOCH + Duration::MAX {
             debug!("Suspending task: {:?}", current_task);
-            return;
+            return true;
         }
 
         let timestamp = at.duration_since_epoch().as_micros();
@@ -152,6 +159,8 @@ impl TimeDriver {
         self.timer_queue.push(current_task, timestamp);
 
         unsafe { current_task.as_mut().wakeup_at = timestamp };
+
+        true
     }
 }
 

--- a/esp-preempt/src/timer/mod.rs
+++ b/esp-preempt/src/timer/mod.rs
@@ -177,7 +177,7 @@ extern "C" fn timer_tick_handler(#[cfg(xtensa)] _context: &mut esp_hal::trapfram
         // software interrupt manually.
         cfg_if::cfg_if! {
             if #[cfg(any(riscv, esp32))] {
-                SCHEDULER.yield_task();
+                crate::task::yield_task();
             } else {
                 scheduler.switch_task(_context)
             }

--- a/esp-preempt/src/wait_queue.rs
+++ b/esp-preempt/src/wait_queue.rs
@@ -1,0 +1,44 @@
+use esp_hal::time::{Duration, Instant};
+
+use crate::{
+    SCHEDULER,
+    task::{TaskQueue, TaskReadyQueueElement},
+};
+
+pub(crate) struct WaitQueue {
+    // A task is either blocked, or ready. Since it can't be both, we can reuse the ready queue
+    // element. Note however, that a task can simultaneously be in the timer queue and a wait
+    // queue!
+    pub(crate) waiting_tasks: TaskQueue<TaskReadyQueueElement>,
+}
+
+impl WaitQueue {
+    pub(crate) const fn new() -> Self {
+        Self {
+            waiting_tasks: TaskQueue::new(),
+        }
+    }
+
+    pub(crate) fn notify(&mut self) {
+        SCHEDULER.with(|scheduler| {
+            // Let's wake up all waiting tasks. This is far from optimal, but it's simple and will
+            // ensure that the highest priority task is notified first.
+            while let Some(waken_task) = self.waiting_tasks.pop() {
+                scheduler.resume_task(waken_task);
+            }
+        });
+    }
+
+    pub(crate) fn wait_with_deadline(&mut self, deadline: Option<Instant>) {
+        SCHEDULER.with(|scheduler| {
+            self.waiting_tasks.push(unwrap!(scheduler.current_task));
+
+            let wake_at = if let Some(deadline) = deadline {
+                deadline
+            } else {
+                Instant::EPOCH + Duration::MAX
+            };
+            scheduler.sleep_until(wake_at);
+        });
+    }
+}

--- a/esp-radio/src/wifi/os_adapter/mod.rs
+++ b/esp-radio/src/wifi/os_adapter/mod.rs
@@ -275,6 +275,7 @@ pub unsafe extern "C" fn wifi_thread_semphr_get() -> *mut c_void {
 ///
 /// *************************************************************************
 pub unsafe extern "C" fn mutex_create() -> *mut c_void {
+    trace!("mutex_create");
     crate::compat::mutex::mutex_create(false)
 }
 
@@ -292,6 +293,7 @@ pub unsafe extern "C" fn mutex_create() -> *mut c_void {
 ///
 /// *************************************************************************
 pub unsafe extern "C" fn recursive_mutex_create() -> *mut c_void {
+    trace!("recursive_mutex_create");
     crate::compat::mutex::mutex_create(true)
 }
 

--- a/hil-test/tests/esp_radio_init.rs
+++ b/hil-test/tests/esp_radio_init.rs
@@ -2,7 +2,7 @@
 //! disabled in common ways
 
 //% CHIPS: esp32 esp32s2 esp32c2 esp32c3 esp32c6 esp32s3
-//% FEATURES: unstable esp-radio esp-alloc esp-radio/wifi esp-radio/unstable embassy
+//% FEATURES: unstable esp-radio esp-alloc esp-radio/wifi esp-radio/unstable embassy defmt
 
 #![no_std]
 #![no_main]
@@ -111,12 +111,18 @@ mod tests {
 
     #[test]
     #[cfg(soc_has_wifi)]
-    fn test_wifi_can_be_initialized(peripherals: Peripherals) {
-        let timg0 = TimerGroup::new(peripherals.TIMG0);
+    fn test_wifi_can_be_initialized(mut p: Peripherals) {
+        let timg0 = TimerGroup::new(p.TIMG0);
         esp_preempt::init(timg0.timer0);
 
-        let esp_radio_ctrl = esp_radio::init().unwrap();
+        let esp_radio_ctrl =
+            &*mk_static!(esp_radio::Controller<'static>, esp_radio::init().unwrap());
 
-        _ = esp_radio::wifi::new(&esp_radio_ctrl, peripherals.WIFI).unwrap();
+        // Initialize, then de-initialize wifi
+        let wifi = esp_radio::wifi::new(&esp_radio_ctrl, p.WIFI.reborrow()).unwrap();
+        drop(wifi);
+
+        // Now, can we do it again?
+        let _wifi = esp_radio::wifi::new(&esp_radio_ctrl, p.WIFI.reborrow()).unwrap();
     }
 }

--- a/hil-test/tests/esp_radio_init.rs
+++ b/hil-test/tests/esp_radio_init.rs
@@ -2,7 +2,7 @@
 //! disabled in common ways
 
 //% CHIPS: esp32 esp32s2 esp32c2 esp32c3 esp32c6 esp32s3
-//% FEATURES: unstable esp-radio esp-alloc esp-radio/wifi esp-radio/unstable embassy defmt
+//% FEATURES: unstable esp-radio esp-alloc esp-radio/wifi esp-radio/unstable embassy
 
 #![no_std]
 #![no_main]


### PR DESCRIPTION
No more busy looping - except in the idle task, because something needs to be running. Unfortunately, we don't currently have priority levels, so the idle task isn't as idle as it should be.

The PR also introduces a basic stack overflow detection, an idle task, and fixes saving context of deleted tasks.