### PR TITLE
change building documentation section of CONTRIBUTING.md

### DIFF
--- a/documentation/CONTRIBUTING.md
+++ b/documentation/CONTRIBUTING.md
@@ -86,7 +86,7 @@ Ensuring the quality and reliability of `esp-hal` is a shared responsibility, an
 Further steps that can (or should) be taken in testing:
 
 * Using [xtask], build examples for the specified chip.
-* When documentation or doctests change, run `cargo xtask build documentation` and `cargo xtask run doc-tests <CHIP>` to build the documentation and run the doctests. To reduce build/test time, use `--packages` to specify the package and `--chips` (for documentation builds) to specify the target chip.
+* When documentation or doctests change, run `cargo xtask build documentation` and `cargo xtask run doc-tests <CHIP>` to build the documentation and run the doctests. To reduce build/test time, use `--packages` to specify the package(s) and `--chips` (for documentation builds) to specify the target chip(s).
 * Run the [HIL] tests locally if changes have been made to them.
 
 For detailed instructions on how to use our HIL tests with comment commands, see the [HIL guide].


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.


### Description
Updated the documentation/doctest checklist item to use the actual `xtask` CLI commands that can be run directly (`cargo xtask build documentation` and `cargo xtask run doc-tests <CHIP>`), and mentioned how `--packages` and `--chips` narrow the scope to reduce build time (otherwise building the documentation is very slow). Refer to the documentation of [`xtask`](https://github.com/esp-rs/esp-hal/tree/71bf774fb610c648eab2f504c3c4768c3a146357/xtask)

The original wording was `build-documentation` and `run-doc-test`. Perhaps these are old commands.

### Question

Why `cargo xtask run doc-test <CHIP>` specify the chip to test with an argument instead of an option like `cargo xtask build documentation --chips esp32c6`? Should we make these two commands more consistent? 

