### PR TITLE
Eliminate vulnerability in binary-size CI action. 

### DIFF
--- a/.github/workflows/binary_size.yml
+++ b/.github/workflows/binary_size.yml
@@ -12,8 +12,7 @@ jobs:
         contains(github.event.comment.body, '/test-size') &&
         (
           github.event.comment.author_association == 'OWNER' ||
-          github.event.comment.author_association == 'MEMBER' ||
-          github.event.comment.user.login == github.event.issue.user.login
+          github.event.comment.author_association == 'MEMBER'
         ) }}
           
     runs-on: ubuntu-latest


### PR DESCRIPTION
Noticed it while working on https://github.com/esp-rs/esp-hal/issues/4429

Currently, everyone can run that `/test-size` command everywhere, which introduces a potential safety vulnerability. This PR should limit it and enable it only for `esp-rs` org owners, members and a person who committed a PR.