### PR TITLE
Try to fix baseline-generation

### DIFF
--- a/.github/workflows/api-baseline-check.yml
+++ b/.github/workflows/api-baseline-check.yml
@@ -50,11 +50,13 @@ jobs:
                     # Extract packages from "breaking-change-" labels
                     PACKAGES=""
                     if [ -n "$LABELS" ]; then
-                      PACKAGES=$(echo "$LABELS" \
-                        | grep -E '^breaking-change-[a-z0-9-]+$' || true \
-                        | sed 's/^breaking-change-//' \
-                        | tr '\n' ',' \
-                        | sed 's/,$//')
+                      PACKAGES=$(echo "$LABELS" | \
+                        tr ',' '\n' | \
+                        sed 's/ //g' | \
+                        grep "^breaking-change-" | \
+                        sed 's/breaking-change-//g' | \
+                        tr '\n' ',' | \
+                        sed 's/,$//') || PACKAGES=""
 
                       if [ -n "$PACKAGES" ]; then
                         # TODO: skip only specific packages, not the whole check

--- a/.github/workflows/api-baseline-generation.yml
+++ b/.github/workflows/api-baseline-generation.yml
@@ -115,11 +115,13 @@ jobs:
             # Extract packages from "breaking-change-" labels
             PACKAGES=""
             if [ -n "$LABELS" ]; then
-              PACKAGES=$(echo "$LABELS" \
-                | grep -E '^breaking-change-[a-z0-9-]+$' || true \
-                | sed 's/^breaking-change-//' \
-                | tr '\n' ',' \
-                | sed 's/,$//')
+              PACKAGES=$(echo "$LABELS" | \
+                tr ',' '\n' | \
+                sed 's/ //g' | \
+                grep "^breaking-change-" | \
+                sed 's/breaking-change-//g' | \
+                tr '\n' ',' | \
+                sed 's/,$//') || PACKAGES=""
             fi
 
             if [ -n "$PACKAGES" ]; then


### PR DESCRIPTION
~I'm adding a `breaking-change-esp-hal` label to try to simulate the run from https://github.com/esp-rs/esp-hal/issues/4748 i.e `Trigger reason: breaking_change`. I will kill the CI if it starts generating baselines. I hope playing with label will not cause any troubles. Tried to test it on my fork but the job wasn't triggered.~

It won't work this way