### PR TITLE
Init syscall table

### DIFF
--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -699,5 +699,9 @@ pub fn init(config: Config) -> Peripherals {
     #[cfg(feature = "psram")]
     crate::psram::init_psram(config.psram);
 
+    unsafe {
+        esp_rom_sys::init_syscall_table();
+    }
+
     peripherals
 }

--- a/esp-rom-sys/CHANGELOG.md
+++ b/esp-rom-sys/CHANGELOG.md
@@ -9,9 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Initialize the syscall table (#4177)
 
 ### Changed
 
+- Updated linker scripts (#4113)
 
 ### Fixed
 

--- a/esp-rom-sys/README.md
+++ b/esp-rom-sys/README.md
@@ -6,7 +6,7 @@
 ![Crates.io](https://img.shields.io/crates/l/esp-rom-sys?labelColor=1C2C2E&style=flat-square)
 [![Matrix](https://img.shields.io/matrix/esp-rs:matrix.org?label=join%20matrix&labelColor=1C2C2E&color=BEC5C9&logo=matrix&style=flat-square)](https://matrix.to/#/#esp-rs:matrix.org)
 
-ROM code support.
+ROM code support. This is an implementation detail of the esp-hal ecosystem crates.
 
 This includes the definition of ROM code function addresses.
 

--- a/esp-rom-sys/ld/esp32c2/rom/additional.ld
+++ b/esp-rom-sys/ld/esp32c2/rom/additional.ld
@@ -23,3 +23,5 @@ PROVIDE ( atoi = __atoi );
 PROVIDE ( mktime = __mktime );
 
 PROVIDE( abs = 0x40000558 );
+
+syscall_table_ptr = 0x3fcdffd8;

--- a/esp-rom-sys/ld/esp32c3/rom/additional.ld
+++ b/esp-rom-sys/ld/esp32c3/rom/additional.ld
@@ -27,3 +27,5 @@ EXTERN(__atoi);
 PROVIDE ( strnlen = __strnlen );
 PROVIDE ( atoi = __atoi );
 PROVIDE ( mktime = __mktime );
+
+syscall_table_ptr = 0x3fcdffe0;

--- a/esp-rom-sys/ld/esp32c6/rom/additional.ld
+++ b/esp-rom-sys/ld/esp32c6/rom/additional.ld
@@ -23,3 +23,5 @@ EXTERN(__atoi);
 PROVIDE ( strnlen = __strnlen );
 PROVIDE ( atoi = __atoi );
 PROVIDE ( mktime = __mktime );
+
+syscall_table_ptr = 0x4087ffd4;

--- a/esp-rom-sys/ld/esp32h2/rom/additional.ld
+++ b/esp-rom-sys/ld/esp32h2/rom/additional.ld
@@ -25,3 +25,5 @@ EXTERN(__atoi);
 PROVIDE ( strnlen = __strnlen );
 PROVIDE ( atoi = __atoi );
 PROVIDE ( mktime = __mktime );
+
+syscall_table_ptr = 0x4084ffd4;

--- a/esp-rom-sys/ld/esp32s3/rom/additional.ld
+++ b/esp-rom-sys/ld/esp32s3/rom/additional.ld
@@ -27,3 +27,5 @@ EXTERN(__atoi);
 PROVIDE ( strnlen = __strnlen );
 PROVIDE ( atoi = __atoi );
 PROVIDE ( mktime = __mktime );
+
+syscall_table_ptr = 0x3fceffd4;

--- a/esp-rom-sys/src/lib.rs
+++ b/esp-rom-sys/src/lib.rs
@@ -42,16 +42,19 @@ macro_rules! before_snippet {
 }
 
 pub mod rom;
+mod syscall;
+
+pub use syscall::init_syscall_table;
 
 /// This is needed by `libesp_rom.a` (if used)
 /// Other crates (i.e. esp-radio) also rely on this being defined somewhere
 #[unsafe(no_mangle)]
 unsafe extern "C" fn __assert_func(
     file: *const core::ffi::c_char,
-    line: u32,
+    line: i32,
     func: *const core::ffi::c_char,
     expr: *const core::ffi::c_char,
-) {
+) -> ! {
     unsafe {
         panic!(
             "__assert_func in {}:{} ({}): {}",

--- a/esp-rom-sys/src/syscall/mod.rs
+++ b/esp-rom-sys/src/syscall/mod.rs
@@ -72,7 +72,7 @@ unsafe extern "C" fn abort_wrapper() {
 /// Should only get called once.
 #[allow(clippy::missing_transmute_annotations)]
 pub unsafe fn init_syscall_table() {
-    unsafe {
+    let syscall_table = unsafe {
         (&mut *core::ptr::addr_of_mut!(S_STUB_TABLE)).write(chip_specific::syscall_stub_table {
             __getreent: Some(core::mem::transmute(not_implemented as usize)),
             _malloc_r: Some(core::mem::transmute(not_implemented as usize)),
@@ -115,13 +115,8 @@ pub unsafe fn init_syscall_table() {
             __assert_func: Some(super::__assert_func),
             __sinit: Some(core::mem::transmute(not_implemented as usize)),
             _cleanup_r: Some(core::mem::transmute(not_implemented as usize)),
-        });
-
-        S_STUB_TABLE.assume_init();
+        })
     };
-
-    let syscall_table =
-        core::ptr::addr_of!(S_STUB_TABLE) as *const chip_specific::syscall_stub_table;
 
     cfg_if::cfg_if! {
         if #[cfg(esp32)] {

--- a/esp-rom-sys/src/syscall/mod.rs
+++ b/esp-rom-sys/src/syscall/mod.rs
@@ -1,0 +1,148 @@
+#![allow(non_camel_case_types)]
+
+// future chips or ECOs _might_ be different - at least ESP-IDF defines the struct per chip
+#[cfg_attr(
+    any(esp32, esp32s2, esp32s3, esp32c2, esp32c3, esp32c6, esp32h2),
+    path = "v1.rs"
+)]
+pub(crate) mod chip_specific;
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _reent {
+    _unused: [u8; 0],
+    // the real struct is found here: https://sourceware.org/git/?p=newlib-cygwin.git;a=blob;f=newlib/libc/include/sys/reent.h;h=eafac960fd6ca374b7503f50bf8aa2bd1ee1573e;hb=refs/heads/main#l379
+}
+
+pub type clock_t = ::core::ffi::c_long;
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct tms {
+    _unused: [u8; 0],
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct timeval {
+    _unused: [u8; 0],
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct stat {
+    _unused: [u8; 0],
+}
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __lock {
+    _unused: [u8; 0],
+}
+
+pub type _LOCK_T = *mut __lock;
+
+pub type _lock_t = _LOCK_T;
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct _iobuf {
+    pub _placeholder: *mut ::core::ffi::c_void,
+}
+
+#[allow(clippy::upper_case_acronyms)]
+pub type FILE = _iobuf;
+
+pub type va_list = *mut ::core::ffi::c_char;
+
+static mut S_STUB_TABLE: core::mem::MaybeUninit<chip_specific::syscall_stub_table> =
+    core::mem::MaybeUninit::uninit();
+
+unsafe extern "C" fn not_implemented() {
+    panic!("Function called via syscall table is not implemented!");
+}
+
+unsafe extern "C" fn abort_wrapper() {
+    panic!("Abort called from ROM code!");
+}
+
+/// Initialize the syscall table.
+///
+/// # Safety
+/// Should only get called once.
+#[allow(clippy::missing_transmute_annotations)]
+pub unsafe fn init_syscall_table() {
+    unsafe {
+        (&mut *core::ptr::addr_of_mut!(S_STUB_TABLE)).write(chip_specific::syscall_stub_table {
+            __getreent: Some(core::mem::transmute(not_implemented as usize)),
+            _malloc_r: Some(core::mem::transmute(not_implemented as usize)),
+            _free_r: Some(core::mem::transmute(not_implemented as usize)),
+            _realloc_r: Some(core::mem::transmute(not_implemented as usize)),
+            _calloc_r: Some(core::mem::transmute(not_implemented as usize)),
+            _abort: Some(abort_wrapper),
+            _system_r: Some(core::mem::transmute(not_implemented as usize)),
+            _rename_r: Some(core::mem::transmute(not_implemented as usize)),
+            _times_r: Some(core::mem::transmute(not_implemented as usize)),
+            _gettimeofday_r: Some(core::mem::transmute(not_implemented as usize)),
+            _raise_r: Some(core::mem::transmute(not_implemented as usize)),
+            _unlink_r: Some(core::mem::transmute(not_implemented as usize)),
+            _link_r: Some(core::mem::transmute(not_implemented as usize)),
+            _stat_r: Some(core::mem::transmute(not_implemented as usize)),
+            _fstat_r: Some(core::mem::transmute(not_implemented as usize)),
+            _sbrk_r: Some(core::mem::transmute(not_implemented as usize)),
+            _getpid_r: Some(core::mem::transmute(not_implemented as usize)),
+            _kill_r: Some(core::mem::transmute(not_implemented as usize)),
+            _exit_r: Some(core::mem::transmute(not_implemented as usize)),
+            _close_r: Some(core::mem::transmute(not_implemented as usize)),
+            _open_r: Some(core::mem::transmute(not_implemented as usize)),
+            _write_r: Some(core::mem::transmute(not_implemented as usize)),
+            _lseek_r: Some(core::mem::transmute(not_implemented as usize)),
+            _read_r: Some(core::mem::transmute(not_implemented as usize)),
+            _retarget_lock_init: Some(core::mem::transmute(not_implemented as usize)),
+            _retarget_lock_init_recursive: Some(core::mem::transmute(not_implemented as usize)),
+            _retarget_lock_close: Some(core::mem::transmute(not_implemented as usize)),
+            _retarget_lock_close_recursive: Some(core::mem::transmute(not_implemented as usize)),
+            _retarget_lock_acquire: Some(core::mem::transmute(not_implemented as usize)),
+            _retarget_lock_acquire_recursive: Some(core::mem::transmute(not_implemented as usize)),
+            _retarget_lock_try_acquire: Some(core::mem::transmute(not_implemented as usize)),
+            _retarget_lock_try_acquire_recursive: Some(core::mem::transmute(
+                not_implemented as usize,
+            )),
+            _retarget_lock_release: Some(core::mem::transmute(not_implemented as usize)),
+            _retarget_lock_release_recursive: Some(core::mem::transmute(not_implemented as usize)),
+            _printf_float: Some(core::mem::transmute(not_implemented as usize)),
+            _scanf_float: Some(core::mem::transmute(not_implemented as usize)),
+            __assert_func: Some(super::__assert_func),
+            __sinit: Some(core::mem::transmute(not_implemented as usize)),
+            _cleanup_r: Some(core::mem::transmute(not_implemented as usize)),
+        });
+
+        S_STUB_TABLE.assume_init();
+    };
+
+    let syscall_table =
+        core::ptr::addr_of!(S_STUB_TABLE) as *const chip_specific::syscall_stub_table;
+
+    cfg_if::cfg_if! {
+        if #[cfg(esp32)] {
+            unsafe extern "C" {
+                static mut syscall_table_ptr_pro: *const chip_specific::syscall_stub_table;
+                static mut syscall_table_ptr_app: *const chip_specific::syscall_stub_table;
+            }
+            unsafe {
+                syscall_table_ptr_pro = syscall_table;
+                syscall_table_ptr_app = syscall_table;
+            }
+        } else if #[cfg(esp32s2)] {
+            unsafe extern "C" {
+                static mut syscall_table_ptr_pro: *const chip_specific::syscall_stub_table;
+            }
+            unsafe { syscall_table_ptr_pro = syscall_table; }
+        } else {
+            unsafe extern "C" {
+                static mut syscall_table_ptr: *const chip_specific::syscall_stub_table;
+            }
+            unsafe { syscall_table_ptr = syscall_table; }
+        }
+    };
+}

--- a/esp-rom-sys/src/syscall/v1.rs
+++ b/esp-rom-sys/src/syscall/v1.rs
@@ -1,0 +1,173 @@
+use super::*;
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct syscall_stub_table {
+    pub __getreent: ::core::option::Option<unsafe extern "C" fn() -> *mut _reent>,
+    pub _malloc_r: ::core::option::Option<
+        unsafe extern "C" fn(r: *mut _reent, arg1: usize) -> *mut ::core::ffi::c_void,
+    >,
+    pub _free_r: ::core::option::Option<
+        unsafe extern "C" fn(r: *mut _reent, arg1: *mut ::core::ffi::c_void),
+    >,
+    pub _realloc_r: ::core::option::Option<
+        unsafe extern "C" fn(
+            r: *mut _reent,
+            arg1: *mut ::core::ffi::c_void,
+            arg2: usize,
+        ) -> *mut ::core::ffi::c_void,
+    >,
+    pub _calloc_r: ::core::option::Option<
+        unsafe extern "C" fn(r: *mut _reent, arg1: usize, arg2: usize) -> *mut ::core::ffi::c_void,
+    >,
+    pub _abort: ::core::option::Option<unsafe extern "C" fn()>,
+    pub _system_r: ::core::option::Option<
+        unsafe extern "C" fn(
+            r: *mut _reent,
+            arg1: *const ::core::ffi::c_char,
+        ) -> ::core::ffi::c_int,
+    >,
+    pub _rename_r: ::core::option::Option<
+        unsafe extern "C" fn(
+            r: *mut _reent,
+            arg1: *const ::core::ffi::c_char,
+            arg2: *const ::core::ffi::c_char,
+        ) -> ::core::ffi::c_int,
+    >,
+    pub _times_r:
+        ::core::option::Option<unsafe extern "C" fn(r: *mut _reent, arg1: *mut tms) -> clock_t>,
+    pub _gettimeofday_r: ::core::option::Option<
+        unsafe extern "C" fn(
+            r: *mut _reent,
+            arg1: *mut timeval,
+            arg2: *mut ::core::ffi::c_void,
+        ) -> ::core::ffi::c_int,
+    >,
+    pub _raise_r: ::core::option::Option<unsafe extern "C" fn(r: *mut _reent)>,
+    pub _unlink_r: ::core::option::Option<
+        unsafe extern "C" fn(
+            r: *mut _reent,
+            arg1: *const ::core::ffi::c_char,
+        ) -> ::core::ffi::c_int,
+    >,
+    pub _link_r: ::core::option::Option<
+        unsafe extern "C" fn(
+            r: *mut _reent,
+            arg1: *const ::core::ffi::c_char,
+            arg2: *const ::core::ffi::c_char,
+        ) -> ::core::ffi::c_int,
+    >,
+    pub _stat_r: ::core::option::Option<
+        unsafe extern "C" fn(
+            r: *mut _reent,
+            arg1: *const ::core::ffi::c_char,
+            arg2: *mut stat,
+        ) -> ::core::ffi::c_int,
+    >,
+    pub _fstat_r: ::core::option::Option<
+        unsafe extern "C" fn(
+            r: *mut _reent,
+            arg1: ::core::ffi::c_int,
+            arg2: *mut stat,
+        ) -> ::core::ffi::c_int,
+    >,
+    pub _sbrk_r: ::core::option::Option<
+        unsafe extern "C" fn(r: *mut _reent, arg1: isize) -> *mut ::core::ffi::c_void,
+    >,
+    pub _getpid_r:
+        ::core::option::Option<unsafe extern "C" fn(r: *mut _reent) -> ::core::ffi::c_int>,
+    pub _kill_r: ::core::option::Option<
+        unsafe extern "C" fn(
+            r: *mut _reent,
+            arg1: ::core::ffi::c_int,
+            arg2: ::core::ffi::c_int,
+        ) -> ::core::ffi::c_int,
+    >,
+    pub _exit_r:
+        ::core::option::Option<unsafe extern "C" fn(r: *mut _reent, arg1: ::core::ffi::c_int)>,
+    pub _close_r: ::core::option::Option<
+        unsafe extern "C" fn(r: *mut _reent, arg1: ::core::ffi::c_int) -> ::core::ffi::c_int,
+    >,
+    pub _open_r: ::core::option::Option<
+        unsafe extern "C" fn(
+            r: *mut _reent,
+            arg1: *const ::core::ffi::c_char,
+            arg2: ::core::ffi::c_int,
+            arg3: ::core::ffi::c_int,
+        ) -> ::core::ffi::c_int,
+    >,
+    pub _write_r: ::core::option::Option<
+        unsafe extern "C" fn(
+            r: *mut _reent,
+            arg1: ::core::ffi::c_int,
+            arg2: *const ::core::ffi::c_void,
+            arg3: ::core::ffi::c_int,
+        ) -> ::core::ffi::c_int,
+    >,
+    pub _lseek_r: ::core::option::Option<
+        unsafe extern "C" fn(
+            r: *mut _reent,
+            arg1: ::core::ffi::c_int,
+            arg2: ::core::ffi::c_int,
+            arg3: ::core::ffi::c_int,
+        ) -> ::core::ffi::c_int,
+    >,
+    pub _read_r: ::core::option::Option<
+        unsafe extern "C" fn(
+            r: *mut _reent,
+            arg1: ::core::ffi::c_int,
+            arg2: *mut ::core::ffi::c_void,
+            arg3: ::core::ffi::c_int,
+        ) -> ::core::ffi::c_int,
+    >,
+    pub _retarget_lock_init: ::core::option::Option<unsafe extern "C" fn(lock: *mut _LOCK_T)>,
+    pub _retarget_lock_init_recursive:
+        ::core::option::Option<unsafe extern "C" fn(lock: *mut _LOCK_T)>,
+    pub _retarget_lock_close: ::core::option::Option<unsafe extern "C" fn(lock: _LOCK_T)>,
+    pub _retarget_lock_close_recursive: ::core::option::Option<unsafe extern "C" fn(lock: _LOCK_T)>,
+    pub _retarget_lock_acquire: ::core::option::Option<unsafe extern "C" fn(lock: _LOCK_T)>,
+    pub _retarget_lock_acquire_recursive:
+        ::core::option::Option<unsafe extern "C" fn(lock: _LOCK_T)>,
+    pub _retarget_lock_try_acquire:
+        ::core::option::Option<unsafe extern "C" fn(lock: _LOCK_T) -> ::core::ffi::c_int>,
+    pub _retarget_lock_try_acquire_recursive:
+        ::core::option::Option<unsafe extern "C" fn(lock: _LOCK_T) -> ::core::ffi::c_int>,
+    pub _retarget_lock_release: ::core::option::Option<unsafe extern "C" fn(lock: _LOCK_T)>,
+    pub _retarget_lock_release_recursive:
+        ::core::option::Option<unsafe extern "C" fn(lock: _LOCK_T)>,
+    #[allow(clippy::type_complexity)]
+    pub _printf_float: ::core::option::Option<
+        unsafe extern "C" fn(
+            data: *mut _reent,
+            pdata: *mut ::core::ffi::c_void,
+            fp: *mut FILE,
+            pfunc: ::core::option::Option<
+                unsafe extern "C" fn(
+                    arg1: *mut _reent,
+                    arg2: *mut FILE,
+                    arg3: *const ::core::ffi::c_char,
+                    len: usize,
+                ) -> ::core::ffi::c_int,
+            >,
+            ap: *mut va_list,
+        ) -> ::core::ffi::c_int,
+    >,
+    pub _scanf_float: ::core::option::Option<
+        unsafe extern "C" fn(
+            rptr: *mut _reent,
+            pdata: *mut ::core::ffi::c_void,
+            fp: *mut FILE,
+            ap: *mut va_list,
+        ) -> ::core::ffi::c_int,
+    >,
+    pub __assert_func: ::core::option::Option<
+        unsafe extern "C" fn(
+            file: *const ::core::ffi::c_char,
+            line: ::core::ffi::c_int,
+            func: *const ::core::ffi::c_char,
+            failedexpr: *const ::core::ffi::c_char,
+        ) -> !,
+    >,
+    pub __sinit: ::core::option::Option<unsafe extern "C" fn(r: *mut _reent)>,
+    pub _cleanup_r: ::core::option::Option<unsafe extern "C" fn(r: *mut _reent)>,
+}


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

This initializes the syscall table - we cannot really provide a lot of useful functions but at least getting a clear panic message instead of some mysterious exception might be helpful - especially with things like esp-radio

Also seeing some useful assert message from e.g. the MMU or flash functions might be nice to have.

`skip-changelog` for the not user facing change in esp-hal

#### Testing

Manual testing with some modified code

