### PR TITLE
default ble_ll_sync_cnt to 0 as in esp-idf Kconfig

### DIFF
--- a/esp-radio/CHANGELOG.md
+++ b/esp-radio/CHANGELOG.md
@@ -6,7 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Set `ble_ll_sync_cnt` to 0 on C6, C2 and H2 as in esp-idf Kconfig default (#4241)
 
 ### Added
 
@@ -52,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `scan_mode`, `(ap_)beacon_timeout`, `listen_interval` and `failure_retry_cnt` config options have been replaced by runtime options in `AccessPointConfig`, `ClientConfig` and `EapClientConfig` (#4224)
 - The `ieee802154_rx_queue_size` config option has been replaced by a runtime option in `esp_radio::ieee802154::Config` (#4224)
 - The default value of `wifi_max_burst_size` has been changed to 3 (#4231)
+- Set `ble_ll_sync_cnt` to 0 on C6, C2 and H2 as in esp-idf Kconfig default (#4241)
 
 ### Fixed
 

--- a/esp-radio/CHANGELOG.md
+++ b/esp-radio/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Set `ble_ll_sync_cnt` to 0 on C6, C2 and H2 as in esp-idf Kconfig default (#4241)
 
 ### Added
 

--- a/esp-radio/src/ble/os_adapter_esp32c2.rs
+++ b/esp-radio/src/ble/os_adapter_esp32c2.rs
@@ -46,7 +46,7 @@ pub(crate) fn create_ble_config(config: &Config) -> esp_bt_controller_config_t {
         ble_hci_evt_hi_buf_count: 30,
         ble_hci_evt_lo_buf_count: 8,
         ble_ll_sync_list_cnt: 5,
-        ble_ll_sync_cnt: 20,
+        ble_ll_sync_cnt: 0,
         ble_ll_rsp_dup_list_count: 20,
         ble_ll_adv_dup_list_count: 20,
         ble_ll_tx_pwr_dbm: 9,

--- a/esp-radio/src/ble/os_adapter_esp32c6.rs
+++ b/esp-radio/src/ble/os_adapter_esp32c6.rs
@@ -42,7 +42,7 @@ pub(crate) fn create_ble_config(config: &Config) -> esp_bt_controller_config_t {
         ble_hci_evt_hi_buf_count: 30,
         ble_hci_evt_lo_buf_count: 8,
         ble_ll_sync_list_cnt: 5,
-        ble_ll_sync_cnt: 20,
+        ble_ll_sync_cnt: 0,
         ble_ll_rsp_dup_list_count: 20,
         ble_ll_adv_dup_list_count: 20,
         ble_ll_tx_pwr_dbm: 9,

--- a/esp-radio/src/ble/os_adapter_esp32h2.rs
+++ b/esp-radio/src/ble/os_adapter_esp32h2.rs
@@ -42,7 +42,7 @@ pub(crate) fn create_ble_config(config: &Config) -> esp_bt_controller_config_t {
         ble_hci_evt_hi_buf_count: 30,
         ble_hci_evt_lo_buf_count: 8,
         ble_ll_sync_list_cnt: 5,
-        ble_ll_sync_cnt: 20,
+        ble_ll_sync_cnt: 0,
         ble_ll_rsp_dup_list_count: 20,
         ble_ll_adv_dup_list_count: 20,
         ble_ll_tx_pwr_dbm: 9,


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖
Pulled from those Kconfigs
https://github.com/espressif/esp-idf/blob/master/components/bt/controller/esp32c6/Kconfig.in#L203
https://github.com/espressif/esp-idf/blob/master/components/bt/controller/esp32c2/Kconfig.in#L186
https://github.com/espressif/esp-idf/blob/master/components/bt/controller/esp32h2/Kconfig.in#L203

All of those chips default to 0 on `ble_ll_sync_cnt`, and 20 is outside the ranges defined in Kconfig too, probaly a copy and paste mistake from ble_ll_rsp_dup_list_count

#### Description
Changing that saves almost 20kB of HEAP when having BLE active.

#### Testing
Tested on C6 with a flutter testing app, didn't notice anything breaking with a basic gatt app.
