### PR TITLE
fix MCP server subprocess spawning

### DIFF
--- a/xtask/src/commands/mcp.rs
+++ b/xtask/src/commands/mcp.rs
@@ -24,13 +24,18 @@ use serde_json::Value;
 // ---------------------------------------------------------------------------
 // Subprocess helper
 
-/// Spawn the current xtask executable with `args`, feed newlines into its
-/// stdin (to silently dismiss any interactive `inquire` prompts), and capture
-/// stdout + stderr.
+/// Spawn xtask with `args`, feed newlines into its stdin (to silently
+/// dismiss any interactive `inquire` prompts), and capture stdout + stderr.
+///
+/// Uses `cargo xtask` rather than `current_exe()` because cargo rebuilds
+/// the binary in-place, which invalidates the `/proc/self/exe` symlink on
+/// Linux (it gets a ` (deleted)` suffix) and causes ENOENT on re-spawn.
 pub fn run_xtask_subprocess(args: &[String]) -> Result<String> {
-    let exe = std::env::current_exe()?;
-    let mut child = std::process::Command::new(&exe)
-        .args(args)
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".into());
+    let mut full_args = vec!["xtask".to_string()];
+    full_args.extend_from_slice(args);
+    let mut child = std::process::Command::new(&cargo)
+        .args(&full_args)
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())

--- a/xtask/src/commands/run.rs
+++ b/xtask/src/commands/run.rs
@@ -213,30 +213,34 @@ pub fn run_examples(
     examples.sort_by_key(|ex| ex.tag());
 
     let console = console::Term::stdout();
+    let interactive = console.is_term();
 
     for example in examples {
         let mut skip = false;
 
         log::info!("Running example '{}'", example.output_file_name());
-        if let Some(description) = example.description() {
-            log::info!(
-                "\n\n{}\n\nPress ENTER to run example, `s` to skip",
-                description.trim()
-            );
-        } else {
-            log::info!("\n\nPress ENTER to run example, `s` to skip");
-        }
 
-        loop {
-            let key = console.read_key();
+        if interactive {
+            if let Some(description) = example.description() {
+                log::info!(
+                    "\n\n{}\n\nPress ENTER to run example, `s` to skip",
+                    description.trim()
+                );
+            } else {
+                log::info!("\n\nPress ENTER to run example, `s` to skip");
+            }
 
-            match key {
-                Ok(console::Key::Enter) => break,
-                Ok(console::Key::Char('s')) => {
-                    skip = true;
-                    break;
+            loop {
+                let key = console.read_key();
+
+                match key {
+                    Ok(console::Key::Enter) => break,
+                    Ok(console::Key::Char('s')) => {
+                        skip = true;
+                        break;
+                    }
+                    _ => (),
                 }
-                _ => (),
             }
         }
 
@@ -255,18 +259,22 @@ pub fn run_examples(
 
             if let Err(error) = result {
                 log::error!("Failed to run example: {}", error);
-                log::info!("Retry or skip? (r/s)");
-                loop {
-                    let key = console.read_key();
+                if interactive {
+                    log::info!("Retry or skip? (r/s)");
+                    loop {
+                        let key = console.read_key();
 
-                    match key {
-                        Ok(console::Key::Char('r')) => break,
-                        Ok(console::Key::Char('s')) => {
-                            skip = true;
-                            break;
+                        match key {
+                            Ok(console::Key::Char('r')) => break,
+                            Ok(console::Key::Char('s')) => {
+                                skip = true;
+                                break;
+                            }
+                            _ => (),
                         }
-                        _ => (),
                     }
+                } else {
+                    return Err(error);
                 }
             } else {
                 break;


### PR DESCRIPTION
Use `cargo xtask` instead of `current_exe()` for subprocess spawning. On Linux, cargo rebuilds replace the binary in-place which invalidates the `/proc/self/exe` symlink (gets a ` (deleted)` suffix), causing ENOENT on re-spawn.

Also skip interactive console prompts (press Enter/skip) when stdout is not a TTY, so MCP tool calls don't hang.