### PR TITLE
xtask: Add `SemVer` checks for `esp-rom-sys`

### DIFF
--- a/esp-rom-sys/Cargo.toml
+++ b/esp-rom-sys/Cargo.toml
@@ -13,6 +13,7 @@ license       = "MIT OR Apache-2.0"
 links         = "esp_rom_sys"
 
 [package.metadata.espressif]
+semver-checked = true
 forever-unstable = true
 check-configs = [{ features = [] }]
 clippy-configs = [{ features = [] }]

--- a/xtask/src/commands/release/plan.rs
+++ b/xtask/src/commands/release/plan.rs
@@ -6,7 +6,6 @@ use clap::Args;
 use esp_metadata::Chip;
 use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
-use toml_edit::{Item, Value};
 
 use crate::{
     Package,
@@ -135,24 +134,7 @@ pub fn plan(workspace: &Path, args: PlanArgs) -> Result<()> {
             let amount = if package.is_semver_checked() {
                 min_package_update(workspace, package, &all_chips)?
             } else {
-                let forever_unstable = if let Some(metadata) =
-                    package_tomls[&package].espressif_metadata()
-                    && let Some(Item::Value(forever_unstable)) = metadata.get("forever-unstable")
-                {
-                    // Special case: some packages are perma-unstable, meaning they won't ever have
-                    // a stable release. For these packages, we always use a
-                    // patch release.
-                    if let Value::Boolean(forever_unstable) = forever_unstable {
-                        *forever_unstable.value()
-                    } else {
-                        log::warn!(
-                            "Invalid value for 'forever-unstable' in metadata - must be a boolean"
-                        );
-                        true
-                    }
-                } else {
-                    false
-                };
+                let forever_unstable = package_tomls[&package].package.is_forever_unstable();
 
                 if forever_unstable {
                     ReleaseType::Patch

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -490,6 +490,9 @@ impl Package {
             crate::commands::generate_rom_symbols::generate_rom_symbols(&package_path, chip)?;
         }
         Ok(())
+    }
+
+    #[cfg(feature = "semver-checks")]
     fn is_forever_unstable(&self) -> bool {
         match self
             .toml()

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -490,6 +490,19 @@ impl Package {
             crate::commands::generate_rom_symbols::generate_rom_symbols(&package_path, chip)?;
         }
         Ok(())
+    fn is_forever_unstable(&self) -> bool {
+        match self
+            .toml()
+            .espressif_metadata()
+            .and_then(|m| m.get("forever-unstable"))
+        {
+            Some(Item::Value(Value::Boolean(b))) => *b.value(),
+            Some(Item::Value(_)) => {
+                log::warn!("Invalid value for 'forever-unstable' in metadata - must be a boolean");
+                true
+            }
+            _ => false,
+        }
     }
 }
 

--- a/xtask/src/semver_check.rs
+++ b/xtask/src/semver_check.rs
@@ -135,9 +135,11 @@ fn required_bump(required_bumps: &[ReleaseType], forever_unstable: bool) -> Rele
         }
     }
 
-    if forever_unstable && min_required_update == ReleaseType::Major {
-        log::warn!("Downgrading required bump from Minor to Patch for unstable package",);
-        min_required_update = ReleaseType::Minor;
+    if forever_unstable && min_required_update != ReleaseType::Patch {
+        panic!(
+            "Forever-unstable package can only receive a patch release but received {:?}!",
+            min_required_update
+        );
     }
 
     min_required_update
@@ -169,16 +171,23 @@ mod tests {
     }
 
     #[test]
-    fn forever_unstable_downgrades_major_to_minor() {
+    #[should_panic(
+        expected = "Forever-unstable package can only receive a patch release but received Major"
+    )]
+    fn forever_unstable_downgrades_major_to_patch() {
         let bumps = [ReleaseType::Major];
 
         let result = required_bump(&bumps, true);
+    }
 
-        assert_eq!(
-            result,
-            ReleaseType::Minor,
-            "forever-unstable packages must never require a major bump"
-        );
+    #[test]
+    #[should_panic(
+        expected = "Forever-unstable package can only receive a patch release but received Minor"
+    )]
+    fn forever_unstable_downgrades_minor_to_patch() {
+        let bumps = [ReleaseType::Minor];
+
+        let result = required_bump(&bumps, true);
     }
 
     #[test]


### PR DESCRIPTION
This might be a bit of a hacky solution, but I tried to convince` cargo-semver-checks` that `esp-rom-sys` is not intended to ever reach 1.0, and I failed.

To test this, I changned a pub fn name in `esp-rom-sys/src/rom/crc.rs`:
```diff
-pub fn crc8_be(crc: u8, buf: &[u8]) -> u8 {
+pub fn crc8_be_change(crc: u8, buf: &[u8]) -> u8 {
```

Ran `cargo xrelease plan esp-rom-sys --allow-non-main`:
```rust
[2025-12-01T14:51:54Z INFO  xtask::commands::release::semver_check::checker] Downloading API baselines for esp-rom-sys
[2025-12-01T14:51:54Z INFO  xtask::commands::release::semver_check::checker] Attempting to download from GitHub Actions artifact: api-baselines-esp-rom-sys
[2025-12-01T14:51:54Z INFO  xtask::commands::release::semver_check::checker] Attempting to download artifact: api-baselines-esp-rom-sys from esp-rs/esp-hal
[2025-12-01T14:51:56Z INFO  xtask::commands::release::semver_check::checker] Successfully downloaded baselines from artifact api-baselines-esp-rom-sys
[2025-12-01T14:51:56Z INFO  xtask::commands::release::semver_check::checker] Found 7 baseline files for esp-rom-sys
    Checking <unknown> v0.1.3 -> v0.1.3 (no change; assume minor)
     Checked [   0.024s] 140 checks: 139 pass, 1 fail, 0 warn, 38 skip

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/function_missing.ron

Failed in:
  function esp_rom_sys::rom::crc::crc8_be, previously in file src/rom/crc.rs:122

     Summary semver requires new major version: 1 major and 0 minor checks failed
```

> Summary semver requires new major version: 1 major and 0 minor checks failed

Is the reason for the "hacky" solution.

The final `.jsonc`:
```jsonc
{
  "base": "esp-rom-sys-semver",
  "packages": [
    {
      "package": "esp-metadata-generated",
      "semver_checked": false,
      "current_version": "0.3.0",
      "new_version": "0.4.0",
      "tag_name": "esp-metadata-generated-v0.4.0",
      "bump": "Minor"
    },
    {
      "package": "esp-rom-sys",
      "semver_checked": true,
      "current_version": "0.1.3",
      "new_version": "0.2.0",
      "tag_name": "esp-rom-sys-v0.2.0",
      "bump": "Minor"
    }
  ]
}
```



closes https://github.com/esp-rs/esp-hal/issues/4489