### PR TITLE
Enable back ports from closed PRs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -2,7 +2,9 @@ name: Backport merged PR
 
 on:
   pull_request_target: 
-    types: [closed]     # this workflow will act on closed PR - no sense in opening PR with unconfirmed changes
+    types:
+      - closed  # this workflow will act on closed PR - no sense in opening PR with unconfirmed changes
+      - labeled # will fire if the label was added on an already closed PR
 
 permissions:
   contents: write
@@ -13,7 +15,13 @@ jobs:
     # only already merged PRs that have at least one "*-backport" label
     if: >
       github.event.pull_request.merged == true &&
-      contains(join(github.event.pull_request.labels.*.name, ' '), '-backport')
+      (
+        (github.event.action == 'closed' &&
+         contains(join(github.event.pull_request.labels.*.name, ' '), '-backport'))
+        ||
+        (github.event.action == 'labeled' &&
+         contains(github.event.label.name, '-backport'))
+      )
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
An addition to https://github.com/esp-rs/esp-hal/pull/4582, which allows backporting already merged and closed PRs too

Worked here: https://github.com/playfulFence/esp-hal/pull/21, created [this](https://github.com/playfulFence/esp-hal/pull/22) backport PR