### PR TITLE
Provide __global_pointer$ in linker script

### DIFF
--- a/esp-hal/ld/sections/rwdata.x
+++ b/esp-hal/ld/sections/rwdata.x
@@ -3,6 +3,8 @@
   _data_start = ABSOLUTE(.);
   . = ALIGN (4);
 
+  PROVIDE(__global_pointer$ = . + 0x800);
+
   #IF ESP_HAL_CONFIG_PLACE_SWITCH_TABLES_IN_RAM
     *(.rodata.*_esp_hal_internal_handler*)
     *(.rodata..Lswitch.table.*)


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
- [ ] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖
See the commit message for details. (tl;dr: This prevents the linker from putting this symbol in sections where it doesn't belong. Other than that, it doesn't currently matter, because llvm does not appear to have implemented gp relaxation, yet.)

Fixes: https://github.com/esp-rs/esp-hal/issues/4149
Supersedes: https://github.com/esp-rs/esp-generate/pull/226

#### Testing
Compile test on C3. (The actual program I'm testing still hangs, but that's probably a different issue.)