### PR TITLE
Do not trigger CI run when labels change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ name: CI
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    types: [opened, synchronize, reopened]
   push:
     branches-ignore:
       - "gh-readonly-queue/**"


### PR DESCRIPTION
There is _some_ argument for cancelling CI using the non-code-change label, but I think it's okay to just not run CI on labels, and accept that if a CI run has started, maybe it's okay to leave it running - runs can be cancelled (or restarted!) manually anyway. On the other hand, we were triggering CI runs on merged PRs for the backport label, and silly things like waiting-for-author also triggered a complete run. Given this is resource and time intersive, maybe we shouldn't do it.