### PR TITLE
Fix UB in `scan_results`

### DIFF
--- a/esp-radio/CHANGELOG.md
+++ b/esp-radio/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Avoid 802.15.4 rx stopping when BLE is used at the same time (#4348)
+- Fixed undefined behaviour in `WifiController::scan_with_config` (#4408)
 
 ### Removed
 

--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -3043,8 +3043,8 @@ impl WifiController<'_> {
 
         let mut record: MaybeUninit<include::wifi_ap_record_t> = MaybeUninit::uninit();
         for _ in 0..usize::min(bss_total as usize, max) {
-            let record = unsafe { MaybeUninit::assume_init_mut(&mut record) };
-            unsafe { esp_wifi_result!(include::esp_wifi_scan_get_ap_record(record))? };
+            unsafe { esp_wifi_result!(include::esp_wifi_scan_get_ap_record(record.as_mut_ptr()))? };
+            let record = unsafe { MaybeUninit::assume_init_ref(&record) };
             let ap_info = convert_ap_info(record);
             scanned.push(ap_info);
         }


### PR DESCRIPTION
Using `assume_init_*` on uninitialized memory always results in underfined behavour by definition.