### PR TITLE
xtask: Ignore non-chip features

### DIFF
--- a/xtask/src/firmware.rs
+++ b/xtask/src/firmware.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeSet, HashMap},
+    collections::HashMap,
     fs,
     path::{Path, PathBuf},
 };
@@ -359,8 +359,7 @@ pub fn load_cargo_toml(examples_path: &Path) -> Result<Vec<Metadata>> {
         let chips = toml
             .features
             .keys()
-            .map(|chip| Chip::from_str(&chip, true).unwrap())
-            .collect::<BTreeSet<_>>();
+            .filter_map(|chip| Chip::from_str(&chip, true).ok());
 
         for chip in chips {
             examples.push(Metadata {


### PR DESCRIPTION
While our current examples only have chip features, it's quite convenient sometimes to overwrite them with reproducers - but the xtask freaks out if the reproducer has any features other than chip names. This PR relaxes this a bit.

This PR also removes the temporary BTreeSet as we can just iterate over the features directly - a single feature name can't appear twice in Cargo.toml.