### PR TITLE
esp-radio: Rename `Config` to `WifiApStaConfig` and `WifiConfig` to `Config`

### DIFF
--- a/esp-radio/CHANGELOG.md
+++ b/esp-radio/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update bt-hci version to add additional HCI commands (#3920)
 - A number of enums/structs have been marked as `#[non_exhaustive]` (#3981, #4017)
   - `AuthMethod`, `Protocol`, `AccessPointInfo`, `AccessPointConfiguration`, `ClientConfiguration`, `Capability`, `Configuration`, `WifiEvent`, `InternalWifiError`, `ScanTypeConfig`, `WifiState`, and `WifiMode`
-- The `Configuration`, `WifiConfig`, `ClientConfiguration`, `AccessPointConfiguration`, and `EapClientConfiguration` enums have been renamed to `ModeConfig`, `Config`, `ClientConfig`, `AccessPointConfig`, and `EapClientConfig` (#3994, #4278)
+- The `Configuration`, `ClientConfiguration`, `AccessPointConfiguration`, and `EapClientConfiguration` enums have been renamed to `ModeConfig`, `ClientConfig`, `AccessPointConfig`, and `EapClientConfig` (#3994, #4278)
   - Error types implements `core::error:Error`
 - Use `esp-phy` internally for PHY initialization (#3892)
 - `ap_state()` and `sta_state()` marked as stable (#4017)

--- a/esp-radio/CHANGELOG.md
+++ b/esp-radio/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update bt-hci version to add additional HCI commands (#3920)
 - A number of enums/structs have been marked as `#[non_exhaustive]` (#3981, #4017)
   - `AuthMethod`, `Protocol`, `AccessPointInfo`, `AccessPointConfiguration`, `ClientConfiguration`, `Capability`, `Configuration`, `WifiEvent`, `InternalWifiError`, `ScanTypeConfig`, `WifiState`, and `WifiMode`
-- The `Configuration`, `ClientConfiguration`, `AccessPointConfiguration`, and `EapClientConfiguration` enums have been renamed to `Config`, `ClientConfig`, `AccessPointConfig`, and `EapClientConfig` (#3994)
+- The `Configuration`, `WifiConfig`, `ClientConfiguration`, `AccessPointConfiguration`, and `EapClientConfiguration` enums have been renamed to `ModeConfig`, `Config`, `ClientConfig`, `AccessPointConfig`, and `EapClientConfig` (#3994, #4278)
   - Error types implements `core::error:Error`
 - Use `esp-phy` internally for PHY initialization (#3892)
 - `ap_state()` and `sta_state()` marked as stable (#4017)

--- a/esp-radio/MIGRATING-0.15.0.md
+++ b/esp-radio/MIGRATING-0.15.0.md
@@ -83,17 +83,15 @@ The `scan_with_config_sync_max`, `scan_with_config_sync_max`, `scan_n`, and `sca
 +let (controller, ifaces) = esp_radio::wifi::new(&ctrl, p.WIFI, config).unwrap();
 ```
 
-The `Configuration`, `WifiConfig`,  `ClientConfiguration`, `AccessPointConfiguration`, and `EapClientConfiguration` enums have been renamed to `ModeConfig`, `Config`, `ClientConfig`, `AccessPointConfig`, and `EapClientConfig`:
+The `Configuration`, `ClientConfiguration`, `AccessPointConfiguration`, and `EapClientConfiguration` enums have been renamed to `ModeConfig`, `ClientConfig`, `AccessPointConfig`, and `EapClientConfig`:
 
 ```diff
 use esp_radio::wifi::{
 -    AccessPointConfiguration,
--    WifiConfig,
 -    ClientConfiguration,
 -    Configuration,
 -    EapClientConfiguration,
 +    AccessPointConfig,
-+    Config,
 +    ClientConfig,
 +    ModeConfig,
 +    EapClientConfig

--- a/esp-radio/MIGRATING-0.15.0.md
+++ b/esp-radio/MIGRATING-0.15.0.md
@@ -83,17 +83,19 @@ The `scan_with_config_sync_max`, `scan_with_config_sync_max`, `scan_n`, and `sca
 +let (controller, ifaces) = esp_radio::wifi::new(&ctrl, p.WIFI, config).unwrap();
 ```
 
-The `Configuration`, `ClientConfiguration`, `AccessPointConfiguration`, and `EapClientConfiguration` enums have been renamed to `Config`, `ClientConfig`, `AccessPointConfig`, and `EapClientConfig`:
+The `Configuration`, `WifiConfig`,  `ClientConfiguration`, `AccessPointConfiguration`, and `EapClientConfiguration` enums have been renamed to `ModeConfig`, `Config`, `ClientConfig`, `AccessPointConfig`, and `EapClientConfig`:
 
 ```diff
 use esp_radio::wifi::{
 -    AccessPointConfiguration,
+-    WifiConfig,
 -    ClientConfiguration,
 -    Configuration,
 -    EapClientConfiguration,
 +    AccessPointConfig,
-+    ClientConfig,
 +    Config,
++    ClientConfig,
++    ModeConfig,
 +    EapClientConfig
 }
 ```
@@ -113,7 +115,7 @@ Same for `set_configuration()` to `set_config()`:
 -         config.ssid = "esp-radio".into();
 -         config
 -     });
-+ let ap_config = Config::AccessPoint(AccessPointConfig::default().with_ssid("esp-radio".into()));
++ let ap_config = ModeConfig::AccessPoint(AccessPointConfig::default().with_ssid("esp-radio".into()));
 ```
 
 ### BLE
@@ -146,7 +148,7 @@ The `BleController` can now be configured using `esp_radio::ble::Config`:
 -            .with_password("password".into()),
 -        AccessPointConfig::default().with_ssid("esp-radio".into()),
 -    );
-+    let client_config = Config::ApSta(
++    let client_config = ModeConfig::ApSta(
 +        ClientConfig::default()
 +            .with_ssid("ssid".into())
 +            .with_password("password".into()),

--- a/examples/wifi/access_point/src/main.rs
+++ b/examples/wifi/access_point/src/main.rs
@@ -30,7 +30,7 @@ use esp_hal::{
 use esp_println::{print, println};
 use esp_radio::wifi::{
     AccessPointConfig,
-    Config,
+    ModeConfig,
     event::{self, EventExt},
 };
 use smoltcp::iface::{SocketSet, SocketStorage};
@@ -88,7 +88,8 @@ fn main() -> ! {
     let socket_set = SocketSet::new(&mut socket_set_entries[..]);
     let mut stack = Stack::new(iface, device, socket_set, now, rng.random());
 
-    let ap_config = Config::AccessPoint(AccessPointConfig::default().with_ssid("esp-radio".into()));
+    let ap_config =
+        ModeConfig::AccessPoint(AccessPointConfig::default().with_ssid("esp-radio".into()));
     let res = controller.set_config(&ap_config);
     println!("wifi_set_configuration returned {:?}", res);
 

--- a/examples/wifi/access_point_with_sta/src/main.rs
+++ b/examples/wifi/access_point_with_sta/src/main.rs
@@ -30,7 +30,7 @@ use esp_hal::{
     timer::timg::TimerGroup,
 };
 use esp_println::{print, println};
-use esp_radio::wifi::{AccessPointConfig, ClientConfig, Config};
+use esp_radio::wifi::{AccessPointConfig, ClientConfig, ModeConfig};
 use smoltcp::{
     iface::{SocketSet, SocketStorage},
     wire::IpAddress,
@@ -81,7 +81,7 @@ fn main() -> ! {
     sta_socket_set.add(smoltcp::socket::dhcpv4::Socket::new());
     let sta_stack = Stack::new(sta_interface, sta_device, sta_socket_set, now, rng.random());
 
-    let client_config = Config::ApSta(
+    let client_config = ModeConfig::ApSta(
         ClientConfig::default()
             .with_ssid(SSID.into())
             .with_password(PASSWORD.into()),

--- a/examples/wifi/coex/src/main.rs
+++ b/examples/wifi/coex/src/main.rs
@@ -41,7 +41,7 @@ use esp_hal::{
 use esp_println::{print, println};
 use esp_radio::{
     ble::controller::BleConnector,
-    wifi::{ClientConfig, Config},
+    wifi::{ClientConfig, ModeConfig},
 };
 use smoltcp::{
     iface::{SocketSet, SocketStorage},
@@ -130,7 +130,7 @@ fn main() -> ! {
     let rng = Rng::new();
     let stack = Stack::new(iface, device, socket_set, now, rng.random());
 
-    let client_config = Config::Client(
+    let client_config = ModeConfig::Client(
         ClientConfig::default()
             .with_ssid(SSID.into())
             .with_password(PASSWORD.into()),

--- a/examples/wifi/dhcp/src/main.rs
+++ b/examples/wifi/dhcp/src/main.rs
@@ -27,7 +27,7 @@ use esp_hal::{
     timer::timg::TimerGroup,
 };
 use esp_println::{print, println};
-use esp_radio::wifi::{ClientConfig, Config, ScanConfig};
+use esp_radio::wifi::{ClientConfig, ModeConfig, ScanConfig};
 use smoltcp::{
     iface::{SocketSet, SocketStorage},
     wire::{DhcpOption, IpAddress},
@@ -82,7 +82,7 @@ fn main() -> ! {
         .set_power_saving(esp_radio::wifi::PowerSaveMode::None)
         .unwrap();
 
-    let client_config = Config::Client(
+    let client_config = ModeConfig::Client(
         ClientConfig::default()
             .with_ssid(SSID.into())
             .with_password(PASSWORD.into()),

--- a/examples/wifi/embassy_access_point/src/main.rs
+++ b/examples/wifi/embassy_access_point/src/main.rs
@@ -34,7 +34,7 @@ use esp_hal::{clock::CpuClock, ram, rng::Rng, timer::timg::TimerGroup};
 use esp_println::{print, println};
 use esp_radio::{
     Controller,
-    wifi::{AccessPointConfig, Config, WifiApState, WifiController, WifiDevice, WifiEvent},
+    wifi::{AccessPointConfig, ModeConfig, WifiApState, WifiController, WifiDevice, WifiEvent},
 };
 
 esp_bootloader_esp_idf::esp_app_desc!();
@@ -249,7 +249,7 @@ async fn connection(mut controller: WifiController<'static>) {
         }
         if !matches!(controller.is_started(), Ok(true)) {
             let client_config =
-                Config::AccessPoint(AccessPointConfig::default().with_ssid("esp-radio".into()));
+                ModeConfig::AccessPoint(AccessPointConfig::default().with_ssid("esp-radio".into()));
             controller.set_config(&client_config).unwrap();
             println!("Starting wifi");
             controller.start_async().await.unwrap();

--- a/examples/wifi/embassy_access_point_with_sta/src/main.rs
+++ b/examples/wifi/embassy_access_point_with_sta/src/main.rs
@@ -43,7 +43,7 @@ use esp_radio::{
     wifi::{
         AccessPointConfig,
         ClientConfig,
-        Config,
+        ModeConfig,
         WifiApState,
         WifiController,
         WifiDevice,
@@ -116,7 +116,7 @@ async fn main(spawner: Spawner) -> ! {
         seed,
     );
 
-    let client_config = Config::ApSta(
+    let client_config = ModeConfig::ApSta(
         ClientConfig::default()
             .with_ssid(SSID.into())
             .with_password(PASSWORD.into()),

--- a/examples/wifi/embassy_dhcp/src/main.rs
+++ b/examples/wifi/embassy_dhcp/src/main.rs
@@ -22,7 +22,15 @@ use esp_hal::{clock::CpuClock, ram, rng::Rng, timer::timg::TimerGroup};
 use esp_println::println;
 use esp_radio::{
     Controller,
-    wifi::{ClientConfig, Config, ScanConfig, WifiController, WifiDevice, WifiEvent, WifiStaState},
+    wifi::{
+        ClientConfig,
+        ModeConfig,
+        ScanConfig,
+        WifiController,
+        WifiDevice,
+        WifiEvent,
+        WifiStaState,
+    },
 };
 
 esp_bootloader_esp_idf::esp_app_desc!();
@@ -156,7 +164,7 @@ async fn connection(mut controller: WifiController<'static>) {
             _ => {}
         }
         if !matches!(controller.is_started(), Ok(true)) {
-            let client_config = Config::Client(
+            let client_config = ModeConfig::Client(
                 ClientConfig::default()
                     .with_ssid(SSID.into())
                     .with_password(PASSWORD.into()),

--- a/examples/wifi/embassy_sntp/src/main.rs
+++ b/examples/wifi/embassy_sntp/src/main.rs
@@ -28,7 +28,15 @@ use esp_hal::{clock::CpuClock, rng::Rng, rtc_cntl::Rtc, timer::timg::TimerGroup}
 use esp_println::println;
 use esp_radio::{
     Controller,
-    wifi::{ClientConfig, Config, ScanConfig, WifiController, WifiDevice, WifiEvent, WifiStaState},
+    wifi::{
+        ClientConfig,
+        ModeConfig,
+        ScanConfig,
+        WifiController,
+        WifiDevice,
+        WifiEvent,
+        WifiStaState,
+    },
 };
 use log::{error, info};
 use sntpc::{NtpContext, NtpTimestampGenerator, get_time};
@@ -213,7 +221,7 @@ async fn connection(mut controller: WifiController<'static>) {
             Timer::after(Duration::from_millis(5000)).await
         }
         if !matches!(controller.is_started(), Ok(true)) {
-            let client_config = Config::Client(
+            let client_config = ModeConfig::Client(
                 ClientConfig::default()
                     .with_ssid(SSID.into())
                     .with_password(PASSWORD.into()),

--- a/examples/wifi/static_ip/src/main.rs
+++ b/examples/wifi/static_ip/src/main.rs
@@ -23,7 +23,7 @@ use esp_hal::{
     timer::timg::TimerGroup,
 };
 use esp_println::{print, println};
-use esp_radio::wifi::{ClientConfig, Config, ScanConfig};
+use esp_radio::wifi::{ClientConfig, ModeConfig, ScanConfig};
 use smoltcp::iface::{SocketSet, SocketStorage};
 
 esp_bootloader_esp_idf::esp_app_desc!();
@@ -70,7 +70,7 @@ fn main() -> ! {
     let now = || time::Instant::now().duration_since_epoch().as_millis();
     let mut stack = Stack::new(iface, device, socket_set, now, rng.random());
 
-    let client_config = Config::Client(
+    let client_config = ModeConfig::Client(
         ClientConfig::default()
             .with_ssid(SSID.into())
             .with_password(PASSWORD.into()),

--- a/qa-test/src/bin/embassy_wifi_bench.rs
+++ b/qa-test/src/bin/embassy_wifi_bench.rs
@@ -31,7 +31,7 @@ use esp_hal::{clock::CpuClock, ram, rng::Rng, timer::timg::TimerGroup};
 use esp_println::println;
 use esp_radio::{
     Controller,
-    wifi::{ClientConfig, Config, WifiController, WifiDevice, WifiEvent, WifiStaState},
+    wifi::{ClientConfig, ModeConfig, WifiController, WifiDevice, WifiEvent, WifiStaState},
 };
 
 esp_bootloader_esp_idf::esp_app_desc!();
@@ -154,7 +154,7 @@ async fn connection(mut controller: WifiController<'static>) {
             _ => {}
         }
         if !matches!(controller.is_started(), Ok(true)) {
-            let client_config = Config::Client(
+            let client_config = ModeConfig::Client(
                 ClientConfig::default()
                     .with_ssid(SSID.into())
                     .with_password(PASSWORD.into()),

--- a/qa-test/src/bin/embassy_wifi_i2s.rs
+++ b/qa-test/src/bin/embassy_wifi_i2s.rs
@@ -27,7 +27,7 @@ use esp_radio::{
     Controller,
     wifi::{
         ClientConfig,
-        Config as WifiConfig,
+        ModeConfig,
         WifiController,
         WifiDevice,
         WifiEvent,
@@ -69,7 +69,7 @@ async fn connection_manager(
     println!("📡 Starting WiFi connection manager");
 
     if !matches!(controller.is_started(), Ok(true)) {
-        let client_config = WifiConfig::Client(
+        let client_config = ModeConfig::Client(
             ClientConfig::default()
                 .with_ssid(SSID.into())
                 .with_password(PASSWORD.into()),

--- a/qa-test/src/bin/embassy_wifi_stress.rs
+++ b/qa-test/src/bin/embassy_wifi_stress.rs
@@ -24,7 +24,7 @@ use esp_hal::{
     timer::timg::TimerGroup,
 };
 use esp_println::println;
-use esp_radio::wifi::{ClientConfig, ScanConfig, WifiConfig, WifiMode};
+use esp_radio::wifi::{ClientConfig, Config, ModeConfig, ScanConfig, WifiMode};
 
 esp_bootloader_esp_idf::esp_app_desc!();
 
@@ -52,7 +52,7 @@ async fn main(_spawner: Spawner) {
     let (mut controller, _interfaces) = esp_radio::wifi::new(
         esp_wifi_ctrl,
         peripherals.WIFI.reborrow(),
-        WifiConfig::default(),
+        Config::default(),
     )
     .unwrap();
 
@@ -109,7 +109,7 @@ async fn main(_spawner: Spawner) {
         println!("Best AP found: {:?}", best_one);
         println!("Connecting to WiFi SSID: {}", SSID);
 
-        let client_config = esp_radio::wifi::Config::Client(
+        let client_config = ModeConfig(
             ClientConfig::default()
                 .with_ssid(best_one.ssid.clone())
                 .with_bssid(best_one.bssid)

--- a/qa-test/src/bin/embassy_wifi_stress.rs
+++ b/qa-test/src/bin/embassy_wifi_stress.rs
@@ -109,7 +109,7 @@ async fn main(_spawner: Spawner) {
         println!("Best AP found: {:?}", best_one);
         println!("Connecting to WiFi SSID: {}", SSID);
 
-        let client_config = ModeConfig(
+        let client_config = ModeConfig::Client(
             ClientConfig::default()
                 .with_ssid(best_one.ssid.clone())
                 .with_bssid(best_one.bssid)

--- a/qa-test/src/bin/wifi_bench.rs
+++ b/qa-test/src/bin/wifi_bench.rs
@@ -34,7 +34,7 @@ use esp_hal::{
     timer::timg::TimerGroup,
 };
 use esp_println::println;
-use esp_radio::wifi::{ClientConfig, Config, ScanConfig};
+use esp_radio::wifi::{ClientConfig, ModeConfig, ScanConfig};
 use smoltcp::{
     iface::{SocketSet, SocketStorage},
     wire::{DhcpOption, IpAddress},
@@ -101,7 +101,7 @@ fn main() -> ! {
     let now = || time::Instant::now().duration_since_epoch().as_millis();
     let stack = Stack::new(iface, device, socket_set, now, rng.random());
 
-    let client_config = Config::Client(
+    let client_config = ModeConfig::Client(
         ClientConfig::default()
             .with_ssid(SSID.into())
             .with_password(PASSWORD.into()),

--- a/qa-test/src/bin/wifi_csi.rs
+++ b/qa-test/src/bin/wifi_csi.rs
@@ -18,7 +18,7 @@ use esp_backtrace as _;
 use esp_hal::interrupt::software::SoftwareInterruptControl;
 use esp_hal::{clock::CpuClock, main, rng::Rng, time, timer::timg::TimerGroup};
 use esp_println::println;
-use esp_radio::wifi::{ClientConfig, Config, CsiConfig, ScanConfig};
+use esp_radio::wifi::{ClientConfig, CsiConfig, ModeConfig, ScanConfig};
 use smoltcp::{
     iface::{SocketSet, SocketStorage},
     wire::DhcpOption,
@@ -68,7 +68,7 @@ fn main() -> ! {
     let now = || time::Instant::now().duration_since_epoch().as_millis();
     let stack = Stack::new(iface, device, socket_set, now, rng.random());
 
-    let client_config = Config::Client(
+    let client_config = ModeConfig::Client(
         ClientConfig::default()
             .with_ssid(SSID.into())
             .with_password(PASSWORD.into()),


### PR DESCRIPTION
To align things with `BLE`,  `WifiConfig` is renamed to `Config`. The old `Config` is renamed to `WifiApStaConfig`.

closes https://github.com/esp-rs/esp-hal/issues/4271