### PR TITLE
Remove `esp-radio/serde`

### DIFF
--- a/esp-radio/CHANGELOG.md
+++ b/esp-radio/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- The `serde` feature has been removed (#4435)
 
 ## [v0.17.0] - 2025-10-30
 

--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -79,7 +79,6 @@ embedded-io-06 = { package = "embedded-io", version = "0.6", default-features = 
 embedded-io-async-06 = { package = "embedded-io-async", version = "0.6", default-features = false, optional = true }
 embedded-io-07 = { package = "embedded-io", version = "0.7", default-features = false, optional = true }
 embedded-io-async-07 = { package = "embedded-io-async", version = "0.7", default-features = false, optional = true }
-serde = { version = "1.0.218", default-features = false, features = ["derive"], optional = true }
 smoltcp = { version = "0.12.0", default-features = false, features = [
   "medium-ethernet",
   "socket-raw",
@@ -222,9 +221,6 @@ ieee802154 = ["dep:byte", "dep:ieee802154"]
 
 ## Provide implementations of smoltcp traits
 smoltcp = ["dep:smoltcp"]
-
-## Implement serde Serialize / Deserialize
-serde = ["dep:serde", "enumset?/serde"]
 
 #! ### Logging Feature Flags
 ## Enable logging output using version 0.4 of the `log` crate.

--- a/esp-radio/MIGRATING-0.17.0.md
+++ b/esp-radio/MIGRATING-0.17.0.md
@@ -1,1 +1,29 @@
 # Migration Guide from 0.17.0 to {{currentVersion}}
+
+## The `serde` feature has been removed
+
+You will have to provide your own datatypes that you wish to serialize/deserialize. For this, you have two options:
+
+1. Implement the `Serialize` and `Deserialize` traits [manually](https://serde.rs/impl-serialize.html) for your custom types.
+2. Implement the types and conversions to/from esp-radio types.
+
+For example, you may want to mirror `ScanMethod`, so that you can store it in flash as a configuraton option. In this case, you could do the following:
+
+```rust
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Serialize, Deserialize)] // and possibly more
+pub enum ScanMethod {
+    Fast,
+    AllChannels,
+}
+
+impl From<ScanMethod> for esp_radio::wifi::ScanMethod {
+    fn from(scan_method: ScanMethod) -> Self {
+        match scan_method {
+            ScanMethod::Fast => Self::Fast,
+            ScanMethod::AllChannels => Self::AllChannels,
+        }
+    }
+}
+```

--- a/esp-radio/src/ble/os_adapter_esp32.rs
+++ b/esp-radio/src/ble/os_adapter_esp32.rs
@@ -279,7 +279,6 @@ static BTDM_DRAM_AVAILABLE_REGION: [btdm_dram_available_region_t; 7] = [
 
 /// Bluetooth controller configuration.
 #[derive(BuilderLite, Clone, Copy, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Config {
     /// The priority of the RTOS task.

--- a/esp-radio/src/ble/os_adapter_esp32c2.rs
+++ b/esp-radio/src/ble/os_adapter_esp32c2.rs
@@ -20,7 +20,6 @@ pub(crate) static mut ISR_INTERRUPT_7: (*mut c_void, *mut c_void) =
 
 /// Transmission Power Level
 #[derive(Default, Clone, Copy, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum TxPower {
     /// -24 dBm
@@ -105,7 +104,6 @@ impl TxPower {
 
 /// Bluetooth controller configuration.
 #[derive(BuilderLite, Clone, Copy, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Config {
     /// The priority of the RTOS task.

--- a/esp-radio/src/ble/os_adapter_esp32c3_s3.rs
+++ b/esp-radio/src/ble/os_adapter_esp32c3_s3.rs
@@ -287,7 +287,6 @@ unsafe extern "C" {
 
 /// Antenna Selection
 #[derive(Default, Clone, Copy, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Antenna {
     /// Use Antenna 0
@@ -299,7 +298,6 @@ pub enum Antenna {
 
 /// Transmission Power Level
 #[derive(Default, Clone, Copy, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum TxPower {
     /// -15 dBm
@@ -372,7 +370,6 @@ impl TxPower {
 
 /// BLE CCA mode.
 #[derive(Default, Clone, Copy, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum CcaMode {
     /// Disabled
@@ -386,7 +383,6 @@ pub enum CcaMode {
 
 /// Bluetooth controller configuration.
 #[derive(BuilderLite, Clone, Copy, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Config {
     /// The priority of the RTOS task.

--- a/esp-radio/src/ble/os_adapter_esp32c6.rs
+++ b/esp-radio/src/ble/os_adapter_esp32c6.rs
@@ -20,7 +20,6 @@ pub(crate) static mut ISR_INTERRUPT_7: (*mut c_void, *mut c_void) =
 
 /// Transmission Power Level
 #[derive(Default, Clone, Copy, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum TxPower {
     /// -15 dBm
@@ -93,7 +92,6 @@ impl TxPower {
 
 /// Bluetooth controller configuration.
 #[derive(BuilderLite, Clone, Copy, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Config {
     /// The priority of the RTOS task.

--- a/esp-radio/src/ble/os_adapter_esp32h2.rs
+++ b/esp-radio/src/ble/os_adapter_esp32h2.rs
@@ -19,7 +19,6 @@ pub(crate) static mut ISR_INTERRUPT_3: (*mut c_void, *mut c_void) =
 
 /// Transmission Power Level
 #[derive(Default, Clone, Copy, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum TxPower {
     /// -24 dBm
@@ -104,7 +103,6 @@ impl TxPower {
 
 /// Bluetooth controller configuration.
 #[derive(BuilderLite, Clone, Copy, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Config {
     /// The priority of the RTOS task.

--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -19,8 +19,6 @@ use num_derive::FromPrimitive;
 pub(crate) use os_adapter::*;
 use portable_atomic::{AtomicUsize, Ordering};
 use procmacros::BuilderLite;
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
 #[cfg(all(feature = "smoltcp", feature = "unstable"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 use smoltcp::phy::{Device, DeviceCapabilities, RxToken, TxToken};
@@ -154,7 +152,6 @@ use crate::sys::{
 /// Supported Wi-Fi authentication methods.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[non_exhaustive]
 pub enum AuthMethod {
     /// No authentication (open network).
@@ -189,7 +186,6 @@ pub enum AuthMethod {
 /// Supported Wi-Fi protocols.
 #[derive(Debug, Default, PartialOrd, EnumSetType)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[non_exhaustive]
 pub enum Protocol {
     /// 802.11b protocol.
@@ -232,7 +228,6 @@ impl Protocol {
 /// Secondary Wi-Fi channels.
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub enum SecondaryChannel {
     // TODO: Need to extend that for 5GHz
     /// No secondary channel (default).
@@ -248,7 +243,6 @@ pub enum SecondaryChannel {
 
 /// Access point country information.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct Country([u8; 2]);
 
 impl Country {
@@ -292,7 +286,6 @@ impl defmt::Format for Country {
 /// Information about a detected Wi-Fi access point.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[non_exhaustive]
 pub struct AccessPointInfo {
     /// The SSID of the access point.
@@ -321,7 +314,6 @@ pub struct AccessPointInfo {
 
 /// Configuration for a Wi-Fi access point.
 #[derive(BuilderLite, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct AccessPointConfig {
     /// The SSID of the access point.
     #[builder_lite(reference)]
@@ -453,7 +445,6 @@ pub enum ScanMethod {
 
 /// Client configuration for a Wi-Fi connection.
 #[derive(BuilderLite, Clone, Eq, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct ClientConfig {
     /// The SSID of the Wi-Fi network.
     #[builder_lite(reference)]
@@ -588,7 +579,6 @@ impl defmt::Format for ClientConfig {
 /// Configuration for EAP-FAST authentication protocol.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg(feature = "wifi-eap")]
 #[instability::unstable]
 pub struct EapFastConfig {
@@ -603,7 +593,6 @@ pub struct EapFastConfig {
 /// Phase 2 authentication methods
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg(feature = "wifi-eap")]
 #[instability::unstable]
 pub enum TtlsPhase2Method {
@@ -652,7 +641,6 @@ type CertificateAndKey = (&'static [u8], &'static [u8], Option<&'static [u8]>);
 
 /// Configuration for an EAP (Extensible Authentication Protocol) client.
 #[derive(BuilderLite, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[cfg(feature = "wifi-eap")]
 #[instability::unstable]
 pub struct EapClientConfig {
@@ -875,7 +863,6 @@ impl Default for EapClientConfig {
 /// Introduces Wi-Fi configuration options.
 #[derive(EnumSetType, Debug, PartialOrd)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[non_exhaustive]
 pub enum Capability {
     /// The device operates as a client, connecting to an existing network.
@@ -894,7 +881,6 @@ pub enum Capability {
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[non_exhaustive]
 pub enum ModeConfig {
     /// No configuration (default).
@@ -912,7 +898,6 @@ pub enum ModeConfig {
 
     /// EAP client configuration for enterprise Wi-Fi.
     #[cfg(feature = "wifi-eap")]
-    #[cfg_attr(feature = "serde", serde(skip))]
     EapClient(EapClientConfig),
 }
 
@@ -973,7 +958,6 @@ impl AuthMethodExt for AuthMethod {
 /// Wi-Fi Mode (Sta and/or Ap)
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 #[non_exhaustive]
 pub enum WifiMode {
     /// Station mode.


### PR DESCRIPTION
Closes #4421

Previously, serde was available for use so that users could store/retrieve configuration from non-volatile memory. While it might make sense to provide implementations for stable types, unstable configuration types would cause issues: we can change a type, and users would start bumping into surprising deserialization errors. The best we can do is to not provide Serialize/Deserialize, which, while slightly annoying to work around, allows users to come up with their own way to handle NVM data format versioning.