### PR TITLE
Add a guide for creating reproducers

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -17,7 +17,7 @@ assignees: ''
 1. ...
 2. ...
 
-<!-- Please share a minimal reproducer which demonstrates the issue. `documentation/REPRODUCERS.md` gives some hints how an ideal reproducer should look like. -->
+<!-- Please share a minimal reproducer which demonstrates the issue. `documentation/REPRODUCERS.md` gives some hints what an ideal reproducer should look like. -->
 
 <!-- Make sure you are able to reproduce the bug in the `main` branch, too. -->
 

--- a/documentation/REPRODUCERS.md
+++ b/documentation/REPRODUCERS.md
@@ -11,7 +11,7 @@ To be effective, your reproducer should adhere to the following principles:
 - Self-Contained and Buildable: The code must be a complete project (use `esp-generate` to create the skeleton) that can be built and run without any modifications by the person trying to reproduce the issue.
 - Minimal: It should contain only the code strictly necessary to demonstrate the issue. Remove any unrelated features, dependencies, or verbose logging that doesn't contribute to the problem.
 - No Unrelated Dependencies: Avoid including external crates or libraries unless they are directly necessary for the specific feature you are reporting a bug on.
-- Avoid referencing a crate modified by you - even if it's just added logging. Ideally reference the latest released version of a crate _or_ use a git-reference pointing to a specific (latest as of the time of writing) commit
+- Avoid referencing a crate modified by you - even if it's just added logging. Ideally reference the latest released version of a crate _or_ use a git-reference pointing to a specific commit (ideally the latest at the time of creating the reproducer)
 - External Hardware and Wiring: If the issue requires external components (e.g., an LED, an I2C sensor), explicitly state the required hardware and provide a clear, simple description or diagram of the wiring.
 
 ## Special Considerations for Connectivity Issues


### PR DESCRIPTION
This adds a guide on how provided reproducers should look like.

It's a first version addressing pain-points we have seen during in the last couple of days. I'm pretty sure there is more to add so feel free to suggest any additions
