### PR TITLE
chore(backtrace): Remove non-existent feature from documentation

### DIFF
--- a/esp-backtrace/Cargo.toml
+++ b/esp-backtrace/Cargo.toml
@@ -25,7 +25,7 @@ clippy-configs = [
 
 [package.metadata.docs.rs]
 default-target = "riscv32imc-unknown-none-elf"
-features       = ["esp32c3", "panic-handler", "exception-handler", "println", "esp-println/uart"]
+features       = ["esp32c3", "panic-handler", "println", "esp-println/uart"]
 
 [lib]
 bench = false


### PR DESCRIPTION
### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] ~My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.~
  - I didn't do that - I think the change is small enough that it does not need changelog.
- [ ] ~I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).~
  - Again, not applicable.
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

The `exception-handler` feature does not exist anymore. Do not mention it in docs.

#### Testing

N/A
