### PR TITLE
WIP: initial Ethernet driver (MAC, DMA, MDIO, PHY)

### DIFF
--- a/esp-hal/src/ethernet/dma.rs
+++ b/esp-hal/src/ethernet/dma.rs
@@ -1,0 +1,94 @@
+use core::ptr;
+
+const DESC_OWN: u32 = 1 << 31;
+const DESC_FS: u32 = 1 << 29;
+const DESC_LS: u32 = 1 << 28;
+
+#[repr(C, align(16))]
+pub struct DmaDesc {
+    pub status: u32,
+    pub length: u32,
+    pub buffer: *mut u8,
+    pub next: *mut DmaDesc,
+}
+
+#[repr(C, align(16))]
+pub struct DmaRing<const N: usize> {
+    desc: [DmaDesc; N],
+    buffers: [[u8; 1536]; N],
+    index: usize,
+}
+
+impl<const N: usize> DmaRing<N> {
+    pub const fn new() -> Self {
+        const EMPTY: DmaDesc = DmaDesc {
+            status: 0,
+            length: 0,
+            buffer: ptr::null_mut(),
+            next: ptr::null_mut(),
+        };
+
+        Self {
+            desc: [EMPTY; N],
+            buffers: [[0u8; 1536]; N],
+            index: 0,
+        }
+    }
+
+    pub fn init(&mut self, is_rx: bool) {
+        for i in 0..N {
+            self.desc[i].buffer = self.buffers[i].as_mut_ptr();
+            self.desc[i].next = &mut self.desc[(i + 1) % N];
+            self.desc[i].status = if is_rx { DESC_OWN } else { 0 };
+            self.desc[i].length = 1536;
+        }
+    }
+
+    #[inline(always)]
+    pub fn desc_ptr(&mut self) -> *mut DmaDesc {
+        self.desc.as_mut_ptr()
+    }
+
+    fn current(&mut self) -> &mut DmaDesc {
+        &mut self.desc[self.index]
+    }
+
+    fn advance(&mut self) {
+        self.index = (self.index + 1) % N;
+    }
+
+    pub fn prepare_tx(&mut self, data: &[u8]) -> bool {
+        let d = self.current();
+
+        if d.status & DESC_OWN != 0 {
+            return false;
+        }
+
+        unsafe {
+            core::ptr::copy_nonoverlapping(data.as_ptr(), d.buffer, data.len());
+        }
+
+        d.length = data.len() as u32;
+        d.status = DESC_OWN | DESC_FS | DESC_LS;
+
+        self.advance();
+        true
+    }
+
+    pub fn try_recv(&mut self) -> Option<&[u8]> {
+        let d = self.current();
+
+        if d.status & DESC_OWN != 0 {
+            return None;
+        }
+
+        let len = d.length as usize;
+
+        let slice = unsafe { core::slice::from_raw_parts(d.buffer, len) };
+
+        d.status = DESC_OWN;
+
+        self.advance();
+        Some(slice)
+    }
+}

--- a/esp-hal/src/ethernet/mac.rs
+++ b/esp-hal/src/ethernet/mac.rs
@@ -1,0 +1,61 @@
+use super::types::EthRegBlock;
+use super::dma::DmaRing;
+use super::phy::Phy;
+use crate::peripherals::ETH;
+
+pub struct Ethernet<'a, P: Phy, const RX: usize, const TX: usize> {
+    regs: EthRegBlock,
+    phy: P,
+    rx: &'a mut DmaRing<RX>,
+    tx: &'a mut DmaRing<TX>,
+}
+
+impl<'a, P: Phy, const RX: usize, const TX: usize> Ethernet<'a, P, RX, TX> {
+    pub fn new(
+        eth: ETH,
+        phy: P,
+        rx: &'a mut DmaRing<RX>,
+        tx: &'a mut DmaRing<TX>,
+    ) -> Self {
+        Self {
+            regs: EthRegBlock::new(eth),
+            phy,
+            rx,
+            tx,
+        }
+    }
+
+    pub fn init(&mut self, mac: [u8; 6]) {
+        self.rx.init(true);
+        self.tx.init(false);
+
+        let regs = self.regs.regs_mut();
+
+        regs.reset_dma();
+
+        regs.dma_rx_desc.write(self.rx.desc_ptr() as u32);
+        regs.dma_tx_desc.write(self.tx.desc_ptr() as u32);
+
+        self.phy.init(regs);
+        while !self.phy.link_up(regs) {}
+
+        regs.set_mac_address(mac);
+        regs.enable_mac();
+        regs.enable_dma();
+
+        regs.start_rx();
+        regs.start_tx();
+    }
+
+    pub fn send(&mut self, data: &[u8]) -> bool {
+        let ok = self.tx.prepare_tx(data);
+        if ok {
+            self.regs.regs_mut().start_tx();
+        }
+        ok
+    }
+
+    pub fn poll(&mut self) -> Option<&[u8]> {
+        self.rx.try_recv()
+    }
+}

--- a/esp-hal/src/ethernet/mod.rs
+++ b/esp-hal/src/ethernet/mod.rs
@@ -1,0 +1,7 @@
+pub mod mac;
+pub mod phy;
+pub mod dma;
+pub mod types;
+
+pub use mac::{EthernetMac, MacConfig};
+pub use phy::{EthernetPhy, PhyConfig};

--- a/esp-hal/src/ethernet/phy.rs
+++ b/esp-hal/src/ethernet/phy.rs
@@ -1,0 +1,37 @@
+use super::types::EthRegisters;
+
+pub trait Phy {
+    fn init(&mut self, regs: &mut EthRegisters);
+    fn link_up(&self, regs: &mut EthRegisters) -> bool;
+}
+
+pub struct Lan8720 {
+    phy_addr: u8,
+}
+
+impl Lan8720 {
+    pub fn new(addr: u8) -> Self {
+        Self { phy_addr: addr }
+    }
+}
+
+impl Phy for Lan8720 {
+    fn init(&mut self, regs: &mut EthRegisters) {
+        const BMCR_RESET: u16 = 1 << 15;
+
+        regs.mdio_write(self.phy_addr, 0, BMCR_RESET);
+        while regs.mdio_read(self.phy_addr, 0) & BMCR_RESET != 0 {}
+
+        loop {
+            let bmsr = regs.mdio_read(self.phy_addr, 1);
+            if bmsr & (1 << 2) != 0 {
+                break;
+            }
+        }
+    }
+
+    fn link_up(&self, regs: &mut EthRegisters) -> bool {
+        let bmsr = regs.mdio_read(self.phy_addr, 1);
+        bmsr & (1 << 2) != 0
+    }
+}

--- a/esp-hal/src/ethernet/tests.rs
+++ b/esp-hal/src/ethernet/tests.rs
@@ -1,0 +1,27 @@
+use crate::soc::volatile::Volatile;
+use crate::peripherals::ETH;
+use core::ptr::NonNull;
+
+#[repr(C)]
+pub struct EthRegisters {
+    pub mac_conf: Volatile<u32>,
+    pub dma_conf: Volatile<u32>,
+    pub dma_rx_desc: Volatile<u32>,
+    pub dma_tx_desc: Volatile<u32>,
+}
+
+pub struct EthRegBlock {
+    ptr: NonNull<EthRegisters>,
+}
+
+impl EthRegBlock {
+    pub fn new(_: ETH) -> Self {
+        Self {
+            ptr: unsafe { NonNull::new_unchecked(0x6000_0000 as *mut _) },
+        }
+    }
+
+    pub fn regs_mut(&mut self) -> &mut EthRegisters {
+        unsafe { self.ptr.as_mut() }
+    }
+}

--- a/esp-hal/src/ethernet/types.rs
+++ b/esp-hal/src/ethernet/types.rs
@@ -1,0 +1,113 @@
+use core::ptr::NonNull;
+use crate::peripherals::ETH;
+use crate::soc::volatile::Volatile;
+
+const ETH_BASE: usize = 0x3FF6_9000;
+
+#[repr(C)]
+pub struct EthRegisters {
+    pub mac_conf: Volatile<u32>,        // 0x000
+    pub mac_addr0: Volatile<u32>,        // 0x004
+    pub mac_addr1: Volatile<u32>,        // 0x008
+    _r0: [u32; 9],                       // 0x00C..0x02C
+    pub mac_mii_addr: Volatile<u32>,     // 0x030
+    pub mac_mii_data: Volatile<u32>,     // 0x034
+    _r1: [u32; 3],                       // 0x038..0x044
+    pub dma_bus_mode: Volatile<u32>,     // 0x048
+    pub dma_tx_poll: Volatile<u32>,      // 0x04C
+    pub dma_rx_poll: Volatile<u32>,      // 0x050
+    pub dma_rx_desc: Volatile<u32>,      // 0x054
+    pub dma_tx_desc: Volatile<u32>,      // 0x058
+    pub dma_status: Volatile<u32>,       // 0x05C
+    pub dma_conf: Volatile<u32>,         // 0x060
+}
+
+pub struct EthRegBlock {
+    ptr: NonNull<EthRegisters>,
+}
+
+impl EthRegBlock {
+    pub fn new(_: ETH) -> Self {
+        Self {
+            ptr: unsafe { NonNull::new_unchecked(ETH_BASE as *mut EthRegisters) },
+        }
+    }
+
+    #[inline(always)]
+    pub fn regs_mut(&mut self) -> &mut EthRegisters {
+        unsafe { self.ptr.as_mut() }
+    }
+}
+
+impl EthRegisters {
+    pub fn reset_dma(&mut self) {
+        const SWR: u32 = 1 << 0;
+        self.dma_bus_mode.write(SWR);
+        while self.dma_bus_mode.read() & SWR != 0 {}
+    }
+
+    pub fn enable_dma(&mut self) {
+        const RX_EN: u32 = 1 << 1;
+        const TX_EN: u32 = 1 << 13;
+        self.dma_conf.modify(|v| v | RX_EN | TX_EN);
+    }
+
+    pub fn enable_mac(&mut self) {
+        const RX: u32 = 1 << 2;
+        const TX: u32 = 1 << 3;
+        self.mac_conf.modify(|v| v | RX | TX);
+    }
+
+    pub fn set_mac_address(&mut self, mac: [u8; 6]) {
+        let low =
+            (mac[3] as u32) << 24 |
+            (mac[2] as u32) << 16 |
+            (mac[1] as u32) << 8  |
+            (mac[0] as u32);
+
+        let high =
+            (mac[5] as u32) << 8 |
+            (mac[4] as u32);
+
+        self.mac_addr0.write(low);
+        self.mac_addr1.write(high);
+    }
+
+    pub fn start_rx(&mut self) {
+        self.dma_rx_poll.write(1);
+    }
+
+    pub fn start_tx(&mut self) {
+        self.dma_tx_poll.write(1);
+    }
+
+    pub fn mdio_write(&mut self, phy: u8, reg: u8, val: u16) {
+        const MII_BUSY: u32 = 1 << 0;
+        const MII_WRITE: u32 = 1 << 1;
+
+        self.mac_mii_data.write(val as u32);
+
+        self.mac_mii_addr.write(
+            (phy as u32) << 11 |
+            (reg as u32) << 6 |
+            MII_WRITE |
+            MII_BUSY
+        );
+
+        while self.mac_mii_addr.read() & MII_BUSY != 0 {}
+    }
+
+    pub fn mdio_read(&mut self, phy: u8, reg: u8) -> u16 {
+        const MII_BUSY: u32 = 1 << 0;
+
+        self.mac_mii_addr.write(
+            (phy as u32) << 11 |
+            (reg as u32) << 6 |
+            MII_BUSY
+        );
+
+        while self.mac_mii_addr.read() & MII_BUSY != 0 {}
+
+        self.mac_mii_data.read() as u16
+    }
+}


### PR DESCRIPTION
Refs: #4163

This PR adds an initial  work-in-progress Ethernet driver skeleton for ESP32.

The goal of this PR is to establish the core architecture and low-level building blocks so further work can iterate on top of it.

## What is included

- Ethernet module structure in `esp-hal`
- DMA descriptor ring abstraction (TX/RX)
- Basic MAC register block abstraction
- MDIO read/write support
- Basic PHY bring-up path (reset + link wait, currently LAN8720)
- MAC + DMA initialization path
- Basic send/poll API surface

## What is NOT done yet

⚠️ This is not a fully working Ethernet driver yet.

Missing / incomplete parts:

- Full and verified ESP32 Ethernet register map
- Correct and fully verified DMA descriptor format for ESP32
- Cache and memory placement guarantees for DMA buffers
- Proper MAC configuration (speed, duplex, filtering, etc.)
- Interrupt handling
- RX/TX path validation on real hardware
- smoltcp integration
- Error handling and recovery paths
- Support for other PHYs

## Why this PR is opened now

This PR is opened early to:

- Get feedback on architecture and module layout
- Validate DMA abstraction approach
- Validate MAC/PHY split and API design
- Iterate incrementally instead of dropping a huge change at once

## Status

- Compiles
- DMA logic is unit-tested
- Hardware functionality is **not yet confirmed**

## Next steps (planned)

- Verify and complete register map
- Fix DMA descriptor flags according to ESP32 TRM
- Bring up PHY on real hardware
- Get first RX/TX packets working
- Add interrupts
- Integrate with smoltcp


