### PR TITLE
xtask: Add `check-global-symbols` for checking global unmangled Rust symbols in compiled `.rlib`

### DIFF
--- a/.github/workflows/api-baseline-check.yml
+++ b/.github/workflows/api-baseline-check.yml
@@ -29,7 +29,7 @@ jobs:
             # Install the Rust toolchain for Xtensa devices:
             - uses: esp-rs/xtensa-toolchain@v1.6
               with:
-                  version: 1.89.0.0
+                  version: 1.90.0.0
 
             # Install the Rust stable toolchain for RISC-V devices:
             - uses: dtolnay/rust-toolchain@v1

--- a/.github/workflows/api-baseline-generation.yml
+++ b/.github/workflows/api-baseline-generation.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Install xtensa toolchain
         uses: esp-rs/xtensa-toolchain@v1.6
         with:
-          version: 1.89.0.0
+          version: 1.90.0.0
 
       - name: Check if baseline generation is needed
         id: check-generation

--- a/.github/workflows/ci_nightly.yml
+++ b/.github/workflows/ci_nightly.yml
@@ -87,4 +87,4 @@ jobs:
               --title "Nightly CI Failure" \
               --body "One or more jobs failed! [View the failed workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})." \
               --label "ci-nightly"
-
+              --assignee JurajSadel

--- a/.github/workflows/ci_nightly.yml
+++ b/.github/workflows/ci_nightly.yml
@@ -65,7 +65,7 @@ jobs:
        # Install the Rust toolchain for Xtensa devices:
       - uses: esp-rs/xtensa-toolchain@v1.6
         with:
-          version: 1.89.0.0
+          version: 1.90.0.0
 
       # Check all chips at once only for esp-hal
       - name: Run check-global-symbols

--- a/.github/workflows/ci_nightly.yml
+++ b/.github/workflows/ci_nightly.yml
@@ -50,24 +50,41 @@ jobs:
         shell: bash
         run: cargo xtask ci ${{ matrix.device }} --toolchain nightly
 
-      - if: failure()
-        name: Create or Update GitHub Issue
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          sudo apt-get install gh -y
-          ISSUE_NAME=$(gh issue list --state open --search "Nightly CI Failure in:title" --json number --jq '.[0].number')
-
-          if [[ -z "$ISSUE_NAME" ]];
-          then
-            gh issue create \
-              --title "Nightly CI Failure" \
-              --body "Nightly CI Workflow Failed! [View the failed job](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})." \
-              --label "ci-nightly"
-          fi
-
       # Check for unused dependencies through esp-hal packages
       - name: Install and run cargo machete
         run: |
           cargo install cargo-machete
           cargo machete
+
+  check-global-symbols:
+    name: Check Global Symbols in esp-hal
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+       # Install the Rust toolchain for Xtensa devices:
+      - uses: esp-rs/xtensa-toolchain@v1.6
+        with:
+          version: 1.89.0.0
+
+      # Check all chips at once only for esp-hal
+      - name: Run check-global-symbols
+        run: cargo xtask check-global-symbols
+
+  create-issue:
+    name: Create GitHub Issue if any job failed
+    runs-on: ubuntu-latest
+    needs: [esp-hal-nightly, check-global-symbols]
+    if: ${{ failure() }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          sudo apt-get install gh -y
+          ISSUE_NAME=$(gh issue list --state open --search "Nightly CI Failure in:title" --json number --jq '.[0].number')
+          if [[ -z "$ISSUE_NAME" ]];
+          then
+            gh issue create \
+              --title "Nightly CI Failure" \
+              --body "One or more jobs failed! [View the failed workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})." \
+              --label "ci-nightly"
+

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -48,7 +48,7 @@ test  = false
 bitflags                 = "2.9.0"
 bytemuck                 = "1.22.0"
 cfg-if                   = "1.0.0"
-critical-section         = { version = "1.2.0", features = ["restore-state-u32"] }
+critical-section         = { version = "1.2.0", features = ["restore-state-u32"], optional = true }
 embedded-hal             = "1.0.0"
 embedded-hal-async       = "1.0.0"
 enumset                  = "1.1.6"
@@ -224,6 +224,7 @@ rt = [
     "esp32h2?/rt",
     "esp32s2?/rt",
     "esp32s3?/rt",
+    "critical-section",
 ]
 
 ## Enable a simple exception handler turning exceptions into panics.

--- a/esp-hal/src/peripherals.rs
+++ b/esp-hal/src/peripherals.rs
@@ -188,9 +188,9 @@ for_each_peripheral! {
         }
 
         impl Peripherals {
-            /// Returns all the peripherals *once*
+            /// Returns all the peripherals *once*.
             #[inline]
-            #[cfg_attr(not(feature = "rt"), expect(dead_code))]
+            #[cfg(feature = "rt")]
             pub(crate) fn take() -> Self {
                 #[unsafe(no_mangle)]
                 static mut _ESP_HAL_DEVICE_PERIPHERALS: bool = false;
@@ -202,6 +202,13 @@ for_each_peripheral! {
                     _ESP_HAL_DEVICE_PERIPHERALS = true;
                     Self::steal()
                 })
+            }
+
+            /// Returns all the peripherals *once*.
+            #[inline]
+            #[cfg(not(feature = "rt"))]
+            pub(crate) fn take() -> Self {
+                crate::ESP_HAL_LOCK.lock(|| unsafe { Self::steal() })
             }
 
             /// Unsafely create an instance of this peripheral out of thin air.

--- a/esp-hal/src/peripherals.rs
+++ b/esp-hal/src/peripherals.rs
@@ -204,13 +204,6 @@ for_each_peripheral! {
                 })
             }
 
-            /// Returns all the peripherals *once*.
-            #[inline]
-            #[cfg(not(feature = "rt"))]
-            pub(crate) fn take() -> Self {
-                crate::ESP_HAL_LOCK.lock(|| unsafe { Self::steal() })
-            }
-
             /// Unsafely create an instance of this peripheral out of thin air.
             ///
             /// # Safety

--- a/esp-hal/src/sync.rs
+++ b/esp-hal/src/sync.rs
@@ -93,6 +93,7 @@ unsafe impl embassy_sync::blocking_mutex::raw::RawMutex for RawPriorityLimitedMu
 mod critical_section {
     struct CriticalSection;
 
+    #[cfg(feature = "rt")]
     critical_section::set_impl!(CriticalSection);
 
     static CRITICAL_SECTION: esp_sync::RawMutex = esp_sync::RawMutex::new();

--- a/esp-hal/src/sync.rs
+++ b/esp-hal/src/sync.rs
@@ -90,10 +90,10 @@ unsafe impl embassy_sync::blocking_mutex::raw::RawMutex for RawPriorityLimitedMu
 }
 
 #[cfg(impl_critical_section)]
+#[cfg(feature = "rt")]
 mod critical_section {
     struct CriticalSection;
 
-    #[cfg(feature = "rt")]
     critical_section::set_impl!(CriticalSection);
 
     static CRITICAL_SECTION: esp_sync::RawMutex = esp_sync::RawMutex::new();

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -16,9 +16,11 @@ kuchikiki    = { version = "0.8.2", optional = true }
 log          = "0.4.22"
 minijinja    = { version = "2.5.0", default-features = false }
 opener       = { version = "0.7.2", optional = true }
+object       = "0.37"
 parking_lot  = "0.12.3"
 prettyplease = { version = "0.2.34" }
 regex        = { version = "1.11.1", optional = true }
+rustc-demangle = "0.1"
 rocket       = { version = "0.5.1", optional = true }
 semver       = { version = "1.0.23", features = ["serde"] }
 serde        = { version = "1.0.215", default-features = false, features = ["derive"] }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -5,31 +5,31 @@ edition = "2024"
 publish = false
 
 [dependencies]
-anyhow       = "1.0.93"
-clap         = { version = "4.5.20", features = ["derive", "wrap_help"] }
-console      = "0.15.10"
-env_logger   = { version = "0.11.5", default-features = false, features = ["auto-color", "humantime"] }
-esp-metadata = { path = "../esp-metadata", features = ["clap"] }
-inquire      = "0.7.5"
-jiff         = { version = "0.2.13", default-features = false, features = ["std"] }
-kuchikiki    = { version = "0.8.2", optional = true }
-log          = "0.4.22"
-minijinja    = { version = "2.5.0", default-features = false }
-opener       = { version = "0.7.2", optional = true }
-object       = "0.37"
-parking_lot  = "0.12.3"
-prettyplease = { version = "0.2.34" }
-regex        = { version = "1.11.1", optional = true }
+anyhow         = "1.0.93"
+clap           = { version = "4.5.20", features = ["derive", "wrap_help"] }
+console        = "0.15.10"
+env_logger     = { version = "0.11.5", default-features = false, features = ["auto-color", "humantime"] }
+esp-metadata   = { path = "../esp-metadata", features = ["clap"] }
+inquire        = "0.7.5"
+jiff           = { version = "0.2.13", default-features = false, features = ["std"] }
+kuchikiki      = { version = "0.8.2", optional = true }
+log            = "0.4.22"
+minijinja      = { version = "2.5.0", default-features = false }
+opener         = { version = "0.7.2", optional = true }
+object         = "0.37"
+parking_lot    = "0.12.3"
+prettyplease   = { version = "0.2.34" }
+regex          = { version = "1.11.1", optional = true }
 rustc-demangle = "0.1"
-rocket       = { version = "0.5.1", optional = true }
-semver       = { version = "1.0.23", features = ["serde"] }
-serde        = { version = "1.0.215", default-features = false, features = ["derive"] }
-serde_json   = "1.0.70"
-somni-expr   = { version = "0.2.0" }
-strum        = { version = "0.27.1", features = ["derive"] }
-syn          = { version = "2", default-features = false, features = ["full", "parsing"] }
-toml_edit    = { version = "0.22.22", features = ["serde"] }
-walkdir      = "2.5.0"
+rocket         = { version = "0.5.1", optional = true }
+semver         = { version = "1.0.23", features = ["serde"] }
+serde          = { version = "1.0.215", default-features = false, features = ["derive"] }
+serde_json     = "1.0.70"
+somni-expr     = { version = "0.2.0" }
+strum          = { version = "0.27.1", features = ["derive"] }
+syn            = { version = "2", default-features = false, features = ["full", "parsing"] }
+toml_edit      = { version = "0.22.22", features = ["serde"] }
+walkdir        = "2.5.0"
 
 # Only required when building documentation for deployment:
 reqwest = { version = "0.12.12", features = [

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -19,6 +19,7 @@ Commands:
   check-changelog            Check the changelog for packages
   update-chip-support-table  Re-generate the chip support table in the esp-hal README
   host-tests                 Run host tests for all the packages where they are present
+  check-global-symbols       Check global symbols in the compiled `.rlib`
   help                       Print this message or the help of the given subcommand(s)
 
 Options:

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,13 +1,14 @@
 use std::{
     fs,
     path::{Path, PathBuf},
+    process::Command,
     time::Instant,
 };
 
 use anyhow::{Context, Result, bail};
 use clap::{Args, Parser};
 use esp_metadata::{Chip, Config};
-use object::{Object, ObjectSymbol, read::archive::ArchiveFile};
+use object::{Object, ObjectSymbol, SymbolKind, read::archive::ArchiveFile};
 use rustc_demangle::try_demangle;
 use strum::IntoEnumIterator;
 use xtask::{
@@ -219,7 +220,7 @@ fn main() -> Result<()> {
         Cli::UpdateMetadata(args) => update_metadata(&workspace, args.check),
         Cli::HostTests(args) => host_tests(&workspace, args),
         Cli::CheckGlobalSymbols(args) => {
-            check_global_symbols(&workspace, &args.packages, &args.chips)
+            check_global_symbols(&workspace, args.packages[0], &args.chips)
         }
     }
 }
@@ -732,158 +733,107 @@ fn host_tests(workspace: &Path, args: HostTestsArgs) -> Result<()> {
     Ok(())
 }
 
-/// Find the most recently modified rlib for the specified package in the deps_dir.
-fn find_esp_hal_rlib(deps_dir: &Path, package: &Package) -> Result<PathBuf> {
-    println!("Looking for {} rlib in: {}", package, deps_dir.display());
+/// Build the given package for the given chip and return its `.rlib path` with `esp` toolchain.
+fn build_rlib(package: &str, chip: &str, target: &str) -> Result<PathBuf> {
+    let workspace = std::env::current_dir().with_context(|| "Failed to get the current dir!")?;
+    let cmd = Command::new("cargo")
+        .args(&[
+            "+esp",
+            "build",
+            "--no-default-features",
+            "--features",
+            chip,
+            "--target",
+            target,
+            "-Zbuild-std=core,alloc",
+        ])
+        .current_dir(workspace.join(package.to_string()))
+        .status()
+        .context("Failed to run cargo build")?;
 
-    let crate_name = package.to_string().replace('-', "_");
-    let prefix = format!("lib{}-", crate_name);
+    let lib_name = format!("lib{}.rlib", package.replace('-', "_"));
+    let rlib_path = Path::new("target")
+        .join(target)
+        .join("debug")
+        .join(&lib_name);
 
-    fs::read_dir(deps_dir)
-        .with_context(|| format!("Failed to read directory: {}", deps_dir.display()))?
-        .filter_map(|entry| {
-            let path = entry.ok()?.path();
-            let name = path.file_name()?.to_str()?;
-            if name.starts_with(&prefix) && name.ends_with(".rlib") {
-                path.metadata()
-                    .ok()
-                    .and_then(|m| m.modified().ok())
-                    .map(|t| (path, t))
-            } else {
-                None
-            }
-        })
-        .max_by_key(|(_, time)| *time)
-        .map(|(path, _)| path)
-        .ok_or_else(|| anyhow::anyhow!("No rlib found for {} in {}", package, deps_dir.display()))
+    if !rlib_path.exists() {
+        anyhow::bail!("Expected rlib not found: {}", rlib_path.display());
+    }
+
+    Ok(rlib_path)
 }
 
 /// Check global symbols in the compiled rlib of the specified packages for the
 /// specified chips. Reports any unmangled global symbols that may pollute the
 /// global namespace.
-fn check_global_symbols(workspace: &Path, packages: &[Package], chips: &[Chip]) -> Result<()> {
+fn check_global_symbols(workspace: &Path, package: Package, chips: &[Chip]) -> Result<()> {
     let mut total_problematic = 0;
-    let mut checked_packages = 0;
 
-    for package in packages {
-        for chip in chips {
-            let target = package.target_triple(chip)?;
-            let deps_dir = workspace.join("target").join(&target).join("debug/deps");
+    let package = Package::EspHal; // Only esp-hal for now
 
-            let rlib_path = match find_esp_hal_rlib(&deps_dir, package) {
-                Ok(path) => path,
-                Err(e) => {
-                    println!("⚠️  No rlib found for {} on {}: {}", package, chip, e);
-                    continue;
-                }
-            };
+    for chip in chips {
+        let target = package.target_triple(chip)?;
+        let deps_dir = workspace.join("target").join(&target).join("debug/deps");
 
-            println!(
-                "🔍 Checking global symbols for {} on {}:\n   {}",
-                package,
-                chip,
-                rlib_path.display()
-            );
+        let rlib_path = match build_rlib(&package.to_string(), &chip.to_string(), &target) {
+            Ok(path) => path,
+            Err(e) => {
+                println!(
+                    "Failed to build/find rlib for {} on {}: {}",
+                    package, chip, e
+                );
+                continue;
+            }
+        };
 
-            let data = std::fs::read(&rlib_path)?;
-            let archive = ArchiveFile::parse(data.as_slice())?;
+        log::info!("Checking global symbols for {} on {}:\n", package, chip);
 
-            let mut problematic_symbols = Vec::new();
-            let mut rust_symbol_count = 0;
+        let data = std::fs::read(&rlib_path)
+            .with_context(|| format!("Failed to read {}!", rlib_path.display()))?;
+        let archive = ArchiveFile::parse(data.as_slice())
+            .with_context(|| format!("Failed to create archive!"))?;
 
-            for member in archive.members().flatten() {
-                if let Ok(obj) = object::File::parse(member.data(data.as_slice())?) {
-                    for symbol in obj.symbols().filter(|s| s.is_global() && s.is_definition()) {
-                        if let Ok(name) = symbol.name() {
-                            if is_allowed_global_symbol(name) {
-                                continue;
-                            }
-                            if try_demangle(name).is_ok() {
-                                rust_symbol_count += 1;
-                            } else {
-                                problematic_symbols.push((
-                                    name.to_string(),
-                                    format!("{:?}", symbol.kind()),
-                                    symbol.section_index().map(|i| i.0).unwrap_or(0),
-                                ));
-                            }
-                        }
+        let mut problematic_symbols: Vec<(String, SymbolKind, usize)> = Vec::new();
+
+        for member in archive.members().flatten() {
+            let obj = object::File::parse(
+                member
+                    .data(data.as_slice())
+                    .with_context(|| "Failed to parse archive!")?,
+            )?;
+
+            for symbol in obj.symbols().filter(|s| s.is_global() && s.is_definition()) {
+                if let Ok(name) = symbol.name() {
+                    if try_demangle(name).is_err() {
+                        let section = symbol.section_index().map(|i| i.0).unwrap_or(0);
+                        problematic_symbols.push((name.to_string(), symbol.kind(), section));
                     }
                 }
             }
+        }
 
-            let total_symbols = rust_symbol_count + problematic_symbols.len();
+        if problematic_symbols.is_empty() {
+            println!("All global symbols are properly mangled Rust symbols\n");
+        } else {
             println!(
-                "   📊 Found {total_symbols} global symbols\n   ✅ {rust_symbol_count} properly mangled Rust symbols"
+                "Found {} potentially problematic global symbols:",
+                problematic_symbols.len(),
             );
 
-            if problematic_symbols.is_empty() {
-                println!("   ✅ All global symbols are properly mangled Rust symbols\n");
-            } else {
-                println!(
-                    "   ❌ Found {} potentially problematic global symbols (may pollute global namespace):",
-                    problematic_symbols.len()
-                );
-                for (symbol, kind, section) in &problematic_symbols {
-                    let symbol_type = match kind.as_str() {
-                        "Text" => "T",
-                        "Data" => "D",
-                        "Unknown" => "U",
-                        _ => &kind,
-                    };
-                    println!(
-                        "      {:>16} {} {}",
-                        format!("{:x}", section),
-                        symbol_type,
-                        symbol
-                    );
-                }
-                println!();
-
-                total_problematic += problematic_symbols.len();
+            for (name, kind, section) in &problematic_symbols {
+                println!("{:?} {}", kind, name);
             }
 
-            checked_packages += 1;
+            total_problematic += problematic_symbols.len();
         }
     }
-
-    println!(
-        "\n{}\n📋 Final Summary:\n   Checked {} package-chip combinations\n   Total problematic symbols found: {}",
-        "=".repeat(60),
-        checked_packages,
-        total_problematic
-    );
 
     if total_problematic > 0 {
         Err(anyhow::anyhow!(
             "Found {total_problematic} unmangled global symbols across all packages/chips"
         ))
     } else {
-        println!("🎉 All packages passed namespace checks!");
         Ok(())
     }
-}
-
-/// Global symbols that are expected to be unmangled.
-fn is_allowed_global_symbol(name: &str) -> bool {
-    name.starts_with("__rustc_")
-        || name.starts_with("__rtti_")
-        || name.starts_with("__DWARF")
-        || name.starts_with("__debug_")
-        || name.starts_with("__eh_frame")
-        || name.starts_with("__stack_")
-        || name.starts_with("__heap_")
-        || name.starts_with("__data_")
-        || name.starts_with("__bss_")
-        || name.starts_with("__text_")
-        || matches!(
-            name,
-            "_start"
-                | "main"
-                | "__stack_size"
-                | "__heap_size"
-                | "__dso_handle"
-                | "__tdata_start"
-                | "__tbss_start"
-        )
 }


### PR DESCRIPTION
`cargo xtask check-global-symbols esp-hal --chips esp32c6`:
```rust
🔍 Checking global symbols for esp-hal on esp32c6:
   /Users/jurajsadel/esp-rs/esp-hal/target/riscv32imac-unknown-none-elf/debug/deps/libesp_hal-3dc25ca23feb78db.rlib
   📊 Found 5614 global symbols
   ✅ 5604 properly mangled Rust symbols
   ❌ Found 10 potentially problematic global symbols (may pollute global namespace):
                     3 T _setup_interrupts
                     5 T _start_trap_rust_hal
                     7 T handle_interrupts
                     3 T ExceptionHandler
                   2d6 D _ESP_HAL_DEVICE_PERIPHERALS
                     3 T EspDefaultHandler
                     a T _critical_section_1_0_acquire
                     c T _critical_section_1_0_release
                    13 T hal_main
                     c D build_info.CHIP_NAME


============================================================
📋 Final Summary:
   Checked 1 package-chip combinations
   Total problematic symbols found: 10
Error: Found 10 unmangled global symbols across all packages/chips
```

Few things to decide/address:
1.) This currently errors out if the `.rlib` is not present
2.) How do we want to run it in CI since it requires `cargo build`? In nightly-CI for now?


closes https://github.com/esp-rs/esp-hal/issues/3738