### PR TITLE
Require bidirectional GPIO singletons/drivers for bi-directional signals

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Ecc` methods now return a result handle that can be used to retrieve the result of the operation. (#5061)
 - `Ecc` modular arithmetic methods now take the modulus as an argument (#5073)
 - `Ecc::new` now takes a configuration parameter (#5073)
+- It's no longer possible to pass `esp_hal::gpio::Output` to bidirectional peripheral signals (half-duplex SPI, I2C) (#5093)
 
 ### Fixed
 

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -135,7 +135,7 @@ use crate::{
         OutputSignal,
         PinGuard,
         Pull,
-        interconnect::{self, PeripheralOutput},
+        interconnect::{self, PeripheralInput, PeripheralOutput},
     },
     handler,
     interrupt::InterruptHandler,
@@ -1143,10 +1143,21 @@ where
         self.driver().reset_fsm(*error == Error::Timeout)
     }
 
+    #[procmacros::doc_replace]
     /// Connect a pin to the I2C SDA signal.
     ///
     /// This will replace previous pin assignments for this signal.
-    pub fn with_sda(mut self, sda: impl PeripheralOutput<'d>) -> Self {
+    ///
+    /// ## Example
+    ///
+    /// ```rust, no_run
+    /// # {before_snippet}
+    /// use esp_hal::i2c::master::{Config, I2c};
+    ///
+    /// let i2c = I2c::new(peripherals.I2C0, Config::default())?.with_sda(peripherals.GPIO2);
+    /// # {after_snippet}
+    /// ```
+    pub fn with_sda(mut self, sda: impl PeripheralInput<'d> + PeripheralOutput<'d>) -> Self {
         let info = self.driver().info;
         let input = info.sda_input;
         let output = info.sda_output;
@@ -1165,11 +1176,11 @@ where
     /// ```rust, no_run
     /// # {before_snippet}
     /// use esp_hal::i2c::master::{Config, I2c};
-    /// const DEVICE_ADDR: u8 = 0x77;
+    ///
     /// let i2c = I2c::new(peripherals.I2C0, Config::default())?.with_scl(peripherals.GPIO2);
     /// # {after_snippet}
     /// ```
-    pub fn with_scl(mut self, scl: impl PeripheralOutput<'d>) -> Self {
+    pub fn with_scl(mut self, scl: impl PeripheralInput<'d> + PeripheralOutput<'d>) -> Self {
         let info = self.driver().info;
         let input = info.scl_input;
         let output = info.scl_output;

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -892,7 +892,7 @@ macro_rules! def_with_sio_pin {
         #[doc = " Enables both input and output functionality for the pin, and connects it"]
         #[doc = concat!(" to the SIO", stringify!($n), " output and input signals.")]
         #[instability::unstable]
-        pub fn $fn(mut self, sio: impl PeripheralOutput<'d>) -> Self {
+        pub fn $fn(mut self, sio: impl PeripheralInput<'d> + PeripheralOutput<'d>) -> Self {
             self.pins.$field = self.connect_sio_pin(sio.into(), $n);
 
             self
@@ -1034,7 +1034,7 @@ where
     /// See also [Self::with_mosi] when you only need a one-directional MOSI
     /// signal.
     #[instability::unstable]
-    pub fn with_sio0(mut self, mosi: impl PeripheralOutput<'d>) -> Self {
+    pub fn with_sio0(mut self, mosi: impl PeripheralInput<'d> + PeripheralOutput<'d>) -> Self {
         self.pins.sio0_pin = self.connect_sio_pin(mosi.into(), 0);
 
         self
@@ -1052,7 +1052,7 @@ where
     /// See also [Self::with_miso] when you only need a one-directional MISO
     /// signal.
     #[instability::unstable]
-    pub fn with_sio1(mut self, sio1: impl PeripheralOutput<'d>) -> Self {
+    pub fn with_sio1(mut self, sio1: impl PeripheralInput<'d> + PeripheralOutput<'d>) -> Self {
         self.pins.sio1_pin = self.connect_sio_pin(sio1.into(), 1);
 
         self

--- a/hil-test/src/bin/spi_half_duplex_slave_qspi.rs
+++ b/hil-test/src/bin/spi_half_duplex_slave_qspi.rs
@@ -271,7 +271,7 @@ mod read {
 mod write {
     use esp_hal::{
         Blocking,
-        gpio::interconnect::InputSignal,
+        gpio::{Flex, interconnect::InputSignal},
         pcnt::{Pcnt, channel::EdgeMode, unit::Unit},
         spi::{
             Mode,
@@ -321,7 +321,12 @@ mod write {
             }
         }
 
-        let (mosi_loopback, mosi) = unsafe { mosi.split() };
+        let mut mosi = Flex::new(mosi);
+
+        mosi.set_input_enable(true);
+        mosi.set_output_enable(true);
+
+        let mosi_loopback = mosi.peripheral_input();
 
         let spi = Spi::new(
             peripherals.SPI2,
@@ -691,7 +696,7 @@ mod qspi {
         Blocking,
         dma::{DmaRxBuf, DmaTxBuf},
         dma_buffers,
-        gpio::{AnyPin, Input, InputConfig, Level, Output, OutputConfig, Pull},
+        gpio::{AnyPin, Flex, Input, InputConfig, Level, Output, OutputConfig, Pull},
         spi::{
             Mode,
             master::{Address, Command, Config, DataMode, Spi, SpiDma},
@@ -990,7 +995,10 @@ mod qspi {
         let unit0 = pcnt.unit0;
         let unit1 = pcnt.unit1;
 
-        let (mosi_loopback, mosi) = unsafe { mosi.split() };
+        let mut mosi = Flex::new(mosi);
+        mosi.set_input_enable(true);
+        mosi.set_output_enable(true);
+        let mosi_loopback = mosi.peripheral_input();
 
         unit0.channel0.set_edge_signal(mosi_loopback);
         unit0
@@ -1013,15 +1021,22 @@ mod qspi {
         let unit0 = pcnt.unit0;
         let unit1 = pcnt.unit1;
 
-        let (mosi_loopback, mosi) = unsafe { mosi.split() };
-        let (gpio_loopback, gpio) = unsafe { gpio.split() };
+        let mut mosi = Flex::new(mosi);
+        mosi.set_input_enable(true);
+        mosi.set_output_enable(true);
+        let mosi_loopback = mosi.peripheral_input();
+
+        let mut sio1 = Flex::new(gpio);
+        sio1.set_input_enable(true);
+        sio1.set_output_enable(true);
+        let sio1_loopback = sio1.peripheral_input();
 
         unit0.channel0.set_edge_signal(mosi_loopback);
         unit0
             .channel0
             .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
 
-        unit1.channel0.set_edge_signal(gpio_loopback);
+        unit1.channel0.set_edge_signal(sio1_loopback);
         unit1
             .channel0
             .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
@@ -1029,7 +1044,7 @@ mod qspi {
         let spi = ctx
             .spi
             .with_sio0(mosi)
-            .with_sio1(gpio)
+            .with_sio1(sio1)
             .with_dma(ctx.dma_channel);
 
         execute_write(unit0, unit1, spi, 0b0000_0010, true);
@@ -1042,19 +1057,26 @@ mod qspi {
         // up by a resistor if the command phase doesn't drive its line.
         let [gpio, _, mosi] = ctx.gpios;
 
+        let mut mosi = Flex::new(mosi);
+        mosi.set_input_enable(true);
+        mosi.set_output_enable(true);
+        let mosi_loopback = mosi.peripheral_input();
+
+        let mut sio2 = Flex::new(gpio);
+        sio2.set_input_enable(true);
+        sio2.set_output_enable(true);
+        let sio2_loopback = sio2.peripheral_input();
+
         let pcnt = Pcnt::new(ctx.pcnt);
         let unit0 = pcnt.unit0;
         let unit1 = pcnt.unit1;
-
-        let (mosi_loopback, mosi) = unsafe { mosi.split() };
-        let (gpio_loopback, gpio) = unsafe { gpio.split() };
 
         unit0.channel0.set_edge_signal(mosi_loopback);
         unit0
             .channel0
             .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
 
-        unit1.channel0.set_edge_signal(gpio_loopback);
+        unit1.channel0.set_edge_signal(sio2_loopback);
         unit1
             .channel0
             .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
@@ -1062,7 +1084,7 @@ mod qspi {
         let spi = ctx
             .spi
             .with_sio0(mosi)
-            .with_sio2(gpio)
+            .with_sio2(sio2)
             .with_dma(ctx.dma_channel);
 
         execute_write(unit0, unit1, spi, 0b0000_0100, true);
@@ -1079,15 +1101,22 @@ mod qspi {
         let unit0 = pcnt.unit0;
         let unit1 = pcnt.unit1;
 
-        let (mosi_loopback, mosi) = unsafe { mosi.split() };
-        let (gpio_loopback, gpio) = unsafe { gpio.split() };
+        let mut mosi = Flex::new(mosi);
+        mosi.set_input_enable(true);
+        mosi.set_output_enable(true);
+        let mosi_loopback = mosi.peripheral_input();
+
+        let mut sio3 = Flex::new(gpio);
+        sio3.set_input_enable(true);
+        sio3.set_output_enable(true);
+        let sio3_loopback = sio3.peripheral_input();
 
         unit0.channel0.set_edge_signal(mosi_loopback);
         unit0
             .channel0
             .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
 
-        unit1.channel0.set_edge_signal(gpio_loopback);
+        unit1.channel0.set_edge_signal(sio3_loopback);
         unit1
             .channel0
             .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
@@ -1095,7 +1124,7 @@ mod qspi {
         let spi = ctx
             .spi
             .with_sio0(mosi)
-            .with_sio3(gpio)
+            .with_sio3(sio3)
             .with_dma(ctx.dma_channel);
 
         execute_write(unit0, unit1, spi, 0b0000_1000, true);

--- a/hil-test/src/bin/spi_half_duplex_write_psram.rs
+++ b/hil-test/src/bin/spi_half_duplex_write_psram.rs
@@ -14,7 +14,7 @@ use esp_hal::{
     dma::{DmaRxBuf, DmaTxBuf, ExternalBurstConfig},
     dma_buffers,
     dma_descriptors_chunk_size,
-    gpio::interconnect::InputSignal,
+    gpio::{Flex, interconnect::InputSignal},
     pcnt::{Pcnt, channel::EdgeMode, unit::Unit},
     spi::{
         Mode,
@@ -47,6 +47,7 @@ struct Context {
 
 #[embedded_test::tests(default_timeout = 3)]
 mod tests {
+
     use super::*;
 
     #[init]
@@ -63,7 +64,10 @@ mod tests {
 
         let dma_channel = peripherals.DMA_CH0;
 
-        let (mosi_loopback, mosi) = unsafe { mosi.split() };
+        let mut mosi = Flex::new(mosi);
+        mosi.set_input_enable(true);
+        mosi.set_output_enable(true);
+        let mosi_loopback = mosi.peripheral_input();
 
         let spi = Spi::new(
             peripherals.SPI2,


### PR DESCRIPTION
Output pins are always a strict superset of input pins, but drivers are not - passing an Output driver to these functions isn't very useful, so it shouldn't be possible. This PR will let us document for #4830 how a Flex driver can be set up for I2C if one doesn't want internal pullups.