### PR TITLE
CI(api-baselines): Don't fail CI if labels don't match any `breaking-change-*` label

### DIFF
--- a/.github/workflows/api-baseline-generation.yml
+++ b/.github/workflows/api-baseline-generation.yml
@@ -113,11 +113,14 @@ jobs:
             echo "$LABELS"
 
             # Extract packages from "breaking-change-" labels
-            PACKAGES=$(echo "$LABELS" \
-              | grep -E '^breaking-change-[a-z0-9-]+$' \
-              | sed 's/^breaking-change-//' \
-              | tr '\n' ',' \
-              | sed 's/,$//')
+            PACKAGES=""
+            if [ -n "$LABELS" ]; then
+              PACKAGES=$(echo "$LABELS" \
+                | grep -E '^breaking-change-[a-z0-9-]+$' || true \
+                | sed 's/^breaking-change-//' \
+                | tr '\n' ',' \
+                | sed 's/,$//')
+            fi
 
             if [ -n "$PACKAGES" ]; then
               echo "Breaking change detected for package(s): $PACKAGES"


### PR DESCRIPTION
If `grep -E '^breaking-change-[a-z0-9-]+$'` matches nothing, it exits with status 1 which ends up killing the CI. This PR should fix this. 

cc https://github.com/esp-rs/esp-hal/actions/runs/20616528483/job/59210259331

With this change the CI is green on my fork, at least (both push and manual trigger) 🤞 🥺 