### PR TITLE
Fix warning without unstable

### DIFF
--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -699,7 +699,7 @@ impl crate::interrupt::InterruptConfigurable for Io<'_> {
 
 for_each_analog_function! {
     (($_ch:ident, ADCn_CHm, $_n:literal, $_m:literal), $gpio:ident) => {
-        #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
+        #[instability::unstable]
         impl $crate::gpio::AnalogPin for crate::peripherals::$gpio<'_> {
             #[cfg(riscv)]
             fn set_analog(&self, _: private::Internal) {

--- a/esp-hal/src/soc/esp32/gpio.rs
+++ b/esp-hal/src/soc/esp32/gpio.rs
@@ -76,6 +76,7 @@ macro_rules! rtcio_analog {
 
             impl $crate::peripherals::$pin_peri<'_> {
                 /// Configures the pin for analog mode.
+                #[cfg(feature = "unstable")]
                 pub(crate) fn set_analog_impl(&self) {
                     use $crate::gpio::RtcPin;
                     let rtcio = $crate::peripherals::RTC_IO::regs();

--- a/esp-hal/src/soc/esp32s2/gpio.rs
+++ b/esp-hal/src/soc/esp32s2/gpio.rs
@@ -134,6 +134,7 @@ for_each_lp_function! {
 for_each_analog_function! {
     (($_ch:ident, ADCn_CHm, $_n:literal, $_m:literal), $gpio:ident) => {
         impl crate::peripherals::$gpio<'_> {
+            #[cfg(feature = "unstable")]
             pub(crate) fn set_analog_impl(&self) {
                 use crate::gpio::RtcPin;
                 enable_iomux_clk_gate();

--- a/esp-hal/src/soc/esp32s3/gpio.rs
+++ b/esp-hal/src/soc/esp32s3/gpio.rs
@@ -74,6 +74,7 @@ macro_rules! rtcio_analog {
                 $crate::ignore!($analog);
                 impl $crate::peripherals::[<GPIO $pin_num>]<'_> {
                     /// Configures the pin for analog mode.
+                    #[cfg(feature = "unstable")]
                     pub(crate) fn set_analog_impl(&self) {
                         use $crate::gpio::RtcPin;
                         enable_iomux_clk_gate();


### PR DESCRIPTION
The trait is unstable -> implementing it needs to be unstable, or the code itself, or what it calls is warned as dead.