### PR TITLE
Fix deprecated TWAI link

### DIFF
--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -583,7 +583,7 @@ pub enum BaudRate {
 
 impl BaudRate {
     /// Convert the BaudRate into the timings that the peripheral needs.
-    // See: https://github.com/espressif/esp-idf/tree/master/components/hal/include/hal/twai_types.h
+    // See: https://github.com/espressif/esp-idf/tree/ab4200e/components/esp_hal_twai/include/hal/twai_types.h
     const fn timing(self) -> TimingConfig {
         #[cfg(not(esp32h2))]
         let timing = match self {


### PR DESCRIPTION
Fixes broken TWAI link due to migration: https://github.com/esp-rs/esp-hal/actions/runs/19963274348/job/57248620591?pr=4615