### PR TITLE
fix render issue of ## Examples in `dedicated.rs`

### DIFF
--- a/esp-hal/src/gpio/dedicated.rs
+++ b/esp-hal/src/gpio/dedicated.rs
@@ -486,7 +486,7 @@ another core, either directly, or indirectly via a thread that is not pinned to 
 </section>
 "#
 )]
-///
+#[doc = ""]
 /// ## Examples
 ///
 /// ```rust, no_run
@@ -635,7 +635,7 @@ another core, either directly, or indirectly via a thread that is not pinned to 
 </section>
 "#
 )]
-///
+#[doc = ""]
 /// ## Examples
 ///
 /// ```rust, no_run


### PR DESCRIPTION
## Description

The second-level heading "Examples" in the documentation for `DedicatedGpioInput`, `DedicatedGpioOutput`, and `DedicatedGpioFlex` is not rendered correctly: 

<img width="1500" height="288" alt="d6f88d9a62c2b5524be3871623023608" src="https://github.com/user-attachments/assets/4a88e122-5002-461b-864d-2b9787fbcfb7" />


## Testing

The documentation after this fix:

<img width="1502" height="317" alt="image" src="https://github.com/user-attachments/assets/fac9739c-6121-41a4-a63a-b08327a2f23c" />
