### PR TITLE
Fix crash on deleting a non-current task

### DIFF
--- a/esp-rtos/CHANGELOG.md
+++ b/esp-rtos/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a bug causing a crash when deleting a task (#4338)
 
 ### Removed
 

--- a/esp-rtos/src/run_queue.rs
+++ b/esp-rtos/src/run_queue.rs
@@ -168,9 +168,7 @@ impl RunQueue {
 
         ready_task.set_state(TaskState::Ready);
         if let Some(mut containing_queue) = unsafe { ready_task.as_mut().current_queue.take() } {
-            unsafe {
-                containing_queue.as_mut().remove(ready_task);
-            }
+            unsafe { containing_queue.as_mut().remove(ready_task) };
         }
         self.ready_tasks[priority_n].push(ready_task);
 


### PR DESCRIPTION
Fixes #4336

When deleting another task, the task needs to be removed from wait queues and timer queues, otherwise an operation that would make them ready before the scheduler gets to actually deleting them will change the task's state.