### PR TITLE
feat(example): Restore lp_blinky Example for ESP32-S2, and S3

### DIFF
--- a/examples/peripheral/lp_core/lp_blinky/Cargo.toml
+++ b/examples/peripheral/lp_core/lp_blinky/Cargo.toml
@@ -19,6 +19,16 @@ esp32c6 = [
     "esp-bootloader-esp-idf/esp32c6",
     "esp-hal/esp32c6",
 ]
+esp32s3 = [
+    "esp-backtrace/esp32s3",
+    "esp-bootloader-esp-idf/esp32s3",
+    "esp-hal/esp32s3",
+]
+esp32s2 = [
+    "esp-backtrace/esp32s2",
+    "esp-bootloader-esp-idf/esp32s2",
+    "esp-hal/esp32s2",
+]
 
 [profile.release]
 debug            = true

--- a/examples/peripheral/lp_core/lp_blinky/src/main.rs
+++ b/examples/peripheral/lp_core/lp_blinky/src/main.rs
@@ -12,16 +12,22 @@
 #![no_main]
 
 use esp_backtrace as _;
+#[cfg(feature = "esp32c6")]
 use esp_hal::{
     gpio::lp_io::LowPowerOutput,
-    load_lp_code,
     lp_core::{LpCore, LpCoreWakeupSource},
-    main,
 };
+#[cfg(any(feature = "esp32s2", feature = "esp32s3"))]
+use esp_hal::{
+    gpio::rtc_io::LowPowerOutput,
+    ulp_core::{UlpCore, UlpCoreWakeupSource},
+};
+use esp_hal::{load_lp_code, main};
 use esp_println::{print, println};
 
 esp_bootloader_esp_idf::esp_app_desc!();
 
+#[cfg(feature = "esp32c6")]
 #[main]
 fn main() -> ! {
     esp_println::logger::init_logger_from_env();
@@ -42,9 +48,42 @@ fn main() -> ! {
 
     // start LP core
     lp_core_code.run(&mut lp_core, LpCoreWakeupSource::HpCpu, lp_pin);
-    println!("lpcore run");
+    println!("lp core run");
 
-    let data = (0x5000_2000) as *mut u32;
+    let data = (0x5000_2000) as *const u32;
+    loop {
+        print!("Current {:x}           \u{000d}", unsafe {
+            data.read_volatile()
+        });
+    }
+}
+
+#[cfg(any(feature = "esp32s2", feature = "esp32s3"))]
+#[main]
+fn main() -> ! {
+    esp_println::logger::init_logger_from_env();
+    let peripherals = esp_hal::init(esp_hal::Config::default());
+
+    // configure GPIO 1 as LP output pin
+    let rtc_pin = LowPowerOutput::new(peripherals.GPIO1);
+
+    let mut ulp_core = UlpCore::new(peripherals.ULP_RISCV_CORE);
+    #[cfg(not(feature = "esp32s2"))]
+    {
+        ulp_core.stop(); // currently not implemented for ESP32-S2.
+        println!("ulp core stopped");
+    }
+
+    // load code to ULP coprocessor
+    let ulp_core_code = load_lp_code!(
+        "../../../../esp-lp-hal/target/riscv32imc-unknown-none-elf/release/examples/blinky"
+    );
+
+    // start ULP coprocessor
+    ulp_core_code.run(&mut ulp_core, UlpCoreWakeupSource::HpCpu, rtc_pin);
+    println!("ulp core run");
+
+    let data = (0x5000_0400) as *const u32;
     loop {
         print!("Current {:x}           \u{000d}", unsafe {
             data.read_volatile()


### PR DESCRIPTION
## Description
This pull request restores the example for running code on the ULP coprocessor for the ESP32-S3 and S2.  
I have restored ESP32-S2/S3 support for the `lp_blinky` example.  
**Note**: I have only tested this on the ESP32-S3-DevKitC. **Untested on ESP32-S2, though it compiles successfully.**

### Example Detail
The `lp_blinky` example demonstrates ULP coprocessor usage. The ULP code increments a counter and toggles an LED on GPIO1, while the main processor prints the current counter value (`src/main.rs`).

## Testing
I have performed the following tests:
```sh
$ cd esp-lp-hal; cargo esp32s3; cd .. # Compile ULP code
$ cargo xtask build examples lp_blinky --chip esp32s2
$ cargo xtask build examples lp_blinky --chip esp32s3
$ cargo xtask run example lp_blinky --chip esp32s3
$ cd esp-lp-hal; cargo esp32c6; cd.. # Check for esp32c6
$ cargo xtask run example lp_blinky --chip esp32c6
```
**Results**:
I confirmed that the LED blinks as expected and the UART output shows the counter incrementing correctly.

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.