### PR TITLE
RMT: move channel specification to esp-metadata

### DIFF
--- a/esp-metadata-generated/src/_generated_esp32.rs
+++ b/esp-metadata-generated/src/_generated_esp32.rs
@@ -254,6 +254,46 @@ macro_rules! for_each_aes_key_length {
         _for_each_inner!((modes(128, 0, 4), (192, 1, 5), (256, 2, 6)));
     };
 }
+/// This macro can be used to generate code for each channel of the RMT peripheral.
+///
+/// For an explanation on the general syntax, as well as usage of individual/repeated
+/// matchers, refer to [the crate-level documentation][crate#for_each-macros].
+///
+/// This macro has three options for its "Individual matcher" case:
+///
+/// - `all`: `($num:literal)`
+/// - `tx`: `($num:literal, $idx:literal)`
+/// - `rx`: `($num:literal, $idx:literal)`
+///
+/// Macro fragments:
+///
+/// - `$num`: number of the channel, e.g. `0`
+/// - `$idx`: index of the channel among channels of the same capability, e.g. `0`
+///
+/// Example data:
+///
+/// - `all`: `(0)`
+/// - `tx`: `(1, 1)`
+/// - `rx`: `(2, 0)`
+#[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_rmt_channel {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
+        _for_each_inner!((0)); _for_each_inner!((1)); _for_each_inner!((2));
+        _for_each_inner!((3)); _for_each_inner!((4)); _for_each_inner!((5));
+        _for_each_inner!((6)); _for_each_inner!((7)); _for_each_inner!((0, 0));
+        _for_each_inner!((1, 1)); _for_each_inner!((2, 2)); _for_each_inner!((3, 3));
+        _for_each_inner!((4, 4)); _for_each_inner!((5, 5)); _for_each_inner!((6, 6));
+        _for_each_inner!((7, 7)); _for_each_inner!((0, 0)); _for_each_inner!((1, 1));
+        _for_each_inner!((2, 2)); _for_each_inner!((3, 3)); _for_each_inner!((4, 4));
+        _for_each_inner!((5, 5)); _for_each_inner!((6, 6)); _for_each_inner!((7, 7));
+        _for_each_inner!((all(0), (1), (2), (3), (4), (5), (6), (7)));
+        _for_each_inner!((tx(0, 0), (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6), (7,
+        7))); _for_each_inner!((rx(0, 0), (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6),
+        (7, 7)));
+    };
+}
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rsa_exponentiation {

--- a/esp-metadata-generated/src/_generated_esp32c3.rs
+++ b/esp-metadata-generated/src/_generated_esp32c3.rs
@@ -261,6 +261,39 @@ macro_rules! for_each_aes_key_length {
         _for_each_inner!((modes(128, 0, 4), (256, 2, 6)));
     };
 }
+/// This macro can be used to generate code for each channel of the RMT peripheral.
+///
+/// For an explanation on the general syntax, as well as usage of individual/repeated
+/// matchers, refer to [the crate-level documentation][crate#for_each-macros].
+///
+/// This macro has three options for its "Individual matcher" case:
+///
+/// - `all`: `($num:literal)`
+/// - `tx`: `($num:literal, $idx:literal)`
+/// - `rx`: `($num:literal, $idx:literal)`
+///
+/// Macro fragments:
+///
+/// - `$num`: number of the channel, e.g. `0`
+/// - `$idx`: index of the channel among channels of the same capability, e.g. `0`
+///
+/// Example data:
+///
+/// - `all`: `(0)`
+/// - `tx`: `(1, 1)`
+/// - `rx`: `(2, 0)`
+#[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_rmt_channel {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
+        _for_each_inner!((0)); _for_each_inner!((1)); _for_each_inner!((2));
+        _for_each_inner!((3)); _for_each_inner!((0, 0)); _for_each_inner!((1, 1));
+        _for_each_inner!((2, 0)); _for_each_inner!((3, 1)); _for_each_inner!((all(0),
+        (1), (2), (3))); _for_each_inner!((tx(0, 0), (1, 1))); _for_each_inner!((rx(2,
+        0), (3, 1)));
+    };
+}
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rsa_exponentiation {

--- a/esp-metadata-generated/src/_generated_esp32c6.rs
+++ b/esp-metadata-generated/src/_generated_esp32c6.rs
@@ -273,6 +273,39 @@ macro_rules! for_each_aes_key_length {
         _for_each_inner!((modes(128, 0, 4), (256, 2, 6)));
     };
 }
+/// This macro can be used to generate code for each channel of the RMT peripheral.
+///
+/// For an explanation on the general syntax, as well as usage of individual/repeated
+/// matchers, refer to [the crate-level documentation][crate#for_each-macros].
+///
+/// This macro has three options for its "Individual matcher" case:
+///
+/// - `all`: `($num:literal)`
+/// - `tx`: `($num:literal, $idx:literal)`
+/// - `rx`: `($num:literal, $idx:literal)`
+///
+/// Macro fragments:
+///
+/// - `$num`: number of the channel, e.g. `0`
+/// - `$idx`: index of the channel among channels of the same capability, e.g. `0`
+///
+/// Example data:
+///
+/// - `all`: `(0)`
+/// - `tx`: `(1, 1)`
+/// - `rx`: `(2, 0)`
+#[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_rmt_channel {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
+        _for_each_inner!((0)); _for_each_inner!((1)); _for_each_inner!((2));
+        _for_each_inner!((3)); _for_each_inner!((0, 0)); _for_each_inner!((1, 1));
+        _for_each_inner!((2, 0)); _for_each_inner!((3, 1)); _for_each_inner!((all(0),
+        (1), (2), (3))); _for_each_inner!((tx(0, 0), (1, 1))); _for_each_inner!((rx(2,
+        0), (3, 1)));
+    };
+}
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rsa_exponentiation {

--- a/esp-metadata-generated/src/_generated_esp32h2.rs
+++ b/esp-metadata-generated/src/_generated_esp32h2.rs
@@ -258,6 +258,39 @@ macro_rules! for_each_aes_key_length {
         _for_each_inner!((modes(128, 0, 4), (256, 2, 6)));
     };
 }
+/// This macro can be used to generate code for each channel of the RMT peripheral.
+///
+/// For an explanation on the general syntax, as well as usage of individual/repeated
+/// matchers, refer to [the crate-level documentation][crate#for_each-macros].
+///
+/// This macro has three options for its "Individual matcher" case:
+///
+/// - `all`: `($num:literal)`
+/// - `tx`: `($num:literal, $idx:literal)`
+/// - `rx`: `($num:literal, $idx:literal)`
+///
+/// Macro fragments:
+///
+/// - `$num`: number of the channel, e.g. `0`
+/// - `$idx`: index of the channel among channels of the same capability, e.g. `0`
+///
+/// Example data:
+///
+/// - `all`: `(0)`
+/// - `tx`: `(1, 1)`
+/// - `rx`: `(2, 0)`
+#[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_rmt_channel {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
+        _for_each_inner!((0)); _for_each_inner!((1)); _for_each_inner!((2));
+        _for_each_inner!((3)); _for_each_inner!((0, 0)); _for_each_inner!((1, 1));
+        _for_each_inner!((2, 0)); _for_each_inner!((3, 1)); _for_each_inner!((all(0),
+        (1), (2), (3))); _for_each_inner!((tx(0, 0), (1, 1))); _for_each_inner!((rx(2,
+        0), (3, 1)));
+    };
+}
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rsa_exponentiation {

--- a/esp-metadata-generated/src/_generated_esp32s2.rs
+++ b/esp-metadata-generated/src/_generated_esp32s2.rs
@@ -262,6 +262,40 @@ macro_rules! for_each_aes_key_length {
         _for_each_inner!((modes(128, 0, 4), (192, 1, 5), (256, 2, 6)));
     };
 }
+/// This macro can be used to generate code for each channel of the RMT peripheral.
+///
+/// For an explanation on the general syntax, as well as usage of individual/repeated
+/// matchers, refer to [the crate-level documentation][crate#for_each-macros].
+///
+/// This macro has three options for its "Individual matcher" case:
+///
+/// - `all`: `($num:literal)`
+/// - `tx`: `($num:literal, $idx:literal)`
+/// - `rx`: `($num:literal, $idx:literal)`
+///
+/// Macro fragments:
+///
+/// - `$num`: number of the channel, e.g. `0`
+/// - `$idx`: index of the channel among channels of the same capability, e.g. `0`
+///
+/// Example data:
+///
+/// - `all`: `(0)`
+/// - `tx`: `(1, 1)`
+/// - `rx`: `(2, 0)`
+#[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_rmt_channel {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
+        _for_each_inner!((0)); _for_each_inner!((1)); _for_each_inner!((2));
+        _for_each_inner!((3)); _for_each_inner!((0, 0)); _for_each_inner!((1, 1));
+        _for_each_inner!((2, 2)); _for_each_inner!((3, 3)); _for_each_inner!((0, 0));
+        _for_each_inner!((1, 1)); _for_each_inner!((2, 2)); _for_each_inner!((3, 3));
+        _for_each_inner!((all(0), (1), (2), (3))); _for_each_inner!((tx(0, 0), (1, 1),
+        (2, 2), (3, 3))); _for_each_inner!((rx(0, 0), (1, 1), (2, 2), (3, 3)));
+    };
+}
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rsa_exponentiation {

--- a/esp-metadata-generated/src/_generated_esp32s3.rs
+++ b/esp-metadata-generated/src/_generated_esp32s3.rs
@@ -255,6 +255,42 @@ macro_rules! for_each_aes_key_length {
         _for_each_inner!((modes(128, 0, 4), (256, 2, 6)));
     };
 }
+/// This macro can be used to generate code for each channel of the RMT peripheral.
+///
+/// For an explanation on the general syntax, as well as usage of individual/repeated
+/// matchers, refer to [the crate-level documentation][crate#for_each-macros].
+///
+/// This macro has three options for its "Individual matcher" case:
+///
+/// - `all`: `($num:literal)`
+/// - `tx`: `($num:literal, $idx:literal)`
+/// - `rx`: `($num:literal, $idx:literal)`
+///
+/// Macro fragments:
+///
+/// - `$num`: number of the channel, e.g. `0`
+/// - `$idx`: index of the channel among channels of the same capability, e.g. `0`
+///
+/// Example data:
+///
+/// - `all`: `(0)`
+/// - `tx`: `(1, 1)`
+/// - `rx`: `(2, 0)`
+#[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_rmt_channel {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
+        _for_each_inner!((0)); _for_each_inner!((1)); _for_each_inner!((2));
+        _for_each_inner!((3)); _for_each_inner!((4)); _for_each_inner!((5));
+        _for_each_inner!((6)); _for_each_inner!((7)); _for_each_inner!((0, 0));
+        _for_each_inner!((1, 1)); _for_each_inner!((2, 2)); _for_each_inner!((3, 3));
+        _for_each_inner!((4, 0)); _for_each_inner!((5, 1)); _for_each_inner!((6, 2));
+        _for_each_inner!((7, 3)); _for_each_inner!((all(0), (1), (2), (3), (4), (5), (6),
+        (7))); _for_each_inner!((tx(0, 0), (1, 1), (2, 2), (3, 3)));
+        _for_each_inner!((rx(4, 0), (5, 1), (6, 2), (7, 3)));
+    };
+}
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rsa_exponentiation {

--- a/esp-metadata/devices/esp32.toml
+++ b/esp-metadata/devices/esp32.toml
@@ -601,6 +601,7 @@ status_registers = 3
 support_status = "partial"
 ram_start = 0x3ff56800
 channel_ram_size = 64
+channels = ["RxTx", "RxTx", "RxTx", "RxTx", "RxTx", "RxTx", "RxTx", "RxTx"]
 
 [device.rsa]
 support_status = "partial"

--- a/esp-metadata/devices/esp32c3.toml
+++ b/esp-metadata/devices/esp32c3.toml
@@ -306,6 +306,7 @@ status_registers = 2
 support_status = "partial"
 ram_start = 0x60016400
 channel_ram_size = 48
+channels = ["Tx", "Tx", "Rx", "Rx"]
 
 [device.rsa]
 support_status = "partial"

--- a/esp-metadata/devices/esp32c6.toml
+++ b/esp-metadata/devices/esp32c6.toml
@@ -462,6 +462,7 @@ status_registers = 3
 support_status = "partial"
 ram_start = 0x60006400
 channel_ram_size = 48
+channels = ["Tx", "Tx", "Rx", "Rx"]
 
 [device.rsa]
 support_status = "partial"

--- a/esp-metadata/devices/esp32h2.toml
+++ b/esp-metadata/devices/esp32h2.toml
@@ -379,6 +379,7 @@ status_registers = 2
 support_status = "partial"
 ram_start = 0x60007400
 channel_ram_size = 48
+channels = ["Tx", "Tx", "Rx", "Rx"]
 
 [device.rsa]
 support_status = "partial"

--- a/esp-metadata/devices/esp32s2.toml
+++ b/esp-metadata/devices/esp32s2.toml
@@ -423,6 +423,7 @@ status_registers = 3
 support_status = "partial"
 ram_start = 0x3f416400
 channel_ram_size = 64
+channels = ["RxTx", "RxTx", "RxTx", "RxTx"]
 
 [device.rsa]
 support_status = "partial"

--- a/esp-metadata/devices/esp32s3.toml
+++ b/esp-metadata/devices/esp32s3.toml
@@ -598,6 +598,7 @@ status_registers = 4
 support_status = "partial"
 ram_start = 0x60016800
 channel_ram_size = 48
+channels = ["Tx", "Tx", "Tx", "Tx", "Rx", "Rx", "Rx", "Rx"]
 
 [device.rsa]
 support_status = "partial"

--- a/esp-metadata/src/cfg.rs
+++ b/esp-metadata/src/cfg.rs
@@ -1,6 +1,7 @@
 pub(crate) mod aes;
 pub(crate) mod gpio;
 pub(crate) mod i2c_master;
+pub(crate) mod rmt;
 pub(crate) mod rsa;
 pub(crate) mod sha;
 pub(crate) mod soc;
@@ -11,6 +12,7 @@ pub(crate) mod uart;
 pub(crate) use aes::*;
 pub(crate) use gpio::*;
 pub(crate) use i2c_master::*;
+pub(crate) use rmt::*;
 pub(crate) use sha::*;
 pub(crate) use spi_master::*;
 pub(crate) use spi_slave::*;
@@ -474,6 +476,7 @@ driver_configs![
         properties: {
             ram_start: u32,
             channel_ram_size: u32,
+            channels: RmtChannelConfig,
         }
     },
     RngProperties {

--- a/esp-metadata/src/cfg/rmt.rs
+++ b/esp-metadata/src/cfg/rmt.rs
@@ -1,0 +1,95 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+
+use crate::{cfg::GenericProperty, generate_for_each_macro, number};
+
+/// The capabilities of an RMT channel, used in [device.rmt.channels]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Deserialize, serde::Serialize)]
+pub(crate) enum RmtChannelCapability {
+    Rx,
+    Tx,
+    RxTx,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub(crate) struct RmtChannelConfig(
+    /// The capability of each channel
+    Vec<RmtChannelCapability>,
+);
+
+/// Generates `for_each_rmt_channel!` which can be used to implement channel creators and the main
+/// driver struct for the RMT peripheral.
+///
+/// The macro generates code for each [device.rmt.channels[X]] entry.
+impl GenericProperty for RmtChannelConfig {
+    fn for_each_macro(&self) -> Option<TokenStream> {
+        let channel_cfgs = self
+            .0
+            .iter()
+            .enumerate()
+            .map(|(num, _)| {
+                let num = number(num);
+                quote! {
+                    #num
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let make_channel_cfgs = |filter: fn(RmtChannelCapability) -> bool| {
+            self.0
+                .iter()
+                .enumerate()
+                .filter(|&(_, &cap)| filter(cap))
+                .enumerate()
+                .map(|(idx, (num, _))| {
+                    let num = number(num);
+                    let idx = number(idx);
+                    quote! {
+                        #num, #idx
+                    }
+                })
+                .collect::<Vec<_>>()
+        };
+
+        let tx_channel_cfgs = make_channel_cfgs(|cap| {
+            matches!(cap, RmtChannelCapability::Tx | RmtChannelCapability::RxTx)
+        });
+        let rx_channel_cfgs = make_channel_cfgs(|cap| {
+            matches!(cap, RmtChannelCapability::Rx | RmtChannelCapability::RxTx)
+        });
+
+        let for_each = generate_for_each_macro(
+            "rmt_channel",
+            &[
+                ("all", &channel_cfgs),
+                ("tx", &tx_channel_cfgs),
+                ("rx", &rx_channel_cfgs),
+            ],
+        );
+
+        Some(quote! {
+            /// This macro can be used to generate code for each channel of the RMT peripheral.
+            ///
+            /// For an explanation on the general syntax, as well as usage of individual/repeated
+            /// matchers, refer to [the crate-level documentation][crate#for_each-macros].
+            ///
+            /// This macro has three options for its "Individual matcher" case:
+            ///
+            /// - `all`: `($num:literal)`
+            /// - `tx`: `($num:literal, $idx:literal)`
+            /// - `rx`: `($num:literal, $idx:literal)`
+            ///
+            /// Macro fragments:
+            ///
+            /// - `$num`: number of the channel, e.g. `0`
+            /// - `$idx`: index of the channel among channels of the same capability, e.g. `0`
+            ///
+            /// Example data:
+            ///
+            /// - `all`: `(0)`
+            /// - `tx`: `(1, 1)`
+            /// - `rx`: `(2, 0)`
+            #for_each
+        })
+    }
+}


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖
Replaces `cfg_if` by `esp-metadata` for declaring RMT channels as suggested in https://github.com/esp-rs/esp-hal/pull/3917#discussion_r2264607504.

#### Testing
HIL tests.
