### PR TITLE
RMT: Remove unnecessary `Sized` bounds

### DIFF
--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -825,10 +825,7 @@ for_each_rmt_channel!(
                     fn configure_tx(
                         self,
                         config: &TxChannelConfig,
-                    ) -> Result<Channel<'ch, Dm, Tx>, ConfigError>
-                    where
-                        Self: Sized,
-                    {
+                    ) -> Result<Channel<'ch, Dm, Tx>, ConfigError> {
                         let raw = unsafe { DynChannelAccess::conjure(ChannelIndex::[<Ch $idx>]) };
 
                         apply_tx_config(raw, config, false)?;
@@ -862,10 +859,7 @@ for_each_rmt_channel!(
                     fn configure_rx(
                         self,
                         config: &RxChannelConfig,
-                    ) -> Result<Channel<'ch, Dm, Rx>, ConfigError>
-                    where
-                        Self: Sized,
-                    {
+                    ) -> Result<Channel<'ch, Dm, Rx>, ConfigError> {
                         let raw = unsafe { DynChannelAccess::conjure(ChannelIndex::[<Ch $idx>]) };
 
                         apply_rx_config(raw, config, false)?;
@@ -1898,7 +1892,6 @@ impl<'ch> Channel<'ch, Blocking, Rx> {
         data: &'data mut [T],
     ) -> Result<RxTransaction<'ch, 'data, T>, (Error, Self)>
     where
-        Self: Sized,
         T: From<PulseCode>,
     {
         let raw = self.raw;
@@ -1995,7 +1988,6 @@ impl Channel<'_, Async, Tx> {
     #[cfg_attr(place_rmt_driver_in_ram, ram)]
     pub fn transmit<T>(&mut self, mut data: &[T]) -> impl Future<Output = Result<(), Error>>
     where
-        Self: Sized,
         T: Into<PulseCode> + Copy,
     {
         let raw = self.raw;
@@ -2118,7 +2110,6 @@ impl Channel<'_, Async, Rx> {
     #[cfg_attr(place_rmt_driver_in_ram, ram)]
     pub fn receive<T>(&mut self, data: &mut [T]) -> impl Future<Output = Result<usize, Error>>
     where
-        Self: Sized,
         T: From<PulseCode> + Unpin,
     {
         let raw = self.raw;


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
A few `Sized` bounds were left over from previous versions of the driver where these methods were part of a trait's default implementation. Now, they're implemented on concrete types, so the bounds are redundant.

#### Testing
HIL test build
