### PR TITLE
Fix incorrect locking in PCNT

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ESP32-S3/ESP32-C2: WiFi will work after light-sleep with default settings (#4826)
 - ESP32-S2: Fixed an issue where enabling TRNG can prevent WiFi from working (#4856)
 - Fixed an issue that caused the stack guard to overwrite data moved to the second core (#4914)
+- PCNT: Fixed some potential data race issues (#4932)
 
 ### Removed
 

--- a/esp-hal/src/pcnt/channel.rs
+++ b/esp-hal/src/pcnt/channel.rs
@@ -46,10 +46,8 @@ impl<const UNIT: usize, const NUM: usize> Channel<'_, UNIT, NUM> {
         let conf0 = pcnt.unit(UNIT).conf0();
 
         conf0.modify(|_, w| {
-            w.ch_hctrl_mode(NUM as u8)
-                .variant(high)
-                .ch_lctrl_mode(NUM as u8)
-                .variant(low)
+            w.ch_hctrl_mode(NUM as u8).variant(high);
+            w.ch_lctrl_mode(NUM as u8).variant(low)
         });
     }
 

--- a/esp-hal/src/pcnt/mod.rs
+++ b/esp-hal/src/pcnt/mod.rs
@@ -138,6 +138,8 @@ impl<'d> Pcnt<'d> {
         let guard = GenericPeripheralGuard::new();
         let pcnt = PCNT::regs();
 
+        let unit_count = pcnt.unit_iter().count() as u8;
+
         // disable filter, all events, and channel settings
         for unit in pcnt.unit_iter() {
             unit.conf0().write(|w| unsafe {
@@ -148,11 +150,6 @@ impl<'d> Pcnt<'d> {
 
         // Remove reset bit from units.
         pcnt.ctrl().modify(|_, w| {
-            #[cfg(not(esp32))]
-            let unit_count = 4;
-            #[cfg(esp32)]
-            let unit_count = 8;
-
             for i in 0..unit_count {
                 w.cnt_rst_u(i).clear_bit();
             }

--- a/esp-hal/src/system.rs
+++ b/esp-hal/src/system.rs
@@ -5,6 +5,7 @@ use esp_sync::NonReentrantMutex;
 cfg_if::cfg_if! {
     if #[cfg(soc_multi_core_enabled)] {
         pub(crate) mod multi_core;
+        #[cfg(feature = "unstable")]
         pub use multi_core::*;
     }
 }


### PR DESCRIPTION
One mutex per Unit meant that each unit was able to access the shared registers, defeating the purpose of the mutex. 🤦‍♂️