### PR TITLE
Clean up radio interrupt dispatch

### DIFF
--- a/esp-radio/src/ble/npl.rs
+++ b/esp-radio/src/ble/npl.rs
@@ -329,10 +329,11 @@ pub(crate) struct ExtFuncsT {
 }
 
 static G_OSI_FUNCS: ExtFuncsT = ExtFuncsT {
-    #[cfg(not(esp32c2))]
-    ext_version: 0x20250415,
-    #[cfg(esp32c2)]
-    ext_version: 0x20221122,
+    ext_version: if cfg!(esp32c2) {
+        0x20221122
+    } else {
+        0x20250415
+    },
 
     esp_intr_alloc: Some(self::ble_os_adapter_chip_specific::esp_intr_alloc),
     esp_intr_free: Some(esp_intr_free),

--- a/esp-radio/src/ble/os_adapter_esp32c2.rs
+++ b/esp-radio/src/ble/os_adapter_esp32c2.rs
@@ -4,14 +4,12 @@ use super::*;
 use crate::{
     ble::InvalidConfigError,
     hal::{clock::Clocks, efuse::Efuse, interrupt, peripherals::BT},
+    interrupt_dispatch::Handler,
     sys::include::esp_bt_controller_config_t,
 };
 
-pub(crate) static mut ISR_INTERRUPT_4: (*mut c_void, *mut c_void) =
-    (core::ptr::null_mut(), core::ptr::null_mut());
-
-pub(crate) static mut ISR_INTERRUPT_7: (*mut c_void, *mut c_void) =
-    (core::ptr::null_mut(), core::ptr::null_mut());
+static ISR_INTERRUPT_4: Handler = Handler::new();
+static ISR_INTERRUPT_7: Handler = Handler::new();
 
 /// Transmission Power Level
 #[derive(Default, Clone, Copy, Eq, PartialEq)]
@@ -355,18 +353,16 @@ pub(super) unsafe extern "C" fn esp_intr_alloc(
         source, flags, handler, arg, ret_handle
     );
 
-    unsafe {
-        match source {
-            4 => {
-                ISR_INTERRUPT_4 = (handler, arg);
-                BT::steal().enable_mac_interrupt(interrupt::Priority::Priority1);
-            }
-            7 => {
-                ISR_INTERRUPT_7 = (handler, arg);
-                BT::steal().enable_lp_timer_interrupt(interrupt::Priority::Priority1);
-            }
-            _ => panic!("Unexpected interrupt source {}", source),
-        }
+    match source {
+        4 => unsafe {
+            ISR_INTERRUPT_4.set(handler, arg);
+            BT::steal().enable_mac_interrupt(interrupt::Priority::Priority1);
+        },
+        7 => unsafe {
+            ISR_INTERRUPT_7.set(handler, arg);
+            BT::steal().enable_lp_timer_interrupt(interrupt::Priority::Priority1);
+        },
+        _ => panic!("Unexpected interrupt source {}", source),
     }
 
     0
@@ -402,43 +398,13 @@ pub(crate) fn shutdown_ble_isr() {
 }
 
 #[unsafe(no_mangle)]
+#[crate::hal::ram]
 extern "C" fn LP_TIMER() {
-    unsafe {
-        trace!("LP_TIMER interrupt");
-
-        let (fnc, arg) = ISR_INTERRUPT_7;
-
-        trace!("interrupt LP_TIMER {:?} {:?}", fnc, arg);
-
-        if !fnc.is_null() {
-            trace!("interrupt LP_TIMER call");
-
-            let fnc: fn(*mut c_void) = core::mem::transmute(fnc);
-            fnc(arg);
-            trace!("LP_TIMER done");
-        }
-
-        trace!("interrupt LP_TIMER done");
-    };
+    ISR_INTERRUPT_7.dispatch();
 }
 
 #[unsafe(no_mangle)]
+#[crate::hal::ram]
 extern "C" fn BT_MAC() {
-    unsafe {
-        trace!("BT_MAC interrupt");
-
-        let (fnc, arg) = ISR_INTERRUPT_4;
-
-        trace!("interrupt BT_MAC {:?} {:?}", fnc, arg);
-
-        if !fnc.is_null() {
-            trace!("interrupt BT_MAC call");
-
-            let fnc: fn(*mut c_void) = core::mem::transmute(fnc);
-            fnc(arg);
-            trace!("BT_MAC done");
-        }
-
-        trace!("interrupt BT_MAC done");
-    };
+    ISR_INTERRUPT_4.dispatch();
 }

--- a/esp-radio/src/ble/os_adapter_esp32h2.rs
+++ b/esp-radio/src/ble/os_adapter_esp32h2.rs
@@ -4,14 +4,12 @@ use super::*;
 use crate::{
     ble::InvalidConfigError,
     hal::{clock::ModemClockController, interrupt, peripherals::BT},
+    interrupt_dispatch::Handler,
     sys::include::esp_bt_controller_config_t,
 };
 
-pub(crate) static mut ISR_INTERRUPT_15: (*mut c_void, *mut c_void) =
-    (core::ptr::null_mut(), core::ptr::null_mut());
-
-pub(crate) static mut ISR_INTERRUPT_3: (*mut c_void, *mut c_void) =
-    (core::ptr::null_mut(), core::ptr::null_mut());
+static ISR_INTERRUPT_3: Handler = Handler::new();
+static ISR_INTERRUPT_15: Handler = Handler::new();
 
 /// Transmission Power Level
 #[derive(Default, Clone, Copy, Eq, PartialEq)]
@@ -365,18 +363,16 @@ pub(super) unsafe extern "C" fn esp_intr_alloc(
         source, flags, handler, arg, ret_handle
     );
 
-    unsafe {
-        match source {
-            3 => {
-                ISR_INTERRUPT_3 = (handler, arg);
-                BT::steal().enable_lp_timer_interrupt(interrupt::Priority::Priority1);
-            }
-            15 => {
-                ISR_INTERRUPT_15 = (handler, arg);
-                BT::steal().enable_mac_interrupt(interrupt::Priority::Priority1);
-            }
-            _ => panic!("Unexpected interrupt source {}", source),
-        }
+    match source {
+        3 => unsafe {
+            ISR_INTERRUPT_3.set(handler, arg);
+            BT::steal().enable_lp_timer_interrupt(interrupt::Priority::Priority1);
+        },
+        15 => unsafe {
+            ISR_INTERRUPT_15.set(handler, arg);
+            BT::steal().enable_mac_interrupt(interrupt::Priority::Priority1);
+        },
+        _ => panic!("Unexpected interrupt source {}", source),
     }
 
     0
@@ -390,45 +386,15 @@ pub(super) fn ble_rtc_clk_init() {
 }
 
 #[unsafe(no_mangle)]
+#[crate::hal::ram]
 extern "C" fn LP_BLE_TIMER() {
-    unsafe {
-        trace!("LP_TIMER interrupt");
-
-        let (fnc, arg) = ISR_INTERRUPT_3;
-
-        trace!("interrupt LP_TIMER {:?} {:?}", fnc, arg);
-
-        if !fnc.is_null() {
-            trace!("interrupt LP_TIMER call");
-
-            let fnc: fn(*mut c_void) = core::mem::transmute(fnc);
-            fnc(arg);
-            trace!("LP_TIMER done");
-        }
-
-        trace!("interrupt LP_TIMER done");
-    };
+    ISR_INTERRUPT_3.dispatch();
 }
 
 #[unsafe(no_mangle)]
+#[crate::hal::ram]
 extern "C" fn BT_MAC() {
-    unsafe {
-        trace!("BT_MAC interrupt");
-
-        let (fnc, arg) = ISR_INTERRUPT_15;
-
-        trace!("interrupt BT_MAC {:?} {:?}", fnc, arg);
-
-        if !fnc.is_null() {
-            trace!("interrupt BT_MAC call");
-
-            let fnc: fn(*mut c_void) = core::mem::transmute(fnc);
-            fnc(arg);
-            trace!("BT_MAC done");
-        }
-
-        trace!("interrupt BT_MAC done");
-    };
+    ISR_INTERRUPT_15.dispatch();
 }
 
 pub(crate) fn shutdown_ble_isr() {

--- a/esp-radio/src/interrupt_dispatch.rs
+++ b/esp-radio/src/interrupt_dispatch.rs
@@ -1,0 +1,36 @@
+use core::{ffi::c_void, sync::atomic::Ordering};
+
+use portable_atomic::AtomicPtr;
+
+pub(crate) struct Handler {
+    f: AtomicPtr<c_void>,
+    arg: AtomicPtr<c_void>,
+}
+
+impl Handler {
+    pub const fn new() -> Self {
+        Self {
+            f: AtomicPtr::new(core::ptr::null_mut()),
+            arg: AtomicPtr::new(core::ptr::null_mut()),
+        }
+    }
+
+    pub fn set(&self, f: *const c_void, arg: *const c_void) {
+        self.arg.store(arg.cast_mut(), Ordering::Relaxed);
+        self.f.store(f.cast_mut(), Ordering::Release);
+    }
+
+    #[crate::hal::ram]
+    pub fn dispatch(&self) {
+        let f = self.f.load(Ordering::Acquire);
+        if !f.is_null() {
+            let func = unsafe {
+                core::mem::transmute::<*const c_void, unsafe extern "C" fn(*mut c_void)>(f)
+            };
+            let arg = self.arg.load(Ordering::Relaxed);
+            trace!("calling {:x} with {:x}", f as usize, arg as usize);
+            unsafe { func(arg) };
+            trace!("{:x} done", f as usize);
+        }
+    }
+}

--- a/esp-radio/src/lib.rs
+++ b/esp-radio/src/lib.rs
@@ -233,6 +233,7 @@ macro_rules! unstable_module {
 }
 
 mod compat;
+mod interrupt_dispatch;
 mod time;
 
 #[cfg(feature = "wifi")]

--- a/esp-radio/src/wifi/os_adapter/esp32c3.rs
+++ b/esp-radio/src/wifi/os_adapter/esp32c3.rs
@@ -3,8 +3,11 @@ use crate::{
         interrupt::Priority,
         peripherals::{INTERRUPT_CORE0, WIFI},
     },
+    interrupt_dispatch::Handler,
     sys::c_types::c_void,
 };
+
+static ISR_INTERRUPT_1: Handler = Handler::new();
 
 pub(crate) fn chip_ints_on(mask: u32) {
     unsafe {
@@ -55,12 +58,7 @@ pub(crate) unsafe extern "C" fn set_intr(
 pub unsafe extern "C" fn set_isr(n: i32, f: *mut c_void, arg: *mut c_void) {
     trace!("set_isr - interrupt {} function {:?} arg {:?}", n, f, arg);
     match n {
-        0 => unsafe {
-            crate::wifi::ISR_INTERRUPT_1 = (f, arg);
-        },
-        1 => unsafe {
-            crate::wifi::ISR_INTERRUPT_1 = (f, arg);
-        },
+        0 | 1 => ISR_INTERRUPT_1.set(f, arg),
         _ => panic!("set_isr - unsupported interrupt number {}", n),
     }
 
@@ -71,35 +69,15 @@ pub unsafe extern "C" fn set_isr(n: i32, f: *mut c_void, arg: *mut c_void) {
 }
 
 #[unsafe(no_mangle)]
+#[crate::hal::ram]
 extern "C" fn WIFI_MAC() {
-    unsafe {
-        let (fnc, arg) = crate::wifi::ISR_INTERRUPT_1;
-
-        trace!("interrupt WIFI_MAC {:?} {:?}", fnc, arg);
-
-        if !fnc.is_null() {
-            let fnc: fn(*mut c_void) = core::mem::transmute(fnc);
-            fnc(arg);
-        }
-
-        trace!("interrupt 1 done");
-    };
+    ISR_INTERRUPT_1.dispatch();
 }
 
 #[unsafe(no_mangle)]
+#[crate::hal::ram]
 extern "C" fn WIFI_PWR() {
-    unsafe {
-        let (fnc, arg) = crate::wifi::ISR_INTERRUPT_1;
-
-        trace!("interrupt WIFI_PWR {:?} {:?}", fnc, arg);
-
-        if !fnc.is_null() {
-            let fnc: fn(*mut c_void) = core::mem::transmute(fnc);
-            fnc(arg);
-        }
-
-        trace!("interrupt 1 done");
-    };
+    ISR_INTERRUPT_1.dispatch();
 }
 
 pub(crate) fn shutdown_wifi_isr() {

--- a/esp-radio/src/wifi/os_adapter/esp32c6.rs
+++ b/esp-radio/src/wifi/os_adapter/esp32c6.rs
@@ -3,8 +3,11 @@ use crate::{
         interrupt::Priority,
         peripherals::{INTPRI, WIFI},
     },
+    interrupt_dispatch::Handler,
     sys::c_types::{c_int, c_void},
 };
+
+static ISR_INTERRUPT_1: Handler = Handler::new();
 
 pub(crate) fn chip_ints_on(mask: u32) {
     unsafe {
@@ -68,12 +71,7 @@ pub unsafe extern "C" fn set_isr(n: i32, f: *mut c_void, arg: *mut c_void) {
     trace!("set_isr - interrupt {} function {:?} arg {:?}", n, f, arg);
 
     match n {
-        0 => unsafe {
-            crate::wifi::ISR_INTERRUPT_1 = (f, arg);
-        },
-        1 => unsafe {
-            crate::wifi::ISR_INTERRUPT_1 = (f, arg);
-        },
+        0 | 1 => ISR_INTERRUPT_1.set(f, arg),
         _ => panic!("set_isr - unsupported interrupt number {}", n),
     }
 
@@ -84,35 +82,15 @@ pub unsafe extern "C" fn set_isr(n: i32, f: *mut c_void, arg: *mut c_void) {
 }
 
 #[unsafe(no_mangle)]
+#[crate::hal::ram]
 extern "C" fn WIFI_MAC() {
-    unsafe {
-        let (fnc, arg) = crate::wifi::ISR_INTERRUPT_1;
-
-        trace!("interrupt WIFI_MAC {:?} {:?}", fnc, arg);
-
-        if !fnc.is_null() {
-            let fnc: fn(*mut c_void) = core::mem::transmute(fnc);
-            fnc(arg);
-        }
-
-        trace!("interrupt 1 done");
-    };
+    ISR_INTERRUPT_1.dispatch();
 }
 
 #[unsafe(no_mangle)]
+#[crate::hal::ram]
 extern "C" fn WIFI_PWR() {
-    unsafe {
-        let (fnc, arg) = crate::wifi::ISR_INTERRUPT_1;
-
-        trace!("interrupt WIFI_PWR {:?} {:?}", fnc, arg);
-
-        if !fnc.is_null() {
-            let fnc: fn(*mut c_void) = core::mem::transmute(fnc);
-            fnc(arg);
-        }
-
-        trace!("interrupt 1 done");
-    };
+    ISR_INTERRUPT_1.dispatch();
 }
 
 pub(crate) fn shutdown_wifi_isr() {

--- a/esp-radio/src/wifi/os_adapter/esp32s2.rs
+++ b/esp-radio/src/wifi/os_adapter/esp32s2.rs
@@ -1,7 +1,10 @@
 use crate::{
     hal::{interrupt::Priority, peripherals::WIFI},
+    interrupt_dispatch::Handler,
     sys::c_types::c_void,
 };
+
+static ISR_INTERRUPT_1: Handler = Handler::new();
 
 pub(crate) fn chip_ints_on(mask: u32) {
     unsafe { crate::hal::xtensa_lx::interrupt::enable_mask(mask) };
@@ -57,12 +60,7 @@ pub unsafe extern "C" fn set_isr(n: i32, f: *mut c_void, arg: *mut c_void) {
     trace!("set_isr - interrupt {} function {:?} arg {:?}", n, f, arg);
 
     match n {
-        0 => unsafe {
-            crate::wifi::ISR_INTERRUPT_1 = (f, arg);
-        },
-        1 => unsafe {
-            crate::wifi::ISR_INTERRUPT_1 = (f, arg);
-        },
+        0 | 1 => ISR_INTERRUPT_1.set(f, arg),
         _ => panic!("set_isr - unsupported interrupt number {}", n),
     }
 
@@ -73,32 +71,15 @@ pub unsafe extern "C" fn set_isr(n: i32, f: *mut c_void, arg: *mut c_void) {
 }
 
 #[unsafe(no_mangle)]
+#[crate::hal::ram]
 extern "C" fn WIFI_MAC() {
-    unsafe {
-        let (fnc, arg) = crate::wifi::ISR_INTERRUPT_1;
-        trace!("interrupt WIFI_MAC {:?} {:?}", fnc, arg);
-
-        if !fnc.is_null() {
-            let fnc: fn(*mut c_void) = core::mem::transmute(fnc);
-            fnc(arg);
-        }
-    }
+    ISR_INTERRUPT_1.dispatch();
 }
 
 #[unsafe(no_mangle)]
+#[crate::hal::ram]
 extern "C" fn WIFI_PWR() {
-    unsafe {
-        let (fnc, arg) = crate::wifi::ISR_INTERRUPT_1;
-
-        trace!("interrupt WIFI_PWR {:?} {:?}", fnc, arg);
-
-        if !fnc.is_null() {
-            let fnc: fn(*mut c_void) = core::mem::transmute(fnc);
-            fnc(arg);
-        }
-
-        trace!("interrupt 1 done");
-    };
+    ISR_INTERRUPT_1.dispatch();
 }
 
 pub(crate) fn shutdown_wifi_isr() {

--- a/esp-radio/src/wifi/os_adapter/esp32s3.rs
+++ b/esp-radio/src/wifi/os_adapter/esp32s3.rs
@@ -1,7 +1,10 @@
 use crate::{
     hal::{interrupt::Priority, peripherals::WIFI},
+    interrupt_dispatch::Handler,
     sys::c_types::c_void,
 };
+
+static ISR_INTERRUPT_1: Handler = Handler::new();
 
 pub(crate) fn chip_ints_on(mask: u32) {
     unsafe { crate::hal::xtensa_lx::interrupt::enable_mask(mask) };
@@ -45,9 +48,7 @@ pub unsafe extern "C" fn set_isr(n: i32, f: *mut c_void, arg: *mut c_void) {
     trace!("set_isr - interrupt {} function {:?} arg {:?}", n, f, arg);
 
     match n {
-        0 | 1 => unsafe {
-            crate::wifi::ISR_INTERRUPT_1 = (f, arg);
-        },
+        0 | 1 => ISR_INTERRUPT_1.set(f, arg),
         _ => panic!("set_isr - unsupported interrupt number {}", n),
     }
 
@@ -58,31 +59,15 @@ pub unsafe extern "C" fn set_isr(n: i32, f: *mut c_void, arg: *mut c_void) {
 }
 
 #[unsafe(no_mangle)]
+#[crate::hal::ram]
 extern "C" fn WIFI_MAC() {
-    unsafe {
-        let (fnc, arg) = crate::wifi::ISR_INTERRUPT_1;
-        trace!("interrupt WIFI_MAC {:?} {:?}", fnc, arg);
-
-        if !fnc.is_null() {
-            let fnc: fn(*mut c_void) = core::mem::transmute(fnc);
-            fnc(arg);
-        }
-    }
+    ISR_INTERRUPT_1.dispatch();
 }
 
 #[unsafe(no_mangle)]
+#[crate::hal::ram]
 extern "C" fn WIFI_PWR() {
-    unsafe {
-        let (fnc, arg) = crate::wifi::ISR_INTERRUPT_1;
-        trace!("interrupt WIFI_PWR {:?} {:?}", fnc, arg);
-
-        if !fnc.is_null() {
-            let fnc: fn(*mut c_void) = core::mem::transmute(fnc);
-            fnc(arg);
-        }
-
-        trace!("interrupt 1 done");
-    }
+    ISR_INTERRUPT_1.dispatch();
 }
 
 pub(crate) fn shutdown_wifi_isr() {

--- a/esp-radio/src/wifi/os_adapter/mod.rs
+++ b/esp-radio/src/wifi/os_adapter/mod.rs
@@ -88,9 +88,6 @@ pub unsafe extern "C" fn clear_intr(intr_source: u32, intr_num: u32) {
     trace!("clear_intr called {} {}", intr_source, intr_num);
 }
 
-pub static mut ISR_INTERRUPT_1: (*mut c_void, *mut c_void) =
-    (core::ptr::null_mut(), core::ptr::null_mut());
-
 /// **************************************************************************
 /// Name: esp32c3_ints_on
 ///


### PR DESCRIPTION
This PR encapsulates the copy-pasted heaps of unsafe code that forwarded interrupts to functions registered by the blobs. The PR also moves interrupt handlers to RAM.