### PR TITLE
twai: do not abort transmissions on recoverable errors

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -83,6 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - I2C error recovery logic issues (#4000)
 - I2S: Fixed RX half-sample bits configuration bug causing microphone noise (#4109)
 - RISC-V: Direct interrupt vectoring (#4171)
+- TWAI: Fixed unnecessary transmission abortions (#4222)
 
 ### Removed
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -83,7 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - I2C error recovery logic issues (#4000)
 - I2S: Fixed RX half-sample bits configuration bug causing microphone noise (#4109)
 - RISC-V: Direct interrupt vectoring (#4171)
-- TWAI: Fixed unnecessary transmission abortions (#4222)
+- TWAI: Fixed unnecessary transmission abortions (#4227)
 
 ### Removed
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

The TWAI driver's interrupt handler currently aborts transmissions if certain (error) interrupts were triggered. This causes the transmission of frames to become unreliable, because the `transmit_async` operation does not return any error codes if a transmission was aborted.

Additionally, the TWAI controller is designed to be a reliable and, with the exception of the bus-off state, normally would simply try to rentransmit a message on its own. Therefore, this commit removes transmission abortion on errors and, instead, only aborts a transmission if the controller changes into the bus-off state.

Fixes #4222

#### Testing

I tested the change using the example provided in #4222 with a setup of three ESP32-C3 (+ CAN-Transceivers) that are connected to each other via a CAN-bus. 