### PR TITLE
Ensure we only download the latest non-expired artifact

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -40,7 +40,7 @@ reqwest = { version = "0.12.12", features = [
 ], optional = true }
 
 # This pulls a gazillion crates - don't include it by default
-cargo-semver-checks = { version = "0.43.0", optional = true }
+cargo-semver-checks = { version = "0.45.0", optional = true }
 
 flate2 = { version = "1.1.1", optional = true }
 temp-file = { version = "0.1.9", optional = true }


### PR DESCRIPTION
The diff is kinda horrible here due to the indentation change of removing the loop. Essentially this will filter to find the latest non-expired baseline, instead of trying to download them all. (also updates cargo-semver checks to support the new format)