### PR TITLE
UART: stabilize `read_ready` and `write_ready`

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- UART: `read_ready` and `write_ready` are now stable (#4600)
 - RMT: `SingleShotTxTransaction` has been renamed to `TxTransaction`. (#4302)
 - RMT: `ChannelCreator::configure_tx` and `ChannelCreator::configure_rx` now take the configuration by reference. (#4302)
 - RMT: `ChannelCreator::configure_tx` and `ChannelCreator::configure_rx` don't take a pin anymore, instead `Channel::with_pin` has been added. (#4302)

--- a/esp-hal/src/uart/mod.rs
+++ b/esp-hal/src/uart/mod.rs
@@ -1310,7 +1310,8 @@ where
     /// The UART hardware continuously receives bytes and stores them in the RX
     /// FIFO. This function reads the bytes from the RX FIFO and returns
     /// them in the provided buffer. If the hardware buffer is empty, this
-    /// function will block until data is available.
+    /// function will block until data is available. The [`Self::read_ready`]
+    /// function can be used to check if data is available without blocking.
     ///
     /// The function returns the number of bytes read into the buffer. This may
     /// be less than the length of the buffer. This function only returns 0
@@ -1833,7 +1834,6 @@ where
     /// }
     /// # {after_snippet}
     /// ```
-    #[instability::unstable]
     pub fn write_ready(&mut self) -> bool {
         self.tx.write_ready()
     }
@@ -1918,7 +1918,6 @@ where
     ///
     /// # {after_snippet}
     /// ```
-    #[instability::unstable]
     pub fn read_ready(&mut self) -> bool {
         self.rx.read_ready()
     }


### PR DESCRIPTION
These functions are simple, they are required to work with UART in a guaranteed-nonblocking way, and they are unlikely to change. They have also been more extensively documented, with usage examples, and both of these functions are covered by at least one HIL test.