### PR TITLE
Allow `if_same_then_else` lint

### DIFF
--- a/esp-alloc/src/lib.rs
+++ b/esp-alloc/src/lib.rs
@@ -231,7 +231,7 @@ impl Display for RegionStats {
 }
 
 #[cfg(feature = "defmt")]
-#[expect(clippy::if_same_then_else)]
+#[allow(clippy::if_same_then_else)]
 impl defmt::Format for RegionStats {
     fn format(&self, fmt: defmt::Formatter<'_>) {
         let usage_percent = self.used * 100 / self.size;


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
This PR fixes a `nighly` Clippy lint

#### Testing
`cargo xtask ci esp32c2 --toolchain nightly` now succeeds. Nightly CI run: https://github.com/SergioGasquez/esp-hal/actions/runs/20779247062