### PR TITLE
fixup bump version for new examples structure

### DIFF
--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -56,7 +56,7 @@ esp-alloc = { version = "0.8.0", path = "../esp-alloc", optional = true }
 esp-config = { version = "0.5.0", path = "../esp-config" }
 esp-metadata-generated = { version = "0.1.0", path = "../esp-metadata-generated" }
 esp-sync = { version = "0.0.0", path = "../esp-sync" }
-esp-phy = { path = "../esp-phy/" }
+esp-phy = { version = "0.0.1", path = "../esp-phy/" }
 esp-wifi-sys = { version = "0.8.1" }
 num-derive = "0.4.2"
 num-traits = { version = "0.2.19", default-features = false }


### PR DESCRIPTION
The examples are now separate packages, so this must be handled in the dependency checks.