### PR TITLE
Even more cargo-batch, encode configs in Cargo.toml

### DIFF
--- a/esp-alloc/Cargo.toml
+++ b/esp-alloc/Cargo.toml
@@ -16,6 +16,9 @@ check-configs = [
     { features = [] },
     { features = ["defmt"] }
 ]
+clippy-configs = [
+    { features = ["defmt"] },
+]
 
 [package.metadata.docs.rs]
 default-target = "riscv32imc-unknown-none-elf"

--- a/esp-alloc/Cargo.toml
+++ b/esp-alloc/Cargo.toml
@@ -11,7 +11,7 @@ repository    = "https://github.com/esp-rs/esp-hal"
 license       = "MIT OR Apache-2.0"
 
 [package.metadata.espressif]
-doc-config = [{ features = ["defmt"] }]
+doc-config = { features = ["defmt"] }
 check-configs = [
     { features = [] },
     { features = ["defmt"] }

--- a/esp-alloc/Cargo.toml
+++ b/esp-alloc/Cargo.toml
@@ -12,6 +12,10 @@ license       = "MIT OR Apache-2.0"
 
 [package.metadata.espressif]
 doc-config = [{ features = ["defmt"] }]
+check-configs = [
+    { features = [] },
+    { features = ["defmt"] }
+]
 
 [package.metadata.docs.rs]
 default-target = "riscv32imc-unknown-none-elf"

--- a/esp-alloc/Cargo.toml
+++ b/esp-alloc/Cargo.toml
@@ -10,6 +10,9 @@ categories    = ["embedded", "memory-management", "no-std"]
 repository    = "https://github.com/esp-rs/esp-hal"
 license       = "MIT OR Apache-2.0"
 
+[package.metadata.espressif]
+doc-config = [{ features = ["defmt"] }]
+
 [package.metadata.docs.rs]
 default-target = "riscv32imc-unknown-none-elf"
 features       = ["nightly"]

--- a/esp-backtrace/Cargo.toml
+++ b/esp-backtrace/Cargo.toml
@@ -12,6 +12,10 @@ license       = "MIT OR Apache-2.0"
 
 [package.metadata.espressif]
 doc-config = [{ features = ["defmt"] }]
+check-configs = [
+    { features = ["println", "esp-println/auto"] },
+    { features = ["defmt"] }
+]
 
 [package.metadata.docs.rs]
 default-target = "riscv32imc-unknown-none-elf"

--- a/esp-backtrace/Cargo.toml
+++ b/esp-backtrace/Cargo.toml
@@ -11,7 +11,7 @@ repository    = "https://github.com/esp-rs/esp-hal"
 license       = "MIT OR Apache-2.0"
 
 [package.metadata.espressif]
-doc-config = [{ features = ["defmt"] }]
+doc-config = { features = ["defmt"] }
 check-configs = [
     { features = ["println", "esp-println/auto"] },
     { features = ["defmt"] },

--- a/esp-backtrace/Cargo.toml
+++ b/esp-backtrace/Cargo.toml
@@ -10,6 +10,9 @@ categories    = ["embedded", "hardware-support", "no-std"]
 repository    = "https://github.com/esp-rs/esp-hal"
 license       = "MIT OR Apache-2.0"
 
+[package.metadata.espressif]
+doc-config = [{ features = ["defmt"] }]
+
 [package.metadata.docs.rs]
 default-target = "riscv32imc-unknown-none-elf"
 features       = ["esp32c3", "panic-handler", "exception-handler", "println", "esp-println/uart"]

--- a/esp-backtrace/Cargo.toml
+++ b/esp-backtrace/Cargo.toml
@@ -14,7 +14,10 @@ license       = "MIT OR Apache-2.0"
 doc-config = [{ features = ["defmt"] }]
 check-configs = [
     { features = ["println", "esp-println/auto"] },
-    { features = ["defmt"] }
+    { features = ["defmt"] },
+    { features = ["defmt", "panic-handler", "custom-halt"] },
+    { features = ["defmt", "panic-handler", "halt-cores"] },
+    { features = ["defmt", "panic-handler", "semihosting"] }
 ]
 clippy-configs = [
     { features = ["panic-handler", "halt-cores", "defmt"] },
@@ -70,6 +73,7 @@ print-float-registers = [] # TODO support esp32p4
 # additional functionality:
 ## Print messages in red
 colors               = []
+# TODO: these features assume panic-handler is enabled but they don't enforce it.
 ## Invoke the extern function `custom_halt()` instead of doing a loop {} in case of a panic. This feature does not imply the `halt-cores` feature.
 custom-halt          = []
 ## Invoke the extern function `custom_pre_backtrace()` before handling a panic

--- a/esp-backtrace/Cargo.toml
+++ b/esp-backtrace/Cargo.toml
@@ -16,6 +16,9 @@ check-configs = [
     { features = ["println", "esp-println/auto"] },
     { features = ["defmt"] }
 ]
+clippy-configs = [
+    { features = ["panic-handler", "halt-cores", "defmt"] },
+]
 
 [package.metadata.docs.rs]
 default-target = "riscv32imc-unknown-none-elf"

--- a/esp-backtrace/src/lib.rs
+++ b/esp-backtrace/src/lib.rs
@@ -120,7 +120,7 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
         println!("0x{:x}", frame.program_counter());
     }
 
-    abort();
+    abort()
 }
 
 // Ensure that the address is in DRAM.
@@ -186,7 +186,7 @@ fn abort() -> ! {
 
     cfg_if::cfg_if! {
         if #[cfg(feature = "semihosting")] {
-            critical_section::with(|_| {
+            arch::interrupt_free(|| {
                 semihosting::process::abort();
             });
         } else if #[cfg(feature = "halt-cores")] {
@@ -201,5 +201,8 @@ fn abort() -> ! {
     }
 
     #[allow(unreachable_code)]
-    arch::interrupt_free(|| loop {})
+    arch::interrupt_free(|| {
+        #[allow(clippy::empty_loop)]
+        loop {}
+    })
 }

--- a/esp-bootloader-esp-idf/Cargo.toml
+++ b/esp-bootloader-esp-idf/Cargo.toml
@@ -17,6 +17,9 @@ check-configs = [
     { features = ["log-04"] },
     { features = ["defmt", "validation"] },
 ]
+clippy-configs = [
+    { features = ["defmt", "validation"] },
+]
 
 [package.metadata.docs.rs]
 default-target = "riscv32imac-unknown-none-elf"

--- a/esp-bootloader-esp-idf/Cargo.toml
+++ b/esp-bootloader-esp-idf/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/esp-rs/esp-hal"
 license = "MIT OR Apache-2.0"
 
 [package.metadata.espressif]
-doc-config = [{ features = ["defmt", "validation"] }]
+doc-config = { features = ["defmt", "validation"] }
 check-configs = [
     { features = [] },
     { features = ["log-04"] },

--- a/esp-bootloader-esp-idf/Cargo.toml
+++ b/esp-bootloader-esp-idf/Cargo.toml
@@ -12,6 +12,11 @@ license = "MIT OR Apache-2.0"
 
 [package.metadata.espressif]
 doc-config = [{ features = ["defmt", "validation"] }]
+check-configs = [
+    { features = [] },
+    { features = ["log-04"] },
+    { features = ["defmt", "validation"] },
+]
 
 [package.metadata.docs.rs]
 default-target = "riscv32imac-unknown-none-elf"

--- a/esp-bootloader-esp-idf/Cargo.toml
+++ b/esp-bootloader-esp-idf/Cargo.toml
@@ -10,6 +10,9 @@ categories = ["embedded", "hardware-support", "no-std"]
 repository = "https://github.com/esp-rs/esp-hal"
 license = "MIT OR Apache-2.0"
 
+[package.metadata.espressif]
+doc-config = [{ features = ["defmt", "validation"] }]
+
 [package.metadata.docs.rs]
 default-target = "riscv32imac-unknown-none-elf"
 

--- a/esp-config/Cargo.toml
+++ b/esp-config/Cargo.toml
@@ -9,7 +9,7 @@ repository    = "https://github.com/esp-rs/esp-hal"
 license       = "MIT OR Apache-2.0"
 
 [package.metadata.espressif]
-doc-config = [{ features = ["build"] }]
+doc-config = { features = ["build"] }
 check-configs = [
     { features = [] },
     { features = ["build"] },

--- a/esp-config/Cargo.toml
+++ b/esp-config/Cargo.toml
@@ -10,6 +10,10 @@ license       = "MIT OR Apache-2.0"
 
 [package.metadata.espressif]
 doc-config = [{ features = ["build"] }]
+check-configs = [
+    { features = [] },
+    { features = ["build"] },
+]
 
 [lib]
 bench = false

--- a/esp-config/Cargo.toml
+++ b/esp-config/Cargo.toml
@@ -8,6 +8,9 @@ documentation = "https://docs.espressif.com/projects/rust/esp-config/latest/"
 repository    = "https://github.com/esp-rs/esp-hal"
 license       = "MIT OR Apache-2.0"
 
+[package.metadata.espressif]
+doc-config = [{ features = ["build"] }]
+
 [lib]
 bench = false
 test  = true

--- a/esp-config/Cargo.toml
+++ b/esp-config/Cargo.toml
@@ -14,6 +14,9 @@ check-configs = [
     { features = [] },
     { features = ["build"] },
 ]
+clippy-configs = [
+    { features = ["tui"] },
+]
 
 [lib]
 bench = false

--- a/esp-config/src/bin/esp-config/main.rs
+++ b/esp-config/src/bin/esp-config/main.rs
@@ -70,7 +70,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 .map(|entry| entry.file_name().to_string_lossy().to_string())
                 .collect();
 
-            if files.len() > 0 {
+            if !files.is_empty() {
                 let terminal = tui::init_terminal()?;
                 let mut chooser = tui::ConfigChooser::new(files);
                 config_file = chooser.run(terminal)?;
@@ -134,7 +134,7 @@ fn apply_config(
     previous_cfg: Vec<CrateConfig>,
     config_toml_path: &PathBuf,
 ) -> Result<(), Box<dyn Error>> {
-    let mut config = std::fs::read_to_string(&config_toml_path)?
+    let mut config = std::fs::read_to_string(config_toml_path)?
         .as_str()
         .parse::<DocumentMut>()?;
 
@@ -171,7 +171,7 @@ fn apply_config(
         }
     }
 
-    std::fs::write(&config_toml_path, config.to_string().as_bytes())?;
+    std::fs::write(config_toml_path, config.to_string().as_bytes())?;
 
     Ok(())
 }

--- a/esp-hal-embassy/Cargo.toml
+++ b/esp-hal-embassy/Cargo.toml
@@ -12,6 +12,13 @@ license       = "MIT OR Apache-2.0"
 
 [package.metadata.espressif]
 doc-config = [{ features = ["esp-hal/unstable", "esp-hal/rt", "defmt", "executors"] }]
+check-configs = [
+    { features = ["esp-hal/unstable", "esp-hal/rt"] },
+    { features = ["esp-hal/unstable", "esp-hal/rt", "defmt"] },
+    { features = ["esp-hal/unstable", "esp-hal/rt", "log-04"] },
+    { features = ["esp-hal/unstable", "esp-hal/rt", "defmt", "executors"] },
+    { features = ["esp-hal/unstable", "esp-hal/rt", "log-04", "executors"] },
+]
 
 [package.metadata.docs.rs]
 default-target = "riscv32imac-unknown-none-elf"

--- a/esp-hal-embassy/Cargo.toml
+++ b/esp-hal-embassy/Cargo.toml
@@ -11,7 +11,7 @@ repository    = "https://github.com/esp-rs/esp-hal"
 license       = "MIT OR Apache-2.0"
 
 [package.metadata.espressif]
-doc-config = [{ features = ["esp-hal/unstable", "esp-hal/rt", "defmt", "executors"] }]
+doc-config = { features = ["esp-hal/unstable", "esp-hal/rt", "defmt", "executors"] }
 check-configs = [
     { features = ["esp-hal/unstable", "esp-hal/rt"] },
     { features = ["esp-hal/unstable", "esp-hal/rt", "defmt"] },

--- a/esp-hal-embassy/Cargo.toml
+++ b/esp-hal-embassy/Cargo.toml
@@ -10,6 +10,9 @@ categories    = ["asynchronous", "embedded", "hardware-support", "no-std"]
 repository    = "https://github.com/esp-rs/esp-hal"
 license       = "MIT OR Apache-2.0"
 
+[package.metadata.espressif]
+doc-config = [{ features = ["esp-hal/unstable", "esp-hal/rt", "defmt", "executors"] }]
+
 [package.metadata.docs.rs]
 default-target = "riscv32imac-unknown-none-elf"
 features       = ["esp32c6"]

--- a/esp-hal-embassy/Cargo.toml
+++ b/esp-hal-embassy/Cargo.toml
@@ -19,6 +19,9 @@ check-configs = [
     { features = ["esp-hal/unstable", "esp-hal/rt", "defmt", "executors"] },
     { features = ["esp-hal/unstable", "esp-hal/rt", "log-04", "executors"] },
 ]
+clippy-configs = [
+    { features = ["esp-hal/unstable", "esp-hal/rt", "log-04", "executors"] },
+]
 
 [package.metadata.docs.rs]
 default-target = "riscv32imac-unknown-none-elf"

--- a/esp-hal-procmacros/Cargo.toml
+++ b/esp-hal-procmacros/Cargo.toml
@@ -8,6 +8,9 @@ documentation = "https://docs.espressif.com/projects/rust/esp-hal-procmacros/lat
 repository    = "https://github.com/esp-rs/esp-hal"
 license       = "MIT OR Apache-2.0"
 
+[package.metadata.espressif]
+doc-config = [{ features = ["embassy"] }]
+
 [package.metadata.docs.rs]
 features = ["embassy", "has-ulp-core", "interrupt", "ram", "is-ulp-core"]
 

--- a/esp-hal-procmacros/Cargo.toml
+++ b/esp-hal-procmacros/Cargo.toml
@@ -9,7 +9,7 @@ repository    = "https://github.com/esp-rs/esp-hal"
 license       = "MIT OR Apache-2.0"
 
 [package.metadata.espressif]
-doc-config = [{ features = ["embassy"] }]
+doc-config = { features = ["embassy"] }
 check-configs = [
     { features = [] },
     { features = ["embassy"] }

--- a/esp-hal-procmacros/Cargo.toml
+++ b/esp-hal-procmacros/Cargo.toml
@@ -10,6 +10,10 @@ license       = "MIT OR Apache-2.0"
 
 [package.metadata.espressif]
 doc-config = [{ features = ["embassy"] }]
+check-configs = [
+    { features = [] },
+    { features = ["embassy"] }
+]
 
 [package.metadata.docs.rs]
 features = ["embassy", "has-ulp-core", "interrupt", "ram", "is-ulp-core"]

--- a/esp-hal-procmacros/Cargo.toml
+++ b/esp-hal-procmacros/Cargo.toml
@@ -14,6 +14,9 @@ check-configs = [
     { features = [] },
     { features = ["embassy"] }
 ]
+clippy-configs = [
+    { features = ["embassy"] },
+]
 
 [package.metadata.docs.rs]
 features = ["embassy", "has-ulp-core", "interrupt", "ram", "is-ulp-core"]

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -27,6 +27,9 @@ check-configs = [
     { features = ["unstable", "rt", "__usb_otg"], if = 'chip_has("soc_has_usb0")' },
     { features = ["unstable", "rt", "__bluetooth"], if = 'chip_has("bt")' },
 ]
+clippy-configs = [
+    { features = ["unstable", "rt"] },
+]
 
 [package.metadata.docs.rs]
 default-target = "riscv32imac-unknown-none-elf"

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -13,6 +13,12 @@ exclude = [ "api-baseline", "MIGRATING-*", "CHANGELOG.md" ]
 
 [package.metadata.espressif]
 semver_checked = true
+doc-config = [
+    { features = ["unstable", "rt"] },
+    { features = ["psram"], append_if = 'chip_has("psram")' },
+    { features = ["__usb_otg"], append_if = 'chip_has("usb0")' },
+    { features = ["__bluetooth"], append_if = 'chip_has("bt")' },
+]
 
 [package.metadata.docs.rs]
 default-target = "riscv32imac-unknown-none-elf"

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -16,8 +16,16 @@ semver_checked = true
 doc-config = [
     { features = ["unstable", "rt"] },
     { features = ["psram"], append_if = 'chip_has("psram")' },
-    { features = ["__usb_otg"], append_if = 'chip_has("usb0")' },
+    { features = ["__usb_otg"], append_if = 'chip_has("soc_has_usb0")' },
     { features = ["__bluetooth"], append_if = 'chip_has("bt")' },
+]
+check-configs = [
+    { features = [] },
+    { features = ["rt"] },
+    { features = ["unstable", "rt"] },
+    { features = ["unstable", "rt", "psram"], if = 'chip_has("psram")' },
+    { features = ["unstable", "rt", "__usb_otg"], if = 'chip_has("soc_has_usb0")' },
+    { features = ["unstable", "rt", "__bluetooth"], if = 'chip_has("bt")' },
 ]
 
 [package.metadata.docs.rs]

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -11,6 +11,9 @@ repository    = "https://github.com/esp-rs/esp-hal"
 license       = "MIT OR Apache-2.0"
 exclude = [ "api-baseline", "MIGRATING-*", "CHANGELOG.md" ]
 
+[package.metadata.espressif]
+semver_checked = true
+
 [package.metadata.docs.rs]
 default-target = "riscv32imac-unknown-none-elf"
 features       = ["esp32c6", "unstable"]

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -13,12 +13,11 @@ exclude = [ "api-baseline", "MIGRATING-*", "CHANGELOG.md" ]
 
 [package.metadata.espressif]
 semver_checked = true
-doc-config = [
-    { features = ["unstable", "rt"] },
-    { features = ["psram"], append_if = 'chip_has("psram")' },
-    { features = ["__usb_otg"], append_if = 'chip_has("soc_has_usb0")' },
-    { features = ["__bluetooth"], append_if = 'chip_has("bt")' },
-]
+doc-config = { features = ["unstable", "rt"], append = [
+    { if = 'chip_has("psram")', features = ["psram"] },
+    { if = 'chip_has("soc_has_usb0")', features = ["__usb_otg"] },
+    { if = 'chip_has("bt")', features = ["__bluetooth"] },
+] }
 check-configs = [
     { features = [] },
     { features = ["rt"] },
@@ -27,8 +26,13 @@ check-configs = [
     { features = ["unstable", "rt", "__usb_otg"], if = 'chip_has("soc_has_usb0")' },
     { features = ["unstable", "rt", "__bluetooth"], if = 'chip_has("bt")' },
 ]
+# Prefer fewer, but more complex clippy rules. A clippy run should cover as much code as possible.
 clippy-configs = [
-    { features = ["unstable", "rt"] },
+    { features = ["unstable", "rt"], append = [
+        { if = 'chip_has("psram")', features = ["psram"] },
+        { if = 'chip_has("soc_has_usb0")', features = ["__usb_otg"] },
+        { if = 'chip_has("bt")', features = ["__bluetooth"] },
+    ] },
 ]
 
 [package.metadata.docs.rs]

--- a/esp-hal/src/psram/mod.rs
+++ b/esp-hal/src/psram/mod.rs
@@ -47,12 +47,14 @@
 use core::ops::Range;
 
 #[cfg(feature = "psram")]
+#[cfg_attr(docsrs, doc(cfg(feature = "psram")))]
 #[cfg_attr(esp32, path = "esp32.rs")]
 #[cfg_attr(esp32s2, path = "esp32s2.rs")]
 #[cfg_attr(esp32s3, path = "esp32s3.rs")]
 pub(crate) mod implem;
 
 #[cfg(feature = "psram")]
+#[cfg_attr(docsrs, doc(cfg(feature = "psram")))]
 pub use implem::*;
 
 /// Size of PSRAM

--- a/esp-lp-hal/Cargo.toml
+++ b/esp-lp-hal/Cargo.toml
@@ -21,6 +21,12 @@ doc-config = [
     { features = ["embedded-hal"] },
     { features = ["embedded-io"], append_if = 'chip_has("lp_core")' },
 ]
+check-configs = [
+    { features = [] },
+    { features = ["embedded-hal"] },
+    { features = ["embedded-io"] },
+    { features = ["embedded-hal", "embedded-io"] },
+]
 
 [lib]
 bench = false

--- a/esp-lp-hal/Cargo.toml
+++ b/esp-lp-hal/Cargo.toml
@@ -17,10 +17,9 @@ rustdoc-args   = ["--cfg", "docsrs"]
 
 [package.metadata.espressif]
 targets_lp_core = true
-doc-config = [
-    { features = ["embedded-hal"] },
-    { features = ["embedded-io"], append_if = 'chip_has("lp_core")' },
-]
+doc-config = { features = ["embedded-hal"], append = [
+    { features = ["embedded-io"], if = 'chip_has("lp_core")' },
+] }
 check-configs = [
     { features = [] },
     { features = ["embedded-hal"] },

--- a/esp-lp-hal/Cargo.toml
+++ b/esp-lp-hal/Cargo.toml
@@ -27,6 +27,9 @@ check-configs = [
     { features = ["embedded-io"] },
     { features = ["embedded-hal", "embedded-io"] },
 ]
+clippy-configs = [
+    { features = ["embedded-hal", "embedded-io"] },
+]
 
 [lib]
 bench = false

--- a/esp-lp-hal/Cargo.toml
+++ b/esp-lp-hal/Cargo.toml
@@ -15,6 +15,9 @@ default-target = "riscv32imac-unknown-none-elf"
 features       = ["esp32c6"]
 rustdoc-args   = ["--cfg", "docsrs"]
 
+[package.metadata.espressif]
+targets_lp_core = true
+
 [lib]
 bench = false
 test  = false

--- a/esp-lp-hal/Cargo.toml
+++ b/esp-lp-hal/Cargo.toml
@@ -17,6 +17,10 @@ rustdoc-args   = ["--cfg", "docsrs"]
 
 [package.metadata.espressif]
 targets_lp_core = true
+doc-config = [
+    { features = ["embedded-hal"] },
+    { features = ["embedded-io"], append_if = 'chip_has("lp_core")' },
+]
 
 [lib]
 bench = false

--- a/esp-metadata-generated/Cargo.toml
+++ b/esp-metadata-generated/Cargo.toml
@@ -13,6 +13,7 @@ check-configs = [
     { features = [] },
     { features = ["build-script"] },
 ]
+clippy-configs = [] # don't waste time on this
 
 [dependencies]
 

--- a/esp-metadata-generated/Cargo.toml
+++ b/esp-metadata-generated/Cargo.toml
@@ -8,6 +8,12 @@ documentation = "https://docs.espressif.com/projects/rust/esp-metadata-generated
 repository    = "https://github.com/esp-rs/esp-hal"
 license       = "MIT OR Apache-2.0"
 
+[package.metadata.espressif]
+check-configs = [
+    { features = [] },
+    { features = ["build-script"] },
+]
+
 [dependencies]
 
 [build-dependencies]

--- a/esp-metadata/Cargo.toml
+++ b/esp-metadata/Cargo.toml
@@ -8,6 +8,12 @@ documentation = "https://docs.espressif.com/projects/rust/esp-metadata/latest/"
 repository    = "https://github.com/esp-rs/esp-hal"
 license       = "MIT OR Apache-2.0"
 
+[package.metadata.espressif]
+check-configs = [
+    { features = [] },
+    { features = ["clap"] },
+]
+
 [dependencies]
 anyhow     = "1.0"
 clap       = { version = "4.5", features = ["derive"], optional = true }

--- a/esp-metadata/Cargo.toml
+++ b/esp-metadata/Cargo.toml
@@ -13,6 +13,7 @@ check-configs = [
     { features = [] },
     { features = ["clap"] },
 ]
+clippy-configs = [] # don't waste time on this
 
 [dependencies]
 anyhow     = "1.0"

--- a/esp-preempt/Cargo.toml
+++ b/esp-preempt/Cargo.toml
@@ -16,6 +16,9 @@ check-configs = [
     { features = ["esp-hal/unstable"] },
     { features = ["esp-hal/unstable", "esp-alloc"] },
 ]
+clippy-configs = [
+    { features = ["esp-hal/unstable", "esp-alloc", "defmt"] },
+]
 
 [package.metadata.docs.rs]
 default-target = "riscv32imac-unknown-none-elf"

--- a/esp-preempt/Cargo.toml
+++ b/esp-preempt/Cargo.toml
@@ -12,6 +12,10 @@ license       = "MIT OR Apache-2.0"
 
 [package.metadata.espressif]
 doc-config = [{ features = ["esp-hal/unstable"] }]
+check-configs = [
+    { features = ["esp-hal/unstable"] },
+    { features = ["esp-hal/unstable", "esp-alloc"] },
+]
 
 [package.metadata.docs.rs]
 default-target = "riscv32imac-unknown-none-elf"

--- a/esp-preempt/Cargo.toml
+++ b/esp-preempt/Cargo.toml
@@ -11,7 +11,7 @@ repository    = "https://github.com/esp-rs/esp-hal"
 license       = "MIT OR Apache-2.0"
 
 [package.metadata.espressif]
-doc-config = [{ features = ["esp-hal/unstable"] }]
+doc-config = { features = ["esp-hal/unstable"] }
 check-configs = [
     { features = ["esp-hal/unstable"] },
     { features = ["esp-hal/unstable", "esp-alloc"] },

--- a/esp-preempt/Cargo.toml
+++ b/esp-preempt/Cargo.toml
@@ -10,6 +10,9 @@ categories    = ["embedded", "hardware-support", "no-std"]
 repository    = "https://github.com/esp-rs/esp-hal"
 license       = "MIT OR Apache-2.0"
 
+[package.metadata.espressif]
+doc-config = [{ features = ["esp-hal/unstable"] }]
+
 [package.metadata.docs.rs]
 default-target = "riscv32imac-unknown-none-elf"
 features       = ["esp32c6"]

--- a/esp-println/Cargo.toml
+++ b/esp-println/Cargo.toml
@@ -21,6 +21,10 @@ check-configs = [
     { features = ["auto", "log-04", "timestamp"] },
     { features = ["auto", "defmt-espflash", "timestamp"] },
 ]
+clippy-configs = [
+    { features = ["auto", "log-04", "timestamp"] },
+    { features = ["auto", "defmt-espflash", "timestamp"] },
+]
 
 [package.metadata.docs.rs]
 cargo-args     = ["-Z", "build-std=core"]

--- a/esp-println/Cargo.toml
+++ b/esp-println/Cargo.toml
@@ -11,6 +11,9 @@ repository    = "https://github.com/esp-rs/esp-hal"
 license       = "MIT OR Apache-2.0"
 links         = "esp-println"
 
+[package.metadata.espressif]
+doc-config = [{ features = ["auto", "defmt-espflash", "critical-section"] }]
+
 [package.metadata.docs.rs]
 cargo-args     = ["-Z", "build-std=core"]
 default-target = "riscv32imc-unknown-none-elf"

--- a/esp-println/Cargo.toml
+++ b/esp-println/Cargo.toml
@@ -17,7 +17,7 @@ check-configs = [
     { features = ["auto"] },
     { features = ["jtag-serial"], if = 'chip_has("soc_has_usb_serial_jtag")' },
     { features = ["uart"] },
-    # { features = ["no-op"] }, # FIXME
+    { features = ["no-op"] },
     { features = ["auto", "log-04", "timestamp"] },
     { features = ["auto", "defmt-espflash", "timestamp"] },
 ]

--- a/esp-println/Cargo.toml
+++ b/esp-println/Cargo.toml
@@ -15,7 +15,7 @@ links         = "esp-println"
 doc-config = [{ features = ["auto", "defmt-espflash", "critical-section"] }]
 check-configs = [
     { features = ["auto"] },
-    { features = ["jtag-serial"] },
+    { features = ["jtag-serial"], if = 'chip_has("soc_has_usb_serial_jtag")' },
     { features = ["uart"] },
     # { features = ["no-op"] }, # FIXME
     { features = ["auto", "log-04", "timestamp"] },

--- a/esp-println/Cargo.toml
+++ b/esp-println/Cargo.toml
@@ -13,6 +13,14 @@ links         = "esp-println"
 
 [package.metadata.espressif]
 doc-config = [{ features = ["auto", "defmt-espflash", "critical-section"] }]
+check-configs = [
+    { features = ["auto"] },
+    { features = ["jtag-serial"] },
+    { features = ["uart"] },
+    # { features = ["no-op"] }, # FIXME
+    { features = ["auto", "log-04", "timestamp"] },
+    { features = ["auto", "defmt-espflash", "timestamp"] },
+]
 
 [package.metadata.docs.rs]
 cargo-args     = ["-Z", "build-std=core"]

--- a/esp-println/Cargo.toml
+++ b/esp-println/Cargo.toml
@@ -12,7 +12,7 @@ license       = "MIT OR Apache-2.0"
 links         = "esp-println"
 
 [package.metadata.espressif]
-doc-config = [{ features = ["auto", "defmt-espflash", "critical-section"] }]
+doc-config = { features = ["auto", "defmt-espflash", "critical-section"] }
 check-configs = [
     { features = ["auto"] },
     { features = ["jtag-serial"], if = 'chip_has("soc_has_usb_serial_jtag")' },

--- a/esp-println/build.rs
+++ b/esp-println/build.rs
@@ -15,7 +15,7 @@ macro_rules! assert_unique_used_features {
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Ensure that only a single communication method is specified
-    assert_unique_used_features!("jtag-serial", "uart", "auto");
+    assert_unique_used_features!("jtag-serial", "uart", "auto", "no-op");
 
     let chip = esp_metadata_generated::Chip::from_cargo_feature()?;
     // Ensure that, if the `jtag-serial` communication method feature is enabled,

--- a/esp-println/src/lib.rs
+++ b/esp-println/src/lib.rs
@@ -129,6 +129,9 @@ type PrinterImpl = uart_printer::Printer;
 #[cfg(feature = "auto")]
 type PrinterImpl = auto_printer::Printer;
 
+#[cfg(feature = "no-op")]
+type PrinterImpl = noop::Printer;
+
 #[cfg(all(
     feature = "auto",
     any(
@@ -466,6 +469,17 @@ mod uart_printer {
         }
 
         pub fn flush(_token: LockToken<'_>) {}
+    }
+}
+
+#[cfg(feature = "no-op")]
+mod noop {
+    pub struct Printer;
+
+    impl Printer {
+        pub fn write_bytes_in_cs(_bytes: &[u8], _token: super::LockToken<'_>) {}
+
+        pub fn flush(_token: super::LockToken<'_>) {}
     }
 }
 

--- a/esp-println/src/logger.rs
+++ b/esp-println/src/logger.rs
@@ -52,7 +52,7 @@ impl log::Log for EspEnvLogger {
 
     #[allow(unused)]
     fn log(&self, record: &log::Record) {
-        if self.enabled(&record.metadata()) {
+        if self.enabled(record.metadata()) {
             print_log_record(record);
         }
     }
@@ -61,28 +61,26 @@ impl log::Log for EspEnvLogger {
 }
 
 fn print_log_record(record: &log::Record) {
-    const RESET: &str = "\u{001B}[0m";
-    const RED: &str = "\u{001B}[31m";
-    const GREEN: &str = "\u{001B}[32m";
-    const YELLOW: &str = "\u{001B}[33m";
-    const BLUE: &str = "\u{001B}[34m";
-    const CYAN: &str = "\u{001B}[35m";
+    let (color, reset) = if cfg!(feature = "colors") {
+        const RESET: &str = "\u{001B}[0m";
+        const RED: &str = "\u{001B}[31m";
+        const GREEN: &str = "\u{001B}[32m";
+        const YELLOW: &str = "\u{001B}[33m";
+        const BLUE: &str = "\u{001B}[34m";
+        const CYAN: &str = "\u{001B}[35m";
 
-    #[cfg(feature = "colors")]
-    let color = match record.level() {
-        log::Level::Error => RED,
-        log::Level::Warn => YELLOW,
-        log::Level::Info => GREEN,
-        log::Level::Debug => BLUE,
-        log::Level::Trace => CYAN,
+        let color = match record.level() {
+            log::Level::Error => RED,
+            log::Level::Warn => YELLOW,
+            log::Level::Info => GREEN,
+            log::Level::Debug => BLUE,
+            log::Level::Trace => CYAN,
+        };
+        let reset = RESET;
+        (color, reset)
+    } else {
+        ("", "")
     };
-    #[cfg(feature = "colors")]
-    let reset = RESET;
-
-    #[cfg(not(feature = "colors"))]
-    let color = "";
-    #[cfg(not(feature = "colors"))]
-    let reset = "";
 
     #[cfg(feature = "timestamp")]
     println!(

--- a/esp-radio-preempt-driver/Cargo.toml
+++ b/esp-radio-preempt-driver/Cargo.toml
@@ -10,4 +10,7 @@ categories    = ["embedded", "hardware-support", "no-std"]
 repository    = "https://github.com/esp-rs/esp-hal"
 license       = "MIT OR Apache-2.0"
 
+[package.metadata.espressif]
+check-configs = [{ features = [] }]
+
 [dependencies]

--- a/esp-radio-preempt-driver/Cargo.toml
+++ b/esp-radio-preempt-driver/Cargo.toml
@@ -12,5 +12,6 @@ license       = "MIT OR Apache-2.0"
 
 [package.metadata.espressif]
 check-configs = [{ features = [] }]
+clippy-configs = [{ features = [] }]
 
 [dependencies]

--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -19,6 +19,16 @@ doc-config = [
     { features = ["coex"], append_if = 'chip_has("wifi") && chip_has("bt")' },
     { features = ["unstable"], append_if = 'chip_has("wifi") || chip_has("bt") || chip_has("ieee802154")' },
 ]
+check-configs = [
+    { features = ["esp-hal/unstable", "esp-hal/rt"] },
+    { features = ["esp-hal/unstable", "esp-hal/rt", "defmt"] },
+    { features = ["esp-hal/unstable", "esp-hal/rt", "wifi"], if = 'chip_has("wifi")' },
+    { features = ["esp-hal/unstable", "esp-hal/rt", "unstable", "defmt", "wifi", "wifi-eap", "esp-now", "sniffer", "smoltcp/proto-ipv4", "smoltcp/proto-ipv6"], if = 'chip_has("wifi")' },
+    { features = ["esp-hal/unstable", "esp-hal/rt", "unstable", "ble"], if = 'chip_has("bt")' },
+    { features = ["esp-hal/unstable", "esp-hal/rt", "unstable", "ieee802154"], if = 'chip_has("ieee802154")' },
+    { features = ["esp-hal/unstable", "esp-hal/rt", "unstable", "defmt", "wifi", "wifi-eap", "esp-now", "sniffer", "smoltcp/proto-ipv4", "smoltcp/proto-ipv6", "ble", "coex"], if = 'chip_has("wifi") && chip_has("bt")' },
+    { features = ["esp-hal/unstable", "esp-hal/rt", "wifi-eap", "unstable"], if = 'chip_has("wifi")' },
+]
 
 [lib]
 bench = false

--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -29,6 +29,11 @@ check-configs = [
     { features = ["esp-hal/unstable", "esp-hal/rt", "unstable", "defmt", "wifi", "wifi-eap", "esp-now", "sniffer", "smoltcp/proto-ipv4", "smoltcp/proto-ipv6", "ble", "coex"], if = 'chip_has("wifi") && chip_has("bt")' },
     { features = ["esp-hal/unstable", "esp-hal/rt", "wifi-eap", "unstable"], if = 'chip_has("wifi")' },
 ]
+clippy-configs = [
+    { features = ["esp-hal/unstable", "esp-hal/rt"] },
+    { features = ["esp-hal/unstable", "esp-hal/rt", "wifi"], if = 'chip_has("wifi")' },
+    { features = ["esp-hal/unstable", "esp-hal/rt", "wifi-eap", "unstable""], if = 'chip_has("wifi")' },
+]
 
 [lib]
 bench = false

--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -10,6 +10,16 @@ categories = ["embedded", "hardware-support", "no-std"]
 repository = "https://github.com/esp-rs/esp-hal"
 license = "MIT OR Apache-2.0"
 
+[package.metadata.espressif]
+doc-config = [
+    { features = ["esp-hal/unstable", "esp-hal/rt", "defmt"] },
+    { features = ["wifi", "wifi-eap", "esp-now", "sniffer", "smoltcp/proto-ipv4", "smoltcp/proto-ipv6"], append_if = 'chip_has("wifi")' },
+    { features = ["ble"], append_if = 'chip_has("bt")' },
+    { features = ["ieee802154", "__docs_build"], append_if = 'chip_has("ieee802154")' },
+    { features = ["coex"], append_if = 'chip_has("wifi") && chip_has("bt")' },
+    { features = ["unstable"], append_if = 'chip_has("wifi") || chip_has("bt") || chip_has("ieee802154")' },
+]
+
 [lib]
 bench = false
 test  = false

--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -11,14 +11,13 @@ repository = "https://github.com/esp-rs/esp-hal"
 license = "MIT OR Apache-2.0"
 
 [package.metadata.espressif]
-doc-config = [
-    { features = ["esp-hal/unstable", "esp-hal/rt", "defmt"] },
-    { features = ["wifi", "wifi-eap", "esp-now", "sniffer", "smoltcp/proto-ipv4", "smoltcp/proto-ipv6"], append_if = 'chip_has("wifi")' },
-    { features = ["ble"], append_if = 'chip_has("bt")' },
-    { features = ["ieee802154", "__docs_build"], append_if = 'chip_has("ieee802154")' },
-    { features = ["coex"], append_if = 'chip_has("wifi") && chip_has("bt")' },
-    { features = ["unstable"], append_if = 'chip_has("wifi") || chip_has("bt") || chip_has("ieee802154")' },
-]
+doc-config = { features = ["esp-hal/unstable", "esp-hal/rt", "defmt"], append = [
+    { if = 'chip_has("wifi")', features = ["wifi", "wifi-eap", "esp-now", "sniffer", "smoltcp/proto-ipv4", "smoltcp/proto-ipv6"] },
+    { if = 'chip_has("bt")', features = ["ble"] },
+    { if = 'chip_has("ieee802154")', features = ["ieee802154", "__docs_build"] },
+    { if = 'chip_has("wifi") && chip_has("bt")', features = ["coex"] },
+    { if = 'chip_has("wifi") || chip_has("bt") || chip_has("ieee802154")', features = ["unstable"] },
+] }
 check-configs = [
     { features = ["esp-hal/unstable", "esp-hal/rt"] },
     { features = ["esp-hal/unstable", "esp-hal/rt", "defmt"] },
@@ -32,7 +31,7 @@ check-configs = [
 clippy-configs = [
     { features = ["esp-hal/unstable", "esp-hal/rt"] },
     { features = ["esp-hal/unstable", "esp-hal/rt", "wifi"], if = 'chip_has("wifi")' },
-    { features = ["esp-hal/unstable", "esp-hal/rt", "wifi-eap", "unstable""], if = 'chip_has("wifi")' },
+    { features = ["esp-hal/unstable", "esp-hal/rt", "wifi-eap", "unstable"], if = 'chip_has("wifi")' },
 ]
 
 [lib]

--- a/esp-riscv-rt/Cargo.toml
+++ b/esp-riscv-rt/Cargo.toml
@@ -20,6 +20,7 @@ check-configs = [
     { features = ["no-mie-mip"] },
     { features = ["rtc-ram", "no-mie-mip"] },
 ]
+clippy-configs = [{ features = ["rtc-ram"] }]
 
 [lib]
 bench = false

--- a/esp-riscv-rt/Cargo.toml
+++ b/esp-riscv-rt/Cargo.toml
@@ -13,8 +13,6 @@ links         = "esp-riscv-rt"
 
 [package.metadata.espressif]
 doc-config = [{ features = ["rtc-ram"] }]
-
-[package.metadata.espressif]
 requires_target = ["riscv32imc-unknown-none-elf", "riscv32imac-unknown-none-elf"]
 
 [lib]

--- a/esp-riscv-rt/Cargo.toml
+++ b/esp-riscv-rt/Cargo.toml
@@ -12,6 +12,9 @@ license       = "MIT OR Apache-2.0"
 links         = "esp-riscv-rt"
 
 [package.metadata.espressif]
+doc-config = [{ features = ["rtc-ram"] }]
+
+[package.metadata.espressif]
 requires_target = ["riscv32imc-unknown-none-elf", "riscv32imac-unknown-none-elf"]
 
 [lib]

--- a/esp-riscv-rt/Cargo.toml
+++ b/esp-riscv-rt/Cargo.toml
@@ -14,6 +14,12 @@ links         = "esp-riscv-rt"
 [package.metadata.espressif]
 doc-config = [{ features = ["rtc-ram"] }]
 requires_target = ["riscv32imc-unknown-none-elf", "riscv32imac-unknown-none-elf"]
+check-configs = [
+    { features = [] },
+    { features = ["rtc-ram"] },
+    { features = ["no-mie-mip"] },
+    { features = ["rtc-ram", "no-mie-mip"] },
+]
 
 [lib]
 bench = false

--- a/esp-riscv-rt/Cargo.toml
+++ b/esp-riscv-rt/Cargo.toml
@@ -11,6 +11,9 @@ repository    = "https://github.com/esp-rs/esp-hal"
 license       = "MIT OR Apache-2.0"
 links         = "esp-riscv-rt"
 
+[package.metadata.espressif]
+requires_target = ["riscv32imc-unknown-none-elf", "riscv32imac-unknown-none-elf"]
+
 [lib]
 bench = false
 test  = false

--- a/esp-riscv-rt/Cargo.toml
+++ b/esp-riscv-rt/Cargo.toml
@@ -12,7 +12,7 @@ license       = "MIT OR Apache-2.0"
 links         = "esp-riscv-rt"
 
 [package.metadata.espressif]
-doc-config = [{ features = ["rtc-ram"] }]
+doc-config = { features = ["rtc-ram"] }
 requires_target = ["riscv32imc-unknown-none-elf", "riscv32imac-unknown-none-elf"]
 check-configs = [
     { features = [] },

--- a/esp-rom-sys/Cargo.toml
+++ b/esp-rom-sys/Cargo.toml
@@ -12,6 +12,11 @@ license       = "MIT OR Apache-2.0"
 
 links         = "esp_rom_sys"
 
+[package.metadata.espressif]
+check-configs = [
+    { features = [] },
+]
+
 [package.metadata.docs.rs]
 default-target = "riscv32imac-unknown-none-elf"
 features       = ["esp32c6"]

--- a/esp-rom-sys/Cargo.toml
+++ b/esp-rom-sys/Cargo.toml
@@ -13,9 +13,8 @@ license       = "MIT OR Apache-2.0"
 links         = "esp_rom_sys"
 
 [package.metadata.espressif]
-check-configs = [
-    { features = [] },
-]
+check-configs = [{ features = [] }]
+clippy-configs = [{ features = [] }]
 
 [package.metadata.docs.rs]
 default-target = "riscv32imac-unknown-none-elf"

--- a/esp-storage/Cargo.toml
+++ b/esp-storage/Cargo.toml
@@ -15,7 +15,9 @@ check-configs = [
     { features = [] },
     { features = ["critical-section"] },
     { features = ["bytewise-read"] },
+    { features = ["critical-section", "bytewise-read"] },
 ]
+clippy-configs = [{ features = ["critical-section", "bytewise-read"] }]
 
 [package.metadata.docs.rs]
 default-target = "riscv32imac-unknown-none-elf"

--- a/esp-storage/Cargo.toml
+++ b/esp-storage/Cargo.toml
@@ -12,12 +12,22 @@ license       = "MIT OR Apache-2.0"
 
 [package.metadata.espressif]
 check-configs = [
-    { features = [] },
-    { features = ["critical-section"] },
-    { features = ["bytewise-read"] },
-    { features = ["critical-section", "bytewise-read"] },
+    { features = [], append = [
+        { features = ["portable-atomic/unsafe-assume-single-core"], if = 'chip == "esp32c2" || chip == "esp32c3" || chip == "esp32s2"' }
+    ] },
+    { features = ["critical-section"], append = [
+        { features = ["portable-atomic/unsafe-assume-single-core"], if = 'chip == "esp32c2" || chip == "esp32c3" || chip == "esp32s2"' }
+    ] },
+    { features = ["bytewise-read"], append = [
+        { features = ["portable-atomic/unsafe-assume-single-core"], if = 'chip == "esp32c2" || chip == "esp32c3" || chip == "esp32s2"' }
+    ] },
+    { features = ["critical-section", "bytewise-read"], append = [
+        { features = ["portable-atomic/unsafe-assume-single-core"], if = 'chip == "esp32c2" || chip == "esp32c3" || chip == "esp32s2"' }
+    ] },
 ]
-clippy-configs = [{ features = ["critical-section", "bytewise-read"] }]
+clippy-configs = [{ features = ["critical-section", "bytewise-read"], append = [
+    { features = ["portable-atomic/unsafe-assume-single-core"], if = 'chip == "esp32c2" || chip == "esp32c3" || chip == "esp32s2"' }
+]}]
 
 [package.metadata.docs.rs]
 default-target = "riscv32imac-unknown-none-elf"

--- a/esp-storage/Cargo.toml
+++ b/esp-storage/Cargo.toml
@@ -10,6 +10,13 @@ categories    = ["embedded", "hardware-support", "no-std"]
 repository    = "https://github.com/esp-rs/esp-hal"
 license       = "MIT OR Apache-2.0"
 
+[package.metadata.espressif]
+check-configs = [
+    { features = [] },
+    { features = ["critical-section"] },
+    { features = ["bytewise-read"] },
+]
+
 [package.metadata.docs.rs]
 default-target = "riscv32imac-unknown-none-elf"
 features       = ["esp32c6"]

--- a/esp-storage/src/lib.rs
+++ b/esp-storage/src/lib.rs
@@ -25,7 +25,7 @@ fn maybe_with_critical_section<R>(f: impl FnOnce() -> R) -> R {
     {
         static LOCK: esp_sync::RawMutex = esp_sync::RawMutex::new();
 
-        return LOCK.lock(f);
+        LOCK.lock(f)
     }
 
     #[cfg(not(feature = "critical-section"))]

--- a/esp-sync/Cargo.toml
+++ b/esp-sync/Cargo.toml
@@ -16,6 +16,7 @@ check-configs = [
     { features = ["log-04"] },
     { features = ["defmt"] },
 ]
+clippy-configs = [{ features = ["defmt"] }]
 
 [dependencies]
 cfg-if = "1"

--- a/esp-sync/Cargo.toml
+++ b/esp-sync/Cargo.toml
@@ -10,6 +10,13 @@ repository    = "https://github.com/esp-rs/esp-hal"
 license       = "MIT OR Apache-2.0"
 exclude       = [ "MIGRATING-*", "CHANGELOG.md" ]
 
+[package.metadata.espressif]
+check-configs = [
+    { features = [] },
+    { features = ["log-04"] },
+    { features = ["defmt"] },
+]
+
 [dependencies]
 cfg-if = "1"
 document-features = "0.2"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -23,6 +23,7 @@ rocket       = { version = "0.5.1", optional = true }
 semver       = { version = "1.0.23", features = ["serde"] }
 serde        = { version = "1.0.215", default-features = false, features = ["derive"] }
 serde_json   = "1.0.70"
+somni-expr   = { version = "0.1.0" }
 strum        = { version = "0.27.1", features = ["derive"] }
 syn          = { version = "2", default-features = false, features = ["full", "parsing"] }
 toml_edit    = { version = "0.22.22", features = ["serde"] }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -16,6 +16,7 @@ kuchikiki    = { version = "0.8.2", optional = true }
 log          = "0.4.22"
 minijinja    = { version = "2.5.0", default-features = false }
 opener       = { version = "0.7.2", optional = true }
+parking_lot  = "0.12.3"
 prettyplease = { version = "0.2.34" }
 regex        = { version = "1.11.1", optional = true }
 rocket       = { version = "0.5.1", optional = true }

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -379,9 +379,7 @@ impl CargoCommandBatcher {
 
             for item in group.iter() {
                 // Only some commands can be batched
-                let batchable = [
-                    "build", "doc", "check", // soon(TM)
-                ];
+                let batchable = ["build", "doc", "check"];
                 if !batchable
                     .iter()
                     .any(|&subcommand| subcommand == item.subcommand)

--- a/xtask/src/commands/release/bump_version.rs
+++ b/xtask/src/commands/release/bump_version.rs
@@ -405,7 +405,7 @@ mod tests {
         let mut doc = CargoToml {
             manifest: toml.parse::<DocumentMut>().unwrap(),
             package: Package::EspHal,
-            workspace: Path::new(""),
+            workspace: PathBuf::new(),
         };
         let errors = check_crate_before_bumping(&mut doc);
         pretty_assertions::assert_eq!(

--- a/xtask/src/commands/release/bump_version.rs
+++ b/xtask/src/commands/release/bump_version.rs
@@ -65,7 +65,7 @@ pub fn bump_version(workspace: &Path, args: BumpVersionArgs) -> Result<()> {
 
 /// Update the specified package by bumping its version, updating its changelog,
 pub fn update_package(
-    package: &mut CargoToml<'_>,
+    package: &mut CargoToml,
     version: &VersionBump,
     dry_run: bool,
 ) -> Result<semver::Version> {
@@ -77,7 +77,7 @@ pub fn update_package(
     Ok(new_version)
 }
 
-fn check_crate_before_bumping(manifest: &mut CargoToml<'_>) -> Result<()> {
+fn check_crate_before_bumping(manifest: &mut CargoToml) -> Result<()> {
     // Collect errors into a vector to preserve order.
     let mut errors = Vec::new();
 
@@ -175,7 +175,7 @@ fn check_dependency_before_bumping(item: &Item) -> Result<()> {
 
 /// Bump the version of the specified package by the specified amount.
 fn bump_crate_version(
-    bumped_package: &mut CargoToml<'_>,
+    bumped_package: &mut CargoToml,
     amount: &VersionBump,
     dry_run: bool,
 ) -> Result<semver::Version> {
@@ -197,7 +197,7 @@ fn bump_crate_version(
 
     let package_name = bumped_package.package.to_string();
     for pkg in Package::iter() {
-        let mut dependent = CargoToml::new(bumped_package.workspace, pkg)
+        let mut dependent = CargoToml::new(&bumped_package.workspace, pkg)
             .with_context(|| format!("Could not load Cargo.toml of {pkg}"))?;
 
         if dependent.change_version_of_dependency(&package_name, &version) {
@@ -268,7 +268,7 @@ pub fn do_version_bump(version: &semver::Version, amount: &VersionBump) -> Resul
 }
 
 fn finalize_changelog(
-    bumped_package: &CargoToml<'_>,
+    bumped_package: &CargoToml,
     new_version: &semver::Version,
     dry_run: bool,
 ) -> Result<()> {
@@ -306,7 +306,7 @@ fn finalize_changelog(
 }
 
 fn finalize_placeholders(
-    bumped_package: &CargoToml<'_>,
+    bumped_package: &CargoToml,
     new_version: &semver::Version,
     dry_run: bool,
 ) -> Result<()> {

--- a/xtask/src/commands/release/plan.rs
+++ b/xtask/src/commands/release/plan.rs
@@ -81,7 +81,7 @@ pub fn plan(workspace: &Path, args: PlanArgs) -> Result<()> {
     let mut packages_to_release = args
         .packages
         .iter()
-        .filter(|p| p.is_published(workspace))
+        .filter(|p| p.is_published())
         .flat_map(|p| related_crates(workspace, *p))
         .collect::<Vec<_>>();
 

--- a/xtask/src/commands/release/publish.rs
+++ b/xtask/src/commands/release/publish.rs
@@ -23,7 +23,7 @@ pub fn publish(workspace: &Path, args: PublishArgs) -> Result<()> {
     let package_path = windows_safe_path(&workspace.join(&package_name));
 
     ensure!(
-        args.package.is_published(workspace),
+        args.package.is_published(),
         "Invalid package '{}' specified, this package should not be published!",
         args.package
     );

--- a/xtask/src/commands/release/tag_releases.rs
+++ b/xtask/src/commands/release/tag_releases.rs
@@ -33,7 +33,7 @@ pub fn tag_releases(workspace: &Path, mut args: TagReleasesArgs) -> Result<()> {
         // If a package does not require documentation, this also means that it is not
         // published (maybe this function needs a better name), so we can skip tagging
         // it:
-        if !package.is_published(workspace) {
+        if !package.is_published() {
             continue;
         }
 

--- a/xtask/src/commands/run.rs
+++ b/xtask/src/commands/run.rs
@@ -62,7 +62,7 @@ pub fn run_doc_tests(workspace: &Path, args: DocTestArgs) -> Result<()> {
     let target = args.package.target_triple(&chip)?;
     let mut features = args
         .package
-        .feature_rules(&esp_metadata::Config::for_chip(&chip));
+        .doc_feature_rules(&esp_metadata::Config::for_chip(&chip));
     features.push(chip.to_string());
 
     // We need `nightly` for building the doc tests, unfortunately:

--- a/xtask/src/documentation.rs
+++ b/xtask/src/documentation.rs
@@ -205,9 +205,9 @@ fn cargo_doc(workspace: &Path, package: Package, chip: Option<Chip>) -> Result<P
     let mut features = vec![];
     if let Some(chip) = &chip {
         features.push(chip.to_string());
-        features.extend(package.feature_rules(Config::for_chip(chip)));
+        features.extend(package.doc_feature_rules(Config::for_chip(chip)));
     } else {
-        features.extend(package.feature_rules(&Config::empty()));
+        features.extend(package.doc_feature_rules(&Config::empty()));
     }
 
     // Build up an array of command-line arguments to pass to `cargo`:

--- a/xtask/src/documentation.rs
+++ b/xtask/src/documentation.rs
@@ -39,7 +39,7 @@ pub fn build_documentation(
 
     for package in packages {
         // Not all packages need documentation built:
-        if !package.is_published(workspace) {
+        if !package.is_published() {
             continue;
         }
 
@@ -326,7 +326,7 @@ pub fn build_documentation_index(workspace: &Path, packages: &mut [Package]) -> 
     for package in packages {
         log::debug!("Building documentation index for package '{package}'");
         // Not all packages have documentation built:
-        if !package.is_published(workspace) {
+        if !package.is_published() {
             continue;
         }
 
@@ -462,7 +462,7 @@ fn generate_documentation_meta_for_index(workspace: &Path) -> Result<Vec<Value>>
 
     for package in Package::iter() {
         // Not all packages have documentation built:
-        if !package.is_published(workspace) {
+        if !package.is_published() {
             continue;
         }
 

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -481,7 +481,17 @@ impl Package {
 
     #[cfg(feature = "release")]
     fn is_semver_checked(&self) -> bool {
-        [Self::EspHal].contains(self)
+        let Some(metadata) = self.toml().espressif_metadata() else {
+            return false;
+        };
+
+        let Some(Item::Value(semver_checked)) = metadata.get("semver_checked") else {
+            return false;
+        };
+
+        semver_checked
+            .as_bool()
+            .expect("semver_checked must be a boolean")
     }
 }
 

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -370,8 +370,11 @@ impl Package {
     }
 
     fn targets_lp_core(&self) -> bool {
-        let toml = self.toml();
+        if *self == Package::Examples {
+            return false;
+        }
 
+        let toml = self.toml();
         let Some(metadata) = toml.espressif_metadata() else {
             return false;
         };
@@ -396,6 +399,10 @@ impl Package {
 
     /// Validate that the specified chip is valid for the specified package.
     pub fn validate_package_chip(&self, chip: &Chip) -> Result<()> {
+        if *self == Package::Examples {
+            return Ok(());
+        }
+
         if self.targets_lp_core() && !chip.has_lp_core() {
             return Err(anyhow!(
                 "Package '{self}' requires an LP core, but '{chip}' does not have one",
@@ -429,7 +436,8 @@ impl Package {
 
     #[cfg(feature = "release")]
     fn is_semver_checked(&self) -> bool {
-        let Some(metadata) = self.toml().espressif_metadata() else {
+        let toml = self.toml();
+        let Some(metadata) = toml.espressif_metadata() else {
             return false;
         };
 

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -211,6 +211,7 @@ impl Package {
         eval_context.add_function("chip_has", |symbol: &str| {
             config.all().iter().any(|sym| sym == symbol)
         });
+        eval_context.add_variable("chip", config.name());
 
         if let Some(condition) = table.get("if") {
             let Some(expr) = condition.as_str() else {

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -417,9 +417,13 @@ impl Package {
         cases
     }
 
+    fn targets_lp_core(&self) -> bool {
+        self == Package::EspLpHal
+    }
+
     /// Return the target triple for a given package/chip pair.
     pub fn target_triple(&self, chip: &Chip) -> Result<String> {
-        if *self == Package::EspLpHal {
+        if self.targets_lp_core() {
             chip.lp_target().map(ToString::to_string)
         } else {
             Ok(chip.target())
@@ -429,11 +433,11 @@ impl Package {
     /// Validate that the specified chip is valid for the specified package.
     pub fn validate_package_chip(&self, chip: &Chip) -> Result<()> {
         let check = match self {
-            Package::EspLpHal => chip.has_lp_core(),
             Package::XtensaLx | Package::XtensaLxRt | Package::XtensaLxRtProcMacros => {
                 chip.is_xtensa()
             }
             Package::EspRiscvRt => chip.is_riscv(),
+            p if p.targets_lp_core() => chip.has_lp_core(),
             _ => true,
         };
 

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -329,66 +329,57 @@ impl Package {
 
     /// Additional feature rules to test subsets of features for a package.
     pub fn lint_feature_rules(&self, config: &Config) -> Vec<Vec<String>> {
-        let mut cases = Vec::new();
+        let mut cases = vec![];
 
-        // For now we run a lot of clippy checks, but that will change.
-        cases.push(self.doc_feature_rules(config));
+        let toml = self.toml();
+        if let Some(metadata) = toml.espressif_metadata()
+            && let Some(config_meta) = metadata.get("clippy-configs")
+        {
+            let Item::Value(Value::Array(tables)) = config_meta else {
+                panic!(
+                    "clippy-configs must be an array of tables. {:?}",
+                    config_meta
+                );
+            };
 
-        match self {
-            Package::EspHal => {
-                // This checks if the `esp-hal` crate compiles with the no features (other than the
-                // chip selection)
-
-                // This tests that disabling the `rt` feature works
-                cases.push(vec![]);
-                // This checks if the `esp-hal` crate compiles _without_ the `unstable` feature
-                // enabled
-                cases.push(vec!["rt".to_owned()]);
-            }
-            Package::EspRadio => {
-                // Minimal set of features that when enabled _should_ still compile:
-                cases.push(vec!["esp-hal/rt".to_owned(), "esp-hal/unstable".to_owned()]);
-                if config.contains("wifi") {
-                    // This tests if `wifi` feature works without `esp-radio/unstable`
-                    cases.push(vec![
-                        "esp-hal/rt".to_owned(),
-                        "esp-hal/unstable".to_owned(),
-                        "wifi".to_owned(),
-                    ]);
-                    // This tests `wifi-eap` feature
-                    cases.push(vec![
-                        "esp-hal/rt".to_owned(),
-                        "esp-hal/unstable".to_owned(),
-                        "wifi-eap".to_owned(),
-                        "unstable".to_owned(),
-                    ]);
+            for table in tables {
+                let Value::InlineTable(table) = table else {
+                    panic!("clippy-configs must be an array of tables. {:?}", table);
+                };
+                // Filter based on conditions
+                if let Some(condition) = table.get("if") {
+                    if let Some(expr) = condition.as_str() {
+                        let mut eval_context = somni_expr::Context::new();
+                        eval_context.add_function("chip_has", |symbol: &str| {
+                            config.all().iter().any(|sym| sym == symbol)
+                        });
+                        if !eval_context
+                            .evaluate::<bool>(expr)
+                            .expect("Failed to evaluate expression")
+                        {
+                            continue;
+                        }
+                    } else {
+                        panic!("`if` condition must be a string.");
+                    };
                 }
-            }
-            Package::EspMetadataGenerated => {
-                cases.push(vec!["build-script".to_owned()]);
-            }
-            Package::EspPreempt => {
-                cases.push(vec!["esp-alloc".to_owned(), "esp-hal/unstable".to_owned()])
-            }
-            Package::EspStorage => {
-                // TODO: https://github.com/esp-rs/esp-hal/issues/4136
-                if config.name() == "esp32c2"
-                    || config.name() == "esp32c3"
-                    || config.name() == "esp32s2"
-                {
-                    // println!("kokot usho");
-                    cases.push(vec![
-                        "defmt".to_owned(),
-                        "portable-atomic/unsafe-assume-single-core".to_owned(),
-                    ]);
-                } else {
-                    cases.push(vec!["defmt".to_owned()]);
+
+                let mut features = Vec::new();
+                if let Some(config_features) = table.get("features") {
+                    let Value::Array(config_features) = config_features else {
+                        panic!("features must be an array.");
+                    };
+
+                    for feature in config_features {
+                        let feature = feature.as_str().expect("features must be strings.");
+                        features.push(feature.to_owned());
+                    }
                 }
+                cases.push(features);
             }
-            _ => {}
         }
 
-        log::debug!("Lint feature cases for package '{}': {:?}", self, cases);
+        log::debug!("Check features for package '{}': {:?}", self, cases);
         cases
     }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -266,7 +266,8 @@ fn check_packages(workspace: &Path, args: CheckPackagesArgs) -> Result<()> {
             log::debug!("  for chip: {}", chip);
             let device = Config::for_chip(chip);
 
-            if package.validate_package_chip(chip).is_err() {
+            if let Err(e) = package.validate_package_chip(chip) {
+                log::warn!("{e}. Skipping");
                 continue;
             }
 
@@ -361,7 +362,8 @@ fn lint_packages(workspace: &Path, args: LintPackagesArgs) -> Result<()> {
             log::debug!("  for chip: {}", chip);
             let device = Config::for_chip(chip);
 
-            if package.validate_package_chip(chip).is_err() {
+            if let Err(e) = package.validate_package_chip(chip) {
+                log::warn!("{e}. Skipping");
                 continue;
             }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -258,7 +258,7 @@ fn check_packages(workspace: &Path, args: CheckPackagesArgs) -> Result<()> {
 
     let mut commands = CargoCommandBatcher::new();
 
-    for package in packages.iter().filter(|p| p.is_published(workspace)) {
+    for package in packages.iter().filter(|p| p.is_published()) {
         // Unfortunately each package has its own unique requirements for
         // building, so we need to handle each individually (though there
         // is *some* overlap)
@@ -353,7 +353,7 @@ fn lint_packages(workspace: &Path, args: LintPackagesArgs) -> Result<()> {
     let mut packages = args.packages;
     packages.sort();
 
-    for package in packages.iter().filter(|p| p.is_published(workspace)) {
+    for package in packages.iter().filter(|p| p.is_published()) {
         // Unfortunately each package has its own unique requirements for
         // building, so we need to handle each individually (though there
         // is *some* overlap)

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -512,24 +512,11 @@ fn run_ci_checks(workspace: &Path, args: CiArgs) -> Result<()> {
         std::env::set_var("CI", "true");
     }
 
-    // TODO: enable checking all crates once cargo-batch has check support
-    // runner.run("Check crates", || {
-    //     check_packages(
-    //         workspace,
-    //         LintPackagesArgs {
-    //             packages: Package::iter().collect(),
-    //             chips: vec![args.chip],
-    //             fix: false,
-    //             toolchain: args.toolchain.clone(),
-    //         },
-    //     )
-    // });
-
-    runner.run("Check esp-hal", || {
+    runner.run("Check crates", || {
         check_packages(
             workspace,
             CheckPackagesArgs {
-                packages: vec![Package::EspHal],
+                packages: Package::iter().collect(),
                 chips: vec![args.chip],
                 toolchain: args.toolchain.clone(),
             },

--- a/xtensa-lx-rt-proc-macros/Cargo.toml
+++ b/xtensa-lx-rt-proc-macros/Cargo.toml
@@ -10,6 +10,9 @@ license = "MIT OR Apache-2.0"
 keywords = ["esp32", "xtensa-lx-rt", "runtime", "startup"]
 categories = ["embedded", "no-std"]
 
+[package.metadata.espressif]
+requires_target = ["xtensa-esp32-none-elf", "xtensa-esp32s2-none-elf", "xtensa-esp32s3-none-elf"]
+
 [lib]
 proc-macro = true
 

--- a/xtensa-lx-rt/Cargo.toml
+++ b/xtensa-lx-rt/Cargo.toml
@@ -11,6 +11,9 @@ keywords      = ["lx", "peripheral", "register", "xtensa"]
 categories    = ["embedded", "hardware-support", "no-std"]
 links         = "xtensa-lx-rt"
 
+[package.metadata.espressif]
+requires_target = ["xtensa-esp32-none-elf", "xtensa-esp32s2-none-elf", "xtensa-esp32s3-none-elf"]
+
 [lib]
 bench = false
 test  = false

--- a/xtensa-lx/Cargo.toml
+++ b/xtensa-lx/Cargo.toml
@@ -10,6 +10,9 @@ license       = "MIT OR Apache-2.0"
 categories    = ["embedded", "hardware-support", "no-std"]
 keywords      = ["lx", "peripheral", "register", "xtensa"]
 
+[package.metadata.espressif]
+requires_target = ["xtensa-esp32-none-elf", "xtensa-esp32s2-none-elf", "xtensa-esp32s3-none-elf"]
+
 [lib]
 bench = false
 test  = false


### PR DESCRIPTION
Now we run cargo-check on all packages on the mac runner. It might take a bit of time, but it's quite comprehensive, and cargo-batch helps minimize the overhead (~1minute/chip).

Includes fixes to discovered problems and clippy lint violations, too.

We might be a bit more selective with examples/running clippy in the future, e.g. we can run them only in the merge queue (while building/checking only a subset on push), instead of complete runs for every push. That way, the initial CI run would be complete, but we'd still catch all the problems that we would have. Just maybe a bit later.