### PR TITLE
XTL -> XTAL

### DIFF
--- a/esp-hal/src/clock/mod.rs
+++ b/esp-hal/src/clock/mod.rs
@@ -1161,7 +1161,7 @@ impl Clocks {
                 cpu_clock: Rate::from_hz(crate::soc::clocks::cpu_clk_frequency(clocks)),
                 apb_clock: Rate::from_hz(crate::soc::clocks::apb_clk_frequency(clocks)),
                 // FIXME: this assumes there is a crystal
-                xtal_clock: Rate::from_hz(crate::soc::clocks::xtl_clk_frequency(clocks)),
+                xtal_clock: Rate::from_hz(crate::soc::clocks::xtal_clk_frequency(clocks)),
                 i2c_clock: Rate::from_hz(crate::soc::clocks::apb_clk_frequency(clocks)),
                 // TODO: model PLL_F160M
                 pwm_clock: Rate::from_mhz(160),
@@ -1190,7 +1190,7 @@ impl Clocks {
             Self {
                 cpu_clock: Rate::from_hz(crate::soc::clocks::cpu_clk_frequency(clocks)),
                 apb_clock: Rate::from_hz(crate::soc::clocks::apb_clk_frequency(clocks)),
-                xtal_clock: Rate::from_hz(crate::soc::clocks::xtl_clk_frequency(clocks)),
+                xtal_clock: Rate::from_hz(crate::soc::clocks::xtal_clk_frequency(clocks)),
             }
         })
     }
@@ -1216,7 +1216,7 @@ impl Clocks {
             Self {
                 cpu_clock: Rate::from_hz(crate::soc::clocks::cpu_clk_frequency(clocks)),
                 apb_clock: Rate::from_hz(crate::soc::clocks::apb_clk_frequency(clocks)),
-                xtal_clock: Rate::from_hz(crate::soc::clocks::xtl_clk_frequency(clocks)),
+                xtal_clock: Rate::from_hz(crate::soc::clocks::xtal_clk_frequency(clocks)),
             }
         })
     }

--- a/esp-hal/src/soc/esp32c3/clocks.rs
+++ b/esp-hal/src/soc/esp32c3/clocks.rs
@@ -47,7 +47,7 @@ impl CpuClock {
         // with, and changing it breaks USB Serial/JTAG.
         let mut config = match self {
             CpuClock::_80MHz => ClockConfig {
-                xtl_clk: None,
+                xtal_clk: None,
                 system_pre_div: None,
                 pll_clk: Some(PllClkConfig::_480),
                 cpu_pll_div_out: Some(CpuPllDivOutConfig::_80),
@@ -58,7 +58,7 @@ impl CpuClock {
                 low_power_clk: Some(LowPowerClkConfig::RtcSlow),
             },
             CpuClock::_160MHz => ClockConfig {
-                xtl_clk: None,
+                xtal_clk: None,
                 system_pre_div: None,
                 pll_clk: Some(PllClkConfig::_480),
                 cpu_pll_div_out: Some(CpuPllDivOutConfig::_160),
@@ -71,18 +71,18 @@ impl CpuClock {
             CpuClock::Custom(clock_config) => clock_config,
         };
 
-        if config.xtl_clk.is_none() {
+        if config.xtal_clk.is_none() {
             // TODO: support multiple crystal frequencies (esp-idf supports 32M).
-            config.xtl_clk = Some(XtlClkConfig::_40);
+            config.xtal_clk = Some(XtalClkConfig::_40);
         }
 
         config.apply();
     }
 }
 
-// XTL_CLK
+// XTAL_CLK
 
-fn configure_xtl_clk_impl(_clocks: &mut ClockTree, config: XtlClkConfig) {
+fn configure_xtal_clk_impl(_clocks: &mut ClockTree, config: XtalClkConfig) {
     // The stored configuration affects PLL settings instead. We save the value in a register
     // similar to ESP-IDF, just in case something relies on that, or, if we can in the future read
     // back the value instead of wasting RAM on it.
@@ -122,7 +122,7 @@ fn enable_pll_clk_impl(clocks: &mut ClockTree, en: bool) {
 
     // Digital part
     let pll_freq = unwrap!(clocks.pll_clk);
-    let xtal_freq = unwrap!(clocks.xtl_clk);
+    let xtal_freq = unwrap!(clocks.xtal_clk);
     SYSTEM::regs()
         .cpu_per_conf()
         .modify(|_, w| w.pll_freq_sel().bit(pll_freq == PllClkConfig::_480));
@@ -146,7 +146,7 @@ fn enable_pll_clk_impl(clocks: &mut ClockTree, en: bool) {
         PllClkConfig::_480 => {
             // Configure 480M PLL
             match xtal_freq {
-                XtlClkConfig::_40 => {
+                XtalClkConfig::_40 => {
                     div_ref = 0;
                     // Will multiply by 8 + 4 = 12
                     div7_0 = 8;
@@ -164,7 +164,7 @@ fn enable_pll_clk_impl(clocks: &mut ClockTree, en: bool) {
         PllClkConfig::_320 => {
             // Configure 320M PLL
             match xtal_freq {
-                XtlClkConfig::_40 => {
+                XtalClkConfig::_40 => {
                     div_ref = 0;
                     // Will multiply by 4 + 4 = 8
                     div7_0 = 4;

--- a/esp-metadata-generated/src/_build_script_utils.rs
+++ b/esp-metadata-generated/src/_build_script_utils.rs
@@ -281,7 +281,7 @@ impl Chip {
                     "soc_rc_fast_clk_default_is_set",
                     "soc_rc_slow_clock=\"150000\"",
                     "soc_rc_slow_clock_is_set",
-                    "soc_has_clock_node_xtl_clk",
+                    "soc_has_clock_node_xtal_clk",
                     "soc_has_clock_node_pll_clk",
                     "soc_has_clock_node_apll_clk",
                     "soc_has_clock_node_rc_fast_clk",
@@ -469,7 +469,7 @@ impl Chip {
                     "cargo:rustc-cfg=soc_rc_fast_clk_default_is_set",
                     "cargo:rustc-cfg=soc_rc_slow_clock=\"150000\"",
                     "cargo:rustc-cfg=soc_rc_slow_clock_is_set",
-                    "cargo:rustc-cfg=soc_has_clock_node_xtl_clk",
+                    "cargo:rustc-cfg=soc_has_clock_node_xtal_clk",
                     "cargo:rustc-cfg=soc_has_clock_node_pll_clk",
                     "cargo:rustc-cfg=soc_has_clock_node_apll_clk",
                     "cargo:rustc-cfg=soc_has_clock_node_rc_fast_clk",
@@ -636,7 +636,7 @@ impl Chip {
                     "soc_rc_fast_clk_default_is_set",
                     "soc_rc_slow_clock=\"136000\"",
                     "soc_rc_slow_clock_is_set",
-                    "soc_has_clock_node_xtl_clk",
+                    "soc_has_clock_node_xtal_clk",
                     "soc_has_clock_node_pll_clk",
                     "soc_has_clock_node_rc_fast_clk",
                     "soc_has_clock_node_osc_slow_clk",
@@ -782,7 +782,7 @@ impl Chip {
                     "cargo:rustc-cfg=soc_rc_fast_clk_default_is_set",
                     "cargo:rustc-cfg=soc_rc_slow_clock=\"136000\"",
                     "cargo:rustc-cfg=soc_rc_slow_clock_is_set",
-                    "cargo:rustc-cfg=soc_has_clock_node_xtl_clk",
+                    "cargo:rustc-cfg=soc_has_clock_node_xtal_clk",
                     "cargo:rustc-cfg=soc_has_clock_node_pll_clk",
                     "cargo:rustc-cfg=soc_has_clock_node_rc_fast_clk",
                     "cargo:rustc-cfg=soc_has_clock_node_osc_slow_clk",
@@ -964,7 +964,7 @@ impl Chip {
                     "soc_rc_fast_clk_default_is_set",
                     "soc_rc_slow_clock=\"136000\"",
                     "soc_rc_slow_clock_is_set",
-                    "soc_has_clock_node_xtl_clk",
+                    "soc_has_clock_node_xtal_clk",
                     "soc_has_clock_node_pll_clk",
                     "soc_has_clock_node_rc_fast_clk",
                     "soc_has_clock_node_xtal32k_clk",
@@ -1150,7 +1150,7 @@ impl Chip {
                     "cargo:rustc-cfg=soc_rc_fast_clk_default_is_set",
                     "cargo:rustc-cfg=soc_rc_slow_clock=\"136000\"",
                     "cargo:rustc-cfg=soc_rc_slow_clock_is_set",
-                    "cargo:rustc-cfg=soc_has_clock_node_xtl_clk",
+                    "cargo:rustc-cfg=soc_has_clock_node_xtal_clk",
                     "cargo:rustc-cfg=soc_has_clock_node_pll_clk",
                     "cargo:rustc-cfg=soc_has_clock_node_rc_fast_clk",
                     "cargo:rustc-cfg=soc_has_clock_node_xtal32k_clk",
@@ -3183,7 +3183,7 @@ pub fn emit_check_cfg_directives() {
     println!("cargo:rustc-check-cfg=cfg(soc_ref_tick_hz_is_set)");
     println!("cargo:rustc-check-cfg=cfg(soc_rc_fast_clk_default_is_set)");
     println!("cargo:rustc-check-cfg=cfg(soc_rc_slow_clock_is_set)");
-    println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_xtl_clk)");
+    println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_xtal_clk)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_pll_clk)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_apll_clk)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_rc_fast_clk)");
@@ -3361,7 +3361,6 @@ pub fn emit_check_cfg_directives() {
     println!("cargo:rustc-check-cfg=cfg(ulp_riscv)");
     println!("cargo:rustc-check-cfg=cfg(ieee802154)");
     println!("cargo:rustc-check-cfg=cfg(soc_cpu_has_prv_mode)");
-    println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_xtal_clk)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_soc_root_clk)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_hp_root_clk)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_cpu_hs_div)");

--- a/esp-metadata-generated/src/_generated_esp32c2.rs
+++ b/esp-metadata-generated/src/_generated_esp32c2.rs
@@ -220,9 +220,9 @@ macro_rules! for_each_soc_xtal_options {
 #[macro_export]
 /// ESP-HAL must provide implementation for the following functions:
 /// ```rust, no_run
-/// // XTL_CLK
+/// // XTAL_CLK
 ///
-/// fn configure_xtl_clk_impl(_clocks: &mut ClockTree, _config: XtlClkConfig) {
+/// fn configure_xtal_clk_impl(_clocks: &mut ClockTree, _config: XtalClkConfig) {
 ///     todo!()
 /// }
 ///
@@ -454,20 +454,20 @@ macro_rules! for_each_soc_xtal_options {
 /// ```
 macro_rules! define_clock_tree_types {
     () => {
-        /// Selects the output frequency of `XTL_CLK`.
+        /// Selects the output frequency of `XTAL_CLK`.
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-        pub enum XtlClkConfig {
+        pub enum XtalClkConfig {
             /// 26 MHz
             _26,
             /// 40 MHz
             _40,
         }
-        impl XtlClkConfig {
+        impl XtalClkConfig {
             pub fn value(&self) -> u32 {
                 match self {
-                    XtlClkConfig::_26 => 26000000,
-                    XtlClkConfig::_40 => 40000000,
+                    XtalClkConfig::_26 => 26000000,
+                    XtalClkConfig::_40 => 40000000,
                 }
             }
         }
@@ -475,7 +475,7 @@ macro_rules! define_clock_tree_types {
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum SystemPreDivInConfig {
-            /// Selects `XTL_CLK`.
+            /// Selects `XTAL_CLK`.
             Xtal,
             /// Selects `RC_FAST_CLK`.
             RcFast,
@@ -616,7 +616,7 @@ macro_rules! define_clock_tree_types {
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum LowPowerClkConfig {
-            /// Selects `XTL_CLK`.
+            /// Selects `XTAL_CLK`.
             Xtal,
             /// Selects `RC_FAST_CLK`.
             RcFast,
@@ -630,7 +630,7 @@ macro_rules! define_clock_tree_types {
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Timg0FunctionClockConfig {
             #[default]
-            /// Selects `XTL_CLK`.
+            /// Selects `XTAL_CLK`.
             XtalClk,
             /// Selects `PLL_40M`.
             Pll40m,
@@ -648,7 +648,7 @@ macro_rules! define_clock_tree_types {
         }
         /// Represents the device's clock tree.
         pub struct ClockTree {
-            xtl_clk: Option<XtlClkConfig>,
+            xtal_clk: Option<XtalClkConfig>,
             system_pre_div_in: Option<SystemPreDivInConfig>,
             system_pre_div: Option<SystemPreDivConfig>,
             cpu_pll_div: Option<CpuPllDivConfig>,
@@ -681,9 +681,9 @@ macro_rules! define_clock_tree_types {
             pub fn with<R>(f: impl FnOnce(&mut ClockTree) -> R) -> R {
                 CLOCK_TREE.with(f)
             }
-            /// Returns the current configuration of the XTL_CLK clock tree node
-            pub fn xtl_clk(&self) -> Option<XtlClkConfig> {
-                self.xtl_clk
+            /// Returns the current configuration of the XTAL_CLK clock tree node
+            pub fn xtal_clk(&self) -> Option<XtalClkConfig> {
+                self.xtal_clk
             }
             /// Returns the current configuration of the SYSTEM_PRE_DIV_IN clock tree node
             pub fn system_pre_div_in(&self) -> Option<SystemPreDivInConfig> {
@@ -740,7 +740,7 @@ macro_rules! define_clock_tree_types {
         }
         static CLOCK_TREE: ::esp_sync::NonReentrantMutex<ClockTree> =
             ::esp_sync::NonReentrantMutex::new(ClockTree {
-                xtl_clk: None,
+                xtal_clk: None,
                 system_pre_div_in: None,
                 system_pre_div: None,
                 cpu_pll_div: None,
@@ -768,22 +768,22 @@ macro_rules! define_clock_tree_types {
                 timg0_function_clock_refcount: 0,
                 timg0_calibration_clock_refcount: 0,
             });
-        pub fn configure_xtl_clk(clocks: &mut ClockTree, config: XtlClkConfig) {
-            clocks.xtl_clk = Some(config);
-            configure_xtl_clk_impl(clocks, config);
+        pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
+            clocks.xtal_clk = Some(config);
+            configure_xtal_clk_impl(clocks, config);
         }
-        fn request_xtl_clk(_clocks: &mut ClockTree) {}
-        fn release_xtl_clk(_clocks: &mut ClockTree) {}
-        pub fn xtl_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            unwrap!(clocks.xtl_clk).value()
+        fn request_xtal_clk(_clocks: &mut ClockTree) {}
+        fn release_xtal_clk(_clocks: &mut ClockTree) {}
+        pub fn xtal_clk_frequency(clocks: &mut ClockTree) -> u32 {
+            unwrap!(clocks.xtal_clk).value()
         }
         pub fn request_pll_clk(clocks: &mut ClockTree) {
-            request_xtl_clk(clocks);
+            request_xtal_clk(clocks);
             enable_pll_clk_impl(clocks, true);
         }
         pub fn release_pll_clk(clocks: &mut ClockTree) {
             enable_pll_clk_impl(clocks, false);
-            release_xtl_clk(clocks);
+            release_xtal_clk(clocks);
         }
         pub fn pll_clk_frequency(clocks: &mut ClockTree) -> u32 {
             480000000
@@ -858,7 +858,7 @@ macro_rules! define_clock_tree_types {
             selector: SystemPreDivInConfig,
         ) {
             match selector {
-                SystemPreDivInConfig::Xtal => request_xtl_clk(clocks),
+                SystemPreDivInConfig::Xtal => request_xtal_clk(clocks),
                 SystemPreDivInConfig::RcFast => request_rc_fast_clk(clocks),
             }
         }
@@ -867,7 +867,7 @@ macro_rules! define_clock_tree_types {
             selector: SystemPreDivInConfig,
         ) {
             match selector {
-                SystemPreDivInConfig::Xtal => release_xtl_clk(clocks),
+                SystemPreDivInConfig::Xtal => release_xtal_clk(clocks),
                 SystemPreDivInConfig::RcFast => release_rc_fast_clk(clocks),
             }
         }
@@ -883,7 +883,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn system_pre_div_in_frequency(clocks: &mut ClockTree) -> u32 {
             match unwrap!(clocks.system_pre_div_in) {
-                SystemPreDivInConfig::Xtal => xtl_clk_frequency(clocks),
+                SystemPreDivInConfig::Xtal => xtal_clk_frequency(clocks),
                 SystemPreDivInConfig::RcFast => rc_fast_clk_frequency(clocks),
             }
         }
@@ -1167,15 +1167,15 @@ macro_rules! define_clock_tree_types {
             (rc_fast_clk_frequency(clocks) / (unwrap!(clocks.rc_fast_clk_div_n).value() + 1))
         }
         pub fn request_xtal_div_clk(clocks: &mut ClockTree) {
-            request_xtl_clk(clocks);
+            request_xtal_clk(clocks);
             enable_xtal_div_clk_impl(clocks, true);
         }
         pub fn release_xtal_div_clk(clocks: &mut ClockTree) {
             enable_xtal_div_clk_impl(clocks, false);
-            release_xtl_clk(clocks);
+            release_xtal_clk(clocks);
         }
         pub fn xtal_div_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            (xtl_clk_frequency(clocks) / 2)
+            (xtal_clk_frequency(clocks) / 2)
         }
         pub fn configure_rtc_slow_clk(clocks: &mut ClockTree, new_selector: RtcSlowClkConfig) {
             let old_selector = clocks.rtc_slow_clk.replace(new_selector);
@@ -1274,7 +1274,7 @@ macro_rules! define_clock_tree_types {
         }
         fn low_power_clk_request_upstream(clocks: &mut ClockTree, selector: LowPowerClkConfig) {
             match selector {
-                LowPowerClkConfig::Xtal => request_xtl_clk(clocks),
+                LowPowerClkConfig::Xtal => request_xtal_clk(clocks),
                 LowPowerClkConfig::RcFast => request_rc_fast_clk(clocks),
                 LowPowerClkConfig::OscSlow => request_osc_slow_clk(clocks),
                 LowPowerClkConfig::RtcSlow => request_rtc_slow_clk(clocks),
@@ -1282,7 +1282,7 @@ macro_rules! define_clock_tree_types {
         }
         fn low_power_clk_release_upstream(clocks: &mut ClockTree, selector: LowPowerClkConfig) {
             match selector {
-                LowPowerClkConfig::Xtal => release_xtl_clk(clocks),
+                LowPowerClkConfig::Xtal => release_xtal_clk(clocks),
                 LowPowerClkConfig::RcFast => release_rc_fast_clk(clocks),
                 LowPowerClkConfig::OscSlow => release_osc_slow_clk(clocks),
                 LowPowerClkConfig::RtcSlow => release_rtc_slow_clk(clocks),
@@ -1304,7 +1304,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn low_power_clk_frequency(clocks: &mut ClockTree) -> u32 {
             match unwrap!(clocks.low_power_clk) {
-                LowPowerClkConfig::Xtal => xtl_clk_frequency(clocks),
+                LowPowerClkConfig::Xtal => xtal_clk_frequency(clocks),
                 LowPowerClkConfig::RcFast => rc_fast_clk_frequency(clocks),
                 LowPowerClkConfig::OscSlow => osc_slow_clk_frequency(clocks),
                 LowPowerClkConfig::RtcSlow => rtc_slow_clk_frequency(clocks),
@@ -1330,7 +1330,7 @@ macro_rules! define_clock_tree_types {
             selector: Timg0FunctionClockConfig,
         ) {
             match selector {
-                Timg0FunctionClockConfig::XtalClk => request_xtl_clk(clocks),
+                Timg0FunctionClockConfig::XtalClk => request_xtal_clk(clocks),
                 Timg0FunctionClockConfig::Pll40m => request_pll_40m(clocks),
             }
         }
@@ -1339,7 +1339,7 @@ macro_rules! define_clock_tree_types {
             selector: Timg0FunctionClockConfig,
         ) {
             match selector {
-                Timg0FunctionClockConfig::XtalClk => release_xtl_clk(clocks),
+                Timg0FunctionClockConfig::XtalClk => release_xtal_clk(clocks),
                 Timg0FunctionClockConfig::Pll40m => release_pll_40m(clocks),
             }
         }
@@ -1359,7 +1359,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn timg0_function_clock_frequency(clocks: &mut ClockTree) -> u32 {
             match unwrap!(clocks.timg0_function_clock) {
-                Timg0FunctionClockConfig::XtalClk => xtl_clk_frequency(clocks),
+                Timg0FunctionClockConfig::XtalClk => xtal_clk_frequency(clocks),
                 Timg0FunctionClockConfig::Pll40m => pll_40m_frequency(clocks),
             }
         }
@@ -1422,15 +1422,15 @@ macro_rules! define_clock_tree_types {
         /// Clock tree configuration.
         ///
         /// The fields of this struct are optional, with the following caveats:
-        /// - If `XTL_CLK` is not specified, the crystal frequency will be automatically detected if
-        ///   possible.
+        /// - If `XTAL_CLK` is not specified, the crystal frequency will be automatically detected
+        ///   if possible.
         /// - The CPU and its upstream clock nodes will be set to a default configuration.
         /// - Other unspecified clock sources will not be useable by peripherals.
         #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub struct ClockConfig {
-            /// `XTL_CLK` configuration.
-            pub xtl_clk: Option<XtlClkConfig>,
+            /// `XTAL_CLK` configuration.
+            pub xtal_clk: Option<XtalClkConfig>,
             /// `SYSTEM_PRE_DIV` configuration.
             pub system_pre_div: Option<SystemPreDivConfig>,
             /// `CPU_PLL_DIV` configuration.
@@ -1449,8 +1449,8 @@ macro_rules! define_clock_tree_types {
         impl ClockConfig {
             fn apply(&self) {
                 ClockTree::with(|clocks| {
-                    if let Some(config) = self.xtl_clk {
-                        configure_xtl_clk(clocks, config);
+                    if let Some(config) = self.xtal_clk {
+                        configure_xtal_clk(clocks, config);
                     }
                     if let Some(config) = self.system_pre_div {
                         configure_system_pre_div(clocks, config);

--- a/esp-metadata-generated/src/_generated_esp32c3.rs
+++ b/esp-metadata-generated/src/_generated_esp32c3.rs
@@ -288,9 +288,9 @@ macro_rules! for_each_soc_xtal_options {
 #[macro_export]
 /// ESP-HAL must provide implementation for the following functions:
 /// ```rust, no_run
-/// // XTL_CLK
+/// // XTAL_CLK
 ///
-/// fn configure_xtl_clk_impl(_clocks: &mut ClockTree, _config: XtlClkConfig) {
+/// fn configure_xtal_clk_impl(_clocks: &mut ClockTree, _config: XtalClkConfig) {
 ///     todo!()
 /// }
 ///
@@ -528,21 +528,21 @@ macro_rules! for_each_soc_xtal_options {
 /// ```
 macro_rules! define_clock_tree_types {
     () => {
-        /// Selects the output frequency of `XTL_CLK`.
+        /// Selects the output frequency of `XTAL_CLK`.
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-        pub enum XtlClkConfig {
+        pub enum XtalClkConfig {
             /// 40 MHz
             _40,
         }
-        impl XtlClkConfig {
+        impl XtalClkConfig {
             pub fn value(&self) -> u32 {
                 match self {
-                    XtlClkConfig::_40 => 40000000,
+                    XtalClkConfig::_40 => 40000000,
                 }
             }
         }
-        /// Selects the output frequency of `PLL_CLK`. Depends on `XTL_CLK`.
+        /// Selects the output frequency of `PLL_CLK`. Depends on `XTAL_CLK`.
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum PllClkConfig {
@@ -563,7 +563,7 @@ macro_rules! define_clock_tree_types {
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum SystemPreDivInConfig {
-            /// Selects `XTL_CLK`.
+            /// Selects `XTAL_CLK`.
             Xtal,
             /// Selects `RC_FAST_CLK`.
             RcFast,
@@ -686,7 +686,7 @@ macro_rules! define_clock_tree_types {
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum LowPowerClkConfig {
-            /// Selects `XTL_CLK`.
+            /// Selects `XTAL_CLK`.
             Xtal,
             /// Selects `RC_FAST_CLK`.
             RcFast,
@@ -700,7 +700,7 @@ macro_rules! define_clock_tree_types {
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum Timg0FunctionClockConfig {
             #[default]
-            /// Selects `XTL_CLK`.
+            /// Selects `XTAL_CLK`.
             XtalClk,
             /// Selects `APB_CLK`.
             ApbClk,
@@ -718,7 +718,7 @@ macro_rules! define_clock_tree_types {
         }
         /// Represents the device's clock tree.
         pub struct ClockTree {
-            xtl_clk: Option<XtlClkConfig>,
+            xtal_clk: Option<XtalClkConfig>,
             pll_clk: Option<PllClkConfig>,
             system_pre_div_in: Option<SystemPreDivInConfig>,
             system_pre_div: Option<SystemPreDivConfig>,
@@ -752,9 +752,9 @@ macro_rules! define_clock_tree_types {
             pub fn with<R>(f: impl FnOnce(&mut ClockTree) -> R) -> R {
                 CLOCK_TREE.with(f)
             }
-            /// Returns the current configuration of the XTL_CLK clock tree node
-            pub fn xtl_clk(&self) -> Option<XtlClkConfig> {
-                self.xtl_clk
+            /// Returns the current configuration of the XTAL_CLK clock tree node
+            pub fn xtal_clk(&self) -> Option<XtalClkConfig> {
+                self.xtal_clk
             }
             /// Returns the current configuration of the PLL_CLK clock tree node
             pub fn pll_clk(&self) -> Option<PllClkConfig> {
@@ -819,7 +819,7 @@ macro_rules! define_clock_tree_types {
         }
         static CLOCK_TREE: ::esp_sync::NonReentrantMutex<ClockTree> =
             ::esp_sync::NonReentrantMutex::new(ClockTree {
-                xtl_clk: None,
+                xtal_clk: None,
                 pll_clk: None,
                 system_pre_div_in: None,
                 system_pre_div: None,
@@ -848,26 +848,26 @@ macro_rules! define_clock_tree_types {
                 timg1_function_clock_refcount: 0,
                 timg1_calibration_clock_refcount: 0,
             });
-        pub fn configure_xtl_clk(clocks: &mut ClockTree, config: XtlClkConfig) {
-            clocks.xtl_clk = Some(config);
-            configure_xtl_clk_impl(clocks, config);
+        pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
+            clocks.xtal_clk = Some(config);
+            configure_xtal_clk_impl(clocks, config);
         }
-        fn request_xtl_clk(_clocks: &mut ClockTree) {}
-        fn release_xtl_clk(_clocks: &mut ClockTree) {}
-        pub fn xtl_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            unwrap!(clocks.xtl_clk).value()
+        fn request_xtal_clk(_clocks: &mut ClockTree) {}
+        fn release_xtal_clk(_clocks: &mut ClockTree) {}
+        pub fn xtal_clk_frequency(clocks: &mut ClockTree) -> u32 {
+            unwrap!(clocks.xtal_clk).value()
         }
         pub fn configure_pll_clk(clocks: &mut ClockTree, config: PllClkConfig) {
             clocks.pll_clk = Some(config);
             configure_pll_clk_impl(clocks, config);
         }
         pub fn request_pll_clk(clocks: &mut ClockTree) {
-            request_xtl_clk(clocks);
+            request_xtal_clk(clocks);
             enable_pll_clk_impl(clocks, true);
         }
         pub fn release_pll_clk(clocks: &mut ClockTree) {
             enable_pll_clk_impl(clocks, false);
-            release_xtl_clk(clocks);
+            release_xtal_clk(clocks);
         }
         pub fn pll_clk_frequency(clocks: &mut ClockTree) -> u32 {
             unwrap!(clocks.pll_clk).value()
@@ -942,7 +942,7 @@ macro_rules! define_clock_tree_types {
             selector: SystemPreDivInConfig,
         ) {
             match selector {
-                SystemPreDivInConfig::Xtal => request_xtl_clk(clocks),
+                SystemPreDivInConfig::Xtal => request_xtal_clk(clocks),
                 SystemPreDivInConfig::RcFast => request_rc_fast_clk(clocks),
             }
         }
@@ -951,7 +951,7 @@ macro_rules! define_clock_tree_types {
             selector: SystemPreDivInConfig,
         ) {
             match selector {
-                SystemPreDivInConfig::Xtal => release_xtl_clk(clocks),
+                SystemPreDivInConfig::Xtal => release_xtal_clk(clocks),
                 SystemPreDivInConfig::RcFast => release_rc_fast_clk(clocks),
             }
         }
@@ -967,7 +967,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn system_pre_div_in_frequency(clocks: &mut ClockTree) -> u32 {
             match unwrap!(clocks.system_pre_div_in) {
-                SystemPreDivInConfig::Xtal => xtl_clk_frequency(clocks),
+                SystemPreDivInConfig::Xtal => xtal_clk_frequency(clocks),
                 SystemPreDivInConfig::RcFast => rc_fast_clk_frequency(clocks),
             }
         }
@@ -1174,15 +1174,15 @@ macro_rules! define_clock_tree_types {
             (rc_fast_clk_frequency(clocks) / (unwrap!(clocks.rc_fast_clk_div_n).value() + 1))
         }
         pub fn request_xtal_div_clk(clocks: &mut ClockTree) {
-            request_xtl_clk(clocks);
+            request_xtal_clk(clocks);
             enable_xtal_div_clk_impl(clocks, true);
         }
         pub fn release_xtal_div_clk(clocks: &mut ClockTree) {
             enable_xtal_div_clk_impl(clocks, false);
-            release_xtl_clk(clocks);
+            release_xtal_clk(clocks);
         }
         pub fn xtal_div_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            (xtl_clk_frequency(clocks) / 2)
+            (xtal_clk_frequency(clocks) / 2)
         }
         pub fn configure_rtc_slow_clk(clocks: &mut ClockTree, new_selector: RtcSlowClkConfig) {
             let old_selector = clocks.rtc_slow_clk.replace(new_selector);
@@ -1281,7 +1281,7 @@ macro_rules! define_clock_tree_types {
         }
         fn low_power_clk_request_upstream(clocks: &mut ClockTree, selector: LowPowerClkConfig) {
             match selector {
-                LowPowerClkConfig::Xtal => request_xtl_clk(clocks),
+                LowPowerClkConfig::Xtal => request_xtal_clk(clocks),
                 LowPowerClkConfig::RcFast => request_rc_fast_clk(clocks),
                 LowPowerClkConfig::Xtal32k => request_xtal32k_clk(clocks),
                 LowPowerClkConfig::RtcSlow => request_rtc_slow_clk(clocks),
@@ -1289,7 +1289,7 @@ macro_rules! define_clock_tree_types {
         }
         fn low_power_clk_release_upstream(clocks: &mut ClockTree, selector: LowPowerClkConfig) {
             match selector {
-                LowPowerClkConfig::Xtal => release_xtl_clk(clocks),
+                LowPowerClkConfig::Xtal => release_xtal_clk(clocks),
                 LowPowerClkConfig::RcFast => release_rc_fast_clk(clocks),
                 LowPowerClkConfig::Xtal32k => release_xtal32k_clk(clocks),
                 LowPowerClkConfig::RtcSlow => release_rtc_slow_clk(clocks),
@@ -1311,7 +1311,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn low_power_clk_frequency(clocks: &mut ClockTree) -> u32 {
             match unwrap!(clocks.low_power_clk) {
-                LowPowerClkConfig::Xtal => xtl_clk_frequency(clocks),
+                LowPowerClkConfig::Xtal => xtal_clk_frequency(clocks),
                 LowPowerClkConfig::RcFast => rc_fast_clk_frequency(clocks),
                 LowPowerClkConfig::Xtal32k => xtal32k_clk_frequency(clocks),
                 LowPowerClkConfig::RtcSlow => rtc_slow_clk_frequency(clocks),
@@ -1337,7 +1337,7 @@ macro_rules! define_clock_tree_types {
             selector: Timg0FunctionClockConfig,
         ) {
             match selector {
-                Timg0FunctionClockConfig::XtalClk => request_xtl_clk(clocks),
+                Timg0FunctionClockConfig::XtalClk => request_xtal_clk(clocks),
                 Timg0FunctionClockConfig::ApbClk => request_apb_clk(clocks),
             }
         }
@@ -1346,7 +1346,7 @@ macro_rules! define_clock_tree_types {
             selector: Timg0FunctionClockConfig,
         ) {
             match selector {
-                Timg0FunctionClockConfig::XtalClk => release_xtl_clk(clocks),
+                Timg0FunctionClockConfig::XtalClk => release_xtal_clk(clocks),
                 Timg0FunctionClockConfig::ApbClk => release_apb_clk(clocks),
             }
         }
@@ -1366,7 +1366,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn timg0_function_clock_frequency(clocks: &mut ClockTree) -> u32 {
             match unwrap!(clocks.timg0_function_clock) {
-                Timg0FunctionClockConfig::XtalClk => xtl_clk_frequency(clocks),
+                Timg0FunctionClockConfig::XtalClk => xtal_clk_frequency(clocks),
                 Timg0FunctionClockConfig::ApbClk => apb_clk_frequency(clocks),
             }
         }
@@ -1446,7 +1446,7 @@ macro_rules! define_clock_tree_types {
             selector: Timg0FunctionClockConfig,
         ) {
             match selector {
-                Timg0FunctionClockConfig::XtalClk => request_xtl_clk(clocks),
+                Timg0FunctionClockConfig::XtalClk => request_xtal_clk(clocks),
                 Timg0FunctionClockConfig::ApbClk => request_apb_clk(clocks),
             }
         }
@@ -1455,7 +1455,7 @@ macro_rules! define_clock_tree_types {
             selector: Timg0FunctionClockConfig,
         ) {
             match selector {
-                Timg0FunctionClockConfig::XtalClk => release_xtl_clk(clocks),
+                Timg0FunctionClockConfig::XtalClk => release_xtal_clk(clocks),
                 Timg0FunctionClockConfig::ApbClk => release_apb_clk(clocks),
             }
         }
@@ -1475,7 +1475,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn timg1_function_clock_frequency(clocks: &mut ClockTree) -> u32 {
             match unwrap!(clocks.timg1_function_clock) {
-                Timg0FunctionClockConfig::XtalClk => xtl_clk_frequency(clocks),
+                Timg0FunctionClockConfig::XtalClk => xtal_clk_frequency(clocks),
                 Timg0FunctionClockConfig::ApbClk => apb_clk_frequency(clocks),
             }
         }
@@ -1538,15 +1538,15 @@ macro_rules! define_clock_tree_types {
         /// Clock tree configuration.
         ///
         /// The fields of this struct are optional, with the following caveats:
-        /// - If `XTL_CLK` is not specified, the crystal frequency will be automatically detected if
-        ///   possible.
+        /// - If `XTAL_CLK` is not specified, the crystal frequency will be automatically detected
+        ///   if possible.
         /// - The CPU and its upstream clock nodes will be set to a default configuration.
         /// - Other unspecified clock sources will not be useable by peripherals.
         #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub struct ClockConfig {
-            /// `XTL_CLK` configuration.
-            pub xtl_clk: Option<XtlClkConfig>,
+            /// `XTAL_CLK` configuration.
+            pub xtal_clk: Option<XtalClkConfig>,
             /// `PLL_CLK` configuration.
             pub pll_clk: Option<PllClkConfig>,
             /// `SYSTEM_PRE_DIV` configuration.
@@ -1567,8 +1567,8 @@ macro_rules! define_clock_tree_types {
         impl ClockConfig {
             fn apply(&self) {
                 ClockTree::with(|clocks| {
-                    if let Some(config) = self.xtl_clk {
-                        configure_xtl_clk(clocks, config);
+                    if let Some(config) = self.xtal_clk {
+                        configure_xtal_clk(clocks, config);
                     }
                     if let Some(config) = self.pll_clk {
                         configure_pll_clk(clocks, config);

--- a/esp-metadata-generated/src/_generated_esp32c6.rs
+++ b/esp-metadata-generated/src/_generated_esp32c6.rs
@@ -1988,8 +1988,8 @@ macro_rules! define_clock_tree_types {
         /// Clock tree configuration.
         ///
         /// The fields of this struct are optional, with the following caveats:
-        /// - If `XTL_CLK` is not specified, the crystal frequency will be automatically detected if
-        ///   possible.
+        /// - If `XTAL_CLK` is not specified, the crystal frequency will be automatically detected
+        ///   if possible.
         /// - The CPU and its upstream clock nodes will be set to a default configuration.
         /// - Other unspecified clock sources will not be useable by peripherals.
         #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]

--- a/esp-metadata-generated/src/_generated_esp32h2.rs
+++ b/esp-metadata-generated/src/_generated_esp32h2.rs
@@ -1239,8 +1239,8 @@ macro_rules! define_clock_tree_types {
         /// Clock tree configuration.
         ///
         /// The fields of this struct are optional, with the following caveats:
-        /// - If `XTL_CLK` is not specified, the crystal frequency will be automatically detected if
-        ///   possible.
+        /// - If `XTAL_CLK` is not specified, the crystal frequency will be automatically detected
+        ///   if possible.
         /// - The CPU and its upstream clock nodes will be set to a default configuration.
         /// - Other unspecified clock sources will not be useable by peripherals.
         #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]

--- a/esp-metadata-generated/src/_generated_esp32s2.rs
+++ b/esp-metadata-generated/src/_generated_esp32s2.rs
@@ -295,8 +295,8 @@ macro_rules! define_clock_tree_types {
         /// Clock tree configuration.
         ///
         /// The fields of this struct are optional, with the following caveats:
-        /// - If `XTL_CLK` is not specified, the crystal frequency will be automatically detected if
-        ///   possible.
+        /// - If `XTAL_CLK` is not specified, the crystal frequency will be automatically detected
+        ///   if possible.
         /// - The CPU and its upstream clock nodes will be set to a default configuration.
         /// - Other unspecified clock sources will not be useable by peripherals.
         #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]

--- a/esp-metadata-generated/src/_generated_esp32s3.rs
+++ b/esp-metadata-generated/src/_generated_esp32s3.rs
@@ -298,8 +298,8 @@ macro_rules! define_clock_tree_types {
         /// Clock tree configuration.
         ///
         /// The fields of this struct are optional, with the following caveats:
-        /// - If `XTL_CLK` is not specified, the crystal frequency will be automatically detected if
-        ///   possible.
+        /// - If `XTAL_CLK` is not specified, the crystal frequency will be automatically detected
+        ///   if possible.
         /// - The CPU and its upstream clock nodes will be set to a default configuration.
         /// - Other unspecified clock sources will not be useable by peripherals.
         #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]

--- a/esp-metadata/devices/esp32.toml
+++ b/esp-metadata/devices/esp32.toml
@@ -118,9 +118,9 @@ memory_map = { ranges = [
 #
 # `clocks` in a peripheral clock definition can either be a different `peripheral_clocks` entry (string), or a new definition (array) that uses the same syntax as `system_clocks` above.
 clocks = { system_clocks = { clock_tree = [
-    { name = "XTL_CLK",     type = "source",                    values = "26, 40",                     output = "VALUE * 1_000_000", always_on = true }, # 2-40MHz, always on? sw ability to measure using an internal RC clock
-    { name = "PLL_CLK",     type = "derived", from = "XTL_CLK", values = "320, 480",                   output = "VALUE * 1_000_000", reject = "VALUE == 480_000_000 && CPU_PLL_DIV == 4" },
-    { name = "APLL_CLK",    type = "derived", from = "PLL_CLK", values = "16_000_000 ..= 128_000_000", output = "VALUE" },
+    { name = "XTAL_CLK",     type = "source",                    values = "26, 40",                     output = "VALUE * 1_000_000", always_on = true }, # 2-40MHz, always on? sw ability to measure using an internal RC clock
+    { name = "PLL_CLK",     type = "derived", from = "XTAL_CLK", values = "320, 480",                   output = "VALUE * 1_000_000", reject = "VALUE == 480_000_000 && CPU_PLL_DIV == 4" },
+    { name = "APLL_CLK",    type = "derived", from = "PLL_CLK",  values = "16_000_000 ..= 128_000_000", output = "VALUE" },
     { name = "RC_FAST_CLK", type = "source",  output = "8_000_000" }, # this is supposed to be adjustable using RTC_CNTL_CK8M_DIV_SEL
 
     # CPU and related clocks
@@ -142,7 +142,7 @@ clocks = { system_clocks = { clock_tree = [
     # Each item may have a `reject` list of conditions to validate the clock tree config.
     #
     # Free parameters:
-    # - value of XTL_CLK (can be fixed or "measured")
+    # - value of XTAL_CLK (can be fixed or "measured")
     # - value of PLL_CLK (320/480)
     # - value of APLL_CLK (target frequency, maybe?)
     # - value of SYSCON_PRE_DIV (divisor)
@@ -177,7 +177,7 @@ clocks = { system_clocks = { clock_tree = [
 
     # DIVB Divisor for low-speed clock sources (XTAL, FOSC)
     { name = "SYSCON_PRE_DIV_IN", type = "mux", variants = [
-        { name = "XTAL",    outputs = "XTL_CLK" },
+        { name = "XTAL",    outputs = "XTAL_CLK" },
         { name = "RC_FAST", outputs = "RC_FAST_CLK" },
     ] },
     { name = "SYSCON_PRE_DIV", type = "divider", divisors = "0 .. 1024", output = "SYSCON_PRE_DIV_IN / (DIVISOR + 1)" },
@@ -216,7 +216,7 @@ clocks = { system_clocks = { clock_tree = [
     { name = "XTAL32K_CLK",     type = "source",  output = "32768" },
     { name = "RC_SLOW_CLK",     type = "source",  output = "150_000" },
     { name = "RC_FAST_DIV_CLK", type = "divider", output = "RC_FAST_CLK / 256" },
-    { name = "XTAL_DIV_CLK",    type = "divider", output = "XTL_CLK / 4" }, # source: esp-idf SOC_RTC_FAST_CLK_SRC_XTAL_D4
+    { name = "XTAL_DIV_CLK",    type = "divider", output = "XTAL_CLK / 4" }, # source: esp-idf SOC_RTC_FAST_CLK_SRC_XTAL_D4
 
     { name = "RTC_SLOW_CLK", type = "mux", variants = [
         { name = "XTAL",    outputs = "XTAL32K_CLK" },
@@ -229,7 +229,7 @@ clocks = { system_clocks = { clock_tree = [
     ] },
     # Wireless low-power clock. Unsure how to configure this or if it's needed at all, esp-idf does not seem to use this MUX.
     #{ name = "LOW_POWER_CLK", type = "mux", variants = [
-    #    { name = "XTAL",     outputs = "XTL_CLK" },
+    #    { name = "XTAL",     outputs = "XTAL_CLK" },
     #    { name = "RC_FAST",  outputs = "RC_FAST_CLK" },
     #    { name = "RC_SLOW",  outputs = "RC_SLOW_CLK" },
     #    { name = "RTC_SLOW", outputs = "RTC_SLOW_CLK" },

--- a/esp-metadata/devices/esp32c2.toml
+++ b/esp-metadata/devices/esp32c2.toml
@@ -91,8 +91,8 @@ memory_map = { ranges = [
 
 clocks = { system_clocks = { clock_tree = [
     # High-speed clock sources
-    { name = "XTL_CLK",     type = "source",  values = "26, 40", output = "VALUE * 1_000_000", always_on = true },
-    { name = "PLL_CLK",     type = "derived", from = "XTL_CLK",  output = "480_000_000" },
+    { name = "XTAL_CLK",    type = "source",  values = "26, 40", output = "VALUE * 1_000_000", always_on = true },
+    { name = "PLL_CLK",     type = "derived", from = "XTAL_CLK", output = "480_000_000" },
     { name = "RC_FAST_CLK", type = "source",                     output = "17_500_000" },
 
     # Low-speed clocks
@@ -102,7 +102,7 @@ clocks = { system_clocks = { clock_tree = [
 
     # CPU clock source dividers
     { name = "SYSTEM_PRE_DIV_IN", type = "mux", variants = [
-        { name = "XTAL",    outputs = "XTL_CLK" },
+        { name = "XTAL",    outputs = "XTAL_CLK" },
         { name = "RC_FAST", outputs = "RC_FAST_CLK" },
     ] },
     { name = "SYSTEM_PRE_DIV", type = "divider", divisors = "0 .. 1024", output = "SYSTEM_PRE_DIV_IN / (DIVISOR + 1)" },
@@ -137,7 +137,7 @@ clocks = { system_clocks = { clock_tree = [
     
     # Low-power clocks
     { name = "RC_FAST_CLK_DIV_N", type = "divider", divisors = "0 ..= 3", output = "RC_FAST_CLK / (DIVISOR + 1)" }, # RC_DIV
-    { name = "XTAL_DIV_CLK",      type = "divider", output = "XTL_CLK / 2" }, # XTAL_DIV
+    { name = "XTAL_DIV_CLK",      type = "divider", output = "XTAL_CLK / 2" }, # XTAL_DIV
     { name = "RTC_SLOW_CLK", type = "mux", variants = [ # RTC_CNTL_ANA_CLK_RTC_SEL
         { name = "OSC_SLOW", outputs = "OSC_SLOW_CLK" },
         { name = "RC_SLOW",  outputs = "RC_SLOW_CLK" },
@@ -150,7 +150,7 @@ clocks = { system_clocks = { clock_tree = [
     
     # Low-power wireless clock source
     { name = "LOW_POWER_CLK", type = "mux", variants = [
-        { name = "XTAL",     outputs = "XTL_CLK" },
+        { name = "XTAL",     outputs = "XTAL_CLK" },
         { name = "RC_FAST",  outputs = "RC_FAST_CLK" },
         { name = "OSC_SLOW", outputs = "OSC_SLOW_CLK" },
         { name = "RTC_SLOW", outputs = "RTC_SLOW_CLK" },
@@ -179,7 +179,7 @@ clocks = { system_clocks = { clock_tree = [
     { name = "UartMem", keep_enabled = true }, # TODO: keep_enabled can be removed once esp-println needs explicit initialization
     { name = "Timg0", template_params = { peripheral = "timergroup" }, keep_enabled = true, clocks = [
         { name = "FUNCTION_CLOCK", type = "mux", default = "XTAL_CLK", variants = [
-            { name = "XTAL_CLK", outputs = "XTL_CLK" },
+            { name = "XTAL_CLK", outputs = "XTAL_CLK" },
             { name = "PLL_40M",  outputs = "PLL_40M" },
         ] },
         { name = "CALIBRATION_CLOCK", type = "mux", variants = [

--- a/esp-metadata/devices/esp32c3.toml
+++ b/esp-metadata/devices/esp32c3.toml
@@ -98,9 +98,9 @@ memory_map = { ranges = [
 
 clocks = { system_clocks = { clock_tree = [
     # High-speed clock sources
-    { name = "XTL_CLK",     type = "source",  values = "40",                         output = "VALUE * 1_000_000", always_on = true },
-    { name = "PLL_CLK",     type = "derived", from = "XTL_CLK", values = "320, 480", output = "VALUE * 1_000_000" },
-    { name = "RC_FAST_CLK", type = "source",                                         output = "17_500_000" },
+    { name = "XTAL_CLK",    type = "source",  values = "40",                          output = "VALUE * 1_000_000", always_on = true },
+    { name = "PLL_CLK",     type = "derived", from = "XTAL_CLK", values = "320, 480", output = "VALUE * 1_000_000" },
+    { name = "RC_FAST_CLK", type = "source",                                          output = "17_500_000" },
 
     # Low-speed clocks
     { name = "XTAL32K_CLK",     type = "source",  output = "32768" },
@@ -109,7 +109,7 @@ clocks = { system_clocks = { clock_tree = [
 
     # CPU clock source dividers
     { name = "SYSTEM_PRE_DIV_IN", type = "mux", variants = [
-        { name = "XTAL",    outputs = "XTL_CLK" },
+        { name = "XTAL",    outputs = "XTAL_CLK" },
         { name = "RC_FAST", outputs = "RC_FAST_CLK" },
     ] },
     { name = "SYSTEM_PRE_DIV",  type = "divider", divisors = "0 .. 1024", output = "SYSTEM_PRE_DIV_IN / (DIVISOR + 1)" },
@@ -139,7 +139,7 @@ clocks = { system_clocks = { clock_tree = [
 
     # Low-power clocks
     { name = "RC_FAST_CLK_DIV_N", type = "divider", divisors = "0 ..= 3", output = "RC_FAST_CLK / (DIVISOR + 1)" },
-    { name = "XTAL_DIV_CLK",      type = "divider", output = "XTL_CLK / 2" },
+    { name = "XTAL_DIV_CLK",      type = "divider", output = "XTAL_CLK / 2" },
     { name = "RTC_SLOW_CLK", type = "mux", variants = [
         { name = "XTAL32K", outputs = "XTAL32K_CLK" },
         { name = "RC_SLOW", outputs = "RC_SLOW_CLK" },
@@ -152,7 +152,7 @@ clocks = { system_clocks = { clock_tree = [
 
     # Low-power wireless clock source
     { name = "LOW_POWER_CLK", type = "mux", variants = [
-        { name = "XTAL",     outputs = "XTL_CLK" },
+        { name = "XTAL",     outputs = "XTAL_CLK" },
         { name = "RC_FAST",  outputs = "RC_FAST_CLK" },
         { name = "XTAL32K",  outputs = "XTAL32K_CLK" },
         { name = "RTC_SLOW", outputs = "RTC_SLOW_CLK" },
@@ -189,7 +189,7 @@ clocks = { system_clocks = { clock_tree = [
     { name = "Timg1", template_params = { peripheral = "timergroup1" }, clocks = "Timg0" },
     { name = "Timg0", template_params = { peripheral = "timergroup" }, keep_enabled = true, clocks = [
         { name = "FUNCTION_CLOCK", type = "mux", default = "XTAL_CLK", variants = [
-            { name = "XTAL_CLK", outputs = "XTL_CLK" },
+            { name = "XTAL_CLK", outputs = "XTAL_CLK" },
             { name = "APB_CLK",  outputs = "APB_CLK" },
         ] },
         { name = "CALIBRATION_CLOCK", type = "mux", variants = [

--- a/esp-metadata/src/cfg/soc.rs
+++ b/esp-metadata/src/cfg/soc.rs
@@ -127,7 +127,7 @@ pub(crate) struct ProcessedClockData {
 }
 
 impl ProcessedClockData {
-    /// Returns a node by its name (e.g. `XTL_CLK`).
+    /// Returns a node by its name (e.g. `XTAL_CLK`).
     ///
     /// As the clock tree is stored as a vector, this method performs a linear search.
     fn node(&self, name: &str) -> &dyn ClockTreeNodeType {
@@ -299,8 +299,8 @@ impl SystemClocks {
                     /// Clock tree configuration.
                     ///
                     /// The fields of this struct are optional, with the following caveats:
-                    /// - If `XTL_CLK` is not specified, the crystal frequency will be automatically detected if
-                    ///   possible.
+                    /// - If `XTAL_CLK` is not specified, the crystal frequency will be automatically detected
+                    ///   if possible.
                     /// - The CPU and its upstream clock nodes will be set to a default configuration.
                     /// - Other unspecified clock sources will not be useable by peripherals.
                     #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
This PR unifies the name of the high-speed crystal oscillator clock source. C2 and C3 documentation already calls the node XTAL, only ESP32 was the odd one out, but starting with this PR the naming should be consistent. It means there are no separate `soc_has_clock_node_xtl_clk` and `soc_has_clock_node_xtal_clk` cfg symbols anymore, which would probably have been a source of WTFs.