### PR TITLE
RMT: don't require physical pin connections for loopback HIL tests

### DIFF
--- a/hil-test/tests/rmt.rs
+++ b/hil-test/tests/rmt.rs
@@ -9,7 +9,12 @@
 use esp_hal::{
     Blocking,
     DriverMode,
-    gpio::{InputPin, Level, NoPin, OutputPin},
+    gpio::{
+        Flex,
+        Level,
+        NoPin,
+        interconnect::{PeripheralInput, PeripheralOutput},
+    },
     rmt::{
         Channel,
         Error,
@@ -36,10 +41,10 @@ cfg_if::cfg_if! {
     }
 }
 
-fn setup<Dm: DriverMode>(
+fn setup<'a, Dm: DriverMode>(
     rmt: Rmt<'static, Dm>,
-    rx: impl InputPin,
-    tx: impl OutputPin,
+    rx: impl PeripheralInput<'a>,
+    tx: impl PeripheralOutput<'a>,
     tx_config: TxChannelConfig,
     rx_config: RxChannelConfig,
 ) -> (Channel<Dm, Tx>, Channel<Dm, Rx>) {
@@ -105,7 +110,8 @@ fn do_rmt_loopback_inner<const TX_LEN: usize>(
 // another one for receive, and verify that the data matches.
 fn do_rmt_loopback<const TX_LEN: usize>(tx_memsize: u8, rx_memsize: u8) {
     let peripherals = esp_hal::init(esp_hal::Config::default());
-    let (rx, tx) = hil_test::common_test_pins!(peripherals);
+    let (_, pin) = hil_test::common_test_pins!(peripherals);
+    let (rx, tx) = Flex::new(pin).split();
     let rmt = Rmt::new(peripherals.RMT, FREQ).unwrap();
 
     let tx_config = TxChannelConfig::default().with_memsize(tx_memsize);
@@ -122,7 +128,8 @@ fn do_rmt_loopback<const TX_LEN: usize>(tx_memsize: u8, rx_memsize: u8) {
 // another one for receive, and verify that the data matches.
 async fn do_rmt_loopback_async<const TX_LEN: usize>(tx_memsize: u8, rx_memsize: u8) {
     let peripherals = esp_hal::init(esp_hal::Config::default());
-    let (rx, tx) = hil_test::common_test_pins!(peripherals);
+    let (_, pin) = hil_test::common_test_pins!(peripherals);
+    let (rx, tx) = Flex::new(pin).split();
     let rmt = Rmt::new(peripherals.RMT, FREQ).unwrap().into_async();
 
     let tx_config = TxChannelConfig::default().with_memsize(tx_memsize);
@@ -156,7 +163,8 @@ fn do_rmt_single_shot<const TX_LEN: usize>(
     write_end_marker: bool,
 ) -> Result<(), Error> {
     let peripherals = esp_hal::init(esp_hal::Config::default());
-    let (rx, tx) = hil_test::common_test_pins!(peripherals);
+    let (_, pin) = hil_test::common_test_pins!(peripherals);
+    let (rx, tx) = Flex::new(pin).split();
     let rmt = Rmt::new(peripherals.RMT, FREQ).unwrap();
 
     let tx_config = TxChannelConfig::default()
@@ -286,8 +294,7 @@ mod tests {
     macro_rules! test_channel_pair {
         (
             $peripherals:ident,
-            $tx_pin:ident,
-            $rx_pin:ident,
+            $pin:ident,
             $tx_channel:ident,
             $rx_channel:ident
         ) => {
@@ -298,15 +305,12 @@ mod tests {
             let tx_config = TxChannelConfig::default();
             let rx_config = RxChannelConfig::default().with_idle_threshold(1000);
 
-            let tx_channel = rmt
-                .$tx_channel
-                .configure_tx($tx_pin.reborrow(), tx_config)
-                .unwrap();
+            let pin = Flex::new($pin.reborrow());
+            let (rx_pin, tx_pin) = pin.split();
 
-            let rx_channel = rmt
-                .$rx_channel
-                .configure_rx($rx_pin.reborrow(), rx_config)
-                .unwrap();
+            let tx_channel = rmt.$tx_channel.configure_tx(tx_pin, tx_config).unwrap();
+
+            let rx_channel = rmt.$rx_channel.configure_rx(rx_pin, rx_config).unwrap();
 
             do_rmt_loopback_inner::<20>(tx_channel, rx_channel);
         };
@@ -318,7 +322,7 @@ mod tests {
     #[test]
     fn rmt_use_all_channels() {
         let mut p = esp_hal::init(esp_hal::Config::default());
-        let (mut rx, mut tx) = hil_test::common_test_pins!(p);
+        let (_, mut pin) = hil_test::common_test_pins!(p);
 
         // FIXME: Find a way to implement these with less boilerplate and without a macro.
         // Maybe use ChannelCreator::steal() (doesn't help right now because it uses a const
@@ -327,47 +331,47 @@ mod tests {
         // Chips with combined RxTx channels
         #[cfg(esp32)]
         {
-            test_channel_pair!(p, tx, rx, channel0, channel1);
-            test_channel_pair!(p, tx, rx, channel0, channel2);
-            test_channel_pair!(p, tx, rx, channel0, channel3);
-            test_channel_pair!(p, tx, rx, channel0, channel4);
-            test_channel_pair!(p, tx, rx, channel0, channel5);
-            test_channel_pair!(p, tx, rx, channel0, channel6);
-            test_channel_pair!(p, tx, rx, channel0, channel7);
+            test_channel_pair!(p, pin, channel0, channel1);
+            test_channel_pair!(p, pin, channel0, channel2);
+            test_channel_pair!(p, pin, channel0, channel3);
+            test_channel_pair!(p, pin, channel0, channel4);
+            test_channel_pair!(p, pin, channel0, channel5);
+            test_channel_pair!(p, pin, channel0, channel6);
+            test_channel_pair!(p, pin, channel0, channel7);
 
-            test_channel_pair!(p, tx, rx, channel1, channel0);
-            test_channel_pair!(p, tx, rx, channel2, channel0);
-            test_channel_pair!(p, tx, rx, channel3, channel0);
-            test_channel_pair!(p, tx, rx, channel4, channel0);
-            test_channel_pair!(p, tx, rx, channel5, channel0);
-            test_channel_pair!(p, tx, rx, channel6, channel0);
-            test_channel_pair!(p, tx, rx, channel7, channel0);
+            test_channel_pair!(p, pin, channel1, channel0);
+            test_channel_pair!(p, pin, channel2, channel0);
+            test_channel_pair!(p, pin, channel3, channel0);
+            test_channel_pair!(p, pin, channel4, channel0);
+            test_channel_pair!(p, pin, channel5, channel0);
+            test_channel_pair!(p, pin, channel6, channel0);
+            test_channel_pair!(p, pin, channel7, channel0);
         }
 
         #[cfg(esp32s2)]
         {
-            test_channel_pair!(p, tx, rx, channel0, channel1);
-            test_channel_pair!(p, tx, rx, channel0, channel2);
-            test_channel_pair!(p, tx, rx, channel0, channel3);
+            test_channel_pair!(p, pin, channel0, channel1);
+            test_channel_pair!(p, pin, channel0, channel2);
+            test_channel_pair!(p, pin, channel0, channel3);
 
-            test_channel_pair!(p, tx, rx, channel1, channel0);
-            test_channel_pair!(p, tx, rx, channel2, channel0);
-            test_channel_pair!(p, tx, rx, channel3, channel0);
+            test_channel_pair!(p, pin, channel1, channel0);
+            test_channel_pair!(p, pin, channel2, channel0);
+            test_channel_pair!(p, pin, channel3, channel0);
         }
 
         // Chips with separate Rx and Tx channels
         #[cfg(esp32s3)]
         {
-            test_channel_pair!(p, tx, rx, channel0, channel4);
-            test_channel_pair!(p, tx, rx, channel1, channel5);
-            test_channel_pair!(p, tx, rx, channel2, channel6);
-            test_channel_pair!(p, tx, rx, channel3, channel7);
+            test_channel_pair!(p, pin, channel0, channel4);
+            test_channel_pair!(p, pin, channel1, channel5);
+            test_channel_pair!(p, pin, channel2, channel6);
+            test_channel_pair!(p, pin, channel3, channel7);
         }
 
         #[cfg(not(any(esp32, esp32s2, esp32s3)))]
         {
-            test_channel_pair!(p, tx, rx, channel0, channel2);
-            test_channel_pair!(p, tx, rx, channel1, channel3);
+            test_channel_pair!(p, pin, channel0, channel2);
+            test_channel_pair!(p, pin, channel1, channel3);
         }
     }
 }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖
This replaces the use of externally connected pins for loopback tests by using a single GPIO and splitting it into input/output halves:

```diff
-let (rx, tx) = hil_test::common_test_pins!(peripherals);
+let (_, pin) = hil_test::common_test_pins!(peripherals);
+let (rx, tx) = Flex::new(pin).split();
```

I found this a little more convenient when running HIL tests locally since I don't need to actually connect pins first. I'm not entirely sure whether this has any drawbacks regarding the rigor of these HIL tests. What do you think?

There's some prior art in the TWAI test:

https://github.com/esp-rs/esp-hal/blob/9c35cf9b169ee6b2f26d3df0e199d3885a47d8b6/hil-test/tests/twai.rs#L30-L32

No changelog entry required since this only changes HIL tests.

#### Testing
HIL tests locally on esp32c3.
