### PR TITLE
Use github actions artifacts to store semver baseline

### DIFF
--- a/.github/workflows/api-baseline-check.yml
+++ b/.github/workflows/api-baseline-check.yml
@@ -1,0 +1,51 @@
+name: API Baseline Check
+
+on:
+    pull_request:
+        types: [opened, synchronize, reopened, labeled, unlabeled]
+
+env:
+    CARGO_TERM_COLOR: always
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+# Cancel any currently running workflows from the same PR, branch, or
+# tag when a new workflow is triggered.
+#
+# https://stackoverflow.com/a/66336834
+concurrency:
+    cancel-in-progress: true
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+
+jobs:
+    baseline-check:
+        runs-on: ubuntu-latest
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'breaking-change') }}
+        env:
+            CARGO_TARGET_DIR: ${{ github.workspace }}/target
+
+        steps:
+            - uses: actions/checkout@v4
+
+            # Install the Rust toolchain for Xtensa devices:
+            - uses: esp-rs/xtensa-toolchain@v1.6
+              with:
+                  version: 1.89.0.0
+
+            # Install the Rust stable toolchain for RISC-V devices:
+            - uses: dtolnay/rust-toolchain@v1
+              with:
+                  target: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf
+                  toolchain: stable
+                  components: rust-src
+
+            - name: Semver-Check
+              shell: bash
+              run: |
+                  cargo xcheck semver-check download-baselines
+                  cargo xcheck semver-check --chips esp32 check
+                  cargo xcheck semver-check --chips esp32s2 check
+                  cargo xcheck semver-check --chips esp32s3 check
+                  cargo xcheck semver-check --chips esp32c2 check
+                  cargo xcheck semver-check --chips esp32c3 check
+                  cargo xcheck semver-check --chips esp32c6 check
+                  cargo xcheck semver-check --chips esp32h2 check

--- a/.github/workflows/api-baseline-generation.yml
+++ b/.github/workflows/api-baseline-generation.yml
@@ -1,0 +1,194 @@
+name: API Baseline Generation
+
+on:
+    push:
+        branches:
+            - main
+    workflow_dispatch:
+        inputs:
+            source_branch:
+                description: "Branch to generate baseline from"
+                required: true
+                default: "main"
+                type: string
+            target_repository:
+                description: "Target repository for baseline storage (owner/repo)"
+                required: false
+                default: ""
+                type: string
+            force_regeneration:
+                description: "Force baseline regeneration even without breaking change"
+                required: false
+                default: false
+                type: boolean
+
+env:
+    CARGO_TERM_COLOR: always
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    GITHUB_REPOSITORY: ${{ github.repository }}
+
+jobs:
+    manage-baselines:
+        runs-on: ubuntu-latest
+        env:
+            CARGO_TARGET_DIR: ${{ github.workspace }}/target
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+              with:
+                  ref: ${{ github.event.inputs.source_branch || 'main' }}
+                  fetch-depth: 0 # Fetch full history for PR detection
+
+            - name: Set target repository
+              if: github.event_name == 'workflow_dispatch'
+              shell: bash
+              run: |
+                  if [ -n "${{ github.event.inputs.target_repository }}" ]; then
+                    TARGET_REPO="${{ github.event.inputs.target_repository }}"
+                    echo "Using custom target repository: $TARGET_REPO"
+                  else
+                    TARGET_REPO="${{ github.repository }}"
+                    echo "Using current repository: $TARGET_REPO"
+                  fi
+                  echo "GITHUB_REPOSITORY=$TARGET_REPO" >> $GITHUB_ENV
+                  echo "📦 Target repository for baselines: $TARGET_REPO"
+
+            - name: Install Rust toolchain
+              uses: dtolnay/rust-toolchain@v1
+              with:
+                  toolchain: stable
+                  components: rust-src
+
+            - name: Install xtensa toolchain
+              uses: esp-rs/xtensa-toolchain@v1.6
+              with:
+                  version: 1.89.0.0
+
+            - name: Check if baseline generation is needed
+              id: check-generation
+              shell: bash
+              run: |
+                  # Always generate for manual dispatch
+                  if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+                    if [ "${{ github.event.inputs.force_regeneration }}" = "true" ]; then
+                      echo "Manual baseline regeneration requested (force_regeneration=true)"
+                      echo "should_generate=true" >> $GITHUB_OUTPUT
+                      echo "trigger_reason=manual_force" >> $GITHUB_OUTPUT
+                    else
+                      echo "Manual baseline generation requested"
+                      echo "should_generate=true" >> $GITHUB_OUTPUT
+                      echo "trigger_reason=manual" >> $GITHUB_OUTPUT
+                    fi
+                    exit 0
+                  fi
+
+                  # For push events, check for breaking changes
+                  echo "Checking for breaking change in merged PR..."
+
+                  # Get the commit message of the last commit
+                  COMMIT_MSG=$(git log -1 --pretty=%B)
+                  echo "Last commit message: $COMMIT_MSG"
+
+                  # Extract PR number from commit message if it follows conventional format
+                  PR_NUMBER=""
+                  if echo "$COMMIT_MSG" | grep -q "#"; then
+                    PR_NUMBER=$(echo "$COMMIT_MSG" | grep -o "#[0-9]*" | grep -o "[0-9]*")
+                  fi
+
+                  if [ -n "$PR_NUMBER" ]; then
+                    echo "Found PR number: $PR_NUMBER"
+
+                    # Check if the PR had the breaking-change label
+                    LABELS=$(gh pr view $PR_NUMBER --json labels --jq '.labels[].name' 2>/dev/null || echo "")
+                    echo "PR labels: $LABELS"
+
+                    if echo "$LABELS" | grep -q "breaking-change"; then
+                      echo "Breaking change detected in PR #$PR_NUMBER"
+                      echo "should_generate=true" >> $GITHUB_OUTPUT
+                      echo "trigger_reason=breaking_change" >> $GITHUB_OUTPUT
+                    else
+                      echo "No breaking change label found in PR #$PR_NUMBER"
+                      echo "should_generate=false" >> $GITHUB_OUTPUT
+                      echo "trigger_reason=none" >> $GITHUB_OUTPUT
+                    fi
+                  else
+                    echo "No PR number found in commit message"
+                    echo "should_generate=false" >> $GITHUB_OUTPUT
+                    echo "trigger_reason=none" >> $GITHUB_OUTPUT
+                  fi
+
+            - name: Generate API baselines
+              if: steps.check-generation.outputs.should_generate == 'true'
+              shell: bash
+              run: |
+                  echo "Starting API baseline generation..."
+                  echo "Trigger reason: ${{ steps.check-generation.outputs.trigger_reason }}"
+                  cargo xcheck semver-check generate-baseline
+                  echo "API baseline generation completed"
+
+            - name: Upload API baselines as artifact
+              if: steps.check-generation.outputs.should_generate == 'true'
+              uses: actions/upload-artifact@v4
+              with:
+                  name: api-baselines
+                  path: esp-hal/api-baseline/
+                  retention-days: 90 # Maximum for public repos
+
+            - name: Create baseline summary
+              if: steps.check-generation.outputs.should_generate == 'true'
+              shell: bash
+              run: |
+                  echo "Successfully generated and uploaded API baselines"
+                  echo "Artifact name: api-baselines"
+                  echo "Retention: 90 days (expires on $(date -d '+90 days' '+%Y-%m-%d'))"
+                  echo "Source branch: ${{ github.event.inputs.source_branch || 'main' }}"
+                  echo "Commit: ${{ github.sha }}"
+                  echo "Target repository: $GITHUB_REPOSITORY"
+
+                  # Create appropriate summary based on trigger reason
+                  if [ "${{ steps.check-generation.outputs.trigger_reason }}" = "breaking_change" ]; then
+                    echo "## Breaking Change Baseline Regeneration" >> $GITHUB_STEP_SUMMARY
+                    echo "" >> $GITHUB_STEP_SUMMARY
+                    echo "This API baseline regeneration was automatically triggered due to a breaking change in the merged PR." >> $GITHUB_STEP_SUMMARY
+                    echo "" >> $GITHUB_STEP_SUMMARY
+                  elif [ "${{ steps.check-generation.outputs.trigger_reason }}" = "manual_force" ]; then
+                    echo "## Manual Baseline Regeneration (Forced)" >> $GITHUB_STEP_SUMMARY
+                    echo "" >> $GITHUB_STEP_SUMMARY
+                    echo "This API baseline regeneration was manually triggered with force regeneration enabled." >> $GITHUB_STEP_SUMMARY
+                    echo "" >> $GITHUB_STEP_SUMMARY
+                  elif [ "${{ steps.check-generation.outputs.trigger_reason }}" = "manual" ]; then
+                    echo "## Manual Baseline Generation" >> $GITHUB_STEP_SUMMARY
+                    echo "" >> $GITHUB_STEP_SUMMARY
+                    echo "This API baseline generation was manually triggered." >> $GITHUB_STEP_SUMMARY
+                    echo "" >> $GITHUB_STEP_SUMMARY
+                  else
+                    echo "## Baseline Generation Summary" >> $GITHUB_STEP_SUMMARY
+                    echo "" >> $GITHUB_STEP_SUMMARY
+                  fi
+
+                  echo "- **Target Repository**: \`$GITHUB_REPOSITORY\`" >> $GITHUB_STEP_SUMMARY
+                  echo "- **Source Branch**: \`${{ github.event.inputs.source_branch || 'main' }}\`" >> $GITHUB_STEP_SUMMARY
+                  echo "- **Artifact Name**: \`api-baselines\`" >> $GITHUB_STEP_SUMMARY
+                  echo "- **Retention**: 90 days (expires $(date -d '+90 days' '+%Y-%m-%d'))" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "### Baseline Files Generated" >> $GITHUB_STEP_SUMMARY
+                  echo "| Chip | File Size |" >> $GITHUB_STEP_SUMMARY
+                  echo "|------|-----------|" >> $GITHUB_STEP_SUMMARY
+
+                  cd esp-hal/api-baseline
+                  for file in *.json.gz; do
+                      if [ -f "$file" ]; then
+                          chip=$(basename "$file" .json.gz)
+                          size=$(du -h "$file" | cut -f1)
+                          echo "| $chip | $size |" >> $GITHUB_STEP_SUMMARY
+                      fi
+                  done
+
+            - name: Create no-action summary
+              if: steps.check-generation.outputs.should_generate == 'false'
+              shell: bash
+              run: |
+                  echo "## No Baseline Generation Needed" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "No breaking change detected in the merged PR. API baselines will not be regenerated." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@
 # updates which must be made to the CI workflow in order to reflect this; the
 # changes are:
 #
-# 1.) In the 'esp-hal' job, add the appropriate build and semver-check command.
+# 1.) In the 'esp-hal' job, add the appropriate build command.
 # 1a.) If the device has a low-power core (which is supported in
 #      `esp-lp-hal`), then update the `if` condition to build prerequisites.
 # 2.) In the 'msrv' job, add checks as needed for the new chip.
@@ -82,18 +82,6 @@ jobs:
           cargo xcheck ci esp32c3 --toolchain stable --no-lint --no-docs
           cargo xcheck ci esp32c6 --toolchain stable --no-lint --no-docs
           cargo xcheck ci esp32h2 --toolchain stable --no-lint --no-docs
-
-      - name: Semver-Check
-        shell: bash
-        # always invokes +esp internally
-        run: |
-          cargo xcheck semver-check --chips esp32 check
-          cargo xcheck semver-check --chips esp32s2 check
-          cargo xcheck semver-check --chips esp32s3 check
-          cargo xcheck semver-check --chips esp32c2 check
-          cargo xcheck semver-check --chips esp32c3 check
-          cargo xcheck semver-check --chips esp32c6 check
-          cargo xcheck semver-check --chips esp32h2 check
 
   detect-extras-runner:
     uses: ./.github/workflows/check_runner.yml

--- a/xtask/src/commands/release/semver_check.rs
+++ b/xtask/src/commands/release/semver_check.rs
@@ -11,6 +11,7 @@ use crate::Package;
 pub enum SemverCheckCmd {
     GenerateBaseline,
     Check,
+    DownloadBaselines,
 }
 
 /// Arguments for performing semver checks on the public API of packages.
@@ -36,9 +37,9 @@ pub fn semver_checks(workspace: &Path, args: SemverCheckArgs) -> anyhow::Result<
         let _ = workspace;
         let _ = args;
 
-        return Err(anyhow::anyhow!(
+        Err(anyhow::anyhow!(
             "Feature `semver-checks` is not enabled. Use the `xcheck` alias",
-        ));
+        ))
     }
 
     #[cfg(feature = "semver-checks")]
@@ -49,6 +50,7 @@ pub fn semver_checks(workspace: &Path, args: SemverCheckArgs) -> anyhow::Result<
         SemverCheckCmd::Check => {
             checker::check_for_breaking_changes(&workspace, args.packages, args.chips)
         }
+        SemverCheckCmd::DownloadBaselines => checker::download_baselines(&workspace, args.packages),
     }
 }
 
@@ -174,5 +176,247 @@ pub mod checker {
         } else {
             Ok(())
         }
+    }
+
+    #[derive(Debug)]
+    enum BaselineSource {
+        Artifact(String), // GitHub Actions artifact name
+    }
+
+    /// Download API baselines from GitHub Actions artifacts for the specified packages.
+    /// Fails with helpful error message if baselines are not available.
+    pub fn download_baselines(workspace: &Path, packages: Vec<Package>) -> anyhow::Result<()> {
+        for package in packages {
+            log::info!("Downloading API baselines for {package}");
+
+            let package_name = package.to_string();
+            let package_path = crate::windows_safe_path(&workspace.join(&package_name));
+            let baseline_dir = package_path.join("api-baseline");
+
+            // Remove existing baselines
+            if baseline_dir.exists() {
+                std::fs::remove_dir_all(&baseline_dir)?;
+            }
+
+            // Try to download from GitHub Actions artifacts
+            // Note: Artifacts have a 90-day retention limit for public repositories
+            let baseline_sources = vec![BaselineSource::Artifact("api-baselines".to_string())];
+
+            let mut downloaded = false;
+            for baseline_source in baseline_sources {
+                match &baseline_source {
+                    BaselineSource::Artifact(artifact_name) => {
+                        log::info!(
+                            "Attempting to download from GitHub Actions artifact: {artifact_name}"
+                        );
+                        let repo = std::env::var("GITHUB_REPOSITORY")
+                            .unwrap_or_else(|_| "esp-rs/esp-hal".to_string());
+                        if try_download_from_artifact(&package_path, artifact_name, &repo)? {
+                            log::info!(
+                                "Successfully downloaded baselines from artifact {artifact_name}"
+                            );
+                            downloaded = true;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if !downloaded {
+                return Err(anyhow::anyhow!("No API baselines found for {package}!"));
+            }
+
+            // Verify that baselines were extracted correctly
+            if !baseline_dir.exists() {
+                return Err(anyhow::anyhow!(
+                    "Baseline directory not found after extraction: {}",
+                    baseline_dir.display()
+                ));
+            }
+
+            let baseline_files: Vec<_> = std::fs::read_dir(&baseline_dir)?
+                .filter_map(|entry| entry.ok())
+                .filter(|entry| {
+                    entry
+                        .path()
+                        .extension()
+                        .and_then(|ext| ext.to_str())
+                        .map(|ext| ext == "gz")
+                        .unwrap_or(false)
+                })
+                .collect();
+
+            if baseline_files.is_empty() {
+                return Err(anyhow::anyhow!(
+                    "No baseline files found in extracted directory: {}",
+                    baseline_dir.display()
+                ));
+            }
+
+            log::info!(
+                "Found {} baseline files for {package}",
+                baseline_files.len()
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Try to download baselines from a GitHub Actions artifact
+    fn try_download_from_artifact(
+        package_path: &PathBuf,
+        artifact_name: &str,
+        repo: &str,
+    ) -> anyhow::Result<bool> {
+        use std::process::Command;
+
+        // Check if GitHub CLI is available
+        let gh_check = Command::new("gh").arg("--version").output();
+        if gh_check.is_err() {
+            log::debug!("GitHub CLI (gh) not available, skipping artifact download");
+            return Ok(false);
+        }
+
+        // Check if we're in a GitHub Actions environment (or allow override for testing)
+        if std::env::var("GITHUB_ACTIONS").is_err() && std::env::var("GITHUB_REPOSITORY").is_err() {
+            log::debug!(
+                "Not in GitHub Actions environment and no GITHUB_REPOSITORY set, skipping artifact download"
+            );
+            return Ok(false);
+        }
+
+        // GitHub CLI can download artifacts from recent workflow runs
+        log::debug!("Attempting to download artifact: {artifact_name} from {repo}");
+
+        // Get list of recent successful workflow runs
+        let list_output = Command::new("gh")
+            .args([
+                "run",
+                "list",
+                "--repo",
+                repo,
+                "--status",
+                "success",
+                "--limit",
+                "20", // Increased limit to check more runs
+                "--json",
+                "databaseId,workflowName,conclusion",
+            ])
+            .output();
+
+        let runs = match list_output {
+            Ok(result) if result.status.success() => {
+                let runs_json = String::from_utf8_lossy(&result.stdout);
+                log::debug!("Available runs: {}", runs_json);
+
+                if let Ok(runs) = serde_json::from_str::<serde_json::Value>(&runs_json) {
+                    if let Some(runs_array) = runs.as_array() {
+                        runs_array.clone()
+                    } else {
+                        vec![]
+                    }
+                } else {
+                    vec![]
+                }
+            }
+            _ => vec![],
+        };
+
+        if runs.is_empty() {
+            log::debug!("No successful workflow runs found");
+            return Ok(false);
+        }
+
+        // Try each run until we find one with the artifact
+        for run in runs {
+            let run_id = match run.get("databaseId").and_then(|v| v.as_u64()) {
+                Some(id) => id.to_string(),
+                None => continue,
+            };
+
+            let workflow_name = run
+                .get("workflowName")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown");
+
+            log::debug!(
+                "Trying to download artifact from run ID: {} (workflow: {})",
+                run_id,
+                workflow_name
+            );
+
+            let output = Command::new("gh")
+                .args([
+                    "run",
+                    "download",
+                    &run_id,
+                    "--repo",
+                    repo,
+                    "--name",
+                    artifact_name,
+                    "--dir",
+                    package_path.to_str().unwrap(),
+                ])
+                .output();
+
+            match output {
+                Ok(result) if result.status.success() => {
+                    log::debug!(
+                        "Successfully downloaded artifact {artifact_name} from run {}",
+                        run_id
+                    );
+
+                    // The artifact files are downloaded directly to the package directory
+                    // We need to move them to the api-baseline subdirectory
+                    let baseline_dir = package_path.join("api-baseline");
+                    std::fs::create_dir_all(&baseline_dir)?;
+
+                    // Move any .json.gz files from package_path to baseline_dir
+                    if let Ok(entries) = std::fs::read_dir(package_path) {
+                        for entry in entries.flatten() {
+                            let path = entry.path();
+                            if path.extension().and_then(|s| s.to_str()) == Some("gz")
+                                && path
+                                    .file_stem()
+                                    .and_then(|s| s.to_str())
+                                    .map(|s| s.ends_with(".json"))
+                                    .unwrap_or(false)
+                            {
+                                let filename = path.file_name().unwrap();
+                                let dest = baseline_dir.join(filename);
+                                if let Err(e) = std::fs::rename(&path, &dest) {
+                                    log::warn!(
+                                        "Failed to move {} to baseline directory: {}",
+                                        path.display(),
+                                        e
+                                    );
+                                } else {
+                                    log::debug!("Moved {} to {}", path.display(), dest.display());
+                                }
+                            }
+                        }
+                    }
+
+                    return Ok(true);
+                }
+                Ok(result) => {
+                    let stderr = String::from_utf8_lossy(&result.stderr);
+                    let stdout = String::from_utf8_lossy(&result.stdout);
+                    log::debug!(
+                        "Artifact {artifact_name} not available in run {} (workflow: {}). stdout: {stdout}, stderr: {stderr}",
+                        run_id,
+                        workflow_name
+                    );
+                    // Continue to next run
+                }
+                Err(e) => {
+                    log::debug!("Error running gh command for run {}: {}", run_id, e);
+                    // Continue to next run
+                }
+            }
+        }
+
+        log::debug!("No runs found with artifact {}", artifact_name);
+        Ok(false)
     }
 }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
- [ ] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
This PR uses GHA artifacts to store the API baseline. The workflow would be the following: 
When a PR includes semver breaking changes, we add a label to it (atm its `breaking-changes` but `semver-breaking-changes` or something similar migth be better (?)). This would skip the semver checks, and when the PR is merged it will trigger regenerating the semver baseline and uploading the artifacts to the GHA.

#### Testing
Tested in my fork: 
- Created a PR without the `breaking-change` label, check that the semver checks are executed.
- Add the `breaking-change` label to the PR, verify that the [semver checks are not executed](https://github.com/SergioGasquez/esp-hal/actions/runs/18189910021).
- Verify that merging the PR with the label, triggers the [baseline generation workflow](https://github.com/SergioGasquez/esp-hal/actions/runs/18189932989).