### PR TITLE
Prepare releases

### DIFF
--- a/esp-alloc/Cargo.toml
+++ b/esp-alloc/Cargo.toml
@@ -33,14 +33,14 @@ allocator-api2        = { version = "0.3.0", default-features = false }
 defmt                 = { version = "1.0.1", optional = true }
 cfg-if                = "1"
 enumset               = "1"
-esp-sync              = { version = "0.1.0", path = "../esp-sync" }
+esp-sync              = { version = "0.1.1", path = "../esp-sync" }
 document-features     = "0.2"
 
 linked_list_allocator = { version = "0.10.5", default-features = false, features = ["const_mut_refs"] }
 rlsf = { version = "0.2", features = ["unstable"] }
 
 [build-dependencies]
-esp-config   = { version = "0.6.0", path = "../esp-config", features = ["build"] }
+esp-config   = { version = "0.6.1", path = "../esp-config", features = ["build"] }
 
 [features]
 default = ["compat"]

--- a/esp-backtrace/CHANGELOG.md
+++ b/esp-backtrace/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 
+## [v0.18.1] - 2025-10-30
+
 ## [v0.18.0] - 2025-10-13
 
 ### Changed
@@ -109,4 +111,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v0.16.0]: https://github.com/esp-rs/esp-hal/compare/esp-backtrace-v0.15.1...esp-backtrace-v0.16.0
 [v0.17.0]: https://github.com/esp-rs/esp-hal/compare/esp-backtrace-v0.16.0...esp-backtrace-v0.17.0
 [v0.18.0]: https://github.com/esp-rs/esp-hal/compare/esp-backtrace-v0.17.0...esp-backtrace-v0.18.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-backtrace-v0.18.0...HEAD
+[v0.18.1]: https://github.com/esp-rs/esp-hal/compare/esp-backtrace-v0.18.0...esp-backtrace-v0.18.1
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-backtrace-v0.18.1...HEAD

--- a/esp-backtrace/Cargo.toml
+++ b/esp-backtrace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-backtrace"
-version       = "0.18.0"
+version       = "0.18.1"
 edition       = "2024"
 rust-version  = "1.86.0"
 description   = "Bare-metal backtrace support for Espressif devices"
@@ -34,9 +34,9 @@ test  = false
 [dependencies]
 cfg-if      = "1"
 defmt       = { version = "1", optional = true }
-esp-config  = { version = "0.6.0", path = "../esp-config" }
+esp-config  = { version = "0.6.1", path = "../esp-config" }
 esp-metadata-generated = { version = "0.3.0", path = "../esp-metadata-generated" }
-esp-println = { version = "0.16.0", optional = true, default-features = false, path = "../esp-println" }
+esp-println = { version = "0.16.1", optional = true, default-features = false, path = "../esp-println" }
 heapless    = "0.9"
 semihosting = { version = "0.1.20", optional = true }
 document-features = "0.2"
@@ -48,7 +48,7 @@ riscv            = { version = "0.15.0" }
 xtensa-lx        = { version = "0.13.0", path = "../xtensa-lx" }
 
 [build-dependencies]
-esp-config   = { version = "0.6.0", path = "../esp-config", features = ["build"] }
+esp-config   = { version = "0.6.1", path = "../esp-config", features = ["build"] }
 esp-metadata-generated = { version = "0.3.0", path = "../esp-metadata-generated", features = ["build-script"] }
 
 [features]

--- a/esp-bootloader-esp-idf/Cargo.toml
+++ b/esp-bootloader-esp-idf/Cargo.toml
@@ -32,10 +32,10 @@ test  = true
 cfg-if = "1"
 defmt = { version = "1.0.1", optional = true }
 document-features = "0.2"
-esp-config = { version = "0.6.0", path = "../esp-config" }
+esp-config = { version = "0.6.1", path = "../esp-config" }
 esp-hal-procmacros = { version = "0.21.0", path = "../esp-hal-procmacros", features = ["__esp_idf_bootloader"] }
 esp-metadata-generated = { version = "0.3.0", path = "../esp-metadata-generated" }
-esp-rom-sys = { version = "0.1.2", path = "../esp-rom-sys", optional = true }
+esp-rom-sys = { version = "0.1.3", path = "../esp-rom-sys", optional = true }
 embedded-storage = "0.3.1"
 log-04 = { package = "log", version = "0.4", optional = true }
 strum = { version = "0.27", default-features = false, features = ["derive"] }
@@ -45,7 +45,7 @@ md-5 = { version = "0.10.6", default-features = false, optional = true }
 
 [build-dependencies]
 jiff       = { version = "0.2.13", default-features = false, features = ["std"] }
-esp-config = { version = "0.6.0", path = "../esp-config", features = ["build"] }
+esp-config = { version = "0.6.1", path = "../esp-config", features = ["build"] }
 
 [features]
 default = ["validation"]

--- a/esp-config/CHANGELOG.md
+++ b/esp-config/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 
+## [v0.6.1] - 2025-10-30
+
 ## [v0.6.0] - 2025-10-13
 
 ## [v0.5.0] - 2025-07-16
@@ -74,4 +76,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v0.4.0]: https://github.com/esp-rs/esp-hal/compare/esp-config-v0.3.1...esp-config-v0.4.0
 [v0.5.0]: https://github.com/esp-rs/esp-hal/compare/esp-config-v0.4.0...esp-config-v0.5.0
 [v0.6.0]: https://github.com/esp-rs/esp-hal/compare/esp-config-v0.5.0...esp-config-v0.6.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-config-v0.6.0...HEAD
+[v0.6.1]: https://github.com/esp-rs/esp-hal/compare/esp-config-v0.6.0...esp-config-v0.6.1
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-config-v0.6.1...HEAD

--- a/esp-config/Cargo.toml
+++ b/esp-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-config"
-version       = "0.6.0"
+version       = "0.6.1"
 edition       = "2024"
 rust-version  = "1.86.0"
 description   = "Configure projects using esp-hal and related packages"

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -55,7 +55,7 @@ enumset                  = "1.1"
 paste                    = "1.0.15"
 portable-atomic          = { version = "1.11", default-features = false }
 
-esp-rom-sys              = { version = "0.1.2", path = "../esp-rom-sys" }
+esp-rom-sys              = { version = "0.1.3", path = "../esp-rom-sys" }
 
 # Unstable dependencies that are not (strictly) part of the public API
 bitfield                 = "0.19"
@@ -67,9 +67,9 @@ fugit                    = "0.3.7"
 instability              = "0.3.9"
 strum                    = { version = "0.27.1", default-features = false, features = ["derive"] }
 
-esp-config               = { version = "0.6.0", path = "../esp-config" }
+esp-config               = { version = "0.6.1", path = "../esp-config" }
 esp-metadata-generated   = { version = "0.3.0", path = "../esp-metadata-generated" }
-esp-sync                 = { version = "0.1.0", path = "../esp-sync" }
+esp-sync                 = { version = "0.1.1", path = "../esp-sync" }
 procmacros               = { version = "0.21.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
 
 # Dependencies that are optional because they are used by unstable drivers.
@@ -122,7 +122,7 @@ xtensa-lx-rt     = { version = "0.21.0", path = "../xtensa-lx-rt", optional = tr
 
 [build-dependencies]
 esp-metadata-generated = { version = "0.3.0", path = "../esp-metadata-generated", features = ["build-script"] }
-esp-config   = { version = "0.6.0", path = "../esp-config", features = ["build"] }
+esp-config   = { version = "0.6.1", path = "../esp-config", features = ["build"] }
 
 [dev-dependencies]
 crypto-bigint = { version = "0.5.5", default-features = false }

--- a/esp-phy/CHANGELOG.md
+++ b/esp-phy/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 
+## [v0.1.1] - 2025-10-30
+
 ## [v0.1.0] - 2025-10-13
 
 ### Added
@@ -26,4 +28,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release (#3892)
 
 [v0.1.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-phy-v0.1.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-phy-v0.1.0...HEAD
+[v0.1.1]: https://github.com/esp-rs/esp-hal/compare/esp-phy-v0.1.0...esp-phy-v0.1.1
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-phy-v0.1.1...HEAD

--- a/esp-phy/Cargo.toml
+++ b/esp-phy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-phy"
-version       = "0.1.0"
+version       = "0.1.1"
 edition       = "2024"
 description   = "PHY initialization"
 documentation = "https://docs.espressif.com/projects/rust/esp-phy/latest/"
@@ -32,13 +32,13 @@ document-features = "0.2"
 esp-hal = { version = "1.0.0", path = "../esp-hal", default-features = false, features = ["requires-unstable"] }
 esp-wifi-sys = "0.8.1"
 esp-metadata-generated = { version = "0.3.0", path = "../esp-metadata-generated" }
-esp-sync = { version = "0.1.0", path = "../esp-sync" }
+esp-sync = { version = "0.1.1", path = "../esp-sync" }
 
 defmt = { version = "1.0.1", optional = true }
 log-04 = { version = "0.4.27", package = "log", optional = true }
 
 [build-dependencies]
-esp-config   = { version = "0.6.0", path = "../esp-config", features = ["build"] }
+esp-config   = { version = "0.6.1", path = "../esp-config", features = ["build"] }
 esp-metadata-generated = { version = "0.3.0", path = "../esp-metadata-generated", features = ["build-script"] }
 
 [features]

--- a/esp-println/CHANGELOG.md
+++ b/esp-println/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 
+## [v0.16.1] - 2025-10-30
+
 ## [v0.16.0] - 2025-10-13
 
 ### Changed
@@ -119,4 +121,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v0.14.0]: https://github.com/esp-rs/esp-hal/compare/esp-println-v0.13.1...esp-println-v0.14.0
 [v0.15.0]: https://github.com/esp-rs/esp-hal/compare/esp-println-v0.14.0...esp-println-v0.15.0
 [v0.16.0]: https://github.com/esp-rs/esp-hal/compare/esp-println-v0.15.0...esp-println-v0.16.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-println-v0.16.0...HEAD
+[v0.16.1]: https://github.com/esp-rs/esp-hal/compare/esp-println-v0.16.0...esp-println-v0.16.1
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-println-v0.16.1...HEAD

--- a/esp-println/Cargo.toml
+++ b/esp-println/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-println"
-version       = "0.16.0"
+version       = "0.16.1"
 edition       = "2024"
 rust-version  = "1.86.0"
 description   = "Provides `print!` and `println!` implementations various Espressif devices"
@@ -39,7 +39,7 @@ test  = false
 document-features = "0.2"
 
 # Unstable dependencies that are not (strictly) part of the public API
-esp-sync = { version = "0.1.0", path = "../esp-sync", optional = true }
+esp-sync = { version = "0.1.1", path = "../esp-sync", optional = true }
 
 # Optional dependencies
 portable-atomic  = { version = "1.11", optional = true, default-features = false }

--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -53,10 +53,10 @@ instability = "0.3.9"
 allocator-api2 = { version = "0.3.0", default-features = false, features = ["alloc"] }
 document-features  = "0.2"
 esp-alloc = { version = "0.9.0", path = "../esp-alloc", optional = true }
-esp-config = { version = "0.6.0", path = "../esp-config" }
+esp-config = { version = "0.6.1", path = "../esp-config" }
 esp-metadata-generated = { version = "0.3.0", path = "../esp-metadata-generated" }
-esp-sync = { version = "0.1.0", path = "../esp-sync" }
-esp-phy = { version = "0.1.0", path = "../esp-phy/" }
+esp-sync = { version = "0.1.1", path = "../esp-sync" }
+esp-phy = { version = "0.1.1", path = "../esp-phy/" }
 esp-wifi-sys = { version = "0.8.1" }
 num-derive = "0.4.2"
 num-traits = { version = "0.2.19", default-features = false }
@@ -85,7 +85,7 @@ defmt = { version = "1.0.1", optional = true }
 log-04 = { package = "log", version = "0.4.27", optional = true }
 
 [build-dependencies]
-esp-config = { version = "0.6.0", path = "../esp-config", features = ["build"] }
+esp-config = { version = "0.6.1", path = "../esp-config", features = ["build"] }
 esp-metadata-generated = { version = "0.3.0", path = "../esp-metadata-generated", features = ["build-script"] }
 
 [features]

--- a/esp-rom-sys/CHANGELOG.md
+++ b/esp-rom-sys/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 
+## [v0.1.3] - 2025-10-30
+
 ## [v0.1.2] - 2025-10-13
 
 ### Added
@@ -40,4 +42,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v0.1.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-rom-sys-v0.1.0
 [v0.1.1]: https://github.com/esp-rs/esp-hal/compare/esp-rom-sys-v0.1.0...esp-rom-sys-v0.1.1
 [v0.1.2]: https://github.com/esp-rs/esp-hal/compare/esp-rom-sys-v0.1.1...esp-rom-sys-v0.1.2
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-rom-sys-v0.1.2...HEAD
+[v0.1.3]: https://github.com/esp-rs/esp-hal/compare/esp-rom-sys-v0.1.2...esp-rom-sys-v0.1.3
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-rom-sys-v0.1.3...HEAD

--- a/esp-rom-sys/Cargo.toml
+++ b/esp-rom-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-rom-sys"
-version       = "0.1.2"
+version       = "0.1.3"
 edition       = "2024"
 rust-version  = "1.87.0"
 description   = "ROM code support"

--- a/esp-rtos/Cargo.toml
+++ b/esp-rtos/Cargo.toml
@@ -43,8 +43,8 @@ allocator-api2 = { version = "0.3.0", default-features = false, features = ["all
 document-features  = "0.2"
 embassy-sync = "0.7"
 esp-alloc = { version = "0.9.0", path = "../esp-alloc", optional = true }
-esp-config = { version = "0.6.0", path = "../esp-config" }
-esp-sync = { version = "0.1.0", path = "../esp-sync" }
+esp-config = { version = "0.6.1", path = "../esp-config" }
+esp-sync = { version = "0.1.1", path = "../esp-sync" }
 esp-radio-rtos-driver = { version = "0.2.0", path = "../esp-radio-rtos-driver", optional = true }
 macros = { version = "0.21.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
 portable-atomic = { version = "1.11", default-features = false }
@@ -59,7 +59,7 @@ defmt            = { version = "1.0", optional = true }
 log-04           = { package = "log", version = "0.4", optional = true }
 
 [build-dependencies]
-esp-config             = { version = "0.6.0", path = "../esp-config", features = ["build"] }
+esp-config             = { version = "0.6.1", path = "../esp-config", features = ["build"] }
 esp-metadata-generated = { version = "0.3.0", path = "../esp-metadata-generated", features = ["build-script"] }
 
 [dev-dependencies]

--- a/esp-storage/CHANGELOG.md
+++ b/esp-storage/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 
+## [v0.8.1] - 2025-10-30
+
 ## [v0.8.0] - 2025-10-13
 
 ### Added
@@ -80,4 +82,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v0.6.0]: https://github.com/esp-rs/esp-hal/compare/esp-storage-v0.5.0...esp-storage-v0.6.0
 [v0.7.0]: https://github.com/esp-rs/esp-hal/compare/esp-storage-v0.6.0...esp-storage-v0.7.0
 [v0.8.0]: https://github.com/esp-rs/esp-hal/compare/esp-storage-v0.7.0...esp-storage-v0.8.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-storage-v0.8.0...HEAD
+[v0.8.1]: https://github.com/esp-rs/esp-hal/compare/esp-storage-v0.8.0...esp-storage-v0.8.1
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-storage-v0.8.1...HEAD

--- a/esp-storage/Cargo.toml
+++ b/esp-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-storage"
-version       = "0.8.0"
+version       = "0.8.1"
 edition       = "2024"
 rust-version  = "1.86.0"
 description   = "Implementation of embedded-storage traits to access unencrypted ESP32 flash"
@@ -32,8 +32,8 @@ procmacros       = { version = "0.21.0", package = "esp-hal-procmacros", path = 
 esp-hal = { version = "1.0.0", path = "../esp-hal", default-features = false, optional = true}
 
 # Optional dependencies
-esp-sync         = { version = "0.1.0", path = "../esp-sync", optional = true }
-esp-rom-sys      = { version = "0.1.2", path = "../esp-rom-sys", optional = true }
+esp-sync         = { version = "0.1.1", path = "../esp-sync", optional = true }
+esp-rom-sys      = { version = "0.1.3", path = "../esp-rom-sys", optional = true }
 defmt  = { version = "1.0.1", optional = true }
 
 # Unstable dependencies that are not (strictly) part of the public API

--- a/esp-sync/CHANGELOG.md
+++ b/esp-sync/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 
+## [v0.1.1] - 2025-10-30
+
 ## [v0.1.0] - 2025-10-13
 
 ### Added
@@ -26,4 +28,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release (#4023)
 
 [v0.1.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-sync-v0.1.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-sync-v0.1.0...HEAD
+[v0.1.1]: https://github.com/esp-rs/esp-hal/compare/esp-sync-v0.1.0...esp-sync-v0.1.1
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-sync-v0.1.1...HEAD

--- a/esp-sync/Cargo.toml
+++ b/esp-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-sync"
-version       = "0.1.0"
+version       = "0.1.1"
 edition       = "2024"
 rust-version  = "1.88.0"
 description   = "Synchronization primitives for Espressif devices"


### PR DESCRIPTION
This pull request prepares the following packages for release:

- esp-sync: 0.1.1
- esp-rom-sys: 0.1.3
- esp-config: 0.6.1
- esp-println: 0.16.1
- esp-backtrace: 0.18.1
- esp-phy: 0.1.1
- esp-storage: 0.8.1

The release plan used for this release:

```json
{
  "base": "main",
  "packages": [
    {
      "package": "esp-sync",
      "semver_checked": false,
      "current_version": "0.1.0",
      "new_version": "0.1.1",
      "tag_name": "esp-sync-v0.1.1",
      "bump": "Patch"
    },
    {
      "package": "esp-rom-sys",
      "semver_checked": false,
      "current_version": "0.1.2",
      "new_version": "0.1.3",
      "tag_name": "esp-rom-sys-v0.1.3",
      "bump": "Patch"
    },
    {
      "package": "esp-config",
      "semver_checked": false,
      "current_version": "0.6.0",
      "new_version": "0.6.1",
      "tag_name": "esp-config-v0.6.1",
      "bump": "Patch"
    },
    {
      "package": "esp-println",
      "semver_checked": false,
      "current_version": "0.16.0",
      "new_version": "0.16.1",
      "tag_name": "esp-println-v0.16.1",
      "bump": "Patch"
    },
    {
      "package": "esp-backtrace",
      "semver_checked": false,
      "current_version": "0.18.0",
      "new_version": "0.18.1",
      "tag_name": "esp-backtrace-v0.18.1",
      "bump": "Patch"
    },
    {
      "package": "esp-phy",
      "semver_checked": false,
      "current_version": "0.1.0",
      "new_version": "0.1.1",
      "tag_name": "esp-phy-v0.1.1",
      "bump": "Patch"
    },
    {
      "package": "esp-storage",
      "semver_checked": false,
      "current_version": "0.8.0",
      "new_version": "0.8.1",
      "tag_name": "esp-storage-v0.8.1",
      "bump": "Patch"
    }
  ]
}
```

Please review the changes and merge them into the `main` branch.

After merging, please make sure you have this release plan in the repo root,
then run the following command on the `main` branch to tag and publish the packages:

```
cargo xrelease publish-plan --no-dry-run
```
