### PR TITLE
Ensure software interrupts are triggered

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - UART: correct documentation of `read` which incorrectly stated that it would never block (#4586)
 - Fixed System Timer timestamp inaccuracy when using uncommon crystal frequencies (#4634)
 - `SystemTimer::ticks_per_second()` now correctly returns the number of ticks per second. (#4634)
+- The interrupt request set by `SoftwareInterrupt::raise()` should now take effect before returning. (#4706)
 
 ### Removed
 

--- a/esp-metadata-generated/src/_generated_esp32.rs
+++ b/esp-metadata-generated/src/_generated_esp32.rs
@@ -2191,6 +2191,25 @@ macro_rules! for_each_aes_key_length {
         _for_each_inner!((modes(128, 0, 4), (192, 1, 5), (256, 2, 6)));
     };
 }
+#[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_sw_interrupt {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
+        _for_each_inner!((0, FROM_CPU_INTR0, software_interrupt0)); _for_each_inner!((1,
+        FROM_CPU_INTR1, software_interrupt1)); _for_each_inner!((2, FROM_CPU_INTR2,
+        software_interrupt2)); _for_each_inner!((3, FROM_CPU_INTR3,
+        software_interrupt3)); _for_each_inner!((all(0, FROM_CPU_INTR0,
+        software_interrupt0), (1, FROM_CPU_INTR1, software_interrupt1), (2,
+        FROM_CPU_INTR2, software_interrupt2), (3, FROM_CPU_INTR3, software_interrupt3)));
+    };
+}
+#[macro_export]
+macro_rules! sw_interrupt_delay {
+    () => {
+        unsafe {}
+    };
+}
 /// This macro can be used to generate code for each channel of the RMT peripheral.
 ///
 /// For an explanation on the general syntax, as well as usage of individual/repeated

--- a/esp-metadata-generated/src/_generated_esp32c2.rs
+++ b/esp-metadata-generated/src/_generated_esp32c2.rs
@@ -1681,6 +1681,31 @@ macro_rules! memory_range {
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_sw_interrupt {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
+        _for_each_inner!((0, FROM_CPU_INTR0, software_interrupt0)); _for_each_inner!((1,
+        FROM_CPU_INTR1, software_interrupt1)); _for_each_inner!((2, FROM_CPU_INTR2,
+        software_interrupt2)); _for_each_inner!((3, FROM_CPU_INTR3,
+        software_interrupt3)); _for_each_inner!((all(0, FROM_CPU_INTR0,
+        software_interrupt0), (1, FROM_CPU_INTR1, software_interrupt1), (2,
+        FROM_CPU_INTR2, software_interrupt2), (3, FROM_CPU_INTR3, software_interrupt3)));
+    };
+}
+#[macro_export]
+macro_rules! sw_interrupt_delay {
+    () => {
+        unsafe {
+            ::core::arch::asm!("nop");
+            ::core::arch::asm!("nop");
+            ::core::arch::asm!("nop");
+            ::core::arch::asm!("nop");
+            ::core::arch::asm!("nop");
+        }
+    };
+}
+#[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_sha_algorithm {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }

--- a/esp-metadata-generated/src/_generated_esp32c3.rs
+++ b/esp-metadata-generated/src/_generated_esp32c3.rs
@@ -1922,6 +1922,31 @@ macro_rules! for_each_aes_key_length {
         _for_each_inner!((modes(128, 0, 4), (256, 2, 6)));
     };
 }
+#[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_sw_interrupt {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
+        _for_each_inner!((0, FROM_CPU_INTR0, software_interrupt0)); _for_each_inner!((1,
+        FROM_CPU_INTR1, software_interrupt1)); _for_each_inner!((2, FROM_CPU_INTR2,
+        software_interrupt2)); _for_each_inner!((3, FROM_CPU_INTR3,
+        software_interrupt3)); _for_each_inner!((all(0, FROM_CPU_INTR0,
+        software_interrupt0), (1, FROM_CPU_INTR1, software_interrupt1), (2,
+        FROM_CPU_INTR2, software_interrupt2), (3, FROM_CPU_INTR3, software_interrupt3)));
+    };
+}
+#[macro_export]
+macro_rules! sw_interrupt_delay {
+    () => {
+        unsafe {
+            ::core::arch::asm!("nop");
+            ::core::arch::asm!("nop");
+            ::core::arch::asm!("nop");
+            ::core::arch::asm!("nop");
+            ::core::arch::asm!("nop");
+        }
+    };
+}
 /// This macro can be used to generate code for each channel of the RMT peripheral.
 ///
 /// For an explanation on the general syntax, as well as usage of individual/repeated

--- a/esp-metadata-generated/src/_generated_esp32c6.rs
+++ b/esp-metadata-generated/src/_generated_esp32c6.rs
@@ -2500,6 +2500,40 @@ macro_rules! for_each_aes_key_length {
         _for_each_inner!((modes(128, 0, 4), (256, 2, 6)));
     };
 }
+#[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_sw_interrupt {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
+        _for_each_inner!((0, FROM_CPU_INTR0, software_interrupt0)); _for_each_inner!((1,
+        FROM_CPU_INTR1, software_interrupt1)); _for_each_inner!((2, FROM_CPU_INTR2,
+        software_interrupt2)); _for_each_inner!((3, FROM_CPU_INTR3,
+        software_interrupt3)); _for_each_inner!((all(0, FROM_CPU_INTR0,
+        software_interrupt0), (1, FROM_CPU_INTR1, software_interrupt1), (2,
+        FROM_CPU_INTR2, software_interrupt2), (3, FROM_CPU_INTR3, software_interrupt3)));
+    };
+}
+#[macro_export]
+macro_rules! sw_interrupt_delay {
+    () => {
+        unsafe {
+            ::core::arch::asm!("nop");
+            ::core::arch::asm!("nop");
+            ::core::arch::asm!("nop");
+            ::core::arch::asm!("nop");
+            ::core::arch::asm!("nop");
+            ::core::arch::asm!("nop");
+            ::core::arch::asm!("nop");
+            ::core::arch::asm!("nop");
+            ::core::arch::asm!("nop");
+            ::core::arch::asm!("nop");
+            ::core::arch::asm!("nop");
+            ::core::arch::asm!("nop");
+            ::core::arch::asm!("nop");
+            ::core::arch::asm!("nop");
+        }
+    };
+}
 /// This macro can be used to generate code for each channel of the RMT peripheral.
 ///
 /// For an explanation on the general syntax, as well as usage of individual/repeated

--- a/esp-metadata-generated/src/_generated_esp32h2.rs
+++ b/esp-metadata-generated/src/_generated_esp32h2.rs
@@ -1816,6 +1816,31 @@ macro_rules! for_each_aes_key_length {
         _for_each_inner!((modes(128, 0, 4), (256, 2, 6)));
     };
 }
+#[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_sw_interrupt {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
+        _for_each_inner!((0, FROM_CPU_INTR0, software_interrupt0)); _for_each_inner!((1,
+        FROM_CPU_INTR1, software_interrupt1)); _for_each_inner!((2, FROM_CPU_INTR2,
+        software_interrupt2)); _for_each_inner!((3, FROM_CPU_INTR3,
+        software_interrupt3)); _for_each_inner!((all(0, FROM_CPU_INTR0,
+        software_interrupt0), (1, FROM_CPU_INTR1, software_interrupt1), (2,
+        FROM_CPU_INTR2, software_interrupt2), (3, FROM_CPU_INTR3, software_interrupt3)));
+    };
+}
+#[macro_export]
+macro_rules! sw_interrupt_delay {
+    () => {
+        unsafe {
+            ::core::arch::asm!("nop");
+            ::core::arch::asm!("nop");
+            ::core::arch::asm!("nop");
+            ::core::arch::asm!("nop");
+            ::core::arch::asm!("nop");
+        }
+    };
+}
 /// This macro can be used to generate code for each channel of the RMT peripheral.
 ///
 /// For an explanation on the general syntax, as well as usage of individual/repeated

--- a/esp-metadata-generated/src/_generated_esp32s2.rs
+++ b/esp-metadata-generated/src/_generated_esp32s2.rs
@@ -2194,6 +2194,25 @@ macro_rules! for_each_aes_key_length {
         _for_each_inner!((modes(128, 0, 4), (192, 1, 5), (256, 2, 6)));
     };
 }
+#[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_sw_interrupt {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
+        _for_each_inner!((0, FROM_CPU_INTR0, software_interrupt0)); _for_each_inner!((1,
+        FROM_CPU_INTR1, software_interrupt1)); _for_each_inner!((2, FROM_CPU_INTR2,
+        software_interrupt2)); _for_each_inner!((3, FROM_CPU_INTR3,
+        software_interrupt3)); _for_each_inner!((all(0, FROM_CPU_INTR0,
+        software_interrupt0), (1, FROM_CPU_INTR1, software_interrupt1), (2,
+        FROM_CPU_INTR2, software_interrupt2), (3, FROM_CPU_INTR3, software_interrupt3)));
+    };
+}
+#[macro_export]
+macro_rules! sw_interrupt_delay {
+    () => {
+        unsafe {}
+    };
+}
 /// This macro can be used to generate code for each channel of the RMT peripheral.
 ///
 /// For an explanation on the general syntax, as well as usage of individual/repeated

--- a/esp-metadata-generated/src/_generated_esp32s3.rs
+++ b/esp-metadata-generated/src/_generated_esp32s3.rs
@@ -2196,6 +2196,25 @@ macro_rules! for_each_aes_key_length {
         _for_each_inner!((modes(128, 0, 4), (256, 2, 6)));
     };
 }
+#[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_sw_interrupt {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
+        _for_each_inner!((0, FROM_CPU_INTR0, software_interrupt0)); _for_each_inner!((1,
+        FROM_CPU_INTR1, software_interrupt1)); _for_each_inner!((2, FROM_CPU_INTR2,
+        software_interrupt2)); _for_each_inner!((3, FROM_CPU_INTR3,
+        software_interrupt3)); _for_each_inner!((all(0, FROM_CPU_INTR0,
+        software_interrupt0), (1, FROM_CPU_INTR1, software_interrupt1), (2,
+        FROM_CPU_INTR2, software_interrupt2), (3, FROM_CPU_INTR3, software_interrupt3)));
+    };
+}
+#[macro_export]
+macro_rules! sw_interrupt_delay {
+    () => {
+        unsafe {}
+    };
+}
 /// This macro can be used to generate code for each channel of the RMT peripheral.
 ///
 /// For an explanation on the general syntax, as well as usage of individual/repeated

--- a/esp-metadata/devices/esp32.toml
+++ b/esp-metadata/devices/esp32.toml
@@ -785,6 +785,8 @@ support_status = "not_supported"
 [device.interrupts]
 support_status = "partial"
 status_registers = 3
+software_interrupt_count = 4
+software_interrupt_delay = 0
 
 [device.rmt]
 support_status = "partial"

--- a/esp-metadata/devices/esp32c2.toml
+++ b/esp-metadata/devices/esp32c2.toml
@@ -362,6 +362,8 @@ bus_timeout_is_exponential = true
 [device.interrupts]
 support_status = "partial"
 status_registers = 2
+software_interrupt_count = 4
+software_interrupt_delay = 5
 
 [device.sha]
 support_status = "partial"

--- a/esp-metadata/devices/esp32c3.toml
+++ b/esp-metadata/devices/esp32c3.toml
@@ -416,6 +416,8 @@ support_status = "not_supported"
 [device.interrupts]
 support_status = "partial"
 status_registers = 2
+software_interrupt_count = 4
+software_interrupt_delay = 5
 
 [device.rmt]
 support_status = "partial"

--- a/esp-metadata/devices/esp32c6.toml
+++ b/esp-metadata/devices/esp32c6.toml
@@ -596,6 +596,8 @@ support_status = "not_supported"
 [device.interrupts]
 support_status = "partial"
 status_registers = 3
+software_interrupt_count = 4
+software_interrupt_delay = 14 # CPU-speed sensitive - what's clocked from where?
 
 [device.rmt]
 support_status = "partial"

--- a/esp-metadata/devices/esp32h2.toml
+++ b/esp-metadata/devices/esp32h2.toml
@@ -488,6 +488,8 @@ support_status = "not_supported"
 [device.interrupts]
 support_status = "partial"
 status_registers = 2
+software_interrupt_count = 4
+software_interrupt_delay = 5
 
 [device.rmt]
 support_status = "partial"

--- a/esp-metadata/devices/esp32s2.toml
+++ b/esp-metadata/devices/esp32s2.toml
@@ -552,6 +552,8 @@ support_status = "not_supported"
 [device.interrupts]
 support_status = "partial"
 status_registers = 3
+software_interrupt_count = 4
+software_interrupt_delay = 0
 
 [device.rmt]
 support_status = "partial"

--- a/esp-metadata/devices/esp32s3.toml
+++ b/esp-metadata/devices/esp32s3.toml
@@ -723,6 +723,8 @@ support_status = "not_supported"
 [device.interrupts]
 support_status = "partial"
 status_registers = 4
+software_interrupt_count = 4
+software_interrupt_delay = 0
 
 [device.rmt]
 support_status = "partial"

--- a/esp-metadata/src/cfg.rs
+++ b/esp-metadata/src/cfg.rs
@@ -1,6 +1,7 @@
 pub(crate) mod aes;
 pub(crate) mod gpio;
 pub(crate) mod i2c_master;
+pub(crate) mod interrupt;
 pub(crate) mod rmt;
 pub(crate) mod rsa;
 pub(crate) mod sha;
@@ -12,6 +13,7 @@ pub(crate) mod uart;
 pub(crate) use aes::*;
 pub(crate) use gpio::*;
 pub(crate) use i2c_master::*;
+pub(crate) use interrupt::*;
 pub(crate) use rmt::*;
 pub(crate) use sha::*;
 pub(crate) use soc::*;
@@ -435,6 +437,8 @@ driver_configs![
         name: "Interrupts",
         properties: {
             status_registers: u32,
+            #[serde(flatten)]
+            software_interrupt_properties: SoftwareInterruptProperties,
         }
     },
     IoMuxProperties {

--- a/esp-metadata/src/cfg/interrupt.rs
+++ b/esp-metadata/src/cfg/interrupt.rs
@@ -1,0 +1,46 @@
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+
+use crate::{cfg::GenericProperty, generate_for_each_macro, number};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+pub struct SoftwareInterruptProperties {
+    #[serde(rename = "software_interrupt_count")]
+    count: u32,
+    #[serde(rename = "software_interrupt_delay")]
+    delay: u32,
+}
+
+/// Generates `for_each_sw_interrupt!` which can be used to implement SoftwareInterruptControl, and
+/// `sw_interrupt_delay` which repeats `nop` enough times to ensure the interrupt is fired before
+/// returning.
+impl GenericProperty for SoftwareInterruptProperties {
+    fn macros(&self) -> Option<TokenStream> {
+        let nops =
+            std::iter::repeat(quote! { ::core::arch::asm!("nop"); }).take(self.delay as usize);
+
+        let channels = (0..self.count)
+            .map(|i| {
+                let idx = number(i);
+                let interrupt = format_ident!("FROM_CPU_INTR{}", i);
+                let field = format_ident!("software_interrupt{}", i);
+                quote! { #idx, #interrupt, #field }
+            })
+            .collect::<Vec<_>>();
+
+        let for_each_sw_interrupt = generate_for_each_macro("sw_interrupt", &[("all", &channels)]);
+
+        Some(quote! {
+            #for_each_sw_interrupt
+
+            #[macro_export]
+            macro_rules! sw_interrupt_delay {
+                () => {
+                    unsafe {
+                        #(#nops)*
+                    }
+                };
+            }
+        })
+    }
+}

--- a/esp-rtos/src/task/riscv.rs
+++ b/esp-rtos/src/task/riscv.rs
@@ -332,10 +332,4 @@ pub(crate) fn yield_task() {
         #[cfg(multi_core)]
         Cpu::AppCpu => unsafe { SoftwareInterrupt::<'static, 1>::steal() }.raise(),
     }
-
-    // It takes a bit for the software interrupt to be serviced.
-    esp_hal::riscv::asm::nop();
-    esp_hal::riscv::asm::nop();
-    esp_hal::riscv::asm::nop();
-    esp_hal::riscv::asm::nop();
 }

--- a/esp-rtos/src/task/xtensa.rs
+++ b/esp-rtos/src/task/xtensa.rs
@@ -174,19 +174,9 @@ pub(crate) fn yield_task() {
     }
 
     #[cfg(esp32)]
-    {
-        match Cpu::current() {
-            Cpu::ProCpu => unsafe { SoftwareInterrupt::<'static, 0>::steal() }.raise(),
-            Cpu::AppCpu => unsafe { SoftwareInterrupt::<'static, 1>::steal() }.raise(),
-        }
-
-        // It takes a bit for the software interrupt to be serviced.
-        unsafe {
-            core::arch::asm!("nop");
-            core::arch::asm!("nop");
-            core::arch::asm!("nop");
-            core::arch::asm!("nop");
-        }
+    match Cpu::current() {
+        Cpu::ProCpu => unsafe { SoftwareInterrupt::<'static, 0>::steal() }.raise(),
+        Cpu::AppCpu => unsafe { SoftwareInterrupt::<'static, 1>::steal() }.raise(),
     }
 }
 


### PR DESCRIPTION
As it turns out, there is a varying amount of delay between firing a software interrupt, and it taking effect. We have previously assumed only 4 CPU cycles is enough for this, but as the data in this PR shows, that was a bit too optimistic. This is instead a worst-case estimation (I went through each chip and hand-tuned the delays), to ensure that when `raise` returns, the interrupt has already fired unless masked. Since we rely on software interrupts for task switching on multiple chips, code must not continue unless the scheduler has handed back the control to the yielding task.

This PR refactors the software interrupt driver to make the number of interrupts, and the inserted delay configurable per target, and adds a pair of test cases that verify the expected behaviour.

skip-changelog label added for esp-rtos - while this PR may fix bugs, it's not actually known if that is the case.