### PR TITLE
Xtensa: Remove direct interrupt binding

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -84,7 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `RtcClock::xtal_freq()` and the `XtalClock` enum (#4724)
 - `Rtc::estimate_xtal_frequency()` (#4851)
 - `RtcFastClock`, `RtcSlowClock` (#4851)
-- `esp_hal::interrupt::enable_direct` from ESP32, ESP32-S2 and ESP32-S3 (#5007)
+- `esp_hal::interrupt::{map, enable_direct, RESERVED_INTERRUPTS}` from ESP32, ESP32-S2 and ESP32-S3 (#5007)
 
 ## [v1.0.0] - 2025-10-30
 

--- a/esp-hal/src/interrupt/mod.rs
+++ b/esp-hal/src/interrupt/mod.rs
@@ -17,14 +17,17 @@
 //! only meant to be used in very special situations (mostly internal to the HAL
 //! or the supporting libraries). Those are outside the scope of this
 //! documentation.
-//!
-//! It is even possible, but not recommended, to bind an interrupt directly to a
-//! CPU interrupt. This can offer lower latency, at the cost of more complexity
-//! in the interrupt handler. See the `direct_vectoring.rs` example
-//!
-//! We reserve a number of CPU interrupts, which cannot be used; see
-//! [`RESERVED_INTERRUPTS`].
-//!
+#![cfg_attr(
+    riscv,
+    doc = r#"
+It is even possible, but not recommended, to bind an interrupt directly to a
+CPU interrupt. This can offer lower latency, at the cost of more complexity
+in the interrupt handler. See the `direct_vectoring.rs` example
+
+We reserve a number of CPU interrupts, which cannot be used; see
+[`RESERVED_INTERRUPTS`].
+"#
+)]
 //! ## Examples
 //!
 //! ### Using the peripheral driver to register an interrupt handler


### PR DESCRIPTION
I just don't think this feature is valuable in its current form. The way our (and Xtensa's) interrupt handling works, every peripheral interrupt is handled the same way: a CPU interrupt of a given level hits, we read the 3-4 interrupt status registers, we iterate through their bits, and handle what's pending at the given level. This process doesn't care about _which_ CPU interrupt is pending, so direct-binding a handler literally makes no difference.

Where it could make a difference is the higher priority interrupt handlers. They need to be written in assembly because EXCM is configured to 3 on our CPUs, so exceptions (like window over/underflow) wouldn't be handled in them. However, we still need code to dispatch a particular CPU interrupt to a particular interrupt handler, which we don't currently have.