### PR TITLE
Direct bindable interrupt enum

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `esp_hal::interrupt::status` has been replaced by `esp_hal::interrupt::InterruptStatus::current()` (#4997)
 - `esp_hal::interrupt::bind_interrupt` and `enable` have been merged into `bind_handler` which is now safe and infallible (#4996)
 - `esp_hal::peripherals::Peripherals.WIFI` and `esp_hal::peripherals::WIFI` are now stable (#5026)
+- RISC-V: `esp_hal::interrupt::enable_direct` now takes a `DirectBindableCpuInterrupt` and is infallible (#5037)
 
 ### Fixed
 
@@ -89,7 +90,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `RtcClock::xtal_freq()` and the `XtalClock` enum (#4724)
 - `Rtc::estimate_xtal_frequency()` (#4851)
 - `RtcFastClock`, `RtcSlowClock` (#4851)
-- `esp_hal::interrupt::{enable_direct, RESERVED_INTERRUPTS}` from ESP32, ESP32-S2 and ESP32-S3 (#5007)
+- `esp_hal::interrupt::enable_direct` from ESP32, ESP32-S2 and ESP32-S3 (#5007)
+- `esp_hal::interrupt::RESERVED_INTERRUPTS` (#5007, #5037)
 - `esp_hal::interrupt::map` (#4996, #5007)
 - `InterruptHandler::new_not_nested` (#5000)
 - `esp_hal::interrupt::Priority::None` (#4996)

--- a/esp-hal/MIGRATING-1.0.0.md
+++ b/esp-hal/MIGRATING-1.0.0.md
@@ -107,3 +107,24 @@ The `RtcClock::xtal_freq()` function and the `XtalClock` enum have been removed.
 ```rust
 let xtal_clock = esp_hal::clock::Clocks::get().xtal_clock;
 ```
+
+## Interrupt handling changes
+
+### Direct binding interrupt handlers
+
+On Xtensa MCUs (ESP32, ESP32-S2, ESP32-S3) the direct binding option has been removed.
+
+On RISC-V MCUs, the `interrupt::enable_direct` function now takes a `DirectBindableCpuInterrupt` and is infallible:
+
+```diff
+ interrupt::enable_direct(
+     peripheral_interrupt,
+     interrupt_priority,
+-    CpuInterrupt::Interrupt25,
++    DirectBindableCpuInterrupt::Interrupt0,
+     handler_function,
+-).unwrap();
++);
+```
+
+`DirectBindableCpuInterrupt` is numbered from 0, and corresponds to CPU interrupt numbers that are not disabled or reserved for vectoring.

--- a/esp-hal/src/interrupt/mod.rs
+++ b/esp-hal/src/interrupt/mod.rs
@@ -22,10 +22,7 @@
     doc = r#"
 It is even possible, but not recommended, to bind an interrupt directly to a
 CPU interrupt. This can offer lower latency, at the cost of more complexity
-in the interrupt handler. See the `direct_vectoring.rs` example
-
-We reserve a number of CPU interrupts, which cannot be used; see
-[`RESERVED_INTERRUPTS`].
+in the interrupt handler.
 "#
 )]
 //! ## Examples

--- a/esp-hal/src/interrupt/riscv.rs
+++ b/esp-hal/src/interrupt/riscv.rs
@@ -28,14 +28,6 @@ use crate::{
     system::Cpu,
 };
 
-/// Errors related to direct binding of interrupts
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum DirectBindingError {
-    /// The CPU interrupt is a reserved interrupt
-    CpuInterruptReserved,
-}
-
 /// Interrupt kind
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum InterruptKind {
@@ -50,7 +42,7 @@ for_each_interrupt!(
         paste::paste! {
             /// Enumeration of available CPU interrupts.
             #[repr(u32)]
-            #[derive(Debug, Copy, Clone)]
+            #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
             #[cfg_attr(feature = "defmt", derive(defmt::Format))]
             pub enum CpuInterrupt {
                 $(
@@ -65,6 +57,34 @@ for_each_interrupt!(
                     match n {
                         $(n if n == $n && n != DISABLED_CPU_INTERRUPT => Some(Self:: [<Interrupt $n>]),)*
                         _ => None
+                    }
+                }
+            }
+        }
+    };
+);
+
+for_each_classified_interrupt!(
+    (direct_bindable $( ([$class:ident $idx_in_class:literal] $n:literal) ),*) => {
+        paste::paste! {
+            /// Enumeration of CPU interrupts available for direct binding.
+            #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+            #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+            pub enum DirectBindableCpuInterrupt {
+                $(
+                    #[doc = concat!(" Direct bindable CPU interrupt number ", stringify!($idx_in_class), ".")]
+                    #[doc = " "]
+                    #[doc = concat!(" Corresponds to CPU interrupt ", stringify!($n), ".")]
+                    [<Interrupt $idx_in_class>] = $n,
+                )*
+            }
+
+            impl From<DirectBindableCpuInterrupt> for CpuInterrupt {
+                fn from(bindable: DirectBindableCpuInterrupt) -> CpuInterrupt {
+                    match bindable {
+                        $(
+                            DirectBindableCpuInterrupt::[<Interrupt $idx_in_class>] => CpuInterrupt::[<Interrupt $n>],
+                        )*
                     }
                 }
             }
@@ -181,43 +201,8 @@ impl TryFrom<u32> for Priority {
     }
 }
 
-// TODO: provide a `DirectBoundInterrupt` enum that lists the available options. This enables
-// portable direct binding.
-
 #[cfg_attr(place_switch_tables_in_ram, unsafe(link_section = ".rwtext"))]
 pub(super) static DISABLED_CPU_INTERRUPT: u32 = property!("interrupts.disabled_interrupt");
-
-/// The number of reserved (not directly bindable) interrupts.
-const RESERVED_COUNT: usize = const {
-    let mut count = 0;
-    for_each_interrupt!(([disabled $n:tt] $_:literal) => { count += 1; };);
-    for_each_interrupt!(([reserved $n:tt] $_:literal) => { count += 1; };);
-    for_each_interrupt!(([vector $n:tt] $_:literal) => { count += 1; };);
-    count
-};
-
-/// The interrupts reserved by the HAL
-#[cfg_attr(place_switch_tables_in_ram, unsafe(link_section = ".rwtext"))]
-pub static RESERVED_INTERRUPTS: [u32; RESERVED_COUNT] = const {
-    let mut counter = 0;
-    let mut reserved = [0; RESERVED_COUNT];
-    for_each_interrupt!(
-        ([disabled $_n:tt] $interrupt:literal) => {
-            reserved[counter] = $interrupt as u32;
-            counter += 1;
-        };
-        ([reserved $_n:tt] $interrupt:literal) => {
-            reserved[counter] = $interrupt as u32;
-            counter += 1;
-        };
-        ([vector $_n:tt] $interrupt:literal) => {
-            reserved[counter] = $interrupt as u32;
-            counter += 1;
-        };
-    );
-
-    reserved
-};
 
 /// The number of vectored interrupts / The number of priority levels.
 const VECTOR_COUNT: usize = const {
@@ -267,7 +252,7 @@ pub(super) static INTERRUPT_TO_PRIORITY: [Option<Priority>; INTERRUPT_COUNT] = c
     priorities
 };
 
-/// Enable an interrupt by directly binding it to a available CPU interrupt
+/// Enable an interrupt by directly binding it to an available CPU interrupt
 ///
 /// ⚠️ This installs a *raw trap handler*, the `handler` user provides is written directly into the
 /// CPU interrupt vector table. That means:
@@ -282,19 +267,12 @@ pub(super) static INTERRUPT_TO_PRIORITY: [Option<Priority>; INTERRUPT_COUNT] = c
 ///
 /// Unless you are sure that you need such low-level control to achieve the lowest possible latency,
 /// you most likely want to use [`enable`][crate::interrupt::enable] instead.
-///
-/// Trying using a reserved interrupt from [`RESERVED_INTERRUPTS`] will return
-/// an error.
 pub fn enable_direct(
     interrupt: Interrupt,
     level: Priority,
-    cpu_interrupt: CpuInterrupt,
+    cpu_interrupt: DirectBindableCpuInterrupt,
     handler: unsafe extern "C" fn(),
-) -> Result<(), DirectBindingError> {
-    if RESERVED_INTERRUPTS.contains(&(cpu_interrupt as _)) {
-        return Err(DirectBindingError::CpuInterruptReserved);
-    }
-
+) {
     super::map_raw(Cpu::current(), interrupt, cpu_interrupt as u32);
     cpu_int::set_priority_raw(cpu_interrupt as u32, level);
 
@@ -346,7 +324,6 @@ pub fn enable_direct(
     }
 
     cpu_int::enable_cpu_interrupt_raw(cpu_interrupt as u32);
-    Ok(())
 }
 
 // helper: returns correctly encoded RISC-V `jal` instruction

--- a/esp-metadata-generated/src/_generated_esp32c2.rs
+++ b/esp-metadata-generated/src/_generated_esp32c2.rs
@@ -331,6 +331,55 @@ macro_rules! for_each_interrupt {
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_classified_interrupt {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner_classified_interrupt { $(($pattern) => $code;)*
+        ($other : tt) => {} } _for_each_inner_classified_interrupt!(([direct_bindable 0]
+        1)); _for_each_inner_classified_interrupt!(([direct_bindable 1] 2));
+        _for_each_inner_classified_interrupt!(([direct_bindable 2] 3));
+        _for_each_inner_classified_interrupt!(([direct_bindable 3] 4));
+        _for_each_inner_classified_interrupt!(([direct_bindable 4] 5));
+        _for_each_inner_classified_interrupt!(([direct_bindable 5] 6));
+        _for_each_inner_classified_interrupt!(([direct_bindable 6] 7));
+        _for_each_inner_classified_interrupt!(([direct_bindable 7] 8));
+        _for_each_inner_classified_interrupt!(([direct_bindable 8] 9));
+        _for_each_inner_classified_interrupt!(([direct_bindable 9] 10));
+        _for_each_inner_classified_interrupt!(([direct_bindable 10] 11));
+        _for_each_inner_classified_interrupt!(([direct_bindable 11] 12));
+        _for_each_inner_classified_interrupt!(([direct_bindable 12] 13));
+        _for_each_inner_classified_interrupt!(([direct_bindable 13] 14));
+        _for_each_inner_classified_interrupt!(([direct_bindable 14] 15));
+        _for_each_inner_classified_interrupt!(([direct_bindable 15] 16));
+        _for_each_inner_classified_interrupt!(([vector 0] 17));
+        _for_each_inner_classified_interrupt!(([vector 1] 18));
+        _for_each_inner_classified_interrupt!(([vector 2] 19));
+        _for_each_inner_classified_interrupt!(([vector 3] 20));
+        _for_each_inner_classified_interrupt!(([vector 4] 21));
+        _for_each_inner_classified_interrupt!(([vector 5] 22));
+        _for_each_inner_classified_interrupt!(([vector 6] 23));
+        _for_each_inner_classified_interrupt!(([vector 7] 24));
+        _for_each_inner_classified_interrupt!(([vector 8] 25));
+        _for_each_inner_classified_interrupt!(([vector 9] 26));
+        _for_each_inner_classified_interrupt!(([vector 10] 27));
+        _for_each_inner_classified_interrupt!(([vector 11] 28));
+        _for_each_inner_classified_interrupt!(([vector 12] 29));
+        _for_each_inner_classified_interrupt!(([vector 13] 30));
+        _for_each_inner_classified_interrupt!(([vector 14] 31));
+        _for_each_inner_classified_interrupt!((direct_bindable([direct_bindable 0] 1),
+        ([direct_bindable 1] 2), ([direct_bindable 2] 3), ([direct_bindable 3] 4),
+        ([direct_bindable 4] 5), ([direct_bindable 5] 6), ([direct_bindable 6] 7),
+        ([direct_bindable 7] 8), ([direct_bindable 8] 9), ([direct_bindable 9] 10),
+        ([direct_bindable 10] 11), ([direct_bindable 11] 12), ([direct_bindable 12] 13),
+        ([direct_bindable 13] 14), ([direct_bindable 14] 15), ([direct_bindable 15]
+        16))); _for_each_inner_classified_interrupt!((vector([vector 0] 17), ([vector 1]
+        18), ([vector 2] 19), ([vector 3] 20), ([vector 4] 21), ([vector 5] 22), ([vector
+        6] 23), ([vector 7] 24), ([vector 8] 25), ([vector 9] 26), ([vector 10] 27),
+        ([vector 11] 28), ([vector 12] 29), ([vector 13] 30), ([vector 14] 31)));
+        _for_each_inner_classified_interrupt!((reserved));
+    };
+}
+#[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_interrupt_priority {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_interrupt_priority { $(($pattern) => $code;)*

--- a/esp-metadata-generated/src/_generated_esp32c3.rs
+++ b/esp-metadata-generated/src/_generated_esp32c3.rs
@@ -406,6 +406,55 @@ macro_rules! for_each_interrupt {
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_classified_interrupt {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner_classified_interrupt { $(($pattern) => $code;)*
+        ($other : tt) => {} } _for_each_inner_classified_interrupt!(([direct_bindable 0]
+        1)); _for_each_inner_classified_interrupt!(([direct_bindable 1] 2));
+        _for_each_inner_classified_interrupt!(([direct_bindable 2] 3));
+        _for_each_inner_classified_interrupt!(([direct_bindable 3] 4));
+        _for_each_inner_classified_interrupt!(([direct_bindable 4] 5));
+        _for_each_inner_classified_interrupt!(([direct_bindable 5] 6));
+        _for_each_inner_classified_interrupt!(([direct_bindable 6] 7));
+        _for_each_inner_classified_interrupt!(([direct_bindable 7] 8));
+        _for_each_inner_classified_interrupt!(([direct_bindable 8] 9));
+        _for_each_inner_classified_interrupt!(([direct_bindable 9] 10));
+        _for_each_inner_classified_interrupt!(([direct_bindable 10] 11));
+        _for_each_inner_classified_interrupt!(([direct_bindable 11] 12));
+        _for_each_inner_classified_interrupt!(([direct_bindable 12] 13));
+        _for_each_inner_classified_interrupt!(([direct_bindable 13] 14));
+        _for_each_inner_classified_interrupt!(([direct_bindable 14] 15));
+        _for_each_inner_classified_interrupt!(([direct_bindable 15] 16));
+        _for_each_inner_classified_interrupt!(([vector 0] 17));
+        _for_each_inner_classified_interrupt!(([vector 1] 18));
+        _for_each_inner_classified_interrupt!(([vector 2] 19));
+        _for_each_inner_classified_interrupt!(([vector 3] 20));
+        _for_each_inner_classified_interrupt!(([vector 4] 21));
+        _for_each_inner_classified_interrupt!(([vector 5] 22));
+        _for_each_inner_classified_interrupt!(([vector 6] 23));
+        _for_each_inner_classified_interrupt!(([vector 7] 24));
+        _for_each_inner_classified_interrupt!(([vector 8] 25));
+        _for_each_inner_classified_interrupt!(([vector 9] 26));
+        _for_each_inner_classified_interrupt!(([vector 10] 27));
+        _for_each_inner_classified_interrupt!(([vector 11] 28));
+        _for_each_inner_classified_interrupt!(([vector 12] 29));
+        _for_each_inner_classified_interrupt!(([vector 13] 30));
+        _for_each_inner_classified_interrupt!(([vector 14] 31));
+        _for_each_inner_classified_interrupt!((direct_bindable([direct_bindable 0] 1),
+        ([direct_bindable 1] 2), ([direct_bindable 2] 3), ([direct_bindable 3] 4),
+        ([direct_bindable 4] 5), ([direct_bindable 5] 6), ([direct_bindable 6] 7),
+        ([direct_bindable 7] 8), ([direct_bindable 8] 9), ([direct_bindable 9] 10),
+        ([direct_bindable 10] 11), ([direct_bindable 11] 12), ([direct_bindable 12] 13),
+        ([direct_bindable 13] 14), ([direct_bindable 14] 15), ([direct_bindable 15]
+        16))); _for_each_inner_classified_interrupt!((vector([vector 0] 17), ([vector 1]
+        18), ([vector 2] 19), ([vector 3] 20), ([vector 4] 21), ([vector 5] 22), ([vector
+        6] 23), ([vector 7] 24), ([vector 8] 25), ([vector 9] 26), ([vector 10] 27),
+        ([vector 11] 28), ([vector 12] 29), ([vector 13] 30), ([vector 14] 31)));
+        _for_each_inner_classified_interrupt!((reserved));
+    };
+}
+#[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_interrupt_priority {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_interrupt_priority { $(($pattern) => $code;)*

--- a/esp-metadata-generated/src/_generated_esp32c5.rs
+++ b/esp-metadata-generated/src/_generated_esp32c5.rs
@@ -453,6 +453,76 @@ macro_rules! for_each_interrupt {
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_classified_interrupt {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner_classified_interrupt { $(($pattern) => $code;)*
+        ($other : tt) => {} } _for_each_inner_classified_interrupt!(([direct_bindable 0]
+        24)); _for_each_inner_classified_interrupt!(([direct_bindable 1] 25));
+        _for_each_inner_classified_interrupt!(([direct_bindable 2] 26));
+        _for_each_inner_classified_interrupt!(([direct_bindable 3] 27));
+        _for_each_inner_classified_interrupt!(([direct_bindable 4] 28));
+        _for_each_inner_classified_interrupt!(([direct_bindable 5] 29));
+        _for_each_inner_classified_interrupt!(([direct_bindable 6] 30));
+        _for_each_inner_classified_interrupt!(([direct_bindable 7] 31));
+        _for_each_inner_classified_interrupt!(([direct_bindable 8] 32));
+        _for_each_inner_classified_interrupt!(([direct_bindable 9] 33));
+        _for_each_inner_classified_interrupt!(([direct_bindable 10] 34));
+        _for_each_inner_classified_interrupt!(([direct_bindable 11] 35));
+        _for_each_inner_classified_interrupt!(([direct_bindable 12] 36));
+        _for_each_inner_classified_interrupt!(([direct_bindable 13] 37));
+        _for_each_inner_classified_interrupt!(([direct_bindable 14] 38));
+        _for_each_inner_classified_interrupt!(([direct_bindable 15] 39));
+        _for_each_inner_classified_interrupt!(([direct_bindable 16] 40));
+        _for_each_inner_classified_interrupt!(([direct_bindable 17] 41));
+        _for_each_inner_classified_interrupt!(([direct_bindable 18] 42));
+        _for_each_inner_classified_interrupt!(([direct_bindable 19] 43));
+        _for_each_inner_classified_interrupt!(([direct_bindable 20] 44));
+        _for_each_inner_classified_interrupt!(([direct_bindable 21] 45));
+        _for_each_inner_classified_interrupt!(([direct_bindable 22] 46));
+        _for_each_inner_classified_interrupt!(([direct_bindable 23] 47));
+        _for_each_inner_classified_interrupt!(([vector 0] 16));
+        _for_each_inner_classified_interrupt!(([vector 1] 17));
+        _for_each_inner_classified_interrupt!(([vector 2] 18));
+        _for_each_inner_classified_interrupt!(([vector 3] 19));
+        _for_each_inner_classified_interrupt!(([vector 4] 20));
+        _for_each_inner_classified_interrupt!(([vector 5] 21));
+        _for_each_inner_classified_interrupt!(([vector 6] 22));
+        _for_each_inner_classified_interrupt!(([vector 7] 23));
+        _for_each_inner_classified_interrupt!(([reserved 0] 1));
+        _for_each_inner_classified_interrupt!(([reserved 1] 2));
+        _for_each_inner_classified_interrupt!(([reserved 2] 3));
+        _for_each_inner_classified_interrupt!(([reserved 3] 4));
+        _for_each_inner_classified_interrupt!(([reserved 4] 5));
+        _for_each_inner_classified_interrupt!(([reserved 5] 6));
+        _for_each_inner_classified_interrupt!(([reserved 6] 7));
+        _for_each_inner_classified_interrupt!(([reserved 7] 8));
+        _for_each_inner_classified_interrupt!(([reserved 8] 9));
+        _for_each_inner_classified_interrupt!(([reserved 9] 10));
+        _for_each_inner_classified_interrupt!(([reserved 10] 11));
+        _for_each_inner_classified_interrupt!(([reserved 11] 12));
+        _for_each_inner_classified_interrupt!(([reserved 12] 13));
+        _for_each_inner_classified_interrupt!(([reserved 13] 14));
+        _for_each_inner_classified_interrupt!(([reserved 14] 15));
+        _for_each_inner_classified_interrupt!((direct_bindable([direct_bindable 0] 24),
+        ([direct_bindable 1] 25), ([direct_bindable 2] 26), ([direct_bindable 3] 27),
+        ([direct_bindable 4] 28), ([direct_bindable 5] 29), ([direct_bindable 6] 30),
+        ([direct_bindable 7] 31), ([direct_bindable 8] 32), ([direct_bindable 9] 33),
+        ([direct_bindable 10] 34), ([direct_bindable 11] 35), ([direct_bindable 12] 36),
+        ([direct_bindable 13] 37), ([direct_bindable 14] 38), ([direct_bindable 15] 39),
+        ([direct_bindable 16] 40), ([direct_bindable 17] 41), ([direct_bindable 18] 42),
+        ([direct_bindable 19] 43), ([direct_bindable 20] 44), ([direct_bindable 21] 45),
+        ([direct_bindable 22] 46), ([direct_bindable 23] 47)));
+        _for_each_inner_classified_interrupt!((vector([vector 0] 16), ([vector 1] 17),
+        ([vector 2] 18), ([vector 3] 19), ([vector 4] 20), ([vector 5] 21), ([vector 6]
+        22), ([vector 7] 23))); _for_each_inner_classified_interrupt!((reserved([reserved
+        0] 1), ([reserved 1] 2), ([reserved 2] 3), ([reserved 3] 4), ([reserved 4] 5),
+        ([reserved 5] 6), ([reserved 6] 7), ([reserved 7] 8), ([reserved 8] 9),
+        ([reserved 9] 10), ([reserved 10] 11), ([reserved 11] 12), ([reserved 12] 13),
+        ([reserved 13] 14), ([reserved 14] 15)));
+    };
+}
+#[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_interrupt_priority {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_interrupt_priority { $(($pattern) => $code;)*

--- a/esp-metadata-generated/src/_generated_esp32c6.rs
+++ b/esp-metadata-generated/src/_generated_esp32c6.rs
@@ -435,6 +435,55 @@ macro_rules! for_each_interrupt {
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_classified_interrupt {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner_classified_interrupt { $(($pattern) => $code;)*
+        ($other : tt) => {} } _for_each_inner_classified_interrupt!(([direct_bindable 0]
+        1)); _for_each_inner_classified_interrupt!(([direct_bindable 1] 2));
+        _for_each_inner_classified_interrupt!(([direct_bindable 2] 5));
+        _for_each_inner_classified_interrupt!(([direct_bindable 3] 6));
+        _for_each_inner_classified_interrupt!(([direct_bindable 4] 8));
+        _for_each_inner_classified_interrupt!(([direct_bindable 5] 9));
+        _for_each_inner_classified_interrupt!(([direct_bindable 6] 10));
+        _for_each_inner_classified_interrupt!(([direct_bindable 7] 11));
+        _for_each_inner_classified_interrupt!(([direct_bindable 8] 12));
+        _for_each_inner_classified_interrupt!(([direct_bindable 9] 13));
+        _for_each_inner_classified_interrupt!(([direct_bindable 10] 14));
+        _for_each_inner_classified_interrupt!(([direct_bindable 11] 15));
+        _for_each_inner_classified_interrupt!(([vector 0] 16));
+        _for_each_inner_classified_interrupt!(([vector 1] 17));
+        _for_each_inner_classified_interrupt!(([vector 2] 18));
+        _for_each_inner_classified_interrupt!(([vector 3] 19));
+        _for_each_inner_classified_interrupt!(([vector 4] 20));
+        _for_each_inner_classified_interrupt!(([vector 5] 21));
+        _for_each_inner_classified_interrupt!(([vector 6] 22));
+        _for_each_inner_classified_interrupt!(([vector 7] 23));
+        _for_each_inner_classified_interrupt!(([vector 8] 24));
+        _for_each_inner_classified_interrupt!(([vector 9] 25));
+        _for_each_inner_classified_interrupt!(([vector 10] 26));
+        _for_each_inner_classified_interrupt!(([vector 11] 27));
+        _for_each_inner_classified_interrupt!(([vector 12] 28));
+        _for_each_inner_classified_interrupt!(([vector 13] 29));
+        _for_each_inner_classified_interrupt!(([vector 14] 30));
+        _for_each_inner_classified_interrupt!(([reserved 0] 0));
+        _for_each_inner_classified_interrupt!(([reserved 1] 3));
+        _for_each_inner_classified_interrupt!(([reserved 2] 4));
+        _for_each_inner_classified_interrupt!(([reserved 3] 7));
+        _for_each_inner_classified_interrupt!((direct_bindable([direct_bindable 0] 1),
+        ([direct_bindable 1] 2), ([direct_bindable 2] 5), ([direct_bindable 3] 6),
+        ([direct_bindable 4] 8), ([direct_bindable 5] 9), ([direct_bindable 6] 10),
+        ([direct_bindable 7] 11), ([direct_bindable 8] 12), ([direct_bindable 9] 13),
+        ([direct_bindable 10] 14), ([direct_bindable 11] 15)));
+        _for_each_inner_classified_interrupt!((vector([vector 0] 16), ([vector 1] 17),
+        ([vector 2] 18), ([vector 3] 19), ([vector 4] 20), ([vector 5] 21), ([vector 6]
+        22), ([vector 7] 23), ([vector 8] 24), ([vector 9] 25), ([vector 10] 26),
+        ([vector 11] 27), ([vector 12] 28), ([vector 13] 29), ([vector 14] 30)));
+        _for_each_inner_classified_interrupt!((reserved([reserved 0] 0), ([reserved 1]
+        3), ([reserved 2] 4), ([reserved 3] 7)));
+    };
+}
+#[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_interrupt_priority {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_interrupt_priority { $(($pattern) => $code;)*

--- a/esp-metadata-generated/src/_generated_esp32h2.rs
+++ b/esp-metadata-generated/src/_generated_esp32h2.rs
@@ -411,6 +411,55 @@ macro_rules! for_each_interrupt {
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_classified_interrupt {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner_classified_interrupt { $(($pattern) => $code;)*
+        ($other : tt) => {} } _for_each_inner_classified_interrupt!(([direct_bindable 0]
+        1)); _for_each_inner_classified_interrupt!(([direct_bindable 1] 2));
+        _for_each_inner_classified_interrupt!(([direct_bindable 2] 5));
+        _for_each_inner_classified_interrupt!(([direct_bindable 3] 6));
+        _for_each_inner_classified_interrupt!(([direct_bindable 4] 8));
+        _for_each_inner_classified_interrupt!(([direct_bindable 5] 9));
+        _for_each_inner_classified_interrupt!(([direct_bindable 6] 10));
+        _for_each_inner_classified_interrupt!(([direct_bindable 7] 11));
+        _for_each_inner_classified_interrupt!(([direct_bindable 8] 12));
+        _for_each_inner_classified_interrupt!(([direct_bindable 9] 13));
+        _for_each_inner_classified_interrupt!(([direct_bindable 10] 14));
+        _for_each_inner_classified_interrupt!(([direct_bindable 11] 15));
+        _for_each_inner_classified_interrupt!(([vector 0] 16));
+        _for_each_inner_classified_interrupt!(([vector 1] 17));
+        _for_each_inner_classified_interrupt!(([vector 2] 18));
+        _for_each_inner_classified_interrupt!(([vector 3] 19));
+        _for_each_inner_classified_interrupt!(([vector 4] 20));
+        _for_each_inner_classified_interrupt!(([vector 5] 21));
+        _for_each_inner_classified_interrupt!(([vector 6] 22));
+        _for_each_inner_classified_interrupt!(([vector 7] 23));
+        _for_each_inner_classified_interrupt!(([vector 8] 24));
+        _for_each_inner_classified_interrupt!(([vector 9] 25));
+        _for_each_inner_classified_interrupt!(([vector 10] 26));
+        _for_each_inner_classified_interrupt!(([vector 11] 27));
+        _for_each_inner_classified_interrupt!(([vector 12] 28));
+        _for_each_inner_classified_interrupt!(([vector 13] 29));
+        _for_each_inner_classified_interrupt!(([vector 14] 30));
+        _for_each_inner_classified_interrupt!(([reserved 0] 0));
+        _for_each_inner_classified_interrupt!(([reserved 1] 3));
+        _for_each_inner_classified_interrupt!(([reserved 2] 4));
+        _for_each_inner_classified_interrupt!(([reserved 3] 7));
+        _for_each_inner_classified_interrupt!((direct_bindable([direct_bindable 0] 1),
+        ([direct_bindable 1] 2), ([direct_bindable 2] 5), ([direct_bindable 3] 6),
+        ([direct_bindable 4] 8), ([direct_bindable 5] 9), ([direct_bindable 6] 10),
+        ([direct_bindable 7] 11), ([direct_bindable 8] 12), ([direct_bindable 9] 13),
+        ([direct_bindable 10] 14), ([direct_bindable 11] 15)));
+        _for_each_inner_classified_interrupt!((vector([vector 0] 16), ([vector 1] 17),
+        ([vector 2] 18), ([vector 3] 19), ([vector 4] 20), ([vector 5] 21), ([vector 6]
+        22), ([vector 7] 23), ([vector 8] 24), ([vector 9] 25), ([vector 10] 26),
+        ([vector 11] 27), ([vector 12] 28), ([vector 13] 29), ([vector 14] 30)));
+        _for_each_inner_classified_interrupt!((reserved([reserved 0] 0), ([reserved 1]
+        3), ([reserved 2] 4), ([reserved 3] 7)));
+    };
+}
+#[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_interrupt_priority {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_interrupt_priority { $(($pattern) => $code;)*

--- a/esp-metadata/src/cfg/interrupt.rs
+++ b/esp-metadata/src/cfg/interrupt.rs
@@ -198,6 +198,14 @@ impl GenericProperty for InterruptControllerProperties {
         }
 
         let for_each_interrupt = generate_for_each_macro("interrupt", &[("all", &all)]);
+        let for_each_direct_bindable_interrupt = generate_for_each_macro(
+            "classified_interrupt",
+            &[
+                ("direct_bindable", &direct_bindable),
+                ("vector", &vector),
+                ("reserved", &reserved),
+            ],
+        );
 
         let all_priorities = (0..properties.priority_levels)
             .map(|p| {
@@ -216,6 +224,7 @@ impl GenericProperty for InterruptControllerProperties {
 
         Some(quote! {
             #for_each_interrupt
+            #for_each_direct_bindable_interrupt
             #for_each_priority
         })
     }
@@ -257,5 +266,5 @@ fn is_contiguous(mut iter: impl Iterator<Item = usize>) -> bool {
             prev = next;
         }
     }
-    return true;
+    true
 }

--- a/esp-rtos/src/task/riscv.rs
+++ b/esp-rtos/src/task/riscv.rs
@@ -159,19 +159,12 @@ pub(crate) fn setup_multitasking<const IRQ: u8>(_irq: SoftwareInterrupt<'static,
         _ => panic!("Invalid IRQ number"),
     };
 
-    let cpu_interrupt = if cfg!(interrupt_controller = "clic") {
-        interrupt::CpuInterrupt::Interrupt25
-    } else {
-        interrupt::CpuInterrupt::Interrupt15
-    };
-
-    // TODO: perhaps we need to provide an enum for the direct vector-able interrupts
-    unwrap!(interrupt::enable_direct(
+    interrupt::enable_direct(
         interrupt,
         interrupt::Priority::min(),
-        cpu_interrupt,
+        interrupt::DirectBindableCpuInterrupt::Interrupt0,
         swint_handler_trampoline,
-    ));
+    );
 }
 
 #[cfg(multi_core)]

--- a/hil-test/src/bin/interrupt.rs
+++ b/hil-test/src/bin/interrupt.rs
@@ -99,10 +99,9 @@ mod tests {
         interrupt::enable_direct(
             Interrupt::FROM_CPU_INTR0,
             Priority::Priority3,
-            CpuInterrupt::Interrupt5,
+            interrupt::DirectBindableCpuInterrupt::Interrupt0,
             interrupt_handler,
-        )
-        .unwrap();
+        );
 
         Context { sw0_trigger_addr }
     }


### PR DESCRIPTION
This PR makes it impossible to overwrite vectored interrupt handlers by direct-binding an interrupt handler to them.