### PR TITLE
Provide `_getreent` by `esp-rtos`

### DIFF
--- a/esp-rom-sys/src/lib.rs
+++ b/esp-rom-sys/src/lib.rs
@@ -44,7 +44,7 @@ macro_rules! before_snippet {
 pub mod rom;
 mod syscall;
 
-pub use syscall::init_syscall_table;
+pub use syscall::{_reent, SYSCALL_TABLE, init_syscall_table};
 
 /// This is needed by `libesp_rom.a` (if used)
 /// Other crates (i.e. esp-radio) also rely on this being defined somewhere

--- a/esp-rom-sys/src/syscall/mod.rs
+++ b/esp-rom-sys/src/syscall/mod.rs
@@ -1,5 +1,7 @@
 #![allow(non_camel_case_types)]
 
+use core::ffi::{c_char, c_int, c_long, c_void};
+
 // future chips or ECOs _might_ be different - at least ESP-IDF defines the struct per chip
 #[cfg_attr(
     any(esp32, esp32s2, esp32s3, esp32c2, esp32c3, esp32c6, esp32h2),
@@ -7,14 +9,7 @@
 )]
 pub(crate) mod chip_specific;
 
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct _reent {
-    _unused: [u8; 0],
-    // the real struct is found here: https://sourceware.org/git/?p=newlib-cygwin.git;a=blob;f=newlib/libc/include/sys/reent.h;h=eafac960fd6ca374b7503f50bf8aa2bd1ee1573e;hb=refs/heads/main#l379
-}
-
-pub type clock_t = ::core::ffi::c_long;
+pub type clock_t = c_long;
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -47,16 +42,123 @@ pub type _lock_t = _LOCK_T;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct _iobuf {
-    pub _placeholder: *mut ::core::ffi::c_void,
+    pub _placeholder: *mut c_void,
 }
 
 #[allow(clippy::upper_case_acronyms)]
-pub type FILE = _iobuf;
+pub type __FILE = _iobuf;
+
+#[allow(clippy::upper_case_acronyms)]
+pub type FILE = __FILE;
+
+pub type __tm = ();
+pub type _rand48 = ();
+pub type _misc_reent = ();
+pub type __locale_t = ();
+pub type _mprec = ();
+pub type _on_exit_args = ();
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct _atexit {
+    pub _next: *mut _atexit,
+    pub _ind: c_int,
+    pub _fns: [Option<unsafe extern "C" fn()>; 32],
+    pub _on_exit_args_ptr: *mut _on_exit_args,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct _glue {
+    pub _next: *mut _glue,
+    pub _niobs: c_int,
+    pub _iobs: *mut __FILE,
+}
+
+/// Reentrancy struct.
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct _reent {
+    // Consider as opaque for now.
+    _errno: c_int,
+    _stdin: *mut __FILE,
+    _stdout: *mut __FILE,
+    _stderr: *mut __FILE,
+    _inc: c_int,
+    _emergency: *mut c_char,
+    _reserved_0: c_int,
+    _reserved_1: c_int,
+    _locale: *mut __locale_t,
+    _mp: *mut _mprec,
+    __cleanup: Option<unsafe extern "C" fn(arg1: *mut _reent)>,
+    _gamma_signgam: c_int,
+    _cvtlen: c_int,
+    _cvtbuf: *mut c_char,
+    _r48: *mut _rand48,
+    _localtime_buf: *mut __tm,
+    _asctime_buf: *mut c_char,
+    _sig_func: *mut Option<unsafe extern "C" fn(arg1: c_int)>,
+    _reserved_6: *mut _atexit,
+    _reserved_7: _atexit,
+    _reserved_8: _glue,
+    __sf: *mut __FILE,
+    _misc: *mut _misc_reent,
+    _signal_buf: *mut c_char,
+}
 
 pub type va_list = *mut ::core::ffi::c_char;
 
-static mut S_STUB_TABLE: core::mem::MaybeUninit<chip_specific::syscall_stub_table> =
-    core::mem::MaybeUninit::uninit();
+/// The syscall table that ROM functions use.
+#[allow(clippy::missing_transmute_annotations)]
+pub static mut SYSCALL_TABLE: chip_specific::syscall_stub_table = unsafe {
+    chip_specific::syscall_stub_table {
+        __getreent: Some(core::mem::transmute(not_implemented as *const fn())),
+        _malloc_r: Some(core::mem::transmute(not_implemented as *const fn())),
+        _free_r: Some(core::mem::transmute(not_implemented as *const fn())),
+        _realloc_r: Some(core::mem::transmute(not_implemented as *const fn())),
+        _calloc_r: Some(core::mem::transmute(not_implemented as *const fn())),
+        _abort: Some(abort_wrapper),
+        _system_r: Some(core::mem::transmute(not_implemented as *const fn())),
+        _rename_r: Some(core::mem::transmute(not_implemented as *const fn())),
+        _times_r: Some(core::mem::transmute(not_implemented as *const fn())),
+        _gettimeofday_r: Some(core::mem::transmute(not_implemented as *const fn())),
+        _raise_r: Some(core::mem::transmute(not_implemented as *const fn())),
+        _unlink_r: Some(core::mem::transmute(not_implemented as *const fn())),
+        _link_r: Some(core::mem::transmute(not_implemented as *const fn())),
+        _stat_r: Some(core::mem::transmute(not_implemented as *const fn())),
+        _fstat_r: Some(core::mem::transmute(not_implemented as *const fn())),
+        _sbrk_r: Some(core::mem::transmute(not_implemented as *const fn())),
+        _getpid_r: Some(core::mem::transmute(not_implemented as *const fn())),
+        _kill_r: Some(core::mem::transmute(not_implemented as *const fn())),
+        _exit_r: Some(core::mem::transmute(not_implemented as *const fn())),
+        _close_r: Some(core::mem::transmute(not_implemented as *const fn())),
+        _open_r: Some(core::mem::transmute(not_implemented as *const fn())),
+        _write_r: Some(core::mem::transmute(not_implemented as *const fn())),
+        _lseek_r: Some(core::mem::transmute(not_implemented as *const fn())),
+        _read_r: Some(core::mem::transmute(not_implemented as *const fn())),
+        _retarget_lock_init: Some(core::mem::transmute(not_implemented as *const fn())),
+        _retarget_lock_init_recursive: Some(core::mem::transmute(not_implemented as *const fn())),
+        _retarget_lock_close: Some(core::mem::transmute(not_implemented as *const fn())),
+        _retarget_lock_close_recursive: Some(core::mem::transmute(not_implemented as *const fn())),
+        _retarget_lock_acquire: Some(core::mem::transmute(not_implemented as *const fn())),
+        _retarget_lock_acquire_recursive: Some(core::mem::transmute(
+            not_implemented as *const fn(),
+        )),
+        _retarget_lock_try_acquire: Some(core::mem::transmute(not_implemented as *const fn())),
+        _retarget_lock_try_acquire_recursive: Some(core::mem::transmute(
+            not_implemented as *const fn(),
+        )),
+        _retarget_lock_release: Some(core::mem::transmute(not_implemented as *const fn())),
+        _retarget_lock_release_recursive: Some(core::mem::transmute(
+            not_implemented as *const fn(),
+        )),
+        _printf_float: Some(core::mem::transmute(not_implemented as *const fn())),
+        _scanf_float: Some(core::mem::transmute(not_implemented as *const fn())),
+        __assert_func: Some(super::__assert_func),
+        __sinit: Some(core::mem::transmute(not_implemented as *const fn())),
+        _cleanup_r: Some(core::mem::transmute(not_implemented as *const fn())),
+    }
+};
 
 unsafe extern "C" fn not_implemented() {
     panic!("Function called via syscall table is not implemented!");
@@ -72,52 +174,6 @@ unsafe extern "C" fn abort_wrapper() {
 /// Should only get called once.
 #[allow(clippy::missing_transmute_annotations)]
 pub unsafe fn init_syscall_table() {
-    let syscall_table = unsafe {
-        (&mut *core::ptr::addr_of_mut!(S_STUB_TABLE)).write(chip_specific::syscall_stub_table {
-            __getreent: Some(core::mem::transmute(not_implemented as usize)),
-            _malloc_r: Some(core::mem::transmute(not_implemented as usize)),
-            _free_r: Some(core::mem::transmute(not_implemented as usize)),
-            _realloc_r: Some(core::mem::transmute(not_implemented as usize)),
-            _calloc_r: Some(core::mem::transmute(not_implemented as usize)),
-            _abort: Some(abort_wrapper),
-            _system_r: Some(core::mem::transmute(not_implemented as usize)),
-            _rename_r: Some(core::mem::transmute(not_implemented as usize)),
-            _times_r: Some(core::mem::transmute(not_implemented as usize)),
-            _gettimeofday_r: Some(core::mem::transmute(not_implemented as usize)),
-            _raise_r: Some(core::mem::transmute(not_implemented as usize)),
-            _unlink_r: Some(core::mem::transmute(not_implemented as usize)),
-            _link_r: Some(core::mem::transmute(not_implemented as usize)),
-            _stat_r: Some(core::mem::transmute(not_implemented as usize)),
-            _fstat_r: Some(core::mem::transmute(not_implemented as usize)),
-            _sbrk_r: Some(core::mem::transmute(not_implemented as usize)),
-            _getpid_r: Some(core::mem::transmute(not_implemented as usize)),
-            _kill_r: Some(core::mem::transmute(not_implemented as usize)),
-            _exit_r: Some(core::mem::transmute(not_implemented as usize)),
-            _close_r: Some(core::mem::transmute(not_implemented as usize)),
-            _open_r: Some(core::mem::transmute(not_implemented as usize)),
-            _write_r: Some(core::mem::transmute(not_implemented as usize)),
-            _lseek_r: Some(core::mem::transmute(not_implemented as usize)),
-            _read_r: Some(core::mem::transmute(not_implemented as usize)),
-            _retarget_lock_init: Some(core::mem::transmute(not_implemented as usize)),
-            _retarget_lock_init_recursive: Some(core::mem::transmute(not_implemented as usize)),
-            _retarget_lock_close: Some(core::mem::transmute(not_implemented as usize)),
-            _retarget_lock_close_recursive: Some(core::mem::transmute(not_implemented as usize)),
-            _retarget_lock_acquire: Some(core::mem::transmute(not_implemented as usize)),
-            _retarget_lock_acquire_recursive: Some(core::mem::transmute(not_implemented as usize)),
-            _retarget_lock_try_acquire: Some(core::mem::transmute(not_implemented as usize)),
-            _retarget_lock_try_acquire_recursive: Some(core::mem::transmute(
-                not_implemented as usize,
-            )),
-            _retarget_lock_release: Some(core::mem::transmute(not_implemented as usize)),
-            _retarget_lock_release_recursive: Some(core::mem::transmute(not_implemented as usize)),
-            _printf_float: Some(core::mem::transmute(not_implemented as usize)),
-            _scanf_float: Some(core::mem::transmute(not_implemented as usize)),
-            __assert_func: Some(super::__assert_func),
-            __sinit: Some(core::mem::transmute(not_implemented as usize)),
-            _cleanup_r: Some(core::mem::transmute(not_implemented as usize)),
-        })
-    };
-
     cfg_if::cfg_if! {
         if #[cfg(esp32)] {
             unsafe extern "C" {
@@ -125,19 +181,19 @@ pub unsafe fn init_syscall_table() {
                 static mut syscall_table_ptr_app: *const chip_specific::syscall_stub_table;
             }
             unsafe {
-                syscall_table_ptr_pro = syscall_table;
-                syscall_table_ptr_app = syscall_table;
+                syscall_table_ptr_pro = &raw const SYSCALL_TABLE;
+                syscall_table_ptr_app = &raw const SYSCALL_TABLE;
             }
         } else if #[cfg(esp32s2)] {
             unsafe extern "C" {
                 static mut syscall_table_ptr_pro: *const chip_specific::syscall_stub_table;
             }
-            unsafe { syscall_table_ptr_pro = syscall_table; }
+            unsafe { syscall_table_ptr_pro = &raw const SYSCALL_TABLE; }
         } else {
             unsafe extern "C" {
                 static mut syscall_table_ptr: *const chip_specific::syscall_stub_table;
             }
-            unsafe { syscall_table_ptr = syscall_table; }
+            unsafe { syscall_table_ptr = &raw const SYSCALL_TABLE; }
         }
     };
 }

--- a/esp-rom-sys/src/syscall/v1.rs
+++ b/esp-rom-sys/src/syscall/v1.rs
@@ -1,4 +1,4 @@
-use super::*;
+use crate::syscall::*;
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/esp-rtos/CHANGELOG.md
+++ b/esp-rtos/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Provide implementation for the `_getreent` syscall when the `alloc` feature is enabled (#4473)
 
 ### Changed
 

--- a/esp-rtos/Cargo.toml
+++ b/esp-rtos/Cargo.toml
@@ -36,6 +36,7 @@ esp-hal = { version = "1.0.0", path = "../esp-hal", default-features = false, fe
     # and uses reexported riscv/xtena-lx from esp-hal
     "requires-unstable", "rt"
 ] }
+esp-rom-sys = { version = "0.1.3", path = "../esp-rom-sys" }
 
 cfg-if = "1"
 rtos-trace = { version = "0.2.0", optional = true }
@@ -97,19 +98,19 @@ rtos-trace = ["dep:rtos-trace"]
 #! One of the following features must be enabled to select the target chip:
 
 ##
-esp32 = ["esp-hal/esp32", "esp-metadata-generated/esp32"]
+esp32 = ["esp-hal/esp32", "esp-metadata-generated/esp32", "esp-rom-sys/esp32"]
 ##
-esp32c2 = ["esp-hal/esp32c2", "esp-metadata-generated/esp32c2"]
+esp32c2 = ["esp-hal/esp32c2", "esp-metadata-generated/esp32c2", "esp-rom-sys/esp32c2"]
 ##
-esp32c3 = ["esp-hal/esp32c3", "esp-metadata-generated/esp32c3"]
+esp32c3 = ["esp-hal/esp32c3", "esp-metadata-generated/esp32c3", "esp-rom-sys/esp32c3"]
 ##
-esp32c6 = ["esp-hal/esp32c6", "esp-metadata-generated/esp32c6"]
+esp32c6 = ["esp-hal/esp32c6", "esp-metadata-generated/esp32c6", "esp-rom-sys/esp32c6"]
 ##
-esp32h2 = ["esp-hal/esp32h2", "esp-metadata-generated/esp32h2"]
+esp32h2 = ["esp-hal/esp32h2", "esp-metadata-generated/esp32h2", "esp-rom-sys/esp32h2"]
 ##
-esp32s2 = ["esp-hal/esp32s2", "esp-metadata-generated/esp32s2"]
+esp32s2 = ["esp-hal/esp32s2", "esp-metadata-generated/esp32s2", "esp-rom-sys/esp32s2"]
 ##
-esp32s3 = ["esp-hal/esp32s3", "esp-metadata-generated/esp32s3"]
+esp32s3 = ["esp-hal/esp32s3", "esp-metadata-generated/esp32s3", "esp-rom-sys/esp32s3"]
 
 #! ### Logging Feature Flags
 ## Enable logging output using version 0.4 of the `log` crate.

--- a/esp-rtos/src/esp_radio/mod.rs
+++ b/esp-rtos/src/esp_radio/mod.rs
@@ -94,13 +94,7 @@ impl esp_radio_rtos_driver::Scheduler for Scheduler {
     }
 
     fn current_task_thread_semaphore(&self) -> SemaphorePtr {
-        task::with_current_task(|task| {
-            NonNull::from(
-                task.thread_semaphore
-                    .get_or_insert_with(|| Semaphore::new_counting(0, 1)),
-            )
-            .cast()
-        })
+        task::with_current_task(|task| NonNull::from(&task.thread_local.thread_semaphore).cast())
     }
 
     fn usleep(&self, us: u32) {

--- a/esp-rtos/src/lib.rs
+++ b/esp-rtos/src/lib.rs
@@ -63,6 +63,7 @@ mod esp_radio;
 mod run_queue;
 mod scheduler;
 pub mod semaphore;
+mod syscall;
 mod task;
 mod timer;
 mod wait_queue;
@@ -294,6 +295,7 @@ pub fn start_with_idle_hook(
 
     SCHEDULER.with(move |scheduler| {
         scheduler.setup(TimeDriver::new(timer.timer()), idle_hook);
+        syscall::setup_syscalls();
 
         // Allocate the default task.
 

--- a/esp-rtos/src/scheduler.rs
+++ b/esp-rtos/src/scheduler.rs
@@ -27,6 +27,7 @@ use crate::{
         TaskListItem,
         TaskPtr,
         TaskState,
+        ThreadLocalData,
     },
     timer::TimeDriver,
 };
@@ -67,8 +68,7 @@ impl CpuSchedulerState {
 
             main_task: Task {
                 cpu_context: CpuContext::new(),
-                #[cfg(feature = "esp-radio")]
-                thread_semaphore: None,
+                thread_local: ThreadLocalData::new(),
                 state: TaskState::Ready,
                 stack: core::ptr::slice_from_raw_parts_mut(core::ptr::null_mut(), 0),
                 #[cfg(any(hw_task_overflow_detection, sw_task_overflow_detection))]

--- a/esp-rtos/src/syscall.rs
+++ b/esp-rtos/src/syscall.rs
@@ -1,0 +1,24 @@
+#[cfg(feature = "alloc")]
+use esp_rom_sys::SYSCALL_TABLE;
+
+#[cfg(feature = "alloc")]
+extern "C" fn _getreent() -> *mut esp_rom_sys::_reent {
+    use allocator_api2::boxed::Box;
+    crate::task::with_current_task(|task| {
+        task.thread_local
+            .reent
+            .get_or_insert_with(|| unsafe {
+                // Safety: _reent is a C-type containing integers and pointers, it is safe to
+                // zero-initialize it.
+                Box::new_zeroed().assume_init()
+            })
+            .as_mut() as *mut _
+    })
+}
+
+pub fn setup_syscalls() {
+    #[cfg(feature = "alloc")]
+    unsafe {
+        SYSCALL_TABLE.__getreent = Some(_getreent);
+    }
+}


### PR DESCRIPTION
Closes #4426
Closes #4432

This PR exposes the `_reent` type and `SYSCALL_TABLE` in esp-rom-sys. This allows other crates (namely, esp-rtos) to inject syscalls. For now, only `_getreent` is implemented, and a zeroed `_reent` struct is allocated for each task, but in the future other syscalls may be implemented.

`_getreent` is not provided without `esp-rtos` and alloc, because the struct is rather big and nothing seems to need it outside esp-radio. For the same reason, it is also lazy-initialized. If this turns out to be a problem, we'll be able to provide a no-alloc implementation, but for now I think that wouldn't be entirely reasonable to do.