### PR TITLE
Fix RTOS time driver stopping unexpectedly

### DIFF
--- a/esp-rtos/CHANGELOG.md
+++ b/esp-rtos/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a bug causing timers to stop working in certain cases. (#4393)
 
 ### Removed
 

--- a/esp-rtos/src/timer/embassy.rs
+++ b/esp-rtos/src/timer/embassy.rs
@@ -53,9 +53,7 @@ impl TimerQueue {
     }
 
     pub(crate) fn handle_alarm(&self, now: u64) {
-        self.inner.with(|inner| {
-            inner.handle_alarm(now);
-        });
+        self.inner.with(|inner| inner.handle_alarm(now))
     }
 
     pub(crate) fn next_wakeup(&self) -> u64 {

--- a/esp-rtos/src/timer/mod.rs
+++ b/esp-rtos/src/timer/mod.rs
@@ -285,6 +285,12 @@ extern "C" fn timer_tick_handler() {
         if now >= time_driver.timer_queue.time_slice_target[1] {
             crate::task::schedule_other_core();
         }
+
+        // Re-arm the timer. This should be relatively cheap, and ensures that the timer will keep
+        // ticking even if the interrupt doesn't trigger a context switch.
+        // FIXME: this SHOULD be relatively cheap, but arming the timer involves u64 division.
+        time_driver.current_alarm = u64::MAX;
+        time_driver.arm_next_wakeup(now);
     });
 
     #[cfg(feature = "rtos-trace")]


### PR DESCRIPTION
This PR fixes the issue discovered in https://github.com/esp-rs/esp-hal/discussions/4392. In some cases, the timer may tick, but not end up causing a context switch. In these cases, the timer would not get re-armed, missing future events.