### PR TITLE
Prevent the blobs from controlling the PHY clock

### DIFF
--- a/esp-hal/src/clock/mod.rs
+++ b/esp-hal/src/clock/mod.rs
@@ -1373,8 +1373,12 @@ fn increase_phy_clock_ref_count_internal() {
         if phy_clock_ref_count == 0 {
             clocks_ll::enable_phy(true);
         }
+        let new_phy_clock_ref_count = unwrap!(
+            phy_clock_ref_count.checked_add(1),
+            "PHY clock ref count overflowed."
+        );
 
-        phy_clock_ref_counter.set(phy_clock_ref_count + 1);
+        phy_clock_ref_counter.set(new_phy_clock_ref_count);
     })
 }
 
@@ -1389,6 +1393,7 @@ fn decrease_phy_clock_ref_count_internal() {
         if new_phy_clock_ref_count == 0 {
             clocks_ll::enable_phy(false);
         }
+
         phy_clock_ref_counter.set(new_phy_clock_ref_count);
     })
 }

--- a/esp-phy/src/lib.rs
+++ b/esp-phy/src/lib.rs
@@ -261,12 +261,12 @@ impl PhyState {
 /// Global PHY initialization state
 static PHY_STATE: NonReentrantMutex<PhyState> = NonReentrantMutex::new(PhyState::new());
 
-#[derive(Debug)]
 /// Prevents the PHY from being deinitialized.
 ///
 /// As long as at least one [PhyInitGuard] exists, the PHY will remain initialized. To release this
 /// guard, you can either let it go out of scope, or use [PhyInitGuard::release] to explicitly
 /// release it.
+#[derive(Debug)]
 pub struct PhyInitGuard<'d> {
     _phy_clock_guard: PhyClockGuard<'d>,
 }

--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -197,10 +197,10 @@ serde = ["dep:serde", "enumset?/serde"]
 
 #! ### Logging Feature Flags
 ## Enable logging output using version 0.4 of the `log` crate.
-log-04 = ["dep:log-04", "esp-hal/log-04", "esp-wifi-sys/log"]
+log-04 = ["dep:log-04", "esp-hal/log-04", "esp-wifi-sys/log", "esp-phy/log-04"]
 
 ## Enable logging output using `defmt` and implement `defmt::Format` on certain types.
-defmt = ["dep:defmt", "smoltcp?/defmt", "esp-hal/defmt", "bt-hci?/defmt", "esp-wifi-sys/defmt", "enumset/defmt", "heapless/defmt", "esp-sync/defmt"]
+defmt = ["dep:defmt", "smoltcp?/defmt", "esp-hal/defmt", "bt-hci?/defmt", "esp-wifi-sys/defmt", "enumset/defmt", "heapless/defmt", "esp-sync/defmt", "esp-phy/defmt"]
 
 #! ### Unstable APIs
 #! Unstable APIs are drivers and features that are not yet ready for general use.


### PR DESCRIPTION
Closes #4265

esp-idf would just silently overflow and randomly disable its own PHY clocks, we instead don't let the blobs touch them at all. This might have been introduced by the blob update, but I haven't checked.