### PR TITLE
Less wasted memory for the BLE examples

### DIFF
--- a/examples/ble/bas_peripheral/src/main.rs
+++ b/examples/ble/bas_peripheral/src/main.rs
@@ -37,7 +37,7 @@ async fn main(_s: Spawner) {
 
     let bluetooth = peripherals.BT;
     let connector = BleConnector::new(radio, bluetooth, Default::default()).unwrap();
-    let controller: ExternalController<_, 20> = ExternalController::new(connector);
+    let controller: ExternalController<_, 1> = ExternalController::new(connector);
 
     ble_bas_peripheral_run(controller).await;
 }

--- a/examples/ble/scanner/src/main.rs
+++ b/examples/ble/scanner/src/main.rs
@@ -43,7 +43,7 @@ async fn main(_s: Spawner) {
 
     let bluetooth = peripherals.BT;
     let connector = BleConnector::new(radio, bluetooth, Default::default()).unwrap();
-    let controller: ExternalController<_, 20> = ExternalController::new(connector);
+    let controller: ExternalController<_, 1> = ExternalController::new(connector);
 
     ble_scanner_run(controller).await;
 }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

Reserving 20 slots seems wasteful since we can only have one in-flight command

#### Testing
run the examples
