### PR TITLE
Use zerocopy in place of references for the definition of PartitionEntry

### DIFF
--- a/esp-bootloader-esp-idf/Cargo.toml
+++ b/esp-bootloader-esp-idf/Cargo.toml
@@ -42,6 +42,7 @@ strum = { version = "0.27", default-features = false, features = ["derive"] }
 
 crc = { version = "3.3.0", optional = true }
 md-5 = { version = "0.10.6", default-features = false, optional = true }
+zerocopy = { version = "0.8.33", features = ["derive"] }
 
 [build-dependencies]
 jiff       = { version = "0.2.13", default-features = false, features = ["std"] }

--- a/esp-bootloader-esp-idf/src/ota.rs
+++ b/esp-bootloader-esp-idf/src/ota.rs
@@ -430,7 +430,7 @@ mod tests {
         };
 
         let mock_region = FlashRegion {
-            raw: mock_entry,
+            raw: mock_entry.clone(),
             flash: &mut mock_flash,
         };
 
@@ -478,7 +478,7 @@ mod tests {
         mock_flash.data[0x1000..][..0x20].copy_from_slice(SLOT_INITIAL);
 
         let mock_region = FlashRegion {
-            raw: mock_entry,
+            raw: mock_entry.clone(),
             flash: &mut mock_flash,
         };
 
@@ -516,7 +516,7 @@ mod tests {
         mock_flash.data[0x1000..][..0x20].copy_from_slice(SLOT_COUNT_2_NEW);
 
         let mock_region = FlashRegion {
-            raw: mock_entry,
+            raw: mock_entry.clone(),
             flash: &mut mock_flash,
         };
 
@@ -552,7 +552,7 @@ mod tests {
         };
 
         let mock_region = FlashRegion {
-            raw: mock_entry,
+            raw: mock_entry.clone(),
             flash: &mut mock_flash,
         };
 
@@ -616,7 +616,7 @@ mod tests {
         };
 
         let mock_region = FlashRegion {
-            raw: mock_entry,
+            raw: mock_entry.clone(),
             flash: &mut mock_flash,
         };
 
@@ -699,7 +699,7 @@ mod tests {
         };
 
         let mock_region = FlashRegion {
-            raw: mock_entry,
+            raw: mock_entry.clone(),
             flash: &mut mock_flash,
         };
 

--- a/esp-bootloader-esp-idf/src/ota.rs
+++ b/esp-bootloader-esp-idf/src/ota.rs
@@ -355,6 +355,8 @@ where
 
 #[cfg(test)]
 mod tests {
+    use zerocopy::FromBytes;
+
     use super::*;
     use crate::partitions::PartitionEntry;
 
@@ -421,9 +423,7 @@ mod tests {
     fn test_initial_state_and_next_slot() {
         let mut binary = PARTITION_RAW;
 
-        let mock_entry = PartitionEntry {
-            binary: &mut binary,
-        };
+        let mock_entry = PartitionEntry::ref_from_bytes(&binary).unwrap();
 
         let mut mock_flash = MockFlash {
             data: [0xff; 0x2000],
@@ -468,9 +468,7 @@ mod tests {
     fn test_slot0_valid_next_slot() {
         let mut binary = PARTITION_RAW;
 
-        let mock_entry = PartitionEntry {
-            binary: &mut binary,
-        };
+        let mock_entry = PartitionEntry::ref_from_bytes(&binary).unwrap();
 
         let mut mock_flash = MockFlash {
             data: [0xff; 0x2000],
@@ -508,9 +506,7 @@ mod tests {
     fn test_slot1_new_next_slot() {
         let mut binary = PARTITION_RAW;
 
-        let mock_entry = PartitionEntry {
-            binary: &mut binary,
-        };
+        let mock_entry = PartitionEntry::ref_from_bytes(&binary).unwrap();
 
         let mut mock_flash = MockFlash {
             data: [0xff; 0x2000],
@@ -549,9 +545,7 @@ mod tests {
     fn test_multi_updates() {
         let mut binary = PARTITION_RAW;
 
-        let mock_entry = PartitionEntry {
-            binary: &mut binary,
-        };
+        let mock_entry = PartitionEntry::ref_from_bytes(&binary).unwrap();
 
         let mut mock_flash = MockFlash {
             data: [0xff; 0x2000],
@@ -615,9 +609,7 @@ mod tests {
     fn test_multi_updates_4_apps() {
         let mut binary = PARTITION_RAW;
 
-        let mock_entry = PartitionEntry {
-            binary: &mut binary,
-        };
+        let mock_entry = PartitionEntry::ref_from_bytes(&binary).unwrap();
 
         let mut mock_flash = MockFlash {
             data: [0xff; 0x2000],
@@ -700,9 +692,7 @@ mod tests {
     fn test_multi_updates_skip_parts() {
         let mut binary = PARTITION_RAW;
 
-        let mock_entry = PartitionEntry {
-            binary: &mut binary,
-        };
+        let mock_entry = PartitionEntry::ref_from_bytes(&binary).unwrap();
 
         let mut mock_flash = MockFlash {
             data: [0xff; 0x2000],

--- a/esp-bootloader-esp-idf/src/ota_updater.rs
+++ b/esp-bootloader-esp-idf/src/ota_updater.rs
@@ -79,7 +79,7 @@ where
                 crate::partitions::DataPartitionSubType::Ota,
             ))?;
         if let Some(ota_part) = ota_part {
-            let ota_part = ota_part.as_embedded_storage(self.flash);
+            let ota_part = ota_part.clone().as_embedded_storage(self.flash);
             let ota = crate::ota::Ota::new(ota_part, self.ota_count)?;
             Ok(ota)
         } else {
@@ -152,6 +152,7 @@ where
             .pt
             .find_partition(crate::partitions::PartitionType::App(next_slot))?
             .ok_or(Error::Invalid)?
+            .clone()
             .as_embedded_storage(self.flash);
 
         Ok((flash_region, next_slot))

--- a/esp-bootloader-esp-idf/src/partitions.rs
+++ b/esp-bootloader-esp-idf/src/partitions.rs
@@ -99,6 +99,8 @@ impl PartitionEntry {
         self.flags() & 0b10 != 0
     }
 
+    #[cfg(not(feature = "std"))]
+    /// Get the currently booted partition.
     pub fn is_booted(&self) -> bool {
         cfg_if::cfg_if! {
             if #[cfg(feature = "esp32")] {

--- a/esp-bootloader-esp-idf/src/partitions.rs
+++ b/esp-bootloader-esp-idf/src/partitions.rs
@@ -17,7 +17,7 @@ pub const PARTITION_TABLE_MAX_LEN: usize = 0xC00;
 const PARTITION_TABLE_OFFSET: u32 =
     esp_config::esp_config_int!(u32, "ESP_BOOTLOADER_ESP_IDF_CONFIG_PARTITION_TABLE_OFFSET");
 
-pub const RAW_ENTRY_LEN: usize = 32;
+const RAW_ENTRY_LEN: usize = 32;
 const ENTRY_MAGIC: u16 = 0x50aa;
 const MD5_MAGIC: u16 = 0xebeb;
 
@@ -25,7 +25,7 @@ const OTA_SUBTYPE_OFFSET: u8 = 0x10;
 
 use zerocopy::little_endian::{U16 as u16_le, U32 as u32_le};
 /// Represents a single partition entry.
-#[derive(Clone, Immutable, FromBytes, IntoBytes, KnownLayout, Unaligned)]
+#[derive(Clone, Copy, Immutable, FromBytes, IntoBytes, KnownLayout, Unaligned)]
 #[repr(packed)]
 pub struct PartitionEntry {
     magic: u16_le,

--- a/esp-bootloader-esp-idf/src/partitions.rs
+++ b/esp-bootloader-esp-idf/src/partitions.rs
@@ -26,7 +26,7 @@ const OTA_SUBTYPE_OFFSET: u8 = 0x10;
 use zerocopy::little_endian::{U16 as u16_le, U32 as u32_le};
 /// Represents a single partition entry.
 #[derive(Clone, Immutable, FromBytes, KnownLayout)]
-#[repr(packed)]
+#[repr(C)]
 pub struct PartitionEntry {
     magic: u16_le,
     raw_type: u8,


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
- [ ] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖
Use zerocopy in place of references to define PartitionEntry. 

Details are provided in issue

#### Testing
<img width="1420" height="725" alt="image" src="https://github.com/user-attachments/assets/ec330775-1003-4985-a556-f52de051cab5" />

command ran:
```sh
cd esp-bootloader-esp-idf
cargo test --lib --tests --features "std esp32c3"
```
