### PR TITLE
Revert to LLFF as the default

### DIFF
--- a/esp-alloc/CHANGELOG.md
+++ b/esp-alloc/CHANGELOG.md
@@ -11,12 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added chip-selection features (#4023)
 - New default feature (`compat`) enables implementations for `malloc`, `free`, `calloc`, `realloc` and others (#3890, #4043)
-- `ESP_ALLOC_CONFIG_HEAP_ALGORITHM` to select the global heap algorithm (#4130)
+- `ESP_ALLOC_CONFIG_HEAP_ALGORITHM` to select the global heap algorithm (LLFF, TLSF) (#4130, #4316)
+- Added option to use TLSF as the heap allocator, implemented by the `rlsf` crate (#4130, #4316)
 
 ### Changed
 
 - Make stats structs fields public (#3828)
-- The default heap allocator is now TLSF, implemented by the `rlsf` crate (#3950)
 - Fixed documentation to use `ram(reclaimed)` instead of a no longer valid linker_section syntax. (#4245)
 
 ### Fixed

--- a/esp-alloc/esp_config.yml
+++ b/esp-alloc/esp_config.yml
@@ -5,7 +5,7 @@ options:
     description: "The heap algorithm to use. TLSF offers higher performance
       and bounded allocation time, but uses more memory."
     default:
-      - value: '"TLSF"'
+      - value: '"LLFF"'
     constraints:
       - type:
           validator: enumeration


### PR DESCRIPTION
TLSF requires an unexpected amount of RAM, which can make updating to the new esp-alloc more surprising than ideal.