### PR TITLE
Remove duplicated log when formatting packages

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -198,7 +198,6 @@ fn fmt_packages(workspace: &Path, args: FmtPackagesArgs) -> Result<()> {
     packages.sort();
 
     for package in packages {
-        log::info!("Formatting package: {}", package);
         xtask::format_package(workspace, package, args.check)?;
     }
 


### PR DESCRIPTION
Right now it prints it twice:
```
[2025-09-17T13:02:11Z INFO  xtask] Formatting package: esp-alloc
[2025-09-17T13:02:11Z INFO  xtask] Formatting package: esp-alloc
...
```