### PR TITLE
Attempt to fix `skip-ci-non-code-change` for merge-queue

### DIFF
--- a/.github/workflows/api-baseline-check.yml
+++ b/.github/workflows/api-baseline-check.yml
@@ -18,12 +18,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
 
 jobs:
+  get-labels:
+    uses: ./.github/workflows/get-labels.yml
   baseline-check:
-    if: ${{ github.event_name != 'pull_request' ||
-      (
-      !contains(github.event.pull_request.labels.*.name, 'skip-ci-non-code-change') &&
-      !contains(github.event.pull_request.labels.*.name, 'breaking-change-esp-hal')
-      ) }}
+    needs: get-labels
+    if: |
+      !contains(needs.get-labels.outputs.labels, 'skip-ci-non-code-change') &&
+      !contains(needs.get-labels.outputs.labels, 'breaking-change-esp-hal')
     runs-on: ubuntu-latest
     env:
       CARGO_TARGET_DIR: ${{ github.workspace }}/target
@@ -31,70 +32,19 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Detect label in merge queue
-        if: github.event_name == 'merge_group'
-        id: skip_in_merge_queue
-        run: |
-          COMMIT_MSG=$(git log -1 --pretty=%B)
-          echo "Last commit message: $COMMIT_MSG"
-
-          # Extract PR number from commit message if it follows conventional format
-          PR_NUMBER=""
-          if echo "$COMMIT_MSG" | grep -q "#"; then
-            PR_NUMBER=$(echo "$COMMIT_MSG" | grep -o "#[0-9]*" | grep -o "[0-9]*")
-          fi
-
-          if [ -n "$PR_NUMBER" ]; then
-            echo "Found PR number: $PR_NUMBER"
-
-            LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' 2>/dev/null || true)
-            echo "PR labels:"
-            echo "$LABELS"
-
-            # Extract packages from "breaking-change-" labels
-            PACKAGES=""
-            if [ -n "$LABELS" ]; then
-              # -o: only output matches, not rows
-              # -P: Perl-compatible regular expressions
-              # `(?<=)`: look-behind: match only if this is present, but do not make this part of the match
-              PACKAGES=$(echo "$LABELS" \
-                | grep -oP '(?<=^breaking-change-)[a-z0-9-]+$' || true \
-                | tr '\n' ',' \
-                | sed 's/,$//')
-
-              if [ -n "$PACKAGES" ]; then
-                # TODO: skip only specific packages, not the whole check
-                echo "Breaking change made for package(s): $PACKAGES"
-                echo "skip_check=true" >> "$GITHUB_OUTPUT"
-              else
-                echo "No breaking-change-* labels found"
-                echo "skip_check=false" >> "$GITHUB_OUTPUT"
-              fi
-            else
-              echo "No labels found in commit message"
-              echo "skip_check=false" >> "$GITHUB_OUTPUT"
-            fi
-          else
-            echo "No PR number found in commit message"
-            echo "skip_check=false" >> "$GITHUB_OUTPUT"
-          fi
-
       # Install the Rust toolchain for Xtensa devices:
       - uses: esp-rs/xtensa-toolchain@v1.6
-        if: github.event_name != 'merge_group' || steps.skip_in_merge_queue.outputs.skip_check != 'true'
         with:
           version: 1.92.0.0
 
       # Install the Rust stable toolchain for RISC-V devices:
       - uses: dtolnay/rust-toolchain@v1
-        if: github.event_name != 'merge_group' || steps.skip_in_merge_queue.outputs.skip_check != 'true'
         with:
           target: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf
           toolchain: stable
           components: rust-src
 
       - name: Semver-Check
-        if: github.event_name != 'merge_group' || steps.skip_in_merge_queue.outputs.skip_check != 'true'
         shell: bash
         run: |
           cargo xcheck semver-check download-baselines

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -14,9 +14,12 @@ on:
     types: [opened, reopened, labeled, unlabeled, synchronize, ready_for_review]
 
 jobs:
+  get-labels:
+    uses: ./.github/workflows/get-labels.yml
   changelog:
+    needs: get-labels
     if: ${{ github.event_name != 'pull_request' ||
-      (!contains(github.event.pull_request.labels.*.name, 'skip-ci-non-code-change') &&
+      (!contains(needs.get-labels.outputs.labels, 'skip-ci-non-code-change') &&
       !github.event.pull_request.draft) }} # don't bother checking the changelog for draft PRs
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   MSRV: "1.88.0"
   DEFMT_LOG: trace
-  SKIP_CI: ${{ contains(github.event.pull_request.labels.*.name, 'skip-ci-non-code-change') }}
 
 # Cancel any currently running workflows from the same PR, branch, or
 # tag when a new workflow is triggered.
@@ -39,9 +38,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
 
 jobs:
+  get-labels:
+    uses: ./.github/workflows/get-labels.yml
+
   # --------------------------------------------------------------------------
   # Build Packages
   esp-hal:
+    needs: get-labels
     runs-on: macos-m1-self-hosted
     env:
       CARGO_TARGET_DIR: ${{ github.workspace }}/target
@@ -51,6 +54,7 @@ jobs:
       STATIC_IP: 1.1.1.1
       GATEWAY_IP: 1.1.1.1
       HOST_IP: 1.1.1.1
+      SKIP_CI: ${{ contains(needs.get-labels.outputs.labels, 'skip-ci-non-code-change') }}
 
     strategy:
       fail-fast: false
@@ -64,7 +68,7 @@ jobs:
       - name: Skip CI
         if: env.SKIP_CI == 'true'
         run: |
-          echo "skip-ci-non-code-change label present — skipping build"
+          echo "skipping build"
           exit 0
 
       - uses: actions/checkout@v6
@@ -111,18 +115,20 @@ jobs:
           cargo xcheck ci esp32h2 --toolchain stable --no-lint --no-docs
 
   detect-extras-runner:
+    needs: get-labels
     if: ${{ github.event_name != 'pull_request' ||
-      !contains(github.event.pull_request.labels.*.name, 'skip-ci-non-code-change') }}
+      !contains(needs.get-labels.outputs.labels, 'skip-ci-non-code-change') }}
     uses: ./.github/workflows/check_runner.yml
     with:
       primary-runner: macos-m1-self-hosted
       fallback-runner: ubuntu-latest
 
   extras:
-    needs: detect-extras-runner
+    needs: [get-labels, detect-extras-runner]
     if: ${{ github.event_name != 'pull_request' ||
-      !contains(github.event.pull_request.labels.*.name, 'skip-ci-non-code-change') }}
+      !contains(needs.get-labels.outputs.labels, 'skip-ci-non-code-change') }}
     runs-on: ${{ needs.detect-extras-runner.outputs.selected-runner }}
+
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@v1
@@ -142,8 +148,9 @@ jobs:
         run: cd extras/ieee802154-sniffer && cargo build
 
   docs:
+    needs: get-labels
     if: ${{ github.event_name != 'pull_request' ||
-      !contains(github.event.pull_request.labels.*.name, 'skip-ci-non-code-change') }}
+      !contains(needs.get-labels.outputs.labels, 'skip-ci-non-code-change') }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -188,7 +195,10 @@ jobs:
   # MSRV
 
   msrv:
+    needs: get-labels
     runs-on: ubuntu-latest
+    env:
+      SKIP_CI: ${{ contains(needs.get-labels.outputs.labels, 'skip-ci-non-code-change') }}
 
     strategy:
       fail-fast: false
@@ -201,7 +211,7 @@ jobs:
       - name: Skip CI
         if: env.SKIP_CI == 'true'
         run: |
-          echo "skip-ci-non-code-change label present — skipping build"
+          echo "skipping build"
           exit 0
 
       - uses: actions/checkout@v6
@@ -242,8 +252,9 @@ jobs:
   # host tests
 
   detect-host-tests-runner:
+    needs: get-labels
     if: ${{ github.event_name != 'pull_request' ||
-      !contains(github.event.pull_request.labels.*.name, 'skip-ci-non-code-change') }}
+      !contains(needs.get-labels.outputs.labels, 'skip-ci-non-code-change') }}
     uses: ./.github/workflows/check_runner.yml
     with:
       primary-runner: macos-m1-self-hosted
@@ -252,7 +263,7 @@ jobs:
   host-tests:
     needs: detect-host-tests-runner
     if: ${{ github.event_name != 'pull_request' ||
-      !contains(github.event.pull_request.labels.*.name, 'skip-ci-non-code-change') }}
+      !contains(needs.get-labels.outputs.labels, 'skip-ci-non-code-change') }}
     runs-on: ${{ needs.detect-host-tests-runner.outputs.selected-runner }}
     steps:
       - uses: actions/checkout@v6
@@ -280,8 +291,9 @@ jobs:
   # Check links in .rs, .md, and .toml files
 
   link-check:
+    needs: get-labels
     if: ${{ github.event_name != 'pull_request' ||
-      !contains(github.event.pull_request.labels.*.name, 'skip-ci-non-code-change') }}
+      !contains(needs.get-labels.outputs.labels, 'skip-ci-non-code-change') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/get-labels.yml
+++ b/.github/workflows/get-labels.yml
@@ -1,0 +1,57 @@
+name: Get Labels
+
+on:
+  workflow_call:
+    outputs:
+      labels:
+        description: "Space-separated list of all labels"
+        value: ${{ jobs.get-labels.outputs.labels }}
+      packages:
+        description: "Space-separated list of packages with breaking changes"
+        value: ${{ jobs.get-labels.outputs.packages }}
+
+jobs:
+  get-labels:
+    runs-on: ubuntu-latest
+    outputs:
+      labels: ${{ steps.list.outputs.labels }}
+      packages: ${{ steps.list.outputs.packages }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: List labels
+        id: list
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            LABELS=$(printf "%b" "${{ join(github.event.pull_request.labels.*.name, '\n') }}")
+          elif [[ "${{ github.event_name }}" == "merge_group" ]]; then
+            COMMIT_MSG=$(git log -1 --pretty=%B)
+            PR_NUMBER=$(echo "$COMMIT_MSG" | grep -o "#[0-9]*" | grep -o "[0-9]*" || true)
+            if [ -n "$PR_NUMBER" ]; then
+              LABELS=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' 2>/dev/null || true)
+            fi
+          fi
+
+          PACKAGES=""
+          if [ -n "$LABELS" ]; then
+            # -o: only output matches, not rows
+            # -P: Perl-compatible regular expressions
+            # `(?<=)`: look-behind: match only if this is present, but do not make this part of the match
+            PACKAGES=$(echo "$LABELS" \
+              | grep -oP '(?<=^breaking-change-)[a-z0-9-]+$' || true \
+              | tr '\n' ',' \
+              | sed 's/,$//')
+            fi
+
+          # Convert labels to space-separated for the 'labels' output
+          LABELS_SPACE=$(echo "$LABELS" | tr '\n' ' ' | xargs)
+          # Convert comma-separated PACKAGES to space-separated
+          PACKAGES_SPACE=$(echo "$PACKAGES" | tr ',' ' ')
+
+          echo "labels=$LABELS_SPACE" >> "$GITHUB_OUTPUT"
+          echo "packages=$PACKAGES_SPACE" >> "$GITHUB_OUTPUT"
+
+          echo "Detected labels: $LABELS_SPACE"
+          echo "Detected packages: $PACKAGES_SPACE"


### PR DESCRIPTION
This PR introduces the separate workflow that checks, if CI should be skipped or not for PRs AND MQs (hopefully). 