### PR TITLE
Implement Clone for crypto frontend types

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unsafely expose GPIO pins that are only available on certain chip/module variants (#4520)
 - ESP32-H2: light sleep and deep sleep support with timer and EXT1 wakeup sources (#4587, #4641)
 - Unstable detailed clock configuration options (#4660, #4674)
+- `RsaContext`, `AesContext` now derive `Clone`. (#4709)
+- `Sha<X>Context` now derive `Clone`, except on ESP32. (#4709)
 
 ### Changed
 

--- a/esp-hal/src/aes/mod.rs
+++ b/esp-hal/src/aes/mod.rs
@@ -1319,6 +1319,17 @@ struct AesOperation {
     key: Key,
 }
 
+impl Clone for AesOperation {
+    fn clone(&self) -> Self {
+        Self {
+            mode: self.mode,
+            cipher_mode: self.cipher_mode,
+            buffers: self.buffers,
+            key: self.key.copy(),
+        }
+    }
+}
+
 // Safety: AesOperation is safe to share between threads, in the context of a WorkQueue. The
 // WorkQueue ensures that only a single location can access the data. All the internals, except
 // for the pointers, are Sync. The pointers are safe to share because they point at data that the
@@ -1487,6 +1498,7 @@ impl<'t, 'd> AesWorkQueueDriver<'t, 'd> {
 }
 
 /// An AES work queue user.
+#[derive(Clone)]
 pub struct AesContext {
     cipher_mode: CipherState,
     frontend: WorkQueueFrontend<AesOperation>,

--- a/esp-hal/src/rsa/mod.rs
+++ b/esp-hal/src/rsa/mod.rs
@@ -1060,6 +1060,7 @@ impl<'t, 'd> RsaWorkQueueDriver<'t, 'd> {
     }
 }
 
+#[derive(Clone)]
 struct RsaWorkItem {
     // Acceleration options
     #[cfg(not(esp32))]
@@ -1075,6 +1076,7 @@ struct RsaWorkItem {
 unsafe impl Sync for RsaWorkItem {}
 unsafe impl Send for RsaWorkItem {}
 
+#[derive(Clone)]
 enum RsaOperation {
     // Z = X * Y
     // len(Z) = len(X) + len(Y)
@@ -1128,6 +1130,7 @@ fn rsa_work_queue_handler() {
     options using [enable_search_acceleration][Self::enable_search_acceleration] and
     [enable_acceleration][Self::enable_acceleration] when appropriate."
 )]
+#[derive(Clone)]
 pub struct RsaContext {
     frontend: WorkQueueFrontend<RsaWorkItem>,
 }

--- a/esp-hal/src/sha.rs
+++ b/esp-hal/src/sha.rs
@@ -750,6 +750,7 @@ fn m_mem(sha: &crate::peripherals::SHA<'_>, index: usize) -> *mut u32 {
     }
 }
 
+#[derive(Clone)]
 struct ShaOperation {
     operation: ShaOperationKind,
     // Buffer containing pieced-together message bytes, not necessarily a complete block. Not a fat
@@ -1095,6 +1096,7 @@ enum SoftwareHasher {
 }
 
 // Common implementation, to be hidden behind algo-dependent contexts.
+#[cfg_attr(not(esp32), derive(Clone))]
 struct ShaContext<const CHUNK_BYTES: usize, const DIGEST_WORDS: usize> {
     frontend: WorkQueueFrontend<ShaOperation>,
     buffer: [u8; CHUNK_BYTES],
@@ -1312,6 +1314,7 @@ pub enum FinalizeError {
 macro_rules! impl_worker_context {
     ($name:ident, $full_name:literal, $algo:expr, $digest_len:literal ) => {
         #[doc = concat!("A ", $full_name, " context.")]
+        #[cfg_attr(not(esp32), derive(Clone))]
         pub struct $name(ShaContext<{ $algo.chunk_length() }, { $algo.digest_length() / 4 }>);
 
         impl $name {

--- a/esp-hal/src/work_queue.rs
+++ b/esp-hal/src/work_queue.rs
@@ -451,6 +451,18 @@ pub(crate) struct WorkItem<T: Sync + Send> {
     waker: WakerRegistration,
 }
 
+impl<T: Sync + Send + Clone> Clone for WorkItem<T> {
+    fn clone(&self) -> Self {
+        Self {
+            // A work item can only be cloned when it's not in a queue.
+            next: None,
+            status: Poll::Pending(false),
+            data: self.data.clone(),
+            waker: WakerRegistration::new(),
+        }
+    }
+}
+
 impl<T: Sync + Send> WorkItem<T> {
     /// Completes the work item.
     ///
@@ -687,6 +699,7 @@ where
 }
 
 /// Used by work queue clients, allows hiding WorkItem.
+#[derive(Clone)]
 pub(crate) struct WorkQueueFrontend<T: Sync + Send> {
     work_item: WorkItem<T>,
 }
@@ -716,5 +729,3 @@ impl<T: Sync + Send> WorkQueueFrontend<T> {
         Handle::from_completed_work_item(queue, &mut self.work_item)
     }
 }
-
-// TODO: implement individual algo context wrappers


### PR DESCRIPTION
These frontend types can be freely created, and they contain the partial result of their respective operation. They can be big, but there is no underlying reason to prevent cloning them, e.g. to branch off calculation after some common prefix has been processed.

ESP32 is again a special case, because we can't save SHA state on it. This means we can't clone a frontend that started operation using hardware, and that means we can't clone SHA context at all - conditionally failing would be a worse solution than just removing hardware acceleration altogether.

Closes #4707