### PR TITLE
Do not generate trivial checks

### DIFF
--- a/esp-metadata-generated/src/_generated_esp32.rs
+++ b/esp-metadata-generated/src/_generated_esp32.rs
@@ -644,7 +644,7 @@ macro_rules! define_clock_tree_types {
             /// valid range (0 ..= 1023).
             pub const fn new(divisor: u32) -> Self {
                 ::core::assert!(
-                    divisor >= 0u32 && divisor <= 1023u32,
+                    divisor <= 1023u32,
                     "`SYSCON_PRE_DIV` divisor value must be between 0 and 1023 (inclusive)."
                 );
                 Self(divisor)
@@ -692,7 +692,7 @@ macro_rules! define_clock_tree_types {
             /// valid range (0 ..= 255).
             pub const fn new(divisor: u32) -> Self {
                 ::core::assert!(
-                    divisor >= 0u32 && divisor <= 255u32,
+                    divisor <= 255u32,
                     "`REF_TICK_XTAL` divisor value must be between 0 and 255 (inclusive)."
                 );
                 Self(divisor)
@@ -716,7 +716,7 @@ macro_rules! define_clock_tree_types {
             /// valid range (0 ..= 255).
             pub const fn new(divisor: u32) -> Self {
                 ::core::assert!(
-                    divisor >= 0u32 && divisor <= 255u32,
+                    divisor <= 255u32,
                     "`REF_TICK_FOSC` divisor value must be between 0 and 255 (inclusive)."
                 );
                 Self(divisor)
@@ -740,7 +740,7 @@ macro_rules! define_clock_tree_types {
             /// valid range (0 ..= 255).
             pub const fn new(divisor: u32) -> Self {
                 ::core::assert!(
-                    divisor >= 0u32 && divisor <= 255u32,
+                    divisor <= 255u32,
                     "`REF_TICK_APLL` divisor value must be between 0 and 255 (inclusive)."
                 );
                 Self(divisor)
@@ -764,7 +764,7 @@ macro_rules! define_clock_tree_types {
             /// valid range (0 ..= 255).
             pub const fn new(divisor: u32) -> Self {
                 ::core::assert!(
-                    divisor >= 0u32 && divisor <= 255u32,
+                    divisor <= 255u32,
                     "`REF_TICK_PLL` divisor value must be between 0 and 255 (inclusive)."
                 );
                 Self(divisor)

--- a/esp-metadata-generated/src/_generated_esp32c2.rs
+++ b/esp-metadata-generated/src/_generated_esp32c2.rs
@@ -495,7 +495,7 @@ macro_rules! define_clock_tree_types {
             /// valid range (0 ..= 1023).
             pub const fn new(divisor: u32) -> Self {
                 ::core::assert!(
-                    divisor >= 0u32 && divisor <= 1023u32,
+                    divisor <= 1023u32,
                     "`SYSTEM_PRE_DIV` divisor value must be between 0 and 1023 (inclusive)."
                 );
                 Self(divisor)
@@ -583,7 +583,7 @@ macro_rules! define_clock_tree_types {
             /// valid range (0 ..= 3).
             pub const fn new(divisor: u32) -> Self {
                 ::core::assert!(
-                    divisor >= 0u32 && divisor <= 3u32,
+                    divisor <= 3u32,
                     "`RC_FAST_CLK_DIV_N` divisor value must be between 0 and 3 (inclusive)."
                 );
                 Self(divisor)

--- a/esp-metadata/src/cfg/soc/clock_tree/divider.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/divider.rs
@@ -255,7 +255,12 @@ impl ClockTreeNodeType for Divider {
                 .map(|l| quote! { #[doc = #l] })
                 .collect();
 
-                quote! { ::core::assert!(divisor >= #min && divisor <= #max, #assert_failed); }
+                // Divisor is unsigned, avoid generating `>= 0`.
+                if min == 0 {
+                    quote! { ::core::assert!(divisor <= #max, #assert_failed); }
+                } else {
+                    quote! { ::core::assert!(divisor >= #min && divisor <= #max, #assert_failed); }
+                }
             });
 
             Some(quote! {

--- a/esp-metadata/src/cfg/soc/clock_tree/source.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/source.rs
@@ -228,7 +228,12 @@ impl ClockTreeNodeType for Source {
  valid range ({min_readable} {min_unit} - {max_readable} {max_unit})."#)
                 .lines().map(|l| quote! { #[doc = #l] }).collect();
 
-                quote! { ::core::assert!(frequency >= #min && frequency <= #max, #assert_failed); }
+                // Frequency is unsigned, avoid generating `>= 0`.
+                if min == 0 {
+                    quote! { ::core::assert!(frequency <= #max, #assert_failed); }
+                } else {
+                    quote! { ::core::assert!(frequency >= #min && frequency <= #max, #assert_failed); }
+                }
             });
 
             Some(quote! {


### PR DESCRIPTION
Copilot doesn't like these, so even if the compiler can just yeet the checks, let's make sure they are not in the source in the first place.

cc #4502