### PR TITLE
Prepare esp-rtos patch release

### DIFF
--- a/esp-rtos/CHANGELOG.md
+++ b/esp-rtos/CHANGELOG.md
@@ -15,10 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed a bug causing a crash when deleting a task (#4338)
 
 ### Removed
 
+
+## [v0.1.1] - 2025-10-14
+
+### Fixed
+
+- Fixed a bug causing a crash when deleting a task (#4338)
 
 ## [v0.1.0] - 2025-10-13
 
@@ -28,4 +33,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `esp-hal-embassy` crate has been merged into `esp-rtos`. (#4172)
 
 [v0.1.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-rtos-v0.1.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-rtos-v0.1.0...HEAD
+[v0.1.1]: https://github.com/esp-rs/esp-hal/compare/esp-rtos-v0.1.0...esp-rtos-v0.1.1
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-rtos-v0.1.1...HEAD

--- a/esp-rtos/Cargo.toml
+++ b/esp-rtos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-rtos"
-version       = "0.1.0"
+version       = "0.1.1"
 edition       = "2024"
 rust-version  = "1.86.0"
 description   = "A task scheduler for Espressif devices"


### PR DESCRIPTION
This pull request prepares the following packages for release:

- esp-rtos: 0.1.1

The release plan used for this release:

```json
{
  "base": "main",
  "packages": [
    {
      "package": "esp-rtos",
      "semver_checked": false,
      "current_version": "0.1.0",
      "new_version": "0.1.1",
      "tag_name": "esp-rtos-v0.1.1",
      "bump": "Patch"
    }
  ]
}
```
