### PR TITLE
CI(binary_size): Swap order of elfs passed to `bloaty` action

### DIFF
--- a/.github/workflows/binary_size.yml
+++ b/.github/workflows/binary_size.yml
@@ -121,7 +121,7 @@ jobs:
         id: bloaty-qa
         uses: carlosperate/bloaty-action@v1
         with:
-          bloaty-args: -d sections base_qa_build_${{ matrix.target.soc }}.elf -- pr_qa_build_${{ matrix.target.soc }}.elf
+          bloaty-args: -d sections pr_qa_build_${{ matrix.target.soc }}.elf -- base_qa_build_${{ matrix.target.soc }}.elf
           output-to-summary: false
         continue-on-error: true
 


### PR DESCRIPTION
The order of ELFs passed to `bloaty` didn’t match the order used in the generated report, causing the signs (+/–) to be reversed.