### PR TITLE
Remove the coex cfg

### DIFF
--- a/esp-radio/build.rs
+++ b/esp-radio/build.rs
@@ -103,7 +103,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         print_warning(message);
     }
 
-    println!("cargo:rustc-check-cfg=cfg(coex)");
     #[cfg(feature = "coex")]
     {
         assert!(
@@ -114,9 +113,6 @@ fn main() -> Result<(), Box<dyn Error>> {
 
             "#
         );
-
-        #[cfg(all(feature = "wifi", feature = "ble"))]
-        println!("cargo:rustc-cfg=coex");
 
         #[cfg(not(feature = "wifi"))]
         println!("cargo:warning=coex is enabled but wifi is not");

--- a/esp-radio/src/ble/btdm.rs
+++ b/esp-radio/src/ble/btdm.rs
@@ -259,7 +259,7 @@ unsafe extern "C" fn btdm_sleep_exit_phase3() {
 
 unsafe extern "C" fn coex_schm_status_bit_set(_typ: i32, status: i32) {
     trace!("coex_schm_status_bit_set {} {}", _typ, status);
-    #[cfg(coex)]
+    #[cfg(feature = "coex")]
     unsafe {
         crate::sys::include::coex_schm_status_bit_set(_typ as u32, status as u32)
     };
@@ -267,7 +267,7 @@ unsafe extern "C" fn coex_schm_status_bit_set(_typ: i32, status: i32) {
 
 unsafe extern "C" fn coex_schm_status_bit_clear(_typ: i32, status: i32) {
     trace!("coex_schm_status_bit_clear {} {}", _typ, status);
-    #[cfg(coex)]
+    #[cfg(feature = "coex")]
     unsafe {
         crate::sys::include::coex_schm_status_bit_clear(_typ as u32, status as u32)
     };
@@ -325,7 +325,7 @@ pub(crate) fn ble_init(config: &Config) -> PhyInitGuard<'static> {
         let res = btdm_osi_funcs_register(addr_of!(G_OSI_FUNCS));
         assert!(res == 0, "btdm_osi_funcs_register returned {}", res);
 
-        #[cfg(coex)]
+        #[cfg(feature = "coex")]
         {
             let res = crate::wifi::coex_init();
             assert!(res == 0, "coex_init failed");
@@ -352,7 +352,7 @@ pub(crate) fn ble_init(config: &Config) -> PhyInitGuard<'static> {
 
         debug!("The btdm_controller_init was initialized");
 
-        #[cfg(coex)]
+        #[cfg(feature = "coex")]
         crate::sys::include::coex_enable();
 
         phy_init_guard = esp_hal::peripherals::BT::steal().enable_phy();
@@ -370,7 +370,7 @@ pub(crate) fn ble_init(config: &Config) -> PhyInitGuard<'static> {
             }
         }
 
-        #[cfg(coex)]
+        #[cfg(feature = "coex")]
         coex_enable();
 
         btdm_controller_enable(esp_bt_mode_t_ESP_BT_MODE_BLE);
@@ -417,14 +417,14 @@ pub fn send_hci(data: &[u8]) {
 
                 PACKET_SENT.store(false, Ordering::Relaxed);
 
-                #[cfg(all(esp32, coex))]
+                #[cfg(all(esp32, feature = "coex"))]
                 ble_os_adapter_chip_specific::async_wakeup_request(
                     ble_os_adapter_chip_specific::BTDM_ASYNC_WAKEUP_REQ_HCI,
                 );
 
                 API_vhci_host_send_packet(packet.as_ptr(), packet.len() as u16);
 
-                #[cfg(all(esp32, coex))]
+                #[cfg(all(esp32, feature = "coex"))]
                 ble_os_adapter_chip_specific::async_wakeup_request_end(
                     ble_os_adapter_chip_specific::BTDM_ASYNC_WAKEUP_REQ_HCI,
                 );

--- a/esp-radio/src/ble/npl.rs
+++ b/esp-radio/src/ble/npl.rs
@@ -1083,7 +1083,7 @@ pub(crate) fn ble_init(config: &Config) -> PhyInitGuard<'static> {
             assert!(res == 0, "esp_ble_rom_func_ptr_init_all returned {}", res);
         }
 
-        #[cfg(coex)]
+        #[cfg(feature = "coex")]
         {
             let res = crate::wifi::coex_init();
             assert!(res == 0, "coex_init failed");
@@ -1133,7 +1133,7 @@ pub(crate) fn ble_init(config: &Config) -> PhyInitGuard<'static> {
 
         coex_pti_v2();
 
-        #[cfg(coex)]
+        #[cfg(feature = "coex")]
         {
             let rc = ble_osi_coex_funcs_register(&G_COEX_FUNCS as *const OsiCoexFuncsT);
             assert!(rc == 0, "ble_osi_coex_funcs_register returned {}", rc);
@@ -1192,7 +1192,7 @@ pub(crate) fn ble_init(config: &Config) -> PhyInitGuard<'static> {
             assert!(res == 0, "esp_ble_msys_init returned {}", res);
         }
 
-        #[cfg(coex)]
+        #[cfg(feature = "coex")]
         crate::sys::include::coex_enable();
 
         let mut mac = [0u8; 6];

--- a/esp-radio/src/ble/os_adapter_esp32.rs
+++ b/esp-radio/src/ble/os_adapter_esp32.rs
@@ -87,7 +87,7 @@ pub(super) struct osi_funcs_s {
     coex_schm_status_bit_set: Option<unsafe extern "C" fn(i32, i32)>,
     coex_schm_interval_get: Option<unsafe extern "C" fn() -> u32>,
     coex_schm_curr_period_get: Option<unsafe extern "C" fn() -> u8>,
-    coex_schm_curr_phase_get: Option<unsafe extern "C" fn() -> *const ()>,
+    coex_schm_curr_phase_get: Option<unsafe extern "C" fn() -> *mut c_void>,
     coex_wifi_channel_get: Option<unsafe extern "C" fn(*mut u8, *mut u8) -> i32>,
     coex_register_wifi_channel_change_callback:
         Option<unsafe extern "C" fn(unsafe extern "C" fn()) -> i32>,
@@ -102,8 +102,8 @@ pub(super) struct osi_funcs_s {
 
 pub(super) static G_OSI_FUNCS: osi_funcs_s = osi_funcs_s {
     version: 0x00010005,
-    set_isr: Some(ble_os_adapter_chip_specific::set_isr),
-    ints_on: Some(ble_os_adapter_chip_specific::ints_on),
+    set_isr: Some(set_isr),
+    ints_on: Some(ints_on),
     interrupt_disable: Some(interrupt_disable),
     interrupt_restore: Some(interrupt_enable),
     task_yield: Some(task_yield),
@@ -142,25 +142,21 @@ pub(super) static G_OSI_FUNCS: osi_funcs_s = osi_funcs_s {
     btdm_sleep_exit_phase1: Some(btdm_sleep_exit_phase1),
     btdm_sleep_exit_phase2: Some(btdm_sleep_exit_phase2),
     btdm_sleep_exit_phase3: Some(btdm_sleep_exit_phase3),
-    coex_bt_wakeup_request: Some(ble_os_adapter_chip_specific::coex_bt_wakeup_request),
-    coex_bt_wakeup_request_end: Some(ble_os_adapter_chip_specific::coex_bt_wakeup_request_end),
-    coex_bt_request: Some(ble_os_adapter_chip_specific::coex_bt_request),
-    coex_bt_release: Some(ble_os_adapter_chip_specific::coex_bt_release),
-    coex_register_bt_cb: Some(ble_os_adapter_chip_specific::coex_register_bt_cb_wrapper),
-    coex_bb_reset_lock: Some(ble_os_adapter_chip_specific::coex_bb_reset_lock),
-    coex_bb_reset_unlock: Some(ble_os_adapter_chip_specific::coex_bb_reset_unlock),
-    coex_schm_register_btdm_callback: Some(
-        ble_os_adapter_chip_specific::coex_schm_register_btdm_callback_wrapper,
-    ),
+    coex_bt_wakeup_request: Some(coex_bt_wakeup_request),
+    coex_bt_wakeup_request_end: Some(coex_bt_wakeup_request_end),
+    coex_bt_request: Some(coex_bt_request),
+    coex_bt_release: Some(coex_bt_release),
+    coex_register_bt_cb: Some(coex_register_bt_cb),
+    coex_bb_reset_lock: Some(coex_bb_reset_lock),
+    coex_bb_reset_unlock: Some(coex_bb_reset_unlock),
+    coex_schm_register_btdm_callback: Some(coex_schm_register_btdm_callback_wrapper),
     coex_schm_status_bit_clear: Some(coex_schm_status_bit_clear),
     coex_schm_status_bit_set: Some(coex_schm_status_bit_set),
-    coex_schm_interval_get: Some(ble_os_adapter_chip_specific::coex_schm_interval_get),
-    coex_schm_curr_period_get: Some(ble_os_adapter_chip_specific::coex_schm_curr_period_get),
-    coex_schm_curr_phase_get: Some(ble_os_adapter_chip_specific::coex_schm_curr_phase_get),
-    coex_wifi_channel_get: Some(ble_os_adapter_chip_specific::coex_wifi_channel_get),
-    coex_register_wifi_channel_change_callback: Some(
-        ble_os_adapter_chip_specific::coex_register_wifi_channel_change_callback,
-    ),
+    coex_schm_interval_get: Some(coex_schm_interval_get),
+    coex_schm_curr_period_get: Some(coex_schm_curr_period_get),
+    coex_schm_curr_phase_get: Some(coex_schm_curr_phase_get),
+    coex_wifi_channel_get: Some(coex_wifi_channel_get),
+    coex_register_wifi_channel_change_callback: Some(coex_register_wifi_channel_change_callback),
     set_isr13: Some(set_isr13),
     interrupt_l3_disable: Some(interrupt_l3_disable),
     interrupt_l3_restore: Some(interrupt_l3_restore),
@@ -473,9 +469,9 @@ pub(crate) unsafe extern "C" fn coex_bt_wakeup_request() -> bool {
 
     // This should really be
     // ```rust,norun
-    // #[cfg(coex)]
+    // #[cfg(feature = "coex")]
     // return async_wakeup_request(BTDM_ASYNC_WAKEUP_REQ_COEX);
-    // #[cfg(not(coex))]
+    // #[cfg(not(feature = "coex"))]
     // true
     // ```
     //
@@ -489,7 +485,7 @@ pub(crate) unsafe extern "C" fn coex_bt_wakeup_request_end() {
 
     // This should really be
     // ```rust,norun
-    // #[cfg(coex)]
+    // #[cfg(feature = "coex")]
     // async_wakeup_request_end(BTDM_ASYNC_WAKEUP_REQ_COEX);
     // ```
     //
@@ -497,156 +493,56 @@ pub(crate) unsafe extern "C" fn coex_bt_wakeup_request_end() {
     // In a similar scenario this function isn't called in ESP-IDF.
 }
 
-#[allow(unused_variables)]
-pub(crate) unsafe extern "C" fn coex_bt_request(event: u32, latency: u32, duration: u32) -> i32 {
-    trace!("coex_bt_request");
-    unsafe extern "C" {
-        #[cfg(coex)]
-        fn coex_bt_request(event: u32, latency: u32, duration: u32) -> i32;
-    }
-
-    #[cfg(coex)]
-    return unsafe { coex_bt_request(event, latency, duration) };
-
-    #[cfg(not(coex))]
-    0
+extern_coex_fns! {
+    fn coex_bt_request(event: u32, latency: u32, duration: u32) -> i32;
+    fn coex_bt_release(event: u32) -> i32;
+    fn coex_register_bt_cb(callback: unsafe extern "C" fn()) -> i32;
+    fn coex_bb_reset_lock() -> u32;
+    fn coex_bb_reset_unlock(event: u32);
+    fn coex_register_wifi_channel_change_callback(callback: unsafe extern "C" fn()) -> i32;
 }
 
-#[allow(unused_variables)]
-pub(crate) unsafe extern "C" fn coex_bt_release(event: u32) -> i32 {
-    trace!("coex_bt_release");
-    unsafe extern "C" {
-        #[cfg(coex)]
-        fn coex_bt_release(event: u32) -> i32;
-    }
-
-    #[cfg(coex)]
-    return unsafe { coex_bt_release(event) };
-
-    #[cfg(not(coex))]
-    0
-}
-
-pub(crate) unsafe extern "C" fn coex_register_bt_cb_wrapper(
-    callback: unsafe extern "C" fn(),
-) -> i32 {
-    trace!("coex_register_bt_cb {:?}", callback);
-    unsafe extern "C" {
-        #[cfg(coex)]
-        fn coex_register_bt_cb(callback: unsafe extern "C" fn()) -> i32;
-    }
-
-    #[cfg(coex)]
-    return unsafe { coex_register_bt_cb(callback) };
-
-    #[cfg(not(coex))]
-    0
-}
-
-pub(crate) unsafe extern "C" fn coex_bb_reset_lock() -> u32 {
-    trace!("coex_bb_reset_lock");
-    unsafe extern "C" {
-        #[cfg(coex)]
-        fn coex_bb_reset_lock() -> u32;
-    }
-
-    #[cfg(coex)]
-    return unsafe { coex_bb_reset_lock() };
-
-    #[cfg(not(coex))]
-    0
-}
-
-#[allow(unused_variables)]
-pub(crate) unsafe extern "C" fn coex_bb_reset_unlock(event: u32) {
-    trace!("coex_bb_reset_unlock");
-    unsafe extern "C" {
-        #[cfg(coex)]
-        fn coex_bb_reset_unlock(event: u32);
-    }
-
-    #[cfg(coex)]
-    unsafe {
-        coex_bb_reset_unlock(event)
-    };
+coex_fns! {
+    fn coex_schm_interval_get() -> u32;
+    fn coex_schm_curr_period_get() -> u8;
+    fn coex_schm_curr_phase_get() -> *mut c_void;
 }
 
 pub(crate) unsafe extern "C" fn coex_schm_register_btdm_callback_wrapper(
     callback: unsafe extern "C" fn(),
 ) -> i32 {
     trace!("coex_schm_register_btdm_callback {:?}", callback);
-    unsafe extern "C" {
-        #[cfg(coex)]
-        fn coex_schm_register_callback(kind: u32, callback: unsafe extern "C" fn()) -> i32;
+
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "coex")] {
+            unsafe extern "C" {
+                fn coex_schm_register_callback(kind: u32, callback: unsafe extern "C" fn()) -> i32;
+            }
+            const COEX_SCHM_CALLBACK_TYPE_BT: u32 = 1;
+            unsafe { coex_schm_register_callback(COEX_SCHM_CALLBACK_TYPE_BT, callback) }
+        } else {
+            0
+        }
     }
-
-    #[cfg(coex)]
-    return unsafe { coex_schm_register_callback(1, callback) }; // COEX_SCHM_CALLBACK_TYPE_BT = 1
-
-    #[cfg(not(coex))]
-    0
-}
-
-pub(crate) unsafe extern "C" fn coex_schm_interval_get() -> u32 {
-    trace!("coex_schm_interval_get");
-
-    #[cfg(coex)]
-    return unsafe { crate::sys::include::coex_schm_interval_get() };
-
-    #[cfg(not(coex))]
-    0
-}
-
-pub(crate) unsafe extern "C" fn coex_schm_curr_period_get() -> u8 {
-    trace!("coex_schm_curr_period_get");
-
-    #[cfg(coex)]
-    return unsafe { crate::sys::include::coex_schm_curr_period_get() };
-
-    #[cfg(not(coex))]
-    0
-}
-
-pub(crate) unsafe extern "C" fn coex_schm_curr_phase_get() -> *const () {
-    trace!("coex_schm_curr_phase_get");
-
-    #[cfg(coex)]
-    return unsafe { crate::sys::include::coex_schm_curr_phase_get() } as *const ();
-
-    #[cfg(not(coex))]
-    return core::ptr::null::<()>();
 }
 
 #[allow(unused_variables)]
-pub(crate) unsafe extern "C" fn coex_wifi_channel_get(primary: *mut u8, secondary: *mut u8) -> i32 {
-    trace!("coex_wifi_channel_get");
-    unsafe extern "C" {
-        #[cfg(coex)]
-        fn coex_wifi_channel_get(primary: *mut u8, secondary: *mut u8) -> i32;
-    }
-
-    #[cfg(coex)]
-    return unsafe { coex_wifi_channel_get(primary, secondary) };
-
-    #[cfg(not(coex))]
-    -1
-}
-
-#[allow(unused_variables)]
-pub(crate) unsafe extern "C" fn coex_register_wifi_channel_change_callback(
-    callback: unsafe extern "C" fn(),
+pub(crate) unsafe extern "C" fn coex_wifi_channel_get(
+    _primary: *mut u8,
+    _secondary: *mut u8,
 ) -> i32 {
-    trace!("coex_register_wifi_channel_change_callback");
-    unsafe extern "C" {
-        #[cfg(coex)]
-        fn coex_register_wifi_channel_change_callback(callback: unsafe extern "C" fn()) -> i32;
+    trace!("coex_wifi_channel_get");
+
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "coex")] {
+            unsafe extern "C" {
+                fn coex_wifi_channel_get(_primary: *mut u8, _secondary: *mut u8) -> i32;
+            }
+            unsafe { coex_wifi_channel_get(_primary, _secondary) }
+        } else {
+            -1
+        }
     }
-
-    #[cfg(coex)]
-    return unsafe { coex_register_wifi_channel_change_callback(callback) };
-
-    #[cfg(not(coex))]
-    0
 }
 
 pub(crate) unsafe extern "C" fn set_isr(n: i32, f: unsafe extern "C" fn(), arg: *const ()) -> i32 {
@@ -676,10 +572,10 @@ pub(crate) unsafe extern "C" fn ints_on(mask: u32) {
     }
 }
 
-#[cfg(coex)]
+#[cfg(feature = "coex")]
 pub(crate) const BTDM_ASYNC_WAKEUP_REQ_HCI: i32 = 0;
 
-#[cfg(coex)]
+#[cfg(feature = "coex")]
 pub(crate) const BTDM_ASYNC_WAKEUP_REQ_COEX: i32 = 1;
 
 // const BTDM_ASYNC_WAKEUP_REQMAX: i32 = 2;
@@ -697,7 +593,7 @@ pub(crate) const BTDM_ASYNC_WAKEUP_REQ_COEX: i32 = 1;
 ///   true if request lock is needed, false otherwise
 ///
 /// *************************************************************************
-#[cfg(coex)]
+#[cfg(feature = "coex")]
 pub(crate) fn async_wakeup_request(event: i32) -> bool {
     trace!("async_wakeup_request {}", event);
 
@@ -747,7 +643,7 @@ pub(crate) fn async_wakeup_request(event: i32) -> bool {
 ///   true if request lock is needed, false otherwise
 ///
 /// *************************************************************************
-#[cfg(coex)]
+#[cfg(feature = "coex")]
 pub(crate) fn async_wakeup_request_end(event: i32) {
     trace!("async_wakeup_request_end {}", event);
 

--- a/esp-radio/src/ble/os_adapter_esp32c3_s3.rs
+++ b/esp-radio/src/ble/os_adapter_esp32c3_s3.rs
@@ -72,12 +72,12 @@ pub(super) struct osi_funcs_s {
     btdm_sleep_exit_phase3: Option<unsafe extern "C" fn()>,
     coex_wifi_sleep_set: Option<unsafe extern "C" fn(i32)>,
     coex_core_ble_conn_dyn_prio_get: Option<unsafe extern "C" fn(*mut i32, *mut i32) -> i32>,
-    coex_schm_register_btdm_callback: Option<unsafe extern "C" fn(*const ()) -> i32>,
+    coex_schm_register_btdm_callback: Option<unsafe extern "C" fn(*mut c_void) -> i32>,
     coex_schm_status_bit_set: Option<unsafe extern "C" fn(i32, i32)>,
     coex_schm_status_bit_clear: Option<unsafe extern "C" fn(i32, i32)>,
-    coex_schm_interval_get: Option<unsafe extern "C" fn() -> i32>,
+    coex_schm_interval_get: Option<unsafe extern "C" fn() -> u32>,
     coex_schm_curr_period_get: Option<unsafe extern "C" fn() -> u8>,
-    coex_schm_curr_phase_get: Option<unsafe extern "C" fn() -> *const ()>,
+    coex_schm_curr_phase_get: Option<unsafe extern "C" fn() -> *mut c_void>,
     interrupt_on: Option<unsafe extern "C" fn(i32) -> i32>,
     interrupt_off: Option<unsafe extern "C" fn(i32) -> i32>,
     esp_hw_power_down: Option<unsafe extern "C" fn()>,
@@ -94,9 +94,9 @@ pub(super) struct osi_funcs_s {
 pub(super) static G_OSI_FUNCS: osi_funcs_s = osi_funcs_s {
     magic: 0xfadebead,
     version: 0x0001000A,
-    interrupt_alloc: Some(ble_os_adapter_chip_specific::interrupt_set),
-    interrupt_free: Some(ble_os_adapter_chip_specific::interrupt_clear),
-    interrupt_handler_set: Some(ble_os_adapter_chip_specific::interrupt_handler_set),
+    interrupt_alloc: Some(interrupt_set),
+    interrupt_free: Some(interrupt_clear),
+    interrupt_handler_set: Some(interrupt_handler_set),
     interrupt_disable: Some(interrupt_disable),
     interrupt_restore: Some(interrupt_enable),
     task_yield: Some(task_yield),
@@ -135,21 +135,19 @@ pub(super) static G_OSI_FUNCS: osi_funcs_s = osi_funcs_s {
     btdm_sleep_exit_phase1: Some(btdm_sleep_exit_phase1),
     btdm_sleep_exit_phase2: Some(btdm_sleep_exit_phase2),
     btdm_sleep_exit_phase3: Some(btdm_sleep_exit_phase3),
-    coex_wifi_sleep_set: Some(ble_os_adapter_chip_specific::coex_wifi_sleep_set),
-    coex_core_ble_conn_dyn_prio_get: Some(
-        ble_os_adapter_chip_specific::coex_core_ble_conn_dyn_prio_get,
-    ),
+    coex_wifi_sleep_set: Some(coex_wifi_sleep_set),
+    coex_core_ble_conn_dyn_prio_get: Some(coex_core_ble_conn_dyn_prio_get),
     coex_schm_register_btdm_callback: Some(coex_schm_register_btdm_callback),
     coex_schm_status_bit_set: Some(coex_schm_status_bit_set),
     coex_schm_status_bit_clear: Some(coex_schm_status_bit_clear),
     coex_schm_interval_get: Some(coex_schm_interval_get),
     coex_schm_curr_period_get: Some(coex_schm_curr_period_get),
     coex_schm_curr_phase_get: Some(coex_schm_curr_phase_get),
-    interrupt_on: Some(ble_os_adapter_chip_specific::interrupt_on),
-    interrupt_off: Some(ble_os_adapter_chip_specific::interrupt_off),
-    esp_hw_power_down: Some(ble_os_adapter_chip_specific::esp_hw_power_down),
-    esp_hw_power_up: Some(ble_os_adapter_chip_specific::esp_hw_power_up),
-    ets_backup_dma_copy: Some(ble_os_adapter_chip_specific::ets_backup_dma_copy),
+    interrupt_on: Some(interrupt_on),
+    interrupt_off: Some(interrupt_off),
+    esp_hw_power_down: Some(esp_hw_power_down),
+    esp_hw_power_up: Some(esp_hw_power_up),
+    ets_backup_dma_copy: Some(ets_backup_dma_copy),
     ets_delay_us: Some(ets_delay_us_wrapper),
     btdm_rom_table_ready: Some(btdm_rom_table_ready_wrapper),
     coex_bt_wakeup_request: Some(coex_bt_wakeup_request),
@@ -167,53 +165,29 @@ extern "C" fn assert_wrapper() {
     panic!("assert_wrapper called - inspect the logs");
 }
 
-extern "C" fn coex_schm_register_btdm_callback(_callback: *const ()) -> i32 {
+extern_coex_fns! {
+    fn coex_core_ble_conn_dyn_prio_get(low: *mut i32, high: *mut i32) -> i32;
+}
+
+coex_fns! {
+    fn coex_schm_interval_get() -> u32;
+    fn coex_schm_curr_period_get() -> u8;
+    fn coex_schm_curr_phase_get() -> *mut c_void;
+}
+
+extern "C" fn coex_schm_register_btdm_callback(_callback: *mut c_void) -> i32 {
     trace!("coex_schm_register_btdm_callback");
 
-    #[cfg(coex)]
-    unsafe {
-        // COEX_SCHM_CALLBACK_TYPE_BT
-        coex_schm_register_callback(1, _callback as *mut crate::sys::c_types::c_void)
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "coex")] {
+            unsafe {
+                const COEX_SCHM_CALLBACK_TYPE_BT: u32 = 1;
+                coex_schm_register_callback(COEX_SCHM_CALLBACK_TYPE_BT, _callback)
+            }
+        } else {
+            0
+        }
     }
-
-    #[cfg(not(coex))]
-    0
-}
-
-extern "C" fn coex_schm_interval_get() -> i32 {
-    trace!("coex_schm_interval_get");
-
-    #[cfg(coex)]
-    unsafe {
-        crate::sys::include::coex_schm_interval_get() as i32
-    }
-
-    #[cfg(not(coex))]
-    0
-}
-
-extern "C" fn coex_schm_curr_period_get() -> u8 {
-    trace!("coex_schm_curr_period_get");
-
-    #[cfg(coex)]
-    unsafe {
-        crate::sys::include::coex_schm_curr_period_get()
-    }
-
-    #[cfg(not(coex))]
-    0
-}
-
-extern "C" fn coex_schm_curr_phase_get() -> *const () {
-    trace!("coex_schm_curr_phase_get");
-
-    #[cfg(coex)]
-    unsafe {
-        crate::sys::include::coex_schm_curr_phase_get().cast()
-    }
-
-    #[cfg(not(coex))]
-    core::ptr::null()
 }
 
 extern "C" fn coex_bt_wakeup_request() {
@@ -697,23 +671,6 @@ pub(crate) unsafe extern "C" fn coex_wifi_sleep_set(sleep: i32) {
         "ignored coex_wifi_sleep_set {} - because original implementation does the same",
         sleep
     );
-}
-
-#[allow(unused_variables, dead_code)]
-pub(crate) unsafe extern "C" fn coex_core_ble_conn_dyn_prio_get(
-    low: *mut i32,
-    high: *mut i32,
-) -> i32 {
-    unsafe extern "C" {
-        fn coex_core_ble_conn_dyn_prio_get(low: *mut i32, high: *mut i32) -> i32;
-    }
-    trace!("coex_core_ble_conn_dyn_prio_get");
-
-    #[cfg(coex)]
-    return unsafe { coex_core_ble_conn_dyn_prio_get(low, high) };
-
-    #[cfg(not(coex))]
-    0
 }
 
 pub(crate) unsafe extern "C" fn esp_hw_power_down() {

--- a/esp-radio/src/coex_utils.rs
+++ b/esp-radio/src/coex_utils.rs
@@ -1,0 +1,50 @@
+#![macro_use]
+#![allow(unused_macros)]
+
+macro_rules! coex_fns {
+    (
+        $(
+            $(#[$meta:meta])?
+            fn $name:ident $args:tt $(-> $ret:ty)?;
+        )*
+    ) => {
+        $(
+            #[cfg(feature = "coex")]
+            $(#[$meta])?
+            pub(crate) use crate::sys::include::$name;
+
+            #[cfg(not(feature = "coex"))]
+            $(#[$meta])?
+            #[allow(unused_variables)]
+            pub(crate) unsafe extern "C" fn $name $args $(-> $ret)? {
+                $(<$ret>::default())?
+            }
+        )*
+    };
+}
+
+macro_rules! extern_coex_fns {
+    (
+        $(
+            $(#[$meta:meta])?
+            fn $name:ident ($($arg:ident: $arg_ty:ty),*) $(-> $ret:ty)?;
+        )*
+    ) => {
+        $(
+            $(#[$meta])?
+            #[allow(unused_variables)]
+            pub(crate) unsafe extern "C" fn $name ($($arg: $arg_ty),*) $(-> $ret)? {
+                cfg_if::cfg_if! {
+                    if #[cfg(feature = "coex")] {
+                        unsafe extern "C" {
+                            fn $name($($arg: $arg_ty),*) $(-> $ret)?;
+                        }
+                        unsafe { $name ($($arg),*) }
+                    } else {
+                        $(<$ret>::default())?
+                    }
+                }
+            }
+        )*
+    };
+}

--- a/esp-radio/src/lib.rs
+++ b/esp-radio/src/lib.rs
@@ -168,7 +168,8 @@ extern crate esp_metadata_generated;
 
 extern crate alloc;
 
-// MUST be the first module
+// These modules rely on `#[macro_use]` so they must be the first ones declared
+mod coex_utils;
 mod fmt;
 pub(crate) mod reg_access;
 
@@ -326,7 +327,7 @@ pub(crate) fn init() {
     wifi_set_log_verbose();
     init_radio_clocks();
 
-    #[cfg(coex)]
+    #[cfg(feature = "coex")]
     match crate::wifi::coex_initialize() {
         0 => {}
         error => panic!("Failed to initialize coexistence, error code: {}", error),
@@ -337,7 +338,7 @@ pub(crate) fn init() {
 
 pub(crate) fn deinit() {
     // Disable coexistence
-    #[cfg(coex)]
+    #[cfg(feature = "coex")]
     {
         unsafe { crate::wifi::os_adapter::coex_disable() };
         unsafe { crate::wifi::os_adapter::coex_deinit() };

--- a/esp-radio/src/wifi/internal.rs
+++ b/esp-radio/src/wifi/internal.rs
@@ -1,4 +1,8 @@
 use super::os_adapter::{self, *};
+#[cfg(feature = "coex")]
+use crate::hal::ram;
+#[cfg(feature = "coex")]
+use crate::sys::c_types::c_void;
 use crate::{
     common_adapter::*,
     sys::include::{
@@ -8,10 +12,8 @@ use crate::{
         wifi_osi_funcs_t,
     },
 };
-#[cfg(coex)]
-use crate::{hal::ram, sys::c_types::c_void};
 
-#[cfg(all(coex, wifi_driver_supported, bt_driver_supported))]
+#[cfg(all(feature = "coex", wifi_driver_supported, bt_driver_supported))]
 pub(super) static mut G_COEX_ADAPTER_FUNCS: crate::sys::include::coex_adapter_funcs_t =
     crate::sys::include::coex_adapter_funcs_t {
         _version: crate::sys::include::COEX_ADAPTER_VERSION as i32,
@@ -49,13 +51,13 @@ pub(super) static mut G_COEX_ADAPTER_FUNCS: crate::sys::include::coex_adapter_fu
         _xtal_freq_get: Some(xtal_freq_get_wrapper),
     };
 
-#[cfg(coex)]
+#[cfg(feature = "coex")]
 #[ram]
 unsafe extern "C" fn xtal_freq_get_wrapper() -> i32 {
     crate::hal::clock::Clocks::get().xtal_clock.as_mhz() as i32
 }
 
-#[cfg(coex)]
+#[cfg(feature = "coex")]
 unsafe extern "C" fn esp_coexist_debug_matrix_init_wrapper(
     _evt: i32,
     _sig: i32,
@@ -65,19 +67,19 @@ unsafe extern "C" fn esp_coexist_debug_matrix_init_wrapper(
     crate::sys::include::ESP_ERR_NOT_SUPPORTED as i32
 }
 
-#[cfg(coex)]
+#[cfg(feature = "coex")]
 #[ram]
 unsafe extern "C" fn semphr_take_from_isr_wrapper(semphr: *mut c_void, hptw: *mut c_void) -> i32 {
     unsafe { crate::common_adapter::semphr_take_from_isr(semphr, hptw as *mut bool) }
 }
 
-#[cfg(coex)]
+#[cfg(feature = "coex")]
 #[ram]
 unsafe extern "C" fn semphr_give_from_isr_wrapper(semphr: *mut c_void, hptw: *mut c_void) -> i32 {
     unsafe { crate::common_adapter::semphr_give_from_isr(semphr, hptw as *mut bool) }
 }
 
-#[cfg(coex)]
+#[cfg(feature = "coex")]
 unsafe extern "C" fn is_in_isr_wrapper() -> i32 {
     crate::is_interrupts_disabled() as i32
 }
@@ -218,7 +220,7 @@ pub(crate) static __ESP_RADIO_G_WIFI_OSI_FUNCS: wifi_osi_funcs_t = wifi_osi_func
     _sleep_retention_find_link_by_id: Some(
         os_adapter_chip_specific::sleep_retention_find_link_by_id_dummy,
     ),
-    _coex_schm_process_restart: Some(coex_schm_process_restart_wrapper),
+    _coex_schm_process_restart: Some(coex_schm_process_restart),
     _coex_schm_register_cb: Some(coex_schm_register_cb_wrapper),
 
     _coex_schm_flexible_period_set: Some(coex_schm_flexible_period_set),

--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -896,7 +896,7 @@ pub(crate) fn wifi_init(_wifi: crate::hal::peripherals::WIFI<'_>) -> Result<(), 
     #[cfg(esp32)]
     set_mac_time_update_cb(_wifi);
     unsafe {
-        #[cfg(coex)]
+        #[cfg(feature = "coex")]
         esp_wifi_result!(coex_init())?;
 
         esp_wifi_result!(esp_wifi_init_internal(addr_of!(internal::G_CONFIG)))?;
@@ -921,7 +921,7 @@ pub(crate) fn wifi_init(_wifi: crate::hal::peripherals::WIFI<'_>) -> Result<(), 
     }
 }
 
-#[cfg(coex)]
+#[cfg(feature = "coex")]
 pub(crate) fn coex_initialize() -> i32 {
     debug!("call coex-initialize");
     unsafe {
@@ -942,15 +942,15 @@ pub(crate) fn coex_initialize() -> i32 {
 }
 
 pub(crate) unsafe extern "C" fn coex_init() -> i32 {
-    #[cfg(coex)]
-    {
-        debug!("coex-init");
-        #[allow(clippy::needless_return)]
-        return unsafe { crate::sys::include::coex_init() };
-    }
+    debug!("coex-init");
 
-    #[cfg(not(coex))]
-    0
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "coex")] {
+            unsafe { crate::sys::include::coex_init() }
+        } else {
+            0
+        }
+    }
 }
 
 fn wifi_deinit() -> Result<(), crate::WifiError> {

--- a/esp-radio/src/wifi/os_adapter/mod.rs
+++ b/esp-radio/src/wifi/os_adapter/mod.rs
@@ -423,10 +423,7 @@ fn common_task_create(
     );
 
     unsafe {
-        let task_func = core::mem::transmute::<
-            *mut c_void,
-            extern "C" fn(*mut crate::sys::c_types::c_void),
-        >(task_func);
+        let task_func = core::mem::transmute::<*mut c_void, extern "C" fn(*mut c_void)>(task_func);
 
         let task = crate::preempt::task_create(
             task_name,
@@ -1463,53 +1460,30 @@ pub unsafe extern "C" fn wifi_delete_queue(queue: *mut c_void) {
     crate::compat::queue::queue_delete(*boxed)
 }
 
-/// **************************************************************************
-/// Name: wifi_coex_deinit
-///
-/// Description:
-///   Don't support
-///
-/// *************************************************************************
-pub unsafe extern "C" fn coex_deinit() {
-    trace!("coex_deinit");
-
-    #[cfg(coex)]
-    unsafe {
-        crate::sys::include::coex_deinit()
-    };
+coex_fns! {
+    fn coex_deinit();
+    fn coex_enable() -> i32;
+    fn coex_disable();
+    fn coex_wifi_request(event: u32, latency: u32, duration: u32) -> c_int;
+    fn coex_wifi_release(event: u32) -> c_int;
+    fn coex_wifi_channel_set(primary: u8, secondary: u8) -> c_int;
+    fn coex_event_duration_get(_event: u32, _duration: *mut u32) -> c_int;
+    #[cfg(not(any(esp32, esp32s2)))]
+    fn coex_pti_get(event: u32, pti: *mut u8) -> c_int;
+    fn coex_schm_status_bit_clear(type_: u32, status: u32);
+    fn coex_schm_status_bit_set(type_: u32, status: u32);
+    fn coex_schm_interval_set(interval: u32) -> c_int;
+    fn coex_schm_interval_get() -> u32;
+    fn coex_schm_curr_period_get() -> u8;
+    fn coex_schm_curr_phase_get() -> *mut c_void;
+    fn coex_schm_process_restart() -> c_int;
+    fn coex_register_start_cb(cb: Option<unsafe extern "C" fn() -> c_int>) -> c_int;
+    fn coex_schm_get_phase_by_idx(phase_idx: i32) -> *mut c_void;
 }
 
-/// **************************************************************************
-/// Name: wifi_coex_enable
-///
-/// Description:
-///   Don't support
-///
-/// *************************************************************************
-pub unsafe extern "C" fn coex_enable() -> c_int {
-    trace!("coex_enable");
-
-    #[cfg(coex)]
-    return unsafe { crate::sys::include::coex_enable() };
-
-    #[cfg(not(coex))]
-    0
-}
-
-/// **************************************************************************
-/// Name: wifi_coex_disable
-///
-/// Description:
-///   Don't support
-///
-/// *************************************************************************
-pub unsafe extern "C" fn coex_disable() {
-    trace!("coex_disable");
-
-    #[cfg(coex)]
-    unsafe {
-        crate::sys::include::coex_disable()
-    };
+extern_coex_fns! {
+    fn coex_schm_flexible_period_set(period: u8) -> i32;
+    fn coex_schm_flexible_period_get() -> u8;
 }
 
 /// **************************************************************************
@@ -1522,102 +1496,14 @@ pub unsafe extern "C" fn coex_disable() {
 pub unsafe extern "C" fn coex_status_get() -> u32 {
     trace!("coex_status_get");
 
-    #[cfg(coex)]
-    return unsafe { crate::sys::include::coex_status_get(0b1) }; // COEX_STATUS_GET_WIFI_BITMAP
-
-    #[cfg(not(coex))]
-    0
-}
-
-/// **************************************************************************
-/// Name: esp_coex_wifi_request
-///
-/// Description:
-///   Don't support
-///
-/// *************************************************************************
-#[cfg_attr(not(coex), allow(unused_variables))]
-pub unsafe extern "C" fn coex_wifi_request(event: u32, latency: u32, duration: u32) -> c_int {
-    trace!("coex_wifi_request");
-
-    #[cfg(coex)]
-    return unsafe { crate::sys::include::coex_wifi_request(event, latency, duration) };
-
-    #[cfg(not(coex))]
-    0
-}
-
-/// **************************************************************************
-/// Name: esp_coex_wifi_release
-///
-/// Description:
-///   Don't support
-///
-/// *************************************************************************
-#[cfg_attr(not(coex), allow(unused_variables))]
-pub unsafe extern "C" fn coex_wifi_release(event: u32) -> c_int {
-    trace!("coex_wifi_release");
-
-    #[cfg(coex)]
-    return unsafe { crate::sys::include::coex_wifi_release(event) };
-
-    #[cfg(not(coex))]
-    0
-}
-
-/// **************************************************************************
-/// Name: wifi_coex_wifi_set_channel
-///
-/// Description:
-///   Don't support
-///
-/// *************************************************************************
-#[cfg_attr(not(coex), allow(unused_variables))]
-pub unsafe extern "C" fn coex_wifi_channel_set(primary: u8, secondary: u8) -> c_int {
-    trace!("coex_wifi_channel_set");
-
-    #[cfg(coex)]
-    return unsafe { crate::sys::include::coex_wifi_channel_set(primary, secondary) };
-
-    #[cfg(not(coex))]
-    0
-}
-
-/// **************************************************************************
-/// Name: wifi_coex_get_event_duration
-///
-/// Description:
-///   Don't support
-///
-/// *************************************************************************
-#[cfg_attr(not(coex), allow(unused_variables))]
-pub unsafe extern "C" fn coex_event_duration_get(event: u32, duration: *mut u32) -> c_int {
-    trace!("coex_event_duration_get");
-
-    #[cfg(coex)]
-    return unsafe { crate::sys::include::coex_event_duration_get(event, duration) };
-
-    #[cfg(not(coex))]
-    0
-}
-
-/// **************************************************************************
-/// Name: wifi_coex_get_pti
-///
-/// Description:
-///   Don't support
-///
-/// *************************************************************************
-#[cfg(any(esp32c3, esp32c2, esp32c5, esp32c6, esp32s3))]
-#[cfg_attr(not(coex), allow(unused_variables))]
-pub unsafe extern "C" fn coex_pti_get(event: u32, pti: *mut u8) -> c_int {
-    trace!("coex_pti_get");
-
-    #[cfg(coex)]
-    return unsafe { crate::sys::include::coex_pti_get(event, pti) };
-
-    #[cfg(not(coex))]
-    0
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "coex")] {
+            const COEX_STATUS_GET_WIFI_BITMAP: u8 = 1;
+            unsafe { crate::sys::include::coex_status_get(COEX_STATUS_GET_WIFI_BITMAP) }
+        } else {
+            0
+        }
+    }
 }
 
 #[cfg(any(esp32, esp32s2))]
@@ -1626,195 +1512,25 @@ pub unsafe extern "C" fn coex_pti_get(event: u32, pti: *mut u8) -> c_int {
     0
 }
 
-/// **************************************************************************
-/// Name: wifi_coex_clear_schm_status_bit
-///
-/// Description:
-///   Don't support
-///
-/// *************************************************************************
-#[allow(unused_variables)]
-pub unsafe extern "C" fn coex_schm_status_bit_clear(type_: u32, status: u32) {
-    trace!("coex_schm_status_bit_clear");
-
-    #[cfg(coex)]
-    unsafe {
-        crate::sys::include::coex_schm_status_bit_clear(type_, status)
-    };
-}
-
-/// **************************************************************************
-/// Name: wifi_coex_set_schm_status_bit
-///
-/// Description:
-///   Don't support
-///
-/// *************************************************************************
-#[allow(unused_variables)]
-pub unsafe extern "C" fn coex_schm_status_bit_set(type_: u32, status: u32) {
-    trace!("coex_schm_status_bit_set");
-
-    #[cfg(coex)]
-    unsafe {
-        crate::sys::include::coex_schm_status_bit_set(type_, status)
-    };
-}
-
-/// **************************************************************************
-/// Name: wifi_coex_set_schm_interval
-///
-/// Description:
-///   Don't support
-///
-/// *************************************************************************
-#[allow(unused_variables)]
-pub unsafe extern "C" fn coex_schm_interval_set(interval: u32) -> c_int {
-    trace!("coex_schm_interval_set");
-
-    #[cfg(coex)]
-    return unsafe { crate::sys::include::coex_schm_interval_set(interval) };
-
-    #[cfg(not(coex))]
-    0
-}
-
-/// **************************************************************************
-/// Name: wifi_coex_get_schm_interval
-///
-/// Description:
-///   Don't support
-///
-/// *************************************************************************
-#[allow(unused_variables)]
-pub unsafe extern "C" fn coex_schm_interval_get() -> u32 {
-    trace!("coex_schm_interval_get");
-
-    #[cfg(coex)]
-    return unsafe { crate::sys::include::coex_schm_interval_get() };
-
-    #[cfg(not(coex))]
-    0
-}
-
-/// **************************************************************************
-/// Name: wifi_coex_get_schm_curr_period
-///
-/// Description:
-///   Don't support
-///
-/// *************************************************************************
-#[allow(unused_variables)]
-pub unsafe extern "C" fn coex_schm_curr_period_get() -> u8 {
-    trace!("coex_schm_curr_period_get");
-
-    #[cfg(coex)]
-    return unsafe { crate::sys::include::coex_schm_curr_period_get() };
-
-    #[cfg(not(coex))]
-    0
-}
-
-/// **************************************************************************
-/// Name: wifi_coex_get_schm_curr_phase
-///
-/// Description:
-///   Don't support
-///
-/// *************************************************************************
-#[allow(unused_variables)]
-pub unsafe extern "C" fn coex_schm_curr_phase_get() -> *mut c_void {
-    trace!("coex_schm_curr_phase_get");
-
-    #[cfg(coex)]
-    return unsafe { crate::sys::include::coex_schm_curr_phase_get() };
-
-    #[cfg(not(coex))]
-    return core::ptr::null_mut();
-}
-
-pub unsafe extern "C" fn coex_schm_process_restart_wrapper() -> crate::sys::c_types::c_int {
-    trace!("coex_schm_process_restart_wrapper");
-
-    #[cfg(not(coex))]
-    return 0;
-
-    #[cfg(coex)]
-    unsafe {
-        crate::sys::include::coex_schm_process_restart()
-    }
-}
-
 #[allow(unused_variables)]
 pub unsafe extern "C" fn coex_schm_register_cb_wrapper(
-    arg1: crate::sys::c_types::c_int,
-    cb: ::core::option::Option<
-        unsafe extern "C" fn(arg1: crate::sys::c_types::c_int) -> crate::sys::c_types::c_int,
-    >,
-) -> crate::sys::c_types::c_int {
+    arg1: c_int,
+    cb: Option<unsafe extern "C" fn(arg1: c_int) -> c_int>,
+) -> c_int {
     trace!("coex_schm_register_cb_wrapper {} {:?}", arg1, cb);
 
-    #[cfg(not(coex))]
-    return 0;
-
-    #[cfg(coex)]
-    unsafe {
-        crate::sys::include::coex_schm_register_callback(
-            arg1 as u32,
-            unwrap!(cb) as *const crate::sys::c_types::c_void as *mut crate::sys::c_types::c_void,
-        )
-    }
-}
-
-pub unsafe extern "C" fn coex_schm_flexible_period_set(period: u8) -> i32 {
-    trace!("coex_schm_flexible_period_set {}", period);
-
-    #[cfg(coex)]
-    unsafe {
-        unsafe extern "C" {
-            fn coex_schm_flexible_period_set(period: u8) -> i32;
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "coex")] {
+            unsafe {
+                crate::sys::include::coex_schm_register_callback(
+                    arg1 as u32,
+                    unwrap!(cb) as *mut c_void,
+                )
+            }
+        } else {
+            0
         }
-
-        coex_schm_flexible_period_set(period)
     }
-
-    #[cfg(not(coex))]
-    0
-}
-
-pub unsafe extern "C" fn coex_schm_flexible_period_get() -> u8 {
-    trace!("coex_schm_flexible_period_get");
-
-    #[cfg(coex)]
-    unsafe {
-        unsafe extern "C" {
-            fn coex_schm_flexible_period_get() -> u8;
-        }
-
-        coex_schm_flexible_period_get()
-    }
-
-    #[cfg(not(coex))]
-    0
-}
-
-pub unsafe extern "C" fn coex_register_start_cb(
-    _cb: Option<unsafe extern "C" fn() -> crate::sys::c_types::c_int>,
-) -> crate::sys::c_types::c_int {
-    #[cfg(coex)]
-    return unsafe { crate::sys::include::coex_register_start_cb(_cb) };
-
-    #[cfg(not(coex))]
-    0
-}
-
-pub unsafe extern "C" fn coex_schm_get_phase_by_idx(
-    _phase_idx: i32,
-) -> *mut crate::sys::c_types::c_void {
-    #[cfg(coex)]
-    return unsafe { crate::sys::include::coex_schm_get_phase_by_idx(_phase_idx) };
-
-    #[cfg(not(coex))]
-    core::ptr::null_mut()
 }
 
 /// **************************************************************************


### PR DESCRIPTION
This PR removes `cfg(coex)` in favour of `cfg(feature = "coex")` and cleans up a bunch of function dispatch code.