### PR TITLE
H2: Generalize RNG workaround

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - C5: Add PCNT support (#4934)
 - C5: Initial UART support (#4948)
 - C5: Add SPI support (#4943)
+- Support ESP32-H2 rev 1.2 (#4949, #4969)
 
 ### Changed
 
@@ -896,7 +897,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add interrupt related functions to `PeriodicTimer`/`OneShotTimer`, added `ErasedTimer` (#1753)
 - Added blocking `read_bytes` method to `Uart` and `UartRx` (#1784)
 - Add method to expose `InputPin::is_interrupt_set` in `Input<InputPin>` for use in interrupt handlers (#1829)
-- Support ESP32-H2 rev 1.2 (#4949)
 
 ### Fixed
 

--- a/esp-hal/src/peripherals/mod.rs
+++ b/esp-hal/src/peripherals/mod.rs
@@ -14,6 +14,10 @@ pub use pac::Interrupt;
 
 pub(crate) use crate::soc::pac;
 
+#[cfg(esp32h2)]
+#[path = "overlay_h2.rs"]
+mod overlay;
+
 /// Macro to create a peripheral structure.
 macro_rules! create_peripheral {
     ($(#[$attr:meta])* $name:ident <= virtual ($($interrupt:ident: { $bind:ident, $enable:ident, $disable:ident }),*)) => {

--- a/esp-hal/src/peripherals/overlay_h2.rs
+++ b/esp-hal/src/peripherals/overlay_h2.rs
@@ -1,0 +1,48 @@
+use core::ops::Deref;
+
+use super::*;
+
+// RNG must be marked `virtual` for this to work.
+impl RNG<'_> {
+    /// Return a reference to the register block
+    #[inline(always)]
+    #[instability::unstable]
+    pub const fn regs<'a>() -> &'a RngRegisterBlock {
+        &RngRegisterBlock
+    }
+
+    /// Return a reference to the register block
+    #[inline(always)]
+    #[instability::unstable]
+    pub fn register_block(&self) -> &RngRegisterBlock {
+        &RngRegisterBlock
+    }
+}
+
+/// Register block overlay for the RNG peripheral
+#[instability::unstable]
+pub struct RngRegisterBlock;
+
+// This Deref makes it possible to use the rest of the registers.
+impl Deref for RngRegisterBlock {
+    type Target = pac::rng::RegisterBlock;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*pac::RNG::ptr() }
+    }
+}
+
+impl RngRegisterBlock {
+    /// Random number data
+    pub fn data(&self) -> &pac::rng::DATA {
+        let ptr = unsafe { pac::RNG::steal().data() as *const pac::rng::DATA };
+        if crate::soc::chip_revision_above(102) {
+            // On H2-ECO5+ the LPPERI peripherals contains an additional register inserted before
+            // the `rng_data` register.
+            // https://github.com/espressif/esp-idf/commit/4c5e1a03414a6d55be4b42ba071b30ad228414f6#diff-bc8f2eca37e32ee4ba21ac812e4934998e764132a400479c4d091eb6f7e2e444
+            unsafe { &*ptr.add(1) }
+        } else {
+            unsafe { &*ptr }
+        }
+    }
+}

--- a/esp-hal/src/rng/ll.rs
+++ b/esp-hal/src/rng/ll.rs
@@ -64,21 +64,7 @@ fn read_one(wait_cycles: usize) -> u32 {
             if now.wrapping_sub(*last_wait_start) >= wait_cycles {
                 *last_wait_start = now;
 
-                cfg_if::cfg_if! {
-                    if #[cfg(not(esp32h2))] {
-                        Some(RNG::regs().data().read().bits())
-                    } else {
-                        // TODO find a better way to do this
-                        //
-                        // On H2-ECO5+ the LPPERI peripherals contains an additional register inserted before the `rng_data` register.
-                        // https://github.com/espressif/esp-idf/commit/4c5e1a03414a6d55be4b42ba071b30ad228414f6#diff-bc8f2eca37e32ee4ba21ac812e4934998e764132a400479c4d091eb6f7e2e444
-                        if crate::soc::chip_revision_above(102) {
-                            Some(unsafe { RNG::regs().data().as_ptr().add(1).read_volatile() })
-                        } else {
-                            Some(RNG::regs().data().read().bits())
-                        }
-                    }
-                }
+                Some(RNG::regs().data().read().bits())
             } else {
                 None
             }

--- a/esp-metadata-generated/src/_generated_esp32h2.rs
+++ b/esp-metadata-generated/src/_generated_esp32h2.rs
@@ -2964,7 +2964,7 @@ macro_rules! for_each_peripheral {
         = "PMU peripheral singleton"] PMU <= PMU() (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc = "RMT peripheral singleton"] RMT
         <= RMT() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
-        "RNG peripheral singleton"] RNG <= RNG() (unstable)));
+        "RNG peripheral singleton"] RNG <= virtual() (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc = "RSA peripheral singleton"] RSA
         <= RSA(RSA : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt
         }) (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
@@ -3255,7 +3255,7 @@ macro_rules! for_each_peripheral {
         "PLIC_MX peripheral singleton"] PLIC_MX <= PLIC_MX() (unstable)), (@ peri_type
         #[doc = "PMU peripheral singleton"] PMU <= PMU() (unstable)), (@ peri_type #[doc
         = "RMT peripheral singleton"] RMT <= RMT() (unstable)), (@ peri_type #[doc =
-        "RNG peripheral singleton"] RNG <= RNG() (unstable)), (@ peri_type #[doc =
+        "RNG peripheral singleton"] RNG <= virtual() (unstable)), (@ peri_type #[doc =
         "RSA peripheral singleton"] RSA <= RSA(RSA : { bind_peri_interrupt,
         enable_peri_interrupt, disable_peri_interrupt }) (unstable)), (@ peri_type #[doc
         = "SHA peripheral singleton"] SHA <= SHA(SHA : { bind_peri_interrupt,

--- a/esp-metadata/devices/esp32h2.toml
+++ b/esp-metadata/devices/esp32h2.toml
@@ -55,7 +55,7 @@ peripherals = [
     { name = "PLIC_MX" },
     { name = "PMU" },
     { name = "RMT" },
-    { name = "RNG" },
+    { name = "RNG", virtual = true }, # a) RNG is LP_PERI in truth. b) we need to offset the rng_data register at runtime for newer revisions.
     { name = "RSA", interrupts = { peri = "RSA" } },
     { name = "SHA", interrupts = { peri = "SHA" }, dma_peripheral = 7 },
     { name = "ETM", pac = "SOC_ETM" },


### PR DESCRIPTION
cc #4950

This PR updates H2's RNG peripheral to not use the PAC register block directly. Instead we create and return our own overlay type, which by default deref's to the PAC register block, but we can overwrite its functions with custom ones. This gives us a way to opt in to logic that manipulates the register address based on chip revision, without scattering the logic around the codebase.

We could also generate the overlay type and the `register_block` functions that return it, but that machinery can wait until we have to work around more of these.