### PR TITLE
Cut CI jobs in half

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,16 +50,26 @@ jobs:
       GATEWAY_IP: 1.1.1.1
       HOST_IP: 1.1.1.1
 
+    strategy:
+      fail-fast: false
+      matrix:
+        # load-blance runners a bit
+        group:
+          - xtensa
+          - riscv
+
     steps:
       - uses: actions/checkout@v4
 
       # Install the Rust toolchain for Xtensa devices:
       - uses: esp-rs/xtensa-toolchain@v1.6
+        if: matrix.group == 'xtensa'
         with:
           version: 1.90.0.0
 
       # Install the Rust stable toolchain for RISC-V devices:
       - uses: dtolnay/rust-toolchain@v1
+        if: matrix.group == 'riscv'
         with:
           target: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf
           toolchain: stable
@@ -71,13 +81,20 @@ jobs:
               cargo install --git https://github.com/embassy-rs/cargo-batch cargo --bin cargo-batch --locked --force
           fi
 
-      - name: Build and Check
+      - name: Build and Check Xtensa
+        if: matrix.group == 'xtensa'
         shell: bash
         run: |
           # lints and docs are checked separately
           cargo xcheck ci esp32 --toolchain esp --no-lint --no-docs
           cargo xcheck ci esp32s2 --toolchain esp --no-lint --no-docs
           cargo xcheck ci esp32s3 --toolchain esp --no-lint --no-docs
+
+      - name: Build and Check RISC-V
+        if: matrix.group == 'riscv'
+        shell: bash
+        run: |
+          # lints and docs are checked separately
           cargo xcheck ci esp32c2 --toolchain stable --no-lint --no-docs
           cargo xcheck ci esp32c3 --toolchain stable --no-lint --no-docs
           cargo xcheck ci esp32c6 --toolchain stable --no-lint --no-docs
@@ -112,6 +129,14 @@ jobs:
 
   docs:
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        group:
+          - xtensa
+          - riscv
+
     steps:
       - uses: actions/checkout@v4
 
@@ -133,10 +158,15 @@ jobs:
           toolchain: nightly
           components: rust-src
 
-      - name: Build docs
+      - name: Build Xtensa docs
+        if: matrix.group == 'xtensa'
         shell: bash
-        run: |
-          cargo xtask build documentation
+        run: cargo xtask build documentation --chips esp32,esp32s2,esp32s3
+
+      - name: Build RISC-V docs
+        if: matrix.group == 'riscv'
+        shell: bash
+        run: cargo xtask build documentation --chips esp32c2,esp32c3,esp32c6,esp32h2
 
   # --------------------------------------------------------------------------
   # MSRV
@@ -144,27 +174,43 @@ jobs:
   msrv:
     runs-on: ubuntu-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        group:
+          - xtensa
+          - riscv
+
     steps:
       - uses: actions/checkout@v4
       - uses: esp-rs/xtensa-toolchain@v1.6
+        if: matrix.group == 'xtensa'
         with:
           version: ${{ env.MSRV }}
+
+      - name: esp toolchain checks
+        if: matrix.group == 'xtensa'
+        run: rustc +esp --version --verbose
+
       - uses: dtolnay/rust-toolchain@v1
+        if: matrix.group == 'riscv'
         with:
           target: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf,x86_64-unknown-linux-gnu
           toolchain: ${{ env.MSRV }}
           components: rust-src,clippy
 
       - name: Stable toolchain checks
+        if: matrix.group == 'riscv'
         run: rustc +${{ env.MSRV }} --version --verbose
-      - name: esp toolchain checks
-        run: rustc +esp --version --verbose
 
       # Verify the MSRV for all chips by running a lint session
-      - name: msrv RISCV (esp-hal)
+      - name: msrv RISC-V (esp-hal)
+        if: matrix.group == 'riscv'
         run: |
           cargo xtask lint-packages --chips esp32c2,esp32c3,esp32c6,esp32h2 --toolchain ${{ env.MSRV }}
+
       - name: msrv Xtensa (esp-hal)
+        if: matrix.group == 'xtensa'
         run: |
           cargo xtask lint-packages --chips esp32,esp32s2,esp32s3 --toolchain esp
 


### PR DESCRIPTION
Now that we have two runners, let's try to use them in parallel. Also cut the docs/msrv tasks similarly in two, to reduce their runtime at the cost of eating up more runners.