### PR TITLE
Fix clippy lints

### DIFF
--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1916,10 +1916,10 @@ where
                     if crate::soc::addr_in_range(des.buffer as usize, psram_range.clone()) {
                         uses_psram = true;
                         // both the size and address of the buffer must be aligned
-                        if des.buffer as usize % alignment != 0 {
+                        if !(des.buffer as usize).is_multiple_of(alignment) {
                             return Err(DmaError::InvalidAlignment(DmaAlignmentError::Address));
                         }
-                        if des.size() % alignment != 0 {
+                        if !des.size().is_multiple_of(alignment) {
                             return Err(DmaError::InvalidAlignment(DmaAlignmentError::Size));
                         }
                         unsafe {crate::soc::cache_invalidate_addr(des.buffer as u32, des.size() as u32); }
@@ -2182,10 +2182,10 @@ where
                     if crate::soc::addr_in_range(des.buffer as usize, psram_range.clone()) {
                         uses_psram = true;
                         // both the size and address of the buffer must be aligned
-                        if des.buffer as usize % alignment != 0 {
+                        if !(des.buffer as usize).is_multiple_of(alignment) {
                             return Err(DmaError::InvalidAlignment(DmaAlignmentError::Address));
                         }
-                        if des.size() % alignment != 0 {
+                        if !des.size().is_multiple_of(alignment) {
                             return Err(DmaError::InvalidAlignment(DmaAlignmentError::Size));
                         }
                         unsafe { crate::soc::cache_writeback_addr(des.buffer as u32, des.size() as u32); }


### PR DESCRIPTION
```
error: manual implementation of `.is_multiple_of()`
    --> src\dma\mod.rs:2185:28
     |
2185 |                         if des.buffer as usize % alignment != 0 {
     |                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `!(des.buffer as usize).is_multiple_of(alignment)`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_is_multiple_of
```

I'm not sure why the nightly CI didn't pick this up