### PR TITLE
Fix AES touching memory at inappropriate places

### DIFF
--- a/esp-hal/src/aes/mod.rs
+++ b/esp-hal/src/aes/mod.rs
@@ -941,9 +941,11 @@ pub mod dma {
                     // Write out PSRAM data if needed:
                     #[cfg(psram_dma)]
                     for buffer in self.unaligned_data_buffers.iter_mut() {
-                        if let Some(buffer) = buffer.take() {
+                        // Avoid copying the write_back buffer
+                        if let Some(buffer) = buffer.as_ref() {
                             buffer.write_back();
                         }
+                        *buffer = None;
                     }
                     #[cfg(psram_dma)]
                     if crate::psram::psram_range().contains(&item.buffers.output.addr().get()) {

--- a/esp-hal/src/dma/buffers.rs
+++ b/esp-hal/src/dma/buffers.rs
@@ -1739,8 +1739,9 @@ pub(crate) unsafe fn prepare_for_rx(
                     data,
                 );
 
-                // Invalidate data written by the DMA
+                // Invalidate data written by the DMA. As this likely affects more data than we touched, write back first.
                 unsafe {
+                    crate::soc::cache_writeback_addr(data_addr as u32, consumed_bytes as u32);
                     crate::soc::cache_invalidate_addr(data_addr as u32, consumed_bytes as u32);
                 }
 
@@ -1935,7 +1936,7 @@ impl ManualWritebackBuffer {
         }
     }
 
-    pub fn write_back(self) {
+    pub fn write_back(&self) {
         unsafe {
             self.dst_address
                 .as_ptr()

--- a/hil-test/tests/aes.rs
+++ b/hil-test/tests/aes.rs
@@ -334,7 +334,7 @@ fn run_unaligned_dma_tests<const MAX_SHIFT: usize>(memory: &mut [u8]) {
         memory.fill(0);
         let buffer = &mut memory[shift..][..PLAINTEXT_BUF_SIZE];
         run_cipher_tests(buffer);
-        assert_eq!(
+        hil_test::assert_eq!(
             memory[..shift],
             zeros[..shift],
             "Out of bounds write with shift {}",


### PR DESCRIPTION
This likely writes back more data than necessary (i.e. it may be slow), but I dont think we have sufficient tests right now to try and constrain the written-back region.