### PR TITLE
Set consistent style options for documentation

### DIFF
--- a/esp-alloc/src/lib.rs
+++ b/esp-alloc/src/lib.rs
@@ -137,7 +137,7 @@
 //! Internal | ████████████░░░░░░░░░░░░░░░░░░░░░░░ | Used: 35% (Used 46148 of 131068, free: 84920)
 //! ```
 //! ## Feature Flags
-#![doc = document_features::document_features!()]
+#![doc = document_features::document_features!(feature_label = r#"<span class="stab portability"><code>{feature}</code></span>"#)]
 #![no_std]
 #![cfg_attr(feature = "nightly", feature(allocator_api))]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]

--- a/esp-backtrace/src/lib.rs
+++ b/esp-backtrace/src/lib.rs
@@ -17,7 +17,7 @@
 //! handler).
 //!
 //! ## Features
-#![doc = document_features::document_features!()]
+#![doc = document_features::document_features!(feature_label = r#"<span class="stab portability"><code>{feature}</code></span>"#)]
 //! ## Additional configuration
 //!
 //! We've exposed some configuration options that don't fit into cargo

--- a/esp-hal-procmacros/src/lib.rs
+++ b/esp-hal-procmacros/src/lib.rs
@@ -40,7 +40,7 @@
 //! ```
 //!
 //! ## Feature Flags
-#![doc = document_features::document_features!()]
+#![doc = document_features::document_features!(feature_label = r#"<span class="stab portability"><code>{feature}</code></span>"#)]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 
 use proc_macro::TokenStream;

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added the `float-save-restore` feature for Xtensa MCUs. (#4394)
+- Added the `float-save-restore` feature (enabled by default) for Xtensa MCUs. (#4394)
 
 ### Changed
 

--- a/esp-lp-hal/src/lib.rs
+++ b/esp-lp-hal/src/lib.rs
@@ -12,7 +12,7 @@
 //! for that device.
 //!
 //! ## Feature Flags
-#![doc = document_features::document_features!()]
+#![doc = document_features::document_features!(feature_label = r#"<span class="stab portability"><code>{feature}</code></span>"#)]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 #![allow(asm_sub_register)]
 #![deny(missing_docs)]

--- a/esp-println/src/lib.rs
+++ b/esp-println/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 //! ## Feature Flags
-#![doc = document_features::document_features!()]
+#![doc = document_features::document_features!(feature_label = r#"<span class="stab portability"><code>{feature}</code></span>"#)]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 #![allow(rustdoc::bare_urls)]
 #![no_std]

--- a/esp-riscv-rt/src/lib.rs
+++ b/esp-riscv-rt/src/lib.rs
@@ -8,7 +8,7 @@
 //! - `#[entry]` to declare the entry point of the program
 //!
 //! ## Feature Flags
-#![doc = document_features::document_features!()]
+#![doc = document_features::document_features!(feature_label = r#"<span class="stab portability"><code>{feature}</code></span>"#)]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 #![deny(missing_docs)]
 #![no_std]

--- a/esp-rom-sys/src/lib.rs
+++ b/esp-rom-sys/src/lib.rs
@@ -1,6 +1,6 @@
 #![doc = include_str!("../README.md")]
 //! ## Feature Flags
-#![doc = document_features::document_features!()]
+#![doc = document_features::document_features!(feature_label = r#"<span class="stab portability"><code>{feature}</code></span>"#)]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 #![allow(rustdoc::bare_urls)]
 #![no_std]

--- a/esp-rtos/src/lib.rs
+++ b/esp-rtos/src/lib.rs
@@ -70,7 +70,8 @@ esp_rtos::start_second_core(
 #![doc = include_str!(concat!(env!("OUT_DIR"), "/esp_rtos_config_table.md"))]
 #![doc = ""]
 //! ## Feature Flags
-#![doc = document_features::document_features!()]
+#![doc = document_features::document_features!(feature_label = r#"<span class="stab portability"><code>{feature}</code></span>"#)]
+#![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 #![no_std]
 #![cfg_attr(xtensa, feature(asm_experimental_arch))]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/esp-storage/src/lib.rs
+++ b/esp-storage/src/lib.rs
@@ -1,5 +1,6 @@
 //! ## Feature Flags
-#![doc = document_features::document_features!()]
+#![doc = document_features::document_features!(feature_label = r#"<span class="stab portability"><code>{feature}</code></span>"#)]
+#![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 #![cfg_attr(not(all(test, feature = "emulation")), no_std)]
 
 #[cfg_attr(not(feature = "emulation"), path = "hardware.rs")]

--- a/xtensa-lx-rt/src/lib.rs
+++ b/xtensa-lx-rt/src/lib.rs
@@ -1,7 +1,7 @@
 //! Minimal startup/runtime for Xtensa LX CPUs.
 //!
 //! ## Feature Flags
-#![doc = document_features::document_features!()]
+#![doc = document_features::document_features!(feature_label = r#"<span class="stab portability"><code>{feature}</code></span>"#)]
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 #![allow(asm_sub_register, named_asm_labels)]
 #![feature(asm_experimental_arch)]

--- a/xtensa-lx/src/lib.rs
+++ b/xtensa-lx/src/lib.rs
@@ -1,6 +1,4 @@
 //! Low-level access to Xtensa LX processors and peripherals.
-//!
-//! ## Feature Flags
 #![doc(html_logo_url = "https://avatars.githubusercontent.com/u/46717278")]
 #![allow(asm_sub_register)]
 #![feature(asm_experimental_arch)]


### PR DESCRIPTION
Before
<img width="728" height="394" alt="image" src="https://github.com/user-attachments/assets/1860cf74-d4e3-4f93-a1b3-0023822c4921" />

After

<img width="847" height="385" alt="image" src="https://github.com/user-attachments/assets/2d43c8ac-fd7f-4895-b481-d8965fd27c9e" />
