### PR TITLE
Delete task when it exits

### DIFF
--- a/esp-preempt/src/task/mod.rs
+++ b/esp-preempt/src/task/mod.rs
@@ -262,6 +262,12 @@ pub(crate) struct Task {
 const STACK_CANARY: u32 =
     const { esp_config::esp_config_int!(u32, "ESP_HAL_CONFIG_STACK_GUARD_VALUE") };
 
+#[cfg(feature = "esp-radio")]
+extern "C" fn task_wrapper(task_fn: extern "C" fn(*mut c_void), param: *mut c_void) {
+    task_fn(param);
+    schedule_task_deletion(core::ptr::null_mut());
+}
+
 impl Task {
     #[cfg(feature = "esp-radio")]
     pub(crate) fn new(

--- a/esp-preempt/src/task/riscv.rs
+++ b/esp-preempt/src/task/riscv.rs
@@ -128,8 +128,9 @@ pub(crate) fn new_task_context(
     let stack_top = stack_top - (stack_top % 16);
 
     CpuContext {
-        pc: task as usize,
-        a0: param as usize,
+        pc: super::task_wrapper as usize,
+        a0: task as usize,
+        a1: param as usize,
         sp: stack_top,
         ..Default::default()
     }

--- a/esp-preempt/src/task/xtensa.rs
+++ b/esp-preempt/src/task/xtensa.rs
@@ -47,10 +47,11 @@ pub(crate) fn new_task_context(
     }
 
     CpuContext {
-        PC: task_fn as usize as u32,
+        PC: super::task_wrapper as usize as u32,
         A0: 0,
         A1: stack_top,
-        A6: param as usize as u32,
+        A6: task_fn as usize as u32,
+        A7: param as usize as u32,
 
         // For windowed ABI set WOE and CALLINC (pretend task was 'call4'd)
         PS: 0x00040000 | ((1 & 3) << 16),

--- a/hil-test/src/bin/esp_radio_init.rs
+++ b/hil-test/src/bin/esp_radio_init.rs
@@ -247,11 +247,6 @@ mod tests {
             }
 
             context.time_slice_observed.give();
-
-            // TODO: support one-shot tasks in esp-preempt
-            unsafe {
-                preempt::schedule_task_deletion(core::ptr::null_mut());
-            }
         }
 
         unsafe {
@@ -337,11 +332,6 @@ mod tests {
 
             info!("High: released mutex");
             context.mutex.give();
-
-            // TODO: support one-shot tasks in esp-preempt
-            unsafe {
-                preempt::schedule_task_deletion(core::ptr::null_mut());
-            }
         }
         extern "C" fn medium_priority_task(context: *mut c_void) {
             let context = unsafe { &*(context as *const TestContext) };
@@ -351,11 +341,6 @@ mod tests {
 
             info!("Medium: marking test finished");
             context.ready_semaphore.give();
-
-            // TODO: support one-shot tasks in esp-preempt
-            unsafe {
-                preempt::schedule_task_deletion(core::ptr::null_mut());
-            }
         }
 
         unsafe {
@@ -426,21 +411,11 @@ mod tests {
             let context = unsafe { &*(context as *const TestContext) };
 
             count_impl(context, Cpu::AppCpu);
-
-            // TODO: support one-shot tasks in esp-preempt
-            unsafe {
-                preempt::schedule_task_deletion(core::ptr::null_mut());
-            }
         }
         extern "C" fn count_on_pro_core(context: *mut c_void) {
             let context = unsafe { &*(context as *const TestContext) };
 
             count_impl(context, Cpu::ProCpu);
-
-            // TODO: support one-shot tasks in esp-preempt
-            unsafe {
-                preempt::schedule_task_deletion(core::ptr::null_mut());
-            }
         }
 
         esp_preempt::start(


### PR DESCRIPTION
This PR wraps task functions so that they delete themselves if their function returns.

We could also use this function to mark unwind info with `.cfi_undefined ra` so that debuggers stop unwinding - but it doesn't make a difference for us, since probe-rs doesn't stop unwinding 😑, and we'd also need naked wrapper functions + assembly for that.