### PR TITLE
Hopefully fix triggering bug of binary-size workflow

### DIFF
--- a/.github/workflows/binary_size.yml
+++ b/.github/workflows/binary_size.yml
@@ -6,14 +6,7 @@ on:
 
 jobs:
   binary_size:
-    if: >
-      ${{
-        github.event.issue.pull_request &&
-        contains(github.event.comment.body, '/test-size') &&
-        (
-          github.event.comment.author_association == 'OWNER' ||
-          github.event.comment.author_association == 'MEMBER'
-        ) }}
+    if: ${{ github.event.issue.pull_request && startsWith(github.event.comment.body, '/test-size') && (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER') }}
           
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Hopefully fixes https://github.com/esp-rs/esp-hal/pull/4446 as it's triggers the job for any comment made 🤞 
I tested this in my fork and the workflow was triggered correctly with this logic 🥺 
