### PR TITLE
Fix nightly CI

### DIFF
--- a/.github/workflows/ci_nightly.yml
+++ b/.github/workflows/ci_nightly.yml
@@ -86,6 +86,6 @@ jobs:
             gh issue create \
               --title "Nightly CI Failure" \
               --body "One or more jobs failed! [View the failed workflow](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})." \
-              --label "ci-nightly"
+              --label "ci-nightly" \
               --assignee JurajSadel
           fi


### PR DESCRIPTION
Fixes syntax error https://github.com/esp-rs/esp-hal/actions/runs/18608118115/job/53061809481#step:3:25. The H2 error should be gone. 

closes https://github.com/esp-rs/esp-hal/issues/4375