### PR TITLE
RTOS/embassy: Add missing feature gate

### DIFF
--- a/esp-rtos/src/lib.rs
+++ b/esp-rtos/src/lib.rs
@@ -114,6 +114,7 @@ use esp_hal::{
     peripherals::CPU_CTRL,
     system::{CpuControl, Stack},
 };
+#[cfg(feature = "embassy")]
 #[cfg_attr(docsrs, doc(cfg(feature = "embassy")))]
 pub use macros::rtos_main as main;
 pub(crate) use scheduler::SCHEDULER;


### PR DESCRIPTION
Trying to use the main macro without the embassy feature just gave a very unclear error. The intent was to not even reexport the macro (as the doc decoration suggests), not sure how i forgot the actual feature gate.