### PR TITLE
Update broken link to developer guidelines in CONTRIBUTING.md

### DIFF
--- a/documentation/CONTRIBUTING.md
+++ b/documentation/CONTRIBUTING.md
@@ -33,13 +33,13 @@ Welcome aboard! If you're new to `esp-hal` or open-source contribution, here are
 *   Workflow Insights: [GitHub Flow]
 *   Collaborating via [Pull Requests]
 
-Before adding or changing code, review the [esp-rs API guidelines].
+Before adding or changing code, review the [esp-rs developer guidelines].
 
 [GitHub's Guide]: https://docs.github.com/en/get-started/exploring-projects-on-github/finding-ways-to-contribute-to-open-source-on-github
 [Setting Up Git]: https://docs.github.com/en/get-started/quickstart/set-up-git
 [GitHub Flow]: https://docs.github.com/en/get-started/quickstart/github-flow
 [Pull Requests]: https://docs.github.com/en/github/collaborating-with-pull-requests
-[esp-rs developer guidelines]: ./documentation/DEVELOPER-GUIDELINES.md
+[esp-rs developer guidelines]: ./DEVELOPER-GUIDELINES.md
 [HIL guide]: https://github.com/esp-rs/esp-hal/blob/main/documentation/HIL-GUIDE.md
 
 ## Getting Started


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

Fix a broken link in the contributing guide.

This link was broken for two reasons:
- the developer guide was renamed in #3049, and one reference to this was missed in #3202
- the contributing guide was moved in #1947, which mistakenly added the directory `documentation/` to the link

#### Description

- change link name to match the referenced document
- remove `documentation/` from link path

#### Testing

I tested this by following the link in `CONTRIBUTING.md` ~~[in the branch for this PR](https://github.com/KevinWMatthews/esp-hal/blob/fix-contributing-guide-link/documentation/CONTRIBUTING.md#new-contributor-guide)~~ [in main](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md#new-contributor-guide).