### PR TITLE
Mark PHY calibration data functions unstable

### DIFF
--- a/esp-radio/CHANGELOG.md
+++ b/esp-radio/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `phy_calibration_data` and `set_phy_calibration_data` are now marked as `unstable`. (#4463)
 
 ### Fixed
 

--- a/esp-radio/src/common_adapter.rs
+++ b/esp-radio/src/common_adapter.rs
@@ -5,7 +5,7 @@ use crate::{
     hal::{self, ram},
     sys::{
         c_types::{c_char, c_int, c_ulong, c_void},
-        include::{esp_event_base_t, esp_phy_calibration_data_t, timeval},
+        include::{esp_event_base_t, timeval},
     },
     time::blob_ticks_to_micros,
 };
@@ -393,27 +393,6 @@ pub(crate) fn enable_wifi_power_domain() {
             .dig_iso()
             .modify(|_, w| w.wifi_force_iso().clear_bit());
     }
-}
-
-/// Get calibration data.
-///
-/// Returns the last calibration result.
-///
-/// If you see the data is different than what was persisted before, consider persisting the new
-/// data.
-pub fn phy_calibration_data(data: &mut [u8; esp_phy::PHY_CALIBRATION_DATA_LENGTH]) {
-    // Although we're ignoring the result here, this doesn't change the behavior, as this just
-    // doesn't do anything in case an error is returned.
-    let _ = esp_phy::backup_phy_calibration_data(data);
-}
-
-/// Set calibration data.
-///
-/// This will be used next time the phy gets initialized.
-pub fn set_phy_calibration_data(data: &[u8; core::mem::size_of::<esp_phy_calibration_data_t>()]) {
-    // Although we're ignoring the result here, this doesn't change the behavior, as this just
-    // doesn't do anything in case an error is returned.
-    let _ = esp_phy::set_phy_calibration_data(data);
 }
 
 /// **************************************************************************

--- a/esp-radio/src/lib.rs
+++ b/esp-radio/src/lib.rs
@@ -138,7 +138,6 @@ mod fmt;
 
 use core::marker::PhantomData;
 
-pub use common_adapter::{phy_calibration_data, set_phy_calibration_data};
 use esp_hal::{
     self as hal,
 
@@ -155,6 +154,7 @@ use hal::{
     clock::{Clocks, init_radio_clocks},
     time::Rate,
 };
+use sys::include::esp_phy_calibration_data_t;
 
 pub(crate) mod sys {
     #[cfg(esp32)]
@@ -425,4 +425,26 @@ pub fn wifi_set_log_verbose() {
 
         esp_wifi_internal_set_log_level(wifi_log_level_t_WIFI_LOG_VERBOSE);
     }
+}
+
+/// Get calibration data.
+///
+/// Returns the last calibration result.
+///
+/// If you see the data is different than what was persisted before, consider persisting the new
+/// data.
+#[instability::unstable]
+pub fn phy_calibration_data(data: &mut [u8; esp_phy::PHY_CALIBRATION_DATA_LENGTH]) {
+    // FIXME: return an error to the user.
+    let _ = esp_phy::backup_phy_calibration_data(data);
+}
+
+/// Set calibration data.
+///
+/// This will be used next time the phy gets initialized.
+#[instability::unstable]
+pub fn set_phy_calibration_data(data: &[u8; core::mem::size_of::<esp_phy_calibration_data_t>()]) {
+    // Although we're ignoring the result here, this doesn't change the behavior, as this just
+    // doesn't do anything in case an error is returned.
+    let _ = esp_phy::set_phy_calibration_data(data);
 }


### PR DESCRIPTION
cc #4455 (not closing because at least `phy_calibration_data` should still return an error).