### PR TITLE
RTOS: Try to be more helpful with the executor

### DIFF
--- a/esp-rtos/src/scheduler.rs
+++ b/esp-rtos/src/scheduler.rs
@@ -117,6 +117,13 @@ impl SchedulerState {
         }
     }
 
+    pub(crate) fn current_task(&self, cpu: Cpu) -> TaskPtr {
+        unwrap!(
+            self.per_cpu[cpu as usize].current_task,
+            "The scheduler is not running on the current CPU. Make sure you start the scheduler before calling OS functions."
+        )
+    }
+
     pub(crate) fn setup(&mut self, time_driver: TimeDriver, idle_hook: IdleFn) {
         assert!(
             self.time_driver.is_none(),
@@ -442,8 +449,7 @@ impl Scheduler {
 
     pub(crate) fn sleep_until(&self, wake_at: Instant) -> bool {
         self.with(|scheduler| {
-            let current_cpu = Cpu::current() as usize;
-            let current_task = unwrap!(scheduler.per_cpu[current_cpu].current_task);
+            let current_task = scheduler.current_task(Cpu::current());
             if scheduler.sleep_task_until(current_task, wake_at) {
                 task::yield_task();
                 true

--- a/esp-rtos/src/semaphore.rs
+++ b/esp-rtos/src/semaphore.rs
@@ -46,8 +46,7 @@ impl SemaphoreInner {
                 ..
             } => {
                 SCHEDULER.with(|scheduler| {
-                    let current_cpu = Cpu::current() as usize;
-                    let current = unwrap!(scheduler.per_cpu[current_cpu].current_task);
+                    let current = scheduler.current_task(Cpu::current());
                     if let Some(owner) = owner {
                         if *owner == current && *recursive {
                             *lock_counter += 1;

--- a/esp-rtos/src/wait_queue.rs
+++ b/esp-rtos/src/wait_queue.rs
@@ -32,9 +32,7 @@ impl WaitQueue {
 
     pub(crate) fn wait_with_deadline(&mut self, deadline: Instant) {
         SCHEDULER.with(|scheduler| {
-            let current_cpu = Cpu::current() as usize;
-            let mut task = unwrap!(scheduler.per_cpu[current_cpu].current_task);
-
+            let mut task = scheduler.current_task(Cpu::current());
             if scheduler.sleep_task_until(task, deadline) {
                 self.waiting_tasks.push(task);
                 unsafe {


### PR DESCRIPTION
Let's print more helpful errors when the current task isn't set, or when the executor is started on core 1.

Closes #4312