### PR TITLE
wifi_bench: Fix memory layout to fix S2

### DIFF
--- a/qa-test/src/bin/wifi_bench.rs
+++ b/qa-test/src/bin/wifi_bench.rs
@@ -59,7 +59,9 @@ fn main() -> ! {
     let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
     let peripherals = esp_hal::init(config);
 
-    esp_alloc::heap_allocator!(size: 72 * 1024);
+    esp_alloc::heap_allocator!(size: 32 * 1024);
+    // add some more RAM
+    esp_alloc::heap_allocator!(#[unsafe(link_section = ".dram2_uninit")] size: 64 * 1024);
 
     let server_address: Ipv4Addr = HOST_IP.parse().expect("Invalid HOST_IP address");
 


### PR DESCRIPTION
Running the example before this PR just crashes with `unwrap of `Self::try_get()` failed: NoneError`.