### PR TITLE
Remove links to tests

### DIFF
--- a/esp-hal/src/ecc.rs
+++ b/esp-hal/src/ecc.rs
@@ -18,11 +18,6 @@
 //!
 //! Inputs of the ECC hardware accelerator must be provided in big-endian
 //! representation. The driver handles the inner representation of the blocks.
-//!
-//! ## Examples
-//! Visit the [ECC] test for an example of using the ECC Accelerator.
-//!
-//! [ECC]: https://github.com/esp-rs/esp-hal/blob/main/hil-test/src/bin/ecc.rs
 
 use core::marker::PhantomData;
 

--- a/esp-hal/src/rsa/mod.rs
+++ b/esp-hal/src/rsa/mod.rs
@@ -12,13 +12,6 @@
 //!
 //! The RSA accelerator also supports operands of different lengths, which
 //! provides more flexibility during the computation.
-//!
-//! ## Examples
-//!
-//! ### Modular Exponentiation, Modular Multiplication, and Multiplication
-//! Visit the [RSA test suite] for an example of using the peripheral.
-//!
-//! [RSA test suite]: https://github.com/esp-rs/esp-hal/blob/main/hil-test/src/bin/rsa.rs
 
 use core::{marker::PhantomData, ptr::NonNull, task::Poll};
 


### PR DESCRIPTION
Perhaps it would be best to provide actually readable examples, right now we just keep breaking linkcheck with test changes.