### PR TITLE
Re-add Send to async drivers

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -50,6 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `LP_UART` now has its own configuration structure (#4667)
 - The `MEM2MEM` peripheral singletons have been re-numbered from 0-8 (#4944)
 - The `DmaPeripheral::Mem2MemX` variants have been renamed to `Mem2memX` and re-numbered from 0-8 (#4944)
+- `Async` drivers now implement `Send` again (#4986)
 
 ### Fixed
 

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -278,8 +278,6 @@ macro_rules! unstable_driver {
     };
 }
 
-use core::marker::PhantomData;
-
 pub use esp_metadata_generated::chip;
 use esp_rom_sys as _;
 pub(crate) use unstable_driver;
@@ -510,16 +508,12 @@ pub struct Blocking;
 /// When initializing an async driver, the driver disables user-specified
 /// interrupt handlers, and sets up internal interrupt handlers that drive the
 /// driver's async API. The driver's interrupt handlers run on the same core as
-/// the driver was initialized on. This means that the driver can not be sent
-/// across threads, to prevent incorrect concurrent access to the peripheral.
+/// the driver was initialized on.
 ///
-/// Switching back to blocking mode will disable the interrupt handlers and
-/// return the driver to a state where it can be sent across threads.
+/// Switching back to blocking mode will disable the interrupt handlers.
 #[derive(Debug)]
 #[non_exhaustive]
-pub struct Async(PhantomData<*const ()>);
-
-unsafe impl Sync for Async {}
+pub struct Async;
 
 impl crate::DriverMode for Blocking {}
 impl crate::DriverMode for Async {}

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -47,6 +47,7 @@ use core::{
 #[cfg(spi_master_supports_dma)]
 pub use dma::*;
 use enumset::{EnumSet, EnumSetType};
+use esp_sync::RawMutex;
 use procmacros::doc_replace;
 #[cfg(place_spi_master_driver_in_ram)]
 use procmacros::ram;
@@ -3951,6 +3952,7 @@ for_each_spi_master! {
 
                 static STATE: State = State {
                     waker: AtomicWaker::new(),
+                    mutex: RawMutex::new(),
                     #[cfg(esp32)]
                     esp32_hack: Esp32Hack {
                         timing_miso_delay: Cell::new(None),
@@ -3976,6 +3978,10 @@ impl QspiInstance for AnySpi<'_> {}
 pub struct State {
     waker: AtomicWaker,
 
+    // Ensures that register operations in Futures and interrupt handlers can't run concurrently.
+    // TODO: if we expose an interrupt-focused API, we'll need to protect its operations, too.
+    mutex: RawMutex,
+
     #[cfg(esp32)]
     esp32_hack: Esp32Hack,
 }
@@ -3991,11 +3997,13 @@ unsafe impl Sync for Esp32Hack {}
 
 #[cfg_attr(place_spi_master_driver_in_ram, ram)]
 fn handle_async(info: &'static Info, state: &'static State) {
-    let driver = Driver { info, state };
-    if driver.interrupts().contains(SpiInterrupt::TransferDone) {
-        driver.enable_listen(SpiInterrupt::TransferDone.into(), false);
-        state.waker.wake();
-    }
+    state.mutex.lock(|| {
+        let driver = Driver { info, state };
+        if driver.interrupts().contains(SpiInterrupt::TransferDone) {
+            driver.enable_listen(SpiInterrupt::TransferDone.into(), false);
+            state.waker.wake();
+        }
+    })
 }
 
 /// SPI data mode
@@ -4055,6 +4063,7 @@ impl AnySpi<'_> {
 
 struct SpiFuture<'a> {
     driver: &'a Driver,
+    listening: bool,
 }
 
 impl<'a> SpiFuture<'a> {
@@ -4062,11 +4071,18 @@ impl<'a> SpiFuture<'a> {
     fn setup(driver: &'a Driver) -> impl Future<Output = Self> {
         // Make sure this is called before starting an async operation. On the ESP32,
         // calling after may cause the interrupt to not fire.
+        // FIXME: flush() should not clear the interrupt, and has no option to listen
+        // before starting the transfer. Do we have sufficient tests around this?
         core::future::poll_fn(move |cx| {
-            driver.state.waker.register(cx.waker());
-            driver.clear_interrupts(SpiInterrupt::TransferDone.into());
-            driver.enable_listen(SpiInterrupt::TransferDone.into(), true);
-            Poll::Ready(Self { driver })
+            driver.state.mutex.lock(|| {
+                driver.state.waker.register(cx.waker());
+                driver.clear_interrupts(SpiInterrupt::TransferDone.into());
+                driver.enable_listen(SpiInterrupt::TransferDone.into(), true);
+            });
+            Poll::Ready(Self {
+                driver,
+                listening: true,
+            })
         })
     }
 }
@@ -4074,14 +4090,20 @@ impl<'a> SpiFuture<'a> {
 impl Future for SpiFuture<'_> {
     type Output = ();
 
-    fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
         if self
             .driver
             .interrupts()
             .contains(SpiInterrupt::TransferDone)
         {
-            self.driver
-                .clear_interrupts(SpiInterrupt::TransferDone.into());
+            self.driver.state.mutex.lock(|| {
+                self.driver
+                    .enable_listen(SpiInterrupt::TransferDone.into(), false);
+                self.driver
+                    .clear_interrupts(SpiInterrupt::TransferDone.into());
+            });
+
+            self.listening = false;
             return Poll::Ready(());
         }
 
@@ -4091,7 +4113,11 @@ impl Future for SpiFuture<'_> {
 
 impl Drop for SpiFuture<'_> {
     fn drop(&mut self) {
-        self.driver
-            .enable_listen(SpiInterrupt::TransferDone.into(), false);
+        if self.listening {
+            self.driver.state.mutex.lock(|| {
+                self.driver
+                    .enable_listen(SpiInterrupt::TransferDone.into(), false);
+            });
+        }
     }
 }

--- a/esp-hal/src/uart/mod.rs
+++ b/esp-hal/src/uart/mod.rs
@@ -50,6 +50,7 @@ crate::unstable_driver! {
 use core::{marker::PhantomData, sync::atomic::Ordering, task::Poll};
 
 use enumset::{EnumSet, EnumSetType};
+use esp_sync::RawMutex;
 use portable_atomic::AtomicBool;
 
 use crate::{
@@ -791,6 +792,7 @@ where
     /// supported by the hardware.
     #[instability::unstable]
     pub fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError> {
+        // FIXME: thread safety
         self.uart
             .info()
             .set_tx_fifo_empty_threshold(config.tx.fifo_empty_threshold)?;
@@ -1263,6 +1265,7 @@ where
     /// supported by the hardware.
     #[instability::unstable]
     pub fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError> {
+        // FIXME: thread safety
         self.uart
             .info()
             .set_rx_fifo_full_threshold(config.rx.fifo_full_threshold)?;
@@ -2493,7 +2496,9 @@ impl core::future::Future for UartRxFuture {
         } else {
             self.state.rx_waker.register(cx.waker());
             if !self.registered {
-                self.uart.enable_listen_rx(self.events, true);
+                self.state.mutex.lock(|| {
+                    self.uart.enable_listen_rx(self.events, true);
+                });
                 self.registered = true;
             }
             Poll::Pending
@@ -2506,7 +2511,11 @@ impl Drop for UartRxFuture {
         // Although the isr disables the interrupt that occurred directly, we need to
         // disable the other interrupts (= the ones that did not occur), as
         // soon as this future goes out of scope.
-        self.uart.enable_listen_rx(self.events, false);
+        if self.registered {
+            self.state.mutex.lock(|| {
+                self.uart.enable_listen_rx(self.events, false);
+            });
+        }
     }
 }
 
@@ -2543,7 +2552,9 @@ impl core::future::Future for UartTxFuture {
         } else {
             self.state.tx_waker.register(cx.waker());
             if !self.registered {
-                self.uart.enable_listen_tx(self.events, true);
+                self.state.mutex.lock(|| {
+                    self.uart.enable_listen_tx(self.events, true);
+                });
                 self.registered = true;
             }
             Poll::Pending
@@ -2556,7 +2567,11 @@ impl Drop for UartTxFuture {
         // Although the isr disables the interrupt that occurred directly, we need to
         // disable the other interrupts (= the ones that did not occur), as
         // soon as this future goes out of scope.
-        self.uart.enable_listen_tx(self.events, false);
+        if self.registered {
+            self.state.mutex.lock(|| {
+                self.uart.enable_listen_tx(self.events, false);
+            });
+        }
     }
 }
 
@@ -2684,16 +2699,18 @@ pub(super) fn intr_handler(uart: &Info, state: &State) {
         | interrupts.parity_err().bit_is_set();
     let tx_wake = interrupts.tx_done().bit_is_set() | interrupts.txfifo_empty().bit_is_set();
 
-    uart.regs()
-        .int_ena()
-        .modify(|r, w| unsafe { w.bits(r.bits() & !interrupt_bits) });
+    state.mutex.lock(|| {
+        uart.regs()
+            .int_ena()
+            .modify(|r, w| unsafe { w.bits(r.bits() & !interrupt_bits) });
 
-    if tx_wake {
-        state.tx_waker.wake();
-    }
-    if rx_wake {
-        state.rx_waker.wake();
-    }
+        if tx_wake {
+            state.tx_waker.wake();
+        }
+        if rx_wake {
+            state.rx_waker.wake();
+        }
+    });
 }
 
 /// Low-power UART
@@ -3019,6 +3036,9 @@ pub struct State {
 
     /// Stores whether the RX half is configured for async operation.
     pub is_tx_async: AtomicBool,
+
+    /// Mutex for the UART instance.
+    pub mutex: RawMutex,
 }
 
 impl Info {
@@ -3753,6 +3773,7 @@ for_each_uart! {
                     rx_waker: AtomicWaker::new(),
                     is_rx_async: AtomicBool::new(false),
                     is_tx_async: AtomicBool::new(false),
+                    mutex: RawMutex::new(),
                 };
 
                 fn request_uart_clks(clocks: &mut ClockTree) {

--- a/hil-test/src/bin/esp_radio/esp_rtos.rs
+++ b/hil-test/src/bin/esp_radio/esp_rtos.rs
@@ -578,7 +578,7 @@ mod tests {
 
         static SIGNAL: Signal<RawMutex, ()> = Signal::new();
 
-        let _gaurd = esp_hal::system::CpuControl::new(ctx.cpu_cntl)
+        let _guard = esp_hal::system::CpuControl::new(ctx.cpu_cntl)
             .start_app_core(
                 #[allow(static_mut_refs)]
                 unsafe {


### PR DESCRIPTION
In https://github.com/esp-rs/esp-hal/pull/2980 we changed Async driver to be `!Send` to prevent sending them to a different CPU. This was done to ensure that the interrupt handlers run on the same core where the drivers do.

This is now being undone for the following reasons:
- It is too restrictive. Besides dedicated GPIOs basically no peripherals require code to run on a specific core.
- RTOS-es, like Ariel OS or even esp-rtos can migrate a thread to a different core, regardless of some drivers on a thread being `!Send`. This means that we can't make assumptions on which core a particular driver is running, so our solution gave us only a false sense of safety.

This PR adds locks for the **stable** drivers and accepts that the rest may be silently unsound.