### PR TITLE
CI: Add a workflow for checking and notifying about merge conflicts

### DIFF
--- a/.github/workflows/merge-conflict.yml
+++ b/.github/workflows/merge-conflict.yml
@@ -15,4 +15,4 @@ jobs:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
           dirtyLabel: "merge-conflict"
           removeOnDirtyLabel: true
-          commentOnDirty: "Notification about merge conflicts. Please resolve the conflicts."
+          commentOnDirty: "New commits in main has made this PR unmergable. Please resolve the conflicts."


### PR DESCRIPTION
When merge conflict is present in a PR, the CI adds `merge-conflict` label (so we can filter this), posts
"Notification about merge conflicts. Please resolve the conflicts." comment and automatically removes the label when conflicts have been resolved. 

Tested here: https://github.com/JurajSadel/esp-hal/pull/21