### PR TITLE
Fix embassy timer queue

### DIFF
--- a/esp-rtos/src/scheduler.rs
+++ b/esp-rtos/src/scheduler.rs
@@ -332,6 +332,10 @@ impl SchedulerState {
 
     pub(crate) fn switch_task(&mut self, #[cfg(xtensa)] trap_frame: &mut CpuContext) {
         self.run_scheduler(|current_context, next_context| {
+            trace!(
+                "Task switch: {:x} -> {:x}",
+                current_context as usize, next_context as usize
+            );
             task::task_switch(
                 current_context,
                 next_context,

--- a/esp-rtos/src/timer/embassy.rs
+++ b/esp-rtos/src/timer/embassy.rs
@@ -16,8 +16,9 @@ impl TimerQueueInner {
     }
 
     pub(crate) fn handle_alarm(&mut self, now: u64) {
-        let next = self.queue.next_expiration(now);
-        self.next_wakeup = next;
+        if now >= self.next_wakeup {
+            self.next_wakeup = self.queue.next_expiration(now);
+        }
     }
 
     fn schedule_wake(&mut self, at: u64, waker: &Waker) -> bool {

--- a/esp-rtos/src/timer/embassy.rs
+++ b/esp-rtos/src/timer/embassy.rs
@@ -22,7 +22,7 @@ impl TimerQueueInner {
 
     fn schedule_wake(&mut self, at: u64, waker: &Waker) -> bool {
         if self.queue.schedule_wake(at, waker) {
-            self.next_wakeup = at;
+            self.next_wakeup = self.next_wakeup.min(at);
             true
         } else {
             false


### PR DESCRIPTION
Closes #4210

This PR fixes an issue where adding a new embassy task to the timer queue incorrectly overwrote the next wakeup time. This resulted in tasks not getting readied on time. The solution is to correctly track the minimum of the stored wakeup time and the new deadline.