### PR TITLE
fix(esp-radio): non-compiling CountryInfo example

### DIFF
--- a/esp-radio/CHANGELOG.md
+++ b/esp-radio/CHANGELOG.md
@@ -15,7 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- non-compiling CountryInfo example (#4424)
 
 ### Removed
 


### PR DESCRIPTION
Noticed that the example does not match the API docs while reading the documentation:
https://docs.espressif.com/projects/rust/esp-radio/0.17.0/esp32/esp_radio/wifi/struct.CountryInfo.html