### PR TITLE
Fix warning on H2

### DIFF
--- a/esp-hal/src/peripherals/overlay_h2.rs
+++ b/esp-hal/src/peripherals/overlay_h2.rs
@@ -34,6 +34,7 @@ impl Deref for RngRegisterBlock {
 
 impl RngRegisterBlock {
     /// Random number data
+    #[instability::unstable]
     pub fn data(&self) -> &pac::rng::DATA {
         let ptr = unsafe { pac::RNG::steal().data() as *const pac::rng::DATA };
         if crate::soc::chip_revision_above(102) {


### PR DESCRIPTION
The function is not used unless `unstable` is enabled, and the type itself is marked `unstable`. Because RNG (and unstable drivers in general) do not exist without `unstable`, and unstable peripheral types are not visible externally, this function can only be used when the `unstable` feature is enabled. Instead of `expect(dead_code)` we can just make the function unstable for the same, but more idiomatic end result.