### PR TITLE
Ping i2c sensor after cancellation

### DIFF
--- a/hil-test/tests/i2c.rs
+++ b/hil-test/tests/i2c.rs
@@ -251,6 +251,10 @@ mod tests {
             );
 
             defmt::info!("Transaction cancelled");
+
+            // Ping the sensor to ensure we don't randomly get an address failure in the next
+            // iteration.
+            _ = i2c.write_async(DUT_ADDRESS, &[]).await;
         }
 
         let mut read_data = [0u8; 22];


### PR DESCRIPTION
We shouldn't need this, but perhaps our sensor doesn't like the stop condition we try to feed it.