### PR TITLE
semver download: don't exit early when not in gh runner

### DIFF
--- a/xtask/src/commands/release/semver_check.rs
+++ b/xtask/src/commands/release/semver_check.rs
@@ -273,20 +273,12 @@ pub mod checker {
         // Check if GitHub CLI is available
         let gh_check = Command::new("gh").arg("--version").output();
         if gh_check.is_err() {
-            log::debug!("GitHub CLI (gh) not available, skipping artifact download");
-            return Ok(false);
-        }
-
-        // Check if we're in a GitHub Actions environment (or allow override for testing)
-        if std::env::var("GITHUB_ACTIONS").is_err() && std::env::var("GITHUB_REPOSITORY").is_err() {
-            log::debug!(
-                "Not in GitHub Actions environment and no GITHUB_REPOSITORY set, skipping artifact download"
-            );
+            log::error!("GitHub CLI (gh) not available, skipping artifact download");
             return Ok(false);
         }
 
         // Query repository artifacts via GitHub API and download the one matching `artifact_name`
-        log::debug!("Attempting to download artifact: {artifact_name} from {repo}");
+        log::info!("Attempting to download artifact: {artifact_name} from {repo}");
 
         // List artifacts for the repository, filtered by name
         let list_output = Command::new("gh")

--- a/xtask/src/semver_check.rs
+++ b/xtask/src/semver_check.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Error};
 use cargo_semver_checks::{Check, GlobalConfig, ReleaseType, Rustdoc};
 use esp_metadata::Chip;
 
-use crate::{Package, cargo::CargoArgsBuilder};
+use crate::{Package, cargo::CargoArgsBuilder, commands::checker::download_baselines};
 
 /// Return the minimum required bump for the next release.
 /// Even if nothing changed this will be [ReleaseType::Patch]
@@ -31,6 +31,9 @@ pub fn minimum_update(
 
     let baseline_path_gz =
         PathBuf::from(&package_path).join(format!("api-baseline/{}.json.gz", file_name));
+    if !baseline_path_gz.exists() {
+        download_baselines(&package_path, vec![package])?;
+    }
     let baseline_path =
         temp_file::TempFile::new().with_context(|| format!("Failed to create a TempFile!"))?;
     let buffer = Vec::new();


### PR DESCRIPTION
This check seemed a bit strong, it works just fine as long as `gh` is installed. This also adds logic to download the baselines if needed during the release planning process.