### PR TITLE
Fix rare Xtensa crash

### DIFF
--- a/esp-rtos/CHANGELOG.md
+++ b/esp-rtos/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue on ESP32 that prevented completing some interrupt handlers (#4459)
 - Fixed a possible deadlock on multi-core chips (#4478)
 - Fixed a memory leak of 48 bytes when deleting esp-radio timers (#4541)
-- Fixed a rare crash on Xtensa MCUs (#?)
+- Fixed a rare crash on Xtensa MCUs (#4580)
 
 ### Removed
 

--- a/esp-rtos/CHANGELOG.md
+++ b/esp-rtos/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an issue on ESP32 that prevented completing some interrupt handlers (#4459)
 - Fixed a possible deadlock on multi-core chips (#4478)
 - Fixed a memory leak of 48 bytes when deleting esp-radio timers (#4541)
+- Fixed a rare crash on Xtensa MCUs (#?)
 
 ### Removed
 

--- a/esp-rtos/src/task/xtensa.rs
+++ b/esp-rtos/src/task/xtensa.rs
@@ -85,8 +85,10 @@ pub(crate) fn new_task_context(
         A6: task_fn as usize as u32,
         A7: param as usize as u32,
 
-        // For windowed ABI set WOE and CALLINC (pretend task was 'call4'd)
-        PS: 0x00040000 | ((1 & 3) << 16),
+        // For windowed ABI set WOE, UM, EXCM and CALLINC1 (pretend task was 'call4'd)
+        // UM and EXCM are important, so that restoring context will correctly restore an exception
+        // context (where the context switch happens).
+        PS: 0x00060030,
 
         ..Default::default()
     }

--- a/esp-rtos/src/task/xtensa.rs
+++ b/esp-rtos/src/task/xtensa.rs
@@ -88,7 +88,7 @@ pub(crate) fn new_task_context(
         // For windowed ABI set WOE, UM, EXCM and CALLINC1 (pretend task was 'call4'd)
         // UM and EXCM are important, so that restoring context will correctly restore an exception
         // context (where the context switch happens).
-        PS: 0x00060030,
+        PS: 0x00050030,
 
         ..Default::default()
     }

--- a/xtensa-lx-rt/CHANGELOG.md
+++ b/xtensa-lx-rt/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed offset of `DoubleException` handler (#?)
+- Fixed offset of `DoubleException` handler (#4580)
 
 ### Removed
 

--- a/xtensa-lx-rt/CHANGELOG.md
+++ b/xtensa-lx-rt/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed offset of `DoubleException` handler (#?)
 
 ### Removed
 

--- a/xtensa-lx-rt/exception-esp32.x.template
+++ b/xtensa-lx-rt/exception-esp32.x.template
@@ -54,43 +54,43 @@ SECTIONS {
 
   .vectors :
   {
-    /* 
-      Each vector has 64 bytes that it must fit inside. For each vector we calculate the size of the previous one, 
+    /*
+      Each vector has 64 bytes that it must fit inside. For each vector we calculate the size of the previous one,
       and subtract that from 64 and start the new vector there.
     */
     _init_start = ABSOLUTE(.);
-    . = ALIGN(64);
+    . = 0x0;
     KEEP(*(.WindowOverflow4.text));
-    . = ALIGN(64);
+    . = 0x40;
     KEEP(*(.WindowUnderflow4.text));
-    . = ALIGN(64);
+    . = 0x80;
     KEEP(*(.WindowOverflow8.text));
-    . = ALIGN(64);
+    . = 0xC0;
     KEEP(*(.WindowUnderflow8.text));
-    . = ALIGN(64);
+    . = 0x100;
     KEEP(*(.WindowOverflow12.text));
-    . = ALIGN(64);
+    . = 0x140;
     KEEP(*(.WindowUnderflow12.text));
-    . = ALIGN(64);
+    . = 0x180;
     KEEP(*(.Level2InterruptVector.text));
-    . = ALIGN(64);
+    . = 0x1C0;
     KEEP(*(.Level3InterruptVector.text));
-    . = ALIGN(64);
+    . = 0x200;
     KEEP(*(.Level4InterruptVector.text));
-    . = ALIGN(64);
+    . = 0x240;
     KEEP(*(.Level5InterruptVector.text));
-    . = ALIGN(64);
+    . = 0x280;
     KEEP(*(.DebugExceptionVector.text));
-    . = ALIGN(64);
+    . = 0x2C0;
     KEEP(*(.NMIExceptionVector.text));
-    . = ALIGN(64);
+    . = 0x300;
     KEEP(*(.KernelExceptionVector.text));
-    . = ALIGN(64);
+    . = 0x340;
     KEEP(*(.UserExceptionVector.text));
-    . = ALIGN(128);
+    /* mind the gap */
+    . = 0x3C0;
     KEEP(*(.DoubleExceptionVector.text));
-    . = ALIGN(64);
-    . = ALIGN(0x400);
+    . = 0x400;
     _init_end = ABSOLUTE(.);
   } > vectors_seg
 }


### PR DESCRIPTION
Closes #4573

The initial PS value we've used (with EXCM = 0 bit in particular) allowed the CPU to handle an interrupt while the task's context was being restored. This could corrupt the stack pointer, leading to a crash.

This PR fixes an additional issue in `xtensa-lx-rt`, which has previously placed the `DoubleExceptionVector` 64 bytes before its intended location. The previous `. = ALIGN(128);` could not produce the required offset of `0x3C0` because it's not actually 128-byte aligned.