### PR TITLE
Add a way how to generate baselines from a git rev and add `esp-rom-sys`

### DIFF
--- a/.github/workflows/api-baseline-generation.yml
+++ b/.github/workflows/api-baseline-generation.yml
@@ -21,6 +21,14 @@ on:
         required: false
         default: false
         type: boolean
+      tag_name:
+        description: "The Git tag to generate the baseline from"
+        required: false
+        default: ""
+      package_name:
+        description: "The package name"
+        required: true
+        default: "esp-hal"
 
 env:
   CARGO_TERM_COLOR: always
@@ -37,7 +45,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.source_branch || 'main' }}
+          ref: ${{ github.event.inputs.tag_name || github.event.inputs.source_branch || 'main' }}
           fetch-depth: 10
 
       - name: Set target repository
@@ -124,23 +132,24 @@ jobs:
         run: |
           echo "Starting API baseline generation..."
           echo "Trigger reason: ${{ steps.check-generation.outputs.trigger_reason }}"
-          cargo xcheck semver-check generate-baseline
+          cargo xcheck semver-check --packages ${{ github.event.inputs.package_name }} generate-baseline
           echo "API baseline generation completed"
 
       - name: Upload API baselines as artifact
         if: steps.check-generation.outputs.should_generate == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: api-baselines-esp-hal
-          path: esp-hal/api-baseline/
+          name: api-baselines-${{ github.event.inputs.package_name }}
+          path: ${{ github.event.inputs.package_name }}/api-baseline/
           retention-days: 90 # Maximum for public repos
 
       - name: Create baseline summary
         if: steps.check-generation.outputs.should_generate == 'true'
         shell: bash
         run: |
+          PACKAGE_NAME="${{ github.event.inputs.package_name }}"
           echo "Successfully generated and uploaded API baselines"
-          echo "Artifact name: api-baselines-esp-hal"
+          echo "Artifact name: api-baselines-$PACKAGE_NAME"
           echo "Retention: 90 days (expires on $(date -d '+90 days' '+%Y-%m-%d'))"
           echo "Source branch: ${{ github.event.inputs.source_branch || 'main' }}"
           echo "Commit: ${{ github.sha }}"
@@ -169,14 +178,14 @@ jobs:
 
           echo "- **Target Repository**: \`$GITHUB_REPOSITORY\`" >> $GITHUB_STEP_SUMMARY
           echo "- **Source Branch**: \`${{ github.event.inputs.source_branch || 'main' }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "- **Artifact Name**: \`api-baselines-esp-hal\`" >> $GITHUB_STEP_SUMMARY
+          echo "- **Artifact Name**: \`api-baselines-$PACKAGE_NAME\`" >> $GITHUB_STEP_SUMMARY
           echo "- **Retention**: 90 days (expires $(date -d '+90 days' '+%Y-%m-%d'))" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Baseline Files Generated" >> $GITHUB_STEP_SUMMARY
           echo "| Chip | File Size |" >> $GITHUB_STEP_SUMMARY
           echo "|------|-----------|" >> $GITHUB_STEP_SUMMARY
 
-          cd esp-hal/api-baseline
+          cd "$PACKAGE_NAME/api-baseline"
           for file in *.json.gz; do
               if [ -f "$file" ]; then
                   chip=$(basename "$file" .json.gz)

--- a/xtask/src/commands/release/semver_check.rs
+++ b/xtask/src/commands/release/semver_check.rs
@@ -22,7 +22,7 @@ pub struct SemverCheckArgs {
     pub command: SemverCheckCmd,
 
     /// Package(s) to target.
-    #[arg(long, value_enum, value_delimiter = ',', default_values_t = vec![Package::EspHal])]
+    #[arg(long, value_enum, value_delimiter = ',', default_values_t = vec![Package::EspHal, Package::EspRomSys])]
     pub packages: Vec<Package>,
 
     /// Chip(s) to target.
@@ -200,9 +200,9 @@ pub mod checker {
 
             // Try to download from GitHub Actions artifacts
             // Note: Artifacts have a 90-day retention limit for public repositories
-            let baseline_sources = vec![BaselineSource::Artifact(
-                "api-baselines-esp-hal".to_string(),
-            )];
+            let artifact_name = format!("api-baselines-{}", package_name);
+
+            let baseline_sources = vec![BaselineSource::Artifact(artifact_name)];
 
             let mut downloaded = false;
             for baseline_source in baseline_sources {


### PR DESCRIPTION
We currently have generated baselines only for `esp-hal`. This PR adds a way how to generate baseline from a git tag (we need to generate baseline for `esp-rom-sys`, cc https://github.com/esp-rs/esp-hal/issues/4489 ) and in future we will have more packages that need to be checked - so let's try to automate it. 

TODO: I'm not sure how to proceed with `breaking-change-esp-hal` label.

EDIT: I might have missed something here so I expect a few iterations to get it right.

cc https://github.com/esp-rs/esp-hal/pull/4565