### PR TITLE
refactor(rtos): remove unneeded timer handler cast

### DIFF
--- a/esp-rtos/src/timer/mod.rs
+++ b/esp-rtos/src/timer/mod.rs
@@ -113,15 +113,13 @@ impl TimeDriver {
         // priority limited locks.
         let timer_priority = Priority::Priority1;
 
-        let cb: extern "C" fn() = unsafe { core::mem::transmute(timer_tick_handler as *const ()) };
-
         cfg_if::cfg_if! {
             if #[cfg(riscv)] {
                 // Register the interrupt handler without nesting to satisfy the requirements of the
                 // task switching code
-                let handler = InterruptHandler::new_not_nested(cb, timer_priority);
+                let handler = InterruptHandler::new_not_nested(timer_tick_handler, timer_priority);
             } else {
-                let handler = InterruptHandler::new(cb, timer_priority);
+                let handler = InterruptHandler::new(timer_tick_handler, timer_priority);
             }
         };
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

We have a mostly copied version of this in Ariel. While trying to add a "Safety" comment, I realized the the cast might not be needed.

#### Testing
Describe how you tested your changes.
