### PR TITLE
ESP32: Change internal timer frequency to 1MHz

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- ESP32: Reduced the TIMG0_LACT divider to 1 MHz (#4503)
 
 ### Fixed
 


### PR DESCRIPTION
We count in units of 1us, so for efficiency we should also set the internal timer to count up in 1us increments instead of 1/16us.