### PR TITLE
Custom idle hooks

### DIFF
--- a/esp-rtos/src/scheduler.rs
+++ b/esp-rtos/src/scheduler.rs
@@ -13,6 +13,7 @@ use crate::{
     task::{
         self,
         CpuContext,
+        IdleFn,
         Task,
         TaskAllocListElement,
         TaskDeleteListElement,
@@ -99,14 +100,14 @@ impl SchedulerState {
         }
     }
 
-    pub(crate) fn setup(&mut self, time_driver: TimeDriver) {
+    pub(crate) fn setup(&mut self, time_driver: TimeDriver, idle_hook: IdleFn) {
         assert!(
             self.time_driver.is_none(),
             "The scheduler has already been started"
         );
         self.time_driver = Some(time_driver);
         for cpu in 0..Cpu::COUNT {
-            task::set_idle_hook_entry(&mut self.per_cpu[cpu].idle_context);
+            task::set_idle_hook_entry(&mut self.per_cpu[cpu].idle_context, idle_hook);
         }
     }
 

--- a/esp-rtos/src/task/mod.rs
+++ b/esp-rtos/src/task/mod.rs
@@ -20,6 +20,8 @@ use crate::InternalMemory;
 use crate::semaphore::Semaphore;
 use crate::{SCHEDULER, run_queue::RunQueue, scheduler::SchedulerState, wait_queue::WaitQueue};
 
+pub type IdleFn = extern "C" fn() -> !;
+
 #[derive(Clone, Copy, PartialEq, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) enum TaskState {

--- a/esp-rtos/src/task/riscv.rs
+++ b/esp-rtos/src/task/riscv.rs
@@ -107,16 +107,16 @@ impl CpuContext {
     }
 }
 
-extern "C" fn idle_hook() -> ! {
+pub(crate) extern "C" fn idle_hook() -> ! {
     loop {
         unsafe { core::arch::asm!("wfi") };
     }
 }
 
-pub(crate) fn set_idle_hook_entry(idle_context: &mut CpuContext) {
+pub(crate) fn set_idle_hook_entry(idle_context: &mut CpuContext, hook_fn: super::IdleFn) {
     // Point idle context PC at the assembly that calls the idle hook. We need a new stack
     // frame for the idle task on the main stack.
-    idle_context.pc = idle_hook as usize;
+    idle_context.pc = hook_fn as usize;
 }
 
 #[cfg(feature = "esp-radio")]


### PR DESCRIPTION
This PR is intended as an alternative to the old `low-power-wait` configuration - users can register a function that just loops when idle.