### PR TITLE
only provide __global_pointer$ on riscv

### DIFF
--- a/esp-hal/ld/riscv/hal-defaults.x
+++ b/esp-hal/ld/riscv/hal-defaults.x
@@ -5,6 +5,7 @@ We don't use the linker scripts defined in riscv-rt (since we have special needs
 */
 
 PROVIDE(_stext = ORIGIN(ROTEXT));
+PROVIDE(__global_pointer$ = ALIGN(_data_start, 4) + 0x800);
 
 /* Default abort entry point. If no abort symbol is provided, then abort maps to _default_abort. */
 EXTERN(_default_abort);

--- a/esp-hal/ld/sections/rwdata.x
+++ b/esp-hal/ld/sections/rwdata.x
@@ -3,8 +3,6 @@
   _data_start = ABSOLUTE(.);
   . = ALIGN (4);
 
-  PROVIDE(__global_pointer$ = . + 0x800);
-
   #IF ESP_HAL_CONFIG_PLACE_SWITCH_TABLES_IN_RAM
     *(.rodata.*_esp_hal_internal_handler*)
     *(.rodata..Lswitch.table.*)


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
- [ ] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖
What I just realized is that the symbol is provided unconditionally by https://github.com/esp-rs/esp-hal/pull/4197, while it's really a RISCV-only thing. It probably does no harm on Xtensa, but it might be slightly cleaner if the symbol wasn't defined there?

#### Testing
-
