### PR TITLE
I2C: Check errors while waiting for commands

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RMT: All blocking methods now return the channel on failure. (#4302)
 - RMT: the `place_rmt_driver_in_ram` option now also places the async interrupt handler in RAM. (#4302)
 - RMT: When dropping a Tx channel, the driver now disconnects the output pin from the peripheral. (#4302)
+- I2C: avoid potential infinite loop while checking for command completion (#4519)
 
 ### Removed
 

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -2221,6 +2221,8 @@ impl Driver<'_> {
             Instant::EPOCH
         };
 
+        self.check_errors()?;
+
         for cmd_reg in self.regs().comd_iter() {
             let cmd = cmd_reg.read();
 


### PR DESCRIPTION
This PR seems to fix an issue on the C2, where in some cases commands just don't complete.