### PR TITLE
Allow `doc_replace` to replace in line

### DIFF
--- a/esp-hal-procmacros/CHANGELOG.md
+++ b/esp-hal-procmacros/CHANGELOG.md
@@ -9,12 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `doc_replace` can now replace `__placeholders__` in-line (#5119)
 
 ### Changed
 
 - The `handler` macro no longer generates code to check the Priority (#4996)
 
 ### Fixed
+
 - Fixed the logic for determining which sections should be loaded in `load_lp_code!` macro (#4612)
 
 

--- a/esp-hal-procmacros/src/doc_replace.rs
+++ b/esp-hal-procmacros/src/doc_replace.rs
@@ -6,6 +6,7 @@ use syn::{
     AttrStyle,
     Attribute,
     Expr,
+    ExprLit,
     Item,
     Lit,
     LitStr,
@@ -20,7 +21,16 @@ use syn::{
 };
 
 struct Replacements {
+    // Placeholder => [attribute contents]
+    //
+    // Replaces `# {tag}` placeholders with the attribute contents. Replaces the entire line.
     line_replacements: HashMap<String, Vec<TokenStream2>>,
+
+    // Placeholder => [(condition, string contents)], may be unconditional.
+    //
+    // Replaces `__tag__` placeholders with the string contents. Replaces only the placeholder
+    // inside the line, and applies the condition to the entire line if present.
+    inline_replacements: HashMap<String, Vec<(Option<TokenStream>, String)>>,
 }
 
 impl Replacements {
@@ -37,17 +47,28 @@ impl Replacements {
                         attrs.push(syn::parse_quote_spanned! { span => #![ #line ] });
                     }
                 }
+            } else if let Some((placeholder, replacements)) = self
+                .inline_replacements
+                .iter()
+                .find(|(k, _v)| trimmed.contains(k.as_str()))
+            {
+                for (cfg, replacement) in replacements.iter() {
+                    let line = line.replace(placeholder, replacement);
+                    let line = create_raw_string(&line);
+                    let attr_inner = if let Some(condition) = cfg {
+                        quote! { cfg_attr(#condition, doc = #line) }
+                    } else {
+                        quote! { doc = #line }
+                    };
+                    if outer {
+                        attrs.push(syn::parse_quote_spanned! { span => #[ #attr_inner ] });
+                    } else {
+                        attrs.push(syn::parse_quote_spanned! { span => #![ #attr_inner ] });
+                    }
+                }
             } else {
                 // Just append the line, in the expected format (`doc = r" Foobar"`)
-                let hash = if line.contains("#\"") {
-                    "##"
-                } else if line.contains('"') {
-                    "#"
-                } else {
-                    ""
-                };
-
-                let line = TokenStream2::from_str(&format!("r{hash}\"{line}\"{hash}")).unwrap();
+                let line = create_raw_string(line);
                 if outer {
                     attrs.push(syn::parse_quote_spanned! { span => #[doc = #line] });
                 } else {
@@ -61,35 +82,80 @@ impl Replacements {
     }
 }
 
+fn create_raw_string(line: &str) -> TokenStream2 {
+    let hash = if line.contains("#\"") {
+        "##"
+    } else if line.contains('"') {
+        "#"
+    } else {
+        ""
+    };
+
+    TokenStream2::from_str(&format!("r{hash}\"{line}\"{hash}")).unwrap()
+}
+
 impl Parse for Replacements {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-        let mut replacements = HashMap::new();
+        let mut line_replacements = HashMap::new();
+        let mut inline_replacements = HashMap::new();
+
+        let mut add_line_replacement = |placeholder: &str, replacement: Vec<TokenStream2>| {
+            line_replacements.insert(format!("# {{{placeholder}}}"), replacement);
+        };
+        let mut add_inline_replacement =
+            |placeholder: &str, replacement: Vec<(Option<TokenStream2>, String)>| {
+                // The placeholder must be a valid Rust identifier to keep rustfmt happy
+                inline_replacements.insert(format!("__{placeholder}__"), replacement);
+            };
+
         if !input.is_empty() {
             let args = Punctuated::<Replacement, Token![,]>::parse_terminated(input)?;
             for arg in args {
-                let replacement = match arg.replacement {
-                    ReplacementKind::Literal(expr) => vec![quote! {
-                        doc = #expr
-                    }],
+                match arg.replacement {
+                    ReplacementKind::Literal(expr) => {
+                        if let Expr::Lit(ExprLit {
+                            lit: Lit::Str(ref lit_str),
+                            ..
+                        }) = expr
+                        {
+                            add_inline_replacement(&arg.placeholder, vec![(None, lit_str.value())]);
+                        }
+
+                        add_line_replacement(
+                            &arg.placeholder,
+                            vec![quote! {
+                                doc = #expr
+                            }],
+                        );
+                    }
                     ReplacementKind::Choice(items) => {
-                        let mut branches = vec![];
+                        let mut conditions = vec![];
+                        let mut bodies = vec![];
+                        let mut lit_strs = vec![];
                         let mut cfgs = vec![];
 
                         for branch in items {
                             let body = branch.body;
+
+                            if let Expr::Lit(ExprLit {
+                                lit: Lit::Str(ref lit_str),
+                                ..
+                            }) = body
+                            {
+                                lit_strs.push(lit_str.value());
+                            }
+
                             match branch.condition {
                                 Some(Meta::List(cfg)) if cfg.path.is_ident("cfg") => {
                                     let condition = cfg.tokens;
 
                                     cfgs.push(condition.clone());
-                                    branches.push(quote! {
-                                        cfg_attr(#condition, doc = #body)
-                                    });
+                                    conditions.push(condition);
+                                    bodies.push(body);
                                 }
                                 None => {
-                                    branches.push(quote! {
-                                        cfg_attr(not(any( #(#cfgs),*) ), doc = #body)
-                                    });
+                                    conditions.push(quote! { not(any( #(#cfgs),*) ) });
+                                    bodies.push(body);
                                 }
                                 _ => {
                                     return Err(syn::Error::new(
@@ -97,19 +163,36 @@ impl Parse for Replacements {
                                         "Expected a cfg condition or catch-all condition using `_`",
                                     ));
                                 }
-                            };
+                            }
                         }
 
-                        branches
-                    }
-                };
+                        let branches = conditions
+                            .iter()
+                            .zip(bodies.iter())
+                            .map(|(condition, body)| {
+                                quote! {
+                                    cfg_attr(#condition, doc = #body)
+                                }
+                            })
+                            .collect::<Vec<_>>();
+                        add_line_replacement(&arg.placeholder, branches);
 
-                replacements.insert(arg.placeholder, replacement);
+                        if lit_strs.len() == bodies.len() {
+                            let branches = conditions
+                                .into_iter()
+                                .map(Some)
+                                .zip(lit_strs.into_iter())
+                                .collect::<Vec<_>>();
+                            add_inline_replacement(&arg.placeholder, branches);
+                        }
+                    }
+                }
             }
         }
 
         Ok(Self {
-            line_replacements: replacements,
+            line_replacements,
+            inline_replacements,
         })
     }
 }
@@ -126,7 +209,7 @@ impl Parse for Replacement {
         let replacement: ReplacementKind = input.parse()?;
 
         Ok(Self {
-            placeholder: format!("# {{{}}}", placeholder.value()),
+            placeholder: placeholder.value(),
             replacement,
         })
     }
@@ -391,6 +474,66 @@ mod tests {
                 /// ```rust, no_run
                 #[cfg_attr (esp32h2 , doc = "let freq = Rate::from_mhz(32);")]
                 #[cfg_attr (not (any (esp32h2)) , doc = "let freq = Rate::from_mhz(80);")]
+                #[doc = crate::before_snippet!()]
+                /// let peripherals = esp_hal::init(esp_hal::Config::default());
+                #[doc = crate::after_snippet!()]
+                /// ```
+                struct Foo {}
+            }
+            .to_string()
+        );
+    }
+
+    #[test]
+    fn test_custom_inline_replacements() {
+        let result = replace(
+            quote! {
+                "freq" => {
+                    cfg(esp32h2) => "32",
+                    _ => "80"
+                },
+                "other" => "Replacement"
+            }
+            .into(),
+            quote! {
+                /// # Configuration
+                /// ## Overview
+                /// This module contains the initial configuration for the system.
+                /// ## Configuration
+                /// In the [`esp_hal::init()`][crate::init] method, we can configure different
+                /// parameters for the system:
+                /// - CPU clock configuration.
+                /// - Watchdog configuration.
+                /// ## __other__ Examples
+                /// ### Default initialization
+                /// ```rust, no_run
+                /// let freq = Rate::from_mhz(__freq__);
+                /// # {before_snippet}
+                /// let peripherals = esp_hal::init(esp_hal::Config::default());
+                /// # {after_snippet}
+                /// ```
+                struct Foo {
+                }
+            }
+            .into(),
+        );
+
+        assert_eq!(
+            result.to_string(),
+            quote! {
+                /// # Configuration
+                /// ## Overview
+                /// This module contains the initial configuration for the system.
+                /// ## Configuration
+                /// In the [`esp_hal::init()`][crate::init] method, we can configure different
+                /// parameters for the system:
+                /// - CPU clock configuration.
+                /// - Watchdog configuration.
+                /// ## Replacement Examples
+                /// ### Default initialization
+                /// ```rust, no_run
+                #[cfg_attr (esp32h2 , doc = r" let freq = Rate::from_mhz(32);")]
+                #[cfg_attr (not (any (esp32h2)) , doc = r" let freq = Rate::from_mhz(80);")]
                 #[doc = crate::before_snippet!()]
                 /// let peripherals = esp_hal::init(esp_hal::Config::default());
                 #[doc = crate::after_snippet!()]

--- a/esp-hal-procmacros/src/lib.rs
+++ b/esp-hal-procmacros/src/lib.rs
@@ -123,10 +123,13 @@ pub fn ram(args: TokenStream, input: TokenStream) -> TokenStream {
 /// documentation of the annotated item.
 ///
 /// Replacements can be placed in the documentation as `# {placeholder}`. Each
-/// replacement must be its own line, it's not possible to place a placeholder in the middle of a
-/// line. The `before_snippet` and `after_snippet` placeholders are expanded to the
-/// `esp_hal::before_snippet!()` and `esp_hal::after_snippet!()` macros, and are expected to be
-/// used in example code blocks.
+/// replacement must be its own line. The `before_snippet` and `after_snippet` placeholders are
+/// expanded to the `esp_hal::before_snippet!()` and `esp_hal::after_snippet!()` macros, and are
+/// expected to be used in example code blocks.
+///
+/// In-line replacements can be placed in the middle of a line as `__placeholder__`. Currently,
+/// only literal strings can be substituted into in-line placeholders, and only one placeholder
+/// can be used per line.
 ///
 /// You can also define custom replacements in the attribute. A replacement can be
 /// an unconditional literal (i.e. a string that is always substituted into the doc comment),
@@ -153,6 +156,8 @@ pub fn ram(args: TokenStream, input: TokenStream) -> TokenStream {
 /// /// # {literal_placeholder}
 /// /// // here is some more code
 /// /// # {conditional_placeholder}
+/// ///
+/// /// The macro even supports __conditional_placeholder__ replacements in-line.
 /// /// ```
 /// fn my_function() {}
 /// ```

--- a/esp-hal/src/aes/mod.rs
+++ b/esp-hal/src/aes/mod.rs
@@ -695,8 +695,8 @@ pub mod dma {
 
     #[procmacros::doc_replace(
         "dma_channel" => {
-            cfg(esp32s2) => "let dma_channel = peripherals.DMA_CRYPTO;",
-            _ => "let dma_channel = peripherals.DMA_CH0;"
+            cfg(esp32s2) => "DMA_CRYPTO",
+            _ => "DMA_CH0"
         }
     )]
     /// DMA-enabled AES processing backend.
@@ -714,9 +714,8 @@ pub mod dma {
     /// ```rust, no_run
     /// # {before_snippet}
     /// use esp_hal::aes::{AesContext, Operation, cipher_modes::Ecb, dma::AesDmaBackend};
-    /// #
-    /// # {dma_channel}
-    /// let mut aes = AesDmaBackend::new(peripherals.AES, dma_channel);
+    ///
+    /// let mut aes = AesDmaBackend::new(peripherals.AES, peripherals.__dma_channel__);
     /// // Start the backend, which allows processing AES operations.
     /// let _backend = aes.start();
     ///
@@ -767,8 +766,8 @@ pub mod dma {
     impl<'d> AesDmaBackend<'d> {
         #[procmacros::doc_replace(
             "dma_channel" => {
-                cfg(esp32s2) => "let dma_channel = peripherals.DMA_CRYPTO;",
-                _ => "let dma_channel = peripherals.DMA_CH0;"
+                cfg(esp32s2) => "DMA_CRYPTO",
+                _ => "DMA_CH0"
             }
         )]
         /// Creates a new DMA-enabled AES backend.
@@ -781,8 +780,7 @@ pub mod dma {
         /// # {before_snippet}
         /// use esp_hal::aes::dma::AesDmaBackend;
         ///
-        /// # {dma_channel}
-        /// let mut aes = AesDmaBackend::new(peripherals.AES, dma_channel);
+        /// let mut aes = AesDmaBackend::new(peripherals.AES, peripherals.__dma_channel__);
         /// # {after_snippet}
         /// ```
         pub fn new(aes: AES<'d>, dma: impl DmaChannelFor<AES<'d>>) -> Self {
@@ -800,8 +798,8 @@ pub mod dma {
 
         #[procmacros::doc_replace(
             "dma_channel" => {
-                cfg(esp32s2) => "let dma_channel = peripherals.DMA_CRYPTO;",
-                _ => "let dma_channel = peripherals.DMA_CH0;"
+                cfg(esp32s2) => "DMA_CRYPTO",
+                _ => "DMA_CH0"
             }
         )]
         /// Registers the DMA-driven AES driver to process AES operations.
@@ -814,8 +812,7 @@ pub mod dma {
         /// # {before_snippet}
         /// use esp_hal::aes::dma::AesDmaBackend;
         ///
-        /// # {dma_channel}
-        /// let mut aes = AesDmaBackend::new(peripherals.AES, dma_channel);
+        /// let mut aes = AesDmaBackend::new(peripherals.AES, peripherals.__dma_channel__);
         /// let _handle = aes.start();
         /// # {after_snippet}
         /// ```

--- a/esp-hal/src/analog/adc/mod.rs
+++ b/esp-hal/src/analog/adc/mod.rs
@@ -1,8 +1,8 @@
 #![cfg_attr(docsrs, procmacros::doc_replace(
     "analog_pin" => {
-        cfg(esp32) => "let analog_pin = peripherals.GPIO32;",
-        cfg(any(esp32s2, esp32s3)) => "let analog_pin = peripherals.GPIO3;",
-        cfg(not(any(esp32, esp32s2, esp32s3)))  => "let analog_pin = peripherals.GPIO2;"
+        cfg(esp32) => "GPIO32",
+        cfg(any(esp32s2, esp32s3)) => "GPIO3",
+        cfg(not(any(esp32, esp32s2, esp32s3)))  => "GPIO2"
     }
 ))]
 //! # Analog to Digital Converter (ADC)
@@ -34,9 +34,8 @@
 //! # use esp_hal::analog::adc::Attenuation;
 //! # use esp_hal::analog::adc::Adc;
 //! # use esp_hal::delay::Delay;
-//! # {analog_pin}
 //! let mut adc1_config = AdcConfig::new();
-//! let mut pin = adc1_config.enable_pin(analog_pin, Attenuation::_11dB);
+//! let mut pin = adc1_config.enable_pin(peripherals.__analog_pin__, Attenuation::_11dB);
 //! let mut adc1 = Adc::new(peripherals.ADC1, adc1_config);
 //!
 //! let mut delay = Delay::new();

--- a/esp-hal/src/analog/dac.rs
+++ b/esp-hal/src/analog/dac.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(docsrs, procmacros::doc_replace(
     "dac1_pin" => {
-        cfg(esp32) => "let dac1_pin = peripherals.GPIO25;",
-        cfg(esp32s2) => "let dac1_pin = peripherals.GPIO17;"
+        cfg(esp32) => "GPIO25",
+        cfg(esp32s2) => "GPIO17"
     }
 ))]
 //! # Digital to Analog Converter (DAC)
@@ -26,8 +26,7 @@
 //! # use esp_hal::analog::dac::Dac;
 //! # use esp_hal::delay::Delay;
 //! # use embedded_hal::delay::DelayNs;
-//! # {dac1_pin}
-//! let mut dac1 = Dac::new(peripherals.DAC1, dac1_pin);
+//! let mut dac1 = Dac::new(peripherals.DAC1, peripherals.__dac1_pin__);
 //!
 //! let mut delay = Delay::new();
 //!

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(docsrs, procmacros::doc_replace(
     "dma_channel" => {
-        cfg(dma_kind = "pdma") => "let dma_channel = peripherals.DMA_SPI2;",
-        cfg(dma_kind = "gdma") => "let dma_channel = peripherals.DMA_CH0;"
+        cfg(dma_kind = "pdma") => "DMA_SPI2",
+        cfg(dma_kind = "gdma") => "DMA_CH0"
     }
 ))]
 //! # Direct Memory Access (DMA)
@@ -25,7 +25,6 @@
 //! # {before_snippet}
 //! # use esp_hal::dma_buffers;
 //! # use esp_hal::spi::{master::{Config, Spi}, Mode};
-//! # {dma_channel}
 //! let sclk = peripherals.GPIO0;
 //! let miso = peripherals.GPIO2;
 //! let mosi = peripherals.GPIO4;
@@ -41,7 +40,7 @@
 //! .with_mosi(mosi)
 //! .with_miso(miso)
 //! .with_cs(cs)
-//! .with_dma(dma_channel);
+//! .with_dma(peripherals.__dma_channel__);
 //! # {after_snippet}
 //! ```
 //!
@@ -1616,8 +1615,8 @@ impl<DEG: DmaChannel> DmaChannelConvert<DEG> for DEG {
 
 #[procmacros::doc_replace(
     "dma_channel" => {
-        cfg(dma_kind = "pdma") => "let dma_channel = peripherals.DMA_SPI2;",
-        cfg(dma_kind = "gdma") => "let dma_channel = peripherals.DMA_CH0;"
+        cfg(dma_kind = "pdma") => "DMA_SPI2",
+        cfg(dma_kind = "gdma") => "DMA_CH0"
     },
     "note" => {
         cfg(dma_kind = "pdma") => "\n\nNote that using mismatching channels (e.g. trying to use `DMA_SPI2` with SPI3) may compile, but will panic in runtime.\n\n",
@@ -1650,11 +1649,9 @@ impl<DEG: DmaChannel> DmaChannelConvert<DEG> for DEG {
 ///     spi.with_dma(channel)
 /// }
 ///
-/// # {dma_channel}
-///
 /// let spi = Spi::new(peripherals.SPI2, Config::default())?;
 ///
-/// let spi_dma = configures_spi_dma(spi, dma_channel);
+/// let spi_dma = configures_spi_dma(spi, peripherals.__dma_channel__);
 /// # {after_snippet}
 /// ```
 pub trait DmaChannelFor<P: DmaEligible>:

--- a/esp-hal/src/i2s/master.rs
+++ b/esp-hal/src/i2s/master.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(docsrs, procmacros::doc_replace(
     "dma_channel" => {
-        cfg(any(esp32, esp32s2)) => "let dma_channel = peripherals.DMA_I2S0;",
-        cfg(not(any(esp32, esp32s2))) => "let dma_channel = peripherals.DMA_CH0;"
+        cfg(any(esp32, esp32s2)) => "DMA_I2S0",
+        cfg(not(any(esp32, esp32s2))) => "DMA_CH0"
     },
     "mclk" => {
         cfg(not(esp32)) => "let i2s = i2s.with_mclk(peripherals.GPIO0);",
@@ -77,12 +77,11 @@
 //! # {before_snippet}
 //! # use esp_hal::i2s::master::{I2s, Channels, DataFormat, Config};
 //! # use esp_hal::dma_buffers;
-//! # {dma_channel}
 //! let (mut rx_buffer, rx_descriptors, _, _) = dma_buffers!(4 * 4092, 0);
 //!
 //! let i2s = I2s::new(
 //!     peripherals.I2S0,
-//!     dma_channel,
+//!     peripherals.__dma_channel__,
 //!     Config::new_tdm_philips()
 //!         .with_sample_rate(Rate::from_hz(44100))
 //!         .with_data_format(DataFormat::Data16Channel16)

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -5,14 +5,7 @@
 //! # Bare-metal (`no_std`) HAL for all Espressif ESP32 devices.
 //!
 //! This documentation is built for the
-#![cfg_attr(esp32, doc = "**ESP32**")]
-#![cfg_attr(esp32s2, doc = "**ESP32-S2**")]
-#![cfg_attr(esp32s3, doc = "**ESP32-S3**")]
-#![cfg_attr(esp32c2, doc = "**ESP32-C2**")]
-#![cfg_attr(esp32c3, doc = "**ESP32-C3**")]
-#![cfg_attr(esp32c5, doc = "**ESP32-C5**")]
-#![cfg_attr(esp32c6, doc = "**ESP32-C6**")]
-#![cfg_attr(esp32h2, doc = "**ESP32-H2**")]
+#![doc = concat!("**", chip_pretty!(), "**")]
 //! . Please ensure you are reading the correct [documentation] for your target
 //! device.
 //!

--- a/esp-hal/src/mcpwm/mod.rs
+++ b/esp-hal/src/mcpwm/mod.rs
@@ -1,13 +1,13 @@
 #![cfg_attr(docsrs, procmacros::doc_replace(
-    "clock_cfg" => {
-        cfg(not(esp32h2)) => "let clock_cfg = PeripheralClockConfig::with_frequency(Rate::from_mhz(40))?;",
-        cfg(esp32h2) => "let clock_cfg = PeripheralClockConfig::with_frequency(Rate::from_mhz(32))?;"
+    "mcpwm_freq" => {
+        cfg(not(esp32h2)) => "40",
+        cfg(esp32h2) => "32"
     },
     "clock_src" => {
-        cfg(esp32) => "Clock source is PLL_F160M (160 MHz) by default.",
-        cfg(esp32s3) => "Clock source is CRYPTO_PWM_CLK (160 MHz) by default.",
-        cfg(esp32c6) => "Clock source is PLL_F160M (160 MHz) by default.",
-        cfg(esp32h2) => "Clock source is PLL_F96M_CLK (96 MHz) by default.",
+        cfg(esp32) => "PLL_F160M (160 MHz)",
+        cfg(esp32s3) => "CRYPTO_PWM_CLK (160 MHz)",
+        cfg(esp32c6) => "PLL_F160M (160 MHz)",
+        cfg(esp32h2) => "PLL_F96M_CLK (96 MHz)",
     }
 ))]
 //! # Motor Control Pulse Width Modulator (MCPWM)
@@ -46,7 +46,7 @@
 //! * Fault Detection Module (Not yet implemented)
 //! * Capture Module (Not yet implemented)
 //!
-//! # {clock_src}
+//! Clock source is __clock_src__ by default.
 //!
 //! ## Examples
 //!
@@ -62,11 +62,12 @@
 //! # let pin = peripherals.GPIO0;
 //!
 //! // initialize peripheral
-//! # {clock_cfg}
+//! let clock_cfg = PeripheralClockConfig::with_frequency(Rate::from_mhz(__mcpwm_freq__))?;
 //! let mut mcpwm = McPwm::new(peripherals.MCPWM0, clock_cfg);
 //!
 //! // connect operator0 to timer0
 //! mcpwm.operator0.set_timer(&mcpwm.timer0);
+//!
 //! // connect operator0 to pin
 //! let mut pwm_pin = mcpwm
 //!     .operator0

--- a/esp-hal/src/mcpwm/operator.rs
+++ b/esp-hal/src/mcpwm/operator.rs
@@ -441,9 +441,9 @@ impl<PWM: PwmPeripheral, const OP: u8, const IS_A: bool> embedded_hal::pwm::SetD
 }
 
 #[procmacros::doc_replace(
-    "clock_cfg" => {
-        cfg(not(esp32h2)) => "let clock_cfg = PeripheralClockConfig::with_frequency(Rate::from_mhz(40))?;",
-        cfg(esp32h2) => "let clock_cfg = PeripheralClockConfig::with_frequency(Rate::from_mhz(32))?;"
+    "mcpwm_clk" => {
+        cfg(not(esp32h2)) => "40",
+        cfg(esp32h2) => "32"
     }
 )]
 /// Two pins driven by the same timer and operator
@@ -459,10 +459,14 @@ impl<PWM: PwmPeripheral, const OP: u8, const IS_A: bool> embedded_hal::pwm::SetD
 /// # use esp_hal::mcpwm::operator::{DeadTimeCfg, PwmPinConfig, PWMStream};
 /// // active high complementary using PWMA input
 /// let bridge_active = DeadTimeCfg::new_ahc();
+///
 /// // use PWMB as input for both outputs
 /// let bridge_off = DeadTimeCfg::new_bypass().set_output_swap(PWMStream::PWMA, true);
-/// # {clock_cfg}
-/// let mut mcpwm = McPwm::new(peripherals.MCPWM0, clock_cfg);
+///
+/// let mut mcpwm = McPwm::new(
+///     peripherals.MCPWM0,
+///     PeripheralClockConfig::with_frequency(Rate::from_mhz(__mcpwm_clk__))?,
+/// );
 ///
 /// let mut pins = mcpwm.operator0.with_linked_pins(
 ///     peripherals.GPIO0,

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -1,22 +1,18 @@
 #![cfg_attr(docsrs, procmacros::doc_replace(
     "freq" => {
-        cfg(esp32h2) => "let freq = Rate::from_mhz(32);",
-        _ => "let freq = Rate::from_mhz(80);"
+        cfg(esp32h2) => "32",
+        _ => "80"
     },
     "channel" => {
-        cfg(any(esp32, esp32s2)) => "let mut channel = rmt.channel0.configure_rx(&rx_config)?.with_pin(peripherals.GPIO4);",
-        cfg(esp32s3) => "let mut channel = rmt.channel7.configure_rx(&rx_config)?.with_pin(peripherals.GPIO4);",
-        _ => "let mut channel = rmt.channel2.configure_rx(&rx_config)?.with_pin(peripherals.GPIO4);"
+        cfg(any(esp32, esp32s2)) => "channel0",
+        cfg(esp32s3) => "channel7",
+        _ => "channel2"
     },
     "channels_desc" => {
-        cfg(esp32) => "8 channels, each of them can be either receiver or transmitter.",
-        cfg(esp32s2) => "4 channels, each of them can be either receiver or transmitter.",
-        cfg(esp32s3) => "8 channels, `Channel<0>`-`Channel<3>` hardcoded for transmitting signals and `Channel<4>`-`Channel<7>` hardcoded for receiving signals.",
-        cfg(any(esp32c3, esp32c6, esp32h2)) => "4 channels, `Channel<0>` and `Channel<1>` hardcoded for transmitting signals and `Channel<2>` and `Channel<3>` hardcoded for receiving signals.",
-    },
-    "rx_size_limit" => {
-        cfg(any(esp32, esp32s2)) => "The length of the received data cannot exceed the allocated RMT RAM.",
-        _ => ""
+        cfg(esp32) => "8 channels, each of them can be either receiver or transmitter",
+        cfg(esp32s2) => "4 channels, each of them can be either receiver or transmitter",
+        cfg(esp32s3) => "8 channels, `Channel<0>`-`Channel<3>` hardcoded for transmitting signals and `Channel<4>`-`Channel<7>` hardcoded for receiving signals",
+        cfg(any(esp32c3, esp32c5, esp32c6, esp32h2)) => "4 channels, `Channel<0>` and `Channel<1>` hardcoded for transmitting signals and `Channel<2>` and `Channel<3>` hardcoded for receiving signals",
     }
 ))]
 //! # Remote Control Peripheral (RMT)
@@ -38,8 +34,7 @@
 //!
 //! ### Channels
 //!
-//! There are
-//! # {channels_desc}
+//! There are __channels_desc__.
 //!
 //! For more information, please refer to the
 #![doc = concat!("[ESP-IDF documentation](https://docs.espressif.com/projects/esp-idf/en/latest/", chip!(), "/api-reference/peripherals/rmt.html)")]
@@ -60,8 +55,7 @@
 //! # use esp_hal::rmt::TxChannelConfig;
 //! # use esp_hal::rmt::Rmt;
 //! # use crate::esp_hal::rmt::TxChannelCreator;
-//! # {freq}
-//! let rmt = Rmt::new(peripherals.RMT, freq)?;
+//! let rmt = Rmt::new(peripherals.RMT, Rate::from_mhz(__freq__))?;
 //! let mut channel = rmt
 //!     .channel0
 //!     .configure_tx(
@@ -84,10 +78,9 @@
 //! # use esp_hal::delay::Delay;
 //! # use esp_hal::gpio::Level;
 //! # use esp_hal::rmt::{PulseCode, Rmt, TxChannelConfig, TxChannelCreator};
-//!
+//! #
 //! // Configure frequency based on chip type
-//! # {freq}
-//! let rmt = Rmt::new(peripherals.RMT, freq)?;
+//! let rmt = Rmt::new(peripherals.RMT, Rate::from_mhz(__freq__))?;
 //!
 //! let tx_config = TxChannelConfig::default().with_clk_divider(255);
 //!
@@ -116,19 +109,21 @@
 //! # use esp_hal::rmt::{PulseCode, Rmt, RxChannelConfig, RxChannelCreator};
 //! # use esp_hal::delay::Delay;
 //! # use esp_hal::gpio::{Level, Output, OutputConfig};
-//!
+//! #
 //! const WIDTH: usize = 80;
 //!
 //! let mut out = Output::new(peripherals.GPIO5, Level::Low, OutputConfig::default());
 //!
 //! // Configure frequency based on chip type
-//! # {freq}
-//! let rmt = Rmt::new(peripherals.RMT, freq)?;
+//! let rmt = Rmt::new(peripherals.RMT, Rate::from_mhz(__freq__))?;
 //!
 //! let rx_config = RxChannelConfig::default()
 //!     .with_clk_divider(1)
 //!     .with_idle_threshold(10000);
-//! # {channel}
+//! let mut channel = rmt
+//!     .__channel__
+//!     .configure_rx(&rx_config)?
+//!     .with_pin(peripherals.GPIO4);
 //! let delay = Delay::new();
 //! let mut data: [PulseCode; 48] = [PulseCode::default(); 48];
 //!
@@ -1901,6 +1896,12 @@ impl<'ch> RxTransaction<'ch, '_> {
 
 /// Channel is RX mode
 impl<'ch> Channel<'ch, Blocking, Rx> {
+    #[procmacros::doc_replace(
+        "rx_size_limit" => {
+            cfg(any(esp32, esp32s2)) => "The length of the received data cannot exceed the allocated RMT RAM.",
+            _ => ""
+        }
+    )]
     /// Start receiving pulse codes into the given buffer.
     /// This returns a [RxTransaction] which can be used to wait for receive to
     /// complete and get back the channel for further use.
@@ -2088,6 +2089,12 @@ impl core::future::Future for RxFuture<'_> {
 
 /// RX channel in async mode
 impl Channel<'_, Async, Rx> {
+    #[procmacros::doc_replace(
+        "rx_size_limit" => {
+            cfg(any(esp32, esp32s2)) => "The length of the received data cannot exceed the allocated RMT RAM.",
+            _ => ""
+        }
+    )]
     /// Start receiving a pulse code sequence.
     ///
     /// # {rx_size_limit}

--- a/esp-hal/src/rng/mod.rs
+++ b/esp-hal/src/rng/mod.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(docsrs, procmacros::doc_replace(
     "analog_pin" => {
-        cfg(esp32) => "let analog_pin = peripherals.GPIO32;",
-        cfg(not(esp32)) => "let analog_pin = peripherals.GPIO3;"
+        cfg(esp32) => "GPIO32",
+        _ => "GPIO3"
     },
     "documentation" => concat!("[ESP-IDF documentation](https://docs.espressif.com/projects/esp-idf/en/latest/", chip!(), "/api-reference/system/random.html)")
 ))]
@@ -124,10 +124,8 @@ let rng = trng.downgrade();
 // Drop the true random number source. ADC is available now.
 core::mem::drop(trng_source);
 
-# {analog_pin}
-
 let mut adc1_config = AdcConfig::new();
-let mut adc1_pin = adc1_config.enable_pin(analog_pin, Attenuation::_11dB);
+let mut adc1_pin = adc1_config.enable_pin(peripherals.__analog_pin__, Attenuation::_11dB);
 let mut adc1 = Adc::<ADC1, Blocking>::new(peripherals.ADC1, adc1_config);
 let pin_value: u16 = nb::block!(adc1.read_oneshot(&mut adc1_pin))?;
 

--- a/esp-hal/src/rtc_cntl/sleep/mod.rs
+++ b/esp-hal/src/rtc_cntl/sleep/mod.rs
@@ -208,12 +208,12 @@ impl<'a, 'b> Ext1WakeupSource<'a, 'b> {
 
 #[procmacros::doc_replace(
     "pin_low" => {
-        cfg(esp32c6) => "let mut pin_low = peripherals.GPIO2;",
-        cfg(esp32h2) => "let mut pin_low = peripherals.GPIO9;"
+        cfg(esp32c6) => "GPIO2",
+        cfg(esp32h2) => "GPIO9",
     },
     "pin_high" => {
-        cfg(esp32c6) => "let mut pin_high = peripherals.GPIO3;",
-        cfg(esp32h2) => "let mut pin_high = peripherals.GPIO10;"
+        cfg(esp32c6) => "GPIO3",
+        cfg(esp32h2) => "GPIO10"
     },
 )]
 /// External wake-up source (Ext1).
@@ -224,14 +224,12 @@ impl<'a, 'b> Ext1WakeupSource<'a, 'b> {
 /// # use esp_hal::rtc_cntl::{reset_reason, sleep::{Ext1WakeupSource, TimerWakeupSource, WakeupLevel}, wakeup_cause, Rtc, SocResetReason};
 /// # use esp_hal::system::Cpu;
 /// # use esp_hal::gpio::{Input, InputConfig, Pull, RtcPinWithResistors};
-///
+/// #
 /// let delay = Delay::new();
 /// let mut rtc = Rtc::new(peripherals.LPWR);
 ///
 /// let config = InputConfig::default().with_pull(Pull::None);
-/// # {pin_low}
-/// # {pin_high}
-/// let mut pin_low_input = Input::new(pin_low.reborrow(), config);
+/// let mut pin_low_input = Input::new(peripherals.__pin_low__.reborrow(), config);
 ///
 /// let reason = reset_reason(Cpu::ProCpu);
 /// let wake_reason = wakeup_cause();
@@ -244,8 +242,8 @@ impl<'a, 'b> Ext1WakeupSource<'a, 'b> {
 ///
 /// let wakeup_pins: &mut [(&mut dyn RtcPinWithResistors, WakeupLevel)] =
 /// &mut [
-///     (&mut pin_low, WakeupLevel::Low),
-///     (&mut pin_high, WakeupLevel::High),
+///     (&mut peripherals.__pin_low__, WakeupLevel::Low),
+///     (&mut peripherals.__pin_high__, WakeupLevel::High),
 /// ];
 ///
 /// let ext1 = Ext1WakeupSource::new(wakeup_pins);
@@ -273,16 +271,16 @@ impl<'a, 'b> Ext1WakeupSource<'a, 'b> {
 
 #[procmacros::doc_replace(
     "pin0" => {
-        cfg(any(esp32c3, esp32c2)) => "let mut pin_0 = peripherals.GPIO2;",
-        cfg(any(esp32s2, esp32s3)) => "let mut pin_0 = peripherals.GPIO17;"
+        cfg(any(esp32c3, esp32c2)) => "GPIO2",
+        cfg(any(esp32s2, esp32s3)) => "GPIO17"
     },
     "pin1" => {
-        cfg(any(esp32c3, esp32c2)) => "let mut pin_1 = peripherals.GPIO3;",
-        cfg(any(esp32s2, esp32s3)) => "let mut pin_1 = peripherals.GPIO18;"
+        cfg(any(esp32c3, esp32c2)) => "GPIO3",
+        cfg(any(esp32s2, esp32s3)) => "GPIO18"
     },
-    "wakeup_pins" => {
-        cfg(any(esp32c3, esp32c2)) => "let wakeup_pins: &mut [(&mut dyn gpio::RtcPinWithResistors, WakeupLevel)] = \n\t&mut [(&mut pin_0, WakeupLevel::Low),(&mut pin_1, WakeupLevel::High)];",
-        cfg(any(esp32s2, esp32s3)) => "let wakeup_pins: &mut [(&mut dyn gpio::RtcPin, WakeupLevel)] = \n\t&mut [(&mut pin_0, WakeupLevel::Low),(&mut pin_1, WakeupLevel::High)];"
+    "rtc_pin_trait" => {
+        cfg(any(esp32c3, esp32c2)) => "gpio::RtcPinWithResistors",
+        cfg(any(esp32s2, esp32s3)) => "gpio::RtcPin"
     },
 )]
 /// RTC_IO wakeup source
@@ -311,9 +309,10 @@ impl<'a, 'b> Ext1WakeupSource<'a, 'b> {
 ///
 /// let delay = Delay::new();
 /// let timer = TimerWakeupSource::new(Duration::from_secs(10));
-/// # {pin0}
-/// # {pin1}
-/// # {wakeup_pins}
+/// let wakeup_pins: &mut [(&mut dyn __rtc_pin_trait__, WakeupLevel)] = &mut [
+///     (&mut peripherals.__pin0__, WakeupLevel::Low),
+///     (&mut peripherals.__pin1__, WakeupLevel::High),
+/// ];
 ///
 /// let rtcio = RtcioWakeupSource::new(wakeup_pins);
 /// delay.delay_millis(100);

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -774,12 +774,12 @@ impl<'d> Spi<'d, Blocking> {
     }
 
     #[doc_replace(
-        "header" => {
-            cfg(multi_core) => "Registers an interrupt handler for the peripheral on the current core.",
-            _ => "Registers an interrupt handler for the peripheral.",
+        "peripheral_on" => {
+            cfg(multi_core) => "peripheral on the current core",
+            _ => "peripheral",
         }
     )]
-    /// # {header}
+    /// # Registers an interrupt handler for the __peripheral_on__.
     ///
     /// Note that this will replace any previously registered interrupt
     /// handlers.
@@ -1092,17 +1092,16 @@ where
 
     #[doc_replace(
         "max_frequency" => {
-            cfg(esp32h2) => " 48MHz",
-            _ => " 80MHz",
+            cfg(esp32h2) => "48MHz",
+            _ => "80MHz",
         }
     )]
     /// Change the bus configuration.
     ///
     /// # Errors
     ///
-    /// If frequency passed in config exceeds
-    /// # {max_frequency}
-    /// or is below 70kHz, [`ConfigError::FrequencyOutOfRange`] error will be returned.
+    /// If frequency passed in config exceeds __max_frequency__ or is below 70kHz,
+    /// [`ConfigError::FrequencyOutOfRange`] error will be returned.
     ///
     /// ## Example
     ///
@@ -1371,8 +1370,8 @@ mod dma {
     impl<'d> Spi<'d, Blocking> {
         #[doc_replace(
             "dma_channel" => {
-                cfg(any(esp32, esp32s2)) => "let dma_channel = peripherals.DMA_SPI2;",
-                _ => "let dma_channel = peripherals.DMA_CH0;",
+                cfg(any(esp32, esp32s2)) => "DMA_SPI2",
+                _ => "DMA_CH0",
             }
         )]
         /// Configures the SPI instance to use DMA with the specified channel.
@@ -1390,11 +1389,9 @@ mod dma {
         ///         master::{Config, Spi},
         ///     },
         /// };
-        /// # {dma_channel}
         /// let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(32000);
         ///
         /// let dma_rx_buf = DmaRxBuf::new(rx_descriptors, rx_buffer)?;
-        ///
         /// let dma_tx_buf = DmaTxBuf::new(tx_descriptors, tx_buffer)?;
         ///
         /// let mut spi = Spi::new(
@@ -1403,7 +1400,7 @@ mod dma {
         ///         .with_frequency(Rate::from_khz(100))
         ///         .with_mode(Mode::_0),
         /// )?
-        /// .with_dma(dma_channel)
+        /// .with_dma(peripherals.__dma_channel__)
         /// .with_buffers(dma_rx_buf, dma_tx_buf);
         /// # {after_snippet}
         /// ```
@@ -1415,8 +1412,8 @@ mod dma {
 
     #[doc_replace(
         "dma_channel" => {
-            cfg(any(esp32, esp32s2)) => "let dma_channel = peripherals.DMA_SPI2;",
-            _ => "let dma_channel = peripherals.DMA_CH0;",
+            cfg(any(esp32, esp32s2)) => "DMA_SPI2",
+            _ => "DMA_CH0",
         }
     )]
     /// A DMA capable SPI instance.
@@ -1436,11 +1433,9 @@ mod dma {
     ///         master::{Config, Spi},
     ///     },
     /// };
-    /// # {dma_channel}
     /// let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(32000);
     ///
     /// let dma_rx_buf = DmaRxBuf::new(rx_descriptors, rx_buffer)?;
-    ///
     /// let dma_tx_buf = DmaTxBuf::new(tx_descriptors, tx_buffer)?;
     ///
     /// let mut spi = Spi::new(
@@ -1449,7 +1444,7 @@ mod dma {
     ///         .with_frequency(Rate::from_khz(100))
     ///         .with_mode(Mode::_0),
     /// )?
-    /// .with_dma(dma_channel)
+    /// .with_dma(peripherals.__dma_channel__)
     /// .with_buffers(dma_rx_buf, dma_tx_buf);
     /// #
     /// # {after_snippet}

--- a/esp-hal/src/spi/slave.rs
+++ b/esp-hal/src/spi/slave.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(docsrs, procmacros::doc_replace(
     "dma_channel" => {
-        cfg(any(esp32, esp32s2)) => "let dma_channel = peripherals.DMA_SPI2;",
-        _ => "let dma_channel = peripherals.DMA_CH0;"
+        cfg(any(esp32, esp32s2)) => "DMA_SPI2",
+        _ => "DMA_CH0",
     },
 ))]
 //! # Serial Peripheral Interface - Slave Mode
@@ -27,7 +27,6 @@
 # use esp_hal::dma::{DmaRxBuf, DmaTxBuf};
 # use esp_hal::spi::Mode;
 # use esp_hal::spi::slave::Spi;
-# {dma_channel}
 let sclk = peripherals.GPIO0;
 let miso = peripherals.GPIO1;
 let mosi = peripherals.GPIO2;
@@ -41,7 +40,7 @@ let mut spi = Spi::new(peripherals.SPI2, Mode::_0)
     .with_mosi(mosi)
     .with_miso(miso)
     .with_cs(cs)
-    .with_dma(dma_channel);
+    .with_dma(peripherals.__dma_channel__);
 
 let transfer = spi.transfer(50, dma_rx_buf, 50, dma_tx_buf)?;
 

--- a/esp-hal/src/time.rs
+++ b/esp-hal/src/time.rs
@@ -248,8 +248,7 @@ impl Instant {
     ///
     /// The counter won’t measure time in sleep-mode.
     ///
-    /// The timer has a 1 microsecond resolution and will wrap after
-    /// # {wrap_after}
+    /// The timer has a 1 microsecond resolution and will wrap after __wrap_after__.
     ///
     /// <section class="warning">
     /// Note that this function returns an unreliable value before <code>esp_hal::init()</code> is

--- a/esp-hal/src/timer/timg.rs
+++ b/esp-hal/src/timer/timg.rs
@@ -104,9 +104,7 @@ cfg_if::cfg_if! {
         _ => "a general purpose timer",
     }
 )]
-/// A timer group consisting of
-/// # {timers}
-/// and a watchdog timer.
+/// A timer group consisting of __timers__ and a watchdog timer.
 pub struct TimerGroup<'d, T>
 where
     T: TimerGroupInstance + 'd,

--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -287,14 +287,14 @@ impl SecondaryChannel {
 }
 
 #[cfg_attr(docsrs, procmacros::doc_replace(
-    "hint_5g" => {
-        cfg(wifi_has_5g) => "The default is [BandMode::Auto].",
-        _ => "The default is [BandMode::_2_4G]"
+    "default_band_mode" => {
+        cfg(wifi_has_5g) => "BandMode::Auto",
+        _ => "BandMode::_2_4G"
     },
 ))]
 /// Wi-Fi band mode.
 ///
-/// # {hint_5g}
+/// The default is [`__default_band_mode__`].
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -2599,28 +2599,23 @@ impl WifiController<'_> {
         Ok(())
     }
 
-    #[cfg_attr(docsrs, procmacros::doc_replace(
-        "hint_5g" => {
-            cfg(wifi_has_5g) => "
-When the WiFi band mode is set to [BandMode::_5G], it operates exclusively on the 5GHz channels.
+    /// Set Wi-Fi band mode.
+    ///
+    /// When the Wi-Fi band mode is set to [`BandMode::_2_4G`], it operates exclusively on the
+    /// 2.4GHz channels.
+    #[cfg_attr(
+        wifi_has_5g,
+        doc = r"
+When the WiFi band mode is set to [`BandMode::_5G`], it operates exclusively on the 5GHz channels.
 
-When the WiFi band mode is set to [BandMode::Auto], it can operate on both the 2.4GHz and
+When the WiFi band mode is set to [`BandMode::Auto`], it can operate on both the 2.4GHz and
 5GHz channels.
 
 When a WiFi band mode change triggers a band change, if no channel is set for the current
 band, a default channel will be assigned: channel 1 for 2.4G band and channel 36 for 5G
 band.
-            ",
-            _ => ""
-        },
-    ))]
-    /// Set WiFi band mode.
-    ///
-    /// When the WiFi band mode is set to [BandMode::_2_4G], it operates exclusively on the 2.4GHz
-    /// channels.
-    ///
-    /// # {hint_5g}
-    ///
+"
+    )]
     /// The controller needs to be configured and started before setting the band mode.
     #[instability::unstable]
     pub fn set_band_mode(&mut self, band_mode: BandMode) -> Result<(), WifiError> {
@@ -2693,18 +2688,15 @@ band.
         Ok((primary, SecondaryChannel::from_raw(secondary)))
     }
 
-    #[cfg_attr(docsrs, procmacros::doc_replace(
-        "hint_5g" => {
-            cfg(wifi_has_5g) => "
+    /// Sets the primary and secondary Wi-Fi channel.
+    #[cfg_attr(
+        wifi_has_5g,
+        doc = r"
+
 When operating in 5 GHz band, the second channel is automatically determined by the primary
 channel according to the 802.11 standard. Any manually configured second channel will be
-ignored.",
-            _ => ""
-        },
-    ))]
-    /// Sets the primary and secondary Wi-Fi channel.
-    ///
-    /// # {hint_5g}
+ignored."
+    )]
     #[instability::unstable]
     pub fn set_channel(
         &mut self,


### PR DESCRIPTION
This PR adds the ability to `doc_replace` to replace `__placeholders__` in the middle of the line. This allows shortening some of the replacement specifications, cleaning up both the source and the rendered documentation. Currently, only literal strings can be substituted (i.e. the macro does not (yet) perform `concat!("before", expression, "after")` transformation). The double underscore delimiter has been chosen to allow `rustfmt` to work - which is the whole point of `doc_replace`.