### PR TITLE
Remove BLE workarounds

### DIFF
--- a/esp-radio/src/ble/btdm.rs
+++ b/esp-radio/src/ble/btdm.rs
@@ -122,7 +122,7 @@ unsafe extern "C" fn interrupt_disable() {
 
 #[ram]
 unsafe extern "C" fn task_yield() {
-    todo!();
+    crate::preempt::yield_task();
 }
 
 unsafe extern "C" fn task_yield_from_isr() {


### PR DESCRIPTION
These don't seem to be needed anymore, either because of the RTOS, or the blob update.