### PR TITLE
I2C: sample SDA earlier

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -95,6 +95,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TWAI: Fixed receive_async erroneously returning RX FIFO overrun errors (#4244)
 - Subtracting Instant values with large difference no longer panics (#4249)
 - ADC: Fixed integer overflow in curve calibration polynomial evaluation (#4240)
+- I2C: Fix position of SDA sampling point (#4268)
 
 ### Removed
 

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -1902,7 +1902,7 @@ impl Driver<'_> {
         Ok(())
     }
 
-    #[cfg(any(esp32c2, esp32c3, esp32c6, esp32h2, esp32s3))]
+    #[cfg(not(any(esp32, esp32s2)))]
     /// Sets the frequency of the I2C interface by calculating and applying the
     /// associated timings - corresponds to i2c_ll_cal_bus_clk and
     /// i2c_ll_set_bus_timing in ESP-IDF
@@ -1929,7 +1929,7 @@ impl Driver<'_> {
         };
         let scl_high = half_cycle - scl_wait_high;
         let sda_hold = half_cycle / 4;
-        let sda_sample = half_cycle / 2 + scl_wait_high;
+        let sda_sample = half_cycle / 2;
         let setup = half_cycle;
         let hold = half_cycle;
 

--- a/qa-test/src/bin/i2c_bmp180_calibration_data.rs
+++ b/qa-test/src/bin/i2c_bmp180_calibration_data.rs
@@ -23,6 +23,7 @@ esp_bootloader_esp_idf::esp_app_desc!();
 
 #[main]
 fn main() -> ! {
+    esp_println::logger::init_logger_from_env();
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
     // Create a new peripheral object with the described wiring and standard


### PR DESCRIPTION
This change aligns the value of `sda_sample` with esp-idf code.

Revival of #3040