### PR TITLE
Ensure async waker code lives in IRAM

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RMT: `ChannelCreator::configure_tx` and `ChannelCreator::configure_rx` don't take a pin anymore, instead `Channel::with_pin` has been added. (#4302)
 - RMT: Configuration errors have been split out of `rmt::Error` into the new `rmt::ConfigError` enum. (#4494)
 - RMT: `Rmt::new()` now returns `Error::UnreachableTargetFrequency` instead of panicking when requesting 0 Hz. (#4509)
+- `AtomicWaker::wake` is now placed in IRAM (#4627)
 - Internal clock configuration rework (#4501)
 - RMT: Support for `Into<PulseCode>` and `From<PulseCode>` has been removed from Tx and Rx methods, respectively, in favor of requiring `PulseCode` directly. (#4616)
 

--- a/esp-hal/src/asynch.rs
+++ b/esp-hal/src/asynch.rs
@@ -18,12 +18,15 @@ impl AtomicWaker {
         }
     }
 
-    delegate::delegate! {
-        to self.waker {
-            /// Register a waker. Overwrites the previous waker, if any.
-            pub fn register(&self, w: &Waker);
-            /// Wake the registered waker, if any.
-            pub fn wake(&self);
-        }
+    /// Register a waker. Overwrites the previous waker, if any.
+    #[inline]
+    pub fn register(&self, w: &Waker) {
+        self.waker.register(w);
+    }
+
+    /// Wake the registered waker, if any.
+    #[crate::ram]
+    pub fn wake(&self) {
+        self.waker.wake();
     }
 }

--- a/esp-sync/CHANGELOG.md
+++ b/esp-sync/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Added `#[inline]` attributes to ensure better codegen (#4627)
 
 ### Fixed
 


### PR DESCRIPTION
This PR adds `#[inline]` attributes to lock code to ensure it gets all inlined, and replaces the `#[inline]` inserted by `delegate` with `#[ram]` to ensure that the wake method we call from interrupt handlers don't need to be loaded from flash.

The end result is that interrupts now call a function that live in RAM, and everything that can be inlined into them, is (at least under the conditions I've tested with). Since `AtomicWaker` is not generic, this should only increase IRAM use by a limited amount.

This is a VERY slight (~10 over 500k counts) perf improvement in the `embassy_executor_benchmark`, and at the same time reduces the binary size by an equally small amount.