### PR TITLE
esp-storage: Erase by 64KB blocks when possible

### DIFF
--- a/esp-rom-sys/src/rom/spiflash.rs
+++ b/esp-rom-sys/src/rom/spiflash.rs
@@ -22,6 +22,9 @@ unsafe extern "C" {
     /// Erase a sector of flash. Uses SPI flash command 20H.
     pub fn esp_rom_spiflash_erase_sector(sector_number: u32) -> i32;
 
+    /// Erase a block of flash.
+    pub fn esp_rom_spiflash_erase_block(block_number: u32) -> i32;
+
     /// Write Data to Flash, you should Erase it yourself if need.
     ///
     /// `dest_addr` should be 4 bytes aligned.

--- a/esp-storage/CHANGELOG.md
+++ b/esp-storage/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Speed up erase by erasing entire blocks when possible (#5079)
+
 
 ### Fixed
 

--- a/esp-storage/src/common.rs
+++ b/esp-storage/src/common.rs
@@ -89,6 +89,8 @@ impl<'d> FlashStorage<'d> {
     pub const WORD_SIZE: u32 = 4;
     /// Flash sector size in bytes.
     pub const SECTOR_SIZE: u32 = 4096;
+    /// Flash block size in bytes.
+    pub const BLOCK_SIZE: u32 = 65536;
 
     /// Create a new flash storage instance.
     ///
@@ -178,12 +180,25 @@ impl<'d> FlashStorage<'d> {
         Ok(())
     }
 
-    pub(crate) fn internal_erase(&mut self, sector: u32) -> Result<(), FlashStorageError> {
+    pub(crate) fn internal_erase_sector(&mut self, sector: u32) -> Result<(), FlashStorageError> {
         #[cfg(multi_core)]
         let unpark = self.multi_core_strategy.pre_write()?;
 
         self.unlock_once()?;
         check_rc(chip_specific::spiflash_erase_sector(sector))?;
+
+        #[cfg(multi_core)]
+        self.multi_core_strategy.post_write(unpark);
+
+        Ok(())
+    }
+
+    pub(crate) fn internal_erase_block(&mut self, block: u32) -> Result<(), FlashStorageError> {
+        #[cfg(multi_core)]
+        let unpark = self.multi_core_strategy.pre_write()?;
+
+        self.unlock_once()?;
+        check_rc(chip_specific::spiflash_erase_block(block))?;
 
         #[cfg(multi_core)]
         self.multi_core_strategy.post_write(unpark);

--- a/esp-storage/src/hardware.rs
+++ b/esp-storage/src/hardware.rs
@@ -20,6 +20,11 @@ pub(crate) fn spiflash_erase_sector(sector_number: u32) -> i32 {
 }
 
 #[ram]
+pub(crate) fn spiflash_erase_block(block_number: u32) -> i32 {
+    maybe_with_critical_section(|| unsafe { esp_rom_spiflash_erase_block(block_number) })
+}
+
+#[ram]
 pub(crate) fn spiflash_write(dest_addr: u32, data: *const u32, len: u32) -> i32 {
     maybe_with_critical_section(|| unsafe { esp_rom_spiflash_write(dest_addr, data, len) })
 }

--- a/esp-storage/src/ll.rs
+++ b/esp-storage/src/ll.rs
@@ -32,13 +32,25 @@ pub unsafe fn spiflash_unlock() -> Result<(), i32> {
     }
 }
 
-/// Low-level SPI NOR Flash erase
+/// Low-level SPI NOR Flash sector erase
 ///
 /// # Safety
 ///
 /// The `sector_number` * sector_size should not exceeds the size of flash.
 pub unsafe fn spiflash_erase_sector(sector_number: u32) -> Result<(), i32> {
     match chip_specific::spiflash_erase_sector(sector_number) {
+        0 => Ok(()),
+        value => Err(value),
+    }
+}
+
+/// Low-level SPI NOR Flash block erase
+///
+/// # Safety
+///
+/// The `block_number` * block_size should not exceeds the size of flash.
+pub unsafe fn spiflash_erase_block(block_number: u32) -> Result<(), i32> {
+    match chip_specific::spiflash_erase_block(block_number) {
         0 => Ok(()),
         value => Err(value),
     }

--- a/esp-storage/src/nor_flash.rs
+++ b/esp-storage/src/nor_flash.rs
@@ -180,8 +180,23 @@ impl NorFlash for FlashStorage<'_> {
         self.check_alignment::<{ SZ }>(from, len)?;
         self.check_bounds(from, len)?;
 
-        for sector in from / Self::SECTOR_SIZE..to / Self::SECTOR_SIZE {
-            self.internal_erase(sector)?;
+        // First erase by sector up to the block boundary.
+        let mut address = from;
+        while address < to && (address % Self::BLOCK_SIZE) != 0 {
+            self.internal_erase_sector(address / Self::SECTOR_SIZE)?;
+            address += Self::SECTOR_SIZE;
+        }
+
+        // Then erase as much as possible by blocks.
+        while (to - address) >= Self::BLOCK_SIZE {
+            self.internal_erase_block(address / Self::BLOCK_SIZE)?;
+            address += Self::BLOCK_SIZE;
+        }
+
+        // Finally, erase any remaining sectors.
+        while address < to {
+            self.internal_erase_sector(address / Self::SECTOR_SIZE)?;
+            address += Self::SECTOR_SIZE;
         }
 
         Ok(())
@@ -198,8 +213,9 @@ mod tests {
 
     const WORD_SIZE: u32 = 4;
     const SECTOR_SIZE: u32 = 4 << 10;
-    const NUM_SECTORS: u32 = 3;
-    const FLASH_SIZE: u32 = SECTOR_SIZE * NUM_SECTORS;
+    const BLOCK_SIZE: u32 = 4 << 14;
+    const NUM_BLOCKS: u32 = 3;
+    const FLASH_SIZE: u32 = BLOCK_SIZE * NUM_BLOCKS;
     const MAX_OFFSET: u32 = SECTOR_SIZE * 1;
     const MAX_LENGTH: u32 = SECTOR_SIZE * 2;
 
@@ -269,7 +285,7 @@ mod tests {
     #[cfg(not(feature = "bytewise-read"))]
     fn aligned_read() {
         let mut flash = FlashStorage::new(Flash::new());
-        flash.capacity = 4 * 4096;
+        flash.capacity = FLASH_SIZE as usize;
         let src = TestBuffer::seq();
         let mut data = TestBuffer::default();
 
@@ -289,7 +305,7 @@ mod tests {
     #[cfg(not(feature = "bytewise-read"))]
     fn not_aligned_read_aligned_buffer() {
         let mut flash = FlashStorage::new(Flash::new());
-        flash.capacity = 4 * 4096;
+        flash.capacity = FLASH_SIZE as usize;
         let mut data = TestBuffer::default();
 
         for (off, len) in range_gen::<WORD_SIZE, MAX_OFFSET, MAX_LENGTH>(Some(false)) {
@@ -301,7 +317,7 @@ mod tests {
     #[cfg(not(feature = "bytewise-read"))]
     fn aligned_read_not_aligned_buffer() {
         let mut flash = FlashStorage::new(Flash::new());
-        flash.capacity = 4 * 4096;
+        flash.capacity = FLASH_SIZE as usize;
         let src = TestBuffer::seq();
         let mut data = TestBuffer::default();
 
@@ -324,7 +340,7 @@ mod tests {
     fn bytewise_read_aligned_buffer() {
         let mut flash = FlashStorage::new(Flash::new());
 
-        flash.capacity = 4 * 4096;
+        flash.capacity = FLASH_SIZE as usize;
         let src = TestBuffer::seq();
         let mut data = TestBuffer::default();
 
@@ -345,7 +361,7 @@ mod tests {
     fn bytewise_read_not_aligned_buffer() {
         let mut flash = FlashStorage::new(Flash::new());
 
-        flash.capacity = 4 * 4096;
+        flash.capacity = FLASH_SIZE as usize;
         let src = TestBuffer::seq();
         let mut data = TestBuffer::default();
 
@@ -366,7 +382,7 @@ mod tests {
     #[test]
     fn write_not_aligned_buffer() {
         let mut flash = FlashStorage::new(Flash::new());
-        flash.capacity = 4 * 4096;
+        flash.capacity = FLASH_SIZE as usize;
         let mut read_data = TestBuffer::default();
         let write_data = TestBuffer::seq();
 
@@ -376,5 +392,32 @@ mod tests {
         flash.read(0, &mut read_data.data[..128]).unwrap();
 
         assert_eq!(&read_data.data[..128], &write_data.data[1..129]);
+    }
+
+    #[test]
+    fn erase_across_blocks() {
+        let mut flash = FlashStorage::new(Flash::new());
+        flash.capacity = FLASH_SIZE as usize;
+        let mut read_data = TestBuffer::default();
+        let write_data = [0u8; SECTOR_SIZE as usize];
+
+        // An entire block and some sectors before and after
+        let from = BLOCK_SIZE - (2 * SECTOR_SIZE);
+        let to = (2 * BLOCK_SIZE) + (1 * SECTOR_SIZE);
+
+        // Clear area before and after erase
+        flash.erase(from - SECTOR_SIZE, from).unwrap();
+        flash.write(from - SECTOR_SIZE, &write_data).unwrap();
+        flash.erase(to, to + SECTOR_SIZE).unwrap();
+        flash.write(to, &write_data).unwrap();
+
+        // Erase and verify that only the desired parts were touched
+        flash.erase(from, to).unwrap();
+        flash.read(0, &mut read_data.data).unwrap();
+        for i in from..to {
+            assert_eq!(read_data.data[i as usize], 0xFF);
+        }
+        assert_eq!(read_data.data[(from - 1) as usize], 0x0);
+        assert_eq!(read_data.data[to as usize], 0x0);
     }
 }

--- a/esp-storage/src/storage.rs
+++ b/esp-storage/src/storage.rs
@@ -61,7 +61,7 @@ impl Storage for FlashStorage<'_> {
             let len = bytes.len().min((Self::SECTOR_SIZE - data_offset) as _);
 
             sector_data[data_offset as usize..][..len].copy_from_slice(&bytes[..len]);
-            self.internal_erase(aligned_offset / Self::SECTOR_SIZE)?;
+            self.internal_erase_sector(aligned_offset / Self::SECTOR_SIZE)?;
             self.internal_write(aligned_offset, sector_data)?;
 
             aligned_offset += Self::SECTOR_SIZE;

--- a/esp-storage/src/stub.rs
+++ b/esp-storage/src/stub.rs
@@ -7,8 +7,10 @@ const ERROR_CODE: i32 = 1;
 const ERASE_BYTE: u8 = 0xff;
 const WORD_SIZE: u32 = 4;
 const SECTOR_SIZE: u32 = 4 << 10;
-const NUM_SECTORS: u32 = 4;
-const FLASH_SIZE: u32 = SECTOR_SIZE * NUM_SECTORS;
+const BLOCK_SIZE: u32 = 4 << 14;
+const NUM_BLOCKS: u32 = 4;
+const FLASH_SIZE: u32 = BLOCK_SIZE * NUM_BLOCKS;
+const NUM_SECTORS: u32 = FLASH_SIZE / SECTOR_SIZE;
 
 static mut FLASH_LOCK: bool = true;
 static mut FLASH_DATA: [u8; FLASH_SIZE as usize] = [0u8; FLASH_SIZE as usize];
@@ -82,6 +84,19 @@ pub(crate) fn spiflash_erase_sector(sector_number: u32) -> i32 {
         maybe_with_critical_section(|| {
             let dst_addr = sector_number * SECTOR_SIZE;
             let len = SECTOR_SIZE;
+            unsafe { FLASH_DATA[dst_addr as usize..][..len as usize].fill(ERASE_BYTE) };
+        });
+        SUCCESS_CODE
+    } else {
+        ERROR_CODE
+    }
+}
+
+pub(crate) fn spiflash_erase_block(block_number: u32) -> i32 {
+    if check::<1, NUM_BLOCKS, 1>(block_number, 1, ptr::null(), true) {
+        maybe_with_critical_section(|| {
+            let dst_addr = block_number * BLOCK_SIZE;
+            let len = BLOCK_SIZE;
             unsafe { FLASH_DATA[dst_addr as usize..][..len as usize].fill(ERASE_BYTE) };
         });
         SUCCESS_CODE


### PR DESCRIPTION
This updates esp-storage to use block erases when possible instead of only sector erases. Block erases are generally much faster (e.g. on an ESP32-S3-MINI-1, they're about 3x faster for the same amount of data).

Blocks are 64KB aligned, so regular sector erases are used for the beginning and end of the erase.

## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [n/a] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [n/a] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Please provide a clear and concise description of your changes, including the motivation behind these changes. The context is crucial for the reviewers.

#### Testing
Describe how you tested your changes.
