### PR TITLE
RMT:  Use new Encoder trait for Tx data

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unsafely expose GPIO pins that are only available on certain chip/module variants (#4520)
 - ESP32-H2: light sleep and deep sleep support with timer and EXT1 wakeup sources (#4587, #4641)
 - Unstable detailed clock configuration options (#4660, #4674)
+- RMT: Added the `Encoder` trait and `CopyEncoder`, `IterEncoder` and `BytesEncoder` implementations. (#4604)
 
 ### Changed
 
@@ -30,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RMT: Support for `Into<PulseCode>` and `From<PulseCode>` has been removed from Tx and Rx methods, respectively, in favor of requiring `PulseCode` directly. (#4616)
 - RMT: Tx handling has been revised: Some errors will now be returned by `TxTransaction::wait()` instead of `Channel::transmit`. `Channel::transmit_continuously()` can now also report `Error::EndMarkerMissing`. (#4617)
 - `Rtc::time_since_boot()` has been renamed to `Rtc::time_since_power_up()` (#4630)
+- RMT: Tx methods now take data as `impl Encoder`. (#4604)
 
 ### Fixed
 

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -247,7 +247,7 @@ use crate::{
 mod reader;
 use reader::{ReaderState, RmtReader};
 mod writer;
-pub use writer::{CopyEncoder, Encoder, RmtSlot, RmtWriter};
+pub use writer::{CopyEncoder, Encoder, IterEncoder, RmtSlot, RmtWriter};
 use writer::{EncoderExt, WriterContext, WriterState};
 
 /// A configuration error

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -247,7 +247,17 @@ use crate::{
 mod reader;
 use reader::{ReaderState, RmtReader};
 mod writer;
-pub use writer::{CopyEncoder, Encoder, IterEncoder, RmtSlot, RmtWriter};
+pub use writer::{
+    BitOrder,
+    BytesEncoder,
+    CopyEncoder,
+    Encoder,
+    IterEncoder,
+    LsbFirst,
+    MsbFirst,
+    RmtSlot,
+    RmtWriter,
+};
 use writer::{EncoderExt, WriterContext, WriterState};
 
 /// A configuration error

--- a/esp-hal/src/rmt/writer.rs
+++ b/esp-hal/src/rmt/writer.rs
@@ -247,6 +247,8 @@ impl WriterContext {
     }
 }
 
+// Do not add an EncoderExt: Encoder bound here: That would add the Encoder::encode method to the
+// vtable, preventing optimizing it away (it should always be inlined in EncoderExt::write).
 pub(super) trait EncoderExt {
     fn write(&mut self, writer: &mut WriterContext, raw: DynChannelAccess<Tx>, initial: bool);
 }

--- a/esp-hal/src/rmt/writer.rs
+++ b/esp-hal/src/rmt/writer.rs
@@ -1,7 +1,188 @@
+use core::ops::ControlFlow;
+
 #[cfg(place_rmt_driver_in_ram)]
 use procmacros::ram;
 
 use super::{DynChannelAccess, Error, PulseCode, Tx};
+
+/// Access to a free slot in an RMT channel hardware buffer.
+///
+/// An `RmtSlot` indicates a guarantee that there's a free slot in memory
+/// that can immediately be written to. If this slot isn't used, the
+/// next call to `RmtWriter.next` will use the same slot again (i.e.
+/// there will be no garbage data due to skipping unused slots).
+///
+/// See [`Encoder::encode`] and [`RmtWriter::next`] for more details.
+#[derive(Debug)]
+pub struct RmtSlot<'a> {
+    writer: &'a mut RmtWriter,
+}
+
+impl<'a> RmtSlot<'a> {
+    /// Append a `PulseCode` to the RMT hardware buffer.
+    #[inline(always)]
+    pub fn write(self, code: PulseCode) {
+        let writer = self.writer;
+
+        debug_assert!(writer.ptr < writer.end);
+
+        unsafe { writer.ptr.write_volatile(code) }
+
+        writer.ptr = unsafe { writer.ptr.add(1) };
+        writer.last_code = code;
+    }
+}
+
+/// Provides methods to fill (part of) the RMT channel hardware buffer.
+///
+/// An `RmtWriter` is provided to [`Encoder::encode`], see there for more details.
+pub struct RmtWriter {
+    // Most recently written PulseCode
+    last_code: PulseCode,
+    // Current write pointer
+    ptr: *mut PulseCode,
+    // Start of the slice to be written
+    start: *mut PulseCode,
+    // End of the slice to be written
+    end: *mut PulseCode,
+}
+
+// Given a pointer to RMT RAM, return the channel it belongs to
+fn get_ch(ptr: *mut PulseCode) -> i32 {
+    let diff = unsafe { ptr.offset_from(property!("rmt.ram_start") as *mut PulseCode) };
+    (diff / property!("rmt.channel_ram_size")) as i32
+}
+
+// Given a pointer to RMT RAM, return the offset relative to start of the channel's RAM
+fn get_offset(ptr: *mut PulseCode) -> i32 {
+    let diff = unsafe { ptr.offset_from(property!("rmt.ram_start") as *mut PulseCode) };
+    (diff % property!("rmt.channel_ram_size")) as i32
+}
+
+impl core::fmt::Debug for RmtWriter {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "RmtWriter {{ last_code: {:?}, ptr: CH{} + {:#x}, start: CH{} + {:#x}, end: CH{} + {:#x} }}",
+            self.last_code,
+            get_ch(self.ptr),
+            get_offset(self.ptr),
+            get_ch(self.start),
+            get_offset(self.start),
+            get_ch(self.end),
+            get_offset(self.end),
+        )
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for RmtWriter {
+    fn format(&self, fmt: defmt::Formatter<'_>) {
+        defmt::write!(
+            fmt,
+            "RmtWriter {{ last_code: {:?}, ptr: CH{} + {:#x}, start: CH{} + {:#x}, end: CH{} + {:#x} }}",
+            self.last_code,
+            get_ch(self.ptr),
+            get_offset(self.ptr),
+            get_ch(self.start),
+            get_offset(self.start),
+            get_ch(self.end),
+            get_offset(self.end),
+        )
+    }
+}
+
+impl RmtWriter {
+    /// Try to obtain a slot in the channel's hardware buffer.
+    ///
+    /// Returns `None` if the buffer is full; in this case [`Encoder::encode`] must return.
+    #[inline(always)]
+    pub fn next<'s>(&'s mut self) -> Option<RmtSlot<'s>> {
+        if self.ptr >= self.end {
+            return None;
+        }
+
+        Some(RmtSlot { writer: self })
+    }
+
+    /// Write several pulse codes to the channel's hardware buffer.
+    ///
+    /// `f` will be called up to `count` times to obtain pulse codes. Returns the actual number of
+    /// codes written. If less than `count`, the buffer is full and [`Encoder::encode`] must
+    /// return.
+    ///
+    /// This explicitly supports `count = 0`, thus callers can avoid to check for that condition.
+    ///
+    /// This can lead to more efficient code compared to repeated use of [`RmtWriter::next`] when
+    /// the caller can provide an infallible function that yields `count` pulse codes.
+    #[inline(always)]
+    pub fn write_many<F>(&mut self, count: usize, mut f: F) -> usize
+    where
+        F: FnMut() -> PulseCode,
+    {
+        let count = count.min(unsafe { self.end.offset_from(self.ptr) } as usize);
+
+        let mut last_code = self.last_code;
+        let mut ptr = self.ptr;
+        let end = unsafe { self.ptr.add(count) };
+
+        while ptr < end {
+            last_code = f();
+            unsafe { ptr.write_volatile(last_code) };
+            ptr = unsafe { ptr.add(1) };
+        }
+
+        debug_assert!(self.ptr <= self.end);
+
+        self.ptr = ptr;
+        self.last_code = last_code;
+
+        count
+    }
+}
+
+/// A trait to convert arbitrary data to RMT [`PulseCode`]s.
+///
+/// Implementations need to provide the single `encode` method, which transmit methods will
+/// (potentially repeatedly) call to obtain pulse codes.
+pub trait Encoder {
+    /// (Re)Fill an RMT channel hardware buffer.
+    ///
+    /// Implementations can provide arbitrary conversions of data types, which will be performed
+    /// just before writing to the hardware, without intermediate buffering of `PulseCode`s.
+    /// This should mainly be used for low-cost operations (e.g. simple state machines and shift
+    /// out bits), since it needs to be fast enough to refill hardware buffers before transmission
+    /// exhausts them. If this cannot be guaranteed reliably, consider performing conversion to
+    /// `PulseCode`s upfront, before calling the channel's transmit methods.
+    ///
+    /// This function must write pulse codes via the `writer` until the latter indicates that the
+    /// buffer is full. Otherwise, the `writer` will consider the `Encoder` to be exhausted and not
+    /// call it again to check for more data. Upon exhaustion of the `Encoder` the last pulse code
+    /// written should contain an end marker. If the `Encoder` fails to provide one, the driver
+    /// will still ensure that transmission is never started or eventually stops, and return
+    /// `Error::EndMarkerMissing` from the transmit method. However, there are no further
+    /// guarantees: In particular, the current driver code might lead to truncated transmission in
+    /// this error case.
+    ///
+    /// In addition to writing less codes than the `writer` would allow for, implementations can
+    /// indicate that they have completed by returning `ControlFlow::Break`. This leads to a slight
+    /// optimization in case that the encoding ended just at the end of the hardware buffer, and
+    /// would otherwise only be detected when the subsequent call to `encode` would write zero
+    /// symbols.
+    ///
+    /// While this will presently not be called again after being exhausted, implementations must
+    /// not rely on this for safety or correctness. Rather, they should return without writing any
+    /// pulse codes in that case.
+    ///
+    /// For best performance, this should be inlined. It is likely that the compiler does so
+    /// automatically (since the driver has only a single, non-generic function that calls this
+    /// method). To be extra sure, consider marking your implementation of this method as
+    /// `#[inline(always)]`. This also applies when you're using the `PLACE_RMT_DRIVER_IN_RAM`
+    /// configuration: `encode` will be inlined in a driver-internal function, which in turn will
+    /// be placed in RAM. Annotating this method with `#[ram]` would prevent inlining and likely
+    /// impair performance.
+    fn encode(&mut self, writer: &mut RmtWriter) -> ControlFlow<()>;
+}
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -64,50 +245,44 @@ impl WriterContext {
     pub(super) fn state(&self) -> WriterState {
         self.state
     }
+}
 
+pub(super) trait EncoderExt {
+    fn write(&mut self, writer: &mut WriterContext, raw: DynChannelAccess<Tx>, initial: bool);
+}
+
+impl<E: Encoder + ?Sized> EncoderExt for E {
     // Copy from `data` to the hardware buffer, advancing the `data` slice accordingly.
     //
     // If `initial` is set, fill the entire buffer. Otherwise, append half the buffer's length from
     // `data`.
     #[cfg_attr(place_rmt_driver_in_ram, ram)]
-    pub(super) fn write(
-        &mut self,
-        data: &mut &[PulseCode],
-        raw: DynChannelAccess<Tx>,
-        initial: bool,
-    ) {
-        if self.state != WriterState::Active {
+    fn write(&mut self, context: &mut WriterContext, raw: DynChannelAccess<Tx>, initial: bool) {
+        if context.state != WriterState::Active {
             return;
         }
 
-        debug_assert!(!initial || self.offset == 0);
+        debug_assert!(!initial || context.offset == 0);
 
         let ram_start = raw.channel_ram_start();
         let memsize = raw.memsize().codes();
-        let ram_end = unsafe { ram_start.add(memsize) };
 
         let max_count = if initial { memsize } else { memsize / 2 };
-        let count = data.len().min(max_count);
 
-        let mut ram_ptr = unsafe { ram_start.add(self.offset as usize) };
+        let start = unsafe { ram_start.add(context.offset as usize) };
+        let mut writer = RmtWriter {
+            last_code: context.last_code,
+            ptr: start,
+            start,
+            end: unsafe { start.add(max_count) },
+        };
 
-        let mut data_ptr = data.as_ptr();
-        let data_end = unsafe { data_ptr.add(count) };
+        let done = self.encode(&mut writer);
+        context.last_code = writer.last_code;
+        context.written += unsafe { writer.ptr.offset_from(writer.start) } as usize;
 
-        let mut last_code = self.last_code;
-        while data_ptr < data_end {
-            // SAFETY: The iteration `count` is smaller than both `max_count` and `data.len()` such
-            // that incrementing both pointers cannot advance them beyond their allocation's end.
-            unsafe {
-                last_code = data_ptr.read();
-                ram_ptr.write_volatile(last_code);
-                ram_ptr = ram_ptr.add(1);
-                data_ptr = data_ptr.add(1);
-            }
-        }
-
-        self.last_code = last_code;
-        self.written += count;
+        debug_assert!(writer.ptr.addr() >= writer.start.addr());
+        debug_assert!(writer.ptr.addr() <= writer.end.addr());
 
         // If the input data was not exhausted, update offset as
         //
@@ -119,25 +294,37 @@ impl WriterContext {
         //
         // Otherwise, the new position is invalid but the new slice is empty and we won't use the
         // offset again. In either case, the unsigned subtraction will not underflow.
-        self.offset = memsize as u16 - max_count as u16 - self.offset;
+        context.offset = memsize as u16 - max_count as u16 - context.offset;
 
-        // The panic can never trigger since count <= data.len()!
-        data.split_off(..count).unwrap();
-        if data.is_empty() {
-            self.state = if self.written == 0 {
-                // data was empty
+        if writer.ptr < writer.end || done.is_break() {
+            context.state = if context.written == 0 {
+                // The encoder was empty
                 WriterState::Error(Error::InvalidArgument)
-            } else if last_code.is_end_marker() {
-                // Do not check for end markers in the inner loop above since this would
-                // substantially increase the instruction count there. Instead, only check the last
-                // code to report on error.
+            } else if writer.last_code.is_end_marker() {
+                // Do not check for end markers in the inner loop in Encoder::encode() since this
+                // would substantially increase the instruction count there. Instead, only check
+                // the last code to report on error.
                 WriterState::Done
             } else {
                 // Write an extra end marker to prevent looping forever with wrapping tx.
-                if ram_ptr < ram_end {
-                    unsafe { ram_ptr.write_volatile(PulseCode::end_marker()) };
+                if writer.ptr < writer.end {
+                    unsafe { writer.ptr.write_volatile(PulseCode::end_marker()) };
                     WriterState::Error(Error::EndMarkerMissing)
                 } else {
+                    // // The buffer is full, and we would need to wait for the next
+                    // // Event::Threshold before writing an end marker.
+                    // // However, the data was invalid by missing an end marker,
+                    // // and the only guarantee that we provide is that transmission will
+                    // // eventually stop and return an error. Thus, to avoid the logic to implement
+                    // // this, simply modify the last code that was written to
+                    // // contain an end marker.
+                    // unsafe {
+                    //     writer
+                    //         .ptr
+                    //         .sub(1)
+                    //         .write_volatile(writer.last_code.with_length2(0).unwrap())
+                    // };
+
                     // The buffer is full, and we can't easily write an end marker. (Short of
                     // overwriting some other code, which might be ok since hitting this error case
                     // always indicates a bug in user code.)
@@ -149,6 +336,48 @@ impl WriterContext {
             };
         }
 
-        debug_assert!(self.offset == 0 || self.offset as usize == memsize / 2);
+        debug_assert!(context.offset == 0 || context.offset as usize == memsize / 2);
+    }
+}
+
+/// An [`Encoder`] that simply copies a slice of `PulseCode`s to the hardware.
+#[derive(Clone, Debug)]
+pub struct CopyEncoder<'a> {
+    data: &'a [PulseCode],
+}
+
+impl<'a> CopyEncoder<'a> {
+    /// Create a new instance that transmits the provided `data`.
+    pub fn new(data: &'a [PulseCode]) -> Self {
+        Self { data }
+    }
+}
+
+impl<'a> Encoder for CopyEncoder<'a> {
+    #[inline(always)]
+    fn encode(&mut self, writer: &mut RmtWriter) -> ControlFlow<()> {
+        let len = self.data.len();
+        let mut ptr = self.data.as_ptr();
+        let end = unsafe { ptr.add(len) };
+
+        let written = writer.write_many(len, || {
+            // SAFETY: write_many() guarantees that this will be called at most
+            // `len` times, such the pointer will remain in-bounds.
+            // FIXME: Check whether we can use safe indexing here and the compiler is smart enough
+            // to optimize the bounds check.
+            let code = unsafe { ptr.read() };
+            ptr = unsafe { ptr.add(1) };
+            code
+        });
+
+        debug_assert!(ptr <= end);
+
+        self.data.split_off(..written).unwrap();
+
+        if self.data.is_empty() {
+            ControlFlow::Break(())
+        } else {
+            ControlFlow::Continue(())
+        }
     }
 }

--- a/esp-hal/src/rmt/writer.rs
+++ b/esp-hal/src/rmt/writer.rs
@@ -50,6 +50,7 @@ pub(super) struct WriterContext {
 }
 
 impl WriterContext {
+    #[inline]
     pub(super) fn new() -> Self {
         Self {
             offset: 0,

--- a/esp-hal/src/rmt/writer.rs
+++ b/esp-hal/src/rmt/writer.rs
@@ -36,7 +36,7 @@ impl WriterState {
 
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub(super) struct RmtWriter {
+pub(super) struct WriterContext {
     // The position in channel RAM to continue writing at; must be either
     // 0 or half the available RAM size if there's further data.
     // The position may be invalid if there's no data left.
@@ -49,7 +49,7 @@ pub(super) struct RmtWriter {
     state: WriterState,
 }
 
-impl RmtWriter {
+impl WriterContext {
     pub(super) fn new() -> Self {
         Self {
             offset: 0,

--- a/examples/async/embassy_rmt_tx/src/main.rs
+++ b/examples/async/embassy_rmt_tx/src/main.rs
@@ -14,7 +14,7 @@ use esp_backtrace as _;
 use esp_hal::{
     gpio::Level,
     interrupt::software::SoftwareInterruptControl,
-    rmt::{PulseCode, Rmt, TxChannelConfig, TxChannelCreator},
+    rmt::{CopyEncoder, PulseCode, Rmt, TxChannelConfig, TxChannelCreator},
     time::Rate,
     timer::timg::TimerGroup,
 };
@@ -56,7 +56,8 @@ async fn main(_spawner: Spawner) {
 
     loop {
         println!("transmit");
-        channel.transmit(&data).await.unwrap();
+        let mut encoder = CopyEncoder::new(&data);
+        channel.transmit(&mut encoder).await.unwrap();
         println!("transmitted\n");
         Timer::after(Duration::from_millis(500)).await;
     }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖
This changes the input data type for RMT Tx methods from `&[PulseCode]` to `&mut impl Encoder` where `Encoder` is conceptually similar to `Iterator<Item = PulseCode>`, but allows for more efficient code in many cases.

IDF has a similar encoder type: https://docs.espressif.com/projects/esp-idf/en/latest/esp32c3/api-reference/peripherals/rmt.html#rmt-rmt-encoder

#### General design
The `Encoder` trait differs from `Iterator<Item = PulseCode>` mainly in the following aspects:

- Writing data is driven by the `encode` method, which calls `RmtWriter` methods to push to the hardware, rather than `RmtWriter` pulling data from an iterator.
- The `RmtWriter::write_many` method helps write several codes to the hardware in a very tight loop.

The combination of both allows achieving very efficient inner loops when copying data to the hardware, without requiring unsafe code on the user side and without exposing any direct hardware access or any specifics about how much data is written to the user code: See for example the `BytesEncoder` implementation. I've not been able to achieve the same performance with just `Iterator`s.

Specifically, the pattern from `BytesEncoder` is similar to what's required to send data to WS2812-style LEDs:
Fetch R, G, B bytes from RAM, assemble in the correct order into a u32, then shift out bits and write a PulseCode for each. That maps very cleanly to `write_many`, but leads to overhead with iterators.

I've been benchmarking this[^1] using cycle counters, here are some results for a WS2812 LED stripe encoder/pulse code iterator which are the fastest I've been able to achieve:

[^1]: I intend to propose to merge the benchmarking code into esp-hal, but I'm not sure about the design yet, and it probably needs some cleanup.

```
// base case: not using Encoder, just write zeros to the hardware using raw pointers
Render benchmark (base): RMT BenchmarkResult:
	CPU clock: 160MHz
	Iterations: 39
	Codes written: 1441
	Encoding time: 126us
	Encoding time / code: 88ns ~ 14 cycles

// pre-compute PulseCodes and use CopyEncoder
Render benchmark (slice): RMT BenchmarkResult:
	CPU clock: 160MHz
	Iterations: 32
	Codes written: 1441
	Encoding time: 154us (9% of 1710us tx time)
	Encoding time / code: 107ns ~ 17 cycles

// custom impl of Iterator<Item = PulseCode> for an LED stripe encoder type
Render benchmark (iter): RMT BenchmarkResult:
	CPU clock: 160MHz
	Iterations: 20
	Codes written: 1441
	Encoding time: 249us (14% of 1710us tx time)
	Encoding time / code: 172ns ~ 27 cycles

// custom impl of Encoder for an LED stripe encoder type
Render benchmark (enc): RMT BenchmarkResult:
	CPU clock: 160MHz
	Iterations: 29
	Codes written: 1441
	Encoding time: 170us (9% of 1710us tx time)
	Encoding time / code: 118ns ~ 18 cycles
```

"Encoding time" is just the time to run the `encoder_write` function, not including any polling or interrupt/embassy dispatch overhead. Thus, the fact that it takes "only" ~10% of tx time is a bit misleading.

Note that the custom encoder version has a 40% lower cycle count compared to the iterator version, and is on par with with the `CopyEncoder` (which requires precomputing PulseCodes in a large buffer). Both encoder variants are quite close to the performance ceiling of the base case, which I presume is limited due to the APB speed.

In this case, the inner loop of the encoder compiles to optimal assembly, cf. the decompiled version[^2]:

[^2]:  From esp32c3; the last `ptr_ = ptr` assignment is spurious, there's no corresponding instruction in the loop. `data_word` holds 24 bits of RGB data which are shifted out MSB-first.

<img width="412" height="206" alt="Screenshot From 2025-12-03 12-28-43" src="https://github.com/user-attachments/assets/d499dd3d-a68d-46fc-bb17-f6ea9cc820b5" />

whereas the iterator version remains more convoluted.

#### API
The PR continues to use a single `transmit()` method for various data types, requiring explictly wrapping things in an `Encoder`:

```rust
let mut enc = CopyEncoder::new(&data);
channel.transmit(&mut enc)?;
```

I also considered an `IntoEncoder` trait with `fn transmit(&mut self, data: impl IntoEncoder)` with implementations provided for

- `&[PulseCode]`,
- `I where I: `IntoIterator<Item = PulseCode>`,
- `E where E: Encoder`.

However, that immediately runs into issues with specialization due to the blanket impls.

Alternatively, one could consider different transmit method, i.e.

- `fn transmit_slice(&mut self, data: &[PulseCode]) -> ...`,
- `fn transmit_iter(&mut self, data: impl IntoIterator<Item = PulseCode>) -> ...`,
- `fn transmit_enc(&mut self, data: impl Encoder) -> ...`.

The disadvantage is that this blows up the number of methods significantly. In particular, if/when methods are split into `transmit(&mut self, ...)` and `transmit_owned(self, ...)` [similar to the SHA driver, as suggested by @Dominaezzz](https://github.com/esp-rs/esp-hal/pull/3716#discussion_r2179900769), this would lead to combinatorial explosion of the number of channel methods. Additionally, having such per-datatype methods isn't really much simpler than explictly creating encoders, in my opinion.

#### Questions

- I mentioned that I added some benchmarking code: This needs support in esp-hal for low-level hardware access. Would something like this in principle be in-scope for the project?
- Should `BytesEncoder` be part of `esp-hal` directly`? It might make more sense to move it to an example, showcasing how to write an efficient `Encoder`.


#### Testing
HIL tests, incl. new ones.


Closes https://github.com/esp-rs/esp-hal/issues/1768
