### PR TITLE
Add half_duplex_write_async method to SpiDmaBus

### DIFF
--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -2360,7 +2360,6 @@ mod dma {
 
             Ok(())
         }
-        
 
         #[instability::unstable]
         pub async fn half_duplex_write_async(

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -2361,6 +2361,9 @@ mod dma {
             Ok(())
         }
 
+        /// Half-duplex write using DMA.
+        ///
+        /// Returns [`DmaError::Overflow`] if the buffer exceeds the DMA Buffer
         #[instability::unstable]
         pub async fn half_duplex_write_async(
             &mut self,

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -2360,6 +2360,42 @@ mod dma {
 
             Ok(())
         }
+        
+
+        #[instability::unstable]
+        pub async fn half_duplex_write_async(
+            &mut self,
+            data_mode: DataMode,
+            cmd: Command,
+            address: Address,
+            dummy: u8,
+            buffer: &[u8],
+        ) -> Result<(), Error> {
+            if buffer.len() > self.tx_buf.capacity() {
+                return Err(Error::from(DmaError::Overflow));
+            }
+
+            self.spi_dma.wait_for_idle_async().await;
+            self.tx_buf.as_mut_slice()[..buffer.len()].copy_from_slice(buffer);
+
+            let mut spi = DropGuard::new(&mut self.spi_dma, |spi| spi.cancel_transfer());
+
+            unsafe {
+                spi.start_half_duplex_write(
+                    data_mode,
+                    cmd,
+                    address,
+                    dummy,
+                    buffer.len(),
+                    &mut self.tx_buf,
+                )?;
+            }
+
+            spi.wait_for_idle_async().await;
+            spi.defuse();
+
+            Ok(())
+        }
     }
 
     impl<'d, Dm> SpiDmaBus<'d, Dm>


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
- [ ] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
SpiDmaBus has convenience async methods but lacks half duplex write async version. the existing version does a busy poll which is not desired in async environments

#### Testing
Verified on my hardware. no test code in place.