### PR TITLE
Remove info about non-open APs

### DIFF
--- a/esp-radio/README.md
+++ b/esp-radio/README.md
@@ -28,10 +28,6 @@ If a cell contains an em dash (&mdash;) this means that the particular feature i
 | ESP32-S2 |                          ✓                           |                       &mdash;                       |                       &mdash;                        |    ✓    | &mdash; |
 | ESP32-S3 |                          ✓                           |                          ✓                          |                          ✓                           |    ✓    | &mdash; |
 
-## Missing / To be done
-
-- Support for non-open SoftAP
-
 ## Bluetooth stack
 We recommend using [`TrouBLE`] as the Bluetooth stack. You can find detailed examples [here].
 


### PR DESCRIPTION
We had this obsolete info in esp-radio's README for long enough. See https://github.com/esp-rs/esp-hal/issues/4938#issuecomment-3873041213
