### PR TITLE
make the S3 ADC less bad

### DIFF
--- a/esp-hal/src/analog/adc/xtensa.rs
+++ b/esp-hal/src/analog/adc/xtensa.rs
@@ -172,6 +172,7 @@ impl RegisterAccess for crate::peripherals::ADC1<'_> {
     fn calibration_init() {
         // https://github.com/espressif/esp-idf/blob/800f141f94c0f880c162de476512e183df671307/components/hal/esp32s3/include/hal/adc_ll.h#L833
         // https://github.com/espressif/esp-idf/blob/800f141f94c0f880c162de476512e183df671307/components/hal/esp32s2/include/hal/adc_ll.h#L1145
+        #[cfg(esp32s2)]
         regi2c::ADC_SAR1_DREF.write_field(4);
     }
 
@@ -488,7 +489,9 @@ where
 #[cfg(esp32s3)]
 impl super::AdcCalEfuse for crate::peripherals::ADC1<'_> {
     fn init_code(atten: Attenuation) -> Option<u16> {
-        Efuse::rtc_calib_init_code(AdcCalibUnit::ADC1, atten)
+        // The efuse init code appears to be quite bad
+        // use the "connect to gnd" fallback instead
+        None
     }
 
     fn cal_mv(atten: Attenuation) -> u16 {


### PR DESCRIPTION
This PR is for testing purposes only.

On my S3 board the efuse init code was `2267`.
This lead to the 0-300mV range to read as 0.
The init code obtained from manual calibration is `1999` which leads to much better results.

This reverts part of https://github.com/esp-rs/esp-hal/pull/4286.
This was necessary to make manual calibration work.

Could someone check if this indeed improves the ADC values and then try to understand why the efuse init code is off by so much.

Maybe we could actually get some official docs for what all the regs do 🙏