### PR TITLE
Conditionally hide feature flag docs

### DIFF
--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -274,7 +274,7 @@ defmt = [
     "esp-sync/defmt"
 ]
 
-#DOC_IF chip("esp32") || chip("esp32s2") || chip("esp32s3")
+#DOC_IF has("psram")
 #! ### PSRAM Feature Flags
 
 ## Use externally connected PSRAM (`quad` by default, can be configured to `octal` via ESP_HAL_CONFIG_PSRAM_MODE)


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

Closes #4381

This implements kind-of doc-hiding support for features documented via `document-features`.

It's done by pre-processing Cargo.toml, looking for `#DOC_IF`  / `#DOC_ENDIF`  comments.



#### Testing

Building documentation for various chips locally
