### PR TITLE
Inline control of upstream clock nodes

### DIFF
--- a/esp-metadata-generated/src/_generated_esp32.rs
+++ b/esp-metadata-generated/src/_generated_esp32.rs
@@ -1021,33 +1021,31 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_cpu_pll_div_in(clocks: &mut ClockTree, new_selector: CpuPllDivInConfig) {
             let old_selector = clocks.cpu_pll_div_in.replace(new_selector);
-            cpu_pll_div_in_request_upstream(clocks, new_selector);
-            configure_cpu_pll_div_in_impl(clocks, old_selector, new_selector);
-            if let Some(old_selector) = old_selector {
-                cpu_pll_div_in_release_upstream(clocks, old_selector);
-            }
-        }
-        fn cpu_pll_div_in_request_upstream(clocks: &mut ClockTree, selector: CpuPllDivInConfig) {
-            match selector {
+            match new_selector {
                 CpuPllDivInConfig::Pll => request_pll_clk(clocks),
                 CpuPllDivInConfig::Apll => request_apll_clk(clocks),
             }
-        }
-        fn cpu_pll_div_in_release_upstream(clocks: &mut ClockTree, selector: CpuPllDivInConfig) {
-            match selector {
-                CpuPllDivInConfig::Pll => release_pll_clk(clocks),
-                CpuPllDivInConfig::Apll => release_apll_clk(clocks),
+            configure_cpu_pll_div_in_impl(clocks, old_selector, new_selector);
+            if let Some(old_selector) = old_selector {
+                match old_selector {
+                    CpuPllDivInConfig::Pll => release_pll_clk(clocks),
+                    CpuPllDivInConfig::Apll => release_apll_clk(clocks),
+                }
             }
         }
         pub fn request_cpu_pll_div_in(clocks: &mut ClockTree) {
-            let selector = unwrap!(clocks.cpu_pll_div_in);
-            cpu_pll_div_in_request_upstream(clocks, selector);
+            match unwrap!(clocks.cpu_pll_div_in) {
+                CpuPllDivInConfig::Pll => request_pll_clk(clocks),
+                CpuPllDivInConfig::Apll => request_apll_clk(clocks),
+            }
             enable_cpu_pll_div_in_impl(clocks, true);
         }
         pub fn release_cpu_pll_div_in(clocks: &mut ClockTree) {
             enable_cpu_pll_div_in_impl(clocks, false);
-            let selector = unwrap!(clocks.cpu_pll_div_in);
-            cpu_pll_div_in_release_upstream(clocks, selector);
+            match unwrap!(clocks.cpu_pll_div_in) {
+                CpuPllDivInConfig::Pll => release_pll_clk(clocks),
+                CpuPllDivInConfig::Apll => release_apll_clk(clocks),
+            }
         }
         pub fn cpu_pll_div_in_frequency(clocks: &mut ClockTree) -> u32 {
             match unwrap!(clocks.cpu_pll_div_in) {
@@ -1078,39 +1076,31 @@ macro_rules! define_clock_tree_types {
             new_selector: SysconPreDivInConfig,
         ) {
             let old_selector = clocks.syscon_pre_div_in.replace(new_selector);
-            syscon_pre_div_in_request_upstream(clocks, new_selector);
-            configure_syscon_pre_div_in_impl(clocks, old_selector, new_selector);
-            if let Some(old_selector) = old_selector {
-                syscon_pre_div_in_release_upstream(clocks, old_selector);
-            }
-        }
-        fn syscon_pre_div_in_request_upstream(
-            clocks: &mut ClockTree,
-            selector: SysconPreDivInConfig,
-        ) {
-            match selector {
+            match new_selector {
                 SysconPreDivInConfig::Xtal => request_xtal_clk(clocks),
                 SysconPreDivInConfig::RcFast => request_rc_fast_clk(clocks),
             }
-        }
-        fn syscon_pre_div_in_release_upstream(
-            clocks: &mut ClockTree,
-            selector: SysconPreDivInConfig,
-        ) {
-            match selector {
-                SysconPreDivInConfig::Xtal => release_xtal_clk(clocks),
-                SysconPreDivInConfig::RcFast => release_rc_fast_clk(clocks),
+            configure_syscon_pre_div_in_impl(clocks, old_selector, new_selector);
+            if let Some(old_selector) = old_selector {
+                match old_selector {
+                    SysconPreDivInConfig::Xtal => release_xtal_clk(clocks),
+                    SysconPreDivInConfig::RcFast => release_rc_fast_clk(clocks),
+                }
             }
         }
         pub fn request_syscon_pre_div_in(clocks: &mut ClockTree) {
-            let selector = unwrap!(clocks.syscon_pre_div_in);
-            syscon_pre_div_in_request_upstream(clocks, selector);
+            match unwrap!(clocks.syscon_pre_div_in) {
+                SysconPreDivInConfig::Xtal => request_xtal_clk(clocks),
+                SysconPreDivInConfig::RcFast => request_rc_fast_clk(clocks),
+            }
             enable_syscon_pre_div_in_impl(clocks, true);
         }
         pub fn release_syscon_pre_div_in(clocks: &mut ClockTree) {
             enable_syscon_pre_div_in_impl(clocks, false);
-            let selector = unwrap!(clocks.syscon_pre_div_in);
-            syscon_pre_div_in_release_upstream(clocks, selector);
+            match unwrap!(clocks.syscon_pre_div_in) {
+                SysconPreDivInConfig::Xtal => release_xtal_clk(clocks),
+                SysconPreDivInConfig::RcFast => release_rc_fast_clk(clocks),
+            }
         }
         pub fn syscon_pre_div_in_frequency(clocks: &mut ClockTree) -> u32 {
             match unwrap!(clocks.syscon_pre_div_in) {
@@ -1136,41 +1126,41 @@ macro_rules! define_clock_tree_types {
         pub fn configure_apb_clk(clocks: &mut ClockTree, new_selector: ApbClkConfig) {
             let old_selector = clocks.apb_clk.replace(new_selector);
             if clocks.apb_clk_refcount > 0 {
-                apb_clk_request_upstream(clocks, new_selector);
+                match new_selector {
+                    ApbClkConfig::Pll80m => request_apb_clk_80m(clocks),
+                    ApbClkConfig::CpuDiv2 => request_apb_clk_cpu_div2(clocks),
+                    ApbClkConfig::Cpu => request_cpu_clk(clocks),
+                }
                 configure_apb_clk_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
-                    apb_clk_release_upstream(clocks, old_selector);
+                    match old_selector {
+                        ApbClkConfig::Pll80m => release_apb_clk_80m(clocks),
+                        ApbClkConfig::CpuDiv2 => release_apb_clk_cpu_div2(clocks),
+                        ApbClkConfig::Cpu => release_cpu_clk(clocks),
+                    }
                 }
             } else {
                 configure_apb_clk_impl(clocks, old_selector, new_selector);
             }
         }
-        fn apb_clk_request_upstream(clocks: &mut ClockTree, selector: ApbClkConfig) {
-            match selector {
-                ApbClkConfig::Pll80m => request_apb_clk_80m(clocks),
-                ApbClkConfig::CpuDiv2 => request_apb_clk_cpu_div2(clocks),
-                ApbClkConfig::Cpu => request_cpu_clk(clocks),
-            }
-        }
-        fn apb_clk_release_upstream(clocks: &mut ClockTree, selector: ApbClkConfig) {
-            match selector {
-                ApbClkConfig::Pll80m => release_apb_clk_80m(clocks),
-                ApbClkConfig::CpuDiv2 => release_apb_clk_cpu_div2(clocks),
-                ApbClkConfig::Cpu => release_cpu_clk(clocks),
-            }
-        }
         pub fn request_apb_clk(clocks: &mut ClockTree) {
             if increment_reference_count(&mut clocks.apb_clk_refcount) {
-                let selector = unwrap!(clocks.apb_clk);
-                apb_clk_request_upstream(clocks, selector);
+                match unwrap!(clocks.apb_clk) {
+                    ApbClkConfig::Pll80m => request_apb_clk_80m(clocks),
+                    ApbClkConfig::CpuDiv2 => request_apb_clk_cpu_div2(clocks),
+                    ApbClkConfig::Cpu => request_cpu_clk(clocks),
+                }
                 enable_apb_clk_impl(clocks, true);
             }
         }
         pub fn release_apb_clk(clocks: &mut ClockTree) {
             if decrement_reference_count(&mut clocks.apb_clk_refcount) {
                 enable_apb_clk_impl(clocks, false);
-                let selector = unwrap!(clocks.apb_clk);
-                apb_clk_release_upstream(clocks, selector);
+                match unwrap!(clocks.apb_clk) {
+                    ApbClkConfig::Pll80m => release_apb_clk_80m(clocks),
+                    ApbClkConfig::CpuDiv2 => release_apb_clk_cpu_div2(clocks),
+                    ApbClkConfig::Cpu => release_cpu_clk(clocks),
+                }
             }
         }
         pub fn apb_clk_frequency(clocks: &mut ClockTree) -> u32 {
@@ -1183,43 +1173,45 @@ macro_rules! define_clock_tree_types {
         pub fn configure_ref_tick(clocks: &mut ClockTree, new_selector: RefTickConfig) {
             let old_selector = clocks.ref_tick.replace(new_selector);
             if clocks.ref_tick_refcount > 0 {
-                ref_tick_request_upstream(clocks, new_selector);
+                match new_selector {
+                    RefTickConfig::Pll => request_ref_tick_pll(clocks),
+                    RefTickConfig::Apll => request_ref_tick_apll(clocks),
+                    RefTickConfig::Xtal => request_ref_tick_xtal(clocks),
+                    RefTickConfig::Fosc => request_ref_tick_fosc(clocks),
+                }
                 configure_ref_tick_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
-                    ref_tick_release_upstream(clocks, old_selector);
+                    match old_selector {
+                        RefTickConfig::Pll => release_ref_tick_pll(clocks),
+                        RefTickConfig::Apll => release_ref_tick_apll(clocks),
+                        RefTickConfig::Xtal => release_ref_tick_xtal(clocks),
+                        RefTickConfig::Fosc => release_ref_tick_fosc(clocks),
+                    }
                 }
             } else {
                 configure_ref_tick_impl(clocks, old_selector, new_selector);
             }
         }
-        fn ref_tick_request_upstream(clocks: &mut ClockTree, selector: RefTickConfig) {
-            match selector {
-                RefTickConfig::Pll => request_ref_tick_pll(clocks),
-                RefTickConfig::Apll => request_ref_tick_apll(clocks),
-                RefTickConfig::Xtal => request_ref_tick_xtal(clocks),
-                RefTickConfig::Fosc => request_ref_tick_fosc(clocks),
-            }
-        }
-        fn ref_tick_release_upstream(clocks: &mut ClockTree, selector: RefTickConfig) {
-            match selector {
-                RefTickConfig::Pll => release_ref_tick_pll(clocks),
-                RefTickConfig::Apll => release_ref_tick_apll(clocks),
-                RefTickConfig::Xtal => release_ref_tick_xtal(clocks),
-                RefTickConfig::Fosc => release_ref_tick_fosc(clocks),
-            }
-        }
         pub fn request_ref_tick(clocks: &mut ClockTree) {
             if increment_reference_count(&mut clocks.ref_tick_refcount) {
-                let selector = unwrap!(clocks.ref_tick);
-                ref_tick_request_upstream(clocks, selector);
+                match unwrap!(clocks.ref_tick) {
+                    RefTickConfig::Pll => request_ref_tick_pll(clocks),
+                    RefTickConfig::Apll => request_ref_tick_apll(clocks),
+                    RefTickConfig::Xtal => request_ref_tick_xtal(clocks),
+                    RefTickConfig::Fosc => request_ref_tick_fosc(clocks),
+                }
                 enable_ref_tick_impl(clocks, true);
             }
         }
         pub fn release_ref_tick(clocks: &mut ClockTree) {
             if decrement_reference_count(&mut clocks.ref_tick_refcount) {
                 enable_ref_tick_impl(clocks, false);
-                let selector = unwrap!(clocks.ref_tick);
-                ref_tick_release_upstream(clocks, selector);
+                match unwrap!(clocks.ref_tick) {
+                    RefTickConfig::Pll => release_ref_tick_pll(clocks),
+                    RefTickConfig::Apll => release_ref_tick_apll(clocks),
+                    RefTickConfig::Xtal => release_ref_tick_xtal(clocks),
+                    RefTickConfig::Fosc => release_ref_tick_fosc(clocks),
+                }
             }
         }
         pub fn ref_tick_frequency(clocks: &mut ClockTree) -> u32 {
@@ -1326,26 +1318,20 @@ macro_rules! define_clock_tree_types {
                     configure_ref_tick_pll(clocks, config_value);
                 }
             }
-            cpu_clk_request_upstream(clocks, new_selector);
-            configure_cpu_clk_impl(clocks, old_selector, new_selector);
-            if let Some(old_selector) = old_selector {
-                cpu_clk_release_upstream(clocks, old_selector);
-            }
-        }
-        fn cpu_clk_request_upstream(clocks: &mut ClockTree, selector: CpuClkConfig) {
-            match selector {
+            match new_selector {
                 CpuClkConfig::Xtal => request_syscon_pre_div(clocks),
                 CpuClkConfig::RcFast => request_syscon_pre_div(clocks),
                 CpuClkConfig::Apll => request_cpu_pll_div(clocks),
                 CpuClkConfig::Pll => request_cpu_pll_div(clocks),
             }
-        }
-        fn cpu_clk_release_upstream(clocks: &mut ClockTree, selector: CpuClkConfig) {
-            match selector {
-                CpuClkConfig::Xtal => release_syscon_pre_div(clocks),
-                CpuClkConfig::RcFast => release_syscon_pre_div(clocks),
-                CpuClkConfig::Apll => release_cpu_pll_div(clocks),
-                CpuClkConfig::Pll => release_cpu_pll_div(clocks),
+            configure_cpu_clk_impl(clocks, old_selector, new_selector);
+            if let Some(old_selector) = old_selector {
+                match old_selector {
+                    CpuClkConfig::Xtal => release_syscon_pre_div(clocks),
+                    CpuClkConfig::RcFast => release_syscon_pre_div(clocks),
+                    CpuClkConfig::Apll => release_cpu_pll_div(clocks),
+                    CpuClkConfig::Pll => release_cpu_pll_div(clocks),
+                }
             }
         }
         fn request_cpu_clk(_clocks: &mut ClockTree) {}
@@ -1435,41 +1421,41 @@ macro_rules! define_clock_tree_types {
         pub fn configure_rtc_slow_clk(clocks: &mut ClockTree, new_selector: RtcSlowClkConfig) {
             let old_selector = clocks.rtc_slow_clk.replace(new_selector);
             if clocks.rtc_slow_clk_refcount > 0 {
-                rtc_slow_clk_request_upstream(clocks, new_selector);
+                match new_selector {
+                    RtcSlowClkConfig::Xtal => request_xtal32k_clk(clocks),
+                    RtcSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
+                    RtcSlowClkConfig::RcFast => request_rc_fast_div_clk(clocks),
+                }
                 configure_rtc_slow_clk_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
-                    rtc_slow_clk_release_upstream(clocks, old_selector);
+                    match old_selector {
+                        RtcSlowClkConfig::Xtal => release_xtal32k_clk(clocks),
+                        RtcSlowClkConfig::RcSlow => release_rc_slow_clk(clocks),
+                        RtcSlowClkConfig::RcFast => release_rc_fast_div_clk(clocks),
+                    }
                 }
             } else {
                 configure_rtc_slow_clk_impl(clocks, old_selector, new_selector);
             }
         }
-        fn rtc_slow_clk_request_upstream(clocks: &mut ClockTree, selector: RtcSlowClkConfig) {
-            match selector {
-                RtcSlowClkConfig::Xtal => request_xtal32k_clk(clocks),
-                RtcSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
-                RtcSlowClkConfig::RcFast => request_rc_fast_div_clk(clocks),
-            }
-        }
-        fn rtc_slow_clk_release_upstream(clocks: &mut ClockTree, selector: RtcSlowClkConfig) {
-            match selector {
-                RtcSlowClkConfig::Xtal => release_xtal32k_clk(clocks),
-                RtcSlowClkConfig::RcSlow => release_rc_slow_clk(clocks),
-                RtcSlowClkConfig::RcFast => release_rc_fast_div_clk(clocks),
-            }
-        }
         pub fn request_rtc_slow_clk(clocks: &mut ClockTree) {
             if increment_reference_count(&mut clocks.rtc_slow_clk_refcount) {
-                let selector = unwrap!(clocks.rtc_slow_clk);
-                rtc_slow_clk_request_upstream(clocks, selector);
+                match unwrap!(clocks.rtc_slow_clk) {
+                    RtcSlowClkConfig::Xtal => request_xtal32k_clk(clocks),
+                    RtcSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
+                    RtcSlowClkConfig::RcFast => request_rc_fast_div_clk(clocks),
+                }
                 enable_rtc_slow_clk_impl(clocks, true);
             }
         }
         pub fn release_rtc_slow_clk(clocks: &mut ClockTree) {
             if decrement_reference_count(&mut clocks.rtc_slow_clk_refcount) {
                 enable_rtc_slow_clk_impl(clocks, false);
-                let selector = unwrap!(clocks.rtc_slow_clk);
-                rtc_slow_clk_release_upstream(clocks, selector);
+                match unwrap!(clocks.rtc_slow_clk) {
+                    RtcSlowClkConfig::Xtal => release_xtal32k_clk(clocks),
+                    RtcSlowClkConfig::RcSlow => release_rc_slow_clk(clocks),
+                    RtcSlowClkConfig::RcFast => release_rc_fast_div_clk(clocks),
+                }
             }
         }
         pub fn rtc_slow_clk_frequency(clocks: &mut ClockTree) -> u32 {
@@ -1482,39 +1468,37 @@ macro_rules! define_clock_tree_types {
         pub fn configure_rtc_fast_clk(clocks: &mut ClockTree, new_selector: RtcFastClkConfig) {
             let old_selector = clocks.rtc_fast_clk.replace(new_selector);
             if clocks.rtc_fast_clk_refcount > 0 {
-                rtc_fast_clk_request_upstream(clocks, new_selector);
+                match new_selector {
+                    RtcFastClkConfig::Xtal => request_xtal_div_clk(clocks),
+                    RtcFastClkConfig::Rc => request_rc_fast_clk(clocks),
+                }
                 configure_rtc_fast_clk_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
-                    rtc_fast_clk_release_upstream(clocks, old_selector);
+                    match old_selector {
+                        RtcFastClkConfig::Xtal => release_xtal_div_clk(clocks),
+                        RtcFastClkConfig::Rc => release_rc_fast_clk(clocks),
+                    }
                 }
             } else {
                 configure_rtc_fast_clk_impl(clocks, old_selector, new_selector);
             }
         }
-        fn rtc_fast_clk_request_upstream(clocks: &mut ClockTree, selector: RtcFastClkConfig) {
-            match selector {
-                RtcFastClkConfig::Xtal => request_xtal_div_clk(clocks),
-                RtcFastClkConfig::Rc => request_rc_fast_clk(clocks),
-            }
-        }
-        fn rtc_fast_clk_release_upstream(clocks: &mut ClockTree, selector: RtcFastClkConfig) {
-            match selector {
-                RtcFastClkConfig::Xtal => release_xtal_div_clk(clocks),
-                RtcFastClkConfig::Rc => release_rc_fast_clk(clocks),
-            }
-        }
         pub fn request_rtc_fast_clk(clocks: &mut ClockTree) {
             if increment_reference_count(&mut clocks.rtc_fast_clk_refcount) {
-                let selector = unwrap!(clocks.rtc_fast_clk);
-                rtc_fast_clk_request_upstream(clocks, selector);
+                match unwrap!(clocks.rtc_fast_clk) {
+                    RtcFastClkConfig::Xtal => request_xtal_div_clk(clocks),
+                    RtcFastClkConfig::Rc => request_rc_fast_clk(clocks),
+                }
                 enable_rtc_fast_clk_impl(clocks, true);
             }
         }
         pub fn release_rtc_fast_clk(clocks: &mut ClockTree) {
             if decrement_reference_count(&mut clocks.rtc_fast_clk_refcount) {
                 enable_rtc_fast_clk_impl(clocks, false);
-                let selector = unwrap!(clocks.rtc_fast_clk);
-                rtc_fast_clk_release_upstream(clocks, selector);
+                match unwrap!(clocks.rtc_fast_clk) {
+                    RtcFastClkConfig::Xtal => release_xtal_div_clk(clocks),
+                    RtcFastClkConfig::Rc => release_rc_fast_clk(clocks),
+                }
             }
         }
         pub fn rtc_fast_clk_frequency(clocks: &mut ClockTree) -> u32 {
@@ -1529,47 +1513,43 @@ macro_rules! define_clock_tree_types {
         ) {
             let old_selector = clocks.timg0_calibration_clock.replace(new_selector);
             if clocks.timg0_calibration_clock_refcount > 0 {
-                timg0_calibration_clock_request_upstream(clocks, new_selector);
+                match new_selector {
+                    Timg0CalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
+                    Timg0CalibrationClockConfig::RcFastDivClk => request_rc_fast_div_clk(clocks),
+                    Timg0CalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
+                }
                 configure_timg0_calibration_clock_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
-                    timg0_calibration_clock_release_upstream(clocks, old_selector);
+                    match old_selector {
+                        Timg0CalibrationClockConfig::RcSlowClk => release_rc_slow_clk(clocks),
+                        Timg0CalibrationClockConfig::RcFastDivClk => {
+                            release_rc_fast_div_clk(clocks)
+                        }
+                        Timg0CalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
+                    }
                 }
             } else {
                 configure_timg0_calibration_clock_impl(clocks, old_selector, new_selector);
             }
         }
-        fn timg0_calibration_clock_request_upstream(
-            clocks: &mut ClockTree,
-            selector: Timg0CalibrationClockConfig,
-        ) {
-            match selector {
-                Timg0CalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
-                Timg0CalibrationClockConfig::RcFastDivClk => request_rc_fast_div_clk(clocks),
-                Timg0CalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
-            }
-        }
-        fn timg0_calibration_clock_release_upstream(
-            clocks: &mut ClockTree,
-            selector: Timg0CalibrationClockConfig,
-        ) {
-            match selector {
-                Timg0CalibrationClockConfig::RcSlowClk => release_rc_slow_clk(clocks),
-                Timg0CalibrationClockConfig::RcFastDivClk => release_rc_fast_div_clk(clocks),
-                Timg0CalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
-            }
-        }
         pub fn request_timg0_calibration_clock(clocks: &mut ClockTree) {
             if increment_reference_count(&mut clocks.timg0_calibration_clock_refcount) {
-                let selector = unwrap!(clocks.timg0_calibration_clock);
-                timg0_calibration_clock_request_upstream(clocks, selector);
+                match unwrap!(clocks.timg0_calibration_clock) {
+                    Timg0CalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
+                    Timg0CalibrationClockConfig::RcFastDivClk => request_rc_fast_div_clk(clocks),
+                    Timg0CalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
+                }
                 enable_timg0_calibration_clock_impl(clocks, true);
             }
         }
         pub fn release_timg0_calibration_clock(clocks: &mut ClockTree) {
             if decrement_reference_count(&mut clocks.timg0_calibration_clock_refcount) {
                 enable_timg0_calibration_clock_impl(clocks, false);
-                let selector = unwrap!(clocks.timg0_calibration_clock);
-                timg0_calibration_clock_release_upstream(clocks, selector);
+                match unwrap!(clocks.timg0_calibration_clock) {
+                    Timg0CalibrationClockConfig::RcSlowClk => release_rc_slow_clk(clocks),
+                    Timg0CalibrationClockConfig::RcFastDivClk => release_rc_fast_div_clk(clocks),
+                    Timg0CalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
+                }
             }
         }
         pub fn timg0_calibration_clock_frequency(clocks: &mut ClockTree) -> u32 {
@@ -1585,47 +1565,43 @@ macro_rules! define_clock_tree_types {
         ) {
             let old_selector = clocks.timg1_calibration_clock.replace(new_selector);
             if clocks.timg1_calibration_clock_refcount > 0 {
-                timg1_calibration_clock_request_upstream(clocks, new_selector);
+                match new_selector {
+                    Timg0CalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
+                    Timg0CalibrationClockConfig::RcFastDivClk => request_rc_fast_div_clk(clocks),
+                    Timg0CalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
+                }
                 configure_timg1_calibration_clock_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
-                    timg1_calibration_clock_release_upstream(clocks, old_selector);
+                    match old_selector {
+                        Timg0CalibrationClockConfig::RcSlowClk => release_rc_slow_clk(clocks),
+                        Timg0CalibrationClockConfig::RcFastDivClk => {
+                            release_rc_fast_div_clk(clocks)
+                        }
+                        Timg0CalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
+                    }
                 }
             } else {
                 configure_timg1_calibration_clock_impl(clocks, old_selector, new_selector);
             }
         }
-        fn timg1_calibration_clock_request_upstream(
-            clocks: &mut ClockTree,
-            selector: Timg0CalibrationClockConfig,
-        ) {
-            match selector {
-                Timg0CalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
-                Timg0CalibrationClockConfig::RcFastDivClk => request_rc_fast_div_clk(clocks),
-                Timg0CalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
-            }
-        }
-        fn timg1_calibration_clock_release_upstream(
-            clocks: &mut ClockTree,
-            selector: Timg0CalibrationClockConfig,
-        ) {
-            match selector {
-                Timg0CalibrationClockConfig::RcSlowClk => release_rc_slow_clk(clocks),
-                Timg0CalibrationClockConfig::RcFastDivClk => release_rc_fast_div_clk(clocks),
-                Timg0CalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
-            }
-        }
         pub fn request_timg1_calibration_clock(clocks: &mut ClockTree) {
             if increment_reference_count(&mut clocks.timg1_calibration_clock_refcount) {
-                let selector = unwrap!(clocks.timg1_calibration_clock);
-                timg1_calibration_clock_request_upstream(clocks, selector);
+                match unwrap!(clocks.timg1_calibration_clock) {
+                    Timg0CalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
+                    Timg0CalibrationClockConfig::RcFastDivClk => request_rc_fast_div_clk(clocks),
+                    Timg0CalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
+                }
                 enable_timg1_calibration_clock_impl(clocks, true);
             }
         }
         pub fn release_timg1_calibration_clock(clocks: &mut ClockTree) {
             if decrement_reference_count(&mut clocks.timg1_calibration_clock_refcount) {
                 enable_timg1_calibration_clock_impl(clocks, false);
-                let selector = unwrap!(clocks.timg1_calibration_clock);
-                timg1_calibration_clock_release_upstream(clocks, selector);
+                match unwrap!(clocks.timg1_calibration_clock) {
+                    Timg0CalibrationClockConfig::RcSlowClk => release_rc_slow_clk(clocks),
+                    Timg0CalibrationClockConfig::RcFastDivClk => release_rc_fast_div_clk(clocks),
+                    Timg0CalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
+                }
             }
         }
         pub fn timg1_calibration_clock_frequency(clocks: &mut ClockTree) -> u32 {

--- a/esp-metadata-generated/src/_generated_esp32c2.rs
+++ b/esp-metadata-generated/src/_generated_esp32c2.rs
@@ -847,39 +847,31 @@ macro_rules! define_clock_tree_types {
             new_selector: SystemPreDivInConfig,
         ) {
             let old_selector = clocks.system_pre_div_in.replace(new_selector);
-            system_pre_div_in_request_upstream(clocks, new_selector);
-            configure_system_pre_div_in_impl(clocks, old_selector, new_selector);
-            if let Some(old_selector) = old_selector {
-                system_pre_div_in_release_upstream(clocks, old_selector);
-            }
-        }
-        fn system_pre_div_in_request_upstream(
-            clocks: &mut ClockTree,
-            selector: SystemPreDivInConfig,
-        ) {
-            match selector {
+            match new_selector {
                 SystemPreDivInConfig::Xtal => request_xtal_clk(clocks),
                 SystemPreDivInConfig::RcFast => request_rc_fast_clk(clocks),
             }
-        }
-        fn system_pre_div_in_release_upstream(
-            clocks: &mut ClockTree,
-            selector: SystemPreDivInConfig,
-        ) {
-            match selector {
-                SystemPreDivInConfig::Xtal => release_xtal_clk(clocks),
-                SystemPreDivInConfig::RcFast => release_rc_fast_clk(clocks),
+            configure_system_pre_div_in_impl(clocks, old_selector, new_selector);
+            if let Some(old_selector) = old_selector {
+                match old_selector {
+                    SystemPreDivInConfig::Xtal => release_xtal_clk(clocks),
+                    SystemPreDivInConfig::RcFast => release_rc_fast_clk(clocks),
+                }
             }
         }
         pub fn request_system_pre_div_in(clocks: &mut ClockTree) {
-            let selector = unwrap!(clocks.system_pre_div_in);
-            system_pre_div_in_request_upstream(clocks, selector);
+            match unwrap!(clocks.system_pre_div_in) {
+                SystemPreDivInConfig::Xtal => request_xtal_clk(clocks),
+                SystemPreDivInConfig::RcFast => request_rc_fast_clk(clocks),
+            }
             enable_system_pre_div_in_impl(clocks, true);
         }
         pub fn release_system_pre_div_in(clocks: &mut ClockTree) {
             enable_system_pre_div_in_impl(clocks, false);
-            let selector = unwrap!(clocks.system_pre_div_in);
-            system_pre_div_in_release_upstream(clocks, selector);
+            match unwrap!(clocks.system_pre_div_in) {
+                SystemPreDivInConfig::Xtal => release_xtal_clk(clocks),
+                SystemPreDivInConfig::RcFast => release_rc_fast_clk(clocks),
+            }
         }
         pub fn system_pre_div_in_frequency(clocks: &mut ClockTree) -> u32 {
             match unwrap!(clocks.system_pre_div_in) {
@@ -920,39 +912,37 @@ macro_rules! define_clock_tree_types {
         pub fn configure_apb_clk(clocks: &mut ClockTree, new_selector: ApbClkConfig) {
             let old_selector = clocks.apb_clk.replace(new_selector);
             if clocks.apb_clk_refcount > 0 {
-                apb_clk_request_upstream(clocks, new_selector);
+                match new_selector {
+                    ApbClkConfig::Pll40m => request_pll_40m(clocks),
+                    ApbClkConfig::Cpu => request_cpu_clk(clocks),
+                }
                 configure_apb_clk_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
-                    apb_clk_release_upstream(clocks, old_selector);
+                    match old_selector {
+                        ApbClkConfig::Pll40m => release_pll_40m(clocks),
+                        ApbClkConfig::Cpu => release_cpu_clk(clocks),
+                    }
                 }
             } else {
                 configure_apb_clk_impl(clocks, old_selector, new_selector);
             }
         }
-        fn apb_clk_request_upstream(clocks: &mut ClockTree, selector: ApbClkConfig) {
-            match selector {
-                ApbClkConfig::Pll40m => request_pll_40m(clocks),
-                ApbClkConfig::Cpu => request_cpu_clk(clocks),
-            }
-        }
-        fn apb_clk_release_upstream(clocks: &mut ClockTree, selector: ApbClkConfig) {
-            match selector {
-                ApbClkConfig::Pll40m => release_pll_40m(clocks),
-                ApbClkConfig::Cpu => release_cpu_clk(clocks),
-            }
-        }
         pub fn request_apb_clk(clocks: &mut ClockTree) {
             if increment_reference_count(&mut clocks.apb_clk_refcount) {
-                let selector = unwrap!(clocks.apb_clk);
-                apb_clk_request_upstream(clocks, selector);
+                match unwrap!(clocks.apb_clk) {
+                    ApbClkConfig::Pll40m => request_pll_40m(clocks),
+                    ApbClkConfig::Cpu => request_cpu_clk(clocks),
+                }
                 enable_apb_clk_impl(clocks, true);
             }
         }
         pub fn release_apb_clk(clocks: &mut ClockTree) {
             if decrement_reference_count(&mut clocks.apb_clk_refcount) {
                 enable_apb_clk_impl(clocks, false);
-                let selector = unwrap!(clocks.apb_clk);
-                apb_clk_release_upstream(clocks, selector);
+                match unwrap!(clocks.apb_clk) {
+                    ApbClkConfig::Pll40m => release_pll_40m(clocks),
+                    ApbClkConfig::Cpu => release_cpu_clk(clocks),
+                }
             }
         }
         pub fn apb_clk_frequency(clocks: &mut ClockTree) -> u32 {
@@ -964,39 +954,37 @@ macro_rules! define_clock_tree_types {
         pub fn configure_crypto_clk(clocks: &mut ClockTree, new_selector: CryptoClkConfig) {
             let old_selector = clocks.crypto_clk.replace(new_selector);
             if clocks.crypto_clk_refcount > 0 {
-                crypto_clk_request_upstream(clocks, new_selector);
+                match new_selector {
+                    CryptoClkConfig::Pll80m => request_pll_80m(clocks),
+                    CryptoClkConfig::Cpu => request_cpu_clk(clocks),
+                }
                 configure_crypto_clk_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
-                    crypto_clk_release_upstream(clocks, old_selector);
+                    match old_selector {
+                        CryptoClkConfig::Pll80m => release_pll_80m(clocks),
+                        CryptoClkConfig::Cpu => release_cpu_clk(clocks),
+                    }
                 }
             } else {
                 configure_crypto_clk_impl(clocks, old_selector, new_selector);
             }
         }
-        fn crypto_clk_request_upstream(clocks: &mut ClockTree, selector: CryptoClkConfig) {
-            match selector {
-                CryptoClkConfig::Pll80m => request_pll_80m(clocks),
-                CryptoClkConfig::Cpu => request_cpu_clk(clocks),
-            }
-        }
-        fn crypto_clk_release_upstream(clocks: &mut ClockTree, selector: CryptoClkConfig) {
-            match selector {
-                CryptoClkConfig::Pll80m => release_pll_80m(clocks),
-                CryptoClkConfig::Cpu => release_cpu_clk(clocks),
-            }
-        }
         pub fn request_crypto_clk(clocks: &mut ClockTree) {
             if increment_reference_count(&mut clocks.crypto_clk_refcount) {
-                let selector = unwrap!(clocks.crypto_clk);
-                crypto_clk_request_upstream(clocks, selector);
+                match unwrap!(clocks.crypto_clk) {
+                    CryptoClkConfig::Pll80m => request_pll_80m(clocks),
+                    CryptoClkConfig::Cpu => request_cpu_clk(clocks),
+                }
                 enable_crypto_clk_impl(clocks, true);
             }
         }
         pub fn release_crypto_clk(clocks: &mut ClockTree) {
             if decrement_reference_count(&mut clocks.crypto_clk_refcount) {
                 enable_crypto_clk_impl(clocks, false);
-                let selector = unwrap!(clocks.crypto_clk);
-                crypto_clk_release_upstream(clocks, selector);
+                match unwrap!(clocks.crypto_clk) {
+                    CryptoClkConfig::Pll80m => release_pll_80m(clocks),
+                    CryptoClkConfig::Cpu => release_cpu_clk(clocks),
+                }
             }
         }
         pub fn crypto_clk_frequency(clocks: &mut ClockTree) -> u32 {
@@ -1008,39 +996,37 @@ macro_rules! define_clock_tree_types {
         pub fn configure_mspi_clk(clocks: &mut ClockTree, new_selector: MspiClkConfig) {
             let old_selector = clocks.mspi_clk.replace(new_selector);
             if clocks.mspi_clk_refcount > 0 {
-                mspi_clk_request_upstream(clocks, new_selector);
+                match new_selector {
+                    MspiClkConfig::CpuDiv2 => request_cpu_div2(clocks),
+                    MspiClkConfig::Cpu => request_cpu_clk(clocks),
+                }
                 configure_mspi_clk_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
-                    mspi_clk_release_upstream(clocks, old_selector);
+                    match old_selector {
+                        MspiClkConfig::CpuDiv2 => release_cpu_div2(clocks),
+                        MspiClkConfig::Cpu => release_cpu_clk(clocks),
+                    }
                 }
             } else {
                 configure_mspi_clk_impl(clocks, old_selector, new_selector);
             }
         }
-        fn mspi_clk_request_upstream(clocks: &mut ClockTree, selector: MspiClkConfig) {
-            match selector {
-                MspiClkConfig::CpuDiv2 => request_cpu_div2(clocks),
-                MspiClkConfig::Cpu => request_cpu_clk(clocks),
-            }
-        }
-        fn mspi_clk_release_upstream(clocks: &mut ClockTree, selector: MspiClkConfig) {
-            match selector {
-                MspiClkConfig::CpuDiv2 => release_cpu_div2(clocks),
-                MspiClkConfig::Cpu => release_cpu_clk(clocks),
-            }
-        }
         pub fn request_mspi_clk(clocks: &mut ClockTree) {
             if increment_reference_count(&mut clocks.mspi_clk_refcount) {
-                let selector = unwrap!(clocks.mspi_clk);
-                mspi_clk_request_upstream(clocks, selector);
+                match unwrap!(clocks.mspi_clk) {
+                    MspiClkConfig::CpuDiv2 => request_cpu_div2(clocks),
+                    MspiClkConfig::Cpu => request_cpu_clk(clocks),
+                }
                 enable_mspi_clk_impl(clocks, true);
             }
         }
         pub fn release_mspi_clk(clocks: &mut ClockTree) {
             if decrement_reference_count(&mut clocks.mspi_clk_refcount) {
                 enable_mspi_clk_impl(clocks, false);
-                let selector = unwrap!(clocks.mspi_clk);
-                mspi_clk_release_upstream(clocks, selector);
+                match unwrap!(clocks.mspi_clk) {
+                    MspiClkConfig::CpuDiv2 => release_cpu_div2(clocks),
+                    MspiClkConfig::Cpu => release_cpu_clk(clocks),
+                }
             }
         }
         pub fn mspi_clk_frequency(clocks: &mut ClockTree) -> u32 {
@@ -1070,24 +1056,18 @@ macro_rules! define_clock_tree_types {
                     configure_mspi_clk(clocks, MspiClkConfig::CpuDiv2);
                 }
             }
-            cpu_clk_request_upstream(clocks, new_selector);
-            configure_cpu_clk_impl(clocks, old_selector, new_selector);
-            if let Some(old_selector) = old_selector {
-                cpu_clk_release_upstream(clocks, old_selector);
-            }
-        }
-        fn cpu_clk_request_upstream(clocks: &mut ClockTree, selector: CpuClkConfig) {
-            match selector {
+            match new_selector {
                 CpuClkConfig::Xtal => request_system_pre_div(clocks),
                 CpuClkConfig::RcFast => request_system_pre_div(clocks),
                 CpuClkConfig::Pll => request_cpu_pll_div(clocks),
             }
-        }
-        fn cpu_clk_release_upstream(clocks: &mut ClockTree, selector: CpuClkConfig) {
-            match selector {
-                CpuClkConfig::Xtal => release_system_pre_div(clocks),
-                CpuClkConfig::RcFast => release_system_pre_div(clocks),
-                CpuClkConfig::Pll => release_cpu_pll_div(clocks),
+            configure_cpu_clk_impl(clocks, old_selector, new_selector);
+            if let Some(old_selector) = old_selector {
+                match old_selector {
+                    CpuClkConfig::Xtal => release_system_pre_div(clocks),
+                    CpuClkConfig::RcFast => release_system_pre_div(clocks),
+                    CpuClkConfig::Pll => release_cpu_pll_div(clocks),
+                }
             }
         }
         fn request_cpu_clk(_clocks: &mut ClockTree) {}
@@ -1179,35 +1159,35 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_rtc_slow_clk(clocks: &mut ClockTree, new_selector: RtcSlowClkConfig) {
             let old_selector = clocks.rtc_slow_clk.replace(new_selector);
-            rtc_slow_clk_request_upstream(clocks, new_selector);
-            configure_rtc_slow_clk_impl(clocks, old_selector, new_selector);
-            if let Some(old_selector) = old_selector {
-                rtc_slow_clk_release_upstream(clocks, old_selector);
-            }
-        }
-        fn rtc_slow_clk_request_upstream(clocks: &mut ClockTree, selector: RtcSlowClkConfig) {
-            match selector {
+            match new_selector {
                 RtcSlowClkConfig::OscSlow => request_osc_slow_clk(clocks),
                 RtcSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
                 RtcSlowClkConfig::RcFast => request_rc_fast_div_clk(clocks),
             }
-        }
-        fn rtc_slow_clk_release_upstream(clocks: &mut ClockTree, selector: RtcSlowClkConfig) {
-            match selector {
-                RtcSlowClkConfig::OscSlow => release_osc_slow_clk(clocks),
-                RtcSlowClkConfig::RcSlow => release_rc_slow_clk(clocks),
-                RtcSlowClkConfig::RcFast => release_rc_fast_div_clk(clocks),
+            configure_rtc_slow_clk_impl(clocks, old_selector, new_selector);
+            if let Some(old_selector) = old_selector {
+                match old_selector {
+                    RtcSlowClkConfig::OscSlow => release_osc_slow_clk(clocks),
+                    RtcSlowClkConfig::RcSlow => release_rc_slow_clk(clocks),
+                    RtcSlowClkConfig::RcFast => release_rc_fast_div_clk(clocks),
+                }
             }
         }
         pub fn request_rtc_slow_clk(clocks: &mut ClockTree) {
-            let selector = unwrap!(clocks.rtc_slow_clk);
-            rtc_slow_clk_request_upstream(clocks, selector);
+            match unwrap!(clocks.rtc_slow_clk) {
+                RtcSlowClkConfig::OscSlow => request_osc_slow_clk(clocks),
+                RtcSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
+                RtcSlowClkConfig::RcFast => request_rc_fast_div_clk(clocks),
+            }
             enable_rtc_slow_clk_impl(clocks, true);
         }
         pub fn release_rtc_slow_clk(clocks: &mut ClockTree) {
             enable_rtc_slow_clk_impl(clocks, false);
-            let selector = unwrap!(clocks.rtc_slow_clk);
-            rtc_slow_clk_release_upstream(clocks, selector);
+            match unwrap!(clocks.rtc_slow_clk) {
+                RtcSlowClkConfig::OscSlow => release_osc_slow_clk(clocks),
+                RtcSlowClkConfig::RcSlow => release_rc_slow_clk(clocks),
+                RtcSlowClkConfig::RcFast => release_rc_fast_div_clk(clocks),
+            }
         }
         pub fn rtc_slow_clk_frequency(clocks: &mut ClockTree) -> u32 {
             match unwrap!(clocks.rtc_slow_clk) {
@@ -1219,39 +1199,37 @@ macro_rules! define_clock_tree_types {
         pub fn configure_rtc_fast_clk(clocks: &mut ClockTree, new_selector: RtcFastClkConfig) {
             let old_selector = clocks.rtc_fast_clk.replace(new_selector);
             if clocks.rtc_fast_clk_refcount > 0 {
-                rtc_fast_clk_request_upstream(clocks, new_selector);
+                match new_selector {
+                    RtcFastClkConfig::Xtal => request_xtal_div_clk(clocks),
+                    RtcFastClkConfig::Rc => request_rc_fast_clk_div_n(clocks),
+                }
                 configure_rtc_fast_clk_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
-                    rtc_fast_clk_release_upstream(clocks, old_selector);
+                    match old_selector {
+                        RtcFastClkConfig::Xtal => release_xtal_div_clk(clocks),
+                        RtcFastClkConfig::Rc => release_rc_fast_clk_div_n(clocks),
+                    }
                 }
             } else {
                 configure_rtc_fast_clk_impl(clocks, old_selector, new_selector);
             }
         }
-        fn rtc_fast_clk_request_upstream(clocks: &mut ClockTree, selector: RtcFastClkConfig) {
-            match selector {
-                RtcFastClkConfig::Xtal => request_xtal_div_clk(clocks),
-                RtcFastClkConfig::Rc => request_rc_fast_clk_div_n(clocks),
-            }
-        }
-        fn rtc_fast_clk_release_upstream(clocks: &mut ClockTree, selector: RtcFastClkConfig) {
-            match selector {
-                RtcFastClkConfig::Xtal => release_xtal_div_clk(clocks),
-                RtcFastClkConfig::Rc => release_rc_fast_clk_div_n(clocks),
-            }
-        }
         pub fn request_rtc_fast_clk(clocks: &mut ClockTree) {
             if increment_reference_count(&mut clocks.rtc_fast_clk_refcount) {
-                let selector = unwrap!(clocks.rtc_fast_clk);
-                rtc_fast_clk_request_upstream(clocks, selector);
+                match unwrap!(clocks.rtc_fast_clk) {
+                    RtcFastClkConfig::Xtal => request_xtal_div_clk(clocks),
+                    RtcFastClkConfig::Rc => request_rc_fast_clk_div_n(clocks),
+                }
                 enable_rtc_fast_clk_impl(clocks, true);
             }
         }
         pub fn release_rtc_fast_clk(clocks: &mut ClockTree) {
             if decrement_reference_count(&mut clocks.rtc_fast_clk_refcount) {
                 enable_rtc_fast_clk_impl(clocks, false);
-                let selector = unwrap!(clocks.rtc_fast_clk);
-                rtc_fast_clk_release_upstream(clocks, selector);
+                match unwrap!(clocks.rtc_fast_clk) {
+                    RtcFastClkConfig::Xtal => release_xtal_div_clk(clocks),
+                    RtcFastClkConfig::Rc => release_rc_fast_clk_div_n(clocks),
+                }
             }
         }
         pub fn rtc_fast_clk_frequency(clocks: &mut ClockTree) -> u32 {
@@ -1263,43 +1241,45 @@ macro_rules! define_clock_tree_types {
         pub fn configure_low_power_clk(clocks: &mut ClockTree, new_selector: LowPowerClkConfig) {
             let old_selector = clocks.low_power_clk.replace(new_selector);
             if clocks.low_power_clk_refcount > 0 {
-                low_power_clk_request_upstream(clocks, new_selector);
+                match new_selector {
+                    LowPowerClkConfig::Xtal => request_xtal_clk(clocks),
+                    LowPowerClkConfig::RcFast => request_rc_fast_clk(clocks),
+                    LowPowerClkConfig::OscSlow => request_osc_slow_clk(clocks),
+                    LowPowerClkConfig::RtcSlow => request_rtc_slow_clk(clocks),
+                }
                 configure_low_power_clk_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
-                    low_power_clk_release_upstream(clocks, old_selector);
+                    match old_selector {
+                        LowPowerClkConfig::Xtal => release_xtal_clk(clocks),
+                        LowPowerClkConfig::RcFast => release_rc_fast_clk(clocks),
+                        LowPowerClkConfig::OscSlow => release_osc_slow_clk(clocks),
+                        LowPowerClkConfig::RtcSlow => release_rtc_slow_clk(clocks),
+                    }
                 }
             } else {
                 configure_low_power_clk_impl(clocks, old_selector, new_selector);
             }
         }
-        fn low_power_clk_request_upstream(clocks: &mut ClockTree, selector: LowPowerClkConfig) {
-            match selector {
-                LowPowerClkConfig::Xtal => request_xtal_clk(clocks),
-                LowPowerClkConfig::RcFast => request_rc_fast_clk(clocks),
-                LowPowerClkConfig::OscSlow => request_osc_slow_clk(clocks),
-                LowPowerClkConfig::RtcSlow => request_rtc_slow_clk(clocks),
-            }
-        }
-        fn low_power_clk_release_upstream(clocks: &mut ClockTree, selector: LowPowerClkConfig) {
-            match selector {
-                LowPowerClkConfig::Xtal => release_xtal_clk(clocks),
-                LowPowerClkConfig::RcFast => release_rc_fast_clk(clocks),
-                LowPowerClkConfig::OscSlow => release_osc_slow_clk(clocks),
-                LowPowerClkConfig::RtcSlow => release_rtc_slow_clk(clocks),
-            }
-        }
         pub fn request_low_power_clk(clocks: &mut ClockTree) {
             if increment_reference_count(&mut clocks.low_power_clk_refcount) {
-                let selector = unwrap!(clocks.low_power_clk);
-                low_power_clk_request_upstream(clocks, selector);
+                match unwrap!(clocks.low_power_clk) {
+                    LowPowerClkConfig::Xtal => request_xtal_clk(clocks),
+                    LowPowerClkConfig::RcFast => request_rc_fast_clk(clocks),
+                    LowPowerClkConfig::OscSlow => request_osc_slow_clk(clocks),
+                    LowPowerClkConfig::RtcSlow => request_rtc_slow_clk(clocks),
+                }
                 enable_low_power_clk_impl(clocks, true);
             }
         }
         pub fn release_low_power_clk(clocks: &mut ClockTree) {
             if decrement_reference_count(&mut clocks.low_power_clk_refcount) {
                 enable_low_power_clk_impl(clocks, false);
-                let selector = unwrap!(clocks.low_power_clk);
-                low_power_clk_release_upstream(clocks, selector);
+                match unwrap!(clocks.low_power_clk) {
+                    LowPowerClkConfig::Xtal => release_xtal_clk(clocks),
+                    LowPowerClkConfig::RcFast => release_rc_fast_clk(clocks),
+                    LowPowerClkConfig::OscSlow => release_osc_slow_clk(clocks),
+                    LowPowerClkConfig::RtcSlow => release_rtc_slow_clk(clocks),
+                }
             }
         }
         pub fn low_power_clk_frequency(clocks: &mut ClockTree) -> u32 {
@@ -1316,45 +1296,37 @@ macro_rules! define_clock_tree_types {
         ) {
             let old_selector = clocks.timg0_function_clock.replace(new_selector);
             if clocks.timg0_function_clock_refcount > 0 {
-                timg0_function_clock_request_upstream(clocks, new_selector);
+                match new_selector {
+                    Timg0FunctionClockConfig::XtalClk => request_xtal_clk(clocks),
+                    Timg0FunctionClockConfig::Pll40m => request_pll_40m(clocks),
+                }
                 configure_timg0_function_clock_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
-                    timg0_function_clock_release_upstream(clocks, old_selector);
+                    match old_selector {
+                        Timg0FunctionClockConfig::XtalClk => release_xtal_clk(clocks),
+                        Timg0FunctionClockConfig::Pll40m => release_pll_40m(clocks),
+                    }
                 }
             } else {
                 configure_timg0_function_clock_impl(clocks, old_selector, new_selector);
             }
         }
-        fn timg0_function_clock_request_upstream(
-            clocks: &mut ClockTree,
-            selector: Timg0FunctionClockConfig,
-        ) {
-            match selector {
-                Timg0FunctionClockConfig::XtalClk => request_xtal_clk(clocks),
-                Timg0FunctionClockConfig::Pll40m => request_pll_40m(clocks),
-            }
-        }
-        fn timg0_function_clock_release_upstream(
-            clocks: &mut ClockTree,
-            selector: Timg0FunctionClockConfig,
-        ) {
-            match selector {
-                Timg0FunctionClockConfig::XtalClk => release_xtal_clk(clocks),
-                Timg0FunctionClockConfig::Pll40m => release_pll_40m(clocks),
-            }
-        }
         pub fn request_timg0_function_clock(clocks: &mut ClockTree) {
             if increment_reference_count(&mut clocks.timg0_function_clock_refcount) {
-                let selector = unwrap!(clocks.timg0_function_clock);
-                timg0_function_clock_request_upstream(clocks, selector);
+                match unwrap!(clocks.timg0_function_clock) {
+                    Timg0FunctionClockConfig::XtalClk => request_xtal_clk(clocks),
+                    Timg0FunctionClockConfig::Pll40m => request_pll_40m(clocks),
+                }
                 enable_timg0_function_clock_impl(clocks, true);
             }
         }
         pub fn release_timg0_function_clock(clocks: &mut ClockTree) {
             if decrement_reference_count(&mut clocks.timg0_function_clock_refcount) {
                 enable_timg0_function_clock_impl(clocks, false);
-                let selector = unwrap!(clocks.timg0_function_clock);
-                timg0_function_clock_release_upstream(clocks, selector);
+                match unwrap!(clocks.timg0_function_clock) {
+                    Timg0FunctionClockConfig::XtalClk => release_xtal_clk(clocks),
+                    Timg0FunctionClockConfig::Pll40m => release_pll_40m(clocks),
+                }
             }
         }
         pub fn timg0_function_clock_frequency(clocks: &mut ClockTree) -> u32 {
@@ -1369,47 +1341,43 @@ macro_rules! define_clock_tree_types {
         ) {
             let old_selector = clocks.timg0_calibration_clock.replace(new_selector);
             if clocks.timg0_calibration_clock_refcount > 0 {
-                timg0_calibration_clock_request_upstream(clocks, new_selector);
+                match new_selector {
+                    Timg0CalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
+                    Timg0CalibrationClockConfig::RcFastDivClk => request_rc_fast_div_clk(clocks),
+                    Timg0CalibrationClockConfig::Osc32kClk => request_osc_slow_clk(clocks),
+                }
                 configure_timg0_calibration_clock_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
-                    timg0_calibration_clock_release_upstream(clocks, old_selector);
+                    match old_selector {
+                        Timg0CalibrationClockConfig::RcSlowClk => release_rc_slow_clk(clocks),
+                        Timg0CalibrationClockConfig::RcFastDivClk => {
+                            release_rc_fast_div_clk(clocks)
+                        }
+                        Timg0CalibrationClockConfig::Osc32kClk => release_osc_slow_clk(clocks),
+                    }
                 }
             } else {
                 configure_timg0_calibration_clock_impl(clocks, old_selector, new_selector);
             }
         }
-        fn timg0_calibration_clock_request_upstream(
-            clocks: &mut ClockTree,
-            selector: Timg0CalibrationClockConfig,
-        ) {
-            match selector {
-                Timg0CalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
-                Timg0CalibrationClockConfig::RcFastDivClk => request_rc_fast_div_clk(clocks),
-                Timg0CalibrationClockConfig::Osc32kClk => request_osc_slow_clk(clocks),
-            }
-        }
-        fn timg0_calibration_clock_release_upstream(
-            clocks: &mut ClockTree,
-            selector: Timg0CalibrationClockConfig,
-        ) {
-            match selector {
-                Timg0CalibrationClockConfig::RcSlowClk => release_rc_slow_clk(clocks),
-                Timg0CalibrationClockConfig::RcFastDivClk => release_rc_fast_div_clk(clocks),
-                Timg0CalibrationClockConfig::Osc32kClk => release_osc_slow_clk(clocks),
-            }
-        }
         pub fn request_timg0_calibration_clock(clocks: &mut ClockTree) {
             if increment_reference_count(&mut clocks.timg0_calibration_clock_refcount) {
-                let selector = unwrap!(clocks.timg0_calibration_clock);
-                timg0_calibration_clock_request_upstream(clocks, selector);
+                match unwrap!(clocks.timg0_calibration_clock) {
+                    Timg0CalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
+                    Timg0CalibrationClockConfig::RcFastDivClk => request_rc_fast_div_clk(clocks),
+                    Timg0CalibrationClockConfig::Osc32kClk => request_osc_slow_clk(clocks),
+                }
                 enable_timg0_calibration_clock_impl(clocks, true);
             }
         }
         pub fn release_timg0_calibration_clock(clocks: &mut ClockTree) {
             if decrement_reference_count(&mut clocks.timg0_calibration_clock_refcount) {
                 enable_timg0_calibration_clock_impl(clocks, false);
-                let selector = unwrap!(clocks.timg0_calibration_clock);
-                timg0_calibration_clock_release_upstream(clocks, selector);
+                match unwrap!(clocks.timg0_calibration_clock) {
+                    Timg0CalibrationClockConfig::RcSlowClk => release_rc_slow_clk(clocks),
+                    Timg0CalibrationClockConfig::RcFastDivClk => release_rc_fast_div_clk(clocks),
+                    Timg0CalibrationClockConfig::Osc32kClk => release_osc_slow_clk(clocks),
+                }
             }
         }
         pub fn timg0_calibration_clock_frequency(clocks: &mut ClockTree) -> u32 {

--- a/esp-metadata-generated/src/_generated_esp32c3.rs
+++ b/esp-metadata-generated/src/_generated_esp32c3.rs
@@ -931,39 +931,31 @@ macro_rules! define_clock_tree_types {
             new_selector: SystemPreDivInConfig,
         ) {
             let old_selector = clocks.system_pre_div_in.replace(new_selector);
-            system_pre_div_in_request_upstream(clocks, new_selector);
-            configure_system_pre_div_in_impl(clocks, old_selector, new_selector);
-            if let Some(old_selector) = old_selector {
-                system_pre_div_in_release_upstream(clocks, old_selector);
-            }
-        }
-        fn system_pre_div_in_request_upstream(
-            clocks: &mut ClockTree,
-            selector: SystemPreDivInConfig,
-        ) {
-            match selector {
+            match new_selector {
                 SystemPreDivInConfig::Xtal => request_xtal_clk(clocks),
                 SystemPreDivInConfig::RcFast => request_rc_fast_clk(clocks),
             }
-        }
-        fn system_pre_div_in_release_upstream(
-            clocks: &mut ClockTree,
-            selector: SystemPreDivInConfig,
-        ) {
-            match selector {
-                SystemPreDivInConfig::Xtal => release_xtal_clk(clocks),
-                SystemPreDivInConfig::RcFast => release_rc_fast_clk(clocks),
+            configure_system_pre_div_in_impl(clocks, old_selector, new_selector);
+            if let Some(old_selector) = old_selector {
+                match old_selector {
+                    SystemPreDivInConfig::Xtal => release_xtal_clk(clocks),
+                    SystemPreDivInConfig::RcFast => release_rc_fast_clk(clocks),
+                }
             }
         }
         pub fn request_system_pre_div_in(clocks: &mut ClockTree) {
-            let selector = unwrap!(clocks.system_pre_div_in);
-            system_pre_div_in_request_upstream(clocks, selector);
+            match unwrap!(clocks.system_pre_div_in) {
+                SystemPreDivInConfig::Xtal => request_xtal_clk(clocks),
+                SystemPreDivInConfig::RcFast => request_rc_fast_clk(clocks),
+            }
             enable_system_pre_div_in_impl(clocks, true);
         }
         pub fn release_system_pre_div_in(clocks: &mut ClockTree) {
             enable_system_pre_div_in_impl(clocks, false);
-            let selector = unwrap!(clocks.system_pre_div_in);
-            system_pre_div_in_release_upstream(clocks, selector);
+            match unwrap!(clocks.system_pre_div_in) {
+                SystemPreDivInConfig::Xtal => release_xtal_clk(clocks),
+                SystemPreDivInConfig::RcFast => release_rc_fast_clk(clocks),
+            }
         }
         pub fn system_pre_div_in_frequency(clocks: &mut ClockTree) -> u32 {
             match unwrap!(clocks.system_pre_div_in) {
@@ -1004,39 +996,37 @@ macro_rules! define_clock_tree_types {
         pub fn configure_apb_clk(clocks: &mut ClockTree, new_selector: ApbClkConfig) {
             let old_selector = clocks.apb_clk.replace(new_selector);
             if clocks.apb_clk_refcount > 0 {
-                apb_clk_request_upstream(clocks, new_selector);
+                match new_selector {
+                    ApbClkConfig::Pll80m => request_pll_80m(clocks),
+                    ApbClkConfig::Cpu => request_cpu_clk(clocks),
+                }
                 configure_apb_clk_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
-                    apb_clk_release_upstream(clocks, old_selector);
+                    match old_selector {
+                        ApbClkConfig::Pll80m => release_pll_80m(clocks),
+                        ApbClkConfig::Cpu => release_cpu_clk(clocks),
+                    }
                 }
             } else {
                 configure_apb_clk_impl(clocks, old_selector, new_selector);
             }
         }
-        fn apb_clk_request_upstream(clocks: &mut ClockTree, selector: ApbClkConfig) {
-            match selector {
-                ApbClkConfig::Pll80m => request_pll_80m(clocks),
-                ApbClkConfig::Cpu => request_cpu_clk(clocks),
-            }
-        }
-        fn apb_clk_release_upstream(clocks: &mut ClockTree, selector: ApbClkConfig) {
-            match selector {
-                ApbClkConfig::Pll80m => release_pll_80m(clocks),
-                ApbClkConfig::Cpu => release_cpu_clk(clocks),
-            }
-        }
         pub fn request_apb_clk(clocks: &mut ClockTree) {
             if increment_reference_count(&mut clocks.apb_clk_refcount) {
-                let selector = unwrap!(clocks.apb_clk);
-                apb_clk_request_upstream(clocks, selector);
+                match unwrap!(clocks.apb_clk) {
+                    ApbClkConfig::Pll80m => request_pll_80m(clocks),
+                    ApbClkConfig::Cpu => request_cpu_clk(clocks),
+                }
                 enable_apb_clk_impl(clocks, true);
             }
         }
         pub fn release_apb_clk(clocks: &mut ClockTree) {
             if decrement_reference_count(&mut clocks.apb_clk_refcount) {
                 enable_apb_clk_impl(clocks, false);
-                let selector = unwrap!(clocks.apb_clk);
-                apb_clk_release_upstream(clocks, selector);
+                match unwrap!(clocks.apb_clk) {
+                    ApbClkConfig::Pll80m => release_pll_80m(clocks),
+                    ApbClkConfig::Cpu => release_cpu_clk(clocks),
+                }
             }
         }
         pub fn apb_clk_frequency(clocks: &mut ClockTree) -> u32 {
@@ -1048,39 +1038,37 @@ macro_rules! define_clock_tree_types {
         pub fn configure_crypto_clk(clocks: &mut ClockTree, new_selector: CryptoClkConfig) {
             let old_selector = clocks.crypto_clk.replace(new_selector);
             if clocks.crypto_clk_refcount > 0 {
-                crypto_clk_request_upstream(clocks, new_selector);
+                match new_selector {
+                    CryptoClkConfig::Pll160m => request_pll_160m(clocks),
+                    CryptoClkConfig::Cpu => request_cpu_clk(clocks),
+                }
                 configure_crypto_clk_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
-                    crypto_clk_release_upstream(clocks, old_selector);
+                    match old_selector {
+                        CryptoClkConfig::Pll160m => release_pll_160m(clocks),
+                        CryptoClkConfig::Cpu => release_cpu_clk(clocks),
+                    }
                 }
             } else {
                 configure_crypto_clk_impl(clocks, old_selector, new_selector);
             }
         }
-        fn crypto_clk_request_upstream(clocks: &mut ClockTree, selector: CryptoClkConfig) {
-            match selector {
-                CryptoClkConfig::Pll160m => request_pll_160m(clocks),
-                CryptoClkConfig::Cpu => request_cpu_clk(clocks),
-            }
-        }
-        fn crypto_clk_release_upstream(clocks: &mut ClockTree, selector: CryptoClkConfig) {
-            match selector {
-                CryptoClkConfig::Pll160m => release_pll_160m(clocks),
-                CryptoClkConfig::Cpu => release_cpu_clk(clocks),
-            }
-        }
         pub fn request_crypto_clk(clocks: &mut ClockTree) {
             if increment_reference_count(&mut clocks.crypto_clk_refcount) {
-                let selector = unwrap!(clocks.crypto_clk);
-                crypto_clk_request_upstream(clocks, selector);
+                match unwrap!(clocks.crypto_clk) {
+                    CryptoClkConfig::Pll160m => request_pll_160m(clocks),
+                    CryptoClkConfig::Cpu => request_cpu_clk(clocks),
+                }
                 enable_crypto_clk_impl(clocks, true);
             }
         }
         pub fn release_crypto_clk(clocks: &mut ClockTree) {
             if decrement_reference_count(&mut clocks.crypto_clk_refcount) {
                 enable_crypto_clk_impl(clocks, false);
-                let selector = unwrap!(clocks.crypto_clk);
-                crypto_clk_release_upstream(clocks, selector);
+                match unwrap!(clocks.crypto_clk) {
+                    CryptoClkConfig::Pll160m => release_pll_160m(clocks),
+                    CryptoClkConfig::Cpu => release_cpu_clk(clocks),
+                }
             }
         }
         pub fn crypto_clk_frequency(clocks: &mut ClockTree) -> u32 {
@@ -1107,24 +1095,18 @@ macro_rules! define_clock_tree_types {
                     configure_crypto_clk(clocks, CryptoClkConfig::Pll160m);
                 }
             }
-            cpu_clk_request_upstream(clocks, new_selector);
-            configure_cpu_clk_impl(clocks, old_selector, new_selector);
-            if let Some(old_selector) = old_selector {
-                cpu_clk_release_upstream(clocks, old_selector);
-            }
-        }
-        fn cpu_clk_request_upstream(clocks: &mut ClockTree, selector: CpuClkConfig) {
-            match selector {
+            match new_selector {
                 CpuClkConfig::Xtal => request_system_pre_div(clocks),
                 CpuClkConfig::RcFast => request_system_pre_div(clocks),
                 CpuClkConfig::Pll => request_cpu_pll_div_out(clocks),
             }
-        }
-        fn cpu_clk_release_upstream(clocks: &mut ClockTree, selector: CpuClkConfig) {
-            match selector {
-                CpuClkConfig::Xtal => release_system_pre_div(clocks),
-                CpuClkConfig::RcFast => release_system_pre_div(clocks),
-                CpuClkConfig::Pll => release_cpu_pll_div_out(clocks),
+            configure_cpu_clk_impl(clocks, old_selector, new_selector);
+            if let Some(old_selector) = old_selector {
+                match old_selector {
+                    CpuClkConfig::Xtal => release_system_pre_div(clocks),
+                    CpuClkConfig::RcFast => release_system_pre_div(clocks),
+                    CpuClkConfig::Pll => release_cpu_pll_div_out(clocks),
+                }
             }
         }
         fn request_cpu_clk(_clocks: &mut ClockTree) {}
@@ -1186,35 +1168,35 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_rtc_slow_clk(clocks: &mut ClockTree, new_selector: RtcSlowClkConfig) {
             let old_selector = clocks.rtc_slow_clk.replace(new_selector);
-            rtc_slow_clk_request_upstream(clocks, new_selector);
-            configure_rtc_slow_clk_impl(clocks, old_selector, new_selector);
-            if let Some(old_selector) = old_selector {
-                rtc_slow_clk_release_upstream(clocks, old_selector);
-            }
-        }
-        fn rtc_slow_clk_request_upstream(clocks: &mut ClockTree, selector: RtcSlowClkConfig) {
-            match selector {
+            match new_selector {
                 RtcSlowClkConfig::Xtal32k => request_xtal32k_clk(clocks),
                 RtcSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
                 RtcSlowClkConfig::RcFast => request_rc_fast_div_clk(clocks),
             }
-        }
-        fn rtc_slow_clk_release_upstream(clocks: &mut ClockTree, selector: RtcSlowClkConfig) {
-            match selector {
-                RtcSlowClkConfig::Xtal32k => release_xtal32k_clk(clocks),
-                RtcSlowClkConfig::RcSlow => release_rc_slow_clk(clocks),
-                RtcSlowClkConfig::RcFast => release_rc_fast_div_clk(clocks),
+            configure_rtc_slow_clk_impl(clocks, old_selector, new_selector);
+            if let Some(old_selector) = old_selector {
+                match old_selector {
+                    RtcSlowClkConfig::Xtal32k => release_xtal32k_clk(clocks),
+                    RtcSlowClkConfig::RcSlow => release_rc_slow_clk(clocks),
+                    RtcSlowClkConfig::RcFast => release_rc_fast_div_clk(clocks),
+                }
             }
         }
         pub fn request_rtc_slow_clk(clocks: &mut ClockTree) {
-            let selector = unwrap!(clocks.rtc_slow_clk);
-            rtc_slow_clk_request_upstream(clocks, selector);
+            match unwrap!(clocks.rtc_slow_clk) {
+                RtcSlowClkConfig::Xtal32k => request_xtal32k_clk(clocks),
+                RtcSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
+                RtcSlowClkConfig::RcFast => request_rc_fast_div_clk(clocks),
+            }
             enable_rtc_slow_clk_impl(clocks, true);
         }
         pub fn release_rtc_slow_clk(clocks: &mut ClockTree) {
             enable_rtc_slow_clk_impl(clocks, false);
-            let selector = unwrap!(clocks.rtc_slow_clk);
-            rtc_slow_clk_release_upstream(clocks, selector);
+            match unwrap!(clocks.rtc_slow_clk) {
+                RtcSlowClkConfig::Xtal32k => release_xtal32k_clk(clocks),
+                RtcSlowClkConfig::RcSlow => release_rc_slow_clk(clocks),
+                RtcSlowClkConfig::RcFast => release_rc_fast_div_clk(clocks),
+            }
         }
         pub fn rtc_slow_clk_frequency(clocks: &mut ClockTree) -> u32 {
             match unwrap!(clocks.rtc_slow_clk) {
@@ -1226,39 +1208,37 @@ macro_rules! define_clock_tree_types {
         pub fn configure_rtc_fast_clk(clocks: &mut ClockTree, new_selector: RtcFastClkConfig) {
             let old_selector = clocks.rtc_fast_clk.replace(new_selector);
             if clocks.rtc_fast_clk_refcount > 0 {
-                rtc_fast_clk_request_upstream(clocks, new_selector);
+                match new_selector {
+                    RtcFastClkConfig::Xtal => request_xtal_div_clk(clocks),
+                    RtcFastClkConfig::Rc => request_rc_fast_clk_div_n(clocks),
+                }
                 configure_rtc_fast_clk_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
-                    rtc_fast_clk_release_upstream(clocks, old_selector);
+                    match old_selector {
+                        RtcFastClkConfig::Xtal => release_xtal_div_clk(clocks),
+                        RtcFastClkConfig::Rc => release_rc_fast_clk_div_n(clocks),
+                    }
                 }
             } else {
                 configure_rtc_fast_clk_impl(clocks, old_selector, new_selector);
             }
         }
-        fn rtc_fast_clk_request_upstream(clocks: &mut ClockTree, selector: RtcFastClkConfig) {
-            match selector {
-                RtcFastClkConfig::Xtal => request_xtal_div_clk(clocks),
-                RtcFastClkConfig::Rc => request_rc_fast_clk_div_n(clocks),
-            }
-        }
-        fn rtc_fast_clk_release_upstream(clocks: &mut ClockTree, selector: RtcFastClkConfig) {
-            match selector {
-                RtcFastClkConfig::Xtal => release_xtal_div_clk(clocks),
-                RtcFastClkConfig::Rc => release_rc_fast_clk_div_n(clocks),
-            }
-        }
         pub fn request_rtc_fast_clk(clocks: &mut ClockTree) {
             if increment_reference_count(&mut clocks.rtc_fast_clk_refcount) {
-                let selector = unwrap!(clocks.rtc_fast_clk);
-                rtc_fast_clk_request_upstream(clocks, selector);
+                match unwrap!(clocks.rtc_fast_clk) {
+                    RtcFastClkConfig::Xtal => request_xtal_div_clk(clocks),
+                    RtcFastClkConfig::Rc => request_rc_fast_clk_div_n(clocks),
+                }
                 enable_rtc_fast_clk_impl(clocks, true);
             }
         }
         pub fn release_rtc_fast_clk(clocks: &mut ClockTree) {
             if decrement_reference_count(&mut clocks.rtc_fast_clk_refcount) {
                 enable_rtc_fast_clk_impl(clocks, false);
-                let selector = unwrap!(clocks.rtc_fast_clk);
-                rtc_fast_clk_release_upstream(clocks, selector);
+                match unwrap!(clocks.rtc_fast_clk) {
+                    RtcFastClkConfig::Xtal => release_xtal_div_clk(clocks),
+                    RtcFastClkConfig::Rc => release_rc_fast_clk_div_n(clocks),
+                }
             }
         }
         pub fn rtc_fast_clk_frequency(clocks: &mut ClockTree) -> u32 {
@@ -1270,43 +1250,45 @@ macro_rules! define_clock_tree_types {
         pub fn configure_low_power_clk(clocks: &mut ClockTree, new_selector: LowPowerClkConfig) {
             let old_selector = clocks.low_power_clk.replace(new_selector);
             if clocks.low_power_clk_refcount > 0 {
-                low_power_clk_request_upstream(clocks, new_selector);
+                match new_selector {
+                    LowPowerClkConfig::Xtal => request_xtal_clk(clocks),
+                    LowPowerClkConfig::RcFast => request_rc_fast_clk(clocks),
+                    LowPowerClkConfig::Xtal32k => request_xtal32k_clk(clocks),
+                    LowPowerClkConfig::RtcSlow => request_rtc_slow_clk(clocks),
+                }
                 configure_low_power_clk_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
-                    low_power_clk_release_upstream(clocks, old_selector);
+                    match old_selector {
+                        LowPowerClkConfig::Xtal => release_xtal_clk(clocks),
+                        LowPowerClkConfig::RcFast => release_rc_fast_clk(clocks),
+                        LowPowerClkConfig::Xtal32k => release_xtal32k_clk(clocks),
+                        LowPowerClkConfig::RtcSlow => release_rtc_slow_clk(clocks),
+                    }
                 }
             } else {
                 configure_low_power_clk_impl(clocks, old_selector, new_selector);
             }
         }
-        fn low_power_clk_request_upstream(clocks: &mut ClockTree, selector: LowPowerClkConfig) {
-            match selector {
-                LowPowerClkConfig::Xtal => request_xtal_clk(clocks),
-                LowPowerClkConfig::RcFast => request_rc_fast_clk(clocks),
-                LowPowerClkConfig::Xtal32k => request_xtal32k_clk(clocks),
-                LowPowerClkConfig::RtcSlow => request_rtc_slow_clk(clocks),
-            }
-        }
-        fn low_power_clk_release_upstream(clocks: &mut ClockTree, selector: LowPowerClkConfig) {
-            match selector {
-                LowPowerClkConfig::Xtal => release_xtal_clk(clocks),
-                LowPowerClkConfig::RcFast => release_rc_fast_clk(clocks),
-                LowPowerClkConfig::Xtal32k => release_xtal32k_clk(clocks),
-                LowPowerClkConfig::RtcSlow => release_rtc_slow_clk(clocks),
-            }
-        }
         pub fn request_low_power_clk(clocks: &mut ClockTree) {
             if increment_reference_count(&mut clocks.low_power_clk_refcount) {
-                let selector = unwrap!(clocks.low_power_clk);
-                low_power_clk_request_upstream(clocks, selector);
+                match unwrap!(clocks.low_power_clk) {
+                    LowPowerClkConfig::Xtal => request_xtal_clk(clocks),
+                    LowPowerClkConfig::RcFast => request_rc_fast_clk(clocks),
+                    LowPowerClkConfig::Xtal32k => request_xtal32k_clk(clocks),
+                    LowPowerClkConfig::RtcSlow => request_rtc_slow_clk(clocks),
+                }
                 enable_low_power_clk_impl(clocks, true);
             }
         }
         pub fn release_low_power_clk(clocks: &mut ClockTree) {
             if decrement_reference_count(&mut clocks.low_power_clk_refcount) {
                 enable_low_power_clk_impl(clocks, false);
-                let selector = unwrap!(clocks.low_power_clk);
-                low_power_clk_release_upstream(clocks, selector);
+                match unwrap!(clocks.low_power_clk) {
+                    LowPowerClkConfig::Xtal => release_xtal_clk(clocks),
+                    LowPowerClkConfig::RcFast => release_rc_fast_clk(clocks),
+                    LowPowerClkConfig::Xtal32k => release_xtal32k_clk(clocks),
+                    LowPowerClkConfig::RtcSlow => release_rtc_slow_clk(clocks),
+                }
             }
         }
         pub fn low_power_clk_frequency(clocks: &mut ClockTree) -> u32 {
@@ -1323,45 +1305,37 @@ macro_rules! define_clock_tree_types {
         ) {
             let old_selector = clocks.timg0_function_clock.replace(new_selector);
             if clocks.timg0_function_clock_refcount > 0 {
-                timg0_function_clock_request_upstream(clocks, new_selector);
+                match new_selector {
+                    Timg0FunctionClockConfig::XtalClk => request_xtal_clk(clocks),
+                    Timg0FunctionClockConfig::ApbClk => request_apb_clk(clocks),
+                }
                 configure_timg0_function_clock_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
-                    timg0_function_clock_release_upstream(clocks, old_selector);
+                    match old_selector {
+                        Timg0FunctionClockConfig::XtalClk => release_xtal_clk(clocks),
+                        Timg0FunctionClockConfig::ApbClk => release_apb_clk(clocks),
+                    }
                 }
             } else {
                 configure_timg0_function_clock_impl(clocks, old_selector, new_selector);
             }
         }
-        fn timg0_function_clock_request_upstream(
-            clocks: &mut ClockTree,
-            selector: Timg0FunctionClockConfig,
-        ) {
-            match selector {
-                Timg0FunctionClockConfig::XtalClk => request_xtal_clk(clocks),
-                Timg0FunctionClockConfig::ApbClk => request_apb_clk(clocks),
-            }
-        }
-        fn timg0_function_clock_release_upstream(
-            clocks: &mut ClockTree,
-            selector: Timg0FunctionClockConfig,
-        ) {
-            match selector {
-                Timg0FunctionClockConfig::XtalClk => release_xtal_clk(clocks),
-                Timg0FunctionClockConfig::ApbClk => release_apb_clk(clocks),
-            }
-        }
         pub fn request_timg0_function_clock(clocks: &mut ClockTree) {
             if increment_reference_count(&mut clocks.timg0_function_clock_refcount) {
-                let selector = unwrap!(clocks.timg0_function_clock);
-                timg0_function_clock_request_upstream(clocks, selector);
+                match unwrap!(clocks.timg0_function_clock) {
+                    Timg0FunctionClockConfig::XtalClk => request_xtal_clk(clocks),
+                    Timg0FunctionClockConfig::ApbClk => request_apb_clk(clocks),
+                }
                 enable_timg0_function_clock_impl(clocks, true);
             }
         }
         pub fn release_timg0_function_clock(clocks: &mut ClockTree) {
             if decrement_reference_count(&mut clocks.timg0_function_clock_refcount) {
                 enable_timg0_function_clock_impl(clocks, false);
-                let selector = unwrap!(clocks.timg0_function_clock);
-                timg0_function_clock_release_upstream(clocks, selector);
+                match unwrap!(clocks.timg0_function_clock) {
+                    Timg0FunctionClockConfig::XtalClk => release_xtal_clk(clocks),
+                    Timg0FunctionClockConfig::ApbClk => release_apb_clk(clocks),
+                }
             }
         }
         pub fn timg0_function_clock_frequency(clocks: &mut ClockTree) -> u32 {
@@ -1376,47 +1350,43 @@ macro_rules! define_clock_tree_types {
         ) {
             let old_selector = clocks.timg0_calibration_clock.replace(new_selector);
             if clocks.timg0_calibration_clock_refcount > 0 {
-                timg0_calibration_clock_request_upstream(clocks, new_selector);
+                match new_selector {
+                    Timg0CalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
+                    Timg0CalibrationClockConfig::RcFastDivClk => request_rc_fast_div_clk(clocks),
+                    Timg0CalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
+                }
                 configure_timg0_calibration_clock_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
-                    timg0_calibration_clock_release_upstream(clocks, old_selector);
+                    match old_selector {
+                        Timg0CalibrationClockConfig::RcSlowClk => release_rc_slow_clk(clocks),
+                        Timg0CalibrationClockConfig::RcFastDivClk => {
+                            release_rc_fast_div_clk(clocks)
+                        }
+                        Timg0CalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
+                    }
                 }
             } else {
                 configure_timg0_calibration_clock_impl(clocks, old_selector, new_selector);
             }
         }
-        fn timg0_calibration_clock_request_upstream(
-            clocks: &mut ClockTree,
-            selector: Timg0CalibrationClockConfig,
-        ) {
-            match selector {
-                Timg0CalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
-                Timg0CalibrationClockConfig::RcFastDivClk => request_rc_fast_div_clk(clocks),
-                Timg0CalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
-            }
-        }
-        fn timg0_calibration_clock_release_upstream(
-            clocks: &mut ClockTree,
-            selector: Timg0CalibrationClockConfig,
-        ) {
-            match selector {
-                Timg0CalibrationClockConfig::RcSlowClk => release_rc_slow_clk(clocks),
-                Timg0CalibrationClockConfig::RcFastDivClk => release_rc_fast_div_clk(clocks),
-                Timg0CalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
-            }
-        }
         pub fn request_timg0_calibration_clock(clocks: &mut ClockTree) {
             if increment_reference_count(&mut clocks.timg0_calibration_clock_refcount) {
-                let selector = unwrap!(clocks.timg0_calibration_clock);
-                timg0_calibration_clock_request_upstream(clocks, selector);
+                match unwrap!(clocks.timg0_calibration_clock) {
+                    Timg0CalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
+                    Timg0CalibrationClockConfig::RcFastDivClk => request_rc_fast_div_clk(clocks),
+                    Timg0CalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
+                }
                 enable_timg0_calibration_clock_impl(clocks, true);
             }
         }
         pub fn release_timg0_calibration_clock(clocks: &mut ClockTree) {
             if decrement_reference_count(&mut clocks.timg0_calibration_clock_refcount) {
                 enable_timg0_calibration_clock_impl(clocks, false);
-                let selector = unwrap!(clocks.timg0_calibration_clock);
-                timg0_calibration_clock_release_upstream(clocks, selector);
+                match unwrap!(clocks.timg0_calibration_clock) {
+                    Timg0CalibrationClockConfig::RcSlowClk => release_rc_slow_clk(clocks),
+                    Timg0CalibrationClockConfig::RcFastDivClk => release_rc_fast_div_clk(clocks),
+                    Timg0CalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
+                }
             }
         }
         pub fn timg0_calibration_clock_frequency(clocks: &mut ClockTree) -> u32 {
@@ -1432,45 +1402,37 @@ macro_rules! define_clock_tree_types {
         ) {
             let old_selector = clocks.timg1_function_clock.replace(new_selector);
             if clocks.timg1_function_clock_refcount > 0 {
-                timg1_function_clock_request_upstream(clocks, new_selector);
+                match new_selector {
+                    Timg0FunctionClockConfig::XtalClk => request_xtal_clk(clocks),
+                    Timg0FunctionClockConfig::ApbClk => request_apb_clk(clocks),
+                }
                 configure_timg1_function_clock_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
-                    timg1_function_clock_release_upstream(clocks, old_selector);
+                    match old_selector {
+                        Timg0FunctionClockConfig::XtalClk => release_xtal_clk(clocks),
+                        Timg0FunctionClockConfig::ApbClk => release_apb_clk(clocks),
+                    }
                 }
             } else {
                 configure_timg1_function_clock_impl(clocks, old_selector, new_selector);
             }
         }
-        fn timg1_function_clock_request_upstream(
-            clocks: &mut ClockTree,
-            selector: Timg0FunctionClockConfig,
-        ) {
-            match selector {
-                Timg0FunctionClockConfig::XtalClk => request_xtal_clk(clocks),
-                Timg0FunctionClockConfig::ApbClk => request_apb_clk(clocks),
-            }
-        }
-        fn timg1_function_clock_release_upstream(
-            clocks: &mut ClockTree,
-            selector: Timg0FunctionClockConfig,
-        ) {
-            match selector {
-                Timg0FunctionClockConfig::XtalClk => release_xtal_clk(clocks),
-                Timg0FunctionClockConfig::ApbClk => release_apb_clk(clocks),
-            }
-        }
         pub fn request_timg1_function_clock(clocks: &mut ClockTree) {
             if increment_reference_count(&mut clocks.timg1_function_clock_refcount) {
-                let selector = unwrap!(clocks.timg1_function_clock);
-                timg1_function_clock_request_upstream(clocks, selector);
+                match unwrap!(clocks.timg1_function_clock) {
+                    Timg0FunctionClockConfig::XtalClk => request_xtal_clk(clocks),
+                    Timg0FunctionClockConfig::ApbClk => request_apb_clk(clocks),
+                }
                 enable_timg1_function_clock_impl(clocks, true);
             }
         }
         pub fn release_timg1_function_clock(clocks: &mut ClockTree) {
             if decrement_reference_count(&mut clocks.timg1_function_clock_refcount) {
                 enable_timg1_function_clock_impl(clocks, false);
-                let selector = unwrap!(clocks.timg1_function_clock);
-                timg1_function_clock_release_upstream(clocks, selector);
+                match unwrap!(clocks.timg1_function_clock) {
+                    Timg0FunctionClockConfig::XtalClk => release_xtal_clk(clocks),
+                    Timg0FunctionClockConfig::ApbClk => release_apb_clk(clocks),
+                }
             }
         }
         pub fn timg1_function_clock_frequency(clocks: &mut ClockTree) -> u32 {
@@ -1485,47 +1447,43 @@ macro_rules! define_clock_tree_types {
         ) {
             let old_selector = clocks.timg1_calibration_clock.replace(new_selector);
             if clocks.timg1_calibration_clock_refcount > 0 {
-                timg1_calibration_clock_request_upstream(clocks, new_selector);
+                match new_selector {
+                    Timg0CalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
+                    Timg0CalibrationClockConfig::RcFastDivClk => request_rc_fast_div_clk(clocks),
+                    Timg0CalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
+                }
                 configure_timg1_calibration_clock_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
-                    timg1_calibration_clock_release_upstream(clocks, old_selector);
+                    match old_selector {
+                        Timg0CalibrationClockConfig::RcSlowClk => release_rc_slow_clk(clocks),
+                        Timg0CalibrationClockConfig::RcFastDivClk => {
+                            release_rc_fast_div_clk(clocks)
+                        }
+                        Timg0CalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
+                    }
                 }
             } else {
                 configure_timg1_calibration_clock_impl(clocks, old_selector, new_selector);
             }
         }
-        fn timg1_calibration_clock_request_upstream(
-            clocks: &mut ClockTree,
-            selector: Timg0CalibrationClockConfig,
-        ) {
-            match selector {
-                Timg0CalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
-                Timg0CalibrationClockConfig::RcFastDivClk => request_rc_fast_div_clk(clocks),
-                Timg0CalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
-            }
-        }
-        fn timg1_calibration_clock_release_upstream(
-            clocks: &mut ClockTree,
-            selector: Timg0CalibrationClockConfig,
-        ) {
-            match selector {
-                Timg0CalibrationClockConfig::RcSlowClk => release_rc_slow_clk(clocks),
-                Timg0CalibrationClockConfig::RcFastDivClk => release_rc_fast_div_clk(clocks),
-                Timg0CalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
-            }
-        }
         pub fn request_timg1_calibration_clock(clocks: &mut ClockTree) {
             if increment_reference_count(&mut clocks.timg1_calibration_clock_refcount) {
-                let selector = unwrap!(clocks.timg1_calibration_clock);
-                timg1_calibration_clock_request_upstream(clocks, selector);
+                match unwrap!(clocks.timg1_calibration_clock) {
+                    Timg0CalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
+                    Timg0CalibrationClockConfig::RcFastDivClk => request_rc_fast_div_clk(clocks),
+                    Timg0CalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
+                }
                 enable_timg1_calibration_clock_impl(clocks, true);
             }
         }
         pub fn release_timg1_calibration_clock(clocks: &mut ClockTree) {
             if decrement_reference_count(&mut clocks.timg1_calibration_clock_refcount) {
                 enable_timg1_calibration_clock_impl(clocks, false);
-                let selector = unwrap!(clocks.timg1_calibration_clock);
-                timg1_calibration_clock_release_upstream(clocks, selector);
+                match unwrap!(clocks.timg1_calibration_clock) {
+                    Timg0CalibrationClockConfig::RcSlowClk => release_rc_slow_clk(clocks),
+                    Timg0CalibrationClockConfig::RcFastDivClk => release_rc_fast_div_clk(clocks),
+                    Timg0CalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
+                }
             }
         }
         pub fn timg1_calibration_clock_frequency(clocks: &mut ClockTree) -> u32 {

--- a/esp-metadata-generated/src/_generated_esp32h2.rs
+++ b/esp-metadata-generated/src/_generated_esp32h2.rs
@@ -807,43 +807,45 @@ macro_rules! define_clock_tree_types {
         pub fn configure_hp_root_clk(clocks: &mut ClockTree, new_selector: HpRootClkConfig) {
             let old_selector = clocks.hp_root_clk.replace(new_selector);
             if clocks.hp_root_clk_refcount > 0 {
-                hp_root_clk_request_upstream(clocks, new_selector);
+                match new_selector {
+                    HpRootClkConfig::Pll96 => request_pll_f96m_clk(clocks),
+                    HpRootClkConfig::Pll64 => request_pll_f64m_clk(clocks),
+                    HpRootClkConfig::Xtal => request_xtal_clk(clocks),
+                    HpRootClkConfig::RcFast => request_rc_fast_clk(clocks),
+                }
                 configure_hp_root_clk_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
-                    hp_root_clk_release_upstream(clocks, old_selector);
+                    match old_selector {
+                        HpRootClkConfig::Pll96 => release_pll_f96m_clk(clocks),
+                        HpRootClkConfig::Pll64 => release_pll_f64m_clk(clocks),
+                        HpRootClkConfig::Xtal => release_xtal_clk(clocks),
+                        HpRootClkConfig::RcFast => release_rc_fast_clk(clocks),
+                    }
                 }
             } else {
                 configure_hp_root_clk_impl(clocks, old_selector, new_selector);
             }
         }
-        fn hp_root_clk_request_upstream(clocks: &mut ClockTree, selector: HpRootClkConfig) {
-            match selector {
-                HpRootClkConfig::Pll96 => request_pll_f96m_clk(clocks),
-                HpRootClkConfig::Pll64 => request_pll_f64m_clk(clocks),
-                HpRootClkConfig::Xtal => request_xtal_clk(clocks),
-                HpRootClkConfig::RcFast => request_rc_fast_clk(clocks),
-            }
-        }
-        fn hp_root_clk_release_upstream(clocks: &mut ClockTree, selector: HpRootClkConfig) {
-            match selector {
-                HpRootClkConfig::Pll96 => release_pll_f96m_clk(clocks),
-                HpRootClkConfig::Pll64 => release_pll_f64m_clk(clocks),
-                HpRootClkConfig::Xtal => release_xtal_clk(clocks),
-                HpRootClkConfig::RcFast => release_rc_fast_clk(clocks),
-            }
-        }
         pub fn request_hp_root_clk(clocks: &mut ClockTree) {
             if increment_reference_count(&mut clocks.hp_root_clk_refcount) {
-                let selector = unwrap!(clocks.hp_root_clk);
-                hp_root_clk_request_upstream(clocks, selector);
+                match unwrap!(clocks.hp_root_clk) {
+                    HpRootClkConfig::Pll96 => request_pll_f96m_clk(clocks),
+                    HpRootClkConfig::Pll64 => request_pll_f64m_clk(clocks),
+                    HpRootClkConfig::Xtal => request_xtal_clk(clocks),
+                    HpRootClkConfig::RcFast => request_rc_fast_clk(clocks),
+                }
                 enable_hp_root_clk_impl(clocks, true);
             }
         }
         pub fn release_hp_root_clk(clocks: &mut ClockTree) {
             if decrement_reference_count(&mut clocks.hp_root_clk_refcount) {
                 enable_hp_root_clk_impl(clocks, false);
-                let selector = unwrap!(clocks.hp_root_clk);
-                hp_root_clk_release_upstream(clocks, selector);
+                match unwrap!(clocks.hp_root_clk) {
+                    HpRootClkConfig::Pll96 => release_pll_f96m_clk(clocks),
+                    HpRootClkConfig::Pll64 => release_pll_f64m_clk(clocks),
+                    HpRootClkConfig::Xtal => release_xtal_clk(clocks),
+                    HpRootClkConfig::RcFast => release_rc_fast_clk(clocks),
+                }
             }
         }
         pub fn hp_root_clk_frequency(clocks: &mut ClockTree) -> u32 {
@@ -921,41 +923,41 @@ macro_rules! define_clock_tree_types {
         pub fn configure_lp_fast_clk(clocks: &mut ClockTree, new_selector: LpFastClkConfig) {
             let old_selector = clocks.lp_fast_clk.replace(new_selector);
             if clocks.lp_fast_clk_refcount > 0 {
-                lp_fast_clk_request_upstream(clocks, new_selector);
+                match new_selector {
+                    LpFastClkConfig::RcFastClk => request_rc_fast_clk(clocks),
+                    LpFastClkConfig::PllLpClk => request_pll_lp_clk(clocks),
+                    LpFastClkConfig::XtalD2Clk => request_xtal_d2_clk(clocks),
+                }
                 configure_lp_fast_clk_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
-                    lp_fast_clk_release_upstream(clocks, old_selector);
+                    match old_selector {
+                        LpFastClkConfig::RcFastClk => release_rc_fast_clk(clocks),
+                        LpFastClkConfig::PllLpClk => release_pll_lp_clk(clocks),
+                        LpFastClkConfig::XtalD2Clk => release_xtal_d2_clk(clocks),
+                    }
                 }
             } else {
                 configure_lp_fast_clk_impl(clocks, old_selector, new_selector);
             }
         }
-        fn lp_fast_clk_request_upstream(clocks: &mut ClockTree, selector: LpFastClkConfig) {
-            match selector {
-                LpFastClkConfig::RcFastClk => request_rc_fast_clk(clocks),
-                LpFastClkConfig::PllLpClk => request_pll_lp_clk(clocks),
-                LpFastClkConfig::XtalD2Clk => request_xtal_d2_clk(clocks),
-            }
-        }
-        fn lp_fast_clk_release_upstream(clocks: &mut ClockTree, selector: LpFastClkConfig) {
-            match selector {
-                LpFastClkConfig::RcFastClk => release_rc_fast_clk(clocks),
-                LpFastClkConfig::PllLpClk => release_pll_lp_clk(clocks),
-                LpFastClkConfig::XtalD2Clk => release_xtal_d2_clk(clocks),
-            }
-        }
         pub fn request_lp_fast_clk(clocks: &mut ClockTree) {
             if increment_reference_count(&mut clocks.lp_fast_clk_refcount) {
-                let selector = unwrap!(clocks.lp_fast_clk);
-                lp_fast_clk_request_upstream(clocks, selector);
+                match unwrap!(clocks.lp_fast_clk) {
+                    LpFastClkConfig::RcFastClk => request_rc_fast_clk(clocks),
+                    LpFastClkConfig::PllLpClk => request_pll_lp_clk(clocks),
+                    LpFastClkConfig::XtalD2Clk => request_xtal_d2_clk(clocks),
+                }
                 enable_lp_fast_clk_impl(clocks, true);
             }
         }
         pub fn release_lp_fast_clk(clocks: &mut ClockTree) {
             if decrement_reference_count(&mut clocks.lp_fast_clk_refcount) {
                 enable_lp_fast_clk_impl(clocks, false);
-                let selector = unwrap!(clocks.lp_fast_clk);
-                lp_fast_clk_release_upstream(clocks, selector);
+                match unwrap!(clocks.lp_fast_clk) {
+                    LpFastClkConfig::RcFastClk => release_rc_fast_clk(clocks),
+                    LpFastClkConfig::PllLpClk => release_pll_lp_clk(clocks),
+                    LpFastClkConfig::XtalD2Clk => release_xtal_d2_clk(clocks),
+                }
             }
         }
         pub fn lp_fast_clk_frequency(clocks: &mut ClockTree) -> u32 {
@@ -968,41 +970,41 @@ macro_rules! define_clock_tree_types {
         pub fn configure_lp_slow_clk(clocks: &mut ClockTree, new_selector: LpSlowClkConfig) {
             let old_selector = clocks.lp_slow_clk.replace(new_selector);
             if clocks.lp_slow_clk_refcount > 0 {
-                lp_slow_clk_request_upstream(clocks, new_selector);
+                match new_selector {
+                    LpSlowClkConfig::Xtal32kClk => request_xtal32k_clk(clocks),
+                    LpSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
+                    LpSlowClkConfig::OscSlow => request_osc_slow_clk(clocks),
+                }
                 configure_lp_slow_clk_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
-                    lp_slow_clk_release_upstream(clocks, old_selector);
+                    match old_selector {
+                        LpSlowClkConfig::Xtal32kClk => release_xtal32k_clk(clocks),
+                        LpSlowClkConfig::RcSlow => release_rc_slow_clk(clocks),
+                        LpSlowClkConfig::OscSlow => release_osc_slow_clk(clocks),
+                    }
                 }
             } else {
                 configure_lp_slow_clk_impl(clocks, old_selector, new_selector);
             }
         }
-        fn lp_slow_clk_request_upstream(clocks: &mut ClockTree, selector: LpSlowClkConfig) {
-            match selector {
-                LpSlowClkConfig::Xtal32kClk => request_xtal32k_clk(clocks),
-                LpSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
-                LpSlowClkConfig::OscSlow => request_osc_slow_clk(clocks),
-            }
-        }
-        fn lp_slow_clk_release_upstream(clocks: &mut ClockTree, selector: LpSlowClkConfig) {
-            match selector {
-                LpSlowClkConfig::Xtal32kClk => release_xtal32k_clk(clocks),
-                LpSlowClkConfig::RcSlow => release_rc_slow_clk(clocks),
-                LpSlowClkConfig::OscSlow => release_osc_slow_clk(clocks),
-            }
-        }
         pub fn request_lp_slow_clk(clocks: &mut ClockTree) {
             if increment_reference_count(&mut clocks.lp_slow_clk_refcount) {
-                let selector = unwrap!(clocks.lp_slow_clk);
-                lp_slow_clk_request_upstream(clocks, selector);
+                match unwrap!(clocks.lp_slow_clk) {
+                    LpSlowClkConfig::Xtal32kClk => request_xtal32k_clk(clocks),
+                    LpSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
+                    LpSlowClkConfig::OscSlow => request_osc_slow_clk(clocks),
+                }
                 enable_lp_slow_clk_impl(clocks, true);
             }
         }
         pub fn release_lp_slow_clk(clocks: &mut ClockTree) {
             if decrement_reference_count(&mut clocks.lp_slow_clk_refcount) {
                 enable_lp_slow_clk_impl(clocks, false);
-                let selector = unwrap!(clocks.lp_slow_clk);
-                lp_slow_clk_release_upstream(clocks, selector);
+                match unwrap!(clocks.lp_slow_clk) {
+                    LpSlowClkConfig::Xtal32kClk => release_xtal32k_clk(clocks),
+                    LpSlowClkConfig::RcSlow => release_rc_slow_clk(clocks),
+                    LpSlowClkConfig::OscSlow => release_osc_slow_clk(clocks),
+                }
             }
         }
         pub fn lp_slow_clk_frequency(clocks: &mut ClockTree) -> u32 {
@@ -1018,47 +1020,41 @@ macro_rules! define_clock_tree_types {
         ) {
             let old_selector = clocks.timg0_function_clock.replace(new_selector);
             if clocks.timg0_function_clock_refcount > 0 {
-                timg0_function_clock_request_upstream(clocks, new_selector);
+                match new_selector {
+                    Timg0FunctionClockConfig::XtalClk => request_xtal_clk(clocks),
+                    Timg0FunctionClockConfig::RcFastClk => request_rc_fast_clk(clocks),
+                    Timg0FunctionClockConfig::PllF48m => request_pll_f48m_clk(clocks),
+                }
                 configure_timg0_function_clock_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
-                    timg0_function_clock_release_upstream(clocks, old_selector);
+                    match old_selector {
+                        Timg0FunctionClockConfig::XtalClk => release_xtal_clk(clocks),
+                        Timg0FunctionClockConfig::RcFastClk => release_rc_fast_clk(clocks),
+                        Timg0FunctionClockConfig::PllF48m => release_pll_f48m_clk(clocks),
+                    }
                 }
             } else {
                 configure_timg0_function_clock_impl(clocks, old_selector, new_selector);
             }
         }
-        fn timg0_function_clock_request_upstream(
-            clocks: &mut ClockTree,
-            selector: Timg0FunctionClockConfig,
-        ) {
-            match selector {
-                Timg0FunctionClockConfig::XtalClk => request_xtal_clk(clocks),
-                Timg0FunctionClockConfig::RcFastClk => request_rc_fast_clk(clocks),
-                Timg0FunctionClockConfig::PllF48m => request_pll_f48m_clk(clocks),
-            }
-        }
-        fn timg0_function_clock_release_upstream(
-            clocks: &mut ClockTree,
-            selector: Timg0FunctionClockConfig,
-        ) {
-            match selector {
-                Timg0FunctionClockConfig::XtalClk => release_xtal_clk(clocks),
-                Timg0FunctionClockConfig::RcFastClk => release_rc_fast_clk(clocks),
-                Timg0FunctionClockConfig::PllF48m => release_pll_f48m_clk(clocks),
-            }
-        }
         pub fn request_timg0_function_clock(clocks: &mut ClockTree) {
             if increment_reference_count(&mut clocks.timg0_function_clock_refcount) {
-                let selector = unwrap!(clocks.timg0_function_clock);
-                timg0_function_clock_request_upstream(clocks, selector);
+                match unwrap!(clocks.timg0_function_clock) {
+                    Timg0FunctionClockConfig::XtalClk => request_xtal_clk(clocks),
+                    Timg0FunctionClockConfig::RcFastClk => request_rc_fast_clk(clocks),
+                    Timg0FunctionClockConfig::PllF48m => request_pll_f48m_clk(clocks),
+                }
                 enable_timg0_function_clock_impl(clocks, true);
             }
         }
         pub fn release_timg0_function_clock(clocks: &mut ClockTree) {
             if decrement_reference_count(&mut clocks.timg0_function_clock_refcount) {
                 enable_timg0_function_clock_impl(clocks, false);
-                let selector = unwrap!(clocks.timg0_function_clock);
-                timg0_function_clock_release_upstream(clocks, selector);
+                match unwrap!(clocks.timg0_function_clock) {
+                    Timg0FunctionClockConfig::XtalClk => release_xtal_clk(clocks),
+                    Timg0FunctionClockConfig::RcFastClk => release_rc_fast_clk(clocks),
+                    Timg0FunctionClockConfig::PllF48m => release_pll_f48m_clk(clocks),
+                }
             }
         }
         pub fn timg0_function_clock_frequency(clocks: &mut ClockTree) -> u32 {
@@ -1074,47 +1070,41 @@ macro_rules! define_clock_tree_types {
         ) {
             let old_selector = clocks.timg0_calibration_clock.replace(new_selector);
             if clocks.timg0_calibration_clock_refcount > 0 {
-                timg0_calibration_clock_request_upstream(clocks, new_selector);
+                match new_selector {
+                    Timg0CalibrationClockConfig::RtcSlowClk => request_lp_slow_clk(clocks),
+                    Timg0CalibrationClockConfig::RcFastClk => request_rc_fast_clk(clocks),
+                    Timg0CalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
+                }
                 configure_timg0_calibration_clock_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
-                    timg0_calibration_clock_release_upstream(clocks, old_selector);
+                    match old_selector {
+                        Timg0CalibrationClockConfig::RtcSlowClk => release_lp_slow_clk(clocks),
+                        Timg0CalibrationClockConfig::RcFastClk => release_rc_fast_clk(clocks),
+                        Timg0CalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
+                    }
                 }
             } else {
                 configure_timg0_calibration_clock_impl(clocks, old_selector, new_selector);
             }
         }
-        fn timg0_calibration_clock_request_upstream(
-            clocks: &mut ClockTree,
-            selector: Timg0CalibrationClockConfig,
-        ) {
-            match selector {
-                Timg0CalibrationClockConfig::RtcSlowClk => request_lp_slow_clk(clocks),
-                Timg0CalibrationClockConfig::RcFastClk => request_rc_fast_clk(clocks),
-                Timg0CalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
-            }
-        }
-        fn timg0_calibration_clock_release_upstream(
-            clocks: &mut ClockTree,
-            selector: Timg0CalibrationClockConfig,
-        ) {
-            match selector {
-                Timg0CalibrationClockConfig::RtcSlowClk => release_lp_slow_clk(clocks),
-                Timg0CalibrationClockConfig::RcFastClk => release_rc_fast_clk(clocks),
-                Timg0CalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
-            }
-        }
         pub fn request_timg0_calibration_clock(clocks: &mut ClockTree) {
             if increment_reference_count(&mut clocks.timg0_calibration_clock_refcount) {
-                let selector = unwrap!(clocks.timg0_calibration_clock);
-                timg0_calibration_clock_request_upstream(clocks, selector);
+                match unwrap!(clocks.timg0_calibration_clock) {
+                    Timg0CalibrationClockConfig::RtcSlowClk => request_lp_slow_clk(clocks),
+                    Timg0CalibrationClockConfig::RcFastClk => request_rc_fast_clk(clocks),
+                    Timg0CalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
+                }
                 enable_timg0_calibration_clock_impl(clocks, true);
             }
         }
         pub fn release_timg0_calibration_clock(clocks: &mut ClockTree) {
             if decrement_reference_count(&mut clocks.timg0_calibration_clock_refcount) {
                 enable_timg0_calibration_clock_impl(clocks, false);
-                let selector = unwrap!(clocks.timg0_calibration_clock);
-                timg0_calibration_clock_release_upstream(clocks, selector);
+                match unwrap!(clocks.timg0_calibration_clock) {
+                    Timg0CalibrationClockConfig::RtcSlowClk => release_lp_slow_clk(clocks),
+                    Timg0CalibrationClockConfig::RcFastClk => release_rc_fast_clk(clocks),
+                    Timg0CalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
+                }
             }
         }
         pub fn timg0_calibration_clock_frequency(clocks: &mut ClockTree) -> u32 {
@@ -1130,47 +1120,41 @@ macro_rules! define_clock_tree_types {
         ) {
             let old_selector = clocks.timg1_function_clock.replace(new_selector);
             if clocks.timg1_function_clock_refcount > 0 {
-                timg1_function_clock_request_upstream(clocks, new_selector);
+                match new_selector {
+                    Timg0FunctionClockConfig::XtalClk => request_xtal_clk(clocks),
+                    Timg0FunctionClockConfig::RcFastClk => request_rc_fast_clk(clocks),
+                    Timg0FunctionClockConfig::PllF48m => request_pll_f48m_clk(clocks),
+                }
                 configure_timg1_function_clock_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
-                    timg1_function_clock_release_upstream(clocks, old_selector);
+                    match old_selector {
+                        Timg0FunctionClockConfig::XtalClk => release_xtal_clk(clocks),
+                        Timg0FunctionClockConfig::RcFastClk => release_rc_fast_clk(clocks),
+                        Timg0FunctionClockConfig::PllF48m => release_pll_f48m_clk(clocks),
+                    }
                 }
             } else {
                 configure_timg1_function_clock_impl(clocks, old_selector, new_selector);
             }
         }
-        fn timg1_function_clock_request_upstream(
-            clocks: &mut ClockTree,
-            selector: Timg0FunctionClockConfig,
-        ) {
-            match selector {
-                Timg0FunctionClockConfig::XtalClk => request_xtal_clk(clocks),
-                Timg0FunctionClockConfig::RcFastClk => request_rc_fast_clk(clocks),
-                Timg0FunctionClockConfig::PllF48m => request_pll_f48m_clk(clocks),
-            }
-        }
-        fn timg1_function_clock_release_upstream(
-            clocks: &mut ClockTree,
-            selector: Timg0FunctionClockConfig,
-        ) {
-            match selector {
-                Timg0FunctionClockConfig::XtalClk => release_xtal_clk(clocks),
-                Timg0FunctionClockConfig::RcFastClk => release_rc_fast_clk(clocks),
-                Timg0FunctionClockConfig::PllF48m => release_pll_f48m_clk(clocks),
-            }
-        }
         pub fn request_timg1_function_clock(clocks: &mut ClockTree) {
             if increment_reference_count(&mut clocks.timg1_function_clock_refcount) {
-                let selector = unwrap!(clocks.timg1_function_clock);
-                timg1_function_clock_request_upstream(clocks, selector);
+                match unwrap!(clocks.timg1_function_clock) {
+                    Timg0FunctionClockConfig::XtalClk => request_xtal_clk(clocks),
+                    Timg0FunctionClockConfig::RcFastClk => request_rc_fast_clk(clocks),
+                    Timg0FunctionClockConfig::PllF48m => request_pll_f48m_clk(clocks),
+                }
                 enable_timg1_function_clock_impl(clocks, true);
             }
         }
         pub fn release_timg1_function_clock(clocks: &mut ClockTree) {
             if decrement_reference_count(&mut clocks.timg1_function_clock_refcount) {
                 enable_timg1_function_clock_impl(clocks, false);
-                let selector = unwrap!(clocks.timg1_function_clock);
-                timg1_function_clock_release_upstream(clocks, selector);
+                match unwrap!(clocks.timg1_function_clock) {
+                    Timg0FunctionClockConfig::XtalClk => release_xtal_clk(clocks),
+                    Timg0FunctionClockConfig::RcFastClk => release_rc_fast_clk(clocks),
+                    Timg0FunctionClockConfig::PllF48m => release_pll_f48m_clk(clocks),
+                }
             }
         }
         pub fn timg1_function_clock_frequency(clocks: &mut ClockTree) -> u32 {
@@ -1186,47 +1170,41 @@ macro_rules! define_clock_tree_types {
         ) {
             let old_selector = clocks.timg1_calibration_clock.replace(new_selector);
             if clocks.timg1_calibration_clock_refcount > 0 {
-                timg1_calibration_clock_request_upstream(clocks, new_selector);
+                match new_selector {
+                    Timg0CalibrationClockConfig::RtcSlowClk => request_lp_slow_clk(clocks),
+                    Timg0CalibrationClockConfig::RcFastClk => request_rc_fast_clk(clocks),
+                    Timg0CalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
+                }
                 configure_timg1_calibration_clock_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
-                    timg1_calibration_clock_release_upstream(clocks, old_selector);
+                    match old_selector {
+                        Timg0CalibrationClockConfig::RtcSlowClk => release_lp_slow_clk(clocks),
+                        Timg0CalibrationClockConfig::RcFastClk => release_rc_fast_clk(clocks),
+                        Timg0CalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
+                    }
                 }
             } else {
                 configure_timg1_calibration_clock_impl(clocks, old_selector, new_selector);
             }
         }
-        fn timg1_calibration_clock_request_upstream(
-            clocks: &mut ClockTree,
-            selector: Timg0CalibrationClockConfig,
-        ) {
-            match selector {
-                Timg0CalibrationClockConfig::RtcSlowClk => request_lp_slow_clk(clocks),
-                Timg0CalibrationClockConfig::RcFastClk => request_rc_fast_clk(clocks),
-                Timg0CalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
-            }
-        }
-        fn timg1_calibration_clock_release_upstream(
-            clocks: &mut ClockTree,
-            selector: Timg0CalibrationClockConfig,
-        ) {
-            match selector {
-                Timg0CalibrationClockConfig::RtcSlowClk => release_lp_slow_clk(clocks),
-                Timg0CalibrationClockConfig::RcFastClk => release_rc_fast_clk(clocks),
-                Timg0CalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
-            }
-        }
         pub fn request_timg1_calibration_clock(clocks: &mut ClockTree) {
             if increment_reference_count(&mut clocks.timg1_calibration_clock_refcount) {
-                let selector = unwrap!(clocks.timg1_calibration_clock);
-                timg1_calibration_clock_request_upstream(clocks, selector);
+                match unwrap!(clocks.timg1_calibration_clock) {
+                    Timg0CalibrationClockConfig::RtcSlowClk => request_lp_slow_clk(clocks),
+                    Timg0CalibrationClockConfig::RcFastClk => request_rc_fast_clk(clocks),
+                    Timg0CalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
+                }
                 enable_timg1_calibration_clock_impl(clocks, true);
             }
         }
         pub fn release_timg1_calibration_clock(clocks: &mut ClockTree) {
             if decrement_reference_count(&mut clocks.timg1_calibration_clock_refcount) {
                 enable_timg1_calibration_clock_impl(clocks, false);
-                let selector = unwrap!(clocks.timg1_calibration_clock);
-                timg1_calibration_clock_release_upstream(clocks, selector);
+                match unwrap!(clocks.timg1_calibration_clock) {
+                    Timg0CalibrationClockConfig::RtcSlowClk => release_lp_slow_clk(clocks),
+                    Timg0CalibrationClockConfig::RcFastClk => release_rc_fast_clk(clocks),
+                    Timg0CalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
+                }
             }
         }
         pub fn timg1_calibration_clock_frequency(clocks: &mut ClockTree) -> u32 {

--- a/esp-metadata-generated/src/_generated_esp32s3.rs
+++ b/esp-metadata-generated/src/_generated_esp32s3.rs
@@ -945,39 +945,31 @@ macro_rules! define_clock_tree_types {
             new_selector: SystemPreDivInConfig,
         ) {
             let old_selector = clocks.system_pre_div_in.replace(new_selector);
-            system_pre_div_in_request_upstream(clocks, new_selector);
-            configure_system_pre_div_in_impl(clocks, old_selector, new_selector);
-            if let Some(old_selector) = old_selector {
-                system_pre_div_in_release_upstream(clocks, old_selector);
-            }
-        }
-        fn system_pre_div_in_request_upstream(
-            clocks: &mut ClockTree,
-            selector: SystemPreDivInConfig,
-        ) {
-            match selector {
+            match new_selector {
                 SystemPreDivInConfig::Xtal => request_xtal_clk(clocks),
                 SystemPreDivInConfig::RcFast => request_rc_fast_clk(clocks),
             }
-        }
-        fn system_pre_div_in_release_upstream(
-            clocks: &mut ClockTree,
-            selector: SystemPreDivInConfig,
-        ) {
-            match selector {
-                SystemPreDivInConfig::Xtal => release_xtal_clk(clocks),
-                SystemPreDivInConfig::RcFast => release_rc_fast_clk(clocks),
+            configure_system_pre_div_in_impl(clocks, old_selector, new_selector);
+            if let Some(old_selector) = old_selector {
+                match old_selector {
+                    SystemPreDivInConfig::Xtal => release_xtal_clk(clocks),
+                    SystemPreDivInConfig::RcFast => release_rc_fast_clk(clocks),
+                }
             }
         }
         pub fn request_system_pre_div_in(clocks: &mut ClockTree) {
-            let selector = unwrap!(clocks.system_pre_div_in);
-            system_pre_div_in_request_upstream(clocks, selector);
+            match unwrap!(clocks.system_pre_div_in) {
+                SystemPreDivInConfig::Xtal => request_xtal_clk(clocks),
+                SystemPreDivInConfig::RcFast => request_rc_fast_clk(clocks),
+            }
             enable_system_pre_div_in_impl(clocks, true);
         }
         pub fn release_system_pre_div_in(clocks: &mut ClockTree) {
             enable_system_pre_div_in_impl(clocks, false);
-            let selector = unwrap!(clocks.system_pre_div_in);
-            system_pre_div_in_release_upstream(clocks, selector);
+            match unwrap!(clocks.system_pre_div_in) {
+                SystemPreDivInConfig::Xtal => release_xtal_clk(clocks),
+                SystemPreDivInConfig::RcFast => release_rc_fast_clk(clocks),
+            }
         }
         pub fn system_pre_div_in_frequency(clocks: &mut ClockTree) -> u32 {
             match unwrap!(clocks.system_pre_div_in) {
@@ -1021,39 +1013,37 @@ macro_rules! define_clock_tree_types {
         pub fn configure_apb_clk(clocks: &mut ClockTree, new_selector: ApbClkConfig) {
             let old_selector = clocks.apb_clk.replace(new_selector);
             if clocks.apb_clk_refcount > 0 {
-                apb_clk_request_upstream(clocks, new_selector);
+                match new_selector {
+                    ApbClkConfig::Pll => request_apb_80m(clocks),
+                    ApbClkConfig::Cpu => request_cpu_clk(clocks),
+                }
                 configure_apb_clk_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
-                    apb_clk_release_upstream(clocks, old_selector);
+                    match old_selector {
+                        ApbClkConfig::Pll => release_apb_80m(clocks),
+                        ApbClkConfig::Cpu => release_cpu_clk(clocks),
+                    }
                 }
             } else {
                 configure_apb_clk_impl(clocks, old_selector, new_selector);
             }
         }
-        fn apb_clk_request_upstream(clocks: &mut ClockTree, selector: ApbClkConfig) {
-            match selector {
-                ApbClkConfig::Pll => request_apb_80m(clocks),
-                ApbClkConfig::Cpu => request_cpu_clk(clocks),
-            }
-        }
-        fn apb_clk_release_upstream(clocks: &mut ClockTree, selector: ApbClkConfig) {
-            match selector {
-                ApbClkConfig::Pll => release_apb_80m(clocks),
-                ApbClkConfig::Cpu => release_cpu_clk(clocks),
-            }
-        }
         pub fn request_apb_clk(clocks: &mut ClockTree) {
             if increment_reference_count(&mut clocks.apb_clk_refcount) {
-                let selector = unwrap!(clocks.apb_clk);
-                apb_clk_request_upstream(clocks, selector);
+                match unwrap!(clocks.apb_clk) {
+                    ApbClkConfig::Pll => request_apb_80m(clocks),
+                    ApbClkConfig::Cpu => request_cpu_clk(clocks),
+                }
                 enable_apb_clk_impl(clocks, true);
             }
         }
         pub fn release_apb_clk(clocks: &mut ClockTree) {
             if decrement_reference_count(&mut clocks.apb_clk_refcount) {
                 enable_apb_clk_impl(clocks, false);
-                let selector = unwrap!(clocks.apb_clk);
-                apb_clk_release_upstream(clocks, selector);
+                match unwrap!(clocks.apb_clk) {
+                    ApbClkConfig::Pll => release_apb_80m(clocks),
+                    ApbClkConfig::Cpu => release_cpu_clk(clocks),
+                }
             }
         }
         pub fn apb_clk_frequency(clocks: &mut ClockTree) -> u32 {
@@ -1065,39 +1055,37 @@ macro_rules! define_clock_tree_types {
         pub fn configure_crypto_pwm_clk(clocks: &mut ClockTree, new_selector: CryptoPwmClkConfig) {
             let old_selector = clocks.crypto_pwm_clk.replace(new_selector);
             if clocks.crypto_pwm_clk_refcount > 0 {
-                crypto_pwm_clk_request_upstream(clocks, new_selector);
+                match new_selector {
+                    CryptoPwmClkConfig::Pll => request_pll_160m(clocks),
+                    CryptoPwmClkConfig::Cpu => request_cpu_clk(clocks),
+                }
                 configure_crypto_pwm_clk_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
-                    crypto_pwm_clk_release_upstream(clocks, old_selector);
+                    match old_selector {
+                        CryptoPwmClkConfig::Pll => release_pll_160m(clocks),
+                        CryptoPwmClkConfig::Cpu => release_cpu_clk(clocks),
+                    }
                 }
             } else {
                 configure_crypto_pwm_clk_impl(clocks, old_selector, new_selector);
             }
         }
-        fn crypto_pwm_clk_request_upstream(clocks: &mut ClockTree, selector: CryptoPwmClkConfig) {
-            match selector {
-                CryptoPwmClkConfig::Pll => request_pll_160m(clocks),
-                CryptoPwmClkConfig::Cpu => request_cpu_clk(clocks),
-            }
-        }
-        fn crypto_pwm_clk_release_upstream(clocks: &mut ClockTree, selector: CryptoPwmClkConfig) {
-            match selector {
-                CryptoPwmClkConfig::Pll => release_pll_160m(clocks),
-                CryptoPwmClkConfig::Cpu => release_cpu_clk(clocks),
-            }
-        }
         pub fn request_crypto_pwm_clk(clocks: &mut ClockTree) {
             if increment_reference_count(&mut clocks.crypto_pwm_clk_refcount) {
-                let selector = unwrap!(clocks.crypto_pwm_clk);
-                crypto_pwm_clk_request_upstream(clocks, selector);
+                match unwrap!(clocks.crypto_pwm_clk) {
+                    CryptoPwmClkConfig::Pll => request_pll_160m(clocks),
+                    CryptoPwmClkConfig::Cpu => request_cpu_clk(clocks),
+                }
                 enable_crypto_pwm_clk_impl(clocks, true);
             }
         }
         pub fn release_crypto_pwm_clk(clocks: &mut ClockTree) {
             if decrement_reference_count(&mut clocks.crypto_pwm_clk_refcount) {
                 enable_crypto_pwm_clk_impl(clocks, false);
-                let selector = unwrap!(clocks.crypto_pwm_clk);
-                crypto_pwm_clk_release_upstream(clocks, selector);
+                match unwrap!(clocks.crypto_pwm_clk) {
+                    CryptoPwmClkConfig::Pll => release_pll_160m(clocks),
+                    CryptoPwmClkConfig::Cpu => release_cpu_clk(clocks),
+                }
             }
         }
         pub fn crypto_pwm_clk_frequency(clocks: &mut ClockTree) -> u32 {
@@ -1124,24 +1112,18 @@ macro_rules! define_clock_tree_types {
                     configure_crypto_pwm_clk(clocks, CryptoPwmClkConfig::Pll);
                 }
             }
-            cpu_clk_request_upstream(clocks, new_selector);
-            configure_cpu_clk_impl(clocks, old_selector, new_selector);
-            if let Some(old_selector) = old_selector {
-                cpu_clk_release_upstream(clocks, old_selector);
-            }
-        }
-        fn cpu_clk_request_upstream(clocks: &mut ClockTree, selector: CpuClkConfig) {
-            match selector {
+            match new_selector {
                 CpuClkConfig::Xtal => request_system_pre_div(clocks),
                 CpuClkConfig::RcFast => request_system_pre_div(clocks),
                 CpuClkConfig::Pll => request_cpu_pll_div_out(clocks),
             }
-        }
-        fn cpu_clk_release_upstream(clocks: &mut ClockTree, selector: CpuClkConfig) {
-            match selector {
-                CpuClkConfig::Xtal => release_system_pre_div(clocks),
-                CpuClkConfig::RcFast => release_system_pre_div(clocks),
-                CpuClkConfig::Pll => release_cpu_pll_div_out(clocks),
+            configure_cpu_clk_impl(clocks, old_selector, new_selector);
+            if let Some(old_selector) = old_selector {
+                match old_selector {
+                    CpuClkConfig::Xtal => release_system_pre_div(clocks),
+                    CpuClkConfig::RcFast => release_system_pre_div(clocks),
+                    CpuClkConfig::Pll => release_cpu_pll_div_out(clocks),
+                }
             }
         }
         fn request_cpu_clk(_clocks: &mut ClockTree) {}
@@ -1218,35 +1200,35 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_rtc_slow_clk(clocks: &mut ClockTree, new_selector: RtcSlowClkConfig) {
             let old_selector = clocks.rtc_slow_clk.replace(new_selector);
-            rtc_slow_clk_request_upstream(clocks, new_selector);
-            configure_rtc_slow_clk_impl(clocks, old_selector, new_selector);
-            if let Some(old_selector) = old_selector {
-                rtc_slow_clk_release_upstream(clocks, old_selector);
-            }
-        }
-        fn rtc_slow_clk_request_upstream(clocks: &mut ClockTree, selector: RtcSlowClkConfig) {
-            match selector {
+            match new_selector {
                 RtcSlowClkConfig::Xtal32k => request_xtal32k_clk(clocks),
                 RtcSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
                 RtcSlowClkConfig::RcFast => request_rc_fast_div_clk(clocks),
             }
-        }
-        fn rtc_slow_clk_release_upstream(clocks: &mut ClockTree, selector: RtcSlowClkConfig) {
-            match selector {
-                RtcSlowClkConfig::Xtal32k => release_xtal32k_clk(clocks),
-                RtcSlowClkConfig::RcSlow => release_rc_slow_clk(clocks),
-                RtcSlowClkConfig::RcFast => release_rc_fast_div_clk(clocks),
+            configure_rtc_slow_clk_impl(clocks, old_selector, new_selector);
+            if let Some(old_selector) = old_selector {
+                match old_selector {
+                    RtcSlowClkConfig::Xtal32k => release_xtal32k_clk(clocks),
+                    RtcSlowClkConfig::RcSlow => release_rc_slow_clk(clocks),
+                    RtcSlowClkConfig::RcFast => release_rc_fast_div_clk(clocks),
+                }
             }
         }
         pub fn request_rtc_slow_clk(clocks: &mut ClockTree) {
-            let selector = unwrap!(clocks.rtc_slow_clk);
-            rtc_slow_clk_request_upstream(clocks, selector);
+            match unwrap!(clocks.rtc_slow_clk) {
+                RtcSlowClkConfig::Xtal32k => request_xtal32k_clk(clocks),
+                RtcSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
+                RtcSlowClkConfig::RcFast => request_rc_fast_div_clk(clocks),
+            }
             enable_rtc_slow_clk_impl(clocks, true);
         }
         pub fn release_rtc_slow_clk(clocks: &mut ClockTree) {
             enable_rtc_slow_clk_impl(clocks, false);
-            let selector = unwrap!(clocks.rtc_slow_clk);
-            rtc_slow_clk_release_upstream(clocks, selector);
+            match unwrap!(clocks.rtc_slow_clk) {
+                RtcSlowClkConfig::Xtal32k => release_xtal32k_clk(clocks),
+                RtcSlowClkConfig::RcSlow => release_rc_slow_clk(clocks),
+                RtcSlowClkConfig::RcFast => release_rc_fast_div_clk(clocks),
+            }
         }
         pub fn rtc_slow_clk_frequency(clocks: &mut ClockTree) -> u32 {
             match unwrap!(clocks.rtc_slow_clk) {
@@ -1258,39 +1240,37 @@ macro_rules! define_clock_tree_types {
         pub fn configure_rtc_fast_clk(clocks: &mut ClockTree, new_selector: RtcFastClkConfig) {
             let old_selector = clocks.rtc_fast_clk.replace(new_selector);
             if clocks.rtc_fast_clk_refcount > 0 {
-                rtc_fast_clk_request_upstream(clocks, new_selector);
+                match new_selector {
+                    RtcFastClkConfig::Xtal => request_xtal_div_clk(clocks),
+                    RtcFastClkConfig::Rc => request_rc_fast_clk_div_n(clocks),
+                }
                 configure_rtc_fast_clk_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
-                    rtc_fast_clk_release_upstream(clocks, old_selector);
+                    match old_selector {
+                        RtcFastClkConfig::Xtal => release_xtal_div_clk(clocks),
+                        RtcFastClkConfig::Rc => release_rc_fast_clk_div_n(clocks),
+                    }
                 }
             } else {
                 configure_rtc_fast_clk_impl(clocks, old_selector, new_selector);
             }
         }
-        fn rtc_fast_clk_request_upstream(clocks: &mut ClockTree, selector: RtcFastClkConfig) {
-            match selector {
-                RtcFastClkConfig::Xtal => request_xtal_div_clk(clocks),
-                RtcFastClkConfig::Rc => request_rc_fast_clk_div_n(clocks),
-            }
-        }
-        fn rtc_fast_clk_release_upstream(clocks: &mut ClockTree, selector: RtcFastClkConfig) {
-            match selector {
-                RtcFastClkConfig::Xtal => release_xtal_div_clk(clocks),
-                RtcFastClkConfig::Rc => release_rc_fast_clk_div_n(clocks),
-            }
-        }
         pub fn request_rtc_fast_clk(clocks: &mut ClockTree) {
             if increment_reference_count(&mut clocks.rtc_fast_clk_refcount) {
-                let selector = unwrap!(clocks.rtc_fast_clk);
-                rtc_fast_clk_request_upstream(clocks, selector);
+                match unwrap!(clocks.rtc_fast_clk) {
+                    RtcFastClkConfig::Xtal => request_xtal_div_clk(clocks),
+                    RtcFastClkConfig::Rc => request_rc_fast_clk_div_n(clocks),
+                }
                 enable_rtc_fast_clk_impl(clocks, true);
             }
         }
         pub fn release_rtc_fast_clk(clocks: &mut ClockTree) {
             if decrement_reference_count(&mut clocks.rtc_fast_clk_refcount) {
                 enable_rtc_fast_clk_impl(clocks, false);
-                let selector = unwrap!(clocks.rtc_fast_clk);
-                rtc_fast_clk_release_upstream(clocks, selector);
+                match unwrap!(clocks.rtc_fast_clk) {
+                    RtcFastClkConfig::Xtal => release_xtal_div_clk(clocks),
+                    RtcFastClkConfig::Rc => release_rc_fast_clk_div_n(clocks),
+                }
             }
         }
         pub fn rtc_fast_clk_frequency(clocks: &mut ClockTree) -> u32 {
@@ -1302,43 +1282,45 @@ macro_rules! define_clock_tree_types {
         pub fn configure_low_power_clk(clocks: &mut ClockTree, new_selector: LowPowerClkConfig) {
             let old_selector = clocks.low_power_clk.replace(new_selector);
             if clocks.low_power_clk_refcount > 0 {
-                low_power_clk_request_upstream(clocks, new_selector);
+                match new_selector {
+                    LowPowerClkConfig::Xtal => request_xtal_clk(clocks),
+                    LowPowerClkConfig::RcFast => request_rc_fast_clk(clocks),
+                    LowPowerClkConfig::Xtal32k => request_xtal32k_clk(clocks),
+                    LowPowerClkConfig::RtcSlow => request_rtc_slow_clk(clocks),
+                }
                 configure_low_power_clk_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
-                    low_power_clk_release_upstream(clocks, old_selector);
+                    match old_selector {
+                        LowPowerClkConfig::Xtal => release_xtal_clk(clocks),
+                        LowPowerClkConfig::RcFast => release_rc_fast_clk(clocks),
+                        LowPowerClkConfig::Xtal32k => release_xtal32k_clk(clocks),
+                        LowPowerClkConfig::RtcSlow => release_rtc_slow_clk(clocks),
+                    }
                 }
             } else {
                 configure_low_power_clk_impl(clocks, old_selector, new_selector);
             }
         }
-        fn low_power_clk_request_upstream(clocks: &mut ClockTree, selector: LowPowerClkConfig) {
-            match selector {
-                LowPowerClkConfig::Xtal => request_xtal_clk(clocks),
-                LowPowerClkConfig::RcFast => request_rc_fast_clk(clocks),
-                LowPowerClkConfig::Xtal32k => request_xtal32k_clk(clocks),
-                LowPowerClkConfig::RtcSlow => request_rtc_slow_clk(clocks),
-            }
-        }
-        fn low_power_clk_release_upstream(clocks: &mut ClockTree, selector: LowPowerClkConfig) {
-            match selector {
-                LowPowerClkConfig::Xtal => release_xtal_clk(clocks),
-                LowPowerClkConfig::RcFast => release_rc_fast_clk(clocks),
-                LowPowerClkConfig::Xtal32k => release_xtal32k_clk(clocks),
-                LowPowerClkConfig::RtcSlow => release_rtc_slow_clk(clocks),
-            }
-        }
         pub fn request_low_power_clk(clocks: &mut ClockTree) {
             if increment_reference_count(&mut clocks.low_power_clk_refcount) {
-                let selector = unwrap!(clocks.low_power_clk);
-                low_power_clk_request_upstream(clocks, selector);
+                match unwrap!(clocks.low_power_clk) {
+                    LowPowerClkConfig::Xtal => request_xtal_clk(clocks),
+                    LowPowerClkConfig::RcFast => request_rc_fast_clk(clocks),
+                    LowPowerClkConfig::Xtal32k => request_xtal32k_clk(clocks),
+                    LowPowerClkConfig::RtcSlow => request_rtc_slow_clk(clocks),
+                }
                 enable_low_power_clk_impl(clocks, true);
             }
         }
         pub fn release_low_power_clk(clocks: &mut ClockTree) {
             if decrement_reference_count(&mut clocks.low_power_clk_refcount) {
                 enable_low_power_clk_impl(clocks, false);
-                let selector = unwrap!(clocks.low_power_clk);
-                low_power_clk_release_upstream(clocks, selector);
+                match unwrap!(clocks.low_power_clk) {
+                    LowPowerClkConfig::Xtal => release_xtal_clk(clocks),
+                    LowPowerClkConfig::RcFast => release_rc_fast_clk(clocks),
+                    LowPowerClkConfig::Xtal32k => release_xtal32k_clk(clocks),
+                    LowPowerClkConfig::RtcSlow => release_rtc_slow_clk(clocks),
+                }
             }
         }
         pub fn low_power_clk_frequency(clocks: &mut ClockTree) -> u32 {
@@ -1355,45 +1337,37 @@ macro_rules! define_clock_tree_types {
         ) {
             let old_selector = clocks.timg0_function_clock.replace(new_selector);
             if clocks.timg0_function_clock_refcount > 0 {
-                timg0_function_clock_request_upstream(clocks, new_selector);
+                match new_selector {
+                    Timg0FunctionClockConfig::XtalClk => request_xtal_clk(clocks),
+                    Timg0FunctionClockConfig::ApbClk => request_apb_clk(clocks),
+                }
                 configure_timg0_function_clock_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
-                    timg0_function_clock_release_upstream(clocks, old_selector);
+                    match old_selector {
+                        Timg0FunctionClockConfig::XtalClk => release_xtal_clk(clocks),
+                        Timg0FunctionClockConfig::ApbClk => release_apb_clk(clocks),
+                    }
                 }
             } else {
                 configure_timg0_function_clock_impl(clocks, old_selector, new_selector);
             }
         }
-        fn timg0_function_clock_request_upstream(
-            clocks: &mut ClockTree,
-            selector: Timg0FunctionClockConfig,
-        ) {
-            match selector {
-                Timg0FunctionClockConfig::XtalClk => request_xtal_clk(clocks),
-                Timg0FunctionClockConfig::ApbClk => request_apb_clk(clocks),
-            }
-        }
-        fn timg0_function_clock_release_upstream(
-            clocks: &mut ClockTree,
-            selector: Timg0FunctionClockConfig,
-        ) {
-            match selector {
-                Timg0FunctionClockConfig::XtalClk => release_xtal_clk(clocks),
-                Timg0FunctionClockConfig::ApbClk => release_apb_clk(clocks),
-            }
-        }
         pub fn request_timg0_function_clock(clocks: &mut ClockTree) {
             if increment_reference_count(&mut clocks.timg0_function_clock_refcount) {
-                let selector = unwrap!(clocks.timg0_function_clock);
-                timg0_function_clock_request_upstream(clocks, selector);
+                match unwrap!(clocks.timg0_function_clock) {
+                    Timg0FunctionClockConfig::XtalClk => request_xtal_clk(clocks),
+                    Timg0FunctionClockConfig::ApbClk => request_apb_clk(clocks),
+                }
                 enable_timg0_function_clock_impl(clocks, true);
             }
         }
         pub fn release_timg0_function_clock(clocks: &mut ClockTree) {
             if decrement_reference_count(&mut clocks.timg0_function_clock_refcount) {
                 enable_timg0_function_clock_impl(clocks, false);
-                let selector = unwrap!(clocks.timg0_function_clock);
-                timg0_function_clock_release_upstream(clocks, selector);
+                match unwrap!(clocks.timg0_function_clock) {
+                    Timg0FunctionClockConfig::XtalClk => release_xtal_clk(clocks),
+                    Timg0FunctionClockConfig::ApbClk => release_apb_clk(clocks),
+                }
             }
         }
         pub fn timg0_function_clock_frequency(clocks: &mut ClockTree) -> u32 {
@@ -1408,47 +1382,43 @@ macro_rules! define_clock_tree_types {
         ) {
             let old_selector = clocks.timg0_calibration_clock.replace(new_selector);
             if clocks.timg0_calibration_clock_refcount > 0 {
-                timg0_calibration_clock_request_upstream(clocks, new_selector);
+                match new_selector {
+                    Timg0CalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
+                    Timg0CalibrationClockConfig::RcFastDivClk => request_rc_fast_div_clk(clocks),
+                    Timg0CalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
+                }
                 configure_timg0_calibration_clock_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
-                    timg0_calibration_clock_release_upstream(clocks, old_selector);
+                    match old_selector {
+                        Timg0CalibrationClockConfig::RcSlowClk => release_rc_slow_clk(clocks),
+                        Timg0CalibrationClockConfig::RcFastDivClk => {
+                            release_rc_fast_div_clk(clocks)
+                        }
+                        Timg0CalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
+                    }
                 }
             } else {
                 configure_timg0_calibration_clock_impl(clocks, old_selector, new_selector);
             }
         }
-        fn timg0_calibration_clock_request_upstream(
-            clocks: &mut ClockTree,
-            selector: Timg0CalibrationClockConfig,
-        ) {
-            match selector {
-                Timg0CalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
-                Timg0CalibrationClockConfig::RcFastDivClk => request_rc_fast_div_clk(clocks),
-                Timg0CalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
-            }
-        }
-        fn timg0_calibration_clock_release_upstream(
-            clocks: &mut ClockTree,
-            selector: Timg0CalibrationClockConfig,
-        ) {
-            match selector {
-                Timg0CalibrationClockConfig::RcSlowClk => release_rc_slow_clk(clocks),
-                Timg0CalibrationClockConfig::RcFastDivClk => release_rc_fast_div_clk(clocks),
-                Timg0CalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
-            }
-        }
         pub fn request_timg0_calibration_clock(clocks: &mut ClockTree) {
             if increment_reference_count(&mut clocks.timg0_calibration_clock_refcount) {
-                let selector = unwrap!(clocks.timg0_calibration_clock);
-                timg0_calibration_clock_request_upstream(clocks, selector);
+                match unwrap!(clocks.timg0_calibration_clock) {
+                    Timg0CalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
+                    Timg0CalibrationClockConfig::RcFastDivClk => request_rc_fast_div_clk(clocks),
+                    Timg0CalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
+                }
                 enable_timg0_calibration_clock_impl(clocks, true);
             }
         }
         pub fn release_timg0_calibration_clock(clocks: &mut ClockTree) {
             if decrement_reference_count(&mut clocks.timg0_calibration_clock_refcount) {
                 enable_timg0_calibration_clock_impl(clocks, false);
-                let selector = unwrap!(clocks.timg0_calibration_clock);
-                timg0_calibration_clock_release_upstream(clocks, selector);
+                match unwrap!(clocks.timg0_calibration_clock) {
+                    Timg0CalibrationClockConfig::RcSlowClk => release_rc_slow_clk(clocks),
+                    Timg0CalibrationClockConfig::RcFastDivClk => release_rc_fast_div_clk(clocks),
+                    Timg0CalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
+                }
             }
         }
         pub fn timg0_calibration_clock_frequency(clocks: &mut ClockTree) -> u32 {
@@ -1464,45 +1434,37 @@ macro_rules! define_clock_tree_types {
         ) {
             let old_selector = clocks.timg1_function_clock.replace(new_selector);
             if clocks.timg1_function_clock_refcount > 0 {
-                timg1_function_clock_request_upstream(clocks, new_selector);
+                match new_selector {
+                    Timg0FunctionClockConfig::XtalClk => request_xtal_clk(clocks),
+                    Timg0FunctionClockConfig::ApbClk => request_apb_clk(clocks),
+                }
                 configure_timg1_function_clock_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
-                    timg1_function_clock_release_upstream(clocks, old_selector);
+                    match old_selector {
+                        Timg0FunctionClockConfig::XtalClk => release_xtal_clk(clocks),
+                        Timg0FunctionClockConfig::ApbClk => release_apb_clk(clocks),
+                    }
                 }
             } else {
                 configure_timg1_function_clock_impl(clocks, old_selector, new_selector);
             }
         }
-        fn timg1_function_clock_request_upstream(
-            clocks: &mut ClockTree,
-            selector: Timg0FunctionClockConfig,
-        ) {
-            match selector {
-                Timg0FunctionClockConfig::XtalClk => request_xtal_clk(clocks),
-                Timg0FunctionClockConfig::ApbClk => request_apb_clk(clocks),
-            }
-        }
-        fn timg1_function_clock_release_upstream(
-            clocks: &mut ClockTree,
-            selector: Timg0FunctionClockConfig,
-        ) {
-            match selector {
-                Timg0FunctionClockConfig::XtalClk => release_xtal_clk(clocks),
-                Timg0FunctionClockConfig::ApbClk => release_apb_clk(clocks),
-            }
-        }
         pub fn request_timg1_function_clock(clocks: &mut ClockTree) {
             if increment_reference_count(&mut clocks.timg1_function_clock_refcount) {
-                let selector = unwrap!(clocks.timg1_function_clock);
-                timg1_function_clock_request_upstream(clocks, selector);
+                match unwrap!(clocks.timg1_function_clock) {
+                    Timg0FunctionClockConfig::XtalClk => request_xtal_clk(clocks),
+                    Timg0FunctionClockConfig::ApbClk => request_apb_clk(clocks),
+                }
                 enable_timg1_function_clock_impl(clocks, true);
             }
         }
         pub fn release_timg1_function_clock(clocks: &mut ClockTree) {
             if decrement_reference_count(&mut clocks.timg1_function_clock_refcount) {
                 enable_timg1_function_clock_impl(clocks, false);
-                let selector = unwrap!(clocks.timg1_function_clock);
-                timg1_function_clock_release_upstream(clocks, selector);
+                match unwrap!(clocks.timg1_function_clock) {
+                    Timg0FunctionClockConfig::XtalClk => release_xtal_clk(clocks),
+                    Timg0FunctionClockConfig::ApbClk => release_apb_clk(clocks),
+                }
             }
         }
         pub fn timg1_function_clock_frequency(clocks: &mut ClockTree) -> u32 {
@@ -1517,47 +1479,43 @@ macro_rules! define_clock_tree_types {
         ) {
             let old_selector = clocks.timg1_calibration_clock.replace(new_selector);
             if clocks.timg1_calibration_clock_refcount > 0 {
-                timg1_calibration_clock_request_upstream(clocks, new_selector);
+                match new_selector {
+                    Timg0CalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
+                    Timg0CalibrationClockConfig::RcFastDivClk => request_rc_fast_div_clk(clocks),
+                    Timg0CalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
+                }
                 configure_timg1_calibration_clock_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
-                    timg1_calibration_clock_release_upstream(clocks, old_selector);
+                    match old_selector {
+                        Timg0CalibrationClockConfig::RcSlowClk => release_rc_slow_clk(clocks),
+                        Timg0CalibrationClockConfig::RcFastDivClk => {
+                            release_rc_fast_div_clk(clocks)
+                        }
+                        Timg0CalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
+                    }
                 }
             } else {
                 configure_timg1_calibration_clock_impl(clocks, old_selector, new_selector);
             }
         }
-        fn timg1_calibration_clock_request_upstream(
-            clocks: &mut ClockTree,
-            selector: Timg0CalibrationClockConfig,
-        ) {
-            match selector {
-                Timg0CalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
-                Timg0CalibrationClockConfig::RcFastDivClk => request_rc_fast_div_clk(clocks),
-                Timg0CalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
-            }
-        }
-        fn timg1_calibration_clock_release_upstream(
-            clocks: &mut ClockTree,
-            selector: Timg0CalibrationClockConfig,
-        ) {
-            match selector {
-                Timg0CalibrationClockConfig::RcSlowClk => release_rc_slow_clk(clocks),
-                Timg0CalibrationClockConfig::RcFastDivClk => release_rc_fast_div_clk(clocks),
-                Timg0CalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
-            }
-        }
         pub fn request_timg1_calibration_clock(clocks: &mut ClockTree) {
             if increment_reference_count(&mut clocks.timg1_calibration_clock_refcount) {
-                let selector = unwrap!(clocks.timg1_calibration_clock);
-                timg1_calibration_clock_request_upstream(clocks, selector);
+                match unwrap!(clocks.timg1_calibration_clock) {
+                    Timg0CalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
+                    Timg0CalibrationClockConfig::RcFastDivClk => request_rc_fast_div_clk(clocks),
+                    Timg0CalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
+                }
                 enable_timg1_calibration_clock_impl(clocks, true);
             }
         }
         pub fn release_timg1_calibration_clock(clocks: &mut ClockTree) {
             if decrement_reference_count(&mut clocks.timg1_calibration_clock_refcount) {
                 enable_timg1_calibration_clock_impl(clocks, false);
-                let selector = unwrap!(clocks.timg1_calibration_clock);
-                timg1_calibration_clock_release_upstream(clocks, selector);
+                match unwrap!(clocks.timg1_calibration_clock) {
+                    Timg0CalibrationClockConfig::RcSlowClk => release_rc_slow_clk(clocks),
+                    Timg0CalibrationClockConfig::RcFastDivClk => release_rc_fast_div_clk(clocks),
+                    Timg0CalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
+                }
             }
         }
         pub fn timg1_calibration_clock_frequency(clocks: &mut ClockTree) -> u32 {


### PR DESCRIPTION
This PR inlines the implementation of `x_request/release_upstream` functions into their call sites. The previous implementation assumed that a config type always exists for the clock node, which is not true for single-variant multiplexers. This change enables such single-variant mux nodes, which will be used to model peripheral clocks that have a single option.

cc #4502