### PR TITLE
Fix some timer queue related issues

### DIFF
--- a/esp-rtos/Cargo.toml
+++ b/esp-rtos/Cargo.toml
@@ -40,6 +40,7 @@ cfg-if = "1"
 # Unstable dependencies that are not (strictly) part of the public API
 allocator-api2 = { version = "0.3.0", default-features = false, features = ["alloc"], optional = true }
 document-features  = "0.2.11"
+embassy-sync = "0.7"
 esp-alloc = { version = "0.8.0", path = "../esp-alloc", optional = true }
 esp-config = { version = "0.5.0", path = "../esp-config" }
 esp-sync = { version = "0.0.0", path = "../esp-sync" }

--- a/esp-rtos/src/timer/mod.rs
+++ b/esp-rtos/src/timer/mod.rs
@@ -183,8 +183,13 @@ impl TimeDriver {
 
 #[esp_hal::ram]
 extern "C" fn timer_tick_handler() {
+    // Must not be inside a scheduler lock, because waking a thread-mode executor requires locking
+    // the scheduler, which is non-reentrant.
     #[cfg(feature = "embassy")]
     TIMER_QUEUE.handle_alarm(crate::now());
+
+    // Race condition? Other core can delay an async task here. It will re-arm the timer, but will
+    // that alarm not be processed in this round of the interrupt handler.
 
     SCHEDULER.with(|scheduler| {
         let time_driver = unwrap!(scheduler.time_driver.as_mut());
@@ -202,12 +207,16 @@ extern "C" fn timer_tick_handler() {
 
             debug!("Task {:?} is ready", ready_task);
 
+            // TODO: we can yield here for each task. That will ensure a task switch is scheduled
+            // only the relevant core(s).
             scheduler.run_queue.mark_task_ready(ready_task);
         });
 
         // The timer interrupt fires when a task is ready to run, an embassy timer expires or when a
         // time slice tick expires. Trigger a context switch in all cases, which context switch will
         // re-arm the timer.
+        // TODO: if we track which core needs time slicing, we won't need to unconditionally yield
+        // on both cores.
 
         // `Scheduler::switch_task` must be called on a single interrupt priority level only.
         // To ensure this, we call yield_task to pend the software interrupt.
@@ -223,5 +232,7 @@ extern "C" fn timer_tick_handler() {
         //
         // The rest of the lineup could switch tasks here, but it's not done to save some IRAM.
         crate::task::yield_task();
+        #[cfg(multi_core)]
+        crate::task::schedule_other_core();
     });
 }

--- a/hil-test/.cargo/config.toml
+++ b/hil-test/.cargo/config.toml
@@ -21,7 +21,7 @@ rustflags = [
 ]
 
 [env]
-DEFMT_LOG = "info,embedded_test=warn"
+DEFMT_LOG = "info,embedded_test=warn,esp_rtos=trace"
 
 [unstable]
 build-std = ["core", "alloc"]

--- a/hil-test/src/bin/esp_radio_init.rs
+++ b/hil-test/src/bin/esp_radio_init.rs
@@ -2,7 +2,7 @@
 //! disabled in common ways
 
 //% CHIPS: esp32 esp32s2 esp32c2 esp32c3 esp32c6 esp32s3
-//% FEATURES: unstable esp-radio esp-alloc esp-radio/wifi esp-radio/unstable embassy defmt
+//% FEATURES: unstable esp-radio esp-alloc esp-radio/wifi esp-radio/unstable embassy
 
 #![no_std]
 #![no_main]

--- a/hil-test/src/bin/esp_radio_init.rs
+++ b/hil-test/src/bin/esp_radio_init.rs
@@ -2,7 +2,7 @@
 //! disabled in common ways
 
 //% CHIPS: esp32 esp32s2 esp32c2 esp32c3 esp32c6 esp32s3
-//% FEATURES: unstable esp-radio esp-alloc esp-radio/wifi esp-radio/unstable embassy
+//% FEATURES: unstable esp-radio esp-alloc esp-radio/wifi esp-radio/unstable embassy defmt
 
 #![no_std]
 #![no_main]

--- a/hil-test/src/bin/esp_radio_init.rs
+++ b/hil-test/src/bin/esp_radio_init.rs
@@ -396,10 +396,12 @@ mod tests {
             loop {
                 if Cpu::current() == core {
                     counter += 1;
+                    // Let's also test that the delay works on both cores.
+                    CurrentThreadHandle::get().delay(Duration::from_micros(100));
                 } else {
                     preempt::yield_task();
                 }
-                if counter == 1000 {
+                if counter == 10 {
                     context.ready_semaphore.give();
                     break;
                 }


### PR DESCRIPTION
This PR fixes two separate issues:

- timer queue failed to wake tasks on the second core
- embassy timers previously could miss their ticks if events happened in a particular sequence