### PR TITLE
Don't use ADC2 efuse calibration parameters for ADC1

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -100,6 +100,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - TWAI: Fixed receive_async erroneously returning RX FIFO overrun errors (#4244)
 - Subtracting Instant values with large difference no longer panics (#4249)
 - ADC: Fixed integer overflow in curve calibration polynomial evaluation (#4240)
+- ADC: Fixed bug where ADC1 would used ADC2 efuse calibration data (#4285)
 - RMT: `Channel::transmit_continuously` also triggers the loopcount interrupt when only using a single repetition. (#4260)
 - I2C: Fix position of SDA sampling point (#4268)
 

--- a/esp-hal/src/analog/adc/riscv.rs
+++ b/esp-hal/src/analog/adc/riscv.rs
@@ -21,7 +21,7 @@ use procmacros::handler;
 pub use self::calibration::*;
 use super::{AdcCalSource, AdcConfig, Attenuation};
 #[cfg(any(esp32c2, esp32c3, esp32c6, esp32h2))]
-use crate::efuse::Efuse;
+use crate::efuse::{AdcCalibUnit, Efuse};
 use crate::{
     Async,
     Blocking,
@@ -424,30 +424,30 @@ impl<ADCI> InterruptConfigurable for Adc<'_, ADCI, Blocking> {
 #[cfg(adc_adc1)]
 impl super::AdcCalEfuse for crate::peripherals::ADC1<'_> {
     fn init_code(atten: Attenuation) -> Option<u16> {
-        Efuse::rtc_calib_init_code(1, atten)
+        Efuse::rtc_calib_init_code(AdcCalibUnit::ADC1, atten)
     }
 
     fn cal_mv(atten: Attenuation) -> u16 {
-        Efuse::rtc_calib_cal_mv(1, atten)
+        Efuse::rtc_calib_cal_mv(AdcCalibUnit::ADC1, atten)
     }
 
     fn cal_code(atten: Attenuation) -> Option<u16> {
-        Efuse::rtc_calib_cal_code(1, atten)
+        Efuse::rtc_calib_cal_code(AdcCalibUnit::ADC1, atten)
     }
 }
 
 #[cfg(adc_adc2)]
 impl super::AdcCalEfuse for crate::peripherals::ADC2<'_> {
     fn init_code(atten: Attenuation) -> Option<u16> {
-        Efuse::rtc_calib_init_code(2, atten)
+        Efuse::rtc_calib_init_code(AdcCalibUnit::ADC2, atten)
     }
 
     fn cal_mv(atten: Attenuation) -> u16 {
-        Efuse::rtc_calib_cal_mv(2, atten)
+        Efuse::rtc_calib_cal_mv(AdcCalibUnit::ADC2, atten)
     }
 
     fn cal_code(atten: Attenuation) -> Option<u16> {
-        Efuse::rtc_calib_cal_code(2, atten)
+        Efuse::rtc_calib_cal_code(AdcCalibUnit::ADC2, atten)
     }
 }
 

--- a/esp-hal/src/analog/adc/xtensa.rs
+++ b/esp-hal/src/analog/adc/xtensa.rs
@@ -4,7 +4,7 @@ use core::marker::PhantomData;
 pub use self::calibration::*;
 use super::{AdcCalScheme, AdcCalSource, AdcChannel, AdcConfig, AdcPin, Attenuation};
 #[cfg(esp32s3)]
-use crate::efuse::Efuse;
+use crate::efuse::{AdcCalibUnit, Efuse};
 use crate::{
     peripherals::{APB_SARADC, SENS},
     soc::regi2c,
@@ -492,29 +492,29 @@ where
 #[cfg(esp32s3)]
 impl super::AdcCalEfuse for crate::peripherals::ADC1<'_> {
     fn init_code(atten: Attenuation) -> Option<u16> {
-        Efuse::rtc_calib_init_code(1, atten)
+        Efuse::rtc_calib_init_code(AdcCalibUnit::ADC1, atten)
     }
 
     fn cal_mv(atten: Attenuation) -> u16 {
-        Efuse::rtc_calib_cal_mv(1, atten)
+        Efuse::rtc_calib_cal_mv(AdcCalibUnit::ADC1, atten)
     }
 
     fn cal_code(atten: Attenuation) -> Option<u16> {
-        Efuse::rtc_calib_cal_code(1, atten)
+        Efuse::rtc_calib_cal_code(AdcCalibUnit::ADC1, atten)
     }
 }
 
 #[cfg(esp32s3)]
 impl super::AdcCalEfuse for crate::peripherals::ADC2<'_> {
     fn init_code(atten: Attenuation) -> Option<u16> {
-        Efuse::rtc_calib_init_code(2, atten)
+        Efuse::rtc_calib_init_code(AdcCalibUnit::ADC2, atten)
     }
 
     fn cal_mv(atten: Attenuation) -> u16 {
-        Efuse::rtc_calib_cal_mv(2, atten)
+        Efuse::rtc_calib_cal_mv(AdcCalibUnit::ADC2, atten)
     }
 
     fn cal_code(atten: Attenuation) -> Option<u16> {
-        Efuse::rtc_calib_cal_code(2, atten)
+        Efuse::rtc_calib_cal_code(AdcCalibUnit::ADC2, atten)
     }
 }

--- a/esp-hal/src/efuse/esp32c2/mod.rs
+++ b/esp-hal/src/efuse/esp32c2/mod.rs
@@ -3,6 +3,12 @@ use crate::{analog::adc::Attenuation, peripherals::EFUSE};
 mod fields;
 pub use fields::*;
 
+/// Selects which ADC we are interested in the efuse calibration data for
+pub enum AdcCalibUnit {
+    /// Select efuse calibration data for ADC1
+    ADC1,
+}
+
 impl super::Efuse {
     /// Get status of SPI boot encryption.
     pub fn flash_encryption() -> bool {
@@ -39,7 +45,7 @@ impl super::Efuse {
     /// Get ADC initial code for specified attenuation from efuse
     ///
     /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c2/esp_efuse_rtc_calib.c#L27>
-    pub fn rtc_calib_init_code(_unit: u8, atten: Attenuation) -> Option<u16> {
+    pub fn rtc_calib_init_code(_unit: AdcCalibUnit, atten: Attenuation) -> Option<u16> {
         let version = Self::rtc_calib_version();
 
         if version != 1 {
@@ -68,7 +74,7 @@ impl super::Efuse {
     /// Get ADC reference point voltage for specified attenuation in millivolts
     ///
     /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c2/esp_efuse_rtc_calib.c#L65>
-    pub fn rtc_calib_cal_mv(_unit: u8, atten: Attenuation) -> u16 {
+    pub fn rtc_calib_cal_mv(_unit: AdcCalibUnit, atten: Attenuation) -> u16 {
         match atten {
             Attenuation::_0dB => 400,
             Attenuation::_11dB => 1370,
@@ -78,7 +84,7 @@ impl super::Efuse {
     /// Get ADC reference point digital code for specified attenuation
     ///
     /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c2/esp_efuse_rtc_calib.c#L65>
-    pub fn rtc_calib_cal_code(_unit: u8, atten: Attenuation) -> Option<u16> {
+    pub fn rtc_calib_cal_code(_unit: AdcCalibUnit, atten: Attenuation) -> Option<u16> {
         let version = Self::rtc_calib_version();
 
         if version != 1 {

--- a/esp-hal/src/efuse/esp32c3/mod.rs
+++ b/esp-hal/src/efuse/esp32c3/mod.rs
@@ -3,6 +3,14 @@ use crate::{analog::adc::Attenuation, peripherals::EFUSE};
 mod fields;
 pub use fields::*;
 
+/// Selects which ADC we are interested in the efuse calibration data for
+pub enum AdcCalibUnit {
+    /// Select efuse calibration data for ADC1
+    ADC1,
+    /// Select efuse calibration data for ADC2
+    ADC2,
+}
+
 impl super::Efuse {
     /// Get status of SPI boot encryption.
     pub fn flash_encryption() -> bool {
@@ -40,7 +48,7 @@ impl super::Efuse {
     /// Get ADC initial code for specified attenuation from efuse
     ///
     /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c3/esp_efuse_rtc_calib.c#L25>
-    pub fn rtc_calib_init_code(_unit: u8, atten: Attenuation) -> Option<u16> {
+    pub fn rtc_calib_init_code(_unit: AdcCalibUnit, atten: Attenuation) -> Option<u16> {
         let version = Self::rtc_calib_version();
 
         if version != 1 {
@@ -61,7 +69,7 @@ impl super::Efuse {
     /// Get ADC reference point voltage for specified attenuation in millivolts
     ///
     /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c3/esp_efuse_rtc_calib.c#L49>
-    pub fn rtc_calib_cal_mv(_unit: u8, atten: Attenuation) -> u16 {
+    pub fn rtc_calib_cal_mv(_unit: AdcCalibUnit, atten: Attenuation) -> u16 {
         match atten {
             Attenuation::_0dB => 400,
             Attenuation::_2p5dB => 550,
@@ -73,7 +81,7 @@ impl super::Efuse {
     /// Get ADC reference point digital code for specified attenuation
     ///
     /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c3/esp_efuse_rtc_calib.c#L49>
-    pub fn rtc_calib_cal_code(_unit: u8, atten: Attenuation) -> Option<u16> {
+    pub fn rtc_calib_cal_code(_unit: AdcCalibUnit, atten: Attenuation) -> Option<u16> {
         let version = Self::rtc_calib_version();
 
         if version != 1 {

--- a/esp-hal/src/efuse/esp32c6/mod.rs
+++ b/esp-hal/src/efuse/esp32c6/mod.rs
@@ -3,6 +3,14 @@ use crate::{analog::adc::Attenuation, peripherals::EFUSE};
 mod fields;
 pub use fields::*;
 
+/// Selects which ADC we are interested in the efuse calibration data for
+pub enum AdcCalibUnit {
+    /// Select efuse calibration data for ADC1
+    ADC1,
+    /// Select efuse calibration data for ADC2
+    ADC2,
+}
+
 impl super::Efuse {
     /// Get status of SPI boot encryption.
     pub fn flash_encryption() -> bool {
@@ -39,7 +47,7 @@ impl super::Efuse {
     /// Get ADC initial code for specified attenuation from efuse
     ///
     /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c6/esp_efuse_rtc_calib.c#L32>
-    pub fn rtc_calib_init_code(_unit: u8, atten: Attenuation) -> Option<u16> {
+    pub fn rtc_calib_init_code(_unit: AdcCalibUnit, atten: Attenuation) -> Option<u16> {
         let version = Self::rtc_calib_version();
 
         if version != 1 {
@@ -60,7 +68,7 @@ impl super::Efuse {
     /// Get ADC reference point voltage for specified attenuation in millivolts
     ///
     /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c6/esp_efuse_rtc_calib.c#L42>
-    pub fn rtc_calib_cal_mv(_unit: u8, atten: Attenuation) -> u16 {
+    pub fn rtc_calib_cal_mv(_unit: AdcCalibUnit, atten: Attenuation) -> u16 {
         match atten {
             Attenuation::_0dB => 400,
             Attenuation::_2p5dB => 550,
@@ -72,7 +80,7 @@ impl super::Efuse {
     /// Get ADC reference point digital code for specified attenuation
     ///
     /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c6/esp_efuse_rtc_calib.c#L42>
-    pub fn rtc_calib_cal_code(_unit: u8, atten: Attenuation) -> Option<u16> {
+    pub fn rtc_calib_cal_code(_unit: AdcCalibUnit, atten: Attenuation) -> Option<u16> {
         let version = Self::rtc_calib_version();
 
         if version != 1 {

--- a/esp-hal/src/efuse/esp32h2/mod.rs
+++ b/esp-hal/src/efuse/esp32h2/mod.rs
@@ -3,6 +3,12 @@ use crate::{analog::adc::Attenuation, peripherals::EFUSE};
 mod fields;
 pub use fields::*;
 
+/// Selects which ADC we are interested in the efuse calibration data for
+pub enum AdcCalibUnit {
+    /// Select efuse calibration data for ADC1
+    ADC1,
+}
+
 impl super::Efuse {
     /// Get status of SPI boot encryption.
     pub fn flash_encryption() -> bool {
@@ -38,7 +44,7 @@ impl super::Efuse {
     /// Get ADC initial code for specified attenuation from efuse
     ///
     /// See: <https://github.com/espressif/esp-idf/blob/be06a6f/components/efuse/esp32h2/esp_efuse_rtc_calib.c#L33>
-    pub fn rtc_calib_init_code(_unit: u8, atten: Attenuation) -> Option<u16> {
+    pub fn rtc_calib_init_code(_unit: AdcCalibUnit, atten: Attenuation) -> Option<u16> {
         let version = Self::rtc_calib_version();
 
         if version > 4 {
@@ -59,7 +65,7 @@ impl super::Efuse {
     /// Get ADC reference point voltage for specified attenuation in millivolts
     ///
     /// See: <https://github.com/espressif/esp-idf/blob/be06a6f/components/efuse/esp32h2/esp_efuse_rtc_calib.c#L91>
-    pub fn rtc_calib_cal_mv(_unit: u8, atten: Attenuation) -> u16 {
+    pub fn rtc_calib_cal_mv(_unit: AdcCalibUnit, atten: Attenuation) -> u16 {
         const INPUT_VOUT_MV: [[u16; 4]; 1] = [
             [750, 1000, 1500, 2800], // Calibration V1 coefficients
         ];
@@ -83,7 +89,7 @@ impl super::Efuse {
     /// Returns the call code
     ///
     /// See: <https://github.com/espressif/esp-idf/blob/17a2461297076481858b7f76482676a521cc727a/components/efuse/esp32h2/esp_efuse_rtc_calib.c#L91>
-    pub fn rtc_calib_cal_code(_unit: u8, atten: Attenuation) -> Option<u16> {
+    pub fn rtc_calib_cal_code(_unit: AdcCalibUnit, atten: Attenuation) -> Option<u16> {
         let cal_code: u16 = Self::read_field_le(match atten {
             Attenuation::_0dB => ADC1_HI_DOUT_ATTEN0,
             Attenuation::_2p5dB => ADC1_HI_DOUT_ATTEN1,

--- a/esp-hal/src/efuse/esp32s3/mod.rs
+++ b/esp-hal/src/efuse/esp32s3/mod.rs
@@ -3,6 +3,14 @@ use crate::{analog::adc::Attenuation, peripherals::EFUSE};
 mod fields;
 pub use fields::*;
 
+/// Selects which ADC we are interested in the efuse calibration data for
+pub enum AdcCalibUnit {
+    /// Select efuse calibration data for ADC1
+    ADC1,
+    /// Select efuse calibration data for ADC2
+    ADC2,
+}
+
 impl super::Efuse {
     /// Get status of SPI boot encryption.
     pub fn flash_encryption() -> bool {
@@ -40,42 +48,44 @@ impl super::Efuse {
     /// Get ADC initial code for specified attenuation from efuse
     ///
     /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32s3/esp_efuse_rtc_calib.c#L28>
-    pub fn rtc_calib_init_code(unit: u8, atten: Attenuation) -> Option<u16> {
+    pub fn rtc_calib_init_code(unit: AdcCalibUnit, atten: Attenuation) -> Option<u16> {
         let version = Self::rtc_calib_version();
 
         if version != 1 {
             return None;
         }
 
-        let adc_icode_diff: [u16; 4] = if unit == 0 {
-            [
+        let adc_icode_diff: [u16; 4] = match unit {
+            AdcCalibUnit::ADC1 => [
                 Self::read_field_le(ADC1_INIT_CODE_ATTEN0),
                 Self::read_field_le(ADC1_INIT_CODE_ATTEN1),
                 Self::read_field_le(ADC1_INIT_CODE_ATTEN2),
                 Self::read_field_le(ADC1_INIT_CODE_ATTEN3),
-            ]
-        } else {
-            [
+            ],
+            AdcCalibUnit::ADC2 => [
                 Self::read_field_le(ADC2_INIT_CODE_ATTEN0),
                 Self::read_field_le(ADC2_INIT_CODE_ATTEN1),
                 Self::read_field_le(ADC2_INIT_CODE_ATTEN2),
                 Self::read_field_le(ADC2_INIT_CODE_ATTEN3),
-            ]
+            ],
         };
 
         // Version 1 logic for calculating ADC ICode based on EFUSE burnt value
 
         let mut adc_icode = [0; 4];
-        if unit == 0 {
-            adc_icode[0] = adc_icode_diff[0] + 1850;
-            adc_icode[1] = adc_icode_diff[1] + adc_icode[0] + 90;
-            adc_icode[2] = adc_icode_diff[2] + adc_icode[1];
-            adc_icode[3] = adc_icode_diff[3] + adc_icode[2] + 70;
-        } else {
-            adc_icode[0] = adc_icode_diff[0] + 2020;
-            adc_icode[1] = adc_icode_diff[1] + adc_icode[0];
-            adc_icode[2] = adc_icode_diff[2] + adc_icode[1];
-            adc_icode[3] = adc_icode_diff[3] + adc_icode[2];
+        match unit {
+            AdcCalibUnit::ADC1 => {
+                adc_icode[0] = adc_icode_diff[0] + 1850;
+                adc_icode[1] = adc_icode_diff[1] + adc_icode[0] + 90;
+                adc_icode[2] = adc_icode_diff[2] + adc_icode[1];
+                adc_icode[3] = adc_icode_diff[3] + adc_icode[2] + 70;
+            }
+            AdcCalibUnit::ADC2 => {
+                adc_icode[0] = adc_icode_diff[0] + 2020;
+                adc_icode[1] = adc_icode_diff[1] + adc_icode[0];
+                adc_icode[2] = adc_icode_diff[2] + adc_icode[1];
+                adc_icode[3] = adc_icode_diff[3] + adc_icode[2];
+            }
         }
 
         Some(
@@ -91,14 +101,14 @@ impl super::Efuse {
     /// Get ADC reference point voltage for specified attenuation in millivolts
     ///
     /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32s3/esp_efuse_rtc_calib.c#L63>
-    pub fn rtc_calib_cal_mv(_unit: u8, _atten: Attenuation) -> u16 {
+    pub fn rtc_calib_cal_mv(_unit: AdcCalibUnit, _atten: Attenuation) -> u16 {
         850
     }
 
     /// Get ADC reference point digital code for specified attenuation
     ///
     /// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32s3/esp_efuse_rtc_calib.c#L63>
-    pub fn rtc_calib_cal_code(unit: u8, atten: Attenuation) -> Option<u16> {
+    pub fn rtc_calib_cal_code(unit: AdcCalibUnit, atten: Attenuation) -> Option<u16> {
         let version = Self::rtc_calib_version();
 
         if version != 1 {
@@ -134,10 +144,9 @@ impl super::Efuse {
             Attenuation::_11dB => 3,
         };
 
-        Some(if unit == 0 {
-            adc1_vol[atten]
-        } else {
-            adc2_vol[atten]
+        Some(match unit {
+            AdcCalibUnit::ADC1 => adc1_vol[atten],
+            AdcCalibUnit::ADC2 => adc2_vol[atten],
         })
     }
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- ~[ ] I have updated existing examples or added new ones (if applicable).~
- [X] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [X] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- ~[ ] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).~
- [X] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [X] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

This PR addresses #4285, where ADC readings would be slightly off, in part due to incorrect calibration parameters being used.

#### Description

This PR is a work-in-progress. Even though the correct calibration values are now being used, the values still don't match. I want to try to hunt down a few more discrepancies before finalizing this PR.

<!--The problem stems from mismatched conventions: the efuse retrieval function uses a [0-indexed convention to select an ADC](https://github.com/esp-rs/esp-hal/blob/0267f7c3740964c0e92497395f7d7ade83145216/esp-hal/src/efuse/esp32s3/mod.rs#L50), while its callers use a [1-indexed convention](https://github.com/esp-rs/esp-hal/blob/0267f7c3740964c0e92497395f7d7ade83145216/esp-hal/src/analog/adc/xtensa.rs#L495). This results in the ADC2 calibration data always being used. I decided to make this argument into an enum to get type-level checking for invalid values. -->

#### Testing

In progress!