### PR TITLE
Do not allow using CPU interrupt 1

### DIFF
--- a/esp-hal/src/interrupt/riscv.rs
+++ b/esp-hal/src/interrupt/riscv.rs
@@ -273,9 +273,6 @@ pub fn enable_direct(
     cpu_interrupt: DirectBindableCpuInterrupt,
     handler: unsafe extern "C" fn(),
 ) {
-    super::map_raw(Cpu::current(), interrupt, cpu_interrupt as u32);
-    cpu_int::set_priority_raw(cpu_interrupt as u32, level);
-
     cfg_if::cfg_if! {
         if #[cfg(interrupt_controller = "clic")] {
             let clic = unsafe { crate::soc::pac::CLIC::steal() };
@@ -323,6 +320,9 @@ pub fn enable_direct(
         core::arch::asm!("fence.i");
     }
 
+    super::map_raw(Cpu::current(), interrupt, cpu_interrupt as u32);
+    cpu_int::set_priority_raw(cpu_interrupt as u32, level);
+    cpu_int::set_kind_raw(cpu_interrupt as u32, InterruptKind::Level);
     cpu_int::enable_cpu_interrupt_raw(cpu_interrupt as u32);
 }
 

--- a/esp-metadata-generated/src/_generated_esp32c2.rs
+++ b/esp-metadata-generated/src/_generated_esp32c2.rs
@@ -291,22 +291,22 @@ macro_rules! for_each_interrupt {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_interrupt { $(($pattern) => $code;)* ($other : tt)
         => {} } _for_each_inner_interrupt!(([disabled 0] 0));
-        _for_each_inner_interrupt!(([direct_bindable 0] 1));
-        _for_each_inner_interrupt!(([direct_bindable 1] 2));
-        _for_each_inner_interrupt!(([direct_bindable 2] 3));
-        _for_each_inner_interrupt!(([direct_bindable 3] 4));
-        _for_each_inner_interrupt!(([direct_bindable 4] 5));
-        _for_each_inner_interrupt!(([direct_bindable 5] 6));
-        _for_each_inner_interrupt!(([direct_bindable 6] 7));
-        _for_each_inner_interrupt!(([direct_bindable 7] 8));
-        _for_each_inner_interrupt!(([direct_bindable 8] 9));
-        _for_each_inner_interrupt!(([direct_bindable 9] 10));
-        _for_each_inner_interrupt!(([direct_bindable 10] 11));
-        _for_each_inner_interrupt!(([direct_bindable 11] 12));
-        _for_each_inner_interrupt!(([direct_bindable 12] 13));
-        _for_each_inner_interrupt!(([direct_bindable 13] 14));
-        _for_each_inner_interrupt!(([direct_bindable 14] 15));
-        _for_each_inner_interrupt!(([direct_bindable 15] 16));
+        _for_each_inner_interrupt!(([reserved 0] 1));
+        _for_each_inner_interrupt!(([direct_bindable 0] 2));
+        _for_each_inner_interrupt!(([direct_bindable 1] 3));
+        _for_each_inner_interrupt!(([direct_bindable 2] 4));
+        _for_each_inner_interrupt!(([direct_bindable 3] 5));
+        _for_each_inner_interrupt!(([direct_bindable 4] 6));
+        _for_each_inner_interrupt!(([direct_bindable 5] 7));
+        _for_each_inner_interrupt!(([direct_bindable 6] 8));
+        _for_each_inner_interrupt!(([direct_bindable 7] 9));
+        _for_each_inner_interrupt!(([direct_bindable 8] 10));
+        _for_each_inner_interrupt!(([direct_bindable 9] 11));
+        _for_each_inner_interrupt!(([direct_bindable 10] 12));
+        _for_each_inner_interrupt!(([direct_bindable 11] 13));
+        _for_each_inner_interrupt!(([direct_bindable 12] 14));
+        _for_each_inner_interrupt!(([direct_bindable 13] 15));
+        _for_each_inner_interrupt!(([direct_bindable 14] 16));
         _for_each_inner_interrupt!(([vector 0] 17)); _for_each_inner_interrupt!(([vector
         1] 18)); _for_each_inner_interrupt!(([vector 2] 19));
         _for_each_inner_interrupt!(([vector 3] 20)); _for_each_inner_interrupt!(([vector
@@ -317,12 +317,12 @@ macro_rules! for_each_interrupt {
         10] 27)); _for_each_inner_interrupt!(([vector 11] 28));
         _for_each_inner_interrupt!(([vector 12] 29)); _for_each_inner_interrupt!(([vector
         13] 30)); _for_each_inner_interrupt!(([vector 14] 31));
-        _for_each_inner_interrupt!((all([disabled 0] 0), ([direct_bindable 0] 1),
-        ([direct_bindable 1] 2), ([direct_bindable 2] 3), ([direct_bindable 3] 4),
-        ([direct_bindable 4] 5), ([direct_bindable 5] 6), ([direct_bindable 6] 7),
-        ([direct_bindable 7] 8), ([direct_bindable 8] 9), ([direct_bindable 9] 10),
-        ([direct_bindable 10] 11), ([direct_bindable 11] 12), ([direct_bindable 12] 13),
-        ([direct_bindable 13] 14), ([direct_bindable 14] 15), ([direct_bindable 15] 16),
+        _for_each_inner_interrupt!((all([disabled 0] 0), ([reserved 0] 1),
+        ([direct_bindable 0] 2), ([direct_bindable 1] 3), ([direct_bindable 2] 4),
+        ([direct_bindable 3] 5), ([direct_bindable 4] 6), ([direct_bindable 5] 7),
+        ([direct_bindable 6] 8), ([direct_bindable 7] 9), ([direct_bindable 8] 10),
+        ([direct_bindable 9] 11), ([direct_bindable 10] 12), ([direct_bindable 11] 13),
+        ([direct_bindable 12] 14), ([direct_bindable 13] 15), ([direct_bindable 14] 16),
         ([vector 0] 17), ([vector 1] 18), ([vector 2] 19), ([vector 3] 20), ([vector 4]
         21), ([vector 5] 22), ([vector 6] 23), ([vector 7] 24), ([vector 8] 25), ([vector
         9] 26), ([vector 10] 27), ([vector 11] 28), ([vector 12] 29), ([vector 13] 30),
@@ -335,21 +335,20 @@ macro_rules! for_each_classified_interrupt {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_classified_interrupt { $(($pattern) => $code;)*
         ($other : tt) => {} } _for_each_inner_classified_interrupt!(([direct_bindable 0]
-        1)); _for_each_inner_classified_interrupt!(([direct_bindable 1] 2));
-        _for_each_inner_classified_interrupt!(([direct_bindable 2] 3));
-        _for_each_inner_classified_interrupt!(([direct_bindable 3] 4));
-        _for_each_inner_classified_interrupt!(([direct_bindable 4] 5));
-        _for_each_inner_classified_interrupt!(([direct_bindable 5] 6));
-        _for_each_inner_classified_interrupt!(([direct_bindable 6] 7));
-        _for_each_inner_classified_interrupt!(([direct_bindable 7] 8));
-        _for_each_inner_classified_interrupt!(([direct_bindable 8] 9));
-        _for_each_inner_classified_interrupt!(([direct_bindable 9] 10));
-        _for_each_inner_classified_interrupt!(([direct_bindable 10] 11));
-        _for_each_inner_classified_interrupt!(([direct_bindable 11] 12));
-        _for_each_inner_classified_interrupt!(([direct_bindable 12] 13));
-        _for_each_inner_classified_interrupt!(([direct_bindable 13] 14));
-        _for_each_inner_classified_interrupt!(([direct_bindable 14] 15));
-        _for_each_inner_classified_interrupt!(([direct_bindable 15] 16));
+        2)); _for_each_inner_classified_interrupt!(([direct_bindable 1] 3));
+        _for_each_inner_classified_interrupt!(([direct_bindable 2] 4));
+        _for_each_inner_classified_interrupt!(([direct_bindable 3] 5));
+        _for_each_inner_classified_interrupt!(([direct_bindable 4] 6));
+        _for_each_inner_classified_interrupt!(([direct_bindable 5] 7));
+        _for_each_inner_classified_interrupt!(([direct_bindable 6] 8));
+        _for_each_inner_classified_interrupt!(([direct_bindable 7] 9));
+        _for_each_inner_classified_interrupt!(([direct_bindable 8] 10));
+        _for_each_inner_classified_interrupt!(([direct_bindable 9] 11));
+        _for_each_inner_classified_interrupt!(([direct_bindable 10] 12));
+        _for_each_inner_classified_interrupt!(([direct_bindable 11] 13));
+        _for_each_inner_classified_interrupt!(([direct_bindable 12] 14));
+        _for_each_inner_classified_interrupt!(([direct_bindable 13] 15));
+        _for_each_inner_classified_interrupt!(([direct_bindable 14] 16));
         _for_each_inner_classified_interrupt!(([vector 0] 17));
         _for_each_inner_classified_interrupt!(([vector 1] 18));
         _for_each_inner_classified_interrupt!(([vector 2] 19));
@@ -365,17 +364,18 @@ macro_rules! for_each_classified_interrupt {
         _for_each_inner_classified_interrupt!(([vector 12] 29));
         _for_each_inner_classified_interrupt!(([vector 13] 30));
         _for_each_inner_classified_interrupt!(([vector 14] 31));
-        _for_each_inner_classified_interrupt!((direct_bindable([direct_bindable 0] 1),
-        ([direct_bindable 1] 2), ([direct_bindable 2] 3), ([direct_bindable 3] 4),
-        ([direct_bindable 4] 5), ([direct_bindable 5] 6), ([direct_bindable 6] 7),
-        ([direct_bindable 7] 8), ([direct_bindable 8] 9), ([direct_bindable 9] 10),
-        ([direct_bindable 10] 11), ([direct_bindable 11] 12), ([direct_bindable 12] 13),
-        ([direct_bindable 13] 14), ([direct_bindable 14] 15), ([direct_bindable 15]
-        16))); _for_each_inner_classified_interrupt!((vector([vector 0] 17), ([vector 1]
-        18), ([vector 2] 19), ([vector 3] 20), ([vector 4] 21), ([vector 5] 22), ([vector
-        6] 23), ([vector 7] 24), ([vector 8] 25), ([vector 9] 26), ([vector 10] 27),
+        _for_each_inner_classified_interrupt!(([reserved 0] 1));
+        _for_each_inner_classified_interrupt!((direct_bindable([direct_bindable 0] 2),
+        ([direct_bindable 1] 3), ([direct_bindable 2] 4), ([direct_bindable 3] 5),
+        ([direct_bindable 4] 6), ([direct_bindable 5] 7), ([direct_bindable 6] 8),
+        ([direct_bindable 7] 9), ([direct_bindable 8] 10), ([direct_bindable 9] 11),
+        ([direct_bindable 10] 12), ([direct_bindable 11] 13), ([direct_bindable 12] 14),
+        ([direct_bindable 13] 15), ([direct_bindable 14] 16)));
+        _for_each_inner_classified_interrupt!((vector([vector 0] 17), ([vector 1] 18),
+        ([vector 2] 19), ([vector 3] 20), ([vector 4] 21), ([vector 5] 22), ([vector 6]
+        23), ([vector 7] 24), ([vector 8] 25), ([vector 9] 26), ([vector 10] 27),
         ([vector 11] 28), ([vector 12] 29), ([vector 13] 30), ([vector 14] 31)));
-        _for_each_inner_classified_interrupt!((reserved));
+        _for_each_inner_classified_interrupt!((reserved([reserved 0] 1)));
     };
 }
 #[macro_export]

--- a/esp-metadata-generated/src/_generated_esp32c3.rs
+++ b/esp-metadata-generated/src/_generated_esp32c3.rs
@@ -366,22 +366,22 @@ macro_rules! for_each_interrupt {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_interrupt { $(($pattern) => $code;)* ($other : tt)
         => {} } _for_each_inner_interrupt!(([disabled 0] 0));
-        _for_each_inner_interrupt!(([direct_bindable 0] 1));
-        _for_each_inner_interrupt!(([direct_bindable 1] 2));
-        _for_each_inner_interrupt!(([direct_bindable 2] 3));
-        _for_each_inner_interrupt!(([direct_bindable 3] 4));
-        _for_each_inner_interrupt!(([direct_bindable 4] 5));
-        _for_each_inner_interrupt!(([direct_bindable 5] 6));
-        _for_each_inner_interrupt!(([direct_bindable 6] 7));
-        _for_each_inner_interrupt!(([direct_bindable 7] 8));
-        _for_each_inner_interrupt!(([direct_bindable 8] 9));
-        _for_each_inner_interrupt!(([direct_bindable 9] 10));
-        _for_each_inner_interrupt!(([direct_bindable 10] 11));
-        _for_each_inner_interrupt!(([direct_bindable 11] 12));
-        _for_each_inner_interrupt!(([direct_bindable 12] 13));
-        _for_each_inner_interrupt!(([direct_bindable 13] 14));
-        _for_each_inner_interrupt!(([direct_bindable 14] 15));
-        _for_each_inner_interrupt!(([direct_bindable 15] 16));
+        _for_each_inner_interrupt!(([reserved 0] 1));
+        _for_each_inner_interrupt!(([direct_bindable 0] 2));
+        _for_each_inner_interrupt!(([direct_bindable 1] 3));
+        _for_each_inner_interrupt!(([direct_bindable 2] 4));
+        _for_each_inner_interrupt!(([direct_bindable 3] 5));
+        _for_each_inner_interrupt!(([direct_bindable 4] 6));
+        _for_each_inner_interrupt!(([direct_bindable 5] 7));
+        _for_each_inner_interrupt!(([direct_bindable 6] 8));
+        _for_each_inner_interrupt!(([direct_bindable 7] 9));
+        _for_each_inner_interrupt!(([direct_bindable 8] 10));
+        _for_each_inner_interrupt!(([direct_bindable 9] 11));
+        _for_each_inner_interrupt!(([direct_bindable 10] 12));
+        _for_each_inner_interrupt!(([direct_bindable 11] 13));
+        _for_each_inner_interrupt!(([direct_bindable 12] 14));
+        _for_each_inner_interrupt!(([direct_bindable 13] 15));
+        _for_each_inner_interrupt!(([direct_bindable 14] 16));
         _for_each_inner_interrupt!(([vector 0] 17)); _for_each_inner_interrupt!(([vector
         1] 18)); _for_each_inner_interrupt!(([vector 2] 19));
         _for_each_inner_interrupt!(([vector 3] 20)); _for_each_inner_interrupt!(([vector
@@ -392,12 +392,12 @@ macro_rules! for_each_interrupt {
         10] 27)); _for_each_inner_interrupt!(([vector 11] 28));
         _for_each_inner_interrupt!(([vector 12] 29)); _for_each_inner_interrupt!(([vector
         13] 30)); _for_each_inner_interrupt!(([vector 14] 31));
-        _for_each_inner_interrupt!((all([disabled 0] 0), ([direct_bindable 0] 1),
-        ([direct_bindable 1] 2), ([direct_bindable 2] 3), ([direct_bindable 3] 4),
-        ([direct_bindable 4] 5), ([direct_bindable 5] 6), ([direct_bindable 6] 7),
-        ([direct_bindable 7] 8), ([direct_bindable 8] 9), ([direct_bindable 9] 10),
-        ([direct_bindable 10] 11), ([direct_bindable 11] 12), ([direct_bindable 12] 13),
-        ([direct_bindable 13] 14), ([direct_bindable 14] 15), ([direct_bindable 15] 16),
+        _for_each_inner_interrupt!((all([disabled 0] 0), ([reserved 0] 1),
+        ([direct_bindable 0] 2), ([direct_bindable 1] 3), ([direct_bindable 2] 4),
+        ([direct_bindable 3] 5), ([direct_bindable 4] 6), ([direct_bindable 5] 7),
+        ([direct_bindable 6] 8), ([direct_bindable 7] 9), ([direct_bindable 8] 10),
+        ([direct_bindable 9] 11), ([direct_bindable 10] 12), ([direct_bindable 11] 13),
+        ([direct_bindable 12] 14), ([direct_bindable 13] 15), ([direct_bindable 14] 16),
         ([vector 0] 17), ([vector 1] 18), ([vector 2] 19), ([vector 3] 20), ([vector 4]
         21), ([vector 5] 22), ([vector 6] 23), ([vector 7] 24), ([vector 8] 25), ([vector
         9] 26), ([vector 10] 27), ([vector 11] 28), ([vector 12] 29), ([vector 13] 30),
@@ -410,21 +410,20 @@ macro_rules! for_each_classified_interrupt {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_classified_interrupt { $(($pattern) => $code;)*
         ($other : tt) => {} } _for_each_inner_classified_interrupt!(([direct_bindable 0]
-        1)); _for_each_inner_classified_interrupt!(([direct_bindable 1] 2));
-        _for_each_inner_classified_interrupt!(([direct_bindable 2] 3));
-        _for_each_inner_classified_interrupt!(([direct_bindable 3] 4));
-        _for_each_inner_classified_interrupt!(([direct_bindable 4] 5));
-        _for_each_inner_classified_interrupt!(([direct_bindable 5] 6));
-        _for_each_inner_classified_interrupt!(([direct_bindable 6] 7));
-        _for_each_inner_classified_interrupt!(([direct_bindable 7] 8));
-        _for_each_inner_classified_interrupt!(([direct_bindable 8] 9));
-        _for_each_inner_classified_interrupt!(([direct_bindable 9] 10));
-        _for_each_inner_classified_interrupt!(([direct_bindable 10] 11));
-        _for_each_inner_classified_interrupt!(([direct_bindable 11] 12));
-        _for_each_inner_classified_interrupt!(([direct_bindable 12] 13));
-        _for_each_inner_classified_interrupt!(([direct_bindable 13] 14));
-        _for_each_inner_classified_interrupt!(([direct_bindable 14] 15));
-        _for_each_inner_classified_interrupt!(([direct_bindable 15] 16));
+        2)); _for_each_inner_classified_interrupt!(([direct_bindable 1] 3));
+        _for_each_inner_classified_interrupt!(([direct_bindable 2] 4));
+        _for_each_inner_classified_interrupt!(([direct_bindable 3] 5));
+        _for_each_inner_classified_interrupt!(([direct_bindable 4] 6));
+        _for_each_inner_classified_interrupt!(([direct_bindable 5] 7));
+        _for_each_inner_classified_interrupt!(([direct_bindable 6] 8));
+        _for_each_inner_classified_interrupt!(([direct_bindable 7] 9));
+        _for_each_inner_classified_interrupt!(([direct_bindable 8] 10));
+        _for_each_inner_classified_interrupt!(([direct_bindable 9] 11));
+        _for_each_inner_classified_interrupt!(([direct_bindable 10] 12));
+        _for_each_inner_classified_interrupt!(([direct_bindable 11] 13));
+        _for_each_inner_classified_interrupt!(([direct_bindable 12] 14));
+        _for_each_inner_classified_interrupt!(([direct_bindable 13] 15));
+        _for_each_inner_classified_interrupt!(([direct_bindable 14] 16));
         _for_each_inner_classified_interrupt!(([vector 0] 17));
         _for_each_inner_classified_interrupt!(([vector 1] 18));
         _for_each_inner_classified_interrupt!(([vector 2] 19));
@@ -440,17 +439,18 @@ macro_rules! for_each_classified_interrupt {
         _for_each_inner_classified_interrupt!(([vector 12] 29));
         _for_each_inner_classified_interrupt!(([vector 13] 30));
         _for_each_inner_classified_interrupt!(([vector 14] 31));
-        _for_each_inner_classified_interrupt!((direct_bindable([direct_bindable 0] 1),
-        ([direct_bindable 1] 2), ([direct_bindable 2] 3), ([direct_bindable 3] 4),
-        ([direct_bindable 4] 5), ([direct_bindable 5] 6), ([direct_bindable 6] 7),
-        ([direct_bindable 7] 8), ([direct_bindable 8] 9), ([direct_bindable 9] 10),
-        ([direct_bindable 10] 11), ([direct_bindable 11] 12), ([direct_bindable 12] 13),
-        ([direct_bindable 13] 14), ([direct_bindable 14] 15), ([direct_bindable 15]
-        16))); _for_each_inner_classified_interrupt!((vector([vector 0] 17), ([vector 1]
-        18), ([vector 2] 19), ([vector 3] 20), ([vector 4] 21), ([vector 5] 22), ([vector
-        6] 23), ([vector 7] 24), ([vector 8] 25), ([vector 9] 26), ([vector 10] 27),
+        _for_each_inner_classified_interrupt!(([reserved 0] 1));
+        _for_each_inner_classified_interrupt!((direct_bindable([direct_bindable 0] 2),
+        ([direct_bindable 1] 3), ([direct_bindable 2] 4), ([direct_bindable 3] 5),
+        ([direct_bindable 4] 6), ([direct_bindable 5] 7), ([direct_bindable 6] 8),
+        ([direct_bindable 7] 9), ([direct_bindable 8] 10), ([direct_bindable 9] 11),
+        ([direct_bindable 10] 12), ([direct_bindable 11] 13), ([direct_bindable 12] 14),
+        ([direct_bindable 13] 15), ([direct_bindable 14] 16)));
+        _for_each_inner_classified_interrupt!((vector([vector 0] 17), ([vector 1] 18),
+        ([vector 2] 19), ([vector 3] 20), ([vector 4] 21), ([vector 5] 22), ([vector 6]
+        23), ([vector 7] 24), ([vector 8] 25), ([vector 9] 26), ([vector 10] 27),
         ([vector 11] 28), ([vector 12] 29), ([vector 13] 30), ([vector 14] 31)));
-        _for_each_inner_classified_interrupt!((reserved));
+        _for_each_inner_classified_interrupt!((reserved([reserved 0] 1)));
     };
 }
 #[macro_export]

--- a/esp-metadata/src/cfg/interrupt.rs
+++ b/esp-metadata/src/cfg/interrupt.rs
@@ -57,7 +57,10 @@ impl RiscvFlavour {
     /// Interrupt lines reserved by hardware.
     fn reserved_interrupts(&self) -> impl Iterator<Item = usize> {
         let reserved: &[_] = match self {
-            RiscvFlavour::Basic => &[0], // Disabled interrupt
+            RiscvFlavour::Basic => &[
+                0, // Permanently disabled
+                1, // Either disabled or reserved for Wi-Fi, unclear
+            ],
             RiscvFlavour::Plic => {
                 // Some CLINT interrupts
                 &[0, 3, 4, 7]


### PR DESCRIPTION
On C2 and C3 https://github.com/esp-rs/esp-hal/pull/5037 remapped interrupts so that esp-rtos uses CPU interrupt 1 as its context switch handler. This interrupt doesn't seem to work, but it's unclear why:
- the TRM doesn't say anything
- ESP-IDF says it's reserved by Wi-Fi (but then it is incorrect about other interrupts being disabled...)

This PR removes CPU interrupt 1 from the list of direct-bindable interrupts on C2 and C3