### PR TITLE
Option to force the stack-guard even if a debugger is connected

### DIFF
--- a/esp-hal/esp_config.yml
+++ b/esp-hal/esp_config.yml
@@ -112,6 +112,11 @@ options:
   default:
     - value: true
 
+- name: stack-guard-monitoring-with-debugger-connected
+  description: Enable the stack guard also with a debugger connected.
+  default:
+    - value: true
+
 - name: impl-critical-section
   description: "Provide a `critical-section` implementation. Note that if disabled,
                you will need to provide a `critical-section` implementation which is

--- a/esp-hal/src/debugger.rs
+++ b/esp-hal/src/debugger.rs
@@ -24,7 +24,8 @@ pub fn debugger_connected() -> bool {
 }
 
 /// Set a word-sized data breakpoint at the given address.
-/// No breakpoint will be set if a debugger is currently attached.
+/// No breakpoint will be set when a debugger is currently attached if
+/// the `stack_guard_monitoring_with_debugger_connected` option is false.
 ///
 /// Breakpoint 0 is used.
 ///
@@ -33,7 +34,9 @@ pub fn debugger_connected() -> bool {
 pub unsafe fn set_stack_watchpoint(addr: usize) {
     assert!(addr.is_multiple_of(4));
 
-    if !crate::debugger::debugger_connected() {
+    if cfg!(stack_guard_monitoring_with_debugger_connected)
+        || !crate::debugger::debugger_connected()
+    {
         cfg_if::cfg_if! {
             if #[cfg(xtensa)] {
                 let addr = addr & !0b11;


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

Previously when running via `probe-rs run` the stack guard wasn't active since a debugger is attached. This adds an option (enabled by default) to force the stack guard anyways.

#### Testing

Manual testing
