### PR TITLE
If a cherrypick fails, PR with the conflicts for manual intervention

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -77,4 +77,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           target_branches: ${{ steps.detect.outputs.target_branch }}
           label_pattern: ".*-backport$"
-          experimental: "{\"conflict_resolution\": \"draft_commit_conflicts\"}"
+          experimental: '{"conflict_resolution": "draft_commit_conflicts"}'


### PR DESCRIPTION
I missed https://github.com/esp-rs/esp-hal/pull/4586#issuecomment-3606876643 but luckily @bugadani caught it. This PR changes the backlog action to create the PR regardless of cherry pick success.