### PR TITLE
Derive defmt::Format for BleConnectorError

### DIFF
--- a/esp-radio/src/ble/controller/mod.rs
+++ b/esp-radio/src/ble/controller/mod.rs
@@ -37,6 +37,7 @@ impl<'d> BleConnector<'d> {
 }
 
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 /// Error type for the BLE connector.
 #[instability::unstable]
 pub enum BleConnectorError {


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Derive the missing `defmt::Format` for `BleConnectorError`. Otherwise, [examples/ble/bas_peripheral](https://github.com/esp-rs/esp-hal/blob/main/examples/ble/bas_peripheral) couldn't be compiled when ported to `defmt` (uses `defmt::panic` or `defmt::unwrap` on the results).

#### Testing
Manual test. Compiling local port to `defmt` of [examples/ble/bas_peripheral](https://github.com/esp-rs/esp-hal/blob/main/examples/ble/bas_peripheral) works.