### PR TITLE
Prepare esp-sync 0.2 release

### DIFF
--- a/esp-alloc/Cargo.toml
+++ b/esp-alloc/Cargo.toml
@@ -33,7 +33,7 @@ allocator-api2        = { version = "0.3.0", default-features = false }
 defmt                 = { version = "1.0.1", optional = true }
 cfg-if                = "1"
 enumset               = "1"
-esp-sync              = { version = "0.1.0", path = "../esp-sync" }
+esp-sync              = { version = "0.2.0", path = "../esp-sync" }
 document-features     = "0.2"
 
 linked_list_allocator = { version = "0.10.5", default-features = false, features = ["const_mut_refs"] }

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -69,7 +69,7 @@ strum                    = { version = "0.27.1", default-features = false, featu
 
 esp-config               = { version = "0.6.0", path = "../esp-config" }
 esp-metadata-generated   = { version = "0.3.0", path = "../esp-metadata-generated" }
-esp-sync                 = { version = "0.1.0", path = "../esp-sync" }
+esp-sync                 = { version = "0.2.0", path = "../esp-sync" }
 procmacros               = { version = "0.21.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
 
 # Dependencies that are optional because they are used by unstable drivers.

--- a/esp-phy/Cargo.toml
+++ b/esp-phy/Cargo.toml
@@ -32,7 +32,7 @@ document-features = "0.2"
 esp-hal = { version = "1.0.0", path = "../esp-hal", default-features = false, features = ["requires-unstable"] }
 esp-wifi-sys = "0.8.1"
 esp-metadata-generated = { version = "0.3.0", path = "../esp-metadata-generated" }
-esp-sync = { version = "0.1.0", path = "../esp-sync" }
+esp-sync = { version = "0.2.0", path = "../esp-sync" }
 
 defmt = { version = "1.0.1", optional = true }
 log-04 = { version = "0.4.27", package = "log", optional = true }

--- a/esp-println/Cargo.toml
+++ b/esp-println/Cargo.toml
@@ -39,7 +39,7 @@ test  = false
 document-features = "0.2"
 
 # Unstable dependencies that are not (strictly) part of the public API
-esp-sync = { version = "0.1.0", path = "../esp-sync", optional = true }
+esp-sync = { version = "0.2.0", path = "../esp-sync", optional = true }
 
 # Optional dependencies
 portable-atomic  = { version = "1.11", optional = true, default-features = false }

--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -55,7 +55,7 @@ document-features  = "0.2"
 esp-alloc = { version = "0.9.0", path = "../esp-alloc", optional = true }
 esp-config = { version = "0.6.0", path = "../esp-config" }
 esp-metadata-generated = { version = "0.3.0", path = "../esp-metadata-generated" }
-esp-sync = { version = "0.1.0", path = "../esp-sync" }
+esp-sync = { version = "0.2.0", path = "../esp-sync" }
 esp-phy = { version = "0.1.0", path = "../esp-phy/" }
 esp-wifi-sys = { version = "0.8.1" }
 num-derive = "0.4.2"

--- a/esp-rtos/Cargo.toml
+++ b/esp-rtos/Cargo.toml
@@ -44,7 +44,7 @@ document-features  = "0.2"
 embassy-sync = "0.7"
 esp-alloc = { version = "0.9.0", path = "../esp-alloc", optional = true }
 esp-config = { version = "0.6.0", path = "../esp-config" }
-esp-sync = { version = "0.1.0", path = "../esp-sync" }
+esp-sync = { version = "0.2.0", path = "../esp-sync" }
 esp-radio-rtos-driver = { version = "0.2.0", path = "../esp-radio-rtos-driver", optional = true }
 macros = { version = "0.21.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
 portable-atomic = { version = "1.11", default-features = false }

--- a/esp-storage/Cargo.toml
+++ b/esp-storage/Cargo.toml
@@ -32,7 +32,7 @@ procmacros       = { version = "0.21.0", package = "esp-hal-procmacros", path = 
 esp-hal = { version = "1.0.0", path = "../esp-hal", default-features = false, optional = true}
 
 # Optional dependencies
-esp-sync         = { version = "0.1.0", path = "../esp-sync", optional = true }
+esp-sync         = { version = "0.2.0", path = "../esp-sync", optional = true }
 esp-rom-sys      = { version = "0.1.2", path = "../esp-rom-sys", optional = true }
 defmt  = { version = "1.0.1", optional = true }
 

--- a/esp-sync/CHANGELOG.md
+++ b/esp-sync/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 
+## [v0.2.0] - 2025-10-30
+
 ## [v0.1.0] - 2025-10-13
 
 ### Added
@@ -26,4 +28,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release (#4023)
 
 [v0.1.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-sync-v0.1.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-sync-v0.1.0...HEAD
+[v0.2.0]: https://github.com/esp-rs/esp-hal/compare/esp-sync-v0.1.0...esp-sync-v0.2.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-sync-v0.2.0...HEAD

--- a/esp-sync/Cargo.toml
+++ b/esp-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-sync"
-version       = "0.1.0"
+version       = "0.2.0"
 edition       = "2024"
 rust-version  = "1.88.0"
 description   = "Synchronization primitives for Espressif devices"


### PR DESCRIPTION
This pull request prepares the following packages for release:

- esp-sync: 0.2.0

The release plan used for this release:

```json
{
  "base": "main",
  "packages": [
    {
      "package": "esp-sync",
      "semver_checked": false,
      "current_version": "0.1.0",
      "new_version": "0.2.0",
      "tag_name": "esp-sync-v0.2.0",
      "bump": "Minor"
    }
  ]
}
```

Please review the changes and merge them into the `main` branch.

After merging, please make sure you have this release plan in the repo root,
then run the following command on the `main` branch to tag and publish the packages:

```
cargo xrelease publish-plan --no-dry-run
```
