### PR TITLE
Try to optimize accessing the current task

### DIFF
--- a/esp-rtos/Cargo.toml
+++ b/esp-rtos/Cargo.toml
@@ -61,6 +61,12 @@ embassy-time-queue-utils = { version = "0.3.0", optional = true }
 defmt            = { version = "1.0", optional = true }
 log-04           = { package = "log", version = "0.4", optional = true }
 
+[target.'cfg(target_arch = "riscv32")'.dependencies]
+riscv            = { version = "0.15.0" }
+
+[target.'cfg(target_arch = "xtensa")'.dependencies]
+xtensa-lx        = { version = "0.13.0", path = "../xtensa-lx" }
+
 [build-dependencies]
 esp-config             = { version = "0.6.1", path = "../esp-config", features = ["build"] }
 esp-metadata-generated = { version = "0.3.0", path = "../esp-metadata-generated", features = ["build-script"] }

--- a/esp-rtos/src/embassy/mod.rs
+++ b/esp-rtos/src/embassy/mod.rs
@@ -69,12 +69,12 @@ struct ThreadFlag {
 impl ThreadFlag {
     fn new() -> Self {
         let owner = SCHEDULER.with(|scheduler| {
-            let current_cpu = Cpu::current() as usize;
-            if let Some(current_task) = scheduler.per_cpu[current_cpu].current_task {
+            let current_cpu = Cpu::current();
+            if let Some(current_task) = scheduler.try_get_current_task(current_cpu) {
                 current_task
             } else {
                 // We're cheating, the task hasn't been initialized yet.
-                NonNull::from(&scheduler.per_cpu[current_cpu].main_task)
+                NonNull::from(&scheduler.per_cpu[current_cpu as usize].main_task)
             }
         });
         Self {

--- a/esp-rtos/src/esp_radio/mod.rs
+++ b/esp-rtos/src/esp_radio/mod.rs
@@ -96,10 +96,10 @@ impl esp_radio_rtos_driver::SchedulerImplementation for Scheduler {
     }
 
     fn current_task_thread_semaphore(&self) -> SemaphorePtr {
-        task::with_current_task(|task| {
-            *task.thread_local.thread_semaphore.get_or_insert_with(|| {
-                SemaphoreHandle::new(SemaphoreKind::Counting { max: 1, initial: 0 }).leak()
-            })
+        // SAFETY: `current_task` always returns a valid pointer to the current task.
+        let task = unsafe { self.current_task().as_mut() };
+        *task.thread_local.thread_semaphore.get_or_insert_with(|| {
+            SemaphoreHandle::new(SemaphoreKind::Counting { max: 1, initial: 0 }).leak()
         })
     }
 

--- a/esp-rtos/src/syscall.rs
+++ b/esp-rtos/src/syscall.rs
@@ -7,16 +7,19 @@ use esp_rom_sys::SYSCALL_TABLE;
 #[cfg(feature = "alloc")]
 extern "C" fn _getreent() -> *mut esp_rom_sys::_reent {
     use allocator_api2::boxed::Box;
-    crate::task::with_current_task(|task| {
-        task.thread_local
-            .reent
-            .get_or_insert_with(|| unsafe {
-                // Safety: _reent is a C-type containing integers and pointers, it is safe to
-                // zero-initialize it.
-                Box::new_zeroed().assume_init()
-            })
-            .as_mut() as *mut _
-    })
+
+    use crate::SCHEDULER;
+
+    // SAFETY: `current_task` always returns a valid pointer to the current task.
+    let task = unsafe { SCHEDULER.current_task().as_mut() };
+    task.thread_local
+        .reent
+        .get_or_insert_with(|| unsafe {
+            // Safety: _reent is a C-type containing integers and pointers, it is safe to
+            // zero-initialize it.
+            Box::new_zeroed().assume_init()
+        })
+        .as_mut() as *mut _
 }
 
 #[cfg(feature = "esp-alloc")]


### PR DESCRIPTION
This PR moves the current task pointer out of the mutex-locked scheduler state. This is safe to do, as explained in the comments. Also includes a big bunch of mechanical changes that are necessary to get this to work.

This shouldn't be visible on the embassy benchmark (but it is, for some reason), but it should help a bit in the radio-specific IPC implementations.