### PR TITLE
Generate more unique inner macro names

### DIFF
--- a/esp-metadata-generated/src/_generated_esp32.rs
+++ b/esp-metadata-generated/src/_generated_esp32.rs
@@ -2788,22 +2788,26 @@ macro_rules! memory_range {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_aes_key_length {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((128)); _for_each_inner!((192)); _for_each_inner!((256));
-        _for_each_inner!((128, 0, 4)); _for_each_inner!((192, 1, 5));
-        _for_each_inner!((256, 2, 6)); _for_each_inner!((bits(128), (192), (256)));
-        _for_each_inner!((modes(128, 0, 4), (192, 1, 5), (256, 2, 6)));
+        macro_rules! _for_each_inner_aes_key_length { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_aes_key_length!((128));
+        _for_each_inner_aes_key_length!((192)); _for_each_inner_aes_key_length!((256));
+        _for_each_inner_aes_key_length!((128, 0, 4));
+        _for_each_inner_aes_key_length!((192, 1, 5));
+        _for_each_inner_aes_key_length!((256, 2, 6));
+        _for_each_inner_aes_key_length!((bits(128), (192), (256)));
+        _for_each_inner_aes_key_length!((modes(128, 0, 4), (192, 1, 5), (256, 2, 6)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_sw_interrupt {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((0, FROM_CPU_INTR0, software_interrupt0)); _for_each_inner!((1,
-        FROM_CPU_INTR1, software_interrupt1)); _for_each_inner!((2, FROM_CPU_INTR2,
-        software_interrupt2)); _for_each_inner!((3, FROM_CPU_INTR3,
-        software_interrupt3)); _for_each_inner!((all(0, FROM_CPU_INTR0,
+        macro_rules! _for_each_inner_sw_interrupt { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_sw_interrupt!((0, FROM_CPU_INTR0,
+        software_interrupt0)); _for_each_inner_sw_interrupt!((1, FROM_CPU_INTR1,
+        software_interrupt1)); _for_each_inner_sw_interrupt!((2, FROM_CPU_INTR2,
+        software_interrupt2)); _for_each_inner_sw_interrupt!((3, FROM_CPU_INTR3,
+        software_interrupt3)); _for_each_inner_sw_interrupt!((all(0, FROM_CPU_INTR0,
         software_interrupt0), (1, FROM_CPU_INTR1, software_interrupt1), (2,
         FROM_CPU_INTR2, software_interrupt2), (3, FROM_CPU_INTR3, software_interrupt3)));
     };
@@ -2839,63 +2843,81 @@ macro_rules! sw_interrupt_delay {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rmt_channel {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((0)); _for_each_inner!((1)); _for_each_inner!((2));
-        _for_each_inner!((3)); _for_each_inner!((4)); _for_each_inner!((5));
-        _for_each_inner!((6)); _for_each_inner!((7)); _for_each_inner!((0, 0));
-        _for_each_inner!((1, 1)); _for_each_inner!((2, 2)); _for_each_inner!((3, 3));
-        _for_each_inner!((4, 4)); _for_each_inner!((5, 5)); _for_each_inner!((6, 6));
-        _for_each_inner!((7, 7)); _for_each_inner!((0, 0)); _for_each_inner!((1, 1));
-        _for_each_inner!((2, 2)); _for_each_inner!((3, 3)); _for_each_inner!((4, 4));
-        _for_each_inner!((5, 5)); _for_each_inner!((6, 6)); _for_each_inner!((7, 7));
-        _for_each_inner!((all(0), (1), (2), (3), (4), (5), (6), (7)));
-        _for_each_inner!((tx(0, 0), (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6), (7,
-        7))); _for_each_inner!((rx(0, 0), (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6),
-        (7, 7)));
+        macro_rules! _for_each_inner_rmt_channel { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_rmt_channel!((0)); _for_each_inner_rmt_channel!((1));
+        _for_each_inner_rmt_channel!((2)); _for_each_inner_rmt_channel!((3));
+        _for_each_inner_rmt_channel!((4)); _for_each_inner_rmt_channel!((5));
+        _for_each_inner_rmt_channel!((6)); _for_each_inner_rmt_channel!((7));
+        _for_each_inner_rmt_channel!((0, 0)); _for_each_inner_rmt_channel!((1, 1));
+        _for_each_inner_rmt_channel!((2, 2)); _for_each_inner_rmt_channel!((3, 3));
+        _for_each_inner_rmt_channel!((4, 4)); _for_each_inner_rmt_channel!((5, 5));
+        _for_each_inner_rmt_channel!((6, 6)); _for_each_inner_rmt_channel!((7, 7));
+        _for_each_inner_rmt_channel!((0, 0)); _for_each_inner_rmt_channel!((1, 1));
+        _for_each_inner_rmt_channel!((2, 2)); _for_each_inner_rmt_channel!((3, 3));
+        _for_each_inner_rmt_channel!((4, 4)); _for_each_inner_rmt_channel!((5, 5));
+        _for_each_inner_rmt_channel!((6, 6)); _for_each_inner_rmt_channel!((7, 7));
+        _for_each_inner_rmt_channel!((all(0), (1), (2), (3), (4), (5), (6), (7)));
+        _for_each_inner_rmt_channel!((tx(0, 0), (1, 1), (2, 2), (3, 3), (4, 4), (5, 5),
+        (6, 6), (7, 7))); _for_each_inner_rmt_channel!((rx(0, 0), (1, 1), (2, 2), (3, 3),
+        (4, 4), (5, 5), (6, 6), (7, 7)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rmt_clock_source {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((RefTick, 0)); _for_each_inner!((Apb, 1));
-        _for_each_inner!((Apb)); _for_each_inner!((all(RefTick, 0), (Apb, 1)));
-        _for_each_inner!((default(Apb))); _for_each_inner!((is_boolean));
+        macro_rules! _for_each_inner_rmt_clock_source { $(($pattern) => $code;)* ($other
+        : tt) => {} } _for_each_inner_rmt_clock_source!((RefTick, 0));
+        _for_each_inner_rmt_clock_source!((Apb, 1));
+        _for_each_inner_rmt_clock_source!((Apb));
+        _for_each_inner_rmt_clock_source!((all(RefTick, 0), (Apb, 1)));
+        _for_each_inner_rmt_clock_source!((default(Apb)));
+        _for_each_inner_rmt_clock_source!((is_boolean));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rsa_exponentiation {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((512)); _for_each_inner!((1024)); _for_each_inner!((1536));
-        _for_each_inner!((2048)); _for_each_inner!((2560)); _for_each_inner!((3072));
-        _for_each_inner!((3584)); _for_each_inner!((4096)); _for_each_inner!((all(512),
-        (1024), (1536), (2048), (2560), (3072), (3584), (4096)));
+        macro_rules! _for_each_inner_rsa_exponentiation { $(($pattern) => $code;)*
+        ($other : tt) => {} } _for_each_inner_rsa_exponentiation!((512));
+        _for_each_inner_rsa_exponentiation!((1024));
+        _for_each_inner_rsa_exponentiation!((1536));
+        _for_each_inner_rsa_exponentiation!((2048));
+        _for_each_inner_rsa_exponentiation!((2560));
+        _for_each_inner_rsa_exponentiation!((3072));
+        _for_each_inner_rsa_exponentiation!((3584));
+        _for_each_inner_rsa_exponentiation!((4096));
+        _for_each_inner_rsa_exponentiation!((all(512), (1024), (1536), (2048), (2560),
+        (3072), (3584), (4096)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rsa_multiplication {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((512)); _for_each_inner!((1024)); _for_each_inner!((1536));
-        _for_each_inner!((2048)); _for_each_inner!((all(512), (1024), (1536), (2048)));
+        macro_rules! _for_each_inner_rsa_multiplication { $(($pattern) => $code;)*
+        ($other : tt) => {} } _for_each_inner_rsa_multiplication!((512));
+        _for_each_inner_rsa_multiplication!((1024));
+        _for_each_inner_rsa_multiplication!((1536));
+        _for_each_inner_rsa_multiplication!((2048));
+        _for_each_inner_rsa_multiplication!((all(512), (1024), (1536), (2048)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_sha_algorithm {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((Sha1, "SHA-1"(sizes : 64, 20, 8) (insecure_against :
-        "collision", "length extension"), 0)); _for_each_inner!((Sha256, "SHA-256"(sizes
-        : 64, 32, 8) (insecure_against : "length extension"), 0));
-        _for_each_inner!((Sha384, "SHA-384"(sizes : 128, 48, 16) (insecure_against :),
-        0)); _for_each_inner!((Sha512, "SHA-512"(sizes : 128, 64, 16) (insecure_against :
-        "length extension"), 0)); _for_each_inner!((algos(Sha1, "SHA-1"(sizes : 64, 20,
-        8) (insecure_against : "collision", "length extension"), 0), (Sha256,
+        macro_rules! _for_each_inner_sha_algorithm { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_sha_algorithm!((Sha1, "SHA-1"(sizes : 64, 20, 8)
+        (insecure_against : "collision", "length extension"), 0));
+        _for_each_inner_sha_algorithm!((Sha256, "SHA-256"(sizes : 64, 32, 8)
+        (insecure_against : "length extension"), 0));
+        _for_each_inner_sha_algorithm!((Sha384, "SHA-384"(sizes : 128, 48, 16)
+        (insecure_against :), 0)); _for_each_inner_sha_algorithm!((Sha512,
+        "SHA-512"(sizes : 128, 64, 16) (insecure_against : "length extension"), 0));
+        _for_each_inner_sha_algorithm!((algos(Sha1, "SHA-1"(sizes : 64, 20, 8)
+        (insecure_against : "collision", "length extension"), 0), (Sha256,
         "SHA-256"(sizes : 64, 32, 8) (insecure_against : "length extension"), 0),
         (Sha384, "SHA-384"(sizes : 128, 48, 16) (insecure_against :), 0), (Sha512,
         "SHA-512"(sizes : 128, 64, 16) (insecure_against : "length extension"), 0)));
@@ -2921,11 +2943,11 @@ macro_rules! for_each_sha_algorithm {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_i2c_master {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((I2C0, I2cExt0, I2CEXT0_SCL, I2CEXT0_SDA));
-        _for_each_inner!((I2C1, I2cExt1, I2CEXT1_SCL, I2CEXT1_SDA));
-        _for_each_inner!((all(I2C0, I2cExt0, I2CEXT0_SCL, I2CEXT0_SDA), (I2C1, I2cExt1,
-        I2CEXT1_SCL, I2CEXT1_SDA)));
+        macro_rules! _for_each_inner_i2c_master { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_i2c_master!((I2C0, I2cExt0, I2CEXT0_SCL, I2CEXT0_SDA));
+        _for_each_inner_i2c_master!((I2C1, I2cExt1, I2CEXT1_SCL, I2CEXT1_SDA));
+        _for_each_inner_i2c_master!((all(I2C0, I2cExt0, I2CEXT0_SCL, I2CEXT0_SDA), (I2C1,
+        I2cExt1, I2CEXT1_SCL, I2CEXT1_SDA)));
     };
 }
 /// This macro can be used to generate code for each peripheral instance of the UART driver.
@@ -2948,12 +2970,12 @@ macro_rules! for_each_i2c_master {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_uart {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS));
-        _for_each_inner!((UART1, Uart1, U1RXD, U1TXD, U1CTS, U1RTS));
-        _for_each_inner!((UART2, Uart2, U2RXD, U2TXD, U2CTS, U2RTS));
-        _for_each_inner!((all(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS), (UART1, Uart1,
-        U1RXD, U1TXD, U1CTS, U1RTS), (UART2, Uart2, U2RXD, U2TXD, U2CTS, U2RTS)));
+        macro_rules! _for_each_inner_uart { $(($pattern) => $code;)* ($other : tt) => {}
+        } _for_each_inner_uart!((UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS));
+        _for_each_inner_uart!((UART1, Uart1, U1RXD, U1TXD, U1CTS, U1RTS));
+        _for_each_inner_uart!((UART2, Uart2, U2RXD, U2TXD, U2CTS, U2RTS));
+        _for_each_inner_uart!((all(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS), (UART1,
+        Uart1, U1RXD, U1TXD, U1CTS, U1RTS), (UART2, Uart2, U2RXD, U2TXD, U2CTS, U2RTS)));
     };
 }
 /// This macro can be used to generate code for each peripheral instance of the SPI master driver.
@@ -2981,10 +3003,11 @@ macro_rules! for_each_uart {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_spi_master {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((SPI2, Spi2, HSPICLK[HSPICS0, HSPICS1, HSPICS2] [HSPID, HSPIQ,
-        HSPIWP, HSPIHD], true)); _for_each_inner!((SPI3, Spi3, VSPICLK[VSPICS0, VSPICS1,
-        VSPICS2] [VSPID, VSPIQ, VSPIWP, VSPIHD], true)); _for_each_inner!((all(SPI2,
+        macro_rules! _for_each_inner_spi_master { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_spi_master!((SPI2, Spi2, HSPICLK[HSPICS0, HSPICS1,
+        HSPICS2] [HSPID, HSPIQ, HSPIWP, HSPIHD], true));
+        _for_each_inner_spi_master!((SPI3, Spi3, VSPICLK[VSPICS0, VSPICS1, VSPICS2]
+        [VSPID, VSPIQ, VSPIWP, VSPIHD], true)); _for_each_inner_spi_master!((all(SPI2,
         Spi2, HSPICLK[HSPICS0, HSPICS1, HSPICS2] [HSPID, HSPIQ, HSPIWP, HSPIHD], true),
         (SPI3, Spi3, VSPICLK[VSPICS0, VSPICS1, VSPICS2] [VSPID, VSPIQ, VSPIWP, VSPIHD],
         true)));
@@ -3010,328 +3033,389 @@ macro_rules! for_each_spi_master {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_spi_slave {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((SPI2, Spi2, HSPICLK, HSPID, HSPIQ, HSPICS0));
-        _for_each_inner!((SPI3, Spi3, VSPICLK, VSPID, VSPIQ, VSPICS0));
-        _for_each_inner!((all(SPI2, Spi2, HSPICLK, HSPID, HSPIQ, HSPICS0), (SPI3, Spi3,
-        VSPICLK, VSPID, VSPIQ, VSPICS0)));
+        macro_rules! _for_each_inner_spi_slave { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_spi_slave!((SPI2, Spi2, HSPICLK, HSPID, HSPIQ, HSPICS0));
+        _for_each_inner_spi_slave!((SPI3, Spi3, VSPICLK, VSPID, VSPIQ, VSPICS0));
+        _for_each_inner_spi_slave!((all(SPI2, Spi2, HSPICLK, HSPID, HSPIQ, HSPICS0),
+        (SPI3, Spi3, VSPICLK, VSPID, VSPIQ, VSPICS0)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_peripheral {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((@ peri_type #[doc =
+        macro_rules! _for_each_inner_peripheral { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_peripheral!((@ peri_type #[doc =
         "GPIO0 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
         "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin is a strapping pin, it determines how the chip boots.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO0 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO1 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO0 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO1 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>By default, this pin is used by the UART programming interface.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO1 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO2 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO1 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO2 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin is a strapping pin, it determines how the chip boots.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO2 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO3 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO2 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO3 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>By default, this pin is used by the UART programming interface.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO3 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO4 peripheral singleton"] GPIO4 <= virtual()));
-        _for_each_inner!((@ peri_type #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO3 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO4 peripheral singleton"]
+        GPIO4 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
         "GPIO5 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
         "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin is a strapping pin, it determines how the chip boots.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO5 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO6 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO5 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO6 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI PSRAM.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO6 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO7 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO6 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO7 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI PSRAM.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO7 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO8 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO7 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO8 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI PSRAM.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO8 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO9 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO8 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO9 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI PSRAM.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO9 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO10 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO9 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO10 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI PSRAM.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO10 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO11 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO10 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO11 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI PSRAM.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO11 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO12 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO11 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO12 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin is a strapping pin, it determines how the chip boots.</li>"] #[doc
         =
         "<li>These pins may be used to debug the chip using an external JTAG debugger.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO12 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO13 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO12 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO13 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>These pins may be used to debug the chip using an external JTAG debugger.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO13 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO14 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO13 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO14 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>These pins may be used to debug the chip using an external JTAG debugger.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO14 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO15 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO14 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO15 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin is a strapping pin, it determines how the chip boots.</li>"] #[doc
         =
         "<li>These pins may be used to debug the chip using an external JTAG debugger.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO15 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO16 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO15 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO16 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI PSRAM.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO16 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO17 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO16 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO17 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI PSRAM.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO17 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO18 peripheral singleton"] GPIO18 <= virtual()));
-        _for_each_inner!((@ peri_type #[doc = "GPIO19 peripheral singleton"] GPIO19 <=
-        virtual())); _for_each_inner!((@ peri_type #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO17 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO18 peripheral singleton"]
+        GPIO18 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO19 peripheral singleton"] GPIO19 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
         "GPIO20 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
         "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc = "<li>This pin is only available on ESP32-PICO-V3.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO20 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO21 peripheral singleton"] GPIO21 <= virtual()));
-        _for_each_inner!((@ peri_type #[doc = "GPIO22 peripheral singleton"] GPIO22 <=
-        virtual())); _for_each_inner!((@ peri_type #[doc = "GPIO23 peripheral singleton"]
-        GPIO23 <= virtual())); _for_each_inner!((@ peri_type #[doc =
-        "GPIO25 peripheral singleton"] GPIO25 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO26 peripheral singleton"] GPIO26 <= virtual()));
-        _for_each_inner!((@ peri_type #[doc = "GPIO27 peripheral singleton"] GPIO27 <=
-        virtual())); _for_each_inner!((@ peri_type #[doc = "GPIO32 peripheral singleton"]
-        GPIO32 <= virtual())); _for_each_inner!((@ peri_type #[doc =
-        "GPIO33 peripheral singleton"] GPIO33 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO34 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO20 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO21 peripheral singleton"]
+        GPIO21 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO22 peripheral singleton"] GPIO22 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO23 peripheral singleton"]
+        GPIO23 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO25 peripheral singleton"] GPIO25 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO26 peripheral singleton"]
+        GPIO26 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO27 peripheral singleton"] GPIO27 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO32 peripheral singleton"]
+        GPIO32 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO33 peripheral singleton"] GPIO33 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO34 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc = "<li>This pin can only be used as an input.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO34 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO35 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO34 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO35 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc = "<li>This pin can only be used as an input.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO35 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO36 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO35 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO36 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc = "<li>This pin can only be used as an input.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO36 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO37 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO36 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO37 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc = "<li>This pin can only be used as an input.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO37 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO38 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO37 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO38 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc = "<li>This pin can only be used as an input.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO38 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO39 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO38 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO39 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc = "<li>This pin can only be used as an input.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO39 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "AES peripheral singleton"] AES <= AES() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "APB_CTRL peripheral singleton"] APB_CTRL
-        <= APB_CTRL() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "BB peripheral singleton"] BB <= BB() (unstable))); _for_each_inner!((@ peri_type
-        #[doc = "DPORT peripheral singleton"] DPORT <= DPORT() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "SYSTEM peripheral singleton"] SYSTEM <=
-        DPORT() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "EFUSE peripheral singleton"] EFUSE <= EFUSE() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "EMAC_DMA peripheral singleton"] EMAC_DMA <= EMAC_DMA()
-        (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "EMAC_EXT peripheral singleton"] EMAC_EXT <= EMAC_EXT() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "EMAC_MAC peripheral singleton"] EMAC_MAC
-        <= EMAC_MAC() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "FLASH_ENCRYPTION peripheral singleton"] FLASH_ENCRYPTION <= FLASH_ENCRYPTION()
-        (unstable))); _for_each_inner!((@ peri_type #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO39 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "AES peripheral singleton"] AES
+        <= AES() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "APB_CTRL peripheral singleton"] APB_CTRL <= APB_CTRL() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "BB peripheral singleton"] BB <=
+        BB() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "DPORT peripheral singleton"] DPORT <= DPORT() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "SYSTEM peripheral singleton"]
+        SYSTEM <= DPORT() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "EFUSE peripheral singleton"] EFUSE <= EFUSE() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "EMAC_DMA peripheral singleton"]
+        EMAC_DMA <= EMAC_DMA() (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "EMAC_EXT peripheral singleton"] EMAC_EXT <= EMAC_EXT() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "EMAC_MAC peripheral singleton"]
+        EMAC_MAC <= EMAC_MAC() (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "FLASH_ENCRYPTION peripheral singleton"] FLASH_ENCRYPTION <=
+        FLASH_ENCRYPTION() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "FRC_TIMER peripheral singleton"] FRC_TIMER <= FRC_TIMER() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "GPIO peripheral singleton"] GPIO <= GPIO()
-        (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO peripheral singleton"]
+        GPIO <= GPIO() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "GPIO_SD peripheral singleton"] GPIO_SD <= GPIO_SD() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "HINF peripheral singleton"] HINF <= HINF()
-        (unstable))); _for_each_inner!((@ peri_type #[doc = "I2C0 peripheral singleton"]
-        I2C0 <= I2C0(I2C_EXT0 : { bind_peri_interrupt, enable_peri_interrupt,
-        disable_peri_interrupt }))); _for_each_inner!((@ peri_type #[doc =
-        "I2C1 peripheral singleton"] I2C1 <= I2C1(I2C_EXT1 : { bind_peri_interrupt,
-        enable_peri_interrupt, disable_peri_interrupt }))); _for_each_inner!((@ peri_type
-        #[doc = "I2S0 peripheral singleton"] I2S0 <= I2S0(I2S0 : { bind_peri_interrupt,
+        _for_each_inner_peripheral!((@ peri_type #[doc = "HINF peripheral singleton"]
+        HINF <= HINF() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "I2C0 peripheral singleton"] I2C0 <= I2C0(I2C_EXT0 : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt })));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "I2C1 peripheral singleton"]
+        I2C1 <= I2C1(I2C_EXT1 : { bind_peri_interrupt, enable_peri_interrupt,
+        disable_peri_interrupt }))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "I2S0 peripheral singleton"] I2S0 <= I2S0(I2S0 : { bind_peri_interrupt,
         enable_peri_interrupt, disable_peri_interrupt }) (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "I2S1 peripheral singleton"] I2S1 <=
-        I2S1(I2S1 : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt
-        }) (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "IO_MUX peripheral singleton"] IO_MUX <= IO_MUX() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "LEDC peripheral singleton"] LEDC <= LEDC()
-        (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "I2S1 peripheral singleton"]
+        I2S1 <= I2S1(I2S1 : { bind_peri_interrupt, enable_peri_interrupt,
+        disable_peri_interrupt }) (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "IO_MUX peripheral singleton"] IO_MUX <= IO_MUX() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "LEDC peripheral singleton"]
+        LEDC <= LEDC() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "MCPWM0 peripheral singleton"] MCPWM0 <= MCPWM0() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "MCPWM1 peripheral singleton"] MCPWM1 <=
-        MCPWM1() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "NRX peripheral singleton"] NRX <= NRX() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "PCNT peripheral singleton"] PCNT <= PCNT() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "RMT peripheral singleton"] RMT <= RMT()
-        (unstable))); _for_each_inner!((@ peri_type #[doc = "RNG peripheral singleton"]
-        RNG <= RNG() (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "MCPWM1 peripheral singleton"]
+        MCPWM1 <= MCPWM1() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "NRX peripheral singleton"] NRX <= NRX() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "PCNT peripheral singleton"]
+        PCNT <= PCNT() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "RMT peripheral singleton"] RMT <= RMT() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "RNG peripheral singleton"] RNG
+        <= RNG() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "RSA peripheral singleton"] RSA <= RSA(RSA : { bind_peri_interrupt,
         enable_peri_interrupt, disable_peri_interrupt }) (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "LPWR peripheral singleton"] LPWR <=
-        RTC_CNTL() (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "LPWR peripheral singleton"]
+        LPWR <= RTC_CNTL() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "RTC_I2C peripheral singleton"] RTC_I2C <= RTC_I2C() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "RTC_IO peripheral singleton"] RTC_IO <=
-        RTC_IO() (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "RTC_IO peripheral singleton"]
+        RTC_IO <= RTC_IO() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "SDHOST peripheral singleton"] SDHOST <= SDHOST() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "SENS peripheral singleton"] SENS <= SENS()
-        (unstable))); _for_each_inner!((@ peri_type #[doc = "SHA peripheral singleton"]
-        SHA <= SHA() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "SLC peripheral singleton"] SLC <= SLC() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "SLCHOST peripheral singleton"] SLCHOST <= SLCHOST()
-        (unstable))); _for_each_inner!((@ peri_type #[doc = "SPI0 peripheral singleton"]
-        SPI0 <= SPI0() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "SPI1 peripheral singleton"] SPI1 <= SPI1() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "SPI2 peripheral singleton"] SPI2 <= SPI2(SPI2_DMA : {
-        bind_dma_interrupt, enable_dma_interrupt, disable_dma_interrupt }, SPI2 : {
-        bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })));
-        _for_each_inner!((@ peri_type #[doc = "SPI3 peripheral singleton"] SPI3 <=
-        SPI3(SPI3_DMA : { bind_dma_interrupt, enable_dma_interrupt, disable_dma_interrupt
-        }, SPI3 : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt
-        }))); _for_each_inner!((@ peri_type #[doc = "TIMG0 peripheral singleton"] TIMG0
-        <= TIMG0() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "TIMG1 peripheral singleton"] TIMG1 <= TIMG1() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "TWAI0 peripheral singleton"] TWAI0 <= TWAI0() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "UART0 peripheral singleton"] UART0 <=
-        UART0(UART0 : { bind_peri_interrupt, enable_peri_interrupt,
-        disable_peri_interrupt }))); _for_each_inner!((@ peri_type #[doc =
-        "UART1 peripheral singleton"] UART1 <= UART1(UART1 : { bind_peri_interrupt,
-        enable_peri_interrupt, disable_peri_interrupt }))); _for_each_inner!((@ peri_type
-        #[doc = "UART2 peripheral singleton"] UART2 <= UART2(UART2 : {
-        bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })));
-        _for_each_inner!((@ peri_type #[doc = "UHCI0 peripheral singleton"] UHCI0 <=
-        UHCI0() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "UHCI1 peripheral singleton"] UHCI1 <= UHCI1() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "WIFI peripheral singleton"] WIFI <= WIFI() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "DMA_SPI2 peripheral singleton"] DMA_SPI2
-        <= SPI2() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "DMA_SPI3 peripheral singleton"] DMA_SPI3 <= SPI3() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "DMA_I2S0 peripheral singleton"] DMA_I2S0
-        <= I2S0() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "DMA_I2S1 peripheral singleton"] DMA_I2S1 <= I2S1() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "ADC1 peripheral singleton"] ADC1 <=
-        virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "ADC2 peripheral singleton"] ADC2 <= virtual() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "BT peripheral singleton"] BT <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "CPU_CTRL peripheral singleton"] CPU_CTRL
-        <= virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "DAC1 peripheral singleton"] DAC1 <= virtual() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "DAC2 peripheral singleton"] DAC2 <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "FLASH peripheral singleton"] FLASH <=
-        virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "PSRAM peripheral singleton"] PSRAM <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "SW_INTERRUPT peripheral singleton"]
-        SW_INTERRUPT <= virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "TOUCH peripheral singleton"] TOUCH <= virtual() (unstable)));
-        _for_each_inner!((GPIO0)); _for_each_inner!((GPIO1)); _for_each_inner!((GPIO2));
-        _for_each_inner!((GPIO3)); _for_each_inner!((GPIO4)); _for_each_inner!((GPIO5));
-        _for_each_inner!((GPIO6)); _for_each_inner!((GPIO7)); _for_each_inner!((GPIO8));
-        _for_each_inner!((GPIO9)); _for_each_inner!((GPIO10));
-        _for_each_inner!((GPIO11)); _for_each_inner!((GPIO12));
-        _for_each_inner!((GPIO13)); _for_each_inner!((GPIO14));
-        _for_each_inner!((GPIO15)); _for_each_inner!((GPIO16));
-        _for_each_inner!((GPIO17)); _for_each_inner!((GPIO18));
-        _for_each_inner!((GPIO19)); _for_each_inner!((GPIO20));
-        _for_each_inner!((GPIO21)); _for_each_inner!((GPIO22));
-        _for_each_inner!((GPIO23)); _for_each_inner!((GPIO25));
-        _for_each_inner!((GPIO26)); _for_each_inner!((GPIO27));
-        _for_each_inner!((GPIO32)); _for_each_inner!((GPIO33));
-        _for_each_inner!((GPIO34)); _for_each_inner!((GPIO35));
-        _for_each_inner!((GPIO36)); _for_each_inner!((GPIO37));
-        _for_each_inner!((GPIO38)); _for_each_inner!((GPIO39));
-        _for_each_inner!((AES(unstable))); _for_each_inner!((APB_CTRL(unstable)));
-        _for_each_inner!((BB(unstable))); _for_each_inner!((DPORT(unstable)));
-        _for_each_inner!((SYSTEM(unstable))); _for_each_inner!((EFUSE(unstable)));
-        _for_each_inner!((EMAC_DMA(unstable))); _for_each_inner!((EMAC_EXT(unstable)));
-        _for_each_inner!((EMAC_MAC(unstable)));
-        _for_each_inner!((FLASH_ENCRYPTION(unstable)));
-        _for_each_inner!((FRC_TIMER(unstable))); _for_each_inner!((GPIO(unstable)));
-        _for_each_inner!((GPIO_SD(unstable))); _for_each_inner!((HINF(unstable)));
-        _for_each_inner!((I2C0)); _for_each_inner!((I2C1));
-        _for_each_inner!((I2S0(unstable))); _for_each_inner!((I2S1(unstable)));
-        _for_each_inner!((IO_MUX(unstable))); _for_each_inner!((LEDC(unstable)));
-        _for_each_inner!((MCPWM0(unstable))); _for_each_inner!((MCPWM1(unstable)));
-        _for_each_inner!((NRX(unstable))); _for_each_inner!((PCNT(unstable)));
-        _for_each_inner!((RMT(unstable))); _for_each_inner!((RNG(unstable)));
-        _for_each_inner!((RSA(unstable))); _for_each_inner!((LPWR(unstable)));
-        _for_each_inner!((RTC_I2C(unstable))); _for_each_inner!((RTC_IO(unstable)));
-        _for_each_inner!((SDHOST(unstable))); _for_each_inner!((SENS(unstable)));
-        _for_each_inner!((SHA(unstable))); _for_each_inner!((SLC(unstable)));
-        _for_each_inner!((SLCHOST(unstable))); _for_each_inner!((SPI0(unstable)));
-        _for_each_inner!((SPI1(unstable))); _for_each_inner!((SPI2));
-        _for_each_inner!((SPI3)); _for_each_inner!((TIMG0(unstable)));
-        _for_each_inner!((TIMG1(unstable))); _for_each_inner!((TWAI0(unstable)));
-        _for_each_inner!((UART0)); _for_each_inner!((UART1)); _for_each_inner!((UART2));
-        _for_each_inner!((UHCI0(unstable))); _for_each_inner!((UHCI1(unstable)));
-        _for_each_inner!((WIFI(unstable))); _for_each_inner!((DMA_SPI2(unstable)));
-        _for_each_inner!((DMA_SPI3(unstable))); _for_each_inner!((DMA_I2S0(unstable)));
-        _for_each_inner!((DMA_I2S1(unstable))); _for_each_inner!((ADC1(unstable)));
-        _for_each_inner!((ADC2(unstable))); _for_each_inner!((BT(unstable)));
-        _for_each_inner!((CPU_CTRL(unstable))); _for_each_inner!((DAC1(unstable)));
-        _for_each_inner!((DAC2(unstable))); _for_each_inner!((FLASH(unstable)));
-        _for_each_inner!((PSRAM(unstable))); _for_each_inner!((SW_INTERRUPT(unstable)));
-        _for_each_inner!((TOUCH(unstable))); _for_each_inner!((all(@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "SENS peripheral singleton"]
+        SENS <= SENS() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "SHA peripheral singleton"] SHA <= SHA() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "SLC peripheral singleton"] SLC
+        <= SLC() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "SLCHOST peripheral singleton"] SLCHOST <= SLCHOST() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "SPI0 peripheral singleton"]
+        SPI0 <= SPI0() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "SPI1 peripheral singleton"] SPI1 <= SPI1() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "SPI2 peripheral singleton"]
+        SPI2 <= SPI2(SPI2_DMA : { bind_dma_interrupt, enable_dma_interrupt,
+        disable_dma_interrupt }, SPI2 : { bind_peri_interrupt, enable_peri_interrupt,
+        disable_peri_interrupt }))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "SPI3 peripheral singleton"] SPI3 <= SPI3(SPI3_DMA : { bind_dma_interrupt,
+        enable_dma_interrupt, disable_dma_interrupt }, SPI3 : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt })));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "TIMG0 peripheral singleton"]
+        TIMG0 <= TIMG0() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "TIMG1 peripheral singleton"] TIMG1 <= TIMG1() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "TWAI0 peripheral singleton"]
+        TWAI0 <= TWAI0() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "UART0 peripheral singleton"] UART0 <= UART0(UART0 : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt })));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "UART1 peripheral singleton"]
+        UART1 <= UART1(UART1 : { bind_peri_interrupt, enable_peri_interrupt,
+        disable_peri_interrupt }))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "UART2 peripheral singleton"] UART2 <= UART2(UART2 : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt })));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "UHCI0 peripheral singleton"]
+        UHCI0 <= UHCI0() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "UHCI1 peripheral singleton"] UHCI1 <= UHCI1() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "WIFI peripheral singleton"]
+        WIFI <= WIFI() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "DMA_SPI2 peripheral singleton"] DMA_SPI2 <= SPI2() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_SPI3 peripheral singleton"]
+        DMA_SPI3 <= SPI3() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "DMA_I2S0 peripheral singleton"] DMA_I2S0 <= I2S0() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_I2S1 peripheral singleton"]
+        DMA_I2S1 <= I2S1() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "ADC1 peripheral singleton"] ADC1 <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "ADC2 peripheral singleton"]
+        ADC2 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "BT peripheral singleton"] BT <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "CPU_CTRL peripheral singleton"]
+        CPU_CTRL <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "DAC1 peripheral singleton"] DAC1 <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DAC2 peripheral singleton"]
+        DAC2 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "FLASH peripheral singleton"] FLASH <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "PSRAM peripheral singleton"]
+        PSRAM <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "SW_INTERRUPT peripheral singleton"] SW_INTERRUPT <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "TOUCH peripheral singleton"]
+        TOUCH <= virtual() (unstable))); _for_each_inner_peripheral!((GPIO0));
+        _for_each_inner_peripheral!((GPIO1)); _for_each_inner_peripheral!((GPIO2));
+        _for_each_inner_peripheral!((GPIO3)); _for_each_inner_peripheral!((GPIO4));
+        _for_each_inner_peripheral!((GPIO5)); _for_each_inner_peripheral!((GPIO6));
+        _for_each_inner_peripheral!((GPIO7)); _for_each_inner_peripheral!((GPIO8));
+        _for_each_inner_peripheral!((GPIO9)); _for_each_inner_peripheral!((GPIO10));
+        _for_each_inner_peripheral!((GPIO11)); _for_each_inner_peripheral!((GPIO12));
+        _for_each_inner_peripheral!((GPIO13)); _for_each_inner_peripheral!((GPIO14));
+        _for_each_inner_peripheral!((GPIO15)); _for_each_inner_peripheral!((GPIO16));
+        _for_each_inner_peripheral!((GPIO17)); _for_each_inner_peripheral!((GPIO18));
+        _for_each_inner_peripheral!((GPIO19)); _for_each_inner_peripheral!((GPIO20));
+        _for_each_inner_peripheral!((GPIO21)); _for_each_inner_peripheral!((GPIO22));
+        _for_each_inner_peripheral!((GPIO23)); _for_each_inner_peripheral!((GPIO25));
+        _for_each_inner_peripheral!((GPIO26)); _for_each_inner_peripheral!((GPIO27));
+        _for_each_inner_peripheral!((GPIO32)); _for_each_inner_peripheral!((GPIO33));
+        _for_each_inner_peripheral!((GPIO34)); _for_each_inner_peripheral!((GPIO35));
+        _for_each_inner_peripheral!((GPIO36)); _for_each_inner_peripheral!((GPIO37));
+        _for_each_inner_peripheral!((GPIO38)); _for_each_inner_peripheral!((GPIO39));
+        _for_each_inner_peripheral!((AES(unstable)));
+        _for_each_inner_peripheral!((APB_CTRL(unstable)));
+        _for_each_inner_peripheral!((BB(unstable)));
+        _for_each_inner_peripheral!((DPORT(unstable)));
+        _for_each_inner_peripheral!((SYSTEM(unstable)));
+        _for_each_inner_peripheral!((EFUSE(unstable)));
+        _for_each_inner_peripheral!((EMAC_DMA(unstable)));
+        _for_each_inner_peripheral!((EMAC_EXT(unstable)));
+        _for_each_inner_peripheral!((EMAC_MAC(unstable)));
+        _for_each_inner_peripheral!((FLASH_ENCRYPTION(unstable)));
+        _for_each_inner_peripheral!((FRC_TIMER(unstable)));
+        _for_each_inner_peripheral!((GPIO(unstable)));
+        _for_each_inner_peripheral!((GPIO_SD(unstable)));
+        _for_each_inner_peripheral!((HINF(unstable)));
+        _for_each_inner_peripheral!((I2C0)); _for_each_inner_peripheral!((I2C1));
+        _for_each_inner_peripheral!((I2S0(unstable)));
+        _for_each_inner_peripheral!((I2S1(unstable)));
+        _for_each_inner_peripheral!((IO_MUX(unstable)));
+        _for_each_inner_peripheral!((LEDC(unstable)));
+        _for_each_inner_peripheral!((MCPWM0(unstable)));
+        _for_each_inner_peripheral!((MCPWM1(unstable)));
+        _for_each_inner_peripheral!((NRX(unstable)));
+        _for_each_inner_peripheral!((PCNT(unstable)));
+        _for_each_inner_peripheral!((RMT(unstable)));
+        _for_each_inner_peripheral!((RNG(unstable)));
+        _for_each_inner_peripheral!((RSA(unstable)));
+        _for_each_inner_peripheral!((LPWR(unstable)));
+        _for_each_inner_peripheral!((RTC_I2C(unstable)));
+        _for_each_inner_peripheral!((RTC_IO(unstable)));
+        _for_each_inner_peripheral!((SDHOST(unstable)));
+        _for_each_inner_peripheral!((SENS(unstable)));
+        _for_each_inner_peripheral!((SHA(unstable)));
+        _for_each_inner_peripheral!((SLC(unstable)));
+        _for_each_inner_peripheral!((SLCHOST(unstable)));
+        _for_each_inner_peripheral!((SPI0(unstable)));
+        _for_each_inner_peripheral!((SPI1(unstable)));
+        _for_each_inner_peripheral!((SPI2)); _for_each_inner_peripheral!((SPI3));
+        _for_each_inner_peripheral!((TIMG0(unstable)));
+        _for_each_inner_peripheral!((TIMG1(unstable)));
+        _for_each_inner_peripheral!((TWAI0(unstable)));
+        _for_each_inner_peripheral!((UART0)); _for_each_inner_peripheral!((UART1));
+        _for_each_inner_peripheral!((UART2));
+        _for_each_inner_peripheral!((UHCI0(unstable)));
+        _for_each_inner_peripheral!((UHCI1(unstable)));
+        _for_each_inner_peripheral!((WIFI(unstable)));
+        _for_each_inner_peripheral!((DMA_SPI2(unstable)));
+        _for_each_inner_peripheral!((DMA_SPI3(unstable)));
+        _for_each_inner_peripheral!((DMA_I2S0(unstable)));
+        _for_each_inner_peripheral!((DMA_I2S1(unstable)));
+        _for_each_inner_peripheral!((ADC1(unstable)));
+        _for_each_inner_peripheral!((ADC2(unstable)));
+        _for_each_inner_peripheral!((BT(unstable)));
+        _for_each_inner_peripheral!((CPU_CTRL(unstable)));
+        _for_each_inner_peripheral!((DAC1(unstable)));
+        _for_each_inner_peripheral!((DAC2(unstable)));
+        _for_each_inner_peripheral!((FLASH(unstable)));
+        _for_each_inner_peripheral!((PSRAM(unstable)));
+        _for_each_inner_peripheral!((SW_INTERRUPT(unstable)));
+        _for_each_inner_peripheral!((TOUCH(unstable)));
+        _for_each_inner_peripheral!((all(@ peri_type #[doc =
         "GPIO0 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
         "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
@@ -3569,27 +3653,27 @@ macro_rules! for_each_peripheral {
         (unstable)), (@ peri_type #[doc = "SW_INTERRUPT peripheral singleton"]
         SW_INTERRUPT <= virtual() (unstable)), (@ peri_type #[doc =
         "TOUCH peripheral singleton"] TOUCH <= virtual() (unstable))));
-        _for_each_inner!((singletons(GPIO0), (GPIO1), (GPIO2), (GPIO3), (GPIO4), (GPIO5),
-        (GPIO6), (GPIO7), (GPIO8), (GPIO9), (GPIO10), (GPIO11), (GPIO12), (GPIO13),
-        (GPIO14), (GPIO15), (GPIO16), (GPIO17), (GPIO18), (GPIO19), (GPIO20), (GPIO21),
-        (GPIO22), (GPIO23), (GPIO25), (GPIO26), (GPIO27), (GPIO32), (GPIO33), (GPIO34),
-        (GPIO35), (GPIO36), (GPIO37), (GPIO38), (GPIO39), (AES(unstable)),
-        (APB_CTRL(unstable)), (BB(unstable)), (DPORT(unstable)), (SYSTEM(unstable)),
-        (EFUSE(unstable)), (EMAC_DMA(unstable)), (EMAC_EXT(unstable)),
-        (EMAC_MAC(unstable)), (FLASH_ENCRYPTION(unstable)), (FRC_TIMER(unstable)),
-        (GPIO(unstable)), (GPIO_SD(unstable)), (HINF(unstable)), (I2C0), (I2C1),
-        (I2S0(unstable)), (I2S1(unstable)), (IO_MUX(unstable)), (LEDC(unstable)),
-        (MCPWM0(unstable)), (MCPWM1(unstable)), (NRX(unstable)), (PCNT(unstable)),
-        (RMT(unstable)), (RNG(unstable)), (RSA(unstable)), (LPWR(unstable)),
-        (RTC_I2C(unstable)), (RTC_IO(unstable)), (SDHOST(unstable)), (SENS(unstable)),
-        (SHA(unstable)), (SLC(unstable)), (SLCHOST(unstable)), (SPI0(unstable)),
-        (SPI1(unstable)), (SPI2), (SPI3), (TIMG0(unstable)), (TIMG1(unstable)),
-        (TWAI0(unstable)), (UART0), (UART1), (UART2), (UHCI0(unstable)),
-        (UHCI1(unstable)), (WIFI(unstable)), (DMA_SPI2(unstable)), (DMA_SPI3(unstable)),
-        (DMA_I2S0(unstable)), (DMA_I2S1(unstable)), (ADC1(unstable)), (ADC2(unstable)),
-        (BT(unstable)), (CPU_CTRL(unstable)), (DAC1(unstable)), (DAC2(unstable)),
-        (FLASH(unstable)), (PSRAM(unstable)), (SW_INTERRUPT(unstable)),
-        (TOUCH(unstable))));
+        _for_each_inner_peripheral!((singletons(GPIO0), (GPIO1), (GPIO2), (GPIO3),
+        (GPIO4), (GPIO5), (GPIO6), (GPIO7), (GPIO8), (GPIO9), (GPIO10), (GPIO11),
+        (GPIO12), (GPIO13), (GPIO14), (GPIO15), (GPIO16), (GPIO17), (GPIO18), (GPIO19),
+        (GPIO20), (GPIO21), (GPIO22), (GPIO23), (GPIO25), (GPIO26), (GPIO27), (GPIO32),
+        (GPIO33), (GPIO34), (GPIO35), (GPIO36), (GPIO37), (GPIO38), (GPIO39),
+        (AES(unstable)), (APB_CTRL(unstable)), (BB(unstable)), (DPORT(unstable)),
+        (SYSTEM(unstable)), (EFUSE(unstable)), (EMAC_DMA(unstable)),
+        (EMAC_EXT(unstable)), (EMAC_MAC(unstable)), (FLASH_ENCRYPTION(unstable)),
+        (FRC_TIMER(unstable)), (GPIO(unstable)), (GPIO_SD(unstable)), (HINF(unstable)),
+        (I2C0), (I2C1), (I2S0(unstable)), (I2S1(unstable)), (IO_MUX(unstable)),
+        (LEDC(unstable)), (MCPWM0(unstable)), (MCPWM1(unstable)), (NRX(unstable)),
+        (PCNT(unstable)), (RMT(unstable)), (RNG(unstable)), (RSA(unstable)),
+        (LPWR(unstable)), (RTC_I2C(unstable)), (RTC_IO(unstable)), (SDHOST(unstable)),
+        (SENS(unstable)), (SHA(unstable)), (SLC(unstable)), (SLCHOST(unstable)),
+        (SPI0(unstable)), (SPI1(unstable)), (SPI2), (SPI3), (TIMG0(unstable)),
+        (TIMG1(unstable)), (TWAI0(unstable)), (UART0), (UART1), (UART2),
+        (UHCI0(unstable)), (UHCI1(unstable)), (WIFI(unstable)), (DMA_SPI2(unstable)),
+        (DMA_SPI3(unstable)), (DMA_I2S0(unstable)), (DMA_I2S1(unstable)),
+        (ADC1(unstable)), (ADC2(unstable)), (BT(unstable)), (CPU_CTRL(unstable)),
+        (DAC1(unstable)), (DAC2(unstable)), (FLASH(unstable)), (PSRAM(unstable)),
+        (SW_INTERRUPT(unstable)), (TOUCH(unstable))));
     };
 }
 /// This macro can be used to generate code for each `GPIOn` instance.
@@ -3622,59 +3706,63 @@ macro_rules! for_each_peripheral {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_gpio {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((0, GPIO0(_5 => EMAC_TX_CLK) (_1 => CLK_OUT1 _5 => EMAC_TX_CLK)
-        ([Input] [Output]))); _for_each_inner!((1, GPIO1(_5 => EMAC_RXD2) (_0 => U0TXD _1
-        => CLK_OUT3) ([Input] [Output]))); _for_each_inner!((2, GPIO2(_1 => HSPIWP _3 =>
-        HS2_DATA0 _4 => SD_DATA0) (_1 => HSPIWP _3 => HS2_DATA0 _4 => SD_DATA0) ([Input]
-        [Output]))); _for_each_inner!((3, GPIO3(_0 => U0RXD) (_1 => CLK_OUT2) ([Input]
-        [Output]))); _for_each_inner!((4, GPIO4(_1 => HSPIHD _3 => HS2_DATA1 _4 =>
+        macro_rules! _for_each_inner_gpio { $(($pattern) => $code;)* ($other : tt) => {}
+        } _for_each_inner_gpio!((0, GPIO0(_5 => EMAC_TX_CLK) (_1 => CLK_OUT1 _5 =>
+        EMAC_TX_CLK) ([Input] [Output]))); _for_each_inner_gpio!((1, GPIO1(_5 =>
+        EMAC_RXD2) (_0 => U0TXD _1 => CLK_OUT3) ([Input] [Output])));
+        _for_each_inner_gpio!((2, GPIO2(_1 => HSPIWP _3 => HS2_DATA0 _4 => SD_DATA0) (_1
+        => HSPIWP _3 => HS2_DATA0 _4 => SD_DATA0) ([Input] [Output])));
+        _for_each_inner_gpio!((3, GPIO3(_0 => U0RXD) (_1 => CLK_OUT2) ([Input]
+        [Output]))); _for_each_inner_gpio!((4, GPIO4(_1 => HSPIHD _3 => HS2_DATA1 _4 =>
         SD_DATA1 _5 => EMAC_TX_ER) (_1 => HSPIHD _3 => HS2_DATA1 _4 => SD_DATA1 _5 =>
-        EMAC_TX_ER) ([Input] [Output]))); _for_each_inner!((5, GPIO5(_1 => VSPICS0 _3 =>
-        HS1_DATA6 _5 => EMAC_RX_CLK) (_1 => VSPICS0 _3 => HS1_DATA6) ([Input]
-        [Output]))); _for_each_inner!((6, GPIO6(_1 => SPICLK _4 => U1CTS) (_0 => SD_CLK
-        _1 => SPICLK _3 => HS1_CLK) ([Input] [Output]))); _for_each_inner!((7, GPIO7(_0
-        => SD_DATA0 _1 => SPIQ _3 => HS1_DATA0) (_0 => SD_DATA0 _1 => SPIQ _3 =>
-        HS1_DATA0 _4 => U2RTS) ([Input] [Output]))); _for_each_inner!((8, GPIO8(_0 =>
-        SD_DATA1 _1 => SPID _3 => HS1_DATA1 _4 => U2CTS) (_0 => SD_DATA1 _1 => SPID _3 =>
-        HS1_DATA1) ([Input] [Output]))); _for_each_inner!((9, GPIO9(_0 => SD_DATA2 _1 =>
-        SPIHD _3 => HS1_DATA2 _4 => U1RXD) (_0 => SD_DATA2 _1 => SPIHD _3 => HS1_DATA2)
-        ([Input] [Output]))); _for_each_inner!((10, GPIO10(_0 => SD_DATA3 _1 => SPIWP _3
-        => HS1_DATA3) (_0 => SD_DATA3 _1 => SPIWP _3 => HS1_DATA3 _4 => U1TXD) ([Input]
-        [Output]))); _for_each_inner!((11, GPIO11(_0 => SD_CMD _1 => SPICS0) (_0 =>
-        SD_CMD _1 => SPICS0 _3 => HS1_CMD _4 => U1RTS) ([Input] [Output])));
-        _for_each_inner!((12, GPIO12(_0 => MTDI _1 => HSPIQ _3 => HS2_DATA2 _4 =>
+        EMAC_TX_ER) ([Input] [Output]))); _for_each_inner_gpio!((5, GPIO5(_1 => VSPICS0
+        _3 => HS1_DATA6 _5 => EMAC_RX_CLK) (_1 => VSPICS0 _3 => HS1_DATA6) ([Input]
+        [Output]))); _for_each_inner_gpio!((6, GPIO6(_1 => SPICLK _4 => U1CTS) (_0 =>
+        SD_CLK _1 => SPICLK _3 => HS1_CLK) ([Input] [Output])));
+        _for_each_inner_gpio!((7, GPIO7(_0 => SD_DATA0 _1 => SPIQ _3 => HS1_DATA0) (_0 =>
+        SD_DATA0 _1 => SPIQ _3 => HS1_DATA0 _4 => U2RTS) ([Input] [Output])));
+        _for_each_inner_gpio!((8, GPIO8(_0 => SD_DATA1 _1 => SPID _3 => HS1_DATA1 _4 =>
+        U2CTS) (_0 => SD_DATA1 _1 => SPID _3 => HS1_DATA1) ([Input] [Output])));
+        _for_each_inner_gpio!((9, GPIO9(_0 => SD_DATA2 _1 => SPIHD _3 => HS1_DATA2 _4 =>
+        U1RXD) (_0 => SD_DATA2 _1 => SPIHD _3 => HS1_DATA2) ([Input] [Output])));
+        _for_each_inner_gpio!((10, GPIO10(_0 => SD_DATA3 _1 => SPIWP _3 => HS1_DATA3) (_0
+        => SD_DATA3 _1 => SPIWP _3 => HS1_DATA3 _4 => U1TXD) ([Input] [Output])));
+        _for_each_inner_gpio!((11, GPIO11(_0 => SD_CMD _1 => SPICS0) (_0 => SD_CMD _1 =>
+        SPICS0 _3 => HS1_CMD _4 => U1RTS) ([Input] [Output])));
+        _for_each_inner_gpio!((12, GPIO12(_0 => MTDI _1 => HSPIQ _3 => HS2_DATA2 _4 =>
         SD_DATA2) (_1 => HSPIQ _3 => HS2_DATA2 _4 => SD_DATA2 _5 => EMAC_TXD3) ([Input]
-        [Output]))); _for_each_inner!((13, GPIO13(_0 => MTCK _1 => HSPID _3 => HS2_DATA3
-        _4 => SD_DATA3 _5 => EMAC_RX_ER) (_1 => HSPID _3 => HS2_DATA3 _4 => SD_DATA3 _5
-        => EMAC_RX_ER) ([Input] [Output]))); _for_each_inner!((14, GPIO14(_0 => MTMS _1
-        => HSPICLK) (_1 => HSPICLK _3 => HS2_CLK _4 => SD_CLK _5 => EMAC_TXD2) ([Input]
-        [Output]))); _for_each_inner!((15, GPIO15(_1 => HSPICS0 _4 => SD_CMD _5 =>
-        EMAC_RXD3) (_0 => MTDO _1 => HSPICS0 _3 => HS2_CMD _4 => SD_CMD) ([Input]
-        [Output]))); _for_each_inner!((16, GPIO16(_3 => HS1_DATA4 _4 => U2RXD) (_3 =>
-        HS1_DATA4 _5 => EMAC_CLK_OUT) ([Input] [Output]))); _for_each_inner!((17,
-        GPIO17(_3 => HS1_DATA5) (_3 => HS1_DATA5 _4 => U2TXD _5 => EMAC_CLK_180) ([Input]
-        [Output]))); _for_each_inner!((18, GPIO18(_1 => VSPICLK _3 => HS1_DATA7) (_1 =>
-        VSPICLK _3 => HS1_DATA7) ([Input] [Output]))); _for_each_inner!((19, GPIO19(_1 =>
-        VSPIQ _3 => U0CTS) (_1 => VSPIQ _5 => EMAC_TXD0) ([Input] [Output])));
-        _for_each_inner!((20, GPIO20() () ([Input] [Output]))); _for_each_inner!((21,
-        GPIO21(_1 => VSPIHD) (_1 => VSPIHD _5 => EMAC_TX_EN) ([Input] [Output])));
-        _for_each_inner!((22, GPIO22(_1 => VSPIWP) (_1 => VSPIWP _3 => U0RTS _5 =>
-        EMAC_TXD1) ([Input] [Output]))); _for_each_inner!((23, GPIO23(_1 => VSPID) (_1 =>
-        VSPID _3 => HS1_STROBE) ([Input] [Output]))); _for_each_inner!((25, GPIO25(_5 =>
-        EMAC_RXD0) () ([Input] [Output]))); _for_each_inner!((26, GPIO26(_5 => EMAC_RXD1)
-        () ([Input] [Output]))); _for_each_inner!((27, GPIO27(_5 => EMAC_RX_DV) ()
-        ([Input] [Output]))); _for_each_inner!((32, GPIO32() () ([Input] [Output])));
-        _for_each_inner!((33, GPIO33() () ([Input] [Output]))); _for_each_inner!((34,
-        GPIO34() () ([Input] []))); _for_each_inner!((35, GPIO35() () ([Input] [])));
-        _for_each_inner!((36, GPIO36() () ([Input] []))); _for_each_inner!((37, GPIO37()
-        () ([Input] []))); _for_each_inner!((38, GPIO38() () ([Input] [])));
-        _for_each_inner!((39, GPIO39() () ([Input] []))); _for_each_inner!((all(0,
-        GPIO0(_5 => EMAC_TX_CLK) (_1 => CLK_OUT1 _5 => EMAC_TX_CLK) ([Input] [Output])),
-        (1, GPIO1(_5 => EMAC_RXD2) (_0 => U0TXD _1 => CLK_OUT3) ([Input] [Output])), (2,
-        GPIO2(_1 => HSPIWP _3 => HS2_DATA0 _4 => SD_DATA0) (_1 => HSPIWP _3 => HS2_DATA0
-        _4 => SD_DATA0) ([Input] [Output])), (3, GPIO3(_0 => U0RXD) (_1 => CLK_OUT2)
-        ([Input] [Output])), (4, GPIO4(_1 => HSPIHD _3 => HS2_DATA1 _4 => SD_DATA1 _5 =>
+        [Output]))); _for_each_inner_gpio!((13, GPIO13(_0 => MTCK _1 => HSPID _3 =>
+        HS2_DATA3 _4 => SD_DATA3 _5 => EMAC_RX_ER) (_1 => HSPID _3 => HS2_DATA3 _4 =>
+        SD_DATA3 _5 => EMAC_RX_ER) ([Input] [Output]))); _for_each_inner_gpio!((14,
+        GPIO14(_0 => MTMS _1 => HSPICLK) (_1 => HSPICLK _3 => HS2_CLK _4 => SD_CLK _5 =>
+        EMAC_TXD2) ([Input] [Output]))); _for_each_inner_gpio!((15, GPIO15(_1 => HSPICS0
+        _4 => SD_CMD _5 => EMAC_RXD3) (_0 => MTDO _1 => HSPICS0 _3 => HS2_CMD _4 =>
+        SD_CMD) ([Input] [Output]))); _for_each_inner_gpio!((16, GPIO16(_3 => HS1_DATA4
+        _4 => U2RXD) (_3 => HS1_DATA4 _5 => EMAC_CLK_OUT) ([Input] [Output])));
+        _for_each_inner_gpio!((17, GPIO17(_3 => HS1_DATA5) (_3 => HS1_DATA5 _4 => U2TXD
+        _5 => EMAC_CLK_180) ([Input] [Output]))); _for_each_inner_gpio!((18, GPIO18(_1 =>
+        VSPICLK _3 => HS1_DATA7) (_1 => VSPICLK _3 => HS1_DATA7) ([Input] [Output])));
+        _for_each_inner_gpio!((19, GPIO19(_1 => VSPIQ _3 => U0CTS) (_1 => VSPIQ _5 =>
+        EMAC_TXD0) ([Input] [Output]))); _for_each_inner_gpio!((20, GPIO20() () ([Input]
+        [Output]))); _for_each_inner_gpio!((21, GPIO21(_1 => VSPIHD) (_1 => VSPIHD _5 =>
+        EMAC_TX_EN) ([Input] [Output]))); _for_each_inner_gpio!((22, GPIO22(_1 => VSPIWP)
+        (_1 => VSPIWP _3 => U0RTS _5 => EMAC_TXD1) ([Input] [Output])));
+        _for_each_inner_gpio!((23, GPIO23(_1 => VSPID) (_1 => VSPID _3 => HS1_STROBE)
+        ([Input] [Output]))); _for_each_inner_gpio!((25, GPIO25(_5 => EMAC_RXD0) ()
+        ([Input] [Output]))); _for_each_inner_gpio!((26, GPIO26(_5 => EMAC_RXD1) ()
+        ([Input] [Output]))); _for_each_inner_gpio!((27, GPIO27(_5 => EMAC_RX_DV) ()
+        ([Input] [Output]))); _for_each_inner_gpio!((32, GPIO32() () ([Input]
+        [Output]))); _for_each_inner_gpio!((33, GPIO33() () ([Input] [Output])));
+        _for_each_inner_gpio!((34, GPIO34() () ([Input] []))); _for_each_inner_gpio!((35,
+        GPIO35() () ([Input] []))); _for_each_inner_gpio!((36, GPIO36() () ([Input]
+        []))); _for_each_inner_gpio!((37, GPIO37() () ([Input] [])));
+        _for_each_inner_gpio!((38, GPIO38() () ([Input] []))); _for_each_inner_gpio!((39,
+        GPIO39() () ([Input] []))); _for_each_inner_gpio!((all(0, GPIO0(_5 =>
+        EMAC_TX_CLK) (_1 => CLK_OUT1 _5 => EMAC_TX_CLK) ([Input] [Output])), (1, GPIO1(_5
+        => EMAC_RXD2) (_0 => U0TXD _1 => CLK_OUT3) ([Input] [Output])), (2, GPIO2(_1 =>
+        HSPIWP _3 => HS2_DATA0 _4 => SD_DATA0) (_1 => HSPIWP _3 => HS2_DATA0 _4 =>
+        SD_DATA0) ([Input] [Output])), (3, GPIO3(_0 => U0RXD) (_1 => CLK_OUT2) ([Input]
+        [Output])), (4, GPIO4(_1 => HSPIHD _3 => HS2_DATA1 _4 => SD_DATA1 _5 =>
         EMAC_TX_ER) (_1 => HSPIHD _3 => HS2_DATA1 _4 => SD_DATA1 _5 => EMAC_TX_ER)
         ([Input] [Output])), (5, GPIO5(_1 => VSPICS0 _3 => HS1_DATA6 _5 => EMAC_RX_CLK)
         (_1 => VSPICS0 _3 => HS1_DATA6) ([Input] [Output])), (6, GPIO6(_1 => SPICLK _4 =>
@@ -3740,71 +3828,98 @@ macro_rules! for_each_gpio {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_analog_function {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((ADC2_CH1, GPIO0)); _for_each_inner!((TOUCH1, GPIO0));
-        _for_each_inner!((ADC2_CH2, GPIO2)); _for_each_inner!((TOUCH2, GPIO2));
-        _for_each_inner!((ADC2_CH0, GPIO4)); _for_each_inner!((TOUCH0, GPIO4));
-        _for_each_inner!((ADC2_CH5, GPIO12)); _for_each_inner!((TOUCH5, GPIO12));
-        _for_each_inner!((ADC2_CH4, GPIO13)); _for_each_inner!((TOUCH4, GPIO13));
-        _for_each_inner!((ADC2_CH6, GPIO14)); _for_each_inner!((TOUCH6, GPIO14));
-        _for_each_inner!((ADC2_CH3, GPIO15)); _for_each_inner!((TOUCH3, GPIO15));
-        _for_each_inner!((DAC1, GPIO25)); _for_each_inner!((ADC2_CH8, GPIO25));
-        _for_each_inner!((DAC2, GPIO26)); _for_each_inner!((ADC2_CH9, GPIO26));
-        _for_each_inner!((ADC2_CH7, GPIO27)); _for_each_inner!((TOUCH7, GPIO27));
-        _for_each_inner!((XTAL_32K_P, GPIO32)); _for_each_inner!((ADC1_CH4, GPIO32));
-        _for_each_inner!((TOUCH9, GPIO32)); _for_each_inner!((XTAL_32K_N, GPIO33));
-        _for_each_inner!((ADC1_CH5, GPIO33)); _for_each_inner!((TOUCH8, GPIO33));
-        _for_each_inner!((ADC1_CH6, GPIO34)); _for_each_inner!((ADC1_CH7, GPIO35));
-        _for_each_inner!((ADC_H, GPIO36)); _for_each_inner!((ADC1_CH0, GPIO36));
-        _for_each_inner!((ADC_H, GPIO37)); _for_each_inner!((ADC1_CH1, GPIO37));
-        _for_each_inner!((ADC_H, GPIO38)); _for_each_inner!((ADC1_CH2, GPIO38));
-        _for_each_inner!((ADC_H, GPIO39)); _for_each_inner!((ADC1_CH3, GPIO39));
-        _for_each_inner!(((ADC2_CH1, ADCn_CHm, 2, 1), GPIO0)); _for_each_inner!(((TOUCH1,
-        TOUCHn, 1), GPIO0)); _for_each_inner!(((ADC2_CH2, ADCn_CHm, 2, 2), GPIO2));
-        _for_each_inner!(((TOUCH2, TOUCHn, 2), GPIO2)); _for_each_inner!(((ADC2_CH0,
-        ADCn_CHm, 2, 0), GPIO4)); _for_each_inner!(((TOUCH0, TOUCHn, 0), GPIO4));
-        _for_each_inner!(((ADC2_CH5, ADCn_CHm, 2, 5), GPIO12));
-        _for_each_inner!(((TOUCH5, TOUCHn, 5), GPIO12)); _for_each_inner!(((ADC2_CH4,
-        ADCn_CHm, 2, 4), GPIO13)); _for_each_inner!(((TOUCH4, TOUCHn, 4), GPIO13));
-        _for_each_inner!(((ADC2_CH6, ADCn_CHm, 2, 6), GPIO14));
-        _for_each_inner!(((TOUCH6, TOUCHn, 6), GPIO14)); _for_each_inner!(((ADC2_CH3,
-        ADCn_CHm, 2, 3), GPIO15)); _for_each_inner!(((TOUCH3, TOUCHn, 3), GPIO15));
-        _for_each_inner!(((DAC1, DACn, 1), GPIO25)); _for_each_inner!(((ADC2_CH8,
-        ADCn_CHm, 2, 8), GPIO25)); _for_each_inner!(((DAC2, DACn, 2), GPIO26));
-        _for_each_inner!(((ADC2_CH9, ADCn_CHm, 2, 9), GPIO26));
-        _for_each_inner!(((ADC2_CH7, ADCn_CHm, 2, 7), GPIO27));
-        _for_each_inner!(((TOUCH7, TOUCHn, 7), GPIO27)); _for_each_inner!(((ADC1_CH4,
-        ADCn_CHm, 1, 4), GPIO32)); _for_each_inner!(((TOUCH9, TOUCHn, 9), GPIO32));
-        _for_each_inner!(((ADC1_CH5, ADCn_CHm, 1, 5), GPIO33));
-        _for_each_inner!(((TOUCH8, TOUCHn, 8), GPIO33)); _for_each_inner!(((ADC1_CH6,
-        ADCn_CHm, 1, 6), GPIO34)); _for_each_inner!(((ADC1_CH7, ADCn_CHm, 1, 7),
-        GPIO35)); _for_each_inner!(((ADC1_CH0, ADCn_CHm, 1, 0), GPIO36));
-        _for_each_inner!(((ADC1_CH1, ADCn_CHm, 1, 1), GPIO37));
-        _for_each_inner!(((ADC1_CH2, ADCn_CHm, 1, 2), GPIO38));
-        _for_each_inner!(((ADC1_CH3, ADCn_CHm, 1, 3), GPIO39));
-        _for_each_inner!((all(ADC2_CH1, GPIO0), (TOUCH1, GPIO0), (ADC2_CH2, GPIO2),
-        (TOUCH2, GPIO2), (ADC2_CH0, GPIO4), (TOUCH0, GPIO4), (ADC2_CH5, GPIO12), (TOUCH5,
-        GPIO12), (ADC2_CH4, GPIO13), (TOUCH4, GPIO13), (ADC2_CH6, GPIO14), (TOUCH6,
-        GPIO14), (ADC2_CH3, GPIO15), (TOUCH3, GPIO15), (DAC1, GPIO25), (ADC2_CH8,
-        GPIO25), (DAC2, GPIO26), (ADC2_CH9, GPIO26), (ADC2_CH7, GPIO27), (TOUCH7,
-        GPIO27), (XTAL_32K_P, GPIO32), (ADC1_CH4, GPIO32), (TOUCH9, GPIO32), (XTAL_32K_N,
-        GPIO33), (ADC1_CH5, GPIO33), (TOUCH8, GPIO33), (ADC1_CH6, GPIO34), (ADC1_CH7,
-        GPIO35), (ADC_H, GPIO36), (ADC1_CH0, GPIO36), (ADC_H, GPIO37), (ADC1_CH1,
-        GPIO37), (ADC_H, GPIO38), (ADC1_CH2, GPIO38), (ADC_H, GPIO39), (ADC1_CH3,
-        GPIO39))); _for_each_inner!((all_expanded((ADC2_CH1, ADCn_CHm, 2, 1), GPIO0),
-        ((TOUCH1, TOUCHn, 1), GPIO0), ((ADC2_CH2, ADCn_CHm, 2, 2), GPIO2), ((TOUCH2,
-        TOUCHn, 2), GPIO2), ((ADC2_CH0, ADCn_CHm, 2, 0), GPIO4), ((TOUCH0, TOUCHn, 0),
-        GPIO4), ((ADC2_CH5, ADCn_CHm, 2, 5), GPIO12), ((TOUCH5, TOUCHn, 5), GPIO12),
-        ((ADC2_CH4, ADCn_CHm, 2, 4), GPIO13), ((TOUCH4, TOUCHn, 4), GPIO13), ((ADC2_CH6,
-        ADCn_CHm, 2, 6), GPIO14), ((TOUCH6, TOUCHn, 6), GPIO14), ((ADC2_CH3, ADCn_CHm, 2,
-        3), GPIO15), ((TOUCH3, TOUCHn, 3), GPIO15), ((DAC1, DACn, 1), GPIO25),
-        ((ADC2_CH8, ADCn_CHm, 2, 8), GPIO25), ((DAC2, DACn, 2), GPIO26), ((ADC2_CH9,
-        ADCn_CHm, 2, 9), GPIO26), ((ADC2_CH7, ADCn_CHm, 2, 7), GPIO27), ((TOUCH7, TOUCHn,
-        7), GPIO27), ((ADC1_CH4, ADCn_CHm, 1, 4), GPIO32), ((TOUCH9, TOUCHn, 9), GPIO32),
-        ((ADC1_CH5, ADCn_CHm, 1, 5), GPIO33), ((TOUCH8, TOUCHn, 8), GPIO33), ((ADC1_CH6,
-        ADCn_CHm, 1, 6), GPIO34), ((ADC1_CH7, ADCn_CHm, 1, 7), GPIO35), ((ADC1_CH0,
-        ADCn_CHm, 1, 0), GPIO36), ((ADC1_CH1, ADCn_CHm, 1, 1), GPIO37), ((ADC1_CH2,
-        ADCn_CHm, 1, 2), GPIO38), ((ADC1_CH3, ADCn_CHm, 1, 3), GPIO39)));
+        macro_rules! _for_each_inner_analog_function { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_analog_function!((ADC2_CH1, GPIO0));
+        _for_each_inner_analog_function!((TOUCH1, GPIO0));
+        _for_each_inner_analog_function!((ADC2_CH2, GPIO2));
+        _for_each_inner_analog_function!((TOUCH2, GPIO2));
+        _for_each_inner_analog_function!((ADC2_CH0, GPIO4));
+        _for_each_inner_analog_function!((TOUCH0, GPIO4));
+        _for_each_inner_analog_function!((ADC2_CH5, GPIO12));
+        _for_each_inner_analog_function!((TOUCH5, GPIO12));
+        _for_each_inner_analog_function!((ADC2_CH4, GPIO13));
+        _for_each_inner_analog_function!((TOUCH4, GPIO13));
+        _for_each_inner_analog_function!((ADC2_CH6, GPIO14));
+        _for_each_inner_analog_function!((TOUCH6, GPIO14));
+        _for_each_inner_analog_function!((ADC2_CH3, GPIO15));
+        _for_each_inner_analog_function!((TOUCH3, GPIO15));
+        _for_each_inner_analog_function!((DAC1, GPIO25));
+        _for_each_inner_analog_function!((ADC2_CH8, GPIO25));
+        _for_each_inner_analog_function!((DAC2, GPIO26));
+        _for_each_inner_analog_function!((ADC2_CH9, GPIO26));
+        _for_each_inner_analog_function!((ADC2_CH7, GPIO27));
+        _for_each_inner_analog_function!((TOUCH7, GPIO27));
+        _for_each_inner_analog_function!((XTAL_32K_P, GPIO32));
+        _for_each_inner_analog_function!((ADC1_CH4, GPIO32));
+        _for_each_inner_analog_function!((TOUCH9, GPIO32));
+        _for_each_inner_analog_function!((XTAL_32K_N, GPIO33));
+        _for_each_inner_analog_function!((ADC1_CH5, GPIO33));
+        _for_each_inner_analog_function!((TOUCH8, GPIO33));
+        _for_each_inner_analog_function!((ADC1_CH6, GPIO34));
+        _for_each_inner_analog_function!((ADC1_CH7, GPIO35));
+        _for_each_inner_analog_function!((ADC_H, GPIO36));
+        _for_each_inner_analog_function!((ADC1_CH0, GPIO36));
+        _for_each_inner_analog_function!((ADC_H, GPIO37));
+        _for_each_inner_analog_function!((ADC1_CH1, GPIO37));
+        _for_each_inner_analog_function!((ADC_H, GPIO38));
+        _for_each_inner_analog_function!((ADC1_CH2, GPIO38));
+        _for_each_inner_analog_function!((ADC_H, GPIO39));
+        _for_each_inner_analog_function!((ADC1_CH3, GPIO39));
+        _for_each_inner_analog_function!(((ADC2_CH1, ADCn_CHm, 2, 1), GPIO0));
+        _for_each_inner_analog_function!(((TOUCH1, TOUCHn, 1), GPIO0));
+        _for_each_inner_analog_function!(((ADC2_CH2, ADCn_CHm, 2, 2), GPIO2));
+        _for_each_inner_analog_function!(((TOUCH2, TOUCHn, 2), GPIO2));
+        _for_each_inner_analog_function!(((ADC2_CH0, ADCn_CHm, 2, 0), GPIO4));
+        _for_each_inner_analog_function!(((TOUCH0, TOUCHn, 0), GPIO4));
+        _for_each_inner_analog_function!(((ADC2_CH5, ADCn_CHm, 2, 5), GPIO12));
+        _for_each_inner_analog_function!(((TOUCH5, TOUCHn, 5), GPIO12));
+        _for_each_inner_analog_function!(((ADC2_CH4, ADCn_CHm, 2, 4), GPIO13));
+        _for_each_inner_analog_function!(((TOUCH4, TOUCHn, 4), GPIO13));
+        _for_each_inner_analog_function!(((ADC2_CH6, ADCn_CHm, 2, 6), GPIO14));
+        _for_each_inner_analog_function!(((TOUCH6, TOUCHn, 6), GPIO14));
+        _for_each_inner_analog_function!(((ADC2_CH3, ADCn_CHm, 2, 3), GPIO15));
+        _for_each_inner_analog_function!(((TOUCH3, TOUCHn, 3), GPIO15));
+        _for_each_inner_analog_function!(((DAC1, DACn, 1), GPIO25));
+        _for_each_inner_analog_function!(((ADC2_CH8, ADCn_CHm, 2, 8), GPIO25));
+        _for_each_inner_analog_function!(((DAC2, DACn, 2), GPIO26));
+        _for_each_inner_analog_function!(((ADC2_CH9, ADCn_CHm, 2, 9), GPIO26));
+        _for_each_inner_analog_function!(((ADC2_CH7, ADCn_CHm, 2, 7), GPIO27));
+        _for_each_inner_analog_function!(((TOUCH7, TOUCHn, 7), GPIO27));
+        _for_each_inner_analog_function!(((ADC1_CH4, ADCn_CHm, 1, 4), GPIO32));
+        _for_each_inner_analog_function!(((TOUCH9, TOUCHn, 9), GPIO32));
+        _for_each_inner_analog_function!(((ADC1_CH5, ADCn_CHm, 1, 5), GPIO33));
+        _for_each_inner_analog_function!(((TOUCH8, TOUCHn, 8), GPIO33));
+        _for_each_inner_analog_function!(((ADC1_CH6, ADCn_CHm, 1, 6), GPIO34));
+        _for_each_inner_analog_function!(((ADC1_CH7, ADCn_CHm, 1, 7), GPIO35));
+        _for_each_inner_analog_function!(((ADC1_CH0, ADCn_CHm, 1, 0), GPIO36));
+        _for_each_inner_analog_function!(((ADC1_CH1, ADCn_CHm, 1, 1), GPIO37));
+        _for_each_inner_analog_function!(((ADC1_CH2, ADCn_CHm, 1, 2), GPIO38));
+        _for_each_inner_analog_function!(((ADC1_CH3, ADCn_CHm, 1, 3), GPIO39));
+        _for_each_inner_analog_function!((all(ADC2_CH1, GPIO0), (TOUCH1, GPIO0),
+        (ADC2_CH2, GPIO2), (TOUCH2, GPIO2), (ADC2_CH0, GPIO4), (TOUCH0, GPIO4),
+        (ADC2_CH5, GPIO12), (TOUCH5, GPIO12), (ADC2_CH4, GPIO13), (TOUCH4, GPIO13),
+        (ADC2_CH6, GPIO14), (TOUCH6, GPIO14), (ADC2_CH3, GPIO15), (TOUCH3, GPIO15),
+        (DAC1, GPIO25), (ADC2_CH8, GPIO25), (DAC2, GPIO26), (ADC2_CH9, GPIO26),
+        (ADC2_CH7, GPIO27), (TOUCH7, GPIO27), (XTAL_32K_P, GPIO32), (ADC1_CH4, GPIO32),
+        (TOUCH9, GPIO32), (XTAL_32K_N, GPIO33), (ADC1_CH5, GPIO33), (TOUCH8, GPIO33),
+        (ADC1_CH6, GPIO34), (ADC1_CH7, GPIO35), (ADC_H, GPIO36), (ADC1_CH0, GPIO36),
+        (ADC_H, GPIO37), (ADC1_CH1, GPIO37), (ADC_H, GPIO38), (ADC1_CH2, GPIO38), (ADC_H,
+        GPIO39), (ADC1_CH3, GPIO39)));
+        _for_each_inner_analog_function!((all_expanded((ADC2_CH1, ADCn_CHm, 2, 1),
+        GPIO0), ((TOUCH1, TOUCHn, 1), GPIO0), ((ADC2_CH2, ADCn_CHm, 2, 2), GPIO2),
+        ((TOUCH2, TOUCHn, 2), GPIO2), ((ADC2_CH0, ADCn_CHm, 2, 0), GPIO4), ((TOUCH0,
+        TOUCHn, 0), GPIO4), ((ADC2_CH5, ADCn_CHm, 2, 5), GPIO12), ((TOUCH5, TOUCHn, 5),
+        GPIO12), ((ADC2_CH4, ADCn_CHm, 2, 4), GPIO13), ((TOUCH4, TOUCHn, 4), GPIO13),
+        ((ADC2_CH6, ADCn_CHm, 2, 6), GPIO14), ((TOUCH6, TOUCHn, 6), GPIO14), ((ADC2_CH3,
+        ADCn_CHm, 2, 3), GPIO15), ((TOUCH3, TOUCHn, 3), GPIO15), ((DAC1, DACn, 1),
+        GPIO25), ((ADC2_CH8, ADCn_CHm, 2, 8), GPIO25), ((DAC2, DACn, 2), GPIO26),
+        ((ADC2_CH9, ADCn_CHm, 2, 9), GPIO26), ((ADC2_CH7, ADCn_CHm, 2, 7), GPIO27),
+        ((TOUCH7, TOUCHn, 7), GPIO27), ((ADC1_CH4, ADCn_CHm, 1, 4), GPIO32), ((TOUCH9,
+        TOUCHn, 9), GPIO32), ((ADC1_CH5, ADCn_CHm, 1, 5), GPIO33), ((TOUCH8, TOUCHn, 8),
+        GPIO33), ((ADC1_CH6, ADCn_CHm, 1, 6), GPIO34), ((ADC1_CH7, ADCn_CHm, 1, 7),
+        GPIO35), ((ADC1_CH0, ADCn_CHm, 1, 0), GPIO36), ((ADC1_CH1, ADCn_CHm, 1, 1),
+        GPIO37), ((ADC1_CH2, ADCn_CHm, 1, 2), GPIO38), ((ADC1_CH3, ADCn_CHm, 1, 3),
+        GPIO39)));
     };
 }
 /// This macro can be used to generate code for each LP/RTC function of each GPIO.
@@ -3837,53 +3952,64 @@ macro_rules! for_each_analog_function {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_lp_function {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((RTC_GPIO11, GPIO0)); _for_each_inner!((SAR_I2C_SDA, GPIO0));
-        _for_each_inner!((RTC_GPIO12, GPIO2)); _for_each_inner!((SAR_I2C_SCL, GPIO2));
-        _for_each_inner!((RTC_GPIO10, GPIO4)); _for_each_inner!((SAR_I2C_SCL, GPIO4));
-        _for_each_inner!((RTC_GPIO15, GPIO12)); _for_each_inner!((RTC_GPIO14, GPIO13));
-        _for_each_inner!((RTC_GPIO16, GPIO14)); _for_each_inner!((RTC_GPIO13, GPIO15));
-        _for_each_inner!((SAR_I2C_SDA, GPIO15)); _for_each_inner!((RTC_GPIO6, GPIO25));
-        _for_each_inner!((RTC_GPIO7, GPIO26)); _for_each_inner!((RTC_GPIO17, GPIO27));
-        _for_each_inner!((RTC_GPIO9, GPIO32)); _for_each_inner!((RTC_GPIO8, GPIO33));
-        _for_each_inner!((RTC_GPIO4, GPIO34)); _for_each_inner!((RTC_GPIO5, GPIO35));
-        _for_each_inner!((RTC_GPIO0, GPIO36)); _for_each_inner!((RTC_GPIO1, GPIO37));
-        _for_each_inner!((RTC_GPIO2, GPIO38)); _for_each_inner!((RTC_GPIO3, GPIO39));
-        _for_each_inner!(((RTC_GPIO11, RTC_GPIOn, 11), GPIO0));
-        _for_each_inner!(((RTC_GPIO12, RTC_GPIOn, 12), GPIO2));
-        _for_each_inner!(((RTC_GPIO10, RTC_GPIOn, 10), GPIO4));
-        _for_each_inner!(((RTC_GPIO15, RTC_GPIOn, 15), GPIO12));
-        _for_each_inner!(((RTC_GPIO14, RTC_GPIOn, 14), GPIO13));
-        _for_each_inner!(((RTC_GPIO16, RTC_GPIOn, 16), GPIO14));
-        _for_each_inner!(((RTC_GPIO13, RTC_GPIOn, 13), GPIO15));
-        _for_each_inner!(((RTC_GPIO6, RTC_GPIOn, 6), GPIO25));
-        _for_each_inner!(((RTC_GPIO7, RTC_GPIOn, 7), GPIO26));
-        _for_each_inner!(((RTC_GPIO17, RTC_GPIOn, 17), GPIO27));
-        _for_each_inner!(((RTC_GPIO9, RTC_GPIOn, 9), GPIO32));
-        _for_each_inner!(((RTC_GPIO8, RTC_GPIOn, 8), GPIO33));
-        _for_each_inner!(((RTC_GPIO4, RTC_GPIOn, 4), GPIO34));
-        _for_each_inner!(((RTC_GPIO5, RTC_GPIOn, 5), GPIO35));
-        _for_each_inner!(((RTC_GPIO0, RTC_GPIOn, 0), GPIO36));
-        _for_each_inner!(((RTC_GPIO1, RTC_GPIOn, 1), GPIO37));
-        _for_each_inner!(((RTC_GPIO2, RTC_GPIOn, 2), GPIO38));
-        _for_each_inner!(((RTC_GPIO3, RTC_GPIOn, 3), GPIO39));
-        _for_each_inner!((all(RTC_GPIO11, GPIO0), (SAR_I2C_SDA, GPIO0), (RTC_GPIO12,
-        GPIO2), (SAR_I2C_SCL, GPIO2), (RTC_GPIO10, GPIO4), (SAR_I2C_SCL, GPIO4),
-        (RTC_GPIO15, GPIO12), (RTC_GPIO14, GPIO13), (RTC_GPIO16, GPIO14), (RTC_GPIO13,
-        GPIO15), (SAR_I2C_SDA, GPIO15), (RTC_GPIO6, GPIO25), (RTC_GPIO7, GPIO26),
-        (RTC_GPIO17, GPIO27), (RTC_GPIO9, GPIO32), (RTC_GPIO8, GPIO33), (RTC_GPIO4,
-        GPIO34), (RTC_GPIO5, GPIO35), (RTC_GPIO0, GPIO36), (RTC_GPIO1, GPIO37),
-        (RTC_GPIO2, GPIO38), (RTC_GPIO3, GPIO39)));
-        _for_each_inner!((all_expanded((RTC_GPIO11, RTC_GPIOn, 11), GPIO0), ((RTC_GPIO12,
-        RTC_GPIOn, 12), GPIO2), ((RTC_GPIO10, RTC_GPIOn, 10), GPIO4), ((RTC_GPIO15,
-        RTC_GPIOn, 15), GPIO12), ((RTC_GPIO14, RTC_GPIOn, 14), GPIO13), ((RTC_GPIO16,
-        RTC_GPIOn, 16), GPIO14), ((RTC_GPIO13, RTC_GPIOn, 13), GPIO15), ((RTC_GPIO6,
-        RTC_GPIOn, 6), GPIO25), ((RTC_GPIO7, RTC_GPIOn, 7), GPIO26), ((RTC_GPIO17,
-        RTC_GPIOn, 17), GPIO27), ((RTC_GPIO9, RTC_GPIOn, 9), GPIO32), ((RTC_GPIO8,
-        RTC_GPIOn, 8), GPIO33), ((RTC_GPIO4, RTC_GPIOn, 4), GPIO34), ((RTC_GPIO5,
-        RTC_GPIOn, 5), GPIO35), ((RTC_GPIO0, RTC_GPIOn, 0), GPIO36), ((RTC_GPIO1,
-        RTC_GPIOn, 1), GPIO37), ((RTC_GPIO2, RTC_GPIOn, 2), GPIO38), ((RTC_GPIO3,
-        RTC_GPIOn, 3), GPIO39)));
+        macro_rules! _for_each_inner_lp_function { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_lp_function!((RTC_GPIO11, GPIO0));
+        _for_each_inner_lp_function!((SAR_I2C_SDA, GPIO0));
+        _for_each_inner_lp_function!((RTC_GPIO12, GPIO2));
+        _for_each_inner_lp_function!((SAR_I2C_SCL, GPIO2));
+        _for_each_inner_lp_function!((RTC_GPIO10, GPIO4));
+        _for_each_inner_lp_function!((SAR_I2C_SCL, GPIO4));
+        _for_each_inner_lp_function!((RTC_GPIO15, GPIO12));
+        _for_each_inner_lp_function!((RTC_GPIO14, GPIO13));
+        _for_each_inner_lp_function!((RTC_GPIO16, GPIO14));
+        _for_each_inner_lp_function!((RTC_GPIO13, GPIO15));
+        _for_each_inner_lp_function!((SAR_I2C_SDA, GPIO15));
+        _for_each_inner_lp_function!((RTC_GPIO6, GPIO25));
+        _for_each_inner_lp_function!((RTC_GPIO7, GPIO26));
+        _for_each_inner_lp_function!((RTC_GPIO17, GPIO27));
+        _for_each_inner_lp_function!((RTC_GPIO9, GPIO32));
+        _for_each_inner_lp_function!((RTC_GPIO8, GPIO33));
+        _for_each_inner_lp_function!((RTC_GPIO4, GPIO34));
+        _for_each_inner_lp_function!((RTC_GPIO5, GPIO35));
+        _for_each_inner_lp_function!((RTC_GPIO0, GPIO36));
+        _for_each_inner_lp_function!((RTC_GPIO1, GPIO37));
+        _for_each_inner_lp_function!((RTC_GPIO2, GPIO38));
+        _for_each_inner_lp_function!((RTC_GPIO3, GPIO39));
+        _for_each_inner_lp_function!(((RTC_GPIO11, RTC_GPIOn, 11), GPIO0));
+        _for_each_inner_lp_function!(((RTC_GPIO12, RTC_GPIOn, 12), GPIO2));
+        _for_each_inner_lp_function!(((RTC_GPIO10, RTC_GPIOn, 10), GPIO4));
+        _for_each_inner_lp_function!(((RTC_GPIO15, RTC_GPIOn, 15), GPIO12));
+        _for_each_inner_lp_function!(((RTC_GPIO14, RTC_GPIOn, 14), GPIO13));
+        _for_each_inner_lp_function!(((RTC_GPIO16, RTC_GPIOn, 16), GPIO14));
+        _for_each_inner_lp_function!(((RTC_GPIO13, RTC_GPIOn, 13), GPIO15));
+        _for_each_inner_lp_function!(((RTC_GPIO6, RTC_GPIOn, 6), GPIO25));
+        _for_each_inner_lp_function!(((RTC_GPIO7, RTC_GPIOn, 7), GPIO26));
+        _for_each_inner_lp_function!(((RTC_GPIO17, RTC_GPIOn, 17), GPIO27));
+        _for_each_inner_lp_function!(((RTC_GPIO9, RTC_GPIOn, 9), GPIO32));
+        _for_each_inner_lp_function!(((RTC_GPIO8, RTC_GPIOn, 8), GPIO33));
+        _for_each_inner_lp_function!(((RTC_GPIO4, RTC_GPIOn, 4), GPIO34));
+        _for_each_inner_lp_function!(((RTC_GPIO5, RTC_GPIOn, 5), GPIO35));
+        _for_each_inner_lp_function!(((RTC_GPIO0, RTC_GPIOn, 0), GPIO36));
+        _for_each_inner_lp_function!(((RTC_GPIO1, RTC_GPIOn, 1), GPIO37));
+        _for_each_inner_lp_function!(((RTC_GPIO2, RTC_GPIOn, 2), GPIO38));
+        _for_each_inner_lp_function!(((RTC_GPIO3, RTC_GPIOn, 3), GPIO39));
+        _for_each_inner_lp_function!((all(RTC_GPIO11, GPIO0), (SAR_I2C_SDA, GPIO0),
+        (RTC_GPIO12, GPIO2), (SAR_I2C_SCL, GPIO2), (RTC_GPIO10, GPIO4), (SAR_I2C_SCL,
+        GPIO4), (RTC_GPIO15, GPIO12), (RTC_GPIO14, GPIO13), (RTC_GPIO16, GPIO14),
+        (RTC_GPIO13, GPIO15), (SAR_I2C_SDA, GPIO15), (RTC_GPIO6, GPIO25), (RTC_GPIO7,
+        GPIO26), (RTC_GPIO17, GPIO27), (RTC_GPIO9, GPIO32), (RTC_GPIO8, GPIO33),
+        (RTC_GPIO4, GPIO34), (RTC_GPIO5, GPIO35), (RTC_GPIO0, GPIO36), (RTC_GPIO1,
+        GPIO37), (RTC_GPIO2, GPIO38), (RTC_GPIO3, GPIO39)));
+        _for_each_inner_lp_function!((all_expanded((RTC_GPIO11, RTC_GPIOn, 11), GPIO0),
+        ((RTC_GPIO12, RTC_GPIOn, 12), GPIO2), ((RTC_GPIO10, RTC_GPIOn, 10), GPIO4),
+        ((RTC_GPIO15, RTC_GPIOn, 15), GPIO12), ((RTC_GPIO14, RTC_GPIOn, 14), GPIO13),
+        ((RTC_GPIO16, RTC_GPIOn, 16), GPIO14), ((RTC_GPIO13, RTC_GPIOn, 13), GPIO15),
+        ((RTC_GPIO6, RTC_GPIOn, 6), GPIO25), ((RTC_GPIO7, RTC_GPIOn, 7), GPIO26),
+        ((RTC_GPIO17, RTC_GPIOn, 17), GPIO27), ((RTC_GPIO9, RTC_GPIOn, 9), GPIO32),
+        ((RTC_GPIO8, RTC_GPIOn, 8), GPIO33), ((RTC_GPIO4, RTC_GPIOn, 4), GPIO34),
+        ((RTC_GPIO5, RTC_GPIOn, 5), GPIO35), ((RTC_GPIO0, RTC_GPIOn, 0), GPIO36),
+        ((RTC_GPIO1, RTC_GPIOn, 1), GPIO37), ((RTC_GPIO2, RTC_GPIOn, 2), GPIO38),
+        ((RTC_GPIO3, RTC_GPIOn, 3), GPIO39)));
     };
 }
 /// Defines the `InputSignal` and `OutputSignal` enums.

--- a/esp-metadata-generated/src/_generated_esp32c2.rs
+++ b/esp-metadata-generated/src/_generated_esp32c2.rs
@@ -2213,29 +2213,35 @@ macro_rules! memory_range {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_dedicated_gpio {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((0)); _for_each_inner!((1)); _for_each_inner!((2));
-        _for_each_inner!((3)); _for_each_inner!((4)); _for_each_inner!((5));
-        _for_each_inner!((6)); _for_each_inner!((7)); _for_each_inner!((0, 0,
-        CPU_GPIO_0)); _for_each_inner!((0, 1, CPU_GPIO_1)); _for_each_inner!((0, 2,
-        CPU_GPIO_2)); _for_each_inner!((0, 3, CPU_GPIO_3)); _for_each_inner!((0, 4,
-        CPU_GPIO_4)); _for_each_inner!((0, 5, CPU_GPIO_5)); _for_each_inner!((0, 6,
-        CPU_GPIO_6)); _for_each_inner!((0, 7, CPU_GPIO_7));
-        _for_each_inner!((channels(0), (1), (2), (3), (4), (5), (6), (7)));
-        _for_each_inner!((signals(0, 0, CPU_GPIO_0), (0, 1, CPU_GPIO_1), (0, 2,
-        CPU_GPIO_2), (0, 3, CPU_GPIO_3), (0, 4, CPU_GPIO_4), (0, 5, CPU_GPIO_5), (0, 6,
-        CPU_GPIO_6), (0, 7, CPU_GPIO_7)));
+        macro_rules! _for_each_inner_dedicated_gpio { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_dedicated_gpio!((0));
+        _for_each_inner_dedicated_gpio!((1)); _for_each_inner_dedicated_gpio!((2));
+        _for_each_inner_dedicated_gpio!((3)); _for_each_inner_dedicated_gpio!((4));
+        _for_each_inner_dedicated_gpio!((5)); _for_each_inner_dedicated_gpio!((6));
+        _for_each_inner_dedicated_gpio!((7)); _for_each_inner_dedicated_gpio!((0, 0,
+        CPU_GPIO_0)); _for_each_inner_dedicated_gpio!((0, 1, CPU_GPIO_1));
+        _for_each_inner_dedicated_gpio!((0, 2, CPU_GPIO_2));
+        _for_each_inner_dedicated_gpio!((0, 3, CPU_GPIO_3));
+        _for_each_inner_dedicated_gpio!((0, 4, CPU_GPIO_4));
+        _for_each_inner_dedicated_gpio!((0, 5, CPU_GPIO_5));
+        _for_each_inner_dedicated_gpio!((0, 6, CPU_GPIO_6));
+        _for_each_inner_dedicated_gpio!((0, 7, CPU_GPIO_7));
+        _for_each_inner_dedicated_gpio!((channels(0), (1), (2), (3), (4), (5), (6),
+        (7))); _for_each_inner_dedicated_gpio!((signals(0, 0, CPU_GPIO_0), (0, 1,
+        CPU_GPIO_1), (0, 2, CPU_GPIO_2), (0, 3, CPU_GPIO_3), (0, 4, CPU_GPIO_4), (0, 5,
+        CPU_GPIO_5), (0, 6, CPU_GPIO_6), (0, 7, CPU_GPIO_7)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_sw_interrupt {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((0, FROM_CPU_INTR0, software_interrupt0)); _for_each_inner!((1,
-        FROM_CPU_INTR1, software_interrupt1)); _for_each_inner!((2, FROM_CPU_INTR2,
-        software_interrupt2)); _for_each_inner!((3, FROM_CPU_INTR3,
-        software_interrupt3)); _for_each_inner!((all(0, FROM_CPU_INTR0,
+        macro_rules! _for_each_inner_sw_interrupt { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_sw_interrupt!((0, FROM_CPU_INTR0,
+        software_interrupt0)); _for_each_inner_sw_interrupt!((1, FROM_CPU_INTR1,
+        software_interrupt1)); _for_each_inner_sw_interrupt!((2, FROM_CPU_INTR2,
+        software_interrupt2)); _for_each_inner_sw_interrupt!((3, FROM_CPU_INTR3,
+        software_interrupt3)); _for_each_inner_sw_interrupt!((all(0, FROM_CPU_INTR0,
         software_interrupt0), (1, FROM_CPU_INTR1, software_interrupt1), (2,
         FROM_CPU_INTR2, software_interrupt2), (3, FROM_CPU_INTR3, software_interrupt3)));
     };
@@ -2256,13 +2262,15 @@ macro_rules! sw_interrupt_delay {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_sha_algorithm {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((Sha1, "SHA-1"(sizes : 64, 20, 8) (insecure_against :
-        "collision", "length extension"), 0)); _for_each_inner!((Sha224, "SHA-224"(sizes
-        : 64, 28, 8) (insecure_against : "length extension"), 1));
-        _for_each_inner!((Sha256, "SHA-256"(sizes : 64, 32, 8) (insecure_against :
-        "length extension"), 2)); _for_each_inner!((algos(Sha1, "SHA-1"(sizes : 64, 20,
-        8) (insecure_against : "collision", "length extension"), 0), (Sha224,
+        macro_rules! _for_each_inner_sha_algorithm { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_sha_algorithm!((Sha1, "SHA-1"(sizes : 64, 20, 8)
+        (insecure_against : "collision", "length extension"), 0));
+        _for_each_inner_sha_algorithm!((Sha224, "SHA-224"(sizes : 64, 28, 8)
+        (insecure_against : "length extension"), 1));
+        _for_each_inner_sha_algorithm!((Sha256, "SHA-256"(sizes : 64, 32, 8)
+        (insecure_against : "length extension"), 2));
+        _for_each_inner_sha_algorithm!((algos(Sha1, "SHA-1"(sizes : 64, 20, 8)
+        (insecure_against : "collision", "length extension"), 0), (Sha224,
         "SHA-224"(sizes : 64, 28, 8) (insecure_against : "length extension"), 1),
         (Sha256, "SHA-256"(sizes : 64, 32, 8) (insecure_against : "length extension"),
         2)));
@@ -2288,9 +2296,9 @@ macro_rules! for_each_sha_algorithm {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_i2c_master {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((I2C0, I2cExt0, I2CEXT0_SCL, I2CEXT0_SDA));
-        _for_each_inner!((all(I2C0, I2cExt0, I2CEXT0_SCL, I2CEXT0_SDA)));
+        macro_rules! _for_each_inner_i2c_master { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_i2c_master!((I2C0, I2cExt0, I2CEXT0_SCL, I2CEXT0_SDA));
+        _for_each_inner_i2c_master!((all(I2C0, I2cExt0, I2CEXT0_SCL, I2CEXT0_SDA)));
     };
 }
 /// This macro can be used to generate code for each peripheral instance of the UART driver.
@@ -2313,11 +2321,11 @@ macro_rules! for_each_i2c_master {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_uart {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS));
-        _for_each_inner!((UART1, Uart1, U1RXD, U1TXD, U1CTS, U1RTS));
-        _for_each_inner!((all(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS), (UART1, Uart1,
-        U1RXD, U1TXD, U1CTS, U1RTS)));
+        macro_rules! _for_each_inner_uart { $(($pattern) => $code;)* ($other : tt) => {}
+        } _for_each_inner_uart!((UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS));
+        _for_each_inner_uart!((UART1, Uart1, U1RXD, U1TXD, U1CTS, U1RTS));
+        _for_each_inner_uart!((all(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS), (UART1,
+        Uart1, U1RXD, U1TXD, U1CTS, U1RTS)));
     };
 }
 /// This macro can be used to generate code for each peripheral instance of the SPI master driver.
@@ -2345,11 +2353,11 @@ macro_rules! for_each_uart {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_spi_master {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((SPI2, Spi2, FSPICLK[FSPICS0, FSPICS1, FSPICS2, FSPICS3,
-        FSPICS4, FSPICS5] [FSPID, FSPIQ, FSPIWP, FSPIHD], true));
-        _for_each_inner!((all(SPI2, Spi2, FSPICLK[FSPICS0, FSPICS1, FSPICS2, FSPICS3,
-        FSPICS4, FSPICS5] [FSPID, FSPIQ, FSPIWP, FSPIHD], true)));
+        macro_rules! _for_each_inner_spi_master { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_spi_master!((SPI2, Spi2, FSPICLK[FSPICS0, FSPICS1,
+        FSPICS2, FSPICS3, FSPICS4, FSPICS5] [FSPID, FSPIQ, FSPIWP, FSPIHD], true));
+        _for_each_inner_spi_master!((all(SPI2, Spi2, FSPICLK[FSPICS0, FSPICS1, FSPICS2,
+        FSPICS3, FSPICS4, FSPICS5] [FSPID, FSPIQ, FSPIWP, FSPIHD], true)));
     };
 }
 /// This macro can be used to generate code for each peripheral instance of the SPI slave driver.
@@ -2372,218 +2380,259 @@ macro_rules! for_each_spi_master {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_spi_slave {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((SPI2, Spi2, FSPICLK, FSPID, FSPIQ, FSPICS0));
-        _for_each_inner!((all(SPI2, Spi2, FSPICLK, FSPID, FSPIQ, FSPICS0)));
+        macro_rules! _for_each_inner_spi_slave { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_spi_slave!((SPI2, Spi2, FSPICLK, FSPID, FSPIQ, FSPICS0));
+        _for_each_inner_spi_slave!((all(SPI2, Spi2, FSPICLK, FSPID, FSPIQ, FSPICS0)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_peripheral {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((@ peri_type #[doc = "GPIO0 peripheral singleton"] GPIO0 <=
-        virtual())); _for_each_inner!((@ peri_type #[doc = "GPIO1 peripheral singleton"]
-        GPIO1 <= virtual())); _for_each_inner!((@ peri_type #[doc =
-        "GPIO2 peripheral singleton"] GPIO2 <= virtual())); _for_each_inner!((@ peri_type
-        #[doc = "GPIO3 peripheral singleton"] GPIO3 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO4 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        macro_rules! _for_each_inner_peripheral { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO0 peripheral singleton"] GPIO0 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO1 peripheral singleton"]
+        GPIO1 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO2 peripheral singleton"] GPIO2 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO3 peripheral singleton"]
+        GPIO3 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO4 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>These pins may be used to debug the chip using an external JTAG debugger.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO4 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO5 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO4 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO5 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>These pins may be used to debug the chip using an external JTAG debugger.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO5 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO6 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO5 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO6 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>These pins may be used to debug the chip using an external JTAG debugger.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO6 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO7 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO6 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO7 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>These pins may be used to debug the chip using an external JTAG debugger.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO7 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO8 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO7 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO8 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin is a strapping pin, it determines how the chip boots.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO8 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO9 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO8 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO9 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin is a strapping pin, it determines how the chip boots.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO9 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO10 peripheral singleton"] GPIO10 <= virtual()));
-        _for_each_inner!((@ peri_type #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO9 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO10 peripheral singleton"]
+        GPIO10 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
         "GPIO11 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
         "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO11 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO12 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO11 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO12 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO12 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO13 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO12 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO13 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO13 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO14 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO13 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO14 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO14 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO15 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO14 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO15 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO15 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO16 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO15 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO16 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO16 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO17 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO16 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO17 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO17 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO18 peripheral singleton"] GPIO18 <= virtual()));
-        _for_each_inner!((@ peri_type #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO17 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO18 peripheral singleton"]
+        GPIO18 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
         "GPIO19 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
         "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>By default, this pin is used by the UART programming interface.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO19 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO20 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO19 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO20 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>By default, this pin is used by the UART programming interface.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO20 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "APB_CTRL peripheral singleton"] APB_CTRL <= APB_CTRL()
-        (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "BB peripheral singleton"] BB <= BB()
-        (unstable))); _for_each_inner!((@ peri_type #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO20 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "APB_CTRL peripheral singleton"]
+        APB_CTRL <= APB_CTRL() (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC()
+        (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "BB peripheral singleton"] BB <= BB() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
         "ASSIST_DEBUG peripheral singleton"] ASSIST_DEBUG <= ASSIST_DEBUG() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "DMA peripheral singleton"] DMA <= DMA()
-        (unstable))); _for_each_inner!((@ peri_type #[doc = "ECC peripheral singleton"]
-        ECC <= ECC() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "EFUSE peripheral singleton"] EFUSE <= EFUSE() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "EXTMEM peripheral singleton"] EXTMEM <= EXTMEM() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "GPIO peripheral singleton"] GPIO <= GPIO()
-        (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA peripheral singleton"] DMA
+        <= DMA() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "ECC peripheral singleton"] ECC <= ECC() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "EFUSE peripheral singleton"]
+        EFUSE <= EFUSE() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "EXTMEM peripheral singleton"] EXTMEM <= EXTMEM() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO peripheral singleton"]
+        GPIO <= GPIO() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "I2C_ANA_MST peripheral singleton"] I2C_ANA_MST <= I2C_ANA_MST() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "I2C0 peripheral singleton"] I2C0 <=
-        I2C0(I2C_EXT0 : { bind_peri_interrupt, enable_peri_interrupt,
-        disable_peri_interrupt }))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "I2C0 peripheral singleton"]
+        I2C0 <= I2C0(I2C_EXT0 : { bind_peri_interrupt, enable_peri_interrupt,
+        disable_peri_interrupt }))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "INTERRUPT_CORE0 peripheral singleton"] INTERRUPT_CORE0 <= INTERRUPT_CORE0()
-        (unstable))); _for_each_inner!((@ peri_type #[doc =
+        (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "IO_MUX peripheral singleton"] IO_MUX <= IO_MUX() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "LEDC peripheral singleton"] LEDC <= LEDC()
-        (unstable))); _for_each_inner!((@ peri_type #[doc = "RNG peripheral singleton"]
-        RNG <= RNG() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "LPWR peripheral singleton"] LPWR <= RTC_CNTL() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "MODEM_CLKRST peripheral singleton"] MODEM_CLKRST <=
-        MODEM_CLKRST() (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "LEDC peripheral singleton"]
+        LEDC <= LEDC() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "RNG peripheral singleton"] RNG <= RNG() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "LPWR peripheral singleton"]
+        LPWR <= RTC_CNTL() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "MODEM_CLKRST peripheral singleton"] MODEM_CLKRST <= MODEM_CLKRST() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
         "SENSITIVE peripheral singleton"] SENSITIVE <= SENSITIVE() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "SHA peripheral singleton"] SHA <= SHA(SHA
-        : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
-        (unstable))); _for_each_inner!((@ peri_type #[doc = "SPI0 peripheral singleton"]
-        SPI0 <= SPI0() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "SPI1 peripheral singleton"] SPI1 <= SPI1() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "SPI2 peripheral singleton"] SPI2 <= SPI2(SPI2 : {
-        bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })));
-        _for_each_inner!((@ peri_type #[doc = "SYSTEM peripheral singleton"] SYSTEM <=
-        SYSTEM() (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "SHA peripheral singleton"] SHA
+        <= SHA(SHA : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt
+        }) (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "SPI0 peripheral singleton"] SPI0 <= SPI0() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "SPI1 peripheral singleton"]
+        SPI1 <= SPI1() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "SPI2 peripheral singleton"] SPI2 <= SPI2(SPI2 : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt })));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "SYSTEM peripheral singleton"]
+        SYSTEM <= SYSTEM() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "SYSTIMER peripheral singleton"] SYSTIMER <= SYSTIMER() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "TIMG0 peripheral singleton"] TIMG0 <=
-        TIMG0() (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "TIMG0 peripheral singleton"]
+        TIMG0 <= TIMG0() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "UART0 peripheral singleton"] UART0 <= UART0(UART0 : { bind_peri_interrupt,
-        enable_peri_interrupt, disable_peri_interrupt }))); _for_each_inner!((@ peri_type
-        #[doc = "UART1 peripheral singleton"] UART1 <= UART1(UART1 : {
-        bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })));
-        _for_each_inner!((@ peri_type #[doc = "XTS_AES peripheral singleton"] XTS_AES <=
-        XTS_AES() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "ADC1 peripheral singleton"] ADC1 <=
-        virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "BT peripheral singleton"] BT <= virtual() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "FLASH peripheral singleton"] FLASH <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "GPIO_DEDICATED peripheral singleton"]
-        GPIO_DEDICATED <= virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
+        enable_peri_interrupt, disable_peri_interrupt })));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "UART1 peripheral singleton"]
+        UART1 <= UART1(UART1 : { bind_peri_interrupt, enable_peri_interrupt,
+        disable_peri_interrupt }))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "XTS_AES peripheral singleton"] XTS_AES <= XTS_AES() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH0 peripheral singleton"]
+        DMA_CH0 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "ADC1 peripheral singleton"] ADC1 <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "BT peripheral singleton"] BT <=
+        virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "FLASH peripheral singleton"] FLASH <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO_DEDICATED peripheral singleton"] GPIO_DEDICATED <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
         "SW_INTERRUPT peripheral singleton"] SW_INTERRUPT <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "WIFI peripheral singleton"] WIFI <=
-        virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "WIFI peripheral singleton"]
+        WIFI <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "MEM2MEM1 peripheral singleton"] MEM2MEM1 <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "MEM2MEM2 peripheral singleton"] MEM2MEM2
-        <= virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "MEM2MEM3 peripheral singleton"] MEM2MEM3 <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "MEM2MEM4 peripheral singleton"] MEM2MEM4
-        <= virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "MEM2MEM5 peripheral singleton"] MEM2MEM5 <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "MEM2MEM6 peripheral singleton"] MEM2MEM6
-        <= virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "MEM2MEM7 peripheral singleton"] MEM2MEM7 <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "MEM2MEM8 peripheral singleton"] MEM2MEM8
-        <= virtual() (unstable))); _for_each_inner!((GPIO0)); _for_each_inner!((GPIO1));
-        _for_each_inner!((GPIO2)); _for_each_inner!((GPIO3)); _for_each_inner!((GPIO4));
-        _for_each_inner!((GPIO5)); _for_each_inner!((GPIO6)); _for_each_inner!((GPIO7));
-        _for_each_inner!((GPIO8)); _for_each_inner!((GPIO9)); _for_each_inner!((GPIO10));
-        _for_each_inner!((GPIO11)); _for_each_inner!((GPIO12));
-        _for_each_inner!((GPIO13)); _for_each_inner!((GPIO14));
-        _for_each_inner!((GPIO15)); _for_each_inner!((GPIO16));
-        _for_each_inner!((GPIO17)); _for_each_inner!((GPIO18));
-        _for_each_inner!((GPIO19)); _for_each_inner!((GPIO20));
-        _for_each_inner!((APB_CTRL(unstable))); _for_each_inner!((APB_SARADC(unstable)));
-        _for_each_inner!((BB(unstable))); _for_each_inner!((ASSIST_DEBUG(unstable)));
-        _for_each_inner!((DMA(unstable))); _for_each_inner!((ECC(unstable)));
-        _for_each_inner!((EFUSE(unstable))); _for_each_inner!((EXTMEM(unstable)));
-        _for_each_inner!((GPIO(unstable))); _for_each_inner!((I2C_ANA_MST(unstable)));
-        _for_each_inner!((I2C0)); _for_each_inner!((INTERRUPT_CORE0(unstable)));
-        _for_each_inner!((IO_MUX(unstable))); _for_each_inner!((LEDC(unstable)));
-        _for_each_inner!((RNG(unstable))); _for_each_inner!((LPWR(unstable)));
-        _for_each_inner!((MODEM_CLKRST(unstable)));
-        _for_each_inner!((SENSITIVE(unstable))); _for_each_inner!((SHA(unstable)));
-        _for_each_inner!((SPI0(unstable))); _for_each_inner!((SPI1(unstable)));
-        _for_each_inner!((SPI2)); _for_each_inner!((SYSTEM(unstable)));
-        _for_each_inner!((SYSTIMER(unstable))); _for_each_inner!((TIMG0(unstable)));
-        _for_each_inner!((UART0)); _for_each_inner!((UART1));
-        _for_each_inner!((XTS_AES(unstable))); _for_each_inner!((DMA_CH0(unstable)));
-        _for_each_inner!((ADC1(unstable))); _for_each_inner!((BT(unstable)));
-        _for_each_inner!((FLASH(unstable)));
-        _for_each_inner!((GPIO_DEDICATED(unstable)));
-        _for_each_inner!((SW_INTERRUPT(unstable))); _for_each_inner!((WIFI(unstable)));
-        _for_each_inner!((MEM2MEM1(unstable))); _for_each_inner!((MEM2MEM2(unstable)));
-        _for_each_inner!((MEM2MEM3(unstable))); _for_each_inner!((MEM2MEM4(unstable)));
-        _for_each_inner!((MEM2MEM5(unstable))); _for_each_inner!((MEM2MEM6(unstable)));
-        _for_each_inner!((MEM2MEM7(unstable))); _for_each_inner!((MEM2MEM8(unstable)));
-        _for_each_inner!((all(@ peri_type #[doc = "GPIO0 peripheral singleton"] GPIO0 <=
-        virtual()), (@ peri_type #[doc = "GPIO1 peripheral singleton"] GPIO1 <=
-        virtual()), (@ peri_type #[doc = "GPIO2 peripheral singleton"] GPIO2 <=
-        virtual()), (@ peri_type #[doc = "GPIO3 peripheral singleton"] GPIO3 <=
-        virtual()), (@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "MEM2MEM2 peripheral singleton"]
+        MEM2MEM2 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "MEM2MEM3 peripheral singleton"] MEM2MEM3 <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "MEM2MEM4 peripheral singleton"]
+        MEM2MEM4 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "MEM2MEM5 peripheral singleton"] MEM2MEM5 <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "MEM2MEM6 peripheral singleton"]
+        MEM2MEM6 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "MEM2MEM7 peripheral singleton"] MEM2MEM7 <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "MEM2MEM8 peripheral singleton"]
+        MEM2MEM8 <= virtual() (unstable))); _for_each_inner_peripheral!((GPIO0));
+        _for_each_inner_peripheral!((GPIO1)); _for_each_inner_peripheral!((GPIO2));
+        _for_each_inner_peripheral!((GPIO3)); _for_each_inner_peripheral!((GPIO4));
+        _for_each_inner_peripheral!((GPIO5)); _for_each_inner_peripheral!((GPIO6));
+        _for_each_inner_peripheral!((GPIO7)); _for_each_inner_peripheral!((GPIO8));
+        _for_each_inner_peripheral!((GPIO9)); _for_each_inner_peripheral!((GPIO10));
+        _for_each_inner_peripheral!((GPIO11)); _for_each_inner_peripheral!((GPIO12));
+        _for_each_inner_peripheral!((GPIO13)); _for_each_inner_peripheral!((GPIO14));
+        _for_each_inner_peripheral!((GPIO15)); _for_each_inner_peripheral!((GPIO16));
+        _for_each_inner_peripheral!((GPIO17)); _for_each_inner_peripheral!((GPIO18));
+        _for_each_inner_peripheral!((GPIO19)); _for_each_inner_peripheral!((GPIO20));
+        _for_each_inner_peripheral!((APB_CTRL(unstable)));
+        _for_each_inner_peripheral!((APB_SARADC(unstable)));
+        _for_each_inner_peripheral!((BB(unstable)));
+        _for_each_inner_peripheral!((ASSIST_DEBUG(unstable)));
+        _for_each_inner_peripheral!((DMA(unstable)));
+        _for_each_inner_peripheral!((ECC(unstable)));
+        _for_each_inner_peripheral!((EFUSE(unstable)));
+        _for_each_inner_peripheral!((EXTMEM(unstable)));
+        _for_each_inner_peripheral!((GPIO(unstable)));
+        _for_each_inner_peripheral!((I2C_ANA_MST(unstable)));
+        _for_each_inner_peripheral!((I2C0));
+        _for_each_inner_peripheral!((INTERRUPT_CORE0(unstable)));
+        _for_each_inner_peripheral!((IO_MUX(unstable)));
+        _for_each_inner_peripheral!((LEDC(unstable)));
+        _for_each_inner_peripheral!((RNG(unstable)));
+        _for_each_inner_peripheral!((LPWR(unstable)));
+        _for_each_inner_peripheral!((MODEM_CLKRST(unstable)));
+        _for_each_inner_peripheral!((SENSITIVE(unstable)));
+        _for_each_inner_peripheral!((SHA(unstable)));
+        _for_each_inner_peripheral!((SPI0(unstable)));
+        _for_each_inner_peripheral!((SPI1(unstable)));
+        _for_each_inner_peripheral!((SPI2));
+        _for_each_inner_peripheral!((SYSTEM(unstable)));
+        _for_each_inner_peripheral!((SYSTIMER(unstable)));
+        _for_each_inner_peripheral!((TIMG0(unstable)));
+        _for_each_inner_peripheral!((UART0)); _for_each_inner_peripheral!((UART1));
+        _for_each_inner_peripheral!((XTS_AES(unstable)));
+        _for_each_inner_peripheral!((DMA_CH0(unstable)));
+        _for_each_inner_peripheral!((ADC1(unstable)));
+        _for_each_inner_peripheral!((BT(unstable)));
+        _for_each_inner_peripheral!((FLASH(unstable)));
+        _for_each_inner_peripheral!((GPIO_DEDICATED(unstable)));
+        _for_each_inner_peripheral!((SW_INTERRUPT(unstable)));
+        _for_each_inner_peripheral!((WIFI(unstable)));
+        _for_each_inner_peripheral!((MEM2MEM1(unstable)));
+        _for_each_inner_peripheral!((MEM2MEM2(unstable)));
+        _for_each_inner_peripheral!((MEM2MEM3(unstable)));
+        _for_each_inner_peripheral!((MEM2MEM4(unstable)));
+        _for_each_inner_peripheral!((MEM2MEM5(unstable)));
+        _for_each_inner_peripheral!((MEM2MEM6(unstable)));
+        _for_each_inner_peripheral!((MEM2MEM7(unstable)));
+        _for_each_inner_peripheral!((MEM2MEM8(unstable)));
+        _for_each_inner_peripheral!((all(@ peri_type #[doc =
+        "GPIO0 peripheral singleton"] GPIO0 <= virtual()), (@ peri_type #[doc =
+        "GPIO1 peripheral singleton"] GPIO1 <= virtual()), (@ peri_type #[doc =
+        "GPIO2 peripheral singleton"] GPIO2 <= virtual()), (@ peri_type #[doc =
+        "GPIO3 peripheral singleton"] GPIO3 <= virtual()), (@ peri_type #[doc =
         "GPIO4 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
         "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
@@ -2729,10 +2778,10 @@ macro_rules! for_each_peripheral {
         "MEM2MEM6 peripheral singleton"] MEM2MEM6 <= virtual() (unstable)), (@ peri_type
         #[doc = "MEM2MEM7 peripheral singleton"] MEM2MEM7 <= virtual() (unstable)), (@
         peri_type #[doc = "MEM2MEM8 peripheral singleton"] MEM2MEM8 <= virtual()
-        (unstable)))); _for_each_inner!((singletons(GPIO0), (GPIO1), (GPIO2), (GPIO3),
-        (GPIO4), (GPIO5), (GPIO6), (GPIO7), (GPIO8), (GPIO9), (GPIO10), (GPIO11),
-        (GPIO12), (GPIO13), (GPIO14), (GPIO15), (GPIO16), (GPIO17), (GPIO18), (GPIO19),
-        (GPIO20), (APB_CTRL(unstable)), (APB_SARADC(unstable)), (BB(unstable)),
+        (unstable)))); _for_each_inner_peripheral!((singletons(GPIO0), (GPIO1), (GPIO2),
+        (GPIO3), (GPIO4), (GPIO5), (GPIO6), (GPIO7), (GPIO8), (GPIO9), (GPIO10),
+        (GPIO11), (GPIO12), (GPIO13), (GPIO14), (GPIO15), (GPIO16), (GPIO17), (GPIO18),
+        (GPIO19), (GPIO20), (APB_CTRL(unstable)), (APB_SARADC(unstable)), (BB(unstable)),
         (ASSIST_DEBUG(unstable)), (DMA(unstable)), (ECC(unstable)), (EFUSE(unstable)),
         (EXTMEM(unstable)), (GPIO(unstable)), (I2C_ANA_MST(unstable)), (I2C0),
         (INTERRUPT_CORE0(unstable)), (IO_MUX(unstable)), (LEDC(unstable)),
@@ -2777,41 +2826,44 @@ macro_rules! for_each_peripheral {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_gpio {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((0, GPIO0() () ([Input] [Output]))); _for_each_inner!((1,
-        GPIO1() () ([Input] [Output]))); _for_each_inner!((2, GPIO2(_2 => FSPIQ) (_2 =>
-        FSPIQ) ([Input] [Output]))); _for_each_inner!((3, GPIO3() () ([Input]
-        [Output]))); _for_each_inner!((4, GPIO4(_0 => MTMS _2 => FSPIHD) (_2 => FSPIHD)
-        ([Input] [Output]))); _for_each_inner!((5, GPIO5(_0 => MTDI _2 => FSPIWP) (_2 =>
-        FSPIWP) ([Input] [Output]))); _for_each_inner!((6, GPIO6(_0 => MTCK _2 =>
-        FSPICLK) (_2 => FSPICLK) ([Input] [Output]))); _for_each_inner!((7, GPIO7(_2 =>
-        FSPID) (_0 => MTDO _2 => FSPID) ([Input] [Output]))); _for_each_inner!((8,
-        GPIO8() () ([Input] [Output]))); _for_each_inner!((9, GPIO9() () ([Input]
-        [Output]))); _for_each_inner!((10, GPIO10(_2 => FSPICS0) (_2 => FSPICS0) ([Input]
-        [Output]))); _for_each_inner!((11, GPIO11(_0 => SPIHD) (_0 => SPIHD) ([Input]
-        [Output]))); _for_each_inner!((12, GPIO12(_0 => SPIHD) (_0 => SPIHD) ([Input]
-        [Output]))); _for_each_inner!((13, GPIO13(_0 => SPIWP) (_0 => SPIWP) ([Input]
-        [Output]))); _for_each_inner!((14, GPIO14() (_0 => SPICS0) ([Input] [Output])));
-        _for_each_inner!((15, GPIO15() (_0 => SPICLK) ([Input] [Output])));
-        _for_each_inner!((16, GPIO16(_0 => SPID) (_0 => SPID) ([Input] [Output])));
-        _for_each_inner!((17, GPIO17(_0 => SPIQ) (_0 => SPIQ) ([Input] [Output])));
-        _for_each_inner!((18, GPIO18() () ([Input] [Output]))); _for_each_inner!((19,
-        GPIO19(_0 => U0RXD) () ([Input] [Output]))); _for_each_inner!((20, GPIO20() (_0
-        => U0TXD) ([Input] [Output]))); _for_each_inner!((all(0, GPIO0() () ([Input]
-        [Output])), (1, GPIO1() () ([Input] [Output])), (2, GPIO2(_2 => FSPIQ) (_2 =>
-        FSPIQ) ([Input] [Output])), (3, GPIO3() () ([Input] [Output])), (4, GPIO4(_0 =>
-        MTMS _2 => FSPIHD) (_2 => FSPIHD) ([Input] [Output])), (5, GPIO5(_0 => MTDI _2 =>
-        FSPIWP) (_2 => FSPIWP) ([Input] [Output])), (6, GPIO6(_0 => MTCK _2 => FSPICLK)
-        (_2 => FSPICLK) ([Input] [Output])), (7, GPIO7(_2 => FSPID) (_0 => MTDO _2 =>
-        FSPID) ([Input] [Output])), (8, GPIO8() () ([Input] [Output])), (9, GPIO9() ()
-        ([Input] [Output])), (10, GPIO10(_2 => FSPICS0) (_2 => FSPICS0) ([Input]
-        [Output])), (11, GPIO11(_0 => SPIHD) (_0 => SPIHD) ([Input] [Output])), (12,
-        GPIO12(_0 => SPIHD) (_0 => SPIHD) ([Input] [Output])), (13, GPIO13(_0 => SPIWP)
-        (_0 => SPIWP) ([Input] [Output])), (14, GPIO14() (_0 => SPICS0) ([Input]
-        [Output])), (15, GPIO15() (_0 => SPICLK) ([Input] [Output])), (16, GPIO16(_0 =>
-        SPID) (_0 => SPID) ([Input] [Output])), (17, GPIO17(_0 => SPIQ) (_0 => SPIQ)
-        ([Input] [Output])), (18, GPIO18() () ([Input] [Output])), (19, GPIO19(_0 =>
-        U0RXD) () ([Input] [Output])), (20, GPIO20() (_0 => U0TXD) ([Input] [Output]))));
+        macro_rules! _for_each_inner_gpio { $(($pattern) => $code;)* ($other : tt) => {}
+        } _for_each_inner_gpio!((0, GPIO0() () ([Input] [Output])));
+        _for_each_inner_gpio!((1, GPIO1() () ([Input] [Output])));
+        _for_each_inner_gpio!((2, GPIO2(_2 => FSPIQ) (_2 => FSPIQ) ([Input] [Output])));
+        _for_each_inner_gpio!((3, GPIO3() () ([Input] [Output])));
+        _for_each_inner_gpio!((4, GPIO4(_0 => MTMS _2 => FSPIHD) (_2 => FSPIHD) ([Input]
+        [Output]))); _for_each_inner_gpio!((5, GPIO5(_0 => MTDI _2 => FSPIWP) (_2 =>
+        FSPIWP) ([Input] [Output]))); _for_each_inner_gpio!((6, GPIO6(_0 => MTCK _2 =>
+        FSPICLK) (_2 => FSPICLK) ([Input] [Output]))); _for_each_inner_gpio!((7, GPIO7(_2
+        => FSPID) (_0 => MTDO _2 => FSPID) ([Input] [Output])));
+        _for_each_inner_gpio!((8, GPIO8() () ([Input] [Output])));
+        _for_each_inner_gpio!((9, GPIO9() () ([Input] [Output])));
+        _for_each_inner_gpio!((10, GPIO10(_2 => FSPICS0) (_2 => FSPICS0) ([Input]
+        [Output]))); _for_each_inner_gpio!((11, GPIO11(_0 => SPIHD) (_0 => SPIHD)
+        ([Input] [Output]))); _for_each_inner_gpio!((12, GPIO12(_0 => SPIHD) (_0 =>
+        SPIHD) ([Input] [Output]))); _for_each_inner_gpio!((13, GPIO13(_0 => SPIWP) (_0
+        => SPIWP) ([Input] [Output]))); _for_each_inner_gpio!((14, GPIO14() (_0 =>
+        SPICS0) ([Input] [Output]))); _for_each_inner_gpio!((15, GPIO15() (_0 => SPICLK)
+        ([Input] [Output]))); _for_each_inner_gpio!((16, GPIO16(_0 => SPID) (_0 => SPID)
+        ([Input] [Output]))); _for_each_inner_gpio!((17, GPIO17(_0 => SPIQ) (_0 => SPIQ)
+        ([Input] [Output]))); _for_each_inner_gpio!((18, GPIO18() () ([Input]
+        [Output]))); _for_each_inner_gpio!((19, GPIO19(_0 => U0RXD) () ([Input]
+        [Output]))); _for_each_inner_gpio!((20, GPIO20() (_0 => U0TXD) ([Input]
+        [Output]))); _for_each_inner_gpio!((all(0, GPIO0() () ([Input] [Output])), (1,
+        GPIO1() () ([Input] [Output])), (2, GPIO2(_2 => FSPIQ) (_2 => FSPIQ) ([Input]
+        [Output])), (3, GPIO3() () ([Input] [Output])), (4, GPIO4(_0 => MTMS _2 =>
+        FSPIHD) (_2 => FSPIHD) ([Input] [Output])), (5, GPIO5(_0 => MTDI _2 => FSPIWP)
+        (_2 => FSPIWP) ([Input] [Output])), (6, GPIO6(_0 => MTCK _2 => FSPICLK) (_2 =>
+        FSPICLK) ([Input] [Output])), (7, GPIO7(_2 => FSPID) (_0 => MTDO _2 => FSPID)
+        ([Input] [Output])), (8, GPIO8() () ([Input] [Output])), (9, GPIO9() () ([Input]
+        [Output])), (10, GPIO10(_2 => FSPICS0) (_2 => FSPICS0) ([Input] [Output])), (11,
+        GPIO11(_0 => SPIHD) (_0 => SPIHD) ([Input] [Output])), (12, GPIO12(_0 => SPIHD)
+        (_0 => SPIHD) ([Input] [Output])), (13, GPIO13(_0 => SPIWP) (_0 => SPIWP)
+        ([Input] [Output])), (14, GPIO14() (_0 => SPICS0) ([Input] [Output])), (15,
+        GPIO15() (_0 => SPICLK) ([Input] [Output])), (16, GPIO16(_0 => SPID) (_0 => SPID)
+        ([Input] [Output])), (17, GPIO17(_0 => SPIQ) (_0 => SPIQ) ([Input] [Output])),
+        (18, GPIO18() () ([Input] [Output])), (19, GPIO19(_0 => U0RXD) () ([Input]
+        [Output])), (20, GPIO20() (_0 => U0TXD) ([Input] [Output]))));
     };
 }
 /// This macro can be used to generate code for each analog function of each GPIO.
@@ -2844,19 +2896,22 @@ macro_rules! for_each_gpio {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_analog_function {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((ADC1_CH0, GPIO0)); _for_each_inner!((ADC1_CH1, GPIO1));
-        _for_each_inner!((ADC1_CH2, GPIO2)); _for_each_inner!((ADC1_CH3, GPIO3));
-        _for_each_inner!((ADC1_CH4, GPIO4)); _for_each_inner!(((ADC1_CH0, ADCn_CHm, 1,
-        0), GPIO0)); _for_each_inner!(((ADC1_CH1, ADCn_CHm, 1, 1), GPIO1));
-        _for_each_inner!(((ADC1_CH2, ADCn_CHm, 1, 2), GPIO2));
-        _for_each_inner!(((ADC1_CH3, ADCn_CHm, 1, 3), GPIO3));
-        _for_each_inner!(((ADC1_CH4, ADCn_CHm, 1, 4), GPIO4));
-        _for_each_inner!((all(ADC1_CH0, GPIO0), (ADC1_CH1, GPIO1), (ADC1_CH2, GPIO2),
-        (ADC1_CH3, GPIO3), (ADC1_CH4, GPIO4))); _for_each_inner!((all_expanded((ADC1_CH0,
-        ADCn_CHm, 1, 0), GPIO0), ((ADC1_CH1, ADCn_CHm, 1, 1), GPIO1), ((ADC1_CH2,
-        ADCn_CHm, 1, 2), GPIO2), ((ADC1_CH3, ADCn_CHm, 1, 3), GPIO3), ((ADC1_CH4,
-        ADCn_CHm, 1, 4), GPIO4)));
+        macro_rules! _for_each_inner_analog_function { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_analog_function!((ADC1_CH0, GPIO0));
+        _for_each_inner_analog_function!((ADC1_CH1, GPIO1));
+        _for_each_inner_analog_function!((ADC1_CH2, GPIO2));
+        _for_each_inner_analog_function!((ADC1_CH3, GPIO3));
+        _for_each_inner_analog_function!((ADC1_CH4, GPIO4));
+        _for_each_inner_analog_function!(((ADC1_CH0, ADCn_CHm, 1, 0), GPIO0));
+        _for_each_inner_analog_function!(((ADC1_CH1, ADCn_CHm, 1, 1), GPIO1));
+        _for_each_inner_analog_function!(((ADC1_CH2, ADCn_CHm, 1, 2), GPIO2));
+        _for_each_inner_analog_function!(((ADC1_CH3, ADCn_CHm, 1, 3), GPIO3));
+        _for_each_inner_analog_function!(((ADC1_CH4, ADCn_CHm, 1, 4), GPIO4));
+        _for_each_inner_analog_function!((all(ADC1_CH0, GPIO0), (ADC1_CH1, GPIO1),
+        (ADC1_CH2, GPIO2), (ADC1_CH3, GPIO3), (ADC1_CH4, GPIO4)));
+        _for_each_inner_analog_function!((all_expanded((ADC1_CH0, ADCn_CHm, 1, 0),
+        GPIO0), ((ADC1_CH1, ADCn_CHm, 1, 1), GPIO1), ((ADC1_CH2, ADCn_CHm, 1, 2), GPIO2),
+        ((ADC1_CH3, ADCn_CHm, 1, 3), GPIO3), ((ADC1_CH4, ADCn_CHm, 1, 4), GPIO4)));
     };
 }
 /// This macro can be used to generate code for each LP/RTC function of each GPIO.
@@ -2889,22 +2944,25 @@ macro_rules! for_each_analog_function {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_lp_function {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((RTC_GPIO0, GPIO0)); _for_each_inner!((RTC_GPIO1, GPIO1));
-        _for_each_inner!((RTC_GPIO2, GPIO2)); _for_each_inner!((RTC_GPIO3, GPIO3));
-        _for_each_inner!((RTC_GPIO4, GPIO4)); _for_each_inner!((RTC_GPIO5, GPIO5));
-        _for_each_inner!(((RTC_GPIO0, RTC_GPIOn, 0), GPIO0));
-        _for_each_inner!(((RTC_GPIO1, RTC_GPIOn, 1), GPIO1));
-        _for_each_inner!(((RTC_GPIO2, RTC_GPIOn, 2), GPIO2));
-        _for_each_inner!(((RTC_GPIO3, RTC_GPIOn, 3), GPIO3));
-        _for_each_inner!(((RTC_GPIO4, RTC_GPIOn, 4), GPIO4));
-        _for_each_inner!(((RTC_GPIO5, RTC_GPIOn, 5), GPIO5));
-        _for_each_inner!((all(RTC_GPIO0, GPIO0), (RTC_GPIO1, GPIO1), (RTC_GPIO2, GPIO2),
-        (RTC_GPIO3, GPIO3), (RTC_GPIO4, GPIO4), (RTC_GPIO5, GPIO5)));
-        _for_each_inner!((all_expanded((RTC_GPIO0, RTC_GPIOn, 0), GPIO0), ((RTC_GPIO1,
-        RTC_GPIOn, 1), GPIO1), ((RTC_GPIO2, RTC_GPIOn, 2), GPIO2), ((RTC_GPIO3,
-        RTC_GPIOn, 3), GPIO3), ((RTC_GPIO4, RTC_GPIOn, 4), GPIO4), ((RTC_GPIO5,
-        RTC_GPIOn, 5), GPIO5)));
+        macro_rules! _for_each_inner_lp_function { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_lp_function!((RTC_GPIO0, GPIO0));
+        _for_each_inner_lp_function!((RTC_GPIO1, GPIO1));
+        _for_each_inner_lp_function!((RTC_GPIO2, GPIO2));
+        _for_each_inner_lp_function!((RTC_GPIO3, GPIO3));
+        _for_each_inner_lp_function!((RTC_GPIO4, GPIO4));
+        _for_each_inner_lp_function!((RTC_GPIO5, GPIO5));
+        _for_each_inner_lp_function!(((RTC_GPIO0, RTC_GPIOn, 0), GPIO0));
+        _for_each_inner_lp_function!(((RTC_GPIO1, RTC_GPIOn, 1), GPIO1));
+        _for_each_inner_lp_function!(((RTC_GPIO2, RTC_GPIOn, 2), GPIO2));
+        _for_each_inner_lp_function!(((RTC_GPIO3, RTC_GPIOn, 3), GPIO3));
+        _for_each_inner_lp_function!(((RTC_GPIO4, RTC_GPIOn, 4), GPIO4));
+        _for_each_inner_lp_function!(((RTC_GPIO5, RTC_GPIOn, 5), GPIO5));
+        _for_each_inner_lp_function!((all(RTC_GPIO0, GPIO0), (RTC_GPIO1, GPIO1),
+        (RTC_GPIO2, GPIO2), (RTC_GPIO3, GPIO3), (RTC_GPIO4, GPIO4), (RTC_GPIO5, GPIO5)));
+        _for_each_inner_lp_function!((all_expanded((RTC_GPIO0, RTC_GPIOn, 0), GPIO0),
+        ((RTC_GPIO1, RTC_GPIOn, 1), GPIO1), ((RTC_GPIO2, RTC_GPIOn, 2), GPIO2),
+        ((RTC_GPIO3, RTC_GPIOn, 3), GPIO3), ((RTC_GPIO4, RTC_GPIOn, 4), GPIO4),
+        ((RTC_GPIO5, RTC_GPIOn, 5), GPIO5)));
     };
 }
 /// Defines the `InputSignal` and `OutputSignal` enums.

--- a/esp-metadata-generated/src/_generated_esp32c3.rs
+++ b/esp-metadata-generated/src/_generated_esp32c3.rs
@@ -2524,39 +2524,47 @@ macro_rules! memory_range {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_aes_key_length {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((128)); _for_each_inner!((256)); _for_each_inner!((128, 0, 4));
-        _for_each_inner!((256, 2, 6)); _for_each_inner!((bits(128), (256)));
-        _for_each_inner!((modes(128, 0, 4), (256, 2, 6)));
+        macro_rules! _for_each_inner_aes_key_length { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_aes_key_length!((128));
+        _for_each_inner_aes_key_length!((256)); _for_each_inner_aes_key_length!((128, 0,
+        4)); _for_each_inner_aes_key_length!((256, 2, 6));
+        _for_each_inner_aes_key_length!((bits(128), (256)));
+        _for_each_inner_aes_key_length!((modes(128, 0, 4), (256, 2, 6)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_dedicated_gpio {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((0)); _for_each_inner!((1)); _for_each_inner!((2));
-        _for_each_inner!((3)); _for_each_inner!((4)); _for_each_inner!((5));
-        _for_each_inner!((6)); _for_each_inner!((7)); _for_each_inner!((0, 0,
-        CPU_GPIO_0)); _for_each_inner!((0, 1, CPU_GPIO_1)); _for_each_inner!((0, 2,
-        CPU_GPIO_2)); _for_each_inner!((0, 3, CPU_GPIO_3)); _for_each_inner!((0, 4,
-        CPU_GPIO_4)); _for_each_inner!((0, 5, CPU_GPIO_5)); _for_each_inner!((0, 6,
-        CPU_GPIO_6)); _for_each_inner!((0, 7, CPU_GPIO_7));
-        _for_each_inner!((channels(0), (1), (2), (3), (4), (5), (6), (7)));
-        _for_each_inner!((signals(0, 0, CPU_GPIO_0), (0, 1, CPU_GPIO_1), (0, 2,
-        CPU_GPIO_2), (0, 3, CPU_GPIO_3), (0, 4, CPU_GPIO_4), (0, 5, CPU_GPIO_5), (0, 6,
-        CPU_GPIO_6), (0, 7, CPU_GPIO_7)));
+        macro_rules! _for_each_inner_dedicated_gpio { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_dedicated_gpio!((0));
+        _for_each_inner_dedicated_gpio!((1)); _for_each_inner_dedicated_gpio!((2));
+        _for_each_inner_dedicated_gpio!((3)); _for_each_inner_dedicated_gpio!((4));
+        _for_each_inner_dedicated_gpio!((5)); _for_each_inner_dedicated_gpio!((6));
+        _for_each_inner_dedicated_gpio!((7)); _for_each_inner_dedicated_gpio!((0, 0,
+        CPU_GPIO_0)); _for_each_inner_dedicated_gpio!((0, 1, CPU_GPIO_1));
+        _for_each_inner_dedicated_gpio!((0, 2, CPU_GPIO_2));
+        _for_each_inner_dedicated_gpio!((0, 3, CPU_GPIO_3));
+        _for_each_inner_dedicated_gpio!((0, 4, CPU_GPIO_4));
+        _for_each_inner_dedicated_gpio!((0, 5, CPU_GPIO_5));
+        _for_each_inner_dedicated_gpio!((0, 6, CPU_GPIO_6));
+        _for_each_inner_dedicated_gpio!((0, 7, CPU_GPIO_7));
+        _for_each_inner_dedicated_gpio!((channels(0), (1), (2), (3), (4), (5), (6),
+        (7))); _for_each_inner_dedicated_gpio!((signals(0, 0, CPU_GPIO_0), (0, 1,
+        CPU_GPIO_1), (0, 2, CPU_GPIO_2), (0, 3, CPU_GPIO_3), (0, 4, CPU_GPIO_4), (0, 5,
+        CPU_GPIO_5), (0, 6, CPU_GPIO_6), (0, 7, CPU_GPIO_7)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_sw_interrupt {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((0, FROM_CPU_INTR0, software_interrupt0)); _for_each_inner!((1,
-        FROM_CPU_INTR1, software_interrupt1)); _for_each_inner!((2, FROM_CPU_INTR2,
-        software_interrupt2)); _for_each_inner!((3, FROM_CPU_INTR3,
-        software_interrupt3)); _for_each_inner!((all(0, FROM_CPU_INTR0,
+        macro_rules! _for_each_inner_sw_interrupt { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_sw_interrupt!((0, FROM_CPU_INTR0,
+        software_interrupt0)); _for_each_inner_sw_interrupt!((1, FROM_CPU_INTR1,
+        software_interrupt1)); _for_each_inner_sw_interrupt!((2, FROM_CPU_INTR2,
+        software_interrupt2)); _for_each_inner_sw_interrupt!((3, FROM_CPU_INTR3,
+        software_interrupt3)); _for_each_inner_sw_interrupt!((all(0, FROM_CPU_INTR0,
         software_interrupt0), (1, FROM_CPU_INTR1, software_interrupt1), (2,
         FROM_CPU_INTR2, software_interrupt2), (3, FROM_CPU_INTR3, software_interrupt3)));
     };
@@ -2598,112 +2606,215 @@ macro_rules! sw_interrupt_delay {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rmt_channel {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((0)); _for_each_inner!((1)); _for_each_inner!((2));
-        _for_each_inner!((3)); _for_each_inner!((0, 0)); _for_each_inner!((1, 1));
-        _for_each_inner!((2, 0)); _for_each_inner!((3, 1)); _for_each_inner!((all(0),
-        (1), (2), (3))); _for_each_inner!((tx(0, 0), (1, 1))); _for_each_inner!((rx(2,
-        0), (3, 1)));
+        macro_rules! _for_each_inner_rmt_channel { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_rmt_channel!((0)); _for_each_inner_rmt_channel!((1));
+        _for_each_inner_rmt_channel!((2)); _for_each_inner_rmt_channel!((3));
+        _for_each_inner_rmt_channel!((0, 0)); _for_each_inner_rmt_channel!((1, 1));
+        _for_each_inner_rmt_channel!((2, 0)); _for_each_inner_rmt_channel!((3, 1));
+        _for_each_inner_rmt_channel!((all(0), (1), (2), (3)));
+        _for_each_inner_rmt_channel!((tx(0, 0), (1, 1)));
+        _for_each_inner_rmt_channel!((rx(2, 0), (3, 1)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rmt_clock_source {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((Apb, 1)); _for_each_inner!((RcFast, 2));
-        _for_each_inner!((Xtal, 3)); _for_each_inner!((Apb)); _for_each_inner!((all(Apb,
-        1), (RcFast, 2), (Xtal, 3))); _for_each_inner!((default(Apb)));
+        macro_rules! _for_each_inner_rmt_clock_source { $(($pattern) => $code;)* ($other
+        : tt) => {} } _for_each_inner_rmt_clock_source!((Apb, 1));
+        _for_each_inner_rmt_clock_source!((RcFast, 2));
+        _for_each_inner_rmt_clock_source!((Xtal, 3));
+        _for_each_inner_rmt_clock_source!((Apb));
+        _for_each_inner_rmt_clock_source!((all(Apb, 1), (RcFast, 2), (Xtal, 3)));
+        _for_each_inner_rmt_clock_source!((default(Apb)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rsa_exponentiation {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((32)); _for_each_inner!((64)); _for_each_inner!((96));
-        _for_each_inner!((128)); _for_each_inner!((160)); _for_each_inner!((192));
-        _for_each_inner!((224)); _for_each_inner!((256)); _for_each_inner!((288));
-        _for_each_inner!((320)); _for_each_inner!((352)); _for_each_inner!((384));
-        _for_each_inner!((416)); _for_each_inner!((448)); _for_each_inner!((480));
-        _for_each_inner!((512)); _for_each_inner!((544)); _for_each_inner!((576));
-        _for_each_inner!((608)); _for_each_inner!((640)); _for_each_inner!((672));
-        _for_each_inner!((704)); _for_each_inner!((736)); _for_each_inner!((768));
-        _for_each_inner!((800)); _for_each_inner!((832)); _for_each_inner!((864));
-        _for_each_inner!((896)); _for_each_inner!((928)); _for_each_inner!((960));
-        _for_each_inner!((992)); _for_each_inner!((1024)); _for_each_inner!((1056));
-        _for_each_inner!((1088)); _for_each_inner!((1120)); _for_each_inner!((1152));
-        _for_each_inner!((1184)); _for_each_inner!((1216)); _for_each_inner!((1248));
-        _for_each_inner!((1280)); _for_each_inner!((1312)); _for_each_inner!((1344));
-        _for_each_inner!((1376)); _for_each_inner!((1408)); _for_each_inner!((1440));
-        _for_each_inner!((1472)); _for_each_inner!((1504)); _for_each_inner!((1536));
-        _for_each_inner!((1568)); _for_each_inner!((1600)); _for_each_inner!((1632));
-        _for_each_inner!((1664)); _for_each_inner!((1696)); _for_each_inner!((1728));
-        _for_each_inner!((1760)); _for_each_inner!((1792)); _for_each_inner!((1824));
-        _for_each_inner!((1856)); _for_each_inner!((1888)); _for_each_inner!((1920));
-        _for_each_inner!((1952)); _for_each_inner!((1984)); _for_each_inner!((2016));
-        _for_each_inner!((2048)); _for_each_inner!((2080)); _for_each_inner!((2112));
-        _for_each_inner!((2144)); _for_each_inner!((2176)); _for_each_inner!((2208));
-        _for_each_inner!((2240)); _for_each_inner!((2272)); _for_each_inner!((2304));
-        _for_each_inner!((2336)); _for_each_inner!((2368)); _for_each_inner!((2400));
-        _for_each_inner!((2432)); _for_each_inner!((2464)); _for_each_inner!((2496));
-        _for_each_inner!((2528)); _for_each_inner!((2560)); _for_each_inner!((2592));
-        _for_each_inner!((2624)); _for_each_inner!((2656)); _for_each_inner!((2688));
-        _for_each_inner!((2720)); _for_each_inner!((2752)); _for_each_inner!((2784));
-        _for_each_inner!((2816)); _for_each_inner!((2848)); _for_each_inner!((2880));
-        _for_each_inner!((2912)); _for_each_inner!((2944)); _for_each_inner!((2976));
-        _for_each_inner!((3008)); _for_each_inner!((3040)); _for_each_inner!((3072));
-        _for_each_inner!((all(32), (64), (96), (128), (160), (192), (224), (256), (288),
-        (320), (352), (384), (416), (448), (480), (512), (544), (576), (608), (640),
-        (672), (704), (736), (768), (800), (832), (864), (896), (928), (960), (992),
-        (1024), (1056), (1088), (1120), (1152), (1184), (1216), (1248), (1280), (1312),
-        (1344), (1376), (1408), (1440), (1472), (1504), (1536), (1568), (1600), (1632),
-        (1664), (1696), (1728), (1760), (1792), (1824), (1856), (1888), (1920), (1952),
-        (1984), (2016), (2048), (2080), (2112), (2144), (2176), (2208), (2240), (2272),
-        (2304), (2336), (2368), (2400), (2432), (2464), (2496), (2528), (2560), (2592),
-        (2624), (2656), (2688), (2720), (2752), (2784), (2816), (2848), (2880), (2912),
-        (2944), (2976), (3008), (3040), (3072)));
+        macro_rules! _for_each_inner_rsa_exponentiation { $(($pattern) => $code;)*
+        ($other : tt) => {} } _for_each_inner_rsa_exponentiation!((32));
+        _for_each_inner_rsa_exponentiation!((64));
+        _for_each_inner_rsa_exponentiation!((96));
+        _for_each_inner_rsa_exponentiation!((128));
+        _for_each_inner_rsa_exponentiation!((160));
+        _for_each_inner_rsa_exponentiation!((192));
+        _for_each_inner_rsa_exponentiation!((224));
+        _for_each_inner_rsa_exponentiation!((256));
+        _for_each_inner_rsa_exponentiation!((288));
+        _for_each_inner_rsa_exponentiation!((320));
+        _for_each_inner_rsa_exponentiation!((352));
+        _for_each_inner_rsa_exponentiation!((384));
+        _for_each_inner_rsa_exponentiation!((416));
+        _for_each_inner_rsa_exponentiation!((448));
+        _for_each_inner_rsa_exponentiation!((480));
+        _for_each_inner_rsa_exponentiation!((512));
+        _for_each_inner_rsa_exponentiation!((544));
+        _for_each_inner_rsa_exponentiation!((576));
+        _for_each_inner_rsa_exponentiation!((608));
+        _for_each_inner_rsa_exponentiation!((640));
+        _for_each_inner_rsa_exponentiation!((672));
+        _for_each_inner_rsa_exponentiation!((704));
+        _for_each_inner_rsa_exponentiation!((736));
+        _for_each_inner_rsa_exponentiation!((768));
+        _for_each_inner_rsa_exponentiation!((800));
+        _for_each_inner_rsa_exponentiation!((832));
+        _for_each_inner_rsa_exponentiation!((864));
+        _for_each_inner_rsa_exponentiation!((896));
+        _for_each_inner_rsa_exponentiation!((928));
+        _for_each_inner_rsa_exponentiation!((960));
+        _for_each_inner_rsa_exponentiation!((992));
+        _for_each_inner_rsa_exponentiation!((1024));
+        _for_each_inner_rsa_exponentiation!((1056));
+        _for_each_inner_rsa_exponentiation!((1088));
+        _for_each_inner_rsa_exponentiation!((1120));
+        _for_each_inner_rsa_exponentiation!((1152));
+        _for_each_inner_rsa_exponentiation!((1184));
+        _for_each_inner_rsa_exponentiation!((1216));
+        _for_each_inner_rsa_exponentiation!((1248));
+        _for_each_inner_rsa_exponentiation!((1280));
+        _for_each_inner_rsa_exponentiation!((1312));
+        _for_each_inner_rsa_exponentiation!((1344));
+        _for_each_inner_rsa_exponentiation!((1376));
+        _for_each_inner_rsa_exponentiation!((1408));
+        _for_each_inner_rsa_exponentiation!((1440));
+        _for_each_inner_rsa_exponentiation!((1472));
+        _for_each_inner_rsa_exponentiation!((1504));
+        _for_each_inner_rsa_exponentiation!((1536));
+        _for_each_inner_rsa_exponentiation!((1568));
+        _for_each_inner_rsa_exponentiation!((1600));
+        _for_each_inner_rsa_exponentiation!((1632));
+        _for_each_inner_rsa_exponentiation!((1664));
+        _for_each_inner_rsa_exponentiation!((1696));
+        _for_each_inner_rsa_exponentiation!((1728));
+        _for_each_inner_rsa_exponentiation!((1760));
+        _for_each_inner_rsa_exponentiation!((1792));
+        _for_each_inner_rsa_exponentiation!((1824));
+        _for_each_inner_rsa_exponentiation!((1856));
+        _for_each_inner_rsa_exponentiation!((1888));
+        _for_each_inner_rsa_exponentiation!((1920));
+        _for_each_inner_rsa_exponentiation!((1952));
+        _for_each_inner_rsa_exponentiation!((1984));
+        _for_each_inner_rsa_exponentiation!((2016));
+        _for_each_inner_rsa_exponentiation!((2048));
+        _for_each_inner_rsa_exponentiation!((2080));
+        _for_each_inner_rsa_exponentiation!((2112));
+        _for_each_inner_rsa_exponentiation!((2144));
+        _for_each_inner_rsa_exponentiation!((2176));
+        _for_each_inner_rsa_exponentiation!((2208));
+        _for_each_inner_rsa_exponentiation!((2240));
+        _for_each_inner_rsa_exponentiation!((2272));
+        _for_each_inner_rsa_exponentiation!((2304));
+        _for_each_inner_rsa_exponentiation!((2336));
+        _for_each_inner_rsa_exponentiation!((2368));
+        _for_each_inner_rsa_exponentiation!((2400));
+        _for_each_inner_rsa_exponentiation!((2432));
+        _for_each_inner_rsa_exponentiation!((2464));
+        _for_each_inner_rsa_exponentiation!((2496));
+        _for_each_inner_rsa_exponentiation!((2528));
+        _for_each_inner_rsa_exponentiation!((2560));
+        _for_each_inner_rsa_exponentiation!((2592));
+        _for_each_inner_rsa_exponentiation!((2624));
+        _for_each_inner_rsa_exponentiation!((2656));
+        _for_each_inner_rsa_exponentiation!((2688));
+        _for_each_inner_rsa_exponentiation!((2720));
+        _for_each_inner_rsa_exponentiation!((2752));
+        _for_each_inner_rsa_exponentiation!((2784));
+        _for_each_inner_rsa_exponentiation!((2816));
+        _for_each_inner_rsa_exponentiation!((2848));
+        _for_each_inner_rsa_exponentiation!((2880));
+        _for_each_inner_rsa_exponentiation!((2912));
+        _for_each_inner_rsa_exponentiation!((2944));
+        _for_each_inner_rsa_exponentiation!((2976));
+        _for_each_inner_rsa_exponentiation!((3008));
+        _for_each_inner_rsa_exponentiation!((3040));
+        _for_each_inner_rsa_exponentiation!((3072));
+        _for_each_inner_rsa_exponentiation!((all(32), (64), (96), (128), (160), (192),
+        (224), (256), (288), (320), (352), (384), (416), (448), (480), (512), (544),
+        (576), (608), (640), (672), (704), (736), (768), (800), (832), (864), (896),
+        (928), (960), (992), (1024), (1056), (1088), (1120), (1152), (1184), (1216),
+        (1248), (1280), (1312), (1344), (1376), (1408), (1440), (1472), (1504), (1536),
+        (1568), (1600), (1632), (1664), (1696), (1728), (1760), (1792), (1824), (1856),
+        (1888), (1920), (1952), (1984), (2016), (2048), (2080), (2112), (2144), (2176),
+        (2208), (2240), (2272), (2304), (2336), (2368), (2400), (2432), (2464), (2496),
+        (2528), (2560), (2592), (2624), (2656), (2688), (2720), (2752), (2784), (2816),
+        (2848), (2880), (2912), (2944), (2976), (3008), (3040), (3072)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rsa_multiplication {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((32)); _for_each_inner!((64)); _for_each_inner!((96));
-        _for_each_inner!((128)); _for_each_inner!((160)); _for_each_inner!((192));
-        _for_each_inner!((224)); _for_each_inner!((256)); _for_each_inner!((288));
-        _for_each_inner!((320)); _for_each_inner!((352)); _for_each_inner!((384));
-        _for_each_inner!((416)); _for_each_inner!((448)); _for_each_inner!((480));
-        _for_each_inner!((512)); _for_each_inner!((544)); _for_each_inner!((576));
-        _for_each_inner!((608)); _for_each_inner!((640)); _for_each_inner!((672));
-        _for_each_inner!((704)); _for_each_inner!((736)); _for_each_inner!((768));
-        _for_each_inner!((800)); _for_each_inner!((832)); _for_each_inner!((864));
-        _for_each_inner!((896)); _for_each_inner!((928)); _for_each_inner!((960));
-        _for_each_inner!((992)); _for_each_inner!((1024)); _for_each_inner!((1056));
-        _for_each_inner!((1088)); _for_each_inner!((1120)); _for_each_inner!((1152));
-        _for_each_inner!((1184)); _for_each_inner!((1216)); _for_each_inner!((1248));
-        _for_each_inner!((1280)); _for_each_inner!((1312)); _for_each_inner!((1344));
-        _for_each_inner!((1376)); _for_each_inner!((1408)); _for_each_inner!((1440));
-        _for_each_inner!((1472)); _for_each_inner!((1504)); _for_each_inner!((1536));
-        _for_each_inner!((all(32), (64), (96), (128), (160), (192), (224), (256), (288),
-        (320), (352), (384), (416), (448), (480), (512), (544), (576), (608), (640),
-        (672), (704), (736), (768), (800), (832), (864), (896), (928), (960), (992),
-        (1024), (1056), (1088), (1120), (1152), (1184), (1216), (1248), (1280), (1312),
-        (1344), (1376), (1408), (1440), (1472), (1504), (1536)));
+        macro_rules! _for_each_inner_rsa_multiplication { $(($pattern) => $code;)*
+        ($other : tt) => {} } _for_each_inner_rsa_multiplication!((32));
+        _for_each_inner_rsa_multiplication!((64));
+        _for_each_inner_rsa_multiplication!((96));
+        _for_each_inner_rsa_multiplication!((128));
+        _for_each_inner_rsa_multiplication!((160));
+        _for_each_inner_rsa_multiplication!((192));
+        _for_each_inner_rsa_multiplication!((224));
+        _for_each_inner_rsa_multiplication!((256));
+        _for_each_inner_rsa_multiplication!((288));
+        _for_each_inner_rsa_multiplication!((320));
+        _for_each_inner_rsa_multiplication!((352));
+        _for_each_inner_rsa_multiplication!((384));
+        _for_each_inner_rsa_multiplication!((416));
+        _for_each_inner_rsa_multiplication!((448));
+        _for_each_inner_rsa_multiplication!((480));
+        _for_each_inner_rsa_multiplication!((512));
+        _for_each_inner_rsa_multiplication!((544));
+        _for_each_inner_rsa_multiplication!((576));
+        _for_each_inner_rsa_multiplication!((608));
+        _for_each_inner_rsa_multiplication!((640));
+        _for_each_inner_rsa_multiplication!((672));
+        _for_each_inner_rsa_multiplication!((704));
+        _for_each_inner_rsa_multiplication!((736));
+        _for_each_inner_rsa_multiplication!((768));
+        _for_each_inner_rsa_multiplication!((800));
+        _for_each_inner_rsa_multiplication!((832));
+        _for_each_inner_rsa_multiplication!((864));
+        _for_each_inner_rsa_multiplication!((896));
+        _for_each_inner_rsa_multiplication!((928));
+        _for_each_inner_rsa_multiplication!((960));
+        _for_each_inner_rsa_multiplication!((992));
+        _for_each_inner_rsa_multiplication!((1024));
+        _for_each_inner_rsa_multiplication!((1056));
+        _for_each_inner_rsa_multiplication!((1088));
+        _for_each_inner_rsa_multiplication!((1120));
+        _for_each_inner_rsa_multiplication!((1152));
+        _for_each_inner_rsa_multiplication!((1184));
+        _for_each_inner_rsa_multiplication!((1216));
+        _for_each_inner_rsa_multiplication!((1248));
+        _for_each_inner_rsa_multiplication!((1280));
+        _for_each_inner_rsa_multiplication!((1312));
+        _for_each_inner_rsa_multiplication!((1344));
+        _for_each_inner_rsa_multiplication!((1376));
+        _for_each_inner_rsa_multiplication!((1408));
+        _for_each_inner_rsa_multiplication!((1440));
+        _for_each_inner_rsa_multiplication!((1472));
+        _for_each_inner_rsa_multiplication!((1504));
+        _for_each_inner_rsa_multiplication!((1536));
+        _for_each_inner_rsa_multiplication!((all(32), (64), (96), (128), (160), (192),
+        (224), (256), (288), (320), (352), (384), (416), (448), (480), (512), (544),
+        (576), (608), (640), (672), (704), (736), (768), (800), (832), (864), (896),
+        (928), (960), (992), (1024), (1056), (1088), (1120), (1152), (1184), (1216),
+        (1248), (1280), (1312), (1344), (1376), (1408), (1440), (1472), (1504), (1536)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_sha_algorithm {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((Sha1, "SHA-1"(sizes : 64, 20, 8) (insecure_against :
-        "collision", "length extension"), 0)); _for_each_inner!((Sha224, "SHA-224"(sizes
-        : 64, 28, 8) (insecure_against : "length extension"), 1));
-        _for_each_inner!((Sha256, "SHA-256"(sizes : 64, 32, 8) (insecure_against :
-        "length extension"), 2)); _for_each_inner!((algos(Sha1, "SHA-1"(sizes : 64, 20,
-        8) (insecure_against : "collision", "length extension"), 0), (Sha224,
+        macro_rules! _for_each_inner_sha_algorithm { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_sha_algorithm!((Sha1, "SHA-1"(sizes : 64, 20, 8)
+        (insecure_against : "collision", "length extension"), 0));
+        _for_each_inner_sha_algorithm!((Sha224, "SHA-224"(sizes : 64, 28, 8)
+        (insecure_against : "length extension"), 1));
+        _for_each_inner_sha_algorithm!((Sha256, "SHA-256"(sizes : 64, 32, 8)
+        (insecure_against : "length extension"), 2));
+        _for_each_inner_sha_algorithm!((algos(Sha1, "SHA-1"(sizes : 64, 20, 8)
+        (insecure_against : "collision", "length extension"), 0), (Sha224,
         "SHA-224"(sizes : 64, 28, 8) (insecure_against : "length extension"), 1),
         (Sha256, "SHA-256"(sizes : 64, 32, 8) (insecure_against : "length extension"),
         2)));
@@ -2729,9 +2840,9 @@ macro_rules! for_each_sha_algorithm {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_i2c_master {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((I2C0, I2cExt0, I2CEXT0_SCL, I2CEXT0_SDA));
-        _for_each_inner!((all(I2C0, I2cExt0, I2CEXT0_SCL, I2CEXT0_SDA)));
+        macro_rules! _for_each_inner_i2c_master { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_i2c_master!((I2C0, I2cExt0, I2CEXT0_SCL, I2CEXT0_SDA));
+        _for_each_inner_i2c_master!((all(I2C0, I2cExt0, I2CEXT0_SCL, I2CEXT0_SDA)));
     };
 }
 /// This macro can be used to generate code for each peripheral instance of the UART driver.
@@ -2754,11 +2865,11 @@ macro_rules! for_each_i2c_master {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_uart {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS));
-        _for_each_inner!((UART1, Uart1, U1RXD, U1TXD, U1CTS, U1RTS));
-        _for_each_inner!((all(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS), (UART1, Uart1,
-        U1RXD, U1TXD, U1CTS, U1RTS)));
+        macro_rules! _for_each_inner_uart { $(($pattern) => $code;)* ($other : tt) => {}
+        } _for_each_inner_uart!((UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS));
+        _for_each_inner_uart!((UART1, Uart1, U1RXD, U1TXD, U1CTS, U1RTS));
+        _for_each_inner_uart!((all(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS), (UART1,
+        Uart1, U1RXD, U1TXD, U1CTS, U1RTS)));
     };
 }
 /// This macro can be used to generate code for each peripheral instance of the SPI master driver.
@@ -2786,11 +2897,11 @@ macro_rules! for_each_uart {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_spi_master {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((SPI2, Spi2, FSPICLK[FSPICS0, FSPICS1, FSPICS2, FSPICS3,
-        FSPICS4, FSPICS5] [FSPID, FSPIQ, FSPIWP, FSPIHD], true));
-        _for_each_inner!((all(SPI2, Spi2, FSPICLK[FSPICS0, FSPICS1, FSPICS2, FSPICS3,
-        FSPICS4, FSPICS5] [FSPID, FSPIQ, FSPIWP, FSPIHD], true)));
+        macro_rules! _for_each_inner_spi_master { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_spi_master!((SPI2, Spi2, FSPICLK[FSPICS0, FSPICS1,
+        FSPICS2, FSPICS3, FSPICS4, FSPICS5] [FSPID, FSPIQ, FSPIWP, FSPIHD], true));
+        _for_each_inner_spi_master!((all(SPI2, Spi2, FSPICLK[FSPICS0, FSPICS1, FSPICS2,
+        FSPICS3, FSPICS4, FSPICS5] [FSPID, FSPIQ, FSPIWP, FSPIHD], true)));
     };
 }
 /// This macro can be used to generate code for each peripheral instance of the SPI slave driver.
@@ -2813,241 +2924,289 @@ macro_rules! for_each_spi_master {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_spi_slave {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((SPI2, Spi2, FSPICLK, FSPID, FSPIQ, FSPICS0));
-        _for_each_inner!((all(SPI2, Spi2, FSPICLK, FSPID, FSPIQ, FSPICS0)));
+        macro_rules! _for_each_inner_spi_slave { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_spi_slave!((SPI2, Spi2, FSPICLK, FSPID, FSPIQ, FSPICS0));
+        _for_each_inner_spi_slave!((all(SPI2, Spi2, FSPICLK, FSPID, FSPIQ, FSPICS0)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_peripheral {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((@ peri_type #[doc = "GPIO0 peripheral singleton"] GPIO0 <=
-        virtual())); _for_each_inner!((@ peri_type #[doc = "GPIO1 peripheral singleton"]
-        GPIO1 <= virtual())); _for_each_inner!((@ peri_type #[doc =
+        macro_rules! _for_each_inner_peripheral { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO0 peripheral singleton"] GPIO0 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO1 peripheral singleton"]
+        GPIO1 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
         "GPIO2 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
         "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin is a strapping pin, it determines how the chip boots.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO2 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO3 peripheral singleton"] GPIO3 <= virtual()));
-        _for_each_inner!((@ peri_type #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO2 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO3 peripheral singleton"]
+        GPIO3 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
         "GPIO4 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
         "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>These pins may be used to debug the chip using an external JTAG debugger.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO4 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO5 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO4 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO5 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>These pins may be used to debug the chip using an external JTAG debugger.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO5 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO6 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO5 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO6 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>These pins may be used to debug the chip using an external JTAG debugger.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO6 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO7 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO6 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO7 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>These pins may be used to debug the chip using an external JTAG debugger.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO7 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO8 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO7 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO8 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin is a strapping pin, it determines how the chip boots.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO8 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO9 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO8 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO9 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin is a strapping pin, it determines how the chip boots.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO9 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO10 peripheral singleton"] GPIO10 <= virtual()));
-        _for_each_inner!((@ peri_type #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO9 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO10 peripheral singleton"]
+        GPIO10 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
         "GPIO11 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
         "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO11 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO12 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO11 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO12 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO12 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO13 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO12 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO13 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO13 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO14 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO13 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO14 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO14 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO15 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO14 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO15 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO15 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO16 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO15 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO16 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO16 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO17 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO16 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO17 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO17 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO18 peripheral singleton"] GPIO18 <= virtual()));
-        _for_each_inner!((@ peri_type #[doc = "GPIO19 peripheral singleton"] GPIO19 <=
-        virtual())); _for_each_inner!((@ peri_type #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO17 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO18 peripheral singleton"]
+        GPIO18 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO19 peripheral singleton"] GPIO19 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
         "GPIO20 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
         "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>By default, this pin is used by the UART programming interface.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO20 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO21 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO20 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO21 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>By default, this pin is used by the UART programming interface.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO21 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "AES peripheral singleton"] AES <= AES(AES : {
-        bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
-        (unstable))); _for_each_inner!((@ peri_type #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO21 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "AES peripheral singleton"] AES
+        <= AES(AES : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt
+        }) (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "APB_CTRL peripheral singleton"] APB_CTRL <= APB_CTRL() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "APB_SARADC peripheral singleton"]
-        APB_SARADC <= APB_SARADC() (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
         "ASSIST_DEBUG peripheral singleton"] ASSIST_DEBUG <= ASSIST_DEBUG() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "BB peripheral singleton"] BB <= BB()
-        (unstable))); _for_each_inner!((@ peri_type #[doc = "DMA peripheral singleton"]
-        DMA <= DMA() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "DS peripheral singleton"] DS <= DS() (unstable))); _for_each_inner!((@ peri_type
-        #[doc = "EFUSE peripheral singleton"] EFUSE <= EFUSE() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "EXTMEM peripheral singleton"] EXTMEM <=
-        EXTMEM() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "FE peripheral singleton"] FE <= FE() (unstable))); _for_each_inner!((@ peri_type
-        #[doc = "FE2 peripheral singleton"] FE2 <= FE2() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "GPIO peripheral singleton"] GPIO <= GPIO()
-        (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "GPIO_SD peripheral singleton"] GPIO_SD <= GPIO_SD() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "HMAC peripheral singleton"] HMAC <= HMAC()
-        (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "BB peripheral singleton"] BB <=
+        BB() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "DMA peripheral singleton"] DMA <= DMA() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DS peripheral singleton"] DS <=
+        DS() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "EFUSE peripheral singleton"] EFUSE <= EFUSE() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "EXTMEM peripheral singleton"]
+        EXTMEM <= EXTMEM() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "FE peripheral singleton"] FE <= FE() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "FE2 peripheral singleton"] FE2
+        <= FE2() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO peripheral singleton"] GPIO <= GPIO() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO_SD peripheral singleton"]
+        GPIO_SD <= GPIO_SD() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "HMAC peripheral singleton"] HMAC <= HMAC() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
         "I2C_ANA_MST peripheral singleton"] I2C_ANA_MST <= I2C_ANA_MST() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "I2C0 peripheral singleton"] I2C0 <=
-        I2C0(I2C_EXT0 : { bind_peri_interrupt, enable_peri_interrupt,
-        disable_peri_interrupt }))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "I2C0 peripheral singleton"]
+        I2C0 <= I2C0(I2C_EXT0 : { bind_peri_interrupt, enable_peri_interrupt,
+        disable_peri_interrupt }))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "I2S0 peripheral singleton"] I2S0 <= I2S0(I2S0 : { bind_peri_interrupt,
         enable_peri_interrupt, disable_peri_interrupt }) (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "INTERRUPT_CORE0 peripheral singleton"]
-        INTERRUPT_CORE0 <= INTERRUPT_CORE0() (unstable))); _for_each_inner!((@ peri_type
-        #[doc = "IO_MUX peripheral singleton"] IO_MUX <= IO_MUX() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "LEDC peripheral singleton"] LEDC <= LEDC()
-        (unstable))); _for_each_inner!((@ peri_type #[doc = "NRX peripheral singleton"]
-        NRX <= NRX() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "RMT peripheral singleton"] RMT <= RMT() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "RNG peripheral singleton"] RNG <= RNG() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "RSA peripheral singleton"] RSA <= RSA(RSA
-        : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
-        (unstable))); _for_each_inner!((@ peri_type #[doc = "LPWR peripheral singleton"]
-        LPWR <= RTC_CNTL() (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "INTERRUPT_CORE0 peripheral singleton"] INTERRUPT_CORE0 <= INTERRUPT_CORE0()
+        (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "IO_MUX peripheral singleton"] IO_MUX <= IO_MUX() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "LEDC peripheral singleton"]
+        LEDC <= LEDC() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "NRX peripheral singleton"] NRX <= NRX() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "RMT peripheral singleton"] RMT
+        <= RMT() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "RNG peripheral singleton"] RNG <= RNG() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "RSA peripheral singleton"] RSA
+        <= RSA(RSA : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt
+        }) (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "LPWR peripheral singleton"] LPWR <= RTC_CNTL() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
         "SENSITIVE peripheral singleton"] SENSITIVE <= SENSITIVE() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "SHA peripheral singleton"] SHA <= SHA(SHA
-        : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
-        (unstable))); _for_each_inner!((@ peri_type #[doc = "SPI0 peripheral singleton"]
-        SPI0 <= SPI0() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "SPI1 peripheral singleton"] SPI1 <= SPI1() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "SPI2 peripheral singleton"] SPI2 <= SPI2(SPI2 : {
-        bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })));
-        _for_each_inner!((@ peri_type #[doc = "SYSTEM peripheral singleton"] SYSTEM <=
-        SYSTEM() (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "SHA peripheral singleton"] SHA
+        <= SHA(SHA : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt
+        }) (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "SPI0 peripheral singleton"] SPI0 <= SPI0() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "SPI1 peripheral singleton"]
+        SPI1 <= SPI1() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "SPI2 peripheral singleton"] SPI2 <= SPI2(SPI2 : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt })));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "SYSTEM peripheral singleton"]
+        SYSTEM <= SYSTEM() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "SYSTIMER peripheral singleton"] SYSTIMER <= SYSTIMER() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "TIMG0 peripheral singleton"] TIMG0 <=
-        TIMG0() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "TIMG1 peripheral singleton"] TIMG1 <= TIMG1() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "TWAI0 peripheral singleton"] TWAI0 <= TWAI0() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "UART0 peripheral singleton"] UART0 <=
-        UART0(UART0 : { bind_peri_interrupt, enable_peri_interrupt,
-        disable_peri_interrupt }))); _for_each_inner!((@ peri_type #[doc =
-        "UART1 peripheral singleton"] UART1 <= UART1(UART1 : { bind_peri_interrupt,
-        enable_peri_interrupt, disable_peri_interrupt }))); _for_each_inner!((@ peri_type
-        #[doc = "UHCI0 peripheral singleton"] UHCI0 <= UHCI0() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "USB_DEVICE peripheral singleton"]
-        USB_DEVICE <= USB_DEVICE(USB_DEVICE : { bind_peri_interrupt,
-        enable_peri_interrupt, disable_peri_interrupt }) (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "XTS_AES peripheral singleton"] XTS_AES <=
-        XTS_AES() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "DMA_CH1 peripheral singleton"] DMA_CH1 <=
-        virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "DMA_CH2 peripheral singleton"] DMA_CH2 <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "ADC1 peripheral singleton"] ADC1 <=
-        virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "ADC2 peripheral singleton"] ADC2 <= virtual() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "BT peripheral singleton"] BT <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "FLASH peripheral singleton"] FLASH <=
-        virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "TIMG0 peripheral singleton"]
+        TIMG0 <= TIMG0() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "TIMG1 peripheral singleton"] TIMG1 <= TIMG1() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "TWAI0 peripheral singleton"]
+        TWAI0 <= TWAI0() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "UART0 peripheral singleton"] UART0 <= UART0(UART0 : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt })));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "UART1 peripheral singleton"]
+        UART1 <= UART1(UART1 : { bind_peri_interrupt, enable_peri_interrupt,
+        disable_peri_interrupt }))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "UHCI0 peripheral singleton"] UHCI0 <= UHCI0() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "USB_DEVICE peripheral singleton"] USB_DEVICE <= USB_DEVICE(USB_DEVICE : {
+        bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
+        (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "XTS_AES peripheral singleton"] XTS_AES <= XTS_AES() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH0 peripheral singleton"]
+        DMA_CH0 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH2 peripheral singleton"]
+        DMA_CH2 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "ADC1 peripheral singleton"] ADC1 <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "ADC2 peripheral singleton"]
+        ADC2 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "BT peripheral singleton"] BT <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "FLASH peripheral singleton"]
+        FLASH <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "GPIO_DEDICATED peripheral singleton"] GPIO_DEDICATED <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "SW_INTERRUPT peripheral singleton"]
-        SW_INTERRUPT <= virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "TSENS peripheral singleton"] TSENS <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "WIFI peripheral singleton"] WIFI <=
-        virtual() (unstable))); _for_each_inner!((GPIO0)); _for_each_inner!((GPIO1));
-        _for_each_inner!((GPIO2)); _for_each_inner!((GPIO3)); _for_each_inner!((GPIO4));
-        _for_each_inner!((GPIO5)); _for_each_inner!((GPIO6)); _for_each_inner!((GPIO7));
-        _for_each_inner!((GPIO8)); _for_each_inner!((GPIO9)); _for_each_inner!((GPIO10));
-        _for_each_inner!((GPIO11)); _for_each_inner!((GPIO12));
-        _for_each_inner!((GPIO13)); _for_each_inner!((GPIO14));
-        _for_each_inner!((GPIO15)); _for_each_inner!((GPIO16));
-        _for_each_inner!((GPIO17)); _for_each_inner!((GPIO18));
-        _for_each_inner!((GPIO19)); _for_each_inner!((GPIO20));
-        _for_each_inner!((GPIO21)); _for_each_inner!((AES(unstable)));
-        _for_each_inner!((APB_CTRL(unstable))); _for_each_inner!((APB_SARADC(unstable)));
-        _for_each_inner!((ASSIST_DEBUG(unstable))); _for_each_inner!((BB(unstable)));
-        _for_each_inner!((DMA(unstable))); _for_each_inner!((DS(unstable)));
-        _for_each_inner!((EFUSE(unstable))); _for_each_inner!((EXTMEM(unstable)));
-        _for_each_inner!((FE(unstable))); _for_each_inner!((FE2(unstable)));
-        _for_each_inner!((GPIO(unstable))); _for_each_inner!((GPIO_SD(unstable)));
-        _for_each_inner!((HMAC(unstable))); _for_each_inner!((I2C_ANA_MST(unstable)));
-        _for_each_inner!((I2C0)); _for_each_inner!((I2S0(unstable)));
-        _for_each_inner!((INTERRUPT_CORE0(unstable)));
-        _for_each_inner!((IO_MUX(unstable))); _for_each_inner!((LEDC(unstable)));
-        _for_each_inner!((NRX(unstable))); _for_each_inner!((RMT(unstable)));
-        _for_each_inner!((RNG(unstable))); _for_each_inner!((RSA(unstable)));
-        _for_each_inner!((LPWR(unstable))); _for_each_inner!((SENSITIVE(unstable)));
-        _for_each_inner!((SHA(unstable))); _for_each_inner!((SPI0(unstable)));
-        _for_each_inner!((SPI1(unstable))); _for_each_inner!((SPI2));
-        _for_each_inner!((SYSTEM(unstable))); _for_each_inner!((SYSTIMER(unstable)));
-        _for_each_inner!((TIMG0(unstable))); _for_each_inner!((TIMG1(unstable)));
-        _for_each_inner!((TWAI0(unstable))); _for_each_inner!((UART0));
-        _for_each_inner!((UART1)); _for_each_inner!((UHCI0(unstable)));
-        _for_each_inner!((USB_DEVICE(unstable))); _for_each_inner!((XTS_AES(unstable)));
-        _for_each_inner!((DMA_CH0(unstable))); _for_each_inner!((DMA_CH1(unstable)));
-        _for_each_inner!((DMA_CH2(unstable))); _for_each_inner!((ADC1(unstable)));
-        _for_each_inner!((ADC2(unstable))); _for_each_inner!((BT(unstable)));
-        _for_each_inner!((FLASH(unstable)));
-        _for_each_inner!((GPIO_DEDICATED(unstable)));
-        _for_each_inner!((SW_INTERRUPT(unstable))); _for_each_inner!((TSENS(unstable)));
-        _for_each_inner!((WIFI(unstable))); _for_each_inner!((all(@ peri_type #[doc =
-        "GPIO0 peripheral singleton"] GPIO0 <= virtual()), (@ peri_type #[doc =
-        "GPIO1 peripheral singleton"] GPIO1 <= virtual()), (@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "SW_INTERRUPT peripheral singleton"] SW_INTERRUPT <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "TSENS peripheral singleton"]
+        TSENS <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "WIFI peripheral singleton"] WIFI <= virtual() (unstable)));
+        _for_each_inner_peripheral!((GPIO0)); _for_each_inner_peripheral!((GPIO1));
+        _for_each_inner_peripheral!((GPIO2)); _for_each_inner_peripheral!((GPIO3));
+        _for_each_inner_peripheral!((GPIO4)); _for_each_inner_peripheral!((GPIO5));
+        _for_each_inner_peripheral!((GPIO6)); _for_each_inner_peripheral!((GPIO7));
+        _for_each_inner_peripheral!((GPIO8)); _for_each_inner_peripheral!((GPIO9));
+        _for_each_inner_peripheral!((GPIO10)); _for_each_inner_peripheral!((GPIO11));
+        _for_each_inner_peripheral!((GPIO12)); _for_each_inner_peripheral!((GPIO13));
+        _for_each_inner_peripheral!((GPIO14)); _for_each_inner_peripheral!((GPIO15));
+        _for_each_inner_peripheral!((GPIO16)); _for_each_inner_peripheral!((GPIO17));
+        _for_each_inner_peripheral!((GPIO18)); _for_each_inner_peripheral!((GPIO19));
+        _for_each_inner_peripheral!((GPIO20)); _for_each_inner_peripheral!((GPIO21));
+        _for_each_inner_peripheral!((AES(unstable)));
+        _for_each_inner_peripheral!((APB_CTRL(unstable)));
+        _for_each_inner_peripheral!((APB_SARADC(unstable)));
+        _for_each_inner_peripheral!((ASSIST_DEBUG(unstable)));
+        _for_each_inner_peripheral!((BB(unstable)));
+        _for_each_inner_peripheral!((DMA(unstable)));
+        _for_each_inner_peripheral!((DS(unstable)));
+        _for_each_inner_peripheral!((EFUSE(unstable)));
+        _for_each_inner_peripheral!((EXTMEM(unstable)));
+        _for_each_inner_peripheral!((FE(unstable)));
+        _for_each_inner_peripheral!((FE2(unstable)));
+        _for_each_inner_peripheral!((GPIO(unstable)));
+        _for_each_inner_peripheral!((GPIO_SD(unstable)));
+        _for_each_inner_peripheral!((HMAC(unstable)));
+        _for_each_inner_peripheral!((I2C_ANA_MST(unstable)));
+        _for_each_inner_peripheral!((I2C0));
+        _for_each_inner_peripheral!((I2S0(unstable)));
+        _for_each_inner_peripheral!((INTERRUPT_CORE0(unstable)));
+        _for_each_inner_peripheral!((IO_MUX(unstable)));
+        _for_each_inner_peripheral!((LEDC(unstable)));
+        _for_each_inner_peripheral!((NRX(unstable)));
+        _for_each_inner_peripheral!((RMT(unstable)));
+        _for_each_inner_peripheral!((RNG(unstable)));
+        _for_each_inner_peripheral!((RSA(unstable)));
+        _for_each_inner_peripheral!((LPWR(unstable)));
+        _for_each_inner_peripheral!((SENSITIVE(unstable)));
+        _for_each_inner_peripheral!((SHA(unstable)));
+        _for_each_inner_peripheral!((SPI0(unstable)));
+        _for_each_inner_peripheral!((SPI1(unstable)));
+        _for_each_inner_peripheral!((SPI2));
+        _for_each_inner_peripheral!((SYSTEM(unstable)));
+        _for_each_inner_peripheral!((SYSTIMER(unstable)));
+        _for_each_inner_peripheral!((TIMG0(unstable)));
+        _for_each_inner_peripheral!((TIMG1(unstable)));
+        _for_each_inner_peripheral!((TWAI0(unstable)));
+        _for_each_inner_peripheral!((UART0)); _for_each_inner_peripheral!((UART1));
+        _for_each_inner_peripheral!((UHCI0(unstable)));
+        _for_each_inner_peripheral!((USB_DEVICE(unstable)));
+        _for_each_inner_peripheral!((XTS_AES(unstable)));
+        _for_each_inner_peripheral!((DMA_CH0(unstable)));
+        _for_each_inner_peripheral!((DMA_CH1(unstable)));
+        _for_each_inner_peripheral!((DMA_CH2(unstable)));
+        _for_each_inner_peripheral!((ADC1(unstable)));
+        _for_each_inner_peripheral!((ADC2(unstable)));
+        _for_each_inner_peripheral!((BT(unstable)));
+        _for_each_inner_peripheral!((FLASH(unstable)));
+        _for_each_inner_peripheral!((GPIO_DEDICATED(unstable)));
+        _for_each_inner_peripheral!((SW_INTERRUPT(unstable)));
+        _for_each_inner_peripheral!((TSENS(unstable)));
+        _for_each_inner_peripheral!((WIFI(unstable))); _for_each_inner_peripheral!((all(@
+        peri_type #[doc = "GPIO0 peripheral singleton"] GPIO0 <= virtual()), (@ peri_type
+        #[doc = "GPIO1 peripheral singleton"] GPIO1 <= virtual()), (@ peri_type #[doc =
         "GPIO2 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
         "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
@@ -3213,19 +3372,20 @@ macro_rules! for_each_peripheral {
         SW_INTERRUPT <= virtual() (unstable)), (@ peri_type #[doc =
         "TSENS peripheral singleton"] TSENS <= virtual() (unstable)), (@ peri_type #[doc
         = "WIFI peripheral singleton"] WIFI <= virtual() (unstable))));
-        _for_each_inner!((singletons(GPIO0), (GPIO1), (GPIO2), (GPIO3), (GPIO4), (GPIO5),
-        (GPIO6), (GPIO7), (GPIO8), (GPIO9), (GPIO10), (GPIO11), (GPIO12), (GPIO13),
-        (GPIO14), (GPIO15), (GPIO16), (GPIO17), (GPIO18), (GPIO19), (GPIO20), (GPIO21),
-        (AES(unstable)), (APB_CTRL(unstable)), (APB_SARADC(unstable)),
-        (ASSIST_DEBUG(unstable)), (BB(unstable)), (DMA(unstable)), (DS(unstable)),
-        (EFUSE(unstable)), (EXTMEM(unstable)), (FE(unstable)), (FE2(unstable)),
-        (GPIO(unstable)), (GPIO_SD(unstable)), (HMAC(unstable)), (I2C_ANA_MST(unstable)),
-        (I2C0), (I2S0(unstable)), (INTERRUPT_CORE0(unstable)), (IO_MUX(unstable)),
-        (LEDC(unstable)), (NRX(unstable)), (RMT(unstable)), (RNG(unstable)),
-        (RSA(unstable)), (LPWR(unstable)), (SENSITIVE(unstable)), (SHA(unstable)),
-        (SPI0(unstable)), (SPI1(unstable)), (SPI2), (SYSTEM(unstable)),
-        (SYSTIMER(unstable)), (TIMG0(unstable)), (TIMG1(unstable)), (TWAI0(unstable)),
-        (UART0), (UART1), (UHCI0(unstable)), (USB_DEVICE(unstable)), (XTS_AES(unstable)),
+        _for_each_inner_peripheral!((singletons(GPIO0), (GPIO1), (GPIO2), (GPIO3),
+        (GPIO4), (GPIO5), (GPIO6), (GPIO7), (GPIO8), (GPIO9), (GPIO10), (GPIO11),
+        (GPIO12), (GPIO13), (GPIO14), (GPIO15), (GPIO16), (GPIO17), (GPIO18), (GPIO19),
+        (GPIO20), (GPIO21), (AES(unstable)), (APB_CTRL(unstable)),
+        (APB_SARADC(unstable)), (ASSIST_DEBUG(unstable)), (BB(unstable)),
+        (DMA(unstable)), (DS(unstable)), (EFUSE(unstable)), (EXTMEM(unstable)),
+        (FE(unstable)), (FE2(unstable)), (GPIO(unstable)), (GPIO_SD(unstable)),
+        (HMAC(unstable)), (I2C_ANA_MST(unstable)), (I2C0), (I2S0(unstable)),
+        (INTERRUPT_CORE0(unstable)), (IO_MUX(unstable)), (LEDC(unstable)),
+        (NRX(unstable)), (RMT(unstable)), (RNG(unstable)), (RSA(unstable)),
+        (LPWR(unstable)), (SENSITIVE(unstable)), (SHA(unstable)), (SPI0(unstable)),
+        (SPI1(unstable)), (SPI2), (SYSTEM(unstable)), (SYSTIMER(unstable)),
+        (TIMG0(unstable)), (TIMG1(unstable)), (TWAI0(unstable)), (UART0), (UART1),
+        (UHCI0(unstable)), (USB_DEVICE(unstable)), (XTS_AES(unstable)),
         (DMA_CH0(unstable)), (DMA_CH1(unstable)), (DMA_CH2(unstable)), (ADC1(unstable)),
         (ADC2(unstable)), (BT(unstable)), (FLASH(unstable)), (GPIO_DEDICATED(unstable)),
         (SW_INTERRUPT(unstable)), (TSENS(unstable)), (WIFI(unstable))));
@@ -3261,29 +3421,32 @@ macro_rules! for_each_peripheral {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_gpio {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((0, GPIO0() () ([Input] [Output]))); _for_each_inner!((1,
-        GPIO1() () ([Input] [Output]))); _for_each_inner!((2, GPIO2(_2 => FSPIQ) (_2 =>
-        FSPIQ) ([Input] [Output]))); _for_each_inner!((3, GPIO3() () ([Input]
-        [Output]))); _for_each_inner!((4, GPIO4(_0 => MTMS _2 => FSPIHD) (_2 => FSPIHD)
-        ([Input] [Output]))); _for_each_inner!((5, GPIO5(_0 => MTDI _2 => FSPIWP) (_2 =>
-        FSPIWP) ([Input] [Output]))); _for_each_inner!((6, GPIO6(_0 => MTCK _2 =>
-        FSPICLK) (_2 => FSPICLK) ([Input] [Output]))); _for_each_inner!((7, GPIO7(_2 =>
-        FSPID) (_0 => MTDO _2 => FSPID) ([Input] [Output]))); _for_each_inner!((8,
-        GPIO8() () ([Input] [Output]))); _for_each_inner!((9, GPIO9() () ([Input]
-        [Output]))); _for_each_inner!((10, GPIO10(_2 => FSPICS0) (_2 => FSPICS0) ([Input]
-        [Output]))); _for_each_inner!((11, GPIO11() () ([Input] [Output])));
-        _for_each_inner!((12, GPIO12(_0 => SPIHD) (_0 => SPIHD) ([Input] [Output])));
-        _for_each_inner!((13, GPIO13(_0 => SPIWP) (_0 => SPIWP) ([Input] [Output])));
-        _for_each_inner!((14, GPIO14() (_0 => SPICS0) ([Input] [Output])));
-        _for_each_inner!((15, GPIO15() (_0 => SPICLK) ([Input] [Output])));
-        _for_each_inner!((16, GPIO16(_0 => SPID) (_0 => SPID) ([Input] [Output])));
-        _for_each_inner!((17, GPIO17(_0 => SPIQ) (_0 => SPIQ) ([Input] [Output])));
-        _for_each_inner!((18, GPIO18() () ([Input] [Output]))); _for_each_inner!((19,
-        GPIO19() () ([Input] [Output]))); _for_each_inner!((20, GPIO20(_0 => U0RXD) ()
-        ([Input] [Output]))); _for_each_inner!((21, GPIO21() (_0 => U0TXD) ([Input]
-        [Output]))); _for_each_inner!((all(0, GPIO0() () ([Input] [Output])), (1, GPIO1()
-        () ([Input] [Output])), (2, GPIO2(_2 => FSPIQ) (_2 => FSPIQ) ([Input] [Output])),
+        macro_rules! _for_each_inner_gpio { $(($pattern) => $code;)* ($other : tt) => {}
+        } _for_each_inner_gpio!((0, GPIO0() () ([Input] [Output])));
+        _for_each_inner_gpio!((1, GPIO1() () ([Input] [Output])));
+        _for_each_inner_gpio!((2, GPIO2(_2 => FSPIQ) (_2 => FSPIQ) ([Input] [Output])));
+        _for_each_inner_gpio!((3, GPIO3() () ([Input] [Output])));
+        _for_each_inner_gpio!((4, GPIO4(_0 => MTMS _2 => FSPIHD) (_2 => FSPIHD) ([Input]
+        [Output]))); _for_each_inner_gpio!((5, GPIO5(_0 => MTDI _2 => FSPIWP) (_2 =>
+        FSPIWP) ([Input] [Output]))); _for_each_inner_gpio!((6, GPIO6(_0 => MTCK _2 =>
+        FSPICLK) (_2 => FSPICLK) ([Input] [Output]))); _for_each_inner_gpio!((7, GPIO7(_2
+        => FSPID) (_0 => MTDO _2 => FSPID) ([Input] [Output])));
+        _for_each_inner_gpio!((8, GPIO8() () ([Input] [Output])));
+        _for_each_inner_gpio!((9, GPIO9() () ([Input] [Output])));
+        _for_each_inner_gpio!((10, GPIO10(_2 => FSPICS0) (_2 => FSPICS0) ([Input]
+        [Output]))); _for_each_inner_gpio!((11, GPIO11() () ([Input] [Output])));
+        _for_each_inner_gpio!((12, GPIO12(_0 => SPIHD) (_0 => SPIHD) ([Input]
+        [Output]))); _for_each_inner_gpio!((13, GPIO13(_0 => SPIWP) (_0 => SPIWP)
+        ([Input] [Output]))); _for_each_inner_gpio!((14, GPIO14() (_0 => SPICS0) ([Input]
+        [Output]))); _for_each_inner_gpio!((15, GPIO15() (_0 => SPICLK) ([Input]
+        [Output]))); _for_each_inner_gpio!((16, GPIO16(_0 => SPID) (_0 => SPID) ([Input]
+        [Output]))); _for_each_inner_gpio!((17, GPIO17(_0 => SPIQ) (_0 => SPIQ) ([Input]
+        [Output]))); _for_each_inner_gpio!((18, GPIO18() () ([Input] [Output])));
+        _for_each_inner_gpio!((19, GPIO19() () ([Input] [Output])));
+        _for_each_inner_gpio!((20, GPIO20(_0 => U0RXD) () ([Input] [Output])));
+        _for_each_inner_gpio!((21, GPIO21() (_0 => U0TXD) ([Input] [Output])));
+        _for_each_inner_gpio!((all(0, GPIO0() () ([Input] [Output])), (1, GPIO1() ()
+        ([Input] [Output])), (2, GPIO2(_2 => FSPIQ) (_2 => FSPIQ) ([Input] [Output])),
         (3, GPIO3() () ([Input] [Output])), (4, GPIO4(_0 => MTMS _2 => FSPIHD) (_2 =>
         FSPIHD) ([Input] [Output])), (5, GPIO5(_0 => MTDI _2 => FSPIWP) (_2 => FSPIWP)
         ([Input] [Output])), (6, GPIO6(_0 => MTCK _2 => FSPICLK) (_2 => FSPICLK) ([Input]
@@ -3329,20 +3492,25 @@ macro_rules! for_each_gpio {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_analog_function {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((ADC1_CH0, GPIO0)); _for_each_inner!((ADC1_CH1, GPIO1));
-        _for_each_inner!((ADC1_CH2, GPIO2)); _for_each_inner!((ADC1_CH3, GPIO3));
-        _for_each_inner!((ADC1_CH4, GPIO4)); _for_each_inner!((ADC2_CH0, GPIO5));
-        _for_each_inner!((USB_DM, GPIO18)); _for_each_inner!((USB_DP, GPIO19));
-        _for_each_inner!(((ADC1_CH0, ADCn_CHm, 1, 0), GPIO0));
-        _for_each_inner!(((ADC1_CH1, ADCn_CHm, 1, 1), GPIO1));
-        _for_each_inner!(((ADC1_CH2, ADCn_CHm, 1, 2), GPIO2));
-        _for_each_inner!(((ADC1_CH3, ADCn_CHm, 1, 3), GPIO3));
-        _for_each_inner!(((ADC1_CH4, ADCn_CHm, 1, 4), GPIO4));
-        _for_each_inner!(((ADC2_CH0, ADCn_CHm, 2, 0), GPIO5));
-        _for_each_inner!((all(ADC1_CH0, GPIO0), (ADC1_CH1, GPIO1), (ADC1_CH2, GPIO2),
-        (ADC1_CH3, GPIO3), (ADC1_CH4, GPIO4), (ADC2_CH0, GPIO5), (USB_DM, GPIO18),
-        (USB_DP, GPIO19))); _for_each_inner!((all_expanded((ADC1_CH0, ADCn_CHm, 1, 0),
+        macro_rules! _for_each_inner_analog_function { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_analog_function!((ADC1_CH0, GPIO0));
+        _for_each_inner_analog_function!((ADC1_CH1, GPIO1));
+        _for_each_inner_analog_function!((ADC1_CH2, GPIO2));
+        _for_each_inner_analog_function!((ADC1_CH3, GPIO3));
+        _for_each_inner_analog_function!((ADC1_CH4, GPIO4));
+        _for_each_inner_analog_function!((ADC2_CH0, GPIO5));
+        _for_each_inner_analog_function!((USB_DM, GPIO18));
+        _for_each_inner_analog_function!((USB_DP, GPIO19));
+        _for_each_inner_analog_function!(((ADC1_CH0, ADCn_CHm, 1, 0), GPIO0));
+        _for_each_inner_analog_function!(((ADC1_CH1, ADCn_CHm, 1, 1), GPIO1));
+        _for_each_inner_analog_function!(((ADC1_CH2, ADCn_CHm, 1, 2), GPIO2));
+        _for_each_inner_analog_function!(((ADC1_CH3, ADCn_CHm, 1, 3), GPIO3));
+        _for_each_inner_analog_function!(((ADC1_CH4, ADCn_CHm, 1, 4), GPIO4));
+        _for_each_inner_analog_function!(((ADC2_CH0, ADCn_CHm, 2, 0), GPIO5));
+        _for_each_inner_analog_function!((all(ADC1_CH0, GPIO0), (ADC1_CH1, GPIO1),
+        (ADC1_CH2, GPIO2), (ADC1_CH3, GPIO3), (ADC1_CH4, GPIO4), (ADC2_CH0, GPIO5),
+        (USB_DM, GPIO18), (USB_DP, GPIO19)));
+        _for_each_inner_analog_function!((all_expanded((ADC1_CH0, ADCn_CHm, 1, 0),
         GPIO0), ((ADC1_CH1, ADCn_CHm, 1, 1), GPIO1), ((ADC1_CH2, ADCn_CHm, 1, 2), GPIO2),
         ((ADC1_CH3, ADCn_CHm, 1, 3), GPIO3), ((ADC1_CH4, ADCn_CHm, 1, 4), GPIO4),
         ((ADC2_CH0, ADCn_CHm, 2, 0), GPIO5)));
@@ -3378,22 +3546,25 @@ macro_rules! for_each_analog_function {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_lp_function {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((RTC_GPIO0, GPIO0)); _for_each_inner!((RTC_GPIO1, GPIO1));
-        _for_each_inner!((RTC_GPIO2, GPIO2)); _for_each_inner!((RTC_GPIO3, GPIO3));
-        _for_each_inner!((RTC_GPIO4, GPIO4)); _for_each_inner!((RTC_GPIO5, GPIO5));
-        _for_each_inner!(((RTC_GPIO0, RTC_GPIOn, 0), GPIO0));
-        _for_each_inner!(((RTC_GPIO1, RTC_GPIOn, 1), GPIO1));
-        _for_each_inner!(((RTC_GPIO2, RTC_GPIOn, 2), GPIO2));
-        _for_each_inner!(((RTC_GPIO3, RTC_GPIOn, 3), GPIO3));
-        _for_each_inner!(((RTC_GPIO4, RTC_GPIOn, 4), GPIO4));
-        _for_each_inner!(((RTC_GPIO5, RTC_GPIOn, 5), GPIO5));
-        _for_each_inner!((all(RTC_GPIO0, GPIO0), (RTC_GPIO1, GPIO1), (RTC_GPIO2, GPIO2),
-        (RTC_GPIO3, GPIO3), (RTC_GPIO4, GPIO4), (RTC_GPIO5, GPIO5)));
-        _for_each_inner!((all_expanded((RTC_GPIO0, RTC_GPIOn, 0), GPIO0), ((RTC_GPIO1,
-        RTC_GPIOn, 1), GPIO1), ((RTC_GPIO2, RTC_GPIOn, 2), GPIO2), ((RTC_GPIO3,
-        RTC_GPIOn, 3), GPIO3), ((RTC_GPIO4, RTC_GPIOn, 4), GPIO4), ((RTC_GPIO5,
-        RTC_GPIOn, 5), GPIO5)));
+        macro_rules! _for_each_inner_lp_function { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_lp_function!((RTC_GPIO0, GPIO0));
+        _for_each_inner_lp_function!((RTC_GPIO1, GPIO1));
+        _for_each_inner_lp_function!((RTC_GPIO2, GPIO2));
+        _for_each_inner_lp_function!((RTC_GPIO3, GPIO3));
+        _for_each_inner_lp_function!((RTC_GPIO4, GPIO4));
+        _for_each_inner_lp_function!((RTC_GPIO5, GPIO5));
+        _for_each_inner_lp_function!(((RTC_GPIO0, RTC_GPIOn, 0), GPIO0));
+        _for_each_inner_lp_function!(((RTC_GPIO1, RTC_GPIOn, 1), GPIO1));
+        _for_each_inner_lp_function!(((RTC_GPIO2, RTC_GPIOn, 2), GPIO2));
+        _for_each_inner_lp_function!(((RTC_GPIO3, RTC_GPIOn, 3), GPIO3));
+        _for_each_inner_lp_function!(((RTC_GPIO4, RTC_GPIOn, 4), GPIO4));
+        _for_each_inner_lp_function!(((RTC_GPIO5, RTC_GPIOn, 5), GPIO5));
+        _for_each_inner_lp_function!((all(RTC_GPIO0, GPIO0), (RTC_GPIO1, GPIO1),
+        (RTC_GPIO2, GPIO2), (RTC_GPIO3, GPIO3), (RTC_GPIO4, GPIO4), (RTC_GPIO5, GPIO5)));
+        _for_each_inner_lp_function!((all_expanded((RTC_GPIO0, RTC_GPIOn, 0), GPIO0),
+        ((RTC_GPIO1, RTC_GPIOn, 1), GPIO1), ((RTC_GPIO2, RTC_GPIOn, 2), GPIO2),
+        ((RTC_GPIO3, RTC_GPIOn, 3), GPIO3), ((RTC_GPIO4, RTC_GPIOn, 4), GPIO4),
+        ((RTC_GPIO5, RTC_GPIOn, 5), GPIO5)));
     };
 }
 /// Defines the `InputSignal` and `OutputSignal` enums.

--- a/esp-metadata-generated/src/_generated_esp32c5.rs
+++ b/esp-metadata-generated/src/_generated_esp32c5.rs
@@ -1789,11 +1789,12 @@ macro_rules! memory_range {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_sw_interrupt {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((0, FROM_CPU_INTR0, software_interrupt0)); _for_each_inner!((1,
-        FROM_CPU_INTR1, software_interrupt1)); _for_each_inner!((2, FROM_CPU_INTR2,
-        software_interrupt2)); _for_each_inner!((3, FROM_CPU_INTR3,
-        software_interrupt3)); _for_each_inner!((all(0, FROM_CPU_INTR0,
+        macro_rules! _for_each_inner_sw_interrupt { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_sw_interrupt!((0, FROM_CPU_INTR0,
+        software_interrupt0)); _for_each_inner_sw_interrupt!((1, FROM_CPU_INTR1,
+        software_interrupt1)); _for_each_inner_sw_interrupt!((2, FROM_CPU_INTR2,
+        software_interrupt2)); _for_each_inner_sw_interrupt!((3, FROM_CPU_INTR3,
+        software_interrupt3)); _for_each_inner_sw_interrupt!((all(0, FROM_CPU_INTR0,
         software_interrupt0), (1, FROM_CPU_INTR1, software_interrupt1), (2,
         FROM_CPU_INTR2, software_interrupt2), (3, FROM_CPU_INTR3, software_interrupt3)));
     };
@@ -1833,165 +1834,202 @@ macro_rules! sw_interrupt_delay {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_peripheral {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((@ peri_type #[doc = "APB_SARADC peripheral singleton"]
-        APB_SARADC <= APB_SARADC() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "CLINT peripheral singleton"] CLINT <= CLINT() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "DMA peripheral singleton"] DMA <= DMA() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "DS peripheral singleton"] DS <= DS()
-        (unstable))); _for_each_inner!((@ peri_type #[doc = "ECC peripheral singleton"]
-        ECC <= ECC() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "ECDSA peripheral singleton"] ECDSA <= ECDSA() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "EFUSE peripheral singleton"] EFUSE <= EFUSE() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "ETM peripheral singleton"] ETM <=
-        SOC_ETM() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "HMAC peripheral singleton"] HMAC <= HMAC() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "HP_APM peripheral singleton"] HP_APM <= HP_APM() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "HP_SYS peripheral singleton"] HP_SYS <=
-        HP_SYS() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "HUK peripheral singleton"] HUK <= HUK() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "I2C_ANA_MST peripheral singleton"] I2C_ANA_MST <=
-        I2C_ANA_MST() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "I2C0 peripheral singleton"] I2C0 <= I2C0(I2C_EXT0 : { bind_peri_interrupt,
+        macro_rules! _for_each_inner_peripheral { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_peripheral!((@ peri_type #[doc =
+        "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "CLINT peripheral singleton"]
+        CLINT <= CLINT() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "DMA peripheral singleton"] DMA <= DMA() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DS peripheral singleton"] DS <=
+        DS() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "ECC peripheral singleton"] ECC <= ECC() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "ECDSA peripheral singleton"]
+        ECDSA <= ECDSA() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "EFUSE peripheral singleton"] EFUSE <= EFUSE() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "ETM peripheral singleton"] ETM
+        <= SOC_ETM() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "HMAC peripheral singleton"] HMAC <= HMAC() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "HP_APM peripheral singleton"]
+        HP_APM <= HP_APM() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "HP_SYS peripheral singleton"] HP_SYS <= HP_SYS() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "HUK peripheral singleton"] HUK
+        <= HUK() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "I2C_ANA_MST peripheral singleton"] I2C_ANA_MST <= I2C_ANA_MST() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "I2C0 peripheral singleton"]
+        I2C0 <= I2C0(I2C_EXT0 : { bind_peri_interrupt, enable_peri_interrupt,
+        disable_peri_interrupt }) (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "I2S0 peripheral singleton"] I2S0 <= I2S0(I2S0 : { bind_peri_interrupt,
         enable_peri_interrupt, disable_peri_interrupt }) (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "I2S0 peripheral singleton"] I2S0 <=
-        I2S0(I2S0 : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt
-        }) (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc =
         "INTERRUPT_CORE0 peripheral singleton"] INTERRUPT_CORE0 <= INTERRUPT_CORE0()
-        (unstable))); _for_each_inner!((@ peri_type #[doc =
+        (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "INTPRI peripheral singleton"] INTPRI <= INTPRI() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "IO_MUX peripheral singleton"] IO_MUX <=
-        IO_MUX() (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "IO_MUX peripheral singleton"]
+        IO_MUX <= IO_MUX() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "KEYMNG peripheral singleton"] KEYMNG <= KEYMNG() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "LP_ANA peripheral singleton"] LP_ANA <=
-        LP_ANA() (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "LP_ANA peripheral singleton"]
+        LP_ANA <= LP_ANA() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "LP_AON peripheral singleton"] LP_AON <= LP_AON() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "LP_APM0 peripheral singleton"] LP_APM0 <=
-        LP_APM0() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "LP_CLKRST peripheral singleton"] LP_CLKRST <= LP_CLKRST() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "LP_I2C0 peripheral singleton"] LP_I2C0 <=
-        LP_I2C0() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "LP_I2C_ANA_MST peripheral singleton"] LP_I2C_ANA_MST <= LP_I2C_ANA_MST()
-        (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "LP_APM0 peripheral singleton"]
+        LP_APM0 <= LP_APM0() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "LP_CLKRST peripheral singleton"] LP_CLKRST <= LP_CLKRST() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "LP_I2C0 peripheral singleton"]
+        LP_I2C0 <= LP_I2C0() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "LP_I2C_ANA_MST peripheral singleton"] LP_I2C_ANA_MST <= LP_I2C_ANA_MST()
+        (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "LP_IO_MUX peripheral singleton"] LP_IO_MUX <= LP_IO_MUX() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "LP_PERI peripheral singleton"] LP_PERI <=
-        LPPERI() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "LP_TEE peripheral singleton"] LP_TEE <= LP_TEE() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "LP_TIMER peripheral singleton"] LP_TIMER
-        <= LP_TIMER() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "LP_UART peripheral singleton"] LP_UART <= LP_UART() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "LP_WDT peripheral singleton"] LP_WDT <=
-        LP_WDT() (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "LP_PERI peripheral singleton"]
+        LP_PERI <= LPPERI() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "LP_TEE peripheral singleton"] LP_TEE <= LP_TEE() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "LP_TIMER peripheral singleton"]
+        LP_TIMER <= LP_TIMER() (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "LP_UART peripheral singleton"] LP_UART <= LP_UART() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "LP_WDT peripheral singleton"]
+        LP_WDT <= LP_WDT() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "LPWR peripheral singleton"] LPWR <= LP_CLKRST() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "MCPWM0 peripheral singleton"] MCPWM0 <=
-        MCPWM0() (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "MCPWM0 peripheral singleton"]
+        MCPWM0 <= MCPWM0() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "MEM_MONITOR peripheral singleton"] MEM_MONITOR <= MEM_MONITOR() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "MODEM_LPCON peripheral singleton"]
-        MODEM_LPCON <= MODEM_LPCON() (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "MODEM_LPCON peripheral singleton"] MODEM_LPCON <= MODEM_LPCON() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
         "MODEM_SYSCON peripheral singleton"] MODEM_SYSCON <= MODEM_SYSCON() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "PARL_IO peripheral singleton"] PARL_IO <=
-        PARL_IO(PARL_IO_RX : { bind_rx_interrupt, enable_rx_interrupt,
+        _for_each_inner_peripheral!((@ peri_type #[doc = "PARL_IO peripheral singleton"]
+        PARL_IO <= PARL_IO(PARL_IO_RX : { bind_rx_interrupt, enable_rx_interrupt,
         disable_rx_interrupt }, PARL_IO_TX : { bind_tx_interrupt, enable_tx_interrupt,
-        disable_tx_interrupt }) (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "PAU peripheral singleton"] PAU <= PAU() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "PCR peripheral singleton"] PCR <= PCR() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "PMU peripheral singleton"] PMU <= PMU()
-        (unstable))); _for_each_inner!((@ peri_type #[doc =
+        disable_tx_interrupt }) (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "PAU peripheral singleton"] PAU <= PAU() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "PCR peripheral singleton"] PCR
+        <= PCR() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "PMU peripheral singleton"] PMU <= PMU() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
         "PVT_MONITOR peripheral singleton"] PVT_MONITOR <= PVT() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "RMT peripheral singleton"] RMT <= RMT()
-        (unstable))); _for_each_inner!((@ peri_type #[doc = "RSA peripheral singleton"]
-        RSA <= RSA(RSA : { bind_peri_interrupt, enable_peri_interrupt,
-        disable_peri_interrupt }) (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "SHA peripheral singleton"] SHA <= SHA(SHA : { bind_peri_interrupt,
+        _for_each_inner_peripheral!((@ peri_type #[doc = "RMT peripheral singleton"] RMT
+        <= RMT() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "RSA peripheral singleton"] RSA <= RSA(RSA : { bind_peri_interrupt,
         enable_peri_interrupt, disable_peri_interrupt }) (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "SLC peripheral singleton"] SLC <= SLC()
-        (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "SYSTEM peripheral singleton"] SYSTEM <= PCR() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "SYSTIMER peripheral singleton"] SYSTIMER <= SYSTIMER()
-        (unstable))); _for_each_inner!((@ peri_type #[doc = "TEE peripheral singleton"]
-        TEE <= TEE() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "TIMG0 peripheral singleton"] TIMG0 <= TIMG0() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "TIMG1 peripheral singleton"] TIMG1 <= TIMG1() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "TRACE0 peripheral singleton"] TRACE0 <=
-        TRACE() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "UART0 peripheral singleton"] UART0 <= UART0(UART0 : { bind_peri_interrupt,
-        enable_peri_interrupt, disable_peri_interrupt }) (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "UART1 peripheral singleton"] UART1 <=
-        UART1(UART1 : { bind_peri_interrupt, enable_peri_interrupt,
-        disable_peri_interrupt }) (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "UHCI0 peripheral singleton"] UHCI0 <= UHCI0() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "USB_DEVICE peripheral singleton"] USB_DEVICE <=
-        USB_DEVICE(USB_DEVICE : { bind_peri_interrupt, enable_peri_interrupt,
-        disable_peri_interrupt }) (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "BT peripheral singleton"] BT <= virtual() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "FLASH peripheral singleton"] FLASH <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "LP_CORE peripheral singleton"] LP_CORE <=
-        virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "SW_INTERRUPT peripheral singleton"] SW_INTERRUPT <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "WIFI peripheral singleton"] WIFI <=
-        virtual() (unstable))); _for_each_inner!((APB_SARADC(unstable)));
-        _for_each_inner!((CLINT(unstable))); _for_each_inner!((DMA(unstable)));
-        _for_each_inner!((DS(unstable))); _for_each_inner!((ECC(unstable)));
-        _for_each_inner!((ECDSA(unstable))); _for_each_inner!((EFUSE(unstable)));
-        _for_each_inner!((ETM(unstable))); _for_each_inner!((HMAC(unstable)));
-        _for_each_inner!((HP_APM(unstable))); _for_each_inner!((HP_SYS(unstable)));
-        _for_each_inner!((HUK(unstable))); _for_each_inner!((I2C_ANA_MST(unstable)));
-        _for_each_inner!((I2C0(unstable))); _for_each_inner!((I2S0(unstable)));
-        _for_each_inner!((INTERRUPT_CORE0(unstable)));
-        _for_each_inner!((INTPRI(unstable))); _for_each_inner!((IO_MUX(unstable)));
-        _for_each_inner!((KEYMNG(unstable))); _for_each_inner!((LP_ANA(unstable)));
-        _for_each_inner!((LP_AON(unstable))); _for_each_inner!((LP_APM0(unstable)));
-        _for_each_inner!((LP_CLKRST(unstable))); _for_each_inner!((LP_I2C0(unstable)));
-        _for_each_inner!((LP_I2C_ANA_MST(unstable)));
-        _for_each_inner!((LP_IO_MUX(unstable))); _for_each_inner!((LP_PERI(unstable)));
-        _for_each_inner!((LP_TEE(unstable))); _for_each_inner!((LP_TIMER(unstable)));
-        _for_each_inner!((LP_UART(unstable))); _for_each_inner!((LP_WDT(unstable)));
-        _for_each_inner!((LPWR(unstable))); _for_each_inner!((MCPWM0(unstable)));
-        _for_each_inner!((MEM_MONITOR(unstable)));
-        _for_each_inner!((MODEM_LPCON(unstable)));
-        _for_each_inner!((MODEM_SYSCON(unstable)));
-        _for_each_inner!((PARL_IO(unstable))); _for_each_inner!((PAU(unstable)));
-        _for_each_inner!((PCR(unstable))); _for_each_inner!((PMU(unstable)));
-        _for_each_inner!((PVT_MONITOR(unstable))); _for_each_inner!((RMT(unstable)));
-        _for_each_inner!((RSA(unstable))); _for_each_inner!((SHA(unstable)));
-        _for_each_inner!((SLC(unstable))); _for_each_inner!((SYSTEM(unstable)));
-        _for_each_inner!((SYSTIMER(unstable))); _for_each_inner!((TEE(unstable)));
-        _for_each_inner!((TIMG0(unstable))); _for_each_inner!((TIMG1(unstable)));
-        _for_each_inner!((TRACE0(unstable))); _for_each_inner!((UART0(unstable)));
-        _for_each_inner!((UART1(unstable))); _for_each_inner!((UHCI0(unstable)));
-        _for_each_inner!((USB_DEVICE(unstable))); _for_each_inner!((BT(unstable)));
-        _for_each_inner!((FLASH(unstable))); _for_each_inner!((LP_CORE(unstable)));
-        _for_each_inner!((SW_INTERRUPT(unstable))); _for_each_inner!((WIFI(unstable)));
-        _for_each_inner!((all(@ peri_type #[doc = "APB_SARADC peripheral singleton"]
-        APB_SARADC <= APB_SARADC() (unstable)), (@ peri_type #[doc =
-        "CLINT peripheral singleton"] CLINT <= CLINT() (unstable)), (@ peri_type #[doc =
-        "DMA peripheral singleton"] DMA <= DMA() (unstable)), (@ peri_type #[doc =
-        "DS peripheral singleton"] DS <= DS() (unstable)), (@ peri_type #[doc =
-        "ECC peripheral singleton"] ECC <= ECC() (unstable)), (@ peri_type #[doc =
-        "ECDSA peripheral singleton"] ECDSA <= ECDSA() (unstable)), (@ peri_type #[doc =
-        "EFUSE peripheral singleton"] EFUSE <= EFUSE() (unstable)), (@ peri_type #[doc =
-        "ETM peripheral singleton"] ETM <= SOC_ETM() (unstable)), (@ peri_type #[doc =
-        "HMAC peripheral singleton"] HMAC <= HMAC() (unstable)), (@ peri_type #[doc =
-        "HP_APM peripheral singleton"] HP_APM <= HP_APM() (unstable)), (@ peri_type #[doc
-        = "HP_SYS peripheral singleton"] HP_SYS <= HP_SYS() (unstable)), (@ peri_type
-        #[doc = "HUK peripheral singleton"] HUK <= HUK() (unstable)), (@ peri_type #[doc
-        = "I2C_ANA_MST peripheral singleton"] I2C_ANA_MST <= I2C_ANA_MST() (unstable)),
-        (@ peri_type #[doc = "I2C0 peripheral singleton"] I2C0 <= I2C0(I2C_EXT0 : {
+        _for_each_inner_peripheral!((@ peri_type #[doc = "SHA peripheral singleton"] SHA
+        <= SHA(SHA : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt
+        }) (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "SLC peripheral singleton"] SLC <= SLC() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "SYSTEM peripheral singleton"]
+        SYSTEM <= PCR() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "SYSTIMER peripheral singleton"] SYSTIMER <= SYSTIMER() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "TEE peripheral singleton"] TEE
+        <= TEE() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "TIMG0 peripheral singleton"] TIMG0 <= TIMG0() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "TIMG1 peripheral singleton"]
+        TIMG1 <= TIMG1() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "TRACE0 peripheral singleton"] TRACE0 <= TRACE() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "UART0 peripheral singleton"]
+        UART0 <= UART0(UART0 : { bind_peri_interrupt, enable_peri_interrupt,
+        disable_peri_interrupt }) (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "UART1 peripheral singleton"] UART1 <= UART1(UART1 : {
         bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
-        (unstable)), (@ peri_type #[doc = "I2S0 peripheral singleton"] I2S0 <= I2S0(I2S0
-        : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
-        (unstable)), (@ peri_type #[doc = "INTERRUPT_CORE0 peripheral singleton"]
-        INTERRUPT_CORE0 <= INTERRUPT_CORE0() (unstable)), (@ peri_type #[doc =
-        "INTPRI peripheral singleton"] INTPRI <= INTPRI() (unstable)), (@ peri_type #[doc
-        = "IO_MUX peripheral singleton"] IO_MUX <= IO_MUX() (unstable)), (@ peri_type
-        #[doc = "KEYMNG peripheral singleton"] KEYMNG <= KEYMNG() (unstable)), (@
-        peri_type #[doc = "LP_ANA peripheral singleton"] LP_ANA <= LP_ANA() (unstable)),
-        (@ peri_type #[doc = "LP_AON peripheral singleton"] LP_AON <= LP_AON()
-        (unstable)), (@ peri_type #[doc = "LP_APM0 peripheral singleton"] LP_APM0 <=
-        LP_APM0() (unstable)), (@ peri_type #[doc = "LP_CLKRST peripheral singleton"]
-        LP_CLKRST <= LP_CLKRST() (unstable)), (@ peri_type #[doc =
-        "LP_I2C0 peripheral singleton"] LP_I2C0 <= LP_I2C0() (unstable)), (@ peri_type
-        #[doc = "LP_I2C_ANA_MST peripheral singleton"] LP_I2C_ANA_MST <= LP_I2C_ANA_MST()
+        (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "UHCI0 peripheral singleton"] UHCI0 <= UHCI0() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "USB_DEVICE peripheral singleton"] USB_DEVICE <= USB_DEVICE(USB_DEVICE : {
+        bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
+        (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "BT peripheral singleton"] BT <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "FLASH peripheral singleton"]
+        FLASH <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "LP_CORE peripheral singleton"] LP_CORE <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "SW_INTERRUPT peripheral singleton"] SW_INTERRUPT <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "WIFI peripheral singleton"]
+        WIFI <= virtual() (unstable)));
+        _for_each_inner_peripheral!((APB_SARADC(unstable)));
+        _for_each_inner_peripheral!((CLINT(unstable)));
+        _for_each_inner_peripheral!((DMA(unstable)));
+        _for_each_inner_peripheral!((DS(unstable)));
+        _for_each_inner_peripheral!((ECC(unstable)));
+        _for_each_inner_peripheral!((ECDSA(unstable)));
+        _for_each_inner_peripheral!((EFUSE(unstable)));
+        _for_each_inner_peripheral!((ETM(unstable)));
+        _for_each_inner_peripheral!((HMAC(unstable)));
+        _for_each_inner_peripheral!((HP_APM(unstable)));
+        _for_each_inner_peripheral!((HP_SYS(unstable)));
+        _for_each_inner_peripheral!((HUK(unstable)));
+        _for_each_inner_peripheral!((I2C_ANA_MST(unstable)));
+        _for_each_inner_peripheral!((I2C0(unstable)));
+        _for_each_inner_peripheral!((I2S0(unstable)));
+        _for_each_inner_peripheral!((INTERRUPT_CORE0(unstable)));
+        _for_each_inner_peripheral!((INTPRI(unstable)));
+        _for_each_inner_peripheral!((IO_MUX(unstable)));
+        _for_each_inner_peripheral!((KEYMNG(unstable)));
+        _for_each_inner_peripheral!((LP_ANA(unstable)));
+        _for_each_inner_peripheral!((LP_AON(unstable)));
+        _for_each_inner_peripheral!((LP_APM0(unstable)));
+        _for_each_inner_peripheral!((LP_CLKRST(unstable)));
+        _for_each_inner_peripheral!((LP_I2C0(unstable)));
+        _for_each_inner_peripheral!((LP_I2C_ANA_MST(unstable)));
+        _for_each_inner_peripheral!((LP_IO_MUX(unstable)));
+        _for_each_inner_peripheral!((LP_PERI(unstable)));
+        _for_each_inner_peripheral!((LP_TEE(unstable)));
+        _for_each_inner_peripheral!((LP_TIMER(unstable)));
+        _for_each_inner_peripheral!((LP_UART(unstable)));
+        _for_each_inner_peripheral!((LP_WDT(unstable)));
+        _for_each_inner_peripheral!((LPWR(unstable)));
+        _for_each_inner_peripheral!((MCPWM0(unstable)));
+        _for_each_inner_peripheral!((MEM_MONITOR(unstable)));
+        _for_each_inner_peripheral!((MODEM_LPCON(unstable)));
+        _for_each_inner_peripheral!((MODEM_SYSCON(unstable)));
+        _for_each_inner_peripheral!((PARL_IO(unstable)));
+        _for_each_inner_peripheral!((PAU(unstable)));
+        _for_each_inner_peripheral!((PCR(unstable)));
+        _for_each_inner_peripheral!((PMU(unstable)));
+        _for_each_inner_peripheral!((PVT_MONITOR(unstable)));
+        _for_each_inner_peripheral!((RMT(unstable)));
+        _for_each_inner_peripheral!((RSA(unstable)));
+        _for_each_inner_peripheral!((SHA(unstable)));
+        _for_each_inner_peripheral!((SLC(unstable)));
+        _for_each_inner_peripheral!((SYSTEM(unstable)));
+        _for_each_inner_peripheral!((SYSTIMER(unstable)));
+        _for_each_inner_peripheral!((TEE(unstable)));
+        _for_each_inner_peripheral!((TIMG0(unstable)));
+        _for_each_inner_peripheral!((TIMG1(unstable)));
+        _for_each_inner_peripheral!((TRACE0(unstable)));
+        _for_each_inner_peripheral!((UART0(unstable)));
+        _for_each_inner_peripheral!((UART1(unstable)));
+        _for_each_inner_peripheral!((UHCI0(unstable)));
+        _for_each_inner_peripheral!((USB_DEVICE(unstable)));
+        _for_each_inner_peripheral!((BT(unstable)));
+        _for_each_inner_peripheral!((FLASH(unstable)));
+        _for_each_inner_peripheral!((LP_CORE(unstable)));
+        _for_each_inner_peripheral!((SW_INTERRUPT(unstable)));
+        _for_each_inner_peripheral!((WIFI(unstable))); _for_each_inner_peripheral!((all(@
+        peri_type #[doc = "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC()
+        (unstable)), (@ peri_type #[doc = "CLINT peripheral singleton"] CLINT <= CLINT()
+        (unstable)), (@ peri_type #[doc = "DMA peripheral singleton"] DMA <= DMA()
+        (unstable)), (@ peri_type #[doc = "DS peripheral singleton"] DS <= DS()
+        (unstable)), (@ peri_type #[doc = "ECC peripheral singleton"] ECC <= ECC()
+        (unstable)), (@ peri_type #[doc = "ECDSA peripheral singleton"] ECDSA <= ECDSA()
+        (unstable)), (@ peri_type #[doc = "EFUSE peripheral singleton"] EFUSE <= EFUSE()
+        (unstable)), (@ peri_type #[doc = "ETM peripheral singleton"] ETM <= SOC_ETM()
+        (unstable)), (@ peri_type #[doc = "HMAC peripheral singleton"] HMAC <= HMAC()
+        (unstable)), (@ peri_type #[doc = "HP_APM peripheral singleton"] HP_APM <=
+        HP_APM() (unstable)), (@ peri_type #[doc = "HP_SYS peripheral singleton"] HP_SYS
+        <= HP_SYS() (unstable)), (@ peri_type #[doc = "HUK peripheral singleton"] HUK <=
+        HUK() (unstable)), (@ peri_type #[doc = "I2C_ANA_MST peripheral singleton"]
+        I2C_ANA_MST <= I2C_ANA_MST() (unstable)), (@ peri_type #[doc =
+        "I2C0 peripheral singleton"] I2C0 <= I2C0(I2C_EXT0 : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt }) (unstable)), (@ peri_type #[doc
+        = "I2S0 peripheral singleton"] I2S0 <= I2S0(I2S0 : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt }) (unstable)), (@ peri_type #[doc
+        = "INTERRUPT_CORE0 peripheral singleton"] INTERRUPT_CORE0 <= INTERRUPT_CORE0()
+        (unstable)), (@ peri_type #[doc = "INTPRI peripheral singleton"] INTPRI <=
+        INTPRI() (unstable)), (@ peri_type #[doc = "IO_MUX peripheral singleton"] IO_MUX
+        <= IO_MUX() (unstable)), (@ peri_type #[doc = "KEYMNG peripheral singleton"]
+        KEYMNG <= KEYMNG() (unstable)), (@ peri_type #[doc =
+        "LP_ANA peripheral singleton"] LP_ANA <= LP_ANA() (unstable)), (@ peri_type #[doc
+        = "LP_AON peripheral singleton"] LP_AON <= LP_AON() (unstable)), (@ peri_type
+        #[doc = "LP_APM0 peripheral singleton"] LP_APM0 <= LP_APM0() (unstable)), (@
+        peri_type #[doc = "LP_CLKRST peripheral singleton"] LP_CLKRST <= LP_CLKRST()
+        (unstable)), (@ peri_type #[doc = "LP_I2C0 peripheral singleton"] LP_I2C0 <=
+        LP_I2C0() (unstable)), (@ peri_type #[doc =
+        "LP_I2C_ANA_MST peripheral singleton"] LP_I2C_ANA_MST <= LP_I2C_ANA_MST()
         (unstable)), (@ peri_type #[doc = "LP_IO_MUX peripheral singleton"] LP_IO_MUX <=
         LP_IO_MUX() (unstable)), (@ peri_type #[doc = "LP_PERI peripheral singleton"]
         LP_PERI <= LPPERI() (unstable)), (@ peri_type #[doc =
@@ -2040,7 +2078,7 @@ macro_rules! for_each_peripheral {
         LP_CORE <= virtual() (unstable)), (@ peri_type #[doc =
         "SW_INTERRUPT peripheral singleton"] SW_INTERRUPT <= virtual() (unstable)), (@
         peri_type #[doc = "WIFI peripheral singleton"] WIFI <= virtual() (unstable))));
-        _for_each_inner!((singletons(APB_SARADC(unstable)), (CLINT(unstable)),
+        _for_each_inner_peripheral!((singletons(APB_SARADC(unstable)), (CLINT(unstable)),
         (DMA(unstable)), (DS(unstable)), (ECC(unstable)), (ECDSA(unstable)),
         (EFUSE(unstable)), (ETM(unstable)), (HMAC(unstable)), (HP_APM(unstable)),
         (HP_SYS(unstable)), (HUK(unstable)), (I2C_ANA_MST(unstable)), (I2C0(unstable)),

--- a/esp-metadata-generated/src/_generated_esp32c6.rs
+++ b/esp-metadata-generated/src/_generated_esp32c6.rs
@@ -3018,39 +3018,47 @@ macro_rules! memory_range {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_aes_key_length {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((128)); _for_each_inner!((256)); _for_each_inner!((128, 0, 4));
-        _for_each_inner!((256, 2, 6)); _for_each_inner!((bits(128), (256)));
-        _for_each_inner!((modes(128, 0, 4), (256, 2, 6)));
+        macro_rules! _for_each_inner_aes_key_length { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_aes_key_length!((128));
+        _for_each_inner_aes_key_length!((256)); _for_each_inner_aes_key_length!((128, 0,
+        4)); _for_each_inner_aes_key_length!((256, 2, 6));
+        _for_each_inner_aes_key_length!((bits(128), (256)));
+        _for_each_inner_aes_key_length!((modes(128, 0, 4), (256, 2, 6)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_dedicated_gpio {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((0)); _for_each_inner!((1)); _for_each_inner!((2));
-        _for_each_inner!((3)); _for_each_inner!((4)); _for_each_inner!((5));
-        _for_each_inner!((6)); _for_each_inner!((7)); _for_each_inner!((0, 0,
-        CPU_GPIO_0)); _for_each_inner!((0, 1, CPU_GPIO_1)); _for_each_inner!((0, 2,
-        CPU_GPIO_2)); _for_each_inner!((0, 3, CPU_GPIO_3)); _for_each_inner!((0, 4,
-        CPU_GPIO_4)); _for_each_inner!((0, 5, CPU_GPIO_5)); _for_each_inner!((0, 6,
-        CPU_GPIO_6)); _for_each_inner!((0, 7, CPU_GPIO_7));
-        _for_each_inner!((channels(0), (1), (2), (3), (4), (5), (6), (7)));
-        _for_each_inner!((signals(0, 0, CPU_GPIO_0), (0, 1, CPU_GPIO_1), (0, 2,
-        CPU_GPIO_2), (0, 3, CPU_GPIO_3), (0, 4, CPU_GPIO_4), (0, 5, CPU_GPIO_5), (0, 6,
-        CPU_GPIO_6), (0, 7, CPU_GPIO_7)));
+        macro_rules! _for_each_inner_dedicated_gpio { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_dedicated_gpio!((0));
+        _for_each_inner_dedicated_gpio!((1)); _for_each_inner_dedicated_gpio!((2));
+        _for_each_inner_dedicated_gpio!((3)); _for_each_inner_dedicated_gpio!((4));
+        _for_each_inner_dedicated_gpio!((5)); _for_each_inner_dedicated_gpio!((6));
+        _for_each_inner_dedicated_gpio!((7)); _for_each_inner_dedicated_gpio!((0, 0,
+        CPU_GPIO_0)); _for_each_inner_dedicated_gpio!((0, 1, CPU_GPIO_1));
+        _for_each_inner_dedicated_gpio!((0, 2, CPU_GPIO_2));
+        _for_each_inner_dedicated_gpio!((0, 3, CPU_GPIO_3));
+        _for_each_inner_dedicated_gpio!((0, 4, CPU_GPIO_4));
+        _for_each_inner_dedicated_gpio!((0, 5, CPU_GPIO_5));
+        _for_each_inner_dedicated_gpio!((0, 6, CPU_GPIO_6));
+        _for_each_inner_dedicated_gpio!((0, 7, CPU_GPIO_7));
+        _for_each_inner_dedicated_gpio!((channels(0), (1), (2), (3), (4), (5), (6),
+        (7))); _for_each_inner_dedicated_gpio!((signals(0, 0, CPU_GPIO_0), (0, 1,
+        CPU_GPIO_1), (0, 2, CPU_GPIO_2), (0, 3, CPU_GPIO_3), (0, 4, CPU_GPIO_4), (0, 5,
+        CPU_GPIO_5), (0, 6, CPU_GPIO_6), (0, 7, CPU_GPIO_7)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_sw_interrupt {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((0, FROM_CPU_INTR0, software_interrupt0)); _for_each_inner!((1,
-        FROM_CPU_INTR1, software_interrupt1)); _for_each_inner!((2, FROM_CPU_INTR2,
-        software_interrupt2)); _for_each_inner!((3, FROM_CPU_INTR3,
-        software_interrupt3)); _for_each_inner!((all(0, FROM_CPU_INTR0,
+        macro_rules! _for_each_inner_sw_interrupt { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_sw_interrupt!((0, FROM_CPU_INTR0,
+        software_interrupt0)); _for_each_inner_sw_interrupt!((1, FROM_CPU_INTR1,
+        software_interrupt1)); _for_each_inner_sw_interrupt!((2, FROM_CPU_INTR2,
+        software_interrupt2)); _for_each_inner_sw_interrupt!((3, FROM_CPU_INTR3,
+        software_interrupt3)); _for_each_inner_sw_interrupt!((all(0, FROM_CPU_INTR0,
         software_interrupt0), (1, FROM_CPU_INTR1, software_interrupt1), (2,
         FROM_CPU_INTR2, software_interrupt2), (3, FROM_CPU_INTR3, software_interrupt3)));
     };
@@ -3101,113 +3109,215 @@ macro_rules! sw_interrupt_delay {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rmt_channel {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((0)); _for_each_inner!((1)); _for_each_inner!((2));
-        _for_each_inner!((3)); _for_each_inner!((0, 0)); _for_each_inner!((1, 1));
-        _for_each_inner!((2, 0)); _for_each_inner!((3, 1)); _for_each_inner!((all(0),
-        (1), (2), (3))); _for_each_inner!((tx(0, 0), (1, 1))); _for_each_inner!((rx(2,
-        0), (3, 1)));
+        macro_rules! _for_each_inner_rmt_channel { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_rmt_channel!((0)); _for_each_inner_rmt_channel!((1));
+        _for_each_inner_rmt_channel!((2)); _for_each_inner_rmt_channel!((3));
+        _for_each_inner_rmt_channel!((0, 0)); _for_each_inner_rmt_channel!((1, 1));
+        _for_each_inner_rmt_channel!((2, 0)); _for_each_inner_rmt_channel!((3, 1));
+        _for_each_inner_rmt_channel!((all(0), (1), (2), (3)));
+        _for_each_inner_rmt_channel!((tx(0, 0), (1, 1)));
+        _for_each_inner_rmt_channel!((rx(2, 0), (3, 1)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rmt_clock_source {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((Pll80MHz, 1)); _for_each_inner!((RcFast, 2));
-        _for_each_inner!((Xtal, 3)); _for_each_inner!((Pll80MHz));
-        _for_each_inner!((all(Pll80MHz, 1), (RcFast, 2), (Xtal, 3)));
-        _for_each_inner!((default(Pll80MHz)));
+        macro_rules! _for_each_inner_rmt_clock_source { $(($pattern) => $code;)* ($other
+        : tt) => {} } _for_each_inner_rmt_clock_source!((Pll80MHz, 1));
+        _for_each_inner_rmt_clock_source!((RcFast, 2));
+        _for_each_inner_rmt_clock_source!((Xtal, 3));
+        _for_each_inner_rmt_clock_source!((Pll80MHz));
+        _for_each_inner_rmt_clock_source!((all(Pll80MHz, 1), (RcFast, 2), (Xtal, 3)));
+        _for_each_inner_rmt_clock_source!((default(Pll80MHz)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rsa_exponentiation {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((32)); _for_each_inner!((64)); _for_each_inner!((96));
-        _for_each_inner!((128)); _for_each_inner!((160)); _for_each_inner!((192));
-        _for_each_inner!((224)); _for_each_inner!((256)); _for_each_inner!((288));
-        _for_each_inner!((320)); _for_each_inner!((352)); _for_each_inner!((384));
-        _for_each_inner!((416)); _for_each_inner!((448)); _for_each_inner!((480));
-        _for_each_inner!((512)); _for_each_inner!((544)); _for_each_inner!((576));
-        _for_each_inner!((608)); _for_each_inner!((640)); _for_each_inner!((672));
-        _for_each_inner!((704)); _for_each_inner!((736)); _for_each_inner!((768));
-        _for_each_inner!((800)); _for_each_inner!((832)); _for_each_inner!((864));
-        _for_each_inner!((896)); _for_each_inner!((928)); _for_each_inner!((960));
-        _for_each_inner!((992)); _for_each_inner!((1024)); _for_each_inner!((1056));
-        _for_each_inner!((1088)); _for_each_inner!((1120)); _for_each_inner!((1152));
-        _for_each_inner!((1184)); _for_each_inner!((1216)); _for_each_inner!((1248));
-        _for_each_inner!((1280)); _for_each_inner!((1312)); _for_each_inner!((1344));
-        _for_each_inner!((1376)); _for_each_inner!((1408)); _for_each_inner!((1440));
-        _for_each_inner!((1472)); _for_each_inner!((1504)); _for_each_inner!((1536));
-        _for_each_inner!((1568)); _for_each_inner!((1600)); _for_each_inner!((1632));
-        _for_each_inner!((1664)); _for_each_inner!((1696)); _for_each_inner!((1728));
-        _for_each_inner!((1760)); _for_each_inner!((1792)); _for_each_inner!((1824));
-        _for_each_inner!((1856)); _for_each_inner!((1888)); _for_each_inner!((1920));
-        _for_each_inner!((1952)); _for_each_inner!((1984)); _for_each_inner!((2016));
-        _for_each_inner!((2048)); _for_each_inner!((2080)); _for_each_inner!((2112));
-        _for_each_inner!((2144)); _for_each_inner!((2176)); _for_each_inner!((2208));
-        _for_each_inner!((2240)); _for_each_inner!((2272)); _for_each_inner!((2304));
-        _for_each_inner!((2336)); _for_each_inner!((2368)); _for_each_inner!((2400));
-        _for_each_inner!((2432)); _for_each_inner!((2464)); _for_each_inner!((2496));
-        _for_each_inner!((2528)); _for_each_inner!((2560)); _for_each_inner!((2592));
-        _for_each_inner!((2624)); _for_each_inner!((2656)); _for_each_inner!((2688));
-        _for_each_inner!((2720)); _for_each_inner!((2752)); _for_each_inner!((2784));
-        _for_each_inner!((2816)); _for_each_inner!((2848)); _for_each_inner!((2880));
-        _for_each_inner!((2912)); _for_each_inner!((2944)); _for_each_inner!((2976));
-        _for_each_inner!((3008)); _for_each_inner!((3040)); _for_each_inner!((3072));
-        _for_each_inner!((all(32), (64), (96), (128), (160), (192), (224), (256), (288),
-        (320), (352), (384), (416), (448), (480), (512), (544), (576), (608), (640),
-        (672), (704), (736), (768), (800), (832), (864), (896), (928), (960), (992),
-        (1024), (1056), (1088), (1120), (1152), (1184), (1216), (1248), (1280), (1312),
-        (1344), (1376), (1408), (1440), (1472), (1504), (1536), (1568), (1600), (1632),
-        (1664), (1696), (1728), (1760), (1792), (1824), (1856), (1888), (1920), (1952),
-        (1984), (2016), (2048), (2080), (2112), (2144), (2176), (2208), (2240), (2272),
-        (2304), (2336), (2368), (2400), (2432), (2464), (2496), (2528), (2560), (2592),
-        (2624), (2656), (2688), (2720), (2752), (2784), (2816), (2848), (2880), (2912),
-        (2944), (2976), (3008), (3040), (3072)));
+        macro_rules! _for_each_inner_rsa_exponentiation { $(($pattern) => $code;)*
+        ($other : tt) => {} } _for_each_inner_rsa_exponentiation!((32));
+        _for_each_inner_rsa_exponentiation!((64));
+        _for_each_inner_rsa_exponentiation!((96));
+        _for_each_inner_rsa_exponentiation!((128));
+        _for_each_inner_rsa_exponentiation!((160));
+        _for_each_inner_rsa_exponentiation!((192));
+        _for_each_inner_rsa_exponentiation!((224));
+        _for_each_inner_rsa_exponentiation!((256));
+        _for_each_inner_rsa_exponentiation!((288));
+        _for_each_inner_rsa_exponentiation!((320));
+        _for_each_inner_rsa_exponentiation!((352));
+        _for_each_inner_rsa_exponentiation!((384));
+        _for_each_inner_rsa_exponentiation!((416));
+        _for_each_inner_rsa_exponentiation!((448));
+        _for_each_inner_rsa_exponentiation!((480));
+        _for_each_inner_rsa_exponentiation!((512));
+        _for_each_inner_rsa_exponentiation!((544));
+        _for_each_inner_rsa_exponentiation!((576));
+        _for_each_inner_rsa_exponentiation!((608));
+        _for_each_inner_rsa_exponentiation!((640));
+        _for_each_inner_rsa_exponentiation!((672));
+        _for_each_inner_rsa_exponentiation!((704));
+        _for_each_inner_rsa_exponentiation!((736));
+        _for_each_inner_rsa_exponentiation!((768));
+        _for_each_inner_rsa_exponentiation!((800));
+        _for_each_inner_rsa_exponentiation!((832));
+        _for_each_inner_rsa_exponentiation!((864));
+        _for_each_inner_rsa_exponentiation!((896));
+        _for_each_inner_rsa_exponentiation!((928));
+        _for_each_inner_rsa_exponentiation!((960));
+        _for_each_inner_rsa_exponentiation!((992));
+        _for_each_inner_rsa_exponentiation!((1024));
+        _for_each_inner_rsa_exponentiation!((1056));
+        _for_each_inner_rsa_exponentiation!((1088));
+        _for_each_inner_rsa_exponentiation!((1120));
+        _for_each_inner_rsa_exponentiation!((1152));
+        _for_each_inner_rsa_exponentiation!((1184));
+        _for_each_inner_rsa_exponentiation!((1216));
+        _for_each_inner_rsa_exponentiation!((1248));
+        _for_each_inner_rsa_exponentiation!((1280));
+        _for_each_inner_rsa_exponentiation!((1312));
+        _for_each_inner_rsa_exponentiation!((1344));
+        _for_each_inner_rsa_exponentiation!((1376));
+        _for_each_inner_rsa_exponentiation!((1408));
+        _for_each_inner_rsa_exponentiation!((1440));
+        _for_each_inner_rsa_exponentiation!((1472));
+        _for_each_inner_rsa_exponentiation!((1504));
+        _for_each_inner_rsa_exponentiation!((1536));
+        _for_each_inner_rsa_exponentiation!((1568));
+        _for_each_inner_rsa_exponentiation!((1600));
+        _for_each_inner_rsa_exponentiation!((1632));
+        _for_each_inner_rsa_exponentiation!((1664));
+        _for_each_inner_rsa_exponentiation!((1696));
+        _for_each_inner_rsa_exponentiation!((1728));
+        _for_each_inner_rsa_exponentiation!((1760));
+        _for_each_inner_rsa_exponentiation!((1792));
+        _for_each_inner_rsa_exponentiation!((1824));
+        _for_each_inner_rsa_exponentiation!((1856));
+        _for_each_inner_rsa_exponentiation!((1888));
+        _for_each_inner_rsa_exponentiation!((1920));
+        _for_each_inner_rsa_exponentiation!((1952));
+        _for_each_inner_rsa_exponentiation!((1984));
+        _for_each_inner_rsa_exponentiation!((2016));
+        _for_each_inner_rsa_exponentiation!((2048));
+        _for_each_inner_rsa_exponentiation!((2080));
+        _for_each_inner_rsa_exponentiation!((2112));
+        _for_each_inner_rsa_exponentiation!((2144));
+        _for_each_inner_rsa_exponentiation!((2176));
+        _for_each_inner_rsa_exponentiation!((2208));
+        _for_each_inner_rsa_exponentiation!((2240));
+        _for_each_inner_rsa_exponentiation!((2272));
+        _for_each_inner_rsa_exponentiation!((2304));
+        _for_each_inner_rsa_exponentiation!((2336));
+        _for_each_inner_rsa_exponentiation!((2368));
+        _for_each_inner_rsa_exponentiation!((2400));
+        _for_each_inner_rsa_exponentiation!((2432));
+        _for_each_inner_rsa_exponentiation!((2464));
+        _for_each_inner_rsa_exponentiation!((2496));
+        _for_each_inner_rsa_exponentiation!((2528));
+        _for_each_inner_rsa_exponentiation!((2560));
+        _for_each_inner_rsa_exponentiation!((2592));
+        _for_each_inner_rsa_exponentiation!((2624));
+        _for_each_inner_rsa_exponentiation!((2656));
+        _for_each_inner_rsa_exponentiation!((2688));
+        _for_each_inner_rsa_exponentiation!((2720));
+        _for_each_inner_rsa_exponentiation!((2752));
+        _for_each_inner_rsa_exponentiation!((2784));
+        _for_each_inner_rsa_exponentiation!((2816));
+        _for_each_inner_rsa_exponentiation!((2848));
+        _for_each_inner_rsa_exponentiation!((2880));
+        _for_each_inner_rsa_exponentiation!((2912));
+        _for_each_inner_rsa_exponentiation!((2944));
+        _for_each_inner_rsa_exponentiation!((2976));
+        _for_each_inner_rsa_exponentiation!((3008));
+        _for_each_inner_rsa_exponentiation!((3040));
+        _for_each_inner_rsa_exponentiation!((3072));
+        _for_each_inner_rsa_exponentiation!((all(32), (64), (96), (128), (160), (192),
+        (224), (256), (288), (320), (352), (384), (416), (448), (480), (512), (544),
+        (576), (608), (640), (672), (704), (736), (768), (800), (832), (864), (896),
+        (928), (960), (992), (1024), (1056), (1088), (1120), (1152), (1184), (1216),
+        (1248), (1280), (1312), (1344), (1376), (1408), (1440), (1472), (1504), (1536),
+        (1568), (1600), (1632), (1664), (1696), (1728), (1760), (1792), (1824), (1856),
+        (1888), (1920), (1952), (1984), (2016), (2048), (2080), (2112), (2144), (2176),
+        (2208), (2240), (2272), (2304), (2336), (2368), (2400), (2432), (2464), (2496),
+        (2528), (2560), (2592), (2624), (2656), (2688), (2720), (2752), (2784), (2816),
+        (2848), (2880), (2912), (2944), (2976), (3008), (3040), (3072)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rsa_multiplication {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((32)); _for_each_inner!((64)); _for_each_inner!((96));
-        _for_each_inner!((128)); _for_each_inner!((160)); _for_each_inner!((192));
-        _for_each_inner!((224)); _for_each_inner!((256)); _for_each_inner!((288));
-        _for_each_inner!((320)); _for_each_inner!((352)); _for_each_inner!((384));
-        _for_each_inner!((416)); _for_each_inner!((448)); _for_each_inner!((480));
-        _for_each_inner!((512)); _for_each_inner!((544)); _for_each_inner!((576));
-        _for_each_inner!((608)); _for_each_inner!((640)); _for_each_inner!((672));
-        _for_each_inner!((704)); _for_each_inner!((736)); _for_each_inner!((768));
-        _for_each_inner!((800)); _for_each_inner!((832)); _for_each_inner!((864));
-        _for_each_inner!((896)); _for_each_inner!((928)); _for_each_inner!((960));
-        _for_each_inner!((992)); _for_each_inner!((1024)); _for_each_inner!((1056));
-        _for_each_inner!((1088)); _for_each_inner!((1120)); _for_each_inner!((1152));
-        _for_each_inner!((1184)); _for_each_inner!((1216)); _for_each_inner!((1248));
-        _for_each_inner!((1280)); _for_each_inner!((1312)); _for_each_inner!((1344));
-        _for_each_inner!((1376)); _for_each_inner!((1408)); _for_each_inner!((1440));
-        _for_each_inner!((1472)); _for_each_inner!((1504)); _for_each_inner!((1536));
-        _for_each_inner!((all(32), (64), (96), (128), (160), (192), (224), (256), (288),
-        (320), (352), (384), (416), (448), (480), (512), (544), (576), (608), (640),
-        (672), (704), (736), (768), (800), (832), (864), (896), (928), (960), (992),
-        (1024), (1056), (1088), (1120), (1152), (1184), (1216), (1248), (1280), (1312),
-        (1344), (1376), (1408), (1440), (1472), (1504), (1536)));
+        macro_rules! _for_each_inner_rsa_multiplication { $(($pattern) => $code;)*
+        ($other : tt) => {} } _for_each_inner_rsa_multiplication!((32));
+        _for_each_inner_rsa_multiplication!((64));
+        _for_each_inner_rsa_multiplication!((96));
+        _for_each_inner_rsa_multiplication!((128));
+        _for_each_inner_rsa_multiplication!((160));
+        _for_each_inner_rsa_multiplication!((192));
+        _for_each_inner_rsa_multiplication!((224));
+        _for_each_inner_rsa_multiplication!((256));
+        _for_each_inner_rsa_multiplication!((288));
+        _for_each_inner_rsa_multiplication!((320));
+        _for_each_inner_rsa_multiplication!((352));
+        _for_each_inner_rsa_multiplication!((384));
+        _for_each_inner_rsa_multiplication!((416));
+        _for_each_inner_rsa_multiplication!((448));
+        _for_each_inner_rsa_multiplication!((480));
+        _for_each_inner_rsa_multiplication!((512));
+        _for_each_inner_rsa_multiplication!((544));
+        _for_each_inner_rsa_multiplication!((576));
+        _for_each_inner_rsa_multiplication!((608));
+        _for_each_inner_rsa_multiplication!((640));
+        _for_each_inner_rsa_multiplication!((672));
+        _for_each_inner_rsa_multiplication!((704));
+        _for_each_inner_rsa_multiplication!((736));
+        _for_each_inner_rsa_multiplication!((768));
+        _for_each_inner_rsa_multiplication!((800));
+        _for_each_inner_rsa_multiplication!((832));
+        _for_each_inner_rsa_multiplication!((864));
+        _for_each_inner_rsa_multiplication!((896));
+        _for_each_inner_rsa_multiplication!((928));
+        _for_each_inner_rsa_multiplication!((960));
+        _for_each_inner_rsa_multiplication!((992));
+        _for_each_inner_rsa_multiplication!((1024));
+        _for_each_inner_rsa_multiplication!((1056));
+        _for_each_inner_rsa_multiplication!((1088));
+        _for_each_inner_rsa_multiplication!((1120));
+        _for_each_inner_rsa_multiplication!((1152));
+        _for_each_inner_rsa_multiplication!((1184));
+        _for_each_inner_rsa_multiplication!((1216));
+        _for_each_inner_rsa_multiplication!((1248));
+        _for_each_inner_rsa_multiplication!((1280));
+        _for_each_inner_rsa_multiplication!((1312));
+        _for_each_inner_rsa_multiplication!((1344));
+        _for_each_inner_rsa_multiplication!((1376));
+        _for_each_inner_rsa_multiplication!((1408));
+        _for_each_inner_rsa_multiplication!((1440));
+        _for_each_inner_rsa_multiplication!((1472));
+        _for_each_inner_rsa_multiplication!((1504));
+        _for_each_inner_rsa_multiplication!((1536));
+        _for_each_inner_rsa_multiplication!((all(32), (64), (96), (128), (160), (192),
+        (224), (256), (288), (320), (352), (384), (416), (448), (480), (512), (544),
+        (576), (608), (640), (672), (704), (736), (768), (800), (832), (864), (896),
+        (928), (960), (992), (1024), (1056), (1088), (1120), (1152), (1184), (1216),
+        (1248), (1280), (1312), (1344), (1376), (1408), (1440), (1472), (1504), (1536)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_sha_algorithm {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((Sha1, "SHA-1"(sizes : 64, 20, 8) (insecure_against :
-        "collision", "length extension"), 0)); _for_each_inner!((Sha224, "SHA-224"(sizes
-        : 64, 28, 8) (insecure_against : "length extension"), 1));
-        _for_each_inner!((Sha256, "SHA-256"(sizes : 64, 32, 8) (insecure_against :
-        "length extension"), 2)); _for_each_inner!((algos(Sha1, "SHA-1"(sizes : 64, 20,
-        8) (insecure_against : "collision", "length extension"), 0), (Sha224,
+        macro_rules! _for_each_inner_sha_algorithm { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_sha_algorithm!((Sha1, "SHA-1"(sizes : 64, 20, 8)
+        (insecure_against : "collision", "length extension"), 0));
+        _for_each_inner_sha_algorithm!((Sha224, "SHA-224"(sizes : 64, 28, 8)
+        (insecure_against : "length extension"), 1));
+        _for_each_inner_sha_algorithm!((Sha256, "SHA-256"(sizes : 64, 32, 8)
+        (insecure_against : "length extension"), 2));
+        _for_each_inner_sha_algorithm!((algos(Sha1, "SHA-1"(sizes : 64, 20, 8)
+        (insecure_against : "collision", "length extension"), 0), (Sha224,
         "SHA-224"(sizes : 64, 28, 8) (insecure_against : "length extension"), 1),
         (Sha256, "SHA-256"(sizes : 64, 32, 8) (insecure_against : "length extension"),
         2)));
@@ -3233,9 +3343,9 @@ macro_rules! for_each_sha_algorithm {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_i2c_master {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((I2C0, I2cExt0, I2CEXT0_SCL, I2CEXT0_SDA));
-        _for_each_inner!((all(I2C0, I2cExt0, I2CEXT0_SCL, I2CEXT0_SDA)));
+        macro_rules! _for_each_inner_i2c_master { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_i2c_master!((I2C0, I2cExt0, I2CEXT0_SCL, I2CEXT0_SDA));
+        _for_each_inner_i2c_master!((all(I2C0, I2cExt0, I2CEXT0_SCL, I2CEXT0_SDA)));
     };
 }
 /// This macro can be used to generate code for each peripheral instance of the UART driver.
@@ -3258,11 +3368,11 @@ macro_rules! for_each_i2c_master {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_uart {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS));
-        _for_each_inner!((UART1, Uart1, U1RXD, U1TXD, U1CTS, U1RTS));
-        _for_each_inner!((all(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS), (UART1, Uart1,
-        U1RXD, U1TXD, U1CTS, U1RTS)));
+        macro_rules! _for_each_inner_uart { $(($pattern) => $code;)* ($other : tt) => {}
+        } _for_each_inner_uart!((UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS));
+        _for_each_inner_uart!((UART1, Uart1, U1RXD, U1TXD, U1CTS, U1RTS));
+        _for_each_inner_uart!((all(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS), (UART1,
+        Uart1, U1RXD, U1TXD, U1CTS, U1RTS)));
     };
 }
 /// This macro can be used to generate code for each peripheral instance of the SPI master driver.
@@ -3290,11 +3400,11 @@ macro_rules! for_each_uart {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_spi_master {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((SPI2, Spi2, FSPICLK[FSPICS0, FSPICS1, FSPICS2, FSPICS3,
-        FSPICS4, FSPICS5] [FSPID, FSPIQ, FSPIWP, FSPIHD], true));
-        _for_each_inner!((all(SPI2, Spi2, FSPICLK[FSPICS0, FSPICS1, FSPICS2, FSPICS3,
-        FSPICS4, FSPICS5] [FSPID, FSPIQ, FSPIWP, FSPIHD], true)));
+        macro_rules! _for_each_inner_spi_master { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_spi_master!((SPI2, Spi2, FSPICLK[FSPICS0, FSPICS1,
+        FSPICS2, FSPICS3, FSPICS4, FSPICS5] [FSPID, FSPIQ, FSPIWP, FSPIHD], true));
+        _for_each_inner_spi_master!((all(SPI2, Spi2, FSPICLK[FSPICS0, FSPICS1, FSPICS2,
+        FSPICS3, FSPICS4, FSPICS5] [FSPID, FSPIQ, FSPIWP, FSPIHD], true)));
     };
 }
 /// This macro can be used to generate code for each peripheral instance of the SPI slave driver.
@@ -3317,341 +3427,415 @@ macro_rules! for_each_spi_master {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_spi_slave {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((SPI2, Spi2, FSPICLK, FSPID, FSPIQ, FSPICS0));
-        _for_each_inner!((all(SPI2, Spi2, FSPICLK, FSPID, FSPIQ, FSPICS0)));
+        macro_rules! _for_each_inner_spi_slave { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_spi_slave!((SPI2, Spi2, FSPICLK, FSPID, FSPIQ, FSPICS0));
+        _for_each_inner_spi_slave!((all(SPI2, Spi2, FSPICLK, FSPID, FSPIQ, FSPICS0)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_peripheral {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((@ peri_type #[doc = "GPIO0 peripheral singleton"] GPIO0 <=
-        virtual())); _for_each_inner!((@ peri_type #[doc = "GPIO1 peripheral singleton"]
-        GPIO1 <= virtual())); _for_each_inner!((@ peri_type #[doc =
-        "GPIO2 peripheral singleton"] GPIO2 <= virtual())); _for_each_inner!((@ peri_type
-        #[doc = "GPIO3 peripheral singleton"] GPIO3 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO4 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        macro_rules! _for_each_inner_peripheral { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO0 peripheral singleton"] GPIO0 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO1 peripheral singleton"]
+        GPIO1 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO2 peripheral singleton"] GPIO2 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO3 peripheral singleton"]
+        GPIO3 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO4 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin is a strapping pin, it determines how the chip boots.</li>"] #[doc
         =
         "<li>These pins may be used to debug the chip using an external JTAG debugger.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO4 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO5 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO4 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO5 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin is a strapping pin, it determines how the chip boots.</li>"] #[doc
         =
         "<li>These pins may be used to debug the chip using an external JTAG debugger.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO5 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO6 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO5 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO6 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>These pins may be used to debug the chip using an external JTAG debugger.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO6 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO7 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO6 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO7 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>These pins may be used to debug the chip using an external JTAG debugger.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO7 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO8 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO7 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO8 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin is a strapping pin, it determines how the chip boots.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO8 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO9 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO8 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO9 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin is a strapping pin, it determines how the chip boots.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO9 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO10 peripheral singleton"] GPIO10 <= virtual()));
-        _for_each_inner!((@ peri_type #[doc = "GPIO11 peripheral singleton"] GPIO11 <=
-        virtual())); _for_each_inner!((@ peri_type #[doc = "GPIO12 peripheral singleton"]
-        GPIO12 <= virtual())); _for_each_inner!((@ peri_type #[doc =
-        "GPIO13 peripheral singleton"] GPIO13 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO14 peripheral singleton"] GPIO14 <= virtual()));
-        _for_each_inner!((@ peri_type #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO9 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO10 peripheral singleton"]
+        GPIO10 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO11 peripheral singleton"] GPIO11 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO12 peripheral singleton"]
+        GPIO12 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO13 peripheral singleton"] GPIO13 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO14 peripheral singleton"]
+        GPIO14 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
         "GPIO15 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
         "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin is a strapping pin, it determines how the chip boots.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO15 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO16 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO15 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO16 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>By default, this pin is used by the UART programming interface.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO16 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO17 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO16 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO17 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>By default, this pin is used by the UART programming interface.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO17 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO18 peripheral singleton"] GPIO18 <= virtual()));
-        _for_each_inner!((@ peri_type #[doc = "GPIO19 peripheral singleton"] GPIO19 <=
-        virtual())); _for_each_inner!((@ peri_type #[doc = "GPIO20 peripheral singleton"]
-        GPIO20 <= virtual())); _for_each_inner!((@ peri_type #[doc =
-        "GPIO21 peripheral singleton"] GPIO21 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO22 peripheral singleton"] GPIO22 <= virtual()));
-        _for_each_inner!((@ peri_type #[doc = "GPIO23 peripheral singleton"] GPIO23 <=
-        virtual())); _for_each_inner!((@ peri_type #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO17 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO18 peripheral singleton"]
+        GPIO18 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO19 peripheral singleton"] GPIO19 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO20 peripheral singleton"]
+        GPIO20 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO21 peripheral singleton"] GPIO21 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO22 peripheral singleton"]
+        GPIO22 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO23 peripheral singleton"] GPIO23 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
         "GPIO24 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
         "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO24 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO25 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO24 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO25 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO25 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO26 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO25 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO26 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO26 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO27 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO26 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO27 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO27 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO28 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO27 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO28 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO28 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO29 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO28 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO29 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO29 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO30 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO29 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO30 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO30 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "AES peripheral singleton"] AES <= AES(AES : {
-        bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
-        (unstable))); _for_each_inner!((@ peri_type #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO30 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "AES peripheral singleton"] AES
+        <= AES(AES : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt
+        }) (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "ASSIST_DEBUG peripheral singleton"]
-        ASSIST_DEBUG <= ASSIST_DEBUG() (unstable))); _for_each_inner!((@ peri_type #[doc
-        = "ATOMIC peripheral singleton"] ATOMIC <= ATOMIC() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "DMA peripheral singleton"] DMA <= DMA()
-        (unstable))); _for_each_inner!((@ peri_type #[doc = "DS peripheral singleton"] DS
-        <= DS() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "ECC peripheral singleton"] ECC <= ECC() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "EFUSE peripheral singleton"] EFUSE <= EFUSE() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "EXTMEM peripheral singleton"] EXTMEM <=
-        EXTMEM() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "GPIO peripheral singleton"] GPIO <= GPIO() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "GPIO_SD peripheral singleton"] GPIO_SD <= GPIO_SD()
-        (unstable))); _for_each_inner!((@ peri_type #[doc = "HINF peripheral singleton"]
-        HINF <= HINF() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "HMAC peripheral singleton"] HMAC <= HMAC() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "HP_APM peripheral singleton"] HP_APM <= HP_APM() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "HP_SYS peripheral singleton"] HP_SYS <=
-        HP_SYS() (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "ASSIST_DEBUG peripheral singleton"] ASSIST_DEBUG <= ASSIST_DEBUG() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "ATOMIC peripheral singleton"]
+        ATOMIC <= ATOMIC() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "DMA peripheral singleton"] DMA <= DMA() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DS peripheral singleton"] DS <=
+        DS() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "ECC peripheral singleton"] ECC <= ECC() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "EFUSE peripheral singleton"]
+        EFUSE <= EFUSE() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "EXTMEM peripheral singleton"] EXTMEM <= EXTMEM() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO peripheral singleton"]
+        GPIO <= GPIO() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO_SD peripheral singleton"] GPIO_SD <= GPIO_SD() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "HINF peripheral singleton"]
+        HINF <= HINF() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "HMAC peripheral singleton"] HMAC <= HMAC() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "HP_APM peripheral singleton"]
+        HP_APM <= HP_APM() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "HP_SYS peripheral singleton"] HP_SYS <= HP_SYS() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
         "I2C_ANA_MST peripheral singleton"] I2C_ANA_MST <= I2C_ANA_MST() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "I2C0 peripheral singleton"] I2C0 <=
-        I2C0(I2C_EXT0 : { bind_peri_interrupt, enable_peri_interrupt,
-        disable_peri_interrupt }))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "I2C0 peripheral singleton"]
+        I2C0 <= I2C0(I2C_EXT0 : { bind_peri_interrupt, enable_peri_interrupt,
+        disable_peri_interrupt }))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "I2S0 peripheral singleton"] I2S0 <= I2S0(I2S0 : { bind_peri_interrupt,
         enable_peri_interrupt, disable_peri_interrupt }) (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "IEEE802154 peripheral singleton"]
-        IEEE802154 <= IEEE802154() (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "IEEE802154 peripheral singleton"] IEEE802154 <= IEEE802154() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
         "INTERRUPT_CORE0 peripheral singleton"] INTERRUPT_CORE0 <= INTERRUPT_CORE0()
-        (unstable))); _for_each_inner!((@ peri_type #[doc =
+        (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "INTPRI peripheral singleton"] INTPRI <= INTPRI() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "IO_MUX peripheral singleton"] IO_MUX <=
-        IO_MUX() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "LEDC peripheral singleton"] LEDC <= LEDC() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "LP_ANA peripheral singleton"] LP_ANA <= LP_ANA() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "LP_AON peripheral singleton"] LP_AON <=
-        LP_AON() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "LP_APM peripheral singleton"] LP_APM <= LP_APM() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "LP_APM0 peripheral singleton"] LP_APM0 <=
-        LP_APM0() (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "IO_MUX peripheral singleton"]
+        IO_MUX <= IO_MUX() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "LEDC peripheral singleton"] LEDC <= LEDC() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "LP_ANA peripheral singleton"]
+        LP_ANA <= LP_ANA() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "LP_AON peripheral singleton"] LP_AON <= LP_AON() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "LP_APM peripheral singleton"]
+        LP_APM <= LP_APM() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "LP_APM0 peripheral singleton"] LP_APM0 <= LP_APM0() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
         "LP_CLKRST peripheral singleton"] LP_CLKRST <= LP_CLKRST() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "LP_I2C0 peripheral singleton"] LP_I2C0 <=
-        LP_I2C0() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "LP_I2C_ANA_MST peripheral singleton"] LP_I2C_ANA_MST <= LP_I2C_ANA_MST()
-        (unstable))); _for_each_inner!((@ peri_type #[doc = "LP_IO peripheral singleton"]
-        LP_IO <= LP_IO() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "LP_PERI peripheral singleton"] LP_PERI <= LP_PERI() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "LP_TEE peripheral singleton"] LP_TEE <=
-        LP_TEE() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "LP_TIMER peripheral singleton"] LP_TIMER <= LP_TIMER() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "LP_UART peripheral singleton"] LP_UART <=
-        LP_UART() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "LP_WDT peripheral singleton"] LP_WDT <= LP_WDT() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "LPWR peripheral singleton"] LPWR <=
-        LP_CLKRST() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "MCPWM0 peripheral singleton"] MCPWM0 <= MCPWM0() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "MEM_MONITOR peripheral singleton"]
-        MEM_MONITOR <= MEM_MONITOR() (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "LP_I2C0 peripheral singleton"]
+        LP_I2C0 <= LP_I2C0() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "LP_I2C_ANA_MST peripheral singleton"] LP_I2C_ANA_MST <= LP_I2C_ANA_MST()
+        (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "LP_IO peripheral singleton"] LP_IO <= LP_IO() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "LP_PERI peripheral singleton"]
+        LP_PERI <= LP_PERI() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "LP_TEE peripheral singleton"] LP_TEE <= LP_TEE() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "LP_TIMER peripheral singleton"]
+        LP_TIMER <= LP_TIMER() (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "LP_UART peripheral singleton"] LP_UART <= LP_UART() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "LP_WDT peripheral singleton"]
+        LP_WDT <= LP_WDT() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "LPWR peripheral singleton"] LPWR <= LP_CLKRST() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "MCPWM0 peripheral singleton"]
+        MCPWM0 <= MCPWM0() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "MEM_MONITOR peripheral singleton"] MEM_MONITOR <= MEM_MONITOR() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
         "MODEM_LPCON peripheral singleton"] MODEM_LPCON <= MODEM_LPCON() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "MODEM_SYSCON peripheral singleton"]
-        MODEM_SYSCON <= MODEM_SYSCON() (unstable))); _for_each_inner!((@ peri_type #[doc
-        = "OTP_DEBUG peripheral singleton"] OTP_DEBUG <= OTP_DEBUG() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "PARL_IO peripheral singleton"] PARL_IO <=
-        PARL_IO(PARL_IO : { bind_peri_interrupt, enable_peri_interrupt,
-        disable_peri_interrupt }) (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "PAU peripheral singleton"] PAU <= PAU() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "PCNT peripheral singleton"] PCNT <= PCNT() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "PCR peripheral singleton"] PCR <= PCR()
-        (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "PLIC_MX peripheral singleton"] PLIC_MX <= PLIC_MX() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "PMU peripheral singleton"] PMU <= PMU()
-        (unstable))); _for_each_inner!((@ peri_type #[doc = "RMT peripheral singleton"]
-        RMT <= RMT() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "RNG peripheral singleton"] RNG <= RNG() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "RSA peripheral singleton"] RSA <= RSA(RSA : {
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "MODEM_SYSCON peripheral singleton"] MODEM_SYSCON <= MODEM_SYSCON() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "OTP_DEBUG peripheral singleton"] OTP_DEBUG <= OTP_DEBUG() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "PARL_IO peripheral singleton"]
+        PARL_IO <= PARL_IO(PARL_IO : { bind_peri_interrupt, enable_peri_interrupt,
+        disable_peri_interrupt }) (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "PAU peripheral singleton"] PAU <= PAU() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "PCNT peripheral singleton"]
+        PCNT <= PCNT() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "PCR peripheral singleton"] PCR <= PCR() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "PLIC_MX peripheral singleton"]
+        PLIC_MX <= PLIC_MX() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "PMU peripheral singleton"] PMU <= PMU() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "RMT peripheral singleton"] RMT
+        <= RMT() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "RNG peripheral singleton"] RNG <= RNG() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "RSA peripheral singleton"] RSA
+        <= RSA(RSA : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt
+        }) (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "SHA peripheral singleton"] SHA <= SHA(SHA : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt }) (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "SLCHOST peripheral singleton"]
+        SLCHOST <= SLCHOST() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "ETM peripheral singleton"] ETM <= SOC_ETM() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "SPI0 peripheral singleton"]
+        SPI0 <= SPI0() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "SPI1 peripheral singleton"] SPI1 <= SPI1() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "SPI2 peripheral singleton"]
+        SPI2 <= SPI2(SPI2 : { bind_peri_interrupt, enable_peri_interrupt,
+        disable_peri_interrupt }))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "SYSTEM peripheral singleton"] SYSTEM <= PCR() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "SYSTIMER peripheral singleton"]
+        SYSTIMER <= SYSTIMER() (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "TEE peripheral singleton"] TEE <= TEE() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "TIMG0 peripheral singleton"]
+        TIMG0 <= TIMG0() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "TIMG1 peripheral singleton"] TIMG1 <= TIMG1() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "TRACE0 peripheral singleton"]
+        TRACE0 <= TRACE() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "TWAI0 peripheral singleton"] TWAI0 <= TWAI0() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "TWAI1 peripheral singleton"]
+        TWAI1 <= TWAI1() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "UART0 peripheral singleton"] UART0 <= UART0(UART0 : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt })));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "UART1 peripheral singleton"]
+        UART1 <= UART1(UART1 : { bind_peri_interrupt, enable_peri_interrupt,
+        disable_peri_interrupt }))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "UHCI0 peripheral singleton"] UHCI0 <= UHCI0() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "USB_DEVICE peripheral singleton"] USB_DEVICE <= USB_DEVICE(USB_DEVICE : {
         bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
-        (unstable))); _for_each_inner!((@ peri_type #[doc = "SHA peripheral singleton"]
-        SHA <= SHA(SHA : { bind_peri_interrupt, enable_peri_interrupt,
-        disable_peri_interrupt }) (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "SLCHOST peripheral singleton"] SLCHOST <= SLCHOST() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "ETM peripheral singleton"] ETM <=
-        SOC_ETM() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "SPI0 peripheral singleton"] SPI0 <= SPI0() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "SPI1 peripheral singleton"] SPI1 <= SPI1() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "SPI2 peripheral singleton"] SPI2 <=
-        SPI2(SPI2 : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt
-        }))); _for_each_inner!((@ peri_type #[doc = "SYSTEM peripheral singleton"] SYSTEM
-        <= PCR() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "SYSTIMER peripheral singleton"] SYSTIMER <= SYSTIMER() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "TEE peripheral singleton"] TEE <= TEE()
-        (unstable))); _for_each_inner!((@ peri_type #[doc = "TIMG0 peripheral singleton"]
-        TIMG0 <= TIMG0() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "TIMG1 peripheral singleton"] TIMG1 <= TIMG1() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "TRACE0 peripheral singleton"] TRACE0 <= TRACE() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "TWAI0 peripheral singleton"] TWAI0 <=
-        TWAI0() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "TWAI1 peripheral singleton"] TWAI1 <= TWAI1() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "UART0 peripheral singleton"] UART0 <= UART0(UART0 : {
-        bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })));
-        _for_each_inner!((@ peri_type #[doc = "UART1 peripheral singleton"] UART1 <=
-        UART1(UART1 : { bind_peri_interrupt, enable_peri_interrupt,
-        disable_peri_interrupt }))); _for_each_inner!((@ peri_type #[doc =
-        "UHCI0 peripheral singleton"] UHCI0 <= UHCI0() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "USB_DEVICE peripheral singleton"] USB_DEVICE <=
-        USB_DEVICE(USB_DEVICE : { bind_peri_interrupt, enable_peri_interrupt,
-        disable_peri_interrupt }) (unstable))); _for_each_inner!((@ peri_type #[doc =
+        (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "DMA_CH1 peripheral singleton"] DMA_CH1 <=
-        virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "DMA_CH2 peripheral singleton"] DMA_CH2 <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "ADC1 peripheral singleton"] ADC1 <=
-        virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "BT peripheral singleton"] BT <= virtual() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "FLASH peripheral singleton"] FLASH <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "GPIO_DEDICATED peripheral singleton"]
-        GPIO_DEDICATED <= virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "LP_CORE peripheral singleton"] LP_CORE <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "SW_INTERRUPT peripheral singleton"]
-        SW_INTERRUPT <= virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "TSENS peripheral singleton"] TSENS <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "WIFI peripheral singleton"] WIFI <=
-        virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "MEM2MEM1 peripheral singleton"] MEM2MEM1 <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "MEM2MEM4 peripheral singleton"] MEM2MEM4
-        <= virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "MEM2MEM5 peripheral singleton"] MEM2MEM5 <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "MEM2MEM10 peripheral singleton"] MEM2MEM10
-        <= virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH1 peripheral singleton"]
+        DMA_CH1 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "DMA_CH2 peripheral singleton"] DMA_CH2 <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "ADC1 peripheral singleton"]
+        ADC1 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "BT peripheral singleton"] BT <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "FLASH peripheral singleton"]
+        FLASH <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO_DEDICATED peripheral singleton"] GPIO_DEDICATED <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "LP_CORE peripheral singleton"]
+        LP_CORE <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "SW_INTERRUPT peripheral singleton"] SW_INTERRUPT <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "TSENS peripheral singleton"]
+        TSENS <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "WIFI peripheral singleton"] WIFI <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "MEM2MEM1 peripheral singleton"]
+        MEM2MEM1 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "MEM2MEM4 peripheral singleton"] MEM2MEM4 <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "MEM2MEM5 peripheral singleton"]
+        MEM2MEM5 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "MEM2MEM10 peripheral singleton"] MEM2MEM10 <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
         "MEM2MEM11 peripheral singleton"] MEM2MEM11 <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "MEM2MEM12 peripheral singleton"] MEM2MEM12
-        <= virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "MEM2MEM12 peripheral singleton"] MEM2MEM12 <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
         "MEM2MEM13 peripheral singleton"] MEM2MEM13 <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "MEM2MEM14 peripheral singleton"] MEM2MEM14
-        <= virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "MEM2MEM14 peripheral singleton"] MEM2MEM14 <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
         "MEM2MEM15 peripheral singleton"] MEM2MEM15 <= virtual() (unstable)));
-        _for_each_inner!((GPIO0)); _for_each_inner!((GPIO1)); _for_each_inner!((GPIO2));
-        _for_each_inner!((GPIO3)); _for_each_inner!((GPIO4)); _for_each_inner!((GPIO5));
-        _for_each_inner!((GPIO6)); _for_each_inner!((GPIO7)); _for_each_inner!((GPIO8));
-        _for_each_inner!((GPIO9)); _for_each_inner!((GPIO10));
-        _for_each_inner!((GPIO11)); _for_each_inner!((GPIO12));
-        _for_each_inner!((GPIO13)); _for_each_inner!((GPIO14));
-        _for_each_inner!((GPIO15)); _for_each_inner!((GPIO16));
-        _for_each_inner!((GPIO17)); _for_each_inner!((GPIO18));
-        _for_each_inner!((GPIO19)); _for_each_inner!((GPIO20));
-        _for_each_inner!((GPIO21)); _for_each_inner!((GPIO22));
-        _for_each_inner!((GPIO23)); _for_each_inner!((GPIO24));
-        _for_each_inner!((GPIO25)); _for_each_inner!((GPIO26));
-        _for_each_inner!((GPIO27)); _for_each_inner!((GPIO28));
-        _for_each_inner!((GPIO29)); _for_each_inner!((GPIO30));
-        _for_each_inner!((AES(unstable))); _for_each_inner!((APB_SARADC(unstable)));
-        _for_each_inner!((ASSIST_DEBUG(unstable))); _for_each_inner!((ATOMIC(unstable)));
-        _for_each_inner!((DMA(unstable))); _for_each_inner!((DS(unstable)));
-        _for_each_inner!((ECC(unstable))); _for_each_inner!((EFUSE(unstable)));
-        _for_each_inner!((EXTMEM(unstable))); _for_each_inner!((GPIO(unstable)));
-        _for_each_inner!((GPIO_SD(unstable))); _for_each_inner!((HINF(unstable)));
-        _for_each_inner!((HMAC(unstable))); _for_each_inner!((HP_APM(unstable)));
-        _for_each_inner!((HP_SYS(unstable))); _for_each_inner!((I2C_ANA_MST(unstable)));
-        _for_each_inner!((I2C0)); _for_each_inner!((I2S0(unstable)));
-        _for_each_inner!((IEEE802154(unstable)));
-        _for_each_inner!((INTERRUPT_CORE0(unstable)));
-        _for_each_inner!((INTPRI(unstable))); _for_each_inner!((IO_MUX(unstable)));
-        _for_each_inner!((LEDC(unstable))); _for_each_inner!((LP_ANA(unstable)));
-        _for_each_inner!((LP_AON(unstable))); _for_each_inner!((LP_APM(unstable)));
-        _for_each_inner!((LP_APM0(unstable))); _for_each_inner!((LP_CLKRST(unstable)));
-        _for_each_inner!((LP_I2C0(unstable)));
-        _for_each_inner!((LP_I2C_ANA_MST(unstable)));
-        _for_each_inner!((LP_IO(unstable))); _for_each_inner!((LP_PERI(unstable)));
-        _for_each_inner!((LP_TEE(unstable))); _for_each_inner!((LP_TIMER(unstable)));
-        _for_each_inner!((LP_UART(unstable))); _for_each_inner!((LP_WDT(unstable)));
-        _for_each_inner!((LPWR(unstable))); _for_each_inner!((MCPWM0(unstable)));
-        _for_each_inner!((MEM_MONITOR(unstable)));
-        _for_each_inner!((MODEM_LPCON(unstable)));
-        _for_each_inner!((MODEM_SYSCON(unstable)));
-        _for_each_inner!((OTP_DEBUG(unstable))); _for_each_inner!((PARL_IO(unstable)));
-        _for_each_inner!((PAU(unstable))); _for_each_inner!((PCNT(unstable)));
-        _for_each_inner!((PCR(unstable))); _for_each_inner!((PLIC_MX(unstable)));
-        _for_each_inner!((PMU(unstable))); _for_each_inner!((RMT(unstable)));
-        _for_each_inner!((RNG(unstable))); _for_each_inner!((RSA(unstable)));
-        _for_each_inner!((SHA(unstable))); _for_each_inner!((SLCHOST(unstable)));
-        _for_each_inner!((ETM(unstable))); _for_each_inner!((SPI0(unstable)));
-        _for_each_inner!((SPI1(unstable))); _for_each_inner!((SPI2));
-        _for_each_inner!((SYSTEM(unstable))); _for_each_inner!((SYSTIMER(unstable)));
-        _for_each_inner!((TEE(unstable))); _for_each_inner!((TIMG0(unstable)));
-        _for_each_inner!((TIMG1(unstable))); _for_each_inner!((TRACE0(unstable)));
-        _for_each_inner!((TWAI0(unstable))); _for_each_inner!((TWAI1(unstable)));
-        _for_each_inner!((UART0)); _for_each_inner!((UART1));
-        _for_each_inner!((UHCI0(unstable))); _for_each_inner!((USB_DEVICE(unstable)));
-        _for_each_inner!((DMA_CH0(unstable))); _for_each_inner!((DMA_CH1(unstable)));
-        _for_each_inner!((DMA_CH2(unstable))); _for_each_inner!((ADC1(unstable)));
-        _for_each_inner!((BT(unstable))); _for_each_inner!((FLASH(unstable)));
-        _for_each_inner!((GPIO_DEDICATED(unstable)));
-        _for_each_inner!((LP_CORE(unstable)));
-        _for_each_inner!((SW_INTERRUPT(unstable))); _for_each_inner!((TSENS(unstable)));
-        _for_each_inner!((WIFI(unstable))); _for_each_inner!((MEM2MEM1(unstable)));
-        _for_each_inner!((MEM2MEM4(unstable))); _for_each_inner!((MEM2MEM5(unstable)));
-        _for_each_inner!((MEM2MEM10(unstable))); _for_each_inner!((MEM2MEM11(unstable)));
-        _for_each_inner!((MEM2MEM12(unstable))); _for_each_inner!((MEM2MEM13(unstable)));
-        _for_each_inner!((MEM2MEM14(unstable))); _for_each_inner!((MEM2MEM15(unstable)));
-        _for_each_inner!((all(@ peri_type #[doc = "GPIO0 peripheral singleton"] GPIO0 <=
-        virtual()), (@ peri_type #[doc = "GPIO1 peripheral singleton"] GPIO1 <=
-        virtual()), (@ peri_type #[doc = "GPIO2 peripheral singleton"] GPIO2 <=
-        virtual()), (@ peri_type #[doc = "GPIO3 peripheral singleton"] GPIO3 <=
-        virtual()), (@ peri_type #[doc =
+        _for_each_inner_peripheral!((GPIO0)); _for_each_inner_peripheral!((GPIO1));
+        _for_each_inner_peripheral!((GPIO2)); _for_each_inner_peripheral!((GPIO3));
+        _for_each_inner_peripheral!((GPIO4)); _for_each_inner_peripheral!((GPIO5));
+        _for_each_inner_peripheral!((GPIO6)); _for_each_inner_peripheral!((GPIO7));
+        _for_each_inner_peripheral!((GPIO8)); _for_each_inner_peripheral!((GPIO9));
+        _for_each_inner_peripheral!((GPIO10)); _for_each_inner_peripheral!((GPIO11));
+        _for_each_inner_peripheral!((GPIO12)); _for_each_inner_peripheral!((GPIO13));
+        _for_each_inner_peripheral!((GPIO14)); _for_each_inner_peripheral!((GPIO15));
+        _for_each_inner_peripheral!((GPIO16)); _for_each_inner_peripheral!((GPIO17));
+        _for_each_inner_peripheral!((GPIO18)); _for_each_inner_peripheral!((GPIO19));
+        _for_each_inner_peripheral!((GPIO20)); _for_each_inner_peripheral!((GPIO21));
+        _for_each_inner_peripheral!((GPIO22)); _for_each_inner_peripheral!((GPIO23));
+        _for_each_inner_peripheral!((GPIO24)); _for_each_inner_peripheral!((GPIO25));
+        _for_each_inner_peripheral!((GPIO26)); _for_each_inner_peripheral!((GPIO27));
+        _for_each_inner_peripheral!((GPIO28)); _for_each_inner_peripheral!((GPIO29));
+        _for_each_inner_peripheral!((GPIO30));
+        _for_each_inner_peripheral!((AES(unstable)));
+        _for_each_inner_peripheral!((APB_SARADC(unstable)));
+        _for_each_inner_peripheral!((ASSIST_DEBUG(unstable)));
+        _for_each_inner_peripheral!((ATOMIC(unstable)));
+        _for_each_inner_peripheral!((DMA(unstable)));
+        _for_each_inner_peripheral!((DS(unstable)));
+        _for_each_inner_peripheral!((ECC(unstable)));
+        _for_each_inner_peripheral!((EFUSE(unstable)));
+        _for_each_inner_peripheral!((EXTMEM(unstable)));
+        _for_each_inner_peripheral!((GPIO(unstable)));
+        _for_each_inner_peripheral!((GPIO_SD(unstable)));
+        _for_each_inner_peripheral!((HINF(unstable)));
+        _for_each_inner_peripheral!((HMAC(unstable)));
+        _for_each_inner_peripheral!((HP_APM(unstable)));
+        _for_each_inner_peripheral!((HP_SYS(unstable)));
+        _for_each_inner_peripheral!((I2C_ANA_MST(unstable)));
+        _for_each_inner_peripheral!((I2C0));
+        _for_each_inner_peripheral!((I2S0(unstable)));
+        _for_each_inner_peripheral!((IEEE802154(unstable)));
+        _for_each_inner_peripheral!((INTERRUPT_CORE0(unstable)));
+        _for_each_inner_peripheral!((INTPRI(unstable)));
+        _for_each_inner_peripheral!((IO_MUX(unstable)));
+        _for_each_inner_peripheral!((LEDC(unstable)));
+        _for_each_inner_peripheral!((LP_ANA(unstable)));
+        _for_each_inner_peripheral!((LP_AON(unstable)));
+        _for_each_inner_peripheral!((LP_APM(unstable)));
+        _for_each_inner_peripheral!((LP_APM0(unstable)));
+        _for_each_inner_peripheral!((LP_CLKRST(unstable)));
+        _for_each_inner_peripheral!((LP_I2C0(unstable)));
+        _for_each_inner_peripheral!((LP_I2C_ANA_MST(unstable)));
+        _for_each_inner_peripheral!((LP_IO(unstable)));
+        _for_each_inner_peripheral!((LP_PERI(unstable)));
+        _for_each_inner_peripheral!((LP_TEE(unstable)));
+        _for_each_inner_peripheral!((LP_TIMER(unstable)));
+        _for_each_inner_peripheral!((LP_UART(unstable)));
+        _for_each_inner_peripheral!((LP_WDT(unstable)));
+        _for_each_inner_peripheral!((LPWR(unstable)));
+        _for_each_inner_peripheral!((MCPWM0(unstable)));
+        _for_each_inner_peripheral!((MEM_MONITOR(unstable)));
+        _for_each_inner_peripheral!((MODEM_LPCON(unstable)));
+        _for_each_inner_peripheral!((MODEM_SYSCON(unstable)));
+        _for_each_inner_peripheral!((OTP_DEBUG(unstable)));
+        _for_each_inner_peripheral!((PARL_IO(unstable)));
+        _for_each_inner_peripheral!((PAU(unstable)));
+        _for_each_inner_peripheral!((PCNT(unstable)));
+        _for_each_inner_peripheral!((PCR(unstable)));
+        _for_each_inner_peripheral!((PLIC_MX(unstable)));
+        _for_each_inner_peripheral!((PMU(unstable)));
+        _for_each_inner_peripheral!((RMT(unstable)));
+        _for_each_inner_peripheral!((RNG(unstable)));
+        _for_each_inner_peripheral!((RSA(unstable)));
+        _for_each_inner_peripheral!((SHA(unstable)));
+        _for_each_inner_peripheral!((SLCHOST(unstable)));
+        _for_each_inner_peripheral!((ETM(unstable)));
+        _for_each_inner_peripheral!((SPI0(unstable)));
+        _for_each_inner_peripheral!((SPI1(unstable)));
+        _for_each_inner_peripheral!((SPI2));
+        _for_each_inner_peripheral!((SYSTEM(unstable)));
+        _for_each_inner_peripheral!((SYSTIMER(unstable)));
+        _for_each_inner_peripheral!((TEE(unstable)));
+        _for_each_inner_peripheral!((TIMG0(unstable)));
+        _for_each_inner_peripheral!((TIMG1(unstable)));
+        _for_each_inner_peripheral!((TRACE0(unstable)));
+        _for_each_inner_peripheral!((TWAI0(unstable)));
+        _for_each_inner_peripheral!((TWAI1(unstable)));
+        _for_each_inner_peripheral!((UART0)); _for_each_inner_peripheral!((UART1));
+        _for_each_inner_peripheral!((UHCI0(unstable)));
+        _for_each_inner_peripheral!((USB_DEVICE(unstable)));
+        _for_each_inner_peripheral!((DMA_CH0(unstable)));
+        _for_each_inner_peripheral!((DMA_CH1(unstable)));
+        _for_each_inner_peripheral!((DMA_CH2(unstable)));
+        _for_each_inner_peripheral!((ADC1(unstable)));
+        _for_each_inner_peripheral!((BT(unstable)));
+        _for_each_inner_peripheral!((FLASH(unstable)));
+        _for_each_inner_peripheral!((GPIO_DEDICATED(unstable)));
+        _for_each_inner_peripheral!((LP_CORE(unstable)));
+        _for_each_inner_peripheral!((SW_INTERRUPT(unstable)));
+        _for_each_inner_peripheral!((TSENS(unstable)));
+        _for_each_inner_peripheral!((WIFI(unstable)));
+        _for_each_inner_peripheral!((MEM2MEM1(unstable)));
+        _for_each_inner_peripheral!((MEM2MEM4(unstable)));
+        _for_each_inner_peripheral!((MEM2MEM5(unstable)));
+        _for_each_inner_peripheral!((MEM2MEM10(unstable)));
+        _for_each_inner_peripheral!((MEM2MEM11(unstable)));
+        _for_each_inner_peripheral!((MEM2MEM12(unstable)));
+        _for_each_inner_peripheral!((MEM2MEM13(unstable)));
+        _for_each_inner_peripheral!((MEM2MEM14(unstable)));
+        _for_each_inner_peripheral!((MEM2MEM15(unstable)));
+        _for_each_inner_peripheral!((all(@ peri_type #[doc =
+        "GPIO0 peripheral singleton"] GPIO0 <= virtual()), (@ peri_type #[doc =
+        "GPIO1 peripheral singleton"] GPIO1 <= virtual()), (@ peri_type #[doc =
+        "GPIO2 peripheral singleton"] GPIO2 <= virtual()), (@ peri_type #[doc =
+        "GPIO3 peripheral singleton"] GPIO3 <= virtual()), (@ peri_type #[doc =
         "GPIO4 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
         "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
@@ -3873,11 +4057,11 @@ macro_rules! for_each_peripheral {
         MEM2MEM13 <= virtual() (unstable)), (@ peri_type #[doc =
         "MEM2MEM14 peripheral singleton"] MEM2MEM14 <= virtual() (unstable)), (@
         peri_type #[doc = "MEM2MEM15 peripheral singleton"] MEM2MEM15 <= virtual()
-        (unstable)))); _for_each_inner!((singletons(GPIO0), (GPIO1), (GPIO2), (GPIO3),
-        (GPIO4), (GPIO5), (GPIO6), (GPIO7), (GPIO8), (GPIO9), (GPIO10), (GPIO11),
-        (GPIO12), (GPIO13), (GPIO14), (GPIO15), (GPIO16), (GPIO17), (GPIO18), (GPIO19),
-        (GPIO20), (GPIO21), (GPIO22), (GPIO23), (GPIO24), (GPIO25), (GPIO26), (GPIO27),
-        (GPIO28), (GPIO29), (GPIO30), (AES(unstable)), (APB_SARADC(unstable)),
+        (unstable)))); _for_each_inner_peripheral!((singletons(GPIO0), (GPIO1), (GPIO2),
+        (GPIO3), (GPIO4), (GPIO5), (GPIO6), (GPIO7), (GPIO8), (GPIO9), (GPIO10),
+        (GPIO11), (GPIO12), (GPIO13), (GPIO14), (GPIO15), (GPIO16), (GPIO17), (GPIO18),
+        (GPIO19), (GPIO20), (GPIO21), (GPIO22), (GPIO23), (GPIO24), (GPIO25), (GPIO26),
+        (GPIO27), (GPIO28), (GPIO29), (GPIO30), (AES(unstable)), (APB_SARADC(unstable)),
         (ASSIST_DEBUG(unstable)), (ATOMIC(unstable)), (DMA(unstable)), (DS(unstable)),
         (ECC(unstable)), (EFUSE(unstable)), (EXTMEM(unstable)), (GPIO(unstable)),
         (GPIO_SD(unstable)), (HINF(unstable)), (HMAC(unstable)), (HP_APM(unstable)),
@@ -3934,60 +4118,64 @@ macro_rules! for_each_peripheral {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_gpio {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((0, GPIO0() () ([Input] [Output]))); _for_each_inner!((1,
-        GPIO1() () ([Input] [Output]))); _for_each_inner!((2, GPIO2(_2 => FSPIQ) (_2 =>
-        FSPIQ) ([Input] [Output]))); _for_each_inner!((3, GPIO3() () ([Input]
-        [Output]))); _for_each_inner!((4, GPIO4(_0 => MTMS _2 => FSPIHD) (_2 => FSPIHD)
-        ([Input] [Output]))); _for_each_inner!((5, GPIO5(_0 => MTDI _2 => FSPIWP) (_2 =>
-        FSPIWP) ([Input] [Output]))); _for_each_inner!((6, GPIO6(_0 => MTCK _2 =>
-        FSPICLK) (_2 => FSPICLK) ([Input] [Output]))); _for_each_inner!((7, GPIO7(_2 =>
-        FSPID) (_0 => MTDO _2 => FSPID) ([Input] [Output]))); _for_each_inner!((8,
-        GPIO8() () ([Input] [Output]))); _for_each_inner!((9, GPIO9() () ([Input]
-        [Output]))); _for_each_inner!((10, GPIO10() () ([Input] [Output])));
-        _for_each_inner!((11, GPIO11() () ([Input] [Output]))); _for_each_inner!((12,
-        GPIO12() () ([Input] [Output]))); _for_each_inner!((13, GPIO13() () ([Input]
-        [Output]))); _for_each_inner!((14, GPIO14() () ([Input] [Output])));
-        _for_each_inner!((15, GPIO15() () ([Input] [Output]))); _for_each_inner!((16,
-        GPIO16(_2 => FSPICS0) (_0 => U0TXD _2 => FSPICS0) ([Input] [Output])));
-        _for_each_inner!((17, GPIO17(_0 => U0RXD) (_2 => FSPICS1) ([Input] [Output])));
-        _for_each_inner!((18, GPIO18(_0 => SDIO_CMD) (_0 => SDIO_CMD _2 => FSPICS2)
-        ([Input] [Output]))); _for_each_inner!((19, GPIO19() (_0 => SDIO_CLK _2 =>
-        FSPICS3) ([Input] [Output]))); _for_each_inner!((20, GPIO20(_0 => SDIO_DATA0) (_0
-        => SDIO_DATA0 _2 => FSPICS4) ([Input] [Output]))); _for_each_inner!((21,
-        GPIO21(_0 => SDIO_DATA1) (_0 => SDIO_DATA1 _2 => FSPICS5) ([Input] [Output])));
-        _for_each_inner!((22, GPIO22(_0 => SDIO_DATA2) (_0 => SDIO_DATA2) ([Input]
-        [Output]))); _for_each_inner!((23, GPIO23(_0 => SDIO_DATA3) (_0 => SDIO_DATA3)
-        ([Input] [Output]))); _for_each_inner!((24, GPIO24() (_0 => SPICS0) ([Input]
-        [Output]))); _for_each_inner!((25, GPIO25(_0 => SPIQ) (_0 => SPIQ) ([Input]
-        [Output]))); _for_each_inner!((26, GPIO26(_0 => SPIWP) (_0 => SPIWP) ([Input]
-        [Output]))); _for_each_inner!((27, GPIO27() () ([Input] [Output])));
-        _for_each_inner!((28, GPIO28(_0 => SPIHD) (_0 => SPIHD) ([Input] [Output])));
-        _for_each_inner!((29, GPIO29() (_0 => SPICLK) ([Input] [Output])));
-        _for_each_inner!((30, GPIO30(_0 => SPID) (_0 => SPID) ([Input] [Output])));
-        _for_each_inner!((all(0, GPIO0() () ([Input] [Output])), (1, GPIO1() () ([Input]
-        [Output])), (2, GPIO2(_2 => FSPIQ) (_2 => FSPIQ) ([Input] [Output])), (3, GPIO3()
-        () ([Input] [Output])), (4, GPIO4(_0 => MTMS _2 => FSPIHD) (_2 => FSPIHD)
-        ([Input] [Output])), (5, GPIO5(_0 => MTDI _2 => FSPIWP) (_2 => FSPIWP) ([Input]
-        [Output])), (6, GPIO6(_0 => MTCK _2 => FSPICLK) (_2 => FSPICLK) ([Input]
-        [Output])), (7, GPIO7(_2 => FSPID) (_0 => MTDO _2 => FSPID) ([Input] [Output])),
-        (8, GPIO8() () ([Input] [Output])), (9, GPIO9() () ([Input] [Output])), (10,
-        GPIO10() () ([Input] [Output])), (11, GPIO11() () ([Input] [Output])), (12,
-        GPIO12() () ([Input] [Output])), (13, GPIO13() () ([Input] [Output])), (14,
-        GPIO14() () ([Input] [Output])), (15, GPIO15() () ([Input] [Output])), (16,
-        GPIO16(_2 => FSPICS0) (_0 => U0TXD _2 => FSPICS0) ([Input] [Output])), (17,
-        GPIO17(_0 => U0RXD) (_2 => FSPICS1) ([Input] [Output])), (18, GPIO18(_0 =>
-        SDIO_CMD) (_0 => SDIO_CMD _2 => FSPICS2) ([Input] [Output])), (19, GPIO19() (_0
-        => SDIO_CLK _2 => FSPICS3) ([Input] [Output])), (20, GPIO20(_0 => SDIO_DATA0) (_0
-        => SDIO_DATA0 _2 => FSPICS4) ([Input] [Output])), (21, GPIO21(_0 => SDIO_DATA1)
-        (_0 => SDIO_DATA1 _2 => FSPICS5) ([Input] [Output])), (22, GPIO22(_0 =>
-        SDIO_DATA2) (_0 => SDIO_DATA2) ([Input] [Output])), (23, GPIO23(_0 => SDIO_DATA3)
-        (_0 => SDIO_DATA3) ([Input] [Output])), (24, GPIO24() (_0 => SPICS0) ([Input]
-        [Output])), (25, GPIO25(_0 => SPIQ) (_0 => SPIQ) ([Input] [Output])), (26,
-        GPIO26(_0 => SPIWP) (_0 => SPIWP) ([Input] [Output])), (27, GPIO27() () ([Input]
-        [Output])), (28, GPIO28(_0 => SPIHD) (_0 => SPIHD) ([Input] [Output])), (29,
-        GPIO29() (_0 => SPICLK) ([Input] [Output])), (30, GPIO30(_0 => SPID) (_0 => SPID)
-        ([Input] [Output]))));
+        macro_rules! _for_each_inner_gpio { $(($pattern) => $code;)* ($other : tt) => {}
+        } _for_each_inner_gpio!((0, GPIO0() () ([Input] [Output])));
+        _for_each_inner_gpio!((1, GPIO1() () ([Input] [Output])));
+        _for_each_inner_gpio!((2, GPIO2(_2 => FSPIQ) (_2 => FSPIQ) ([Input] [Output])));
+        _for_each_inner_gpio!((3, GPIO3() () ([Input] [Output])));
+        _for_each_inner_gpio!((4, GPIO4(_0 => MTMS _2 => FSPIHD) (_2 => FSPIHD) ([Input]
+        [Output]))); _for_each_inner_gpio!((5, GPIO5(_0 => MTDI _2 => FSPIWP) (_2 =>
+        FSPIWP) ([Input] [Output]))); _for_each_inner_gpio!((6, GPIO6(_0 => MTCK _2 =>
+        FSPICLK) (_2 => FSPICLK) ([Input] [Output]))); _for_each_inner_gpio!((7, GPIO7(_2
+        => FSPID) (_0 => MTDO _2 => FSPID) ([Input] [Output])));
+        _for_each_inner_gpio!((8, GPIO8() () ([Input] [Output])));
+        _for_each_inner_gpio!((9, GPIO9() () ([Input] [Output])));
+        _for_each_inner_gpio!((10, GPIO10() () ([Input] [Output])));
+        _for_each_inner_gpio!((11, GPIO11() () ([Input] [Output])));
+        _for_each_inner_gpio!((12, GPIO12() () ([Input] [Output])));
+        _for_each_inner_gpio!((13, GPIO13() () ([Input] [Output])));
+        _for_each_inner_gpio!((14, GPIO14() () ([Input] [Output])));
+        _for_each_inner_gpio!((15, GPIO15() () ([Input] [Output])));
+        _for_each_inner_gpio!((16, GPIO16(_2 => FSPICS0) (_0 => U0TXD _2 => FSPICS0)
+        ([Input] [Output]))); _for_each_inner_gpio!((17, GPIO17(_0 => U0RXD) (_2 =>
+        FSPICS1) ([Input] [Output]))); _for_each_inner_gpio!((18, GPIO18(_0 => SDIO_CMD)
+        (_0 => SDIO_CMD _2 => FSPICS2) ([Input] [Output]))); _for_each_inner_gpio!((19,
+        GPIO19() (_0 => SDIO_CLK _2 => FSPICS3) ([Input] [Output])));
+        _for_each_inner_gpio!((20, GPIO20(_0 => SDIO_DATA0) (_0 => SDIO_DATA0 _2 =>
+        FSPICS4) ([Input] [Output]))); _for_each_inner_gpio!((21, GPIO21(_0 =>
+        SDIO_DATA1) (_0 => SDIO_DATA1 _2 => FSPICS5) ([Input] [Output])));
+        _for_each_inner_gpio!((22, GPIO22(_0 => SDIO_DATA2) (_0 => SDIO_DATA2) ([Input]
+        [Output]))); _for_each_inner_gpio!((23, GPIO23(_0 => SDIO_DATA3) (_0 =>
+        SDIO_DATA3) ([Input] [Output]))); _for_each_inner_gpio!((24, GPIO24() (_0 =>
+        SPICS0) ([Input] [Output]))); _for_each_inner_gpio!((25, GPIO25(_0 => SPIQ) (_0
+        => SPIQ) ([Input] [Output]))); _for_each_inner_gpio!((26, GPIO26(_0 => SPIWP) (_0
+        => SPIWP) ([Input] [Output]))); _for_each_inner_gpio!((27, GPIO27() () ([Input]
+        [Output]))); _for_each_inner_gpio!((28, GPIO28(_0 => SPIHD) (_0 => SPIHD)
+        ([Input] [Output]))); _for_each_inner_gpio!((29, GPIO29() (_0 => SPICLK) ([Input]
+        [Output]))); _for_each_inner_gpio!((30, GPIO30(_0 => SPID) (_0 => SPID) ([Input]
+        [Output]))); _for_each_inner_gpio!((all(0, GPIO0() () ([Input] [Output])), (1,
+        GPIO1() () ([Input] [Output])), (2, GPIO2(_2 => FSPIQ) (_2 => FSPIQ) ([Input]
+        [Output])), (3, GPIO3() () ([Input] [Output])), (4, GPIO4(_0 => MTMS _2 =>
+        FSPIHD) (_2 => FSPIHD) ([Input] [Output])), (5, GPIO5(_0 => MTDI _2 => FSPIWP)
+        (_2 => FSPIWP) ([Input] [Output])), (6, GPIO6(_0 => MTCK _2 => FSPICLK) (_2 =>
+        FSPICLK) ([Input] [Output])), (7, GPIO7(_2 => FSPID) (_0 => MTDO _2 => FSPID)
+        ([Input] [Output])), (8, GPIO8() () ([Input] [Output])), (9, GPIO9() () ([Input]
+        [Output])), (10, GPIO10() () ([Input] [Output])), (11, GPIO11() () ([Input]
+        [Output])), (12, GPIO12() () ([Input] [Output])), (13, GPIO13() () ([Input]
+        [Output])), (14, GPIO14() () ([Input] [Output])), (15, GPIO15() () ([Input]
+        [Output])), (16, GPIO16(_2 => FSPICS0) (_0 => U0TXD _2 => FSPICS0) ([Input]
+        [Output])), (17, GPIO17(_0 => U0RXD) (_2 => FSPICS1) ([Input] [Output])), (18,
+        GPIO18(_0 => SDIO_CMD) (_0 => SDIO_CMD _2 => FSPICS2) ([Input] [Output])), (19,
+        GPIO19() (_0 => SDIO_CLK _2 => FSPICS3) ([Input] [Output])), (20, GPIO20(_0 =>
+        SDIO_DATA0) (_0 => SDIO_DATA0 _2 => FSPICS4) ([Input] [Output])), (21, GPIO21(_0
+        => SDIO_DATA1) (_0 => SDIO_DATA1 _2 => FSPICS5) ([Input] [Output])), (22,
+        GPIO22(_0 => SDIO_DATA2) (_0 => SDIO_DATA2) ([Input] [Output])), (23, GPIO23(_0
+        => SDIO_DATA3) (_0 => SDIO_DATA3) ([Input] [Output])), (24, GPIO24() (_0 =>
+        SPICS0) ([Input] [Output])), (25, GPIO25(_0 => SPIQ) (_0 => SPIQ) ([Input]
+        [Output])), (26, GPIO26(_0 => SPIWP) (_0 => SPIWP) ([Input] [Output])), (27,
+        GPIO27() () ([Input] [Output])), (28, GPIO28(_0 => SPIHD) (_0 => SPIHD) ([Input]
+        [Output])), (29, GPIO29() (_0 => SPICLK) ([Input] [Output])), (30, GPIO30(_0 =>
+        SPID) (_0 => SPID) ([Input] [Output]))));
     };
 }
 /// This macro can be used to generate code for each analog function of each GPIO.
@@ -4020,26 +4208,33 @@ macro_rules! for_each_gpio {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_analog_function {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((XTAL_32K_P, GPIO0)); _for_each_inner!((ADC0_CH0, GPIO0));
-        _for_each_inner!((XTAL_32K_N, GPIO1)); _for_each_inner!((ADC0_CH1, GPIO1));
-        _for_each_inner!((ADC0_CH2, GPIO2)); _for_each_inner!((ADC0_CH3, GPIO3));
-        _for_each_inner!((ADC0_CH4, GPIO4)); _for_each_inner!((ADC0_CH5, GPIO5));
-        _for_each_inner!((ADC0_CH6, GPIO6)); _for_each_inner!((USB_DM, GPIO12));
-        _for_each_inner!((USB_DP, GPIO13)); _for_each_inner!(((ADC0_CH0, ADCn_CHm, 0, 0),
-        GPIO0)); _for_each_inner!(((ADC0_CH1, ADCn_CHm, 0, 1), GPIO1));
-        _for_each_inner!(((ADC0_CH2, ADCn_CHm, 0, 2), GPIO2));
-        _for_each_inner!(((ADC0_CH3, ADCn_CHm, 0, 3), GPIO3));
-        _for_each_inner!(((ADC0_CH4, ADCn_CHm, 0, 4), GPIO4));
-        _for_each_inner!(((ADC0_CH5, ADCn_CHm, 0, 5), GPIO5));
-        _for_each_inner!(((ADC0_CH6, ADCn_CHm, 0, 6), GPIO6));
-        _for_each_inner!((all(XTAL_32K_P, GPIO0), (ADC0_CH0, GPIO0), (XTAL_32K_N, GPIO1),
-        (ADC0_CH1, GPIO1), (ADC0_CH2, GPIO2), (ADC0_CH3, GPIO3), (ADC0_CH4, GPIO4),
-        (ADC0_CH5, GPIO5), (ADC0_CH6, GPIO6), (USB_DM, GPIO12), (USB_DP, GPIO13)));
-        _for_each_inner!((all_expanded((ADC0_CH0, ADCn_CHm, 0, 0), GPIO0), ((ADC0_CH1,
-        ADCn_CHm, 0, 1), GPIO1), ((ADC0_CH2, ADCn_CHm, 0, 2), GPIO2), ((ADC0_CH3,
-        ADCn_CHm, 0, 3), GPIO3), ((ADC0_CH4, ADCn_CHm, 0, 4), GPIO4), ((ADC0_CH5,
-        ADCn_CHm, 0, 5), GPIO5), ((ADC0_CH6, ADCn_CHm, 0, 6), GPIO6)));
+        macro_rules! _for_each_inner_analog_function { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_analog_function!((XTAL_32K_P, GPIO0));
+        _for_each_inner_analog_function!((ADC0_CH0, GPIO0));
+        _for_each_inner_analog_function!((XTAL_32K_N, GPIO1));
+        _for_each_inner_analog_function!((ADC0_CH1, GPIO1));
+        _for_each_inner_analog_function!((ADC0_CH2, GPIO2));
+        _for_each_inner_analog_function!((ADC0_CH3, GPIO3));
+        _for_each_inner_analog_function!((ADC0_CH4, GPIO4));
+        _for_each_inner_analog_function!((ADC0_CH5, GPIO5));
+        _for_each_inner_analog_function!((ADC0_CH6, GPIO6));
+        _for_each_inner_analog_function!((USB_DM, GPIO12));
+        _for_each_inner_analog_function!((USB_DP, GPIO13));
+        _for_each_inner_analog_function!(((ADC0_CH0, ADCn_CHm, 0, 0), GPIO0));
+        _for_each_inner_analog_function!(((ADC0_CH1, ADCn_CHm, 0, 1), GPIO1));
+        _for_each_inner_analog_function!(((ADC0_CH2, ADCn_CHm, 0, 2), GPIO2));
+        _for_each_inner_analog_function!(((ADC0_CH3, ADCn_CHm, 0, 3), GPIO3));
+        _for_each_inner_analog_function!(((ADC0_CH4, ADCn_CHm, 0, 4), GPIO4));
+        _for_each_inner_analog_function!(((ADC0_CH5, ADCn_CHm, 0, 5), GPIO5));
+        _for_each_inner_analog_function!(((ADC0_CH6, ADCn_CHm, 0, 6), GPIO6));
+        _for_each_inner_analog_function!((all(XTAL_32K_P, GPIO0), (ADC0_CH0, GPIO0),
+        (XTAL_32K_N, GPIO1), (ADC0_CH1, GPIO1), (ADC0_CH2, GPIO2), (ADC0_CH3, GPIO3),
+        (ADC0_CH4, GPIO4), (ADC0_CH5, GPIO5), (ADC0_CH6, GPIO6), (USB_DM, GPIO12),
+        (USB_DP, GPIO13))); _for_each_inner_analog_function!((all_expanded((ADC0_CH0,
+        ADCn_CHm, 0, 0), GPIO0), ((ADC0_CH1, ADCn_CHm, 0, 1), GPIO1), ((ADC0_CH2,
+        ADCn_CHm, 0, 2), GPIO2), ((ADC0_CH3, ADCn_CHm, 0, 3), GPIO3), ((ADC0_CH4,
+        ADCn_CHm, 0, 4), GPIO4), ((ADC0_CH5, ADCn_CHm, 0, 5), GPIO5), ((ADC0_CH6,
+        ADCn_CHm, 0, 6), GPIO6)));
     };
 }
 /// This macro can be used to generate code for each LP/RTC function of each GPIO.
@@ -4072,29 +4267,40 @@ macro_rules! for_each_analog_function {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_lp_function {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((LP_GPIO0, GPIO0)); _for_each_inner!((LP_UART_DTRN, GPIO0));
-        _for_each_inner!((LP_GPIO1, GPIO1)); _for_each_inner!((LP_UART_DSRN, GPIO1));
-        _for_each_inner!((LP_GPIO2, GPIO2)); _for_each_inner!((LP_UART_RTSN, GPIO2));
-        _for_each_inner!((LP_GPIO3, GPIO3)); _for_each_inner!((LP_UART_CTSN, GPIO3));
-        _for_each_inner!((LP_GPIO4, GPIO4)); _for_each_inner!((LP_UART_RXD, GPIO4));
-        _for_each_inner!((LP_GPIO5, GPIO5)); _for_each_inner!((LP_UART_TXD, GPIO5));
-        _for_each_inner!((LP_GPIO6, GPIO6)); _for_each_inner!((LP_I2C_SDA, GPIO6));
-        _for_each_inner!((LP_GPIO7, GPIO7)); _for_each_inner!((LP_I2C_SCL, GPIO7));
-        _for_each_inner!(((LP_GPIO0, LP_GPIOn, 0), GPIO0)); _for_each_inner!(((LP_GPIO1,
-        LP_GPIOn, 1), GPIO1)); _for_each_inner!(((LP_GPIO2, LP_GPIOn, 2), GPIO2));
-        _for_each_inner!(((LP_GPIO3, LP_GPIOn, 3), GPIO3)); _for_each_inner!(((LP_GPIO4,
-        LP_GPIOn, 4), GPIO4)); _for_each_inner!(((LP_GPIO5, LP_GPIOn, 5), GPIO5));
-        _for_each_inner!(((LP_GPIO6, LP_GPIOn, 6), GPIO6)); _for_each_inner!(((LP_GPIO7,
-        LP_GPIOn, 7), GPIO7)); _for_each_inner!((all(LP_GPIO0, GPIO0), (LP_UART_DTRN,
-        GPIO0), (LP_GPIO1, GPIO1), (LP_UART_DSRN, GPIO1), (LP_GPIO2, GPIO2),
-        (LP_UART_RTSN, GPIO2), (LP_GPIO3, GPIO3), (LP_UART_CTSN, GPIO3), (LP_GPIO4,
-        GPIO4), (LP_UART_RXD, GPIO4), (LP_GPIO5, GPIO5), (LP_UART_TXD, GPIO5), (LP_GPIO6,
-        GPIO6), (LP_I2C_SDA, GPIO6), (LP_GPIO7, GPIO7), (LP_I2C_SCL, GPIO7)));
-        _for_each_inner!((all_expanded((LP_GPIO0, LP_GPIOn, 0), GPIO0), ((LP_GPIO1,
-        LP_GPIOn, 1), GPIO1), ((LP_GPIO2, LP_GPIOn, 2), GPIO2), ((LP_GPIO3, LP_GPIOn, 3),
-        GPIO3), ((LP_GPIO4, LP_GPIOn, 4), GPIO4), ((LP_GPIO5, LP_GPIOn, 5), GPIO5),
-        ((LP_GPIO6, LP_GPIOn, 6), GPIO6), ((LP_GPIO7, LP_GPIOn, 7), GPIO7)));
+        macro_rules! _for_each_inner_lp_function { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_lp_function!((LP_GPIO0, GPIO0));
+        _for_each_inner_lp_function!((LP_UART_DTRN, GPIO0));
+        _for_each_inner_lp_function!((LP_GPIO1, GPIO1));
+        _for_each_inner_lp_function!((LP_UART_DSRN, GPIO1));
+        _for_each_inner_lp_function!((LP_GPIO2, GPIO2));
+        _for_each_inner_lp_function!((LP_UART_RTSN, GPIO2));
+        _for_each_inner_lp_function!((LP_GPIO3, GPIO3));
+        _for_each_inner_lp_function!((LP_UART_CTSN, GPIO3));
+        _for_each_inner_lp_function!((LP_GPIO4, GPIO4));
+        _for_each_inner_lp_function!((LP_UART_RXD, GPIO4));
+        _for_each_inner_lp_function!((LP_GPIO5, GPIO5));
+        _for_each_inner_lp_function!((LP_UART_TXD, GPIO5));
+        _for_each_inner_lp_function!((LP_GPIO6, GPIO6));
+        _for_each_inner_lp_function!((LP_I2C_SDA, GPIO6));
+        _for_each_inner_lp_function!((LP_GPIO7, GPIO7));
+        _for_each_inner_lp_function!((LP_I2C_SCL, GPIO7));
+        _for_each_inner_lp_function!(((LP_GPIO0, LP_GPIOn, 0), GPIO0));
+        _for_each_inner_lp_function!(((LP_GPIO1, LP_GPIOn, 1), GPIO1));
+        _for_each_inner_lp_function!(((LP_GPIO2, LP_GPIOn, 2), GPIO2));
+        _for_each_inner_lp_function!(((LP_GPIO3, LP_GPIOn, 3), GPIO3));
+        _for_each_inner_lp_function!(((LP_GPIO4, LP_GPIOn, 4), GPIO4));
+        _for_each_inner_lp_function!(((LP_GPIO5, LP_GPIOn, 5), GPIO5));
+        _for_each_inner_lp_function!(((LP_GPIO6, LP_GPIOn, 6), GPIO6));
+        _for_each_inner_lp_function!(((LP_GPIO7, LP_GPIOn, 7), GPIO7));
+        _for_each_inner_lp_function!((all(LP_GPIO0, GPIO0), (LP_UART_DTRN, GPIO0),
+        (LP_GPIO1, GPIO1), (LP_UART_DSRN, GPIO1), (LP_GPIO2, GPIO2), (LP_UART_RTSN,
+        GPIO2), (LP_GPIO3, GPIO3), (LP_UART_CTSN, GPIO3), (LP_GPIO4, GPIO4),
+        (LP_UART_RXD, GPIO4), (LP_GPIO5, GPIO5), (LP_UART_TXD, GPIO5), (LP_GPIO6, GPIO6),
+        (LP_I2C_SDA, GPIO6), (LP_GPIO7, GPIO7), (LP_I2C_SCL, GPIO7)));
+        _for_each_inner_lp_function!((all_expanded((LP_GPIO0, LP_GPIOn, 0), GPIO0),
+        ((LP_GPIO1, LP_GPIOn, 1), GPIO1), ((LP_GPIO2, LP_GPIOn, 2), GPIO2), ((LP_GPIO3,
+        LP_GPIOn, 3), GPIO3), ((LP_GPIO4, LP_GPIOn, 4), GPIO4), ((LP_GPIO5, LP_GPIOn, 5),
+        GPIO5), ((LP_GPIO6, LP_GPIOn, 6), GPIO6), ((LP_GPIO7, LP_GPIOn, 7), GPIO7)));
     };
 }
 /// Defines the `InputSignal` and `OutputSignal` enums.

--- a/esp-metadata-generated/src/_generated_esp32h2.rs
+++ b/esp-metadata-generated/src/_generated_esp32h2.rs
@@ -2275,39 +2275,47 @@ macro_rules! memory_range {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_aes_key_length {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((128)); _for_each_inner!((256)); _for_each_inner!((128, 0, 4));
-        _for_each_inner!((256, 2, 6)); _for_each_inner!((bits(128), (256)));
-        _for_each_inner!((modes(128, 0, 4), (256, 2, 6)));
+        macro_rules! _for_each_inner_aes_key_length { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_aes_key_length!((128));
+        _for_each_inner_aes_key_length!((256)); _for_each_inner_aes_key_length!((128, 0,
+        4)); _for_each_inner_aes_key_length!((256, 2, 6));
+        _for_each_inner_aes_key_length!((bits(128), (256)));
+        _for_each_inner_aes_key_length!((modes(128, 0, 4), (256, 2, 6)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_dedicated_gpio {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((0)); _for_each_inner!((1)); _for_each_inner!((2));
-        _for_each_inner!((3)); _for_each_inner!((4)); _for_each_inner!((5));
-        _for_each_inner!((6)); _for_each_inner!((7)); _for_each_inner!((0, 0,
-        CPU_GPIO_0)); _for_each_inner!((0, 1, CPU_GPIO_1)); _for_each_inner!((0, 2,
-        CPU_GPIO_2)); _for_each_inner!((0, 3, CPU_GPIO_3)); _for_each_inner!((0, 4,
-        CPU_GPIO_4)); _for_each_inner!((0, 5, CPU_GPIO_5)); _for_each_inner!((0, 6,
-        CPU_GPIO_6)); _for_each_inner!((0, 7, CPU_GPIO_7));
-        _for_each_inner!((channels(0), (1), (2), (3), (4), (5), (6), (7)));
-        _for_each_inner!((signals(0, 0, CPU_GPIO_0), (0, 1, CPU_GPIO_1), (0, 2,
-        CPU_GPIO_2), (0, 3, CPU_GPIO_3), (0, 4, CPU_GPIO_4), (0, 5, CPU_GPIO_5), (0, 6,
-        CPU_GPIO_6), (0, 7, CPU_GPIO_7)));
+        macro_rules! _for_each_inner_dedicated_gpio { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_dedicated_gpio!((0));
+        _for_each_inner_dedicated_gpio!((1)); _for_each_inner_dedicated_gpio!((2));
+        _for_each_inner_dedicated_gpio!((3)); _for_each_inner_dedicated_gpio!((4));
+        _for_each_inner_dedicated_gpio!((5)); _for_each_inner_dedicated_gpio!((6));
+        _for_each_inner_dedicated_gpio!((7)); _for_each_inner_dedicated_gpio!((0, 0,
+        CPU_GPIO_0)); _for_each_inner_dedicated_gpio!((0, 1, CPU_GPIO_1));
+        _for_each_inner_dedicated_gpio!((0, 2, CPU_GPIO_2));
+        _for_each_inner_dedicated_gpio!((0, 3, CPU_GPIO_3));
+        _for_each_inner_dedicated_gpio!((0, 4, CPU_GPIO_4));
+        _for_each_inner_dedicated_gpio!((0, 5, CPU_GPIO_5));
+        _for_each_inner_dedicated_gpio!((0, 6, CPU_GPIO_6));
+        _for_each_inner_dedicated_gpio!((0, 7, CPU_GPIO_7));
+        _for_each_inner_dedicated_gpio!((channels(0), (1), (2), (3), (4), (5), (6),
+        (7))); _for_each_inner_dedicated_gpio!((signals(0, 0, CPU_GPIO_0), (0, 1,
+        CPU_GPIO_1), (0, 2, CPU_GPIO_2), (0, 3, CPU_GPIO_3), (0, 4, CPU_GPIO_4), (0, 5,
+        CPU_GPIO_5), (0, 6, CPU_GPIO_6), (0, 7, CPU_GPIO_7)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_sw_interrupt {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((0, FROM_CPU_INTR0, software_interrupt0)); _for_each_inner!((1,
-        FROM_CPU_INTR1, software_interrupt1)); _for_each_inner!((2, FROM_CPU_INTR2,
-        software_interrupt2)); _for_each_inner!((3, FROM_CPU_INTR3,
-        software_interrupt3)); _for_each_inner!((all(0, FROM_CPU_INTR0,
+        macro_rules! _for_each_inner_sw_interrupt { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_sw_interrupt!((0, FROM_CPU_INTR0,
+        software_interrupt0)); _for_each_inner_sw_interrupt!((1, FROM_CPU_INTR1,
+        software_interrupt1)); _for_each_inner_sw_interrupt!((2, FROM_CPU_INTR2,
+        software_interrupt2)); _for_each_inner_sw_interrupt!((3, FROM_CPU_INTR3,
+        software_interrupt3)); _for_each_inner_sw_interrupt!((all(0, FROM_CPU_INTR0,
         software_interrupt0), (1, FROM_CPU_INTR1, software_interrupt1), (2,
         FROM_CPU_INTR2, software_interrupt2), (3, FROM_CPU_INTR3, software_interrupt3)));
     };
@@ -2349,112 +2357,215 @@ macro_rules! sw_interrupt_delay {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rmt_channel {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((0)); _for_each_inner!((1)); _for_each_inner!((2));
-        _for_each_inner!((3)); _for_each_inner!((0, 0)); _for_each_inner!((1, 1));
-        _for_each_inner!((2, 0)); _for_each_inner!((3, 1)); _for_each_inner!((all(0),
-        (1), (2), (3))); _for_each_inner!((tx(0, 0), (1, 1))); _for_each_inner!((rx(2,
-        0), (3, 1)));
+        macro_rules! _for_each_inner_rmt_channel { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_rmt_channel!((0)); _for_each_inner_rmt_channel!((1));
+        _for_each_inner_rmt_channel!((2)); _for_each_inner_rmt_channel!((3));
+        _for_each_inner_rmt_channel!((0, 0)); _for_each_inner_rmt_channel!((1, 1));
+        _for_each_inner_rmt_channel!((2, 0)); _for_each_inner_rmt_channel!((3, 1));
+        _for_each_inner_rmt_channel!((all(0), (1), (2), (3)));
+        _for_each_inner_rmt_channel!((tx(0, 0), (1, 1)));
+        _for_each_inner_rmt_channel!((rx(2, 0), (3, 1)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rmt_clock_source {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((Xtal, 0)); _for_each_inner!((RcFast, 1));
-        _for_each_inner!((Xtal)); _for_each_inner!((all(Xtal, 0), (RcFast, 1)));
-        _for_each_inner!((default(Xtal))); _for_each_inner!((is_boolean));
+        macro_rules! _for_each_inner_rmt_clock_source { $(($pattern) => $code;)* ($other
+        : tt) => {} } _for_each_inner_rmt_clock_source!((Xtal, 0));
+        _for_each_inner_rmt_clock_source!((RcFast, 1));
+        _for_each_inner_rmt_clock_source!((Xtal));
+        _for_each_inner_rmt_clock_source!((all(Xtal, 0), (RcFast, 1)));
+        _for_each_inner_rmt_clock_source!((default(Xtal)));
+        _for_each_inner_rmt_clock_source!((is_boolean));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rsa_exponentiation {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((32)); _for_each_inner!((64)); _for_each_inner!((96));
-        _for_each_inner!((128)); _for_each_inner!((160)); _for_each_inner!((192));
-        _for_each_inner!((224)); _for_each_inner!((256)); _for_each_inner!((288));
-        _for_each_inner!((320)); _for_each_inner!((352)); _for_each_inner!((384));
-        _for_each_inner!((416)); _for_each_inner!((448)); _for_each_inner!((480));
-        _for_each_inner!((512)); _for_each_inner!((544)); _for_each_inner!((576));
-        _for_each_inner!((608)); _for_each_inner!((640)); _for_each_inner!((672));
-        _for_each_inner!((704)); _for_each_inner!((736)); _for_each_inner!((768));
-        _for_each_inner!((800)); _for_each_inner!((832)); _for_each_inner!((864));
-        _for_each_inner!((896)); _for_each_inner!((928)); _for_each_inner!((960));
-        _for_each_inner!((992)); _for_each_inner!((1024)); _for_each_inner!((1056));
-        _for_each_inner!((1088)); _for_each_inner!((1120)); _for_each_inner!((1152));
-        _for_each_inner!((1184)); _for_each_inner!((1216)); _for_each_inner!((1248));
-        _for_each_inner!((1280)); _for_each_inner!((1312)); _for_each_inner!((1344));
-        _for_each_inner!((1376)); _for_each_inner!((1408)); _for_each_inner!((1440));
-        _for_each_inner!((1472)); _for_each_inner!((1504)); _for_each_inner!((1536));
-        _for_each_inner!((1568)); _for_each_inner!((1600)); _for_each_inner!((1632));
-        _for_each_inner!((1664)); _for_each_inner!((1696)); _for_each_inner!((1728));
-        _for_each_inner!((1760)); _for_each_inner!((1792)); _for_each_inner!((1824));
-        _for_each_inner!((1856)); _for_each_inner!((1888)); _for_each_inner!((1920));
-        _for_each_inner!((1952)); _for_each_inner!((1984)); _for_each_inner!((2016));
-        _for_each_inner!((2048)); _for_each_inner!((2080)); _for_each_inner!((2112));
-        _for_each_inner!((2144)); _for_each_inner!((2176)); _for_each_inner!((2208));
-        _for_each_inner!((2240)); _for_each_inner!((2272)); _for_each_inner!((2304));
-        _for_each_inner!((2336)); _for_each_inner!((2368)); _for_each_inner!((2400));
-        _for_each_inner!((2432)); _for_each_inner!((2464)); _for_each_inner!((2496));
-        _for_each_inner!((2528)); _for_each_inner!((2560)); _for_each_inner!((2592));
-        _for_each_inner!((2624)); _for_each_inner!((2656)); _for_each_inner!((2688));
-        _for_each_inner!((2720)); _for_each_inner!((2752)); _for_each_inner!((2784));
-        _for_each_inner!((2816)); _for_each_inner!((2848)); _for_each_inner!((2880));
-        _for_each_inner!((2912)); _for_each_inner!((2944)); _for_each_inner!((2976));
-        _for_each_inner!((3008)); _for_each_inner!((3040)); _for_each_inner!((3072));
-        _for_each_inner!((all(32), (64), (96), (128), (160), (192), (224), (256), (288),
-        (320), (352), (384), (416), (448), (480), (512), (544), (576), (608), (640),
-        (672), (704), (736), (768), (800), (832), (864), (896), (928), (960), (992),
-        (1024), (1056), (1088), (1120), (1152), (1184), (1216), (1248), (1280), (1312),
-        (1344), (1376), (1408), (1440), (1472), (1504), (1536), (1568), (1600), (1632),
-        (1664), (1696), (1728), (1760), (1792), (1824), (1856), (1888), (1920), (1952),
-        (1984), (2016), (2048), (2080), (2112), (2144), (2176), (2208), (2240), (2272),
-        (2304), (2336), (2368), (2400), (2432), (2464), (2496), (2528), (2560), (2592),
-        (2624), (2656), (2688), (2720), (2752), (2784), (2816), (2848), (2880), (2912),
-        (2944), (2976), (3008), (3040), (3072)));
+        macro_rules! _for_each_inner_rsa_exponentiation { $(($pattern) => $code;)*
+        ($other : tt) => {} } _for_each_inner_rsa_exponentiation!((32));
+        _for_each_inner_rsa_exponentiation!((64));
+        _for_each_inner_rsa_exponentiation!((96));
+        _for_each_inner_rsa_exponentiation!((128));
+        _for_each_inner_rsa_exponentiation!((160));
+        _for_each_inner_rsa_exponentiation!((192));
+        _for_each_inner_rsa_exponentiation!((224));
+        _for_each_inner_rsa_exponentiation!((256));
+        _for_each_inner_rsa_exponentiation!((288));
+        _for_each_inner_rsa_exponentiation!((320));
+        _for_each_inner_rsa_exponentiation!((352));
+        _for_each_inner_rsa_exponentiation!((384));
+        _for_each_inner_rsa_exponentiation!((416));
+        _for_each_inner_rsa_exponentiation!((448));
+        _for_each_inner_rsa_exponentiation!((480));
+        _for_each_inner_rsa_exponentiation!((512));
+        _for_each_inner_rsa_exponentiation!((544));
+        _for_each_inner_rsa_exponentiation!((576));
+        _for_each_inner_rsa_exponentiation!((608));
+        _for_each_inner_rsa_exponentiation!((640));
+        _for_each_inner_rsa_exponentiation!((672));
+        _for_each_inner_rsa_exponentiation!((704));
+        _for_each_inner_rsa_exponentiation!((736));
+        _for_each_inner_rsa_exponentiation!((768));
+        _for_each_inner_rsa_exponentiation!((800));
+        _for_each_inner_rsa_exponentiation!((832));
+        _for_each_inner_rsa_exponentiation!((864));
+        _for_each_inner_rsa_exponentiation!((896));
+        _for_each_inner_rsa_exponentiation!((928));
+        _for_each_inner_rsa_exponentiation!((960));
+        _for_each_inner_rsa_exponentiation!((992));
+        _for_each_inner_rsa_exponentiation!((1024));
+        _for_each_inner_rsa_exponentiation!((1056));
+        _for_each_inner_rsa_exponentiation!((1088));
+        _for_each_inner_rsa_exponentiation!((1120));
+        _for_each_inner_rsa_exponentiation!((1152));
+        _for_each_inner_rsa_exponentiation!((1184));
+        _for_each_inner_rsa_exponentiation!((1216));
+        _for_each_inner_rsa_exponentiation!((1248));
+        _for_each_inner_rsa_exponentiation!((1280));
+        _for_each_inner_rsa_exponentiation!((1312));
+        _for_each_inner_rsa_exponentiation!((1344));
+        _for_each_inner_rsa_exponentiation!((1376));
+        _for_each_inner_rsa_exponentiation!((1408));
+        _for_each_inner_rsa_exponentiation!((1440));
+        _for_each_inner_rsa_exponentiation!((1472));
+        _for_each_inner_rsa_exponentiation!((1504));
+        _for_each_inner_rsa_exponentiation!((1536));
+        _for_each_inner_rsa_exponentiation!((1568));
+        _for_each_inner_rsa_exponentiation!((1600));
+        _for_each_inner_rsa_exponentiation!((1632));
+        _for_each_inner_rsa_exponentiation!((1664));
+        _for_each_inner_rsa_exponentiation!((1696));
+        _for_each_inner_rsa_exponentiation!((1728));
+        _for_each_inner_rsa_exponentiation!((1760));
+        _for_each_inner_rsa_exponentiation!((1792));
+        _for_each_inner_rsa_exponentiation!((1824));
+        _for_each_inner_rsa_exponentiation!((1856));
+        _for_each_inner_rsa_exponentiation!((1888));
+        _for_each_inner_rsa_exponentiation!((1920));
+        _for_each_inner_rsa_exponentiation!((1952));
+        _for_each_inner_rsa_exponentiation!((1984));
+        _for_each_inner_rsa_exponentiation!((2016));
+        _for_each_inner_rsa_exponentiation!((2048));
+        _for_each_inner_rsa_exponentiation!((2080));
+        _for_each_inner_rsa_exponentiation!((2112));
+        _for_each_inner_rsa_exponentiation!((2144));
+        _for_each_inner_rsa_exponentiation!((2176));
+        _for_each_inner_rsa_exponentiation!((2208));
+        _for_each_inner_rsa_exponentiation!((2240));
+        _for_each_inner_rsa_exponentiation!((2272));
+        _for_each_inner_rsa_exponentiation!((2304));
+        _for_each_inner_rsa_exponentiation!((2336));
+        _for_each_inner_rsa_exponentiation!((2368));
+        _for_each_inner_rsa_exponentiation!((2400));
+        _for_each_inner_rsa_exponentiation!((2432));
+        _for_each_inner_rsa_exponentiation!((2464));
+        _for_each_inner_rsa_exponentiation!((2496));
+        _for_each_inner_rsa_exponentiation!((2528));
+        _for_each_inner_rsa_exponentiation!((2560));
+        _for_each_inner_rsa_exponentiation!((2592));
+        _for_each_inner_rsa_exponentiation!((2624));
+        _for_each_inner_rsa_exponentiation!((2656));
+        _for_each_inner_rsa_exponentiation!((2688));
+        _for_each_inner_rsa_exponentiation!((2720));
+        _for_each_inner_rsa_exponentiation!((2752));
+        _for_each_inner_rsa_exponentiation!((2784));
+        _for_each_inner_rsa_exponentiation!((2816));
+        _for_each_inner_rsa_exponentiation!((2848));
+        _for_each_inner_rsa_exponentiation!((2880));
+        _for_each_inner_rsa_exponentiation!((2912));
+        _for_each_inner_rsa_exponentiation!((2944));
+        _for_each_inner_rsa_exponentiation!((2976));
+        _for_each_inner_rsa_exponentiation!((3008));
+        _for_each_inner_rsa_exponentiation!((3040));
+        _for_each_inner_rsa_exponentiation!((3072));
+        _for_each_inner_rsa_exponentiation!((all(32), (64), (96), (128), (160), (192),
+        (224), (256), (288), (320), (352), (384), (416), (448), (480), (512), (544),
+        (576), (608), (640), (672), (704), (736), (768), (800), (832), (864), (896),
+        (928), (960), (992), (1024), (1056), (1088), (1120), (1152), (1184), (1216),
+        (1248), (1280), (1312), (1344), (1376), (1408), (1440), (1472), (1504), (1536),
+        (1568), (1600), (1632), (1664), (1696), (1728), (1760), (1792), (1824), (1856),
+        (1888), (1920), (1952), (1984), (2016), (2048), (2080), (2112), (2144), (2176),
+        (2208), (2240), (2272), (2304), (2336), (2368), (2400), (2432), (2464), (2496),
+        (2528), (2560), (2592), (2624), (2656), (2688), (2720), (2752), (2784), (2816),
+        (2848), (2880), (2912), (2944), (2976), (3008), (3040), (3072)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rsa_multiplication {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((32)); _for_each_inner!((64)); _for_each_inner!((96));
-        _for_each_inner!((128)); _for_each_inner!((160)); _for_each_inner!((192));
-        _for_each_inner!((224)); _for_each_inner!((256)); _for_each_inner!((288));
-        _for_each_inner!((320)); _for_each_inner!((352)); _for_each_inner!((384));
-        _for_each_inner!((416)); _for_each_inner!((448)); _for_each_inner!((480));
-        _for_each_inner!((512)); _for_each_inner!((544)); _for_each_inner!((576));
-        _for_each_inner!((608)); _for_each_inner!((640)); _for_each_inner!((672));
-        _for_each_inner!((704)); _for_each_inner!((736)); _for_each_inner!((768));
-        _for_each_inner!((800)); _for_each_inner!((832)); _for_each_inner!((864));
-        _for_each_inner!((896)); _for_each_inner!((928)); _for_each_inner!((960));
-        _for_each_inner!((992)); _for_each_inner!((1024)); _for_each_inner!((1056));
-        _for_each_inner!((1088)); _for_each_inner!((1120)); _for_each_inner!((1152));
-        _for_each_inner!((1184)); _for_each_inner!((1216)); _for_each_inner!((1248));
-        _for_each_inner!((1280)); _for_each_inner!((1312)); _for_each_inner!((1344));
-        _for_each_inner!((1376)); _for_each_inner!((1408)); _for_each_inner!((1440));
-        _for_each_inner!((1472)); _for_each_inner!((1504)); _for_each_inner!((1536));
-        _for_each_inner!((all(32), (64), (96), (128), (160), (192), (224), (256), (288),
-        (320), (352), (384), (416), (448), (480), (512), (544), (576), (608), (640),
-        (672), (704), (736), (768), (800), (832), (864), (896), (928), (960), (992),
-        (1024), (1056), (1088), (1120), (1152), (1184), (1216), (1248), (1280), (1312),
-        (1344), (1376), (1408), (1440), (1472), (1504), (1536)));
+        macro_rules! _for_each_inner_rsa_multiplication { $(($pattern) => $code;)*
+        ($other : tt) => {} } _for_each_inner_rsa_multiplication!((32));
+        _for_each_inner_rsa_multiplication!((64));
+        _for_each_inner_rsa_multiplication!((96));
+        _for_each_inner_rsa_multiplication!((128));
+        _for_each_inner_rsa_multiplication!((160));
+        _for_each_inner_rsa_multiplication!((192));
+        _for_each_inner_rsa_multiplication!((224));
+        _for_each_inner_rsa_multiplication!((256));
+        _for_each_inner_rsa_multiplication!((288));
+        _for_each_inner_rsa_multiplication!((320));
+        _for_each_inner_rsa_multiplication!((352));
+        _for_each_inner_rsa_multiplication!((384));
+        _for_each_inner_rsa_multiplication!((416));
+        _for_each_inner_rsa_multiplication!((448));
+        _for_each_inner_rsa_multiplication!((480));
+        _for_each_inner_rsa_multiplication!((512));
+        _for_each_inner_rsa_multiplication!((544));
+        _for_each_inner_rsa_multiplication!((576));
+        _for_each_inner_rsa_multiplication!((608));
+        _for_each_inner_rsa_multiplication!((640));
+        _for_each_inner_rsa_multiplication!((672));
+        _for_each_inner_rsa_multiplication!((704));
+        _for_each_inner_rsa_multiplication!((736));
+        _for_each_inner_rsa_multiplication!((768));
+        _for_each_inner_rsa_multiplication!((800));
+        _for_each_inner_rsa_multiplication!((832));
+        _for_each_inner_rsa_multiplication!((864));
+        _for_each_inner_rsa_multiplication!((896));
+        _for_each_inner_rsa_multiplication!((928));
+        _for_each_inner_rsa_multiplication!((960));
+        _for_each_inner_rsa_multiplication!((992));
+        _for_each_inner_rsa_multiplication!((1024));
+        _for_each_inner_rsa_multiplication!((1056));
+        _for_each_inner_rsa_multiplication!((1088));
+        _for_each_inner_rsa_multiplication!((1120));
+        _for_each_inner_rsa_multiplication!((1152));
+        _for_each_inner_rsa_multiplication!((1184));
+        _for_each_inner_rsa_multiplication!((1216));
+        _for_each_inner_rsa_multiplication!((1248));
+        _for_each_inner_rsa_multiplication!((1280));
+        _for_each_inner_rsa_multiplication!((1312));
+        _for_each_inner_rsa_multiplication!((1344));
+        _for_each_inner_rsa_multiplication!((1376));
+        _for_each_inner_rsa_multiplication!((1408));
+        _for_each_inner_rsa_multiplication!((1440));
+        _for_each_inner_rsa_multiplication!((1472));
+        _for_each_inner_rsa_multiplication!((1504));
+        _for_each_inner_rsa_multiplication!((1536));
+        _for_each_inner_rsa_multiplication!((all(32), (64), (96), (128), (160), (192),
+        (224), (256), (288), (320), (352), (384), (416), (448), (480), (512), (544),
+        (576), (608), (640), (672), (704), (736), (768), (800), (832), (864), (896),
+        (928), (960), (992), (1024), (1056), (1088), (1120), (1152), (1184), (1216),
+        (1248), (1280), (1312), (1344), (1376), (1408), (1440), (1472), (1504), (1536)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_sha_algorithm {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((Sha1, "SHA-1"(sizes : 64, 20, 8) (insecure_against :
-        "collision", "length extension"), 0)); _for_each_inner!((Sha224, "SHA-224"(sizes
-        : 64, 28, 8) (insecure_against : "length extension"), 1));
-        _for_each_inner!((Sha256, "SHA-256"(sizes : 64, 32, 8) (insecure_against :
-        "length extension"), 2)); _for_each_inner!((algos(Sha1, "SHA-1"(sizes : 64, 20,
-        8) (insecure_against : "collision", "length extension"), 0), (Sha224,
+        macro_rules! _for_each_inner_sha_algorithm { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_sha_algorithm!((Sha1, "SHA-1"(sizes : 64, 20, 8)
+        (insecure_against : "collision", "length extension"), 0));
+        _for_each_inner_sha_algorithm!((Sha224, "SHA-224"(sizes : 64, 28, 8)
+        (insecure_against : "length extension"), 1));
+        _for_each_inner_sha_algorithm!((Sha256, "SHA-256"(sizes : 64, 32, 8)
+        (insecure_against : "length extension"), 2));
+        _for_each_inner_sha_algorithm!((algos(Sha1, "SHA-1"(sizes : 64, 20, 8)
+        (insecure_against : "collision", "length extension"), 0), (Sha224,
         "SHA-224"(sizes : 64, 28, 8) (insecure_against : "length extension"), 1),
         (Sha256, "SHA-256"(sizes : 64, 32, 8) (insecure_against : "length extension"),
         2)));
@@ -2480,11 +2591,11 @@ macro_rules! for_each_sha_algorithm {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_i2c_master {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((I2C0, I2cExt0, I2CEXT0_SCL, I2CEXT0_SDA));
-        _for_each_inner!((I2C1, I2cExt1, I2CEXT1_SCL, I2CEXT1_SDA));
-        _for_each_inner!((all(I2C0, I2cExt0, I2CEXT0_SCL, I2CEXT0_SDA), (I2C1, I2cExt1,
-        I2CEXT1_SCL, I2CEXT1_SDA)));
+        macro_rules! _for_each_inner_i2c_master { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_i2c_master!((I2C0, I2cExt0, I2CEXT0_SCL, I2CEXT0_SDA));
+        _for_each_inner_i2c_master!((I2C1, I2cExt1, I2CEXT1_SCL, I2CEXT1_SDA));
+        _for_each_inner_i2c_master!((all(I2C0, I2cExt0, I2CEXT0_SCL, I2CEXT0_SDA), (I2C1,
+        I2cExt1, I2CEXT1_SCL, I2CEXT1_SDA)));
     };
 }
 /// This macro can be used to generate code for each peripheral instance of the UART driver.
@@ -2507,11 +2618,11 @@ macro_rules! for_each_i2c_master {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_uart {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS));
-        _for_each_inner!((UART1, Uart1, U1RXD, U1TXD, U1CTS, U1RTS));
-        _for_each_inner!((all(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS), (UART1, Uart1,
-        U1RXD, U1TXD, U1CTS, U1RTS)));
+        macro_rules! _for_each_inner_uart { $(($pattern) => $code;)* ($other : tt) => {}
+        } _for_each_inner_uart!((UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS));
+        _for_each_inner_uart!((UART1, Uart1, U1RXD, U1TXD, U1CTS, U1RTS));
+        _for_each_inner_uart!((all(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS), (UART1,
+        Uart1, U1RXD, U1TXD, U1CTS, U1RTS)));
     };
 }
 /// This macro can be used to generate code for each peripheral instance of the SPI master driver.
@@ -2539,11 +2650,11 @@ macro_rules! for_each_uart {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_spi_master {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((SPI2, Spi2, FSPICLK[FSPICS0, FSPICS1, FSPICS2, FSPICS3,
-        FSPICS4, FSPICS5] [FSPID, FSPIQ, FSPIWP, FSPIHD], true));
-        _for_each_inner!((all(SPI2, Spi2, FSPICLK[FSPICS0, FSPICS1, FSPICS2, FSPICS3,
-        FSPICS4, FSPICS5] [FSPID, FSPIQ, FSPIWP, FSPIHD], true)));
+        macro_rules! _for_each_inner_spi_master { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_spi_master!((SPI2, Spi2, FSPICLK[FSPICS0, FSPICS1,
+        FSPICS2, FSPICS3, FSPICS4, FSPICS5] [FSPID, FSPIQ, FSPIWP, FSPIHD], true));
+        _for_each_inner_spi_master!((all(SPI2, Spi2, FSPICLK[FSPICS0, FSPICS1, FSPICS2,
+        FSPICS3, FSPICS4, FSPICS5] [FSPID, FSPIQ, FSPIWP, FSPIHD], true)));
     };
 }
 /// This macro can be used to generate code for each peripheral instance of the SPI slave driver.
@@ -2566,267 +2677,331 @@ macro_rules! for_each_spi_master {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_spi_slave {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((SPI2, Spi2, FSPICLK, FSPID, FSPIQ, FSPICS0));
-        _for_each_inner!((all(SPI2, Spi2, FSPICLK, FSPID, FSPIQ, FSPICS0)));
+        macro_rules! _for_each_inner_spi_slave { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_spi_slave!((SPI2, Spi2, FSPICLK, FSPID, FSPIQ, FSPICS0));
+        _for_each_inner_spi_slave!((all(SPI2, Spi2, FSPICLK, FSPID, FSPIQ, FSPICS0)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_peripheral {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((@ peri_type #[doc = "GPIO0 peripheral singleton"] GPIO0 <=
-        virtual())); _for_each_inner!((@ peri_type #[doc = "GPIO1 peripheral singleton"]
-        GPIO1 <= virtual())); _for_each_inner!((@ peri_type #[doc =
+        macro_rules! _for_each_inner_peripheral { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO0 peripheral singleton"] GPIO0 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO1 peripheral singleton"]
+        GPIO1 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
         "GPIO2 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
         "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>These pins may be used to debug the chip using an external JTAG debugger.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO2 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO3 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO2 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO3 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>These pins may be used to debug the chip using an external JTAG debugger.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO3 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO4 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO3 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO4 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>These pins may be used to debug the chip using an external JTAG debugger.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO4 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO5 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO4 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO5 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>These pins may be used to debug the chip using an external JTAG debugger.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO5 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO6 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO5 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO6 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO6 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO7 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO6 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO7 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO7 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO8 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO7 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO8 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin is a strapping pin, it determines how the chip boots.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO8 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO9 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO8 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO9 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin is a strapping pin, it determines how the chip boots.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO9 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO10 peripheral singleton"] GPIO10 <= virtual()));
-        _for_each_inner!((@ peri_type #[doc = "GPIO11 peripheral singleton"] GPIO11 <=
-        virtual())); _for_each_inner!((@ peri_type #[doc = "GPIO12 peripheral singleton"]
-        GPIO12 <= virtual())); _for_each_inner!((@ peri_type #[doc =
-        "GPIO13 peripheral singleton"] GPIO13 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO14 peripheral singleton"] GPIO14 <= virtual()));
-        _for_each_inner!((@ peri_type #[doc = "GPIO22 peripheral singleton"] GPIO22 <=
-        virtual())); _for_each_inner!((@ peri_type #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO9 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO10 peripheral singleton"]
+        GPIO10 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO11 peripheral singleton"] GPIO11 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO12 peripheral singleton"]
+        GPIO12 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO13 peripheral singleton"] GPIO13 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO14 peripheral singleton"]
+        GPIO14 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO22 peripheral singleton"] GPIO22 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
         "GPIO23 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
         "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>By default, this pin is used by the UART programming interface.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO23 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO24 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO23 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO24 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>By default, this pin is used by the UART programming interface.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO24 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO25 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO24 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO25 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin is a strapping pin, it determines how the chip boots.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO25 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO26 peripheral singleton"] GPIO26 <= virtual()));
-        _for_each_inner!((@ peri_type #[doc = "GPIO27 peripheral singleton"] GPIO27 <=
-        virtual())); _for_each_inner!((@ peri_type #[doc = "AES peripheral singleton"]
-        AES <= AES(AES : { bind_peri_interrupt, enable_peri_interrupt,
-        disable_peri_interrupt }) (unstable))); _for_each_inner!((@ peri_type #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO25 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO26 peripheral singleton"]
+        GPIO26 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO27 peripheral singleton"] GPIO27 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "AES peripheral singleton"] AES
+        <= AES(AES : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt
+        }) (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "ASSIST_DEBUG peripheral singleton"]
-        ASSIST_DEBUG <= ASSIST_DEBUG() (unstable))); _for_each_inner!((@ peri_type #[doc
-        = "DMA peripheral singleton"] DMA <= DMA() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "DS peripheral singleton"] DS <= DS() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "ECC peripheral singleton"] ECC <= ECC()
-        (unstable))); _for_each_inner!((@ peri_type #[doc = "EFUSE peripheral singleton"]
-        EFUSE <= EFUSE() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "GPIO peripheral singleton"] GPIO <= GPIO() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "GPIO_SD peripheral singleton"] GPIO_SD <= GPIO_SD()
-        (unstable))); _for_each_inner!((@ peri_type #[doc = "HMAC peripheral singleton"]
-        HMAC <= HMAC() (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "ASSIST_DEBUG peripheral singleton"] ASSIST_DEBUG <= ASSIST_DEBUG() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA peripheral singleton"] DMA
+        <= DMA() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "DS peripheral singleton"] DS <= DS() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "ECC peripheral singleton"] ECC
+        <= ECC() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "EFUSE peripheral singleton"] EFUSE <= EFUSE() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO peripheral singleton"]
+        GPIO <= GPIO() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO_SD peripheral singleton"] GPIO_SD <= GPIO_SD() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "HMAC peripheral singleton"]
+        HMAC <= HMAC() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "HP_APM peripheral singleton"] HP_APM <= HP_APM() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "HP_SYS peripheral singleton"] HP_SYS <=
-        HP_SYS() (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "HP_SYS peripheral singleton"]
+        HP_SYS <= HP_SYS() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "I2C_ANA_MST peripheral singleton"] I2C_ANA_MST <= I2C_ANA_MST() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "I2C0 peripheral singleton"] I2C0 <=
-        I2C0(I2C_EXT0 : { bind_peri_interrupt, enable_peri_interrupt,
-        disable_peri_interrupt }))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "I2C0 peripheral singleton"]
+        I2C0 <= I2C0(I2C_EXT0 : { bind_peri_interrupt, enable_peri_interrupt,
+        disable_peri_interrupt }))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "I2C1 peripheral singleton"] I2C1 <= I2C1(I2C_EXT1 : { bind_peri_interrupt,
-        enable_peri_interrupt, disable_peri_interrupt }))); _for_each_inner!((@ peri_type
-        #[doc = "I2S0 peripheral singleton"] I2S0 <= I2S0(I2S0 : { bind_peri_interrupt,
-        enable_peri_interrupt, disable_peri_interrupt }) (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "IEEE802154 peripheral singleton"]
-        IEEE802154 <= IEEE802154() (unstable))); _for_each_inner!((@ peri_type #[doc =
+        enable_peri_interrupt, disable_peri_interrupt })));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "I2S0 peripheral singleton"]
+        I2S0 <= I2S0(I2S0 : { bind_peri_interrupt, enable_peri_interrupt,
+        disable_peri_interrupt }) (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "IEEE802154 peripheral singleton"] IEEE802154 <= IEEE802154()
+        (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "INTERRUPT_CORE0 peripheral singleton"] INTERRUPT_CORE0 <= INTERRUPT_CORE0()
-        (unstable))); _for_each_inner!((@ peri_type #[doc =
+        (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "INTPRI peripheral singleton"] INTPRI <= INTPRI() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "IO_MUX peripheral singleton"] IO_MUX <=
-        IO_MUX() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "LEDC peripheral singleton"] LEDC <= LEDC() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "LPWR peripheral singleton"] LPWR <= LP_CLKRST() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "LP_ANA peripheral singleton"] LP_ANA <=
-        LP_ANA() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "LP_AON peripheral singleton"] LP_AON <= LP_AON() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "LP_APM peripheral singleton"] LP_APM <=
-        LP_APM() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "LP_APM0 peripheral singleton"] LP_APM0 <= LP_APM0() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "LP_CLKRST peripheral singleton"] LP_CLKRST
-        <= LP_CLKRST() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "LP_PERI peripheral singleton"] LP_PERI <= LP_PERI() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "LP_TIMER peripheral singleton"] LP_TIMER
-        <= LP_TIMER() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "LP_WDT peripheral singleton"] LP_WDT <= LP_WDT() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "MCPWM0 peripheral singleton"] MCPWM0 <=
-        MCPWM0() (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "IO_MUX peripheral singleton"]
+        IO_MUX <= IO_MUX() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "LEDC peripheral singleton"] LEDC <= LEDC() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "LPWR peripheral singleton"]
+        LPWR <= LP_CLKRST() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "LP_ANA peripheral singleton"] LP_ANA <= LP_ANA() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "LP_AON peripheral singleton"]
+        LP_AON <= LP_AON() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "LP_APM peripheral singleton"] LP_APM <= LP_APM() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "LP_APM0 peripheral singleton"]
+        LP_APM0 <= LP_APM0() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "LP_CLKRST peripheral singleton"] LP_CLKRST <= LP_CLKRST() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "LP_PERI peripheral singleton"]
+        LP_PERI <= LP_PERI() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "LP_TIMER peripheral singleton"] LP_TIMER <= LP_TIMER() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "LP_WDT peripheral singleton"]
+        LP_WDT <= LP_WDT() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "MCPWM0 peripheral singleton"] MCPWM0 <= MCPWM0() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
         "MEM_MONITOR peripheral singleton"] MEM_MONITOR <= MEM_MONITOR() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "MODEM_LPCON peripheral singleton"]
-        MODEM_LPCON <= MODEM_LPCON() (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "MODEM_LPCON peripheral singleton"] MODEM_LPCON <= MODEM_LPCON() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
         "MODEM_SYSCON peripheral singleton"] MODEM_SYSCON <= MODEM_SYSCON() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "OTP_DEBUG peripheral singleton"] OTP_DEBUG
-        <= OTP_DEBUG() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "PARL_IO peripheral singleton"] PARL_IO <= PARL_IO(PARL_IO_RX : {
-        bind_rx_interrupt, enable_rx_interrupt, disable_rx_interrupt }, PARL_IO_TX : {
-        bind_tx_interrupt, enable_tx_interrupt, disable_tx_interrupt }) (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "PAU peripheral singleton"] PAU <= PAU()
-        (unstable))); _for_each_inner!((@ peri_type #[doc = "PCNT peripheral singleton"]
-        PCNT <= PCNT() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "PCR peripheral singleton"] PCR <= PCR() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "PLIC_MX peripheral singleton"] PLIC_MX <= PLIC_MX()
-        (unstable))); _for_each_inner!((@ peri_type #[doc = "PMU peripheral singleton"]
-        PMU <= PMU() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "RMT peripheral singleton"] RMT <= RMT() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "RNG peripheral singleton"] RNG <= RNG() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "RSA peripheral singleton"] RSA <= RSA(RSA
-        : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
-        (unstable))); _for_each_inner!((@ peri_type #[doc = "SHA peripheral singleton"]
-        SHA <= SHA(SHA : { bind_peri_interrupt, enable_peri_interrupt,
-        disable_peri_interrupt }) (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "ETM peripheral singleton"] ETM <= SOC_ETM() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "SPI0 peripheral singleton"] SPI0 <= SPI0() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "SPI1 peripheral singleton"] SPI1 <= SPI1()
-        (unstable))); _for_each_inner!((@ peri_type #[doc = "SPI2 peripheral singleton"]
-        SPI2 <= SPI2(SPI2 : { bind_peri_interrupt, enable_peri_interrupt,
-        disable_peri_interrupt }))); _for_each_inner!((@ peri_type #[doc =
-        "SYSTEM peripheral singleton"] SYSTEM <= PCR() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "SYSTIMER peripheral singleton"] SYSTIMER <= SYSTIMER()
-        (unstable))); _for_each_inner!((@ peri_type #[doc = "TEE peripheral singleton"]
-        TEE <= TEE() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "TIMG0 peripheral singleton"] TIMG0 <= TIMG0() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "TIMG1 peripheral singleton"] TIMG1 <= TIMG1() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "TRACE0 peripheral singleton"] TRACE0 <=
-        TRACE() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "TWAI0 peripheral singleton"] TWAI0 <= TWAI0() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "UART0 peripheral singleton"] UART0 <= UART0(UART0 : {
-        bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })));
-        _for_each_inner!((@ peri_type #[doc = "UART1 peripheral singleton"] UART1 <=
-        UART1(UART1 : { bind_peri_interrupt, enable_peri_interrupt,
-        disable_peri_interrupt }))); _for_each_inner!((@ peri_type #[doc =
-        "UHCI0 peripheral singleton"] UHCI0 <= UHCI0() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "USB_DEVICE peripheral singleton"] USB_DEVICE <=
-        USB_DEVICE(USB_DEVICE : { bind_peri_interrupt, enable_peri_interrupt,
-        disable_peri_interrupt }) (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "OTP_DEBUG peripheral singleton"] OTP_DEBUG <= OTP_DEBUG() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "PARL_IO peripheral singleton"]
+        PARL_IO <= PARL_IO(PARL_IO_RX : { bind_rx_interrupt, enable_rx_interrupt,
+        disable_rx_interrupt }, PARL_IO_TX : { bind_tx_interrupt, enable_tx_interrupt,
+        disable_tx_interrupt }) (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "PAU peripheral singleton"] PAU <= PAU() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "PCNT peripheral singleton"]
+        PCNT <= PCNT() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "PCR peripheral singleton"] PCR <= PCR() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "PLIC_MX peripheral singleton"]
+        PLIC_MX <= PLIC_MX() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "PMU peripheral singleton"] PMU <= PMU() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "RMT peripheral singleton"] RMT
+        <= RMT() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "RNG peripheral singleton"] RNG <= RNG() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "RSA peripheral singleton"] RSA
+        <= RSA(RSA : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt
+        }) (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "SHA peripheral singleton"] SHA <= SHA(SHA : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt }) (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "ETM peripheral singleton"] ETM
+        <= SOC_ETM() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "SPI0 peripheral singleton"] SPI0 <= SPI0() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "SPI1 peripheral singleton"]
+        SPI1 <= SPI1() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "SPI2 peripheral singleton"] SPI2 <= SPI2(SPI2 : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt })));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "SYSTEM peripheral singleton"]
+        SYSTEM <= PCR() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "SYSTIMER peripheral singleton"] SYSTIMER <= SYSTIMER() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "TEE peripheral singleton"] TEE
+        <= TEE() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "TIMG0 peripheral singleton"] TIMG0 <= TIMG0() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "TIMG1 peripheral singleton"]
+        TIMG1 <= TIMG1() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "TRACE0 peripheral singleton"] TRACE0 <= TRACE() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "TWAI0 peripheral singleton"]
+        TWAI0 <= TWAI0() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "UART0 peripheral singleton"] UART0 <= UART0(UART0 : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt })));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "UART1 peripheral singleton"]
+        UART1 <= UART1(UART1 : { bind_peri_interrupt, enable_peri_interrupt,
+        disable_peri_interrupt }))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "UHCI0 peripheral singleton"] UHCI0 <= UHCI0() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "USB_DEVICE peripheral singleton"] USB_DEVICE <= USB_DEVICE(USB_DEVICE : {
+        bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
+        (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "DMA_CH1 peripheral singleton"] DMA_CH1 <=
-        virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "DMA_CH2 peripheral singleton"] DMA_CH2 <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "ADC1 peripheral singleton"] ADC1 <=
-        virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "BT peripheral singleton"] BT <= virtual() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "FLASH peripheral singleton"] FLASH <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "GPIO_DEDICATED peripheral singleton"]
-        GPIO_DEDICATED <= virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH1 peripheral singleton"]
+        DMA_CH1 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "DMA_CH2 peripheral singleton"] DMA_CH2 <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "ADC1 peripheral singleton"]
+        ADC1 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "BT peripheral singleton"] BT <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "FLASH peripheral singleton"]
+        FLASH <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO_DEDICATED peripheral singleton"] GPIO_DEDICATED <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
         "SW_INTERRUPT peripheral singleton"] SW_INTERRUPT <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "MEM2MEM1 peripheral singleton"] MEM2MEM1
-        <= virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "MEM2MEM4 peripheral singleton"] MEM2MEM4 <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "MEM2MEM5 peripheral singleton"] MEM2MEM5
-        <= virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "MEM2MEM10 peripheral singleton"] MEM2MEM10 <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "MEM2MEM11 peripheral singleton"] MEM2MEM11
-        <= virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "MEM2MEM1 peripheral singleton"]
+        MEM2MEM1 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "MEM2MEM4 peripheral singleton"] MEM2MEM4 <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "MEM2MEM5 peripheral singleton"]
+        MEM2MEM5 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "MEM2MEM10 peripheral singleton"] MEM2MEM10 <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "MEM2MEM11 peripheral singleton"] MEM2MEM11 <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
         "MEM2MEM12 peripheral singleton"] MEM2MEM12 <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "MEM2MEM13 peripheral singleton"] MEM2MEM13
-        <= virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "MEM2MEM13 peripheral singleton"] MEM2MEM13 <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
         "MEM2MEM14 peripheral singleton"] MEM2MEM14 <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "MEM2MEM15 peripheral singleton"] MEM2MEM15
-        <= virtual() (unstable))); _for_each_inner!((GPIO0)); _for_each_inner!((GPIO1));
-        _for_each_inner!((GPIO2)); _for_each_inner!((GPIO3)); _for_each_inner!((GPIO4));
-        _for_each_inner!((GPIO5)); _for_each_inner!((GPIO6)); _for_each_inner!((GPIO7));
-        _for_each_inner!((GPIO8)); _for_each_inner!((GPIO9)); _for_each_inner!((GPIO10));
-        _for_each_inner!((GPIO11)); _for_each_inner!((GPIO12));
-        _for_each_inner!((GPIO13)); _for_each_inner!((GPIO14));
-        _for_each_inner!((GPIO22)); _for_each_inner!((GPIO23));
-        _for_each_inner!((GPIO24)); _for_each_inner!((GPIO25));
-        _for_each_inner!((GPIO26)); _for_each_inner!((GPIO27));
-        _for_each_inner!((AES(unstable))); _for_each_inner!((APB_SARADC(unstable)));
-        _for_each_inner!((ASSIST_DEBUG(unstable))); _for_each_inner!((DMA(unstable)));
-        _for_each_inner!((DS(unstable))); _for_each_inner!((ECC(unstable)));
-        _for_each_inner!((EFUSE(unstable))); _for_each_inner!((GPIO(unstable)));
-        _for_each_inner!((GPIO_SD(unstable))); _for_each_inner!((HMAC(unstable)));
-        _for_each_inner!((HP_APM(unstable))); _for_each_inner!((HP_SYS(unstable)));
-        _for_each_inner!((I2C_ANA_MST(unstable))); _for_each_inner!((I2C0));
-        _for_each_inner!((I2C1)); _for_each_inner!((I2S0(unstable)));
-        _for_each_inner!((IEEE802154(unstable)));
-        _for_each_inner!((INTERRUPT_CORE0(unstable)));
-        _for_each_inner!((INTPRI(unstable))); _for_each_inner!((IO_MUX(unstable)));
-        _for_each_inner!((LEDC(unstable))); _for_each_inner!((LPWR(unstable)));
-        _for_each_inner!((LP_ANA(unstable))); _for_each_inner!((LP_AON(unstable)));
-        _for_each_inner!((LP_APM(unstable))); _for_each_inner!((LP_APM0(unstable)));
-        _for_each_inner!((LP_CLKRST(unstable))); _for_each_inner!((LP_PERI(unstable)));
-        _for_each_inner!((LP_TIMER(unstable))); _for_each_inner!((LP_WDT(unstable)));
-        _for_each_inner!((MCPWM0(unstable))); _for_each_inner!((MEM_MONITOR(unstable)));
-        _for_each_inner!((MODEM_LPCON(unstable)));
-        _for_each_inner!((MODEM_SYSCON(unstable)));
-        _for_each_inner!((OTP_DEBUG(unstable))); _for_each_inner!((PARL_IO(unstable)));
-        _for_each_inner!((PAU(unstable))); _for_each_inner!((PCNT(unstable)));
-        _for_each_inner!((PCR(unstable))); _for_each_inner!((PLIC_MX(unstable)));
-        _for_each_inner!((PMU(unstable))); _for_each_inner!((RMT(unstable)));
-        _for_each_inner!((RNG(unstable))); _for_each_inner!((RSA(unstable)));
-        _for_each_inner!((SHA(unstable))); _for_each_inner!((ETM(unstable)));
-        _for_each_inner!((SPI0(unstable))); _for_each_inner!((SPI1(unstable)));
-        _for_each_inner!((SPI2)); _for_each_inner!((SYSTEM(unstable)));
-        _for_each_inner!((SYSTIMER(unstable))); _for_each_inner!((TEE(unstable)));
-        _for_each_inner!((TIMG0(unstable))); _for_each_inner!((TIMG1(unstable)));
-        _for_each_inner!((TRACE0(unstable))); _for_each_inner!((TWAI0(unstable)));
-        _for_each_inner!((UART0)); _for_each_inner!((UART1));
-        _for_each_inner!((UHCI0(unstable))); _for_each_inner!((USB_DEVICE(unstable)));
-        _for_each_inner!((DMA_CH0(unstable))); _for_each_inner!((DMA_CH1(unstable)));
-        _for_each_inner!((DMA_CH2(unstable))); _for_each_inner!((ADC1(unstable)));
-        _for_each_inner!((BT(unstable))); _for_each_inner!((FLASH(unstable)));
-        _for_each_inner!((GPIO_DEDICATED(unstable)));
-        _for_each_inner!((SW_INTERRUPT(unstable)));
-        _for_each_inner!((MEM2MEM1(unstable))); _for_each_inner!((MEM2MEM4(unstable)));
-        _for_each_inner!((MEM2MEM5(unstable))); _for_each_inner!((MEM2MEM10(unstable)));
-        _for_each_inner!((MEM2MEM11(unstable))); _for_each_inner!((MEM2MEM12(unstable)));
-        _for_each_inner!((MEM2MEM13(unstable))); _for_each_inner!((MEM2MEM14(unstable)));
-        _for_each_inner!((MEM2MEM15(unstable))); _for_each_inner!((all(@ peri_type #[doc
-        = "GPIO0 peripheral singleton"] GPIO0 <= virtual()), (@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "MEM2MEM15 peripheral singleton"] MEM2MEM15 <= virtual() (unstable)));
+        _for_each_inner_peripheral!((GPIO0)); _for_each_inner_peripheral!((GPIO1));
+        _for_each_inner_peripheral!((GPIO2)); _for_each_inner_peripheral!((GPIO3));
+        _for_each_inner_peripheral!((GPIO4)); _for_each_inner_peripheral!((GPIO5));
+        _for_each_inner_peripheral!((GPIO6)); _for_each_inner_peripheral!((GPIO7));
+        _for_each_inner_peripheral!((GPIO8)); _for_each_inner_peripheral!((GPIO9));
+        _for_each_inner_peripheral!((GPIO10)); _for_each_inner_peripheral!((GPIO11));
+        _for_each_inner_peripheral!((GPIO12)); _for_each_inner_peripheral!((GPIO13));
+        _for_each_inner_peripheral!((GPIO14)); _for_each_inner_peripheral!((GPIO22));
+        _for_each_inner_peripheral!((GPIO23)); _for_each_inner_peripheral!((GPIO24));
+        _for_each_inner_peripheral!((GPIO25)); _for_each_inner_peripheral!((GPIO26));
+        _for_each_inner_peripheral!((GPIO27));
+        _for_each_inner_peripheral!((AES(unstable)));
+        _for_each_inner_peripheral!((APB_SARADC(unstable)));
+        _for_each_inner_peripheral!((ASSIST_DEBUG(unstable)));
+        _for_each_inner_peripheral!((DMA(unstable)));
+        _for_each_inner_peripheral!((DS(unstable)));
+        _for_each_inner_peripheral!((ECC(unstable)));
+        _for_each_inner_peripheral!((EFUSE(unstable)));
+        _for_each_inner_peripheral!((GPIO(unstable)));
+        _for_each_inner_peripheral!((GPIO_SD(unstable)));
+        _for_each_inner_peripheral!((HMAC(unstable)));
+        _for_each_inner_peripheral!((HP_APM(unstable)));
+        _for_each_inner_peripheral!((HP_SYS(unstable)));
+        _for_each_inner_peripheral!((I2C_ANA_MST(unstable)));
+        _for_each_inner_peripheral!((I2C0)); _for_each_inner_peripheral!((I2C1));
+        _for_each_inner_peripheral!((I2S0(unstable)));
+        _for_each_inner_peripheral!((IEEE802154(unstable)));
+        _for_each_inner_peripheral!((INTERRUPT_CORE0(unstable)));
+        _for_each_inner_peripheral!((INTPRI(unstable)));
+        _for_each_inner_peripheral!((IO_MUX(unstable)));
+        _for_each_inner_peripheral!((LEDC(unstable)));
+        _for_each_inner_peripheral!((LPWR(unstable)));
+        _for_each_inner_peripheral!((LP_ANA(unstable)));
+        _for_each_inner_peripheral!((LP_AON(unstable)));
+        _for_each_inner_peripheral!((LP_APM(unstable)));
+        _for_each_inner_peripheral!((LP_APM0(unstable)));
+        _for_each_inner_peripheral!((LP_CLKRST(unstable)));
+        _for_each_inner_peripheral!((LP_PERI(unstable)));
+        _for_each_inner_peripheral!((LP_TIMER(unstable)));
+        _for_each_inner_peripheral!((LP_WDT(unstable)));
+        _for_each_inner_peripheral!((MCPWM0(unstable)));
+        _for_each_inner_peripheral!((MEM_MONITOR(unstable)));
+        _for_each_inner_peripheral!((MODEM_LPCON(unstable)));
+        _for_each_inner_peripheral!((MODEM_SYSCON(unstable)));
+        _for_each_inner_peripheral!((OTP_DEBUG(unstable)));
+        _for_each_inner_peripheral!((PARL_IO(unstable)));
+        _for_each_inner_peripheral!((PAU(unstable)));
+        _for_each_inner_peripheral!((PCNT(unstable)));
+        _for_each_inner_peripheral!((PCR(unstable)));
+        _for_each_inner_peripheral!((PLIC_MX(unstable)));
+        _for_each_inner_peripheral!((PMU(unstable)));
+        _for_each_inner_peripheral!((RMT(unstable)));
+        _for_each_inner_peripheral!((RNG(unstable)));
+        _for_each_inner_peripheral!((RSA(unstable)));
+        _for_each_inner_peripheral!((SHA(unstable)));
+        _for_each_inner_peripheral!((ETM(unstable)));
+        _for_each_inner_peripheral!((SPI0(unstable)));
+        _for_each_inner_peripheral!((SPI1(unstable)));
+        _for_each_inner_peripheral!((SPI2));
+        _for_each_inner_peripheral!((SYSTEM(unstable)));
+        _for_each_inner_peripheral!((SYSTIMER(unstable)));
+        _for_each_inner_peripheral!((TEE(unstable)));
+        _for_each_inner_peripheral!((TIMG0(unstable)));
+        _for_each_inner_peripheral!((TIMG1(unstable)));
+        _for_each_inner_peripheral!((TRACE0(unstable)));
+        _for_each_inner_peripheral!((TWAI0(unstable)));
+        _for_each_inner_peripheral!((UART0)); _for_each_inner_peripheral!((UART1));
+        _for_each_inner_peripheral!((UHCI0(unstable)));
+        _for_each_inner_peripheral!((USB_DEVICE(unstable)));
+        _for_each_inner_peripheral!((DMA_CH0(unstable)));
+        _for_each_inner_peripheral!((DMA_CH1(unstable)));
+        _for_each_inner_peripheral!((DMA_CH2(unstable)));
+        _for_each_inner_peripheral!((ADC1(unstable)));
+        _for_each_inner_peripheral!((BT(unstable)));
+        _for_each_inner_peripheral!((FLASH(unstable)));
+        _for_each_inner_peripheral!((GPIO_DEDICATED(unstable)));
+        _for_each_inner_peripheral!((SW_INTERRUPT(unstable)));
+        _for_each_inner_peripheral!((MEM2MEM1(unstable)));
+        _for_each_inner_peripheral!((MEM2MEM4(unstable)));
+        _for_each_inner_peripheral!((MEM2MEM5(unstable)));
+        _for_each_inner_peripheral!((MEM2MEM10(unstable)));
+        _for_each_inner_peripheral!((MEM2MEM11(unstable)));
+        _for_each_inner_peripheral!((MEM2MEM12(unstable)));
+        _for_each_inner_peripheral!((MEM2MEM13(unstable)));
+        _for_each_inner_peripheral!((MEM2MEM14(unstable)));
+        _for_each_inner_peripheral!((MEM2MEM15(unstable)));
+        _for_each_inner_peripheral!((all(@ peri_type #[doc =
+        "GPIO0 peripheral singleton"] GPIO0 <= virtual()), (@ peri_type #[doc =
         "GPIO1 peripheral singleton"] GPIO1 <= virtual()), (@ peri_type #[doc =
         "GPIO2 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
         "<section class=\"warning\">"] #[doc =
@@ -3001,8 +3176,8 @@ macro_rules! for_each_peripheral {
         "MEM2MEM13 peripheral singleton"] MEM2MEM13 <= virtual() (unstable)), (@
         peri_type #[doc = "MEM2MEM14 peripheral singleton"] MEM2MEM14 <= virtual()
         (unstable)), (@ peri_type #[doc = "MEM2MEM15 peripheral singleton"] MEM2MEM15 <=
-        virtual() (unstable)))); _for_each_inner!((singletons(GPIO0), (GPIO1), (GPIO2),
-        (GPIO3), (GPIO4), (GPIO5), (GPIO6), (GPIO7), (GPIO8), (GPIO9), (GPIO10),
+        virtual() (unstable)))); _for_each_inner_peripheral!((singletons(GPIO0), (GPIO1),
+        (GPIO2), (GPIO3), (GPIO4), (GPIO5), (GPIO6), (GPIO7), (GPIO8), (GPIO9), (GPIO10),
         (GPIO11), (GPIO12), (GPIO13), (GPIO14), (GPIO22), (GPIO23), (GPIO24), (GPIO25),
         (GPIO26), (GPIO27), (AES(unstable)), (APB_SARADC(unstable)),
         (ASSIST_DEBUG(unstable)), (DMA(unstable)), (DS(unstable)), (ECC(unstable)),
@@ -3058,40 +3233,44 @@ macro_rules! for_each_peripheral {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_gpio {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((0, GPIO0(_2 => FSPIQ) (_2 => FSPIQ) ([Input] [Output])));
-        _for_each_inner!((1, GPIO1(_2 => FSPICS0) (_2 => FSPICS0) ([Input] [Output])));
-        _for_each_inner!((2, GPIO2(_0 => MTMS _2 => FSPIWP) (_2 => FSPIWP) ([Input]
-        [Output]))); _for_each_inner!((3, GPIO3(_0 => MTDI _2 => FSPIHD) (_2 => FSPIHD)
-        ([Input] [Output]))); _for_each_inner!((4, GPIO4(_0 => MTCK _2 => FSPICLK) (_2 =>
-        FSPICLK) ([Input] [Output]))); _for_each_inner!((5, GPIO5(_2 => FSPID) (_0 =>
-        MTDO _2 => FSPID) ([Input] [Output]))); _for_each_inner!((6, GPIO6() () ([Input]
-        [Output]))); _for_each_inner!((7, GPIO7() () ([Input] [Output])));
-        _for_each_inner!((8, GPIO8() () ([Input] [Output]))); _for_each_inner!((9,
-        GPIO9() () ([Input] [Output]))); _for_each_inner!((10, GPIO10() () ([Input]
-        [Output]))); _for_each_inner!((11, GPIO11() () ([Input] [Output])));
-        _for_each_inner!((12, GPIO12() () ([Input] [Output]))); _for_each_inner!((13,
-        GPIO13() () ([Input] [Output]))); _for_each_inner!((14, GPIO14() () ([Input]
-        [Output]))); _for_each_inner!((22, GPIO22() () ([Input] [Output])));
-        _for_each_inner!((23, GPIO23(_0 => U0RXD) (_2 => FSPICS1) ([Input] [Output])));
-        _for_each_inner!((24, GPIO24() (_0 => U0TXD _2 => FSPICS2) ([Input] [Output])));
-        _for_each_inner!((25, GPIO25() (_2 => FSPICS3) ([Input] [Output])));
-        _for_each_inner!((26, GPIO26() (_2 => FSPICS4) ([Input] [Output])));
-        _for_each_inner!((27, GPIO27() (_2 => FSPICS5) ([Input] [Output])));
-        _for_each_inner!((all(0, GPIO0(_2 => FSPIQ) (_2 => FSPIQ) ([Input] [Output])),
-        (1, GPIO1(_2 => FSPICS0) (_2 => FSPICS0) ([Input] [Output])), (2, GPIO2(_0 =>
-        MTMS _2 => FSPIWP) (_2 => FSPIWP) ([Input] [Output])), (3, GPIO3(_0 => MTDI _2 =>
-        FSPIHD) (_2 => FSPIHD) ([Input] [Output])), (4, GPIO4(_0 => MTCK _2 => FSPICLK)
-        (_2 => FSPICLK) ([Input] [Output])), (5, GPIO5(_2 => FSPID) (_0 => MTDO _2 =>
-        FSPID) ([Input] [Output])), (6, GPIO6() () ([Input] [Output])), (7, GPIO7() ()
-        ([Input] [Output])), (8, GPIO8() () ([Input] [Output])), (9, GPIO9() () ([Input]
-        [Output])), (10, GPIO10() () ([Input] [Output])), (11, GPIO11() () ([Input]
-        [Output])), (12, GPIO12() () ([Input] [Output])), (13, GPIO13() () ([Input]
-        [Output])), (14, GPIO14() () ([Input] [Output])), (22, GPIO22() () ([Input]
-        [Output])), (23, GPIO23(_0 => U0RXD) (_2 => FSPICS1) ([Input] [Output])), (24,
-        GPIO24() (_0 => U0TXD _2 => FSPICS2) ([Input] [Output])), (25, GPIO25() (_2 =>
-        FSPICS3) ([Input] [Output])), (26, GPIO26() (_2 => FSPICS4) ([Input] [Output])),
-        (27, GPIO27() (_2 => FSPICS5) ([Input] [Output]))));
+        macro_rules! _for_each_inner_gpio { $(($pattern) => $code;)* ($other : tt) => {}
+        } _for_each_inner_gpio!((0, GPIO0(_2 => FSPIQ) (_2 => FSPIQ) ([Input]
+        [Output]))); _for_each_inner_gpio!((1, GPIO1(_2 => FSPICS0) (_2 => FSPICS0)
+        ([Input] [Output]))); _for_each_inner_gpio!((2, GPIO2(_0 => MTMS _2 => FSPIWP)
+        (_2 => FSPIWP) ([Input] [Output]))); _for_each_inner_gpio!((3, GPIO3(_0 => MTDI
+        _2 => FSPIHD) (_2 => FSPIHD) ([Input] [Output]))); _for_each_inner_gpio!((4,
+        GPIO4(_0 => MTCK _2 => FSPICLK) (_2 => FSPICLK) ([Input] [Output])));
+        _for_each_inner_gpio!((5, GPIO5(_2 => FSPID) (_0 => MTDO _2 => FSPID) ([Input]
+        [Output]))); _for_each_inner_gpio!((6, GPIO6() () ([Input] [Output])));
+        _for_each_inner_gpio!((7, GPIO7() () ([Input] [Output])));
+        _for_each_inner_gpio!((8, GPIO8() () ([Input] [Output])));
+        _for_each_inner_gpio!((9, GPIO9() () ([Input] [Output])));
+        _for_each_inner_gpio!((10, GPIO10() () ([Input] [Output])));
+        _for_each_inner_gpio!((11, GPIO11() () ([Input] [Output])));
+        _for_each_inner_gpio!((12, GPIO12() () ([Input] [Output])));
+        _for_each_inner_gpio!((13, GPIO13() () ([Input] [Output])));
+        _for_each_inner_gpio!((14, GPIO14() () ([Input] [Output])));
+        _for_each_inner_gpio!((22, GPIO22() () ([Input] [Output])));
+        _for_each_inner_gpio!((23, GPIO23(_0 => U0RXD) (_2 => FSPICS1) ([Input]
+        [Output]))); _for_each_inner_gpio!((24, GPIO24() (_0 => U0TXD _2 => FSPICS2)
+        ([Input] [Output]))); _for_each_inner_gpio!((25, GPIO25() (_2 => FSPICS3)
+        ([Input] [Output]))); _for_each_inner_gpio!((26, GPIO26() (_2 => FSPICS4)
+        ([Input] [Output]))); _for_each_inner_gpio!((27, GPIO27() (_2 => FSPICS5)
+        ([Input] [Output]))); _for_each_inner_gpio!((all(0, GPIO0(_2 => FSPIQ) (_2 =>
+        FSPIQ) ([Input] [Output])), (1, GPIO1(_2 => FSPICS0) (_2 => FSPICS0) ([Input]
+        [Output])), (2, GPIO2(_0 => MTMS _2 => FSPIWP) (_2 => FSPIWP) ([Input]
+        [Output])), (3, GPIO3(_0 => MTDI _2 => FSPIHD) (_2 => FSPIHD) ([Input]
+        [Output])), (4, GPIO4(_0 => MTCK _2 => FSPICLK) (_2 => FSPICLK) ([Input]
+        [Output])), (5, GPIO5(_2 => FSPID) (_0 => MTDO _2 => FSPID) ([Input] [Output])),
+        (6, GPIO6() () ([Input] [Output])), (7, GPIO7() () ([Input] [Output])), (8,
+        GPIO8() () ([Input] [Output])), (9, GPIO9() () ([Input] [Output])), (10, GPIO10()
+        () ([Input] [Output])), (11, GPIO11() () ([Input] [Output])), (12, GPIO12() ()
+        ([Input] [Output])), (13, GPIO13() () ([Input] [Output])), (14, GPIO14() ()
+        ([Input] [Output])), (22, GPIO22() () ([Input] [Output])), (23, GPIO23(_0 =>
+        U0RXD) (_2 => FSPICS1) ([Input] [Output])), (24, GPIO24() (_0 => U0TXD _2 =>
+        FSPICS2) ([Input] [Output])), (25, GPIO25() (_2 => FSPICS3) ([Input] [Output])),
+        (26, GPIO26() (_2 => FSPICS4) ([Input] [Output])), (27, GPIO27() (_2 => FSPICS5)
+        ([Input] [Output]))));
     };
 }
 /// This macro can be used to generate code for each analog function of each GPIO.
@@ -3124,25 +3303,32 @@ macro_rules! for_each_gpio {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_analog_function {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((ADC1_CH0, GPIO1)); _for_each_inner!((ADC1_CH1, GPIO2));
-        _for_each_inner!((ADC1_CH2, GPIO3)); _for_each_inner!((ADC1_CH3, GPIO4));
-        _for_each_inner!((ADC1_CH4, GPIO5)); _for_each_inner!((ZCD0, GPIO10));
-        _for_each_inner!((ZCD1, GPIO11)); _for_each_inner!((XTAL_32K_P, GPIO13));
-        _for_each_inner!((XTAL_32K_N, GPIO14)); _for_each_inner!((USB_DM, GPIO26));
-        _for_each_inner!((USB_DP, GPIO27)); _for_each_inner!(((ADC1_CH0, ADCn_CHm, 1, 0),
-        GPIO1)); _for_each_inner!(((ADC1_CH1, ADCn_CHm, 1, 1), GPIO2));
-        _for_each_inner!(((ADC1_CH2, ADCn_CHm, 1, 2), GPIO3));
-        _for_each_inner!(((ADC1_CH3, ADCn_CHm, 1, 3), GPIO4));
-        _for_each_inner!(((ADC1_CH4, ADCn_CHm, 1, 4), GPIO5)); _for_each_inner!(((ZCD0,
-        ZCDn, 0), GPIO10)); _for_each_inner!(((ZCD1, ZCDn, 1), GPIO11));
-        _for_each_inner!((all(ADC1_CH0, GPIO1), (ADC1_CH1, GPIO2), (ADC1_CH2, GPIO3),
-        (ADC1_CH3, GPIO4), (ADC1_CH4, GPIO5), (ZCD0, GPIO10), (ZCD1, GPIO11),
-        (XTAL_32K_P, GPIO13), (XTAL_32K_N, GPIO14), (USB_DM, GPIO26), (USB_DP, GPIO27)));
-        _for_each_inner!((all_expanded((ADC1_CH0, ADCn_CHm, 1, 0), GPIO1), ((ADC1_CH1,
-        ADCn_CHm, 1, 1), GPIO2), ((ADC1_CH2, ADCn_CHm, 1, 2), GPIO3), ((ADC1_CH3,
-        ADCn_CHm, 1, 3), GPIO4), ((ADC1_CH4, ADCn_CHm, 1, 4), GPIO5), ((ZCD0, ZCDn, 0),
-        GPIO10), ((ZCD1, ZCDn, 1), GPIO11)));
+        macro_rules! _for_each_inner_analog_function { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_analog_function!((ADC1_CH0, GPIO1));
+        _for_each_inner_analog_function!((ADC1_CH1, GPIO2));
+        _for_each_inner_analog_function!((ADC1_CH2, GPIO3));
+        _for_each_inner_analog_function!((ADC1_CH3, GPIO4));
+        _for_each_inner_analog_function!((ADC1_CH4, GPIO5));
+        _for_each_inner_analog_function!((ZCD0, GPIO10));
+        _for_each_inner_analog_function!((ZCD1, GPIO11));
+        _for_each_inner_analog_function!((XTAL_32K_P, GPIO13));
+        _for_each_inner_analog_function!((XTAL_32K_N, GPIO14));
+        _for_each_inner_analog_function!((USB_DM, GPIO26));
+        _for_each_inner_analog_function!((USB_DP, GPIO27));
+        _for_each_inner_analog_function!(((ADC1_CH0, ADCn_CHm, 1, 0), GPIO1));
+        _for_each_inner_analog_function!(((ADC1_CH1, ADCn_CHm, 1, 1), GPIO2));
+        _for_each_inner_analog_function!(((ADC1_CH2, ADCn_CHm, 1, 2), GPIO3));
+        _for_each_inner_analog_function!(((ADC1_CH3, ADCn_CHm, 1, 3), GPIO4));
+        _for_each_inner_analog_function!(((ADC1_CH4, ADCn_CHm, 1, 4), GPIO5));
+        _for_each_inner_analog_function!(((ZCD0, ZCDn, 0), GPIO10));
+        _for_each_inner_analog_function!(((ZCD1, ZCDn, 1), GPIO11));
+        _for_each_inner_analog_function!((all(ADC1_CH0, GPIO1), (ADC1_CH1, GPIO2),
+        (ADC1_CH2, GPIO3), (ADC1_CH3, GPIO4), (ADC1_CH4, GPIO5), (ZCD0, GPIO10), (ZCD1,
+        GPIO11), (XTAL_32K_P, GPIO13), (XTAL_32K_N, GPIO14), (USB_DM, GPIO26), (USB_DP,
+        GPIO27))); _for_each_inner_analog_function!((all_expanded((ADC1_CH0, ADCn_CHm, 1,
+        0), GPIO1), ((ADC1_CH1, ADCn_CHm, 1, 1), GPIO2), ((ADC1_CH2, ADCn_CHm, 1, 2),
+        GPIO3), ((ADC1_CH3, ADCn_CHm, 1, 3), GPIO4), ((ADC1_CH4, ADCn_CHm, 1, 4), GPIO5),
+        ((ZCD0, ZCDn, 0), GPIO10), ((ZCD1, ZCDn, 1), GPIO11)));
     };
 }
 /// This macro can be used to generate code for each LP/RTC function of each GPIO.
@@ -3175,23 +3361,31 @@ macro_rules! for_each_analog_function {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_lp_function {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((LP_GPIO0, GPIO7)); _for_each_inner!((LP_GPIO1, GPIO8));
-        _for_each_inner!((LP_GPIO2, GPIO9)); _for_each_inner!((LP_GPIO3, GPIO10));
-        _for_each_inner!((LP_GPIO4, GPIO11)); _for_each_inner!((LP_GPIO5, GPIO12));
-        _for_each_inner!((LP_GPIO6, GPIO13)); _for_each_inner!((LP_GPIO7, GPIO14));
-        _for_each_inner!(((LP_GPIO0, LP_GPIOn, 0), GPIO7)); _for_each_inner!(((LP_GPIO1,
-        LP_GPIOn, 1), GPIO8)); _for_each_inner!(((LP_GPIO2, LP_GPIOn, 2), GPIO9));
-        _for_each_inner!(((LP_GPIO3, LP_GPIOn, 3), GPIO10)); _for_each_inner!(((LP_GPIO4,
-        LP_GPIOn, 4), GPIO11)); _for_each_inner!(((LP_GPIO5, LP_GPIOn, 5), GPIO12));
-        _for_each_inner!(((LP_GPIO6, LP_GPIOn, 6), GPIO13)); _for_each_inner!(((LP_GPIO7,
-        LP_GPIOn, 7), GPIO14)); _for_each_inner!((all(LP_GPIO0, GPIO7), (LP_GPIO1,
-        GPIO8), (LP_GPIO2, GPIO9), (LP_GPIO3, GPIO10), (LP_GPIO4, GPIO11), (LP_GPIO5,
-        GPIO12), (LP_GPIO6, GPIO13), (LP_GPIO7, GPIO14)));
-        _for_each_inner!((all_expanded((LP_GPIO0, LP_GPIOn, 0), GPIO7), ((LP_GPIO1,
-        LP_GPIOn, 1), GPIO8), ((LP_GPIO2, LP_GPIOn, 2), GPIO9), ((LP_GPIO3, LP_GPIOn, 3),
-        GPIO10), ((LP_GPIO4, LP_GPIOn, 4), GPIO11), ((LP_GPIO5, LP_GPIOn, 5), GPIO12),
-        ((LP_GPIO6, LP_GPIOn, 6), GPIO13), ((LP_GPIO7, LP_GPIOn, 7), GPIO14)));
+        macro_rules! _for_each_inner_lp_function { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_lp_function!((LP_GPIO0, GPIO7));
+        _for_each_inner_lp_function!((LP_GPIO1, GPIO8));
+        _for_each_inner_lp_function!((LP_GPIO2, GPIO9));
+        _for_each_inner_lp_function!((LP_GPIO3, GPIO10));
+        _for_each_inner_lp_function!((LP_GPIO4, GPIO11));
+        _for_each_inner_lp_function!((LP_GPIO5, GPIO12));
+        _for_each_inner_lp_function!((LP_GPIO6, GPIO13));
+        _for_each_inner_lp_function!((LP_GPIO7, GPIO14));
+        _for_each_inner_lp_function!(((LP_GPIO0, LP_GPIOn, 0), GPIO7));
+        _for_each_inner_lp_function!(((LP_GPIO1, LP_GPIOn, 1), GPIO8));
+        _for_each_inner_lp_function!(((LP_GPIO2, LP_GPIOn, 2), GPIO9));
+        _for_each_inner_lp_function!(((LP_GPIO3, LP_GPIOn, 3), GPIO10));
+        _for_each_inner_lp_function!(((LP_GPIO4, LP_GPIOn, 4), GPIO11));
+        _for_each_inner_lp_function!(((LP_GPIO5, LP_GPIOn, 5), GPIO12));
+        _for_each_inner_lp_function!(((LP_GPIO6, LP_GPIOn, 6), GPIO13));
+        _for_each_inner_lp_function!(((LP_GPIO7, LP_GPIOn, 7), GPIO14));
+        _for_each_inner_lp_function!((all(LP_GPIO0, GPIO7), (LP_GPIO1, GPIO8), (LP_GPIO2,
+        GPIO9), (LP_GPIO3, GPIO10), (LP_GPIO4, GPIO11), (LP_GPIO5, GPIO12), (LP_GPIO6,
+        GPIO13), (LP_GPIO7, GPIO14)));
+        _for_each_inner_lp_function!((all_expanded((LP_GPIO0, LP_GPIOn, 0), GPIO7),
+        ((LP_GPIO1, LP_GPIOn, 1), GPIO8), ((LP_GPIO2, LP_GPIOn, 2), GPIO9), ((LP_GPIO3,
+        LP_GPIOn, 3), GPIO10), ((LP_GPIO4, LP_GPIOn, 4), GPIO11), ((LP_GPIO5, LP_GPIOn,
+        5), GPIO12), ((LP_GPIO6, LP_GPIOn, 6), GPIO13), ((LP_GPIO7, LP_GPIOn, 7),
+        GPIO14)));
     };
 }
 /// Defines the `InputSignal` and `OutputSignal` enums.

--- a/esp-metadata-generated/src/_generated_esp32s2.rs
+++ b/esp-metadata-generated/src/_generated_esp32s2.rs
@@ -2652,40 +2652,50 @@ macro_rules! memory_range {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_aes_key_length {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((128)); _for_each_inner!((192)); _for_each_inner!((256));
-        _for_each_inner!((128, 0, 4)); _for_each_inner!((192, 1, 5));
-        _for_each_inner!((256, 2, 6)); _for_each_inner!((bits(128), (192), (256)));
-        _for_each_inner!((modes(128, 0, 4), (192, 1, 5), (256, 2, 6)));
+        macro_rules! _for_each_inner_aes_key_length { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_aes_key_length!((128));
+        _for_each_inner_aes_key_length!((192)); _for_each_inner_aes_key_length!((256));
+        _for_each_inner_aes_key_length!((128, 0, 4));
+        _for_each_inner_aes_key_length!((192, 1, 5));
+        _for_each_inner_aes_key_length!((256, 2, 6));
+        _for_each_inner_aes_key_length!((bits(128), (192), (256)));
+        _for_each_inner_aes_key_length!((modes(128, 0, 4), (192, 1, 5), (256, 2, 6)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_dedicated_gpio {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((0)); _for_each_inner!((1)); _for_each_inner!((2));
-        _for_each_inner!((3)); _for_each_inner!((4)); _for_each_inner!((5));
-        _for_each_inner!((6)); _for_each_inner!((7)); _for_each_inner!((0, 0,
-        PRO_ALONEGPIO0)); _for_each_inner!((0, 1, PRO_ALONEGPIO1)); _for_each_inner!((0,
-        2, PRO_ALONEGPIO2)); _for_each_inner!((0, 3, PRO_ALONEGPIO3));
-        _for_each_inner!((0, 4, PRO_ALONEGPIO4)); _for_each_inner!((0, 5,
-        PRO_ALONEGPIO5)); _for_each_inner!((0, 6, PRO_ALONEGPIO6)); _for_each_inner!((0,
-        7, PRO_ALONEGPIO7)); _for_each_inner!((channels(0), (1), (2), (3), (4), (5), (6),
-        (7))); _for_each_inner!((signals(0, 0, PRO_ALONEGPIO0), (0, 1, PRO_ALONEGPIO1),
-        (0, 2, PRO_ALONEGPIO2), (0, 3, PRO_ALONEGPIO3), (0, 4, PRO_ALONEGPIO4), (0, 5,
-        PRO_ALONEGPIO5), (0, 6, PRO_ALONEGPIO6), (0, 7, PRO_ALONEGPIO7)));
+        macro_rules! _for_each_inner_dedicated_gpio { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_dedicated_gpio!((0));
+        _for_each_inner_dedicated_gpio!((1)); _for_each_inner_dedicated_gpio!((2));
+        _for_each_inner_dedicated_gpio!((3)); _for_each_inner_dedicated_gpio!((4));
+        _for_each_inner_dedicated_gpio!((5)); _for_each_inner_dedicated_gpio!((6));
+        _for_each_inner_dedicated_gpio!((7)); _for_each_inner_dedicated_gpio!((0, 0,
+        PRO_ALONEGPIO0)); _for_each_inner_dedicated_gpio!((0, 1, PRO_ALONEGPIO1));
+        _for_each_inner_dedicated_gpio!((0, 2, PRO_ALONEGPIO2));
+        _for_each_inner_dedicated_gpio!((0, 3, PRO_ALONEGPIO3));
+        _for_each_inner_dedicated_gpio!((0, 4, PRO_ALONEGPIO4));
+        _for_each_inner_dedicated_gpio!((0, 5, PRO_ALONEGPIO5));
+        _for_each_inner_dedicated_gpio!((0, 6, PRO_ALONEGPIO6));
+        _for_each_inner_dedicated_gpio!((0, 7, PRO_ALONEGPIO7));
+        _for_each_inner_dedicated_gpio!((channels(0), (1), (2), (3), (4), (5), (6),
+        (7))); _for_each_inner_dedicated_gpio!((signals(0, 0, PRO_ALONEGPIO0), (0, 1,
+        PRO_ALONEGPIO1), (0, 2, PRO_ALONEGPIO2), (0, 3, PRO_ALONEGPIO3), (0, 4,
+        PRO_ALONEGPIO4), (0, 5, PRO_ALONEGPIO5), (0, 6, PRO_ALONEGPIO6), (0, 7,
+        PRO_ALONEGPIO7)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_sw_interrupt {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((0, FROM_CPU_INTR0, software_interrupt0)); _for_each_inner!((1,
-        FROM_CPU_INTR1, software_interrupt1)); _for_each_inner!((2, FROM_CPU_INTR2,
-        software_interrupt2)); _for_each_inner!((3, FROM_CPU_INTR3,
-        software_interrupt3)); _for_each_inner!((all(0, FROM_CPU_INTR0,
+        macro_rules! _for_each_inner_sw_interrupt { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_sw_interrupt!((0, FROM_CPU_INTR0,
+        software_interrupt0)); _for_each_inner_sw_interrupt!((1, FROM_CPU_INTR1,
+        software_interrupt1)); _for_each_inner_sw_interrupt!((2, FROM_CPU_INTR2,
+        software_interrupt2)); _for_each_inner_sw_interrupt!((3, FROM_CPU_INTR3,
+        software_interrupt3)); _for_each_inner_sw_interrupt!((all(0, FROM_CPU_INTR0,
         software_interrupt0), (1, FROM_CPU_INTR1, software_interrupt1), (2,
         FROM_CPU_INTR2, software_interrupt2), (3, FROM_CPU_INTR3, software_interrupt3)));
     };
@@ -2721,146 +2731,282 @@ macro_rules! sw_interrupt_delay {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rmt_channel {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((0)); _for_each_inner!((1)); _for_each_inner!((2));
-        _for_each_inner!((3)); _for_each_inner!((0, 0)); _for_each_inner!((1, 1));
-        _for_each_inner!((2, 2)); _for_each_inner!((3, 3)); _for_each_inner!((0, 0));
-        _for_each_inner!((1, 1)); _for_each_inner!((2, 2)); _for_each_inner!((3, 3));
-        _for_each_inner!((all(0), (1), (2), (3))); _for_each_inner!((tx(0, 0), (1, 1),
-        (2, 2), (3, 3))); _for_each_inner!((rx(0, 0), (1, 1), (2, 2), (3, 3)));
+        macro_rules! _for_each_inner_rmt_channel { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_rmt_channel!((0)); _for_each_inner_rmt_channel!((1));
+        _for_each_inner_rmt_channel!((2)); _for_each_inner_rmt_channel!((3));
+        _for_each_inner_rmt_channel!((0, 0)); _for_each_inner_rmt_channel!((1, 1));
+        _for_each_inner_rmt_channel!((2, 2)); _for_each_inner_rmt_channel!((3, 3));
+        _for_each_inner_rmt_channel!((0, 0)); _for_each_inner_rmt_channel!((1, 1));
+        _for_each_inner_rmt_channel!((2, 2)); _for_each_inner_rmt_channel!((3, 3));
+        _for_each_inner_rmt_channel!((all(0), (1), (2), (3)));
+        _for_each_inner_rmt_channel!((tx(0, 0), (1, 1), (2, 2), (3, 3)));
+        _for_each_inner_rmt_channel!((rx(0, 0), (1, 1), (2, 2), (3, 3)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rmt_clock_source {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((RefTick, 0)); _for_each_inner!((Apb, 1));
-        _for_each_inner!((Apb)); _for_each_inner!((all(RefTick, 0), (Apb, 1)));
-        _for_each_inner!((default(Apb))); _for_each_inner!((is_boolean));
+        macro_rules! _for_each_inner_rmt_clock_source { $(($pattern) => $code;)* ($other
+        : tt) => {} } _for_each_inner_rmt_clock_source!((RefTick, 0));
+        _for_each_inner_rmt_clock_source!((Apb, 1));
+        _for_each_inner_rmt_clock_source!((Apb));
+        _for_each_inner_rmt_clock_source!((all(RefTick, 0), (Apb, 1)));
+        _for_each_inner_rmt_clock_source!((default(Apb)));
+        _for_each_inner_rmt_clock_source!((is_boolean));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rsa_exponentiation {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((32)); _for_each_inner!((64)); _for_each_inner!((96));
-        _for_each_inner!((128)); _for_each_inner!((160)); _for_each_inner!((192));
-        _for_each_inner!((224)); _for_each_inner!((256)); _for_each_inner!((288));
-        _for_each_inner!((320)); _for_each_inner!((352)); _for_each_inner!((384));
-        _for_each_inner!((416)); _for_each_inner!((448)); _for_each_inner!((480));
-        _for_each_inner!((512)); _for_each_inner!((544)); _for_each_inner!((576));
-        _for_each_inner!((608)); _for_each_inner!((640)); _for_each_inner!((672));
-        _for_each_inner!((704)); _for_each_inner!((736)); _for_each_inner!((768));
-        _for_each_inner!((800)); _for_each_inner!((832)); _for_each_inner!((864));
-        _for_each_inner!((896)); _for_each_inner!((928)); _for_each_inner!((960));
-        _for_each_inner!((992)); _for_each_inner!((1024)); _for_each_inner!((1056));
-        _for_each_inner!((1088)); _for_each_inner!((1120)); _for_each_inner!((1152));
-        _for_each_inner!((1184)); _for_each_inner!((1216)); _for_each_inner!((1248));
-        _for_each_inner!((1280)); _for_each_inner!((1312)); _for_each_inner!((1344));
-        _for_each_inner!((1376)); _for_each_inner!((1408)); _for_each_inner!((1440));
-        _for_each_inner!((1472)); _for_each_inner!((1504)); _for_each_inner!((1536));
-        _for_each_inner!((1568)); _for_each_inner!((1600)); _for_each_inner!((1632));
-        _for_each_inner!((1664)); _for_each_inner!((1696)); _for_each_inner!((1728));
-        _for_each_inner!((1760)); _for_each_inner!((1792)); _for_each_inner!((1824));
-        _for_each_inner!((1856)); _for_each_inner!((1888)); _for_each_inner!((1920));
-        _for_each_inner!((1952)); _for_each_inner!((1984)); _for_each_inner!((2016));
-        _for_each_inner!((2048)); _for_each_inner!((2080)); _for_each_inner!((2112));
-        _for_each_inner!((2144)); _for_each_inner!((2176)); _for_each_inner!((2208));
-        _for_each_inner!((2240)); _for_each_inner!((2272)); _for_each_inner!((2304));
-        _for_each_inner!((2336)); _for_each_inner!((2368)); _for_each_inner!((2400));
-        _for_each_inner!((2432)); _for_each_inner!((2464)); _for_each_inner!((2496));
-        _for_each_inner!((2528)); _for_each_inner!((2560)); _for_each_inner!((2592));
-        _for_each_inner!((2624)); _for_each_inner!((2656)); _for_each_inner!((2688));
-        _for_each_inner!((2720)); _for_each_inner!((2752)); _for_each_inner!((2784));
-        _for_each_inner!((2816)); _for_each_inner!((2848)); _for_each_inner!((2880));
-        _for_each_inner!((2912)); _for_each_inner!((2944)); _for_each_inner!((2976));
-        _for_each_inner!((3008)); _for_each_inner!((3040)); _for_each_inner!((3072));
-        _for_each_inner!((3104)); _for_each_inner!((3136)); _for_each_inner!((3168));
-        _for_each_inner!((3200)); _for_each_inner!((3232)); _for_each_inner!((3264));
-        _for_each_inner!((3296)); _for_each_inner!((3328)); _for_each_inner!((3360));
-        _for_each_inner!((3392)); _for_each_inner!((3424)); _for_each_inner!((3456));
-        _for_each_inner!((3488)); _for_each_inner!((3520)); _for_each_inner!((3552));
-        _for_each_inner!((3584)); _for_each_inner!((3616)); _for_each_inner!((3648));
-        _for_each_inner!((3680)); _for_each_inner!((3712)); _for_each_inner!((3744));
-        _for_each_inner!((3776)); _for_each_inner!((3808)); _for_each_inner!((3840));
-        _for_each_inner!((3872)); _for_each_inner!((3904)); _for_each_inner!((3936));
-        _for_each_inner!((3968)); _for_each_inner!((4000)); _for_each_inner!((4032));
-        _for_each_inner!((4064)); _for_each_inner!((4096)); _for_each_inner!((all(32),
-        (64), (96), (128), (160), (192), (224), (256), (288), (320), (352), (384), (416),
-        (448), (480), (512), (544), (576), (608), (640), (672), (704), (736), (768),
-        (800), (832), (864), (896), (928), (960), (992), (1024), (1056), (1088), (1120),
-        (1152), (1184), (1216), (1248), (1280), (1312), (1344), (1376), (1408), (1440),
-        (1472), (1504), (1536), (1568), (1600), (1632), (1664), (1696), (1728), (1760),
-        (1792), (1824), (1856), (1888), (1920), (1952), (1984), (2016), (2048), (2080),
-        (2112), (2144), (2176), (2208), (2240), (2272), (2304), (2336), (2368), (2400),
-        (2432), (2464), (2496), (2528), (2560), (2592), (2624), (2656), (2688), (2720),
-        (2752), (2784), (2816), (2848), (2880), (2912), (2944), (2976), (3008), (3040),
-        (3072), (3104), (3136), (3168), (3200), (3232), (3264), (3296), (3328), (3360),
-        (3392), (3424), (3456), (3488), (3520), (3552), (3584), (3616), (3648), (3680),
-        (3712), (3744), (3776), (3808), (3840), (3872), (3904), (3936), (3968), (4000),
-        (4032), (4064), (4096)));
+        macro_rules! _for_each_inner_rsa_exponentiation { $(($pattern) => $code;)*
+        ($other : tt) => {} } _for_each_inner_rsa_exponentiation!((32));
+        _for_each_inner_rsa_exponentiation!((64));
+        _for_each_inner_rsa_exponentiation!((96));
+        _for_each_inner_rsa_exponentiation!((128));
+        _for_each_inner_rsa_exponentiation!((160));
+        _for_each_inner_rsa_exponentiation!((192));
+        _for_each_inner_rsa_exponentiation!((224));
+        _for_each_inner_rsa_exponentiation!((256));
+        _for_each_inner_rsa_exponentiation!((288));
+        _for_each_inner_rsa_exponentiation!((320));
+        _for_each_inner_rsa_exponentiation!((352));
+        _for_each_inner_rsa_exponentiation!((384));
+        _for_each_inner_rsa_exponentiation!((416));
+        _for_each_inner_rsa_exponentiation!((448));
+        _for_each_inner_rsa_exponentiation!((480));
+        _for_each_inner_rsa_exponentiation!((512));
+        _for_each_inner_rsa_exponentiation!((544));
+        _for_each_inner_rsa_exponentiation!((576));
+        _for_each_inner_rsa_exponentiation!((608));
+        _for_each_inner_rsa_exponentiation!((640));
+        _for_each_inner_rsa_exponentiation!((672));
+        _for_each_inner_rsa_exponentiation!((704));
+        _for_each_inner_rsa_exponentiation!((736));
+        _for_each_inner_rsa_exponentiation!((768));
+        _for_each_inner_rsa_exponentiation!((800));
+        _for_each_inner_rsa_exponentiation!((832));
+        _for_each_inner_rsa_exponentiation!((864));
+        _for_each_inner_rsa_exponentiation!((896));
+        _for_each_inner_rsa_exponentiation!((928));
+        _for_each_inner_rsa_exponentiation!((960));
+        _for_each_inner_rsa_exponentiation!((992));
+        _for_each_inner_rsa_exponentiation!((1024));
+        _for_each_inner_rsa_exponentiation!((1056));
+        _for_each_inner_rsa_exponentiation!((1088));
+        _for_each_inner_rsa_exponentiation!((1120));
+        _for_each_inner_rsa_exponentiation!((1152));
+        _for_each_inner_rsa_exponentiation!((1184));
+        _for_each_inner_rsa_exponentiation!((1216));
+        _for_each_inner_rsa_exponentiation!((1248));
+        _for_each_inner_rsa_exponentiation!((1280));
+        _for_each_inner_rsa_exponentiation!((1312));
+        _for_each_inner_rsa_exponentiation!((1344));
+        _for_each_inner_rsa_exponentiation!((1376));
+        _for_each_inner_rsa_exponentiation!((1408));
+        _for_each_inner_rsa_exponentiation!((1440));
+        _for_each_inner_rsa_exponentiation!((1472));
+        _for_each_inner_rsa_exponentiation!((1504));
+        _for_each_inner_rsa_exponentiation!((1536));
+        _for_each_inner_rsa_exponentiation!((1568));
+        _for_each_inner_rsa_exponentiation!((1600));
+        _for_each_inner_rsa_exponentiation!((1632));
+        _for_each_inner_rsa_exponentiation!((1664));
+        _for_each_inner_rsa_exponentiation!((1696));
+        _for_each_inner_rsa_exponentiation!((1728));
+        _for_each_inner_rsa_exponentiation!((1760));
+        _for_each_inner_rsa_exponentiation!((1792));
+        _for_each_inner_rsa_exponentiation!((1824));
+        _for_each_inner_rsa_exponentiation!((1856));
+        _for_each_inner_rsa_exponentiation!((1888));
+        _for_each_inner_rsa_exponentiation!((1920));
+        _for_each_inner_rsa_exponentiation!((1952));
+        _for_each_inner_rsa_exponentiation!((1984));
+        _for_each_inner_rsa_exponentiation!((2016));
+        _for_each_inner_rsa_exponentiation!((2048));
+        _for_each_inner_rsa_exponentiation!((2080));
+        _for_each_inner_rsa_exponentiation!((2112));
+        _for_each_inner_rsa_exponentiation!((2144));
+        _for_each_inner_rsa_exponentiation!((2176));
+        _for_each_inner_rsa_exponentiation!((2208));
+        _for_each_inner_rsa_exponentiation!((2240));
+        _for_each_inner_rsa_exponentiation!((2272));
+        _for_each_inner_rsa_exponentiation!((2304));
+        _for_each_inner_rsa_exponentiation!((2336));
+        _for_each_inner_rsa_exponentiation!((2368));
+        _for_each_inner_rsa_exponentiation!((2400));
+        _for_each_inner_rsa_exponentiation!((2432));
+        _for_each_inner_rsa_exponentiation!((2464));
+        _for_each_inner_rsa_exponentiation!((2496));
+        _for_each_inner_rsa_exponentiation!((2528));
+        _for_each_inner_rsa_exponentiation!((2560));
+        _for_each_inner_rsa_exponentiation!((2592));
+        _for_each_inner_rsa_exponentiation!((2624));
+        _for_each_inner_rsa_exponentiation!((2656));
+        _for_each_inner_rsa_exponentiation!((2688));
+        _for_each_inner_rsa_exponentiation!((2720));
+        _for_each_inner_rsa_exponentiation!((2752));
+        _for_each_inner_rsa_exponentiation!((2784));
+        _for_each_inner_rsa_exponentiation!((2816));
+        _for_each_inner_rsa_exponentiation!((2848));
+        _for_each_inner_rsa_exponentiation!((2880));
+        _for_each_inner_rsa_exponentiation!((2912));
+        _for_each_inner_rsa_exponentiation!((2944));
+        _for_each_inner_rsa_exponentiation!((2976));
+        _for_each_inner_rsa_exponentiation!((3008));
+        _for_each_inner_rsa_exponentiation!((3040));
+        _for_each_inner_rsa_exponentiation!((3072));
+        _for_each_inner_rsa_exponentiation!((3104));
+        _for_each_inner_rsa_exponentiation!((3136));
+        _for_each_inner_rsa_exponentiation!((3168));
+        _for_each_inner_rsa_exponentiation!((3200));
+        _for_each_inner_rsa_exponentiation!((3232));
+        _for_each_inner_rsa_exponentiation!((3264));
+        _for_each_inner_rsa_exponentiation!((3296));
+        _for_each_inner_rsa_exponentiation!((3328));
+        _for_each_inner_rsa_exponentiation!((3360));
+        _for_each_inner_rsa_exponentiation!((3392));
+        _for_each_inner_rsa_exponentiation!((3424));
+        _for_each_inner_rsa_exponentiation!((3456));
+        _for_each_inner_rsa_exponentiation!((3488));
+        _for_each_inner_rsa_exponentiation!((3520));
+        _for_each_inner_rsa_exponentiation!((3552));
+        _for_each_inner_rsa_exponentiation!((3584));
+        _for_each_inner_rsa_exponentiation!((3616));
+        _for_each_inner_rsa_exponentiation!((3648));
+        _for_each_inner_rsa_exponentiation!((3680));
+        _for_each_inner_rsa_exponentiation!((3712));
+        _for_each_inner_rsa_exponentiation!((3744));
+        _for_each_inner_rsa_exponentiation!((3776));
+        _for_each_inner_rsa_exponentiation!((3808));
+        _for_each_inner_rsa_exponentiation!((3840));
+        _for_each_inner_rsa_exponentiation!((3872));
+        _for_each_inner_rsa_exponentiation!((3904));
+        _for_each_inner_rsa_exponentiation!((3936));
+        _for_each_inner_rsa_exponentiation!((3968));
+        _for_each_inner_rsa_exponentiation!((4000));
+        _for_each_inner_rsa_exponentiation!((4032));
+        _for_each_inner_rsa_exponentiation!((4064));
+        _for_each_inner_rsa_exponentiation!((4096));
+        _for_each_inner_rsa_exponentiation!((all(32), (64), (96), (128), (160), (192),
+        (224), (256), (288), (320), (352), (384), (416), (448), (480), (512), (544),
+        (576), (608), (640), (672), (704), (736), (768), (800), (832), (864), (896),
+        (928), (960), (992), (1024), (1056), (1088), (1120), (1152), (1184), (1216),
+        (1248), (1280), (1312), (1344), (1376), (1408), (1440), (1472), (1504), (1536),
+        (1568), (1600), (1632), (1664), (1696), (1728), (1760), (1792), (1824), (1856),
+        (1888), (1920), (1952), (1984), (2016), (2048), (2080), (2112), (2144), (2176),
+        (2208), (2240), (2272), (2304), (2336), (2368), (2400), (2432), (2464), (2496),
+        (2528), (2560), (2592), (2624), (2656), (2688), (2720), (2752), (2784), (2816),
+        (2848), (2880), (2912), (2944), (2976), (3008), (3040), (3072), (3104), (3136),
+        (3168), (3200), (3232), (3264), (3296), (3328), (3360), (3392), (3424), (3456),
+        (3488), (3520), (3552), (3584), (3616), (3648), (3680), (3712), (3744), (3776),
+        (3808), (3840), (3872), (3904), (3936), (3968), (4000), (4032), (4064), (4096)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rsa_multiplication {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((32)); _for_each_inner!((64)); _for_each_inner!((96));
-        _for_each_inner!((128)); _for_each_inner!((160)); _for_each_inner!((192));
-        _for_each_inner!((224)); _for_each_inner!((256)); _for_each_inner!((288));
-        _for_each_inner!((320)); _for_each_inner!((352)); _for_each_inner!((384));
-        _for_each_inner!((416)); _for_each_inner!((448)); _for_each_inner!((480));
-        _for_each_inner!((512)); _for_each_inner!((544)); _for_each_inner!((576));
-        _for_each_inner!((608)); _for_each_inner!((640)); _for_each_inner!((672));
-        _for_each_inner!((704)); _for_each_inner!((736)); _for_each_inner!((768));
-        _for_each_inner!((800)); _for_each_inner!((832)); _for_each_inner!((864));
-        _for_each_inner!((896)); _for_each_inner!((928)); _for_each_inner!((960));
-        _for_each_inner!((992)); _for_each_inner!((1024)); _for_each_inner!((1056));
-        _for_each_inner!((1088)); _for_each_inner!((1120)); _for_each_inner!((1152));
-        _for_each_inner!((1184)); _for_each_inner!((1216)); _for_each_inner!((1248));
-        _for_each_inner!((1280)); _for_each_inner!((1312)); _for_each_inner!((1344));
-        _for_each_inner!((1376)); _for_each_inner!((1408)); _for_each_inner!((1440));
-        _for_each_inner!((1472)); _for_each_inner!((1504)); _for_each_inner!((1536));
-        _for_each_inner!((1568)); _for_each_inner!((1600)); _for_each_inner!((1632));
-        _for_each_inner!((1664)); _for_each_inner!((1696)); _for_each_inner!((1728));
-        _for_each_inner!((1760)); _for_each_inner!((1792)); _for_each_inner!((1824));
-        _for_each_inner!((1856)); _for_each_inner!((1888)); _for_each_inner!((1920));
-        _for_each_inner!((1952)); _for_each_inner!((1984)); _for_each_inner!((2016));
-        _for_each_inner!((2048)); _for_each_inner!((all(32), (64), (96), (128), (160),
-        (192), (224), (256), (288), (320), (352), (384), (416), (448), (480), (512),
-        (544), (576), (608), (640), (672), (704), (736), (768), (800), (832), (864),
-        (896), (928), (960), (992), (1024), (1056), (1088), (1120), (1152), (1184),
-        (1216), (1248), (1280), (1312), (1344), (1376), (1408), (1440), (1472), (1504),
-        (1536), (1568), (1600), (1632), (1664), (1696), (1728), (1760), (1792), (1824),
-        (1856), (1888), (1920), (1952), (1984), (2016), (2048)));
+        macro_rules! _for_each_inner_rsa_multiplication { $(($pattern) => $code;)*
+        ($other : tt) => {} } _for_each_inner_rsa_multiplication!((32));
+        _for_each_inner_rsa_multiplication!((64));
+        _for_each_inner_rsa_multiplication!((96));
+        _for_each_inner_rsa_multiplication!((128));
+        _for_each_inner_rsa_multiplication!((160));
+        _for_each_inner_rsa_multiplication!((192));
+        _for_each_inner_rsa_multiplication!((224));
+        _for_each_inner_rsa_multiplication!((256));
+        _for_each_inner_rsa_multiplication!((288));
+        _for_each_inner_rsa_multiplication!((320));
+        _for_each_inner_rsa_multiplication!((352));
+        _for_each_inner_rsa_multiplication!((384));
+        _for_each_inner_rsa_multiplication!((416));
+        _for_each_inner_rsa_multiplication!((448));
+        _for_each_inner_rsa_multiplication!((480));
+        _for_each_inner_rsa_multiplication!((512));
+        _for_each_inner_rsa_multiplication!((544));
+        _for_each_inner_rsa_multiplication!((576));
+        _for_each_inner_rsa_multiplication!((608));
+        _for_each_inner_rsa_multiplication!((640));
+        _for_each_inner_rsa_multiplication!((672));
+        _for_each_inner_rsa_multiplication!((704));
+        _for_each_inner_rsa_multiplication!((736));
+        _for_each_inner_rsa_multiplication!((768));
+        _for_each_inner_rsa_multiplication!((800));
+        _for_each_inner_rsa_multiplication!((832));
+        _for_each_inner_rsa_multiplication!((864));
+        _for_each_inner_rsa_multiplication!((896));
+        _for_each_inner_rsa_multiplication!((928));
+        _for_each_inner_rsa_multiplication!((960));
+        _for_each_inner_rsa_multiplication!((992));
+        _for_each_inner_rsa_multiplication!((1024));
+        _for_each_inner_rsa_multiplication!((1056));
+        _for_each_inner_rsa_multiplication!((1088));
+        _for_each_inner_rsa_multiplication!((1120));
+        _for_each_inner_rsa_multiplication!((1152));
+        _for_each_inner_rsa_multiplication!((1184));
+        _for_each_inner_rsa_multiplication!((1216));
+        _for_each_inner_rsa_multiplication!((1248));
+        _for_each_inner_rsa_multiplication!((1280));
+        _for_each_inner_rsa_multiplication!((1312));
+        _for_each_inner_rsa_multiplication!((1344));
+        _for_each_inner_rsa_multiplication!((1376));
+        _for_each_inner_rsa_multiplication!((1408));
+        _for_each_inner_rsa_multiplication!((1440));
+        _for_each_inner_rsa_multiplication!((1472));
+        _for_each_inner_rsa_multiplication!((1504));
+        _for_each_inner_rsa_multiplication!((1536));
+        _for_each_inner_rsa_multiplication!((1568));
+        _for_each_inner_rsa_multiplication!((1600));
+        _for_each_inner_rsa_multiplication!((1632));
+        _for_each_inner_rsa_multiplication!((1664));
+        _for_each_inner_rsa_multiplication!((1696));
+        _for_each_inner_rsa_multiplication!((1728));
+        _for_each_inner_rsa_multiplication!((1760));
+        _for_each_inner_rsa_multiplication!((1792));
+        _for_each_inner_rsa_multiplication!((1824));
+        _for_each_inner_rsa_multiplication!((1856));
+        _for_each_inner_rsa_multiplication!((1888));
+        _for_each_inner_rsa_multiplication!((1920));
+        _for_each_inner_rsa_multiplication!((1952));
+        _for_each_inner_rsa_multiplication!((1984));
+        _for_each_inner_rsa_multiplication!((2016));
+        _for_each_inner_rsa_multiplication!((2048));
+        _for_each_inner_rsa_multiplication!((all(32), (64), (96), (128), (160), (192),
+        (224), (256), (288), (320), (352), (384), (416), (448), (480), (512), (544),
+        (576), (608), (640), (672), (704), (736), (768), (800), (832), (864), (896),
+        (928), (960), (992), (1024), (1056), (1088), (1120), (1152), (1184), (1216),
+        (1248), (1280), (1312), (1344), (1376), (1408), (1440), (1472), (1504), (1536),
+        (1568), (1600), (1632), (1664), (1696), (1728), (1760), (1792), (1824), (1856),
+        (1888), (1920), (1952), (1984), (2016), (2048)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_sha_algorithm {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((Sha1, "SHA-1"(sizes : 64, 20, 8) (insecure_against :
-        "collision", "length extension"), 0)); _for_each_inner!((Sha224, "SHA-224"(sizes
-        : 64, 28, 8) (insecure_against : "length extension"), 1));
-        _for_each_inner!((Sha256, "SHA-256"(sizes : 64, 32, 8) (insecure_against :
-        "length extension"), 2)); _for_each_inner!((Sha384, "SHA-384"(sizes : 128, 48,
-        16) (insecure_against :), 3)); _for_each_inner!((Sha512, "SHA-512"(sizes : 128,
-        64, 16) (insecure_against : "length extension"), 4));
-        _for_each_inner!((Sha512_224, "SHA-512/224"(sizes : 128, 28, 16)
-        (insecure_against :), 5)); _for_each_inner!((Sha512_256, "SHA-512/256"(sizes :
-        128, 32, 16) (insecure_against :), 6)); _for_each_inner!((algos(Sha1,
-        "SHA-1"(sizes : 64, 20, 8) (insecure_against : "collision", "length extension"),
-        0), (Sha224, "SHA-224"(sizes : 64, 28, 8) (insecure_against :
-        "length extension"), 1), (Sha256, "SHA-256"(sizes : 64, 32, 8) (insecure_against
-        : "length extension"), 2), (Sha384, "SHA-384"(sizes : 128, 48, 16)
-        (insecure_against :), 3), (Sha512, "SHA-512"(sizes : 128, 64, 16)
-        (insecure_against : "length extension"), 4), (Sha512_224, "SHA-512/224"(sizes :
-        128, 28, 16) (insecure_against :), 5), (Sha512_256, "SHA-512/256"(sizes : 128,
-        32, 16) (insecure_against :), 6)));
+        macro_rules! _for_each_inner_sha_algorithm { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_sha_algorithm!((Sha1, "SHA-1"(sizes : 64, 20, 8)
+        (insecure_against : "collision", "length extension"), 0));
+        _for_each_inner_sha_algorithm!((Sha224, "SHA-224"(sizes : 64, 28, 8)
+        (insecure_against : "length extension"), 1));
+        _for_each_inner_sha_algorithm!((Sha256, "SHA-256"(sizes : 64, 32, 8)
+        (insecure_against : "length extension"), 2));
+        _for_each_inner_sha_algorithm!((Sha384, "SHA-384"(sizes : 128, 48, 16)
+        (insecure_against :), 3)); _for_each_inner_sha_algorithm!((Sha512,
+        "SHA-512"(sizes : 128, 64, 16) (insecure_against : "length extension"), 4));
+        _for_each_inner_sha_algorithm!((Sha512_224, "SHA-512/224"(sizes : 128, 28, 16)
+        (insecure_against :), 5)); _for_each_inner_sha_algorithm!((Sha512_256,
+        "SHA-512/256"(sizes : 128, 32, 16) (insecure_against :), 6));
+        _for_each_inner_sha_algorithm!((algos(Sha1, "SHA-1"(sizes : 64, 20, 8)
+        (insecure_against : "collision", "length extension"), 0), (Sha224,
+        "SHA-224"(sizes : 64, 28, 8) (insecure_against : "length extension"), 1),
+        (Sha256, "SHA-256"(sizes : 64, 32, 8) (insecure_against : "length extension"),
+        2), (Sha384, "SHA-384"(sizes : 128, 48, 16) (insecure_against :), 3), (Sha512,
+        "SHA-512"(sizes : 128, 64, 16) (insecure_against : "length extension"), 4),
+        (Sha512_224, "SHA-512/224"(sizes : 128, 28, 16) (insecure_against :), 5),
+        (Sha512_256, "SHA-512/256"(sizes : 128, 32, 16) (insecure_against :), 6)));
     };
 }
 /// This macro can be used to generate code for each peripheral instance of the I2C master driver.
@@ -2883,11 +3029,11 @@ macro_rules! for_each_sha_algorithm {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_i2c_master {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((I2C0, I2cExt0, I2CEXT0_SCL, I2CEXT0_SDA));
-        _for_each_inner!((I2C1, I2cExt1, I2CEXT1_SCL, I2CEXT1_SDA));
-        _for_each_inner!((all(I2C0, I2cExt0, I2CEXT0_SCL, I2CEXT0_SDA), (I2C1, I2cExt1,
-        I2CEXT1_SCL, I2CEXT1_SDA)));
+        macro_rules! _for_each_inner_i2c_master { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_i2c_master!((I2C0, I2cExt0, I2CEXT0_SCL, I2CEXT0_SDA));
+        _for_each_inner_i2c_master!((I2C1, I2cExt1, I2CEXT1_SCL, I2CEXT1_SDA));
+        _for_each_inner_i2c_master!((all(I2C0, I2cExt0, I2CEXT0_SCL, I2CEXT0_SDA), (I2C1,
+        I2cExt1, I2CEXT1_SCL, I2CEXT1_SDA)));
     };
 }
 /// This macro can be used to generate code for each peripheral instance of the UART driver.
@@ -2910,11 +3056,11 @@ macro_rules! for_each_i2c_master {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_uart {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS));
-        _for_each_inner!((UART1, Uart1, U1RXD, U1TXD, U1CTS, U1RTS));
-        _for_each_inner!((all(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS), (UART1, Uart1,
-        U1RXD, U1TXD, U1CTS, U1RTS)));
+        macro_rules! _for_each_inner_uart { $(($pattern) => $code;)* ($other : tt) => {}
+        } _for_each_inner_uart!((UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS));
+        _for_each_inner_uart!((UART1, Uart1, U1RXD, U1TXD, U1CTS, U1RTS));
+        _for_each_inner_uart!((all(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS), (UART1,
+        Uart1, U1RXD, U1TXD, U1CTS, U1RTS)));
     };
 }
 /// This macro can be used to generate code for each peripheral instance of the SPI master driver.
@@ -2942,14 +3088,15 @@ macro_rules! for_each_uart {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_spi_master {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((SPI2, Spi2, FSPICLK[FSPICS0, FSPICS1, FSPICS2, FSPICS3,
-        FSPICS4, FSPICS5] [FSPID, FSPIQ, FSPIWP, FSPIHD, FSPIIO4, FSPIIO5, FSPIIO6,
-        FSPIIO7], true)); _for_each_inner!((SPI3, Spi3, SPI3_CLK[SPI3_CS0, SPI3_CS1,
-        SPI3_CS2] [SPI3_D, SPI3_Q])); _for_each_inner!((all(SPI2, Spi2, FSPICLK[FSPICS0,
-        FSPICS1, FSPICS2, FSPICS3, FSPICS4, FSPICS5] [FSPID, FSPIQ, FSPIWP, FSPIHD,
-        FSPIIO4, FSPIIO5, FSPIIO6, FSPIIO7], true), (SPI3, Spi3, SPI3_CLK[SPI3_CS0,
-        SPI3_CS1, SPI3_CS2] [SPI3_D, SPI3_Q])));
+        macro_rules! _for_each_inner_spi_master { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_spi_master!((SPI2, Spi2, FSPICLK[FSPICS0, FSPICS1,
+        FSPICS2, FSPICS3, FSPICS4, FSPICS5] [FSPID, FSPIQ, FSPIWP, FSPIHD, FSPIIO4,
+        FSPIIO5, FSPIIO6, FSPIIO7], true)); _for_each_inner_spi_master!((SPI3, Spi3,
+        SPI3_CLK[SPI3_CS0, SPI3_CS1, SPI3_CS2] [SPI3_D, SPI3_Q]));
+        _for_each_inner_spi_master!((all(SPI2, Spi2, FSPICLK[FSPICS0, FSPICS1, FSPICS2,
+        FSPICS3, FSPICS4, FSPICS5] [FSPID, FSPIQ, FSPIWP, FSPIHD, FSPIIO4, FSPIIO5,
+        FSPIIO6, FSPIIO7], true), (SPI3, Spi3, SPI3_CLK[SPI3_CS0, SPI3_CS1, SPI3_CS2]
+        [SPI3_D, SPI3_Q])));
     };
 }
 /// This macro can be used to generate code for each peripheral instance of the SPI slave driver.
@@ -2972,332 +3119,393 @@ macro_rules! for_each_spi_master {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_spi_slave {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((SPI2, Spi2, FSPICLK, FSPID, FSPIQ, FSPICS0));
-        _for_each_inner!((SPI3, Spi3, SPI3_CLK, SPI3_D, SPI3_Q, SPI3_CS0));
-        _for_each_inner!((all(SPI2, Spi2, FSPICLK, FSPID, FSPIQ, FSPICS0), (SPI3, Spi3,
-        SPI3_CLK, SPI3_D, SPI3_Q, SPI3_CS0)));
+        macro_rules! _for_each_inner_spi_slave { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_spi_slave!((SPI2, Spi2, FSPICLK, FSPID, FSPIQ, FSPICS0));
+        _for_each_inner_spi_slave!((SPI3, Spi3, SPI3_CLK, SPI3_D, SPI3_Q, SPI3_CS0));
+        _for_each_inner_spi_slave!((all(SPI2, Spi2, FSPICLK, FSPID, FSPIQ, FSPICS0),
+        (SPI3, Spi3, SPI3_CLK, SPI3_D, SPI3_Q, SPI3_CS0)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_peripheral {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((@ peri_type #[doc =
+        macro_rules! _for_each_inner_peripheral { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_peripheral!((@ peri_type #[doc =
         "GPIO0 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
         "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin is a strapping pin, it determines how the chip boots.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO0 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO1 peripheral singleton"] GPIO1 <= virtual()));
-        _for_each_inner!((@ peri_type #[doc = "GPIO2 peripheral singleton"] GPIO2 <=
-        virtual())); _for_each_inner!((@ peri_type #[doc = "GPIO3 peripheral singleton"]
-        GPIO3 <= virtual())); _for_each_inner!((@ peri_type #[doc =
-        "GPIO4 peripheral singleton"] GPIO4 <= virtual())); _for_each_inner!((@ peri_type
-        #[doc = "GPIO5 peripheral singleton"] GPIO5 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO6 peripheral singleton"] GPIO6 <= virtual()));
-        _for_each_inner!((@ peri_type #[doc = "GPIO7 peripheral singleton"] GPIO7 <=
-        virtual())); _for_each_inner!((@ peri_type #[doc = "GPIO8 peripheral singleton"]
-        GPIO8 <= virtual())); _for_each_inner!((@ peri_type #[doc =
-        "GPIO9 peripheral singleton"] GPIO9 <= virtual())); _for_each_inner!((@ peri_type
-        #[doc = "GPIO10 peripheral singleton"] GPIO10 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO11 peripheral singleton"] GPIO11 <= virtual()));
-        _for_each_inner!((@ peri_type #[doc = "GPIO12 peripheral singleton"] GPIO12 <=
-        virtual())); _for_each_inner!((@ peri_type #[doc = "GPIO13 peripheral singleton"]
-        GPIO13 <= virtual())); _for_each_inner!((@ peri_type #[doc =
-        "GPIO14 peripheral singleton"] GPIO14 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO15 peripheral singleton"] GPIO15 <= virtual()));
-        _for_each_inner!((@ peri_type #[doc = "GPIO16 peripheral singleton"] GPIO16 <=
-        virtual())); _for_each_inner!((@ peri_type #[doc = "GPIO17 peripheral singleton"]
-        GPIO17 <= virtual())); _for_each_inner!((@ peri_type #[doc =
-        "GPIO18 peripheral singleton"] GPIO18 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO19 peripheral singleton"] GPIO19 <= virtual()));
-        _for_each_inner!((@ peri_type #[doc = "GPIO20 peripheral singleton"] GPIO20 <=
-        virtual())); _for_each_inner!((@ peri_type #[doc = "GPIO21 peripheral singleton"]
-        GPIO21 <= virtual())); _for_each_inner!((@ peri_type #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO0 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO1 peripheral singleton"]
+        GPIO1 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO2 peripheral singleton"] GPIO2 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO3 peripheral singleton"]
+        GPIO3 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO4 peripheral singleton"] GPIO4 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO5 peripheral singleton"]
+        GPIO5 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO6 peripheral singleton"] GPIO6 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO7 peripheral singleton"]
+        GPIO7 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO8 peripheral singleton"] GPIO8 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO9 peripheral singleton"]
+        GPIO9 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO10 peripheral singleton"] GPIO10 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO11 peripheral singleton"]
+        GPIO11 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO12 peripheral singleton"] GPIO12 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO13 peripheral singleton"]
+        GPIO13 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO14 peripheral singleton"] GPIO14 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO15 peripheral singleton"]
+        GPIO15 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO16 peripheral singleton"] GPIO16 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO17 peripheral singleton"]
+        GPIO17 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO18 peripheral singleton"] GPIO18 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO19 peripheral singleton"]
+        GPIO19 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO20 peripheral singleton"] GPIO20 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO21 peripheral singleton"]
+        GPIO21 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
         "GPIO26 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
         "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI PSRAM.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO26 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO27 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO26 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO27 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI PSRAM.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO27 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO28 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO27 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO28 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI PSRAM.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO28 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO29 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO28 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO29 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO29 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO30 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
-        "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
-        #[doc = "<ul>"] #[doc =
-        "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
-        "<li>This pin may be reserved for interfacing with SPI PSRAM.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO30 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO31 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO29 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO30 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI PSRAM.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO31 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO32 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO30 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO31 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI PSRAM.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO32 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO33 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO31 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO32 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
+        "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
+        #[doc = "<ul>"] #[doc =
+        "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
+        "<li>This pin may be reserved for interfacing with SPI PSRAM.</li>"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO32 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO33 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with Octal SPI flash.</li>"] #[doc
         = "<li>This pin may be reserved for interfacing with Octal SPI PSRAM.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO33 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO34 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO33 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO34 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with Octal SPI flash.</li>"] #[doc
         = "<li>This pin may be reserved for interfacing with Octal SPI PSRAM.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO34 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO35 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO34 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO35 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with Octal SPI flash.</li>"] #[doc
         = "<li>This pin may be reserved for interfacing with Octal SPI PSRAM.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO35 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO36 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO35 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO36 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with Octal SPI flash.</li>"] #[doc
         = "<li>This pin may be reserved for interfacing with Octal SPI PSRAM.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO36 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO37 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO36 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO37 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with Octal SPI flash.</li>"] #[doc
         = "<li>This pin may be reserved for interfacing with Octal SPI PSRAM.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO37 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO38 peripheral singleton"] GPIO38 <= virtual()));
-        _for_each_inner!((@ peri_type #[doc =
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO37 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO38 peripheral singleton"]
+        GPIO38 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
         "GPIO39 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
         "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>These pins may be used to debug the chip using an external JTAG debugger.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO39 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO40 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO39 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO40 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>These pins may be used to debug the chip using an external JTAG debugger.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO40 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO41 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO40 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO41 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>These pins may be used to debug the chip using an external JTAG debugger.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO41 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO42 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO41 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO42 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>These pins may be used to debug the chip using an external JTAG debugger.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO42 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO43 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO42 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO43 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>By default, this pin is used by the UART programming interface.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO43 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO44 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO43 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO44 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>By default, this pin is used by the UART programming interface.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO44 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO45 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO44 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO45 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin is a strapping pin, it determines how the chip boots.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO45 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO46 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO45 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO46 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin is a strapping pin, it determines how the chip boots.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO46 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "AES peripheral singleton"] AES <= AES(AES : {
-        bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
-        (unstable))); _for_each_inner!((@ peri_type #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO46 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "AES peripheral singleton"] AES
+        <= AES(AES : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt
+        }) (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "DEDICATED_GPIO peripheral singleton"]
-        DEDICATED_GPIO <= DEDICATED_GPIO() (unstable))); _for_each_inner!((@ peri_type
-        #[doc = "DS peripheral singleton"] DS <= DS() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "EFUSE peripheral singleton"] EFUSE <= EFUSE() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "EXTMEM peripheral singleton"] EXTMEM <=
-        EXTMEM() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "FE peripheral singleton"] FE <= FE() (unstable))); _for_each_inner!((@ peri_type
-        #[doc = "FE2 peripheral singleton"] FE2 <= FE2() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "GPIO peripheral singleton"] GPIO <= GPIO()
-        (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "DEDICATED_GPIO peripheral singleton"] DEDICATED_GPIO <= DEDICATED_GPIO()
+        (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "DS peripheral singleton"] DS <= DS() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "EFUSE peripheral singleton"]
+        EFUSE <= EFUSE() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "EXTMEM peripheral singleton"] EXTMEM <= EXTMEM() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "FE peripheral singleton"] FE <=
+        FE() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "FE2 peripheral singleton"] FE2 <= FE2() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO peripheral singleton"]
+        GPIO <= GPIO() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "GPIO_SD peripheral singleton"] GPIO_SD <= GPIO_SD() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "HMAC peripheral singleton"] HMAC <= HMAC()
-        (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "HMAC peripheral singleton"]
+        HMAC <= HMAC() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "I2C_ANA_MST peripheral singleton"] I2C_ANA_MST <= I2C_ANA_MST() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "I2C0 peripheral singleton"] I2C0 <=
-        I2C0(I2C_EXT0 : { bind_peri_interrupt, enable_peri_interrupt,
-        disable_peri_interrupt }))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "I2C0 peripheral singleton"]
+        I2C0 <= I2C0(I2C_EXT0 : { bind_peri_interrupt, enable_peri_interrupt,
+        disable_peri_interrupt }))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "I2C1 peripheral singleton"] I2C1 <= I2C1(I2C_EXT1 : { bind_peri_interrupt,
-        enable_peri_interrupt, disable_peri_interrupt }))); _for_each_inner!((@ peri_type
-        #[doc = "I2S0 peripheral singleton"] I2S0 <= I2S0(I2S0 : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt })));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "I2S0 peripheral singleton"]
+        I2S0 <= I2S0(I2S0 : { bind_peri_interrupt, enable_peri_interrupt,
+        disable_peri_interrupt }) (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "INTERRUPT_CORE0 peripheral singleton"] INTERRUPT_CORE0 <=
+        INTERRUPT_CORE0() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "IO_MUX peripheral singleton"] IO_MUX <= IO_MUX() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "LEDC peripheral singleton"]
+        LEDC <= LEDC() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "NRX peripheral singleton"] NRX <= NRX() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "PCNT peripheral singleton"]
+        PCNT <= PCNT() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "PMS peripheral singleton"] PMS <= PMS() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "RMT peripheral singleton"] RMT
+        <= RMT() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "RNG peripheral singleton"] RNG <= RNG() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "RSA peripheral singleton"] RSA
+        <= RSA(RSA : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt
+        }) (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "LPWR peripheral singleton"] LPWR <= RTC_CNTL() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "RTC_I2C peripheral singleton"]
+        RTC_I2C <= RTC_I2C() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "RTC_IO peripheral singleton"] RTC_IO <= RTC_IO() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "SENS peripheral singleton"]
+        SENS <= SENS() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "SHA peripheral singleton"] SHA <= SHA(SHA : { bind_peri_interrupt,
         enable_peri_interrupt, disable_peri_interrupt }) (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "INTERRUPT_CORE0 peripheral singleton"]
-        INTERRUPT_CORE0 <= INTERRUPT_CORE0() (unstable))); _for_each_inner!((@ peri_type
-        #[doc = "IO_MUX peripheral singleton"] IO_MUX <= IO_MUX() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "LEDC peripheral singleton"] LEDC <= LEDC()
-        (unstable))); _for_each_inner!((@ peri_type #[doc = "NRX peripheral singleton"]
-        NRX <= NRX() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "PCNT peripheral singleton"] PCNT <= PCNT() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "PMS peripheral singleton"] PMS <= PMS() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "RMT peripheral singleton"] RMT <= RMT()
-        (unstable))); _for_each_inner!((@ peri_type #[doc = "RNG peripheral singleton"]
-        RNG <= RNG() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "RSA peripheral singleton"] RSA <= RSA(RSA : { bind_peri_interrupt,
-        enable_peri_interrupt, disable_peri_interrupt }) (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "LPWR peripheral singleton"] LPWR <=
-        RTC_CNTL() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "RTC_I2C peripheral singleton"] RTC_I2C <= RTC_I2C() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "RTC_IO peripheral singleton"] RTC_IO <=
-        RTC_IO() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "SENS peripheral singleton"] SENS <= SENS() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "SHA peripheral singleton"] SHA <= SHA(SHA : {
-        bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
-        (unstable))); _for_each_inner!((@ peri_type #[doc = "SPI0 peripheral singleton"]
-        SPI0 <= SPI0() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "SPI1 peripheral singleton"] SPI1 <= SPI1() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "SPI2 peripheral singleton"] SPI2 <= SPI2(SPI2_DMA : {
-        bind_dma_interrupt, enable_dma_interrupt, disable_dma_interrupt }, SPI2 : {
-        bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })));
-        _for_each_inner!((@ peri_type #[doc = "SPI3 peripheral singleton"] SPI3 <=
-        SPI3(SPI3_DMA : { bind_dma_interrupt, enable_dma_interrupt, disable_dma_interrupt
-        }, SPI3 : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt
-        }))); _for_each_inner!((@ peri_type #[doc = "SYSCON peripheral singleton"] SYSCON
-        <= SYSCON() (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "SPI0 peripheral singleton"]
+        SPI0 <= SPI0() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "SPI1 peripheral singleton"] SPI1 <= SPI1() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "SPI2 peripheral singleton"]
+        SPI2 <= SPI2(SPI2_DMA : { bind_dma_interrupt, enable_dma_interrupt,
+        disable_dma_interrupt }, SPI2 : { bind_peri_interrupt, enable_peri_interrupt,
+        disable_peri_interrupt }))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "SPI3 peripheral singleton"] SPI3 <= SPI3(SPI3_DMA : { bind_dma_interrupt,
+        enable_dma_interrupt, disable_dma_interrupt }, SPI3 : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt })));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "SYSCON peripheral singleton"]
+        SYSCON <= SYSCON() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "SYSTEM peripheral singleton"] SYSTEM <= SYSTEM() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "SYSTIMER peripheral singleton"] SYSTIMER
-        <= SYSTIMER() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "TIMG0 peripheral singleton"] TIMG0 <= TIMG0() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "TIMG1 peripheral singleton"] TIMG1 <= TIMG1() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "TWAI0 peripheral singleton"] TWAI0 <=
-        TWAI0() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "UART0 peripheral singleton"] UART0 <= UART0(UART0 : { bind_peri_interrupt,
-        enable_peri_interrupt, disable_peri_interrupt }))); _for_each_inner!((@ peri_type
-        #[doc = "UART1 peripheral singleton"] UART1 <= UART1(UART1 : {
-        bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })));
-        _for_each_inner!((@ peri_type #[doc = "UHCI0 peripheral singleton"] UHCI0 <=
-        UHCI0() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "USB0 peripheral singleton"] USB0 <= USB0() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "USB_WRAP peripheral singleton"] USB_WRAP <= USB_WRAP()
-        (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "XTS_AES peripheral singleton"] XTS_AES <= XTS_AES() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "WIFI peripheral singleton"] WIFI <= WIFI()
-        (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "SYSTIMER peripheral singleton"]
+        SYSTIMER <= SYSTIMER() (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "TIMG0 peripheral singleton"] TIMG0 <= TIMG0() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "TIMG1 peripheral singleton"]
+        TIMG1 <= TIMG1() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "TWAI0 peripheral singleton"] TWAI0 <= TWAI0() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "UART0 peripheral singleton"]
+        UART0 <= UART0(UART0 : { bind_peri_interrupt, enable_peri_interrupt,
+        disable_peri_interrupt }))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "UART1 peripheral singleton"] UART1 <= UART1(UART1 : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt })));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "UHCI0 peripheral singleton"]
+        UHCI0 <= UHCI0() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "USB0 peripheral singleton"] USB0 <= USB0() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "USB_WRAP peripheral singleton"]
+        USB_WRAP <= USB_WRAP() (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "XTS_AES peripheral singleton"] XTS_AES <= XTS_AES() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "WIFI peripheral singleton"]
+        WIFI <= WIFI() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "DMA_SPI2 peripheral singleton"] DMA_SPI2 <= SPI2() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "DMA_SPI3 peripheral singleton"] DMA_SPI3
-        <= SPI3() (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_SPI3 peripheral singleton"]
+        DMA_SPI3 <= SPI3() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "DMA_I2S0 peripheral singleton"] DMA_I2S0 <= I2S0() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "DMA_CRYPTO peripheral singleton"]
-        DMA_CRYPTO <= CRYPTO_DMA() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "DMA_COPY peripheral singleton"] DMA_COPY <= COPY_DMA() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "ADC1 peripheral singleton"] ADC1 <=
-        virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "ADC2 peripheral singleton"] ADC2 <= virtual() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "DAC1 peripheral singleton"] DAC1 <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "DAC2 peripheral singleton"] DAC2 <=
-        virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "DMA_CRYPTO peripheral singleton"] DMA_CRYPTO <= CRYPTO_DMA() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_COPY peripheral singleton"]
+        DMA_COPY <= COPY_DMA() (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "ADC1 peripheral singleton"] ADC1 <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "ADC2 peripheral singleton"]
+        ADC2 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "DAC1 peripheral singleton"] DAC1 <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DAC2 peripheral singleton"]
+        DAC2 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "FLASH peripheral singleton"] FLASH <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "GPIO_DEDICATED peripheral singleton"]
-        GPIO_DEDICATED <= virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "PSRAM peripheral singleton"] PSRAM <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "SW_INTERRUPT peripheral singleton"]
-        SW_INTERRUPT <= virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO_DEDICATED peripheral singleton"] GPIO_DEDICATED <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "PSRAM peripheral singleton"]
+        PSRAM <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "SW_INTERRUPT peripheral singleton"] SW_INTERRUPT <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
         "ULP_RISCV_CORE peripheral singleton"] ULP_RISCV_CORE <= virtual() (unstable)));
-        _for_each_inner!((GPIO0)); _for_each_inner!((GPIO1)); _for_each_inner!((GPIO2));
-        _for_each_inner!((GPIO3)); _for_each_inner!((GPIO4)); _for_each_inner!((GPIO5));
-        _for_each_inner!((GPIO6)); _for_each_inner!((GPIO7)); _for_each_inner!((GPIO8));
-        _for_each_inner!((GPIO9)); _for_each_inner!((GPIO10));
-        _for_each_inner!((GPIO11)); _for_each_inner!((GPIO12));
-        _for_each_inner!((GPIO13)); _for_each_inner!((GPIO14));
-        _for_each_inner!((GPIO15)); _for_each_inner!((GPIO16));
-        _for_each_inner!((GPIO17)); _for_each_inner!((GPIO18));
-        _for_each_inner!((GPIO19)); _for_each_inner!((GPIO20));
-        _for_each_inner!((GPIO21)); _for_each_inner!((GPIO26));
-        _for_each_inner!((GPIO27)); _for_each_inner!((GPIO28));
-        _for_each_inner!((GPIO29)); _for_each_inner!((GPIO30));
-        _for_each_inner!((GPIO31)); _for_each_inner!((GPIO32));
-        _for_each_inner!((GPIO33)); _for_each_inner!((GPIO34));
-        _for_each_inner!((GPIO35)); _for_each_inner!((GPIO36));
-        _for_each_inner!((GPIO37)); _for_each_inner!((GPIO38));
-        _for_each_inner!((GPIO39)); _for_each_inner!((GPIO40));
-        _for_each_inner!((GPIO41)); _for_each_inner!((GPIO42));
-        _for_each_inner!((GPIO43)); _for_each_inner!((GPIO44));
-        _for_each_inner!((GPIO45)); _for_each_inner!((GPIO46));
-        _for_each_inner!((AES(unstable))); _for_each_inner!((APB_SARADC(unstable)));
-        _for_each_inner!((DEDICATED_GPIO(unstable))); _for_each_inner!((DS(unstable)));
-        _for_each_inner!((EFUSE(unstable))); _for_each_inner!((EXTMEM(unstable)));
-        _for_each_inner!((FE(unstable))); _for_each_inner!((FE2(unstable)));
-        _for_each_inner!((GPIO(unstable))); _for_each_inner!((GPIO_SD(unstable)));
-        _for_each_inner!((HMAC(unstable))); _for_each_inner!((I2C_ANA_MST(unstable)));
-        _for_each_inner!((I2C0)); _for_each_inner!((I2C1));
-        _for_each_inner!((I2S0(unstable)));
-        _for_each_inner!((INTERRUPT_CORE0(unstable)));
-        _for_each_inner!((IO_MUX(unstable))); _for_each_inner!((LEDC(unstable)));
-        _for_each_inner!((NRX(unstable))); _for_each_inner!((PCNT(unstable)));
-        _for_each_inner!((PMS(unstable))); _for_each_inner!((RMT(unstable)));
-        _for_each_inner!((RNG(unstable))); _for_each_inner!((RSA(unstable)));
-        _for_each_inner!((LPWR(unstable))); _for_each_inner!((RTC_I2C(unstable)));
-        _for_each_inner!((RTC_IO(unstable))); _for_each_inner!((SENS(unstable)));
-        _for_each_inner!((SHA(unstable))); _for_each_inner!((SPI0(unstable)));
-        _for_each_inner!((SPI1(unstable))); _for_each_inner!((SPI2));
-        _for_each_inner!((SPI3)); _for_each_inner!((SYSCON(unstable)));
-        _for_each_inner!((SYSTEM(unstable))); _for_each_inner!((SYSTIMER(unstable)));
-        _for_each_inner!((TIMG0(unstable))); _for_each_inner!((TIMG1(unstable)));
-        _for_each_inner!((TWAI0(unstable))); _for_each_inner!((UART0));
-        _for_each_inner!((UART1)); _for_each_inner!((UHCI0(unstable)));
-        _for_each_inner!((USB0(unstable))); _for_each_inner!((USB_WRAP(unstable)));
-        _for_each_inner!((XTS_AES(unstable))); _for_each_inner!((WIFI(unstable)));
-        _for_each_inner!((DMA_SPI2(unstable))); _for_each_inner!((DMA_SPI3(unstable)));
-        _for_each_inner!((DMA_I2S0(unstable))); _for_each_inner!((DMA_CRYPTO(unstable)));
-        _for_each_inner!((DMA_COPY(unstable))); _for_each_inner!((ADC1(unstable)));
-        _for_each_inner!((ADC2(unstable))); _for_each_inner!((DAC1(unstable)));
-        _for_each_inner!((DAC2(unstable))); _for_each_inner!((FLASH(unstable)));
-        _for_each_inner!((GPIO_DEDICATED(unstable)));
-        _for_each_inner!((PSRAM(unstable))); _for_each_inner!((SW_INTERRUPT(unstable)));
-        _for_each_inner!((ULP_RISCV_CORE(unstable))); _for_each_inner!((all(@ peri_type
-        #[doc = "GPIO0 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        _for_each_inner_peripheral!((GPIO0)); _for_each_inner_peripheral!((GPIO1));
+        _for_each_inner_peripheral!((GPIO2)); _for_each_inner_peripheral!((GPIO3));
+        _for_each_inner_peripheral!((GPIO4)); _for_each_inner_peripheral!((GPIO5));
+        _for_each_inner_peripheral!((GPIO6)); _for_each_inner_peripheral!((GPIO7));
+        _for_each_inner_peripheral!((GPIO8)); _for_each_inner_peripheral!((GPIO9));
+        _for_each_inner_peripheral!((GPIO10)); _for_each_inner_peripheral!((GPIO11));
+        _for_each_inner_peripheral!((GPIO12)); _for_each_inner_peripheral!((GPIO13));
+        _for_each_inner_peripheral!((GPIO14)); _for_each_inner_peripheral!((GPIO15));
+        _for_each_inner_peripheral!((GPIO16)); _for_each_inner_peripheral!((GPIO17));
+        _for_each_inner_peripheral!((GPIO18)); _for_each_inner_peripheral!((GPIO19));
+        _for_each_inner_peripheral!((GPIO20)); _for_each_inner_peripheral!((GPIO21));
+        _for_each_inner_peripheral!((GPIO26)); _for_each_inner_peripheral!((GPIO27));
+        _for_each_inner_peripheral!((GPIO28)); _for_each_inner_peripheral!((GPIO29));
+        _for_each_inner_peripheral!((GPIO30)); _for_each_inner_peripheral!((GPIO31));
+        _for_each_inner_peripheral!((GPIO32)); _for_each_inner_peripheral!((GPIO33));
+        _for_each_inner_peripheral!((GPIO34)); _for_each_inner_peripheral!((GPIO35));
+        _for_each_inner_peripheral!((GPIO36)); _for_each_inner_peripheral!((GPIO37));
+        _for_each_inner_peripheral!((GPIO38)); _for_each_inner_peripheral!((GPIO39));
+        _for_each_inner_peripheral!((GPIO40)); _for_each_inner_peripheral!((GPIO41));
+        _for_each_inner_peripheral!((GPIO42)); _for_each_inner_peripheral!((GPIO43));
+        _for_each_inner_peripheral!((GPIO44)); _for_each_inner_peripheral!((GPIO45));
+        _for_each_inner_peripheral!((GPIO46));
+        _for_each_inner_peripheral!((AES(unstable)));
+        _for_each_inner_peripheral!((APB_SARADC(unstable)));
+        _for_each_inner_peripheral!((DEDICATED_GPIO(unstable)));
+        _for_each_inner_peripheral!((DS(unstable)));
+        _for_each_inner_peripheral!((EFUSE(unstable)));
+        _for_each_inner_peripheral!((EXTMEM(unstable)));
+        _for_each_inner_peripheral!((FE(unstable)));
+        _for_each_inner_peripheral!((FE2(unstable)));
+        _for_each_inner_peripheral!((GPIO(unstable)));
+        _for_each_inner_peripheral!((GPIO_SD(unstable)));
+        _for_each_inner_peripheral!((HMAC(unstable)));
+        _for_each_inner_peripheral!((I2C_ANA_MST(unstable)));
+        _for_each_inner_peripheral!((I2C0)); _for_each_inner_peripheral!((I2C1));
+        _for_each_inner_peripheral!((I2S0(unstable)));
+        _for_each_inner_peripheral!((INTERRUPT_CORE0(unstable)));
+        _for_each_inner_peripheral!((IO_MUX(unstable)));
+        _for_each_inner_peripheral!((LEDC(unstable)));
+        _for_each_inner_peripheral!((NRX(unstable)));
+        _for_each_inner_peripheral!((PCNT(unstable)));
+        _for_each_inner_peripheral!((PMS(unstable)));
+        _for_each_inner_peripheral!((RMT(unstable)));
+        _for_each_inner_peripheral!((RNG(unstable)));
+        _for_each_inner_peripheral!((RSA(unstable)));
+        _for_each_inner_peripheral!((LPWR(unstable)));
+        _for_each_inner_peripheral!((RTC_I2C(unstable)));
+        _for_each_inner_peripheral!((RTC_IO(unstable)));
+        _for_each_inner_peripheral!((SENS(unstable)));
+        _for_each_inner_peripheral!((SHA(unstable)));
+        _for_each_inner_peripheral!((SPI0(unstable)));
+        _for_each_inner_peripheral!((SPI1(unstable)));
+        _for_each_inner_peripheral!((SPI2)); _for_each_inner_peripheral!((SPI3));
+        _for_each_inner_peripheral!((SYSCON(unstable)));
+        _for_each_inner_peripheral!((SYSTEM(unstable)));
+        _for_each_inner_peripheral!((SYSTIMER(unstable)));
+        _for_each_inner_peripheral!((TIMG0(unstable)));
+        _for_each_inner_peripheral!((TIMG1(unstable)));
+        _for_each_inner_peripheral!((TWAI0(unstable)));
+        _for_each_inner_peripheral!((UART0)); _for_each_inner_peripheral!((UART1));
+        _for_each_inner_peripheral!((UHCI0(unstable)));
+        _for_each_inner_peripheral!((USB0(unstable)));
+        _for_each_inner_peripheral!((USB_WRAP(unstable)));
+        _for_each_inner_peripheral!((XTS_AES(unstable)));
+        _for_each_inner_peripheral!((WIFI(unstable)));
+        _for_each_inner_peripheral!((DMA_SPI2(unstable)));
+        _for_each_inner_peripheral!((DMA_SPI3(unstable)));
+        _for_each_inner_peripheral!((DMA_I2S0(unstable)));
+        _for_each_inner_peripheral!((DMA_CRYPTO(unstable)));
+        _for_each_inner_peripheral!((DMA_COPY(unstable)));
+        _for_each_inner_peripheral!((ADC1(unstable)));
+        _for_each_inner_peripheral!((ADC2(unstable)));
+        _for_each_inner_peripheral!((DAC1(unstable)));
+        _for_each_inner_peripheral!((DAC2(unstable)));
+        _for_each_inner_peripheral!((FLASH(unstable)));
+        _for_each_inner_peripheral!((GPIO_DEDICATED(unstable)));
+        _for_each_inner_peripheral!((PSRAM(unstable)));
+        _for_each_inner_peripheral!((SW_INTERRUPT(unstable)));
+        _for_each_inner_peripheral!((ULP_RISCV_CORE(unstable)));
+        _for_each_inner_peripheral!((all(@ peri_type #[doc =
+        "GPIO0 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
         "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
@@ -3531,8 +3739,8 @@ macro_rules! for_each_peripheral {
         <= virtual() (unstable)), (@ peri_type #[doc =
         "SW_INTERRUPT peripheral singleton"] SW_INTERRUPT <= virtual() (unstable)), (@
         peri_type #[doc = "ULP_RISCV_CORE peripheral singleton"] ULP_RISCV_CORE <=
-        virtual() (unstable)))); _for_each_inner!((singletons(GPIO0), (GPIO1), (GPIO2),
-        (GPIO3), (GPIO4), (GPIO5), (GPIO6), (GPIO7), (GPIO8), (GPIO9), (GPIO10),
+        virtual() (unstable)))); _for_each_inner_peripheral!((singletons(GPIO0), (GPIO1),
+        (GPIO2), (GPIO3), (GPIO4), (GPIO5), (GPIO6), (GPIO7), (GPIO8), (GPIO9), (GPIO10),
         (GPIO11), (GPIO12), (GPIO13), (GPIO14), (GPIO15), (GPIO16), (GPIO17), (GPIO18),
         (GPIO19), (GPIO20), (GPIO21), (GPIO26), (GPIO27), (GPIO28), (GPIO29), (GPIO30),
         (GPIO31), (GPIO32), (GPIO33), (GPIO34), (GPIO35), (GPIO36), (GPIO37), (GPIO38),
@@ -3585,57 +3793,61 @@ macro_rules! for_each_peripheral {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_gpio {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((0, GPIO0() () ([Input] [Output]))); _for_each_inner!((1,
-        GPIO1() () ([Input] [Output]))); _for_each_inner!((2, GPIO2() () ([Input]
-        [Output]))); _for_each_inner!((3, GPIO3() () ([Input] [Output])));
-        _for_each_inner!((4, GPIO4() () ([Input] [Output]))); _for_each_inner!((5,
-        GPIO5() () ([Input] [Output]))); _for_each_inner!((6, GPIO6() () ([Input]
-        [Output]))); _for_each_inner!((7, GPIO7() () ([Input] [Output])));
-        _for_each_inner!((8, GPIO8() (_3 => SUBSPICS1) ([Input] [Output])));
-        _for_each_inner!((9, GPIO9(_3 => SUBSPIHD _4 => FSPIHD) (_3 => SUBSPIHD _4 =>
-        FSPIHD) ([Input] [Output]))); _for_each_inner!((10, GPIO10(_2 => FSPIIO4 _4 =>
-        FSPICS0) (_2 => FSPIIO4 _3 => SUBSPICS0 _4 => FSPICS0) ([Input] [Output])));
-        _for_each_inner!((11, GPIO11(_2 => FSPIIO5 _3 => SUBSPID _4 => FSPID) (_2 =>
-        FSPIIO5 _3 => SUBSPID _4 => FSPID) ([Input] [Output]))); _for_each_inner!((12,
-        GPIO12(_2 => FSPIIO6 _4 => FSPICLK) (_2 => FSPIIO6 _3 => SUBSPICLK _4 => FSPICLK)
-        ([Input] [Output]))); _for_each_inner!((13, GPIO13(_2 => FSPIIO7 _3 => SUBSPIQ _4
-        => FSPIQ) (_2 => FSPIIO7 _3 => SUBSPIQ _4 => FSPIQ) ([Input] [Output])));
-        _for_each_inner!((14, GPIO14(_3 => SUBSPIWP _4 => FSPIWP) (_2 => FSPIDQS _3 =>
-        SUBSPIWP _4 => FSPIWP) ([Input] [Output]))); _for_each_inner!((15, GPIO15() (_2
-        => U0RTS) ([Input] [Output]))); _for_each_inner!((16, GPIO16(_2 => U0CTS) ()
-        ([Input] [Output]))); _for_each_inner!((17, GPIO17() (_2 => U1TXD) ([Input]
-        [Output]))); _for_each_inner!((18, GPIO18(_2 => U1RXD) (_3 => CLK_OUT3) ([Input]
-        [Output]))); _for_each_inner!((19, GPIO19() (_2 => U1RTS _3 => CLK_OUT2) ([Input]
-        [Output]))); _for_each_inner!((20, GPIO20(_2 => U1CTS) (_3 => CLK_OUT1) ([Input]
-        [Output]))); _for_each_inner!((21, GPIO21() () ([Input] [Output])));
-        _for_each_inner!((26, GPIO26() (_0 => SPICS1) ([Input] [Output])));
-        _for_each_inner!((27, GPIO27(_0 => SPIHD) (_0 => SPIHD) ([Input] [Output])));
-        _for_each_inner!((28, GPIO28(_0 => SPIWP) (_0 => SPIWP) ([Input] [Output])));
-        _for_each_inner!((29, GPIO29() (_0 => SPICS0) ([Input] [Output])));
-        _for_each_inner!((30, GPIO30() (_0 => SPICLK) ([Input] [Output])));
-        _for_each_inner!((31, GPIO31(_0 => SPIQ) (_0 => SPIQ) ([Input] [Output])));
-        _for_each_inner!((32, GPIO32(_0 => SPID) (_0 => SPID) ([Input] [Output])));
-        _for_each_inner!((33, GPIO33(_2 => FSPIHD _3 => SUBSPIHD) (_2 => FSPIHD _3 =>
-        SUBSPIHD) ([Input] [Output]))); _for_each_inner!((34, GPIO34(_2 => FSPICS0) (_2
-        => FSPICS0 _3 => SUBSPICS0) ([Input] [Output]))); _for_each_inner!((35, GPIO35(_2
-        => FSPID _3 => SUBSPID) (_2 => FSPID _3 => SUBSPID) ([Input] [Output])));
-        _for_each_inner!((36, GPIO36(_2 => FSPICLK) (_2 => FSPICLK _3 => SUBSPICLK)
-        ([Input] [Output]))); _for_each_inner!((37, GPIO37(_2 => FSPIQ _3 => SUBSPIQ _4
-        => SPIDQS) (_2 => FSPIQ _3 => SUBSPIQ _4 => SPIDQS) ([Input] [Output])));
-        _for_each_inner!((38, GPIO38(_2 => FSPIWP _3 => SUBSPIWP) (_2 => FSPIWP _3 =>
-        SUBSPIWP) ([Input] [Output]))); _for_each_inner!((39, GPIO39(_0 => MTCK) (_2 =>
-        CLK_OUT3 _3 => SUBSPICS1) ([Input] [Output]))); _for_each_inner!((40, GPIO40()
-        (_0 => MTDO _2 => CLK_OUT2) ([Input] [Output]))); _for_each_inner!((41, GPIO41(_0
-        => MTDI) (_2 => CLK_OUT1) ([Input] [Output]))); _for_each_inner!((42, GPIO42(_0
-        => MTMS) () ([Input] [Output]))); _for_each_inner!((43, GPIO43() (_0 => U0TXD _2
-        => CLK_OUT1) ([Input] [Output]))); _for_each_inner!((44, GPIO44(_0 => U0RXD) (_2
-        => CLK_OUT2) ([Input] [Output]))); _for_each_inner!((45, GPIO45() () ([Input]
-        [Output]))); _for_each_inner!((46, GPIO46() () ([Input] [Output])));
-        _for_each_inner!((all(0, GPIO0() () ([Input] [Output])), (1, GPIO1() () ([Input]
-        [Output])), (2, GPIO2() () ([Input] [Output])), (3, GPIO3() () ([Input]
-        [Output])), (4, GPIO4() () ([Input] [Output])), (5, GPIO5() () ([Input]
-        [Output])), (6, GPIO6() () ([Input] [Output])), (7, GPIO7() () ([Input]
+        macro_rules! _for_each_inner_gpio { $(($pattern) => $code;)* ($other : tt) => {}
+        } _for_each_inner_gpio!((0, GPIO0() () ([Input] [Output])));
+        _for_each_inner_gpio!((1, GPIO1() () ([Input] [Output])));
+        _for_each_inner_gpio!((2, GPIO2() () ([Input] [Output])));
+        _for_each_inner_gpio!((3, GPIO3() () ([Input] [Output])));
+        _for_each_inner_gpio!((4, GPIO4() () ([Input] [Output])));
+        _for_each_inner_gpio!((5, GPIO5() () ([Input] [Output])));
+        _for_each_inner_gpio!((6, GPIO6() () ([Input] [Output])));
+        _for_each_inner_gpio!((7, GPIO7() () ([Input] [Output])));
+        _for_each_inner_gpio!((8, GPIO8() (_3 => SUBSPICS1) ([Input] [Output])));
+        _for_each_inner_gpio!((9, GPIO9(_3 => SUBSPIHD _4 => FSPIHD) (_3 => SUBSPIHD _4
+        => FSPIHD) ([Input] [Output]))); _for_each_inner_gpio!((10, GPIO10(_2 => FSPIIO4
+        _4 => FSPICS0) (_2 => FSPIIO4 _3 => SUBSPICS0 _4 => FSPICS0) ([Input]
+        [Output]))); _for_each_inner_gpio!((11, GPIO11(_2 => FSPIIO5 _3 => SUBSPID _4 =>
+        FSPID) (_2 => FSPIIO5 _3 => SUBSPID _4 => FSPID) ([Input] [Output])));
+        _for_each_inner_gpio!((12, GPIO12(_2 => FSPIIO6 _4 => FSPICLK) (_2 => FSPIIO6 _3
+        => SUBSPICLK _4 => FSPICLK) ([Input] [Output]))); _for_each_inner_gpio!((13,
+        GPIO13(_2 => FSPIIO7 _3 => SUBSPIQ _4 => FSPIQ) (_2 => FSPIIO7 _3 => SUBSPIQ _4
+        => FSPIQ) ([Input] [Output]))); _for_each_inner_gpio!((14, GPIO14(_3 => SUBSPIWP
+        _4 => FSPIWP) (_2 => FSPIDQS _3 => SUBSPIWP _4 => FSPIWP) ([Input] [Output])));
+        _for_each_inner_gpio!((15, GPIO15() (_2 => U0RTS) ([Input] [Output])));
+        _for_each_inner_gpio!((16, GPIO16(_2 => U0CTS) () ([Input] [Output])));
+        _for_each_inner_gpio!((17, GPIO17() (_2 => U1TXD) ([Input] [Output])));
+        _for_each_inner_gpio!((18, GPIO18(_2 => U1RXD) (_3 => CLK_OUT3) ([Input]
+        [Output]))); _for_each_inner_gpio!((19, GPIO19() (_2 => U1RTS _3 => CLK_OUT2)
+        ([Input] [Output]))); _for_each_inner_gpio!((20, GPIO20(_2 => U1CTS) (_3 =>
+        CLK_OUT1) ([Input] [Output]))); _for_each_inner_gpio!((21, GPIO21() () ([Input]
+        [Output]))); _for_each_inner_gpio!((26, GPIO26() (_0 => SPICS1) ([Input]
+        [Output]))); _for_each_inner_gpio!((27, GPIO27(_0 => SPIHD) (_0 => SPIHD)
+        ([Input] [Output]))); _for_each_inner_gpio!((28, GPIO28(_0 => SPIWP) (_0 =>
+        SPIWP) ([Input] [Output]))); _for_each_inner_gpio!((29, GPIO29() (_0 => SPICS0)
+        ([Input] [Output]))); _for_each_inner_gpio!((30, GPIO30() (_0 => SPICLK) ([Input]
+        [Output]))); _for_each_inner_gpio!((31, GPIO31(_0 => SPIQ) (_0 => SPIQ) ([Input]
+        [Output]))); _for_each_inner_gpio!((32, GPIO32(_0 => SPID) (_0 => SPID) ([Input]
+        [Output]))); _for_each_inner_gpio!((33, GPIO33(_2 => FSPIHD _3 => SUBSPIHD) (_2
+        => FSPIHD _3 => SUBSPIHD) ([Input] [Output]))); _for_each_inner_gpio!((34,
+        GPIO34(_2 => FSPICS0) (_2 => FSPICS0 _3 => SUBSPICS0) ([Input] [Output])));
+        _for_each_inner_gpio!((35, GPIO35(_2 => FSPID _3 => SUBSPID) (_2 => FSPID _3 =>
+        SUBSPID) ([Input] [Output]))); _for_each_inner_gpio!((36, GPIO36(_2 => FSPICLK)
+        (_2 => FSPICLK _3 => SUBSPICLK) ([Input] [Output]))); _for_each_inner_gpio!((37,
+        GPIO37(_2 => FSPIQ _3 => SUBSPIQ _4 => SPIDQS) (_2 => FSPIQ _3 => SUBSPIQ _4 =>
+        SPIDQS) ([Input] [Output]))); _for_each_inner_gpio!((38, GPIO38(_2 => FSPIWP _3
+        => SUBSPIWP) (_2 => FSPIWP _3 => SUBSPIWP) ([Input] [Output])));
+        _for_each_inner_gpio!((39, GPIO39(_0 => MTCK) (_2 => CLK_OUT3 _3 => SUBSPICS1)
+        ([Input] [Output]))); _for_each_inner_gpio!((40, GPIO40() (_0 => MTDO _2 =>
+        CLK_OUT2) ([Input] [Output]))); _for_each_inner_gpio!((41, GPIO41(_0 => MTDI) (_2
+        => CLK_OUT1) ([Input] [Output]))); _for_each_inner_gpio!((42, GPIO42(_0 => MTMS)
+        () ([Input] [Output]))); _for_each_inner_gpio!((43, GPIO43() (_0 => U0TXD _2 =>
+        CLK_OUT1) ([Input] [Output]))); _for_each_inner_gpio!((44, GPIO44(_0 => U0RXD)
+        (_2 => CLK_OUT2) ([Input] [Output]))); _for_each_inner_gpio!((45, GPIO45() ()
+        ([Input] [Output]))); _for_each_inner_gpio!((46, GPIO46() () ([Input]
+        [Output]))); _for_each_inner_gpio!((all(0, GPIO0() () ([Input] [Output])), (1,
+        GPIO1() () ([Input] [Output])), (2, GPIO2() () ([Input] [Output])), (3, GPIO3()
+        () ([Input] [Output])), (4, GPIO4() () ([Input] [Output])), (5, GPIO5() ()
+        ([Input] [Output])), (6, GPIO6() () ([Input] [Output])), (7, GPIO7() () ([Input]
         [Output])), (8, GPIO8() (_3 => SUBSPICS1) ([Input] [Output])), (9, GPIO9(_3 =>
         SUBSPIHD _4 => FSPIHD) (_3 => SUBSPIHD _4 => FSPIHD) ([Input] [Output])), (10,
         GPIO10(_2 => FSPIIO4 _4 => FSPICS0) (_2 => FSPIIO4 _3 => SUBSPICS0 _4 => FSPICS0)
@@ -3700,55 +3912,85 @@ macro_rules! for_each_gpio {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_analog_function {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((TOUCH1, GPIO1)); _for_each_inner!((ADC1_CH0, GPIO1));
-        _for_each_inner!((TOUCH2, GPIO2)); _for_each_inner!((ADC1_CH1, GPIO2));
-        _for_each_inner!((TOUCH3, GPIO3)); _for_each_inner!((ADC1_CH2, GPIO3));
-        _for_each_inner!((TOUCH4, GPIO4)); _for_each_inner!((ADC1_CH3, GPIO4));
-        _for_each_inner!((TOUCH5, GPIO5)); _for_each_inner!((ADC1_CH4, GPIO5));
-        _for_each_inner!((TOUCH6, GPIO6)); _for_each_inner!((ADC1_CH5, GPIO6));
-        _for_each_inner!((TOUCH7, GPIO7)); _for_each_inner!((ADC1_CH6, GPIO7));
-        _for_each_inner!((TOUCH8, GPIO8)); _for_each_inner!((ADC1_CH7, GPIO8));
-        _for_each_inner!((TOUCH9, GPIO9)); _for_each_inner!((ADC1_CH8, GPIO9));
-        _for_each_inner!((TOUCH10, GPIO10)); _for_each_inner!((ADC1_CH9, GPIO10));
-        _for_each_inner!((TOUCH11, GPIO11)); _for_each_inner!((ADC2_CH0, GPIO11));
-        _for_each_inner!((TOUCH12, GPIO12)); _for_each_inner!((ADC2_CH1, GPIO12));
-        _for_each_inner!((TOUCH13, GPIO13)); _for_each_inner!((ADC2_CH2, GPIO13));
-        _for_each_inner!((TOUCH14, GPIO14)); _for_each_inner!((ADC2_CH3, GPIO14));
-        _for_each_inner!((XTAL_32K_P, GPIO15)); _for_each_inner!((ADC2_CH4, GPIO15));
-        _for_each_inner!((XTAL_32K_N, GPIO16)); _for_each_inner!((ADC2_CH5, GPIO16));
-        _for_each_inner!((DAC_1, GPIO17)); _for_each_inner!((ADC2_CH6, GPIO17));
-        _for_each_inner!((DAC_2, GPIO18)); _for_each_inner!((ADC2_CH7, GPIO18));
-        _for_each_inner!((USB_DM, GPIO19)); _for_each_inner!((ADC2_CH8, GPIO19));
-        _for_each_inner!((USB_DP, GPIO20)); _for_each_inner!((ADC2_CH9, GPIO20));
-        _for_each_inner!(((TOUCH1, TOUCHn, 1), GPIO1)); _for_each_inner!(((ADC1_CH0,
-        ADCn_CHm, 1, 0), GPIO1)); _for_each_inner!(((TOUCH2, TOUCHn, 2), GPIO2));
-        _for_each_inner!(((ADC1_CH1, ADCn_CHm, 1, 1), GPIO2)); _for_each_inner!(((TOUCH3,
-        TOUCHn, 3), GPIO3)); _for_each_inner!(((ADC1_CH2, ADCn_CHm, 1, 2), GPIO3));
-        _for_each_inner!(((TOUCH4, TOUCHn, 4), GPIO4)); _for_each_inner!(((ADC1_CH3,
-        ADCn_CHm, 1, 3), GPIO4)); _for_each_inner!(((TOUCH5, TOUCHn, 5), GPIO5));
-        _for_each_inner!(((ADC1_CH4, ADCn_CHm, 1, 4), GPIO5)); _for_each_inner!(((TOUCH6,
-        TOUCHn, 6), GPIO6)); _for_each_inner!(((ADC1_CH5, ADCn_CHm, 1, 5), GPIO6));
-        _for_each_inner!(((TOUCH7, TOUCHn, 7), GPIO7)); _for_each_inner!(((ADC1_CH6,
-        ADCn_CHm, 1, 6), GPIO7)); _for_each_inner!(((TOUCH8, TOUCHn, 8), GPIO8));
-        _for_each_inner!(((ADC1_CH7, ADCn_CHm, 1, 7), GPIO8)); _for_each_inner!(((TOUCH9,
-        TOUCHn, 9), GPIO9)); _for_each_inner!(((ADC1_CH8, ADCn_CHm, 1, 8), GPIO9));
-        _for_each_inner!(((TOUCH10, TOUCHn, 10), GPIO10)); _for_each_inner!(((ADC1_CH9,
-        ADCn_CHm, 1, 9), GPIO10)); _for_each_inner!(((TOUCH11, TOUCHn, 11), GPIO11));
-        _for_each_inner!(((ADC2_CH0, ADCn_CHm, 2, 0), GPIO11));
-        _for_each_inner!(((TOUCH12, TOUCHn, 12), GPIO12)); _for_each_inner!(((ADC2_CH1,
-        ADCn_CHm, 2, 1), GPIO12)); _for_each_inner!(((TOUCH13, TOUCHn, 13), GPIO13));
-        _for_each_inner!(((ADC2_CH2, ADCn_CHm, 2, 2), GPIO13));
-        _for_each_inner!(((TOUCH14, TOUCHn, 14), GPIO14)); _for_each_inner!(((ADC2_CH3,
-        ADCn_CHm, 2, 3), GPIO14)); _for_each_inner!(((ADC2_CH4, ADCn_CHm, 2, 4),
-        GPIO15)); _for_each_inner!(((ADC2_CH5, ADCn_CHm, 2, 5), GPIO16));
-        _for_each_inner!(((DAC_1, DAC_n, 1), GPIO17)); _for_each_inner!(((ADC2_CH6,
-        ADCn_CHm, 2, 6), GPIO17)); _for_each_inner!(((DAC_2, DAC_n, 2), GPIO18));
-        _for_each_inner!(((ADC2_CH7, ADCn_CHm, 2, 7), GPIO18));
-        _for_each_inner!(((ADC2_CH8, ADCn_CHm, 2, 8), GPIO19));
-        _for_each_inner!(((ADC2_CH9, ADCn_CHm, 2, 9), GPIO20));
-        _for_each_inner!((all(TOUCH1, GPIO1), (ADC1_CH0, GPIO1), (TOUCH2, GPIO2),
-        (ADC1_CH1, GPIO2), (TOUCH3, GPIO3), (ADC1_CH2, GPIO3), (TOUCH4, GPIO4),
+        macro_rules! _for_each_inner_analog_function { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_analog_function!((TOUCH1, GPIO1));
+        _for_each_inner_analog_function!((ADC1_CH0, GPIO1));
+        _for_each_inner_analog_function!((TOUCH2, GPIO2));
+        _for_each_inner_analog_function!((ADC1_CH1, GPIO2));
+        _for_each_inner_analog_function!((TOUCH3, GPIO3));
+        _for_each_inner_analog_function!((ADC1_CH2, GPIO3));
+        _for_each_inner_analog_function!((TOUCH4, GPIO4));
+        _for_each_inner_analog_function!((ADC1_CH3, GPIO4));
+        _for_each_inner_analog_function!((TOUCH5, GPIO5));
+        _for_each_inner_analog_function!((ADC1_CH4, GPIO5));
+        _for_each_inner_analog_function!((TOUCH6, GPIO6));
+        _for_each_inner_analog_function!((ADC1_CH5, GPIO6));
+        _for_each_inner_analog_function!((TOUCH7, GPIO7));
+        _for_each_inner_analog_function!((ADC1_CH6, GPIO7));
+        _for_each_inner_analog_function!((TOUCH8, GPIO8));
+        _for_each_inner_analog_function!((ADC1_CH7, GPIO8));
+        _for_each_inner_analog_function!((TOUCH9, GPIO9));
+        _for_each_inner_analog_function!((ADC1_CH8, GPIO9));
+        _for_each_inner_analog_function!((TOUCH10, GPIO10));
+        _for_each_inner_analog_function!((ADC1_CH9, GPIO10));
+        _for_each_inner_analog_function!((TOUCH11, GPIO11));
+        _for_each_inner_analog_function!((ADC2_CH0, GPIO11));
+        _for_each_inner_analog_function!((TOUCH12, GPIO12));
+        _for_each_inner_analog_function!((ADC2_CH1, GPIO12));
+        _for_each_inner_analog_function!((TOUCH13, GPIO13));
+        _for_each_inner_analog_function!((ADC2_CH2, GPIO13));
+        _for_each_inner_analog_function!((TOUCH14, GPIO14));
+        _for_each_inner_analog_function!((ADC2_CH3, GPIO14));
+        _for_each_inner_analog_function!((XTAL_32K_P, GPIO15));
+        _for_each_inner_analog_function!((ADC2_CH4, GPIO15));
+        _for_each_inner_analog_function!((XTAL_32K_N, GPIO16));
+        _for_each_inner_analog_function!((ADC2_CH5, GPIO16));
+        _for_each_inner_analog_function!((DAC_1, GPIO17));
+        _for_each_inner_analog_function!((ADC2_CH6, GPIO17));
+        _for_each_inner_analog_function!((DAC_2, GPIO18));
+        _for_each_inner_analog_function!((ADC2_CH7, GPIO18));
+        _for_each_inner_analog_function!((USB_DM, GPIO19));
+        _for_each_inner_analog_function!((ADC2_CH8, GPIO19));
+        _for_each_inner_analog_function!((USB_DP, GPIO20));
+        _for_each_inner_analog_function!((ADC2_CH9, GPIO20));
+        _for_each_inner_analog_function!(((TOUCH1, TOUCHn, 1), GPIO1));
+        _for_each_inner_analog_function!(((ADC1_CH0, ADCn_CHm, 1, 0), GPIO1));
+        _for_each_inner_analog_function!(((TOUCH2, TOUCHn, 2), GPIO2));
+        _for_each_inner_analog_function!(((ADC1_CH1, ADCn_CHm, 1, 1), GPIO2));
+        _for_each_inner_analog_function!(((TOUCH3, TOUCHn, 3), GPIO3));
+        _for_each_inner_analog_function!(((ADC1_CH2, ADCn_CHm, 1, 2), GPIO3));
+        _for_each_inner_analog_function!(((TOUCH4, TOUCHn, 4), GPIO4));
+        _for_each_inner_analog_function!(((ADC1_CH3, ADCn_CHm, 1, 3), GPIO4));
+        _for_each_inner_analog_function!(((TOUCH5, TOUCHn, 5), GPIO5));
+        _for_each_inner_analog_function!(((ADC1_CH4, ADCn_CHm, 1, 4), GPIO5));
+        _for_each_inner_analog_function!(((TOUCH6, TOUCHn, 6), GPIO6));
+        _for_each_inner_analog_function!(((ADC1_CH5, ADCn_CHm, 1, 5), GPIO6));
+        _for_each_inner_analog_function!(((TOUCH7, TOUCHn, 7), GPIO7));
+        _for_each_inner_analog_function!(((ADC1_CH6, ADCn_CHm, 1, 6), GPIO7));
+        _for_each_inner_analog_function!(((TOUCH8, TOUCHn, 8), GPIO8));
+        _for_each_inner_analog_function!(((ADC1_CH7, ADCn_CHm, 1, 7), GPIO8));
+        _for_each_inner_analog_function!(((TOUCH9, TOUCHn, 9), GPIO9));
+        _for_each_inner_analog_function!(((ADC1_CH8, ADCn_CHm, 1, 8), GPIO9));
+        _for_each_inner_analog_function!(((TOUCH10, TOUCHn, 10), GPIO10));
+        _for_each_inner_analog_function!(((ADC1_CH9, ADCn_CHm, 1, 9), GPIO10));
+        _for_each_inner_analog_function!(((TOUCH11, TOUCHn, 11), GPIO11));
+        _for_each_inner_analog_function!(((ADC2_CH0, ADCn_CHm, 2, 0), GPIO11));
+        _for_each_inner_analog_function!(((TOUCH12, TOUCHn, 12), GPIO12));
+        _for_each_inner_analog_function!(((ADC2_CH1, ADCn_CHm, 2, 1), GPIO12));
+        _for_each_inner_analog_function!(((TOUCH13, TOUCHn, 13), GPIO13));
+        _for_each_inner_analog_function!(((ADC2_CH2, ADCn_CHm, 2, 2), GPIO13));
+        _for_each_inner_analog_function!(((TOUCH14, TOUCHn, 14), GPIO14));
+        _for_each_inner_analog_function!(((ADC2_CH3, ADCn_CHm, 2, 3), GPIO14));
+        _for_each_inner_analog_function!(((ADC2_CH4, ADCn_CHm, 2, 4), GPIO15));
+        _for_each_inner_analog_function!(((ADC2_CH5, ADCn_CHm, 2, 5), GPIO16));
+        _for_each_inner_analog_function!(((DAC_1, DAC_n, 1), GPIO17));
+        _for_each_inner_analog_function!(((ADC2_CH6, ADCn_CHm, 2, 6), GPIO17));
+        _for_each_inner_analog_function!(((DAC_2, DAC_n, 2), GPIO18));
+        _for_each_inner_analog_function!(((ADC2_CH7, ADCn_CHm, 2, 7), GPIO18));
+        _for_each_inner_analog_function!(((ADC2_CH8, ADCn_CHm, 2, 8), GPIO19));
+        _for_each_inner_analog_function!(((ADC2_CH9, ADCn_CHm, 2, 9), GPIO20));
+        _for_each_inner_analog_function!((all(TOUCH1, GPIO1), (ADC1_CH0, GPIO1), (TOUCH2,
+        GPIO2), (ADC1_CH1, GPIO2), (TOUCH3, GPIO3), (ADC1_CH2, GPIO3), (TOUCH4, GPIO4),
         (ADC1_CH3, GPIO4), (TOUCH5, GPIO5), (ADC1_CH4, GPIO5), (TOUCH6, GPIO6),
         (ADC1_CH5, GPIO6), (TOUCH7, GPIO7), (ADC1_CH6, GPIO7), (TOUCH8, GPIO8),
         (ADC1_CH7, GPIO8), (TOUCH9, GPIO9), (ADC1_CH8, GPIO9), (TOUCH10, GPIO10),
@@ -3757,23 +3999,24 @@ macro_rules! for_each_analog_function {
         (ADC2_CH3, GPIO14), (XTAL_32K_P, GPIO15), (ADC2_CH4, GPIO15), (XTAL_32K_N,
         GPIO16), (ADC2_CH5, GPIO16), (DAC_1, GPIO17), (ADC2_CH6, GPIO17), (DAC_2,
         GPIO18), (ADC2_CH7, GPIO18), (USB_DM, GPIO19), (ADC2_CH8, GPIO19), (USB_DP,
-        GPIO20), (ADC2_CH9, GPIO20))); _for_each_inner!((all_expanded((TOUCH1, TOUCHn,
-        1), GPIO1), ((ADC1_CH0, ADCn_CHm, 1, 0), GPIO1), ((TOUCH2, TOUCHn, 2), GPIO2),
-        ((ADC1_CH1, ADCn_CHm, 1, 1), GPIO2), ((TOUCH3, TOUCHn, 3), GPIO3), ((ADC1_CH2,
-        ADCn_CHm, 1, 2), GPIO3), ((TOUCH4, TOUCHn, 4), GPIO4), ((ADC1_CH3, ADCn_CHm, 1,
-        3), GPIO4), ((TOUCH5, TOUCHn, 5), GPIO5), ((ADC1_CH4, ADCn_CHm, 1, 4), GPIO5),
-        ((TOUCH6, TOUCHn, 6), GPIO6), ((ADC1_CH5, ADCn_CHm, 1, 5), GPIO6), ((TOUCH7,
-        TOUCHn, 7), GPIO7), ((ADC1_CH6, ADCn_CHm, 1, 6), GPIO7), ((TOUCH8, TOUCHn, 8),
-        GPIO8), ((ADC1_CH7, ADCn_CHm, 1, 7), GPIO8), ((TOUCH9, TOUCHn, 9), GPIO9),
-        ((ADC1_CH8, ADCn_CHm, 1, 8), GPIO9), ((TOUCH10, TOUCHn, 10), GPIO10), ((ADC1_CH9,
-        ADCn_CHm, 1, 9), GPIO10), ((TOUCH11, TOUCHn, 11), GPIO11), ((ADC2_CH0, ADCn_CHm,
-        2, 0), GPIO11), ((TOUCH12, TOUCHn, 12), GPIO12), ((ADC2_CH1, ADCn_CHm, 2, 1),
-        GPIO12), ((TOUCH13, TOUCHn, 13), GPIO13), ((ADC2_CH2, ADCn_CHm, 2, 2), GPIO13),
-        ((TOUCH14, TOUCHn, 14), GPIO14), ((ADC2_CH3, ADCn_CHm, 2, 3), GPIO14),
-        ((ADC2_CH4, ADCn_CHm, 2, 4), GPIO15), ((ADC2_CH5, ADCn_CHm, 2, 5), GPIO16),
-        ((DAC_1, DAC_n, 1), GPIO17), ((ADC2_CH6, ADCn_CHm, 2, 6), GPIO17), ((DAC_2,
-        DAC_n, 2), GPIO18), ((ADC2_CH7, ADCn_CHm, 2, 7), GPIO18), ((ADC2_CH8, ADCn_CHm,
-        2, 8), GPIO19), ((ADC2_CH9, ADCn_CHm, 2, 9), GPIO20)));
+        GPIO20), (ADC2_CH9, GPIO20)));
+        _for_each_inner_analog_function!((all_expanded((TOUCH1, TOUCHn, 1), GPIO1),
+        ((ADC1_CH0, ADCn_CHm, 1, 0), GPIO1), ((TOUCH2, TOUCHn, 2), GPIO2), ((ADC1_CH1,
+        ADCn_CHm, 1, 1), GPIO2), ((TOUCH3, TOUCHn, 3), GPIO3), ((ADC1_CH2, ADCn_CHm, 1,
+        2), GPIO3), ((TOUCH4, TOUCHn, 4), GPIO4), ((ADC1_CH3, ADCn_CHm, 1, 3), GPIO4),
+        ((TOUCH5, TOUCHn, 5), GPIO5), ((ADC1_CH4, ADCn_CHm, 1, 4), GPIO5), ((TOUCH6,
+        TOUCHn, 6), GPIO6), ((ADC1_CH5, ADCn_CHm, 1, 5), GPIO6), ((TOUCH7, TOUCHn, 7),
+        GPIO7), ((ADC1_CH6, ADCn_CHm, 1, 6), GPIO7), ((TOUCH8, TOUCHn, 8), GPIO8),
+        ((ADC1_CH7, ADCn_CHm, 1, 7), GPIO8), ((TOUCH9, TOUCHn, 9), GPIO9), ((ADC1_CH8,
+        ADCn_CHm, 1, 8), GPIO9), ((TOUCH10, TOUCHn, 10), GPIO10), ((ADC1_CH9, ADCn_CHm,
+        1, 9), GPIO10), ((TOUCH11, TOUCHn, 11), GPIO11), ((ADC2_CH0, ADCn_CHm, 2, 0),
+        GPIO11), ((TOUCH12, TOUCHn, 12), GPIO12), ((ADC2_CH1, ADCn_CHm, 2, 1), GPIO12),
+        ((TOUCH13, TOUCHn, 13), GPIO13), ((ADC2_CH2, ADCn_CHm, 2, 2), GPIO13), ((TOUCH14,
+        TOUCHn, 14), GPIO14), ((ADC2_CH3, ADCn_CHm, 2, 3), GPIO14), ((ADC2_CH4, ADCn_CHm,
+        2, 4), GPIO15), ((ADC2_CH5, ADCn_CHm, 2, 5), GPIO16), ((DAC_1, DAC_n, 1),
+        GPIO17), ((ADC2_CH6, ADCn_CHm, 2, 6), GPIO17), ((DAC_2, DAC_n, 2), GPIO18),
+        ((ADC2_CH7, ADCn_CHm, 2, 7), GPIO18), ((ADC2_CH8, ADCn_CHm, 2, 8), GPIO19),
+        ((ADC2_CH9, ADCn_CHm, 2, 9), GPIO20)));
     };
 }
 /// This macro can be used to generate code for each LP/RTC function of each GPIO.
@@ -3806,47 +4049,59 @@ macro_rules! for_each_analog_function {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_lp_function {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((RTC_GPIO0, GPIO0)); _for_each_inner!((RTC_GPIO1, GPIO1));
-        _for_each_inner!((RTC_GPIO2, GPIO2)); _for_each_inner!((RTC_GPIO3, GPIO3));
-        _for_each_inner!((RTC_GPIO4, GPIO4)); _for_each_inner!((RTC_GPIO5, GPIO5));
-        _for_each_inner!((RTC_GPIO6, GPIO6)); _for_each_inner!((RTC_GPIO7, GPIO7));
-        _for_each_inner!((RTC_GPIO8, GPIO8)); _for_each_inner!((RTC_GPIO9, GPIO9));
-        _for_each_inner!((RTC_GPIO10, GPIO10)); _for_each_inner!((RTC_GPIO11, GPIO11));
-        _for_each_inner!((RTC_GPIO12, GPIO12)); _for_each_inner!((RTC_GPIO13, GPIO13));
-        _for_each_inner!((RTC_GPIO14, GPIO14)); _for_each_inner!((RTC_GPIO15, GPIO15));
-        _for_each_inner!((RTC_GPIO16, GPIO16)); _for_each_inner!((RTC_GPIO17, GPIO17));
-        _for_each_inner!((RTC_GPIO18, GPIO18)); _for_each_inner!((RTC_GPIO19, GPIO19));
-        _for_each_inner!((RTC_GPIO20, GPIO20)); _for_each_inner!((RTC_GPIO21, GPIO21));
-        _for_each_inner!(((RTC_GPIO0, RTC_GPIOn, 0), GPIO0));
-        _for_each_inner!(((RTC_GPIO1, RTC_GPIOn, 1), GPIO1));
-        _for_each_inner!(((RTC_GPIO2, RTC_GPIOn, 2), GPIO2));
-        _for_each_inner!(((RTC_GPIO3, RTC_GPIOn, 3), GPIO3));
-        _for_each_inner!(((RTC_GPIO4, RTC_GPIOn, 4), GPIO4));
-        _for_each_inner!(((RTC_GPIO5, RTC_GPIOn, 5), GPIO5));
-        _for_each_inner!(((RTC_GPIO6, RTC_GPIOn, 6), GPIO6));
-        _for_each_inner!(((RTC_GPIO7, RTC_GPIOn, 7), GPIO7));
-        _for_each_inner!(((RTC_GPIO8, RTC_GPIOn, 8), GPIO8));
-        _for_each_inner!(((RTC_GPIO9, RTC_GPIOn, 9), GPIO9));
-        _for_each_inner!(((RTC_GPIO10, RTC_GPIOn, 10), GPIO10));
-        _for_each_inner!(((RTC_GPIO11, RTC_GPIOn, 11), GPIO11));
-        _for_each_inner!(((RTC_GPIO12, RTC_GPIOn, 12), GPIO12));
-        _for_each_inner!(((RTC_GPIO13, RTC_GPIOn, 13), GPIO13));
-        _for_each_inner!(((RTC_GPIO14, RTC_GPIOn, 14), GPIO14));
-        _for_each_inner!(((RTC_GPIO15, RTC_GPIOn, 15), GPIO15));
-        _for_each_inner!(((RTC_GPIO16, RTC_GPIOn, 16), GPIO16));
-        _for_each_inner!(((RTC_GPIO17, RTC_GPIOn, 17), GPIO17));
-        _for_each_inner!(((RTC_GPIO18, RTC_GPIOn, 18), GPIO18));
-        _for_each_inner!(((RTC_GPIO19, RTC_GPIOn, 19), GPIO19));
-        _for_each_inner!(((RTC_GPIO20, RTC_GPIOn, 20), GPIO20));
-        _for_each_inner!(((RTC_GPIO21, RTC_GPIOn, 21), GPIO21));
-        _for_each_inner!((all(RTC_GPIO0, GPIO0), (RTC_GPIO1, GPIO1), (RTC_GPIO2, GPIO2),
-        (RTC_GPIO3, GPIO3), (RTC_GPIO4, GPIO4), (RTC_GPIO5, GPIO5), (RTC_GPIO6, GPIO6),
-        (RTC_GPIO7, GPIO7), (RTC_GPIO8, GPIO8), (RTC_GPIO9, GPIO9), (RTC_GPIO10, GPIO10),
-        (RTC_GPIO11, GPIO11), (RTC_GPIO12, GPIO12), (RTC_GPIO13, GPIO13), (RTC_GPIO14,
-        GPIO14), (RTC_GPIO15, GPIO15), (RTC_GPIO16, GPIO16), (RTC_GPIO17, GPIO17),
-        (RTC_GPIO18, GPIO18), (RTC_GPIO19, GPIO19), (RTC_GPIO20, GPIO20), (RTC_GPIO21,
-        GPIO21))); _for_each_inner!((all_expanded((RTC_GPIO0, RTC_GPIOn, 0), GPIO0),
+        macro_rules! _for_each_inner_lp_function { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_lp_function!((RTC_GPIO0, GPIO0));
+        _for_each_inner_lp_function!((RTC_GPIO1, GPIO1));
+        _for_each_inner_lp_function!((RTC_GPIO2, GPIO2));
+        _for_each_inner_lp_function!((RTC_GPIO3, GPIO3));
+        _for_each_inner_lp_function!((RTC_GPIO4, GPIO4));
+        _for_each_inner_lp_function!((RTC_GPIO5, GPIO5));
+        _for_each_inner_lp_function!((RTC_GPIO6, GPIO6));
+        _for_each_inner_lp_function!((RTC_GPIO7, GPIO7));
+        _for_each_inner_lp_function!((RTC_GPIO8, GPIO8));
+        _for_each_inner_lp_function!((RTC_GPIO9, GPIO9));
+        _for_each_inner_lp_function!((RTC_GPIO10, GPIO10));
+        _for_each_inner_lp_function!((RTC_GPIO11, GPIO11));
+        _for_each_inner_lp_function!((RTC_GPIO12, GPIO12));
+        _for_each_inner_lp_function!((RTC_GPIO13, GPIO13));
+        _for_each_inner_lp_function!((RTC_GPIO14, GPIO14));
+        _for_each_inner_lp_function!((RTC_GPIO15, GPIO15));
+        _for_each_inner_lp_function!((RTC_GPIO16, GPIO16));
+        _for_each_inner_lp_function!((RTC_GPIO17, GPIO17));
+        _for_each_inner_lp_function!((RTC_GPIO18, GPIO18));
+        _for_each_inner_lp_function!((RTC_GPIO19, GPIO19));
+        _for_each_inner_lp_function!((RTC_GPIO20, GPIO20));
+        _for_each_inner_lp_function!((RTC_GPIO21, GPIO21));
+        _for_each_inner_lp_function!(((RTC_GPIO0, RTC_GPIOn, 0), GPIO0));
+        _for_each_inner_lp_function!(((RTC_GPIO1, RTC_GPIOn, 1), GPIO1));
+        _for_each_inner_lp_function!(((RTC_GPIO2, RTC_GPIOn, 2), GPIO2));
+        _for_each_inner_lp_function!(((RTC_GPIO3, RTC_GPIOn, 3), GPIO3));
+        _for_each_inner_lp_function!(((RTC_GPIO4, RTC_GPIOn, 4), GPIO4));
+        _for_each_inner_lp_function!(((RTC_GPIO5, RTC_GPIOn, 5), GPIO5));
+        _for_each_inner_lp_function!(((RTC_GPIO6, RTC_GPIOn, 6), GPIO6));
+        _for_each_inner_lp_function!(((RTC_GPIO7, RTC_GPIOn, 7), GPIO7));
+        _for_each_inner_lp_function!(((RTC_GPIO8, RTC_GPIOn, 8), GPIO8));
+        _for_each_inner_lp_function!(((RTC_GPIO9, RTC_GPIOn, 9), GPIO9));
+        _for_each_inner_lp_function!(((RTC_GPIO10, RTC_GPIOn, 10), GPIO10));
+        _for_each_inner_lp_function!(((RTC_GPIO11, RTC_GPIOn, 11), GPIO11));
+        _for_each_inner_lp_function!(((RTC_GPIO12, RTC_GPIOn, 12), GPIO12));
+        _for_each_inner_lp_function!(((RTC_GPIO13, RTC_GPIOn, 13), GPIO13));
+        _for_each_inner_lp_function!(((RTC_GPIO14, RTC_GPIOn, 14), GPIO14));
+        _for_each_inner_lp_function!(((RTC_GPIO15, RTC_GPIOn, 15), GPIO15));
+        _for_each_inner_lp_function!(((RTC_GPIO16, RTC_GPIOn, 16), GPIO16));
+        _for_each_inner_lp_function!(((RTC_GPIO17, RTC_GPIOn, 17), GPIO17));
+        _for_each_inner_lp_function!(((RTC_GPIO18, RTC_GPIOn, 18), GPIO18));
+        _for_each_inner_lp_function!(((RTC_GPIO19, RTC_GPIOn, 19), GPIO19));
+        _for_each_inner_lp_function!(((RTC_GPIO20, RTC_GPIOn, 20), GPIO20));
+        _for_each_inner_lp_function!(((RTC_GPIO21, RTC_GPIOn, 21), GPIO21));
+        _for_each_inner_lp_function!((all(RTC_GPIO0, GPIO0), (RTC_GPIO1, GPIO1),
+        (RTC_GPIO2, GPIO2), (RTC_GPIO3, GPIO3), (RTC_GPIO4, GPIO4), (RTC_GPIO5, GPIO5),
+        (RTC_GPIO6, GPIO6), (RTC_GPIO7, GPIO7), (RTC_GPIO8, GPIO8), (RTC_GPIO9, GPIO9),
+        (RTC_GPIO10, GPIO10), (RTC_GPIO11, GPIO11), (RTC_GPIO12, GPIO12), (RTC_GPIO13,
+        GPIO13), (RTC_GPIO14, GPIO14), (RTC_GPIO15, GPIO15), (RTC_GPIO16, GPIO16),
+        (RTC_GPIO17, GPIO17), (RTC_GPIO18, GPIO18), (RTC_GPIO19, GPIO19), (RTC_GPIO20,
+        GPIO20), (RTC_GPIO21, GPIO21)));
+        _for_each_inner_lp_function!((all_expanded((RTC_GPIO0, RTC_GPIOn, 0), GPIO0),
         ((RTC_GPIO1, RTC_GPIOn, 1), GPIO1), ((RTC_GPIO2, RTC_GPIOn, 2), GPIO2),
         ((RTC_GPIO3, RTC_GPIOn, 3), GPIO3), ((RTC_GPIO4, RTC_GPIOn, 4), GPIO4),
         ((RTC_GPIO5, RTC_GPIOn, 5), GPIO5), ((RTC_GPIO6, RTC_GPIOn, 6), GPIO6),

--- a/esp-metadata-generated/src/_generated_esp32s3.rs
+++ b/esp-metadata-generated/src/_generated_esp32s3.rs
@@ -2821,45 +2821,58 @@ macro_rules! memory_range {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_aes_key_length {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((128)); _for_each_inner!((256)); _for_each_inner!((128, 0, 4));
-        _for_each_inner!((256, 2, 6)); _for_each_inner!((bits(128), (256)));
-        _for_each_inner!((modes(128, 0, 4), (256, 2, 6)));
+        macro_rules! _for_each_inner_aes_key_length { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_aes_key_length!((128));
+        _for_each_inner_aes_key_length!((256)); _for_each_inner_aes_key_length!((128, 0,
+        4)); _for_each_inner_aes_key_length!((256, 2, 6));
+        _for_each_inner_aes_key_length!((bits(128), (256)));
+        _for_each_inner_aes_key_length!((modes(128, 0, 4), (256, 2, 6)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_dedicated_gpio {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((0)); _for_each_inner!((1)); _for_each_inner!((2));
-        _for_each_inner!((3)); _for_each_inner!((4)); _for_each_inner!((5));
-        _for_each_inner!((6)); _for_each_inner!((7)); _for_each_inner!((0, 0,
-        PRO_ALONEGPIO0)); _for_each_inner!((0, 1, PRO_ALONEGPIO1)); _for_each_inner!((0,
-        2, PRO_ALONEGPIO2)); _for_each_inner!((0, 3, PRO_ALONEGPIO3));
-        _for_each_inner!((0, 4, PRO_ALONEGPIO4)); _for_each_inner!((0, 5,
-        PRO_ALONEGPIO5)); _for_each_inner!((0, 6, PRO_ALONEGPIO6)); _for_each_inner!((0,
-        7, PRO_ALONEGPIO7)); _for_each_inner!((1, 0, CORE1_GPIO0)); _for_each_inner!((1,
-        1, CORE1_GPIO1)); _for_each_inner!((1, 2, CORE1_GPIO2)); _for_each_inner!((1, 3,
-        CORE1_GPIO3)); _for_each_inner!((1, 4, CORE1_GPIO4)); _for_each_inner!((1, 5,
-        CORE1_GPIO5)); _for_each_inner!((1, 6, CORE1_GPIO6)); _for_each_inner!((1, 7,
-        CORE1_GPIO7)); _for_each_inner!((channels(0), (1), (2), (3), (4), (5), (6),
-        (7))); _for_each_inner!((signals(0, 0, PRO_ALONEGPIO0), (0, 1, PRO_ALONEGPIO1),
-        (0, 2, PRO_ALONEGPIO2), (0, 3, PRO_ALONEGPIO3), (0, 4, PRO_ALONEGPIO4), (0, 5,
-        PRO_ALONEGPIO5), (0, 6, PRO_ALONEGPIO6), (0, 7, PRO_ALONEGPIO7), (1, 0,
-        CORE1_GPIO0), (1, 1, CORE1_GPIO1), (1, 2, CORE1_GPIO2), (1, 3, CORE1_GPIO3), (1,
-        4, CORE1_GPIO4), (1, 5, CORE1_GPIO5), (1, 6, CORE1_GPIO6), (1, 7, CORE1_GPIO7)));
+        macro_rules! _for_each_inner_dedicated_gpio { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_dedicated_gpio!((0));
+        _for_each_inner_dedicated_gpio!((1)); _for_each_inner_dedicated_gpio!((2));
+        _for_each_inner_dedicated_gpio!((3)); _for_each_inner_dedicated_gpio!((4));
+        _for_each_inner_dedicated_gpio!((5)); _for_each_inner_dedicated_gpio!((6));
+        _for_each_inner_dedicated_gpio!((7)); _for_each_inner_dedicated_gpio!((0, 0,
+        PRO_ALONEGPIO0)); _for_each_inner_dedicated_gpio!((0, 1, PRO_ALONEGPIO1));
+        _for_each_inner_dedicated_gpio!((0, 2, PRO_ALONEGPIO2));
+        _for_each_inner_dedicated_gpio!((0, 3, PRO_ALONEGPIO3));
+        _for_each_inner_dedicated_gpio!((0, 4, PRO_ALONEGPIO4));
+        _for_each_inner_dedicated_gpio!((0, 5, PRO_ALONEGPIO5));
+        _for_each_inner_dedicated_gpio!((0, 6, PRO_ALONEGPIO6));
+        _for_each_inner_dedicated_gpio!((0, 7, PRO_ALONEGPIO7));
+        _for_each_inner_dedicated_gpio!((1, 0, CORE1_GPIO0));
+        _for_each_inner_dedicated_gpio!((1, 1, CORE1_GPIO1));
+        _for_each_inner_dedicated_gpio!((1, 2, CORE1_GPIO2));
+        _for_each_inner_dedicated_gpio!((1, 3, CORE1_GPIO3));
+        _for_each_inner_dedicated_gpio!((1, 4, CORE1_GPIO4));
+        _for_each_inner_dedicated_gpio!((1, 5, CORE1_GPIO5));
+        _for_each_inner_dedicated_gpio!((1, 6, CORE1_GPIO6));
+        _for_each_inner_dedicated_gpio!((1, 7, CORE1_GPIO7));
+        _for_each_inner_dedicated_gpio!((channels(0), (1), (2), (3), (4), (5), (6),
+        (7))); _for_each_inner_dedicated_gpio!((signals(0, 0, PRO_ALONEGPIO0), (0, 1,
+        PRO_ALONEGPIO1), (0, 2, PRO_ALONEGPIO2), (0, 3, PRO_ALONEGPIO3), (0, 4,
+        PRO_ALONEGPIO4), (0, 5, PRO_ALONEGPIO5), (0, 6, PRO_ALONEGPIO6), (0, 7,
+        PRO_ALONEGPIO7), (1, 0, CORE1_GPIO0), (1, 1, CORE1_GPIO1), (1, 2, CORE1_GPIO2),
+        (1, 3, CORE1_GPIO3), (1, 4, CORE1_GPIO4), (1, 5, CORE1_GPIO5), (1, 6,
+        CORE1_GPIO6), (1, 7, CORE1_GPIO7)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_sw_interrupt {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((0, FROM_CPU_INTR0, software_interrupt0)); _for_each_inner!((1,
-        FROM_CPU_INTR1, software_interrupt1)); _for_each_inner!((2, FROM_CPU_INTR2,
-        software_interrupt2)); _for_each_inner!((3, FROM_CPU_INTR3,
-        software_interrupt3)); _for_each_inner!((all(0, FROM_CPU_INTR0,
+        macro_rules! _for_each_inner_sw_interrupt { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_sw_interrupt!((0, FROM_CPU_INTR0,
+        software_interrupt0)); _for_each_inner_sw_interrupt!((1, FROM_CPU_INTR1,
+        software_interrupt1)); _for_each_inner_sw_interrupt!((2, FROM_CPU_INTR2,
+        software_interrupt2)); _for_each_inner_sw_interrupt!((3, FROM_CPU_INTR3,
+        software_interrupt3)); _for_each_inner_sw_interrupt!((all(0, FROM_CPU_INTR0,
         software_interrupt0), (1, FROM_CPU_INTR1, software_interrupt1), (2,
         FROM_CPU_INTR2, software_interrupt2), (3, FROM_CPU_INTR3, software_interrupt3)));
     };
@@ -2895,148 +2908,284 @@ macro_rules! sw_interrupt_delay {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rmt_channel {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((0)); _for_each_inner!((1)); _for_each_inner!((2));
-        _for_each_inner!((3)); _for_each_inner!((4)); _for_each_inner!((5));
-        _for_each_inner!((6)); _for_each_inner!((7)); _for_each_inner!((0, 0));
-        _for_each_inner!((1, 1)); _for_each_inner!((2, 2)); _for_each_inner!((3, 3));
-        _for_each_inner!((4, 0)); _for_each_inner!((5, 1)); _for_each_inner!((6, 2));
-        _for_each_inner!((7, 3)); _for_each_inner!((all(0), (1), (2), (3), (4), (5), (6),
-        (7))); _for_each_inner!((tx(0, 0), (1, 1), (2, 2), (3, 3)));
-        _for_each_inner!((rx(4, 0), (5, 1), (6, 2), (7, 3)));
+        macro_rules! _for_each_inner_rmt_channel { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_rmt_channel!((0)); _for_each_inner_rmt_channel!((1));
+        _for_each_inner_rmt_channel!((2)); _for_each_inner_rmt_channel!((3));
+        _for_each_inner_rmt_channel!((4)); _for_each_inner_rmt_channel!((5));
+        _for_each_inner_rmt_channel!((6)); _for_each_inner_rmt_channel!((7));
+        _for_each_inner_rmt_channel!((0, 0)); _for_each_inner_rmt_channel!((1, 1));
+        _for_each_inner_rmt_channel!((2, 2)); _for_each_inner_rmt_channel!((3, 3));
+        _for_each_inner_rmt_channel!((4, 0)); _for_each_inner_rmt_channel!((5, 1));
+        _for_each_inner_rmt_channel!((6, 2)); _for_each_inner_rmt_channel!((7, 3));
+        _for_each_inner_rmt_channel!((all(0), (1), (2), (3), (4), (5), (6), (7)));
+        _for_each_inner_rmt_channel!((tx(0, 0), (1, 1), (2, 2), (3, 3)));
+        _for_each_inner_rmt_channel!((rx(4, 0), (5, 1), (6, 2), (7, 3)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rmt_clock_source {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((Apb, 1)); _for_each_inner!((RcFast, 2));
-        _for_each_inner!((Xtal, 3)); _for_each_inner!((Apb)); _for_each_inner!((all(Apb,
-        1), (RcFast, 2), (Xtal, 3))); _for_each_inner!((default(Apb)));
+        macro_rules! _for_each_inner_rmt_clock_source { $(($pattern) => $code;)* ($other
+        : tt) => {} } _for_each_inner_rmt_clock_source!((Apb, 1));
+        _for_each_inner_rmt_clock_source!((RcFast, 2));
+        _for_each_inner_rmt_clock_source!((Xtal, 3));
+        _for_each_inner_rmt_clock_source!((Apb));
+        _for_each_inner_rmt_clock_source!((all(Apb, 1), (RcFast, 2), (Xtal, 3)));
+        _for_each_inner_rmt_clock_source!((default(Apb)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rsa_exponentiation {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((32)); _for_each_inner!((64)); _for_each_inner!((96));
-        _for_each_inner!((128)); _for_each_inner!((160)); _for_each_inner!((192));
-        _for_each_inner!((224)); _for_each_inner!((256)); _for_each_inner!((288));
-        _for_each_inner!((320)); _for_each_inner!((352)); _for_each_inner!((384));
-        _for_each_inner!((416)); _for_each_inner!((448)); _for_each_inner!((480));
-        _for_each_inner!((512)); _for_each_inner!((544)); _for_each_inner!((576));
-        _for_each_inner!((608)); _for_each_inner!((640)); _for_each_inner!((672));
-        _for_each_inner!((704)); _for_each_inner!((736)); _for_each_inner!((768));
-        _for_each_inner!((800)); _for_each_inner!((832)); _for_each_inner!((864));
-        _for_each_inner!((896)); _for_each_inner!((928)); _for_each_inner!((960));
-        _for_each_inner!((992)); _for_each_inner!((1024)); _for_each_inner!((1056));
-        _for_each_inner!((1088)); _for_each_inner!((1120)); _for_each_inner!((1152));
-        _for_each_inner!((1184)); _for_each_inner!((1216)); _for_each_inner!((1248));
-        _for_each_inner!((1280)); _for_each_inner!((1312)); _for_each_inner!((1344));
-        _for_each_inner!((1376)); _for_each_inner!((1408)); _for_each_inner!((1440));
-        _for_each_inner!((1472)); _for_each_inner!((1504)); _for_each_inner!((1536));
-        _for_each_inner!((1568)); _for_each_inner!((1600)); _for_each_inner!((1632));
-        _for_each_inner!((1664)); _for_each_inner!((1696)); _for_each_inner!((1728));
-        _for_each_inner!((1760)); _for_each_inner!((1792)); _for_each_inner!((1824));
-        _for_each_inner!((1856)); _for_each_inner!((1888)); _for_each_inner!((1920));
-        _for_each_inner!((1952)); _for_each_inner!((1984)); _for_each_inner!((2016));
-        _for_each_inner!((2048)); _for_each_inner!((2080)); _for_each_inner!((2112));
-        _for_each_inner!((2144)); _for_each_inner!((2176)); _for_each_inner!((2208));
-        _for_each_inner!((2240)); _for_each_inner!((2272)); _for_each_inner!((2304));
-        _for_each_inner!((2336)); _for_each_inner!((2368)); _for_each_inner!((2400));
-        _for_each_inner!((2432)); _for_each_inner!((2464)); _for_each_inner!((2496));
-        _for_each_inner!((2528)); _for_each_inner!((2560)); _for_each_inner!((2592));
-        _for_each_inner!((2624)); _for_each_inner!((2656)); _for_each_inner!((2688));
-        _for_each_inner!((2720)); _for_each_inner!((2752)); _for_each_inner!((2784));
-        _for_each_inner!((2816)); _for_each_inner!((2848)); _for_each_inner!((2880));
-        _for_each_inner!((2912)); _for_each_inner!((2944)); _for_each_inner!((2976));
-        _for_each_inner!((3008)); _for_each_inner!((3040)); _for_each_inner!((3072));
-        _for_each_inner!((3104)); _for_each_inner!((3136)); _for_each_inner!((3168));
-        _for_each_inner!((3200)); _for_each_inner!((3232)); _for_each_inner!((3264));
-        _for_each_inner!((3296)); _for_each_inner!((3328)); _for_each_inner!((3360));
-        _for_each_inner!((3392)); _for_each_inner!((3424)); _for_each_inner!((3456));
-        _for_each_inner!((3488)); _for_each_inner!((3520)); _for_each_inner!((3552));
-        _for_each_inner!((3584)); _for_each_inner!((3616)); _for_each_inner!((3648));
-        _for_each_inner!((3680)); _for_each_inner!((3712)); _for_each_inner!((3744));
-        _for_each_inner!((3776)); _for_each_inner!((3808)); _for_each_inner!((3840));
-        _for_each_inner!((3872)); _for_each_inner!((3904)); _for_each_inner!((3936));
-        _for_each_inner!((3968)); _for_each_inner!((4000)); _for_each_inner!((4032));
-        _for_each_inner!((4064)); _for_each_inner!((4096)); _for_each_inner!((all(32),
-        (64), (96), (128), (160), (192), (224), (256), (288), (320), (352), (384), (416),
-        (448), (480), (512), (544), (576), (608), (640), (672), (704), (736), (768),
-        (800), (832), (864), (896), (928), (960), (992), (1024), (1056), (1088), (1120),
-        (1152), (1184), (1216), (1248), (1280), (1312), (1344), (1376), (1408), (1440),
-        (1472), (1504), (1536), (1568), (1600), (1632), (1664), (1696), (1728), (1760),
-        (1792), (1824), (1856), (1888), (1920), (1952), (1984), (2016), (2048), (2080),
-        (2112), (2144), (2176), (2208), (2240), (2272), (2304), (2336), (2368), (2400),
-        (2432), (2464), (2496), (2528), (2560), (2592), (2624), (2656), (2688), (2720),
-        (2752), (2784), (2816), (2848), (2880), (2912), (2944), (2976), (3008), (3040),
-        (3072), (3104), (3136), (3168), (3200), (3232), (3264), (3296), (3328), (3360),
-        (3392), (3424), (3456), (3488), (3520), (3552), (3584), (3616), (3648), (3680),
-        (3712), (3744), (3776), (3808), (3840), (3872), (3904), (3936), (3968), (4000),
-        (4032), (4064), (4096)));
+        macro_rules! _for_each_inner_rsa_exponentiation { $(($pattern) => $code;)*
+        ($other : tt) => {} } _for_each_inner_rsa_exponentiation!((32));
+        _for_each_inner_rsa_exponentiation!((64));
+        _for_each_inner_rsa_exponentiation!((96));
+        _for_each_inner_rsa_exponentiation!((128));
+        _for_each_inner_rsa_exponentiation!((160));
+        _for_each_inner_rsa_exponentiation!((192));
+        _for_each_inner_rsa_exponentiation!((224));
+        _for_each_inner_rsa_exponentiation!((256));
+        _for_each_inner_rsa_exponentiation!((288));
+        _for_each_inner_rsa_exponentiation!((320));
+        _for_each_inner_rsa_exponentiation!((352));
+        _for_each_inner_rsa_exponentiation!((384));
+        _for_each_inner_rsa_exponentiation!((416));
+        _for_each_inner_rsa_exponentiation!((448));
+        _for_each_inner_rsa_exponentiation!((480));
+        _for_each_inner_rsa_exponentiation!((512));
+        _for_each_inner_rsa_exponentiation!((544));
+        _for_each_inner_rsa_exponentiation!((576));
+        _for_each_inner_rsa_exponentiation!((608));
+        _for_each_inner_rsa_exponentiation!((640));
+        _for_each_inner_rsa_exponentiation!((672));
+        _for_each_inner_rsa_exponentiation!((704));
+        _for_each_inner_rsa_exponentiation!((736));
+        _for_each_inner_rsa_exponentiation!((768));
+        _for_each_inner_rsa_exponentiation!((800));
+        _for_each_inner_rsa_exponentiation!((832));
+        _for_each_inner_rsa_exponentiation!((864));
+        _for_each_inner_rsa_exponentiation!((896));
+        _for_each_inner_rsa_exponentiation!((928));
+        _for_each_inner_rsa_exponentiation!((960));
+        _for_each_inner_rsa_exponentiation!((992));
+        _for_each_inner_rsa_exponentiation!((1024));
+        _for_each_inner_rsa_exponentiation!((1056));
+        _for_each_inner_rsa_exponentiation!((1088));
+        _for_each_inner_rsa_exponentiation!((1120));
+        _for_each_inner_rsa_exponentiation!((1152));
+        _for_each_inner_rsa_exponentiation!((1184));
+        _for_each_inner_rsa_exponentiation!((1216));
+        _for_each_inner_rsa_exponentiation!((1248));
+        _for_each_inner_rsa_exponentiation!((1280));
+        _for_each_inner_rsa_exponentiation!((1312));
+        _for_each_inner_rsa_exponentiation!((1344));
+        _for_each_inner_rsa_exponentiation!((1376));
+        _for_each_inner_rsa_exponentiation!((1408));
+        _for_each_inner_rsa_exponentiation!((1440));
+        _for_each_inner_rsa_exponentiation!((1472));
+        _for_each_inner_rsa_exponentiation!((1504));
+        _for_each_inner_rsa_exponentiation!((1536));
+        _for_each_inner_rsa_exponentiation!((1568));
+        _for_each_inner_rsa_exponentiation!((1600));
+        _for_each_inner_rsa_exponentiation!((1632));
+        _for_each_inner_rsa_exponentiation!((1664));
+        _for_each_inner_rsa_exponentiation!((1696));
+        _for_each_inner_rsa_exponentiation!((1728));
+        _for_each_inner_rsa_exponentiation!((1760));
+        _for_each_inner_rsa_exponentiation!((1792));
+        _for_each_inner_rsa_exponentiation!((1824));
+        _for_each_inner_rsa_exponentiation!((1856));
+        _for_each_inner_rsa_exponentiation!((1888));
+        _for_each_inner_rsa_exponentiation!((1920));
+        _for_each_inner_rsa_exponentiation!((1952));
+        _for_each_inner_rsa_exponentiation!((1984));
+        _for_each_inner_rsa_exponentiation!((2016));
+        _for_each_inner_rsa_exponentiation!((2048));
+        _for_each_inner_rsa_exponentiation!((2080));
+        _for_each_inner_rsa_exponentiation!((2112));
+        _for_each_inner_rsa_exponentiation!((2144));
+        _for_each_inner_rsa_exponentiation!((2176));
+        _for_each_inner_rsa_exponentiation!((2208));
+        _for_each_inner_rsa_exponentiation!((2240));
+        _for_each_inner_rsa_exponentiation!((2272));
+        _for_each_inner_rsa_exponentiation!((2304));
+        _for_each_inner_rsa_exponentiation!((2336));
+        _for_each_inner_rsa_exponentiation!((2368));
+        _for_each_inner_rsa_exponentiation!((2400));
+        _for_each_inner_rsa_exponentiation!((2432));
+        _for_each_inner_rsa_exponentiation!((2464));
+        _for_each_inner_rsa_exponentiation!((2496));
+        _for_each_inner_rsa_exponentiation!((2528));
+        _for_each_inner_rsa_exponentiation!((2560));
+        _for_each_inner_rsa_exponentiation!((2592));
+        _for_each_inner_rsa_exponentiation!((2624));
+        _for_each_inner_rsa_exponentiation!((2656));
+        _for_each_inner_rsa_exponentiation!((2688));
+        _for_each_inner_rsa_exponentiation!((2720));
+        _for_each_inner_rsa_exponentiation!((2752));
+        _for_each_inner_rsa_exponentiation!((2784));
+        _for_each_inner_rsa_exponentiation!((2816));
+        _for_each_inner_rsa_exponentiation!((2848));
+        _for_each_inner_rsa_exponentiation!((2880));
+        _for_each_inner_rsa_exponentiation!((2912));
+        _for_each_inner_rsa_exponentiation!((2944));
+        _for_each_inner_rsa_exponentiation!((2976));
+        _for_each_inner_rsa_exponentiation!((3008));
+        _for_each_inner_rsa_exponentiation!((3040));
+        _for_each_inner_rsa_exponentiation!((3072));
+        _for_each_inner_rsa_exponentiation!((3104));
+        _for_each_inner_rsa_exponentiation!((3136));
+        _for_each_inner_rsa_exponentiation!((3168));
+        _for_each_inner_rsa_exponentiation!((3200));
+        _for_each_inner_rsa_exponentiation!((3232));
+        _for_each_inner_rsa_exponentiation!((3264));
+        _for_each_inner_rsa_exponentiation!((3296));
+        _for_each_inner_rsa_exponentiation!((3328));
+        _for_each_inner_rsa_exponentiation!((3360));
+        _for_each_inner_rsa_exponentiation!((3392));
+        _for_each_inner_rsa_exponentiation!((3424));
+        _for_each_inner_rsa_exponentiation!((3456));
+        _for_each_inner_rsa_exponentiation!((3488));
+        _for_each_inner_rsa_exponentiation!((3520));
+        _for_each_inner_rsa_exponentiation!((3552));
+        _for_each_inner_rsa_exponentiation!((3584));
+        _for_each_inner_rsa_exponentiation!((3616));
+        _for_each_inner_rsa_exponentiation!((3648));
+        _for_each_inner_rsa_exponentiation!((3680));
+        _for_each_inner_rsa_exponentiation!((3712));
+        _for_each_inner_rsa_exponentiation!((3744));
+        _for_each_inner_rsa_exponentiation!((3776));
+        _for_each_inner_rsa_exponentiation!((3808));
+        _for_each_inner_rsa_exponentiation!((3840));
+        _for_each_inner_rsa_exponentiation!((3872));
+        _for_each_inner_rsa_exponentiation!((3904));
+        _for_each_inner_rsa_exponentiation!((3936));
+        _for_each_inner_rsa_exponentiation!((3968));
+        _for_each_inner_rsa_exponentiation!((4000));
+        _for_each_inner_rsa_exponentiation!((4032));
+        _for_each_inner_rsa_exponentiation!((4064));
+        _for_each_inner_rsa_exponentiation!((4096));
+        _for_each_inner_rsa_exponentiation!((all(32), (64), (96), (128), (160), (192),
+        (224), (256), (288), (320), (352), (384), (416), (448), (480), (512), (544),
+        (576), (608), (640), (672), (704), (736), (768), (800), (832), (864), (896),
+        (928), (960), (992), (1024), (1056), (1088), (1120), (1152), (1184), (1216),
+        (1248), (1280), (1312), (1344), (1376), (1408), (1440), (1472), (1504), (1536),
+        (1568), (1600), (1632), (1664), (1696), (1728), (1760), (1792), (1824), (1856),
+        (1888), (1920), (1952), (1984), (2016), (2048), (2080), (2112), (2144), (2176),
+        (2208), (2240), (2272), (2304), (2336), (2368), (2400), (2432), (2464), (2496),
+        (2528), (2560), (2592), (2624), (2656), (2688), (2720), (2752), (2784), (2816),
+        (2848), (2880), (2912), (2944), (2976), (3008), (3040), (3072), (3104), (3136),
+        (3168), (3200), (3232), (3264), (3296), (3328), (3360), (3392), (3424), (3456),
+        (3488), (3520), (3552), (3584), (3616), (3648), (3680), (3712), (3744), (3776),
+        (3808), (3840), (3872), (3904), (3936), (3968), (4000), (4032), (4064), (4096)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rsa_multiplication {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((32)); _for_each_inner!((64)); _for_each_inner!((96));
-        _for_each_inner!((128)); _for_each_inner!((160)); _for_each_inner!((192));
-        _for_each_inner!((224)); _for_each_inner!((256)); _for_each_inner!((288));
-        _for_each_inner!((320)); _for_each_inner!((352)); _for_each_inner!((384));
-        _for_each_inner!((416)); _for_each_inner!((448)); _for_each_inner!((480));
-        _for_each_inner!((512)); _for_each_inner!((544)); _for_each_inner!((576));
-        _for_each_inner!((608)); _for_each_inner!((640)); _for_each_inner!((672));
-        _for_each_inner!((704)); _for_each_inner!((736)); _for_each_inner!((768));
-        _for_each_inner!((800)); _for_each_inner!((832)); _for_each_inner!((864));
-        _for_each_inner!((896)); _for_each_inner!((928)); _for_each_inner!((960));
-        _for_each_inner!((992)); _for_each_inner!((1024)); _for_each_inner!((1056));
-        _for_each_inner!((1088)); _for_each_inner!((1120)); _for_each_inner!((1152));
-        _for_each_inner!((1184)); _for_each_inner!((1216)); _for_each_inner!((1248));
-        _for_each_inner!((1280)); _for_each_inner!((1312)); _for_each_inner!((1344));
-        _for_each_inner!((1376)); _for_each_inner!((1408)); _for_each_inner!((1440));
-        _for_each_inner!((1472)); _for_each_inner!((1504)); _for_each_inner!((1536));
-        _for_each_inner!((1568)); _for_each_inner!((1600)); _for_each_inner!((1632));
-        _for_each_inner!((1664)); _for_each_inner!((1696)); _for_each_inner!((1728));
-        _for_each_inner!((1760)); _for_each_inner!((1792)); _for_each_inner!((1824));
-        _for_each_inner!((1856)); _for_each_inner!((1888)); _for_each_inner!((1920));
-        _for_each_inner!((1952)); _for_each_inner!((1984)); _for_each_inner!((2016));
-        _for_each_inner!((2048)); _for_each_inner!((all(32), (64), (96), (128), (160),
-        (192), (224), (256), (288), (320), (352), (384), (416), (448), (480), (512),
-        (544), (576), (608), (640), (672), (704), (736), (768), (800), (832), (864),
-        (896), (928), (960), (992), (1024), (1056), (1088), (1120), (1152), (1184),
-        (1216), (1248), (1280), (1312), (1344), (1376), (1408), (1440), (1472), (1504),
-        (1536), (1568), (1600), (1632), (1664), (1696), (1728), (1760), (1792), (1824),
-        (1856), (1888), (1920), (1952), (1984), (2016), (2048)));
+        macro_rules! _for_each_inner_rsa_multiplication { $(($pattern) => $code;)*
+        ($other : tt) => {} } _for_each_inner_rsa_multiplication!((32));
+        _for_each_inner_rsa_multiplication!((64));
+        _for_each_inner_rsa_multiplication!((96));
+        _for_each_inner_rsa_multiplication!((128));
+        _for_each_inner_rsa_multiplication!((160));
+        _for_each_inner_rsa_multiplication!((192));
+        _for_each_inner_rsa_multiplication!((224));
+        _for_each_inner_rsa_multiplication!((256));
+        _for_each_inner_rsa_multiplication!((288));
+        _for_each_inner_rsa_multiplication!((320));
+        _for_each_inner_rsa_multiplication!((352));
+        _for_each_inner_rsa_multiplication!((384));
+        _for_each_inner_rsa_multiplication!((416));
+        _for_each_inner_rsa_multiplication!((448));
+        _for_each_inner_rsa_multiplication!((480));
+        _for_each_inner_rsa_multiplication!((512));
+        _for_each_inner_rsa_multiplication!((544));
+        _for_each_inner_rsa_multiplication!((576));
+        _for_each_inner_rsa_multiplication!((608));
+        _for_each_inner_rsa_multiplication!((640));
+        _for_each_inner_rsa_multiplication!((672));
+        _for_each_inner_rsa_multiplication!((704));
+        _for_each_inner_rsa_multiplication!((736));
+        _for_each_inner_rsa_multiplication!((768));
+        _for_each_inner_rsa_multiplication!((800));
+        _for_each_inner_rsa_multiplication!((832));
+        _for_each_inner_rsa_multiplication!((864));
+        _for_each_inner_rsa_multiplication!((896));
+        _for_each_inner_rsa_multiplication!((928));
+        _for_each_inner_rsa_multiplication!((960));
+        _for_each_inner_rsa_multiplication!((992));
+        _for_each_inner_rsa_multiplication!((1024));
+        _for_each_inner_rsa_multiplication!((1056));
+        _for_each_inner_rsa_multiplication!((1088));
+        _for_each_inner_rsa_multiplication!((1120));
+        _for_each_inner_rsa_multiplication!((1152));
+        _for_each_inner_rsa_multiplication!((1184));
+        _for_each_inner_rsa_multiplication!((1216));
+        _for_each_inner_rsa_multiplication!((1248));
+        _for_each_inner_rsa_multiplication!((1280));
+        _for_each_inner_rsa_multiplication!((1312));
+        _for_each_inner_rsa_multiplication!((1344));
+        _for_each_inner_rsa_multiplication!((1376));
+        _for_each_inner_rsa_multiplication!((1408));
+        _for_each_inner_rsa_multiplication!((1440));
+        _for_each_inner_rsa_multiplication!((1472));
+        _for_each_inner_rsa_multiplication!((1504));
+        _for_each_inner_rsa_multiplication!((1536));
+        _for_each_inner_rsa_multiplication!((1568));
+        _for_each_inner_rsa_multiplication!((1600));
+        _for_each_inner_rsa_multiplication!((1632));
+        _for_each_inner_rsa_multiplication!((1664));
+        _for_each_inner_rsa_multiplication!((1696));
+        _for_each_inner_rsa_multiplication!((1728));
+        _for_each_inner_rsa_multiplication!((1760));
+        _for_each_inner_rsa_multiplication!((1792));
+        _for_each_inner_rsa_multiplication!((1824));
+        _for_each_inner_rsa_multiplication!((1856));
+        _for_each_inner_rsa_multiplication!((1888));
+        _for_each_inner_rsa_multiplication!((1920));
+        _for_each_inner_rsa_multiplication!((1952));
+        _for_each_inner_rsa_multiplication!((1984));
+        _for_each_inner_rsa_multiplication!((2016));
+        _for_each_inner_rsa_multiplication!((2048));
+        _for_each_inner_rsa_multiplication!((all(32), (64), (96), (128), (160), (192),
+        (224), (256), (288), (320), (352), (384), (416), (448), (480), (512), (544),
+        (576), (608), (640), (672), (704), (736), (768), (800), (832), (864), (896),
+        (928), (960), (992), (1024), (1056), (1088), (1120), (1152), (1184), (1216),
+        (1248), (1280), (1312), (1344), (1376), (1408), (1440), (1472), (1504), (1536),
+        (1568), (1600), (1632), (1664), (1696), (1728), (1760), (1792), (1824), (1856),
+        (1888), (1920), (1952), (1984), (2016), (2048)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_sha_algorithm {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((Sha1, "SHA-1"(sizes : 64, 20, 8) (insecure_against :
-        "collision", "length extension"), 0)); _for_each_inner!((Sha224, "SHA-224"(sizes
-        : 64, 28, 8) (insecure_against : "length extension"), 1));
-        _for_each_inner!((Sha256, "SHA-256"(sizes : 64, 32, 8) (insecure_against :
-        "length extension"), 2)); _for_each_inner!((Sha384, "SHA-384"(sizes : 128, 48,
-        16) (insecure_against :), 3)); _for_each_inner!((Sha512, "SHA-512"(sizes : 128,
-        64, 16) (insecure_against : "length extension"), 4));
-        _for_each_inner!((Sha512_224, "SHA-512/224"(sizes : 128, 28, 16)
-        (insecure_against :), 5)); _for_each_inner!((Sha512_256, "SHA-512/256"(sizes :
-        128, 32, 16) (insecure_against :), 6)); _for_each_inner!((algos(Sha1,
-        "SHA-1"(sizes : 64, 20, 8) (insecure_against : "collision", "length extension"),
-        0), (Sha224, "SHA-224"(sizes : 64, 28, 8) (insecure_against :
-        "length extension"), 1), (Sha256, "SHA-256"(sizes : 64, 32, 8) (insecure_against
-        : "length extension"), 2), (Sha384, "SHA-384"(sizes : 128, 48, 16)
-        (insecure_against :), 3), (Sha512, "SHA-512"(sizes : 128, 64, 16)
-        (insecure_against : "length extension"), 4), (Sha512_224, "SHA-512/224"(sizes :
-        128, 28, 16) (insecure_against :), 5), (Sha512_256, "SHA-512/256"(sizes : 128,
-        32, 16) (insecure_against :), 6)));
+        macro_rules! _for_each_inner_sha_algorithm { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_sha_algorithm!((Sha1, "SHA-1"(sizes : 64, 20, 8)
+        (insecure_against : "collision", "length extension"), 0));
+        _for_each_inner_sha_algorithm!((Sha224, "SHA-224"(sizes : 64, 28, 8)
+        (insecure_against : "length extension"), 1));
+        _for_each_inner_sha_algorithm!((Sha256, "SHA-256"(sizes : 64, 32, 8)
+        (insecure_against : "length extension"), 2));
+        _for_each_inner_sha_algorithm!((Sha384, "SHA-384"(sizes : 128, 48, 16)
+        (insecure_against :), 3)); _for_each_inner_sha_algorithm!((Sha512,
+        "SHA-512"(sizes : 128, 64, 16) (insecure_against : "length extension"), 4));
+        _for_each_inner_sha_algorithm!((Sha512_224, "SHA-512/224"(sizes : 128, 28, 16)
+        (insecure_against :), 5)); _for_each_inner_sha_algorithm!((Sha512_256,
+        "SHA-512/256"(sizes : 128, 32, 16) (insecure_against :), 6));
+        _for_each_inner_sha_algorithm!((algos(Sha1, "SHA-1"(sizes : 64, 20, 8)
+        (insecure_against : "collision", "length extension"), 0), (Sha224,
+        "SHA-224"(sizes : 64, 28, 8) (insecure_against : "length extension"), 1),
+        (Sha256, "SHA-256"(sizes : 64, 32, 8) (insecure_against : "length extension"),
+        2), (Sha384, "SHA-384"(sizes : 128, 48, 16) (insecure_against :), 3), (Sha512,
+        "SHA-512"(sizes : 128, 64, 16) (insecure_against : "length extension"), 4),
+        (Sha512_224, "SHA-512/224"(sizes : 128, 28, 16) (insecure_against :), 5),
+        (Sha512_256, "SHA-512/256"(sizes : 128, 32, 16) (insecure_against :), 6)));
     };
 }
 /// This macro can be used to generate code for each peripheral instance of the I2C master driver.
@@ -3059,11 +3208,11 @@ macro_rules! for_each_sha_algorithm {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_i2c_master {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((I2C0, I2cExt0, I2CEXT0_SCL, I2CEXT0_SDA));
-        _for_each_inner!((I2C1, I2cExt1, I2CEXT1_SCL, I2CEXT1_SDA));
-        _for_each_inner!((all(I2C0, I2cExt0, I2CEXT0_SCL, I2CEXT0_SDA), (I2C1, I2cExt1,
-        I2CEXT1_SCL, I2CEXT1_SDA)));
+        macro_rules! _for_each_inner_i2c_master { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_i2c_master!((I2C0, I2cExt0, I2CEXT0_SCL, I2CEXT0_SDA));
+        _for_each_inner_i2c_master!((I2C1, I2cExt1, I2CEXT1_SCL, I2CEXT1_SDA));
+        _for_each_inner_i2c_master!((all(I2C0, I2cExt0, I2CEXT0_SCL, I2CEXT0_SDA), (I2C1,
+        I2cExt1, I2CEXT1_SCL, I2CEXT1_SDA)));
     };
 }
 /// This macro can be used to generate code for each peripheral instance of the UART driver.
@@ -3086,12 +3235,12 @@ macro_rules! for_each_i2c_master {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_uart {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS));
-        _for_each_inner!((UART1, Uart1, U1RXD, U1TXD, U1CTS, U1RTS));
-        _for_each_inner!((UART2, Uart2, U2RXD, U2TXD, U2CTS, U2RTS));
-        _for_each_inner!((all(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS), (UART1, Uart1,
-        U1RXD, U1TXD, U1CTS, U1RTS), (UART2, Uart2, U2RXD, U2TXD, U2CTS, U2RTS)));
+        macro_rules! _for_each_inner_uart { $(($pattern) => $code;)* ($other : tt) => {}
+        } _for_each_inner_uart!((UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS));
+        _for_each_inner_uart!((UART1, Uart1, U1RXD, U1TXD, U1CTS, U1RTS));
+        _for_each_inner_uart!((UART2, Uart2, U2RXD, U2TXD, U2CTS, U2RTS));
+        _for_each_inner_uart!((all(UART0, Uart0, U0RXD, U0TXD, U0CTS, U0RTS), (UART1,
+        Uart1, U1RXD, U1TXD, U1CTS, U1RTS), (UART2, Uart2, U2RXD, U2TXD, U2CTS, U2RTS)));
     };
 }
 /// This macro can be used to generate code for each peripheral instance of the SPI master driver.
@@ -3119,15 +3268,15 @@ macro_rules! for_each_uart {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_spi_master {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((SPI2, Spi2, FSPICLK[FSPICS0, FSPICS1, FSPICS2, FSPICS3,
-        FSPICS4, FSPICS5] [FSPID, FSPIQ, FSPIWP, FSPIHD, FSPIIO4, FSPIIO5, FSPIIO6,
-        FSPIIO7], true)); _for_each_inner!((SPI3, Spi3, SPI3_CLK[SPI3_CS0, SPI3_CS1,
-        SPI3_CS2] [SPI3_D, SPI3_Q, SPI3_WP, SPI3_HD], true)); _for_each_inner!((all(SPI2,
-        Spi2, FSPICLK[FSPICS0, FSPICS1, FSPICS2, FSPICS3, FSPICS4, FSPICS5] [FSPID,
-        FSPIQ, FSPIWP, FSPIHD, FSPIIO4, FSPIIO5, FSPIIO6, FSPIIO7], true), (SPI3, Spi3,
+        macro_rules! _for_each_inner_spi_master { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_spi_master!((SPI2, Spi2, FSPICLK[FSPICS0, FSPICS1,
+        FSPICS2, FSPICS3, FSPICS4, FSPICS5] [FSPID, FSPIQ, FSPIWP, FSPIHD, FSPIIO4,
+        FSPIIO5, FSPIIO6, FSPIIO7], true)); _for_each_inner_spi_master!((SPI3, Spi3,
         SPI3_CLK[SPI3_CS0, SPI3_CS1, SPI3_CS2] [SPI3_D, SPI3_Q, SPI3_WP, SPI3_HD],
-        true)));
+        true)); _for_each_inner_spi_master!((all(SPI2, Spi2, FSPICLK[FSPICS0, FSPICS1,
+        FSPICS2, FSPICS3, FSPICS4, FSPICS5] [FSPID, FSPIQ, FSPIWP, FSPIHD, FSPIIO4,
+        FSPIIO5, FSPIIO6, FSPIIO7], true), (SPI3, Spi3, SPI3_CLK[SPI3_CS0, SPI3_CS1,
+        SPI3_CS2] [SPI3_D, SPI3_Q, SPI3_WP, SPI3_HD], true)));
     };
 }
 /// This macro can be used to generate code for each peripheral instance of the SPI slave driver.
@@ -3150,364 +3299,428 @@ macro_rules! for_each_spi_master {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_spi_slave {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((SPI2, Spi2, FSPICLK, FSPID, FSPIQ, FSPICS0));
-        _for_each_inner!((SPI3, Spi3, SPI3_CLK, SPI3_D, SPI3_Q, SPI3_CS0));
-        _for_each_inner!((all(SPI2, Spi2, FSPICLK, FSPID, FSPIQ, FSPICS0), (SPI3, Spi3,
-        SPI3_CLK, SPI3_D, SPI3_Q, SPI3_CS0)));
+        macro_rules! _for_each_inner_spi_slave { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_spi_slave!((SPI2, Spi2, FSPICLK, FSPID, FSPIQ, FSPICS0));
+        _for_each_inner_spi_slave!((SPI3, Spi3, SPI3_CLK, SPI3_D, SPI3_Q, SPI3_CS0));
+        _for_each_inner_spi_slave!((all(SPI2, Spi2, FSPICLK, FSPID, FSPIQ, FSPICS0),
+        (SPI3, Spi3, SPI3_CLK, SPI3_D, SPI3_Q, SPI3_CS0)));
     };
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_peripheral {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((@ peri_type #[doc =
+        macro_rules! _for_each_inner_peripheral { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_peripheral!((@ peri_type #[doc =
         "GPIO0 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
         "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin is a strapping pin, it determines how the chip boots.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO0 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO1 peripheral singleton"] GPIO1 <= virtual()));
-        _for_each_inner!((@ peri_type #[doc = "GPIO2 peripheral singleton"] GPIO2 <=
-        virtual())); _for_each_inner!((@ peri_type #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO0 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO1 peripheral singleton"]
+        GPIO1 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO2 peripheral singleton"] GPIO2 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
         "GPIO3 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
         "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin is a strapping pin, it determines how the chip boots.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO3 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO4 peripheral singleton"] GPIO4 <= virtual()));
-        _for_each_inner!((@ peri_type #[doc = "GPIO5 peripheral singleton"] GPIO5 <=
-        virtual())); _for_each_inner!((@ peri_type #[doc = "GPIO6 peripheral singleton"]
-        GPIO6 <= virtual())); _for_each_inner!((@ peri_type #[doc =
-        "GPIO7 peripheral singleton"] GPIO7 <= virtual())); _for_each_inner!((@ peri_type
-        #[doc = "GPIO8 peripheral singleton"] GPIO8 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO9 peripheral singleton"] GPIO9 <= virtual()));
-        _for_each_inner!((@ peri_type #[doc = "GPIO10 peripheral singleton"] GPIO10 <=
-        virtual())); _for_each_inner!((@ peri_type #[doc = "GPIO11 peripheral singleton"]
-        GPIO11 <= virtual())); _for_each_inner!((@ peri_type #[doc =
-        "GPIO12 peripheral singleton"] GPIO12 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO13 peripheral singleton"] GPIO13 <= virtual()));
-        _for_each_inner!((@ peri_type #[doc = "GPIO14 peripheral singleton"] GPIO14 <=
-        virtual())); _for_each_inner!((@ peri_type #[doc = "GPIO15 peripheral singleton"]
-        GPIO15 <= virtual())); _for_each_inner!((@ peri_type #[doc =
-        "GPIO16 peripheral singleton"] GPIO16 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO17 peripheral singleton"] GPIO17 <= virtual()));
-        _for_each_inner!((@ peri_type #[doc = "GPIO18 peripheral singleton"] GPIO18 <=
-        virtual())); _for_each_inner!((@ peri_type #[doc = "GPIO19 peripheral singleton"]
-        GPIO19 <= virtual())); _for_each_inner!((@ peri_type #[doc =
-        "GPIO20 peripheral singleton"] GPIO20 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO21 peripheral singleton"] GPIO21 <= virtual()));
-        _for_each_inner!((@ peri_type #[doc =
+        = "</ul>"] #[doc = "</section>"] GPIO3 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO4 peripheral singleton"]
+        GPIO4 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO5 peripheral singleton"] GPIO5 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO6 peripheral singleton"]
+        GPIO6 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO7 peripheral singleton"] GPIO7 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO8 peripheral singleton"]
+        GPIO8 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO9 peripheral singleton"] GPIO9 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO10 peripheral singleton"]
+        GPIO10 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO11 peripheral singleton"] GPIO11 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO12 peripheral singleton"]
+        GPIO12 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO13 peripheral singleton"] GPIO13 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO14 peripheral singleton"]
+        GPIO14 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO15 peripheral singleton"] GPIO15 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO16 peripheral singleton"]
+        GPIO16 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO17 peripheral singleton"] GPIO17 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO18 peripheral singleton"]
+        GPIO18 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO19 peripheral singleton"] GPIO19 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO20 peripheral singleton"]
+        GPIO20 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO21 peripheral singleton"] GPIO21 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
         "GPIO26 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
         "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI PSRAM.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO26 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO27 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO26 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO27 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI PSRAM.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO27 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO28 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO27 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO28 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI PSRAM.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO28 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO29 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO28 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO29 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI PSRAM.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO29 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO30 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO29 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO30 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI PSRAM.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO30 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO31 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO30 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO31 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI PSRAM.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO31 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO32 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO31 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO32 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
-        "</ul>"] #[doc = "</section>"] GPIO32 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO33 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        "</ul>"] #[doc = "</section>"] GPIO32 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO33 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with Octal SPI flash.</li>"] #[doc
         = "<li>This pin may be reserved for interfacing with Octal SPI PSRAM.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO33 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO34 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO33 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO34 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with Octal SPI flash.</li>"] #[doc
         = "<li>This pin may be reserved for interfacing with Octal SPI PSRAM.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO34 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO35 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO34 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO35 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with Octal SPI flash.</li>"] #[doc
         = "<li>This pin may be reserved for interfacing with Octal SPI PSRAM.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO35 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO36 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO35 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO36 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with Octal SPI flash.</li>"] #[doc
         = "<li>This pin may be reserved for interfacing with Octal SPI PSRAM.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO36 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO37 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO36 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO37 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with Octal SPI flash.</li>"] #[doc
         = "<li>This pin may be reserved for interfacing with Octal SPI PSRAM.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO37 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO38 peripheral singleton"] GPIO38 <= virtual()));
-        _for_each_inner!((@ peri_type #[doc =
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO37 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO38 peripheral singleton"]
+        GPIO38 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
         "GPIO39 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
         "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>These pins may be used to debug the chip using an external JTAG debugger.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO39 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO40 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
-        "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
-        #[doc = "<ul>"] #[doc =
-        "<li>These pins may be used to debug the chip using an external JTAG debugger.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO40 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO41 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
-        "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
-        #[doc = "<ul>"] #[doc =
-        "<li>These pins may be used to debug the chip using an external JTAG debugger.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO41 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO42 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
-        "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
-        #[doc = "<ul>"] #[doc =
-        "<li>These pins may be used to debug the chip using an external JTAG debugger.</li>"]
-        #[doc = "</ul>"] #[doc = "</section>"] GPIO42 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO43 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
-        "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
-        #[doc = "<ul>"] #[doc =
-        "<li>By default, this pin is used by the UART programming interface.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO43 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO44 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
-        "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
-        #[doc = "<ul>"] #[doc =
-        "<li>By default, this pin is used by the UART programming interface.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO44 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO45 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
-        "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
-        #[doc = "<ul>"] #[doc =
-        "<li>This pin is a strapping pin, it determines how the chip boots.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO45 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO46 peripheral singleton (Limitations exist)"] #[doc = ""]
-        #[doc = "<section class=\"warning\">"] #[doc =
-        "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
-        #[doc = "<ul>"] #[doc =
-        "<li>This pin is a strapping pin, it determines how the chip boots.</li>"] #[doc
-        = "</ul>"] #[doc = "</section>"] GPIO46 <= virtual())); _for_each_inner!((@
-        peri_type #[doc = "GPIO47 peripheral singleton"] GPIO47 <= virtual()));
-        _for_each_inner!((@ peri_type #[doc = "GPIO48 peripheral singleton"] GPIO48 <=
-        virtual())); _for_each_inner!((@ peri_type #[doc = "AES peripheral singleton"]
-        AES <= AES(AES : { bind_peri_interrupt, enable_peri_interrupt,
-        disable_peri_interrupt }) (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "APB_CTRL peripheral singleton"] APB_CTRL <= APB_CTRL() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "APB_SARADC peripheral singleton"]
-        APB_SARADC <= APB_SARADC() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "ASSIST_DEBUG peripheral singleton"] ASSIST_DEBUG <= ASSIST_DEBUG() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "DMA peripheral singleton"] DMA <= DMA()
-        (unstable))); _for_each_inner!((@ peri_type #[doc = "DS peripheral singleton"] DS
-        <= DS() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "EFUSE peripheral singleton"] EFUSE <= EFUSE() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "EXTMEM peripheral singleton"] EXTMEM <= EXTMEM() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "GPIO peripheral singleton"] GPIO <= GPIO()
-        (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "GPIO_SD peripheral singleton"] GPIO_SD <= GPIO_SD() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "HMAC peripheral singleton"] HMAC <= HMAC()
-        (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "I2C_ANA_MST peripheral singleton"] I2C_ANA_MST <= I2C_ANA_MST() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "I2C0 peripheral singleton"] I2C0 <=
-        I2C0(I2C_EXT0 : { bind_peri_interrupt, enable_peri_interrupt,
-        disable_peri_interrupt }))); _for_each_inner!((@ peri_type #[doc =
-        "I2C1 peripheral singleton"] I2C1 <= I2C1(I2C_EXT1 : { bind_peri_interrupt,
-        enable_peri_interrupt, disable_peri_interrupt }))); _for_each_inner!((@ peri_type
-        #[doc = "I2S0 peripheral singleton"] I2S0 <= I2S0(I2S0 : { bind_peri_interrupt,
-        enable_peri_interrupt, disable_peri_interrupt }) (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "I2S1 peripheral singleton"] I2S1 <=
-        I2S1(I2S1 : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt
-        }) (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "INTERRUPT_CORE0 peripheral singleton"] INTERRUPT_CORE0 <= INTERRUPT_CORE0()
-        (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "INTERRUPT_CORE1 peripheral singleton"] INTERRUPT_CORE1 <= INTERRUPT_CORE1()
-        (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "IO_MUX peripheral singleton"] IO_MUX <= IO_MUX() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "LCD_CAM peripheral singleton"] LCD_CAM <=
-        LCD_CAM() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "LEDC peripheral singleton"] LEDC <= LEDC() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "LPWR peripheral singleton"] LPWR <= RTC_CNTL() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "MCPWM0 peripheral singleton"] MCPWM0 <=
-        MCPWM0() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "MCPWM1 peripheral singleton"] MCPWM1 <= MCPWM1() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "PCNT peripheral singleton"] PCNT <= PCNT()
-        (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "PERI_BACKUP peripheral singleton"] PERI_BACKUP <= PERI_BACKUP() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "RMT peripheral singleton"] RMT <= RMT()
-        (unstable))); _for_each_inner!((@ peri_type #[doc = "RNG peripheral singleton"]
-        RNG <= RNG() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "RSA peripheral singleton"] RSA <= RSA(RSA : { bind_peri_interrupt,
-        enable_peri_interrupt, disable_peri_interrupt }) (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "RTC_CNTL peripheral singleton"] RTC_CNTL
-        <= RTC_CNTL() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "RTC_I2C peripheral singleton"] RTC_I2C <= RTC_I2C() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "RTC_IO peripheral singleton"] RTC_IO <=
-        RTC_IO() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "SDHOST peripheral singleton"] SDHOST <= SDHOST() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "SENS peripheral singleton"] SENS <= SENS()
-        (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "SENSITIVE peripheral singleton"] SENSITIVE <= SENSITIVE() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "SHA peripheral singleton"] SHA <= SHA(SHA
-        : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
-        (unstable))); _for_each_inner!((@ peri_type #[doc = "SPI0 peripheral singleton"]
-        SPI0 <= SPI0() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "SPI1 peripheral singleton"] SPI1 <= SPI1() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "SPI2 peripheral singleton"] SPI2 <= SPI2(SPI2 : {
-        bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })));
-        _for_each_inner!((@ peri_type #[doc = "SPI3 peripheral singleton"] SPI3 <=
-        SPI3(SPI3 : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt
-        }))); _for_each_inner!((@ peri_type #[doc = "SYSTEM peripheral singleton"] SYSTEM
-        <= SYSTEM() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "SYSTIMER peripheral singleton"] SYSTIMER <= SYSTIMER() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "TIMG0 peripheral singleton"] TIMG0 <=
-        TIMG0() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "TIMG1 peripheral singleton"] TIMG1 <= TIMG1() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "TWAI0 peripheral singleton"] TWAI0 <= TWAI0() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "UART0 peripheral singleton"] UART0 <=
-        UART0(UART0 : { bind_peri_interrupt, enable_peri_interrupt,
-        disable_peri_interrupt }))); _for_each_inner!((@ peri_type #[doc =
-        "UART1 peripheral singleton"] UART1 <= UART1(UART1 : { bind_peri_interrupt,
-        enable_peri_interrupt, disable_peri_interrupt }))); _for_each_inner!((@ peri_type
-        #[doc = "UART2 peripheral singleton"] UART2 <= UART2(UART2 : {
-        bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })));
-        _for_each_inner!((@ peri_type #[doc = "UHCI0 peripheral singleton"] UHCI0 <=
-        UHCI0() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "USB0 peripheral singleton"] USB0 <= USB0() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "USB_DEVICE peripheral singleton"] USB_DEVICE <=
-        USB_DEVICE(USB_DEVICE : { bind_peri_interrupt, enable_peri_interrupt,
-        disable_peri_interrupt }) (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "USB_WRAP peripheral singleton"] USB_WRAP <= USB_WRAP() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "WCL peripheral singleton"] WCL <= WCL()
-        (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "XTS_AES peripheral singleton"] XTS_AES <= XTS_AES() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "DMA_CH0 peripheral singleton"] DMA_CH0 <=
-        virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "DMA_CH2 peripheral singleton"] DMA_CH2 <=
-        virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "DMA_CH3 peripheral singleton"] DMA_CH3 <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "DMA_CH4 peripheral singleton"] DMA_CH4 <=
-        virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "ADC1 peripheral singleton"] ADC1 <= virtual() (unstable))); _for_each_inner!((@
-        peri_type #[doc = "ADC2 peripheral singleton"] ADC2 <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "BT peripheral singleton"] BT <= virtual()
-        (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "CPU_CTRL peripheral singleton"] CPU_CTRL <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "FLASH peripheral singleton"] FLASH <=
-        virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "GPIO_DEDICATED peripheral singleton"] GPIO_DEDICATED <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "PSRAM peripheral singleton"] PSRAM <=
-        virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "SW_INTERRUPT peripheral singleton"] SW_INTERRUPT <= virtual() (unstable)));
-        _for_each_inner!((@ peri_type #[doc = "ULP_RISCV_CORE peripheral singleton"]
-        ULP_RISCV_CORE <= virtual() (unstable))); _for_each_inner!((@ peri_type #[doc =
-        "WIFI peripheral singleton"] WIFI <= virtual() (unstable)));
-        _for_each_inner!((GPIO0)); _for_each_inner!((GPIO1)); _for_each_inner!((GPIO2));
-        _for_each_inner!((GPIO3)); _for_each_inner!((GPIO4)); _for_each_inner!((GPIO5));
-        _for_each_inner!((GPIO6)); _for_each_inner!((GPIO7)); _for_each_inner!((GPIO8));
-        _for_each_inner!((GPIO9)); _for_each_inner!((GPIO10));
-        _for_each_inner!((GPIO11)); _for_each_inner!((GPIO12));
-        _for_each_inner!((GPIO13)); _for_each_inner!((GPIO14));
-        _for_each_inner!((GPIO15)); _for_each_inner!((GPIO16));
-        _for_each_inner!((GPIO17)); _for_each_inner!((GPIO18));
-        _for_each_inner!((GPIO19)); _for_each_inner!((GPIO20));
-        _for_each_inner!((GPIO21)); _for_each_inner!((GPIO26));
-        _for_each_inner!((GPIO27)); _for_each_inner!((GPIO28));
-        _for_each_inner!((GPIO29)); _for_each_inner!((GPIO30));
-        _for_each_inner!((GPIO31)); _for_each_inner!((GPIO32));
-        _for_each_inner!((GPIO33)); _for_each_inner!((GPIO34));
-        _for_each_inner!((GPIO35)); _for_each_inner!((GPIO36));
-        _for_each_inner!((GPIO37)); _for_each_inner!((GPIO38));
-        _for_each_inner!((GPIO39)); _for_each_inner!((GPIO40));
-        _for_each_inner!((GPIO41)); _for_each_inner!((GPIO42));
-        _for_each_inner!((GPIO43)); _for_each_inner!((GPIO44));
-        _for_each_inner!((GPIO45)); _for_each_inner!((GPIO46));
-        _for_each_inner!((GPIO47)); _for_each_inner!((GPIO48));
-        _for_each_inner!((AES(unstable))); _for_each_inner!((APB_CTRL(unstable)));
-        _for_each_inner!((APB_SARADC(unstable)));
-        _for_each_inner!((ASSIST_DEBUG(unstable))); _for_each_inner!((DMA(unstable)));
-        _for_each_inner!((DS(unstable))); _for_each_inner!((EFUSE(unstable)));
-        _for_each_inner!((EXTMEM(unstable))); _for_each_inner!((GPIO(unstable)));
-        _for_each_inner!((GPIO_SD(unstable))); _for_each_inner!((HMAC(unstable)));
-        _for_each_inner!((I2C_ANA_MST(unstable))); _for_each_inner!((I2C0));
-        _for_each_inner!((I2C1)); _for_each_inner!((I2S0(unstable)));
-        _for_each_inner!((I2S1(unstable)));
-        _for_each_inner!((INTERRUPT_CORE0(unstable)));
-        _for_each_inner!((INTERRUPT_CORE1(unstable)));
-        _for_each_inner!((IO_MUX(unstable))); _for_each_inner!((LCD_CAM(unstable)));
-        _for_each_inner!((LEDC(unstable))); _for_each_inner!((LPWR(unstable)));
-        _for_each_inner!((MCPWM0(unstable))); _for_each_inner!((MCPWM1(unstable)));
-        _for_each_inner!((PCNT(unstable))); _for_each_inner!((PERI_BACKUP(unstable)));
-        _for_each_inner!((RMT(unstable))); _for_each_inner!((RNG(unstable)));
-        _for_each_inner!((RSA(unstable))); _for_each_inner!((RTC_CNTL(unstable)));
-        _for_each_inner!((RTC_I2C(unstable))); _for_each_inner!((RTC_IO(unstable)));
-        _for_each_inner!((SDHOST(unstable))); _for_each_inner!((SENS(unstable)));
-        _for_each_inner!((SENSITIVE(unstable))); _for_each_inner!((SHA(unstable)));
-        _for_each_inner!((SPI0(unstable))); _for_each_inner!((SPI1(unstable)));
-        _for_each_inner!((SPI2)); _for_each_inner!((SPI3));
-        _for_each_inner!((SYSTEM(unstable))); _for_each_inner!((SYSTIMER(unstable)));
-        _for_each_inner!((TIMG0(unstable))); _for_each_inner!((TIMG1(unstable)));
-        _for_each_inner!((TWAI0(unstable))); _for_each_inner!((UART0));
-        _for_each_inner!((UART1)); _for_each_inner!((UART2));
-        _for_each_inner!((UHCI0(unstable))); _for_each_inner!((USB0(unstable)));
-        _for_each_inner!((USB_DEVICE(unstable))); _for_each_inner!((USB_WRAP(unstable)));
-        _for_each_inner!((WCL(unstable))); _for_each_inner!((XTS_AES(unstable)));
-        _for_each_inner!((DMA_CH0(unstable))); _for_each_inner!((DMA_CH1(unstable)));
-        _for_each_inner!((DMA_CH2(unstable))); _for_each_inner!((DMA_CH3(unstable)));
-        _for_each_inner!((DMA_CH4(unstable))); _for_each_inner!((ADC1(unstable)));
-        _for_each_inner!((ADC2(unstable))); _for_each_inner!((BT(unstable)));
-        _for_each_inner!((CPU_CTRL(unstable))); _for_each_inner!((FLASH(unstable)));
-        _for_each_inner!((GPIO_DEDICATED(unstable)));
-        _for_each_inner!((PSRAM(unstable))); _for_each_inner!((SW_INTERRUPT(unstable)));
-        _for_each_inner!((ULP_RISCV_CORE(unstable))); _for_each_inner!((WIFI(unstable)));
-        _for_each_inner!((all(@ peri_type #[doc =
-        "GPIO0 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO39 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO40 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
         "<section class=\"warning\">"] #[doc =
+        "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
+        #[doc = "<ul>"] #[doc =
+        "<li>These pins may be used to debug the chip using an external JTAG debugger.</li>"]
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO40 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO41 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
+        "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
+        #[doc = "<ul>"] #[doc =
+        "<li>These pins may be used to debug the chip using an external JTAG debugger.</li>"]
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO41 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO42 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
+        "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
+        #[doc = "<ul>"] #[doc =
+        "<li>These pins may be used to debug the chip using an external JTAG debugger.</li>"]
+        #[doc = "</ul>"] #[doc = "</section>"] GPIO42 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO43 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
+        "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
+        #[doc = "<ul>"] #[doc =
+        "<li>By default, this pin is used by the UART programming interface.</li>"] #[doc
+        = "</ul>"] #[doc = "</section>"] GPIO43 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO44 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
+        "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
+        #[doc = "<ul>"] #[doc =
+        "<li>By default, this pin is used by the UART programming interface.</li>"] #[doc
+        = "</ul>"] #[doc = "</section>"] GPIO44 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO45 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
+        "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
+        #[doc = "<ul>"] #[doc =
+        "<li>This pin is a strapping pin, it determines how the chip boots.</li>"] #[doc
+        = "</ul>"] #[doc = "</section>"] GPIO45 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO46 peripheral singleton (Limitations exist)"] #[doc = ""] #[doc =
+        "<section class=\"warning\">"] #[doc =
+        "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
+        #[doc = "<ul>"] #[doc =
+        "<li>This pin is a strapping pin, it determines how the chip boots.</li>"] #[doc
+        = "</ul>"] #[doc = "</section>"] GPIO46 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO47 peripheral singleton"]
+        GPIO47 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO48 peripheral singleton"] GPIO48 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "AES peripheral singleton"] AES
+        <= AES(AES : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt
+        }) (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "APB_CTRL peripheral singleton"] APB_CTRL <= APB_CTRL() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "ASSIST_DEBUG peripheral singleton"] ASSIST_DEBUG <= ASSIST_DEBUG() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA peripheral singleton"] DMA
+        <= DMA() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "DS peripheral singleton"] DS <= DS() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "EFUSE peripheral singleton"]
+        EFUSE <= EFUSE() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "EXTMEM peripheral singleton"] EXTMEM <= EXTMEM() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO peripheral singleton"]
+        GPIO <= GPIO() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO_SD peripheral singleton"] GPIO_SD <= GPIO_SD() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "HMAC peripheral singleton"]
+        HMAC <= HMAC() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "I2C_ANA_MST peripheral singleton"] I2C_ANA_MST <= I2C_ANA_MST() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "I2C0 peripheral singleton"]
+        I2C0 <= I2C0(I2C_EXT0 : { bind_peri_interrupt, enable_peri_interrupt,
+        disable_peri_interrupt }))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "I2C1 peripheral singleton"] I2C1 <= I2C1(I2C_EXT1 : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt })));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "I2S0 peripheral singleton"]
+        I2S0 <= I2S0(I2S0 : { bind_peri_interrupt, enable_peri_interrupt,
+        disable_peri_interrupt }) (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "I2S1 peripheral singleton"] I2S1 <= I2S1(I2S1 : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt }) (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "INTERRUPT_CORE0 peripheral singleton"] INTERRUPT_CORE0 <= INTERRUPT_CORE0()
+        (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "INTERRUPT_CORE1 peripheral singleton"] INTERRUPT_CORE1 <= INTERRUPT_CORE1()
+        (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "IO_MUX peripheral singleton"] IO_MUX <= IO_MUX() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "LCD_CAM peripheral singleton"]
+        LCD_CAM <= LCD_CAM() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "LEDC peripheral singleton"] LEDC <= LEDC() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "LPWR peripheral singleton"]
+        LPWR <= RTC_CNTL() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "MCPWM0 peripheral singleton"] MCPWM0 <= MCPWM0() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "MCPWM1 peripheral singleton"]
+        MCPWM1 <= MCPWM1() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "PCNT peripheral singleton"] PCNT <= PCNT() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "PERI_BACKUP peripheral singleton"] PERI_BACKUP <= PERI_BACKUP() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "RMT peripheral singleton"] RMT
+        <= RMT() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "RNG peripheral singleton"] RNG <= RNG() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "RSA peripheral singleton"] RSA
+        <= RSA(RSA : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt
+        }) (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "RTC_CNTL peripheral singleton"] RTC_CNTL <= RTC_CNTL() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "RTC_I2C peripheral singleton"]
+        RTC_I2C <= RTC_I2C() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "RTC_IO peripheral singleton"] RTC_IO <= RTC_IO() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "SDHOST peripheral singleton"]
+        SDHOST <= SDHOST() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "SENS peripheral singleton"] SENS <= SENS() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "SENSITIVE peripheral singleton"] SENSITIVE <= SENSITIVE() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "SHA peripheral singleton"] SHA
+        <= SHA(SHA : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt
+        }) (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "SPI0 peripheral singleton"] SPI0 <= SPI0() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "SPI1 peripheral singleton"]
+        SPI1 <= SPI1() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "SPI2 peripheral singleton"] SPI2 <= SPI2(SPI2 : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt })));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "SPI3 peripheral singleton"]
+        SPI3 <= SPI3(SPI3 : { bind_peri_interrupt, enable_peri_interrupt,
+        disable_peri_interrupt }))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "SYSTEM peripheral singleton"] SYSTEM <= SYSTEM() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "SYSTIMER peripheral singleton"]
+        SYSTIMER <= SYSTIMER() (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "TIMG0 peripheral singleton"] TIMG0 <= TIMG0() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "TIMG1 peripheral singleton"]
+        TIMG1 <= TIMG1() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "TWAI0 peripheral singleton"] TWAI0 <= TWAI0() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "UART0 peripheral singleton"]
+        UART0 <= UART0(UART0 : { bind_peri_interrupt, enable_peri_interrupt,
+        disable_peri_interrupt }))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "UART1 peripheral singleton"] UART1 <= UART1(UART1 : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt })));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "UART2 peripheral singleton"]
+        UART2 <= UART2(UART2 : { bind_peri_interrupt, enable_peri_interrupt,
+        disable_peri_interrupt }))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "UHCI0 peripheral singleton"] UHCI0 <= UHCI0() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "USB0 peripheral singleton"]
+        USB0 <= USB0() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "USB_DEVICE peripheral singleton"] USB_DEVICE <= USB_DEVICE(USB_DEVICE : {
+        bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
+        (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "USB_WRAP peripheral singleton"] USB_WRAP <= USB_WRAP() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "WCL peripheral singleton"] WCL
+        <= WCL() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "XTS_AES peripheral singleton"] XTS_AES <= XTS_AES() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH0 peripheral singleton"]
+        DMA_CH0 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH2 peripheral singleton"]
+        DMA_CH2 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "DMA_CH3 peripheral singleton"] DMA_CH3 <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH4 peripheral singleton"]
+        DMA_CH4 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "ADC1 peripheral singleton"] ADC1 <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "ADC2 peripheral singleton"]
+        ADC2 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "BT peripheral singleton"] BT <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "CPU_CTRL peripheral singleton"]
+        CPU_CTRL <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "FLASH peripheral singleton"] FLASH <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO_DEDICATED peripheral singleton"] GPIO_DEDICATED <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "PSRAM peripheral singleton"]
+        PSRAM <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "SW_INTERRUPT peripheral singleton"] SW_INTERRUPT <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "ULP_RISCV_CORE peripheral singleton"] ULP_RISCV_CORE <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "WIFI peripheral singleton"]
+        WIFI <= virtual() (unstable))); _for_each_inner_peripheral!((GPIO0));
+        _for_each_inner_peripheral!((GPIO1)); _for_each_inner_peripheral!((GPIO2));
+        _for_each_inner_peripheral!((GPIO3)); _for_each_inner_peripheral!((GPIO4));
+        _for_each_inner_peripheral!((GPIO5)); _for_each_inner_peripheral!((GPIO6));
+        _for_each_inner_peripheral!((GPIO7)); _for_each_inner_peripheral!((GPIO8));
+        _for_each_inner_peripheral!((GPIO9)); _for_each_inner_peripheral!((GPIO10));
+        _for_each_inner_peripheral!((GPIO11)); _for_each_inner_peripheral!((GPIO12));
+        _for_each_inner_peripheral!((GPIO13)); _for_each_inner_peripheral!((GPIO14));
+        _for_each_inner_peripheral!((GPIO15)); _for_each_inner_peripheral!((GPIO16));
+        _for_each_inner_peripheral!((GPIO17)); _for_each_inner_peripheral!((GPIO18));
+        _for_each_inner_peripheral!((GPIO19)); _for_each_inner_peripheral!((GPIO20));
+        _for_each_inner_peripheral!((GPIO21)); _for_each_inner_peripheral!((GPIO26));
+        _for_each_inner_peripheral!((GPIO27)); _for_each_inner_peripheral!((GPIO28));
+        _for_each_inner_peripheral!((GPIO29)); _for_each_inner_peripheral!((GPIO30));
+        _for_each_inner_peripheral!((GPIO31)); _for_each_inner_peripheral!((GPIO32));
+        _for_each_inner_peripheral!((GPIO33)); _for_each_inner_peripheral!((GPIO34));
+        _for_each_inner_peripheral!((GPIO35)); _for_each_inner_peripheral!((GPIO36));
+        _for_each_inner_peripheral!((GPIO37)); _for_each_inner_peripheral!((GPIO38));
+        _for_each_inner_peripheral!((GPIO39)); _for_each_inner_peripheral!((GPIO40));
+        _for_each_inner_peripheral!((GPIO41)); _for_each_inner_peripheral!((GPIO42));
+        _for_each_inner_peripheral!((GPIO43)); _for_each_inner_peripheral!((GPIO44));
+        _for_each_inner_peripheral!((GPIO45)); _for_each_inner_peripheral!((GPIO46));
+        _for_each_inner_peripheral!((GPIO47)); _for_each_inner_peripheral!((GPIO48));
+        _for_each_inner_peripheral!((AES(unstable)));
+        _for_each_inner_peripheral!((APB_CTRL(unstable)));
+        _for_each_inner_peripheral!((APB_SARADC(unstable)));
+        _for_each_inner_peripheral!((ASSIST_DEBUG(unstable)));
+        _for_each_inner_peripheral!((DMA(unstable)));
+        _for_each_inner_peripheral!((DS(unstable)));
+        _for_each_inner_peripheral!((EFUSE(unstable)));
+        _for_each_inner_peripheral!((EXTMEM(unstable)));
+        _for_each_inner_peripheral!((GPIO(unstable)));
+        _for_each_inner_peripheral!((GPIO_SD(unstable)));
+        _for_each_inner_peripheral!((HMAC(unstable)));
+        _for_each_inner_peripheral!((I2C_ANA_MST(unstable)));
+        _for_each_inner_peripheral!((I2C0)); _for_each_inner_peripheral!((I2C1));
+        _for_each_inner_peripheral!((I2S0(unstable)));
+        _for_each_inner_peripheral!((I2S1(unstable)));
+        _for_each_inner_peripheral!((INTERRUPT_CORE0(unstable)));
+        _for_each_inner_peripheral!((INTERRUPT_CORE1(unstable)));
+        _for_each_inner_peripheral!((IO_MUX(unstable)));
+        _for_each_inner_peripheral!((LCD_CAM(unstable)));
+        _for_each_inner_peripheral!((LEDC(unstable)));
+        _for_each_inner_peripheral!((LPWR(unstable)));
+        _for_each_inner_peripheral!((MCPWM0(unstable)));
+        _for_each_inner_peripheral!((MCPWM1(unstable)));
+        _for_each_inner_peripheral!((PCNT(unstable)));
+        _for_each_inner_peripheral!((PERI_BACKUP(unstable)));
+        _for_each_inner_peripheral!((RMT(unstable)));
+        _for_each_inner_peripheral!((RNG(unstable)));
+        _for_each_inner_peripheral!((RSA(unstable)));
+        _for_each_inner_peripheral!((RTC_CNTL(unstable)));
+        _for_each_inner_peripheral!((RTC_I2C(unstable)));
+        _for_each_inner_peripheral!((RTC_IO(unstable)));
+        _for_each_inner_peripheral!((SDHOST(unstable)));
+        _for_each_inner_peripheral!((SENS(unstable)));
+        _for_each_inner_peripheral!((SENSITIVE(unstable)));
+        _for_each_inner_peripheral!((SHA(unstable)));
+        _for_each_inner_peripheral!((SPI0(unstable)));
+        _for_each_inner_peripheral!((SPI1(unstable)));
+        _for_each_inner_peripheral!((SPI2)); _for_each_inner_peripheral!((SPI3));
+        _for_each_inner_peripheral!((SYSTEM(unstable)));
+        _for_each_inner_peripheral!((SYSTIMER(unstable)));
+        _for_each_inner_peripheral!((TIMG0(unstable)));
+        _for_each_inner_peripheral!((TIMG1(unstable)));
+        _for_each_inner_peripheral!((TWAI0(unstable)));
+        _for_each_inner_peripheral!((UART0)); _for_each_inner_peripheral!((UART1));
+        _for_each_inner_peripheral!((UART2));
+        _for_each_inner_peripheral!((UHCI0(unstable)));
+        _for_each_inner_peripheral!((USB0(unstable)));
+        _for_each_inner_peripheral!((USB_DEVICE(unstable)));
+        _for_each_inner_peripheral!((USB_WRAP(unstable)));
+        _for_each_inner_peripheral!((WCL(unstable)));
+        _for_each_inner_peripheral!((XTS_AES(unstable)));
+        _for_each_inner_peripheral!((DMA_CH0(unstable)));
+        _for_each_inner_peripheral!((DMA_CH1(unstable)));
+        _for_each_inner_peripheral!((DMA_CH2(unstable)));
+        _for_each_inner_peripheral!((DMA_CH3(unstable)));
+        _for_each_inner_peripheral!((DMA_CH4(unstable)));
+        _for_each_inner_peripheral!((ADC1(unstable)));
+        _for_each_inner_peripheral!((ADC2(unstable)));
+        _for_each_inner_peripheral!((BT(unstable)));
+        _for_each_inner_peripheral!((CPU_CTRL(unstable)));
+        _for_each_inner_peripheral!((FLASH(unstable)));
+        _for_each_inner_peripheral!((GPIO_DEDICATED(unstable)));
+        _for_each_inner_peripheral!((PSRAM(unstable)));
+        _for_each_inner_peripheral!((SW_INTERRUPT(unstable)));
+        _for_each_inner_peripheral!((ULP_RISCV_CORE(unstable)));
+        _for_each_inner_peripheral!((WIFI(unstable))); _for_each_inner_peripheral!((all(@
+        peri_type #[doc = "GPIO0 peripheral singleton (Limitations exist)"] #[doc = ""]
+        #[doc = "<section class=\"warning\">"] #[doc =
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc =
         "<li>This pin is a strapping pin, it determines how the chip boots.</li>"] #[doc
@@ -3761,25 +3974,26 @@ macro_rules! for_each_peripheral {
         SW_INTERRUPT <= virtual() (unstable)), (@ peri_type #[doc =
         "ULP_RISCV_CORE peripheral singleton"] ULP_RISCV_CORE <= virtual() (unstable)),
         (@ peri_type #[doc = "WIFI peripheral singleton"] WIFI <= virtual()
-        (unstable)))); _for_each_inner!((singletons(GPIO0), (GPIO1), (GPIO2), (GPIO3),
-        (GPIO4), (GPIO5), (GPIO6), (GPIO7), (GPIO8), (GPIO9), (GPIO10), (GPIO11),
-        (GPIO12), (GPIO13), (GPIO14), (GPIO15), (GPIO16), (GPIO17), (GPIO18), (GPIO19),
-        (GPIO20), (GPIO21), (GPIO26), (GPIO27), (GPIO28), (GPIO29), (GPIO30), (GPIO31),
-        (GPIO32), (GPIO33), (GPIO34), (GPIO35), (GPIO36), (GPIO37), (GPIO38), (GPIO39),
-        (GPIO40), (GPIO41), (GPIO42), (GPIO43), (GPIO44), (GPIO45), (GPIO46), (GPIO47),
-        (GPIO48), (AES(unstable)), (APB_CTRL(unstable)), (APB_SARADC(unstable)),
-        (ASSIST_DEBUG(unstable)), (DMA(unstable)), (DS(unstable)), (EFUSE(unstable)),
-        (EXTMEM(unstable)), (GPIO(unstable)), (GPIO_SD(unstable)), (HMAC(unstable)),
-        (I2C_ANA_MST(unstable)), (I2C0), (I2C1), (I2S0(unstable)), (I2S1(unstable)),
-        (INTERRUPT_CORE0(unstable)), (INTERRUPT_CORE1(unstable)), (IO_MUX(unstable)),
-        (LCD_CAM(unstable)), (LEDC(unstable)), (LPWR(unstable)), (MCPWM0(unstable)),
-        (MCPWM1(unstable)), (PCNT(unstable)), (PERI_BACKUP(unstable)), (RMT(unstable)),
-        (RNG(unstable)), (RSA(unstable)), (RTC_CNTL(unstable)), (RTC_I2C(unstable)),
-        (RTC_IO(unstable)), (SDHOST(unstable)), (SENS(unstable)), (SENSITIVE(unstable)),
-        (SHA(unstable)), (SPI0(unstable)), (SPI1(unstable)), (SPI2), (SPI3),
-        (SYSTEM(unstable)), (SYSTIMER(unstable)), (TIMG0(unstable)), (TIMG1(unstable)),
-        (TWAI0(unstable)), (UART0), (UART1), (UART2), (UHCI0(unstable)),
-        (USB0(unstable)), (USB_DEVICE(unstable)), (USB_WRAP(unstable)), (WCL(unstable)),
+        (unstable)))); _for_each_inner_peripheral!((singletons(GPIO0), (GPIO1), (GPIO2),
+        (GPIO3), (GPIO4), (GPIO5), (GPIO6), (GPIO7), (GPIO8), (GPIO9), (GPIO10),
+        (GPIO11), (GPIO12), (GPIO13), (GPIO14), (GPIO15), (GPIO16), (GPIO17), (GPIO18),
+        (GPIO19), (GPIO20), (GPIO21), (GPIO26), (GPIO27), (GPIO28), (GPIO29), (GPIO30),
+        (GPIO31), (GPIO32), (GPIO33), (GPIO34), (GPIO35), (GPIO36), (GPIO37), (GPIO38),
+        (GPIO39), (GPIO40), (GPIO41), (GPIO42), (GPIO43), (GPIO44), (GPIO45), (GPIO46),
+        (GPIO47), (GPIO48), (AES(unstable)), (APB_CTRL(unstable)),
+        (APB_SARADC(unstable)), (ASSIST_DEBUG(unstable)), (DMA(unstable)),
+        (DS(unstable)), (EFUSE(unstable)), (EXTMEM(unstable)), (GPIO(unstable)),
+        (GPIO_SD(unstable)), (HMAC(unstable)), (I2C_ANA_MST(unstable)), (I2C0), (I2C1),
+        (I2S0(unstable)), (I2S1(unstable)), (INTERRUPT_CORE0(unstable)),
+        (INTERRUPT_CORE1(unstable)), (IO_MUX(unstable)), (LCD_CAM(unstable)),
+        (LEDC(unstable)), (LPWR(unstable)), (MCPWM0(unstable)), (MCPWM1(unstable)),
+        (PCNT(unstable)), (PERI_BACKUP(unstable)), (RMT(unstable)), (RNG(unstable)),
+        (RSA(unstable)), (RTC_CNTL(unstable)), (RTC_I2C(unstable)), (RTC_IO(unstable)),
+        (SDHOST(unstable)), (SENS(unstable)), (SENSITIVE(unstable)), (SHA(unstable)),
+        (SPI0(unstable)), (SPI1(unstable)), (SPI2), (SPI3), (SYSTEM(unstable)),
+        (SYSTIMER(unstable)), (TIMG0(unstable)), (TIMG1(unstable)), (TWAI0(unstable)),
+        (UART0), (UART1), (UART2), (UHCI0(unstable)), (USB0(unstable)),
+        (USB_DEVICE(unstable)), (USB_WRAP(unstable)), (WCL(unstable)),
         (XTS_AES(unstable)), (DMA_CH0(unstable)), (DMA_CH1(unstable)),
         (DMA_CH2(unstable)), (DMA_CH3(unstable)), (DMA_CH4(unstable)), (ADC1(unstable)),
         (ADC2(unstable)), (BT(unstable)), (CPU_CTRL(unstable)), (FLASH(unstable)),
@@ -3817,87 +4031,92 @@ macro_rules! for_each_peripheral {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_gpio {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((0, GPIO0() () ([Input] [Output]))); _for_each_inner!((1,
-        GPIO1() () ([Input] [Output]))); _for_each_inner!((2, GPIO2() () ([Input]
-        [Output]))); _for_each_inner!((3, GPIO3() () ([Input] [Output])));
-        _for_each_inner!((4, GPIO4() () ([Input] [Output]))); _for_each_inner!((5,
-        GPIO5() () ([Input] [Output]))); _for_each_inner!((6, GPIO6() () ([Input]
-        [Output]))); _for_each_inner!((7, GPIO7() () ([Input] [Output])));
-        _for_each_inner!((8, GPIO8() (_3 => SUBSPICS1) ([Input] [Output])));
-        _for_each_inner!((9, GPIO9(_3 => SUBSPIHD _4 => FSPIHD) (_3 => SUBSPIHD _4 =>
-        FSPIHD) ([Input] [Output]))); _for_each_inner!((10, GPIO10(_2 => FSPIIO4 _4 =>
-        FSPICS0) (_2 => FSPIIO4 _3 => SUBSPICS0 _4 => FSPICS0) ([Input] [Output])));
-        _for_each_inner!((11, GPIO11(_2 => FSPIIO5 _3 => SUBSPID _4 => FSPID) (_2 =>
-        FSPIIO5 _3 => SUBSPID _4 => FSPID) ([Input] [Output]))); _for_each_inner!((12,
-        GPIO12(_2 => FSPIIO6 _4 => FSPICLK) (_2 => FSPIIO6 _3 => SUBSPICLK _4 => FSPICLK)
-        ([Input] [Output]))); _for_each_inner!((13, GPIO13(_2 => FSPIIO7 _3 => SUBSPIQ _4
-        => FSPIQ) (_2 => FSPIIO7 _3 => SUBSPIQ _4 => FSPIQ) ([Input] [Output])));
-        _for_each_inner!((14, GPIO14(_3 => SUBSPIWP _4 => FSPIWP) (_2 => FSPIDQS _3 =>
-        SUBSPIWP _4 => FSPIWP) ([Input] [Output]))); _for_each_inner!((15, GPIO15() (_2
-        => U0RTS) ([Input] [Output]))); _for_each_inner!((16, GPIO16(_2 => U0CTS) ()
-        ([Input] [Output]))); _for_each_inner!((17, GPIO17() (_2 => U1TXD) ([Input]
-        [Output]))); _for_each_inner!((18, GPIO18(_2 => U1RXD) (_3 => CLK_OUT3) ([Input]
-        [Output]))); _for_each_inner!((19, GPIO19() (_2 => U1RTS _3 => CLK_OUT2) ([Input]
-        [Output]))); _for_each_inner!((20, GPIO20(_2 => U1CTS) (_3 => CLK_OUT1) ([Input]
-        [Output]))); _for_each_inner!((21, GPIO21() () ([Input] [Output])));
-        _for_each_inner!((26, GPIO26() (_0 => SPICS1) ([Input] [Output])));
-        _for_each_inner!((27, GPIO27(_0 => SPIHD) (_0 => SPIHD) ([Input] [Output])));
-        _for_each_inner!((28, GPIO28(_0 => SPIWP) (_0 => SPIWP) ([Input] [Output])));
-        _for_each_inner!((29, GPIO29() (_0 => SPICS0) ([Input] [Output])));
-        _for_each_inner!((30, GPIO30() (_0 => SPICLK) ([Input] [Output])));
-        _for_each_inner!((31, GPIO31(_0 => SPIQ) (_0 => SPIQ) ([Input] [Output])));
-        _for_each_inner!((32, GPIO32(_0 => SPID) (_0 => SPID) ([Input] [Output])));
-        _for_each_inner!((33, GPIO33(_2 => FSPIHD _3 => SUBSPIHD _4 => SPIIO4) (_2 =>
-        FSPIHD _3 => SUBSPIHD _4 => SPIIO4) ([Input] [Output]))); _for_each_inner!((34,
-        GPIO34(_2 => FSPICS0 _4 => SPIIO5) (_2 => FSPICS0 _3 => SUBSPICS0 _4 => SPIIO5)
-        ([Input] [Output]))); _for_each_inner!((35, GPIO35(_2 => FSPID _3 => SUBSPID _4
-        => SPIIO6) (_2 => FSPID _3 => SUBSPID _4 => SPIIO6) ([Input] [Output])));
-        _for_each_inner!((36, GPIO36(_2 => FSPICLK _4 => SPIIO7) (_2 => FSPICLK _3 =>
-        SUBSPICLK _4 => SPIIO7) ([Input] [Output]))); _for_each_inner!((37, GPIO37(_2 =>
-        FSPIQ _3 => SUBSPIQ _4 => SPIDQS) (_2 => FSPIQ _3 => SUBSPIQ _4 => SPIDQS)
-        ([Input] [Output]))); _for_each_inner!((38, GPIO38(_2 => FSPIWP _3 => SUBSPIWP)
-        (_2 => FSPIWP _3 => SUBSPIWP) ([Input] [Output]))); _for_each_inner!((39,
-        GPIO39(_0 => MTCK) (_2 => CLK_OUT3 _3 => SUBSPICS1) ([Input] [Output])));
-        _for_each_inner!((40, GPIO40() (_0 => MTDO _2 => CLK_OUT2) ([Input] [Output])));
-        _for_each_inner!((41, GPIO41(_0 => MTDI) (_2 => CLK_OUT1) ([Input] [Output])));
-        _for_each_inner!((42, GPIO42(_0 => MTMS) () ([Input] [Output])));
-        _for_each_inner!((43, GPIO43() (_0 => U0TXD _2 => CLK_OUT1) ([Input] [Output])));
-        _for_each_inner!((44, GPIO44(_0 => U0RXD) (_2 => CLK_OUT2) ([Input] [Output])));
-        _for_each_inner!((45, GPIO45() () ([Input] [Output]))); _for_each_inner!((46,
-        GPIO46() () ([Input] [Output]))); _for_each_inner!((47, GPIO47() (_0 =>
-        SPICLK_P_DIFF _2 => SUBSPICLK_P_DIFF) ([Input] [Output]))); _for_each_inner!((48,
-        GPIO48() (_0 => SPICLK_N_DIFF _2 => SUBSPICLK_N_DIFF) ([Input] [Output])));
-        _for_each_inner!((all(0, GPIO0() () ([Input] [Output])), (1, GPIO1() () ([Input]
-        [Output])), (2, GPIO2() () ([Input] [Output])), (3, GPIO3() () ([Input]
-        [Output])), (4, GPIO4() () ([Input] [Output])), (5, GPIO5() () ([Input]
-        [Output])), (6, GPIO6() () ([Input] [Output])), (7, GPIO7() () ([Input]
-        [Output])), (8, GPIO8() (_3 => SUBSPICS1) ([Input] [Output])), (9, GPIO9(_3 =>
-        SUBSPIHD _4 => FSPIHD) (_3 => SUBSPIHD _4 => FSPIHD) ([Input] [Output])), (10,
-        GPIO10(_2 => FSPIIO4 _4 => FSPICS0) (_2 => FSPIIO4 _3 => SUBSPICS0 _4 => FSPICS0)
-        ([Input] [Output])), (11, GPIO11(_2 => FSPIIO5 _3 => SUBSPID _4 => FSPID) (_2 =>
-        FSPIIO5 _3 => SUBSPID _4 => FSPID) ([Input] [Output])), (12, GPIO12(_2 => FSPIIO6
-        _4 => FSPICLK) (_2 => FSPIIO6 _3 => SUBSPICLK _4 => FSPICLK) ([Input] [Output])),
-        (13, GPIO13(_2 => FSPIIO7 _3 => SUBSPIQ _4 => FSPIQ) (_2 => FSPIIO7 _3 => SUBSPIQ
-        _4 => FSPIQ) ([Input] [Output])), (14, GPIO14(_3 => SUBSPIWP _4 => FSPIWP) (_2 =>
-        FSPIDQS _3 => SUBSPIWP _4 => FSPIWP) ([Input] [Output])), (15, GPIO15() (_2 =>
-        U0RTS) ([Input] [Output])), (16, GPIO16(_2 => U0CTS) () ([Input] [Output])), (17,
-        GPIO17() (_2 => U1TXD) ([Input] [Output])), (18, GPIO18(_2 => U1RXD) (_3 =>
-        CLK_OUT3) ([Input] [Output])), (19, GPIO19() (_2 => U1RTS _3 => CLK_OUT2)
-        ([Input] [Output])), (20, GPIO20(_2 => U1CTS) (_3 => CLK_OUT1) ([Input]
-        [Output])), (21, GPIO21() () ([Input] [Output])), (26, GPIO26() (_0 => SPICS1)
-        ([Input] [Output])), (27, GPIO27(_0 => SPIHD) (_0 => SPIHD) ([Input] [Output])),
-        (28, GPIO28(_0 => SPIWP) (_0 => SPIWP) ([Input] [Output])), (29, GPIO29() (_0 =>
-        SPICS0) ([Input] [Output])), (30, GPIO30() (_0 => SPICLK) ([Input] [Output])),
-        (31, GPIO31(_0 => SPIQ) (_0 => SPIQ) ([Input] [Output])), (32, GPIO32(_0 => SPID)
-        (_0 => SPID) ([Input] [Output])), (33, GPIO33(_2 => FSPIHD _3 => SUBSPIHD _4 =>
-        SPIIO4) (_2 => FSPIHD _3 => SUBSPIHD _4 => SPIIO4) ([Input] [Output])), (34,
-        GPIO34(_2 => FSPICS0 _4 => SPIIO5) (_2 => FSPICS0 _3 => SUBSPICS0 _4 => SPIIO5)
-        ([Input] [Output])), (35, GPIO35(_2 => FSPID _3 => SUBSPID _4 => SPIIO6) (_2 =>
-        FSPID _3 => SUBSPID _4 => SPIIO6) ([Input] [Output])), (36, GPIO36(_2 => FSPICLK
-        _4 => SPIIO7) (_2 => FSPICLK _3 => SUBSPICLK _4 => SPIIO7) ([Input] [Output])),
-        (37, GPIO37(_2 => FSPIQ _3 => SUBSPIQ _4 => SPIDQS) (_2 => FSPIQ _3 => SUBSPIQ _4
-        => SPIDQS) ([Input] [Output])), (38, GPIO38(_2 => FSPIWP _3 => SUBSPIWP) (_2 =>
+        macro_rules! _for_each_inner_gpio { $(($pattern) => $code;)* ($other : tt) => {}
+        } _for_each_inner_gpio!((0, GPIO0() () ([Input] [Output])));
+        _for_each_inner_gpio!((1, GPIO1() () ([Input] [Output])));
+        _for_each_inner_gpio!((2, GPIO2() () ([Input] [Output])));
+        _for_each_inner_gpio!((3, GPIO3() () ([Input] [Output])));
+        _for_each_inner_gpio!((4, GPIO4() () ([Input] [Output])));
+        _for_each_inner_gpio!((5, GPIO5() () ([Input] [Output])));
+        _for_each_inner_gpio!((6, GPIO6() () ([Input] [Output])));
+        _for_each_inner_gpio!((7, GPIO7() () ([Input] [Output])));
+        _for_each_inner_gpio!((8, GPIO8() (_3 => SUBSPICS1) ([Input] [Output])));
+        _for_each_inner_gpio!((9, GPIO9(_3 => SUBSPIHD _4 => FSPIHD) (_3 => SUBSPIHD _4
+        => FSPIHD) ([Input] [Output]))); _for_each_inner_gpio!((10, GPIO10(_2 => FSPIIO4
+        _4 => FSPICS0) (_2 => FSPIIO4 _3 => SUBSPICS0 _4 => FSPICS0) ([Input]
+        [Output]))); _for_each_inner_gpio!((11, GPIO11(_2 => FSPIIO5 _3 => SUBSPID _4 =>
+        FSPID) (_2 => FSPIIO5 _3 => SUBSPID _4 => FSPID) ([Input] [Output])));
+        _for_each_inner_gpio!((12, GPIO12(_2 => FSPIIO6 _4 => FSPICLK) (_2 => FSPIIO6 _3
+        => SUBSPICLK _4 => FSPICLK) ([Input] [Output]))); _for_each_inner_gpio!((13,
+        GPIO13(_2 => FSPIIO7 _3 => SUBSPIQ _4 => FSPIQ) (_2 => FSPIIO7 _3 => SUBSPIQ _4
+        => FSPIQ) ([Input] [Output]))); _for_each_inner_gpio!((14, GPIO14(_3 => SUBSPIWP
+        _4 => FSPIWP) (_2 => FSPIDQS _3 => SUBSPIWP _4 => FSPIWP) ([Input] [Output])));
+        _for_each_inner_gpio!((15, GPIO15() (_2 => U0RTS) ([Input] [Output])));
+        _for_each_inner_gpio!((16, GPIO16(_2 => U0CTS) () ([Input] [Output])));
+        _for_each_inner_gpio!((17, GPIO17() (_2 => U1TXD) ([Input] [Output])));
+        _for_each_inner_gpio!((18, GPIO18(_2 => U1RXD) (_3 => CLK_OUT3) ([Input]
+        [Output]))); _for_each_inner_gpio!((19, GPIO19() (_2 => U1RTS _3 => CLK_OUT2)
+        ([Input] [Output]))); _for_each_inner_gpio!((20, GPIO20(_2 => U1CTS) (_3 =>
+        CLK_OUT1) ([Input] [Output]))); _for_each_inner_gpio!((21, GPIO21() () ([Input]
+        [Output]))); _for_each_inner_gpio!((26, GPIO26() (_0 => SPICS1) ([Input]
+        [Output]))); _for_each_inner_gpio!((27, GPIO27(_0 => SPIHD) (_0 => SPIHD)
+        ([Input] [Output]))); _for_each_inner_gpio!((28, GPIO28(_0 => SPIWP) (_0 =>
+        SPIWP) ([Input] [Output]))); _for_each_inner_gpio!((29, GPIO29() (_0 => SPICS0)
+        ([Input] [Output]))); _for_each_inner_gpio!((30, GPIO30() (_0 => SPICLK) ([Input]
+        [Output]))); _for_each_inner_gpio!((31, GPIO31(_0 => SPIQ) (_0 => SPIQ) ([Input]
+        [Output]))); _for_each_inner_gpio!((32, GPIO32(_0 => SPID) (_0 => SPID) ([Input]
+        [Output]))); _for_each_inner_gpio!((33, GPIO33(_2 => FSPIHD _3 => SUBSPIHD _4 =>
+        SPIIO4) (_2 => FSPIHD _3 => SUBSPIHD _4 => SPIIO4) ([Input] [Output])));
+        _for_each_inner_gpio!((34, GPIO34(_2 => FSPICS0 _4 => SPIIO5) (_2 => FSPICS0 _3
+        => SUBSPICS0 _4 => SPIIO5) ([Input] [Output]))); _for_each_inner_gpio!((35,
+        GPIO35(_2 => FSPID _3 => SUBSPID _4 => SPIIO6) (_2 => FSPID _3 => SUBSPID _4 =>
+        SPIIO6) ([Input] [Output]))); _for_each_inner_gpio!((36, GPIO36(_2 => FSPICLK _4
+        => SPIIO7) (_2 => FSPICLK _3 => SUBSPICLK _4 => SPIIO7) ([Input] [Output])));
+        _for_each_inner_gpio!((37, GPIO37(_2 => FSPIQ _3 => SUBSPIQ _4 => SPIDQS) (_2 =>
+        FSPIQ _3 => SUBSPIQ _4 => SPIDQS) ([Input] [Output])));
+        _for_each_inner_gpio!((38, GPIO38(_2 => FSPIWP _3 => SUBSPIWP) (_2 => FSPIWP _3
+        => SUBSPIWP) ([Input] [Output]))); _for_each_inner_gpio!((39, GPIO39(_0 => MTCK)
+        (_2 => CLK_OUT3 _3 => SUBSPICS1) ([Input] [Output]))); _for_each_inner_gpio!((40,
+        GPIO40() (_0 => MTDO _2 => CLK_OUT2) ([Input] [Output])));
+        _for_each_inner_gpio!((41, GPIO41(_0 => MTDI) (_2 => CLK_OUT1) ([Input]
+        [Output]))); _for_each_inner_gpio!((42, GPIO42(_0 => MTMS) () ([Input]
+        [Output]))); _for_each_inner_gpio!((43, GPIO43() (_0 => U0TXD _2 => CLK_OUT1)
+        ([Input] [Output]))); _for_each_inner_gpio!((44, GPIO44(_0 => U0RXD) (_2 =>
+        CLK_OUT2) ([Input] [Output]))); _for_each_inner_gpio!((45, GPIO45() () ([Input]
+        [Output]))); _for_each_inner_gpio!((46, GPIO46() () ([Input] [Output])));
+        _for_each_inner_gpio!((47, GPIO47() (_0 => SPICLK_P_DIFF _2 => SUBSPICLK_P_DIFF)
+        ([Input] [Output]))); _for_each_inner_gpio!((48, GPIO48() (_0 => SPICLK_N_DIFF _2
+        => SUBSPICLK_N_DIFF) ([Input] [Output]))); _for_each_inner_gpio!((all(0, GPIO0()
+        () ([Input] [Output])), (1, GPIO1() () ([Input] [Output])), (2, GPIO2() ()
+        ([Input] [Output])), (3, GPIO3() () ([Input] [Output])), (4, GPIO4() () ([Input]
+        [Output])), (5, GPIO5() () ([Input] [Output])), (6, GPIO6() () ([Input]
+        [Output])), (7, GPIO7() () ([Input] [Output])), (8, GPIO8() (_3 => SUBSPICS1)
+        ([Input] [Output])), (9, GPIO9(_3 => SUBSPIHD _4 => FSPIHD) (_3 => SUBSPIHD _4 =>
+        FSPIHD) ([Input] [Output])), (10, GPIO10(_2 => FSPIIO4 _4 => FSPICS0) (_2 =>
+        FSPIIO4 _3 => SUBSPICS0 _4 => FSPICS0) ([Input] [Output])), (11, GPIO11(_2 =>
+        FSPIIO5 _3 => SUBSPID _4 => FSPID) (_2 => FSPIIO5 _3 => SUBSPID _4 => FSPID)
+        ([Input] [Output])), (12, GPIO12(_2 => FSPIIO6 _4 => FSPICLK) (_2 => FSPIIO6 _3
+        => SUBSPICLK _4 => FSPICLK) ([Input] [Output])), (13, GPIO13(_2 => FSPIIO7 _3 =>
+        SUBSPIQ _4 => FSPIQ) (_2 => FSPIIO7 _3 => SUBSPIQ _4 => FSPIQ) ([Input]
+        [Output])), (14, GPIO14(_3 => SUBSPIWP _4 => FSPIWP) (_2 => FSPIDQS _3 =>
+        SUBSPIWP _4 => FSPIWP) ([Input] [Output])), (15, GPIO15() (_2 => U0RTS) ([Input]
+        [Output])), (16, GPIO16(_2 => U0CTS) () ([Input] [Output])), (17, GPIO17() (_2 =>
+        U1TXD) ([Input] [Output])), (18, GPIO18(_2 => U1RXD) (_3 => CLK_OUT3) ([Input]
+        [Output])), (19, GPIO19() (_2 => U1RTS _3 => CLK_OUT2) ([Input] [Output])), (20,
+        GPIO20(_2 => U1CTS) (_3 => CLK_OUT1) ([Input] [Output])), (21, GPIO21() ()
+        ([Input] [Output])), (26, GPIO26() (_0 => SPICS1) ([Input] [Output])), (27,
+        GPIO27(_0 => SPIHD) (_0 => SPIHD) ([Input] [Output])), (28, GPIO28(_0 => SPIWP)
+        (_0 => SPIWP) ([Input] [Output])), (29, GPIO29() (_0 => SPICS0) ([Input]
+        [Output])), (30, GPIO30() (_0 => SPICLK) ([Input] [Output])), (31, GPIO31(_0 =>
+        SPIQ) (_0 => SPIQ) ([Input] [Output])), (32, GPIO32(_0 => SPID) (_0 => SPID)
+        ([Input] [Output])), (33, GPIO33(_2 => FSPIHD _3 => SUBSPIHD _4 => SPIIO4) (_2 =>
+        FSPIHD _3 => SUBSPIHD _4 => SPIIO4) ([Input] [Output])), (34, GPIO34(_2 =>
+        FSPICS0 _4 => SPIIO5) (_2 => FSPICS0 _3 => SUBSPICS0 _4 => SPIIO5) ([Input]
+        [Output])), (35, GPIO35(_2 => FSPID _3 => SUBSPID _4 => SPIIO6) (_2 => FSPID _3
+        => SUBSPID _4 => SPIIO6) ([Input] [Output])), (36, GPIO36(_2 => FSPICLK _4 =>
+        SPIIO7) (_2 => FSPICLK _3 => SUBSPICLK _4 => SPIIO7) ([Input] [Output])), (37,
+        GPIO37(_2 => FSPIQ _3 => SUBSPIQ _4 => SPIDQS) (_2 => FSPIQ _3 => SUBSPIQ _4 =>
+        SPIDQS) ([Input] [Output])), (38, GPIO38(_2 => FSPIWP _3 => SUBSPIWP) (_2 =>
         FSPIWP _3 => SUBSPIWP) ([Input] [Output])), (39, GPIO39(_0 => MTCK) (_2 =>
         CLK_OUT3 _3 => SUBSPICS1) ([Input] [Output])), (40, GPIO40() (_0 => MTDO _2 =>
         CLK_OUT2) ([Input] [Output])), (41, GPIO41(_0 => MTDI) (_2 => CLK_OUT1) ([Input]
@@ -3939,53 +4158,81 @@ macro_rules! for_each_gpio {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_analog_function {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((TOUCH1, GPIO1)); _for_each_inner!((ADC1_CH0, GPIO1));
-        _for_each_inner!((TOUCH2, GPIO2)); _for_each_inner!((ADC1_CH1, GPIO2));
-        _for_each_inner!((TOUCH3, GPIO3)); _for_each_inner!((ADC1_CH2, GPIO3));
-        _for_each_inner!((TOUCH4, GPIO4)); _for_each_inner!((ADC1_CH3, GPIO4));
-        _for_each_inner!((TOUCH5, GPIO5)); _for_each_inner!((ADC1_CH4, GPIO5));
-        _for_each_inner!((TOUCH6, GPIO6)); _for_each_inner!((ADC1_CH5, GPIO6));
-        _for_each_inner!((TOUCH7, GPIO7)); _for_each_inner!((ADC1_CH6, GPIO7));
-        _for_each_inner!((TOUCH8, GPIO8)); _for_each_inner!((ADC1_CH7, GPIO8));
-        _for_each_inner!((TOUCH9, GPIO9)); _for_each_inner!((ADC1_CH8, GPIO9));
-        _for_each_inner!((TOUCH10, GPIO10)); _for_each_inner!((ADC1_CH9, GPIO10));
-        _for_each_inner!((TOUCH11, GPIO11)); _for_each_inner!((ADC2_CH0, GPIO11));
-        _for_each_inner!((TOUCH12, GPIO12)); _for_each_inner!((ADC2_CH1, GPIO12));
-        _for_each_inner!((TOUCH13, GPIO13)); _for_each_inner!((ADC2_CH2, GPIO13));
-        _for_each_inner!((TOUCH14, GPIO14)); _for_each_inner!((ADC2_CH3, GPIO14));
-        _for_each_inner!((XTAL_32K_P, GPIO15)); _for_each_inner!((ADC2_CH4, GPIO15));
-        _for_each_inner!((XTAL_32K_N, GPIO16)); _for_each_inner!((ADC2_CH5, GPIO16));
-        _for_each_inner!((ADC2_CH6, GPIO17)); _for_each_inner!((ADC2_CH7, GPIO18));
-        _for_each_inner!((USB_DM, GPIO19)); _for_each_inner!((ADC2_CH8, GPIO19));
-        _for_each_inner!((USB_DP, GPIO20)); _for_each_inner!((ADC2_CH9, GPIO20));
-        _for_each_inner!(((TOUCH1, TOUCHn, 1), GPIO1)); _for_each_inner!(((ADC1_CH0,
-        ADCn_CHm, 1, 0), GPIO1)); _for_each_inner!(((TOUCH2, TOUCHn, 2), GPIO2));
-        _for_each_inner!(((ADC1_CH1, ADCn_CHm, 1, 1), GPIO2)); _for_each_inner!(((TOUCH3,
-        TOUCHn, 3), GPIO3)); _for_each_inner!(((ADC1_CH2, ADCn_CHm, 1, 2), GPIO3));
-        _for_each_inner!(((TOUCH4, TOUCHn, 4), GPIO4)); _for_each_inner!(((ADC1_CH3,
-        ADCn_CHm, 1, 3), GPIO4)); _for_each_inner!(((TOUCH5, TOUCHn, 5), GPIO5));
-        _for_each_inner!(((ADC1_CH4, ADCn_CHm, 1, 4), GPIO5)); _for_each_inner!(((TOUCH6,
-        TOUCHn, 6), GPIO6)); _for_each_inner!(((ADC1_CH5, ADCn_CHm, 1, 5), GPIO6));
-        _for_each_inner!(((TOUCH7, TOUCHn, 7), GPIO7)); _for_each_inner!(((ADC1_CH6,
-        ADCn_CHm, 1, 6), GPIO7)); _for_each_inner!(((TOUCH8, TOUCHn, 8), GPIO8));
-        _for_each_inner!(((ADC1_CH7, ADCn_CHm, 1, 7), GPIO8)); _for_each_inner!(((TOUCH9,
-        TOUCHn, 9), GPIO9)); _for_each_inner!(((ADC1_CH8, ADCn_CHm, 1, 8), GPIO9));
-        _for_each_inner!(((TOUCH10, TOUCHn, 10), GPIO10)); _for_each_inner!(((ADC1_CH9,
-        ADCn_CHm, 1, 9), GPIO10)); _for_each_inner!(((TOUCH11, TOUCHn, 11), GPIO11));
-        _for_each_inner!(((ADC2_CH0, ADCn_CHm, 2, 0), GPIO11));
-        _for_each_inner!(((TOUCH12, TOUCHn, 12), GPIO12)); _for_each_inner!(((ADC2_CH1,
-        ADCn_CHm, 2, 1), GPIO12)); _for_each_inner!(((TOUCH13, TOUCHn, 13), GPIO13));
-        _for_each_inner!(((ADC2_CH2, ADCn_CHm, 2, 2), GPIO13));
-        _for_each_inner!(((TOUCH14, TOUCHn, 14), GPIO14)); _for_each_inner!(((ADC2_CH3,
-        ADCn_CHm, 2, 3), GPIO14)); _for_each_inner!(((ADC2_CH4, ADCn_CHm, 2, 4),
-        GPIO15)); _for_each_inner!(((ADC2_CH5, ADCn_CHm, 2, 5), GPIO16));
-        _for_each_inner!(((ADC2_CH6, ADCn_CHm, 2, 6), GPIO17));
-        _for_each_inner!(((ADC2_CH7, ADCn_CHm, 2, 7), GPIO18));
-        _for_each_inner!(((ADC2_CH8, ADCn_CHm, 2, 8), GPIO19));
-        _for_each_inner!(((ADC2_CH9, ADCn_CHm, 2, 9), GPIO20));
-        _for_each_inner!((all(TOUCH1, GPIO1), (ADC1_CH0, GPIO1), (TOUCH2, GPIO2),
-        (ADC1_CH1, GPIO2), (TOUCH3, GPIO3), (ADC1_CH2, GPIO3), (TOUCH4, GPIO4),
+        macro_rules! _for_each_inner_analog_function { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_analog_function!((TOUCH1, GPIO1));
+        _for_each_inner_analog_function!((ADC1_CH0, GPIO1));
+        _for_each_inner_analog_function!((TOUCH2, GPIO2));
+        _for_each_inner_analog_function!((ADC1_CH1, GPIO2));
+        _for_each_inner_analog_function!((TOUCH3, GPIO3));
+        _for_each_inner_analog_function!((ADC1_CH2, GPIO3));
+        _for_each_inner_analog_function!((TOUCH4, GPIO4));
+        _for_each_inner_analog_function!((ADC1_CH3, GPIO4));
+        _for_each_inner_analog_function!((TOUCH5, GPIO5));
+        _for_each_inner_analog_function!((ADC1_CH4, GPIO5));
+        _for_each_inner_analog_function!((TOUCH6, GPIO6));
+        _for_each_inner_analog_function!((ADC1_CH5, GPIO6));
+        _for_each_inner_analog_function!((TOUCH7, GPIO7));
+        _for_each_inner_analog_function!((ADC1_CH6, GPIO7));
+        _for_each_inner_analog_function!((TOUCH8, GPIO8));
+        _for_each_inner_analog_function!((ADC1_CH7, GPIO8));
+        _for_each_inner_analog_function!((TOUCH9, GPIO9));
+        _for_each_inner_analog_function!((ADC1_CH8, GPIO9));
+        _for_each_inner_analog_function!((TOUCH10, GPIO10));
+        _for_each_inner_analog_function!((ADC1_CH9, GPIO10));
+        _for_each_inner_analog_function!((TOUCH11, GPIO11));
+        _for_each_inner_analog_function!((ADC2_CH0, GPIO11));
+        _for_each_inner_analog_function!((TOUCH12, GPIO12));
+        _for_each_inner_analog_function!((ADC2_CH1, GPIO12));
+        _for_each_inner_analog_function!((TOUCH13, GPIO13));
+        _for_each_inner_analog_function!((ADC2_CH2, GPIO13));
+        _for_each_inner_analog_function!((TOUCH14, GPIO14));
+        _for_each_inner_analog_function!((ADC2_CH3, GPIO14));
+        _for_each_inner_analog_function!((XTAL_32K_P, GPIO15));
+        _for_each_inner_analog_function!((ADC2_CH4, GPIO15));
+        _for_each_inner_analog_function!((XTAL_32K_N, GPIO16));
+        _for_each_inner_analog_function!((ADC2_CH5, GPIO16));
+        _for_each_inner_analog_function!((ADC2_CH6, GPIO17));
+        _for_each_inner_analog_function!((ADC2_CH7, GPIO18));
+        _for_each_inner_analog_function!((USB_DM, GPIO19));
+        _for_each_inner_analog_function!((ADC2_CH8, GPIO19));
+        _for_each_inner_analog_function!((USB_DP, GPIO20));
+        _for_each_inner_analog_function!((ADC2_CH9, GPIO20));
+        _for_each_inner_analog_function!(((TOUCH1, TOUCHn, 1), GPIO1));
+        _for_each_inner_analog_function!(((ADC1_CH0, ADCn_CHm, 1, 0), GPIO1));
+        _for_each_inner_analog_function!(((TOUCH2, TOUCHn, 2), GPIO2));
+        _for_each_inner_analog_function!(((ADC1_CH1, ADCn_CHm, 1, 1), GPIO2));
+        _for_each_inner_analog_function!(((TOUCH3, TOUCHn, 3), GPIO3));
+        _for_each_inner_analog_function!(((ADC1_CH2, ADCn_CHm, 1, 2), GPIO3));
+        _for_each_inner_analog_function!(((TOUCH4, TOUCHn, 4), GPIO4));
+        _for_each_inner_analog_function!(((ADC1_CH3, ADCn_CHm, 1, 3), GPIO4));
+        _for_each_inner_analog_function!(((TOUCH5, TOUCHn, 5), GPIO5));
+        _for_each_inner_analog_function!(((ADC1_CH4, ADCn_CHm, 1, 4), GPIO5));
+        _for_each_inner_analog_function!(((TOUCH6, TOUCHn, 6), GPIO6));
+        _for_each_inner_analog_function!(((ADC1_CH5, ADCn_CHm, 1, 5), GPIO6));
+        _for_each_inner_analog_function!(((TOUCH7, TOUCHn, 7), GPIO7));
+        _for_each_inner_analog_function!(((ADC1_CH6, ADCn_CHm, 1, 6), GPIO7));
+        _for_each_inner_analog_function!(((TOUCH8, TOUCHn, 8), GPIO8));
+        _for_each_inner_analog_function!(((ADC1_CH7, ADCn_CHm, 1, 7), GPIO8));
+        _for_each_inner_analog_function!(((TOUCH9, TOUCHn, 9), GPIO9));
+        _for_each_inner_analog_function!(((ADC1_CH8, ADCn_CHm, 1, 8), GPIO9));
+        _for_each_inner_analog_function!(((TOUCH10, TOUCHn, 10), GPIO10));
+        _for_each_inner_analog_function!(((ADC1_CH9, ADCn_CHm, 1, 9), GPIO10));
+        _for_each_inner_analog_function!(((TOUCH11, TOUCHn, 11), GPIO11));
+        _for_each_inner_analog_function!(((ADC2_CH0, ADCn_CHm, 2, 0), GPIO11));
+        _for_each_inner_analog_function!(((TOUCH12, TOUCHn, 12), GPIO12));
+        _for_each_inner_analog_function!(((ADC2_CH1, ADCn_CHm, 2, 1), GPIO12));
+        _for_each_inner_analog_function!(((TOUCH13, TOUCHn, 13), GPIO13));
+        _for_each_inner_analog_function!(((ADC2_CH2, ADCn_CHm, 2, 2), GPIO13));
+        _for_each_inner_analog_function!(((TOUCH14, TOUCHn, 14), GPIO14));
+        _for_each_inner_analog_function!(((ADC2_CH3, ADCn_CHm, 2, 3), GPIO14));
+        _for_each_inner_analog_function!(((ADC2_CH4, ADCn_CHm, 2, 4), GPIO15));
+        _for_each_inner_analog_function!(((ADC2_CH5, ADCn_CHm, 2, 5), GPIO16));
+        _for_each_inner_analog_function!(((ADC2_CH6, ADCn_CHm, 2, 6), GPIO17));
+        _for_each_inner_analog_function!(((ADC2_CH7, ADCn_CHm, 2, 7), GPIO18));
+        _for_each_inner_analog_function!(((ADC2_CH8, ADCn_CHm, 2, 8), GPIO19));
+        _for_each_inner_analog_function!(((ADC2_CH9, ADCn_CHm, 2, 9), GPIO20));
+        _for_each_inner_analog_function!((all(TOUCH1, GPIO1), (ADC1_CH0, GPIO1), (TOUCH2,
+        GPIO2), (ADC1_CH1, GPIO2), (TOUCH3, GPIO3), (ADC1_CH2, GPIO3), (TOUCH4, GPIO4),
         (ADC1_CH3, GPIO4), (TOUCH5, GPIO5), (ADC1_CH4, GPIO5), (TOUCH6, GPIO6),
         (ADC1_CH5, GPIO6), (TOUCH7, GPIO7), (ADC1_CH6, GPIO7), (TOUCH8, GPIO8),
         (ADC1_CH7, GPIO8), (TOUCH9, GPIO9), (ADC1_CH8, GPIO9), (TOUCH10, GPIO10),
@@ -3994,22 +4241,22 @@ macro_rules! for_each_analog_function {
         (ADC2_CH3, GPIO14), (XTAL_32K_P, GPIO15), (ADC2_CH4, GPIO15), (XTAL_32K_N,
         GPIO16), (ADC2_CH5, GPIO16), (ADC2_CH6, GPIO17), (ADC2_CH7, GPIO18), (USB_DM,
         GPIO19), (ADC2_CH8, GPIO19), (USB_DP, GPIO20), (ADC2_CH9, GPIO20)));
-        _for_each_inner!((all_expanded((TOUCH1, TOUCHn, 1), GPIO1), ((ADC1_CH0, ADCn_CHm,
-        1, 0), GPIO1), ((TOUCH2, TOUCHn, 2), GPIO2), ((ADC1_CH1, ADCn_CHm, 1, 1), GPIO2),
-        ((TOUCH3, TOUCHn, 3), GPIO3), ((ADC1_CH2, ADCn_CHm, 1, 2), GPIO3), ((TOUCH4,
-        TOUCHn, 4), GPIO4), ((ADC1_CH3, ADCn_CHm, 1, 3), GPIO4), ((TOUCH5, TOUCHn, 5),
-        GPIO5), ((ADC1_CH4, ADCn_CHm, 1, 4), GPIO5), ((TOUCH6, TOUCHn, 6), GPIO6),
-        ((ADC1_CH5, ADCn_CHm, 1, 5), GPIO6), ((TOUCH7, TOUCHn, 7), GPIO7), ((ADC1_CH6,
-        ADCn_CHm, 1, 6), GPIO7), ((TOUCH8, TOUCHn, 8), GPIO8), ((ADC1_CH7, ADCn_CHm, 1,
-        7), GPIO8), ((TOUCH9, TOUCHn, 9), GPIO9), ((ADC1_CH8, ADCn_CHm, 1, 8), GPIO9),
-        ((TOUCH10, TOUCHn, 10), GPIO10), ((ADC1_CH9, ADCn_CHm, 1, 9), GPIO10), ((TOUCH11,
-        TOUCHn, 11), GPIO11), ((ADC2_CH0, ADCn_CHm, 2, 0), GPIO11), ((TOUCH12, TOUCHn,
-        12), GPIO12), ((ADC2_CH1, ADCn_CHm, 2, 1), GPIO12), ((TOUCH13, TOUCHn, 13),
-        GPIO13), ((ADC2_CH2, ADCn_CHm, 2, 2), GPIO13), ((TOUCH14, TOUCHn, 14), GPIO14),
-        ((ADC2_CH3, ADCn_CHm, 2, 3), GPIO14), ((ADC2_CH4, ADCn_CHm, 2, 4), GPIO15),
-        ((ADC2_CH5, ADCn_CHm, 2, 5), GPIO16), ((ADC2_CH6, ADCn_CHm, 2, 6), GPIO17),
-        ((ADC2_CH7, ADCn_CHm, 2, 7), GPIO18), ((ADC2_CH8, ADCn_CHm, 2, 8), GPIO19),
-        ((ADC2_CH9, ADCn_CHm, 2, 9), GPIO20)));
+        _for_each_inner_analog_function!((all_expanded((TOUCH1, TOUCHn, 1), GPIO1),
+        ((ADC1_CH0, ADCn_CHm, 1, 0), GPIO1), ((TOUCH2, TOUCHn, 2), GPIO2), ((ADC1_CH1,
+        ADCn_CHm, 1, 1), GPIO2), ((TOUCH3, TOUCHn, 3), GPIO3), ((ADC1_CH2, ADCn_CHm, 1,
+        2), GPIO3), ((TOUCH4, TOUCHn, 4), GPIO4), ((ADC1_CH3, ADCn_CHm, 1, 3), GPIO4),
+        ((TOUCH5, TOUCHn, 5), GPIO5), ((ADC1_CH4, ADCn_CHm, 1, 4), GPIO5), ((TOUCH6,
+        TOUCHn, 6), GPIO6), ((ADC1_CH5, ADCn_CHm, 1, 5), GPIO6), ((TOUCH7, TOUCHn, 7),
+        GPIO7), ((ADC1_CH6, ADCn_CHm, 1, 6), GPIO7), ((TOUCH8, TOUCHn, 8), GPIO8),
+        ((ADC1_CH7, ADCn_CHm, 1, 7), GPIO8), ((TOUCH9, TOUCHn, 9), GPIO9), ((ADC1_CH8,
+        ADCn_CHm, 1, 8), GPIO9), ((TOUCH10, TOUCHn, 10), GPIO10), ((ADC1_CH9, ADCn_CHm,
+        1, 9), GPIO10), ((TOUCH11, TOUCHn, 11), GPIO11), ((ADC2_CH0, ADCn_CHm, 2, 0),
+        GPIO11), ((TOUCH12, TOUCHn, 12), GPIO12), ((ADC2_CH1, ADCn_CHm, 2, 1), GPIO12),
+        ((TOUCH13, TOUCHn, 13), GPIO13), ((ADC2_CH2, ADCn_CHm, 2, 2), GPIO13), ((TOUCH14,
+        TOUCHn, 14), GPIO14), ((ADC2_CH3, ADCn_CHm, 2, 3), GPIO14), ((ADC2_CH4, ADCn_CHm,
+        2, 4), GPIO15), ((ADC2_CH5, ADCn_CHm, 2, 5), GPIO16), ((ADC2_CH6, ADCn_CHm, 2,
+        6), GPIO17), ((ADC2_CH7, ADCn_CHm, 2, 7), GPIO18), ((ADC2_CH8, ADCn_CHm, 2, 8),
+        GPIO19), ((ADC2_CH9, ADCn_CHm, 2, 9), GPIO20)));
     };
 }
 /// This macro can be used to generate code for each LP/RTC function of each GPIO.
@@ -4042,55 +4289,68 @@ macro_rules! for_each_analog_function {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_lp_function {
     ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner { $(($pattern) => $code;)* ($other : tt) => {} }
-        _for_each_inner!((RTC_GPIO0, GPIO0)); _for_each_inner!((SAR_I2C_SCL_0, GPIO0));
-        _for_each_inner!((RTC_GPIO1, GPIO1)); _for_each_inner!((SAR_I2C_SDA_0, GPIO1));
-        _for_each_inner!((RTC_GPIO2, GPIO2)); _for_each_inner!((SAR_I2C_SCL_1, GPIO2));
-        _for_each_inner!((RTC_GPIO3, GPIO3)); _for_each_inner!((SAR_I2C_SDA_1, GPIO3));
-        _for_each_inner!((RTC_GPIO4, GPIO4)); _for_each_inner!((RTC_GPIO5, GPIO5));
-        _for_each_inner!((RTC_GPIO6, GPIO6)); _for_each_inner!((RTC_GPIO7, GPIO7));
-        _for_each_inner!((RTC_GPIO8, GPIO8)); _for_each_inner!((RTC_GPIO9, GPIO9));
-        _for_each_inner!((RTC_GPIO10, GPIO10)); _for_each_inner!((RTC_GPIO11, GPIO11));
-        _for_each_inner!((RTC_GPIO12, GPIO12)); _for_each_inner!((RTC_GPIO13, GPIO13));
-        _for_each_inner!((RTC_GPIO14, GPIO14)); _for_each_inner!((RTC_GPIO15, GPIO15));
-        _for_each_inner!((RTC_GPIO16, GPIO16)); _for_each_inner!((RTC_GPIO17, GPIO17));
-        _for_each_inner!((RTC_GPIO18, GPIO18)); _for_each_inner!((RTC_GPIO19, GPIO19));
-        _for_each_inner!((RTC_GPIO20, GPIO20)); _for_each_inner!((RTC_GPIO21, GPIO21));
-        _for_each_inner!(((RTC_GPIO0, RTC_GPIOn, 0), GPIO0));
-        _for_each_inner!(((SAR_I2C_SCL_0, SAR_I2C_SCL_n, 0), GPIO0));
-        _for_each_inner!(((RTC_GPIO1, RTC_GPIOn, 1), GPIO1));
-        _for_each_inner!(((SAR_I2C_SDA_0, SAR_I2C_SDA_n, 0), GPIO1));
-        _for_each_inner!(((RTC_GPIO2, RTC_GPIOn, 2), GPIO2));
-        _for_each_inner!(((SAR_I2C_SCL_1, SAR_I2C_SCL_n, 1), GPIO2));
-        _for_each_inner!(((RTC_GPIO3, RTC_GPIOn, 3), GPIO3));
-        _for_each_inner!(((SAR_I2C_SDA_1, SAR_I2C_SDA_n, 1), GPIO3));
-        _for_each_inner!(((RTC_GPIO4, RTC_GPIOn, 4), GPIO4));
-        _for_each_inner!(((RTC_GPIO5, RTC_GPIOn, 5), GPIO5));
-        _for_each_inner!(((RTC_GPIO6, RTC_GPIOn, 6), GPIO6));
-        _for_each_inner!(((RTC_GPIO7, RTC_GPIOn, 7), GPIO7));
-        _for_each_inner!(((RTC_GPIO8, RTC_GPIOn, 8), GPIO8));
-        _for_each_inner!(((RTC_GPIO9, RTC_GPIOn, 9), GPIO9));
-        _for_each_inner!(((RTC_GPIO10, RTC_GPIOn, 10), GPIO10));
-        _for_each_inner!(((RTC_GPIO11, RTC_GPIOn, 11), GPIO11));
-        _for_each_inner!(((RTC_GPIO12, RTC_GPIOn, 12), GPIO12));
-        _for_each_inner!(((RTC_GPIO13, RTC_GPIOn, 13), GPIO13));
-        _for_each_inner!(((RTC_GPIO14, RTC_GPIOn, 14), GPIO14));
-        _for_each_inner!(((RTC_GPIO15, RTC_GPIOn, 15), GPIO15));
-        _for_each_inner!(((RTC_GPIO16, RTC_GPIOn, 16), GPIO16));
-        _for_each_inner!(((RTC_GPIO17, RTC_GPIOn, 17), GPIO17));
-        _for_each_inner!(((RTC_GPIO18, RTC_GPIOn, 18), GPIO18));
-        _for_each_inner!(((RTC_GPIO19, RTC_GPIOn, 19), GPIO19));
-        _for_each_inner!(((RTC_GPIO20, RTC_GPIOn, 20), GPIO20));
-        _for_each_inner!(((RTC_GPIO21, RTC_GPIOn, 21), GPIO21));
-        _for_each_inner!((all(RTC_GPIO0, GPIO0), (SAR_I2C_SCL_0, GPIO0), (RTC_GPIO1,
-        GPIO1), (SAR_I2C_SDA_0, GPIO1), (RTC_GPIO2, GPIO2), (SAR_I2C_SCL_1, GPIO2),
-        (RTC_GPIO3, GPIO3), (SAR_I2C_SDA_1, GPIO3), (RTC_GPIO4, GPIO4), (RTC_GPIO5,
-        GPIO5), (RTC_GPIO6, GPIO6), (RTC_GPIO7, GPIO7), (RTC_GPIO8, GPIO8), (RTC_GPIO9,
-        GPIO9), (RTC_GPIO10, GPIO10), (RTC_GPIO11, GPIO11), (RTC_GPIO12, GPIO12),
-        (RTC_GPIO13, GPIO13), (RTC_GPIO14, GPIO14), (RTC_GPIO15, GPIO15), (RTC_GPIO16,
-        GPIO16), (RTC_GPIO17, GPIO17), (RTC_GPIO18, GPIO18), (RTC_GPIO19, GPIO19),
-        (RTC_GPIO20, GPIO20), (RTC_GPIO21, GPIO21)));
-        _for_each_inner!((all_expanded((RTC_GPIO0, RTC_GPIOn, 0), GPIO0),
+        macro_rules! _for_each_inner_lp_function { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_lp_function!((RTC_GPIO0, GPIO0));
+        _for_each_inner_lp_function!((SAR_I2C_SCL_0, GPIO0));
+        _for_each_inner_lp_function!((RTC_GPIO1, GPIO1));
+        _for_each_inner_lp_function!((SAR_I2C_SDA_0, GPIO1));
+        _for_each_inner_lp_function!((RTC_GPIO2, GPIO2));
+        _for_each_inner_lp_function!((SAR_I2C_SCL_1, GPIO2));
+        _for_each_inner_lp_function!((RTC_GPIO3, GPIO3));
+        _for_each_inner_lp_function!((SAR_I2C_SDA_1, GPIO3));
+        _for_each_inner_lp_function!((RTC_GPIO4, GPIO4));
+        _for_each_inner_lp_function!((RTC_GPIO5, GPIO5));
+        _for_each_inner_lp_function!((RTC_GPIO6, GPIO6));
+        _for_each_inner_lp_function!((RTC_GPIO7, GPIO7));
+        _for_each_inner_lp_function!((RTC_GPIO8, GPIO8));
+        _for_each_inner_lp_function!((RTC_GPIO9, GPIO9));
+        _for_each_inner_lp_function!((RTC_GPIO10, GPIO10));
+        _for_each_inner_lp_function!((RTC_GPIO11, GPIO11));
+        _for_each_inner_lp_function!((RTC_GPIO12, GPIO12));
+        _for_each_inner_lp_function!((RTC_GPIO13, GPIO13));
+        _for_each_inner_lp_function!((RTC_GPIO14, GPIO14));
+        _for_each_inner_lp_function!((RTC_GPIO15, GPIO15));
+        _for_each_inner_lp_function!((RTC_GPIO16, GPIO16));
+        _for_each_inner_lp_function!((RTC_GPIO17, GPIO17));
+        _for_each_inner_lp_function!((RTC_GPIO18, GPIO18));
+        _for_each_inner_lp_function!((RTC_GPIO19, GPIO19));
+        _for_each_inner_lp_function!((RTC_GPIO20, GPIO20));
+        _for_each_inner_lp_function!((RTC_GPIO21, GPIO21));
+        _for_each_inner_lp_function!(((RTC_GPIO0, RTC_GPIOn, 0), GPIO0));
+        _for_each_inner_lp_function!(((SAR_I2C_SCL_0, SAR_I2C_SCL_n, 0), GPIO0));
+        _for_each_inner_lp_function!(((RTC_GPIO1, RTC_GPIOn, 1), GPIO1));
+        _for_each_inner_lp_function!(((SAR_I2C_SDA_0, SAR_I2C_SDA_n, 0), GPIO1));
+        _for_each_inner_lp_function!(((RTC_GPIO2, RTC_GPIOn, 2), GPIO2));
+        _for_each_inner_lp_function!(((SAR_I2C_SCL_1, SAR_I2C_SCL_n, 1), GPIO2));
+        _for_each_inner_lp_function!(((RTC_GPIO3, RTC_GPIOn, 3), GPIO3));
+        _for_each_inner_lp_function!(((SAR_I2C_SDA_1, SAR_I2C_SDA_n, 1), GPIO3));
+        _for_each_inner_lp_function!(((RTC_GPIO4, RTC_GPIOn, 4), GPIO4));
+        _for_each_inner_lp_function!(((RTC_GPIO5, RTC_GPIOn, 5), GPIO5));
+        _for_each_inner_lp_function!(((RTC_GPIO6, RTC_GPIOn, 6), GPIO6));
+        _for_each_inner_lp_function!(((RTC_GPIO7, RTC_GPIOn, 7), GPIO7));
+        _for_each_inner_lp_function!(((RTC_GPIO8, RTC_GPIOn, 8), GPIO8));
+        _for_each_inner_lp_function!(((RTC_GPIO9, RTC_GPIOn, 9), GPIO9));
+        _for_each_inner_lp_function!(((RTC_GPIO10, RTC_GPIOn, 10), GPIO10));
+        _for_each_inner_lp_function!(((RTC_GPIO11, RTC_GPIOn, 11), GPIO11));
+        _for_each_inner_lp_function!(((RTC_GPIO12, RTC_GPIOn, 12), GPIO12));
+        _for_each_inner_lp_function!(((RTC_GPIO13, RTC_GPIOn, 13), GPIO13));
+        _for_each_inner_lp_function!(((RTC_GPIO14, RTC_GPIOn, 14), GPIO14));
+        _for_each_inner_lp_function!(((RTC_GPIO15, RTC_GPIOn, 15), GPIO15));
+        _for_each_inner_lp_function!(((RTC_GPIO16, RTC_GPIOn, 16), GPIO16));
+        _for_each_inner_lp_function!(((RTC_GPIO17, RTC_GPIOn, 17), GPIO17));
+        _for_each_inner_lp_function!(((RTC_GPIO18, RTC_GPIOn, 18), GPIO18));
+        _for_each_inner_lp_function!(((RTC_GPIO19, RTC_GPIOn, 19), GPIO19));
+        _for_each_inner_lp_function!(((RTC_GPIO20, RTC_GPIOn, 20), GPIO20));
+        _for_each_inner_lp_function!(((RTC_GPIO21, RTC_GPIOn, 21), GPIO21));
+        _for_each_inner_lp_function!((all(RTC_GPIO0, GPIO0), (SAR_I2C_SCL_0, GPIO0),
+        (RTC_GPIO1, GPIO1), (SAR_I2C_SDA_0, GPIO1), (RTC_GPIO2, GPIO2), (SAR_I2C_SCL_1,
+        GPIO2), (RTC_GPIO3, GPIO3), (SAR_I2C_SDA_1, GPIO3), (RTC_GPIO4, GPIO4),
+        (RTC_GPIO5, GPIO5), (RTC_GPIO6, GPIO6), (RTC_GPIO7, GPIO7), (RTC_GPIO8, GPIO8),
+        (RTC_GPIO9, GPIO9), (RTC_GPIO10, GPIO10), (RTC_GPIO11, GPIO11), (RTC_GPIO12,
+        GPIO12), (RTC_GPIO13, GPIO13), (RTC_GPIO14, GPIO14), (RTC_GPIO15, GPIO15),
+        (RTC_GPIO16, GPIO16), (RTC_GPIO17, GPIO17), (RTC_GPIO18, GPIO18), (RTC_GPIO19,
+        GPIO19), (RTC_GPIO20, GPIO20), (RTC_GPIO21, GPIO21)));
+        _for_each_inner_lp_function!((all_expanded((RTC_GPIO0, RTC_GPIOn, 0), GPIO0),
         ((SAR_I2C_SCL_0, SAR_I2C_SCL_n, 0), GPIO0), ((RTC_GPIO1, RTC_GPIOn, 1), GPIO1),
         ((SAR_I2C_SDA_0, SAR_I2C_SDA_n, 0), GPIO1), ((RTC_GPIO2, RTC_GPIOn, 2), GPIO2),
         ((SAR_I2C_SCL_1, SAR_I2C_SCL_n, 1), GPIO2), ((RTC_GPIO3, RTC_GPIOn, 3), GPIO3),

--- a/esp-metadata/src/lib.rs
+++ b/esp-metadata/src/lib.rs
@@ -710,6 +710,7 @@ fn generate_for_each_macro(name: &str, branches: &[Branch<'_>]) -> TokenStream {
     let flat_branches = branches.iter().flat_map(|b| b.1.iter());
     let repeat_names = branches.iter().map(|b| TokenStream::from_str(b.0).unwrap());
     let repeat_branches = branches.iter().map(|b| b.1);
+    let inner = format_ident!("_for_each_inner_{name}");
 
     quote! {
         // This macro is called in esp-hal to implement a driver's
@@ -721,7 +722,7 @@ fn generate_for_each_macro(name: &str, branches: &[Branch<'_>]) -> TokenStream {
             (
                 $($pattern:tt => $code:tt;)*
             ) => {
-                macro_rules! _for_each_inner {
+                macro_rules! #inner {
                     $(($pattern) => $code;)*
                     ($other:tt) => {}
                 }
@@ -735,7 +736,7 @@ fn generate_for_each_macro(name: &str, branches: &[Branch<'_>]) -> TokenStream {
                 //     }
                 // }
                 // ```
-                #(_for_each_inner!(( #flat_branches ));)*
+                #( #inner!(( #flat_branches ));)*
 
                 // Generate a single macro call with all branches.
                 // Usage:
@@ -746,7 +747,7 @@ fn generate_for_each_macro(name: &str, branches: &[Branch<'_>]) -> TokenStream {
                 //     }
                 // }
                 // ```
-                #( _for_each_inner!( (#repeat_names #( (#repeat_branches) ),*) ); )*
+                #(  #inner!( (#repeat_names #( (#repeat_branches) ),*) ); )*
             };
         }
     }


### PR DESCRIPTION
Stripped out of https://github.com/esp-rs/esp-hal/pull/4907 because this is the bulk of the line count without any functional changes. This enables nesting different for_each macros, although that's rarely a good idea, and rarely easy to do.