### PR TITLE
HIL: Update `embedded-test` version to 0.7

### DIFF
--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -123,7 +123,7 @@ crypto-bigint       = { version = "0.5.5", default-features = false }
 digest              = { version = "0.10.7", default-features = false }
 elliptic-curve      = { version = "0.13.8", default-features = false, features = ["sec1"] }
 # Add the `embedded-test/defmt` feature for more verbose testing
-embedded-test       = { version = "0.7.0-alpha.3", default-features = false, features = ["embassy", "external-executor", "semihosting", "defmt"], git = "https://github.com/probe-rs/embedded-test", branch = "next" }
+embedded-test       = { version = "0.7", default-features = false, features = ["embassy", "external-executor", "semihosting", "defmt"] }
 hex-literal         = "1.0.0"
 nb                  = "1.1.0"
 p192                = { version = "0.13.0", default-features = false, features = ["arithmetic"] }


### PR DESCRIPTION
I guess we also want to update `probe-rs` to 0.30 on our runners?

closes https://github.com/esp-rs/esp-hal/issues/4425