### PR TITLE
Hide work_queue, clean up

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `work_queue` is no longer public (#4357)
 
 ### Fixed
 

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -228,11 +228,9 @@ pub use xtensa_lx_rt::{self, xtensa_lx};
 
 #[cfg(lp_core)]
 #[instability::unstable]
-#[cfg_attr(not(feature = "unstable"), allow(unused))]
 pub use self::soc::lp_core;
 #[cfg(ulp_riscv_core)]
 #[instability::unstable]
-#[cfg_attr(not(feature = "unstable"), allow(unused))]
 pub use self::soc::ulp_core;
 
 #[cfg(any(soc_has_dport, soc_has_hp_sys, soc_has_pcr, soc_has_system))]
@@ -334,8 +332,9 @@ unstable_module! {
     #[cfg(psram)] // DMA needs some things from here
     pub mod psram;
     pub mod efuse;
-    pub mod work_queue;
 }
+
+mod work_queue;
 
 unstable_driver! {
     #[cfg(soc_has_aes)]

--- a/esp-hal/src/work_queue.rs
+++ b/esp-hal/src/work_queue.rs
@@ -10,7 +10,7 @@
 //!
 //! Posting a work item into the queue returns a handle. The handle can be used to poll whether
 //! the work item has been processed. Dropping the handle will cancel the work item.
-#![cfg_attr(esp32c2, allow(unused))]
+#![cfg_attr(not(feature = "unstable"), allow(unused))]
 
 use core::{future::poll_fn, marker::PhantomData, ptr::NonNull, task::Context};
 


### PR DESCRIPTION
`work_queue` used to be public originally because some types were reexported. It's no longer necessary and I think it just pollutes docs with no added value.