### PR TITLE
Fix `RISC-V` direct vectoring and re-enable `interrupts` HIL test 

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -76,6 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ESP32: Enable up to 4M of PSRAM (#3990)
 - I2C error recovery logic issues (#4000)
 - I2S: Fixed RX half-sample bits configuration bug causing microphone noise (#4109)
+- RISC-V: Direct interrupt vectoring (#4171)
 
 ### Removed
 

--- a/esp-hal/MIGRATING-1.0.0-rc.0.md
+++ b/esp-hal/MIGRATING-1.0.0-rc.0.md
@@ -267,3 +267,18 @@ All RTC clock enums/structs have been moved from `rtc_cntl` to the `clock` modul
 Imports will need to be updated accordingly.
 
 Additionally, enum variant naming violations have been resolved, so the `RtcFastClock` and `RtcSlowClock` prefixes will need to be removed from any variants from these enums.
+
+## Direct vectoring changes
+
+`enable_direct` now requires user to pass handler function to it. 
+
+```diff
+interrupt::enable_direct(
+    Interrupt::FROM_CPU_INTR0,
+    Priority::Priority3,
+    CpuInterrupt::Interrupt20,
++   interrupt_handler,
+)
+.unwrap();
+
+```

--- a/esp-hal/src/interrupt/riscv.rs
+++ b/esp-hal/src/interrupt/riscv.rs
@@ -37,10 +37,6 @@ pub enum Error {
     InvalidInterruptPriority,
     /// The CPU interrupt is a reserved interrupt
     CpuInterruptReserved,
-    /// The enabled trap mode is not correct
-    InvalidTrapMode,
-    /// The resulting offset is out of bounds
-    InvalidOffset,
 }
 
 /// Interrupt kind
@@ -212,11 +208,17 @@ impl TryFrom<u8> for Priority {
 #[cfg_attr(place_switch_tables_in_ram, unsafe(link_section = ".rwtext"))]
 pub static RESERVED_INTERRUPTS: &[u32] = PRIORITY_TO_INTERRUPT;
 
+/// Enable an interrupt by directly binding it to a available CPU interrupt
+///
+/// Unless you are sure, you most likely want to use [`enable`] instead.
+///
+/// Trying using a reserved interrupt from [`RESERVED_INTERRUPTS`] will return
+/// an error.
 pub fn enable_direct(
     interrupt: Interrupt,
     level: Priority,
     cpu_interrupt: CpuInterrupt,
-    handler: unsafe fn(),
+    handler: unsafe extern "C" fn(),
 ) -> Result<(), Error> {
     if RESERVED_INTERRUPTS.contains(&(cpu_interrupt as _)) {
         return Err(Error::CpuInterruptReserved);
@@ -230,9 +232,10 @@ pub fn enable_direct(
 
         let mt = mtvec::read();
 
-        if mt.trap_mode() != mtvec::TrapMode::Vectored {
-            return Err(Error::InvalidTrapMode);
-        }
+        assert_eq!(
+            mt.trap_mode().into_usize(),
+            mtvec::TrapMode::Vectored.into_usize()
+        );
 
         let base_addr = mt.address() as usize;
 
@@ -248,64 +251,6 @@ pub fn enable_direct(
     Ok(())
 }
 
-/// Save caller-saved registers. **Should** be called before the interrupt handler will act,
-/// otherwise, the Rust function (user's potential interrupt handler) will clear the registers and
-/// return to an unpredictable place, since it is using `ret` and not `mret`.
-pub fn save_int_context() {
-    unsafe {
-        core::arch::asm!(
-            "
-                addi sp, sp, -16*4
-                sw ra, 0(sp)
-                sw t0, 1*4(sp)
-                sw t1, 2*4(sp)
-                sw t2, 3*4(sp)
-                sw t3, 4*4(sp)
-                sw t4, 5*4(sp)
-                sw t5, 6*4(sp)
-                sw t6, 7*4(sp)
-                sw a0, 8*4(sp)
-                sw a1, 9*4(sp)
-                sw a2, 10*4(sp)
-                sw a3, 11*4(sp)
-                sw a4, 12*4(sp)
-                sw a5, 13*4(sp)
-                sw a6, 14*4(sp)
-                sw a7, 15*4(sp)
-            "
-        )
-    }
-}
-
-/// Restores caller-saved registers, after being saved with the [`save_context`]. **Should** be
-/// called after the interrupt handler has been executed.
-pub fn restore_int_context() {
-    unsafe {
-        core::arch::asm!(
-            "
-                lw ra, 0*4(sp)
-                lw t0, 1*4(sp)
-                lw t1, 2*4(sp)
-                lw t2, 3*4(sp)
-                lw t3, 4*4(sp)
-                lw t4, 5*4(sp)
-                lw t5, 6*4(sp)
-                lw t6, 7*4(sp)
-                lw a0, 8*4(sp)
-                lw a1, 9*4(sp)
-                lw a2, 10*4(sp)
-                lw a3, 11*4(sp)
-                lw a4, 12*4(sp)
-                lw a5, 13*4(sp)
-                lw a6, 14*4(sp)
-                lw a7, 15*4(sp)
-
-                addi sp, sp, 16*4
-            "
-        )
-    }
-}
-
 // helper: returns correctly encoded RISC-V `jal` instruction
 fn encode_jal_x0(target: usize, pc: usize) -> Result<u32, Error> {
     let offset = (target as isize) - (pc as isize);
@@ -313,9 +258,7 @@ fn encode_jal_x0(target: usize, pc: usize) -> Result<u32, Error> {
     const MIN: isize = -(1isize << 20);
     const MAX: isize = (1isize << 20) - 1;
 
-    if offset % 2 != 0 || offset < MIN || offset > MAX {
-        return Err(Error::InvalidOffset);
-    }
+    assert!(offset % 2 == 0 && (MIN..=MAX).contains(&offset));
 
     let imm = offset as u32;
     let imm20 = (imm >> 20) & 0x1;
@@ -327,7 +270,6 @@ fn encode_jal_x0(target: usize, pc: usize) -> Result<u32, Error> {
         | (imm19_12 << 12)
         | (imm11 << 20)
         | (imm10_1 << 21)
-        | (0u32 << 7)
         // https://lhtin.github.io/01world/app/riscv-isa/?xlen=32&insn_name=jal
         | 0b1101111u32;
 

--- a/esp-hal/src/interrupt/riscv.rs
+++ b/esp-hal/src/interrupt/riscv.rs
@@ -215,12 +215,11 @@ pub static RESERVED_INTERRUPTS: &[u32] = PRIORITY_TO_INTERRUPT;
 ///
 /// - Provided handler will be used as an actual trap-handler
 /// - It is user's responsibility to:
-///   - Save and restore all registers they use (caller-saved).
+///   - Save and restore all registers they use.
 ///   - Clear the interrupt source if necessary.
 ///   - Return using the `mret` instruction.
-/// - The compiler will not insert a function prologue/epilogue for the user, that is why writing a
-///   normal Rust `fn` will almost always result in an error. Instead, the handler should be
-///   declared as `#[naked]` and implemented using the inline assembler.
+/// - The handler should be declared as naked function. The compiler will not insert a function
+///   prologue/epilogue for the user, normal Rust `fn` will result in an error.
 ///
 /// Unless you are sure that you need such low-level control to achieve the lowest possible latency,
 /// you most likely want to use [`enable`] instead.

--- a/esp-riscv-rt/src/lib.rs
+++ b/esp-riscv-rt/src/lib.rs
@@ -172,6 +172,54 @@ _vector_table:
 "#,
 }
 
+// Context save/restore helpers
+global_asm! {
+    r#"
+    .section .trap, "ax"
+    .global save_int_context
+    .global restore_int_context
+save_int_context:
+    addi sp, sp, -16*4
+    sw ra, 0(sp)
+    sw t0, 1*4(sp)
+    sw t1, 2*4(sp)
+    sw t2, 3*4(sp)
+    sw t3, 4*4(sp)
+    sw t4, 5*4(sp)
+    sw t5, 6*4(sp)
+    sw t6, 7*4(sp)
+    sw a0, 8*4(sp)
+    sw a1, 9*4(sp)
+    sw a2, 10*4(sp)
+    sw a3, 11*4(sp)
+    sw a4, 12*4(sp)
+    sw a5, 13*4(sp)
+    sw a6, 14*4(sp)
+    sw a7, 15*4(sp)
+    ret
+
+restore_int_context:
+    lw ra, 0*4(sp)
+    lw t0, 1*4(sp)
+    lw t1, 2*4(sp)
+    lw t2, 3*4(sp)
+    lw t3, 4*4(sp)
+    lw t4, 5*4(sp)
+    lw t5, 6*4(sp)
+    lw t6, 7*4(sp)
+    lw a0, 8*4(sp)
+    lw a1, 9*4(sp)
+    lw a2, 10*4(sp)
+    lw a3, 11*4(sp)
+    lw a4, 12*4(sp)
+    lw a5, 13*4(sp)
+    lw a6, 14*4(sp)
+    lw a7, 15*4(sp)
+    addi sp, sp, 16*4
+    mret
+"#,
+}
+
 macro_rules! define_interrupt {
     ($num:literal, $name:ident, $fname:ident) => {
         #[derive(Copy, Clone)]

--- a/esp-riscv-rt/src/lib.rs
+++ b/esp-riscv-rt/src/lib.rs
@@ -172,54 +172,6 @@ _vector_table:
 "#,
 }
 
-// Context save/restore helpers
-global_asm! {
-    r#"
-    .section .trap, "ax"
-    .global save_int_context
-    .global restore_int_context
-save_int_context:
-    addi sp, sp, -16*4
-    sw ra, 0(sp)
-    sw t0, 1*4(sp)
-    sw t1, 2*4(sp)
-    sw t2, 3*4(sp)
-    sw t3, 4*4(sp)
-    sw t4, 5*4(sp)
-    sw t5, 6*4(sp)
-    sw t6, 7*4(sp)
-    sw a0, 8*4(sp)
-    sw a1, 9*4(sp)
-    sw a2, 10*4(sp)
-    sw a3, 11*4(sp)
-    sw a4, 12*4(sp)
-    sw a5, 13*4(sp)
-    sw a6, 14*4(sp)
-    sw a7, 15*4(sp)
-    ret
-
-restore_int_context:
-    lw ra, 0*4(sp)
-    lw t0, 1*4(sp)
-    lw t1, 2*4(sp)
-    lw t2, 3*4(sp)
-    lw t3, 4*4(sp)
-    lw t4, 5*4(sp)
-    lw t5, 6*4(sp)
-    lw t6, 7*4(sp)
-    lw a0, 8*4(sp)
-    lw a1, 9*4(sp)
-    lw a2, 10*4(sp)
-    lw a3, 11*4(sp)
-    lw a4, 12*4(sp)
-    lw a5, 13*4(sp)
-    lw a6, 14*4(sp)
-    lw a7, 15*4(sp)
-    addi sp, sp, 16*4
-    mret
-"#,
-}
-
 macro_rules! define_interrupt {
     ($num:literal, $name:ident, $fname:ident) => {
         #[derive(Copy, Clone)]

--- a/hil-test/src/bin/interrupt.rs
+++ b/hil-test/src/bin/interrupt.rs
@@ -3,7 +3,7 @@
 //! "Disabled" for now - see https://github.com/esp-rs/esp-hal/pull/1635#issuecomment-2137405251
 
 //% CHIPS: esp32c2 esp32c3 esp32c6 esp32h2
-//% FEATURES: unstable defmt
+//% FEATURES: unstable
 
 #![no_std]
 #![no_main]
@@ -25,37 +25,45 @@ use hil_test as _;
 
 static SWINT0: Mutex<RefCell<Option<SoftwareInterrupt<0>>>> = Mutex::new(RefCell::new(None));
 
-#[allow(unused)] // TODO: Remove attribute when interrupt latency test re-enabled
+#[unsafe(no_mangle)]
+static mut LAST_PERF: u32 = 0;
+
+#[unsafe(no_mangle)]
+static mut SW_TRIGGER_ADDR: *mut u32 = core::ptr::null_mut();
+
 struct Context {
     sw0_trigger_addr: u32,
 }
 
+// We need to place this close to the trap handler for the jump to be resolved properly
 #[unsafe(link_section = ".trap.rust")]
 #[unsafe(no_mangle)]
-fn interrupt_handler() {
-    unsafe { asm!("csrrwi x0, 0x7e1, 0 #disable timer") }
-    critical_section::with(|cs| {
-        SWINT0.borrow_ref_mut(cs).as_mut().unwrap().reset();
-    });
+#[unsafe(naked)]
+#[rustfmt::skip]
+unsafe extern "C" fn interrupt_handler() {
+    core::arch::naked_asm! {"
+        # save affected registers
+        addi sp, sp, -16*4 # allocate 16 words for saving regs (will work with just 2, but RISC-V wants it to be aligned by 16)
+        sw t0, 1*4(sp)
+        sw t1, 2*4(sp)
 
-    let mut perf_counter: u32 = 0;
-    unsafe {
-        asm!(
-            "
-            csrr {x}, 0x7e2
-            ",
-            options(nostack),
-            x = inout(reg) perf_counter,
-        )
-    };
-    defmt::info!("Performance counter:{}", perf_counter);
-    // TODO these values should be adjusted to catch smaller regressions
-    cfg_if::cfg_if! {
-        if #[cfg(any(feature = "esp32c3", feature = "esp32c2"))] {
-            assert!(perf_counter < 1100);
-        } else {
-            assert!(perf_counter < 750);
-        }
+        csrrwi x0, 0x7e1, 0 #disable timer
+
+        lw t0, {sw}  # t0 <- &SW_TRIGGER_ADDR
+        sw x0, 0(t0) # clear (deassert) *SW_TRIGGER_ADDR
+
+        csrr t1, 0x7e2 # read performance counter
+        la t0, {x}
+        sw t1, 0(t0) # store word to LAST_PERF
+
+        # restore affected registers
+        lw t0, 1*4(sp)
+        lw t1, 2*4(sp)
+        addi sp, sp, 16*4
+        mret
+        ",
+        x = sym LAST_PERF,
+        sw = sym SW_TRIGGER_ADDR,
     }
 }
 
@@ -78,6 +86,9 @@ mod tests {
         }
 
         let sw0_trigger_addr = cpu_intr.register_block().cpu_intr_from_cpu(0) as *const _ as u32;
+        unsafe {
+            SW_TRIGGER_ADDR = sw0_trigger_addr as *mut u32;
+        }
 
         critical_section::with(|cs| {
             SWINT0
@@ -96,6 +107,8 @@ mod tests {
         Context { sw0_trigger_addr }
     }
 
+    // Handler function (assigned above) reads cycles count from CSR and stores it into `LAST_PERF`
+    // static, which this test then reads and asserts its value to detect regressions
     #[test]
     #[rustfmt::skip]
     fn interrupt_latency(ctx: Context) {
@@ -108,8 +121,6 @@ mod tests {
                 "
             );
         }
-
-        interrupt::save_int_context();
         
         // interrupt is raised from assembly for max timer granularity.
         unsafe {
@@ -125,6 +136,16 @@ mod tests {
             )
         }
 
-        interrupt::restore_int_context();
+        let perf_counter = unsafe { LAST_PERF };
+        defmt::info!("Performance counter: {}", perf_counter);
+
+        // TODO c3/c2 values should be adjusted to catch smaller regressions
+        cfg_if::cfg_if! {
+        if #[cfg(any(feature = "esp32c3", feature = "esp32c2"))] {
+            assert!(perf_counter < 400);
+        } else {
+            assert!(perf_counter < 155);
+        }
+    }
     }
 }

--- a/qa-test/Cargo.toml
+++ b/qa-test/Cargo.toml
@@ -21,6 +21,7 @@ esp-backtrace = { path = "../esp-backtrace", features = [
     "panic-handler",
     "println",
 ] }
+critical-section   = "1.1.3"
 esp-bootloader-esp-idf = { path = "../esp-bootloader-esp-idf" }
 esp-hal = { path = "../esp-hal", features = ["log-04", "unstable"] }
 esp-hal-embassy = { path = "../esp-hal-embassy" }


### PR DESCRIPTION
Now it's a proper direct vectoring

closes https://github.com/esp-rs/esp-hal/issues/4114
closes https://github.com/esp-rs/esp-hal/issues/2314 too

PS: and it's zooming fast too (H2 on screenshot, C6 does it in 70 cycles 🚀 )
<img width="810" height="171" alt="image" src="https://github.com/user-attachments/assets/d7a9a338-e6e5-4b0f-9ee6-7fdaf26ad6b5" />
