### PR TITLE
CI(binary_size): Give report even when one of the workflows fail

### DIFF
--- a/.github/workflows/binary_size.yml
+++ b/.github/workflows/binary_size.yml
@@ -165,6 +165,7 @@ jobs:
 
   report-results:
     needs: [binary_size]
+    if: always()
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/xtask/src/commands/generate_report.rs
+++ b/xtask/src/commands/generate_report.rs
@@ -20,9 +20,6 @@ pub struct ReportArgs {
 /// Generate a combined binary size report from individual reports in the specified directory.
 pub fn generate_report(workspace: &Path, args: ReportArgs) -> Result<()> {
     let input_dir = &args.input;
-    if !input_dir.is_dir() {
-        anyhow::bail!("Expected a directory, got: {:?}", input_dir);
-    }
 
     let combined_path = workspace.join("report.txt");
     let mut combined = File::create(&combined_path)
@@ -36,7 +33,8 @@ pub fn generate_report(workspace: &Path, args: ReportArgs) -> Result<()> {
     let leading_ws_re = Regex::new(r"^[ \t]+").unwrap();
 
     // Iterate through files like ./results/result-pr-*.txt
-    let mut entries: Vec<_> = fs::read_dir(input_dir)?
+    let mut entries: Vec<_> = fs::read_dir(input_dir)
+        .context("Couldn't open input file for reading!")?
         .filter_map(|e| e.ok())
         .filter(|e| {
             e.path()


### PR DESCRIPTION
If one of the workflows fails, we currently do not get any report. This PR fixes that issue: if at least one workflow succeeds, it will generate a report for the successful workflow.