### PR TITLE
Miscellaneous cleanup in `rtc_cntl` module

### DIFF
--- a/esp-hal/src/rtc_cntl/mod.rs
+++ b/esp-hal/src/rtc_cntl/mod.rs
@@ -242,9 +242,9 @@ impl<'d> Rtc<'d> {
     pub fn new(rtc_cntl: LPWR<'d>) -> Self {
         Self {
             _inner: rtc_cntl,
-            rwdt: Rwdt::new(),
+            rwdt: Rwdt(()),
             #[cfg(swd)]
-            swd: Swd::new(),
+            swd: Swd(()),
         }
     }
 
@@ -470,6 +470,7 @@ impl<'d> Rtc<'d> {
         unwrap!(interrupt::enable(interrupt, handler.priority()));
     }
 }
+
 impl crate::private::Sealed for Rtc<'_> {}
 
 #[instability::unstable]
@@ -513,21 +514,10 @@ pub enum RwdtStage {
 }
 
 /// RTC Watchdog Timer.
-pub struct Rwdt;
-
-impl Default for Rwdt {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+pub struct Rwdt(());
 
 /// RTC Watchdog Timer driver.
 impl Rwdt {
-    /// Create a new RTC watchdog timer instance
-    pub fn new() -> Self {
-        Self
-    }
-
     /// Enable the watchdog timer instance.
     /// Watchdog starts with default settings (`stage 0` resets the system, the
     /// others are deactivated)
@@ -677,16 +667,11 @@ impl Rwdt {
 
 /// Super Watchdog
 #[cfg(swd)]
-pub struct Swd;
+pub struct Swd(());
 
 /// Super Watchdog driver
 #[cfg(swd)]
 impl Swd {
-    /// Create a new super watchdog timer instance
-    pub fn new() -> Self {
-        Self
-    }
-
     /// Enable the watchdog timer instance
     pub fn enable(&mut self) {
         self.set_enabled(true);
@@ -717,13 +702,6 @@ impl Swd {
             .write(|w| w.swd_auto_feed_en().bit(!enable));
 
         self.set_write_protection(true);
-    }
-}
-
-#[cfg(any(esp32c2, esp32c3, esp32c6, esp32h2, esp32s3))]
-impl Default for Swd {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/esp-hal/src/rtc_cntl/mod.rs
+++ b/esp-hal/src/rtc_cntl/mod.rs
@@ -229,8 +229,8 @@ pub struct Rtc<'d> {
     _inner: LPWR<'d>,
     /// Reset Watchdog Timer.
     pub rwdt: Rwdt,
-    #[cfg(any(esp32c2, esp32c3, esp32c6, esp32h2, esp32s3))]
     /// Super Watchdog
+    #[cfg(swd)]
     pub swd: Swd,
 }
 
@@ -242,7 +242,7 @@ impl<'d> Rtc<'d> {
         Self {
             _inner: rtc_cntl,
             rwdt: Rwdt::new(),
-            #[cfg(any(esp32c2, esp32c3, esp32c6, esp32h2, esp32s3))]
+            #[cfg(swd)]
             swd: Swd::new(),
         }
     }
@@ -682,12 +682,12 @@ impl Rwdt {
     }
 }
 
-#[cfg(any(esp32c2, esp32c3, esp32c6, esp32h2, esp32s3))]
 /// Super Watchdog
+#[cfg(swd)]
 pub struct Swd;
 
-#[cfg(any(esp32c2, esp32c3, esp32c6, esp32h2, esp32s3))]
 /// Super Watchdog driver
+#[cfg(swd)]
 impl Swd {
     /// Create a new super watchdog timer instance
     pub fn new() -> Self {

--- a/esp-hal/src/rtc_cntl/mod.rs
+++ b/esp-hal/src/rtc_cntl/mod.rs
@@ -188,7 +188,7 @@ bitflags::bitflags! {
     }
 }
 
-/// Clock source to be calibrated using rtc_clk_cal function
+/// Clock source to be calibrated using `rtc_clk_cal` function
 #[allow(unused)]
 #[cfg(not(any(esp32c6, esp32h2)))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -205,9 +205,10 @@ pub(crate) enum RtcCalSel {
     InternalOsc = 3,
 }
 
-/// Clock source to be calibrated using rtc_clk_cal function
-#[derive(Debug, Clone, Copy, PartialEq)]
+/// Clock source to be calibrated using `rtc_clk_cal` function
 #[cfg(any(esp32c6, esp32h2))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum RtcCalSel {
     /// Currently selected RTC SLOW_CLK
     RtcMux      = -1,

--- a/esp-metadata-generated/src/_build_script_utils.rs
+++ b/esp-metadata-generated/src/_build_script_utils.rs
@@ -502,6 +502,7 @@ impl Chip {
                     "soc_has_mem2mem8",
                     "gdma",
                     "phy",
+                    "swd",
                     "rom_crc_le",
                     "rom_crc_be",
                     "rom_md5_mbedtls",
@@ -619,6 +620,7 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_mem2mem8",
                     "cargo:rustc-cfg=gdma",
                     "cargo:rustc-cfg=phy",
+                    "cargo:rustc-cfg=swd",
                     "cargo:rustc-cfg=rom_crc_le",
                     "cargo:rustc-cfg=rom_crc_be",
                     "cargo:rustc-cfg=rom_md5_mbedtls",
@@ -748,6 +750,7 @@ impl Chip {
                     "soc_has_wifi",
                     "gdma",
                     "phy",
+                    "swd",
                     "rom_crc_le",
                     "rom_crc_be",
                     "rom_md5_bsd",
@@ -894,6 +897,7 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_wifi",
                     "cargo:rustc-cfg=gdma",
                     "cargo:rustc-cfg=phy",
+                    "cargo:rustc-cfg=swd",
                     "cargo:rustc-cfg=rom_crc_le",
                     "cargo:rustc-cfg=rom_crc_be",
                     "cargo:rustc-cfg=rom_md5_bsd",
@@ -1084,6 +1088,7 @@ impl Chip {
                     "plic",
                     "phy",
                     "lp_core",
+                    "swd",
                     "rom_crc_le",
                     "rom_crc_be",
                     "rom_md5_bsd",
@@ -1287,6 +1292,7 @@ impl Chip {
                     "cargo:rustc-cfg=plic",
                     "cargo:rustc-cfg=phy",
                     "cargo:rustc-cfg=lp_core",
+                    "cargo:rustc-cfg=swd",
                     "cargo:rustc-cfg=rom_crc_le",
                     "cargo:rustc-cfg=rom_crc_be",
                     "cargo:rustc-cfg=rom_md5_bsd",
@@ -1481,6 +1487,7 @@ impl Chip {
                     "gdma",
                     "plic",
                     "phy",
+                    "swd",
                     "rom_crc_le",
                     "rom_crc_be",
                     "rom_md5_bsd",
@@ -1658,6 +1665,7 @@ impl Chip {
                     "cargo:rustc-cfg=gdma",
                     "cargo:rustc-cfg=plic",
                     "cargo:rustc-cfg=phy",
+                    "cargo:rustc-cfg=swd",
                     "cargo:rustc-cfg=rom_crc_le",
                     "cargo:rustc-cfg=rom_crc_be",
                     "cargo:rustc-cfg=rom_md5_bsd",
@@ -2172,6 +2180,7 @@ impl Chip {
                     "psram",
                     "psram_dma",
                     "octal_psram",
+                    "swd",
                     "ulp_riscv_core",
                     "rom_crc_le",
                     "rom_crc_be",
@@ -2354,6 +2363,7 @@ impl Chip {
                     "cargo:rustc-cfg=psram",
                     "cargo:rustc-cfg=psram_dma",
                     "cargo:rustc-cfg=octal_psram",
+                    "cargo:rustc-cfg=swd",
                     "cargo:rustc-cfg=ulp_riscv_core",
                     "cargo:rustc-cfg=rom_crc_le",
                     "cargo:rustc-cfg=rom_crc_be",
@@ -2630,6 +2640,7 @@ impl Config {
         println!("cargo:rustc-check-cfg=cfg(soc_has_mem2mem7)");
         println!("cargo:rustc-check-cfg=cfg(soc_has_mem2mem8)");
         println!("cargo:rustc-check-cfg=cfg(gdma)");
+        println!("cargo:rustc-check-cfg=cfg(swd)");
         println!("cargo:rustc-check-cfg=cfg(rom_md5_mbedtls)");
         println!("cargo:rustc-check-cfg=cfg(pm_support_wifi_wakeup)");
         println!("cargo:rustc-check-cfg=cfg(pm_support_bt_wakeup)");

--- a/esp-metadata/devices/esp32c2.toml
+++ b/esp-metadata/devices/esp32c2.toml
@@ -62,6 +62,7 @@ symbols = [
     # Additional peripherals defined by us (the developers):
     "gdma",
     "phy",
+    "swd",
 
     # ROM capabilities
     "rom_crc_le",

--- a/esp-metadata/devices/esp32c3.toml
+++ b/esp-metadata/devices/esp32c3.toml
@@ -70,6 +70,7 @@ symbols = [
     # Additional peripherals defined by us (the developers):
     "gdma",
     "phy",
+    "swd",
 
     # ROM capabilities
     "rom_crc_le",

--- a/esp-metadata/devices/esp32c6.toml
+++ b/esp-metadata/devices/esp32c6.toml
@@ -110,6 +110,7 @@ symbols = [
     "plic",
     "phy",
     "lp_core",
+    "swd",
 
     # ROM capabilities
     "rom_crc_le",

--- a/esp-metadata/devices/esp32h2.toml
+++ b/esp-metadata/devices/esp32h2.toml
@@ -97,6 +97,7 @@ symbols = [
     "gdma",
     "plic",
     "phy",
+    "swd",
 
     # ROM capabilities
     "rom_crc_le",

--- a/esp-metadata/devices/esp32s3.toml
+++ b/esp-metadata/devices/esp32s3.toml
@@ -90,6 +90,7 @@ symbols = [
     "psram",
     "psram_dma",
     "octal_psram",
+    "swd",
     "ulp_riscv_core",
 
     # ROM capabilities


### PR DESCRIPTION
Mostly just random changes, not a clear sense of direction in the linked issue so probably much of this is just personal preference, but at least it feels a bit cleaner to me.

I've split up the work by commit, so anything can be reverted easily if anybody is not a fan of the changes:

- Defined a metadata symbol for the Super Watchdog timer
- Removed unnecessary constructors/`Default` impls for unit structs
- Use `cfg_if` in favour of multiple `#[cfg]`s
- Eliminate some pointless variable definitions (which were only ever referenced once)
- Make derives match for both versions of `RtcCalSel`

Still probably room for improvement in this module, so won't close the issue. If anybody has any concrete input please leave a comment in the issue so it can be addressed in a subsequent PR.

More progress toward #2189 