### PR TITLE
esp-hal: Update `rng` top level docs

### DIFF
--- a/esp-hal/src/rng/mod.rs
+++ b/esp-hal/src/rng/mod.rs
@@ -16,23 +16,13 @@
 //! The hardware RNG produces true random numbers
 //! under any of the following conditions:
 //!
-//! <div class="warning">
-//!
 //! - RF subsystem is enabled (i.e. Wi-Fi or Bluetooth are enabled).
 //! - An ADC is used to generate entropy.
-//! </div>
 //!
 //! When any of these conditions are true, samples of physical noise are
 //! continuously mixed into the internal hardware RNG state to provide entropy.
 //! If none of the above conditions are true, the output of the RNG should be
-//! considered pseudo-random only [`Rng`].
-//!
-//! <div class="warning">
-//!
-//! Note that, when the Wi-Fi module is enabled, the value read from the high-speed ADC can be
-//! saturated in some extreme cases, which lowers the entropy. Thus, it is advisable to also enable
-//! the SAR ADC as the noise source for the random number generator for such cases.
-//! </div>
+//! considered pseudo-random only. See [`Rng`].
 //!
 //! For more information, please refer to the
 //! # {documentation}

--- a/esp-hal/src/rng/trng.rs
+++ b/esp-hal/src/rng/trng.rs
@@ -138,15 +138,14 @@ pub enum TrngError {
 /// can create [`Trng`] instances at any time, as long as the [`TrngSource`] is alive.
 #[cfg_attr(docsrs, procmacros::doc_replace(
     "analog_pin" => {
-        cfg(esp32) => "let analog_pin = peripherals.GPIO32;",
-        cfg(not(esp32)) => "let analog_pin = peripherals.GPIO3;"
+        cfg(esp32) => "GPIO32",
+        _ => "GPIO3"
     }
 ))]
 /// ## Example
 ///
 /// ```rust, no_run
 /// # {before_snippet}
-/// # use esp_hal::Blocking;
 /// # use esp_hal::peripherals::ADC1;
 /// # use esp_hal::analog::adc::{AdcConfig, Attenuation, Adc};
 /// #
@@ -157,7 +156,7 @@ pub enum TrngError {
 /// // ADC is not available from now
 /// let trng_source = TrngSource::new(peripherals.RNG, peripherals.ADC1.reborrow());
 ///
-/// let trng = Trng::try_new().unwrap(); // Unwrap is safe as we have enabled TrngSource.
+/// let trng = Trng::try_new()?;
 ///
 /// // Generate true random numbers
 /// trng.read(&mut buf);
@@ -169,19 +168,17 @@ pub enum TrngError {
 /// // Drop the true random number source. ADC is available now.
 /// core::mem::drop(trng_source);
 ///
-/// # {analog_pin}
-///
 /// let mut adc1_config = AdcConfig::new();
-/// let mut adc1_pin = adc1_config.enable_pin(analog_pin, Attenuation::_11dB);
-/// let mut adc1 = Adc::<ADC1, Blocking>::new(peripherals.ADC1, adc1_config);
-/// let pin_value: u16 = nb::block!(adc1.read_oneshot(&mut adc1_pin))?;
+/// let mut adc1_pin = adc1_config.enable_pin(peripherals.__analog_pin__, Attenuation::_11dB);
+/// let mut adc1 = Adc::new(peripherals.ADC1, adc1_config);
+/// let pin_value = adc1.read_oneshot(&mut adc1_pin)?;
 ///
 /// // Now we can only generate pseudo-random numbers...
 /// rng.read(&mut buf);
 /// let pseudo_random_number = rng.random();
 ///
 /// // ... but the ADC is available for use.
-/// let pin_value: u16 = nb::block!(adc1.read_oneshot(&mut adc1_pin))?;
+/// let pin_value: u16 = adc1.read_oneshot(&mut adc1_pin)?;
 /// # {after_snippet}
 /// ```
 #[derive(Default, Debug)]


### PR DESCRIPTION
Is there any reason why `trng` is not public that I'm missing? 


closes https://github.com/esp-rs/esp-hal/issues/5011