### PR TITLE
RMT: move configuration errors to new ConfigError enum

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RMT: `SingleShotTxTransaction` has been renamed to `TxTransaction`. (#4302)
 - RMT: `ChannelCreator::configure_tx` and `ChannelCreator::configure_rx` now take the configuration by reference. (#4302)
 - RMT: `ChannelCreator::configure_tx` and `ChannelCreator::configure_rx` don't take a pin anymore, instead `Channel::with_pin` has been added. (#4302)
+- RMT: Configuration errors have been split out of `rmt::Error` into the new `rmt::ConfigError` enum. (#4494)
 
 
 ### Fixed

--- a/esp-hal/MIGRATING-1.0.0.md
+++ b/esp-hal/MIGRATING-1.0.0.md
@@ -61,3 +61,11 @@ This applies to
 - `Channel<'_, Blocking, Tx>::transmit`,
 - `Channel<'_, Blocking, Tx>::transmit_continuously`,
 - `Channel<'_, Blocking, Rx>::receive`.
+
+Configuration methods
+- `Rmt::new`,
+- `ChannelCreator::configure_tx`,
+- `ChannelCreator::configure_rx`,
+now return `ConfigError` instead of `Error`.
+Corresponding enum variants have been removed from `Error`, and some variants
+that are now part of `ConfigError` have been renamed.

--- a/hil-test/src/bin/rmt.rs
+++ b/hil-test/src/bin/rmt.rs
@@ -30,6 +30,7 @@ use esp_hal::{
     rmt::{
         CHANNEL_RAM_SIZE,
         Channel,
+        ConfigError,
         Error,
         HAS_RX_WRAP,
         PulseCode,
@@ -520,7 +521,7 @@ mod tests {
         // Configuring channel 1 should fail, since channel 0 already uses its memory.
         let ch1 = rmt.channel1.configure_tx(&TxChannelConfig::default());
 
-        assert!(matches!(ch1, Err(Error::MemoryBlockNotAvailable)));
+        assert!(matches!(ch1, Err(ConfigError::MemoryBlockNotAvailable)));
     }
 
     #[test]
@@ -556,7 +557,7 @@ mod tests {
             .unwrap();
 
         let res = ch0.apply_config(&TxChannelConfig::default().with_memsize(2));
-        assert!(matches!(res, Err(Error::MemoryBlockNotAvailable)));
+        assert!(matches!(res, Err(ConfigError::MemoryBlockNotAvailable)));
 
         core::mem::drop(ch1);
 
@@ -566,7 +567,7 @@ mod tests {
         let res = rmt
             .channel1
             .configure_tx(&TxChannelConfig::default().with_memsize(1));
-        assert!(matches!(res, Err(Error::MemoryBlockNotAvailable)));
+        assert!(matches!(res, Err(ConfigError::MemoryBlockNotAvailable)));
     }
 
     macro_rules! test_channel_pair {


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖
Splits configuration errors for the RMT into a separate `ConfigError` enum, as mandated by the developer guidelines.

#### Testing
build tested HIL tests
