### PR TITLE
turn on asm_experimental_arch only for xtensa

### DIFF
--- a/hil-test/src/bin/gpio.rs
+++ b/hil-test/src/bin/gpio.rs
@@ -6,7 +6,7 @@
 
 #![no_std]
 #![no_main]
-#![cfg_attr(any(esp32s2, esp32s3), feature(asm_experimental_arch))]
+#![cfg_attr(xtensa, feature(asm_experimental_arch))]
 
 use esp_hal::gpio::{AnyPin, Input, InputConfig, Level, Output, OutputConfig, Pin, Pull};
 use hil_test as _;


### PR DESCRIPTION
## Description

When running the gpio HIL test for c6, it won't compile because RISC-V doesn't need `asm_experimental_arch` for inline asm: 

```sh
error[E0554]: `#![feature]` may not be used on the stable release channel
 --> src\bin\gpio.rs:9:1
  |
9 | #![feature(asm_experimental_arch)]
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

So changed `#![feature(asm_experimental_arch)]` to `#![cfg_attr(xtensa, feature(asm_experimental_arch))]`. 

Now `asm_experimental_arch` is enabled only for Xtensa models. 

## Tests

The GPIO HIL tests can now be successfully compiled for both S2 and C6. 

## Question 

I see inline assembly is used for the following lines: 

https://github.com/esp-rs/esp-hal/blob/c12fe036b88d28d336f6d1162ca86d03146f08fe/hil-test/src/bin/gpio.rs#L636-L642

Why do we want to insert these `nop` instructions? 
