### PR TITLE
Avoid triggering a context switch just to arm embassy timers

### DIFF
--- a/esp-rtos/Cargo.toml
+++ b/esp-rtos/Cargo.toml
@@ -36,6 +36,8 @@ esp-hal = { version = "1.0.0-rc.0", path = "../esp-hal", features = [
 ] }
 
 cfg-if = "1"
+paste = { version = "1", optional = true }
+rtos-trace = { version = "0.2.0", optional = true }
 
 # Unstable dependencies that are not (strictly) part of the public API
 allocator-api2 = { version = "0.3.0", default-features = false, features = ["alloc"], optional = true }
@@ -80,8 +82,11 @@ esp-alloc = ["alloc", "dep:esp-alloc"]
 ## Enable embassy integration (time driver and executors).
 embassy = ["dep:embassy-time-driver", "dep:embassy-executor", "dep:embassy-time-queue-utils"]
 
-## Enables esp-radio support.
+## Enable esp-radio support.
 esp-radio = ["alloc", "dep:esp-radio-rtos-driver"]
+
+## Enable rtos-trace support.
+rtos-trace = ["dep:rtos-trace"]
 
 #! ### Chip selection
 #! One of the following features must be enabled to select the target chip:

--- a/esp-rtos/src/run_queue.rs
+++ b/esp-rtos/src/run_queue.rs
@@ -56,6 +56,9 @@ impl RunQueue {
         self.ready_tasks[priority].remove(ready_task);
         self.ready_tasks[priority].push(ready_task);
 
+        #[cfg(feature = "rtos-trace")]
+        rtos_trace::trace::task_ready_begin(ready_task.rtos_trace_id());
+
         self.ready_priority.mark_ready(priority);
         if priority > current_prio || current_prio == 0 {
             debug!(

--- a/esp-rtos/src/task/riscv.rs
+++ b/esp-rtos/src/task/riscv.rs
@@ -5,6 +5,8 @@ use esp_hal::{interrupt::software::SoftwareInterrupt, riscv::register, system::C
 use portable_atomic::Ordering;
 
 use crate::SCHEDULER;
+#[cfg(feature = "rtos-trace")]
+use crate::TraceEvents;
 
 unsafe extern "C" {
     fn sys_switch();
@@ -319,6 +321,12 @@ extern "C" fn swint_handler() {
 
 #[inline]
 pub(crate) fn yield_task() {
+    #[cfg(feature = "rtos-trace")]
+    {
+        rtos_trace::trace::marker_begin(TraceEvents::YieldTask as u32);
+        rtos_trace::trace::marker_end(TraceEvents::YieldTask as u32);
+    }
+
     match Cpu::current() {
         Cpu::ProCpu => unsafe { SoftwareInterrupt::<'static, 0>::steal() }.raise(),
         #[cfg(multi_core)]

--- a/qa-test/Cargo.toml
+++ b/qa-test/Cargo.toml
@@ -41,6 +41,7 @@ smoltcp = { version = "0.12.0", default-features = false, features = [
     "socket-raw",
 ], optional = true }
 static_cell = "2.1.1"
+rtos-trace = { version = "0.2.0", optional = true }
 
 [features]
 unstable = []
@@ -107,6 +108,8 @@ esp32s3 = [
     "esp-println/esp32s3",
     "esp-radio?/esp32s3",
 ]
+
+rtos-trace = ["esp-rtos/rtos-trace", "dep:rtos-trace"]
 
 [profile.release]
 debug            = 2

--- a/qa-test/src/bin/embassy_executor_benchmark.rs
+++ b/qa-test/src/bin/embassy_executor_benchmark.rs
@@ -1,6 +1,7 @@
 //! Embassy executor benchmark, used to try out optimization ideas.
 
 //% CHIPS: esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+//% FEATURES: rtos-trace
 
 #![no_std]
 #![no_main]
@@ -81,6 +82,9 @@ async fn task3() {
 async fn main(spawner: Spawner) {
     let config = esp_hal::Config::default().with_cpu_clock(CLOCK);
     let peripherals = esp_hal::init(config);
+
+    Hooks::init();
+
     #[cfg(target_arch = "riscv32")]
     let sw_int = SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
     let systimer = SystemTimer::new(peripherals.SYSTIMER);
@@ -102,3 +106,78 @@ async fn main(spawner: Spawner) {
     timer.listen();
     timer.schedule(Duration::from_millis(TEST_MILLIS)).unwrap();
 }
+
+struct Hooks {}
+
+impl Hooks {
+    fn init() {
+        use esp_hal::gpio::{AnyPin, Output};
+        let pin = unsafe { AnyPin::steal(2) };
+        let output_pin = Output::new(pin, esp_hal::gpio::Level::Low, Default::default());
+
+        core::mem::forget(output_pin);
+    }
+
+    #[inline]
+    fn pin_high() {
+        unsafe {
+            esp_hal::peripherals::GPIO::regs()
+                .out_w1ts()
+                .write(|w| w.bits(1 << 2));
+        }
+    }
+
+    #[inline]
+    fn pin_low() {
+        unsafe {
+            esp_hal::peripherals::GPIO::regs()
+                .out_w1tc()
+                .write(|w| w.bits(1 << 2));
+        }
+    }
+}
+
+impl rtos_trace::RtosTrace for Hooks {
+    fn start() {}
+    fn stop() {}
+
+    fn task_new(_id: u32) {}
+    fn task_send_info(_id: u32, _info: rtos_trace::TaskInfo) {}
+    fn task_new_stackless(_id: u32, _name: &'static str, _priority: u32) {}
+    fn task_terminate(_id: u32) {}
+    fn task_exec_begin(_id: u32) {}
+    fn task_exec_end() {}
+    fn task_ready_begin(_id: u32) {}
+    fn task_ready_end(_id: u32) {}
+
+    fn system_idle() {}
+
+    fn isr_enter() {}
+    fn isr_exit() {}
+    fn isr_exit_to_scheduler() {}
+
+    fn name_marker(_id: u32, _name: &'static str) {}
+    fn marker(_id: u32) {}
+    fn marker_begin(id: u32) {
+        match id {
+            v if v == esp_rtos::TraceEvents::RunSchedule as u32 => Self::pin_high(),
+            v if v == esp_rtos::TraceEvents::TimerTickHandler as u32 => Self::pin_high(),
+            // v if v == esp_rtos::TraceEvents::YieldTask as u32 => Self::pin_high(),
+            // v if v == esp_rtos::TraceEvents::ProcessTimerQueue as u32 => Self::pin_high(),
+            // v if v == esp_rtos::TraceEvents::ProcessEmbassyTimerQueue as u32 => Self::pin_high(),
+            _ => {}
+        }
+    }
+    fn marker_end(id: u32) {
+        match id {
+            v if v == esp_rtos::TraceEvents::RunSchedule as u32 => Self::pin_low(),
+            v if v == esp_rtos::TraceEvents::TimerTickHandler as u32 => Self::pin_low(),
+            // v if v == esp_rtos::TraceEvents::YieldTask as u32 => Self::pin_low(),
+            // v if v == esp_rtos::TraceEvents::ProcessTimerQueue as u32 => Self::pin_low(),
+            // v if v == esp_rtos::TraceEvents::ProcessEmbassyTimerQueue as u32 => Self::pin_low(),
+            _ => {}
+        }
+    }
+}
+
+rtos_trace::global_trace!(Hooks);


### PR DESCRIPTION
This PR introduces a trace framework and avoids yielding in order to arm embassy timers. The most visible effect of this PR is that the scheduler no longer runs multiple times in quick succession, but otherwise it should be a very mild perf positive change.