### PR TITLE
Clean up interrupt mask operations

### DIFF
--- a/esp-hal/src/interrupt/xtensa.rs
+++ b/esp-hal/src/interrupt/xtensa.rs
@@ -159,9 +159,7 @@ pub fn enable_direct(interrupt: Interrupt, cpu_interrupt: CpuInterrupt) -> Resul
     unsafe {
         map(Cpu::current(), interrupt, cpu_interrupt);
 
-        xtensa_lx::interrupt::enable_mask(
-            xtensa_lx::interrupt::get_mask() | (1 << cpu_interrupt as u32),
-        );
+        xtensa_lx::interrupt::enable_mask(1 << cpu_interrupt as u32);
     }
     Ok(())
 }
@@ -513,9 +511,7 @@ mod vectored {
         unsafe {
             map(cpu, interrupt, cpu_interrupt);
 
-            xtensa_lx::interrupt::enable_mask(
-                xtensa_lx::interrupt::get_mask() | (1 << cpu_interrupt as u32),
-            );
+            xtensa_lx::interrupt::enable_mask(1 << cpu_interrupt as u32);
         }
         Ok(())
     }

--- a/esp-preempt/src/task/xtensa.rs
+++ b/esp-preempt/src/task/xtensa.rs
@@ -72,12 +72,10 @@ const SW_INTERRUPT: u32 = if cfg!(esp32) { 1 << 29 } else { 1 << 7 };
 
 pub(crate) fn setup_multitasking() {
     unsafe {
-        let enabled = xtensa_lx::interrupt::disable();
         xtensa_lx::interrupt::enable_mask(
             SW_INTERRUPT
                 | xtensa_lx_rt::interrupt::CpuInterruptLevel::Level2.mask()
-                | xtensa_lx_rt::interrupt::CpuInterruptLevel::Level6.mask()
-                | enabled,
+                | xtensa_lx_rt::interrupt::CpuInterruptLevel::Level6.mask(),
         );
     }
 }

--- a/xtensa-lx/src/interrupt.rs
+++ b/xtensa-lx/src/interrupt.rs
@@ -154,7 +154,7 @@ where
     let r = f();
 
     // enable previously disabled interrupts
-    unsafe { enable_mask(old_mask) };
+    unsafe { set_mask(old_mask) };
 
     r
 }


### PR DESCRIPTION
`enable_mask` already does read-modify-write, there's no need to do that ourselves.