### PR TITLE
Speedup xtask fmt

### DIFF
--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -902,7 +902,6 @@ fn format_package_path(
     let mut cargo_args = CargoArgsBuilder::default()
         .toolchain("nightly")
         .subcommand("fmt")
-        .arg("--all")
         .build();
 
     if check {


### PR DESCRIPTION
Closes #5027

We passed  `--all` to `cargo fmt` which means

``` 
      --all
          Format all packages, and also their local path-based dependencies
```

This is unnecessary since this way we format a couple of packages over and over again - and also fmt packages which aren't requested to get formatted.

Not passing `--all` will speedup `cargo xtask fmt-packages`
