### PR TITLE
Make getter function documentation not look like setters

### DIFF
--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -660,11 +660,11 @@ impl<Dir: Direction> DynChannelAccess<Dir> {
 pub struct TxChannelConfig {
     /// Channel's clock divider
     clk_divider: u8,
-    /// Set the idle output level to low/high
+    /// Whether the idle output level is low/high
     idle_output_level: Level,
-    /// Enable idle output
+    /// Whether idle output is enabled
     idle_output: bool,
-    /// Enable carrier modulation
+    /// Whether carrier modulation is enabled
     carrier_modulation: bool,
     /// Carrier high phase in ticks
     carrier_high: u16,
@@ -697,7 +697,7 @@ impl Default for TxChannelConfig {
 pub struct RxChannelConfig {
     /// Channel's clock divider
     clk_divider: u8,
-    /// Enable carrier demodulation
+    /// Whether carrier demodulation is enabled
     carrier_modulation: bool,
     /// Carrier high phase in ticks
     carrier_high: u16,


### PR DESCRIPTION
The procedural macro extracts each field's doc comment to use as the documentation for the getter method. For example:

```rust
/// Enable idle output
pub fn idle_output(&self) -> bool
```

While reading this documentation, it looks like the method will *actively* enable the idle output.

Change the doc comments to be a bit more passive to address this.
