### PR TITLE
Deduplicate `config_apply_impl_function`

### DIFF
--- a/esp-hal/src/soc/esp32/clocks.rs
+++ b/esp-hal/src/soc/esp32/clocks.rs
@@ -175,7 +175,11 @@ const BBPLL_BBADC_DSMP_VAL_480M: u8 = 0x74;
 
 // XTAL_CLK
 
-fn configure_xtal_clk_impl(_clocks: &mut ClockTree, config: XtalClkConfig) {
+fn configure_xtal_clk_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<XtalClkConfig>,
+    config: XtalClkConfig,
+) {
     // The stored configuration affects PLL settings instead. We save the value in a register
     // similar to ESP-IDF, just in case something relies on that, or, if we can in the future read
     // back the value instead of wasting RAM on it.
@@ -312,7 +316,11 @@ fn enable_pll_clk_impl(clocks: &mut ClockTree, en: bool) {
     ets_delay_us(SOC_DELAY_PLL_ENABLE_WITH_32K);
 }
 
-fn configure_pll_clk_impl(_clocks: &mut ClockTree, _config: PllClkConfig) {
+fn configure_pll_clk_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<PllClkConfig>,
+    _new_config: PllClkConfig,
+) {
     // Nothing to do. The PLL may still be powered down. We'll configure it in
     // `enable_pll_clk_impl`.
 }
@@ -331,7 +339,11 @@ fn enable_apll_clk_impl(_clocks: &mut ClockTree, en: bool) {
     }
 }
 
-fn configure_apll_clk_impl(_clocks: &mut ClockTree, _config: ApllClkConfig) {
+fn configure_apll_clk_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<ApllClkConfig>,
+    _config: ApllClkConfig,
+) {
     // Nothing to do. The APLL may still be powered down. We'll configure it in
     // `enable_apll_clk_impl`.
 }
@@ -370,8 +382,8 @@ fn enable_cpu_pll_div_in_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_cpu_pll_div_in_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<CpuPllDivInConfig>,
-    _new_selector: CpuPllDivInConfig,
+    _old_config: Option<CpuPllDivInConfig>,
+    _new_config: CpuPllDivInConfig,
 ) {
     // Nothing to do.
 }
@@ -382,7 +394,11 @@ fn enable_cpu_pll_div_impl(_clocks: &mut ClockTree, _en: bool) {
     // Nothing to do.
 }
 
-fn configure_cpu_pll_div_impl(_clocks: &mut ClockTree, _new_config: CpuPllDivConfig) {
+fn configure_cpu_pll_div_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<CpuPllDivConfig>,
+    _new_config: CpuPllDivConfig,
+) {
     // Nothing to do.
 }
 
@@ -396,8 +412,8 @@ fn enable_syscon_pre_div_in_impl(_: &mut ClockTree, _: bool) {
 
 fn configure_syscon_pre_div_in_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<SysconPreDivInConfig>,
-    _new_selector: SysconPreDivInConfig,
+    _old_config: Option<SysconPreDivInConfig>,
+    _new_config: SysconPreDivInConfig,
 ) {
     // Nothing to do.
 }
@@ -408,7 +424,11 @@ fn enable_syscon_pre_div_impl(_clocks: &mut ClockTree, _en: bool) {
     // Nothing to do.
 }
 
-fn configure_syscon_pre_div_impl(_clocks: &mut ClockTree, new_config: SysconPreDivConfig) {
+fn configure_syscon_pre_div_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<SysconPreDivConfig>,
+    new_config: SysconPreDivConfig,
+) {
     APB_CTRL::regs()
         .sysclk_conf()
         .modify(|_, w| unsafe { w.pre_div_cnt().bits(new_config.divisor() as u16 & 0x3FF) });
@@ -422,8 +442,8 @@ fn enable_apb_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_apb_clk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<ApbClkConfig>,
-    _new_selector: ApbClkConfig,
+    _old_config: Option<ApbClkConfig>,
+    _new_config: ApbClkConfig,
 ) {
     // Nothing to do.
 }
@@ -436,8 +456,8 @@ fn enable_ref_tick_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_ref_tick_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<RefTickConfig>,
-    _new_selector: RefTickConfig,
+    _old_config: Option<RefTickConfig>,
+    _new_config: RefTickConfig,
 ) {
     // Nothing to do.
 }
@@ -448,7 +468,11 @@ fn enable_ref_tick_xtal_impl(_clocks: &mut ClockTree, _en: bool) {
     // Nothing to do.
 }
 
-fn configure_ref_tick_xtal_impl(_clocks: &mut ClockTree, new_config: RefTickXtalConfig) {
+fn configure_ref_tick_xtal_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<RefTickXtalConfig>,
+    new_config: RefTickXtalConfig,
+) {
     APB_CTRL::regs()
         .xtal_tick_conf()
         .write(|w| unsafe { w.xtal_tick_num().bits(new_config.divisor() as u8) });
@@ -460,7 +484,11 @@ fn enable_ref_tick_fosc_impl(_clocks: &mut ClockTree, _en: bool) {
     // Nothing to do.
 }
 
-fn configure_ref_tick_fosc_impl(_clocks: &mut ClockTree, new_config: RefTickFoscConfig) {
+fn configure_ref_tick_fosc_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<RefTickFoscConfig>,
+    new_config: RefTickFoscConfig,
+) {
     APB_CTRL::regs()
         .ck8m_tick_conf()
         .write(|w| unsafe { w.ck8m_tick_num().bits(new_config.divisor() as u8) });
@@ -472,7 +500,11 @@ fn enable_ref_tick_apll_impl(_clocks: &mut ClockTree, _en: bool) {
     // Nothing to do.
 }
 
-fn configure_ref_tick_apll_impl(_clocks: &mut ClockTree, new_config: RefTickApllConfig) {
+fn configure_ref_tick_apll_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<RefTickApllConfig>,
+    new_config: RefTickApllConfig,
+) {
     APB_CTRL::regs()
         .apll_tick_conf()
         .write(|w| unsafe { w.apll_tick_num().bits(new_config.divisor() as u8) });
@@ -484,7 +516,11 @@ fn enable_ref_tick_pll_impl(_clocks: &mut ClockTree, _en: bool) {
     // Nothing to do.
 }
 
-fn configure_ref_tick_pll_impl(_clocks: &mut ClockTree, new_config: RefTickPllConfig) {
+fn configure_ref_tick_pll_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<RefTickPllConfig>,
+    new_config: RefTickPllConfig,
+) {
     APB_CTRL::regs()
         .pll_tick_conf()
         .write(|w| unsafe { w.pll_tick_num().bits(new_config.divisor() as u8) });
@@ -494,8 +530,8 @@ fn configure_ref_tick_pll_impl(_clocks: &mut ClockTree, new_config: RefTickPllCo
 
 fn configure_cpu_clk_impl(
     clocks: &mut ClockTree,
-    _old_selector: Option<CpuClkConfig>,
-    new_selector: CpuClkConfig,
+    _old_config: Option<CpuClkConfig>,
+    new_config: CpuClkConfig,
 ) {
     // Based on TRM Table 7.2-2
 
@@ -519,7 +555,7 @@ fn configure_cpu_clk_impl(
         .cpu_per_conf()
         .modify(|_, w| unsafe { w.cpuperiod_sel().bits(clock_source_sel1_bit) });
 
-    LPWR::regs().clk_conf().modify(|_, w| match new_selector {
+    LPWR::regs().clk_conf().modify(|_, w| match new_config {
         CpuClkConfig::Xtal => w.soc_clk_sel().xtal(),
         CpuClkConfig::RcFast => w.soc_clk_sel().ck8m(),
         CpuClkConfig::Apll => w.soc_clk_sel().apll(),
@@ -627,10 +663,10 @@ fn enable_rtc_slow_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_rtc_slow_clk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<RtcSlowClkConfig>,
-    new_selector: RtcSlowClkConfig,
+    _old_config: Option<RtcSlowClkConfig>,
+    new_config: RtcSlowClkConfig,
 ) {
-    LPWR::regs().clk_conf().modify(|_, w| match new_selector {
+    LPWR::regs().clk_conf().modify(|_, w| match new_config {
         RtcSlowClkConfig::RcSlow => w.ana_clk_rtc_sel().slow_ck(),
         RtcSlowClkConfig::Xtal32k => w.ana_clk_rtc_sel().ck_xtal_32k(),
         RtcSlowClkConfig::RcFast => w.ana_clk_rtc_sel().ck8m_d256_out(),
@@ -645,10 +681,10 @@ fn enable_rtc_fast_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_rtc_fast_clk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<RtcFastClkConfig>,
-    new_selector: RtcFastClkConfig,
+    _old_config: Option<RtcFastClkConfig>,
+    new_config: RtcFastClkConfig,
 ) {
-    LPWR::regs().clk_conf().modify(|_, w| match new_selector {
+    LPWR::regs().clk_conf().modify(|_, w| match new_config {
         RtcFastClkConfig::Xtal => w.fast_clk_rtc_sel().xtal_div_4(),
         RtcFastClkConfig::Rc => w.fast_clk_rtc_sel().ck8m(),
     });
@@ -681,8 +717,8 @@ fn enable_mcpwm0_function_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_mcpwm0_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Mcpwm0FunctionClockConfig>,
-    _new_selector: Mcpwm0FunctionClockConfig,
+    _old_config: Option<Mcpwm0FunctionClockConfig>,
+    _new_config: Mcpwm0FunctionClockConfig,
 ) {
     // Nothing to do.
 }
@@ -695,8 +731,8 @@ fn enable_mcpwm1_function_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_mcpwm1_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Mcpwm0FunctionClockConfig>,
-    _new_selector: Mcpwm0FunctionClockConfig,
+    _old_config: Option<Mcpwm0FunctionClockConfig>,
+    _new_config: Mcpwm0FunctionClockConfig,
 ) {
     // Nothing to do.
 }
@@ -720,12 +756,12 @@ impl Timg0CalibrationClockConfig {
 
 fn configure_timg0_calibration_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Timg0CalibrationClockConfig>,
-    new_selector: Timg0CalibrationClockConfig,
+    _old_config: Option<Timg0CalibrationClockConfig>,
+    new_config: Timg0CalibrationClockConfig,
 ) {
     TIMG0::regs()
         .rtccalicfg()
-        .modify(|_, w| unsafe { w.rtc_cali_clk_sel().bits(new_selector.cali_clk_sel_bits()) });
+        .modify(|_, w| unsafe { w.rtc_cali_clk_sel().bits(new_config.cali_clk_sel_bits()) });
 }
 
 // TIMG1_CALIBRATION_CLOCK
@@ -737,12 +773,12 @@ fn enable_timg1_calibration_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_timg1_calibration_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Timg0CalibrationClockConfig>,
-    new_selector: Timg0CalibrationClockConfig,
+    _old_config: Option<Timg0CalibrationClockConfig>,
+    new_config: Timg0CalibrationClockConfig,
 ) {
     TIMG1::regs()
         .rtccalicfg()
-        .modify(|_, w| unsafe { w.rtc_cali_clk_sel().bits(new_selector.cali_clk_sel_bits()) });
+        .modify(|_, w| unsafe { w.rtc_cali_clk_sel().bits(new_config.cali_clk_sel_bits()) });
 }
 
 // UART0_MEM_CLOCK
@@ -753,8 +789,8 @@ fn enable_uart0_mem_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_uart0_mem_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Uart0MemClockConfig>,
-    _new_selector: Uart0MemClockConfig,
+    _old_config: Option<Uart0MemClockConfig>,
+    _new_config: Uart0MemClockConfig,
 ) {
     // Nothing to do.
 }
@@ -767,12 +803,12 @@ fn enable_uart0_function_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_uart0_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Uart0FunctionClockConfig>,
-    new_selector: Uart0FunctionClockConfig,
+    _old_config: Option<Uart0FunctionClockConfig>,
+    new_config: Uart0FunctionClockConfig,
 ) {
     UART0::regs().conf0().modify(|_, w| {
         w.tick_ref_always_on()
-            .bit(new_selector == Uart0FunctionClockConfig::Apb)
+            .bit(new_config == Uart0FunctionClockConfig::Apb)
     });
 }
 
@@ -784,8 +820,8 @@ fn enable_uart1_mem_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_uart1_mem_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Uart0MemClockConfig>,
-    _new_selector: Uart0MemClockConfig,
+    _old_config: Option<Uart0MemClockConfig>,
+    _new_config: Uart0MemClockConfig,
 ) {
     // Nothing to do.
 }
@@ -798,12 +834,12 @@ fn enable_uart1_function_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_uart1_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Uart0FunctionClockConfig>,
-    new_selector: Uart0FunctionClockConfig,
+    _old_config: Option<Uart0FunctionClockConfig>,
+    new_config: Uart0FunctionClockConfig,
 ) {
     UART1::regs().conf0().modify(|_, w| {
         w.tick_ref_always_on()
-            .bit(new_selector == Uart0FunctionClockConfig::Apb)
+            .bit(new_config == Uart0FunctionClockConfig::Apb)
     });
 }
 
@@ -815,8 +851,8 @@ fn enable_uart2_mem_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_uart2_mem_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Uart0MemClockConfig>,
-    _new_selector: Uart0MemClockConfig,
+    _old_config: Option<Uart0MemClockConfig>,
+    _new_config: Uart0MemClockConfig,
 ) {
     // Nothing to do.
 }
@@ -829,11 +865,11 @@ fn enable_uart2_function_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_uart2_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Uart0FunctionClockConfig>,
-    new_selector: Uart0FunctionClockConfig,
+    _old_config: Option<Uart0FunctionClockConfig>,
+    new_config: Uart0FunctionClockConfig,
 ) {
     UART2::regs().conf0().modify(|_, w| {
         w.tick_ref_always_on()
-            .bit(new_selector == Uart0FunctionClockConfig::Apb)
+            .bit(new_config == Uart0FunctionClockConfig::Apb)
     });
 }

--- a/esp-hal/src/soc/esp32c2/clocks.rs
+++ b/esp-hal/src/soc/esp32c2/clocks.rs
@@ -147,7 +147,11 @@ fn detect_xtal_freq(clocks: &mut ClockTree) -> XtalClkConfig {
 
 // XTAL_CLK
 
-fn configure_xtal_clk_impl(_clocks: &mut ClockTree, config: XtalClkConfig) {
+fn configure_xtal_clk_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<XtalClkConfig>,
+    config: XtalClkConfig,
+) {
     // The stored configuration affects PLL settings instead. We save the value in a register
     // similar to ESP-IDF, just in case something relies on that, or, if we can in the future read
     // back the value instead of wasting RAM on it.
@@ -342,8 +346,8 @@ fn enable_system_pre_div_in_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_system_pre_div_in_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<SystemPreDivInConfig>,
-    _new_selector: SystemPreDivInConfig,
+    _old_config: Option<SystemPreDivInConfig>,
+    _new_config: SystemPreDivInConfig,
 ) {
     // Nothing to do.
 }
@@ -354,7 +358,11 @@ fn enable_system_pre_div_impl(_clocks: &mut ClockTree, _en: bool) {
     // Nothing to do.
 }
 
-fn configure_system_pre_div_impl(_clocks: &mut ClockTree, new_config: SystemPreDivConfig) {
+fn configure_system_pre_div_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<SystemPreDivConfig>,
+    new_config: SystemPreDivConfig,
+) {
     SYSTEM::regs()
         .sysclk_conf()
         .modify(|_, w| unsafe { w.pre_div_cnt().bits(new_config.divisor() as u16 & 0x3FF) });
@@ -366,7 +374,11 @@ fn enable_cpu_pll_div_impl(_clocks: &mut ClockTree, _en: bool) {
     // Nothing to do.
 }
 
-fn configure_cpu_pll_div_impl(_clocks: &mut ClockTree, _new_config: CpuPllDivConfig) {
+fn configure_cpu_pll_div_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<CpuPllDivConfig>,
+    _new_config: CpuPllDivConfig,
+) {
     // Nothing to do.
 }
 
@@ -378,8 +390,8 @@ fn enable_apb_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_apb_clk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<ApbClkConfig>,
-    _new_selector: ApbClkConfig,
+    _old_config: Option<ApbClkConfig>,
+    _new_config: ApbClkConfig,
 ) {
     // Nothing to do.
 }
@@ -392,8 +404,8 @@ fn enable_crypto_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_crypto_clk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<CryptoClkConfig>,
-    _new_selector: CryptoClkConfig,
+    _old_config: Option<CryptoClkConfig>,
+    _new_config: CryptoClkConfig,
 ) {
     // Nothing to do, determined by CPU clock.
 }
@@ -406,8 +418,8 @@ fn enable_mspi_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_mspi_clk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<MspiClkConfig>,
-    _new_selector: MspiClkConfig,
+    _old_config: Option<MspiClkConfig>,
+    _new_config: MspiClkConfig,
 ) {
     // Nothing to do, determined by CPU clock.
 }
@@ -416,11 +428,11 @@ fn configure_mspi_clk_impl(
 
 fn configure_cpu_clk_impl(
     clocks: &mut ClockTree,
-    _old_selector: Option<CpuClkConfig>,
-    new_selector: CpuClkConfig,
+    _old_config: Option<CpuClkConfig>,
+    new_config: CpuClkConfig,
 ) {
     // Based on TRM Table 6.2-2
-    if new_selector == CpuClkConfig::Pll {
+    if new_config == CpuClkConfig::Pll {
         SYSTEM::regs().cpu_per_conf().modify(|_, w| unsafe {
             w.cpuperiod_sel().bits(match unwrap!(clocks.cpu_pll_div) {
                 CpuPllDivConfig::_4 => 1,
@@ -430,7 +442,7 @@ fn configure_cpu_clk_impl(
     }
 
     SYSTEM::regs().sysclk_conf().modify(|_, w| unsafe {
-        w.soc_clk_sel().bits(match new_selector {
+        w.soc_clk_sel().bits(match new_config {
             CpuClkConfig::Xtal => 0,
             CpuClkConfig::RcFast => 2,
             CpuClkConfig::Pll => 1,
@@ -482,7 +494,11 @@ fn enable_rc_fast_clk_div_n_impl(_clocks: &mut ClockTree, _en: bool) {
     // Nothing to do.
 }
 
-fn configure_rc_fast_clk_div_n_impl(_clocks: &mut ClockTree, new_config: RcFastClkDivNConfig) {
+fn configure_rc_fast_clk_div_n_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<RcFastClkDivNConfig>,
+    new_config: RcFastClkDivNConfig,
+) {
     let clk_conf = LPWR::regs().clk_conf();
     // Invalidate because we may be changing the divider from some other value
     let new_value = clk_conf.modify(|_, w| w.ck8m_div_sel_vld().clear_bit());
@@ -512,12 +528,12 @@ fn enable_rtc_slow_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_rtc_slow_clk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<RtcSlowClkConfig>,
-    new_selector: RtcSlowClkConfig,
+    _old_config: Option<RtcSlowClkConfig>,
+    new_config: RtcSlowClkConfig,
 ) {
     LPWR::regs().clk_conf().modify(|_, w| unsafe {
         // TODO: variants should be in PAC
-        w.ana_clk_rtc_sel().bits(match new_selector {
+        w.ana_clk_rtc_sel().bits(match new_config {
             RtcSlowClkConfig::OscSlow => 1,
             RtcSlowClkConfig::RcSlow => 0,
             RtcSlowClkConfig::RcFast => 2,
@@ -535,11 +551,11 @@ fn enable_rtc_fast_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_rtc_fast_clk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<RtcFastClkConfig>,
-    new_selector: RtcFastClkConfig,
+    _old_config: Option<RtcFastClkConfig>,
+    new_config: RtcFastClkConfig,
 ) {
     // TODO: variants should be fixed in PAC
-    LPWR::regs().clk_conf().modify(|_, w| match new_selector {
+    LPWR::regs().clk_conf().modify(|_, w| match new_config {
         RtcFastClkConfig::Xtal => w.fast_clk_rtc_sel().clear_bit(),
         RtcFastClkConfig::Rc => w.fast_clk_rtc_sel().set_bit(),
     });
@@ -557,18 +573,18 @@ fn enable_low_power_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_low_power_clk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<LowPowerClkConfig>,
-    new_selector: LowPowerClkConfig,
+    _old_config: Option<LowPowerClkConfig>,
+    new_config: LowPowerClkConfig,
 ) {
     SYSTEM::regs().bt_lpck_div_frac().modify(|_, w| {
         w.lpclk_sel_8m()
-            .bit(new_selector == LowPowerClkConfig::RcFast);
+            .bit(new_config == LowPowerClkConfig::RcFast);
         w.lpclk_sel_rtc_slow()
-            .bit(new_selector == LowPowerClkConfig::RtcSlow);
+            .bit(new_config == LowPowerClkConfig::RtcSlow);
         w.lpclk_sel_xtal()
-            .bit(new_selector == LowPowerClkConfig::Xtal);
+            .bit(new_config == LowPowerClkConfig::Xtal);
         w.lpclk_sel_xtal32k()
-            .bit(new_selector == LowPowerClkConfig::OscSlow)
+            .bit(new_config == LowPowerClkConfig::OscSlow)
     });
 }
 
@@ -602,12 +618,12 @@ fn enable_timg0_function_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_timg0_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Timg0FunctionClockConfig>,
-    new_selector: Timg0FunctionClockConfig,
+    _old_config: Option<Timg0FunctionClockConfig>,
+    new_config: Timg0FunctionClockConfig,
 ) {
     TIMG0::regs().t(0).config().modify(|_, w| {
         w.use_xtal()
-            .bit(new_selector == Timg0FunctionClockConfig::XtalClk)
+            .bit(new_config == Timg0FunctionClockConfig::XtalClk)
     });
 }
 
@@ -620,11 +636,11 @@ fn enable_timg0_calibration_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_timg0_calibration_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Timg0CalibrationClockConfig>,
-    new_selector: Timg0CalibrationClockConfig,
+    _old_config: Option<Timg0CalibrationClockConfig>,
+    new_config: Timg0CalibrationClockConfig,
 ) {
     TIMG0::regs().rtccalicfg().modify(|_, w| unsafe {
-        w.rtc_cali_clk_sel().bits(match new_selector {
+        w.rtc_cali_clk_sel().bits(match new_config {
             Timg0CalibrationClockConfig::RcSlowClk => 0,
             Timg0CalibrationClockConfig::RcFastDivClk => 1,
             Timg0CalibrationClockConfig::Osc32kClk => 2,
@@ -640,12 +656,12 @@ fn enable_timg0_wdt_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_timg0_wdt_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Timg0WdtClockConfig>,
-    new_selector: Timg0WdtClockConfig,
+    _old_config: Option<Timg0WdtClockConfig>,
+    new_config: Timg0WdtClockConfig,
 ) {
     TIMG0::regs().wdtconfig0().modify(|_, w| {
         w.wdt_use_xtal()
-            .bit(new_selector == Timg0WdtClockConfig::XtalClk)
+            .bit(new_config == Timg0WdtClockConfig::XtalClk)
     });
 }
 
@@ -657,8 +673,8 @@ fn enable_uart0_mem_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_uart0_mem_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Uart0MemClockConfig>,
-    _new_selector: Uart0MemClockConfig,
+    _old_config: Option<Uart0MemClockConfig>,
+    _new_config: Uart0MemClockConfig,
 ) {
     // Nothing to do.
 }
@@ -671,11 +687,11 @@ fn enable_uart0_function_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_uart0_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Uart0FunctionClockConfig>,
-    new_selector: Uart0FunctionClockConfig,
+    _old_config: Option<Uart0FunctionClockConfig>,
+    new_config: Uart0FunctionClockConfig,
 ) {
     UART0::regs().clk_conf().modify(|_, w| unsafe {
-        w.sclk_sel().bits(match new_selector {
+        w.sclk_sel().bits(match new_config {
             Uart0FunctionClockConfig::PllF40m => 1,
             Uart0FunctionClockConfig::RcFast => 2,
             Uart0FunctionClockConfig::Xtal => 3,
@@ -691,8 +707,8 @@ fn enable_uart1_mem_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_uart1_mem_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Uart0MemClockConfig>,
-    _new_selector: Uart0MemClockConfig,
+    _old_config: Option<Uart0MemClockConfig>,
+    _new_config: Uart0MemClockConfig,
 ) {
     // Nothing to do.
 }
@@ -705,11 +721,11 @@ fn enable_uart1_function_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_uart1_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Uart0FunctionClockConfig>,
-    new_selector: Uart0FunctionClockConfig,
+    _old_config: Option<Uart0FunctionClockConfig>,
+    new_config: Uart0FunctionClockConfig,
 ) {
     UART1::regs().clk_conf().modify(|_, w| unsafe {
-        w.sclk_sel().bits(match new_selector {
+        w.sclk_sel().bits(match new_config {
             Uart0FunctionClockConfig::PllF40m => 1,
             Uart0FunctionClockConfig::RcFast => 2,
             Uart0FunctionClockConfig::Xtal => 3,

--- a/esp-hal/src/soc/esp32c3/clocks.rs
+++ b/esp-hal/src/soc/esp32c3/clocks.rs
@@ -111,7 +111,11 @@ impl ClockConfig {
 
 // XTAL_CLK
 
-fn configure_xtal_clk_impl(_clocks: &mut ClockTree, _config: XtalClkConfig) {
+fn configure_xtal_clk_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<XtalClkConfig>,
+    _config: XtalClkConfig,
+) {
     // The stored configuration affects PLL settings instead.
 }
 
@@ -215,7 +219,11 @@ fn enable_pll_clk_impl(clocks: &mut ClockTree, en: bool) {
     regi2c::I2C_BBPLL_OC_DLREF_SEL.write_field(1);
 }
 
-fn configure_pll_clk_impl(_clocks: &mut ClockTree, _config: PllClkConfig) {
+fn configure_pll_clk_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<PllClkConfig>,
+    _config: PllClkConfig,
+) {
     // Nothing to do. The PLL may still be powered down. We'll configure it in
     // `enable_pll_clk_impl`.
 }
@@ -315,8 +323,8 @@ fn enable_system_pre_div_in_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_system_pre_div_in_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<SystemPreDivInConfig>,
-    _new_selector: SystemPreDivInConfig,
+    _old_config: Option<SystemPreDivInConfig>,
+    _new_config: SystemPreDivInConfig,
 ) {
     // Nothing to do.
 }
@@ -327,7 +335,11 @@ fn enable_system_pre_div_impl(_clocks: &mut ClockTree, _en: bool) {
     // Nothing to do.
 }
 
-fn configure_system_pre_div_impl(_clocks: &mut ClockTree, new_config: SystemPreDivConfig) {
+fn configure_system_pre_div_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<SystemPreDivConfig>,
+    new_config: SystemPreDivConfig,
+) {
     APB_CTRL::regs()
         .sysclk_conf()
         .modify(|_, w| unsafe { w.pre_div_cnt().bits(new_config.divisor() as u16 & 0x3FF) });
@@ -339,7 +351,11 @@ fn enable_cpu_pll_div_out_impl(_clocks: &mut ClockTree, _en: bool) {
     // Nothing to do.
 }
 
-fn configure_cpu_pll_div_out_impl(_clocks: &mut ClockTree, _config: CpuPllDivOutConfig) {
+fn configure_cpu_pll_div_out_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<CpuPllDivOutConfig>,
+    _config: CpuPllDivOutConfig,
+) {
     // Nothing to do.
 }
 
@@ -351,8 +367,8 @@ fn enable_apb_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_apb_clk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<ApbClkConfig>,
-    _new_selector: ApbClkConfig,
+    _old_config: Option<ApbClkConfig>,
+    _new_config: ApbClkConfig,
 ) {
     // Nothing to do.
 }
@@ -365,8 +381,8 @@ fn enable_crypto_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_crypto_clk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<CryptoClkConfig>,
-    _new_selector: CryptoClkConfig,
+    _old_config: Option<CryptoClkConfig>,
+    _new_config: CryptoClkConfig,
 ) {
     // Nothing to do.
 }
@@ -375,11 +391,11 @@ fn configure_crypto_clk_impl(
 
 fn configure_cpu_clk_impl(
     clocks: &mut ClockTree,
-    _old_selector: Option<CpuClkConfig>,
-    new_selector: CpuClkConfig,
+    _old_config: Option<CpuClkConfig>,
+    new_config: CpuClkConfig,
 ) {
     // Based on TRM Table 6.2-2
-    if new_selector == CpuClkConfig::Pll {
+    if new_config == CpuClkConfig::Pll {
         SYSTEM::regs().cpu_per_conf().modify(|_, w| unsafe {
             w.cpuperiod_sel()
                 .bits(match unwrap!(clocks.cpu_pll_div_out) {
@@ -391,7 +407,7 @@ fn configure_cpu_clk_impl(
 
     SYSTEM::regs().sysclk_conf().modify(|_, w| unsafe {
         w.pre_div_cnt().bits(0);
-        w.soc_clk_sel().bits(match new_selector {
+        w.soc_clk_sel().bits(match new_config {
             CpuClkConfig::Xtal => 0,
             CpuClkConfig::RcFast => 2,
             CpuClkConfig::Pll => 1,
@@ -431,7 +447,11 @@ fn enable_rc_fast_clk_div_n_impl(_clocks: &mut ClockTree, _en: bool) {
     // Nothing to do.
 }
 
-fn configure_rc_fast_clk_div_n_impl(_clocks: &mut ClockTree, new_config: RcFastClkDivNConfig) {
+fn configure_rc_fast_clk_div_n_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<RcFastClkDivNConfig>,
+    new_config: RcFastClkDivNConfig,
+) {
     let clk_conf = LPWR::regs().clk_conf();
     // Invalidate because we may be changing the divider from some other value
     let new_value = clk_conf.modify(|_, w| w.ck8m_div_sel_vld().clear_bit());
@@ -461,12 +481,12 @@ fn enable_rtc_slow_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_rtc_slow_clk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<RtcSlowClkConfig>,
-    new_selector: RtcSlowClkConfig,
+    _old_config: Option<RtcSlowClkConfig>,
+    new_config: RtcSlowClkConfig,
 ) {
     LPWR::regs().clk_conf().modify(|_, w| unsafe {
         // TODO: variants should be in PAC
-        w.ana_clk_rtc_sel().bits(match new_selector {
+        w.ana_clk_rtc_sel().bits(match new_config {
             RtcSlowClkConfig::Xtal32k => 1,
             RtcSlowClkConfig::RcSlow => 0,
             RtcSlowClkConfig::RcFast => 2,
@@ -483,11 +503,11 @@ fn enable_rtc_fast_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_rtc_fast_clk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<RtcFastClkConfig>,
-    new_selector: RtcFastClkConfig,
+    _old_config: Option<RtcFastClkConfig>,
+    new_config: RtcFastClkConfig,
 ) {
     // TODO: variants should be fixed in PAC
-    LPWR::regs().clk_conf().modify(|_, w| match new_selector {
+    LPWR::regs().clk_conf().modify(|_, w| match new_config {
         RtcFastClkConfig::Xtal => w.fast_clk_rtc_sel().clear_bit(),
         RtcFastClkConfig::Rc => w.fast_clk_rtc_sel().set_bit(),
     });
@@ -505,18 +525,18 @@ fn enable_low_power_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_low_power_clk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<LowPowerClkConfig>,
-    new_selector: LowPowerClkConfig,
+    _old_config: Option<LowPowerClkConfig>,
+    new_config: LowPowerClkConfig,
 ) {
     SYSTEM::regs().bt_lpck_div_frac().modify(|_, w| {
         w.lpclk_sel_8m()
-            .bit(new_selector == LowPowerClkConfig::RcFast);
+            .bit(new_config == LowPowerClkConfig::RcFast);
         w.lpclk_sel_rtc_slow()
-            .bit(new_selector == LowPowerClkConfig::RtcSlow);
+            .bit(new_config == LowPowerClkConfig::RtcSlow);
         w.lpclk_sel_xtal()
-            .bit(new_selector == LowPowerClkConfig::Xtal);
+            .bit(new_config == LowPowerClkConfig::Xtal);
         w.lpclk_sel_xtal32k()
-            .bit(new_selector == LowPowerClkConfig::Xtal32k)
+            .bit(new_config == LowPowerClkConfig::Xtal32k)
     });
 }
 
@@ -549,14 +569,14 @@ fn enable_rmt_sclk_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_rmt_sclk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<RmtSclkConfig>,
-    new_selector: RmtSclkConfig,
+    _old_config: Option<RmtSclkConfig>,
+    new_config: RmtSclkConfig,
 ) {
     crate::peripherals::RMT::regs()
         .sys_conf()
         .modify(|_, w| unsafe {
             w.clk_en().clear_bit();
-            w.sclk_sel().bits(match new_selector {
+            w.sclk_sel().bits(match new_config {
                 RmtSclkConfig::ApbClk => 1,
                 RmtSclkConfig::RcFastClk => 2,
                 RmtSclkConfig::XtalClk => 3,
@@ -578,12 +598,12 @@ fn enable_timg0_function_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_timg0_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Timg0FunctionClockConfig>,
-    new_selector: Timg0FunctionClockConfig,
+    _old_config: Option<Timg0FunctionClockConfig>,
+    new_config: Timg0FunctionClockConfig,
 ) {
     TIMG0::regs().t(0).config().modify(|_, w| {
         w.use_xtal()
-            .bit(new_selector == Timg0FunctionClockConfig::XtalClk)
+            .bit(new_config == Timg0FunctionClockConfig::XtalClk)
     });
 }
 
@@ -596,11 +616,11 @@ fn enable_timg0_calibration_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_timg0_calibration_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Timg0CalibrationClockConfig>,
-    new_selector: Timg0CalibrationClockConfig,
+    _old_config: Option<Timg0CalibrationClockConfig>,
+    new_config: Timg0CalibrationClockConfig,
 ) {
     TIMG0::regs().rtccalicfg().modify(|_, w| unsafe {
-        w.rtc_cali_clk_sel().bits(match new_selector {
+        w.rtc_cali_clk_sel().bits(match new_config {
             Timg0CalibrationClockConfig::RcSlowClk => 0,
             Timg0CalibrationClockConfig::RcFastDivClk => 1,
             Timg0CalibrationClockConfig::Xtal32kClk => 2,
@@ -616,12 +636,12 @@ fn enable_timg0_wdt_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_timg0_wdt_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Timg0WdtClockConfig>,
-    new_selector: Timg0WdtClockConfig,
+    _old_config: Option<Timg0WdtClockConfig>,
+    new_config: Timg0WdtClockConfig,
 ) {
     TIMG0::regs().wdtconfig0().modify(|_, w| {
         w.wdt_use_xtal()
-            .bit(new_selector == Timg0WdtClockConfig::XtalClk)
+            .bit(new_config == Timg0WdtClockConfig::XtalClk)
     });
 }
 
@@ -636,12 +656,12 @@ fn enable_timg1_function_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_timg1_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Timg0FunctionClockConfig>,
-    new_selector: Timg0FunctionClockConfig,
+    _old_config: Option<Timg0FunctionClockConfig>,
+    new_config: Timg0FunctionClockConfig,
 ) {
     TIMG1::regs().t(0).config().modify(|_, w| {
         w.use_xtal()
-            .bit(new_selector == Timg0FunctionClockConfig::XtalClk)
+            .bit(new_config == Timg0FunctionClockConfig::XtalClk)
     });
 }
 
@@ -654,11 +674,11 @@ fn enable_timg1_calibration_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_timg1_calibration_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Timg0CalibrationClockConfig>,
-    new_selector: Timg0CalibrationClockConfig,
+    _old_config: Option<Timg0CalibrationClockConfig>,
+    new_config: Timg0CalibrationClockConfig,
 ) {
     TIMG1::regs().rtccalicfg().modify(|_, w| unsafe {
-        w.rtc_cali_clk_sel().bits(match new_selector {
+        w.rtc_cali_clk_sel().bits(match new_config {
             Timg0CalibrationClockConfig::RcSlowClk => 0,
             Timg0CalibrationClockConfig::RcFastDivClk => 1,
             Timg0CalibrationClockConfig::Xtal32kClk => 2,
@@ -674,12 +694,12 @@ fn enable_timg1_wdt_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_timg1_wdt_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Timg0WdtClockConfig>,
-    new_selector: Timg0WdtClockConfig,
+    _old_config: Option<Timg0WdtClockConfig>,
+    new_config: Timg0WdtClockConfig,
 ) {
     TIMG1::regs().wdtconfig0().modify(|_, w| {
         w.wdt_use_xtal()
-            .bit(new_selector == Timg0WdtClockConfig::XtalClk)
+            .bit(new_config == Timg0WdtClockConfig::XtalClk)
     });
 }
 
@@ -691,8 +711,8 @@ fn enable_uart0_mem_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_uart0_mem_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Uart0MemClockConfig>,
-    _new_selector: Uart0MemClockConfig,
+    _old_config: Option<Uart0MemClockConfig>,
+    _new_config: Uart0MemClockConfig,
 ) {
     // Nothing to do.
 }
@@ -705,11 +725,11 @@ fn enable_uart0_function_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_uart0_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Uart0FunctionClockConfig>,
-    new_selector: Uart0FunctionClockConfig,
+    _old_config: Option<Uart0FunctionClockConfig>,
+    new_config: Uart0FunctionClockConfig,
 ) {
     UART0::regs().clk_conf().modify(|_, w| unsafe {
-        w.sclk_sel().bits(match new_selector {
+        w.sclk_sel().bits(match new_config {
             Uart0FunctionClockConfig::Apb => 1,
             Uart0FunctionClockConfig::RcFast => 2,
             Uart0FunctionClockConfig::Xtal => 3,
@@ -725,8 +745,8 @@ fn enable_uart1_mem_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_uart1_mem_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Uart0MemClockConfig>,
-    _new_selector: Uart0MemClockConfig,
+    _old_config: Option<Uart0MemClockConfig>,
+    _new_config: Uart0MemClockConfig,
 ) {
     // Nothing to do.
 }
@@ -739,11 +759,11 @@ fn enable_uart1_function_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_uart1_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Uart0FunctionClockConfig>,
-    new_selector: Uart0FunctionClockConfig,
+    _old_config: Option<Uart0FunctionClockConfig>,
+    new_config: Uart0FunctionClockConfig,
 ) {
     UART1::regs().clk_conf().modify(|_, w| unsafe {
-        w.sclk_sel().bits(match new_selector {
+        w.sclk_sel().bits(match new_config {
             Uart0FunctionClockConfig::Apb => 1,
             Uart0FunctionClockConfig::RcFast => 2,
             Uart0FunctionClockConfig::Xtal => 3,

--- a/esp-hal/src/soc/esp32c5/clocks.rs
+++ b/esp-hal/src/soc/esp32c5/clocks.rs
@@ -119,7 +119,11 @@ impl ClockConfig {
 
 // XTAL_CLK
 
-fn configure_xtal_clk_impl(_clocks: &mut ClockTree, _config: XtalClkConfig) {
+fn configure_xtal_clk_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<XtalClkConfig>,
+    _config: XtalClkConfig,
+) {
     // Nothing to do here.
 }
 
@@ -332,13 +336,13 @@ fn enable_hp_root_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_hp_root_clk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<HpRootClkConfig>,
-    new_selector: HpRootClkConfig,
+    _old_config: Option<HpRootClkConfig>,
+    new_config: HpRootClkConfig,
 ) {
     // TODO: Limit AHB to ensure it's running at <= XTAL_CLK && CPU_CLK must be an integer multiple
     // of AHB
     PCR::regs().sysclk_conf().modify(|_, w| unsafe {
-        w.soc_clk_sel().bits(match new_selector {
+        w.soc_clk_sel().bits(match new_config {
             HpRootClkConfig::Xtal => 0,
             HpRootClkConfig::RcFast => 1,
             HpRootClkConfig::PllF160m => 2,
@@ -353,7 +357,11 @@ fn enable_cpu_clk_impl(_clocks: &mut ClockTree, _en: bool) {
     // Nothing to do here.
 }
 
-fn configure_cpu_clk_impl(_clocks: &mut ClockTree, new_config: CpuClkConfig) {
+fn configure_cpu_clk_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<CpuClkConfig>,
+    new_config: CpuClkConfig,
+) {
     PCR::regs()
         .cpu_freq_conf()
         .modify(|_, w| unsafe { w.cpu_div_num().bits(new_config.divisor() as u8) });
@@ -369,7 +377,11 @@ fn enable_ahb_clk_impl(_clocks: &mut ClockTree, _en: bool) {
     // Nothing to do here.
 }
 
-fn configure_ahb_clk_impl(_clocks: &mut ClockTree, new_config: AhbClkConfig) {
+fn configure_ahb_clk_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<AhbClkConfig>,
+    new_config: AhbClkConfig,
+) {
     PCR::regs()
         .ahb_freq_conf()
         .modify(|_, w| unsafe { w.ahb_div_num().bits(new_config.divisor() as u8) });
@@ -385,7 +397,11 @@ fn enable_apb_clk_impl(_clocks: &mut ClockTree, _en: bool) {
     // Nothing to do here.
 }
 
-fn configure_apb_clk_impl(_clocks: &mut ClockTree, new_config: ApbClkConfig) {
+fn configure_apb_clk_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<ApbClkConfig>,
+    new_config: ApbClkConfig,
+) {
     PCR::regs()
         .apb_freq_conf()
         .modify(|_, w| unsafe { w.apb_div_num().bits(new_config.divisor() as u8) });
@@ -405,11 +421,11 @@ fn enable_lp_fast_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_lp_fast_clk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<LpFastClkConfig>,
-    new_selector: LpFastClkConfig,
+    _old_config: Option<LpFastClkConfig>,
+    new_config: LpFastClkConfig,
 ) {
     LP_CLKRST::regs().lp_clk_conf().modify(|_, w| unsafe {
-        w.fast_clk_sel().bits(match new_selector {
+        w.fast_clk_sel().bits(match new_config {
             LpFastClkConfig::RcFast => 0,
             LpFastClkConfig::XtalD2 => 1,
             LpFastClkConfig::Xtal => 2,
@@ -425,11 +441,11 @@ fn enable_lp_slow_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_lp_slow_clk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<LpSlowClkConfig>,
-    new_selector: LpSlowClkConfig,
+    _old_config: Option<LpSlowClkConfig>,
+    new_config: LpSlowClkConfig,
 ) {
     LP_CLKRST::regs().lp_clk_conf().modify(|_, w| unsafe {
-        w.slow_clk_sel().bits(match new_selector {
+        w.slow_clk_sel().bits(match new_config {
             LpSlowClkConfig::RcSlow => 0,
             LpSlowClkConfig::Xtal32k => 1,
             // LpSlowClkConfig::Ext32k => 2,
@@ -446,11 +462,11 @@ fn enable_crypto_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_crypto_clk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<CryptoClkConfig>,
-    new_selector: CryptoClkConfig,
+    _old_config: Option<CryptoClkConfig>,
+    new_config: CryptoClkConfig,
 ) {
     PCR::regs().sec_conf().modify(|_, w| unsafe {
-        w.sec_clk_sel().bits(match new_selector {
+        w.sec_clk_sel().bits(match new_config {
             CryptoClkConfig::Xtal => 0,
             CryptoClkConfig::Fosc => 1,
             CryptoClkConfig::PllF480m => 2,
@@ -466,11 +482,11 @@ fn enable_timg_calibration_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_timg_calibration_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<TimgCalibrationClockConfig>,
-    new_selector: TimgCalibrationClockConfig,
+    _old_config: Option<TimgCalibrationClockConfig>,
+    new_config: TimgCalibrationClockConfig,
 ) {
     PCR::regs().ctrl_32k_conf().modify(|_, w| unsafe {
-        w._32k_sel().bits(match new_selector {
+        w._32k_sel().bits(match new_config {
             TimgCalibrationClockConfig::OscSlowClk => 0,
             TimgCalibrationClockConfig::Xtal32kClk => 1,
             // TimgCalibrationClockConfig::Ext32kClk => 2,
@@ -490,11 +506,11 @@ fn enable_parlio_rx_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_parlio_rx_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<ParlioRxClockConfig>,
-    new_selector: ParlioRxClockConfig,
+    _old_config: Option<ParlioRxClockConfig>,
+    new_config: ParlioRxClockConfig,
 ) {
     PCR::regs().parl_clk_rx_conf().modify(|_, w| unsafe {
-        w.parl_clk_rx_sel().bits(match new_selector {
+        w.parl_clk_rx_sel().bits(match new_config {
             ParlioRxClockConfig::XtalClk => 0,
             ParlioRxClockConfig::RcFastClk => 1,
             ParlioRxClockConfig::PllF240m => 2,
@@ -512,11 +528,11 @@ fn enable_parlio_tx_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_parlio_tx_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<ParlioTxClockConfig>,
-    new_selector: ParlioTxClockConfig,
+    _old_config: Option<ParlioTxClockConfig>,
+    new_config: ParlioTxClockConfig,
 ) {
     PCR::regs().parl_clk_tx_conf().modify(|_, w| unsafe {
-        w.parl_clk_tx_sel().bits(match new_selector {
+        w.parl_clk_tx_sel().bits(match new_config {
             ParlioTxClockConfig::XtalClk => 0,
             ParlioTxClockConfig::RcFastClk => 1,
             ParlioTxClockConfig::PllF240m => 2,
@@ -539,11 +555,11 @@ fn enable_rmt_sclk_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_rmt_sclk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<RmtSclkConfig>,
-    new_selector: RmtSclkConfig,
+    _old_config: Option<RmtSclkConfig>,
+    new_config: RmtSclkConfig,
 ) {
     PCR::regs().rmt_sclk_conf().modify(|_, w| unsafe {
-        w.sclk_sel().bits(match new_selector {
+        w.sclk_sel().bits(match new_config {
             RmtSclkConfig::XtalClk => 0,
             RmtSclkConfig::RcFastClk => 1,
             RmtSclkConfig::PllF80m => 2,
@@ -561,14 +577,14 @@ fn enable_timg0_function_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_timg0_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Timg0FunctionClockConfig>,
-    new_selector: Timg0FunctionClockConfig,
+    _old_config: Option<Timg0FunctionClockConfig>,
+    new_config: Timg0FunctionClockConfig,
 ) {
     // TODO: add variants to PAC
     PCR::regs()
         .timergroup0_timer_clk_conf()
         .modify(|_, w| unsafe {
-            w.tg0_timer_clk_sel().bits(match new_selector {
+            w.tg0_timer_clk_sel().bits(match new_config {
                 Timg0FunctionClockConfig::XtalClk => 0,
                 Timg0FunctionClockConfig::RcFastClk => 1,
                 Timg0FunctionClockConfig::PllF80m => 2,
@@ -586,13 +602,13 @@ fn enable_timg0_wdt_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_timg0_wdt_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Timg0WdtClockConfig>,
-    new_selector: Timg0WdtClockConfig,
+    _old_config: Option<Timg0WdtClockConfig>,
+    new_config: Timg0WdtClockConfig,
 ) {
     PCR::regs()
         .timergroup0_wdt_clk_conf()
         .modify(|_, w| unsafe {
-            w.tg0_wdt_clk_sel().bits(match new_selector {
+            w.tg0_wdt_clk_sel().bits(match new_config {
                 Timg0WdtClockConfig::XtalClk => 0,
                 Timg0WdtClockConfig::RcFastClk => 1,
                 Timg0WdtClockConfig::PllF80m => 2,
@@ -610,14 +626,14 @@ fn enable_timg1_function_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_timg1_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Timg0FunctionClockConfig>,
-    new_selector: Timg0FunctionClockConfig,
+    _old_config: Option<Timg0FunctionClockConfig>,
+    new_config: Timg0FunctionClockConfig,
 ) {
     // TODO: add variants to PAC
     PCR::regs()
         .timergroup1_timer_clk_conf()
         .modify(|_, w| unsafe {
-            w.tg1_timer_clk_sel().bits(match new_selector {
+            w.tg1_timer_clk_sel().bits(match new_config {
                 Timg0FunctionClockConfig::XtalClk => 0,
                 Timg0FunctionClockConfig::RcFastClk => 1,
                 Timg0FunctionClockConfig::PllF80m => 2,
@@ -635,13 +651,13 @@ fn enable_timg1_wdt_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_timg1_wdt_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Timg0WdtClockConfig>,
-    new_selector: Timg0WdtClockConfig,
+    _old_config: Option<Timg0WdtClockConfig>,
+    new_config: Timg0WdtClockConfig,
 ) {
     PCR::regs()
         .timergroup1_wdt_clk_conf()
         .modify(|_, w| unsafe {
-            w.tg1_wdt_clk_sel().bits(match new_selector {
+            w.tg1_wdt_clk_sel().bits(match new_config {
                 Timg0WdtClockConfig::XtalClk => 0,
                 Timg0WdtClockConfig::RcFastClk => 1,
                 Timg0WdtClockConfig::PllF80m => 2,
@@ -661,11 +677,11 @@ fn enable_uart0_function_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_uart0_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Uart0FunctionClockConfig>,
-    new_selector: Uart0FunctionClockConfig,
+    _old_config: Option<Uart0FunctionClockConfig>,
+    new_config: Uart0FunctionClockConfig,
 ) {
     PCR::regs().uart(0).clk_conf().modify(|_, w| unsafe {
-        w.sclk_sel().bits(match new_selector {
+        w.sclk_sel().bits(match new_config {
             Uart0FunctionClockConfig::Xtal => 0,
             Uart0FunctionClockConfig::RcFast => 1,
             Uart0FunctionClockConfig::PllF80m => 2,
@@ -684,11 +700,11 @@ fn enable_uart1_function_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_uart1_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Uart0FunctionClockConfig>,
-    new_selector: Uart0FunctionClockConfig,
+    _old_config: Option<Uart0FunctionClockConfig>,
+    new_config: Uart0FunctionClockConfig,
 ) {
     PCR::regs().uart(1).clk_conf().modify(|_, w| unsafe {
-        w.sclk_sel().bits(match new_selector {
+        w.sclk_sel().bits(match new_config {
             Uart0FunctionClockConfig::Xtal => 0,
             Uart0FunctionClockConfig::RcFast => 1,
             Uart0FunctionClockConfig::PllF80m => 2,

--- a/esp-hal/src/soc/esp32c6/clocks.rs
+++ b/esp-hal/src/soc/esp32c6/clocks.rs
@@ -114,7 +114,11 @@ impl ClockConfig {
 
 // XTAL_CLK
 
-fn configure_xtal_clk_impl(_clocks: &mut ClockTree, _config: XtalClkConfig) {
+fn configure_xtal_clk_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<XtalClkConfig>,
+    _config: XtalClkConfig,
+) {
     // The stored configuration affects PLL settings instead.
 }
 
@@ -273,7 +277,11 @@ fn enable_hp_root_clk_impl(_clocks: &mut ClockTree, _en: bool) {
     // Nothing to do, managed by hardware.
 }
 
-fn configure_hp_root_clk_impl(_clocks: &mut ClockTree, _new_config: HpRootClkConfig) {
+fn configure_hp_root_clk_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<HpRootClkConfig>,
+    _new_config: HpRootClkConfig,
+) {
     // Nothing to do, managed by hardware.
 }
 
@@ -281,8 +289,8 @@ fn configure_hp_root_clk_impl(_clocks: &mut ClockTree, _new_config: HpRootClkCon
 
 fn configure_cpu_clk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<CpuClkConfig>,
-    _new_selector: CpuClkConfig,
+    _old_config: Option<CpuClkConfig>,
+    _new_config: CpuClkConfig,
 ) {
     // Nothing to do, automatically managed by hardware.
 }
@@ -291,8 +299,8 @@ fn configure_cpu_clk_impl(
 
 fn configure_ahb_clk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<AhbClkConfig>,
-    _new_selector: AhbClkConfig,
+    _old_config: Option<AhbClkConfig>,
+    _new_config: AhbClkConfig,
 ) {
     // Nothing to do, automatically managed by hardware.
 }
@@ -305,8 +313,8 @@ fn enable_mspi_fast_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_mspi_fast_clk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<MspiFastClkConfig>,
-    _new_selector: MspiFastClkConfig,
+    _old_config: Option<MspiFastClkConfig>,
+    _new_config: MspiFastClkConfig,
 ) {
     // Nothing to do, automatically managed by hardware.
 }
@@ -319,11 +327,11 @@ fn enable_soc_root_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_soc_root_clk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<SocRootClkConfig>,
-    new_selector: SocRootClkConfig,
+    _old_config: Option<SocRootClkConfig>,
+    new_config: SocRootClkConfig,
 ) {
     PCR::regs().sysclk_conf().modify(|_, w| unsafe {
-        w.soc_clk_sel().bits(match new_selector {
+        w.soc_clk_sel().bits(match new_config {
             SocRootClkConfig::Xtal => 0,
             SocRootClkConfig::Pll => 1,
             SocRootClkConfig::RcFast => 2,
@@ -337,7 +345,11 @@ fn enable_cpu_hs_div_impl(_clocks: &mut ClockTree, _en: bool) {
     // Nothing to do.
 }
 
-fn configure_cpu_hs_div_impl(_clocks: &mut ClockTree, new_config: CpuHsDivConfig) {
+fn configure_cpu_hs_div_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<CpuHsDivConfig>,
+    new_config: CpuHsDivConfig,
+) {
     PCR::regs()
         .cpu_freq_conf()
         .modify(|_, w| unsafe { w.cpu_hs_div_num().bits(new_config.divisor() as u8) });
@@ -349,7 +361,11 @@ fn enable_cpu_ls_div_impl(_clocks: &mut ClockTree, _en: bool) {
     // Nothing to do.
 }
 
-fn configure_cpu_ls_div_impl(_clocks: &mut ClockTree, new_config: CpuLsDivConfig) {
+fn configure_cpu_ls_div_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<CpuLsDivConfig>,
+    new_config: CpuLsDivConfig,
+) {
     PCR::regs()
         .cpu_freq_conf()
         .modify(|_, w| unsafe { w.cpu_ls_div_num().bits(new_config.divisor() as u8) });
@@ -361,7 +377,11 @@ fn enable_ahb_hs_div_impl(_clocks: &mut ClockTree, _en: bool) {
     // Nothing to do.
 }
 
-fn configure_ahb_hs_div_impl(_clocks: &mut ClockTree, new_config: AhbHsDivConfig) {
+fn configure_ahb_hs_div_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<AhbHsDivConfig>,
+    new_config: AhbHsDivConfig,
+) {
     PCR::regs()
         .ahb_freq_conf()
         .modify(|_, w| unsafe { w.ahb_hs_div_num().bits(new_config.divisor() as u8) });
@@ -373,7 +393,11 @@ fn enable_ahb_ls_div_impl(_clocks: &mut ClockTree, _en: bool) {
     // Nothing to do.
 }
 
-fn configure_ahb_ls_div_impl(_clocks: &mut ClockTree, new_config: AhbLsDivConfig) {
+fn configure_ahb_ls_div_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<AhbLsDivConfig>,
+    new_config: AhbLsDivConfig,
+) {
     PCR::regs()
         .ahb_freq_conf()
         .modify(|_, w| unsafe { w.ahb_ls_div_num().bits(new_config.divisor() as u8) });
@@ -385,7 +409,11 @@ fn enable_apb_clk_impl(_clocks: &mut ClockTree, _en: bool) {
     // Nothing to do.
 }
 
-fn configure_apb_clk_impl(_clocks: &mut ClockTree, new_config: ApbClkConfig) {
+fn configure_apb_clk_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<ApbClkConfig>,
+    new_config: ApbClkConfig,
+) {
     PCR::regs()
         .apb_freq_conf()
         .modify(|_, w| unsafe { w.apb_div_num().bits(new_config.divisor() as u8) });
@@ -397,7 +425,11 @@ fn enable_mspi_fast_hs_clk_impl(_clocks: &mut ClockTree, _en: bool) {
     // Nothing to do, automatically managed by hardware.
 }
 
-fn configure_mspi_fast_hs_clk_impl(_clocks: &mut ClockTree, new_config: MspiFastHsClkConfig) {
+fn configure_mspi_fast_hs_clk_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<MspiFastHsClkConfig>,
+    new_config: MspiFastHsClkConfig,
+) {
     PCR::regs()
         .mspi_clk_conf()
         .modify(|_, w| unsafe { w.mspi_fast_hs_div_num().bits(new_config.divisor() as u8) });
@@ -409,7 +441,11 @@ fn enable_mspi_fast_ls_clk_impl(_clocks: &mut ClockTree, _en: bool) {
     // Nothing to do, automatically managed by hardware.
 }
 
-fn configure_mspi_fast_ls_clk_impl(_clocks: &mut ClockTree, new_config: MspiFastLsClkConfig) {
+fn configure_mspi_fast_ls_clk_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<MspiFastLsClkConfig>,
+    new_config: MspiFastLsClkConfig,
+) {
     PCR::regs()
         .mspi_clk_conf()
         .modify(|_, w| unsafe { w.mspi_fast_ls_div_num().bits(new_config.divisor() as u8) });
@@ -449,11 +485,11 @@ fn enable_ledc_sclk_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_ledc_sclk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<LedcSclkConfig>,
-    new_selector: LedcSclkConfig,
+    _old_config: Option<LedcSclkConfig>,
+    new_config: LedcSclkConfig,
 ) {
     PCR::regs().ledc_sclk_conf().modify(|_, w| unsafe {
-        w.ledc_sclk_sel().bits(match new_selector {
+        w.ledc_sclk_sel().bits(match new_config {
             LedcSclkConfig::PllF80m => 1,
             LedcSclkConfig::RcFastClk => 2,
             LedcSclkConfig::XtalClk => 3,
@@ -471,11 +507,11 @@ fn enable_parlio_rx_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_parlio_rx_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<ParlioRxClockConfig>,
-    new_selector: ParlioRxClockConfig,
+    _old_config: Option<ParlioRxClockConfig>,
+    new_config: ParlioRxClockConfig,
 ) {
     PCR::regs().parl_clk_rx_conf().modify(|_, w| unsafe {
-        w.parl_clk_rx_sel().bits(match new_selector {
+        w.parl_clk_rx_sel().bits(match new_config {
             ParlioRxClockConfig::XtalClk => 0,
             ParlioRxClockConfig::RcFastClk => 2,
             ParlioRxClockConfig::PllF240m => 1,
@@ -493,11 +529,11 @@ fn enable_parlio_tx_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_parlio_tx_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<ParlioTxClockConfig>,
-    new_selector: ParlioTxClockConfig,
+    _old_config: Option<ParlioTxClockConfig>,
+    new_config: ParlioTxClockConfig,
 ) {
     PCR::regs().parl_clk_tx_conf().modify(|_, w| unsafe {
-        w.parl_clk_tx_sel().bits(match new_selector {
+        w.parl_clk_tx_sel().bits(match new_config {
             ParlioTxClockConfig::XtalClk => 0,
             ParlioTxClockConfig::RcFastClk => 2,
             ParlioTxClockConfig::PllF240m => 1,
@@ -515,11 +551,11 @@ fn enable_rmt_sclk_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_rmt_sclk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<RmtSclkConfig>,
-    new_selector: RmtSclkConfig,
+    _old_config: Option<RmtSclkConfig>,
+    new_config: RmtSclkConfig,
 ) {
     PCR::regs().rmt_sclk_conf().modify(|_, w| unsafe {
-        w.sclk_sel().bits(match new_selector {
+        w.sclk_sel().bits(match new_config {
             RmtSclkConfig::PllF80m => 1,
             RmtSclkConfig::RcFastClk => 2,
             RmtSclkConfig::XtalClk => 3,
@@ -541,11 +577,11 @@ fn enable_lp_fast_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_lp_fast_clk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<LpFastClkConfig>,
-    new_selector: LpFastClkConfig,
+    _old_config: Option<LpFastClkConfig>,
+    new_config: LpFastClkConfig,
 ) {
     LP_CLKRST::regs().lp_clk_conf().modify(|_, w| {
-        w.fast_clk_sel().bit(match new_selector {
+        w.fast_clk_sel().bit(match new_config {
             LpFastClkConfig::RcFastClk => false,
             LpFastClkConfig::XtalD2Clk => true,
         })
@@ -560,11 +596,11 @@ fn enable_lp_slow_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_lp_slow_clk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<LpSlowClkConfig>,
-    new_selector: LpSlowClkConfig,
+    _old_config: Option<LpSlowClkConfig>,
+    new_config: LpSlowClkConfig,
 ) {
     LP_CLKRST::regs().lp_clk_conf().modify(|_, w| unsafe {
-        w.slow_clk_sel().bits(match new_selector {
+        w.slow_clk_sel().bits(match new_config {
             LpSlowClkConfig::Xtal32k => 1,
             LpSlowClkConfig::RcSlow => 0,
             LpSlowClkConfig::OscSlow => 2,
@@ -582,11 +618,11 @@ fn enable_mcpwm0_function_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_mcpwm0_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Mcpwm0FunctionClockConfig>,
-    new_selector: Mcpwm0FunctionClockConfig,
+    _old_config: Option<Mcpwm0FunctionClockConfig>,
+    new_config: Mcpwm0FunctionClockConfig,
 ) {
     PCR::regs().pwm_clk_conf().modify(|_, w| unsafe {
-        w.pwm_clkm_sel().bits(match new_selector {
+        w.pwm_clkm_sel().bits(match new_config {
             Mcpwm0FunctionClockConfig::PllF160m => 1,
             Mcpwm0FunctionClockConfig::XtalClk => 2,
             Mcpwm0FunctionClockConfig::RcFastClk => 3,
@@ -604,14 +640,14 @@ fn enable_timg0_function_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_timg0_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Timg0FunctionClockConfig>,
-    new_selector: Timg0FunctionClockConfig,
+    _old_config: Option<Timg0FunctionClockConfig>,
+    new_config: Timg0FunctionClockConfig,
 ) {
     // TODO: add variants to PAC
     PCR::regs()
         .timergroup0_timer_clk_conf()
         .modify(|_, w| unsafe {
-            w.tg0_timer_clk_sel().bits(match new_selector {
+            w.tg0_timer_clk_sel().bits(match new_config {
                 Timg0FunctionClockConfig::XtalClk => 0,
                 Timg0FunctionClockConfig::RcFastClk => 2,
                 Timg0FunctionClockConfig::PllF80m => 1,
@@ -628,11 +664,11 @@ fn enable_timg0_calibration_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_timg0_calibration_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Timg0CalibrationClockConfig>,
-    new_selector: Timg0CalibrationClockConfig,
+    _old_config: Option<Timg0CalibrationClockConfig>,
+    new_config: Timg0CalibrationClockConfig,
 ) {
     TIMG0::regs().rtccalicfg().modify(|_, w| unsafe {
-        w.rtc_cali_clk_sel().bits(match new_selector {
+        w.rtc_cali_clk_sel().bits(match new_config {
             Timg0CalibrationClockConfig::RcSlowClk => 0,
             Timg0CalibrationClockConfig::RcFastDivClk => 1,
             Timg0CalibrationClockConfig::Xtal32kClk => 2,
@@ -650,13 +686,13 @@ fn enable_timg0_wdt_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_timg0_wdt_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Timg0WdtClockConfig>,
-    new_selector: Timg0WdtClockConfig,
+    _old_config: Option<Timg0WdtClockConfig>,
+    new_config: Timg0WdtClockConfig,
 ) {
     PCR::regs()
         .timergroup0_wdt_clk_conf()
         .modify(|_, w| unsafe {
-            w.tg0_wdt_clk_sel().bits(match new_selector {
+            w.tg0_wdt_clk_sel().bits(match new_config {
                 Timg0WdtClockConfig::XtalClk => 0,
                 Timg0WdtClockConfig::PllF80m => 1,
                 Timg0WdtClockConfig::RcFastClk => 2,
@@ -674,14 +710,14 @@ fn enable_timg1_function_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_timg1_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Timg0FunctionClockConfig>,
-    new_selector: Timg0FunctionClockConfig,
+    _old_config: Option<Timg0FunctionClockConfig>,
+    new_config: Timg0FunctionClockConfig,
 ) {
     // TODO: add variants to PAC
     PCR::regs()
         .timergroup1_timer_clk_conf()
         .modify(|_, w| unsafe {
-            w.tg1_timer_clk_sel().bits(match new_selector {
+            w.tg1_timer_clk_sel().bits(match new_config {
                 Timg0FunctionClockConfig::XtalClk => 0,
                 Timg0FunctionClockConfig::RcFastClk => 2,
                 Timg0FunctionClockConfig::PllF80m => 1,
@@ -698,11 +734,11 @@ fn enable_timg1_calibration_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_timg1_calibration_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Timg0CalibrationClockConfig>,
-    new_selector: Timg0CalibrationClockConfig,
+    _old_config: Option<Timg0CalibrationClockConfig>,
+    new_config: Timg0CalibrationClockConfig,
 ) {
     TIMG1::regs().rtccalicfg().modify(|_, w| unsafe {
-        w.rtc_cali_clk_sel().bits(match new_selector {
+        w.rtc_cali_clk_sel().bits(match new_config {
             Timg0CalibrationClockConfig::RcSlowClk => 0,
             Timg0CalibrationClockConfig::RcFastDivClk => 1,
             Timg0CalibrationClockConfig::Xtal32kClk => 2,
@@ -720,13 +756,13 @@ fn enable_timg1_wdt_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_timg1_wdt_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Timg0WdtClockConfig>,
-    new_selector: Timg0WdtClockConfig,
+    _old_config: Option<Timg0WdtClockConfig>,
+    new_config: Timg0WdtClockConfig,
 ) {
     PCR::regs()
         .timergroup1_wdt_clk_conf()
         .modify(|_, w| unsafe {
-            w.tg1_wdt_clk_sel().bits(match new_selector {
+            w.tg1_wdt_clk_sel().bits(match new_config {
                 Timg0WdtClockConfig::XtalClk => 0,
                 Timg0WdtClockConfig::PllF80m => 1,
                 Timg0WdtClockConfig::RcFastClk => 2,
@@ -745,11 +781,11 @@ fn enable_uart0_function_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_uart0_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Uart0FunctionClockConfig>,
-    new_selector: Uart0FunctionClockConfig,
+    _old_config: Option<Uart0FunctionClockConfig>,
+    new_config: Uart0FunctionClockConfig,
 ) {
     PCR::regs().uart(0).clk_conf().modify(|_, w| unsafe {
-        w.sclk_sel().bits(match new_selector {
+        w.sclk_sel().bits(match new_config {
             Uart0FunctionClockConfig::PllF80m => 1,
             Uart0FunctionClockConfig::RcFast => 2,
             Uart0FunctionClockConfig::Xtal => 3,
@@ -768,11 +804,11 @@ fn enable_uart1_function_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_uart1_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Uart0FunctionClockConfig>,
-    new_selector: Uart0FunctionClockConfig,
+    _old_config: Option<Uart0FunctionClockConfig>,
+    new_config: Uart0FunctionClockConfig,
 ) {
     PCR::regs().uart(1).clk_conf().modify(|_, w| unsafe {
-        w.sclk_sel().bits(match new_selector {
+        w.sclk_sel().bits(match new_config {
             Uart0FunctionClockConfig::PllF80m => 1,
             Uart0FunctionClockConfig::RcFast => 2,
             Uart0FunctionClockConfig::Xtal => 3,

--- a/esp-hal/src/soc/esp32h2/clocks.rs
+++ b/esp-hal/src/soc/esp32h2/clocks.rs
@@ -94,7 +94,11 @@ fn clk_ll_bus_update() {
 
 // XTAL_CLK
 
-fn configure_xtal_clk_impl(_clocks: &mut ClockTree, _config: XtalClkConfig) {
+fn configure_xtal_clk_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<XtalClkConfig>,
+    _config: XtalClkConfig,
+) {
     // The stored configuration affects PLL settings instead.
 }
 
@@ -241,11 +245,11 @@ fn enable_hp_root_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_hp_root_clk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<HpRootClkConfig>,
-    new_selector: HpRootClkConfig,
+    _old_config: Option<HpRootClkConfig>,
+    new_config: HpRootClkConfig,
 ) {
     PCR::regs().sysclk_conf().modify(|_, w| unsafe {
-        w.soc_clk_sel().bits(match new_selector {
+        w.soc_clk_sel().bits(match new_config {
             HpRootClkConfig::Pll96 => 1,
             HpRootClkConfig::Pll64 => 3,
             HpRootClkConfig::Xtal => 0,
@@ -264,7 +268,11 @@ fn enable_cpu_clk_impl(_clocks: &mut ClockTree, _en: bool) {
     // Nothing to do
 }
 
-fn configure_cpu_clk_impl(_clocks: &mut ClockTree, new_config: CpuClkConfig) {
+fn configure_cpu_clk_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<CpuClkConfig>,
+    new_config: CpuClkConfig,
+) {
     PCR::regs()
         .cpu_freq_conf()
         .modify(|_, w| unsafe { w.cpu_div_num().bits(new_config.divisor() as u8) });
@@ -280,7 +288,11 @@ fn enable_ahb_clk_impl(_clocks: &mut ClockTree, _en: bool) {
     // Nothing to do
 }
 
-fn configure_ahb_clk_impl(_clocks: &mut ClockTree, new_config: AhbClkConfig) {
+fn configure_ahb_clk_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<AhbClkConfig>,
+    new_config: AhbClkConfig,
+) {
     PCR::regs()
         .ahb_freq_conf()
         .modify(|_, w| unsafe { w.ahb_div_num().bits(new_config.divisor() as u8) });
@@ -296,7 +308,11 @@ fn enable_apb_clk_impl(_clocks: &mut ClockTree, _en: bool) {
     // Nothing to do.
 }
 
-fn configure_apb_clk_impl(_clocks: &mut ClockTree, new_config: ApbClkConfig) {
+fn configure_apb_clk_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<ApbClkConfig>,
+    new_config: ApbClkConfig,
+) {
     PCR::regs()
         .apb_freq_conf()
         .modify(|_, w| unsafe { w.apb_div_num().bits(new_config.divisor() as u8) });
@@ -316,11 +332,11 @@ fn enable_lp_fast_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_lp_fast_clk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<LpFastClkConfig>,
-    new_selector: LpFastClkConfig,
+    _old_config: Option<LpFastClkConfig>,
+    new_config: LpFastClkConfig,
 ) {
     LP_CLKRST::regs().lp_clk_conf().modify(|_, w| unsafe {
-        w.fast_clk_sel().bits(match new_selector {
+        w.fast_clk_sel().bits(match new_config {
             LpFastClkConfig::RcFastClk => 0,
             LpFastClkConfig::XtalD2Clk => 1,
             LpFastClkConfig::PllLpClk => 2,
@@ -336,11 +352,11 @@ fn enable_lp_slow_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_lp_slow_clk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<LpSlowClkConfig>,
-    new_selector: LpSlowClkConfig,
+    _old_config: Option<LpSlowClkConfig>,
+    new_config: LpSlowClkConfig,
 ) {
     LP_CLKRST::regs().lp_clk_conf().modify(|_, w| unsafe {
-        w.slow_clk_sel().bits(match new_selector {
+        w.slow_clk_sel().bits(match new_config {
             LpSlowClkConfig::RcSlow => 0,
             LpSlowClkConfig::Xtal32k => 1,
             LpSlowClkConfig::OscSlow => 2,
@@ -358,11 +374,11 @@ fn enable_mcpwm0_function_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_mcpwm0_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Mcpwm0FunctionClockConfig>,
-    new_selector: Mcpwm0FunctionClockConfig,
+    _old_config: Option<Mcpwm0FunctionClockConfig>,
+    new_config: Mcpwm0FunctionClockConfig,
 ) {
     PCR::regs().pwm_clk_conf().modify(|_, w| unsafe {
-        w.pwm_clkm_sel().bits(match new_selector {
+        w.pwm_clkm_sel().bits(match new_config {
             Mcpwm0FunctionClockConfig::XtalClk => 0,
             Mcpwm0FunctionClockConfig::RcFastClk => 1,
             Mcpwm0FunctionClockConfig::PllF96m => 2,
@@ -380,14 +396,14 @@ fn enable_timg0_function_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_timg0_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Timg0FunctionClockConfig>,
-    new_selector: Timg0FunctionClockConfig,
+    _old_config: Option<Timg0FunctionClockConfig>,
+    new_config: Timg0FunctionClockConfig,
 ) {
     // TODO: add variants to PAC
     PCR::regs()
         .timergroup0_timer_clk_conf()
         .modify(|_, w| unsafe {
-            w.tg0_timer_clk_sel().bits(match new_selector {
+            w.tg0_timer_clk_sel().bits(match new_config {
                 Timg0FunctionClockConfig::XtalClk => 0,
                 Timg0FunctionClockConfig::RcFastClk => 1,
                 Timg0FunctionClockConfig::PllF48m => 2,
@@ -404,11 +420,11 @@ fn enable_timg0_calibration_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_timg0_calibration_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Timg0CalibrationClockConfig>,
-    new_selector: Timg0CalibrationClockConfig,
+    _old_config: Option<Timg0CalibrationClockConfig>,
+    new_config: Timg0CalibrationClockConfig,
 ) {
     TIMG0::regs().rtccalicfg().modify(|_, w| unsafe {
-        w.rtc_cali_clk_sel().bits(match new_selector {
+        w.rtc_cali_clk_sel().bits(match new_config {
             Timg0CalibrationClockConfig::RcSlowClk => 0,
             Timg0CalibrationClockConfig::RcFastDivClk => 1,
             Timg0CalibrationClockConfig::Xtal32kClk => 2,
@@ -426,13 +442,13 @@ fn enable_timg0_wdt_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_timg0_wdt_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Timg0WdtClockConfig>,
-    new_selector: Timg0WdtClockConfig,
+    _old_config: Option<Timg0WdtClockConfig>,
+    new_config: Timg0WdtClockConfig,
 ) {
     PCR::regs()
         .timergroup0_wdt_clk_conf()
         .modify(|_, w| unsafe {
-            w.tg0_wdt_clk_sel().bits(match new_selector {
+            w.tg0_wdt_clk_sel().bits(match new_config {
                 Timg0WdtClockConfig::XtalClk => 0,
                 Timg0WdtClockConfig::RcFastClk => 1,
                 Timg0WdtClockConfig::PllF48m => 2,
@@ -450,11 +466,11 @@ fn enable_parlio_rx_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_parlio_rx_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<ParlioRxClockConfig>,
-    new_selector: ParlioRxClockConfig,
+    _old_config: Option<ParlioRxClockConfig>,
+    new_config: ParlioRxClockConfig,
 ) {
     PCR::regs().parl_clk_rx_conf().modify(|_, w| unsafe {
-        w.parl_clk_rx_sel().bits(match new_selector {
+        w.parl_clk_rx_sel().bits(match new_config {
             ParlioRxClockConfig::XtalClk => 0,
             ParlioRxClockConfig::RcFastClk => 2,
             ParlioRxClockConfig::PllF96m => 1,
@@ -472,11 +488,11 @@ fn enable_parlio_tx_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_parlio_tx_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<ParlioTxClockConfig>,
-    new_selector: ParlioTxClockConfig,
+    _old_config: Option<ParlioTxClockConfig>,
+    new_config: ParlioTxClockConfig,
 ) {
     PCR::regs().parl_clk_tx_conf().modify(|_, w| unsafe {
-        w.parl_clk_tx_sel().bits(match new_selector {
+        w.parl_clk_tx_sel().bits(match new_config {
             ParlioTxClockConfig::XtalClk => 0,
             ParlioTxClockConfig::RcFastClk => 2,
             ParlioTxClockConfig::PllF96m => 1,
@@ -494,11 +510,11 @@ fn enable_rmt_sclk_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_rmt_sclk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<RmtSclkConfig>,
-    new_selector: RmtSclkConfig,
+    _old_config: Option<RmtSclkConfig>,
+    new_config: RmtSclkConfig,
 ) {
     PCR::regs().rmt_sclk_conf().modify(|_, w| {
-        w.sclk_sel().bit(match new_selector {
+        w.sclk_sel().bit(match new_config {
             RmtSclkConfig::XtalClk => false,
             RmtSclkConfig::RcFastClk => true,
         })
@@ -515,14 +531,14 @@ fn enable_timg1_function_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_timg1_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Timg0FunctionClockConfig>,
-    new_selector: Timg0FunctionClockConfig,
+    _old_config: Option<Timg0FunctionClockConfig>,
+    new_config: Timg0FunctionClockConfig,
 ) {
     // TODO: add variants to PAC
     PCR::regs()
         .timergroup1_timer_clk_conf()
         .modify(|_, w| unsafe {
-            w.tg1_timer_clk_sel().bits(match new_selector {
+            w.tg1_timer_clk_sel().bits(match new_config {
                 Timg0FunctionClockConfig::XtalClk => 0,
                 Timg0FunctionClockConfig::RcFastClk => 1,
                 Timg0FunctionClockConfig::PllF48m => 2,
@@ -539,11 +555,11 @@ fn enable_timg1_calibration_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_timg1_calibration_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Timg0CalibrationClockConfig>,
-    new_selector: Timg0CalibrationClockConfig,
+    _old_config: Option<Timg0CalibrationClockConfig>,
+    new_config: Timg0CalibrationClockConfig,
 ) {
     TIMG1::regs().rtccalicfg().modify(|_, w| unsafe {
-        w.rtc_cali_clk_sel().bits(match new_selector {
+        w.rtc_cali_clk_sel().bits(match new_config {
             Timg0CalibrationClockConfig::RcSlowClk => 0,
             Timg0CalibrationClockConfig::RcFastDivClk => 1,
             Timg0CalibrationClockConfig::Xtal32kClk => 2,
@@ -561,13 +577,13 @@ fn enable_timg1_wdt_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_timg1_wdt_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Timg0WdtClockConfig>,
-    new_selector: Timg0WdtClockConfig,
+    _old_config: Option<Timg0WdtClockConfig>,
+    new_config: Timg0WdtClockConfig,
 ) {
     PCR::regs()
         .timergroup1_wdt_clk_conf()
         .modify(|_, w| unsafe {
-            w.tg1_wdt_clk_sel().bits(match new_selector {
+            w.tg1_wdt_clk_sel().bits(match new_config {
                 Timg0WdtClockConfig::XtalClk => 0,
                 Timg0WdtClockConfig::RcFastClk => 1,
                 Timg0WdtClockConfig::PllF48m => 2,
@@ -583,11 +599,11 @@ fn enable_uart0_function_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_uart0_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Uart0FunctionClockConfig>,
-    new_selector: Uart0FunctionClockConfig,
+    _old_config: Option<Uart0FunctionClockConfig>,
+    new_config: Uart0FunctionClockConfig,
 ) {
     PCR::regs().uart(0).clk_conf().modify(|_, w| unsafe {
-        w.sclk_sel().bits(match new_selector {
+        w.sclk_sel().bits(match new_config {
             Uart0FunctionClockConfig::PllF48m => 1,
             Uart0FunctionClockConfig::RcFast => 2,
             Uart0FunctionClockConfig::Xtal => 3,
@@ -606,11 +622,11 @@ fn enable_uart1_function_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_uart1_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Uart0FunctionClockConfig>,
-    new_selector: Uart0FunctionClockConfig,
+    _old_config: Option<Uart0FunctionClockConfig>,
+    new_config: Uart0FunctionClockConfig,
 ) {
     PCR::regs().uart(1).clk_conf().modify(|_, w| unsafe {
-        w.sclk_sel().bits(match new_selector {
+        w.sclk_sel().bits(match new_config {
             Uart0FunctionClockConfig::PllF48m => 1,
             Uart0FunctionClockConfig::RcFast => 2,
             Uart0FunctionClockConfig::Xtal => 3,

--- a/esp-hal/src/soc/esp32s2/clocks.rs
+++ b/esp-hal/src/soc/esp32s2/clocks.rs
@@ -123,7 +123,11 @@ impl ClockConfig {
 
 // XTAL_CLK
 
-fn configure_xtal_clk_impl(_clocks: &mut ClockTree, _config: XtalClkConfig) {
+fn configure_xtal_clk_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<XtalClkConfig>,
+    _config: XtalClkConfig,
+) {
     // The stored configuration affects PLL settings instead.
 }
 
@@ -213,7 +217,11 @@ fn enable_pll_clk_impl(clocks: &mut ClockTree, en: bool) {
     ensure_voltage_minimal(clocks);
 }
 
-fn configure_pll_clk_impl(_clocks: &mut ClockTree, _config: PllClkConfig) {
+fn configure_pll_clk_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<PllClkConfig>,
+    _config: PllClkConfig,
+) {
     // Nothing to do. The PLL may still be powered down. We'll configure it in
     // `enable_pll_clk_impl`.
 }
@@ -232,7 +240,11 @@ fn enable_apll_clk_impl(_clocks: &mut ClockTree, en: bool) {
     }
 }
 
-fn configure_apll_clk_impl(_clocks: &mut ClockTree, _config: ApllClkConfig) {
+fn configure_apll_clk_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<ApllClkConfig>,
+    _config: ApllClkConfig,
+) {
     // Nothing to do. The APLL may still be powered down. We'll configure it in
     // `enable_apll_clk_impl`.
 }
@@ -263,8 +275,8 @@ fn enable_cpu_pll_div_in_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_cpu_pll_div_in_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<CpuPllDivInConfig>,
-    _new_selector: CpuPllDivInConfig,
+    _old_config: Option<CpuPllDivInConfig>,
+    _new_config: CpuPllDivInConfig,
 ) {
     // Nothing to do.
 }
@@ -275,7 +287,11 @@ fn enable_cpu_pll_div_impl(_clocks: &mut ClockTree, _en: bool) {
     // Nothing to do.
 }
 
-fn configure_cpu_pll_div_impl(_clocks: &mut ClockTree, _new_config: CpuPllDivConfig) {
+fn configure_cpu_pll_div_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<CpuPllDivConfig>,
+    _new_config: CpuPllDivConfig,
+) {
     // Nothing to do.
 }
 
@@ -287,8 +303,8 @@ fn enable_system_pre_div_in_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_system_pre_div_in_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<SystemPreDivInConfig>,
-    _new_selector: SystemPreDivInConfig,
+    _old_config: Option<SystemPreDivInConfig>,
+    _new_config: SystemPreDivInConfig,
 ) {
     // Nothing to do.
 }
@@ -299,7 +315,11 @@ fn enable_system_pre_div_impl(_clocks: &mut ClockTree, _en: bool) {
     // Nothing to do.
 }
 
-fn configure_system_pre_div_impl(_clocks: &mut ClockTree, new_config: SystemPreDivConfig) {
+fn configure_system_pre_div_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<SystemPreDivConfig>,
+    new_config: SystemPreDivConfig,
+) {
     SYSTEM::regs()
         .sysclk_conf()
         .modify(|_, w| unsafe { w.pre_div_cnt().bits(new_config.divisor() as u16 & 0x3FF) });
@@ -313,8 +333,8 @@ fn enable_apb_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_apb_clk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<ApbClkConfig>,
-    _new_selector: ApbClkConfig,
+    _old_config: Option<ApbClkConfig>,
+    _new_config: ApbClkConfig,
 ) {
     // Nothing to do.
 }
@@ -327,8 +347,8 @@ fn enable_ref_tick_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_ref_tick_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<RefTickConfig>,
-    _new_selector: RefTickConfig,
+    _old_config: Option<RefTickConfig>,
+    _new_config: RefTickConfig,
 ) {
     // Nothing to do.
 }
@@ -339,7 +359,11 @@ fn enable_ref_tick_xtal_impl(_clocks: &mut ClockTree, _en: bool) {
     // Nothing to do.
 }
 
-fn configure_ref_tick_xtal_impl(_clocks: &mut ClockTree, new_config: RefTickXtalConfig) {
+fn configure_ref_tick_xtal_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<RefTickXtalConfig>,
+    new_config: RefTickXtalConfig,
+) {
     SYSCON::regs()
         .tick_conf()
         .modify(|_, w| unsafe { w.xtal_tick_num().bits(new_config.divisor() as u8) });
@@ -351,7 +375,11 @@ fn enable_ref_tick_ck8m_impl(_clocks: &mut ClockTree, _en: bool) {
     // Nothing to do.
 }
 
-fn configure_ref_tick_ck8m_impl(_clocks: &mut ClockTree, new_config: RefTickCk8mConfig) {
+fn configure_ref_tick_ck8m_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<RefTickCk8mConfig>,
+    new_config: RefTickCk8mConfig,
+) {
     SYSCON::regs()
         .tick_conf()
         .modify(|_, w| unsafe { w.ck8m_tick_num().bits(new_config.divisor() as u8) });
@@ -361,11 +389,11 @@ fn configure_ref_tick_ck8m_impl(_clocks: &mut ClockTree, new_config: RefTickCk8m
 
 fn configure_cpu_clk_impl(
     clocks: &mut ClockTree,
-    _old_selector: Option<CpuClkConfig>,
-    new_selector: CpuClkConfig,
+    _old_config: Option<CpuClkConfig>,
+    new_config: CpuClkConfig,
 ) {
     // Based on TRM Table 6.2-2
-    let clock_source_sel0_bit = match new_selector {
+    let clock_source_sel0_bit = match new_config {
         CpuClkConfig::Xtal => 0,
         CpuClkConfig::RcFast => 2,
         CpuClkConfig::Apll => 3,
@@ -387,7 +415,7 @@ fn configure_cpu_clk_impl(
 
     ensure_voltage_raised(clocks);
 
-    if new_selector == CpuClkConfig::Pll {
+    if new_config == CpuClkConfig::Pll {
         SYSTEM::regs().cpu_per_conf().modify(|_, w| {
             unsafe { w.cpuperiod_sel().bits(clock_source_sel2_bit) };
             w.pll_freq_sel().bit(clock_source_sel1_bit)
@@ -548,11 +576,11 @@ fn enable_rtc_slow_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_rtc_slow_clk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<RtcSlowClkConfig>,
-    new_selector: RtcSlowClkConfig,
+    _old_config: Option<RtcSlowClkConfig>,
+    new_config: RtcSlowClkConfig,
 ) {
     LPWR::regs().clk_conf().modify(|_, w| unsafe {
-        w.ana_clk_rtc_sel().bits(match new_selector {
+        w.ana_clk_rtc_sel().bits(match new_config {
             RtcSlowClkConfig::RcSlow => 0,
             RtcSlowClkConfig::Xtal32k => 1,
             RtcSlowClkConfig::RcFast => 2,
@@ -570,13 +598,12 @@ fn enable_rtc_fast_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_rtc_fast_clk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<RtcFastClkConfig>,
-    new_selector: RtcFastClkConfig,
+    _old_config: Option<RtcFastClkConfig>,
+    new_config: RtcFastClkConfig,
 ) {
-    LPWR::regs().clk_conf().modify(|_, w| {
-        w.fast_clk_rtc_sel()
-            .bit(new_selector == RtcFastClkConfig::Rc)
-    });
+    LPWR::regs()
+        .clk_conf()
+        .modify(|_, w| w.fast_clk_rtc_sel().bit(new_config == RtcFastClkConfig::Rc));
 
     ets_delay_us(3);
 }
@@ -610,16 +637,16 @@ fn enable_timg0_function_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_timg0_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Timg0FunctionClockConfig>,
-    new_selector: Timg0FunctionClockConfig,
+    _old_config: Option<Timg0FunctionClockConfig>,
+    new_config: Timg0FunctionClockConfig,
 ) {
     TIMG0::regs().t(0).config().modify(|_, w| {
         w.use_xtal()
-            .bit(new_selector == Timg0FunctionClockConfig::XtalClk)
+            .bit(new_config == Timg0FunctionClockConfig::XtalClk)
     });
     TIMG0::regs().t(1).config().modify(|_, w| {
         w.use_xtal()
-            .bit(new_selector == Timg0FunctionClockConfig::XtalClk)
+            .bit(new_config == Timg0FunctionClockConfig::XtalClk)
     });
 }
 
@@ -642,12 +669,12 @@ impl Timg0CalibrationClockConfig {
 
 fn configure_timg0_calibration_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Timg0CalibrationClockConfig>,
-    new_selector: Timg0CalibrationClockConfig,
+    _old_config: Option<Timg0CalibrationClockConfig>,
+    new_config: Timg0CalibrationClockConfig,
 ) {
     TIMG0::regs()
         .rtccalicfg()
-        .modify(|_, w| unsafe { w.rtc_cali_clk_sel().bits(new_selector.cali_clk_sel_bits()) });
+        .modify(|_, w| unsafe { w.rtc_cali_clk_sel().bits(new_config.cali_clk_sel_bits()) });
 }
 
 // TIMG1_FUNCTION_CLOCK
@@ -658,16 +685,16 @@ fn enable_timg1_function_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_timg1_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Timg0FunctionClockConfig>,
-    new_selector: Timg0FunctionClockConfig,
+    _old_config: Option<Timg0FunctionClockConfig>,
+    new_config: Timg0FunctionClockConfig,
 ) {
     TIMG1::regs().t(0).config().modify(|_, w| {
         w.use_xtal()
-            .bit(new_selector == Timg0FunctionClockConfig::XtalClk)
+            .bit(new_config == Timg0FunctionClockConfig::XtalClk)
     });
     TIMG1::regs().t(1).config().modify(|_, w| {
         w.use_xtal()
-            .bit(new_selector == Timg0FunctionClockConfig::XtalClk)
+            .bit(new_config == Timg0FunctionClockConfig::XtalClk)
     });
 }
 
@@ -680,12 +707,12 @@ fn enable_timg1_calibration_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_timg1_calibration_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Timg0CalibrationClockConfig>,
-    new_selector: Timg0CalibrationClockConfig,
+    _old_config: Option<Timg0CalibrationClockConfig>,
+    new_config: Timg0CalibrationClockConfig,
 ) {
     TIMG1::regs()
         .rtccalicfg()
-        .modify(|_, w| unsafe { w.rtc_cali_clk_sel().bits(new_selector.cali_clk_sel_bits()) });
+        .modify(|_, w| unsafe { w.rtc_cali_clk_sel().bits(new_config.cali_clk_sel_bits()) });
 }
 
 // UART0_MEM_CLOCK
@@ -696,8 +723,8 @@ fn enable_uart0_mem_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_uart0_mem_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Uart0MemClockConfig>,
-    _new_selector: Uart0MemClockConfig,
+    _old_config: Option<Uart0MemClockConfig>,
+    _new_config: Uart0MemClockConfig,
 ) {
     // Nothing to do.
 }
@@ -710,12 +737,12 @@ fn enable_uart0_function_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_uart0_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Uart0FunctionClockConfig>,
-    new_selector: Uart0FunctionClockConfig,
+    _old_config: Option<Uart0FunctionClockConfig>,
+    new_config: Uart0FunctionClockConfig,
 ) {
     UART0::regs().conf0().modify(|_, w| {
         w.tick_ref_always_on()
-            .bit(new_selector == Uart0FunctionClockConfig::Apb)
+            .bit(new_config == Uart0FunctionClockConfig::Apb)
     });
 }
 
@@ -727,8 +754,8 @@ fn enable_uart1_mem_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_uart1_mem_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Uart0MemClockConfig>,
-    _new_selector: Uart0MemClockConfig,
+    _old_config: Option<Uart0MemClockConfig>,
+    _new_config: Uart0MemClockConfig,
 ) {
     // Nothing to do.
 }
@@ -741,11 +768,11 @@ fn enable_uart1_function_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_uart1_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Uart0FunctionClockConfig>,
-    new_selector: Uart0FunctionClockConfig,
+    _old_config: Option<Uart0FunctionClockConfig>,
+    new_config: Uart0FunctionClockConfig,
 ) {
     UART1::regs().conf0().modify(|_, w| {
         w.tick_ref_always_on()
-            .bit(new_selector == Uart0FunctionClockConfig::Apb)
+            .bit(new_config == Uart0FunctionClockConfig::Apb)
     });
 }

--- a/esp-hal/src/soc/esp32s3/clocks.rs
+++ b/esp-hal/src/soc/esp32s3/clocks.rs
@@ -127,7 +127,11 @@ impl ClockConfig {
 
 // XTAL_CLK
 
-fn configure_xtal_clk_impl(_clocks: &mut ClockTree, _config: XtalClkConfig) {
+fn configure_xtal_clk_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<XtalClkConfig>,
+    _config: XtalClkConfig,
+) {
     // The stored configuration affects PLL settings instead.
 }
 
@@ -242,7 +246,11 @@ fn enable_pll_clk_impl(clocks: &mut ClockTree, en: bool) {
     ensure_voltage_minimal(clocks);
 }
 
-fn configure_pll_clk_impl(_clocks: &mut ClockTree, _config: PllClkConfig) {
+fn configure_pll_clk_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<PllClkConfig>,
+    _config: PllClkConfig,
+) {
     // Nothing to do. The PLL may still be powered down. We'll configure it in
     // `enable_pll_clk_impl`.
 }
@@ -340,8 +348,8 @@ fn enable_system_pre_div_in_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_system_pre_div_in_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<SystemPreDivInConfig>,
-    _new_selector: SystemPreDivInConfig,
+    _old_config: Option<SystemPreDivInConfig>,
+    _new_config: SystemPreDivInConfig,
 ) {
     // Nothing to do.
 }
@@ -352,7 +360,11 @@ fn enable_system_pre_div_impl(_clocks: &mut ClockTree, _en: bool) {
     // Nothing to do.
 }
 
-fn configure_system_pre_div_impl(_clocks: &mut ClockTree, new_config: SystemPreDivConfig) {
+fn configure_system_pre_div_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<SystemPreDivConfig>,
+    new_config: SystemPreDivConfig,
+) {
     SYSTEM::regs()
         .sysclk_conf()
         .modify(|_, w| unsafe { w.pre_div_cnt().bits(new_config.divisor() as u16 & 0x3FF) });
@@ -364,7 +376,11 @@ fn enable_cpu_pll_div_out_impl(_clocks: &mut ClockTree, _en: bool) {
     // Nothing to do.
 }
 
-fn configure_cpu_pll_div_out_impl(_clocks: &mut ClockTree, _config: CpuPllDivOutConfig) {
+fn configure_cpu_pll_div_out_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<CpuPllDivOutConfig>,
+    _config: CpuPllDivOutConfig,
+) {
     // Nothing to do.
 }
 
@@ -376,8 +392,8 @@ fn enable_apb_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_apb_clk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<ApbClkConfig>,
-    _new_selector: ApbClkConfig,
+    _old_config: Option<ApbClkConfig>,
+    _new_config: ApbClkConfig,
 ) {
     // Nothing to do.
 }
@@ -390,8 +406,8 @@ fn enable_crypto_pwm_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_crypto_pwm_clk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<CryptoPwmClkConfig>,
-    _new_selector: CryptoPwmClkConfig,
+    _old_config: Option<CryptoPwmClkConfig>,
+    _new_config: CryptoPwmClkConfig,
 ) {
     // Nothing to do.
 }
@@ -400,11 +416,11 @@ fn configure_crypto_pwm_clk_impl(
 
 fn configure_cpu_clk_impl(
     clocks: &mut ClockTree,
-    _old_selector: Option<CpuClkConfig>,
-    new_selector: CpuClkConfig,
+    _old_config: Option<CpuClkConfig>,
+    new_config: CpuClkConfig,
 ) {
     // Based on TRM Table 7.2-2
-    let clock_source_sel0_bit = match new_selector {
+    let clock_source_sel0_bit = match new_config {
         CpuClkConfig::Xtal => 0,
         CpuClkConfig::RcFast => 2,
         CpuClkConfig::Pll => 1,
@@ -420,7 +436,7 @@ fn configure_cpu_clk_impl(
     };
 
     ensure_voltage_raised(clocks);
-    if new_selector == CpuClkConfig::Pll {
+    if new_config == CpuClkConfig::Pll {
         SYSTEM::regs().cpu_per_conf().modify(|_, w| {
             unsafe { w.cpuperiod_sel().bits(clock_source_sel2_bit) };
             w.pll_freq_sel().bit(clock_source_sel1_bit)
@@ -624,7 +640,11 @@ fn enable_rc_fast_clk_div_n_impl(_clocks: &mut ClockTree, _en: bool) {
     // Nothing to do.
 }
 
-fn configure_rc_fast_clk_div_n_impl(_clocks: &mut ClockTree, new_config: RcFastClkDivNConfig) {
+fn configure_rc_fast_clk_div_n_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<RcFastClkDivNConfig>,
+    new_config: RcFastClkDivNConfig,
+) {
     let clk_conf = LPWR::regs().clk_conf();
     // Invalidate because we may be changing the divider from some other value
     let new_value = clk_conf.modify(|_, w| w.ck8m_div_sel_vld().clear_bit());
@@ -654,12 +674,12 @@ fn enable_rtc_slow_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_rtc_slow_clk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<RtcSlowClkConfig>,
-    new_selector: RtcSlowClkConfig,
+    _old_config: Option<RtcSlowClkConfig>,
+    new_config: RtcSlowClkConfig,
 ) {
     LPWR::regs().clk_conf().modify(|_, w| unsafe {
         // TODO: variants should be in PAC
-        w.ana_clk_rtc_sel().bits(match new_selector {
+        w.ana_clk_rtc_sel().bits(match new_config {
             RtcSlowClkConfig::Xtal32k => 1,
             RtcSlowClkConfig::RcSlow => 0,
             RtcSlowClkConfig::RcFast => 2,
@@ -676,11 +696,11 @@ fn enable_rtc_fast_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_rtc_fast_clk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<RtcFastClkConfig>,
-    new_selector: RtcFastClkConfig,
+    _old_config: Option<RtcFastClkConfig>,
+    new_config: RtcFastClkConfig,
 ) {
     // TODO: variants should be fixed in PAC
-    LPWR::regs().clk_conf().modify(|_, w| match new_selector {
+    LPWR::regs().clk_conf().modify(|_, w| match new_config {
         RtcFastClkConfig::Xtal => w.fast_clk_rtc_sel().clear_bit(),
         RtcFastClkConfig::Rc => w.fast_clk_rtc_sel().set_bit(),
     });
@@ -695,18 +715,18 @@ fn enable_low_power_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_low_power_clk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<LowPowerClkConfig>,
-    new_selector: LowPowerClkConfig,
+    _old_config: Option<LowPowerClkConfig>,
+    new_config: LowPowerClkConfig,
 ) {
     SYSTEM::regs().bt_lpck_div_frac().modify(|_, w| {
         w.lpclk_sel_8m()
-            .bit(new_selector == LowPowerClkConfig::RcFast);
+            .bit(new_config == LowPowerClkConfig::RcFast);
         w.lpclk_sel_rtc_slow()
-            .bit(new_selector == LowPowerClkConfig::RtcSlow);
+            .bit(new_config == LowPowerClkConfig::RtcSlow);
         w.lpclk_sel_xtal()
-            .bit(new_selector == LowPowerClkConfig::Xtal);
+            .bit(new_config == LowPowerClkConfig::Xtal);
         w.lpclk_sel_xtal32k()
-            .bit(new_selector == LowPowerClkConfig::Xtal32k)
+            .bit(new_config == LowPowerClkConfig::Xtal32k)
     });
 }
 
@@ -739,14 +759,14 @@ fn enable_rmt_sclk_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_rmt_sclk_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<RmtSclkConfig>,
-    new_selector: RmtSclkConfig,
+    _old_config: Option<RmtSclkConfig>,
+    new_config: RmtSclkConfig,
 ) {
     crate::peripherals::RMT::regs()
         .sys_conf()
         .modify(|_, w| unsafe {
             w.clk_en().clear_bit();
-            w.sclk_sel().bits(match new_selector {
+            w.sclk_sel().bits(match new_config {
                 RmtSclkConfig::ApbClk => 1,
                 RmtSclkConfig::RcFastClk => 2,
                 RmtSclkConfig::XtalClk => 3,
@@ -762,8 +782,8 @@ fn enable_mcpwm0_function_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_mcpwm0_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Mcpwm0FunctionClockConfig>,
-    _new_selector: Mcpwm0FunctionClockConfig,
+    _old_config: Option<Mcpwm0FunctionClockConfig>,
+    _new_config: Mcpwm0FunctionClockConfig,
 ) {
     // Nothing to do.
 }
@@ -776,8 +796,8 @@ fn enable_mcpwm1_function_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_mcpwm1_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Mcpwm0FunctionClockConfig>,
-    _new_selector: Mcpwm0FunctionClockConfig,
+    _old_config: Option<Mcpwm0FunctionClockConfig>,
+    _new_config: Mcpwm0FunctionClockConfig,
 ) {
     // Nothing to do.
 }
@@ -793,16 +813,16 @@ fn enable_timg0_function_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_timg0_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Timg0FunctionClockConfig>,
-    new_selector: Timg0FunctionClockConfig,
+    _old_config: Option<Timg0FunctionClockConfig>,
+    new_config: Timg0FunctionClockConfig,
 ) {
     TIMG0::regs().t(0).config().modify(|_, w| {
         w.use_xtal()
-            .bit(new_selector == Timg0FunctionClockConfig::XtalClk)
+            .bit(new_config == Timg0FunctionClockConfig::XtalClk)
     });
     TIMG0::regs().t(1).config().modify(|_, w| {
         w.use_xtal()
-            .bit(new_selector == Timg0FunctionClockConfig::XtalClk)
+            .bit(new_config == Timg0FunctionClockConfig::XtalClk)
     });
 }
 
@@ -815,11 +835,11 @@ fn enable_timg0_calibration_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_timg0_calibration_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Timg0CalibrationClockConfig>,
-    new_selector: Timg0CalibrationClockConfig,
+    _old_config: Option<Timg0CalibrationClockConfig>,
+    new_config: Timg0CalibrationClockConfig,
 ) {
     TIMG0::regs().rtccalicfg().modify(|_, w| unsafe {
-        w.rtc_cali_clk_sel().bits(match new_selector {
+        w.rtc_cali_clk_sel().bits(match new_config {
             Timg0CalibrationClockConfig::RcSlowClk => 0,
             Timg0CalibrationClockConfig::RcFastDivClk => 1,
             Timg0CalibrationClockConfig::Xtal32kClk => 2,
@@ -835,16 +855,16 @@ fn enable_timg1_function_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_timg1_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Timg0FunctionClockConfig>,
-    new_selector: Timg0FunctionClockConfig,
+    _old_config: Option<Timg0FunctionClockConfig>,
+    new_config: Timg0FunctionClockConfig,
 ) {
     TIMG1::regs().t(0).config().modify(|_, w| {
         w.use_xtal()
-            .bit(new_selector == Timg0FunctionClockConfig::XtalClk)
+            .bit(new_config == Timg0FunctionClockConfig::XtalClk)
     });
     TIMG1::regs().t(1).config().modify(|_, w| {
         w.use_xtal()
-            .bit(new_selector == Timg0FunctionClockConfig::XtalClk)
+            .bit(new_config == Timg0FunctionClockConfig::XtalClk)
     });
 }
 
@@ -857,11 +877,11 @@ fn enable_timg1_calibration_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_timg1_calibration_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Timg0CalibrationClockConfig>,
-    new_selector: Timg0CalibrationClockConfig,
+    _old_config: Option<Timg0CalibrationClockConfig>,
+    new_config: Timg0CalibrationClockConfig,
 ) {
     TIMG1::regs().rtccalicfg().modify(|_, w| unsafe {
-        w.rtc_cali_clk_sel().bits(match new_selector {
+        w.rtc_cali_clk_sel().bits(match new_config {
             Timg0CalibrationClockConfig::RcSlowClk => 0,
             Timg0CalibrationClockConfig::RcFastDivClk => 1,
             Timg0CalibrationClockConfig::Xtal32kClk => 2,
@@ -877,8 +897,8 @@ fn enable_uart0_mem_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_uart0_mem_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Uart0MemClockConfig>,
-    _new_selector: Uart0MemClockConfig,
+    _old_config: Option<Uart0MemClockConfig>,
+    _new_config: Uart0MemClockConfig,
 ) {
     // Nothing to do.
 }
@@ -891,11 +911,11 @@ fn enable_uart0_function_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_uart0_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Uart0FunctionClockConfig>,
-    new_selector: Uart0FunctionClockConfig,
+    _old_config: Option<Uart0FunctionClockConfig>,
+    new_config: Uart0FunctionClockConfig,
 ) {
     UART0::regs().clk_conf().modify(|_, w| unsafe {
-        w.sclk_sel().bits(match new_selector {
+        w.sclk_sel().bits(match new_config {
             Uart0FunctionClockConfig::Apb => 1,
             Uart0FunctionClockConfig::RcFast => 2,
             Uart0FunctionClockConfig::Xtal => 3,
@@ -911,8 +931,8 @@ fn enable_uart1_mem_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_uart1_mem_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Uart0MemClockConfig>,
-    _new_selector: Uart0MemClockConfig,
+    _old_config: Option<Uart0MemClockConfig>,
+    _new_config: Uart0MemClockConfig,
 ) {
     // Nothing to do.
 }
@@ -925,11 +945,11 @@ fn enable_uart1_function_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_uart1_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Uart0FunctionClockConfig>,
-    new_selector: Uart0FunctionClockConfig,
+    _old_config: Option<Uart0FunctionClockConfig>,
+    new_config: Uart0FunctionClockConfig,
 ) {
     UART1::regs().clk_conf().modify(|_, w| unsafe {
-        w.sclk_sel().bits(match new_selector {
+        w.sclk_sel().bits(match new_config {
             Uart0FunctionClockConfig::Apb => 1,
             Uart0FunctionClockConfig::RcFast => 2,
             Uart0FunctionClockConfig::Xtal => 3,
@@ -945,8 +965,8 @@ fn enable_uart2_mem_clock_impl(_clocks: &mut ClockTree, _en: bool) {
 
 fn configure_uart2_mem_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Uart0MemClockConfig>,
-    _new_selector: Uart0MemClockConfig,
+    _old_config: Option<Uart0MemClockConfig>,
+    _new_config: Uart0MemClockConfig,
 ) {
     // Nothing to do.
 }
@@ -959,11 +979,11 @@ fn enable_uart2_function_clock_impl(_clocks: &mut ClockTree, en: bool) {
 
 fn configure_uart2_function_clock_impl(
     _clocks: &mut ClockTree,
-    _old_selector: Option<Uart0FunctionClockConfig>,
-    new_selector: Uart0FunctionClockConfig,
+    _old_config: Option<Uart0FunctionClockConfig>,
+    new_config: Uart0FunctionClockConfig,
 ) {
     UART2::regs().clk_conf().modify(|_, w| unsafe {
-        w.sclk_sel().bits(match new_selector {
+        w.sclk_sel().bits(match new_config {
             Uart0FunctionClockConfig::Apb => 1,
             Uart0FunctionClockConfig::RcFast => 2,
             Uart0FunctionClockConfig::Xtal => 3,

--- a/esp-metadata-generated/src/_generated_esp32.rs
+++ b/esp-metadata-generated/src/_generated_esp32.rs
@@ -455,7 +455,11 @@ macro_rules! for_each_sha_algorithm {
 /// ```rust, no_run
 /// // XTAL_CLK
 ///
-/// fn configure_xtal_clk_impl(_clocks: &mut ClockTree, _config: XtalClkConfig) {
+/// fn configure_xtal_clk_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<XtalClkConfig>,
+///     _new_config: XtalClkConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -465,7 +469,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_pll_clk_impl(_clocks: &mut ClockTree, _config: PllClkConfig) {
+/// fn configure_pll_clk_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<PllClkConfig>,
+///     _new_config: PllClkConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -475,7 +483,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_apll_clk_impl(_clocks: &mut ClockTree, _config: ApllClkConfig) {
+/// fn configure_apll_clk_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<ApllClkConfig>,
+///     _new_config: ApllClkConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -499,8 +511,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_cpu_pll_div_in_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<CpuPllDivInConfig>,
-///     _new_selector: CpuPllDivInConfig,
+///     _old_config: Option<CpuPllDivInConfig>,
+///     _new_config: CpuPllDivInConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -511,7 +523,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_cpu_pll_div_impl(_clocks: &mut ClockTree, _new_config: CpuPllDivConfig) {
+/// fn configure_cpu_pll_div_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<CpuPllDivConfig>,
+///     _new_config: CpuPllDivConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -523,8 +539,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_syscon_pre_div_in_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<SysconPreDivInConfig>,
-///     _new_selector: SysconPreDivInConfig,
+///     _old_config: Option<SysconPreDivInConfig>,
+///     _new_config: SysconPreDivInConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -535,7 +551,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_syscon_pre_div_impl(_clocks: &mut ClockTree, _new_config: SysconPreDivConfig) {
+/// fn configure_syscon_pre_div_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<SysconPreDivConfig>,
+///     _new_config: SysconPreDivConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -547,8 +567,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_apb_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<ApbClkConfig>,
-///     _new_selector: ApbClkConfig,
+///     _old_config: Option<ApbClkConfig>,
+///     _new_config: ApbClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -561,8 +581,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_ref_tick_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<RefTickConfig>,
-///     _new_selector: RefTickConfig,
+///     _old_config: Option<RefTickConfig>,
+///     _new_config: RefTickConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -573,7 +593,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_ref_tick_xtal_impl(_clocks: &mut ClockTree, _new_config: RefTickXtalConfig) {
+/// fn configure_ref_tick_xtal_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<RefTickXtalConfig>,
+///     _new_config: RefTickXtalConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -583,7 +607,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_ref_tick_fosc_impl(_clocks: &mut ClockTree, _new_config: RefTickFoscConfig) {
+/// fn configure_ref_tick_fosc_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<RefTickFoscConfig>,
+///     _new_config: RefTickFoscConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -593,7 +621,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_ref_tick_apll_impl(_clocks: &mut ClockTree, _new_config: RefTickApllConfig) {
+/// fn configure_ref_tick_apll_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<RefTickApllConfig>,
+///     _new_config: RefTickApllConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -603,7 +635,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_ref_tick_pll_impl(_clocks: &mut ClockTree, _new_config: RefTickPllConfig) {
+/// fn configure_ref_tick_pll_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<RefTickPllConfig>,
+///     _new_config: RefTickPllConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -611,8 +647,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_cpu_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<CpuClkConfig>,
-///     _new_selector: CpuClkConfig,
+///     _old_config: Option<CpuClkConfig>,
+///     _new_config: CpuClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -661,8 +697,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_rtc_slow_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<RtcSlowClkConfig>,
-///     _new_selector: RtcSlowClkConfig,
+///     _old_config: Option<RtcSlowClkConfig>,
+///     _new_config: RtcSlowClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -675,8 +711,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_rtc_fast_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<RtcFastClkConfig>,
-///     _new_selector: RtcFastClkConfig,
+///     _old_config: Option<RtcFastClkConfig>,
+///     _new_config: RtcFastClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -695,8 +731,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_mcpwm0_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Mcpwm0FunctionClockConfig>,
-///     _new_selector: Mcpwm0FunctionClockConfig,
+///     _old_config: Option<Mcpwm0FunctionClockConfig>,
+///     _new_config: Mcpwm0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -709,8 +745,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_mcpwm1_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Mcpwm0FunctionClockConfig>,
-///     _new_selector: Mcpwm0FunctionClockConfig,
+///     _old_config: Option<Mcpwm0FunctionClockConfig>,
+///     _new_config: Mcpwm0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -723,8 +759,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_timg0_calibration_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Timg0CalibrationClockConfig>,
-///     _new_selector: Timg0CalibrationClockConfig,
+///     _old_config: Option<Timg0CalibrationClockConfig>,
+///     _new_config: Timg0CalibrationClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -737,8 +773,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_timg1_calibration_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Timg0CalibrationClockConfig>,
-///     _new_selector: Timg0CalibrationClockConfig,
+///     _old_config: Option<Timg0CalibrationClockConfig>,
+///     _new_config: Timg0CalibrationClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -751,8 +787,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_uart0_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Uart0FunctionClockConfig>,
-///     _new_selector: Uart0FunctionClockConfig,
+///     _old_config: Option<Uart0FunctionClockConfig>,
+///     _new_config: Uart0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -765,8 +801,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_uart0_mem_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Uart0MemClockConfig>,
-///     _new_selector: Uart0MemClockConfig,
+///     _old_config: Option<Uart0MemClockConfig>,
+///     _new_config: Uart0MemClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -779,8 +815,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_uart1_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Uart0FunctionClockConfig>,
-///     _new_selector: Uart0FunctionClockConfig,
+///     _old_config: Option<Uart0FunctionClockConfig>,
+///     _new_config: Uart0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -793,8 +829,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_uart1_mem_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Uart0MemClockConfig>,
-///     _new_selector: Uart0MemClockConfig,
+///     _old_config: Option<Uart0MemClockConfig>,
+///     _new_config: Uart0MemClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -807,8 +843,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_uart2_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Uart0FunctionClockConfig>,
-///     _new_selector: Uart0FunctionClockConfig,
+///     _old_config: Option<Uart0FunctionClockConfig>,
+///     _new_config: Uart0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -821,8 +857,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_uart2_mem_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Uart0MemClockConfig>,
-///     _new_selector: Uart0MemClockConfig,
+///     _old_config: Option<Uart0MemClockConfig>,
+///     _new_config: Uart0MemClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1384,8 +1420,8 @@ macro_rules! define_clock_tree_types {
                 uart2_mem_clock_refcount: 0,
             });
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
-            clocks.xtal_clk = Some(config);
-            configure_xtal_clk_impl(clocks, config);
+            let old_config = clocks.xtal_clk.replace(config);
+            configure_xtal_clk_impl(clocks, old_config, config);
         }
         pub fn xtal_clk_config(clocks: &mut ClockTree) -> Option<XtalClkConfig> {
             clocks.xtal_clk
@@ -1399,8 +1435,8 @@ macro_rules! define_clock_tree_types {
             if let Some(cpu_pll_div) = clocks.cpu_pll_div {
                 assert!(!((config.value() == 480000000) && (cpu_pll_div.value() == 4)));
             }
-            clocks.pll_clk = Some(config);
-            configure_pll_clk_impl(clocks, config);
+            let old_config = clocks.pll_clk.replace(config);
+            configure_pll_clk_impl(clocks, old_config, config);
         }
         pub fn pll_clk_config(clocks: &mut ClockTree) -> Option<PllClkConfig> {
             clocks.pll_clk
@@ -1425,8 +1461,8 @@ macro_rules! define_clock_tree_types {
             unwrap!(clocks.pll_clk).value()
         }
         pub fn configure_apll_clk(clocks: &mut ClockTree, config: ApllClkConfig) {
-            clocks.apll_clk = Some(config);
-            configure_apll_clk_impl(clocks, config);
+            let old_config = clocks.apll_clk.replace(config);
+            configure_apll_clk_impl(clocks, old_config, config);
         }
         pub fn apll_clk_config(clocks: &mut ClockTree) -> Option<ApllClkConfig> {
             clocks.apll_clk
@@ -1527,8 +1563,8 @@ macro_rules! define_clock_tree_types {
             if let Some(pll_clk) = clocks.pll_clk {
                 assert!(!((pll_clk.value() == 480000000) && (config.divisor() == 4)));
             }
-            clocks.cpu_pll_div = Some(config);
-            configure_cpu_pll_div_impl(clocks, config);
+            let old_config = clocks.cpu_pll_div.replace(config);
+            configure_cpu_pll_div_impl(clocks, old_config, config);
         }
         pub fn cpu_pll_div_config(clocks: &mut ClockTree) -> Option<CpuPllDivConfig> {
             clocks.cpu_pll_div
@@ -1593,8 +1629,8 @@ macro_rules! define_clock_tree_types {
             }
         }
         pub fn configure_syscon_pre_div(clocks: &mut ClockTree, config: SysconPreDivConfig) {
-            clocks.syscon_pre_div = Some(config);
-            configure_syscon_pre_div_impl(clocks, config);
+            let old_config = clocks.syscon_pre_div.replace(config);
+            configure_syscon_pre_div_impl(clocks, old_config, config);
         }
         pub fn syscon_pre_div_config(clocks: &mut ClockTree) -> Option<SysconPreDivConfig> {
             clocks.syscon_pre_div
@@ -1728,8 +1764,8 @@ macro_rules! define_clock_tree_types {
             }
         }
         pub fn configure_ref_tick_xtal(clocks: &mut ClockTree, config: RefTickXtalConfig) {
-            clocks.ref_tick_xtal = Some(config);
-            configure_ref_tick_xtal_impl(clocks, config);
+            let old_config = clocks.ref_tick_xtal.replace(config);
+            configure_ref_tick_xtal_impl(clocks, old_config, config);
         }
         pub fn ref_tick_xtal_config(clocks: &mut ClockTree) -> Option<RefTickXtalConfig> {
             clocks.ref_tick_xtal
@@ -1750,8 +1786,8 @@ macro_rules! define_clock_tree_types {
             (apb_clk_frequency(clocks) / (unwrap!(clocks.ref_tick_xtal).divisor() + 1))
         }
         pub fn configure_ref_tick_fosc(clocks: &mut ClockTree, config: RefTickFoscConfig) {
-            clocks.ref_tick_fosc = Some(config);
-            configure_ref_tick_fosc_impl(clocks, config);
+            let old_config = clocks.ref_tick_fosc.replace(config);
+            configure_ref_tick_fosc_impl(clocks, old_config, config);
         }
         pub fn ref_tick_fosc_config(clocks: &mut ClockTree) -> Option<RefTickFoscConfig> {
             clocks.ref_tick_fosc
@@ -1772,8 +1808,8 @@ macro_rules! define_clock_tree_types {
             (apb_clk_frequency(clocks) / (unwrap!(clocks.ref_tick_fosc).divisor() + 1))
         }
         pub fn configure_ref_tick_apll(clocks: &mut ClockTree, config: RefTickApllConfig) {
-            clocks.ref_tick_apll = Some(config);
-            configure_ref_tick_apll_impl(clocks, config);
+            let old_config = clocks.ref_tick_apll.replace(config);
+            configure_ref_tick_apll_impl(clocks, old_config, config);
         }
         pub fn ref_tick_apll_config(clocks: &mut ClockTree) -> Option<RefTickApllConfig> {
             clocks.ref_tick_apll
@@ -1794,8 +1830,8 @@ macro_rules! define_clock_tree_types {
             (apb_clk_frequency(clocks) / (unwrap!(clocks.ref_tick_apll).divisor() + 1))
         }
         pub fn configure_ref_tick_pll(clocks: &mut ClockTree, config: RefTickPllConfig) {
-            clocks.ref_tick_pll = Some(config);
-            configure_ref_tick_pll_impl(clocks, config);
+            let old_config = clocks.ref_tick_pll.replace(config);
+            configure_ref_tick_pll_impl(clocks, old_config, config);
         }
         pub fn ref_tick_pll_config(clocks: &mut ClockTree) -> Option<RefTickPllConfig> {
             clocks.ref_tick_pll

--- a/esp-metadata-generated/src/_generated_esp32c2.rs
+++ b/esp-metadata-generated/src/_generated_esp32c2.rs
@@ -510,7 +510,11 @@ macro_rules! for_each_sha_algorithm {
 /// ```rust, no_run
 /// // XTAL_CLK
 ///
-/// fn configure_xtal_clk_impl(_clocks: &mut ClockTree, _config: XtalClkConfig) {
+/// fn configure_xtal_clk_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<XtalClkConfig>,
+///     _new_config: XtalClkConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -552,8 +556,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_system_pre_div_in_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<SystemPreDivInConfig>,
-///     _new_selector: SystemPreDivInConfig,
+///     _old_config: Option<SystemPreDivInConfig>,
+///     _new_config: SystemPreDivInConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -564,7 +568,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_system_pre_div_impl(_clocks: &mut ClockTree, _new_config: SystemPreDivConfig) {
+/// fn configure_system_pre_div_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<SystemPreDivConfig>,
+///     _new_config: SystemPreDivConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -574,7 +582,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_cpu_pll_div_impl(_clocks: &mut ClockTree, _new_config: CpuPllDivConfig) {
+/// fn configure_cpu_pll_div_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<CpuPllDivConfig>,
+///     _new_config: CpuPllDivConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -586,8 +598,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_apb_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<ApbClkConfig>,
-///     _new_selector: ApbClkConfig,
+///     _old_config: Option<ApbClkConfig>,
+///     _new_config: ApbClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -600,8 +612,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_crypto_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<CryptoClkConfig>,
-///     _new_selector: CryptoClkConfig,
+///     _old_config: Option<CryptoClkConfig>,
+///     _new_config: CryptoClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -614,8 +626,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_mspi_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<MspiClkConfig>,
-///     _new_selector: MspiClkConfig,
+///     _old_config: Option<MspiClkConfig>,
+///     _new_config: MspiClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -624,8 +636,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_cpu_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<CpuClkConfig>,
-///     _new_selector: CpuClkConfig,
+///     _old_config: Option<CpuClkConfig>,
+///     _new_config: CpuClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -660,7 +672,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_rc_fast_clk_div_n_impl(_clocks: &mut ClockTree, _new_config: RcFastClkDivNConfig) {
+/// fn configure_rc_fast_clk_div_n_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<RcFastClkDivNConfig>,
+///     _new_config: RcFastClkDivNConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -678,8 +694,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_rtc_slow_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<RtcSlowClkConfig>,
-///     _new_selector: RtcSlowClkConfig,
+///     _old_config: Option<RtcSlowClkConfig>,
+///     _new_config: RtcSlowClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -692,8 +708,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_rtc_fast_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<RtcFastClkConfig>,
-///     _new_selector: RtcFastClkConfig,
+///     _old_config: Option<RtcFastClkConfig>,
+///     _new_config: RtcFastClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -706,8 +722,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_low_power_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<LowPowerClkConfig>,
-///     _new_selector: LowPowerClkConfig,
+///     _old_config: Option<LowPowerClkConfig>,
+///     _new_config: LowPowerClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -726,8 +742,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_timg0_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Timg0FunctionClockConfig>,
-///     _new_selector: Timg0FunctionClockConfig,
+///     _old_config: Option<Timg0FunctionClockConfig>,
+///     _new_config: Timg0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -740,8 +756,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_timg0_calibration_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Timg0CalibrationClockConfig>,
-///     _new_selector: Timg0CalibrationClockConfig,
+///     _old_config: Option<Timg0CalibrationClockConfig>,
+///     _new_config: Timg0CalibrationClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -754,8 +770,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_timg0_wdt_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Timg0WdtClockConfig>,
-///     _new_selector: Timg0WdtClockConfig,
+///     _old_config: Option<Timg0WdtClockConfig>,
+///     _new_config: Timg0WdtClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -768,8 +784,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_uart0_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Uart0FunctionClockConfig>,
-///     _new_selector: Uart0FunctionClockConfig,
+///     _old_config: Option<Uart0FunctionClockConfig>,
+///     _new_config: Uart0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -782,8 +798,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_uart0_mem_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Uart0MemClockConfig>,
-///     _new_selector: Uart0MemClockConfig,
+///     _old_config: Option<Uart0MemClockConfig>,
+///     _new_config: Uart0MemClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -796,8 +812,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_uart1_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Uart0FunctionClockConfig>,
-///     _new_selector: Uart0FunctionClockConfig,
+///     _old_config: Option<Uart0FunctionClockConfig>,
+///     _new_config: Uart0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -810,8 +826,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_uart1_mem_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Uart0MemClockConfig>,
-///     _new_selector: Uart0MemClockConfig,
+///     _old_config: Option<Uart0MemClockConfig>,
+///     _new_config: Uart0MemClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1219,8 +1235,8 @@ macro_rules! define_clock_tree_types {
                 uart1_mem_clock_refcount: 0,
             });
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
-            clocks.xtal_clk = Some(config);
-            configure_xtal_clk_impl(clocks, config);
+            let old_config = clocks.xtal_clk.replace(config);
+            configure_xtal_clk_impl(clocks, old_config, config);
         }
         pub fn xtal_clk_config(clocks: &mut ClockTree) -> Option<XtalClkConfig> {
             clocks.xtal_clk
@@ -1360,8 +1376,8 @@ macro_rules! define_clock_tree_types {
             }
         }
         pub fn configure_system_pre_div(clocks: &mut ClockTree, config: SystemPreDivConfig) {
-            clocks.system_pre_div = Some(config);
-            configure_system_pre_div_impl(clocks, config);
+            let old_config = clocks.system_pre_div.replace(config);
+            configure_system_pre_div_impl(clocks, old_config, config);
         }
         pub fn system_pre_div_config(clocks: &mut ClockTree) -> Option<SystemPreDivConfig> {
             clocks.system_pre_div
@@ -1382,8 +1398,8 @@ macro_rules! define_clock_tree_types {
             (system_pre_div_in_frequency(clocks) / (unwrap!(clocks.system_pre_div).divisor() + 1))
         }
         pub fn configure_cpu_pll_div(clocks: &mut ClockTree, config: CpuPllDivConfig) {
-            clocks.cpu_pll_div = Some(config);
-            configure_cpu_pll_div_impl(clocks, config);
+            let old_config = clocks.cpu_pll_div.replace(config);
+            configure_cpu_pll_div_impl(clocks, old_config, config);
         }
         pub fn cpu_pll_div_config(clocks: &mut ClockTree) -> Option<CpuPllDivConfig> {
             clocks.cpu_pll_div
@@ -1666,8 +1682,8 @@ macro_rules! define_clock_tree_types {
             (cpu_clk_frequency(clocks) / 2)
         }
         pub fn configure_rc_fast_clk_div_n(clocks: &mut ClockTree, config: RcFastClkDivNConfig) {
-            clocks.rc_fast_clk_div_n = Some(config);
-            configure_rc_fast_clk_div_n_impl(clocks, config);
+            let old_config = clocks.rc_fast_clk_div_n.replace(config);
+            configure_rc_fast_clk_div_n_impl(clocks, old_config, config);
         }
         pub fn rc_fast_clk_div_n_config(clocks: &mut ClockTree) -> Option<RcFastClkDivNConfig> {
             clocks.rc_fast_clk_div_n

--- a/esp-metadata-generated/src/_generated_esp32c3.rs
+++ b/esp-metadata-generated/src/_generated_esp32c3.rs
@@ -767,7 +767,11 @@ macro_rules! for_each_sha_algorithm {
 /// ```rust, no_run
 /// // XTAL_CLK
 ///
-/// fn configure_xtal_clk_impl(_clocks: &mut ClockTree, _config: XtalClkConfig) {
+/// fn configure_xtal_clk_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<XtalClkConfig>,
+///     _new_config: XtalClkConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -777,7 +781,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_pll_clk_impl(_clocks: &mut ClockTree, _config: PllClkConfig) {
+/// fn configure_pll_clk_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<PllClkConfig>,
+///     _new_config: PllClkConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -813,8 +821,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_system_pre_div_in_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<SystemPreDivInConfig>,
-///     _new_selector: SystemPreDivInConfig,
+///     _old_config: Option<SystemPreDivInConfig>,
+///     _new_config: SystemPreDivInConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -825,7 +833,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_system_pre_div_impl(_clocks: &mut ClockTree, _new_config: SystemPreDivConfig) {
+/// fn configure_system_pre_div_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<SystemPreDivConfig>,
+///     _new_config: SystemPreDivConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -835,7 +847,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_cpu_pll_div_out_impl(_clocks: &mut ClockTree, _config: CpuPllDivOutConfig) {
+/// fn configure_cpu_pll_div_out_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<CpuPllDivOutConfig>,
+///     _new_config: CpuPllDivOutConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -847,8 +863,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_apb_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<ApbClkConfig>,
-///     _new_selector: ApbClkConfig,
+///     _old_config: Option<ApbClkConfig>,
+///     _new_config: ApbClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -861,8 +877,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_crypto_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<CryptoClkConfig>,
-///     _new_selector: CryptoClkConfig,
+///     _old_config: Option<CryptoClkConfig>,
+///     _new_config: CryptoClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -871,8 +887,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_cpu_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<CpuClkConfig>,
-///     _new_selector: CpuClkConfig,
+///     _old_config: Option<CpuClkConfig>,
+///     _new_config: CpuClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -895,7 +911,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_rc_fast_clk_div_n_impl(_clocks: &mut ClockTree, _new_config: RcFastClkDivNConfig) {
+/// fn configure_rc_fast_clk_div_n_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<RcFastClkDivNConfig>,
+///     _new_config: RcFastClkDivNConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -913,8 +933,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_rtc_slow_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<RtcSlowClkConfig>,
-///     _new_selector: RtcSlowClkConfig,
+///     _old_config: Option<RtcSlowClkConfig>,
+///     _new_config: RtcSlowClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -927,8 +947,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_rtc_fast_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<RtcFastClkConfig>,
-///     _new_selector: RtcFastClkConfig,
+///     _old_config: Option<RtcFastClkConfig>,
+///     _new_config: RtcFastClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -941,8 +961,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_low_power_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<LowPowerClkConfig>,
-///     _new_selector: LowPowerClkConfig,
+///     _old_config: Option<LowPowerClkConfig>,
+///     _new_config: LowPowerClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -961,8 +981,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_rmt_sclk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<RmtSclkConfig>,
-///     _new_selector: RmtSclkConfig,
+///     _old_config: Option<RmtSclkConfig>,
+///     _new_config: RmtSclkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -975,8 +995,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_timg0_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Timg0FunctionClockConfig>,
-///     _new_selector: Timg0FunctionClockConfig,
+///     _old_config: Option<Timg0FunctionClockConfig>,
+///     _new_config: Timg0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -989,8 +1009,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_timg0_calibration_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Timg0CalibrationClockConfig>,
-///     _new_selector: Timg0CalibrationClockConfig,
+///     _old_config: Option<Timg0CalibrationClockConfig>,
+///     _new_config: Timg0CalibrationClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1003,8 +1023,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_timg0_wdt_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Timg0WdtClockConfig>,
-///     _new_selector: Timg0WdtClockConfig,
+///     _old_config: Option<Timg0WdtClockConfig>,
+///     _new_config: Timg0WdtClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1017,8 +1037,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_timg1_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Timg0FunctionClockConfig>,
-///     _new_selector: Timg0FunctionClockConfig,
+///     _old_config: Option<Timg0FunctionClockConfig>,
+///     _new_config: Timg0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1031,8 +1051,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_timg1_calibration_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Timg0CalibrationClockConfig>,
-///     _new_selector: Timg0CalibrationClockConfig,
+///     _old_config: Option<Timg0CalibrationClockConfig>,
+///     _new_config: Timg0CalibrationClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1045,8 +1065,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_timg1_wdt_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Timg0WdtClockConfig>,
-///     _new_selector: Timg0WdtClockConfig,
+///     _old_config: Option<Timg0WdtClockConfig>,
+///     _new_config: Timg0WdtClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1059,8 +1079,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_uart0_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Uart0FunctionClockConfig>,
-///     _new_selector: Uart0FunctionClockConfig,
+///     _old_config: Option<Uart0FunctionClockConfig>,
+///     _new_config: Uart0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1073,8 +1093,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_uart0_mem_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Uart0MemClockConfig>,
-///     _new_selector: Uart0MemClockConfig,
+///     _old_config: Option<Uart0MemClockConfig>,
+///     _new_config: Uart0MemClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1087,8 +1107,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_uart1_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Uart0FunctionClockConfig>,
-///     _new_selector: Uart0FunctionClockConfig,
+///     _old_config: Option<Uart0FunctionClockConfig>,
+///     _new_config: Uart0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1101,8 +1121,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_uart1_mem_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Uart0MemClockConfig>,
-///     _new_selector: Uart0MemClockConfig,
+///     _old_config: Option<Uart0MemClockConfig>,
+///     _new_config: Uart0MemClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1538,8 +1558,8 @@ macro_rules! define_clock_tree_types {
                 uart1_mem_clock_refcount: 0,
             });
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
-            clocks.xtal_clk = Some(config);
-            configure_xtal_clk_impl(clocks, config);
+            let old_config = clocks.xtal_clk.replace(config);
+            configure_xtal_clk_impl(clocks, old_config, config);
         }
         pub fn xtal_clk_config(clocks: &mut ClockTree) -> Option<XtalClkConfig> {
             clocks.xtal_clk
@@ -1550,8 +1570,8 @@ macro_rules! define_clock_tree_types {
             unwrap!(clocks.xtal_clk).value()
         }
         pub fn configure_pll_clk(clocks: &mut ClockTree, config: PllClkConfig) {
-            clocks.pll_clk = Some(config);
-            configure_pll_clk_impl(clocks, config);
+            let old_config = clocks.pll_clk.replace(config);
+            configure_pll_clk_impl(clocks, old_config, config);
         }
         pub fn pll_clk_config(clocks: &mut ClockTree) -> Option<PllClkConfig> {
             clocks.pll_clk
@@ -1686,8 +1706,8 @@ macro_rules! define_clock_tree_types {
             }
         }
         pub fn configure_system_pre_div(clocks: &mut ClockTree, config: SystemPreDivConfig) {
-            clocks.system_pre_div = Some(config);
-            configure_system_pre_div_impl(clocks, config);
+            let old_config = clocks.system_pre_div.replace(config);
+            configure_system_pre_div_impl(clocks, old_config, config);
         }
         pub fn system_pre_div_config(clocks: &mut ClockTree) -> Option<SystemPreDivConfig> {
             clocks.system_pre_div
@@ -1708,8 +1728,8 @@ macro_rules! define_clock_tree_types {
             (system_pre_div_in_frequency(clocks) / (unwrap!(clocks.system_pre_div).divisor() + 1))
         }
         pub fn configure_cpu_pll_div_out(clocks: &mut ClockTree, config: CpuPllDivOutConfig) {
-            clocks.cpu_pll_div_out = Some(config);
-            configure_cpu_pll_div_out_impl(clocks, config);
+            let old_config = clocks.cpu_pll_div_out.replace(config);
+            configure_cpu_pll_div_out_impl(clocks, old_config, config);
         }
         pub fn cpu_pll_div_out_config(clocks: &mut ClockTree) -> Option<CpuPllDivOutConfig> {
             clocks.cpu_pll_div_out
@@ -1902,8 +1922,8 @@ macro_rules! define_clock_tree_types {
             160000000
         }
         pub fn configure_rc_fast_clk_div_n(clocks: &mut ClockTree, config: RcFastClkDivNConfig) {
-            clocks.rc_fast_clk_div_n = Some(config);
-            configure_rc_fast_clk_div_n_impl(clocks, config);
+            let old_config = clocks.rc_fast_clk_div_n.replace(config);
+            configure_rc_fast_clk_div_n_impl(clocks, old_config, config);
         }
         pub fn rc_fast_clk_div_n_config(clocks: &mut ClockTree) -> Option<RcFastClkDivNConfig> {
             clocks.rc_fast_clk_div_n

--- a/esp-metadata-generated/src/_generated_esp32c5.rs
+++ b/esp-metadata-generated/src/_generated_esp32c5.rs
@@ -890,7 +890,11 @@ macro_rules! for_each_sha_algorithm {
 /// ```rust, no_run
 /// // XTAL_CLK
 ///
-/// fn configure_xtal_clk_impl(_clocks: &mut ClockTree, _config: XtalClkConfig) {
+/// fn configure_xtal_clk_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<XtalClkConfig>,
+///     _new_config: XtalClkConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -986,8 +990,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_hp_root_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<HpRootClkConfig>,
-///     _new_selector: HpRootClkConfig,
+///     _old_config: Option<HpRootClkConfig>,
+///     _new_config: HpRootClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -998,7 +1002,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_cpu_clk_impl(_clocks: &mut ClockTree, _new_config: CpuClkConfig) {
+/// fn configure_cpu_clk_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<CpuClkConfig>,
+///     _new_config: CpuClkConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -1008,7 +1016,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_ahb_clk_impl(_clocks: &mut ClockTree, _new_config: AhbClkConfig) {
+/// fn configure_ahb_clk_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<AhbClkConfig>,
+///     _new_config: AhbClkConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -1018,7 +1030,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_apb_clk_impl(_clocks: &mut ClockTree, _new_config: ApbClkConfig) {
+/// fn configure_apb_clk_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<ApbClkConfig>,
+///     _new_config: ApbClkConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -1036,8 +1052,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_lp_fast_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<LpFastClkConfig>,
-///     _new_selector: LpFastClkConfig,
+///     _old_config: Option<LpFastClkConfig>,
+///     _new_config: LpFastClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1050,8 +1066,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_lp_slow_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<LpSlowClkConfig>,
-///     _new_selector: LpSlowClkConfig,
+///     _old_config: Option<LpSlowClkConfig>,
+///     _new_config: LpSlowClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1064,8 +1080,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_crypto_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<CryptoClkConfig>,
-///     _new_selector: CryptoClkConfig,
+///     _old_config: Option<CryptoClkConfig>,
+///     _new_config: CryptoClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1078,8 +1094,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_timg_calibration_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<TimgCalibrationClockConfig>,
-///     _new_selector: TimgCalibrationClockConfig,
+///     _old_config: Option<TimgCalibrationClockConfig>,
+///     _new_config: TimgCalibrationClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1092,8 +1108,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_parlio_rx_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<ParlioRxClockConfig>,
-///     _new_selector: ParlioRxClockConfig,
+///     _old_config: Option<ParlioRxClockConfig>,
+///     _new_config: ParlioRxClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1106,8 +1122,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_parlio_tx_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<ParlioTxClockConfig>,
-///     _new_selector: ParlioTxClockConfig,
+///     _old_config: Option<ParlioTxClockConfig>,
+///     _new_config: ParlioTxClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1120,8 +1136,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_rmt_sclk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<RmtSclkConfig>,
-///     _new_selector: RmtSclkConfig,
+///     _old_config: Option<RmtSclkConfig>,
+///     _new_config: RmtSclkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1134,8 +1150,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_timg0_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Timg0FunctionClockConfig>,
-///     _new_selector: Timg0FunctionClockConfig,
+///     _old_config: Option<Timg0FunctionClockConfig>,
+///     _new_config: Timg0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1148,8 +1164,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_timg0_wdt_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Timg0WdtClockConfig>,
-///     _new_selector: Timg0WdtClockConfig,
+///     _old_config: Option<Timg0WdtClockConfig>,
+///     _new_config: Timg0WdtClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1162,8 +1178,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_timg1_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Timg0FunctionClockConfig>,
-///     _new_selector: Timg0FunctionClockConfig,
+///     _old_config: Option<Timg0FunctionClockConfig>,
+///     _new_config: Timg0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1176,8 +1192,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_timg1_wdt_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Timg0WdtClockConfig>,
-///     _new_selector: Timg0WdtClockConfig,
+///     _old_config: Option<Timg0WdtClockConfig>,
+///     _new_config: Timg0WdtClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1190,8 +1206,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_uart0_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Uart0FunctionClockConfig>,
-///     _new_selector: Uart0FunctionClockConfig,
+///     _old_config: Option<Uart0FunctionClockConfig>,
+///     _new_config: Uart0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1204,8 +1220,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_uart1_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Uart0FunctionClockConfig>,
-///     _new_selector: Uart0FunctionClockConfig,
+///     _old_config: Option<Uart0FunctionClockConfig>,
+///     _new_config: Uart0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1623,8 +1639,8 @@ macro_rules! define_clock_tree_types {
                 uart1_function_clock_refcount: 0,
             });
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
-            clocks.xtal_clk = Some(config);
-            configure_xtal_clk_impl(clocks, config);
+            let old_config = clocks.xtal_clk.replace(config);
+            configure_xtal_clk_impl(clocks, old_config, config);
         }
         pub fn xtal_clk_config(clocks: &mut ClockTree) -> Option<XtalClkConfig> {
             clocks.xtal_clk
@@ -1948,8 +1964,8 @@ macro_rules! define_clock_tree_types {
             }
         }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, config: CpuClkConfig) {
-            clocks.cpu_clk = Some(config);
-            configure_cpu_clk_impl(clocks, config);
+            let old_config = clocks.cpu_clk.replace(config);
+            configure_cpu_clk_impl(clocks, old_config, config);
         }
         pub fn cpu_clk_config(clocks: &mut ClockTree) -> Option<CpuClkConfig> {
             clocks.cpu_clk
@@ -1974,8 +1990,8 @@ macro_rules! define_clock_tree_types {
             (hp_root_clk_frequency(clocks) / (unwrap!(clocks.cpu_clk).divisor() + 1))
         }
         pub fn configure_ahb_clk(clocks: &mut ClockTree, config: AhbClkConfig) {
-            clocks.ahb_clk = Some(config);
-            configure_ahb_clk_impl(clocks, config);
+            let old_config = clocks.ahb_clk.replace(config);
+            configure_ahb_clk_impl(clocks, old_config, config);
         }
         pub fn ahb_clk_config(clocks: &mut ClockTree) -> Option<AhbClkConfig> {
             clocks.ahb_clk
@@ -1996,8 +2012,8 @@ macro_rules! define_clock_tree_types {
             (hp_root_clk_frequency(clocks) / (unwrap!(clocks.ahb_clk).divisor() + 1))
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, config: ApbClkConfig) {
-            clocks.apb_clk = Some(config);
-            configure_apb_clk_impl(clocks, config);
+            let old_config = clocks.apb_clk.replace(config);
+            configure_apb_clk_impl(clocks, old_config, config);
         }
         pub fn apb_clk_config(clocks: &mut ClockTree) -> Option<ApbClkConfig> {
             clocks.apb_clk

--- a/esp-metadata-generated/src/_generated_esp32c6.rs
+++ b/esp-metadata-generated/src/_generated_esp32c6.rs
@@ -842,7 +842,11 @@ macro_rules! for_each_sha_algorithm {
 /// ```rust, no_run
 /// // XTAL_CLK
 ///
-/// fn configure_xtal_clk_impl(_clocks: &mut ClockTree, _config: XtalClkConfig) {
+/// fn configure_xtal_clk_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<XtalClkConfig>,
+///     _new_config: XtalClkConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -882,7 +886,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_hp_root_clk_impl(_clocks: &mut ClockTree, _new_config: HpRootClkConfig) {
+/// fn configure_hp_root_clk_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<HpRootClkConfig>,
+///     _new_config: HpRootClkConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -890,8 +898,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_cpu_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<CpuClkConfig>,
-///     _new_selector: CpuClkConfig,
+///     _old_config: Option<CpuClkConfig>,
+///     _new_config: CpuClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -900,8 +908,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_ahb_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<AhbClkConfig>,
-///     _new_selector: AhbClkConfig,
+///     _old_config: Option<AhbClkConfig>,
+///     _new_config: AhbClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -914,8 +922,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_mspi_fast_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<MspiFastClkConfig>,
-///     _new_selector: MspiFastClkConfig,
+///     _old_config: Option<MspiFastClkConfig>,
+///     _new_config: MspiFastClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -928,8 +936,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_soc_root_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<SocRootClkConfig>,
-///     _new_selector: SocRootClkConfig,
+///     _old_config: Option<SocRootClkConfig>,
+///     _new_config: SocRootClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -940,7 +948,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_cpu_hs_div_impl(_clocks: &mut ClockTree, _new_config: CpuHsDivConfig) {
+/// fn configure_cpu_hs_div_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<CpuHsDivConfig>,
+///     _new_config: CpuHsDivConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -950,7 +962,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_cpu_ls_div_impl(_clocks: &mut ClockTree, _new_config: CpuLsDivConfig) {
+/// fn configure_cpu_ls_div_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<CpuLsDivConfig>,
+///     _new_config: CpuLsDivConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -960,7 +976,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_ahb_hs_div_impl(_clocks: &mut ClockTree, _new_config: AhbHsDivConfig) {
+/// fn configure_ahb_hs_div_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<AhbHsDivConfig>,
+///     _new_config: AhbHsDivConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -970,7 +990,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_ahb_ls_div_impl(_clocks: &mut ClockTree, _new_config: AhbLsDivConfig) {
+/// fn configure_ahb_ls_div_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<AhbLsDivConfig>,
+///     _new_config: AhbLsDivConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -980,7 +1004,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_apb_clk_impl(_clocks: &mut ClockTree, _new_config: ApbClkConfig) {
+/// fn configure_apb_clk_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<ApbClkConfig>,
+///     _new_config: ApbClkConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -990,7 +1018,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_mspi_fast_hs_clk_impl(_clocks: &mut ClockTree, _new_config: MspiFastHsClkConfig) {
+/// fn configure_mspi_fast_hs_clk_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<MspiFastHsClkConfig>,
+///     _new_config: MspiFastHsClkConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -1000,7 +1032,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_mspi_fast_ls_clk_impl(_clocks: &mut ClockTree, _new_config: MspiFastLsClkConfig) {
+/// fn configure_mspi_fast_ls_clk_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<MspiFastLsClkConfig>,
+///     _new_config: MspiFastLsClkConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -1036,8 +1072,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_ledc_sclk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<LedcSclkConfig>,
-///     _new_selector: LedcSclkConfig,
+///     _old_config: Option<LedcSclkConfig>,
+///     _new_config: LedcSclkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1056,8 +1092,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_lp_fast_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<LpFastClkConfig>,
-///     _new_selector: LpFastClkConfig,
+///     _old_config: Option<LpFastClkConfig>,
+///     _new_config: LpFastClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1070,8 +1106,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_lp_slow_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<LpSlowClkConfig>,
-///     _new_selector: LpSlowClkConfig,
+///     _old_config: Option<LpSlowClkConfig>,
+///     _new_config: LpSlowClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1084,8 +1120,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_mcpwm0_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Mcpwm0FunctionClockConfig>,
-///     _new_selector: Mcpwm0FunctionClockConfig,
+///     _old_config: Option<Mcpwm0FunctionClockConfig>,
+///     _new_config: Mcpwm0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1098,8 +1134,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_parlio_rx_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<ParlioRxClockConfig>,
-///     _new_selector: ParlioRxClockConfig,
+///     _old_config: Option<ParlioRxClockConfig>,
+///     _new_config: ParlioRxClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1112,8 +1148,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_parlio_tx_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<ParlioTxClockConfig>,
-///     _new_selector: ParlioTxClockConfig,
+///     _old_config: Option<ParlioTxClockConfig>,
+///     _new_config: ParlioTxClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1126,8 +1162,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_rmt_sclk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<RmtSclkConfig>,
-///     _new_selector: RmtSclkConfig,
+///     _old_config: Option<RmtSclkConfig>,
+///     _new_config: RmtSclkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1140,8 +1176,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_timg0_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Timg0FunctionClockConfig>,
-///     _new_selector: Timg0FunctionClockConfig,
+///     _old_config: Option<Timg0FunctionClockConfig>,
+///     _new_config: Timg0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1154,8 +1190,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_timg0_calibration_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Timg0CalibrationClockConfig>,
-///     _new_selector: Timg0CalibrationClockConfig,
+///     _old_config: Option<Timg0CalibrationClockConfig>,
+///     _new_config: Timg0CalibrationClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1168,8 +1204,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_timg0_wdt_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Timg0WdtClockConfig>,
-///     _new_selector: Timg0WdtClockConfig,
+///     _old_config: Option<Timg0WdtClockConfig>,
+///     _new_config: Timg0WdtClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1182,8 +1218,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_timg1_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Timg0FunctionClockConfig>,
-///     _new_selector: Timg0FunctionClockConfig,
+///     _old_config: Option<Timg0FunctionClockConfig>,
+///     _new_config: Timg0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1196,8 +1232,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_timg1_calibration_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Timg0CalibrationClockConfig>,
-///     _new_selector: Timg0CalibrationClockConfig,
+///     _old_config: Option<Timg0CalibrationClockConfig>,
+///     _new_config: Timg0CalibrationClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1210,8 +1246,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_timg1_wdt_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Timg0WdtClockConfig>,
-///     _new_selector: Timg0WdtClockConfig,
+///     _old_config: Option<Timg0WdtClockConfig>,
+///     _new_config: Timg0WdtClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1224,8 +1260,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_uart0_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Uart0FunctionClockConfig>,
-///     _new_selector: Uart0FunctionClockConfig,
+///     _old_config: Option<Uart0FunctionClockConfig>,
+///     _new_config: Uart0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1238,8 +1274,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_uart1_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Uart0FunctionClockConfig>,
-///     _new_selector: Uart0FunctionClockConfig,
+///     _old_config: Option<Uart0FunctionClockConfig>,
+///     _new_config: Uart0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1961,8 +1997,8 @@ macro_rules! define_clock_tree_types {
                 uart1_function_clock_refcount: 0,
             });
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
-            clocks.xtal_clk = Some(config);
-            configure_xtal_clk_impl(clocks, config);
+            let old_config = clocks.xtal_clk.replace(config);
+            configure_xtal_clk_impl(clocks, old_config, config);
         }
         pub fn xtal_clk_config(clocks: &mut ClockTree) -> Option<XtalClkConfig> {
             clocks.xtal_clk
@@ -2052,8 +2088,8 @@ macro_rules! define_clock_tree_types {
             136000
         }
         pub fn configure_hp_root_clk(clocks: &mut ClockTree, config: HpRootClkConfig) {
-            clocks.hp_root_clk = Some(config);
-            configure_hp_root_clk_impl(clocks, config);
+            let old_config = clocks.hp_root_clk.replace(config);
+            configure_hp_root_clk_impl(clocks, old_config, config);
         }
         pub fn hp_root_clk_config(clocks: &mut ClockTree) -> Option<HpRootClkConfig> {
             clocks.hp_root_clk
@@ -2246,8 +2282,8 @@ macro_rules! define_clock_tree_types {
             }
         }
         pub fn configure_cpu_hs_div(clocks: &mut ClockTree, config: CpuHsDivConfig) {
-            clocks.cpu_hs_div = Some(config);
-            configure_cpu_hs_div_impl(clocks, config);
+            let old_config = clocks.cpu_hs_div.replace(config);
+            configure_cpu_hs_div_impl(clocks, old_config, config);
         }
         pub fn cpu_hs_div_config(clocks: &mut ClockTree) -> Option<CpuHsDivConfig> {
             clocks.cpu_hs_div
@@ -2268,8 +2304,8 @@ macro_rules! define_clock_tree_types {
             (hp_root_clk_frequency(clocks) / (unwrap!(clocks.cpu_hs_div).divisor() + 1))
         }
         pub fn configure_cpu_ls_div(clocks: &mut ClockTree, config: CpuLsDivConfig) {
-            clocks.cpu_ls_div = Some(config);
-            configure_cpu_ls_div_impl(clocks, config);
+            let old_config = clocks.cpu_ls_div.replace(config);
+            configure_cpu_ls_div_impl(clocks, old_config, config);
         }
         pub fn cpu_ls_div_config(clocks: &mut ClockTree) -> Option<CpuLsDivConfig> {
             clocks.cpu_ls_div
@@ -2290,8 +2326,8 @@ macro_rules! define_clock_tree_types {
             (hp_root_clk_frequency(clocks) / (unwrap!(clocks.cpu_ls_div).divisor() + 1))
         }
         pub fn configure_ahb_hs_div(clocks: &mut ClockTree, config: AhbHsDivConfig) {
-            clocks.ahb_hs_div = Some(config);
-            configure_ahb_hs_div_impl(clocks, config);
+            let old_config = clocks.ahb_hs_div.replace(config);
+            configure_ahb_hs_div_impl(clocks, old_config, config);
         }
         pub fn ahb_hs_div_config(clocks: &mut ClockTree) -> Option<AhbHsDivConfig> {
             clocks.ahb_hs_div
@@ -2312,8 +2348,8 @@ macro_rules! define_clock_tree_types {
             (hp_root_clk_frequency(clocks) / (unwrap!(clocks.ahb_hs_div).divisor() + 1))
         }
         pub fn configure_ahb_ls_div(clocks: &mut ClockTree, config: AhbLsDivConfig) {
-            clocks.ahb_ls_div = Some(config);
-            configure_ahb_ls_div_impl(clocks, config);
+            let old_config = clocks.ahb_ls_div.replace(config);
+            configure_ahb_ls_div_impl(clocks, old_config, config);
         }
         pub fn ahb_ls_div_config(clocks: &mut ClockTree) -> Option<AhbLsDivConfig> {
             clocks.ahb_ls_div
@@ -2334,8 +2370,8 @@ macro_rules! define_clock_tree_types {
             (hp_root_clk_frequency(clocks) / (unwrap!(clocks.ahb_ls_div).divisor() + 1))
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, config: ApbClkConfig) {
-            clocks.apb_clk = Some(config);
-            configure_apb_clk_impl(clocks, config);
+            let old_config = clocks.apb_clk.replace(config);
+            configure_apb_clk_impl(clocks, old_config, config);
         }
         pub fn apb_clk_config(clocks: &mut ClockTree) -> Option<ApbClkConfig> {
             clocks.apb_clk
@@ -2360,8 +2396,8 @@ macro_rules! define_clock_tree_types {
             (ahb_clk_frequency(clocks) / (unwrap!(clocks.apb_clk).divisor() + 1))
         }
         pub fn configure_mspi_fast_hs_clk(clocks: &mut ClockTree, config: MspiFastHsClkConfig) {
-            clocks.mspi_fast_hs_clk = Some(config);
-            configure_mspi_fast_hs_clk_impl(clocks, config);
+            let old_config = clocks.mspi_fast_hs_clk.replace(config);
+            configure_mspi_fast_hs_clk_impl(clocks, old_config, config);
         }
         pub fn mspi_fast_hs_clk_config(clocks: &mut ClockTree) -> Option<MspiFastHsClkConfig> {
             clocks.mspi_fast_hs_clk
@@ -2382,8 +2418,8 @@ macro_rules! define_clock_tree_types {
             (hp_root_clk_frequency(clocks) / (unwrap!(clocks.mspi_fast_hs_clk).divisor() + 1))
         }
         pub fn configure_mspi_fast_ls_clk(clocks: &mut ClockTree, config: MspiFastLsClkConfig) {
-            clocks.mspi_fast_ls_clk = Some(config);
-            configure_mspi_fast_ls_clk_impl(clocks, config);
+            let old_config = clocks.mspi_fast_ls_clk.replace(config);
+            configure_mspi_fast_ls_clk_impl(clocks, old_config, config);
         }
         pub fn mspi_fast_ls_clk_config(clocks: &mut ClockTree) -> Option<MspiFastLsClkConfig> {
             clocks.mspi_fast_ls_clk

--- a/esp-metadata-generated/src/_generated_esp32h2.rs
+++ b/esp-metadata-generated/src/_generated_esp32h2.rs
@@ -816,7 +816,11 @@ macro_rules! for_each_sha_algorithm {
 /// ```rust, no_run
 /// // XTAL_CLK
 ///
-/// fn configure_xtal_clk_impl(_clocks: &mut ClockTree, _config: XtalClkConfig) {
+/// fn configure_xtal_clk_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<XtalClkConfig>,
+///     _new_config: XtalClkConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -876,8 +880,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_hp_root_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<HpRootClkConfig>,
-///     _new_selector: HpRootClkConfig,
+///     _old_config: Option<HpRootClkConfig>,
+///     _new_config: HpRootClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -888,7 +892,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_cpu_clk_impl(_clocks: &mut ClockTree, _new_config: CpuClkConfig) {
+/// fn configure_cpu_clk_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<CpuClkConfig>,
+///     _new_config: CpuClkConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -898,7 +906,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_ahb_clk_impl(_clocks: &mut ClockTree, _new_config: AhbClkConfig) {
+/// fn configure_ahb_clk_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<AhbClkConfig>,
+///     _new_config: AhbClkConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -908,7 +920,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_apb_clk_impl(_clocks: &mut ClockTree, _new_config: ApbClkConfig) {
+/// fn configure_apb_clk_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<ApbClkConfig>,
+///     _new_config: ApbClkConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -926,8 +942,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_lp_fast_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<LpFastClkConfig>,
-///     _new_selector: LpFastClkConfig,
+///     _old_config: Option<LpFastClkConfig>,
+///     _new_config: LpFastClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -940,8 +956,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_lp_slow_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<LpSlowClkConfig>,
-///     _new_selector: LpSlowClkConfig,
+///     _old_config: Option<LpSlowClkConfig>,
+///     _new_config: LpSlowClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -954,8 +970,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_mcpwm0_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Mcpwm0FunctionClockConfig>,
-///     _new_selector: Mcpwm0FunctionClockConfig,
+///     _old_config: Option<Mcpwm0FunctionClockConfig>,
+///     _new_config: Mcpwm0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -968,8 +984,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_parlio_rx_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<ParlioRxClockConfig>,
-///     _new_selector: ParlioRxClockConfig,
+///     _old_config: Option<ParlioRxClockConfig>,
+///     _new_config: ParlioRxClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -982,8 +998,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_parlio_tx_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<ParlioTxClockConfig>,
-///     _new_selector: ParlioTxClockConfig,
+///     _old_config: Option<ParlioTxClockConfig>,
+///     _new_config: ParlioTxClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -996,8 +1012,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_rmt_sclk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<RmtSclkConfig>,
-///     _new_selector: RmtSclkConfig,
+///     _old_config: Option<RmtSclkConfig>,
+///     _new_config: RmtSclkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1010,8 +1026,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_timg0_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Timg0FunctionClockConfig>,
-///     _new_selector: Timg0FunctionClockConfig,
+///     _old_config: Option<Timg0FunctionClockConfig>,
+///     _new_config: Timg0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1024,8 +1040,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_timg0_calibration_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Timg0CalibrationClockConfig>,
-///     _new_selector: Timg0CalibrationClockConfig,
+///     _old_config: Option<Timg0CalibrationClockConfig>,
+///     _new_config: Timg0CalibrationClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1038,8 +1054,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_timg0_wdt_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Timg0WdtClockConfig>,
-///     _new_selector: Timg0WdtClockConfig,
+///     _old_config: Option<Timg0WdtClockConfig>,
+///     _new_config: Timg0WdtClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1052,8 +1068,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_timg1_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Timg0FunctionClockConfig>,
-///     _new_selector: Timg0FunctionClockConfig,
+///     _old_config: Option<Timg0FunctionClockConfig>,
+///     _new_config: Timg0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1066,8 +1082,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_timg1_calibration_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Timg0CalibrationClockConfig>,
-///     _new_selector: Timg0CalibrationClockConfig,
+///     _old_config: Option<Timg0CalibrationClockConfig>,
+///     _new_config: Timg0CalibrationClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1080,8 +1096,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_timg1_wdt_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Timg0WdtClockConfig>,
-///     _new_selector: Timg0WdtClockConfig,
+///     _old_config: Option<Timg0WdtClockConfig>,
+///     _new_config: Timg0WdtClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1094,8 +1110,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_uart0_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Uart0FunctionClockConfig>,
-///     _new_selector: Uart0FunctionClockConfig,
+///     _old_config: Option<Uart0FunctionClockConfig>,
+///     _new_config: Uart0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1108,8 +1124,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_uart1_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Uart0FunctionClockConfig>,
-///     _new_selector: Uart0FunctionClockConfig,
+///     _old_config: Option<Uart0FunctionClockConfig>,
+///     _new_config: Uart0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1511,8 +1527,8 @@ macro_rules! define_clock_tree_types {
                 uart1_function_clock_refcount: 0,
             });
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
-            clocks.xtal_clk = Some(config);
-            configure_xtal_clk_impl(clocks, config);
+            let old_config = clocks.xtal_clk.replace(config);
+            configure_xtal_clk_impl(clocks, old_config, config);
         }
         pub fn xtal_clk_config(clocks: &mut ClockTree) -> Option<XtalClkConfig> {
             clocks.xtal_clk
@@ -1710,8 +1726,8 @@ macro_rules! define_clock_tree_types {
             }
         }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, config: CpuClkConfig) {
-            clocks.cpu_clk = Some(config);
-            configure_cpu_clk_impl(clocks, config);
+            let old_config = clocks.cpu_clk.replace(config);
+            configure_cpu_clk_impl(clocks, old_config, config);
         }
         pub fn cpu_clk_config(clocks: &mut ClockTree) -> Option<CpuClkConfig> {
             clocks.cpu_clk
@@ -1736,8 +1752,8 @@ macro_rules! define_clock_tree_types {
             (hp_root_clk_frequency(clocks) / (unwrap!(clocks.cpu_clk).divisor() + 1))
         }
         pub fn configure_ahb_clk(clocks: &mut ClockTree, config: AhbClkConfig) {
-            clocks.ahb_clk = Some(config);
-            configure_ahb_clk_impl(clocks, config);
+            let old_config = clocks.ahb_clk.replace(config);
+            configure_ahb_clk_impl(clocks, old_config, config);
         }
         pub fn ahb_clk_config(clocks: &mut ClockTree) -> Option<AhbClkConfig> {
             clocks.ahb_clk
@@ -1758,8 +1774,8 @@ macro_rules! define_clock_tree_types {
             (hp_root_clk_frequency(clocks) / (unwrap!(clocks.ahb_clk).divisor() + 1))
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, config: ApbClkConfig) {
-            clocks.apb_clk = Some(config);
-            configure_apb_clk_impl(clocks, config);
+            let old_config = clocks.apb_clk.replace(config);
+            configure_apb_clk_impl(clocks, old_config, config);
         }
         pub fn apb_clk_config(clocks: &mut ClockTree) -> Option<ApbClkConfig> {
             clocks.apb_clk

--- a/esp-metadata-generated/src/_generated_esp32s2.rs
+++ b/esp-metadata-generated/src/_generated_esp32s2.rs
@@ -683,7 +683,11 @@ macro_rules! for_each_sha_algorithm {
 /// ```rust, no_run
 /// // XTAL_CLK
 ///
-/// fn configure_xtal_clk_impl(_clocks: &mut ClockTree, _config: XtalClkConfig) {
+/// fn configure_xtal_clk_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<XtalClkConfig>,
+///     _new_config: XtalClkConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -693,7 +697,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_pll_clk_impl(_clocks: &mut ClockTree, _config: PllClkConfig) {
+/// fn configure_pll_clk_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<PllClkConfig>,
+///     _new_config: PllClkConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -703,7 +711,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_apll_clk_impl(_clocks: &mut ClockTree, _config: ApllClkConfig) {
+/// fn configure_apll_clk_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<ApllClkConfig>,
+///     _new_config: ApllClkConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -721,8 +733,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_cpu_pll_div_in_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<CpuPllDivInConfig>,
-///     _new_selector: CpuPllDivInConfig,
+///     _old_config: Option<CpuPllDivInConfig>,
+///     _new_config: CpuPllDivInConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -733,7 +745,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_cpu_pll_div_impl(_clocks: &mut ClockTree, _new_config: CpuPllDivConfig) {
+/// fn configure_cpu_pll_div_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<CpuPllDivConfig>,
+///     _new_config: CpuPllDivConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -745,8 +761,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_system_pre_div_in_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<SystemPreDivInConfig>,
-///     _new_selector: SystemPreDivInConfig,
+///     _old_config: Option<SystemPreDivInConfig>,
+///     _new_config: SystemPreDivInConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -757,7 +773,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_system_pre_div_impl(_clocks: &mut ClockTree, _new_config: SystemPreDivConfig) {
+/// fn configure_system_pre_div_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<SystemPreDivConfig>,
+///     _new_config: SystemPreDivConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -769,8 +789,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_apb_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<ApbClkConfig>,
-///     _new_selector: ApbClkConfig,
+///     _old_config: Option<ApbClkConfig>,
+///     _new_config: ApbClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -783,8 +803,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_ref_tick_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<RefTickConfig>,
-///     _new_selector: RefTickConfig,
+///     _old_config: Option<RefTickConfig>,
+///     _new_config: RefTickConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -795,7 +815,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_ref_tick_xtal_impl(_clocks: &mut ClockTree, _new_config: RefTickXtalConfig) {
+/// fn configure_ref_tick_xtal_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<RefTickXtalConfig>,
+///     _new_config: RefTickXtalConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -805,7 +829,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_ref_tick_ck8m_impl(_clocks: &mut ClockTree, _new_config: RefTickCk8mConfig) {
+/// fn configure_ref_tick_ck8m_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<RefTickCk8mConfig>,
+///     _new_config: RefTickCk8mConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -813,8 +841,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_cpu_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<CpuClkConfig>,
-///     _new_selector: CpuClkConfig,
+///     _old_config: Option<CpuClkConfig>,
+///     _new_config: CpuClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -863,8 +891,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_rtc_slow_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<RtcSlowClkConfig>,
-///     _new_selector: RtcSlowClkConfig,
+///     _old_config: Option<RtcSlowClkConfig>,
+///     _new_config: RtcSlowClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -877,8 +905,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_rtc_fast_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<RtcFastClkConfig>,
-///     _new_selector: RtcFastClkConfig,
+///     _old_config: Option<RtcFastClkConfig>,
+///     _new_config: RtcFastClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -897,8 +925,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_timg0_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Timg0FunctionClockConfig>,
-///     _new_selector: Timg0FunctionClockConfig,
+///     _old_config: Option<Timg0FunctionClockConfig>,
+///     _new_config: Timg0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -911,8 +939,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_timg0_calibration_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Timg0CalibrationClockConfig>,
-///     _new_selector: Timg0CalibrationClockConfig,
+///     _old_config: Option<Timg0CalibrationClockConfig>,
+///     _new_config: Timg0CalibrationClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -925,8 +953,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_timg1_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Timg0FunctionClockConfig>,
-///     _new_selector: Timg0FunctionClockConfig,
+///     _old_config: Option<Timg0FunctionClockConfig>,
+///     _new_config: Timg0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -939,8 +967,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_timg1_calibration_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Timg0CalibrationClockConfig>,
-///     _new_selector: Timg0CalibrationClockConfig,
+///     _old_config: Option<Timg0CalibrationClockConfig>,
+///     _new_config: Timg0CalibrationClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -953,8 +981,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_uart0_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Uart0FunctionClockConfig>,
-///     _new_selector: Uart0FunctionClockConfig,
+///     _old_config: Option<Uart0FunctionClockConfig>,
+///     _new_config: Uart0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -967,8 +995,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_uart0_mem_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Uart0MemClockConfig>,
-///     _new_selector: Uart0MemClockConfig,
+///     _old_config: Option<Uart0MemClockConfig>,
+///     _new_config: Uart0MemClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -981,8 +1009,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_uart1_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Uart0FunctionClockConfig>,
-///     _new_selector: Uart0FunctionClockConfig,
+///     _old_config: Option<Uart0FunctionClockConfig>,
+///     _new_config: Uart0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -995,8 +1023,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_uart1_mem_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Uart0MemClockConfig>,
-///     _new_selector: Uart0MemClockConfig,
+///     _old_config: Option<Uart0MemClockConfig>,
+///     _new_config: Uart0MemClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1479,8 +1507,8 @@ macro_rules! define_clock_tree_types {
                 uart1_mem_clock_refcount: 0,
             });
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
-            clocks.xtal_clk = Some(config);
-            configure_xtal_clk_impl(clocks, config);
+            let old_config = clocks.xtal_clk.replace(config);
+            configure_xtal_clk_impl(clocks, old_config, config);
         }
         pub fn xtal_clk_config(clocks: &mut ClockTree) -> Option<XtalClkConfig> {
             clocks.xtal_clk
@@ -1491,8 +1519,8 @@ macro_rules! define_clock_tree_types {
             unwrap!(clocks.xtal_clk).value()
         }
         pub fn configure_pll_clk(clocks: &mut ClockTree, config: PllClkConfig) {
-            clocks.pll_clk = Some(config);
-            configure_pll_clk_impl(clocks, config);
+            let old_config = clocks.pll_clk.replace(config);
+            configure_pll_clk_impl(clocks, old_config, config);
         }
         pub fn pll_clk_config(clocks: &mut ClockTree) -> Option<PllClkConfig> {
             clocks.pll_clk
@@ -1517,8 +1545,8 @@ macro_rules! define_clock_tree_types {
             unwrap!(clocks.pll_clk).value()
         }
         pub fn configure_apll_clk(clocks: &mut ClockTree, config: ApllClkConfig) {
-            clocks.apll_clk = Some(config);
-            configure_apll_clk_impl(clocks, config);
+            let old_config = clocks.apll_clk.replace(config);
+            configure_apll_clk_impl(clocks, old_config, config);
         }
         pub fn apll_clk_config(clocks: &mut ClockTree) -> Option<ApllClkConfig> {
             clocks.apll_clk
@@ -1597,8 +1625,8 @@ macro_rules! define_clock_tree_types {
             }
         }
         pub fn configure_cpu_pll_div(clocks: &mut ClockTree, config: CpuPllDivConfig) {
-            clocks.cpu_pll_div = Some(config);
-            configure_cpu_pll_div_impl(clocks, config);
+            let old_config = clocks.cpu_pll_div.replace(config);
+            configure_cpu_pll_div_impl(clocks, old_config, config);
         }
         pub fn cpu_pll_div_config(clocks: &mut ClockTree) -> Option<CpuPllDivConfig> {
             clocks.cpu_pll_div
@@ -1663,8 +1691,8 @@ macro_rules! define_clock_tree_types {
             }
         }
         pub fn configure_system_pre_div(clocks: &mut ClockTree, config: SystemPreDivConfig) {
-            clocks.system_pre_div = Some(config);
-            configure_system_pre_div_impl(clocks, config);
+            let old_config = clocks.system_pre_div.replace(config);
+            configure_system_pre_div_impl(clocks, old_config, config);
         }
         pub fn system_pre_div_config(clocks: &mut ClockTree) -> Option<SystemPreDivConfig> {
             clocks.system_pre_div
@@ -1803,8 +1831,8 @@ macro_rules! define_clock_tree_types {
             }
         }
         pub fn configure_ref_tick_xtal(clocks: &mut ClockTree, config: RefTickXtalConfig) {
-            clocks.ref_tick_xtal = Some(config);
-            configure_ref_tick_xtal_impl(clocks, config);
+            let old_config = clocks.ref_tick_xtal.replace(config);
+            configure_ref_tick_xtal_impl(clocks, old_config, config);
         }
         pub fn ref_tick_xtal_config(clocks: &mut ClockTree) -> Option<RefTickXtalConfig> {
             clocks.ref_tick_xtal
@@ -1825,8 +1853,8 @@ macro_rules! define_clock_tree_types {
             (xtal_clk_frequency(clocks) / (unwrap!(clocks.ref_tick_xtal).divisor() + 1))
         }
         pub fn configure_ref_tick_ck8m(clocks: &mut ClockTree, config: RefTickCk8mConfig) {
-            clocks.ref_tick_ck8m = Some(config);
-            configure_ref_tick_ck8m_impl(clocks, config);
+            let old_config = clocks.ref_tick_ck8m.replace(config);
+            configure_ref_tick_ck8m_impl(clocks, old_config, config);
         }
         pub fn ref_tick_ck8m_config(clocks: &mut ClockTree) -> Option<RefTickCk8mConfig> {
             clocks.ref_tick_ck8m

--- a/esp-metadata-generated/src/_generated_esp32s3.rs
+++ b/esp-metadata-generated/src/_generated_esp32s3.rs
@@ -714,7 +714,11 @@ macro_rules! for_each_sha_algorithm {
 /// ```rust, no_run
 /// // XTAL_CLK
 ///
-/// fn configure_xtal_clk_impl(_clocks: &mut ClockTree, _config: XtalClkConfig) {
+/// fn configure_xtal_clk_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<XtalClkConfig>,
+///     _new_config: XtalClkConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -724,7 +728,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_pll_clk_impl(_clocks: &mut ClockTree, _config: PllClkConfig) {
+/// fn configure_pll_clk_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<PllClkConfig>,
+///     _new_config: PllClkConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -760,8 +768,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_system_pre_div_in_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<SystemPreDivInConfig>,
-///     _new_selector: SystemPreDivInConfig,
+///     _old_config: Option<SystemPreDivInConfig>,
+///     _new_config: SystemPreDivInConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -772,7 +780,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_system_pre_div_impl(_clocks: &mut ClockTree, _new_config: SystemPreDivConfig) {
+/// fn configure_system_pre_div_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<SystemPreDivConfig>,
+///     _new_config: SystemPreDivConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -782,7 +794,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_cpu_pll_div_out_impl(_clocks: &mut ClockTree, _config: CpuPllDivOutConfig) {
+/// fn configure_cpu_pll_div_out_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<CpuPllDivOutConfig>,
+///     _new_config: CpuPllDivOutConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -794,8 +810,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_apb_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<ApbClkConfig>,
-///     _new_selector: ApbClkConfig,
+///     _old_config: Option<ApbClkConfig>,
+///     _new_config: ApbClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -808,8 +824,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_crypto_pwm_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<CryptoPwmClkConfig>,
-///     _new_selector: CryptoPwmClkConfig,
+///     _old_config: Option<CryptoPwmClkConfig>,
+///     _new_config: CryptoPwmClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -818,8 +834,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_cpu_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<CpuClkConfig>,
-///     _new_selector: CpuClkConfig,
+///     _old_config: Option<CpuClkConfig>,
+///     _new_config: CpuClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -848,7 +864,11 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
-/// fn configure_rc_fast_clk_div_n_impl(_clocks: &mut ClockTree, _new_config: RcFastClkDivNConfig) {
+/// fn configure_rc_fast_clk_div_n_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<RcFastClkDivNConfig>,
+///     _new_config: RcFastClkDivNConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -866,8 +886,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_rtc_slow_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<RtcSlowClkConfig>,
-///     _new_selector: RtcSlowClkConfig,
+///     _old_config: Option<RtcSlowClkConfig>,
+///     _new_config: RtcSlowClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -880,8 +900,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_rtc_fast_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<RtcFastClkConfig>,
-///     _new_selector: RtcFastClkConfig,
+///     _old_config: Option<RtcFastClkConfig>,
+///     _new_config: RtcFastClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -894,8 +914,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_low_power_clk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<LowPowerClkConfig>,
-///     _new_selector: LowPowerClkConfig,
+///     _old_config: Option<LowPowerClkConfig>,
+///     _new_config: LowPowerClkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -914,8 +934,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_mcpwm0_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Mcpwm0FunctionClockConfig>,
-///     _new_selector: Mcpwm0FunctionClockConfig,
+///     _old_config: Option<Mcpwm0FunctionClockConfig>,
+///     _new_config: Mcpwm0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -928,8 +948,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_mcpwm1_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Mcpwm0FunctionClockConfig>,
-///     _new_selector: Mcpwm0FunctionClockConfig,
+///     _old_config: Option<Mcpwm0FunctionClockConfig>,
+///     _new_config: Mcpwm0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -942,8 +962,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_rmt_sclk_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<RmtSclkConfig>,
-///     _new_selector: RmtSclkConfig,
+///     _old_config: Option<RmtSclkConfig>,
+///     _new_config: RmtSclkConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -956,8 +976,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_timg0_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Timg0FunctionClockConfig>,
-///     _new_selector: Timg0FunctionClockConfig,
+///     _old_config: Option<Timg0FunctionClockConfig>,
+///     _new_config: Timg0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -970,8 +990,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_timg0_calibration_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Timg0CalibrationClockConfig>,
-///     _new_selector: Timg0CalibrationClockConfig,
+///     _old_config: Option<Timg0CalibrationClockConfig>,
+///     _new_config: Timg0CalibrationClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -984,8 +1004,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_timg1_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Timg0FunctionClockConfig>,
-///     _new_selector: Timg0FunctionClockConfig,
+///     _old_config: Option<Timg0FunctionClockConfig>,
+///     _new_config: Timg0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -998,8 +1018,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_timg1_calibration_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Timg0CalibrationClockConfig>,
-///     _new_selector: Timg0CalibrationClockConfig,
+///     _old_config: Option<Timg0CalibrationClockConfig>,
+///     _new_config: Timg0CalibrationClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1012,8 +1032,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_uart0_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Uart0FunctionClockConfig>,
-///     _new_selector: Uart0FunctionClockConfig,
+///     _old_config: Option<Uart0FunctionClockConfig>,
+///     _new_config: Uart0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1026,8 +1046,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_uart0_mem_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Uart0MemClockConfig>,
-///     _new_selector: Uart0MemClockConfig,
+///     _old_config: Option<Uart0MemClockConfig>,
+///     _new_config: Uart0MemClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1040,8 +1060,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_uart1_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Uart0FunctionClockConfig>,
-///     _new_selector: Uart0FunctionClockConfig,
+///     _old_config: Option<Uart0FunctionClockConfig>,
+///     _new_config: Uart0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1054,8 +1074,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_uart1_mem_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Uart0MemClockConfig>,
-///     _new_selector: Uart0MemClockConfig,
+///     _old_config: Option<Uart0MemClockConfig>,
+///     _new_config: Uart0MemClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1068,8 +1088,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_uart2_function_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Uart0FunctionClockConfig>,
-///     _new_selector: Uart0FunctionClockConfig,
+///     _old_config: Option<Uart0FunctionClockConfig>,
+///     _new_config: Uart0FunctionClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1082,8 +1102,8 @@ macro_rules! for_each_sha_algorithm {
 ///
 /// fn configure_uart2_mem_clock_impl(
 ///     _clocks: &mut ClockTree,
-///     _old_selector: Option<Uart0MemClockConfig>,
-///     _new_selector: Uart0MemClockConfig,
+///     _old_config: Option<Uart0MemClockConfig>,
+///     _new_config: Uart0MemClockConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1540,8 +1560,8 @@ macro_rules! define_clock_tree_types {
                 uart2_mem_clock_refcount: 0,
             });
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
-            clocks.xtal_clk = Some(config);
-            configure_xtal_clk_impl(clocks, config);
+            let old_config = clocks.xtal_clk.replace(config);
+            configure_xtal_clk_impl(clocks, old_config, config);
         }
         pub fn xtal_clk_config(clocks: &mut ClockTree) -> Option<XtalClkConfig> {
             clocks.xtal_clk
@@ -1555,8 +1575,8 @@ macro_rules! define_clock_tree_types {
             if let Some(cpu_pll_div_out) = clocks.cpu_pll_div_out {
                 assert!(!((config.value() == 320000000) && (cpu_pll_div_out.value() == 240000000)));
             }
-            clocks.pll_clk = Some(config);
-            configure_pll_clk_impl(clocks, config);
+            let old_config = clocks.pll_clk.replace(config);
+            configure_pll_clk_impl(clocks, old_config, config);
         }
         pub fn pll_clk_config(clocks: &mut ClockTree) -> Option<PllClkConfig> {
             clocks.pll_clk
@@ -1695,8 +1715,8 @@ macro_rules! define_clock_tree_types {
             }
         }
         pub fn configure_system_pre_div(clocks: &mut ClockTree, config: SystemPreDivConfig) {
-            clocks.system_pre_div = Some(config);
-            configure_system_pre_div_impl(clocks, config);
+            let old_config = clocks.system_pre_div.replace(config);
+            configure_system_pre_div_impl(clocks, old_config, config);
         }
         pub fn system_pre_div_config(clocks: &mut ClockTree) -> Option<SystemPreDivConfig> {
             clocks.system_pre_div
@@ -1720,8 +1740,8 @@ macro_rules! define_clock_tree_types {
             if let Some(pll_clk) = clocks.pll_clk {
                 assert!(!((config.value() == 240000000) && (pll_clk.value() == 320000000)));
             }
-            clocks.cpu_pll_div_out = Some(config);
-            configure_cpu_pll_div_out_impl(clocks, config);
+            let old_config = clocks.cpu_pll_div_out.replace(config);
+            configure_cpu_pll_div_out_impl(clocks, old_config, config);
         }
         pub fn cpu_pll_div_out_config(clocks: &mut ClockTree) -> Option<CpuPllDivOutConfig> {
             clocks.cpu_pll_div_out
@@ -1933,8 +1953,8 @@ macro_rules! define_clock_tree_types {
             80000000
         }
         pub fn configure_rc_fast_clk_div_n(clocks: &mut ClockTree, config: RcFastClkDivNConfig) {
-            clocks.rc_fast_clk_div_n = Some(config);
-            configure_rc_fast_clk_div_n_impl(clocks, config);
+            let old_config = clocks.rc_fast_clk_div_n.replace(config);
+            configure_rc_fast_clk_div_n_impl(clocks, old_config, config);
         }
         pub fn rc_fast_clk_div_n_config(clocks: &mut ClockTree) -> Option<RcFastClkDivNConfig> {
             clocks.rc_fast_clk_div_n

--- a/esp-metadata/src/cfg/soc.rs
+++ b/esp-metadata/src/cfg/soc.rs
@@ -254,7 +254,7 @@ impl ClockTreeNodeInstance {
         let current_config_fn = self.config_current_function(tree);
         let apply_fn_impl = ty_name
             .as_ref()
-            .map(|_| self.node.config_apply_impl_function(self, tree))
+            .map(|_| self.config_apply_impl_function())
             .unwrap_or_default();
         let frequency_function_impl = self.node_frequency_impl(tree);
         let frequency_function_name = self.frequency_function_name();
@@ -368,6 +368,19 @@ impl ClockTreeNodeInstance {
                 },
                 apply_fn_impl,
             ],
+        }
+    }
+
+    /// Generates a stub implementation that the HAL needs to provide.
+    fn config_apply_impl_function(&self) -> TokenStream {
+        let ty_name = self.config_type_name();
+        let apply_fn_name = self.config_apply_function_name();
+        let hal_impl = format_ident!("{}_impl", apply_fn_name);
+
+        quote! {
+            fn #hal_impl(_clocks: &mut ClockTree, _old_config: Option<#ty_name>, _new_config: #ty_name) {
+                todo!()
+            }
         }
     }
 }

--- a/esp-metadata/src/cfg/soc/clock_tree.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree.rs
@@ -313,13 +313,6 @@ pub(crate) trait ClockTreeNodeType: Any {
         instance: &ClockTreeNodeInstance,
         tree: &ProcessedClockData,
     ) -> TokenStream;
-    fn config_apply_impl_function(
-        &self,
-        _instance: &ClockTreeNodeInstance,
-        _tree: &ProcessedClockData,
-    ) -> TokenStream {
-        quote! {}
-    }
 
     fn node_frequency_impl(
         &self,

--- a/esp-metadata/src/cfg/soc/clock_tree/divider.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/divider.rs
@@ -142,23 +142,8 @@ impl ClockTreeNodeType for Divider {
         quote! {
             pub fn #apply_fn_name(clocks: &mut ClockTree, config: #ty_name) {
                 #reject_exprs
-                clocks.#state = Some(config);
-                #hal_impl(clocks, config);
-            }
-        }
-    }
-
-    fn config_apply_impl_function(
-        &self,
-        instance: &ClockTreeNodeInstance,
-        _tree: &ProcessedClockData,
-    ) -> TokenStream {
-        let ty_name = instance.config_type_name();
-        let apply_fn_name = instance.config_apply_function_name();
-        let hal_impl = format_ident!("{}_impl", apply_fn_name);
-        quote! {
-            fn #hal_impl(_clocks: &mut ClockTree, _new_config: #ty_name) {
-                todo!()
+                let old_config = clocks.#state.replace(config);
+                #hal_impl(clocks, old_config, config);
             }
         }
     }

--- a/esp-metadata/src/cfg/soc/clock_tree/mux.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/mux.rs
@@ -87,22 +87,6 @@ impl ClockTreeNodeType for Multiplexer {
         self.impl_config_apply_function(instance, tree)
     }
 
-    fn config_apply_impl_function(
-        &self,
-        instance: &ClockTreeNodeInstance,
-        _tree: &ProcessedClockData,
-    ) -> TokenStream {
-        let ty_name = instance.config_type_name();
-        let apply_fn_name = instance.config_apply_function_name();
-        let hal_impl = format_ident!("{}_impl", apply_fn_name);
-
-        quote! {
-            fn #hal_impl(_clocks: &mut ClockTree, _old_selector: Option<#ty_name>, _new_selector: #ty_name) {
-                todo!()
-            }
-        }
-    }
-
     fn node_frequency_impl(
         &self,
         instance: &ClockTreeNodeInstance,

--- a/esp-metadata/src/cfg/soc/clock_tree/source.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/source.rs
@@ -112,23 +112,8 @@ impl ClockTreeNodeType for Source {
         quote! {
             pub fn #apply_fn_name(clocks: &mut ClockTree, config: #ty_name) {
                 #reject_exprs
-                clocks.#state = Some(config);
-                #hal_impl(clocks, config);
-            }
-        }
-    }
-
-    fn config_apply_impl_function(
-        &self,
-        instance: &ClockTreeNodeInstance,
-        _tree: &ProcessedClockData,
-    ) -> TokenStream {
-        let ty_name = instance.config_type_name();
-        let apply_fn_name = instance.config_apply_function_name();
-        let hal_impl = format_ident!("{}_impl", apply_fn_name);
-        quote! {
-            fn #hal_impl(_clocks: &mut ClockTree, _config: #ty_name) {
-                todo!()
+                let old_config = clocks.#state.replace(config);
+                #hal_impl(clocks, old_config, config);
             }
         }
     }
@@ -335,15 +320,6 @@ impl ClockTreeNodeType for DerivedClockSource {
         tree: &ProcessedClockData,
     ) -> TokenStream {
         self.source_options.config_apply_function(instance, tree)
-    }
-
-    fn config_apply_impl_function(
-        &self,
-        instance: &ClockTreeNodeInstance,
-        tree: &ProcessedClockData,
-    ) -> TokenStream {
-        self.source_options
-            .config_apply_impl_function(instance, tree)
     }
 
     fn node_frequency_impl(


### PR DESCRIPTION
This PR unifies the signature of the functions generated by `config_apply_impl_function` and removes the unnecessary duplicate implementations.