### PR TITLE
feat(radio: ble): expose device mac address

### DIFF
--- a/esp-radio/CHANGELOG.md
+++ b/esp-radio/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `ble::mac` to get the MAC address of the device (#4485)
 - `last_calibration_result` to get the result of the last calibration (#4479)
 
 ### Changed

--- a/esp-radio/src/ble/mod.rs
+++ b/esp-radio/src/ble/mod.rs
@@ -43,6 +43,16 @@ pub(crate) unsafe extern "C" fn free(ptr: *mut crate::sys::c_types::c_void) {
     unsafe { crate::compat::malloc::free(ptr.cast()) }
 }
 
+/// Gets the MAC address of the device.
+#[instability::unstable]
+pub fn mac() -> [u8; 6] {
+    let mut mac = [0u8; 6];
+    unsafe {
+        crate::common_adapter::read_mac(mac.as_mut_ptr(), 2);
+    }
+    mac
+}
+
 struct BleState {
     pub rx_queue: VecDeque<ReceivedPacket>,
     pub hci_read_data: Vec<u8>,


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
    - Using a fixed "random" address is recommended for testing/example purposes.
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

The WiFi subsystem exposes the MAC addresses of both Station and SoftAP interfaces. Since the same implementation is used to retrieve the BT one, it makes sense to expose it as well.

#### Testing

I will test on real HW soon, I assume that it works similarly to the already tested WiFi functions.