### PR TITLE
fixed 1/2

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -84,6 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - I2S: Fixed RX half-sample bits configuration bug causing microphone noise (#4109)
 - RISC-V: Direct interrupt vectoring (#4171)
 - TWAI: Fixed unnecessary transmission abortions (#4227)
+- ADC: Fixed integer overflow in curve calibration polynomial evaluation (#0000)
 
 ### Removed
 


### PR DESCRIPTION
### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

Fixes integer overflow in ADC curve calibration polynomial evaluation that occurs with certain chip/attenuation
combinations.

**Problem:**
The original implementation evaluated the error polynomial using the direct method:

```
err = coeff[0] + coeff[1]*val + coeff[2]*val^2 + ... + coeff[n]*val^n
```

This caused integer overflow on i64 intermediates when evaluating higher-degree polynomials (degree 4 for 11dB
attenuation) with maximum ADC values. For example, with ESP32-S3 at 11dB attenuation and val=4095, the
intermediate value val^4 * coeff[4] reached 21,886,129,118,095,003,125, exceeding i64::MAX.

Solution:
Implemented Horner's method for polynomial evaluation:
```err = coeff[0] + val*(coeff[1] + val*(coeff[2] + ...))```

This restructures the calculation to avoid computing large powers of val, keeping all intermediate values within
i64 bounds. The same calculation now peaks at 3,840,004,913,637,219,905 (41.6% of i64::MAX).

Related:
- Closes #3061
- Similar to closed PR #3090

Testing

- Verified mathematically that Horner's method is equivalent to direct evaluation
- Tested all coefficient sets (ESP32-C3/C6/H2/S3, all attenuations) with full 12-bit ADC range (0-4095)
- In my personal ADC project, I've curve-calibrated a B10K pot on an ESP32-S3, getting ~0V-3.16V range with no overflow.
