### PR TITLE
Change default `wifi_max_burst_size`

### DIFF
--- a/esp-radio/CHANGELOG.md
+++ b/esp-radio/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update to bt-hci version with flash usage improvements (#4146, #4165)
 - `scan_mode`, `(ap_)beacon_timeout`, `listen_interval` and `failure_retry_cnt` config options have been replaced by runtime options in `AccessPointConfig`, `ClientConfig` and `EapClientConfig` (#4224)
 - The `ieee802154_rx_queue_size` config option has been replaced by a runtime option in `esp_radio::ieee802154::Config` (#4224)
+- The default value of `wifi_max_burst_size` has been changed to 3 (#4231)
 
 ### Fixed
 

--- a/esp-radio/esp_config.yml
+++ b/esp-radio/esp_config.yml
@@ -5,7 +5,7 @@ options:
   - name: wifi_max_burst_size
     description: See [smoltcp's documentation](https://docs.rs/smoltcp/0.10.0/smoltcp/phy/struct.DeviceCapabilities.html#structfield.max_burst_size)
     default:
-      - value: 1
+      - value: 3
 
   - name: wifi_mtu
     description: "MTU, see [smoltcp's documentation](https://docs.rs/smoltcp/0.10.0/smoltcp/phy/struct.DeviceCapabilities.html#structfield.max_transmission_unit)"


### PR DESCRIPTION
The default value of 1 throttles download speed considerably. This makes sense since it limits [TCP window_len](https://github.com/smoltcp-rs/smoltcp/blob/c9a78337bb2da90141ca7bf9f703267fead15b0a/src/iface/packet.rs#L152-L161) in smoltcp. That 2 and 3 have this much impact is surprising to me. In this PR I'm setting the default to 3 which seems to be the sweet spot in the benchmark with my setup.

<details><summary>Details</summary>
<p>

wifi_bench
----------
wifi_max_burst_size = 1

Testing download...
download: 13 kB/s
Testing upload...
upload: 680 kB/s
Testing upload+download...
upload+download: 165 kB/s

wifi_max_burst_size = 0

Testing download...
download: 724 kB/s
Testing upload...
upload: 737 kB/s
Testing upload+download...
upload+download: 168 kB/s

wifi_max_burst_size = 2

Testing download...
download: 559 kB/s
Testing upload...
upload: 673 kB/s
Testing upload+download...
upload+download: 161 kB/s

wifi_max_burst_size = 10

Testing download...
download: 792 kB/s
Testing upload...
upload: 623 kB/s
Testing upload+download...
upload+download: 161 kB/s

wifi_max_burst_size = 3

Testing download...
download: 801 kB/s
Testing upload...
upload: 695 kB/s
Testing upload+download...
upload+download: 157 kB/s

embassy_wifi_bench
------------------
wifi_max_burst_size = 1

Testing download...
connecting to 192.168.0.220:4321...
connected, testing...
download: 94 kB/s
Testing upload...
connecting to 192.168.0.220:4322...
connected, testing...
upload: 693 kB/s
Testing upload+download...
connecting to 192.168.0.220:4323...
connected, testing...
upload+download: 121 kB/s

wifi_max_burst_size = 0
Testing download...
connecting to 192.168.0.220:4321...
connected, testing...
download: 754 kB/s
Testing upload...
connecting to 192.168.0.220:4322...
connected, testing...
upload: 779 kB/s
Testing upload+download...
connecting to 192.168.0.220:4323...
connected, testing...
upload+download: 480 kB/s

</p>
</details> 