### PR TITLE
Replace some inline ASM with xtensa_lx implementations

### DIFF
--- a/esp-hal/src/soc/esp32/cpu_control.rs
+++ b/esp-hal/src/soc/esp32/cpu_control.rs
@@ -287,7 +287,7 @@ impl<'d> CpuControl<'d> {
         // set vector table and stack pointer
         unsafe {
             xtensa_lx::set_vecbase(&raw const _init_start);
-            xtensa_lx::set_stack_pointer(unwrap!(APP_CORE_STACK_TOP));
+            xtensa_lx::set_stack_pointer(APP_CORE_STACK_TOP.load(Ordering::Acquire));
         }
 
         // Trampoline to run from the new stack.

--- a/esp-hal/src/soc/esp32/cpu_control.rs
+++ b/esp-hal/src/soc/esp32/cpu_control.rs
@@ -286,8 +286,8 @@ impl<'d> CpuControl<'d> {
 
         // set vector table and stack pointer
         unsafe {
-            core::arch::asm!("wsr.vecbase {0}", in(reg) &raw const _init_start, options(nostack));
-            xtensa_lx::set_stack_pointer(APP_CORE_STACK_TOP.load(Ordering::Acquire));
+            xtensa_lx::set_vecbase(&raw const _init_start);
+            xtensa_lx::set_stack_pointer(unwrap!(APP_CORE_STACK_TOP));
         }
 
         // Trampoline to run from the new stack.

--- a/esp-hal/src/soc/esp32s3/cpu_control.rs
+++ b/esp-hal/src/soc/esp32s3/cpu_control.rs
@@ -225,8 +225,8 @@ impl<'d> CpuControl<'d> {
 
         // set vector table and stack pointer
         unsafe {
-            core::arch::asm!("wsr.vecbase {0}", in(reg) &raw const _init_start, options(nostack));
-            xtensa_lx::set_stack_pointer(APP_CORE_STACK_TOP.load(Ordering::Acquire));
+            xtensa_lx::set_vecbase(&raw const _init_start);
+            xtensa_lx::set_stack_pointer(unwrap!(APP_CORE_STACK_TOP));
         }
 
         // Trampoline to run from the new stack.

--- a/esp-hal/src/soc/esp32s3/cpu_control.rs
+++ b/esp-hal/src/soc/esp32s3/cpu_control.rs
@@ -226,7 +226,7 @@ impl<'d> CpuControl<'d> {
         // set vector table and stack pointer
         unsafe {
             xtensa_lx::set_vecbase(&raw const _init_start);
-            xtensa_lx::set_stack_pointer(unwrap!(APP_CORE_STACK_TOP));
+            xtensa_lx::set_stack_pointer(APP_CORE_STACK_TOP.load(Ordering::Acquire));
         }
 
         // Trampoline to run from the new stack.

--- a/esp-preempt/src/task/xtensa.rs
+++ b/esp-preempt/src/task/xtensa.rs
@@ -87,8 +87,7 @@ pub(crate) fn setup_multitasking() {
 #[cfg_attr(not(esp32), unsafe(export_name = "Software0"))]
 #[cfg_attr(esp32, unsafe(export_name = "Software1"))]
 fn task_switch_interrupt(context: &mut CpuContext) {
-    let intr = SW_INTERRUPT;
-    unsafe { core::arch::asm!("wsr.intclear  {0}", in(reg) intr, options(nostack)) };
+    unsafe { xtensa_lx_rt::xtensa_lx::interrupt::clear(SW_INTERRUPT) };
 
     SCHEDULER.with(|scheduler| scheduler.switch_task(context));
 }

--- a/esp-preempt/src/task/xtensa.rs
+++ b/esp-preempt/src/task/xtensa.rs
@@ -95,6 +95,5 @@ fn task_switch_interrupt(context: &mut CpuContext) {
 
 #[inline]
 pub(crate) fn yield_task() {
-    let intr = SW_INTERRUPT;
-    unsafe { core::arch::asm!("wsr.intset  {0}", in(reg) intr, options(nostack)) };
+    unsafe { xtensa_lx::interrupt::set(SW_INTERRUPT) };
 }

--- a/esp-radio/src/ble/btdm.rs
+++ b/esp-radio/src/ble/btdm.rs
@@ -192,17 +192,12 @@ unsafe extern "C" fn is_in_isr() -> i32 {
     crate::is_interrupts_disabled() as i32
 }
 
+#[cfg(esp32)]
 #[ram]
 unsafe extern "C" fn cause_sw_intr_to_core(_core: i32, _intr_no: i32) -> i32 {
-    #[cfg(any(esp32c3, esp32s3))]
-    todo!("cause_sw_intr_to_core is not implemented for this target");
-
-    #[cfg(esp32)]
-    {
-        trace!("cause_sw_intr_to_core {} {}", _core, _intr_no);
-        unsafe { xtensa_lx_rt::xtensa_lx::interrupt::set(1 << _intr_no) };
-        0
-    }
+    trace!("cause_sw_intr_to_core {} {}", _core, _intr_no);
+    unsafe { xtensa_lx_rt::xtensa_lx::interrupt::set(1 << _intr_no) };
+    0
 }
 
 #[allow(unused)]

--- a/esp-radio/src/ble/btdm.rs
+++ b/esp-radio/src/ble/btdm.rs
@@ -200,8 +200,7 @@ unsafe extern "C" fn cause_sw_intr_to_core(_core: i32, _intr_no: i32) -> i32 {
     #[cfg(esp32)]
     {
         trace!("cause_sw_intr_to_core {} {}", _core, _intr_no);
-        let intr = 1 << _intr_no;
-        unsafe { core::arch::asm!("wsr.intset  {0}", in(reg) intr, options(nostack)) };
+        unsafe { xtensa_lx_rt::xtensa_lx::interrupt::set(1 << _intr_no) };
         0
     }
 }

--- a/esp-radio/src/ble/os_adapter_esp32c3.rs
+++ b/esp-radio/src/ble/os_adapter_esp32c3.rs
@@ -117,7 +117,7 @@ pub(super) static G_OSI_FUNCS: osi_funcs_s = osi_funcs_s {
     task_create: Some(task_create),
     task_delete: Some(task_delete),
     is_in_isr: Some(is_in_isr),
-    cause_sw_intr_to_core: Some(cause_sw_intr_to_core),
+    cause_sw_intr_to_core: None,
     malloc: Some(crate::ble::malloc),
     malloc_internal: Some(crate::ble::malloc_internal),
     free: Some(crate::ble::free),

--- a/esp-radio/src/ble/os_adapter_esp32s3.rs
+++ b/esp-radio/src/ble/os_adapter_esp32s3.rs
@@ -118,7 +118,7 @@ pub(super) static G_OSI_FUNCS: osi_funcs_s = osi_funcs_s {
     task_create: Some(task_create),
     task_delete: Some(task_delete),
     is_in_isr: Some(is_in_isr),
-    cause_sw_intr_to_core: Some(cause_sw_intr_to_core),
+    cause_sw_intr_to_core: None,
     malloc: Some(crate::ble::malloc),
     malloc_internal: Some(crate::ble::malloc_internal),
     free: Some(crate::ble::free),


### PR DESCRIPTION
Minor thing, but `wsr.intset` must be followed by an `rsync` instruction. This PR replaces manual offending ASM (and some more) with calls to the xtensa_lx implementaiton.