### PR TITLE
RV: Dump the stack if frame-pointers are not enabled

### DIFF
--- a/esp-backtrace/CHANGELOG.md
+++ b/esp-backtrace/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `exception-handler` now panics. (#3838)
 - Only halt cores in panics when `halt-cores` feature is enabled. (#4010)
 - It is no longer possible to select multiple halt method features (`halt-cores`, `custom-halt`, `semihosting`) (#4012)
+- RISC-V: If stack-frames are not enabled the panic-handler will now emit a stack dump (#4189)
 
 ### Fixed
 

--- a/esp-backtrace/Cargo.toml
+++ b/esp-backtrace/Cargo.toml
@@ -49,6 +49,7 @@ xtensa-lx        = { version = "0.12.0", path = "../xtensa-lx" }
 
 [build-dependencies]
 esp-config   = { version = "0.5.0", path = "../esp-config", features = ["build"] }
+esp-metadata-generated = { version = "0.1.0", path = "../esp-metadata-generated", features = ["build-script"] }
 
 [features]
 default = ["colors"]

--- a/esp-backtrace/build.rs
+++ b/esp-backtrace/build.rs
@@ -1,3 +1,5 @@
+use std::error::Error;
+
 use esp_config::generate_config_from_yaml_definition;
 
 #[macro_export]
@@ -22,7 +24,10 @@ macro_rules! assert_unique_used_features {
     };
 }
 
-fn main() {
+fn main() -> Result<(), Box<dyn Error>> {
+    // Ensure that exactly one chip has been specified:
+    let chip = esp_metadata_generated::Chip::from_cargo_feature()?;
+
     // Ensure that exactly a backend is selected:
     assert_unique_used_features!("defmt", "println");
 
@@ -43,7 +48,20 @@ fn main() {
     println!("cargo:rerun-if-changed=./esp_config.yml");
     let cfg_yaml = std::fs::read_to_string("./esp_config.yml")
         .expect("Failed to read esp_config.yml for esp-backtrace");
-    generate_config_from_yaml_definition(&cfg_yaml, true, true, None).unwrap();
+    generate_config_from_yaml_definition(&cfg_yaml, true, true, Some(chip))?;
+
+    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+
+    println!("cargo::rustc-check-cfg=cfg(stack_dump)");
+    if target_arch == "riscv32"
+        && !std::env::var("CARGO_ENCODED_RUSTFLAGS")
+            .unwrap_or_default()
+            .contains("force-frame-pointers")
+    {
+        println!("cargo::rustc-cfg=stack_dump");
+    }
+
+    Ok(())
 }
 
 fn print_warning(message: impl core::fmt::Display) {

--- a/esp-backtrace/build.rs
+++ b/esp-backtrace/build.rs
@@ -50,10 +50,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         .expect("Failed to read esp_config.yml for esp-backtrace");
     generate_config_from_yaml_definition(&cfg_yaml, true, true, Some(chip))?;
 
-    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
-
     println!("cargo::rustc-check-cfg=cfg(stack_dump)");
-    if target_arch == "riscv32"
+    if !chip.is_xtensa()
         && !std::env::var("CARGO_ENCODED_RUSTFLAGS")
             .unwrap_or_default()
             .contains("force-frame-pointers")

--- a/esp-backtrace/esp_config.yml
+++ b/esp-backtrace/esp_config.yml
@@ -5,3 +5,17 @@ options:
   description: The maximum number of frames that will be printed in a backtrace.
   default:
     - value: 10
+
+- name: stack-dump-max-size
+  description: Max amount of stack to dump.
+  default:
+    - value: '"8K"'
+  constraints:
+    - type:
+        validator: enumeration
+        value:
+          - '4K'
+          - '8K'
+          - '16K'
+          - '32K'
+  active: 'chip == "esp32c2" || chip == "esp32c3" || chip == "esp32c6" || chip == "esp32h2"'

--- a/esp-backtrace/src/riscv.rs
+++ b/esp-backtrace/src/riscv.rs
@@ -62,3 +62,56 @@ pub(crate) fn backtrace_internal(fp: u32, suppress: u32) -> Backtrace {
 
     result
 }
+
+#[cfg(all(stack_dump, feature = "panic-handler"))]
+pub(super) fn dump_stack() {
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "println")] {
+            const MAX_STACK_DUMP_SIZE: u32 = match () {
+                _ if cfg!(stack_dump_max_size_4k) => 4 * 1024,
+                _ if cfg!(stack_dump_max_size_8k) => 8 * 1024,
+                _ if cfg!(stack_dump_max_size_16k) => 16 * 1024,
+                _ if cfg!(stack_dump_max_size_32k) => 32 * 1024,
+                _ => core::unreachable!(),
+            };
+
+            let (pc, sp) = unsafe {
+                unsafe extern "C" {
+                    #[allow(improper_ctypes)]
+                    fn __get_pc_sp() -> (u32, u32);
+                }
+
+                __get_pc_sp()
+            };
+
+            unsafe extern "C" {
+                static _stack_start: u32;
+            }
+
+            let end = u32::min(
+                core::ptr::addr_of!(_stack_start) as u32,
+                sp + MAX_STACK_DUMP_SIZE,
+            );
+
+            esp_println::print!("STACKDUMP: {:08x} ", pc);
+            for address in sp..end {
+                let byte = unsafe { (address as *const u8).read_volatile() };
+                esp_println::print!("{:02x}", byte);
+            }
+            esp_println::println!();
+        } else {
+            super::println!("Stack dumps are not supported with DEFMT.");
+        }
+    }
+}
+
+#[cfg(all(stack_dump, feature = "panic-handler"))]
+core::arch::global_asm!(
+    "
+.globl __get_pc_sp
+__get_pc_sp:
+    mv a0, ra
+    mv a1, sp
+    ret
+"
+);

--- a/esp-hal/ld/esp32/esp32.x
+++ b/esp-hal/ld/esp32/esp32.x
@@ -16,4 +16,5 @@ INCLUDE "rtc_slow.x"
 INCLUDE "stack.x"
 INCLUDE "dram2.x"
 INCLUDE "metadata.x"
+INCLUDE "eh_frame.x"
 /* End of Shared sections */

--- a/esp-hal/ld/esp32c2/esp32c2.x
+++ b/esp-hal/ld/esp32c2/esp32c2.x
@@ -51,6 +51,7 @@ INCLUDE "text.x"
 INCLUDE "stack.x"
 INCLUDE "dram2.x"
 INCLUDE "metadata.x"
+INCLUDE "eh_frame.x"
 /* End of Shared sections */
 
 _dram_origin = ORIGIN( DRAM );

--- a/esp-hal/ld/esp32c3/esp32c3.x
+++ b/esp-hal/ld/esp32c3/esp32c3.x
@@ -52,6 +52,7 @@ INCLUDE "rtc_fast.x"
 INCLUDE "stack.x"
 INCLUDE "dram2.x"
 INCLUDE "metadata.x"
+INCLUDE "eh_frame.x"
 /* End of Shared sections */
 
 _dram_origin = ORIGIN( DRAM );

--- a/esp-hal/ld/esp32c6/esp32c6.x
+++ b/esp-hal/ld/esp32c6/esp32c6.x
@@ -36,6 +36,7 @@ INCLUDE "rtc_fast.x"
 INCLUDE "stack.x"
 INCLUDE "dram2.x"
 INCLUDE "metadata.x"
+INCLUDE "eh_frame.x"
 /* End of Shared sections #2 */
 
 _dram_origin = ORIGIN( RAM );

--- a/esp-hal/ld/esp32h2/esp32h2.x
+++ b/esp-hal/ld/esp32h2/esp32h2.x
@@ -34,6 +34,7 @@ INCLUDE "rtc_fast.x"
 INCLUDE "stack.x"
 INCLUDE "dram2.x"
 INCLUDE "metadata.x"
+INCLUDE "eh_frame.x"
 /* End of Shared sections #2 */
 
 _dram_origin = ORIGIN( RAM );

--- a/esp-hal/ld/esp32s2/esp32s2.x
+++ b/esp-hal/ld/esp32s2/esp32s2.x
@@ -24,4 +24,5 @@ INCLUDE "rtc_slow.x"
 INCLUDE "stack.x"
 INCLUDE "dram2.x"
 INCLUDE "metadata.x"
+INCLUDE "eh_frame.x"
 /* End of Shared sections */

--- a/esp-hal/ld/esp32s3/esp32s3.x
+++ b/esp-hal/ld/esp32s3/esp32s3.x
@@ -51,4 +51,5 @@ INCLUDE "rtc_slow.x"
 INCLUDE "stack.x"
 INCLUDE "dram2.x"
 INCLUDE "metadata.x"
+INCLUDE "eh_frame.x"
 /* End of Shared sections */

--- a/esp-hal/ld/sections/eh_frame.x
+++ b/esp-hal/ld/sections/eh_frame.x
@@ -1,0 +1,6 @@
+SECTIONS {
+  .eh_frame 0 (INFO) :
+  {
+    KEEP(*(.eh_frame));
+  }
+}


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

On RISC-V we are not able to do a backtrace on the device without forcing frame pointers.

So now the panic-handler will emit a minimal stack dump (i.e. the PC and a good part of the stack contents) in that situation.

There will be an espflash PR soon which enables espflash to decode that into a backtrace.

Sidenote: I noticed that sometimes I got a .eh_frame section even without `-Cforce-unwind-tables` - but that was very random. The really bad thing about that was that it sometimes was located in flash and sometimes in RAM. It happened more often on RV using the esp toolchain. (That's why the linker script addition is for all chips ... shouldn't hurt)

Another sidenote: Not forcing frame-pointers reduced the embassy-dhcp example by approx. 20k ... I didn't expect it to make such a big difference

`skip-changelog` because of the linker script changes

Upd: The `espflash` companion PR is https://github.com/esp-rs/espflash/pull/955

#### Testing
Local testing
