### PR TITLE
esp-rtos: Add toml changes to migration guides

### DIFF
--- a/esp-hal/MIGRATING-1.0.0-rc.0.md
+++ b/esp-hal/MIGRATING-1.0.0-rc.0.md
@@ -179,7 +179,7 @@ The `rmt::Channel::transmit_continuously` and
 
 The RMT driver didn't use to properly tie together lifetimes of its types and
 therefore didn't statically prevent all kinds of concurrent and conflicting
-channel re-use. 
+channel re-use.
 `rmt::Channel` and `rmt::ChannelCreator` now carry a lifetime and can be reborrowed:
 
 ```diff
@@ -339,6 +339,13 @@ interrupt::enable_direct(
 
 The `esp-hal-embassy` has been discontinued. Embassy is continued to be supported as part of `esp-rtos`.
 
+To import `esp_rtos` for `embassy` support, add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+esp-rtos = { version = "0.1.0", features = ["your_chip", "embassy"] }
+```
+
 ### Configuration
 
 `esp-hal-embassy` configuration options have not been ported to `esp-rtos`. `esp-rtos` by default works with a single integrated timer queue.
@@ -414,4 +421,3 @@ esp_rtos::start_second_core(
 ### Interrupt executor changes
 
 Interrupt executors are provided as `esp_rtos::embassy::InterruptExecutor` with no additional changes.
-

--- a/esp-radio/MIGRATING-0.15.0.md
+++ b/esp-radio/MIGRATING-0.15.0.md
@@ -5,6 +5,13 @@
 The `builtin-scheduler` feature has been removed. The functionality has been moved to `esp_rtos`.
 `esp_rtos` needs to be initialized before calling `esp_radio::init`. Failure to do so will result in an error.
 
+To import `esp_rtos` for `esp_radio`, add this to your `Cargo.toml`:
+
+```toml
+[dependencies]
+esp-rtos = { version = "0.1.0", features = ["your_chip", "esp-radio", "esp-alloc"] } # esp-alloc is optional, but recommended
+```
+
 Depending on your chosen OS, you may need to use other `esp_rtos` implementations.
 
 Furthermore, `esp_radio::init` no longer requires `RNG` or a timer.


### PR DESCRIPTION
The package itself isn't trivial, so let's mention what's needed to import it.