### PR TITLE
Allow using non-decimal numbers in divider param specs

### DIFF
--- a/esp-metadata/devices/esp32.toml
+++ b/esp-metadata/devices/esp32.toml
@@ -178,7 +178,7 @@ clocks = { system_clocks = { clock_tree = [
         { name = "XTAL",    outputs = "XTAL_CLK" },
         { name = "RC_FAST", outputs = "RC_FAST_CLK" },
     ] },
-    { name = "SYSCON_PRE_DIV", type = "divider", params = { divisor = "0 .. 1024" }, output = "SYSCON_PRE_DIV_IN / (divisor + 1)" },
+    { name = "SYSCON_PRE_DIV", type = "divider", params = { divisor = "0 .. 0x400" }, output = "SYSCON_PRE_DIV_IN / (divisor + 1)" },
 
     # The meta-switch
     { name = "CPU_CLK", type = "mux", always_on = true, variants = [

--- a/esp-metadata/src/cfg/soc/clock_tree.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree.rs
@@ -530,14 +530,10 @@ impl ValuesExpression {
     }
 
     fn as_range(&self) -> Option<(u32, u32)> {
-        if self.0.len() != 1 {
-            None
+        if let [ValueFragment::Range(min, max)] = self.0.as_slice() {
+            Some((*min, *max))
         } else {
-            let ValueFragment::Range(min, max) = self.0[0] else {
-                return None;
-            };
-
-            Some((min, max))
+            None
         }
     }
 }
@@ -575,10 +571,20 @@ impl FromStr for ValueFragment {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         fn parse_number(s: &str) -> Result<u32, String> {
-            s.replace('_', "")
-                .trim()
-                .parse()
-                .map_err(|e| format!("Invalid number: {}", e))
+            let s = s.replace('_', "");
+            let s = s.trim();
+
+            let result = if s.starts_with("0x") {
+                u32::from_str_radix(&s[2..], 16)
+            } else if s.starts_with("0o") {
+                u32::from_str_radix(&s[2..], 8)
+            } else if s.starts_with("0b") {
+                u32::from_str_radix(&s[2..], 2)
+            } else {
+                s.parse()
+            };
+
+            result.map_err(|e| format!("Failed to parse {s}: {e}"))
         }
 
         if let Some((start, end_incl)) = s.split_once("..=") {


### PR DESCRIPTION
UART SCLK has a fractional divider with a very annoying 20-bit numerator, which is simpler to write as `0..0x10_0000` than  `0..1048576`.