### PR TITLE
Remove non-nested interrupt handler concept

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -85,6 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Rtc::estimate_xtal_frequency()` (#4851)
 - `RtcFastClock`, `RtcSlowClock` (#4851)
 - `esp_hal::interrupt::{map, enable_direct, RESERVED_INTERRUPTS}` from ESP32, ESP32-S2 and ESP32-S3 (#5007)
+- `InterruptHandler::new_not_nested` (#5000)
 
 ## [v1.0.0] - 2025-10-30
 

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -686,7 +686,7 @@ impl<'d> Io<'d> {
                 crate::interrupt::IsrCallback::new(user_gpio_interrupt_handler),
             )
         };
-        USER_INTERRUPT_HANDLER.store(handler.handler().aligned_ptr());
+        USER_INTERRUPT_HANDLER.store(handler.handler().callback());
     }
 }
 

--- a/esp-hal/src/interrupt/mod.rs
+++ b/esp-hal/src/interrupt/mod.rs
@@ -73,8 +73,6 @@ We reserve a number of CPU interrupts, which cannot be used; see
 //! }
 //! ```
 
-use core::num::NonZeroUsize;
-
 #[cfg(riscv)]
 pub use self::riscv::*;
 #[cfg(xtensa)]
@@ -144,54 +142,32 @@ pub trait InterruptConfigurable: crate::private::Sealed {
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct IsrCallback {
-    f: NonZeroUsize,
+    f: extern "C" fn(),
 }
 
 impl IsrCallback {
     /// Construct a new callback from the callback function.
     pub fn new(f: extern "C" fn()) -> Self {
         // a valid fn pointer is non zero
-        Self {
-            f: unwrap!(NonZeroUsize::new(f as usize)),
-        }
-    }
-
-    /// Construct a new callback from the callback function and the nested flag.
-    pub(crate) fn new_with_nested(f: extern "C" fn(), nested: bool) -> Self {
-        // a valid fn pointer is non zero
-        let f = unwrap!(NonZeroUsize::new(f as usize | !nested as usize));
         Self { f }
     }
 
-    /// Construct a new callback from a raw value.
-    ///
-    /// # Panics
-    ///
-    /// Passing zero is invalid and results in a panic.
-    pub fn from_raw(f: usize) -> Self {
-        Self {
-            f: unwrap!(NonZeroUsize::new(f)),
-        }
-    }
-
-    /// Returns the raw value of the callback.
-    ///
-    /// Don't just cast this to function and call it - it might be misaligned.
-    pub fn raw_value(self) -> usize {
-        self.f.into()
+    /// Returns the address of the callback.
+    pub fn address(self) -> usize {
+        self.f as usize
     }
 
     /// The callback function.
     ///
     /// This is aligned and can be called.
-    pub fn aligned_ptr(self) -> extern "C" fn() {
-        unsafe { core::mem::transmute::<usize, extern "C" fn()>(Into::<usize>::into(self.f) & !1) }
+    pub fn callback(self) -> extern "C" fn() {
+        self.f
     }
 }
 
 impl PartialEq for IsrCallback {
     fn eq(&self, other: &Self) -> bool {
-        core::ptr::fn_addr_eq(self.aligned_ptr(), other.aligned_ptr())
+        core::ptr::fn_addr_eq(self.callback(), other.callback())
     }
 }
 
@@ -205,48 +181,19 @@ impl PartialEq for IsrCallback {
 pub struct InterruptHandler {
     f: extern "C" fn(),
     prio: Priority,
-    #[cfg(riscv)]
-    nested: bool,
 }
 
 impl InterruptHandler {
     /// Creates a new [InterruptHandler] which will call the given function at
     /// the given priority.
     pub const fn new(f: extern "C" fn(), prio: Priority) -> Self {
-        Self {
-            f,
-            prio,
-            #[cfg(riscv)]
-            nested: true,
-        }
-    }
-
-    /// Creates a new [InterruptHandler] which will call the given function at
-    /// the given priority with disabled interrupt nesting.
-    ///
-    /// Usually higher priority interrupts get served while handling an interrupt.
-    /// Using this the interrupt handler won't get preempted by higher priority interrupts.
-    #[cfg(riscv)]
-    pub fn new_not_nested(f: extern "C" fn(), prio: Priority) -> Self {
-        Self {
-            f,
-            prio,
-            nested: false,
-        }
+        Self { f, prio }
     }
 
     /// The Isr callback.
     #[inline]
     pub fn handler(&self) -> IsrCallback {
-        cfg_if::cfg_if! {
-            if #[cfg(riscv)] {
-                let nested = self.nested;
-            } else {
-                let nested = true;
-            }
-        }
-
-        IsrCallback::new_with_nested(self.f, nested)
+        IsrCallback::new(self.f)
     }
 
     /// Priority to be used when registering the interrupt

--- a/esp-hal/src/interrupt/xtensa.rs
+++ b/esp-hal/src/interrupt/xtensa.rs
@@ -406,18 +406,22 @@ mod vectored {
         let ptr =
             unsafe { &pac::__INTERRUPTS[interrupt as usize]._handler as *const _ as *mut usize };
         unsafe {
-            ptr.write_volatile(handler.raw_value());
+            ptr.write_volatile(handler.address());
         }
     }
 
     /// Returns the currently bound interrupt handler.
     pub fn bound_handler(interrupt: Interrupt) -> Option<IsrCallback> {
         unsafe {
-            let addr = pac::__INTERRUPTS[interrupt as usize]._handler as usize;
-            if addr == 0 {
+            let func = pac::__INTERRUPTS[interrupt as usize]._handler;
+            if func as usize == 0 {
                 return None;
             }
-            Some(IsrCallback::from_raw(addr))
+
+            Some(IsrCallback::new(core::mem::transmute::<
+                unsafe extern "C" fn(),
+                extern "C" fn(),
+            >(func)))
         }
     }
 

--- a/esp-hal/src/timer/systimer.rs
+++ b/esp-hal/src/timer/systimer.rs
@@ -580,7 +580,7 @@ impl Alarm<'_> {
                 if SYSTIMER::regs().int_raw().read().target(CH).bit_is_set() {
                     let handler = unsafe { HANDLERS[CH as usize] };
                     if let Some(handler) = handler {
-                        (handler.aligned_ptr())();
+                        (handler.callback())();
                     }
                 }
             }

--- a/qa-test/src/bin/gpio_interrupt_latency.rs
+++ b/qa-test/src/bin/gpio_interrupt_latency.rs
@@ -13,7 +13,7 @@
 //! generated square waves are 90 degrees out of phase. DO NOT CONNECT GPIO2 and
 //! GPIO4 - they read back themselves.
 
-//% CHIPS: esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c6 esp32h2
+//% CHIPS: esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c5 esp32c6 esp32h2
 
 #![no_std]
 #![no_main]


### PR DESCRIPTION
I think this is a flawed concept that shouldn't exist. If someone needs their code to not be interrupted, they can use a critical section. For performance-sensitive code, direct-binding is available. The non-nested handler code just adds latency otherwise.