### PR TITLE
C5: Remove old/forgotten code from trap handler

### DIFF
--- a/esp-hal/src/interrupt/riscv.rs
+++ b/esp-hal/src/interrupt/riscv.rs
@@ -781,18 +781,6 @@ mod clic {
         Priority::None
     }
 
-    #[unsafe(no_mangle)]
-    #[unsafe(link_section = ".trap")]
-    pub(super) unsafe extern "C" fn _handle_priority() -> u32 {
-        todo!()
-    }
-
-    #[unsafe(no_mangle)]
-    #[unsafe(link_section = ".trap")]
-    pub(super) unsafe extern "C" fn _restore_priority(stored_prio: u32) {
-        // TODO
-    }
-
     pub(crate) unsafe fn change_current_runlevel(level: Priority) -> Priority {
         // TODO
         Priority::None


### PR DESCRIPTION
This code shouldn't be needed cc https://github.com/esp-rs/esp-hal/pull/3875

closes https://github.com/esp-rs/esp-hal/issues/4874