### PR TITLE
Add basic async/await support for `SimpleMem2MemTransfer`s

### DIFF
--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -2917,6 +2917,18 @@ pub(crate) mod asynch {
         }
     }
 
+    pub struct DmaRxWaitEofInterrupts;
+
+    impl DmaFutureInterrupts<DmaRxInterrupt> for DmaRxWaitEofInterrupts {
+        fn success() -> EnumSet<DmaRxInterrupt> {
+            DmaRxInterrupt::DescriptorEmpty | DmaRxInterrupt::SuccessfulEof
+        }
+
+        fn failure() -> EnumSet<DmaRxInterrupt> {
+            DmaRxInterrupt::DescriptorError.into()
+        }
+    }
+
     /// For a future that waits for `DmaTxInterrupt::Done`.
     #[cfg(any(soc_has_i2s0, soc_has_i2s1))]
     pub struct DmaTxDoneInterrupts;
@@ -3086,6 +3098,7 @@ pub(crate) mod asynch {
     pub type DmaRxFuture<'a, CH> = DmaRxFutureWithInterrupts<'a, CH, DmaRxDefaultInterrupts>;
     pub type DmaTxWaitFuture<'a, CH> = DmaTxFutureWithInterrupts<'a, CH, DmaTxWaitInterrupts>;
     pub type DmaRxWaitFuture<'a, CH> = DmaRxFutureWithInterrupts<'a, CH, DmaRxWaitInterrupts>;
+    pub type DmaRxWaitEofFuture<'a, CH> = DmaRxFutureWithInterrupts<'a, CH, DmaRxWaitEofInterrupts>;
 
     #[cfg(any(soc_has_i2s0, soc_has_i2s1))]
     pub type DmaTxDoneChFuture<'a, CH> = DmaTxFutureWithInterrupts<'a, CH, DmaTxDoneInterrupts>;


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
  - No, it's currently based on v1.0.0, not main
- [ ] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
  - N/A
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Implements `wait_async` methods on `Mem2MemRxTransfer`, `Mem2MemTxTransfer` and `SimpleMem2MemTransfer`, via existing implementations of `Future`.

Related to https://github.com/esp-rs/esp-hal/issues/2884

#### Testing
I'm just running it on my board with an LCD screen. The added code is part of [an implementation of bounce buffers](https://forgejo.limeth.cz/limeth/acid/compare/master...bounce_buffer) for driving a DPI peripheral.