### PR TITLE
Tell if no chip feature was specified in esp-bootloader-esp-idf

### DIFF
--- a/esp-bootloader-esp-idf/Cargo.toml
+++ b/esp-bootloader-esp-idf/Cargo.toml
@@ -46,6 +46,7 @@ md-5 = { version = "0.10.6", default-features = false, optional = true }
 [build-dependencies]
 jiff       = { version = "0.2.13", default-features = false, features = ["std"] }
 esp-config = { version = "0.6.1", path = "../esp-config", features = ["build"] }
+esp-metadata-generated = { version = "0.3.0", path = "../esp-metadata-generated", features = ["build-script"] }
 
 # Make doctests & host-tests work together:
 [target.'cfg(any(target_arch = "riscv32", target_arch = "xtensa"))'.dev-dependencies]

--- a/esp-bootloader-esp-idf/build.rs
+++ b/esp-bootloader-esp-idf/build.rs
@@ -33,11 +33,18 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo::rustc-env=ESP_BOOTLOADER_BUILD_TIME={build_time_formatted}");
     println!("cargo::rustc-env=ESP_BOOTLOADER_BUILD_DATE={build_date_formatted}");
 
+    // Ensure that exactly one chip has been specified (unless the "std" feature is enabled)
+    let chip = if !cfg!(feature = "std") {
+        Some(esp_metadata_generated::Chip::from_cargo_feature().unwrap())
+    } else {
+        None
+    };
+
     // emit config
     println!("cargo:rerun-if-changed=./esp_config.yml");
     let cfg_yaml = std::fs::read_to_string("./esp_config.yml")
         .expect("Failed to read esp_config.yml for esp-bootloader-esp-idf");
-    generate_config_from_yaml_definition(&cfg_yaml, true, true, None).unwrap();
+    generate_config_from_yaml_definition(&cfg_yaml, true, true, chip).unwrap();
 
     Ok(())
 }


### PR DESCRIPTION
I updated a very old small project which had no esp-bootloader-esp-idf dep - ofc I forgot to add the chip feature and was greeted with very confusing/misleading error messages
