### PR TITLE
xtask: Bump version of `cargo-semver-checks`

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -41,7 +41,7 @@ reqwest = { version = "0.12.12", features = [
 ], optional = true }
 
 # This pulls a gazillion crates - don't include it by default
-cargo-semver-checks = { version = "0.45.0", optional = true }
+cargo-semver-checks = { version = "0.46.0", optional = true }
 
 flate2 = { version = "1.1.1", optional = true }
 temp-file = { version = "0.1.9", optional = true }


### PR DESCRIPTION
To fix https://github.com/esp-rs/esp-hal/actions/runs/21590132572/job/62208456912
```rust
[2026-02-02T12:39:44Z INFO  xtask::semver_check] Building doc json for esp-hal with features: ["esp32"]
Error: failed to load rustdoc from file at `"/home/runner/work/esp-hal/esp-hal/target/xtensa-esp32-none-elf/doc/esp_hal.json"`

Caused by:
    unsupported rustdoc format v57 for file: /home/runner/work/esp-hal/esp-hal/target/xtensa-esp32-none-elf/doc/esp_hal.json
    (supported formats are v53, v55, v56)
```

the updated version is not enough: 
```rust
Generated /Users/jurajsadel/esp-rs/esp-hal/target/riscv32imac-unknown-none-elf/doc/esp_hal.json
    Removing stale cached baseline rustdoc for <unknown>

thread 'main' (49918160) panicked at /Users/jurajsadel/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cargo-semver-checks-0.46.0/src/lib.rs:855:13:
assertion `left == right` failed: Deleting and regenerating the baseline JSON file did not resolve the rustdoc version mismatch.
  left: 56
 right: 57
 ```
 
 so we need to also regenerate the baselines, then it should work.