### PR TITLE
Fix clock calculation in I2S

### DIFF
--- a/esp-hal/src/i2s/master.rs
+++ b/esp-hal/src/i2s/master.rs
@@ -2456,7 +2456,7 @@ mod private {
 
                         if mb.abs_diff(ma) < min {
                             denominator = a as u32;
-                            numerator = b as u32;
+                            numerator = (b / 10000) as u32;
                             min = mb.abs_diff(ma);
                         }
                     }


### PR DESCRIPTION
I can't really say that I understand this fixed point calculation, however the fact that b is only divided by 10000 in one case seems obviously wrong to me.

For instance if you call `I2sClockDividers::new(Rate::from_hz(1000000), 2, 8)` you will get:

```
I2sClockDividers {
    mclk_divider: 0,
    bclk_divider: 16,
    denominator: 8,
    numerator: 5,
}
```

This happens because the branch with the exact match is hit. On the other hand if you call `I2sClockDividers::new(Rate::from_hz(1000001), 2, 8)`, then you currently get:

```
I2sClockDividers {
    mclk_divider: 0,
    bclk_divider: 16,
    denominator: 8,
    numerator: 54992,
}
```