### PR TITLE
Add task name to the preempt api

### DIFF
--- a/esp-preempt/src/scheduler.rs
+++ b/esp-preempt/src/scheduler.rs
@@ -98,13 +98,14 @@ impl SchedulerState {
 
     pub(crate) fn create_task(
         &mut self,
+        name: &str,
         task: extern "C" fn(*mut c_void),
         param: *mut c_void,
         task_stack_size: usize,
         priority: usize,
     ) -> TaskPtr {
         let mut task = Box::new_in(
-            Task::new(task, param, task_stack_size, priority),
+            Task::new(name, task, param, task_stack_size, priority),
             InternalMemory,
         );
         task.heap_allocated = true;
@@ -115,7 +116,7 @@ impl SchedulerState {
             task::yield_task();
         }
 
-        debug!("Task created: {:?}", task_ptr);
+        debug!("Task '{}' created: {:?}", name, task_ptr);
 
         task_ptr
     }
@@ -295,12 +296,13 @@ impl Scheduler {
 
     pub(crate) fn create_task(
         &self,
+        name: &str,
         task: extern "C" fn(*mut c_void),
         param: *mut c_void,
         task_stack_size: usize,
         priority: u32,
     ) -> TaskPtr {
-        self.with(|state| state.create_task(task, param, task_stack_size, priority as usize))
+        self.with(|state| state.create_task(name, task, param, task_stack_size, priority as usize))
     }
 
     pub(crate) fn sleep_until(&self, wake_at: Instant) -> bool {
@@ -347,6 +349,7 @@ impl esp_radio_preempt_driver::Scheduler for Scheduler {
 
     fn task_create(
         &self,
+        name: &str,
         task: extern "C" fn(*mut c_void),
         param: *mut c_void,
         priority: u32,
@@ -354,6 +357,7 @@ impl esp_radio_preempt_driver::Scheduler for Scheduler {
         task_stack_size: usize,
     ) -> *mut c_void {
         self.create_task(
+            name,
             task,
             param,
             task_stack_size,

--- a/esp-preempt/src/task/mod.rs
+++ b/esp-preempt/src/task/mod.rs
@@ -231,14 +231,15 @@ const STACK_CANARY: u32 =
 
 impl Task {
     pub(crate) fn new(
+        name: &str,
         task_fn: extern "C" fn(*mut c_void),
         param: *mut c_void,
         task_stack_size: usize,
         priority: usize,
     ) -> Self {
         trace!(
-            "task_create {:?}({:?}) stack_size = {} priority = {}",
-            task_fn, param, task_stack_size, priority
+            "task_create {} {:?}({:?}) stack_size = {} priority = {}",
+            name, task_fn, param, task_stack_size, priority
         );
 
         let task_stack_size_words = task_stack_size / 4;

--- a/esp-preempt/src/timer_queue.rs
+++ b/esp-preempt/src/timer_queue.rs
@@ -57,7 +57,8 @@ impl TimerQueueInner {
             }
         } else {
             // create the timer task
-            let task_ptr = SCHEDULER.create_task(timer_task, core::ptr::null_mut(), 8192, 2);
+            let task_ptr =
+                SCHEDULER.create_task("timer", timer_task, core::ptr::null_mut(), 8192, 2);
             self.task = Some(task_ptr);
             self.next_wakeup = due;
         }

--- a/esp-radio/src/ble/btdm.rs
+++ b/esp-radio/src/ble/btdm.rs
@@ -149,20 +149,18 @@ unsafe extern "C" fn mutex_unlock(_mutex: *const ()) -> i32 {
 
 unsafe extern "C" fn task_create(
     func: *mut crate::binary::c_types::c_void,
-    name: *const c_char,
+    name_ptr: *const c_char,
     stack_depth: u32,
     param: *mut crate::binary::c_types::c_void,
     prio: u32,
     handle: *mut crate::binary::c_types::c_void,
     core_id: u32,
 ) -> i32 {
-    unsafe {
-        let n = str_from_c(name);
-        trace!(
-            "task_create {:?} {:?} {} {} {:?} {} {:?} {}",
-            func, name, n, stack_depth, param, prio, handle, core_id
-        );
-    }
+    let name = unsafe { str_from_c(name_ptr) };
+    trace!(
+        "task_create {:?} {:?} {} {} {:?} {} {:?} {}",
+        func, name_ptr, name, stack_depth, param, prio, handle, core_id
+    );
 
     unsafe {
         let task_func = core::mem::transmute::<
@@ -171,6 +169,7 @@ unsafe extern "C" fn task_create(
         >(func);
 
         let task = crate::preempt::task_create(
+            name,
             task_func,
             param,
             prio,

--- a/esp-radio/src/ble/npl.rs
+++ b/esp-radio/src/ble/npl.rs
@@ -385,14 +385,11 @@ unsafe extern "C" fn task_create(
     task_handle: *const c_void,
     core_id: u32,
 ) -> i32 {
-    unsafe {
-        let name_str = str_from_c(name);
-
-        trace!(
-            "task_create {:?} {} {} {:?} {} {:?} {}",
-            task_func, name_str, stack_depth, param, prio, task_handle, core_id,
-        );
-    };
+    let name_str = unsafe { str_from_c(name) };
+    trace!(
+        "task_create {:?} {} {} {:?} {} {:?} {}",
+        task_func, name_str, stack_depth, param, prio, task_handle, core_id,
+    );
 
     unsafe {
         *(task_handle as *mut usize) = 0;
@@ -402,6 +399,7 @@ unsafe extern "C" fn task_create(
         let task_func = transmute::<*mut c_void, extern "C" fn(*mut c_void)>(task_func);
 
         let task = crate::preempt::task_create(
+            name_str,
             task_func,
             param,
             prio,

--- a/hil-test/src/bin/esp_radio_init.rs
+++ b/hil-test/src/bin/esp_radio_init.rs
@@ -226,6 +226,7 @@ mod tests {
         unsafe {
             info!("Low: spawning high priority task");
             preempt::task_create(
+                "high_priority_task",
                 high_priority_task,
                 (&raw const test_context).cast::<c_void>().cast_mut(),
                 3,
@@ -234,6 +235,7 @@ mod tests {
             );
             info!("Low: spawning medium priority task");
             preempt::task_create(
+                "medium_priority_task",
                 medium_priority_task,
                 (&raw const test_context).cast::<c_void>().cast_mut(),
                 2,


### PR DESCRIPTION
We're not storing this right now, but it may become handy later beyond logging (if we ever get to OS-aware debuggers).