### PR TITLE
chore: update trouble-host and bt-hci version

### DIFF
--- a/esp-radio/CHANGELOG.md
+++ b/esp-radio/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `disconnect_async` now returns `Ok(DisconnectedStationInfo)`. (#4898)
 - `WifiError::Disconnected` is now a tuple-like enum variant `WifiError::Disconnected(DisconnectedStationInfo)` containing details about the disconnection. (#4898)
 - Various structs now use the `Ssid` type to represent SSIDs instead of `String` (#4953)
+- Update to `bt-hci` version 0.8 and `trouble-host` version 0.6 (#4962)
 
 ### Fixed
 

--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -85,7 +85,7 @@ embedded-io-async-06 = { package = "embedded-io-async", version = "0.6", default
 embedded-io-07 = { package = "embedded-io", version = "0.7", default-features = false, optional = true }
 embedded-io-async-07 = { package = "embedded-io-async", version = "0.7", default-features = false, optional = true }
 embassy-net-driver = { version = "0.2.0", optional = true }
-bt-hci = { version = "0.6.0", optional = true }
+bt-hci = { version = "0.8.0", optional = true }
 
 # Logging interfaces, they are mutually exclusive so they need to be behind separate features.
 defmt = { version = "1.0.1", optional = true }

--- a/examples/ble/bas_peripheral/Cargo.toml
+++ b/examples/ble/bas_peripheral/Cargo.toml
@@ -24,7 +24,7 @@ esp-radio = { path = "../../../esp-radio", features = [
     "unstable",
 ] }
 log = "0.4.27"
-trouble-host = { version = "0.5.0", features = [
+trouble-host = { version = "0.6.0", features = [
     "default-packet-pool-mtu-255",
     "derive",
     "scan",

--- a/examples/ble/bas_peripheral/src/main.rs
+++ b/examples/ble/bas_peripheral/src/main.rs
@@ -51,7 +51,7 @@ struct Server {
 struct BatteryService {
     /// Battery Level
     #[descriptor(uuid = descriptors::VALID_RANGE, read, value = [0, 100])]
-    #[descriptor(uuid = descriptors::MEASUREMENT_DESCRIPTION, name = "hello", read, value = "Battery Level")]
+    #[descriptor(uuid = descriptors::MEASUREMENT_DESCRIPTION, name = "hello", read, value = "Battery Level", type = &'static str)]
     #[characteristic(uuid = characteristic::BATTERY_LEVEL, read, notify, value = 10)]
     level: u8,
     #[characteristic(uuid = "408813df-5dd4-1f87-ec11-cdb001100000", write, read, notify)]

--- a/examples/ble/scanner/Cargo.toml
+++ b/examples/ble/scanner/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 publish = false
 
 [dependencies]
-bt-hci = "0.6.0"
+bt-hci = "0.8.0"
 embassy-executor = "0.9.0"
 embassy-futures = "0.1"
 embassy-time = "0.5.0"
@@ -25,7 +25,7 @@ esp-radio = { path = "../../../esp-radio", features = [
 ] }
 heapless = "0.9.1"
 log = "0.4.27"
-trouble-host = { version = "0.5.0", features = [
+trouble-host = { version = "0.6.0", features = [
     "default-packet-pool-mtu-255",
     "derive",
     "scan",

--- a/examples/wifi/embassy_coex/Cargo.toml
+++ b/examples/wifi/embassy_coex/Cargo.toml
@@ -33,7 +33,7 @@ esp-radio = { path = "../../../esp-radio", features = [
     "coex",
 ] }
 static_cell = "2.1.0"
-trouble-host = { version = "0.5.0", features = [
+trouble-host = { version = "0.6.0", features = [
     "default-packet-pool-mtu-255",
     "derive",
     "scan",

--- a/examples/wifi/embassy_coex/src/main.rs
+++ b/examples/wifi/embassy_coex/src/main.rs
@@ -60,7 +60,7 @@ struct Server {
 struct BatteryService {
     /// Battery Level
     #[descriptor(uuid = descriptors::VALID_RANGE, read, value = [0, 100])]
-    #[descriptor(uuid = descriptors::MEASUREMENT_DESCRIPTION, name = "hello", read, value = "Battery Level")]
+    #[descriptor(uuid = descriptors::MEASUREMENT_DESCRIPTION, name = "hello", read, value = "Battery Level", type = &'static str)]
     #[characteristic(uuid = characteristic::BATTERY_LEVEL, read, notify, value = 10)]
     level: u8,
     #[characteristic(uuid = "408813df-5dd4-1f87-ec11-cdb001100000", write, read, notify)]


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Updates bt-hci and trouble-host versions.

#### Testing
Verified that bas_peripheral and scanner examples work on esp32c3