### PR TITLE
Clean up MCPWM clock sources

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - The `ESP_HAL_CONFIG_XTAL_FREQUENCY` configuration option has been removed (#4517)
+- `Clocks::{i2c_clock, pwm_clock, crypto_clock}` fields (#4636, #4647)
 
 ## [v1.0.0] - 2025-10-30
 

--- a/esp-hal/src/mcpwm/operator.rs
+++ b/esp-hal/src/mcpwm/operator.rs
@@ -14,7 +14,7 @@ use core::marker::PhantomData;
 use super::PeripheralGuard;
 use crate::{
     gpio::interconnect::{OutputSignal, PeripheralOutput},
-    mcpwm::{PwmPeripheral, timer::Timer},
+    mcpwm::{PwmClockGuard, PwmPeripheral, timer::Timer},
     pac,
 };
 
@@ -170,12 +170,11 @@ impl DeadTimeCfg {
 pub struct Operator<'d, const OP: u8, PWM> {
     phantom: PhantomData<&'d PWM>,
     _guard: PeripheralGuard,
+    _pwm_clock_guard: PwmClockGuard,
 }
 
 impl<'d, const OP: u8, PWM: PwmPeripheral> Operator<'d, OP, PWM> {
-    pub(super) fn new() -> Self {
-        let guard = PeripheralGuard::new(PWM::peripheral());
-
+    pub(super) fn new(guard: PeripheralGuard) -> Self {
         // Side note:
         // It would have been nice to deselect any timer reference on peripheral
         // initialization.
@@ -185,6 +184,7 @@ impl<'d, const OP: u8, PWM: PwmPeripheral> Operator<'d, OP, PWM> {
         Operator {
             phantom: PhantomData,
             _guard: guard,
+            _pwm_clock_guard: PwmClockGuard::new::<PWM>(),
         }
     }
 

--- a/esp-hal/src/mcpwm/timer.rs
+++ b/esp-hal/src/mcpwm/timer.rs
@@ -8,7 +8,7 @@ use core::marker::PhantomData;
 
 use super::PeripheralGuard;
 use crate::{
-    mcpwm::{FrequencyError, PeripheralClockConfig, PwmPeripheral},
+    mcpwm::{FrequencyError, PeripheralClockConfig, PwmClockGuard, PwmPeripheral},
     pac,
     time::Rate,
 };
@@ -21,14 +21,15 @@ use crate::{
 pub struct Timer<const TIM: u8, PWM> {
     pub(super) phantom: PhantomData<PWM>,
     _guard: PeripheralGuard,
+    _pwm_clock_guard: PwmClockGuard,
 }
 
 impl<const TIM: u8, PWM: PwmPeripheral> Timer<TIM, PWM> {
-    pub(super) fn new() -> Self {
-        let guard = PeripheralGuard::new(PWM::peripheral());
+    pub(super) fn new(guard: PeripheralGuard) -> Self {
         Timer {
             phantom: PhantomData,
             _guard: guard,
+            _pwm_clock_guard: PwmClockGuard::new::<PWM>(),
         }
     }
 

--- a/esp-hal/src/soc/esp32/clocks.rs
+++ b/esp-hal/src/soc/esp32/clocks.rs
@@ -662,6 +662,34 @@ fn configure_rtc_fast_clk_impl(
     });
 }
 
+// MCPWM0_FUNCTION_CLOCK
+
+fn enable_mcpwm0_function_clock_impl(_clocks: &mut ClockTree, _en: bool) {
+    // Nothing to do.
+}
+
+fn configure_mcpwm0_function_clock_impl(
+    _clocks: &mut ClockTree,
+    _old_selector: Option<Mcpwm0FunctionClockConfig>,
+    _new_selector: Mcpwm0FunctionClockConfig,
+) {
+    // Nothing to do.
+}
+
+// MCPWM1_FUNCTION_CLOCK
+
+fn enable_mcpwm1_function_clock_impl(_clocks: &mut ClockTree, _en: bool) {
+    // Nothing to do.
+}
+
+fn configure_mcpwm1_function_clock_impl(
+    _clocks: &mut ClockTree,
+    _old_selector: Option<Mcpwm0FunctionClockConfig>,
+    _new_selector: Mcpwm0FunctionClockConfig,
+) {
+    // Nothing to do.
+}
+
 // TIMG0_CALIBRATION_CLOCK
 
 fn enable_timg0_calibration_clock_impl(_clocks: &mut ClockTree, _en: bool) {

--- a/esp-hal/src/soc/esp32c6/clocks.rs
+++ b/esp-hal/src/soc/esp32c6/clocks.rs
@@ -52,7 +52,6 @@ impl CpuClock {
         mspi_fast_ls_clk: None, // Unused when root clock is PLL
         apb_clk: Some(ApbClkConfig::new(0)),
         ledc_sclk: Some(LedcSclkConfig::PllF80m),
-        mcpwm_clk: Some(McpwmClkConfig::PllF160m),
         lp_fast_clk: Some(LpFastClkConfig::RcFastClk),
         lp_slow_clk: Some(LpSlowClkConfig::RcSlow),
     };
@@ -68,7 +67,6 @@ impl CpuClock {
         mspi_fast_ls_clk: None, // Unused when root clock is PLL
         apb_clk: Some(ApbClkConfig::new(0)),
         ledc_sclk: Some(LedcSclkConfig::PllF80m),
-        mcpwm_clk: Some(McpwmClkConfig::PllF160m),
         lp_fast_clk: Some(LpFastClkConfig::RcFastClk),
         lp_slow_clk: Some(LpSlowClkConfig::RcSlow),
     };
@@ -476,28 +474,6 @@ fn configure_ledc_sclk_impl(
     });
 }
 
-// MCPWM_CLK
-
-fn enable_mcpwm_clk_impl(_clocks: &mut ClockTree, en: bool) {
-    PCR::regs()
-        .pwm_clk_conf()
-        .modify(|_, w| w.pwm_clkm_en().bit(en));
-}
-
-fn configure_mcpwm_clk_impl(
-    _clocks: &mut ClockTree,
-    _old_selector: Option<McpwmClkConfig>,
-    new_selector: McpwmClkConfig,
-) {
-    PCR::regs().pwm_clk_conf().modify(|_, w| unsafe {
-        w.pwm_clkm_sel().bits(match new_selector {
-            McpwmClkConfig::PllF160m => 1,
-            McpwmClkConfig::XtalClk => 2,
-            McpwmClkConfig::RcFastClk => 3,
-        })
-    });
-}
-
 // XTAL_D2_CLK
 
 fn enable_xtal_d2_clk_impl(_clocks: &mut ClockTree, _en: bool) {
@@ -539,6 +515,28 @@ fn configure_lp_slow_clk_impl(
             LpSlowClkConfig::Xtal32kClk => 1,
             LpSlowClkConfig::RcSlow => 0,
             LpSlowClkConfig::OscSlow => 2,
+        })
+    });
+}
+
+// MCPWM0_FUNCTION_CLOCK
+
+fn enable_mcpwm0_function_clock_impl(_clocks: &mut ClockTree, en: bool) {
+    PCR::regs()
+        .pwm_clk_conf()
+        .modify(|_, w| w.pwm_clkm_en().bit(en));
+}
+
+fn configure_mcpwm0_function_clock_impl(
+    _clocks: &mut ClockTree,
+    _old_selector: Option<Mcpwm0FunctionClockConfig>,
+    new_selector: Mcpwm0FunctionClockConfig,
+) {
+    PCR::regs().pwm_clk_conf().modify(|_, w| unsafe {
+        w.pwm_clkm_sel().bits(match new_selector {
+            Mcpwm0FunctionClockConfig::PllF160m => 1,
+            Mcpwm0FunctionClockConfig::XtalClk => 2,
+            Mcpwm0FunctionClockConfig::RcFastClk => 3,
         })
     });
 }

--- a/esp-hal/src/soc/esp32h2/clocks.rs
+++ b/esp-hal/src/soc/esp32h2/clocks.rs
@@ -362,6 +362,28 @@ fn configure_lp_slow_clk_impl(
     });
 }
 
+// MCPWM0_FUNCTION_CLOCK
+
+fn enable_mcpwm0_function_clock_impl(_clocks: &mut ClockTree, en: bool) {
+    PCR::regs()
+        .pwm_clk_conf()
+        .modify(|_, w| w.pwm_clkm_en().bit(en));
+}
+
+fn configure_mcpwm0_function_clock_impl(
+    _clocks: &mut ClockTree,
+    _old_selector: Option<Mcpwm0FunctionClockConfig>,
+    new_selector: Mcpwm0FunctionClockConfig,
+) {
+    PCR::regs().pwm_clk_conf().modify(|_, w| unsafe {
+        w.pwm_clkm_sel().bits(match new_selector {
+            Mcpwm0FunctionClockConfig::XtalClk => 0,
+            Mcpwm0FunctionClockConfig::RcFastClk => 1,
+            Mcpwm0FunctionClockConfig::PllF96m => 2,
+        })
+    });
+}
+
 // TIMG0_FUNCTION_CLOCK
 
 fn enable_timg0_function_clock_impl(_clocks: &mut ClockTree, en: bool) {

--- a/esp-hal/src/soc/esp32s3/clocks.rs
+++ b/esp-hal/src/soc/esp32s3/clocks.rs
@@ -717,6 +717,34 @@ fn configure_low_power_clk_impl(
     });
 }
 
+// MCPWM0_FUNCTION_CLOCK
+
+fn enable_mcpwm0_function_clock_impl(_clocks: &mut ClockTree, _en: bool) {
+    // Nothing to do.
+}
+
+fn configure_mcpwm0_function_clock_impl(
+    _clocks: &mut ClockTree,
+    _old_selector: Option<Mcpwm0FunctionClockConfig>,
+    _new_selector: Mcpwm0FunctionClockConfig,
+) {
+    // Nothing to do.
+}
+
+// MCPWM1_FUNCTION_CLOCK
+
+fn enable_mcpwm1_function_clock_impl(_clocks: &mut ClockTree, _en: bool) {
+    // Nothing to do.
+}
+
+fn configure_mcpwm1_function_clock_impl(
+    _clocks: &mut ClockTree,
+    _old_selector: Option<Mcpwm0FunctionClockConfig>,
+    _new_selector: Mcpwm0FunctionClockConfig,
+) {
+    // Nothing to do.
+}
+
 // TIMG0_FUNCTION_CLOCK
 
 // Note that the function clock is a pre-requisite of the timer, but does not enable the counter.

--- a/esp-hal/src/system.rs
+++ b/esp-hal/src/system.rs
@@ -70,6 +70,16 @@ impl PeripheralGuard {
     }
 }
 
+impl Clone for PeripheralGuard {
+    fn clone(&self) -> Self {
+        Self::new(self.peripheral)
+    }
+
+    fn clone_from(&mut self, _source: &Self) {
+        // This is a no-op since the ref count for P remains the same.
+    }
+}
+
 impl Drop for PeripheralGuard {
     fn drop(&mut self) {
         PeripheralClockControl::disable(self.peripheral);

--- a/esp-metadata-generated/src/_build_script_utils.rs
+++ b/esp-metadata-generated/src/_build_script_utils.rs
@@ -305,6 +305,8 @@ impl Chip {
                     "soc_has_clock_node_xtal_div_clk",
                     "soc_has_clock_node_rtc_slow_clk",
                     "soc_has_clock_node_rtc_fast_clk",
+                    "soc_has_clock_node_mcpwm0_function_clock",
+                    "soc_has_clock_node_mcpwm1_function_clock",
                     "soc_has_clock_node_timg0_calibration_clock",
                     "soc_has_clock_node_timg1_calibration_clock",
                     "has_dram_region",
@@ -494,6 +496,8 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_clock_node_xtal_div_clk",
                     "cargo:rustc-cfg=soc_has_clock_node_rtc_slow_clk",
                     "cargo:rustc-cfg=soc_has_clock_node_rtc_fast_clk",
+                    "cargo:rustc-cfg=soc_has_clock_node_mcpwm0_function_clock",
+                    "cargo:rustc-cfg=soc_has_clock_node_mcpwm1_function_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_timg0_calibration_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_timg1_calibration_clock",
                     "cargo:rustc-cfg=has_dram_region",
@@ -1433,10 +1437,10 @@ impl Chip {
                     "soc_has_clock_node_pll_f160m",
                     "soc_has_clock_node_pll_f240m",
                     "soc_has_clock_node_ledc_sclk",
-                    "soc_has_clock_node_mcpwm_clk",
                     "soc_has_clock_node_xtal_d2_clk",
                     "soc_has_clock_node_lp_fast_clk",
                     "soc_has_clock_node_lp_slow_clk",
+                    "soc_has_clock_node_mcpwm0_function_clock",
                     "soc_has_clock_node_timg0_function_clock",
                     "soc_has_clock_node_timg0_calibration_clock",
                     "soc_has_clock_node_timg1_function_clock",
@@ -1684,10 +1688,10 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_clock_node_pll_f160m",
                     "cargo:rustc-cfg=soc_has_clock_node_pll_f240m",
                     "cargo:rustc-cfg=soc_has_clock_node_ledc_sclk",
-                    "cargo:rustc-cfg=soc_has_clock_node_mcpwm_clk",
                     "cargo:rustc-cfg=soc_has_clock_node_xtal_d2_clk",
                     "cargo:rustc-cfg=soc_has_clock_node_lp_fast_clk",
                     "cargo:rustc-cfg=soc_has_clock_node_lp_slow_clk",
+                    "cargo:rustc-cfg=soc_has_clock_node_mcpwm0_function_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_timg0_function_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_timg0_calibration_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_timg1_function_clock",
@@ -1925,6 +1929,7 @@ impl Chip {
                     "soc_has_clock_node_xtal_d2_clk",
                     "soc_has_clock_node_lp_fast_clk",
                     "soc_has_clock_node_lp_slow_clk",
+                    "soc_has_clock_node_mcpwm0_function_clock",
                     "soc_has_clock_node_timg0_function_clock",
                     "soc_has_clock_node_timg0_calibration_clock",
                     "soc_has_clock_node_timg1_function_clock",
@@ -2136,6 +2141,7 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_clock_node_xtal_d2_clk",
                     "cargo:rustc-cfg=soc_has_clock_node_lp_fast_clk",
                     "cargo:rustc-cfg=soc_has_clock_node_lp_slow_clk",
+                    "cargo:rustc-cfg=soc_has_clock_node_mcpwm0_function_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_timg0_function_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_timg0_calibration_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_timg1_function_clock",
@@ -2808,6 +2814,8 @@ impl Chip {
                     "soc_has_clock_node_rtc_slow_clk",
                     "soc_has_clock_node_rtc_fast_clk",
                     "soc_has_clock_node_low_power_clk",
+                    "soc_has_clock_node_mcpwm0_function_clock",
+                    "soc_has_clock_node_mcpwm1_function_clock",
                     "soc_has_clock_node_timg0_function_clock",
                     "soc_has_clock_node_timg0_calibration_clock",
                     "soc_has_clock_node_timg1_function_clock",
@@ -3034,6 +3042,8 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_clock_node_rtc_slow_clk",
                     "cargo:rustc-cfg=soc_has_clock_node_rtc_fast_clk",
                     "cargo:rustc-cfg=soc_has_clock_node_low_power_clk",
+                    "cargo:rustc-cfg=soc_has_clock_node_mcpwm0_function_clock",
+                    "cargo:rustc-cfg=soc_has_clock_node_mcpwm1_function_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_timg0_function_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_timg0_calibration_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_timg1_function_clock",
@@ -3309,6 +3319,8 @@ pub fn emit_check_cfg_directives() {
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_xtal_div_clk)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_rtc_slow_clk)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_rtc_fast_clk)");
+    println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_mcpwm0_function_clock)");
+    println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_mcpwm1_function_clock)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_timg0_calibration_clock)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_timg1_calibration_clock)");
     println!("cargo:rustc-check-cfg=cfg(has_dram_region)");
@@ -3479,7 +3491,6 @@ pub fn emit_check_cfg_directives() {
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_pll_f160m)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_pll_f240m)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_ledc_sclk)");
-    println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_mcpwm_clk)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_xtal_d2_clk)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_lp_fast_clk)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_lp_slow_clk)");

--- a/esp-metadata-generated/src/_generated_esp32c6.rs
+++ b/esp-metadata-generated/src/_generated_esp32c6.rs
@@ -496,20 +496,6 @@ macro_rules! for_each_soc_xtal_options {
 ///     todo!()
 /// }
 ///
-/// // MCPWM_CLK
-///
-/// fn enable_mcpwm_clk_impl(_clocks: &mut ClockTree, _en: bool) {
-///     todo!()
-/// }
-///
-/// fn configure_mcpwm_clk_impl(
-///     _clocks: &mut ClockTree,
-///     _old_selector: Option<McpwmClkConfig>,
-///     _new_selector: McpwmClkConfig,
-/// ) {
-///     todo!()
-/// }
-///
 /// // XTAL_D2_CLK
 ///
 /// fn enable_xtal_d2_clk_impl(_clocks: &mut ClockTree, _en: bool) {
@@ -540,6 +526,20 @@ macro_rules! for_each_soc_xtal_options {
 ///     _clocks: &mut ClockTree,
 ///     _old_selector: Option<LpSlowClkConfig>,
 ///     _new_selector: LpSlowClkConfig,
+/// ) {
+///     todo!()
+/// }
+///
+/// // MCPWM0_FUNCTION_CLOCK
+///
+/// fn enable_mcpwm0_function_clock_impl(_clocks: &mut ClockTree, _en: bool) {
+///     todo!()
+/// }
+///
+/// fn configure_mcpwm0_function_clock_impl(
+///     _clocks: &mut ClockTree,
+///     _old_selector: Option<Mcpwm0FunctionClockConfig>,
+///     _new_selector: Mcpwm0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -925,17 +925,6 @@ macro_rules! define_clock_tree_types {
             /// Selects `XTAL_CLK`.
             XtalClk,
         }
-        /// The list of clock signals that the `MCPWM_CLK` multiplexer can output.
-        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-        pub enum McpwmClkConfig {
-            /// Selects `PLL_F160M`.
-            PllF160m,
-            /// Selects `RC_FAST_CLK`.
-            RcFastClk,
-            /// Selects `XTAL_CLK`.
-            XtalClk,
-        }
         /// The list of clock signals that the `LP_FAST_CLK` multiplexer can output.
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -955,6 +944,18 @@ macro_rules! define_clock_tree_types {
             RcSlow,
             /// Selects `OSC_SLOW_CLK`.
             OscSlow,
+        }
+        /// The list of clock signals that the `MCPWM0_FUNCTION_CLOCK` multiplexer can output.
+        #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+        pub enum Mcpwm0FunctionClockConfig {
+            #[default]
+            /// Selects `PLL_F160M`.
+            PllF160m,
+            /// Selects `RC_FAST_CLK`.
+            RcFastClk,
+            /// Selects `XTAL_CLK`.
+            XtalClk,
         }
         /// The list of clock signals that the `TIMG0_FUNCTION_CLOCK` multiplexer can output.
         #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
@@ -995,9 +996,9 @@ macro_rules! define_clock_tree_types {
             mspi_fast_hs_clk: Option<MspiFastHsClkConfig>,
             mspi_fast_ls_clk: Option<MspiFastLsClkConfig>,
             ledc_sclk: Option<LedcSclkConfig>,
-            mcpwm_clk: Option<McpwmClkConfig>,
             lp_fast_clk: Option<LpFastClkConfig>,
             lp_slow_clk: Option<LpSlowClkConfig>,
+            mcpwm0_function_clock: Option<Mcpwm0FunctionClockConfig>,
             timg0_function_clock: Option<Timg0FunctionClockConfig>,
             timg0_calibration_clock: Option<Timg0CalibrationClockConfig>,
             timg1_function_clock: Option<Timg0FunctionClockConfig>,
@@ -1012,9 +1013,9 @@ macro_rules! define_clock_tree_types {
             pll_f80m_refcount: u32,
             pll_f240m_refcount: u32,
             ledc_sclk_refcount: u32,
-            mcpwm_clk_refcount: u32,
             lp_fast_clk_refcount: u32,
             lp_slow_clk_refcount: u32,
+            mcpwm0_function_clock_refcount: u32,
             timg0_function_clock_refcount: u32,
             timg0_calibration_clock_refcount: u32,
             timg1_function_clock_refcount: u32,
@@ -1081,10 +1082,6 @@ macro_rules! define_clock_tree_types {
             pub fn ledc_sclk(&self) -> Option<LedcSclkConfig> {
                 self.ledc_sclk
             }
-            /// Returns the current configuration of the MCPWM_CLK clock tree node
-            pub fn mcpwm_clk(&self) -> Option<McpwmClkConfig> {
-                self.mcpwm_clk
-            }
             /// Returns the current configuration of the LP_FAST_CLK clock tree node
             pub fn lp_fast_clk(&self) -> Option<LpFastClkConfig> {
                 self.lp_fast_clk
@@ -1092,6 +1089,10 @@ macro_rules! define_clock_tree_types {
             /// Returns the current configuration of the LP_SLOW_CLK clock tree node
             pub fn lp_slow_clk(&self) -> Option<LpSlowClkConfig> {
                 self.lp_slow_clk
+            }
+            /// Returns the current configuration of the MCPWM0_FUNCTION_CLOCK clock tree node
+            pub fn mcpwm0_function_clock(&self) -> Option<Mcpwm0FunctionClockConfig> {
+                self.mcpwm0_function_clock
             }
             /// Returns the current configuration of the TIMG0_FUNCTION_CLOCK clock tree node
             pub fn timg0_function_clock(&self) -> Option<Timg0FunctionClockConfig> {
@@ -1126,9 +1127,9 @@ macro_rules! define_clock_tree_types {
                 mspi_fast_hs_clk: None,
                 mspi_fast_ls_clk: None,
                 ledc_sclk: None,
-                mcpwm_clk: None,
                 lp_fast_clk: None,
                 lp_slow_clk: None,
+                mcpwm0_function_clock: None,
                 timg0_function_clock: None,
                 timg0_calibration_clock: None,
                 timg1_function_clock: None,
@@ -1143,9 +1144,9 @@ macro_rules! define_clock_tree_types {
                 pll_f80m_refcount: 0,
                 pll_f240m_refcount: 0,
                 ledc_sclk_refcount: 0,
-                mcpwm_clk_refcount: 0,
                 lp_fast_clk_refcount: 0,
                 lp_slow_clk_refcount: 0,
+                mcpwm0_function_clock_refcount: 0,
                 timg0_function_clock_refcount: 0,
                 timg0_calibration_clock_refcount: 0,
                 timg1_function_clock_refcount: 0,
@@ -1598,53 +1599,6 @@ macro_rules! define_clock_tree_types {
                 LedcSclkConfig::XtalClk => xtal_clk_frequency(clocks),
             }
         }
-        pub fn configure_mcpwm_clk(clocks: &mut ClockTree, new_selector: McpwmClkConfig) {
-            let old_selector = clocks.mcpwm_clk.replace(new_selector);
-            if clocks.mcpwm_clk_refcount > 0 {
-                match new_selector {
-                    McpwmClkConfig::PllF160m => request_pll_f160m(clocks),
-                    McpwmClkConfig::RcFastClk => request_rc_fast_clk(clocks),
-                    McpwmClkConfig::XtalClk => request_xtal_clk(clocks),
-                }
-                configure_mcpwm_clk_impl(clocks, old_selector, new_selector);
-                if let Some(old_selector) = old_selector {
-                    match old_selector {
-                        McpwmClkConfig::PllF160m => release_pll_f160m(clocks),
-                        McpwmClkConfig::RcFastClk => release_rc_fast_clk(clocks),
-                        McpwmClkConfig::XtalClk => release_xtal_clk(clocks),
-                    }
-                }
-            } else {
-                configure_mcpwm_clk_impl(clocks, old_selector, new_selector);
-            }
-        }
-        pub fn request_mcpwm_clk(clocks: &mut ClockTree) {
-            if increment_reference_count(&mut clocks.mcpwm_clk_refcount) {
-                match unwrap!(clocks.mcpwm_clk) {
-                    McpwmClkConfig::PllF160m => request_pll_f160m(clocks),
-                    McpwmClkConfig::RcFastClk => request_rc_fast_clk(clocks),
-                    McpwmClkConfig::XtalClk => request_xtal_clk(clocks),
-                }
-                enable_mcpwm_clk_impl(clocks, true);
-            }
-        }
-        pub fn release_mcpwm_clk(clocks: &mut ClockTree) {
-            if decrement_reference_count(&mut clocks.mcpwm_clk_refcount) {
-                enable_mcpwm_clk_impl(clocks, false);
-                match unwrap!(clocks.mcpwm_clk) {
-                    McpwmClkConfig::PllF160m => release_pll_f160m(clocks),
-                    McpwmClkConfig::RcFastClk => release_rc_fast_clk(clocks),
-                    McpwmClkConfig::XtalClk => release_xtal_clk(clocks),
-                }
-            }
-        }
-        pub fn mcpwm_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            match unwrap!(clocks.mcpwm_clk) {
-                McpwmClkConfig::PllF160m => pll_f160m_frequency(clocks),
-                McpwmClkConfig::RcFastClk => rc_fast_clk_frequency(clocks),
-                McpwmClkConfig::XtalClk => xtal_clk_frequency(clocks),
-            }
-        }
         pub fn request_xtal_d2_clk(clocks: &mut ClockTree) {
             request_xtal_clk(clocks);
             enable_xtal_d2_clk_impl(clocks, true);
@@ -1743,6 +1697,56 @@ macro_rules! define_clock_tree_types {
                 LpSlowClkConfig::Xtal32kClk => xtal32k_clk_frequency(clocks),
                 LpSlowClkConfig::RcSlow => rc_slow_clk_frequency(clocks),
                 LpSlowClkConfig::OscSlow => osc_slow_clk_frequency(clocks),
+            }
+        }
+        pub fn configure_mcpwm0_function_clock(
+            clocks: &mut ClockTree,
+            new_selector: Mcpwm0FunctionClockConfig,
+        ) {
+            let old_selector = clocks.mcpwm0_function_clock.replace(new_selector);
+            if clocks.mcpwm0_function_clock_refcount > 0 {
+                match new_selector {
+                    Mcpwm0FunctionClockConfig::PllF160m => request_pll_f160m(clocks),
+                    Mcpwm0FunctionClockConfig::RcFastClk => request_rc_fast_clk(clocks),
+                    Mcpwm0FunctionClockConfig::XtalClk => request_xtal_clk(clocks),
+                }
+                configure_mcpwm0_function_clock_impl(clocks, old_selector, new_selector);
+                if let Some(old_selector) = old_selector {
+                    match old_selector {
+                        Mcpwm0FunctionClockConfig::PllF160m => release_pll_f160m(clocks),
+                        Mcpwm0FunctionClockConfig::RcFastClk => release_rc_fast_clk(clocks),
+                        Mcpwm0FunctionClockConfig::XtalClk => release_xtal_clk(clocks),
+                    }
+                }
+            } else {
+                configure_mcpwm0_function_clock_impl(clocks, old_selector, new_selector);
+            }
+        }
+        pub fn request_mcpwm0_function_clock(clocks: &mut ClockTree) {
+            if increment_reference_count(&mut clocks.mcpwm0_function_clock_refcount) {
+                match unwrap!(clocks.mcpwm0_function_clock) {
+                    Mcpwm0FunctionClockConfig::PllF160m => request_pll_f160m(clocks),
+                    Mcpwm0FunctionClockConfig::RcFastClk => request_rc_fast_clk(clocks),
+                    Mcpwm0FunctionClockConfig::XtalClk => request_xtal_clk(clocks),
+                }
+                enable_mcpwm0_function_clock_impl(clocks, true);
+            }
+        }
+        pub fn release_mcpwm0_function_clock(clocks: &mut ClockTree) {
+            if decrement_reference_count(&mut clocks.mcpwm0_function_clock_refcount) {
+                enable_mcpwm0_function_clock_impl(clocks, false);
+                match unwrap!(clocks.mcpwm0_function_clock) {
+                    Mcpwm0FunctionClockConfig::PllF160m => release_pll_f160m(clocks),
+                    Mcpwm0FunctionClockConfig::RcFastClk => release_rc_fast_clk(clocks),
+                    Mcpwm0FunctionClockConfig::XtalClk => release_xtal_clk(clocks),
+                }
+            }
+        }
+        pub fn mcpwm0_function_clock_frequency(clocks: &mut ClockTree) -> u32 {
+            match unwrap!(clocks.mcpwm0_function_clock) {
+                Mcpwm0FunctionClockConfig::PllF160m => pll_f160m_frequency(clocks),
+                Mcpwm0FunctionClockConfig::RcFastClk => rc_fast_clk_frequency(clocks),
+                Mcpwm0FunctionClockConfig::XtalClk => xtal_clk_frequency(clocks),
             }
         }
         pub fn configure_timg0_function_clock(
@@ -1976,8 +1980,6 @@ macro_rules! define_clock_tree_types {
             pub mspi_fast_ls_clk: Option<MspiFastLsClkConfig>,
             /// `LEDC_SCLK` configuration.
             pub ledc_sclk: Option<LedcSclkConfig>,
-            /// `MCPWM_CLK` configuration.
-            pub mcpwm_clk: Option<McpwmClkConfig>,
             /// `LP_FAST_CLK` configuration.
             pub lp_fast_clk: Option<LpFastClkConfig>,
             /// `LP_SLOW_CLK` configuration.
@@ -2015,9 +2017,6 @@ macro_rules! define_clock_tree_types {
                     }
                     if let Some(config) = self.ledc_sclk {
                         configure_ledc_sclk(clocks, config);
-                    }
-                    if let Some(config) = self.mcpwm_clk {
-                        configure_mcpwm_clk(clocks, config);
                     }
                     if let Some(config) = self.lp_fast_clk {
                         configure_lp_fast_clk(clocks, config);

--- a/esp-metadata/devices/esp32.toml
+++ b/esp-metadata/devices/esp32.toml
@@ -235,6 +235,9 @@ clocks = { system_clocks = { clock_tree = [
     #    { name = "RC_SLOW",  outputs = "RC_SLOW_CLK" },
     #    { name = "RTC_SLOW", outputs = "RTC_SLOW_CLK" },
     #] }
+
+    # Peripheral root clocks
+    # LEDC_SCLK: The TRM is slightly confusing, there is a single mux in the peripheral selecting between APB and RTC_FAST.
 ] }, peripheral_clocks = { templates = [
     # templates
     { name = "clk_en_template", value = "{{control}}::regs().{{clk_en_register}}().modify(|_, w| w.{{clk_en_field}}().bit(enable));" },
@@ -261,10 +264,14 @@ clocks = { system_clocks = { clock_tree = [
     { name = "Uart2" },
     { name = "SpiDma" },
     { name = "I2s1" },
-    { name = "Mcpwm1", template_params = { peripheral = "pwm1" } },
+    { name = "Mcpwm1", template_params = { peripheral = "pwm1" }, clocks = "Mcpwm0" },
     { name = "Twai0", template_params = { peripheral = "twai" } },
     { name = "I2cExt1" },
-    { name = "Mcpwm0", template_params = { peripheral = "pwm0" } },
+    { name = "Mcpwm0", template_params = { peripheral = "pwm0" }, clocks = [
+        { name = "FUNCTION_CLOCK", type = "mux", default = "PLL_F160M", variants = [
+            { name = "PLL_F160M", outputs = "PLL_F160M_CLK" }
+        ] }
+    ] },
     { name = "Spi3" },
     { name = "Timg1", template_params = { peripheral = "timergroup1" }, clocks = "Timg0" }, # same clock options, but different instance
     #{ name = "Efuse" },

--- a/esp-metadata/devices/esp32c6.toml
+++ b/esp-metadata/devices/esp32c6.toml
@@ -192,13 +192,6 @@ clocks = { system_clocks = { clock_tree = [
         { name = "XTAL_CLK",    outputs = "XTAL_CLK" },
     ] },
 
-    # TODO: MCPWM divider
-    { name = "MCPWM_CLK", type = "mux", variants = [
-        { name = "PLL_F160M",   outputs = "PLL_F160M" },
-        { name = "RC_FAST_CLK", outputs = "RC_FAST_CLK" },
-        { name = "XTAL_CLK",    outputs = "XTAL_CLK" },
-    ] },
-
     # LP clocks
     { name = "XTAL_D2_CLK", type = "divider", output = "XTAL_CLK / 2" },
     { name = "LP_FAST_CLK", type = "mux", variants = [
@@ -255,7 +248,14 @@ clocks = { system_clocks = { clock_tree = [
     # { name = "Intmtx" },
     { name = "Pcnt" },
     { name = "Etm" },
-    { name = "Mcpwm0", template_params = { peripheral = "pwm" } },
+    { name = "Mcpwm0", template_params = { peripheral = "pwm" }, clocks = [
+        # TODO: MCPWM divider?
+        { name = "FUNCTION_CLOCK", type = "mux", default = "PLL_F160M", variants = [
+            { name = "PLL_F160M",   outputs = "PLL_F160M" },
+            { name = "RC_FAST_CLK", outputs = "RC_FAST_CLK" },
+            { name = "XTAL_CLK",    outputs = "XTAL_CLK" },
+        ] },
+    ] },
     { name = "ParlIo", template_params = { clk_en_field = "parl_clk_en", rst_field = "parl_rst_en" } },
     { name = "SdioSlave" },
     { name = "Dma", template_params = { peripheral = "gdma" } },

--- a/esp-metadata/devices/esp32h2.toml
+++ b/esp-metadata/devices/esp32h2.toml
@@ -202,7 +202,14 @@ clocks = { system_clocks = { clock_tree = [
     # { name = "Intmtx" },
     { name = "Pcnt" },
     { name = "Etm" },
-    { name = "Mcpwm0", template_params = { peripheral = "pwm" } },
+    { name = "Mcpwm0", template_params = { peripheral = "pwm" }, clocks = [
+        # TODO: MCPWM divider?
+        { name = "FUNCTION_CLOCK", type = "mux", default = "PLL_F96M", variants = [
+            { name = "PLL_F96M",    outputs = "PLL_F96M_CLK" },
+            { name = "RC_FAST_CLK", outputs = "RC_FAST_CLK" },
+            { name = "XTAL_CLK",    outputs = "XTAL_CLK" },
+        ] },
+    ] },
     { name = "ParlIo", template_params = { clk_en_field = "parl_clk_en", rst_field = "parl_rst_en" } },
     { name = "Dma", template_params = { peripheral = "gdma" } },
     { name = "Spi2" },

--- a/esp-metadata/devices/esp32s3.toml
+++ b/esp-metadata/devices/esp32s3.toml
@@ -182,7 +182,7 @@ clocks = { system_clocks = { clock_tree = [
         { name = "RC_FAST",  outputs = "RC_FAST_CLK" },
         { name = "XTAL32K",  outputs = "XTAL32K_CLK" },
         { name = "RTC_SLOW", outputs = "RTC_SLOW_CLK" },
-    ] }
+    ] },
 ] }, peripheral_clocks = { templates = [
     # templates
     { name = "clk_en_template", value = "{{control}}::regs().{{clk_en_register}}().modify(|_, w| w.{{clk_en_field}}().bit(enable));" },
@@ -213,10 +213,14 @@ clocks = { system_clocks = { clock_tree = [
     { name = "UartMem", keep_enabled = true }, # TODO: keep_enabled can be removed once esp-println needs explicit initialization
     { name = "Usb" },
     { name = "I2s1" },
-    { name = "Mcpwm1", template_params = { peripheral = "pwm1" } },
+    { name = "Mcpwm1", template_params = { peripheral = "pwm1" }, clocks = "Mcpwm0" },
     { name = "Twai0", template_params = { peripheral = "twai" } },
     { name = "I2cExt1" },
-    { name = "Mcpwm0", template_params = { peripheral = "pwm0" } },
+    { name = "Mcpwm0", template_params = { peripheral = "pwm0" }, clocks = [
+        { name = "FUNCTION_CLOCK", type = "mux", default = "CRYPTO_PWM_CLK", variants = [
+            { name = "CRYPTO_PWM_CLK", outputs = "CRYPTO_PWM_CLK" }
+        ] }
+    ] },
     { name = "Spi3" },
     { name = "Timg1", template_params = { peripheral = "timergroup1" }, clocks = "Timg0" },
     { name = "Timg0", template_params = { peripheral = "timergroup" }, keep_enabled = true, clocks = [


### PR DESCRIPTION
This PR refactors the MCPWM clock source options into the new clock system, and removes the `Clocks` fields that are no longer needed.