### PR TITLE
Remove enable functions from always_on clock nodes

### DIFF
--- a/esp-hal/src/clock/mod.rs
+++ b/esp-hal/src/clock/mod.rs
@@ -1169,7 +1169,7 @@ impl Clocks {
 impl Clocks {
     /// Configure the CPU clock speed.
     pub(crate) fn configure(cpu_clock_speed: CpuClock) -> Self {
-        use crate::soc::clocks::{ClockTree, request_cpu_clk};
+        use crate::soc::clocks::ClockTree;
 
         // TODO: expose the whole new enum for custom options
         match cpu_clock_speed {
@@ -1180,8 +1180,6 @@ impl Clocks {
         .configure();
 
         ClockTree::with(|clocks| {
-            request_cpu_clk(clocks);
-
             // TODO: this struct can be removed once everything uses the new internal clock tree
             // code
             Self {

--- a/esp-hal/src/soc/esp32/clocks.rs
+++ b/esp-hal/src/soc/esp32/clocks.rs
@@ -419,10 +419,6 @@ fn configure_ref_tick_pll_impl(_clocks: &mut ClockTree, new_config: RefTickPllCo
         .write(|w| unsafe { w.pll_tick_num().bits(new_config.value() as u8) });
 }
 
-fn enable_cpu_clk_impl(_clocks: &mut ClockTree, _en: bool) {
-    // Nothing to do.
-}
-
 fn configure_cpu_clk_impl(
     clocks: &mut ClockTree,
     _old_selector: Option<CpuClkConfig>,

--- a/esp-metadata-generated/src/_generated_esp32.rs
+++ b/esp-metadata-generated/src/_generated_esp32.rs
@@ -320,7 +320,6 @@ macro_rules! for_each_soc_xtal_options {
 /// fn configure_ref_tick_apll_impl(_clocks: &mut ClockTree, _new_config: RefTickApllConfig) {}
 /// fn enable_ref_tick_pll_impl(_clocks: &mut ClockTree, _en: bool) {}
 /// fn configure_ref_tick_pll_impl(_clocks: &mut ClockTree, _new_config: RefTickPllConfig) {}
-/// fn enable_cpu_clk_impl(_clocks: &mut ClockTree, _en: bool) {}
 /// fn configure_cpu_clk_impl(
 ///     _clocks: &mut ClockTree,
 ///     _old_selector: Option<CpuClkConfig>,
@@ -752,8 +751,8 @@ macro_rules! define_clock_tree_types {
             clocks.xtl_clk = Some(config);
             configure_xtl_clk_impl(clocks, config);
         }
-        pub fn request_xtl_clk(clocks: &mut ClockTree) {}
-        pub fn release_xtl_clk(clocks: &mut ClockTree) {}
+        fn request_xtl_clk(_clocks: &mut ClockTree) {}
+        fn release_xtl_clk(_clocks: &mut ClockTree) {}
         pub fn xtl_clk_frequency(clocks: &mut ClockTree) -> u32 {
             unwrap!(clocks.xtl_clk).value()
         }
@@ -1136,16 +1135,8 @@ macro_rules! define_clock_tree_types {
                 CpuClkConfig::Pll => release_cpu_pll_div(clocks),
             }
         }
-        pub fn request_cpu_clk(clocks: &mut ClockTree) {
-            let selector = unwrap!(clocks.cpu_clk);
-            cpu_clk_request_upstream(clocks, selector);
-            enable_cpu_clk_impl(clocks, true);
-        }
-        pub fn release_cpu_clk(clocks: &mut ClockTree) {
-            enable_cpu_clk_impl(clocks, false);
-            let selector = unwrap!(clocks.cpu_clk);
-            cpu_clk_release_upstream(clocks, selector);
-        }
+        fn request_cpu_clk(_clocks: &mut ClockTree) {}
+        fn release_cpu_clk(_clocks: &mut ClockTree) {}
         pub fn cpu_clk_frequency(clocks: &mut ClockTree) -> u32 {
             match unwrap!(clocks.cpu_clk) {
                 CpuClkConfig::Xtal => syscon_pre_div_frequency(clocks),

--- a/esp-metadata/src/cfg/soc.rs
+++ b/esp-metadata/src/cfg/soc.rs
@@ -687,6 +687,7 @@ impl DeviceClocks {
                     has_enable: !(node.always_on()
                         && dependency_graph.inputs(node.name_str()).is_empty()),
                     state_ty: node.config_type_name(),
+                    always_on: node.always_on(),
                 },
             );
         }


### PR DESCRIPTION
This change hides `request/release_cpu_clock`, which was a confusing function. Calling that multiple times just ended up re-requesting upstream clocks which means their refcount increased even if they only had one consumer (the CPU), which was unintended. Now the upstream clocks are requested/released during configuration, which prevents this issue (calling that in a loop requests, then releases the same upstream clock node).

cc #4502