### PR TITLE
RMT: clarify continuous tx API and add HIL tests

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -76,8 +76,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `rmt::Channel` and `rmt::ChannelCreator` now carry a lifetime and can be reborrowed. (#4174)
 - RMT transactions and futures are marked as `#[must_use]` and implement `Drop`. (#4174)
 - The behavior of `rmt::PulseCode` constructors (`new`, `new_clamped`, `try_new`) has been reworked to be more convenient and clear. (#4246)
-- RMT: `Channel::transmit_continuously` now takes an additional `LoopStop` argument. (#4174)
-- RMT: `LoopCount::Finite` and `ContinuousTxTransaction::is_tx_loopcount_interrupt_set` are only defined when the hardware supports it (all except ESP32). (#4174)
+- RMT: `Channel::transmit_continuously` now takes an additional `LoopStop` argument. (#4260)
+- RMT: `LoopCount::Finite` and `ContinuousTxTransaction::is_tx_loopcount_interrupt_set` are only defined when the hardware supports it (all except ESP32). (#4260)
 
 ### Fixed
 
@@ -97,7 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TWAI: Fixed receive_async erroneously returning RX FIFO overrun errors (#4244)
 - Subtracting Instant values with large difference no longer panics (#4249)
 - ADC: Fixed integer overflow in curve calibration polynomial evaluation (#4240)
-- RMT: `Channel::transmit_continuously` also triggers the loopcount interrupt when only using a single repetition. (#4174)
+- RMT: `Channel::transmit_continuously` also triggers the loopcount interrupt when only using a single repetition. (#4260)
 
 ### Removed
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -76,6 +76,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `rmt::Channel` and `rmt::ChannelCreator` now carry a lifetime and can be reborrowed. (#4174)
 - RMT transactions and futures are marked as `#[must_use]` and implement `Drop`. (#4174)
 - The behavior of `rmt::PulseCode` constructors (`new`, `new_clamped`, `try_new`) has been reworked to be more convenient and clear. (#4246)
+- RMT: `Channel::transmit_continuously` now takes an additional `LoopStop` argument. (#4174)
+- RMT: `LoopCount::Finite` and `ContinuousTxTransaction::is_tx_loopcount_interrupt_set` are only defined when the hardware supports it (all except ESP32). (#4174)
 
 ### Fixed
 
@@ -95,6 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TWAI: Fixed receive_async erroneously returning RX FIFO overrun errors (#4244)
 - Subtracting Instant values with large difference no longer panics (#4249)
 - ADC: Fixed integer overflow in curve calibration polynomial evaluation (#4240)
+- RMT: `Channel::transmit_continuously` also triggers the loopcount interrupt when only using a single repetition. (#4174)
 
 ### Removed
 

--- a/esp-hal/MIGRATING-1.0.0-rc.0.md
+++ b/esp-hal/MIGRATING-1.0.0-rc.0.md
@@ -175,7 +175,7 @@ The `rmt::Channel::transmit_continuously` and
 +let tx_trans1 = tx_channel1.transmit_continuously(&data, LoopCount::Finite(count));
 ```
 
-## RMT lifetime changes
+### RMT lifetime changes
 
 The RMT driver didn't use to properly tie together lifetimes of its types and
 therefore didn't statically prevent all kinds of concurrent and conflicting
@@ -198,6 +198,22 @@ Additionally, RMT transaction types
 are marked as `#[must_use]` to account for the fact that it is in general required to poll them to ensure progress.
 Additionally, they now implement `Drop` and stop the ongoing transfer as quickly as possible when dropped,
 ensuring that subsequent transactions start from a well-defined state.
+
+### RMT continuous transmit changes
+
+The behavior of `Channel::transmit_continuously` has been clarified to account
+for the varying hardware support between devices: It now takes an additional
+`LoopStop` argument.
+
+```diff
+- let transaction = channel.transmit_continuously(&data, LoopCount::Finite(count))?;
++ let transaction = channel.transmit_continuously(&data, LoopCount::Finite(count), LoopStop::Manual)?;
+```
+
+Additionally, some enum variants and methods are only defined when the hardware supports them:
+
+- `LoopCount::Finite` and `ContinuousTxTransaction::is_tx_loopcount_interrupt_set` (all except ESP32),
+- `LoopStop::Auto` (ESP32-C6, ESP32-H2, ESP32-S3).
 
 ## DMA changes
 

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -1495,8 +1495,8 @@ where
 
 /// Loop mode for continuous transmission
 ///
-/// Depending on hardware support, automatic stopping of the transmission upon reaching a
-/// specified loop count may not be available.
+/// Depending on hardware support, the `loopcount` interrupt and automatic stopping of the
+/// transmission upon reaching a specified loop count may not be available.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum LoopMode {
@@ -1569,11 +1569,14 @@ impl<'ch> Channel<'ch, Blocking, Tx> {
     ///
     /// This returns a [`ContinuousTxTransaction`] which can be used to stop the
     /// ongoing transmission and get back the channel for further use.
+    ///
+    /// The `mode` argument determines whether transmission will continue until explicitly stopped
+    /// or for a fixed number of iterations; see [`LoopMode`] for more details.
     #[cfg_attr(
         rmt_has_tx_loop_count,
-        doc = "When setting a finite `loopcount`, [`ContinuousTxTransaction::is_loopcount_interrupt_set`] can be used to check if the loop count is reached. The `loopstop` argument determines whether transmission will automatically stop upon reaching the finite `loopcount`."
+        doc = "When using a loop `mode` other than [`LoopMode::Infinite`], [`ContinuousTxTransaction::is_loopcount_interrupt_set`] can be used to check if the loop count is reached."
     )]
-    /// The length of sequence cannot exceed the size of the allocated RMT RAM.
+    /// The length of `data` cannot exceed the size of the allocated RMT RAM.
     #[cfg_attr(place_rmt_driver_in_ram, ram)]
     pub fn transmit_continuously<T>(
         self,


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖
This clarifies what the `Channel::submit_continuously` does, fixes some issues with it, and adds an HIL test (this was entirely untested before). See the commit message:

> It wasn't really well-specified what this method does and hardware support varies wildly.
> The most obvious interpretation to me is that `LoopCount::Finite(n)` should _stop_ tx after `n` repetitions of the data have been submitted. That was never the case, however: Not all devices have hardware support for auto stop, and even on those that have, it wasn't enabled.
> 
> User-facing changes:
> 
> - don't define user-facing API (is_loopcount_interrupt_set, LoopCount::Finite, LoopStop::Auto) when it is not supported such that trying to use unsupported features will fail at compile time
> - add support for finite loopcount for esp32s2 which was missing
> - add support for loop auto stop on supported devices
> - remove dubious special-casing of loopcount 1
> 
> Internal changes:
> - include the new Event::LoopCount in get_tx_status
> - add loopback tests with finite loopcount and manual or auto stop, run on supported devices


#### Testing
HIL tests.
