### PR TITLE
Dummy CI check to satisfy branch protection requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,3 +269,56 @@ jobs:
             './**/*.rs'
             './**/*.md'
             './**/*.toml'
+
+  # Dummy HIL test-build check for PRs
+  #
+  # This job only exists so that the required "build-tests-full (...)" checks
+  # are green on normal PR CI. It does NOT actually build tests.
+  #
+  # The real test builds run in hil.yml on merge_group (and when dispatched
+  # via `/hil full`) using a job with the same id + matrix, so the merge
+  # queue reuses these check names.
+  #
+  # For a reference, check out this GH discussion: https://github.com/orgs/community/discussions/102764
+  build-tests-full:
+    if: github.event_name != 'merge_group'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+        - soc: esp32c2
+          rust-target: riscv32imc-unknown-none-elf
+          runner: esp32c2-jtag
+          host: aarch64
+        - soc: esp32c3
+          rust-target: riscv32imc-unknown-none-elf
+          runner: esp32c3-usb
+          host: armv7
+        - soc: esp32c6
+          rust-target: riscv32imac-unknown-none-elf
+          runner: esp32c6-usb
+          host: armv7
+        - soc: esp32h2
+          rust-target: riscv32imac-unknown-none-elf
+          runner: esp32h2-usb
+          host: armv7
+        - soc: esp32
+          rust-target: xtensa-esp32-none-elf
+          runner: esp32-jtag
+          host: aarch64
+        - soc: esp32s2
+          rust-target: xtensa-esp32s2-none-elf
+          runner: esp32s2-jtag
+          host: armv7
+        - soc: esp32s3
+          rust-target: xtensa-esp32s3-none-elf
+          runner: esp32s3-usb
+          host: armv7
+
+    steps:
+      - name: Dummy placeholder for HIL test builds
+        run: |
+          echo "NOOP: Dummy build-tests-full for ${{ matrix.target.soc }}."
+          echo "Real HIL test builds run only in hil.yml (merge_group or /hil full)."
+

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -91,7 +91,14 @@ jobs:
         with:
           name: xtask-aarch64
           path: target/aarch64-unknown-linux-gnu/release/xtask
-
+  
+  # NOTE:
+  # There is also a dummy job named 'build-tests-full' in `ci.yml` which runs
+  # only on non-merge-group events to satisfy branch protection required
+  # checks on PRs.
+  #
+  # This job is the *real* HIL test-build job, used on merge_group and when
+  # triggered via `/hil full`.
   build-tests-full:
     if: >
       github.event_name == 'merge_group' ||


### PR DESCRIPTION
See https://github.com/orgs/community/discussions/102764 for a reference

We need `build-tests-full` to be a branch protection requirement to ensure the tests at least build, but if we mark the job itself as `required` as is - it will(/might?) never be triggered and we will not be able to even get it to the merge queue (from my understanding), because it's active on `merge_group` and `workflow_dispatch` only. 

TL;DR - GH CI being GH CI and we're just trying to coexist with it 🤷🏼 