### PR TITLE
Avoid additional load seg inserted by espflash

### DIFF
--- a/esp-hal/ld/esp32c6/esp32c6.x
+++ b/esp-hal/ld/esp32c6/esp32c6.x
@@ -17,8 +17,7 @@ SECTIONS {
    * Thus, we need to force a gap here.
    */
   .text_gap (NOLOAD): {
-    . = . + 4;
-    . = ALIGN(4) + 0x20;
+    . = . + 8;
   } > ROM
 }
 INSERT BEFORE .text;

--- a/esp-hal/ld/esp32h2/esp32h2.x
+++ b/esp-hal/ld/esp32h2/esp32h2.x
@@ -16,8 +16,7 @@ SECTIONS {
    * Thus, we need to force a gap here.
    */
   .text_gap (NOLOAD): {
-    . = . + 4;
-    . = ALIGN(4) + 0x20;
+    . = . + 8;
   } > ROM
 }
 INSERT BEFORE .text;


### PR DESCRIPTION
Currently on C6/H2 we see a "random" load segment when booting

```
I (76) esp_image: segment 0: paddr=00010020 vaddr=42000020 size=04234h ( 16948) map
I (87) esp_image: segment 1: paddr=0001425c vaddr=40800000 size=00014h (    20) load          <-- this one!
I (91) esp_image: segment 2: paddr=00014278 vaddr=42004278 size=0aee4h ( 44772) map
I (107) esp_image: segment 3: paddr=0001f164 vaddr=40800014 size=01230h (  4656) load
```

With this change it looks like this

```
I (76) esp_image: segment 0: paddr=00010020 vaddr=42000020 size=03cdch ( 15580) map
I (87) esp_image: segment 1: paddr=00013d04 vaddr=42003d04 size=0a278h ( 41592) map
I (99) esp_image: segment 2: paddr=0001df84 vaddr=40800000 size=011b4h (  4532) load
```
