### PR TITLE
xtask(semver): Pass correct path to the `download_baselines()`

### DIFF
--- a/xtask/src/semver_check.rs
+++ b/xtask/src/semver_check.rs
@@ -32,7 +32,7 @@ pub fn minimum_update(
     let baseline_path_gz =
         PathBuf::from(&package_path).join(format!("api-baseline/{}.json.gz", file_name));
     if !baseline_path_gz.exists() {
-        download_baselines(&package_path, vec![package])?;
+        download_baselines(&workspace, vec![package])?;
     }
     let baseline_path =
         temp_file::TempFile::new().with_context(|| format!("Failed to create a TempFile!"))?;


### PR DESCRIPTION
When baselines are not downloaded and `cargo xrelease plan esp-hal` is called:
```rust
Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.92s
   Generated /Users/jurajsadel/esp-rs/esp-hal/target/xtensa-esp32-none-elf/doc/esp_hal.json
[2025-11-28T21:09:56Z INFO  xtask::commands::release::semver_check::checker] Downloading API baselines for esp-hal
[2025-11-28T21:09:56Z INFO  xtask::commands::release::semver_check::checker] Attempting to download from GitHub Actions artifact: api-baselines-esp-hal
[2025-11-28T21:09:56Z INFO  xtask::commands::release::semver_check::checker] Attempting to download artifact: api-baselines-esp-hal from esp-rs/esp-hal
[2025-11-28T21:10:02Z INFO  xtask::commands::release::semver_check::checker] Successfully downloaded baselines from artifact api-baselines-esp-hal
[2025-11-28T21:10:02Z INFO  xtask::commands::release::semver_check::checker] Found 7 baseline files for esp-hal
Error: No such file or directory (os error 2)
```

and it saves baselines in `/Users/jurajsadel/esp-rs/esp-hal/esp-hal/esp-hal/api-baseline/esp32.json.gz` - too many `esp-hal`s

This PR fixes this.