### PR TITLE
Prepare rc1 release 

### DIFF
--- a/esp-alloc/CHANGELOG.md
+++ b/esp-alloc/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+
+### Changed
+
+
+### Fixed
+
+
+### Removed
+
+
+## [v0.9.0] - 2025-10-13
+
+### Added
+
 - Added chip-selection features (#4023)
 - New default feature (`compat`) enables implementations for `malloc`, `free`, `calloc`, `realloc` and others (#3890, #4043)
 - `ESP_ALLOC_CONFIG_HEAP_ALGORITHM` to select the global heap algorithm (LLFF, TLSF) (#4130, #4316)
@@ -22,9 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix problem of not de-allocating memory in some situations (#3949)
-
-### Removed
-
 
 ## [v0.8.0] - 2025-06-03
 
@@ -77,4 +88,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [0.7.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-alloc-v0.7.0
 [v0.8.0]: https://github.com/esp-rs/esp-hal/compare/esp-alloc-v0.7.0...esp-alloc-v0.8.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-alloc-v0.8.0...HEAD
+[v0.9.0]: https://github.com/esp-rs/esp-hal/compare/esp-alloc-v0.8.0...esp-alloc-v0.9.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-alloc-v0.9.0...HEAD

--- a/esp-alloc/Cargo.toml
+++ b/esp-alloc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-alloc"
-version       = "0.8.0"
+version       = "0.9.0"
 edition       = "2024"
 rust-version  = "1.86.0"
 description   = "A heap allocator for Espressif devices"
@@ -33,14 +33,14 @@ allocator-api2        = { version = "0.3.0", default-features = false }
 defmt                 = { version = "1.0.1", optional = true }
 cfg-if                = "1"
 enumset               = "1"
-esp-sync              = { version = "0.0.0", path = "../esp-sync" }
+esp-sync              = { version = "0.1.0", path = "../esp-sync" }
 document-features     = "0.2"
 
 linked_list_allocator = { version = "0.10.5", default-features = false, features = ["const_mut_refs"] }
 rlsf = { version = "0.2", features = ["unstable"] }
 
 [build-dependencies]
-esp-config   = { version = "0.5.0", path = "../esp-config", features = ["build"] }
+esp-config   = { version = "0.6.0", path = "../esp-config", features = ["build"] }
 
 [features]
 default = ["compat"]

--- a/esp-backtrace/CHANGELOG.md
+++ b/esp-backtrace/CHANGELOG.md
@@ -12,13 +12,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+
+### Fixed
+
+
+### Removed
+
+
+## [v0.18.0] - 2025-10-13
+
+### Changed
+
 - `exception-handler` now panics. (#3838)
 - Only halt cores in panics when `halt-cores` feature is enabled. (#4010)
 - It is no longer possible to select multiple halt method features (`halt-cores`, `custom-halt`, `semihosting`) (#4012)
 - RISC-V: If stack-frames are not enabled the panic-handler will now emit a stack dump (#4189)
-
-### Fixed
-
 
 ### Removed
 
@@ -100,4 +108,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.15.1]: https://github.com/esp-rs/esp-hal/releases/tag/esp-backtrace-v0.15.1
 [v0.16.0]: https://github.com/esp-rs/esp-hal/compare/esp-backtrace-v0.15.1...esp-backtrace-v0.16.0
 [v0.17.0]: https://github.com/esp-rs/esp-hal/compare/esp-backtrace-v0.16.0...esp-backtrace-v0.17.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-backtrace-v0.17.0...HEAD
+[v0.18.0]: https://github.com/esp-rs/esp-hal/compare/esp-backtrace-v0.17.0...esp-backtrace-v0.18.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-backtrace-v0.18.0...HEAD

--- a/esp-backtrace/Cargo.toml
+++ b/esp-backtrace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-backtrace"
-version       = "0.17.0"
+version       = "0.18.0"
 edition       = "2024"
 rust-version  = "1.86.0"
 description   = "Bare-metal backtrace support for Espressif devices"
@@ -34,9 +34,9 @@ test  = false
 [dependencies]
 cfg-if      = "1"
 defmt       = { version = "1", optional = true }
-esp-config  = { version = "0.5.0", path = "../esp-config" }
-esp-metadata-generated = { version = "0.1.0", path = "../esp-metadata-generated" }
-esp-println = { version = "0.15.0", optional = true, default-features = false, path = "../esp-println" }
+esp-config  = { version = "0.6.0", path = "../esp-config" }
+esp-metadata-generated = { version = "0.2.0", path = "../esp-metadata-generated" }
+esp-println = { version = "0.16.0", optional = true, default-features = false, path = "../esp-println" }
 heapless    = "0.9"
 semihosting = { version = "0.1.20", optional = true }
 document-features = "0.2"
@@ -45,11 +45,11 @@ document-features = "0.2"
 riscv            = { version = "0.15.0" }
 
 [target.'cfg(target_arch = "xtensa")'.dependencies]
-xtensa-lx        = { version = "0.12.0", path = "../xtensa-lx" }
+xtensa-lx        = { version = "0.13.0", path = "../xtensa-lx" }
 
 [build-dependencies]
-esp-config   = { version = "0.5.0", path = "../esp-config", features = ["build"] }
-esp-metadata-generated = { version = "0.1.0", path = "../esp-metadata-generated", features = ["build-script"] }
+esp-config   = { version = "0.6.0", path = "../esp-config", features = ["build"] }
+esp-metadata-generated = { version = "0.2.0", path = "../esp-metadata-generated", features = ["build-script"] }
 
 [features]
 default = ["colors"]

--- a/esp-bootloader-esp-idf/CHANGELOG.md
+++ b/esp-bootloader-esp-idf/CHANGELOG.md
@@ -9,8 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+
+### Changed
+
+
+### Fixed
+
+
+### Removed
+
+
+## [v0.3.0] - 2025-10-13
+
+### Added
+
 - `FlashRegion::partition_size` (#3902)
-- `PartitionTable::booted_partition`(#3979)
+- `PartitionTable::booted_partition` (#3979)
 - A new high-level OTA update helper, `OtaUpdater`, has been introduced. This simplifies the process of performing an OTA update by validating the partition table, finding the next available update slot, and handling the activation of the new image. (#4150)
 - Support for partition tables with more than two OTA application partitions (up to 16). The OTA logic now correctly cycles through all available `ota_X` slots. (#4150)
 - `PartitionTable::booted_partition()` function to determine which application partition is currently running by inspecting MMU registers. (#4150)
@@ -28,9 +42,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Don't fail the build on long project names (#3905)
 - FlashRegion: Fix off-by-one bug when bounds checking (#3977)
 - Correctly set the `ESP_IDF_COMPATIBLE_VERSION` in the application descriptor. It was previously using the `MMU_PAGE_SIZE` configuration value by mistake. (#4150)
-
-### Removed
-
 
 ## [v0.2.0] - 2025-07-16
 
@@ -60,4 +71,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [v0.1.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-bootloader-esp-idf-v0.1.0
 [v0.2.0]: https://github.com/esp-rs/esp-hal/compare/esp-bootloader-esp-idf-v0.1.0...esp-bootloader-esp-idf-v0.2.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-bootloader-esp-idf-v0.2.0...HEAD
+[v0.3.0]: https://github.com/esp-rs/esp-hal/compare/esp-bootloader-esp-idf-v0.2.0...esp-bootloader-esp-idf-v0.3.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-bootloader-esp-idf-v0.3.0...HEAD

--- a/esp-bootloader-esp-idf/Cargo.toml
+++ b/esp-bootloader-esp-idf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "esp-bootloader-esp-idf"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.88.0"
 description = "Functionality related to the esp-idf bootloader"
@@ -32,8 +32,8 @@ test  = true
 cfg-if = "1"
 defmt = { version = "1.0.1", optional = true }
 document-features = "0.2"
-esp-config = { version = "0.5.0", path = "../esp-config" }
-esp-rom-sys = { version = "0.1.1", path = "../esp-rom-sys", optional = true }
+esp-config = { version = "0.6.0", path = "../esp-config" }
+esp-rom-sys = { version = "0.1.2", path = "../esp-rom-sys", optional = true }
 embedded-storage = "0.3.1"
 log-04 = { package = "log", version = "0.4", optional = true }
 strum = { version = "0.27", default-features = false, features = ["derive"] }
@@ -43,7 +43,7 @@ md-5 = { version = "0.10.6", default-features = false, optional = true }
 
 [build-dependencies]
 jiff       = { version = "0.2.13", default-features = false, features = ["std"] }
-esp-config = { version = "0.5.0", path = "../esp-config", features = ["build"] }
+esp-config = { version = "0.6.0", path = "../esp-config", features = ["build"] }
 
 [features]
 default = ["validation"]

--- a/esp-config/CHANGELOG.md
+++ b/esp-config/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 
+## [v0.6.0] - 2025-10-13
+
 ## [v0.5.0] - 2025-07-16
 
 ### Added
@@ -71,4 +73,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.3.1]: https://github.com/esp-rs/esp-hal/releases/tag/esp-config-v0.3.1
 [v0.4.0]: https://github.com/esp-rs/esp-hal/compare/esp-config-v0.3.1...esp-config-v0.4.0
 [v0.5.0]: https://github.com/esp-rs/esp-hal/compare/esp-config-v0.4.0...esp-config-v0.5.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-config-v0.5.0...HEAD
+[v0.6.0]: https://github.com/esp-rs/esp-hal/compare/esp-config-v0.5.0...esp-config-v0.6.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-config-v0.6.0...HEAD

--- a/esp-config/Cargo.toml
+++ b/esp-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-config"
-version       = "0.5.0"
+version       = "0.6.0"
 edition       = "2024"
 rust-version  = "1.86.0"
 description   = "Configure projects using esp-hal and related packages"
@@ -33,8 +33,8 @@ document-features = "0.2"
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 serde_yaml     = { version =  "0.9", optional = true }
 somni-expr = { version = "0.2.0", optional = true }
-esp-metadata = { version = "0.8.0", path = "../esp-metadata", features = ["clap"], optional = true }
-esp-metadata-generated = { version = "0.1.0", path = "../esp-metadata-generated", features = ["build-script"], optional = true }
+esp-metadata = { version = "0.9.0", path = "../esp-metadata", features = ["clap"], optional = true }
+esp-metadata-generated = { version = "0.2.0", path = "../esp-metadata-generated", features = ["build-script"], optional = true }
 
 # used by the `tui` feature
 clap            = { version = "4.5", features = ["derive"], optional = true }

--- a/esp-hal-procmacros/CHANGELOG.md
+++ b/esp-hal-procmacros/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+
+### Changed
+
+
+### Fixed
+
+
+### Removed
+
+
+## [v0.20.0] - 2025-10-13
+
+### Added
+
 - Added support for lifetimes and generics to `BuilderLite` derive macro (#3963)
 - Added `ram(reclaimed)` as an alias for `link_section = ".dram2_uninit"` (#4245)
 
@@ -19,8 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Replaced `embassy_main` with `rtos_main` (intended to be called as `esp_rtos::main`) (#4172)
-
-### Removed
 
 ## [v0.19.0] - 2025-07-16
 
@@ -106,4 +118,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.17.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-hal-procmacros-v0.17.0
 [v0.18.0]: https://github.com/esp-rs/esp-hal/compare/esp-hal-procmacros-v0.17.0...esp-hal-procmacros-v0.18.0
 [v0.19.0]: https://github.com/esp-rs/esp-hal/compare/esp-hal-procmacros-v0.18.0...esp-hal-procmacros-v0.19.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-hal-procmacros-v0.19.0...HEAD
+[v0.20.0]: https://github.com/esp-rs/esp-hal/compare/esp-hal-procmacros-v0.19.0...esp-hal-procmacros-v0.20.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-hal-procmacros-v0.20.0...HEAD

--- a/esp-hal-procmacros/Cargo.toml
+++ b/esp-hal-procmacros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-hal-procmacros"
-version       = "0.19.0"
+version       = "0.20.0"
 edition       = "2024"
 rust-version  = "1.88.0"
 description   = "Procedural macros for esp-hal"

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+
+### Changed
+
+
+### Fixed
+
+
+### Removed
+
+
+## [v1.0.0-rc.1] - 2025-10-13
+
+### Added
+
 - A reimplemntation of the `assign_resources!` macro (#3809)
 - `TrngSource` to manage random number generator entropy (#3829)
 - On RISC-V you can opt-out of nested interrupts for an interrupt handler by using `new_not_nested` (#3875)
@@ -42,7 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for `embedded-io 0.7` (#4280)
 - RMT: Wrapping the hardware buffer is now supported for rx/tx and blocking/async channels (#4049)
 - `rmt::CHANNEL_RAM_SIZE` and `rmt::HAS_RX_WRAP` constants have been added (#4049)
-- A new option `ESP_HAL_CONFIG_WRITE_VEC_TABLE_MONITORING` (disabled by default) to check that no unintentional writes to a very vital memory area are made. (Only RISC-V)  (#4225)
+- A new option `ESP_HAL_CONFIG_WRITE_VEC_TABLE_MONITORING` (disabled by default) to check that no unintentional writes to a very vital memory area are made. (Only RISC-V) (#4225)
 - ESP32-C2: Added `Attenuation::_2p5dB` and `Attenuation::_6dB` options (#4324)
 
 ### Changed
@@ -1425,4 +1439,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v1.0.0-beta.0]: https://github.com/esp-rs/esp-hal/compare/v0.23.1...esp-hal-v1.0.0-beta.0
 [v1.0.0-beta.1]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.0.0-beta.0...esp-hal-v1.0.0-beta.1
 [v1.0.0-rc.0]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.0.0-beta.1...esp-hal-v1.0.0-rc.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.0.0-rc.0...HEAD
+[v1.0.0-rc.1]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.0.0-rc.0...esp-hal-v1.0.0-rc.1
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.0.0-rc.1...HEAD

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-hal"
-version       = "1.0.0-rc.0"
+version       = "1.0.0-rc.1"
 edition       = "2024"
 rust-version  = "1.88.0"
 description   = "Bare-metal HAL for Espressif devices"
@@ -55,7 +55,7 @@ enumset                  = "1.1"
 paste                    = "1.0.15"
 portable-atomic          = { version = "1.11", default-features = false }
 
-esp-rom-sys              = { version = "0.1.1", path = "../esp-rom-sys" }
+esp-rom-sys              = { version = "0.1.2", path = "../esp-rom-sys" }
 
 # Unstable dependencies that are not (strictly) part of the public API
 bitfield                 = "0.19"
@@ -67,10 +67,10 @@ fugit                    = "0.3.7"
 instability              = "0.3.9"
 strum                    = { version = "0.27.1", default-features = false, features = ["derive"] }
 
-esp-config               = { version = "0.5.0", path = "../esp-config" }
-esp-metadata-generated   = { version = "0.1.0", path = "../esp-metadata-generated" }
-esp-sync                 = { version = "0.0.0", path = "../esp-sync" }
-procmacros               = { version = "0.19.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
+esp-config               = { version = "0.6.0", path = "../esp-config" }
+esp-metadata-generated   = { version = "0.2.0", path = "../esp-metadata-generated" }
+esp-sync                 = { version = "0.1.0", path = "../esp-sync" }
+procmacros               = { version = "0.20.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
 
 # Dependencies that are optional because they are used by unstable drivers.
 # They are needed when using the `unstable` feature.
@@ -114,15 +114,15 @@ esp32s3 = { version = "0.34", features = ["critical-section", "rt"], optional = 
 
 [target.'cfg(target_arch = "riscv32")'.dependencies]
 riscv            = { version = "0.15.0" }
-esp-riscv-rt     = { version = "0.12.0", path = "../esp-riscv-rt", optional = true }
+esp-riscv-rt     = { version = "0.13.0", path = "../esp-riscv-rt", optional = true }
 
 [target.'cfg(target_arch = "xtensa")'.dependencies]
-xtensa-lx        = { version = "0.12.0", path = "../xtensa-lx" }
-xtensa-lx-rt     = { version = "0.20.0", path = "../xtensa-lx-rt", optional = true }
+xtensa-lx        = { version = "0.13.0", path = "../xtensa-lx" }
+xtensa-lx-rt     = { version = "0.21.0", path = "../xtensa-lx-rt", optional = true }
 
 [build-dependencies]
-esp-metadata-generated = { version = "0.1.0", path = "../esp-metadata-generated", features = ["build-script"] }
-esp-config   = { version = "0.5.0", path = "../esp-config", features = ["build"] }
+esp-metadata-generated = { version = "0.2.0", path = "../esp-metadata-generated", features = ["build-script"] }
+esp-config   = { version = "0.6.0", path = "../esp-config", features = ["build"] }
 
 [dev-dependencies]
 crypto-bigint = { version = "0.5.5", default-features = false }

--- a/esp-hal/MIGRATING-1.0.0-rc.0.md
+++ b/esp-hal/MIGRATING-1.0.0-rc.0.md
@@ -1,4 +1,4 @@
-# Migration Guide from 1.0.0-rc.0 to {{currentVersion}}
+# Migration Guide from 1.0.0-rc.0 to 1.0.0-rc.1
 
 ## RNG changes
 

--- a/esp-lp-hal/CHANGELOG.md
+++ b/esp-lp-hal/CHANGELOG.md
@@ -15,10 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed size of LP_UART's RAM block (#3812)
 
 ### Removed
 
+
+## [v0.3.0] - 2025-10-13
+
+### Fixed
+
+- Fixed size of LP_UART's RAM block (#3812)
 
 ## [v0.2.0] - 2025-06-03
 
@@ -55,4 +60,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - GPIO Input/Output types have been converted to unit structs (#1754)
 
 [v0.2.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-lp-hal-v0.2.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-lp-hal-v0.2.0...HEAD
+[v0.3.0]: https://github.com/esp-rs/esp-hal/compare/esp-lp-hal-v0.2.0...esp-lp-hal-v0.3.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-lp-hal-v0.3.0...HEAD

--- a/esp-lp-hal/Cargo.toml
+++ b/esp-lp-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-lp-hal"
-version       = "0.2.0"
+version       = "0.3.0"
 edition       = "2024"
 rust-version  = "1.86.0"
 description   = "HAL for low-power RISC-V coprocessors found in ESP32 devices"
@@ -45,15 +45,15 @@ esp32c6-lp        = { version = "0.3.0", features = ["critical-section"], option
 esp32s2-ulp       = { version = "0.3.0", features = ["critical-section"], optional = true }
 esp32s3-ulp       = { version = "0.3.0", features = ["critical-section"], optional = true }
 nb                = { version = "1.1.0",  optional = true }
-procmacros        = { version = "0.19.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
+procmacros        = { version = "0.20.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
 riscv             = { version = "0.15", features = ["critical-section-single-hart"] }
-esp-metadata-generated = { version = "0.1.0", path = "../esp-metadata-generated" }
+esp-metadata-generated = { version = "0.2.0", path = "../esp-metadata-generated" }
 
 [dev-dependencies]
 panic-halt = "0.2.0"
 
 [build-dependencies]
-esp-metadata-generated = { version = "0.1.0", path = "../esp-metadata-generated", features = ["build-script"] }
+esp-metadata-generated = { version = "0.2.0", path = "../esp-metadata-generated", features = ["build-script"] }
 
 [features]
 default = ["embedded-hal"]

--- a/esp-metadata-generated/Cargo.toml
+++ b/esp-metadata-generated/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-metadata-generated"
-version       = "0.1.0"
+version       = "0.2.0"
 edition       = "2024"
 rust-version  = "1.86.0"
 description   = "Generated metadata for Espressif devices"

--- a/esp-metadata/CHANGELOG.md
+++ b/esp-metadata/CHANGELOG.md
@@ -15,10 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Output: Include firmware-side metadata macros even if the build-script feature is set. (#3906)
 
 ### Removed
 
+
+## [v0.9.0] - 2025-10-13
+
+### Fixed
+
+- Output: Include firmware-side metadata macros even if the build-script feature is set. (#3906)
 
 ## [v0.8.0] - 2025-07-16
 
@@ -79,4 +84,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.6.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-metadata-v0.6.0
 [v0.7.0]: https://github.com/esp-rs/esp-hal/compare/esp-metadata-v0.6.0...esp-metadata-v0.7.0
 [v0.8.0]: https://github.com/esp-rs/esp-hal/compare/esp-metadata-v0.7.0...esp-metadata-v0.8.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-metadata-v0.8.0...HEAD
+[v0.9.0]: https://github.com/esp-rs/esp-hal/compare/esp-metadata-v0.8.0...esp-metadata-v0.9.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-metadata-v0.9.0...HEAD

--- a/esp-metadata/Cargo.toml
+++ b/esp-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-metadata"
-version       = "0.8.0"
+version       = "0.9.0"
 edition       = "2024"
 rust-version  = "1.86.0"
 description   = "Metadata for Espressif devices"

--- a/esp-phy/CHANGELOG.md
+++ b/esp-phy/CHANGELOG.md
@@ -9,4 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+
+### Changed
+
+
+### Fixed
+
+
+### Removed
+
+
+## [v0.1.0] - 2025-10-13
+
+### Added
+
 - Initial release (#3892)
+
+[v0.1.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-phy-v0.1.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-phy-v0.1.0...HEAD

--- a/esp-phy/Cargo.toml
+++ b/esp-phy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-phy"
-version       = "0.0.1"
+version       = "0.1.0"
 edition       = "2024"
 description   = "PHY initialization"
 documentation = "https://docs.espressif.com/projects/rust/esp-phy/latest/"
@@ -29,17 +29,17 @@ bench = false
 cfg-if = "1"
 
 document-features = "0.2"
-esp-hal = { version = "1.0.0-rc.0", path = "../esp-hal", default-features = false, features = ["requires-unstable"] }
+esp-hal = { version = "1.0.0-rc.1", path = "../esp-hal", default-features = false, features = ["requires-unstable"] }
 esp-wifi-sys = "0.8.1"
-esp-metadata-generated = { version = "0.1.0", path = "../esp-metadata-generated" }
-esp-sync = { version = "0.0.0", path = "../esp-sync" }
+esp-metadata-generated = { version = "0.2.0", path = "../esp-metadata-generated" }
+esp-sync = { version = "0.1.0", path = "../esp-sync" }
 
 defmt = { version = "1.0.1", optional = true }
 log-04 = { version = "0.4.27", package = "log", optional = true }
 
 [build-dependencies]
-esp-config   = { version = "0.5.0", path = "../esp-config", features = ["build"] }
-esp-metadata-generated = { version = "0.1.0", path = "../esp-metadata-generated", features = ["build-script"] }
+esp-config   = { version = "0.6.0", path = "../esp-config", features = ["build"] }
+esp-metadata-generated = { version = "0.2.0", path = "../esp-metadata-generated", features = ["build-script"] }
 
 [features]
 #! ### Logging Feature Flags

--- a/esp-println/CHANGELOG.md
+++ b/esp-println/CHANGELOG.md
@@ -12,14 +12,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+
+### Fixed
+
+
+### Removed
+
+
+## [v0.16.0] - 2025-10-13
+
+### Changed
+
 - Updated `timestamp` example code for Rust edition 2024 (#4211)
 
 ### Fixed
 
 - `critical-section` now wraps the entirety of the `print!` macros (#4162)
-
-### Removed
-
 
 ## [v0.15.0] - 2025-07-16
 
@@ -110,4 +118,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.13.1]: https://github.com/esp-rs/esp-hal/releases/tag/esp-println-v0.13.1
 [v0.14.0]: https://github.com/esp-rs/esp-hal/compare/esp-println-v0.13.1...esp-println-v0.14.0
 [v0.15.0]: https://github.com/esp-rs/esp-hal/compare/esp-println-v0.14.0...esp-println-v0.15.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-println-v0.15.0...HEAD
+[v0.16.0]: https://github.com/esp-rs/esp-hal/compare/esp-println-v0.15.0...esp-println-v0.16.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-println-v0.16.0...HEAD

--- a/esp-println/Cargo.toml
+++ b/esp-println/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-println"
-version       = "0.15.0"
+version       = "0.16.0"
 edition       = "2024"
 rust-version  = "1.86.0"
 description   = "Provides `print!` and `println!` implementations various Espressif devices"
@@ -39,7 +39,7 @@ test  = false
 document-features = "0.2"
 
 # Unstable dependencies that are not (strictly) part of the public API
-esp-sync = { version = "0.0.0", path = "../esp-sync", optional = true }
+esp-sync = { version = "0.1.0", path = "../esp-sync", optional = true }
 
 # Optional dependencies
 portable-atomic  = { version = "1.11", optional = true, default-features = false }
@@ -49,7 +49,7 @@ defmt  = { version = "1.0.1", optional = true }
 log-04 = { package = "log", version = "0.4", optional = true }
 
 [build-dependencies]
-esp-metadata-generated = { version = "0.1.0", path = "../esp-metadata-generated", features = ["build-script"] }
+esp-metadata-generated = { version = "0.2.0", path = "../esp-metadata-generated", features = ["build-script"] }
 log-04 = { package = "log", version = "0.4" }
 
 [features]

--- a/esp-radio-rtos-driver/CHANGELOG.md
+++ b/esp-radio-rtos-driver/CHANGELOG.md
@@ -9,4 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+
+### Changed
+
+
+### Fixed
+
+
+### Removed
+
+
+## [v0.1.0] - 2025-10-13
+
+### Added
+
 - Initial release (#3855)
+
+[v0.1.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-radio-rtos-driver-v0.1.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-radio-rtos-driver-v0.1.0...HEAD

--- a/esp-radio-rtos-driver/Cargo.toml
+++ b/esp-radio-rtos-driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-radio-rtos-driver"
-version       = "0.0.1"
+version       = "0.1.0"
 edition       = "2024"
 rust-version  = "1.86.0"
 description   = "Task scheduler interface for esp-radio"

--- a/esp-radio/CHANGELOG.md
+++ b/esp-radio/CHANGELOG.md
@@ -9,12 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+
+### Changed
+
+
+### Fixed
+
+
+### Removed
+
+
+## [v0.16.0] - 2025-10-13
+
+### Added
+
 - `AccessPointInfo::country` to access the Country Code from the Wi-Fi scan results (#3837)
 - `unstable` feature to opt into `ble`, `esp-now`, `csi`, `sniffer`, `esp-ieee802154` and `smoltcp` APIs (#3865)
 - Added unstable `wifi-eap` feature (#3924)
 - Optional `max` field in `ScanConfig` to allow limiting the number of returned results (#3963)
 - `set_phy_calibration_data` and `phy_calibration_data` (#4001)
-- common traits for `Protocol`, `Country`,  (#4017)
+- common traits for `Protocol`, `Country`, (#4017)
 - `BuilderLite` pattern to `AccessPointConfig`, `ClientConfig`, and `EapClientConfig` (#4017, #4115)
 - lifetime to `Sniffer` (#4017)
 - `dtim_period` parameter for `PowerSaveMode` (#4040)
@@ -328,4 +342,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v0.14.0]: https://github.com/esp-rs/esp-hal/compare/esp-wifi-v0.13.0...esp-wifi-v0.14.0
 [v0.14.1]: https://github.com/esp-rs/esp-hal/compare/esp-wifi-v0.14.0...esp-wifi-v0.14.1
 [v0.15.0]: https://github.com/esp-rs/esp-hal/compare/esp-wifi-v0.14.1...esp-wifi-v0.15.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-wifi-v0.15.0...HEAD
+[v0.16.0]: https://github.com/esp-rs/esp-hal/compare/esp-wifi-v0.15.0...esp-radio-v0.16.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-radio-v0.16.0...HEAD

--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "esp-radio"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2024"
 rust-version  = "1.88.0"
 description = "A WiFi, Bluetooth and ESP-NOW driver for use with Espressif chips and bare-metal Rust"
@@ -41,28 +41,28 @@ test  = false
 
 [dependencies]
 cfg-if  = "1"
-esp-hal = { version = "1.0.0-rc.0", path = "../esp-hal", default-features = false, features = ["requires-unstable"] }
+esp-hal = { version = "1.0.0-rc.1", path = "../esp-hal", default-features = false, features = ["requires-unstable"] }
 portable-atomic = { version = "1.11", default-features = false }
 enumset = { version = "1.1", default-features = false, optional = true }
 
 # ⚠️ Unstable dependencies
-esp-radio-rtos-driver = { version = "0.0.1", path = "../esp-radio-rtos-driver" }
+esp-radio-rtos-driver = { version = "0.1.0", path = "../esp-radio-rtos-driver" }
 instability = "0.3.9"
 
 # Unstable dependencies that are not (strictly) part of the public API
 allocator-api2 = { version = "0.3.0", default-features = false, features = ["alloc"] }
 document-features  = "0.2"
-esp-alloc = { version = "0.8.0", path = "../esp-alloc", optional = true }
-esp-config = { version = "0.5.0", path = "../esp-config" }
-esp-metadata-generated = { version = "0.1.0", path = "../esp-metadata-generated" }
-esp-sync = { version = "0.0.0", path = "../esp-sync" }
-esp-phy = { version = "0.0.1", path = "../esp-phy/" }
+esp-alloc = { version = "0.9.0", path = "../esp-alloc", optional = true }
+esp-config = { version = "0.6.0", path = "../esp-config" }
+esp-metadata-generated = { version = "0.2.0", path = "../esp-metadata-generated" }
+esp-sync = { version = "0.1.0", path = "../esp-sync" }
+esp-phy = { version = "0.1.0", path = "../esp-phy/" }
 esp-wifi-sys = { version = "0.8.1" }
 num-derive = "0.4.2"
 num-traits = { version = "0.2.19", default-features = false }
 portable_atomic_enum = { version = "0.3.1", features = ["portable-atomic"] }
-procmacros = { version = "0.19.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
-xtensa-lx-rt = { version = "0.20.0", path = "../xtensa-lx-rt", optional = true }
+procmacros = { version = "0.20.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
+xtensa-lx-rt = { version = "0.21.0", path = "../xtensa-lx-rt", optional = true }
 byte = { version = "0.2.7", optional = true }
 ieee802154 = { version = "0.6.1", optional = true }
 heapless = "0.9"
@@ -85,8 +85,8 @@ defmt = { version = "1.0.1", optional = true }
 log-04 = { package = "log", version = "0.4.27", optional = true }
 
 [build-dependencies]
-esp-config = { version = "0.5.0", path = "../esp-config", features = ["build"] }
-esp-metadata-generated = { version = "0.1.0", path = "../esp-metadata-generated", features = ["build-script"] }
+esp-config = { version = "0.6.0", path = "../esp-config", features = ["build"] }
+esp-metadata-generated = { version = "0.2.0", path = "../esp-metadata-generated", features = ["build-script"] }
 
 [features]
 default = ["esp-alloc"]

--- a/esp-radio/MIGRATING-0.15.0.md
+++ b/esp-radio/MIGRATING-0.15.0.md
@@ -1,4 +1,4 @@
-# Migration Guide from 0.15.0 to {{currentVersion}}
+# Migration Guide from 0.15.0 to 0.16.0
 
 ## Initialization
 
@@ -40,7 +40,7 @@ On RISC-V devices (ESP32-C2/C3/C6/H2) you'll need to also pass `SoftwareInterrup
 
 ```diff
 - esp-wifi = "0.15.0"
-+ esp-radio = "{{currentVersion}}"
++ esp-radio = "0.16.0"
 ```
 
 ## `EspWifi` prefix has been removed

--- a/esp-riscv-rt/CHANGELOG.md
+++ b/esp-riscv-rt/CHANGELOG.md
@@ -9,14 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+
+### Changed
+
+
+### Fixed
+
+
+### Removed
+
+
+## [v0.13.0] - 2025-10-13
+
+### Added
+
 - A new feature `defmt` which implements `defmt::Format` on `TrapFrame` (#3887)
 
 ### Changed
 
 - The MSRV is bumped to 1.88 (#3887)
-
-### Fixed
-
 
 ### Removed
 
@@ -105,4 +116,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.10.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-riscv-rt-v0.10.0
 [v0.11.0]: https://github.com/esp-rs/esp-hal/compare/esp-riscv-rt-v0.10.0...esp-riscv-rt-v0.11.0
 [v0.12.0]: https://github.com/esp-rs/esp-hal/compare/esp-riscv-rt-v0.11.0...esp-riscv-rt-v0.12.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-riscv-rt-v0.12.0...HEAD
+[v0.13.0]: https://github.com/esp-rs/esp-hal/compare/esp-riscv-rt-v0.12.0...esp-riscv-rt-v0.13.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-riscv-rt-v0.13.0...HEAD

--- a/esp-riscv-rt/Cargo.toml
+++ b/esp-riscv-rt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-riscv-rt"
-version       = "0.12.0"
+version       = "0.13.0"
 edition       = "2024"
 rust-version  = "1.88.0"
 description   = "Minimal runtime / startup for RISC-V CPUs from Espressif"

--- a/esp-rom-sys/CHANGELOG.md
+++ b/esp-rom-sys/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+
+### Changed
+
+
+### Fixed
+
+
+### Removed
+
+
+## [v0.1.2] - 2025-10-13
+
+### Added
+
 - Initialize the syscall table (#4177)
 
 ### Changed
@@ -19,13 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - esp32: c2, c3, s2, s3: fixed "Defalut" typo in ld scripts (#4180)
 
-### Removed
-
-
 ## [v0.1.1] - 2025-07-16
 
 ## [v0.1.0] - 2025-07-01
 
 [v0.1.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-rom-sys-v0.1.0
 [v0.1.1]: https://github.com/esp-rs/esp-hal/compare/esp-rom-sys-v0.1.0...esp-rom-sys-v0.1.1
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-rom-sys-v0.1.1...HEAD
+[v0.1.2]: https://github.com/esp-rs/esp-hal/compare/esp-rom-sys-v0.1.1...esp-rom-sys-v0.1.2
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-rom-sys-v0.1.2...HEAD

--- a/esp-rom-sys/Cargo.toml
+++ b/esp-rom-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-rom-sys"
-version       = "0.1.1"
+version       = "0.1.2"
 edition       = "2024"
 rust-version  = "1.87.0"
 description   = "ROM code support"
@@ -29,7 +29,7 @@ cfg-if              = "1"
 document-features   = "0.2"
 
 [build-dependencies]
-esp-metadata-generated = { version = "0.1.0", path = "../esp-metadata-generated", features = ["build-script"] }
+esp-metadata-generated = { version = "0.2.0", path = "../esp-metadata-generated", features = ["build-script"] }
 
 [features]
 #! ### Chip selection

--- a/esp-rtos/CHANGELOG.md
+++ b/esp-rtos/CHANGELOG.md
@@ -9,5 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+
+### Changed
+
+
+### Fixed
+
+
+### Removed
+
+
+## [v0.1.0] - 2025-10-13
+
+### Added
+
 - Initial release (#3855)
 - The `esp-hal-embassy` crate has been merged into `esp-rtos`. (#4172)
+
+[v0.1.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-rtos-v0.1.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-rtos-v0.1.0...HEAD

--- a/esp-rtos/Cargo.toml
+++ b/esp-rtos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-rtos"
-version       = "0.0.1"
+version       = "0.1.0"
 edition       = "2024"
 rust-version  = "1.86.0"
 description   = "A task scheduler for Espressif devices"
@@ -31,7 +31,7 @@ features       = ["esp32c6", "embassy", "esp-radio"]
 bench = false
 
 [dependencies]
-esp-hal = { version = "1.0.0-rc.0", path = "../esp-hal", features = [
+esp-hal = { version = "1.0.0-rc.1", path = "../esp-hal", features = [
     "requires-unstable",
 ] }
 
@@ -43,11 +43,11 @@ rtos-trace = { version = "0.2.0", optional = true }
 allocator-api2 = { version = "0.3.0", default-features = false, features = ["alloc"], optional = true }
 document-features  = "0.2"
 embassy-sync = "0.7"
-esp-alloc = { version = "0.8.0", path = "../esp-alloc", optional = true }
-esp-config = { version = "0.5.0", path = "../esp-config" }
-esp-sync = { version = "0.0.0", path = "../esp-sync" }
-esp-radio-rtos-driver = { version = "0.0.1", path = "../esp-radio-rtos-driver", optional = true }
-macros = { version = "0.19.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
+esp-alloc = { version = "0.9.0", path = "../esp-alloc", optional = true }
+esp-config = { version = "0.6.0", path = "../esp-config" }
+esp-sync = { version = "0.1.0", path = "../esp-sync" }
+esp-radio-rtos-driver = { version = "0.1.0", path = "../esp-radio-rtos-driver", optional = true }
+macros = { version = "0.20.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
 portable-atomic = { version = "1.11", default-features = false }
 
 # Optional dependencies that enable ecosystem support.
@@ -60,11 +60,11 @@ defmt            = { version = "1.0", optional = true }
 log-04           = { package = "log", version = "0.4", optional = true }
 
 [build-dependencies]
-esp-config             = { version = "0.5.0", path = "../esp-config", features = ["build"] }
-esp-metadata-generated = { version = "0.1.0", path = "../esp-metadata-generated", features = ["build-script"] }
+esp-config             = { version = "0.6.0", path = "../esp-config", features = ["build"] }
+esp-metadata-generated = { version = "0.2.0", path = "../esp-metadata-generated", features = ["build-script"] }
 
 [dev-dependencies]
-esp-hal = { version = "1.0.0-rc.0", path = "../esp-hal", features = ["unstable"] }
+esp-hal = { version = "1.0.0-rc.1", path = "../esp-hal", features = ["unstable"] }
 
 [features]
 default = []

--- a/esp-storage/CHANGELOG.md
+++ b/esp-storage/CHANGELOG.md
@@ -9,20 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `defmt` feature and `FlashStorage`, `FlashStorageError` now implements `Defmt` (#4127)
-- `Drop` impl for `FlashStorage` (#4132)
-- `FlashStorage::new()` now takes a `Flash` argument (#4173)
 
 ### Changed
+
 
 ### Fixed
 
 
 ### Removed
 
+
+## [v0.8.0] - 2025-10-13
+
+### Added
+
+- `defmt` feature and `FlashStorage`, `FlashStorageError` now implements `Defmt` (#4127)
+- `Drop` impl for `FlashStorage` (#4132)
+- `FlashStorage::new()` now takes a `Flash` argument (#4173)
+
+### Removed
+
 - `Default` impl for `FlashStorage` (#4132)
 
-## [v0.8.0] - 2025-09-10
+## v0.8.0 - 2025-09-10
 
 ### Added
 
@@ -70,4 +79,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.5.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-storage-v0.5.0
 [v0.6.0]: https://github.com/esp-rs/esp-hal/compare/esp-storage-v0.5.0...esp-storage-v0.6.0
 [v0.7.0]: https://github.com/esp-rs/esp-hal/compare/esp-storage-v0.6.0...esp-storage-v0.7.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-storage-v0.7.0...HEAD
+[v0.8.0]: https://github.com/esp-rs/esp-hal/compare/esp-storage-v0.7.0...esp-storage-v0.8.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-storage-v0.8.0...HEAD

--- a/esp-storage/Cargo.toml
+++ b/esp-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-storage"
-version       = "0.7.0"
+version       = "0.8.0"
 edition       = "2024"
 rust-version  = "1.86.0"
 description   = "Implementation of embedded-storage traits to access unencrypted ESP32 flash"
@@ -28,19 +28,19 @@ bench = false
 
 [dependencies]
 embedded-storage = "0.3.1"
-procmacros       = { version = "0.19.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
-esp-hal = { version = "1.0.0-rc.0", path = "../esp-hal", default-features = false, optional = true}
+procmacros       = { version = "0.20.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
+esp-hal = { version = "1.0.0-rc.1", path = "../esp-hal", default-features = false, optional = true}
 
 # Optional dependencies
-esp-sync         = { version = "0.0.0", path = "../esp-sync", optional = true }
-esp-rom-sys      = { version = "0.1.1", path = "../esp-rom-sys", optional = true }
+esp-sync         = { version = "0.1.0", path = "../esp-sync", optional = true }
+esp-rom-sys      = { version = "0.1.2", path = "../esp-rom-sys", optional = true }
 defmt  = { version = "1.0.1", optional = true }
 
 # Unstable dependencies that are not (strictly) part of the public API
 document-features = "0.2"
 
 [build-dependencies]
-esp-metadata-generated = { version = "0.1.0", path = "../esp-metadata-generated", features = ["build-script"] }
+esp-metadata-generated = { version = "0.2.0", path = "../esp-metadata-generated", features = ["build-script"] }
 
 [features]
 default = ["critical-section"]

--- a/esp-sync/CHANGELOG.md
+++ b/esp-sync/CHANGELOG.md
@@ -9,4 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+
+### Changed
+
+
+### Fixed
+
+
+### Removed
+
+
+## [v0.1.0] - 2025-10-13
+
+### Added
+
 - Initial release (#4023)
+
+[v0.1.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-sync-v0.1.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-sync-v0.1.0...HEAD

--- a/esp-sync/Cargo.toml
+++ b/esp-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-sync"
-version       = "0.0.0"
+version       = "0.1.0"
 edition       = "2024"
 rust-version  = "1.88.0"
 description   = "Synchronization primitives for Espressif devices"
@@ -21,7 +21,7 @@ clippy-configs = [{ features = ["defmt"] }]
 [dependencies]
 cfg-if = "1"
 document-features = "0.2"
-esp-metadata-generated = { version = "0.1.0", path = "../esp-metadata-generated" }
+esp-metadata-generated = { version = "0.2.0", path = "../esp-metadata-generated" }
 embassy-sync-06 = { package = "embassy-sync", version = "0.6" }
 embassy-sync-07 = { package = "embassy-sync", version = "0.7" }
 
@@ -33,10 +33,10 @@ log-04 = { package = "log", version = "0.4", optional = true }
 riscv            = { version = "0.15" }
 
 [target.'cfg(target_arch = "xtensa")'.dependencies]
-xtensa-lx        = { version = "0.12", path = "../xtensa-lx" }
+xtensa-lx        = { version = "0.13.0", path = "../xtensa-lx" }
 
 [build-dependencies]
-esp-metadata-generated = { version = "0.1.0", path = "../esp-metadata-generated", features = ["build-script"] }
+esp-metadata-generated = { version = "0.2.0", path = "../esp-metadata-generated", features = ["build-script"] }
 
 [features]
 #! ### Chip Support Feature Flags

--- a/xtensa-lx-rt-proc-macros/Cargo.toml
+++ b/xtensa-lx-rt-proc-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtensa-lx-rt-proc-macros"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.86.0"
 description = "Attributes re-exported in `xtensa-lx-rt`"

--- a/xtensa-lx-rt/CHANGELOG.md
+++ b/xtensa-lx-rt/CHANGELOG.md
@@ -9,11 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- A new feature `defmt` which implements `defmt::Format` on `Context` (#3887)
 
 ### Changed
 
-- Removed the `r0` dependency (#4117)
 
 ### Fixed
 
@@ -21,6 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 
+## [v0.21.0] - 2025-10-13
+
+### Added
+
+- A new feature `defmt` which implements `defmt::Format` on `Context` (#3887)
+
+### Changed
+
+- Removed the `r0` dependency (#4117)
 
 ## [v0.20.0] - 2025-07-16
 
@@ -65,4 +72,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.18.0]: https://github.com/esp-rs/esp-hal/releases/tag/xtensa-lx-rt-v0.18.0
 [v0.19.0]: https://github.com/esp-rs/esp-hal/compare/xtensa-lx-rt-v0.18.0...xtensa-lx-rt-v0.19.0
 [v0.20.0]: https://github.com/esp-rs/esp-hal/compare/xtensa-lx-rt-v0.19.0...xtensa-lx-rt-v0.20.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/xtensa-lx-rt-v0.20.0...HEAD
+[v0.21.0]: https://github.com/esp-rs/esp-hal/compare/xtensa-lx-rt-v0.20.0...xtensa-lx-rt-v0.21.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/xtensa-lx-rt-v0.21.0...HEAD

--- a/xtensa-lx-rt/Cargo.toml
+++ b/xtensa-lx-rt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "xtensa-lx-rt"
-version       = "0.20.0"
+version       = "0.21.0"
 edition       = "2024"
 rust-version  = "1.88.0"
 description   = "Minimal startup/runtime for Xtensa LX CPUs"
@@ -21,8 +21,8 @@ test  = false
 [dependencies]
 document-features = "0.2"
 defmt             = {version = "1.0.1", optional = true}
-macros            = { version = "0.4.0", package = "xtensa-lx-rt-proc-macros", path = "../xtensa-lx-rt-proc-macros" }
-xtensa-lx         = { version = "0.12.0", path = "../xtensa-lx" }
+macros            = { version = "0.5.0", package = "xtensa-lx-rt-proc-macros", path = "../xtensa-lx-rt-proc-macros" }
+xtensa-lx         = { version = "0.13.0", path = "../xtensa-lx" }
 
 [build-dependencies]
 

--- a/xtensa-lx/CHANGELOG.md
+++ b/xtensa-lx/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 
+## [v0.13.0] - 2025-10-13
+
 ## [v0.12.0] - 2025-07-16
 
 ### Changed
@@ -64,4 +66,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.10.0]: https://github.com/esp-rs/esp-hal/releases/tag/xtensa-lx-v0.10.0
 [v0.11.0]: https://github.com/esp-rs/esp-hal/compare/xtensa-lx-v0.10.0...xtensa-lx-v0.11.0
 [v0.12.0]: https://github.com/esp-rs/esp-hal/compare/xtensa-lx-v0.11.0...xtensa-lx-v0.12.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/xtensa-lx-v0.12.0...HEAD
+[v0.13.0]: https://github.com/esp-rs/esp-hal/compare/xtensa-lx-v0.12.0...xtensa-lx-v0.13.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/xtensa-lx-v0.13.0...HEAD

--- a/xtensa-lx/Cargo.toml
+++ b/xtensa-lx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "xtensa-lx"
-version       = "0.12.0"
+version       = "0.13.0"
 edition       = "2024"
 rust-version  = "1.86.0"
 description   = "Low-level access to Xtensa LX processors and peripherals"


### PR DESCRIPTION
This pull request prepares the following packages for release:

- xtensa-lx: 0.13.0
- esp-metadata-generated: 0.2.0
- esp-radio-rtos-driver: 0.1.0
- xtensa-lx-rt-proc-macros: 0.5.0
- esp-sync: 0.1.0
- esp-println: 0.16.0
- esp-riscv-rt: 0.13.0
- esp-metadata: 0.9.0
- esp-rom-sys: 0.1.2
- esp-hal-procmacros: 0.20.0
- esp-lp-hal: 0.3.0
- xtensa-lx-rt: 0.21.0
- esp-config: 0.6.0
- esp-backtrace: 0.18.0
- esp-alloc: 0.9.0
- esp-hal: 1.0.0-rc.1
- esp-bootloader-esp-idf: 0.3.0
- esp-phy: 0.1.0
- esp-storage: 0.8.0
- esp-rtos: 0.1.0
- esp-radio: 0.16.0

The release plan used for this release:

```json
{
  "base": "main",
  "packages": [
    {
      "package": "xtensa-lx",
      "semver_checked": false,
      "current_version": "0.12.0",
      "new_version": "0.13.0",
      "tag_name": "xtensa-lx-v0.13.0",
      "bump": "Minor"
    },
    {
      "package": "esp-metadata-generated",
      "semver_checked": false,
      "current_version": "0.1.0",
      "new_version": "0.2.0",
      "tag_name": "esp-metadata-generated-v0.2.0",
      "bump": "Minor"
    },
    {
      "package": "esp-radio-rtos-driver",
      "semver_checked": false,
      "current_version": "0.0.1",
      "new_version": "0.1.0",
      "tag_name": "esp-radio-rtos-driver-v0.1.0",
      "bump": "Minor"
    },
    {
      "package": "xtensa-lx-rt-proc-macros",
      "semver_checked": false,
      "current_version": "0.4.0",
      "new_version": "0.5.0",
      "tag_name": "xtensa-lx-rt-proc-macros-v0.5.0",
      "bump": "Minor"
    },
    {
      "package": "esp-sync",
      "semver_checked": false,
      "current_version": "0.0.0",
      "new_version": "0.1.0",
      "tag_name": "esp-sync-v0.1.0",
      "bump": "Minor"
    },
    {
      "package": "esp-println",
      "semver_checked": false,
      "current_version": "0.15.0",
      "new_version": "0.16.0",
      "tag_name": "esp-println-v0.16.0",
      "bump": "Minor"
    },
    {
      "package": "esp-riscv-rt",
      "semver_checked": false,
      "current_version": "0.12.0",
      "new_version": "0.13.0",
      "tag_name": "esp-riscv-rt-v0.13.0",
      "bump": "Minor"
    },
    {
      "package": "esp-metadata",
      "semver_checked": false,
      "current_version": "0.8.0",
      "new_version": "0.9.0",
      "tag_name": "esp-metadata-v0.9.0",
      "bump": "Minor"
    },
    {
      "package": "esp-rom-sys",
      "semver_checked": false,
      "current_version": "0.1.1",
      "new_version": "0.1.2",
      "tag_name": "esp-rom-sys-v0.1.2",
      "bump": "Patch"
    },
    {
      "package": "esp-hal-procmacros",
      "semver_checked": false,
      "current_version": "0.19.0",
      "new_version": "0.20.0",
      "tag_name": "esp-hal-procmacros-v0.20.0",
      "bump": "Minor"
    },
    {
      "package": "esp-lp-hal",
      "semver_checked": false,
      "current_version": "0.2.0",
      "new_version": "0.3.0",
      "tag_name": "esp-lp-hal-v0.3.0",
      "bump": "Minor"
    },
    {
      "package": "xtensa-lx-rt",
      "semver_checked": false,
      "current_version": "0.20.0",
      "new_version": "0.21.0",
      "tag_name": "xtensa-lx-rt-v0.21.0",
      "bump": "Minor"
    },
    {
      "package": "esp-config",
      "semver_checked": false,
      "current_version": "0.5.0",
      "new_version": "0.6.0",
      "tag_name": "esp-config-v0.6.0",
      "bump": "Minor"
    },
    {
      "package": "esp-backtrace",
      "semver_checked": false,
      "current_version": "0.17.0",
      "new_version": "0.18.0",
      "tag_name": "esp-backtrace-v0.18.0",
      "bump": "Minor"
    },
    {
      "package": "esp-alloc",
      "semver_checked": false,
      "current_version": "0.8.0",
      "new_version": "0.9.0",
      "tag_name": "esp-alloc-v0.9.0",
      "bump": "Minor"
    },
    {
      "package": "esp-hal",
      "semver_checked": true,
      "current_version": "1.0.0-rc.0",
      "new_version": "1.0.0-rc.1",
      "tag_name": "esp-hal-v1.0.0-rc.1",
      "bump": {
        "PreRelease": "rc"
      }
    },
    {
      "package": "esp-bootloader-esp-idf",
      "semver_checked": false,
      "current_version": "0.2.0",
      "new_version": "0.3.0",
      "tag_name": "esp-bootloader-esp-idf-v0.3.0",
      "bump": "Minor"
    },
    {
      "package": "esp-phy",
      "semver_checked": false,
      "current_version": "0.0.1",
      "new_version": "0.1.0",
      "tag_name": "esp-phy-v0.1.0",
      "bump": "Minor"
    },
    {
      "package": "esp-storage",
      "semver_checked": false,
      "current_version": "0.7.0",
      "new_version": "0.8.0",
      "tag_name": "esp-storage-v0.8.0",
      "bump": "Minor"
    },
    {
      "package": "esp-rtos",
      "semver_checked": false,
      "current_version": "0.0.1",
      "new_version": "0.1.0",
      "tag_name": "esp-rtos-v0.1.0",
      "bump": "Minor"
    },
    {
      "package": "esp-radio",
      "semver_checked": false,
      "current_version": "0.15.0",
      "new_version": "0.16.0",
      "tag_name": "esp-radio-v0.16.0",
      "bump": "Minor"
    }
  ]
}
```