### PR TITLE
Model baud rate generator and SCLK divider

### DIFF
--- a/esp-hal/src/soc/esp32/clocks.rs
+++ b/esp-hal/src/soc/esp32/clocks.rs
@@ -810,7 +810,24 @@ fn configure_uart0_function_clock_impl(
 ) {
     UART0::regs().conf0().modify(|_, w| {
         w.tick_ref_always_on()
-            .bit(new_config == Uart0FunctionClockConfig::Apb)
+            .bit(new_config.sclk == Uart0FunctionClockSclk::Apb)
+    });
+}
+
+// UART0_BAUD_RATE_GENERATOR
+
+fn enable_uart0_baud_rate_generator_impl(_clocks: &mut ClockTree, _en: bool) {
+    // Nothing to do.
+}
+
+fn configure_uart0_baud_rate_generator_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<Uart0BaudRateGeneratorConfig>,
+    new_config: Uart0BaudRateGeneratorConfig,
+) {
+    UART0::regs().clkdiv().write(|w| unsafe {
+        w.clkdiv().bits(new_config.integral as _);
+        w.frag().bits(new_config.fractional as _)
     });
 }
 
@@ -841,7 +858,24 @@ fn configure_uart1_function_clock_impl(
 ) {
     UART1::regs().conf0().modify(|_, w| {
         w.tick_ref_always_on()
-            .bit(new_config == Uart0FunctionClockConfig::Apb)
+            .bit(new_config.sclk == Uart0FunctionClockSclk::Apb)
+    });
+}
+
+// UART1_BAUD_RATE_GENERATOR
+
+fn enable_uart1_baud_rate_generator_impl(_clocks: &mut ClockTree, _en: bool) {
+    // Nothing to do.
+}
+
+fn configure_uart1_baud_rate_generator_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<Uart0BaudRateGeneratorConfig>,
+    new_config: Uart0BaudRateGeneratorConfig,
+) {
+    UART1::regs().clkdiv().write(|w| unsafe {
+        w.clkdiv().bits(new_config.integral as _);
+        w.frag().bits(new_config.fractional as _)
     });
 }
 
@@ -872,6 +906,23 @@ fn configure_uart2_function_clock_impl(
 ) {
     UART2::regs().conf0().modify(|_, w| {
         w.tick_ref_always_on()
-            .bit(new_config == Uart0FunctionClockConfig::Apb)
+            .bit(new_config.sclk == Uart0FunctionClockSclk::Apb)
+    });
+}
+
+// UART2_BAUD_RATE_GENERATOR
+
+fn enable_uart2_baud_rate_generator_impl(_clocks: &mut ClockTree, _en: bool) {
+    // Nothing to do.
+}
+
+fn configure_uart2_baud_rate_generator_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<Uart0BaudRateGeneratorConfig>,
+    new_config: Uart0BaudRateGeneratorConfig,
+) {
+    UART2::regs().clkdiv().write(|w| unsafe {
+        w.clkdiv().bits(new_config.integral as _);
+        w.frag().bits(new_config.fractional as _)
     });
 }

--- a/esp-hal/src/soc/esp32c2/clocks.rs
+++ b/esp-hal/src/soc/esp32c2/clocks.rs
@@ -692,11 +692,29 @@ fn configure_uart0_function_clock_impl(
     new_config: Uart0FunctionClockConfig,
 ) {
     UART0::regs().clk_conf().modify(|_, w| unsafe {
-        w.sclk_sel().bits(match new_config {
-            Uart0FunctionClockConfig::PllF40m => 1,
-            Uart0FunctionClockConfig::RcFast => 2,
-            Uart0FunctionClockConfig::Xtal => 3,
-        })
+        w.sclk_sel().bits(match new_config.sclk {
+            Uart0FunctionClockSclk::PllF40m => 1,
+            Uart0FunctionClockSclk::RcFast => 2,
+            Uart0FunctionClockSclk::Xtal => 3,
+        });
+        w.sclk_div_num().bits(new_config.div_num as _)
+    });
+}
+
+// UART0_BAUD_RATE_GENERATOR
+
+fn enable_uart0_baud_rate_generator_impl(_clocks: &mut ClockTree, _en: bool) {
+    // Nothing to do
+}
+
+fn configure_uart0_baud_rate_generator_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<Uart0BaudRateGeneratorConfig>,
+    new_config: Uart0BaudRateGeneratorConfig,
+) {
+    UART0::regs().clkdiv().write(|w| unsafe {
+        w.clkdiv().bits(new_config.integral as _);
+        w.frag().bits(new_config.fractional as _)
     });
 }
 
@@ -726,10 +744,28 @@ fn configure_uart1_function_clock_impl(
     new_config: Uart0FunctionClockConfig,
 ) {
     UART1::regs().clk_conf().modify(|_, w| unsafe {
-        w.sclk_sel().bits(match new_config {
-            Uart0FunctionClockConfig::PllF40m => 1,
-            Uart0FunctionClockConfig::RcFast => 2,
-            Uart0FunctionClockConfig::Xtal => 3,
-        })
+        w.sclk_sel().bits(match new_config.sclk {
+            Uart0FunctionClockSclk::PllF40m => 1,
+            Uart0FunctionClockSclk::RcFast => 2,
+            Uart0FunctionClockSclk::Xtal => 3,
+        });
+        w.sclk_div_num().bits(new_config.div_num as _)
+    });
+}
+
+// UART1_BAUD_RATE_GENERATOR
+
+fn enable_uart1_baud_rate_generator_impl(_clocks: &mut ClockTree, _en: bool) {
+    // Nothing to do
+}
+
+fn configure_uart1_baud_rate_generator_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<Uart0BaudRateGeneratorConfig>,
+    new_config: Uart0BaudRateGeneratorConfig,
+) {
+    UART1::regs().clkdiv().write(|w| unsafe {
+        w.clkdiv().bits(new_config.integral as _);
+        w.frag().bits(new_config.fractional as _)
     });
 }

--- a/esp-hal/src/soc/esp32c3/clocks.rs
+++ b/esp-hal/src/soc/esp32c3/clocks.rs
@@ -729,11 +729,29 @@ fn configure_uart0_function_clock_impl(
     new_config: Uart0FunctionClockConfig,
 ) {
     UART0::regs().clk_conf().modify(|_, w| unsafe {
-        w.sclk_sel().bits(match new_config {
-            Uart0FunctionClockConfig::Apb => 1,
-            Uart0FunctionClockConfig::RcFast => 2,
-            Uart0FunctionClockConfig::Xtal => 3,
-        })
+        w.sclk_sel().bits(match new_config.sclk {
+            Uart0FunctionClockSclk::Apb => 1,
+            Uart0FunctionClockSclk::RcFast => 2,
+            Uart0FunctionClockSclk::Xtal => 3,
+        });
+        w.sclk_div_num().bits(new_config.div_num as _)
+    });
+}
+
+// UART0_BAUD_RATE_GENERATOR
+
+fn enable_uart0_baud_rate_generator_impl(_clocks: &mut ClockTree, _en: bool) {
+    // Nothing to do
+}
+
+fn configure_uart0_baud_rate_generator_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<Uart0BaudRateGeneratorConfig>,
+    new_config: Uart0BaudRateGeneratorConfig,
+) {
+    UART0::regs().clkdiv().write(|w| unsafe {
+        w.clkdiv().bits(new_config.integral as _);
+        w.frag().bits(new_config.fractional as _)
     });
 }
 
@@ -763,10 +781,28 @@ fn configure_uart1_function_clock_impl(
     new_config: Uart0FunctionClockConfig,
 ) {
     UART1::regs().clk_conf().modify(|_, w| unsafe {
-        w.sclk_sel().bits(match new_config {
-            Uart0FunctionClockConfig::Apb => 1,
-            Uart0FunctionClockConfig::RcFast => 2,
-            Uart0FunctionClockConfig::Xtal => 3,
-        })
+        w.sclk_sel().bits(match new_config.sclk {
+            Uart0FunctionClockSclk::Apb => 1,
+            Uart0FunctionClockSclk::RcFast => 2,
+            Uart0FunctionClockSclk::Xtal => 3,
+        });
+        w.sclk_div_num().bits(new_config.div_num as _)
+    });
+}
+
+// UART1_BAUD_RATE_GENERATOR
+
+fn enable_uart1_baud_rate_generator_impl(_clocks: &mut ClockTree, _en: bool) {
+    // Nothing to do
+}
+
+fn configure_uart1_baud_rate_generator_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<Uart0BaudRateGeneratorConfig>,
+    new_config: Uart0BaudRateGeneratorConfig,
+) {
+    UART1::regs().clkdiv().write(|w| unsafe {
+        w.clkdiv().bits(new_config.integral as _);
+        w.frag().bits(new_config.fractional as _)
     });
 }

--- a/esp-hal/src/soc/esp32c5/clocks.rs
+++ b/esp-hal/src/soc/esp32c5/clocks.rs
@@ -16,7 +16,7 @@
 // TODO: This is a temporary place for this, should probably be moved into clocks_ll.
 
 use crate::{
-    peripherals::{I2C_ANA_MST, LP_CLKRST, MODEM_LPCON, PCR, PMU},
+    peripherals::{I2C_ANA_MST, LP_CLKRST, MODEM_LPCON, PCR, PMU, UART0, UART1},
     soc::regi2c,
 };
 
@@ -689,6 +689,23 @@ fn configure_uart0_function_clock_impl(
     configure_uart_function_clock(0, new_config);
 }
 
+// UART0_BAUD_RATE_GENERATOR
+
+fn enable_uart0_baud_rate_generator_impl(_clocks: &mut ClockTree, _en: bool) {
+    // Nothing to do
+}
+
+fn configure_uart0_baud_rate_generator_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<Uart0BaudRateGeneratorConfig>,
+    new_config: Uart0BaudRateGeneratorConfig,
+) {
+    UART0::regs().clkdiv().write(|w| unsafe {
+        w.clkdiv().bits(new_config.integral as _);
+        w.frag().bits(new_config.fractional as _)
+    });
+}
+
 // UART1_FUNCTION_CLOCK
 
 fn enable_uart1_function_clock_impl(_clocks: &mut ClockTree, en: bool) {
@@ -703,6 +720,23 @@ fn configure_uart1_function_clock_impl(
     configure_uart_function_clock(1, new_config);
 }
 
+// UART1_BAUD_RATE_GENERATOR
+
+fn enable_uart1_baud_rate_generator_impl(_clocks: &mut ClockTree, _en: bool) {
+    // Nothing to do
+}
+
+fn configure_uart1_baud_rate_generator_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<Uart0BaudRateGeneratorConfig>,
+    new_config: Uart0BaudRateGeneratorConfig,
+) {
+    UART1::regs().clkdiv().write(|w| unsafe {
+        w.clkdiv().bits(new_config.integral as _);
+        w.frag().bits(new_config.fractional as _)
+    });
+}
+
 fn enable_uart_function_clock(uart: usize, en: bool) {
     PCR::regs()
         .uart(uart)
@@ -712,10 +746,14 @@ fn enable_uart_function_clock(uart: usize, en: bool) {
 
 fn configure_uart_function_clock(uart: usize, new_config: Uart0FunctionClockConfig) {
     PCR::regs().uart(uart).clk_conf().modify(|_, w| unsafe {
-        w.sclk_sel().bits(match new_config {
-            Uart0FunctionClockConfig::Xtal => 0,
-            Uart0FunctionClockConfig::RcFast => 1,
-            Uart0FunctionClockConfig::PllF80m => 2,
-        })
+        w.sclk_sel().bits(match new_config.sclk {
+            Uart0FunctionClockSclk::Xtal => 0,
+            Uart0FunctionClockSclk::RcFast => 1,
+            Uart0FunctionClockSclk::PllF80m => 2,
+        });
+        w.sclk_div_a().bits(0);
+        w.sclk_div_b().bits(0);
+        w.sclk_div_num().bits(new_config.div_num as _);
+        w
     });
 }

--- a/esp-hal/src/soc/esp32c6/clocks.rs
+++ b/esp-hal/src/soc/esp32c6/clocks.rs
@@ -17,7 +17,7 @@
 // TODO: This is a temporary place for this, should probably be moved into clocks_ll.
 
 use crate::{
-    peripherals::{I2C_ANA_MST, LP_CLKRST, MODEM_LPCON, PCR, PMU, TIMG0, TIMG1},
+    peripherals::{I2C_ANA_MST, LP_CLKRST, MODEM_LPCON, PCR, PMU, TIMG0, TIMG1, UART0, UART1},
     soc::regi2c,
 };
 
@@ -794,6 +794,23 @@ fn configure_uart0_function_clock_impl(
     configure_uart_function_clock(0, new_config);
 }
 
+// UART0_BAUD_RATE_GENERATOR
+
+fn enable_uart0_baud_rate_generator_impl(_clocks: &mut ClockTree, _en: bool) {
+    // Nothing to do
+}
+
+fn configure_uart0_baud_rate_generator_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<Uart0BaudRateGeneratorConfig>,
+    new_config: Uart0BaudRateGeneratorConfig,
+) {
+    UART0::regs().clkdiv().write(|w| unsafe {
+        w.clkdiv().bits(new_config.integral as _);
+        w.frag().bits(new_config.fractional as _)
+    });
+}
+
 // UART1_FUNCTION_CLOCK
 
 fn enable_uart1_function_clock_impl(_clocks: &mut ClockTree, en: bool) {
@@ -808,6 +825,23 @@ fn configure_uart1_function_clock_impl(
     configure_uart_function_clock(1, new_config);
 }
 
+// UART1_BAUD_RATE_GENERATOR
+
+fn enable_uart1_baud_rate_generator_impl(_clocks: &mut ClockTree, _en: bool) {
+    // Nothing to do
+}
+
+fn configure_uart1_baud_rate_generator_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<Uart0BaudRateGeneratorConfig>,
+    new_config: Uart0BaudRateGeneratorConfig,
+) {
+    UART1::regs().clkdiv().write(|w| unsafe {
+        w.clkdiv().bits(new_config.integral as _);
+        w.frag().bits(new_config.fractional as _)
+    });
+}
+
 fn enable_uart_function_clock(uart: usize, en: bool) {
     PCR::regs()
         .uart(uart)
@@ -817,10 +851,14 @@ fn enable_uart_function_clock(uart: usize, en: bool) {
 
 fn configure_uart_function_clock(uart: usize, new_config: Uart0FunctionClockConfig) {
     PCR::regs().uart(uart).clk_conf().modify(|_, w| unsafe {
-        w.sclk_sel().bits(match new_config {
-            Uart0FunctionClockConfig::PllF80m => 1,
-            Uart0FunctionClockConfig::RcFast => 2,
-            Uart0FunctionClockConfig::Xtal => 3,
-        })
+        w.sclk_sel().bits(match new_config.sclk {
+            Uart0FunctionClockSclk::PllF80m => 1,
+            Uart0FunctionClockSclk::RcFast => 2,
+            Uart0FunctionClockSclk::Xtal => 3,
+        });
+        w.sclk_div_a().bits(0);
+        w.sclk_div_b().bits(0);
+        w.sclk_div_num().bits(new_config.div_num as _);
+        w
     });
 }

--- a/esp-hal/src/soc/esp32h2/clocks.rs
+++ b/esp-hal/src/soc/esp32h2/clocks.rs
@@ -15,7 +15,7 @@
 // TODO: This is a temporary place for this, should probably be moved into clocks_ll.
 
 use crate::{
-    peripherals::{I2C_ANA_MST, LP_CLKRST, MODEM_LPCON, PCR, PMU, TIMG0, TIMG1},
+    peripherals::{I2C_ANA_MST, LP_CLKRST, MODEM_LPCON, PCR, PMU, TIMG0, TIMG1, UART0, UART1},
     soc::regi2c,
 };
 
@@ -615,6 +615,23 @@ fn configure_uart0_function_clock_impl(
     configure_uart_function_clock(0, new_config);
 }
 
+// UART0_BAUD_RATE_GENERATOR
+
+fn enable_uart0_baud_rate_generator_impl(_clocks: &mut ClockTree, _en: bool) {
+    // Nothing to do
+}
+
+fn configure_uart0_baud_rate_generator_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<Uart0BaudRateGeneratorConfig>,
+    new_config: Uart0BaudRateGeneratorConfig,
+) {
+    UART0::regs().clkdiv().write(|w| unsafe {
+        w.clkdiv().bits(new_config.integral as _);
+        w.frag().bits(new_config.fractional as _)
+    });
+}
+
 // UART1_FUNCTION_CLOCK
 
 fn enable_uart1_function_clock_impl(_clocks: &mut ClockTree, en: bool) {
@@ -629,6 +646,23 @@ fn configure_uart1_function_clock_impl(
     configure_uart_function_clock(1, new_config);
 }
 
+// UART1_BAUD_RATE_GENERATOR
+
+fn enable_uart1_baud_rate_generator_impl(_clocks: &mut ClockTree, _en: bool) {
+    // Nothing to do
+}
+
+fn configure_uart1_baud_rate_generator_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<Uart0BaudRateGeneratorConfig>,
+    new_config: Uart0BaudRateGeneratorConfig,
+) {
+    UART1::regs().clkdiv().write(|w| unsafe {
+        w.clkdiv().bits(new_config.integral as _);
+        w.frag().bits(new_config.fractional as _)
+    });
+}
+
 fn enable_uart_function_clock(uart: usize, en: bool) {
     PCR::regs()
         .uart(uart)
@@ -638,10 +672,14 @@ fn enable_uart_function_clock(uart: usize, en: bool) {
 
 fn configure_uart_function_clock(uart: usize, new_config: Uart0FunctionClockConfig) {
     PCR::regs().uart(uart).clk_conf().modify(|_, w| unsafe {
-        w.sclk_sel().bits(match new_config {
-            Uart0FunctionClockConfig::PllF48m => 1,
-            Uart0FunctionClockConfig::RcFast => 2,
-            Uart0FunctionClockConfig::Xtal => 3,
-        })
+        w.sclk_sel().bits(match new_config.sclk {
+            Uart0FunctionClockSclk::PllF48m => 1,
+            Uart0FunctionClockSclk::RcFast => 2,
+            Uart0FunctionClockSclk::Xtal => 3,
+        });
+        w.sclk_div_a().bits(0);
+        w.sclk_div_b().bits(0);
+        w.sclk_div_num().bits(new_config.div_num as _);
+        w
     });
 }

--- a/esp-hal/src/soc/esp32s2/clocks.rs
+++ b/esp-hal/src/soc/esp32s2/clocks.rs
@@ -742,7 +742,24 @@ fn configure_uart0_function_clock_impl(
 ) {
     UART0::regs().conf0().modify(|_, w| {
         w.tick_ref_always_on()
-            .bit(new_config == Uart0FunctionClockConfig::Apb)
+            .bit(new_config.sclk == Uart0FunctionClockSclk::Apb)
+    });
+}
+
+// UART0_BAUD_RATE_GENERATOR
+
+fn enable_uart0_baud_rate_generator_impl(_clocks: &mut ClockTree, _en: bool) {
+    // Nothing to do.
+}
+
+fn configure_uart0_baud_rate_generator_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<Uart0BaudRateGeneratorConfig>,
+    new_config: Uart0BaudRateGeneratorConfig,
+) {
+    UART0::regs().clkdiv().write(|w| unsafe {
+        w.clkdiv().bits(new_config.integral as _);
+        w.frag().bits(new_config.fractional as _)
     });
 }
 
@@ -773,6 +790,23 @@ fn configure_uart1_function_clock_impl(
 ) {
     UART1::regs().conf0().modify(|_, w| {
         w.tick_ref_always_on()
-            .bit(new_config == Uart0FunctionClockConfig::Apb)
+            .bit(new_config.sclk == Uart0FunctionClockSclk::Apb)
+    });
+}
+
+// UART1_BAUD_RATE_GENERATOR
+
+fn enable_uart1_baud_rate_generator_impl(_clocks: &mut ClockTree, _en: bool) {
+    // Nothing to do.
+}
+
+fn configure_uart1_baud_rate_generator_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<Uart0BaudRateGeneratorConfig>,
+    new_config: Uart0BaudRateGeneratorConfig,
+) {
+    UART1::regs().clkdiv().write(|w| unsafe {
+        w.clkdiv().bits(new_config.integral as _);
+        w.frag().bits(new_config.fractional as _)
     });
 }

--- a/esp-hal/src/soc/esp32s3/clocks.rs
+++ b/esp-hal/src/soc/esp32s3/clocks.rs
@@ -915,11 +915,32 @@ fn configure_uart0_function_clock_impl(
     new_config: Uart0FunctionClockConfig,
 ) {
     UART0::regs().clk_conf().modify(|_, w| unsafe {
-        w.sclk_sel().bits(match new_config {
-            Uart0FunctionClockConfig::Apb => 1,
-            Uart0FunctionClockConfig::RcFast => 2,
-            Uart0FunctionClockConfig::Xtal => 3,
-        })
+        w.sclk_sel().bits(match new_config.sclk {
+            Uart0FunctionClockSclk::Apb => 1,
+            Uart0FunctionClockSclk::RcFast => 2,
+            Uart0FunctionClockSclk::Xtal => 3,
+        });
+        w.sclk_div_a().bits(0);
+        w.sclk_div_b().bits(0);
+        w.sclk_div_num().bits(new_config.div_num as _);
+        w
+    });
+}
+
+// UART0_BAUD_RATE_GENERATOR
+
+fn enable_uart0_baud_rate_generator_impl(_clocks: &mut ClockTree, _en: bool) {
+    // Nothing to do
+}
+
+fn configure_uart0_baud_rate_generator_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<Uart0BaudRateGeneratorConfig>,
+    new_config: Uart0BaudRateGeneratorConfig,
+) {
+    UART0::regs().clkdiv().write(|w| unsafe {
+        w.clkdiv().bits(new_config.integral as _);
+        w.frag().bits(new_config.fractional as _)
     });
 }
 
@@ -949,11 +970,32 @@ fn configure_uart1_function_clock_impl(
     new_config: Uart0FunctionClockConfig,
 ) {
     UART1::regs().clk_conf().modify(|_, w| unsafe {
-        w.sclk_sel().bits(match new_config {
-            Uart0FunctionClockConfig::Apb => 1,
-            Uart0FunctionClockConfig::RcFast => 2,
-            Uart0FunctionClockConfig::Xtal => 3,
-        })
+        w.sclk_sel().bits(match new_config.sclk {
+            Uart0FunctionClockSclk::Apb => 1,
+            Uart0FunctionClockSclk::RcFast => 2,
+            Uart0FunctionClockSclk::Xtal => 3,
+        });
+        w.sclk_div_a().bits(0);
+        w.sclk_div_b().bits(0);
+        w.sclk_div_num().bits(new_config.div_num as _);
+        w
+    });
+}
+
+// UART1_BAUD_RATE_GENERATOR
+
+fn enable_uart1_baud_rate_generator_impl(_clocks: &mut ClockTree, _en: bool) {
+    // Nothing to do
+}
+
+fn configure_uart1_baud_rate_generator_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<Uart0BaudRateGeneratorConfig>,
+    new_config: Uart0BaudRateGeneratorConfig,
+) {
+    UART1::regs().clkdiv().write(|w| unsafe {
+        w.clkdiv().bits(new_config.integral as _);
+        w.frag().bits(new_config.fractional as _)
     });
 }
 
@@ -983,10 +1025,31 @@ fn configure_uart2_function_clock_impl(
     new_config: Uart0FunctionClockConfig,
 ) {
     UART2::regs().clk_conf().modify(|_, w| unsafe {
-        w.sclk_sel().bits(match new_config {
-            Uart0FunctionClockConfig::Apb => 1,
-            Uart0FunctionClockConfig::RcFast => 2,
-            Uart0FunctionClockConfig::Xtal => 3,
-        })
+        w.sclk_sel().bits(match new_config.sclk {
+            Uart0FunctionClockSclk::Apb => 1,
+            Uart0FunctionClockSclk::RcFast => 2,
+            Uart0FunctionClockSclk::Xtal => 3,
+        });
+        w.sclk_div_a().bits(0);
+        w.sclk_div_b().bits(0);
+        w.sclk_div_num().bits(new_config.div_num as _);
+        w
+    });
+}
+
+// UART2_BAUD_RATE_GENERATOR
+
+fn enable_uart2_baud_rate_generator_impl(_clocks: &mut ClockTree, _en: bool) {
+    // Nothing to do
+}
+
+fn configure_uart2_baud_rate_generator_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<Uart0BaudRateGeneratorConfig>,
+    new_config: Uart0BaudRateGeneratorConfig,
+) {
+    UART2::regs().clkdiv().write(|w| unsafe {
+        w.clkdiv().bits(new_config.integral as _);
+        w.frag().bits(new_config.fractional as _)
     });
 }

--- a/esp-hal/src/uart/mod.rs
+++ b/esp-hal/src/uart/mod.rs
@@ -164,9 +164,13 @@ impl embedded_io_07::Error for TxError {
 
 #[cfg(feature = "unstable")]
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
-pub use crate::soc::clocks::Uart0FunctionClockConfig as ClockSource;
+pub use crate::soc::clocks::Uart0FunctionClockSclk as ClockSource;
 #[cfg(not(feature = "unstable"))]
-use crate::soc::clocks::Uart0FunctionClockConfig as ClockSource;
+use crate::soc::clocks::Uart0FunctionClockSclk as ClockSource;
+use crate::soc::clocks::{
+    Uart0BaudRateGeneratorConfig as BaudRateConfig,
+    Uart0FunctionClockConfig as ClockConfig,
+};
 
 /// Number of data bits
 ///
@@ -934,7 +938,7 @@ where
 
 #[inline(always)]
 fn sync_regs(_register_block: &RegisterBlock) {
-    #[cfg(any(esp32c3, esp32c5, esp32c6, esp32h2, esp32s3))]
+    #[cfg(not(any(esp32, esp32s2)))]
     {
         cfg_if::cfg_if! {
             if #[cfg(any(esp32c5, esp32c6, esp32h2))] {
@@ -3004,9 +3008,11 @@ pub struct Info {
 
     pub request_uart_clks: fn(&mut ClockTree),
     pub release_uart_clks: fn(&mut ClockTree),
-    pub configure_sclk: fn(&mut ClockTree, ClockSource),
+    pub configure_sclk: fn(&mut ClockTree, ClockConfig),
+    pub configure_baud_rate: fn(&mut ClockTree, BaudRateConfig),
+    pub baud_rate_clock_frequency: fn(&mut ClockTree) -> u32,
     pub sclk_frequency: fn(&mut ClockTree) -> u32,
-    pub sclk_config_frequency: fn(&mut ClockTree, ClockSource) -> u32,
+    pub sclk_config_frequency: fn(&mut ClockTree, ClockConfig) -> u32,
 }
 
 /// Peripheral state for a UART instance.
@@ -3327,75 +3333,78 @@ impl Info {
         Ok(())
     }
 
-    #[cfg(soc_has_pcr)]
-    fn is_instance(&self, other: impl Instance) -> bool {
-        self == other.info()
-    }
-
     fn sync_regs(&self) {
         sync_regs(self.regs());
     }
 
     fn change_baud(&self, config: &Config) -> Result<(), ConfigError> {
         ClockTree::with(|clocks| {
-            let clk = (self.sclk_config_frequency)(clocks, config.clock_source);
+            let source_config = ClockConfig::new(
+                config.clock_source,
+                #[cfg(any(uart_has_sclk_divider, soc_has_pcr))]
+                0,
+            );
+            let clk = (self.sclk_config_frequency)(clocks, source_config);
+
+            // The UART baud rate clock divider is, depending on the device, either a
+            // 20.4 bit, or a 12.4 bit divider.
+            // TODO: get this info from metadata, based on something like:
+            // property!("clocks.uart0.baud_rate_generator.fractional.max")
+            const FRAC_BITS: u32 = 4;
+            const FRAC_MASK: u32 = (1 << FRAC_BITS) - 1;
 
             // TODO: this block should only prepare the new clock config, and it should
             // be applied only after validating the resulting baud rate.
             cfg_if::cfg_if! {
-                if #[cfg(any(esp32, esp32s2))] {
-                    self.regs().conf0().modify(|_, w| {
-                        w.tick_ref_always_on()
-                            .bit(config.clock_source == ClockSource::Apb)
-                    });
-
-                    let divider = (clk << 4) / config.baudrate;
-                } else {
+                if #[cfg(any(uart_has_sclk_divider, soc_has_pcr))] {
                     const MAX_DIV: u32 = 0b1111_1111_1111 - 1;
-                    let clk_div = (clk.div_ceil(MAX_DIV)).div_ceil(config.baudrate);
+                    let clk_div = clk.div_ceil(MAX_DIV).div_ceil(config.baudrate);
+                    debug!("SCLK: {} divider: {}", clk, clk_div);
 
-                    // define `conf` in scope for modification below
-                    cfg_if::cfg_if! {
-                        if #[cfg(any(esp32c2, esp32c3, esp32s3))] {
-                            let conf = self.regs().clk_conf();
-                        } else {
-                            // UART clocks are configured via PCR
-                            let pcr = crate::peripherals::PCR::regs();
-                            let conf = if self.is_instance(unsafe { crate::peripherals::UART0::steal() }) {
-                                pcr.uart(0).clk_conf()
-                            } else {
-                                pcr.uart(1).clk_conf()
-                            };
-                        }
-                    };
-
-                    // TODO: we should consider a solution that can write this register fully in one go
-                    // as part of the UART_SCLK configuration. Currently this may cause unexpected waveform
-                    // changes in the transmitted data if the clock source is changed, even if the baud
-                    // rate can be kept the same.
-                    conf.modify(|_, w| unsafe {
-                        w.sclk_div_a().bits(0);
-                        w.sclk_div_b().bits(0);
-                        w.sclk_div_num().bits(clk_div as u8 - 1) // TODO: remember the -1
-                    });
-
-                    let divider = (clk << 4) / (config.baudrate * clk_div);
+                    let conf = ClockConfig::new(config.clock_source, clk_div - 1);
+                    let divider = (clk << FRAC_BITS) / (config.baudrate * clk_div);
+                } else {
+                    debug!("SCLK: {}", clk);
+                    let conf = ClockConfig::new(config.clock_source);
+                    let divider = (clk << FRAC_BITS) / config.baudrate;
                 }
             }
 
-            let divider_integer = divider >> 4;
-            let divider_frag = (divider & 0xf) as u8;
+            let divider_integer = divider >> FRAC_BITS;
+            let divider_frag = divider & FRAC_MASK;
+            debug!(
+                "UART CLK divider: {} + {}/16",
+                divider_integer, divider_frag
+            );
 
-            (self.configure_sclk)(clocks, config.clock_source);
-            self.regs().clkdiv().write(|w| unsafe {
-                w.clkdiv().bits(divider_integer as _);
-                w.frag().bits(divider_frag)
-            });
+            (self.configure_sclk)(clocks, conf);
+            (self.configure_baud_rate)(clocks, BaudRateConfig::new(divider_frag, divider_integer));
 
             self.sync_regs();
 
             #[cfg(feature = "unstable")]
-            self.verify_baudrate(clk, config)?;
+            {
+                let deviation_limit = match config.baudrate_tolerance {
+                    BaudrateTolerance::Exact => 1, // Still allow a tiny deviation
+                    BaudrateTolerance::ErrorPercent(percent) => percent as u32,
+                    _ => return Ok(()),
+                };
+
+                let actual_baud = (self.baud_rate_clock_frequency)(clocks);
+                if actual_baud == 0 {
+                    return Err(ConfigError::BaudrateNotAchievable);
+                }
+
+                let deviation = (config.baudrate.abs_diff(actual_baud) * 100) / actual_baud;
+                debug!(
+                    "Nominal baud: {}, actual: {}, deviation: {}%",
+                    config.baudrate, actual_baud, deviation
+                );
+
+                if deviation > deviation_limit {
+                    return Err(ConfigError::BaudrateNotAchievable);
+                }
+            }
 
             Ok(())
         })
@@ -3535,57 +3544,6 @@ impl Info {
 
         txfifo_rst(self.regs(), true);
         txfifo_rst(self.regs(), false);
-    }
-
-    #[cfg(feature = "unstable")]
-    fn verify_baudrate(&self, clk: u32, config: &Config) -> Result<(), ConfigError> {
-        // taken from https://github.com/espressif/esp-idf/blob/c5865270b50529cd32353f588d8a917d89f3dba4/components/hal/esp32c6/include/hal/uart_ll.h#L433-L444
-        // (it's different for different chips)
-        let clkdiv_reg = self.regs().clkdiv().read();
-        let clkdiv_frag = clkdiv_reg.frag().bits() as u32;
-        let clkdiv = clkdiv_reg.clkdiv().bits();
-
-        cfg_if::cfg_if! {
-            if #[cfg(any(esp32, esp32s2))] {
-                let actual_baud = (clk << 4) / ((clkdiv << 4) | clkdiv_frag);
-            } else if #[cfg(any(esp32c2, esp32c3, esp32s3))] {
-                let sclk_div_num = self.regs().clk_conf().read().sclk_div_num().bits() as u32;
-                let actual_baud = (clk << 4) / ((((clkdiv as u32) << 4) | clkdiv_frag) * (sclk_div_num + 1));
-            } else { // esp32c5, esp32c6, esp32h2
-                let pcr = crate::peripherals::PCR::regs();
-                let conf = if self.is_instance(unsafe { crate::peripherals::UART0::steal() }) {
-                    pcr.uart(0).clk_conf()
-                } else {
-                    pcr.uart(1).clk_conf()
-                };
-                let sclk_div_num = conf.read().sclk_div_num().bits() as u32;
-                let actual_baud = (clk << 4) / ((((clkdiv as u32) << 4) | clkdiv_frag) * (sclk_div_num + 1));
-            }
-        };
-
-        match config.baudrate_tolerance {
-            BaudrateTolerance::Exact => {
-                let deviation = ((config.baudrate as i32 - actual_baud as i32).unsigned_abs()
-                    * 100)
-                    / actual_baud;
-                // We tolerate deviation of 1% from the desired baud value, as it never will be
-                // exactly the same
-                if deviation > 1_u32 {
-                    return Err(ConfigError::BaudrateNotAchievable);
-                }
-            }
-            BaudrateTolerance::ErrorPercent(percent) => {
-                let deviation = ((config.baudrate as i32 - actual_baud as i32).unsigned_abs()
-                    * 100)
-                    / actual_baud;
-                if deviation > percent as u32 {
-                    return Err(ConfigError::BaudrateNotAchievable);
-                }
-            }
-            _ => {}
-        }
-
-        Ok(())
     }
 
     fn current_symbol_length(&self) -> u8 {
@@ -3766,6 +3724,7 @@ for_each_uart! {
                 fn request_uart_clks(clocks: &mut ClockTree) {
                     paste::paste! {
                         clocks:: [< request_ $inst:lower _function_clock >](clocks);
+                        clocks:: [< request_ $inst:lower _baud_rate_generator >](clocks);
                         #[cfg(soc_has_clock_node_uart0_mem_clock)]
                         clocks:: [< request_ $inst:lower _mem_clock >](clocks);
                     }
@@ -3775,6 +3734,7 @@ for_each_uart! {
                     paste::paste! {
                         #[cfg(soc_has_clock_node_uart0_mem_clock)]
                         clocks:: [< release_ $inst:lower _mem_clock >](clocks);
+                        clocks:: [< release_ $inst:lower _baud_rate_generator >](clocks);
                         clocks:: [< release_ $inst:lower _function_clock >](clocks);
                     }
                 }
@@ -3790,6 +3750,8 @@ for_each_uart! {
                     request_uart_clks,
                     release_uart_clks,
                     configure_sclk: paste::paste!(clocks:: [< configure_ $inst:lower _function_clock >]),
+                    configure_baud_rate: paste::paste!(clocks:: [< configure_ $inst:lower _baud_rate_generator >]),
+                    baud_rate_clock_frequency: paste::paste!(clocks:: [< $inst:lower _baud_rate_generator_frequency >]),
                     sclk_frequency: paste::paste!(clocks:: [< $inst:lower _function_clock_frequency >]),
                     sclk_config_frequency: paste::paste!(clocks:: [< $inst:lower _function_clock_config_frequency >]),
                 };
@@ -3844,7 +3806,13 @@ struct UartClockGuard<'t> {
 impl<'t> UartClockGuard<'t> {
     fn new(uart: AnyUart<'t>) -> Self {
         ClockTree::with(|clocks| {
-            (uart.info().configure_sclk)(clocks, Default::default());
+            // Apply default SCLK configuration
+            let sclk_config = ClockConfig::new(
+                Default::default(),
+                #[cfg(any(uart_has_sclk_divider, soc_has_pcr))]
+                0,
+            );
+            (uart.info().configure_sclk)(clocks, sclk_config);
             (uart.info().request_uart_clks)(clocks);
         });
 

--- a/esp-metadata-generated/src/_build_script_utils.rs
+++ b/esp-metadata-generated/src/_build_script_utils.rs
@@ -380,10 +380,13 @@ impl Chip {
                     "soc_has_clock_node_timg1_calibration_clock",
                     "soc_has_clock_node_uart0_function_clock",
                     "soc_has_clock_node_uart0_mem_clock",
+                    "soc_has_clock_node_uart0_baud_rate_generator",
                     "soc_has_clock_node_uart1_function_clock",
                     "soc_has_clock_node_uart1_mem_clock",
+                    "soc_has_clock_node_uart1_baud_rate_generator",
                     "soc_has_clock_node_uart2_function_clock",
                     "soc_has_clock_node_uart2_mem_clock",
+                    "soc_has_clock_node_uart2_baud_rate_generator",
                     "has_dram_region",
                     "has_dram2_uninit_region",
                     "spi_master_supports_dma",
@@ -583,10 +586,13 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_clock_node_timg1_calibration_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_uart0_function_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_uart0_mem_clock",
+                    "cargo:rustc-cfg=soc_has_clock_node_uart0_baud_rate_generator",
                     "cargo:rustc-cfg=soc_has_clock_node_uart1_function_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_uart1_mem_clock",
+                    "cargo:rustc-cfg=soc_has_clock_node_uart1_baud_rate_generator",
                     "cargo:rustc-cfg=soc_has_clock_node_uart2_function_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_uart2_mem_clock",
+                    "cargo:rustc-cfg=soc_has_clock_node_uart2_baud_rate_generator",
                     "cargo:rustc-cfg=has_dram_region",
                     "cargo:rustc-cfg=has_dram2_uninit_region",
                     "cargo:rustc-cfg=spi_master_supports_dma",
@@ -904,8 +910,10 @@ impl Chip {
                     "soc_has_clock_node_timg0_wdt_clock",
                     "soc_has_clock_node_uart0_function_clock",
                     "soc_has_clock_node_uart0_mem_clock",
+                    "soc_has_clock_node_uart0_baud_rate_generator",
                     "soc_has_clock_node_uart1_function_clock",
                     "soc_has_clock_node_uart1_mem_clock",
+                    "soc_has_clock_node_uart1_baud_rate_generator",
                     "has_dram_region",
                     "has_dram2_uninit_region",
                     "spi_master_supports_dma",
@@ -915,6 +923,7 @@ impl Chip {
                     "timergroup_timg_has_divcnt_rst",
                     "timergroup_rc_fast_calibration_is_set",
                     "uart_ram_size=\"128\"",
+                    "uart_has_sclk_divider",
                     "wifi_mac_version=\"1\"",
                 ],
                 cfgs: &[
@@ -1063,8 +1072,10 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_clock_node_timg0_wdt_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_uart0_function_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_uart0_mem_clock",
+                    "cargo:rustc-cfg=soc_has_clock_node_uart0_baud_rate_generator",
                     "cargo:rustc-cfg=soc_has_clock_node_uart1_function_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_uart1_mem_clock",
+                    "cargo:rustc-cfg=soc_has_clock_node_uart1_baud_rate_generator",
                     "cargo:rustc-cfg=has_dram_region",
                     "cargo:rustc-cfg=has_dram2_uninit_region",
                     "cargo:rustc-cfg=spi_master_supports_dma",
@@ -1074,6 +1085,7 @@ impl Chip {
                     "cargo:rustc-cfg=timergroup_timg_has_divcnt_rst",
                     "cargo:rustc-cfg=timergroup_rc_fast_calibration_is_set",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
+                    "cargo:rustc-cfg=uart_has_sclk_divider",
                     "cargo:rustc-cfg=wifi_mac_version=\"1\"",
                 ],
                 memory_layout: &MemoryLayout {
@@ -1375,8 +1387,10 @@ impl Chip {
                     "soc_has_clock_node_timg1_wdt_clock",
                     "soc_has_clock_node_uart0_function_clock",
                     "soc_has_clock_node_uart0_mem_clock",
+                    "soc_has_clock_node_uart0_baud_rate_generator",
                     "soc_has_clock_node_uart1_function_clock",
                     "soc_has_clock_node_uart1_mem_clock",
+                    "soc_has_clock_node_uart1_baud_rate_generator",
                     "has_dram_region",
                     "has_dram2_uninit_region",
                     "spi_master_supports_dma",
@@ -1386,6 +1400,7 @@ impl Chip {
                     "timergroup_timg_has_divcnt_rst",
                     "timergroup_rc_fast_calibration_is_set",
                     "uart_ram_size=\"128\"",
+                    "uart_has_sclk_divider",
                     "wifi_mac_version=\"1\"",
                 ],
                 cfgs: &[
@@ -1581,8 +1596,10 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_clock_node_timg1_wdt_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_uart0_function_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_uart0_mem_clock",
+                    "cargo:rustc-cfg=soc_has_clock_node_uart0_baud_rate_generator",
                     "cargo:rustc-cfg=soc_has_clock_node_uart1_function_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_uart1_mem_clock",
+                    "cargo:rustc-cfg=soc_has_clock_node_uart1_baud_rate_generator",
                     "cargo:rustc-cfg=has_dram_region",
                     "cargo:rustc-cfg=has_dram2_uninit_region",
                     "cargo:rustc-cfg=spi_master_supports_dma",
@@ -1592,6 +1609,7 @@ impl Chip {
                     "cargo:rustc-cfg=timergroup_timg_has_divcnt_rst",
                     "cargo:rustc-cfg=timergroup_rc_fast_calibration_is_set",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
+                    "cargo:rustc-cfg=uart_has_sclk_divider",
                     "cargo:rustc-cfg=wifi_mac_version=\"1\"",
                 ],
                 memory_layout: &MemoryLayout {
@@ -1927,7 +1945,9 @@ impl Chip {
                     "soc_has_clock_node_timg1_function_clock",
                     "soc_has_clock_node_timg1_wdt_clock",
                     "soc_has_clock_node_uart0_function_clock",
+                    "soc_has_clock_node_uart0_baud_rate_generator",
                     "soc_has_clock_node_uart1_function_clock",
+                    "soc_has_clock_node_uart1_baud_rate_generator",
                     "has_dram_region",
                     "has_dram2_uninit_region",
                     "spi_master_supports_dma",
@@ -2165,7 +2185,9 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_clock_node_timg1_function_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_timg1_wdt_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_uart0_function_clock",
+                    "cargo:rustc-cfg=soc_has_clock_node_uart0_baud_rate_generator",
                     "cargo:rustc-cfg=soc_has_clock_node_uart1_function_clock",
+                    "cargo:rustc-cfg=soc_has_clock_node_uart1_baud_rate_generator",
                     "cargo:rustc-cfg=has_dram_region",
                     "cargo:rustc-cfg=has_dram2_uninit_region",
                     "cargo:rustc-cfg=spi_master_supports_dma",
@@ -2548,7 +2570,9 @@ impl Chip {
                     "soc_has_clock_node_timg1_calibration_clock",
                     "soc_has_clock_node_timg1_wdt_clock",
                     "soc_has_clock_node_uart0_function_clock",
+                    "soc_has_clock_node_uart0_baud_rate_generator",
                     "soc_has_clock_node_uart1_function_clock",
+                    "soc_has_clock_node_uart1_baud_rate_generator",
                     "has_dram_region",
                     "has_dram2_uninit_region",
                     "spi_master_supports_dma",
@@ -2825,7 +2849,9 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_clock_node_timg1_calibration_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_timg1_wdt_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_uart0_function_clock",
+                    "cargo:rustc-cfg=soc_has_clock_node_uart0_baud_rate_generator",
                     "cargo:rustc-cfg=soc_has_clock_node_uart1_function_clock",
+                    "cargo:rustc-cfg=soc_has_clock_node_uart1_baud_rate_generator",
                     "cargo:rustc-cfg=has_dram_region",
                     "cargo:rustc-cfg=has_dram2_uninit_region",
                     "cargo:rustc-cfg=spi_master_supports_dma",
@@ -3379,7 +3405,9 @@ impl Chip {
                     "soc_has_clock_node_timg1_calibration_clock",
                     "soc_has_clock_node_timg1_wdt_clock",
                     "soc_has_clock_node_uart0_function_clock",
+                    "soc_has_clock_node_uart0_baud_rate_generator",
                     "soc_has_clock_node_uart1_function_clock",
+                    "soc_has_clock_node_uart1_baud_rate_generator",
                     "has_dram_region",
                     "has_dram2_uninit_region",
                     "spi_master_supports_dma",
@@ -3620,7 +3648,9 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_clock_node_timg1_calibration_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_timg1_wdt_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_uart0_function_clock",
+                    "cargo:rustc-cfg=soc_has_clock_node_uart0_baud_rate_generator",
                     "cargo:rustc-cfg=soc_has_clock_node_uart1_function_clock",
+                    "cargo:rustc-cfg=soc_has_clock_node_uart1_baud_rate_generator",
                     "cargo:rustc-cfg=has_dram_region",
                     "cargo:rustc-cfg=has_dram2_uninit_region",
                     "cargo:rustc-cfg=spi_master_supports_dma",
@@ -3939,8 +3969,10 @@ impl Chip {
                     "soc_has_clock_node_timg1_function_clock",
                     "soc_has_clock_node_timg1_calibration_clock",
                     "soc_has_clock_node_uart0_function_clock",
+                    "soc_has_clock_node_uart0_baud_rate_generator",
                     "soc_has_clock_node_uart0_mem_clock",
                     "soc_has_clock_node_uart1_function_clock",
+                    "soc_has_clock_node_uart1_baud_rate_generator",
                     "soc_has_clock_node_uart1_mem_clock",
                     "has_dram_region",
                     "has_dram2_uninit_region",
@@ -4153,8 +4185,10 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_clock_node_timg1_function_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_timg1_calibration_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_uart0_function_clock",
+                    "cargo:rustc-cfg=soc_has_clock_node_uart0_baud_rate_generator",
                     "cargo:rustc-cfg=soc_has_clock_node_uart0_mem_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_uart1_function_clock",
+                    "cargo:rustc-cfg=soc_has_clock_node_uart1_baud_rate_generator",
                     "cargo:rustc-cfg=soc_has_clock_node_uart1_mem_clock",
                     "cargo:rustc-cfg=has_dram_region",
                     "cargo:rustc-cfg=has_dram2_uninit_region",
@@ -4597,10 +4631,13 @@ impl Chip {
                     "soc_has_clock_node_timg1_function_clock",
                     "soc_has_clock_node_timg1_calibration_clock",
                     "soc_has_clock_node_uart0_function_clock",
+                    "soc_has_clock_node_uart0_baud_rate_generator",
                     "soc_has_clock_node_uart0_mem_clock",
                     "soc_has_clock_node_uart1_function_clock",
+                    "soc_has_clock_node_uart1_baud_rate_generator",
                     "soc_has_clock_node_uart1_mem_clock",
                     "soc_has_clock_node_uart2_function_clock",
+                    "soc_has_clock_node_uart2_baud_rate_generator",
                     "soc_has_clock_node_uart2_mem_clock",
                     "has_dram_region",
                     "has_dram2_uninit_region",
@@ -4612,6 +4649,7 @@ impl Chip {
                     "timergroup_timg_has_timer1",
                     "timergroup_rc_fast_calibration_is_set",
                     "uart_ram_size=\"128\"",
+                    "uart_has_sclk_divider",
                     "wifi_mac_version=\"1\"",
                 ],
                 cfgs: &[
@@ -4850,10 +4888,13 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_clock_node_timg1_function_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_timg1_calibration_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_uart0_function_clock",
+                    "cargo:rustc-cfg=soc_has_clock_node_uart0_baud_rate_generator",
                     "cargo:rustc-cfg=soc_has_clock_node_uart0_mem_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_uart1_function_clock",
+                    "cargo:rustc-cfg=soc_has_clock_node_uart1_baud_rate_generator",
                     "cargo:rustc-cfg=soc_has_clock_node_uart1_mem_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_uart2_function_clock",
+                    "cargo:rustc-cfg=soc_has_clock_node_uart2_baud_rate_generator",
                     "cargo:rustc-cfg=soc_has_clock_node_uart2_mem_clock",
                     "cargo:rustc-cfg=has_dram_region",
                     "cargo:rustc-cfg=has_dram2_uninit_region",
@@ -4865,6 +4906,7 @@ impl Chip {
                     "cargo:rustc-cfg=timergroup_timg_has_timer1",
                     "cargo:rustc-cfg=timergroup_rc_fast_calibration_is_set",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
+                    "cargo:rustc-cfg=uart_has_sclk_divider",
                     "cargo:rustc-cfg=wifi_mac_version=\"1\"",
                 ],
                 memory_layout: &MemoryLayout {
@@ -5294,10 +5336,13 @@ pub fn emit_check_cfg_directives() {
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_timg1_calibration_clock)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_uart0_function_clock)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_uart0_mem_clock)");
+    println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_uart0_baud_rate_generator)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_uart1_function_clock)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_uart1_mem_clock)");
+    println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_uart1_baud_rate_generator)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_uart2_function_clock)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_uart2_mem_clock)");
+    println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_uart2_baud_rate_generator)");
     println!("cargo:rustc-check-cfg=cfg(has_dram_region)");
     println!("cargo:rustc-check-cfg=cfg(has_dram2_uninit_region)");
     println!("cargo:rustc-check-cfg=cfg(spi_master_supports_dma)");
@@ -5363,6 +5408,7 @@ pub fn emit_check_cfg_directives() {
     println!("cargo:rustc-check-cfg=cfg(spi_master_has_app_interrupts)");
     println!("cargo:rustc-check-cfg=cfg(spi_master_has_dma_segmented_transfer)");
     println!("cargo:rustc-check-cfg=cfg(timergroup_timg_has_divcnt_rst)");
+    println!("cargo:rustc-check-cfg=cfg(uart_has_sclk_divider)");
     println!("cargo:rustc-check-cfg=cfg(esp32c3)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_ds)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_fe)");

--- a/esp-metadata-generated/src/_generated_esp32.rs
+++ b/esp-metadata-generated/src/_generated_esp32.rs
@@ -295,6 +295,9 @@ macro_rules! property {
     ("uart.peripheral_controls_mem_clk") => {
         false
     };
+    ("uart.has_sclk_divider") => {
+        false
+    };
     ("uhci.combined_uart_selector_field") => {
         false
     };
@@ -807,6 +810,20 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
+/// // UART0_BAUD_RATE_GENERATOR
+///
+/// fn enable_uart0_baud_rate_generator_impl(_clocks: &mut ClockTree, _en: bool) {
+///     todo!()
+/// }
+///
+/// fn configure_uart0_baud_rate_generator_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<Uart0BaudRateGeneratorConfig>,
+///     _new_config: Uart0BaudRateGeneratorConfig,
+/// ) {
+///     todo!()
+/// }
+///
 /// // UART1_FUNCTION_CLOCK
 ///
 /// fn enable_uart1_function_clock_impl(_clocks: &mut ClockTree, _en: bool) {
@@ -835,6 +852,20 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
+/// // UART1_BAUD_RATE_GENERATOR
+///
+/// fn enable_uart1_baud_rate_generator_impl(_clocks: &mut ClockTree, _en: bool) {
+///     todo!()
+/// }
+///
+/// fn configure_uart1_baud_rate_generator_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<Uart0BaudRateGeneratorConfig>,
+///     _new_config: Uart0BaudRateGeneratorConfig,
+/// ) {
+///     todo!()
+/// }
+///
 /// // UART2_FUNCTION_CLOCK
 ///
 /// fn enable_uart2_function_clock_impl(_clocks: &mut ClockTree, _en: bool) {
@@ -859,6 +890,20 @@ macro_rules! for_each_sha_algorithm {
 ///     _clocks: &mut ClockTree,
 ///     _old_config: Option<Uart0MemClockConfig>,
 ///     _new_config: Uart0MemClockConfig,
+/// ) {
+///     todo!()
+/// }
+///
+/// // UART2_BAUD_RATE_GENERATOR
+///
+/// fn enable_uart2_baud_rate_generator_impl(_clocks: &mut ClockTree, _en: bool) {
+///     todo!()
+/// }
+///
+/// fn configure_uart2_baud_rate_generator_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<Uart0BaudRateGeneratorConfig>,
+///     _new_config: Uart0BaudRateGeneratorConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1184,23 +1229,85 @@ macro_rules! define_clock_tree_types {
             /// Selects `XTAL32K_CLK`.
             Xtal32kClk,
         }
-        /// The list of clock signals that the `UART0_FUNCTION_CLOCK` multiplexer can output.
         #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-        pub enum Uart0FunctionClockConfig {
+        pub enum Uart0FunctionClockSclk {
             #[default]
             /// Selects `APB_CLK`.
             Apb,
             /// Selects `REF_TICK`.
             RefTick,
         }
-        /// The list of clock signals that the `UART0_MEM_CLOCK` multiplexer can output.
-        #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+        /// Configures the `UART0_FUNCTION_CLOCK` clock node.
+        ///
+        /// The output is calculated as `OUTPUT = sclk`.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-        pub enum Uart0MemClockConfig {
-            #[default]
-            /// Selects `UART_MEM_CLK`.
-            Mem,
+        pub struct Uart0FunctionClockConfig {
+            sclk: Uart0FunctionClockSclk,
+        }
+        impl Uart0FunctionClockConfig {
+            /// Creates a new configuration for the FUNCTION_CLOCK clock node.
+            pub const fn new(sclk: Uart0FunctionClockSclk) -> Self {
+                Self { sclk }
+            }
+            fn sclk(self) -> Uart0FunctionClockSclk {
+                self.sclk
+            }
+        }
+        /// Configures the `UART0_MEM_CLOCK` clock node.
+        ///
+        /// The output is calculated as `OUTPUT = UART_MEM_CLK`.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+        pub struct Uart0MemClockConfig {}
+        impl Uart0MemClockConfig {
+            /// Creates a new configuration for the MEM_CLOCK clock node.
+            pub const fn new() -> Self {
+                Self {}
+            }
+        }
+        /// Configures the `UART0_BAUD_RATE_GENERATOR` clock node.
+        ///
+        /// The output is calculated as `OUTPUT = (FUNCTION_CLOCK * 16) / (integral * 16 +
+        /// fractional)`.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+        pub struct Uart0BaudRateGeneratorConfig {
+            fractional: u32,
+            integral: u32,
+        }
+        impl Uart0BaudRateGeneratorConfig {
+            /// Creates a new configuration for the BAUD_RATE_GENERATOR clock node.
+            ///
+            /// ## Panics
+            ///
+            /// Panics if the fractional value is outside the
+            /// valid range (0 ..= 15).
+            ///
+            /// Panics if the integral value is outside the
+            /// valid range (0 ..= 1048575).
+            pub const fn new(fractional: u32, integral: u32) -> Self {
+                ::core::assert!(
+                    fractional <= 15,
+                    "`UART0_BAUD_RATE_GENERATOR` fractional must be between 0 and 15 (inclusive)."
+                );
+                ::core::assert!(
+                    integral <= 1048575,
+                    "`UART0_BAUD_RATE_GENERATOR` integral must be between 0 and 1048575 \
+                     (inclusive)."
+                );
+                Self {
+                    fractional,
+                    integral,
+                }
+            }
+            fn fractional(self) -> u32 {
+                self.fractional as u32
+            }
+            fn integral(self) -> u32 {
+                self.integral as u32
+            }
         }
         /// Represents the device's clock tree.
         pub struct ClockTree {
@@ -1226,10 +1333,13 @@ macro_rules! define_clock_tree_types {
             timg1_calibration_clock: Option<Timg0CalibrationClockConfig>,
             uart0_function_clock: Option<Uart0FunctionClockConfig>,
             uart0_mem_clock: Option<Uart0MemClockConfig>,
+            uart0_baud_rate_generator: Option<Uart0BaudRateGeneratorConfig>,
             uart1_function_clock: Option<Uart0FunctionClockConfig>,
             uart1_mem_clock: Option<Uart0MemClockConfig>,
+            uart1_baud_rate_generator: Option<Uart0BaudRateGeneratorConfig>,
             uart2_function_clock: Option<Uart0FunctionClockConfig>,
             uart2_mem_clock: Option<Uart0MemClockConfig>,
+            uart2_baud_rate_generator: Option<Uart0BaudRateGeneratorConfig>,
             pll_clk_refcount: u32,
             rc_fast_clk_refcount: u32,
             pll_f160m_clk_refcount: u32,
@@ -1247,10 +1357,13 @@ macro_rules! define_clock_tree_types {
             timg1_calibration_clock_refcount: u32,
             uart0_function_clock_refcount: u32,
             uart0_mem_clock_refcount: u32,
+            uart0_baud_rate_generator_refcount: u32,
             uart1_function_clock_refcount: u32,
             uart1_mem_clock_refcount: u32,
+            uart1_baud_rate_generator_refcount: u32,
             uart2_function_clock_refcount: u32,
             uart2_mem_clock_refcount: u32,
+            uart2_baud_rate_generator_refcount: u32,
         }
         impl ClockTree {
             /// Locks the clock tree for exclusive access.
@@ -1345,6 +1458,10 @@ macro_rules! define_clock_tree_types {
             pub fn uart0_mem_clock(&self) -> Option<Uart0MemClockConfig> {
                 self.uart0_mem_clock
             }
+            /// Returns the current configuration of the UART0_BAUD_RATE_GENERATOR clock tree node
+            pub fn uart0_baud_rate_generator(&self) -> Option<Uart0BaudRateGeneratorConfig> {
+                self.uart0_baud_rate_generator
+            }
             /// Returns the current configuration of the UART1_FUNCTION_CLOCK clock tree node
             pub fn uart1_function_clock(&self) -> Option<Uart0FunctionClockConfig> {
                 self.uart1_function_clock
@@ -1353,6 +1470,10 @@ macro_rules! define_clock_tree_types {
             pub fn uart1_mem_clock(&self) -> Option<Uart0MemClockConfig> {
                 self.uart1_mem_clock
             }
+            /// Returns the current configuration of the UART1_BAUD_RATE_GENERATOR clock tree node
+            pub fn uart1_baud_rate_generator(&self) -> Option<Uart0BaudRateGeneratorConfig> {
+                self.uart1_baud_rate_generator
+            }
             /// Returns the current configuration of the UART2_FUNCTION_CLOCK clock tree node
             pub fn uart2_function_clock(&self) -> Option<Uart0FunctionClockConfig> {
                 self.uart2_function_clock
@@ -1360,6 +1481,10 @@ macro_rules! define_clock_tree_types {
             /// Returns the current configuration of the UART2_MEM_CLOCK clock tree node
             pub fn uart2_mem_clock(&self) -> Option<Uart0MemClockConfig> {
                 self.uart2_mem_clock
+            }
+            /// Returns the current configuration of the UART2_BAUD_RATE_GENERATOR clock tree node
+            pub fn uart2_baud_rate_generator(&self) -> Option<Uart0BaudRateGeneratorConfig> {
+                self.uart2_baud_rate_generator
             }
         }
         static CLOCK_TREE: ::esp_sync::NonReentrantMutex<ClockTree> =
@@ -1386,10 +1511,13 @@ macro_rules! define_clock_tree_types {
                 timg1_calibration_clock: None,
                 uart0_function_clock: None,
                 uart0_mem_clock: None,
+                uart0_baud_rate_generator: None,
                 uart1_function_clock: None,
                 uart1_mem_clock: None,
+                uart1_baud_rate_generator: None,
                 uart2_function_clock: None,
                 uart2_mem_clock: None,
+                uart2_baud_rate_generator: None,
                 pll_clk_refcount: 0,
                 rc_fast_clk_refcount: 0,
                 pll_f160m_clk_refcount: 0,
@@ -1407,10 +1535,13 @@ macro_rules! define_clock_tree_types {
                 timg1_calibration_clock_refcount: 0,
                 uart0_function_clock_refcount: 0,
                 uart0_mem_clock_refcount: 0,
+                uart0_baud_rate_generator_refcount: 0,
                 uart1_function_clock_refcount: 0,
                 uart1_mem_clock_refcount: 0,
+                uart1_baud_rate_generator_refcount: 0,
                 uart2_function_clock_refcount: 0,
                 uart2_mem_clock_refcount: 0,
+                uart2_baud_rate_generator_refcount: 0,
             });
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
             let old_config = clocks.xtal_clk.replace(config);
@@ -2536,23 +2667,23 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_uart0_function_clock(
             clocks: &mut ClockTree,
-            new_selector: Uart0FunctionClockConfig,
+            config: Uart0FunctionClockConfig,
         ) {
-            let old_selector = clocks.uart0_function_clock.replace(new_selector);
+            let old_config = clocks.uart0_function_clock.replace(config);
             if clocks.uart0_function_clock_refcount > 0 {
-                match new_selector {
-                    Uart0FunctionClockConfig::Apb => request_apb_clk(clocks),
-                    Uart0FunctionClockConfig::RefTick => request_ref_tick(clocks),
+                match config.sclk {
+                    Uart0FunctionClockSclk::Apb => request_apb_clk(clocks),
+                    Uart0FunctionClockSclk::RefTick => request_ref_tick(clocks),
                 }
-                configure_uart0_function_clock_impl(clocks, old_selector, new_selector);
-                if let Some(old_selector) = old_selector {
-                    match old_selector {
-                        Uart0FunctionClockConfig::Apb => release_apb_clk(clocks),
-                        Uart0FunctionClockConfig::RefTick => release_ref_tick(clocks),
+                configure_uart0_function_clock_impl(clocks, old_config, config);
+                if let Some(old_config) = old_config {
+                    match old_config.sclk {
+                        Uart0FunctionClockSclk::Apb => release_apb_clk(clocks),
+                        Uart0FunctionClockSclk::RefTick => release_ref_tick(clocks),
                     }
                 }
             } else {
-                configure_uart0_function_clock_impl(clocks, old_selector, new_selector);
+                configure_uart0_function_clock_impl(clocks, old_config, config);
             }
         }
         pub fn uart0_function_clock_config(
@@ -2564,9 +2695,9 @@ macro_rules! define_clock_tree_types {
             trace!("Requesting UART0_FUNCTION_CLOCK");
             if increment_reference_count(&mut clocks.uart0_function_clock_refcount) {
                 trace!("Enabling UART0_FUNCTION_CLOCK");
-                match unwrap!(clocks.uart0_function_clock) {
-                    Uart0FunctionClockConfig::Apb => request_apb_clk(clocks),
-                    Uart0FunctionClockConfig::RefTick => request_ref_tick(clocks),
+                match unwrap!(clocks.uart0_function_clock).sclk {
+                    Uart0FunctionClockSclk::Apb => request_apb_clk(clocks),
+                    Uart0FunctionClockSclk::RefTick => request_ref_tick(clocks),
                 }
                 enable_uart0_function_clock_impl(clocks, true);
             }
@@ -2576,9 +2707,9 @@ macro_rules! define_clock_tree_types {
             if decrement_reference_count(&mut clocks.uart0_function_clock_refcount) {
                 trace!("Disabling UART0_FUNCTION_CLOCK");
                 enable_uart0_function_clock_impl(clocks, false);
-                match unwrap!(clocks.uart0_function_clock) {
-                    Uart0FunctionClockConfig::Apb => release_apb_clk(clocks),
-                    Uart0FunctionClockConfig::RefTick => release_ref_tick(clocks),
+                match unwrap!(clocks.uart0_function_clock).sclk {
+                    Uart0FunctionClockSclk::Apb => release_apb_clk(clocks),
+                    Uart0FunctionClockSclk::RefTick => release_ref_tick(clocks),
                 }
             }
         }
@@ -2587,9 +2718,9 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: Uart0FunctionClockConfig,
         ) -> u32 {
-            match config {
-                Uart0FunctionClockConfig::Apb => apb_clk_frequency(clocks),
-                Uart0FunctionClockConfig::RefTick => ref_tick_frequency(clocks),
+            match config.sclk {
+                Uart0FunctionClockSclk::Apb => apb_clk_frequency(clocks),
+                Uart0FunctionClockSclk::RefTick => ref_tick_frequency(clocks),
             }
         }
         pub fn uart0_function_clock_frequency(clocks: &mut ClockTree) -> u32 {
@@ -2599,20 +2730,9 @@ macro_rules! define_clock_tree_types {
                 0
             }
         }
-        pub fn configure_uart0_mem_clock(
-            clocks: &mut ClockTree,
-            new_selector: Uart0MemClockConfig,
-        ) {
-            let old_selector = clocks.uart0_mem_clock.replace(new_selector);
-            if clocks.uart0_mem_clock_refcount > 0 {
-                request_uart_mem_clk(clocks);
-                configure_uart0_mem_clock_impl(clocks, old_selector, new_selector);
-                if let Some(old_selector) = old_selector {
-                    release_uart_mem_clk(clocks);
-                }
-            } else {
-                configure_uart0_mem_clock_impl(clocks, old_selector, new_selector);
-            }
+        pub fn configure_uart0_mem_clock(clocks: &mut ClockTree, config: Uart0MemClockConfig) {
+            let old_config = clocks.uart0_mem_clock.replace(config);
+            configure_uart0_mem_clock_impl(clocks, old_config, config);
         }
         pub fn uart0_mem_clock_config(clocks: &mut ClockTree) -> Option<Uart0MemClockConfig> {
             clocks.uart0_mem_clock
@@ -2647,25 +2767,68 @@ macro_rules! define_clock_tree_types {
                 0
             }
         }
+        pub fn configure_uart0_baud_rate_generator(
+            clocks: &mut ClockTree,
+            config: Uart0BaudRateGeneratorConfig,
+        ) {
+            let old_config = clocks.uart0_baud_rate_generator.replace(config);
+            configure_uart0_baud_rate_generator_impl(clocks, old_config, config);
+        }
+        pub fn uart0_baud_rate_generator_config(
+            clocks: &mut ClockTree,
+        ) -> Option<Uart0BaudRateGeneratorConfig> {
+            clocks.uart0_baud_rate_generator
+        }
+        pub fn request_uart0_baud_rate_generator(clocks: &mut ClockTree) {
+            trace!("Requesting UART0_BAUD_RATE_GENERATOR");
+            if increment_reference_count(&mut clocks.uart0_baud_rate_generator_refcount) {
+                trace!("Enabling UART0_BAUD_RATE_GENERATOR");
+                request_uart0_function_clock(clocks);
+                enable_uart0_baud_rate_generator_impl(clocks, true);
+            }
+        }
+        pub fn release_uart0_baud_rate_generator(clocks: &mut ClockTree) {
+            trace!("Releasing UART0_BAUD_RATE_GENERATOR");
+            if decrement_reference_count(&mut clocks.uart0_baud_rate_generator_refcount) {
+                trace!("Disabling UART0_BAUD_RATE_GENERATOR");
+                enable_uart0_baud_rate_generator_impl(clocks, false);
+                release_uart0_function_clock(clocks);
+            }
+        }
+        #[allow(unused_variables)]
+        pub fn uart0_baud_rate_generator_config_frequency(
+            clocks: &mut ClockTree,
+            config: Uart0BaudRateGeneratorConfig,
+        ) -> u32 {
+            ((uart0_function_clock_frequency(clocks) * 16)
+                / ((config.integral() * 16) + config.fractional()))
+        }
+        pub fn uart0_baud_rate_generator_frequency(clocks: &mut ClockTree) -> u32 {
+            if let Some(config) = clocks.uart0_baud_rate_generator {
+                uart0_baud_rate_generator_config_frequency(clocks, config)
+            } else {
+                0
+            }
+        }
         pub fn configure_uart1_function_clock(
             clocks: &mut ClockTree,
-            new_selector: Uart0FunctionClockConfig,
+            config: Uart0FunctionClockConfig,
         ) {
-            let old_selector = clocks.uart1_function_clock.replace(new_selector);
+            let old_config = clocks.uart1_function_clock.replace(config);
             if clocks.uart1_function_clock_refcount > 0 {
-                match new_selector {
-                    Uart0FunctionClockConfig::Apb => request_apb_clk(clocks),
-                    Uart0FunctionClockConfig::RefTick => request_ref_tick(clocks),
+                match config.sclk {
+                    Uart0FunctionClockSclk::Apb => request_apb_clk(clocks),
+                    Uart0FunctionClockSclk::RefTick => request_ref_tick(clocks),
                 }
-                configure_uart1_function_clock_impl(clocks, old_selector, new_selector);
-                if let Some(old_selector) = old_selector {
-                    match old_selector {
-                        Uart0FunctionClockConfig::Apb => release_apb_clk(clocks),
-                        Uart0FunctionClockConfig::RefTick => release_ref_tick(clocks),
+                configure_uart1_function_clock_impl(clocks, old_config, config);
+                if let Some(old_config) = old_config {
+                    match old_config.sclk {
+                        Uart0FunctionClockSclk::Apb => release_apb_clk(clocks),
+                        Uart0FunctionClockSclk::RefTick => release_ref_tick(clocks),
                     }
                 }
             } else {
-                configure_uart1_function_clock_impl(clocks, old_selector, new_selector);
+                configure_uart1_function_clock_impl(clocks, old_config, config);
             }
         }
         pub fn uart1_function_clock_config(
@@ -2677,9 +2840,9 @@ macro_rules! define_clock_tree_types {
             trace!("Requesting UART1_FUNCTION_CLOCK");
             if increment_reference_count(&mut clocks.uart1_function_clock_refcount) {
                 trace!("Enabling UART1_FUNCTION_CLOCK");
-                match unwrap!(clocks.uart1_function_clock) {
-                    Uart0FunctionClockConfig::Apb => request_apb_clk(clocks),
-                    Uart0FunctionClockConfig::RefTick => request_ref_tick(clocks),
+                match unwrap!(clocks.uart1_function_clock).sclk {
+                    Uart0FunctionClockSclk::Apb => request_apb_clk(clocks),
+                    Uart0FunctionClockSclk::RefTick => request_ref_tick(clocks),
                 }
                 enable_uart1_function_clock_impl(clocks, true);
             }
@@ -2689,9 +2852,9 @@ macro_rules! define_clock_tree_types {
             if decrement_reference_count(&mut clocks.uart1_function_clock_refcount) {
                 trace!("Disabling UART1_FUNCTION_CLOCK");
                 enable_uart1_function_clock_impl(clocks, false);
-                match unwrap!(clocks.uart1_function_clock) {
-                    Uart0FunctionClockConfig::Apb => release_apb_clk(clocks),
-                    Uart0FunctionClockConfig::RefTick => release_ref_tick(clocks),
+                match unwrap!(clocks.uart1_function_clock).sclk {
+                    Uart0FunctionClockSclk::Apb => release_apb_clk(clocks),
+                    Uart0FunctionClockSclk::RefTick => release_ref_tick(clocks),
                 }
             }
         }
@@ -2700,9 +2863,9 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: Uart0FunctionClockConfig,
         ) -> u32 {
-            match config {
-                Uart0FunctionClockConfig::Apb => apb_clk_frequency(clocks),
-                Uart0FunctionClockConfig::RefTick => ref_tick_frequency(clocks),
+            match config.sclk {
+                Uart0FunctionClockSclk::Apb => apb_clk_frequency(clocks),
+                Uart0FunctionClockSclk::RefTick => ref_tick_frequency(clocks),
             }
         }
         pub fn uart1_function_clock_frequency(clocks: &mut ClockTree) -> u32 {
@@ -2712,20 +2875,9 @@ macro_rules! define_clock_tree_types {
                 0
             }
         }
-        pub fn configure_uart1_mem_clock(
-            clocks: &mut ClockTree,
-            new_selector: Uart0MemClockConfig,
-        ) {
-            let old_selector = clocks.uart1_mem_clock.replace(new_selector);
-            if clocks.uart1_mem_clock_refcount > 0 {
-                request_uart_mem_clk(clocks);
-                configure_uart1_mem_clock_impl(clocks, old_selector, new_selector);
-                if let Some(old_selector) = old_selector {
-                    release_uart_mem_clk(clocks);
-                }
-            } else {
-                configure_uart1_mem_clock_impl(clocks, old_selector, new_selector);
-            }
+        pub fn configure_uart1_mem_clock(clocks: &mut ClockTree, config: Uart0MemClockConfig) {
+            let old_config = clocks.uart1_mem_clock.replace(config);
+            configure_uart1_mem_clock_impl(clocks, old_config, config);
         }
         pub fn uart1_mem_clock_config(clocks: &mut ClockTree) -> Option<Uart0MemClockConfig> {
             clocks.uart1_mem_clock
@@ -2760,25 +2912,68 @@ macro_rules! define_clock_tree_types {
                 0
             }
         }
+        pub fn configure_uart1_baud_rate_generator(
+            clocks: &mut ClockTree,
+            config: Uart0BaudRateGeneratorConfig,
+        ) {
+            let old_config = clocks.uart1_baud_rate_generator.replace(config);
+            configure_uart1_baud_rate_generator_impl(clocks, old_config, config);
+        }
+        pub fn uart1_baud_rate_generator_config(
+            clocks: &mut ClockTree,
+        ) -> Option<Uart0BaudRateGeneratorConfig> {
+            clocks.uart1_baud_rate_generator
+        }
+        pub fn request_uart1_baud_rate_generator(clocks: &mut ClockTree) {
+            trace!("Requesting UART1_BAUD_RATE_GENERATOR");
+            if increment_reference_count(&mut clocks.uart1_baud_rate_generator_refcount) {
+                trace!("Enabling UART1_BAUD_RATE_GENERATOR");
+                request_uart1_function_clock(clocks);
+                enable_uart1_baud_rate_generator_impl(clocks, true);
+            }
+        }
+        pub fn release_uart1_baud_rate_generator(clocks: &mut ClockTree) {
+            trace!("Releasing UART1_BAUD_RATE_GENERATOR");
+            if decrement_reference_count(&mut clocks.uart1_baud_rate_generator_refcount) {
+                trace!("Disabling UART1_BAUD_RATE_GENERATOR");
+                enable_uart1_baud_rate_generator_impl(clocks, false);
+                release_uart1_function_clock(clocks);
+            }
+        }
+        #[allow(unused_variables)]
+        pub fn uart1_baud_rate_generator_config_frequency(
+            clocks: &mut ClockTree,
+            config: Uart0BaudRateGeneratorConfig,
+        ) -> u32 {
+            ((uart1_function_clock_frequency(clocks) * 16)
+                / ((config.integral() * 16) + config.fractional()))
+        }
+        pub fn uart1_baud_rate_generator_frequency(clocks: &mut ClockTree) -> u32 {
+            if let Some(config) = clocks.uart1_baud_rate_generator {
+                uart1_baud_rate_generator_config_frequency(clocks, config)
+            } else {
+                0
+            }
+        }
         pub fn configure_uart2_function_clock(
             clocks: &mut ClockTree,
-            new_selector: Uart0FunctionClockConfig,
+            config: Uart0FunctionClockConfig,
         ) {
-            let old_selector = clocks.uart2_function_clock.replace(new_selector);
+            let old_config = clocks.uart2_function_clock.replace(config);
             if clocks.uart2_function_clock_refcount > 0 {
-                match new_selector {
-                    Uart0FunctionClockConfig::Apb => request_apb_clk(clocks),
-                    Uart0FunctionClockConfig::RefTick => request_ref_tick(clocks),
+                match config.sclk {
+                    Uart0FunctionClockSclk::Apb => request_apb_clk(clocks),
+                    Uart0FunctionClockSclk::RefTick => request_ref_tick(clocks),
                 }
-                configure_uart2_function_clock_impl(clocks, old_selector, new_selector);
-                if let Some(old_selector) = old_selector {
-                    match old_selector {
-                        Uart0FunctionClockConfig::Apb => release_apb_clk(clocks),
-                        Uart0FunctionClockConfig::RefTick => release_ref_tick(clocks),
+                configure_uart2_function_clock_impl(clocks, old_config, config);
+                if let Some(old_config) = old_config {
+                    match old_config.sclk {
+                        Uart0FunctionClockSclk::Apb => release_apb_clk(clocks),
+                        Uart0FunctionClockSclk::RefTick => release_ref_tick(clocks),
                     }
                 }
             } else {
-                configure_uart2_function_clock_impl(clocks, old_selector, new_selector);
+                configure_uart2_function_clock_impl(clocks, old_config, config);
             }
         }
         pub fn uart2_function_clock_config(
@@ -2790,9 +2985,9 @@ macro_rules! define_clock_tree_types {
             trace!("Requesting UART2_FUNCTION_CLOCK");
             if increment_reference_count(&mut clocks.uart2_function_clock_refcount) {
                 trace!("Enabling UART2_FUNCTION_CLOCK");
-                match unwrap!(clocks.uart2_function_clock) {
-                    Uart0FunctionClockConfig::Apb => request_apb_clk(clocks),
-                    Uart0FunctionClockConfig::RefTick => request_ref_tick(clocks),
+                match unwrap!(clocks.uart2_function_clock).sclk {
+                    Uart0FunctionClockSclk::Apb => request_apb_clk(clocks),
+                    Uart0FunctionClockSclk::RefTick => request_ref_tick(clocks),
                 }
                 enable_uart2_function_clock_impl(clocks, true);
             }
@@ -2802,9 +2997,9 @@ macro_rules! define_clock_tree_types {
             if decrement_reference_count(&mut clocks.uart2_function_clock_refcount) {
                 trace!("Disabling UART2_FUNCTION_CLOCK");
                 enable_uart2_function_clock_impl(clocks, false);
-                match unwrap!(clocks.uart2_function_clock) {
-                    Uart0FunctionClockConfig::Apb => release_apb_clk(clocks),
-                    Uart0FunctionClockConfig::RefTick => release_ref_tick(clocks),
+                match unwrap!(clocks.uart2_function_clock).sclk {
+                    Uart0FunctionClockSclk::Apb => release_apb_clk(clocks),
+                    Uart0FunctionClockSclk::RefTick => release_ref_tick(clocks),
                 }
             }
         }
@@ -2813,9 +3008,9 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: Uart0FunctionClockConfig,
         ) -> u32 {
-            match config {
-                Uart0FunctionClockConfig::Apb => apb_clk_frequency(clocks),
-                Uart0FunctionClockConfig::RefTick => ref_tick_frequency(clocks),
+            match config.sclk {
+                Uart0FunctionClockSclk::Apb => apb_clk_frequency(clocks),
+                Uart0FunctionClockSclk::RefTick => ref_tick_frequency(clocks),
             }
         }
         pub fn uart2_function_clock_frequency(clocks: &mut ClockTree) -> u32 {
@@ -2825,20 +3020,9 @@ macro_rules! define_clock_tree_types {
                 0
             }
         }
-        pub fn configure_uart2_mem_clock(
-            clocks: &mut ClockTree,
-            new_selector: Uart0MemClockConfig,
-        ) {
-            let old_selector = clocks.uart2_mem_clock.replace(new_selector);
-            if clocks.uart2_mem_clock_refcount > 0 {
-                request_uart_mem_clk(clocks);
-                configure_uart2_mem_clock_impl(clocks, old_selector, new_selector);
-                if let Some(old_selector) = old_selector {
-                    release_uart_mem_clk(clocks);
-                }
-            } else {
-                configure_uart2_mem_clock_impl(clocks, old_selector, new_selector);
-            }
+        pub fn configure_uart2_mem_clock(clocks: &mut ClockTree, config: Uart0MemClockConfig) {
+            let old_config = clocks.uart2_mem_clock.replace(config);
+            configure_uart2_mem_clock_impl(clocks, old_config, config);
         }
         pub fn uart2_mem_clock_config(clocks: &mut ClockTree) -> Option<Uart0MemClockConfig> {
             clocks.uart2_mem_clock
@@ -2869,6 +3053,49 @@ macro_rules! define_clock_tree_types {
         pub fn uart2_mem_clock_frequency(clocks: &mut ClockTree) -> u32 {
             if let Some(config) = clocks.uart2_mem_clock {
                 uart2_mem_clock_config_frequency(clocks, config)
+            } else {
+                0
+            }
+        }
+        pub fn configure_uart2_baud_rate_generator(
+            clocks: &mut ClockTree,
+            config: Uart0BaudRateGeneratorConfig,
+        ) {
+            let old_config = clocks.uart2_baud_rate_generator.replace(config);
+            configure_uart2_baud_rate_generator_impl(clocks, old_config, config);
+        }
+        pub fn uart2_baud_rate_generator_config(
+            clocks: &mut ClockTree,
+        ) -> Option<Uart0BaudRateGeneratorConfig> {
+            clocks.uart2_baud_rate_generator
+        }
+        pub fn request_uart2_baud_rate_generator(clocks: &mut ClockTree) {
+            trace!("Requesting UART2_BAUD_RATE_GENERATOR");
+            if increment_reference_count(&mut clocks.uart2_baud_rate_generator_refcount) {
+                trace!("Enabling UART2_BAUD_RATE_GENERATOR");
+                request_uart2_function_clock(clocks);
+                enable_uart2_baud_rate_generator_impl(clocks, true);
+            }
+        }
+        pub fn release_uart2_baud_rate_generator(clocks: &mut ClockTree) {
+            trace!("Releasing UART2_BAUD_RATE_GENERATOR");
+            if decrement_reference_count(&mut clocks.uart2_baud_rate_generator_refcount) {
+                trace!("Disabling UART2_BAUD_RATE_GENERATOR");
+                enable_uart2_baud_rate_generator_impl(clocks, false);
+                release_uart2_function_clock(clocks);
+            }
+        }
+        #[allow(unused_variables)]
+        pub fn uart2_baud_rate_generator_config_frequency(
+            clocks: &mut ClockTree,
+            config: Uart0BaudRateGeneratorConfig,
+        ) -> u32 {
+            ((uart2_function_clock_frequency(clocks) * 16)
+                / ((config.integral() * 16) + config.fractional()))
+        }
+        pub fn uart2_baud_rate_generator_frequency(clocks: &mut ClockTree) -> u32 {
+            if let Some(config) = clocks.uart2_baud_rate_generator {
+                uart2_baud_rate_generator_config_frequency(clocks, config)
             } else {
                 0
             }

--- a/esp-metadata-generated/src/_generated_esp32c2.rs
+++ b/esp-metadata-generated/src/_generated_esp32c2.rs
@@ -274,6 +274,9 @@ macro_rules! property {
     ("uart.peripheral_controls_mem_clk") => {
         false
     };
+    ("uart.has_sclk_divider") => {
+        true
+    };
     ("wifi.has_wifi6") => {
         false
     };
@@ -804,6 +807,20 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
+/// // UART0_BAUD_RATE_GENERATOR
+///
+/// fn enable_uart0_baud_rate_generator_impl(_clocks: &mut ClockTree, _en: bool) {
+///     todo!()
+/// }
+///
+/// fn configure_uart0_baud_rate_generator_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<Uart0BaudRateGeneratorConfig>,
+///     _new_config: Uart0BaudRateGeneratorConfig,
+/// ) {
+///     todo!()
+/// }
+///
 /// // UART1_FUNCTION_CLOCK
 ///
 /// fn enable_uart1_function_clock_impl(_clocks: &mut ClockTree, _en: bool) {
@@ -828,6 +845,20 @@ macro_rules! for_each_sha_algorithm {
 ///     _clocks: &mut ClockTree,
 ///     _old_config: Option<Uart0MemClockConfig>,
 ///     _new_config: Uart0MemClockConfig,
+/// ) {
+///     todo!()
+/// }
+///
+/// // UART1_BAUD_RATE_GENERATOR
+///
+/// fn enable_uart1_baud_rate_generator_impl(_clocks: &mut ClockTree, _en: bool) {
+///     todo!()
+/// }
+///
+/// fn configure_uart1_baud_rate_generator_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<Uart0BaudRateGeneratorConfig>,
+///     _new_config: Uart0BaudRateGeneratorConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1049,10 +1080,9 @@ macro_rules! define_clock_tree_types {
             /// Selects `XTAL_CLK`.
             XtalClk,
         }
-        /// The list of clock signals that the `UART0_FUNCTION_CLOCK` multiplexer can output.
         #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-        pub enum Uart0FunctionClockConfig {
+        pub enum Uart0FunctionClockSclk {
             /// Selects `PLL_40M`.
             PllF40m,
             /// Selects `RC_FAST_CLK`.
@@ -1061,13 +1091,88 @@ macro_rules! define_clock_tree_types {
             /// Selects `XTAL_CLK`.
             Xtal,
         }
-        /// The list of clock signals that the `UART0_MEM_CLOCK` multiplexer can output.
-        #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+        /// Configures the `UART0_FUNCTION_CLOCK` clock node.
+        ///
+        /// The output is calculated as `OUTPUT = sclk / (div_num + 1)`.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-        pub enum Uart0MemClockConfig {
-            #[default]
-            /// Selects `UART_MEM_CLK`.
-            Mem,
+        pub struct Uart0FunctionClockConfig {
+            sclk: Uart0FunctionClockSclk,
+            div_num: u32,
+        }
+        impl Uart0FunctionClockConfig {
+            /// Creates a new configuration for the FUNCTION_CLOCK clock node.
+            ///
+            /// ## Panics
+            ///
+            /// Panics if the div_num value is outside the
+            /// valid range (0 ..= 255).
+            pub const fn new(sclk: Uart0FunctionClockSclk, div_num: u32) -> Self {
+                ::core::assert!(
+                    div_num <= 255,
+                    "`UART0_FUNCTION_CLOCK` div_num must be between 0 and 255 (inclusive)."
+                );
+                Self { sclk, div_num }
+            }
+            fn sclk(self) -> Uart0FunctionClockSclk {
+                self.sclk
+            }
+            fn div_num(self) -> u32 {
+                self.div_num as u32
+            }
+        }
+        /// Configures the `UART0_MEM_CLOCK` clock node.
+        ///
+        /// The output is calculated as `OUTPUT = UART_MEM_CLK`.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+        pub struct Uart0MemClockConfig {}
+        impl Uart0MemClockConfig {
+            /// Creates a new configuration for the MEM_CLOCK clock node.
+            pub const fn new() -> Self {
+                Self {}
+            }
+        }
+        /// Configures the `UART0_BAUD_RATE_GENERATOR` clock node.
+        ///
+        /// The output is calculated as `OUTPUT = (FUNCTION_CLOCK * 16) / (integral * 16 +
+        /// fractional)`.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+        pub struct Uart0BaudRateGeneratorConfig {
+            fractional: u32,
+            integral: u32,
+        }
+        impl Uart0BaudRateGeneratorConfig {
+            /// Creates a new configuration for the BAUD_RATE_GENERATOR clock node.
+            ///
+            /// ## Panics
+            ///
+            /// Panics if the fractional value is outside the
+            /// valid range (0 ..= 15).
+            ///
+            /// Panics if the integral value is outside the
+            /// valid range (0 ..= 4095).
+            pub const fn new(fractional: u32, integral: u32) -> Self {
+                ::core::assert!(
+                    fractional <= 15,
+                    "`UART0_BAUD_RATE_GENERATOR` fractional must be between 0 and 15 (inclusive)."
+                );
+                ::core::assert!(
+                    integral <= 4095,
+                    "`UART0_BAUD_RATE_GENERATOR` integral must be between 0 and 4095 (inclusive)."
+                );
+                Self {
+                    fractional,
+                    integral,
+                }
+            }
+            fn fractional(self) -> u32 {
+                self.fractional as u32
+            }
+            fn integral(self) -> u32 {
+                self.integral as u32
+            }
         }
         /// Represents the device's clock tree.
         pub struct ClockTree {
@@ -1088,8 +1193,10 @@ macro_rules! define_clock_tree_types {
             timg0_wdt_clock: Option<Timg0WdtClockConfig>,
             uart0_function_clock: Option<Uart0FunctionClockConfig>,
             uart0_mem_clock: Option<Uart0MemClockConfig>,
+            uart0_baud_rate_generator: Option<Uart0BaudRateGeneratorConfig>,
             uart1_function_clock: Option<Uart0FunctionClockConfig>,
             uart1_mem_clock: Option<Uart0MemClockConfig>,
+            uart1_baud_rate_generator: Option<Uart0BaudRateGeneratorConfig>,
             rc_fast_clk_refcount: u32,
             osc_slow_clk_refcount: u32,
             rc_slow_clk_refcount: u32,
@@ -1107,8 +1214,10 @@ macro_rules! define_clock_tree_types {
             timg0_wdt_clock_refcount: u32,
             uart0_function_clock_refcount: u32,
             uart0_mem_clock_refcount: u32,
+            uart0_baud_rate_generator_refcount: u32,
             uart1_function_clock_refcount: u32,
             uart1_mem_clock_refcount: u32,
+            uart1_baud_rate_generator_refcount: u32,
         }
         impl ClockTree {
             /// Locks the clock tree for exclusive access.
@@ -1183,6 +1292,10 @@ macro_rules! define_clock_tree_types {
             pub fn uart0_mem_clock(&self) -> Option<Uart0MemClockConfig> {
                 self.uart0_mem_clock
             }
+            /// Returns the current configuration of the UART0_BAUD_RATE_GENERATOR clock tree node
+            pub fn uart0_baud_rate_generator(&self) -> Option<Uart0BaudRateGeneratorConfig> {
+                self.uart0_baud_rate_generator
+            }
             /// Returns the current configuration of the UART1_FUNCTION_CLOCK clock tree node
             pub fn uart1_function_clock(&self) -> Option<Uart0FunctionClockConfig> {
                 self.uart1_function_clock
@@ -1190,6 +1303,10 @@ macro_rules! define_clock_tree_types {
             /// Returns the current configuration of the UART1_MEM_CLOCK clock tree node
             pub fn uart1_mem_clock(&self) -> Option<Uart0MemClockConfig> {
                 self.uart1_mem_clock
+            }
+            /// Returns the current configuration of the UART1_BAUD_RATE_GENERATOR clock tree node
+            pub fn uart1_baud_rate_generator(&self) -> Option<Uart0BaudRateGeneratorConfig> {
+                self.uart1_baud_rate_generator
             }
         }
         static CLOCK_TREE: ::esp_sync::NonReentrantMutex<ClockTree> =
@@ -1211,8 +1328,10 @@ macro_rules! define_clock_tree_types {
                 timg0_wdt_clock: None,
                 uart0_function_clock: None,
                 uart0_mem_clock: None,
+                uart0_baud_rate_generator: None,
                 uart1_function_clock: None,
                 uart1_mem_clock: None,
+                uart1_baud_rate_generator: None,
                 rc_fast_clk_refcount: 0,
                 osc_slow_clk_refcount: 0,
                 rc_slow_clk_refcount: 0,
@@ -1230,8 +1349,10 @@ macro_rules! define_clock_tree_types {
                 timg0_wdt_clock_refcount: 0,
                 uart0_function_clock_refcount: 0,
                 uart0_mem_clock_refcount: 0,
+                uart0_baud_rate_generator_refcount: 0,
                 uart1_function_clock_refcount: 0,
                 uart1_mem_clock_refcount: 0,
+                uart1_baud_rate_generator_refcount: 0,
             });
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
             let old_config = clocks.xtal_clk.replace(config);
@@ -2209,25 +2330,25 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_uart0_function_clock(
             clocks: &mut ClockTree,
-            new_selector: Uart0FunctionClockConfig,
+            config: Uart0FunctionClockConfig,
         ) {
-            let old_selector = clocks.uart0_function_clock.replace(new_selector);
+            let old_config = clocks.uart0_function_clock.replace(config);
             if clocks.uart0_function_clock_refcount > 0 {
-                match new_selector {
-                    Uart0FunctionClockConfig::PllF40m => request_pll_40m(clocks),
-                    Uart0FunctionClockConfig::RcFast => request_rc_fast_clk(clocks),
-                    Uart0FunctionClockConfig::Xtal => request_xtal_clk(clocks),
+                match config.sclk {
+                    Uart0FunctionClockSclk::PllF40m => request_pll_40m(clocks),
+                    Uart0FunctionClockSclk::RcFast => request_rc_fast_clk(clocks),
+                    Uart0FunctionClockSclk::Xtal => request_xtal_clk(clocks),
                 }
-                configure_uart0_function_clock_impl(clocks, old_selector, new_selector);
-                if let Some(old_selector) = old_selector {
-                    match old_selector {
-                        Uart0FunctionClockConfig::PllF40m => release_pll_40m(clocks),
-                        Uart0FunctionClockConfig::RcFast => release_rc_fast_clk(clocks),
-                        Uart0FunctionClockConfig::Xtal => release_xtal_clk(clocks),
+                configure_uart0_function_clock_impl(clocks, old_config, config);
+                if let Some(old_config) = old_config {
+                    match old_config.sclk {
+                        Uart0FunctionClockSclk::PllF40m => release_pll_40m(clocks),
+                        Uart0FunctionClockSclk::RcFast => release_rc_fast_clk(clocks),
+                        Uart0FunctionClockSclk::Xtal => release_xtal_clk(clocks),
                     }
                 }
             } else {
-                configure_uart0_function_clock_impl(clocks, old_selector, new_selector);
+                configure_uart0_function_clock_impl(clocks, old_config, config);
             }
         }
         pub fn uart0_function_clock_config(
@@ -2239,10 +2360,10 @@ macro_rules! define_clock_tree_types {
             trace!("Requesting UART0_FUNCTION_CLOCK");
             if increment_reference_count(&mut clocks.uart0_function_clock_refcount) {
                 trace!("Enabling UART0_FUNCTION_CLOCK");
-                match unwrap!(clocks.uart0_function_clock) {
-                    Uart0FunctionClockConfig::PllF40m => request_pll_40m(clocks),
-                    Uart0FunctionClockConfig::RcFast => request_rc_fast_clk(clocks),
-                    Uart0FunctionClockConfig::Xtal => request_xtal_clk(clocks),
+                match unwrap!(clocks.uart0_function_clock).sclk {
+                    Uart0FunctionClockSclk::PllF40m => request_pll_40m(clocks),
+                    Uart0FunctionClockSclk::RcFast => request_rc_fast_clk(clocks),
+                    Uart0FunctionClockSclk::Xtal => request_xtal_clk(clocks),
                 }
                 enable_uart0_function_clock_impl(clocks, true);
             }
@@ -2252,10 +2373,10 @@ macro_rules! define_clock_tree_types {
             if decrement_reference_count(&mut clocks.uart0_function_clock_refcount) {
                 trace!("Disabling UART0_FUNCTION_CLOCK");
                 enable_uart0_function_clock_impl(clocks, false);
-                match unwrap!(clocks.uart0_function_clock) {
-                    Uart0FunctionClockConfig::PllF40m => release_pll_40m(clocks),
-                    Uart0FunctionClockConfig::RcFast => release_rc_fast_clk(clocks),
-                    Uart0FunctionClockConfig::Xtal => release_xtal_clk(clocks),
+                match unwrap!(clocks.uart0_function_clock).sclk {
+                    Uart0FunctionClockSclk::PllF40m => release_pll_40m(clocks),
+                    Uart0FunctionClockSclk::RcFast => release_rc_fast_clk(clocks),
+                    Uart0FunctionClockSclk::Xtal => release_xtal_clk(clocks),
                 }
             }
         }
@@ -2264,11 +2385,11 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: Uart0FunctionClockConfig,
         ) -> u32 {
-            match config {
-                Uart0FunctionClockConfig::PllF40m => pll_40m_frequency(clocks),
-                Uart0FunctionClockConfig::RcFast => rc_fast_clk_frequency(clocks),
-                Uart0FunctionClockConfig::Xtal => xtal_clk_frequency(clocks),
-            }
+            (match config.sclk {
+                Uart0FunctionClockSclk::PllF40m => pll_40m_frequency(clocks),
+                Uart0FunctionClockSclk::RcFast => rc_fast_clk_frequency(clocks),
+                Uart0FunctionClockSclk::Xtal => xtal_clk_frequency(clocks),
+            } / (config.div_num() + 1))
         }
         pub fn uart0_function_clock_frequency(clocks: &mut ClockTree) -> u32 {
             if let Some(config) = clocks.uart0_function_clock {
@@ -2277,20 +2398,9 @@ macro_rules! define_clock_tree_types {
                 0
             }
         }
-        pub fn configure_uart0_mem_clock(
-            clocks: &mut ClockTree,
-            new_selector: Uart0MemClockConfig,
-        ) {
-            let old_selector = clocks.uart0_mem_clock.replace(new_selector);
-            if clocks.uart0_mem_clock_refcount > 0 {
-                request_uart_mem_clk(clocks);
-                configure_uart0_mem_clock_impl(clocks, old_selector, new_selector);
-                if let Some(old_selector) = old_selector {
-                    release_uart_mem_clk(clocks);
-                }
-            } else {
-                configure_uart0_mem_clock_impl(clocks, old_selector, new_selector);
-            }
+        pub fn configure_uart0_mem_clock(clocks: &mut ClockTree, config: Uart0MemClockConfig) {
+            let old_config = clocks.uart0_mem_clock.replace(config);
+            configure_uart0_mem_clock_impl(clocks, old_config, config);
         }
         pub fn uart0_mem_clock_config(clocks: &mut ClockTree) -> Option<Uart0MemClockConfig> {
             clocks.uart0_mem_clock
@@ -2325,27 +2435,70 @@ macro_rules! define_clock_tree_types {
                 0
             }
         }
+        pub fn configure_uart0_baud_rate_generator(
+            clocks: &mut ClockTree,
+            config: Uart0BaudRateGeneratorConfig,
+        ) {
+            let old_config = clocks.uart0_baud_rate_generator.replace(config);
+            configure_uart0_baud_rate_generator_impl(clocks, old_config, config);
+        }
+        pub fn uart0_baud_rate_generator_config(
+            clocks: &mut ClockTree,
+        ) -> Option<Uart0BaudRateGeneratorConfig> {
+            clocks.uart0_baud_rate_generator
+        }
+        pub fn request_uart0_baud_rate_generator(clocks: &mut ClockTree) {
+            trace!("Requesting UART0_BAUD_RATE_GENERATOR");
+            if increment_reference_count(&mut clocks.uart0_baud_rate_generator_refcount) {
+                trace!("Enabling UART0_BAUD_RATE_GENERATOR");
+                request_uart0_function_clock(clocks);
+                enable_uart0_baud_rate_generator_impl(clocks, true);
+            }
+        }
+        pub fn release_uart0_baud_rate_generator(clocks: &mut ClockTree) {
+            trace!("Releasing UART0_BAUD_RATE_GENERATOR");
+            if decrement_reference_count(&mut clocks.uart0_baud_rate_generator_refcount) {
+                trace!("Disabling UART0_BAUD_RATE_GENERATOR");
+                enable_uart0_baud_rate_generator_impl(clocks, false);
+                release_uart0_function_clock(clocks);
+            }
+        }
+        #[allow(unused_variables)]
+        pub fn uart0_baud_rate_generator_config_frequency(
+            clocks: &mut ClockTree,
+            config: Uart0BaudRateGeneratorConfig,
+        ) -> u32 {
+            ((uart0_function_clock_frequency(clocks) * 16)
+                / ((config.integral() * 16) + config.fractional()))
+        }
+        pub fn uart0_baud_rate_generator_frequency(clocks: &mut ClockTree) -> u32 {
+            if let Some(config) = clocks.uart0_baud_rate_generator {
+                uart0_baud_rate_generator_config_frequency(clocks, config)
+            } else {
+                0
+            }
+        }
         pub fn configure_uart1_function_clock(
             clocks: &mut ClockTree,
-            new_selector: Uart0FunctionClockConfig,
+            config: Uart0FunctionClockConfig,
         ) {
-            let old_selector = clocks.uart1_function_clock.replace(new_selector);
+            let old_config = clocks.uart1_function_clock.replace(config);
             if clocks.uart1_function_clock_refcount > 0 {
-                match new_selector {
-                    Uart0FunctionClockConfig::PllF40m => request_pll_40m(clocks),
-                    Uart0FunctionClockConfig::RcFast => request_rc_fast_clk(clocks),
-                    Uart0FunctionClockConfig::Xtal => request_xtal_clk(clocks),
+                match config.sclk {
+                    Uart0FunctionClockSclk::PllF40m => request_pll_40m(clocks),
+                    Uart0FunctionClockSclk::RcFast => request_rc_fast_clk(clocks),
+                    Uart0FunctionClockSclk::Xtal => request_xtal_clk(clocks),
                 }
-                configure_uart1_function_clock_impl(clocks, old_selector, new_selector);
-                if let Some(old_selector) = old_selector {
-                    match old_selector {
-                        Uart0FunctionClockConfig::PllF40m => release_pll_40m(clocks),
-                        Uart0FunctionClockConfig::RcFast => release_rc_fast_clk(clocks),
-                        Uart0FunctionClockConfig::Xtal => release_xtal_clk(clocks),
+                configure_uart1_function_clock_impl(clocks, old_config, config);
+                if let Some(old_config) = old_config {
+                    match old_config.sclk {
+                        Uart0FunctionClockSclk::PllF40m => release_pll_40m(clocks),
+                        Uart0FunctionClockSclk::RcFast => release_rc_fast_clk(clocks),
+                        Uart0FunctionClockSclk::Xtal => release_xtal_clk(clocks),
                     }
                 }
             } else {
-                configure_uart1_function_clock_impl(clocks, old_selector, new_selector);
+                configure_uart1_function_clock_impl(clocks, old_config, config);
             }
         }
         pub fn uart1_function_clock_config(
@@ -2357,10 +2510,10 @@ macro_rules! define_clock_tree_types {
             trace!("Requesting UART1_FUNCTION_CLOCK");
             if increment_reference_count(&mut clocks.uart1_function_clock_refcount) {
                 trace!("Enabling UART1_FUNCTION_CLOCK");
-                match unwrap!(clocks.uart1_function_clock) {
-                    Uart0FunctionClockConfig::PllF40m => request_pll_40m(clocks),
-                    Uart0FunctionClockConfig::RcFast => request_rc_fast_clk(clocks),
-                    Uart0FunctionClockConfig::Xtal => request_xtal_clk(clocks),
+                match unwrap!(clocks.uart1_function_clock).sclk {
+                    Uart0FunctionClockSclk::PllF40m => request_pll_40m(clocks),
+                    Uart0FunctionClockSclk::RcFast => request_rc_fast_clk(clocks),
+                    Uart0FunctionClockSclk::Xtal => request_xtal_clk(clocks),
                 }
                 enable_uart1_function_clock_impl(clocks, true);
             }
@@ -2370,10 +2523,10 @@ macro_rules! define_clock_tree_types {
             if decrement_reference_count(&mut clocks.uart1_function_clock_refcount) {
                 trace!("Disabling UART1_FUNCTION_CLOCK");
                 enable_uart1_function_clock_impl(clocks, false);
-                match unwrap!(clocks.uart1_function_clock) {
-                    Uart0FunctionClockConfig::PllF40m => release_pll_40m(clocks),
-                    Uart0FunctionClockConfig::RcFast => release_rc_fast_clk(clocks),
-                    Uart0FunctionClockConfig::Xtal => release_xtal_clk(clocks),
+                match unwrap!(clocks.uart1_function_clock).sclk {
+                    Uart0FunctionClockSclk::PllF40m => release_pll_40m(clocks),
+                    Uart0FunctionClockSclk::RcFast => release_rc_fast_clk(clocks),
+                    Uart0FunctionClockSclk::Xtal => release_xtal_clk(clocks),
                 }
             }
         }
@@ -2382,11 +2535,11 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: Uart0FunctionClockConfig,
         ) -> u32 {
-            match config {
-                Uart0FunctionClockConfig::PllF40m => pll_40m_frequency(clocks),
-                Uart0FunctionClockConfig::RcFast => rc_fast_clk_frequency(clocks),
-                Uart0FunctionClockConfig::Xtal => xtal_clk_frequency(clocks),
-            }
+            (match config.sclk {
+                Uart0FunctionClockSclk::PllF40m => pll_40m_frequency(clocks),
+                Uart0FunctionClockSclk::RcFast => rc_fast_clk_frequency(clocks),
+                Uart0FunctionClockSclk::Xtal => xtal_clk_frequency(clocks),
+            } / (config.div_num() + 1))
         }
         pub fn uart1_function_clock_frequency(clocks: &mut ClockTree) -> u32 {
             if let Some(config) = clocks.uart1_function_clock {
@@ -2395,20 +2548,9 @@ macro_rules! define_clock_tree_types {
                 0
             }
         }
-        pub fn configure_uart1_mem_clock(
-            clocks: &mut ClockTree,
-            new_selector: Uart0MemClockConfig,
-        ) {
-            let old_selector = clocks.uart1_mem_clock.replace(new_selector);
-            if clocks.uart1_mem_clock_refcount > 0 {
-                request_uart_mem_clk(clocks);
-                configure_uart1_mem_clock_impl(clocks, old_selector, new_selector);
-                if let Some(old_selector) = old_selector {
-                    release_uart_mem_clk(clocks);
-                }
-            } else {
-                configure_uart1_mem_clock_impl(clocks, old_selector, new_selector);
-            }
+        pub fn configure_uart1_mem_clock(clocks: &mut ClockTree, config: Uart0MemClockConfig) {
+            let old_config = clocks.uart1_mem_clock.replace(config);
+            configure_uart1_mem_clock_impl(clocks, old_config, config);
         }
         pub fn uart1_mem_clock_config(clocks: &mut ClockTree) -> Option<Uart0MemClockConfig> {
             clocks.uart1_mem_clock
@@ -2439,6 +2581,49 @@ macro_rules! define_clock_tree_types {
         pub fn uart1_mem_clock_frequency(clocks: &mut ClockTree) -> u32 {
             if let Some(config) = clocks.uart1_mem_clock {
                 uart1_mem_clock_config_frequency(clocks, config)
+            } else {
+                0
+            }
+        }
+        pub fn configure_uart1_baud_rate_generator(
+            clocks: &mut ClockTree,
+            config: Uart0BaudRateGeneratorConfig,
+        ) {
+            let old_config = clocks.uart1_baud_rate_generator.replace(config);
+            configure_uart1_baud_rate_generator_impl(clocks, old_config, config);
+        }
+        pub fn uart1_baud_rate_generator_config(
+            clocks: &mut ClockTree,
+        ) -> Option<Uart0BaudRateGeneratorConfig> {
+            clocks.uart1_baud_rate_generator
+        }
+        pub fn request_uart1_baud_rate_generator(clocks: &mut ClockTree) {
+            trace!("Requesting UART1_BAUD_RATE_GENERATOR");
+            if increment_reference_count(&mut clocks.uart1_baud_rate_generator_refcount) {
+                trace!("Enabling UART1_BAUD_RATE_GENERATOR");
+                request_uart1_function_clock(clocks);
+                enable_uart1_baud_rate_generator_impl(clocks, true);
+            }
+        }
+        pub fn release_uart1_baud_rate_generator(clocks: &mut ClockTree) {
+            trace!("Releasing UART1_BAUD_RATE_GENERATOR");
+            if decrement_reference_count(&mut clocks.uart1_baud_rate_generator_refcount) {
+                trace!("Disabling UART1_BAUD_RATE_GENERATOR");
+                enable_uart1_baud_rate_generator_impl(clocks, false);
+                release_uart1_function_clock(clocks);
+            }
+        }
+        #[allow(unused_variables)]
+        pub fn uart1_baud_rate_generator_config_frequency(
+            clocks: &mut ClockTree,
+            config: Uart0BaudRateGeneratorConfig,
+        ) -> u32 {
+            ((uart1_function_clock_frequency(clocks) * 16)
+                / ((config.integral() * 16) + config.fractional()))
+        }
+        pub fn uart1_baud_rate_generator_frequency(clocks: &mut ClockTree) -> u32 {
+            if let Some(config) = clocks.uart1_baud_rate_generator {
+                uart1_baud_rate_generator_config_frequency(clocks, config)
             } else {
                 0
             }

--- a/esp-metadata-generated/src/_generated_esp32c3.rs
+++ b/esp-metadata-generated/src/_generated_esp32c3.rs
@@ -325,6 +325,9 @@ macro_rules! property {
     ("uart.peripheral_controls_mem_clk") => {
         false
     };
+    ("uart.has_sclk_divider") => {
+        true
+    };
     ("uhci.combined_uart_selector_field") => {
         false
     };
@@ -1099,6 +1102,20 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
+/// // UART0_BAUD_RATE_GENERATOR
+///
+/// fn enable_uart0_baud_rate_generator_impl(_clocks: &mut ClockTree, _en: bool) {
+///     todo!()
+/// }
+///
+/// fn configure_uart0_baud_rate_generator_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<Uart0BaudRateGeneratorConfig>,
+///     _new_config: Uart0BaudRateGeneratorConfig,
+/// ) {
+///     todo!()
+/// }
+///
 /// // UART1_FUNCTION_CLOCK
 ///
 /// fn enable_uart1_function_clock_impl(_clocks: &mut ClockTree, _en: bool) {
@@ -1123,6 +1140,20 @@ macro_rules! for_each_sha_algorithm {
 ///     _clocks: &mut ClockTree,
 ///     _old_config: Option<Uart0MemClockConfig>,
 ///     _new_config: Uart0MemClockConfig,
+/// ) {
+///     todo!()
+/// }
+///
+/// // UART1_BAUD_RATE_GENERATOR
+///
+/// fn enable_uart1_baud_rate_generator_impl(_clocks: &mut ClockTree, _en: bool) {
+///     todo!()
+/// }
+///
+/// fn configure_uart1_baud_rate_generator_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<Uart0BaudRateGeneratorConfig>,
+///     _new_config: Uart0BaudRateGeneratorConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1343,10 +1374,9 @@ macro_rules! define_clock_tree_types {
             /// Selects `XTAL_CLK`.
             XtalClk,
         }
-        /// The list of clock signals that the `UART0_FUNCTION_CLOCK` multiplexer can output.
         #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-        pub enum Uart0FunctionClockConfig {
+        pub enum Uart0FunctionClockSclk {
             /// Selects `APB_CLK`.
             Apb,
             /// Selects `RC_FAST_CLK`.
@@ -1355,13 +1385,88 @@ macro_rules! define_clock_tree_types {
             /// Selects `XTAL_CLK`.
             Xtal,
         }
-        /// The list of clock signals that the `UART0_MEM_CLOCK` multiplexer can output.
-        #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+        /// Configures the `UART0_FUNCTION_CLOCK` clock node.
+        ///
+        /// The output is calculated as `OUTPUT = sclk / (div_num + 1)`.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-        pub enum Uart0MemClockConfig {
-            #[default]
-            /// Selects `UART_MEM_CLK`.
-            Mem,
+        pub struct Uart0FunctionClockConfig {
+            sclk: Uart0FunctionClockSclk,
+            div_num: u32,
+        }
+        impl Uart0FunctionClockConfig {
+            /// Creates a new configuration for the FUNCTION_CLOCK clock node.
+            ///
+            /// ## Panics
+            ///
+            /// Panics if the div_num value is outside the
+            /// valid range (0 ..= 255).
+            pub const fn new(sclk: Uart0FunctionClockSclk, div_num: u32) -> Self {
+                ::core::assert!(
+                    div_num <= 255,
+                    "`UART0_FUNCTION_CLOCK` div_num must be between 0 and 255 (inclusive)."
+                );
+                Self { sclk, div_num }
+            }
+            fn sclk(self) -> Uart0FunctionClockSclk {
+                self.sclk
+            }
+            fn div_num(self) -> u32 {
+                self.div_num as u32
+            }
+        }
+        /// Configures the `UART0_MEM_CLOCK` clock node.
+        ///
+        /// The output is calculated as `OUTPUT = UART_MEM_CLK`.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+        pub struct Uart0MemClockConfig {}
+        impl Uart0MemClockConfig {
+            /// Creates a new configuration for the MEM_CLOCK clock node.
+            pub const fn new() -> Self {
+                Self {}
+            }
+        }
+        /// Configures the `UART0_BAUD_RATE_GENERATOR` clock node.
+        ///
+        /// The output is calculated as `OUTPUT = (FUNCTION_CLOCK * 16) / (integral * 16 +
+        /// fractional)`.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+        pub struct Uart0BaudRateGeneratorConfig {
+            fractional: u32,
+            integral: u32,
+        }
+        impl Uart0BaudRateGeneratorConfig {
+            /// Creates a new configuration for the BAUD_RATE_GENERATOR clock node.
+            ///
+            /// ## Panics
+            ///
+            /// Panics if the fractional value is outside the
+            /// valid range (0 ..= 15).
+            ///
+            /// Panics if the integral value is outside the
+            /// valid range (0 ..= 4095).
+            pub const fn new(fractional: u32, integral: u32) -> Self {
+                ::core::assert!(
+                    fractional <= 15,
+                    "`UART0_BAUD_RATE_GENERATOR` fractional must be between 0 and 15 (inclusive)."
+                );
+                ::core::assert!(
+                    integral <= 4095,
+                    "`UART0_BAUD_RATE_GENERATOR` integral must be between 0 and 4095 (inclusive)."
+                );
+                Self {
+                    fractional,
+                    integral,
+                }
+            }
+            fn fractional(self) -> u32 {
+                self.fractional as u32
+            }
+            fn integral(self) -> u32 {
+                self.integral as u32
+            }
         }
         /// Represents the device's clock tree.
         pub struct ClockTree {
@@ -1386,8 +1491,10 @@ macro_rules! define_clock_tree_types {
             timg1_wdt_clock: Option<Timg0WdtClockConfig>,
             uart0_function_clock: Option<Uart0FunctionClockConfig>,
             uart0_mem_clock: Option<Uart0MemClockConfig>,
+            uart0_baud_rate_generator: Option<Uart0BaudRateGeneratorConfig>,
             uart1_function_clock: Option<Uart0FunctionClockConfig>,
             uart1_mem_clock: Option<Uart0MemClockConfig>,
+            uart1_baud_rate_generator: Option<Uart0BaudRateGeneratorConfig>,
             rc_fast_clk_refcount: u32,
             xtal32k_clk_refcount: u32,
             rc_slow_clk_refcount: u32,
@@ -1406,8 +1513,10 @@ macro_rules! define_clock_tree_types {
             timg1_wdt_clock_refcount: u32,
             uart0_function_clock_refcount: u32,
             uart0_mem_clock_refcount: u32,
+            uart0_baud_rate_generator_refcount: u32,
             uart1_function_clock_refcount: u32,
             uart1_mem_clock_refcount: u32,
+            uart1_baud_rate_generator_refcount: u32,
         }
         impl ClockTree {
             /// Locks the clock tree for exclusive access.
@@ -1498,6 +1607,10 @@ macro_rules! define_clock_tree_types {
             pub fn uart0_mem_clock(&self) -> Option<Uart0MemClockConfig> {
                 self.uart0_mem_clock
             }
+            /// Returns the current configuration of the UART0_BAUD_RATE_GENERATOR clock tree node
+            pub fn uart0_baud_rate_generator(&self) -> Option<Uart0BaudRateGeneratorConfig> {
+                self.uart0_baud_rate_generator
+            }
             /// Returns the current configuration of the UART1_FUNCTION_CLOCK clock tree node
             pub fn uart1_function_clock(&self) -> Option<Uart0FunctionClockConfig> {
                 self.uart1_function_clock
@@ -1505,6 +1618,10 @@ macro_rules! define_clock_tree_types {
             /// Returns the current configuration of the UART1_MEM_CLOCK clock tree node
             pub fn uart1_mem_clock(&self) -> Option<Uart0MemClockConfig> {
                 self.uart1_mem_clock
+            }
+            /// Returns the current configuration of the UART1_BAUD_RATE_GENERATOR clock tree node
+            pub fn uart1_baud_rate_generator(&self) -> Option<Uart0BaudRateGeneratorConfig> {
+                self.uart1_baud_rate_generator
             }
         }
         static CLOCK_TREE: ::esp_sync::NonReentrantMutex<ClockTree> =
@@ -1530,8 +1647,10 @@ macro_rules! define_clock_tree_types {
                 timg1_wdt_clock: None,
                 uart0_function_clock: None,
                 uart0_mem_clock: None,
+                uart0_baud_rate_generator: None,
                 uart1_function_clock: None,
                 uart1_mem_clock: None,
+                uart1_baud_rate_generator: None,
                 rc_fast_clk_refcount: 0,
                 xtal32k_clk_refcount: 0,
                 rc_slow_clk_refcount: 0,
@@ -1550,8 +1669,10 @@ macro_rules! define_clock_tree_types {
                 timg1_wdt_clock_refcount: 0,
                 uart0_function_clock_refcount: 0,
                 uart0_mem_clock_refcount: 0,
+                uart0_baud_rate_generator_refcount: 0,
                 uart1_function_clock_refcount: 0,
                 uart1_mem_clock_refcount: 0,
+                uart1_baud_rate_generator_refcount: 0,
             });
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
             let old_config = clocks.xtal_clk.replace(config);
@@ -2708,25 +2829,25 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_uart0_function_clock(
             clocks: &mut ClockTree,
-            new_selector: Uart0FunctionClockConfig,
+            config: Uart0FunctionClockConfig,
         ) {
-            let old_selector = clocks.uart0_function_clock.replace(new_selector);
+            let old_config = clocks.uart0_function_clock.replace(config);
             if clocks.uart0_function_clock_refcount > 0 {
-                match new_selector {
-                    Uart0FunctionClockConfig::Apb => request_apb_clk(clocks),
-                    Uart0FunctionClockConfig::RcFast => request_rc_fast_clk(clocks),
-                    Uart0FunctionClockConfig::Xtal => request_xtal_clk(clocks),
+                match config.sclk {
+                    Uart0FunctionClockSclk::Apb => request_apb_clk(clocks),
+                    Uart0FunctionClockSclk::RcFast => request_rc_fast_clk(clocks),
+                    Uart0FunctionClockSclk::Xtal => request_xtal_clk(clocks),
                 }
-                configure_uart0_function_clock_impl(clocks, old_selector, new_selector);
-                if let Some(old_selector) = old_selector {
-                    match old_selector {
-                        Uart0FunctionClockConfig::Apb => release_apb_clk(clocks),
-                        Uart0FunctionClockConfig::RcFast => release_rc_fast_clk(clocks),
-                        Uart0FunctionClockConfig::Xtal => release_xtal_clk(clocks),
+                configure_uart0_function_clock_impl(clocks, old_config, config);
+                if let Some(old_config) = old_config {
+                    match old_config.sclk {
+                        Uart0FunctionClockSclk::Apb => release_apb_clk(clocks),
+                        Uart0FunctionClockSclk::RcFast => release_rc_fast_clk(clocks),
+                        Uart0FunctionClockSclk::Xtal => release_xtal_clk(clocks),
                     }
                 }
             } else {
-                configure_uart0_function_clock_impl(clocks, old_selector, new_selector);
+                configure_uart0_function_clock_impl(clocks, old_config, config);
             }
         }
         pub fn uart0_function_clock_config(
@@ -2738,10 +2859,10 @@ macro_rules! define_clock_tree_types {
             trace!("Requesting UART0_FUNCTION_CLOCK");
             if increment_reference_count(&mut clocks.uart0_function_clock_refcount) {
                 trace!("Enabling UART0_FUNCTION_CLOCK");
-                match unwrap!(clocks.uart0_function_clock) {
-                    Uart0FunctionClockConfig::Apb => request_apb_clk(clocks),
-                    Uart0FunctionClockConfig::RcFast => request_rc_fast_clk(clocks),
-                    Uart0FunctionClockConfig::Xtal => request_xtal_clk(clocks),
+                match unwrap!(clocks.uart0_function_clock).sclk {
+                    Uart0FunctionClockSclk::Apb => request_apb_clk(clocks),
+                    Uart0FunctionClockSclk::RcFast => request_rc_fast_clk(clocks),
+                    Uart0FunctionClockSclk::Xtal => request_xtal_clk(clocks),
                 }
                 enable_uart0_function_clock_impl(clocks, true);
             }
@@ -2751,10 +2872,10 @@ macro_rules! define_clock_tree_types {
             if decrement_reference_count(&mut clocks.uart0_function_clock_refcount) {
                 trace!("Disabling UART0_FUNCTION_CLOCK");
                 enable_uart0_function_clock_impl(clocks, false);
-                match unwrap!(clocks.uart0_function_clock) {
-                    Uart0FunctionClockConfig::Apb => release_apb_clk(clocks),
-                    Uart0FunctionClockConfig::RcFast => release_rc_fast_clk(clocks),
-                    Uart0FunctionClockConfig::Xtal => release_xtal_clk(clocks),
+                match unwrap!(clocks.uart0_function_clock).sclk {
+                    Uart0FunctionClockSclk::Apb => release_apb_clk(clocks),
+                    Uart0FunctionClockSclk::RcFast => release_rc_fast_clk(clocks),
+                    Uart0FunctionClockSclk::Xtal => release_xtal_clk(clocks),
                 }
             }
         }
@@ -2763,11 +2884,11 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: Uart0FunctionClockConfig,
         ) -> u32 {
-            match config {
-                Uart0FunctionClockConfig::Apb => apb_clk_frequency(clocks),
-                Uart0FunctionClockConfig::RcFast => rc_fast_clk_frequency(clocks),
-                Uart0FunctionClockConfig::Xtal => xtal_clk_frequency(clocks),
-            }
+            (match config.sclk {
+                Uart0FunctionClockSclk::Apb => apb_clk_frequency(clocks),
+                Uart0FunctionClockSclk::RcFast => rc_fast_clk_frequency(clocks),
+                Uart0FunctionClockSclk::Xtal => xtal_clk_frequency(clocks),
+            } / (config.div_num() + 1))
         }
         pub fn uart0_function_clock_frequency(clocks: &mut ClockTree) -> u32 {
             if let Some(config) = clocks.uart0_function_clock {
@@ -2776,20 +2897,9 @@ macro_rules! define_clock_tree_types {
                 0
             }
         }
-        pub fn configure_uart0_mem_clock(
-            clocks: &mut ClockTree,
-            new_selector: Uart0MemClockConfig,
-        ) {
-            let old_selector = clocks.uart0_mem_clock.replace(new_selector);
-            if clocks.uart0_mem_clock_refcount > 0 {
-                request_uart_mem_clk(clocks);
-                configure_uart0_mem_clock_impl(clocks, old_selector, new_selector);
-                if let Some(old_selector) = old_selector {
-                    release_uart_mem_clk(clocks);
-                }
-            } else {
-                configure_uart0_mem_clock_impl(clocks, old_selector, new_selector);
-            }
+        pub fn configure_uart0_mem_clock(clocks: &mut ClockTree, config: Uart0MemClockConfig) {
+            let old_config = clocks.uart0_mem_clock.replace(config);
+            configure_uart0_mem_clock_impl(clocks, old_config, config);
         }
         pub fn uart0_mem_clock_config(clocks: &mut ClockTree) -> Option<Uart0MemClockConfig> {
             clocks.uart0_mem_clock
@@ -2824,27 +2934,70 @@ macro_rules! define_clock_tree_types {
                 0
             }
         }
+        pub fn configure_uart0_baud_rate_generator(
+            clocks: &mut ClockTree,
+            config: Uart0BaudRateGeneratorConfig,
+        ) {
+            let old_config = clocks.uart0_baud_rate_generator.replace(config);
+            configure_uart0_baud_rate_generator_impl(clocks, old_config, config);
+        }
+        pub fn uart0_baud_rate_generator_config(
+            clocks: &mut ClockTree,
+        ) -> Option<Uart0BaudRateGeneratorConfig> {
+            clocks.uart0_baud_rate_generator
+        }
+        pub fn request_uart0_baud_rate_generator(clocks: &mut ClockTree) {
+            trace!("Requesting UART0_BAUD_RATE_GENERATOR");
+            if increment_reference_count(&mut clocks.uart0_baud_rate_generator_refcount) {
+                trace!("Enabling UART0_BAUD_RATE_GENERATOR");
+                request_uart0_function_clock(clocks);
+                enable_uart0_baud_rate_generator_impl(clocks, true);
+            }
+        }
+        pub fn release_uart0_baud_rate_generator(clocks: &mut ClockTree) {
+            trace!("Releasing UART0_BAUD_RATE_GENERATOR");
+            if decrement_reference_count(&mut clocks.uart0_baud_rate_generator_refcount) {
+                trace!("Disabling UART0_BAUD_RATE_GENERATOR");
+                enable_uart0_baud_rate_generator_impl(clocks, false);
+                release_uart0_function_clock(clocks);
+            }
+        }
+        #[allow(unused_variables)]
+        pub fn uart0_baud_rate_generator_config_frequency(
+            clocks: &mut ClockTree,
+            config: Uart0BaudRateGeneratorConfig,
+        ) -> u32 {
+            ((uart0_function_clock_frequency(clocks) * 16)
+                / ((config.integral() * 16) + config.fractional()))
+        }
+        pub fn uart0_baud_rate_generator_frequency(clocks: &mut ClockTree) -> u32 {
+            if let Some(config) = clocks.uart0_baud_rate_generator {
+                uart0_baud_rate_generator_config_frequency(clocks, config)
+            } else {
+                0
+            }
+        }
         pub fn configure_uart1_function_clock(
             clocks: &mut ClockTree,
-            new_selector: Uart0FunctionClockConfig,
+            config: Uart0FunctionClockConfig,
         ) {
-            let old_selector = clocks.uart1_function_clock.replace(new_selector);
+            let old_config = clocks.uart1_function_clock.replace(config);
             if clocks.uart1_function_clock_refcount > 0 {
-                match new_selector {
-                    Uart0FunctionClockConfig::Apb => request_apb_clk(clocks),
-                    Uart0FunctionClockConfig::RcFast => request_rc_fast_clk(clocks),
-                    Uart0FunctionClockConfig::Xtal => request_xtal_clk(clocks),
+                match config.sclk {
+                    Uart0FunctionClockSclk::Apb => request_apb_clk(clocks),
+                    Uart0FunctionClockSclk::RcFast => request_rc_fast_clk(clocks),
+                    Uart0FunctionClockSclk::Xtal => request_xtal_clk(clocks),
                 }
-                configure_uart1_function_clock_impl(clocks, old_selector, new_selector);
-                if let Some(old_selector) = old_selector {
-                    match old_selector {
-                        Uart0FunctionClockConfig::Apb => release_apb_clk(clocks),
-                        Uart0FunctionClockConfig::RcFast => release_rc_fast_clk(clocks),
-                        Uart0FunctionClockConfig::Xtal => release_xtal_clk(clocks),
+                configure_uart1_function_clock_impl(clocks, old_config, config);
+                if let Some(old_config) = old_config {
+                    match old_config.sclk {
+                        Uart0FunctionClockSclk::Apb => release_apb_clk(clocks),
+                        Uart0FunctionClockSclk::RcFast => release_rc_fast_clk(clocks),
+                        Uart0FunctionClockSclk::Xtal => release_xtal_clk(clocks),
                     }
                 }
             } else {
-                configure_uart1_function_clock_impl(clocks, old_selector, new_selector);
+                configure_uart1_function_clock_impl(clocks, old_config, config);
             }
         }
         pub fn uart1_function_clock_config(
@@ -2856,10 +3009,10 @@ macro_rules! define_clock_tree_types {
             trace!("Requesting UART1_FUNCTION_CLOCK");
             if increment_reference_count(&mut clocks.uart1_function_clock_refcount) {
                 trace!("Enabling UART1_FUNCTION_CLOCK");
-                match unwrap!(clocks.uart1_function_clock) {
-                    Uart0FunctionClockConfig::Apb => request_apb_clk(clocks),
-                    Uart0FunctionClockConfig::RcFast => request_rc_fast_clk(clocks),
-                    Uart0FunctionClockConfig::Xtal => request_xtal_clk(clocks),
+                match unwrap!(clocks.uart1_function_clock).sclk {
+                    Uart0FunctionClockSclk::Apb => request_apb_clk(clocks),
+                    Uart0FunctionClockSclk::RcFast => request_rc_fast_clk(clocks),
+                    Uart0FunctionClockSclk::Xtal => request_xtal_clk(clocks),
                 }
                 enable_uart1_function_clock_impl(clocks, true);
             }
@@ -2869,10 +3022,10 @@ macro_rules! define_clock_tree_types {
             if decrement_reference_count(&mut clocks.uart1_function_clock_refcount) {
                 trace!("Disabling UART1_FUNCTION_CLOCK");
                 enable_uart1_function_clock_impl(clocks, false);
-                match unwrap!(clocks.uart1_function_clock) {
-                    Uart0FunctionClockConfig::Apb => release_apb_clk(clocks),
-                    Uart0FunctionClockConfig::RcFast => release_rc_fast_clk(clocks),
-                    Uart0FunctionClockConfig::Xtal => release_xtal_clk(clocks),
+                match unwrap!(clocks.uart1_function_clock).sclk {
+                    Uart0FunctionClockSclk::Apb => release_apb_clk(clocks),
+                    Uart0FunctionClockSclk::RcFast => release_rc_fast_clk(clocks),
+                    Uart0FunctionClockSclk::Xtal => release_xtal_clk(clocks),
                 }
             }
         }
@@ -2881,11 +3034,11 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: Uart0FunctionClockConfig,
         ) -> u32 {
-            match config {
-                Uart0FunctionClockConfig::Apb => apb_clk_frequency(clocks),
-                Uart0FunctionClockConfig::RcFast => rc_fast_clk_frequency(clocks),
-                Uart0FunctionClockConfig::Xtal => xtal_clk_frequency(clocks),
-            }
+            (match config.sclk {
+                Uart0FunctionClockSclk::Apb => apb_clk_frequency(clocks),
+                Uart0FunctionClockSclk::RcFast => rc_fast_clk_frequency(clocks),
+                Uart0FunctionClockSclk::Xtal => xtal_clk_frequency(clocks),
+            } / (config.div_num() + 1))
         }
         pub fn uart1_function_clock_frequency(clocks: &mut ClockTree) -> u32 {
             if let Some(config) = clocks.uart1_function_clock {
@@ -2894,20 +3047,9 @@ macro_rules! define_clock_tree_types {
                 0
             }
         }
-        pub fn configure_uart1_mem_clock(
-            clocks: &mut ClockTree,
-            new_selector: Uart0MemClockConfig,
-        ) {
-            let old_selector = clocks.uart1_mem_clock.replace(new_selector);
-            if clocks.uart1_mem_clock_refcount > 0 {
-                request_uart_mem_clk(clocks);
-                configure_uart1_mem_clock_impl(clocks, old_selector, new_selector);
-                if let Some(old_selector) = old_selector {
-                    release_uart_mem_clk(clocks);
-                }
-            } else {
-                configure_uart1_mem_clock_impl(clocks, old_selector, new_selector);
-            }
+        pub fn configure_uart1_mem_clock(clocks: &mut ClockTree, config: Uart0MemClockConfig) {
+            let old_config = clocks.uart1_mem_clock.replace(config);
+            configure_uart1_mem_clock_impl(clocks, old_config, config);
         }
         pub fn uart1_mem_clock_config(clocks: &mut ClockTree) -> Option<Uart0MemClockConfig> {
             clocks.uart1_mem_clock
@@ -2938,6 +3080,49 @@ macro_rules! define_clock_tree_types {
         pub fn uart1_mem_clock_frequency(clocks: &mut ClockTree) -> u32 {
             if let Some(config) = clocks.uart1_mem_clock {
                 uart1_mem_clock_config_frequency(clocks, config)
+            } else {
+                0
+            }
+        }
+        pub fn configure_uart1_baud_rate_generator(
+            clocks: &mut ClockTree,
+            config: Uart0BaudRateGeneratorConfig,
+        ) {
+            let old_config = clocks.uart1_baud_rate_generator.replace(config);
+            configure_uart1_baud_rate_generator_impl(clocks, old_config, config);
+        }
+        pub fn uart1_baud_rate_generator_config(
+            clocks: &mut ClockTree,
+        ) -> Option<Uart0BaudRateGeneratorConfig> {
+            clocks.uart1_baud_rate_generator
+        }
+        pub fn request_uart1_baud_rate_generator(clocks: &mut ClockTree) {
+            trace!("Requesting UART1_BAUD_RATE_GENERATOR");
+            if increment_reference_count(&mut clocks.uart1_baud_rate_generator_refcount) {
+                trace!("Enabling UART1_BAUD_RATE_GENERATOR");
+                request_uart1_function_clock(clocks);
+                enable_uart1_baud_rate_generator_impl(clocks, true);
+            }
+        }
+        pub fn release_uart1_baud_rate_generator(clocks: &mut ClockTree) {
+            trace!("Releasing UART1_BAUD_RATE_GENERATOR");
+            if decrement_reference_count(&mut clocks.uart1_baud_rate_generator_refcount) {
+                trace!("Disabling UART1_BAUD_RATE_GENERATOR");
+                enable_uart1_baud_rate_generator_impl(clocks, false);
+                release_uart1_function_clock(clocks);
+            }
+        }
+        #[allow(unused_variables)]
+        pub fn uart1_baud_rate_generator_config_frequency(
+            clocks: &mut ClockTree,
+            config: Uart0BaudRateGeneratorConfig,
+        ) -> u32 {
+            ((uart1_function_clock_frequency(clocks) * 16)
+                / ((config.integral() * 16) + config.fractional()))
+        }
+        pub fn uart1_baud_rate_generator_frequency(clocks: &mut ClockTree) -> u32 {
+            if let Some(config) = clocks.uart1_baud_rate_generator {
+                uart1_baud_rate_generator_config_frequency(clocks, config)
             } else {
                 0
             }

--- a/esp-metadata-generated/src/_generated_esp32c5.rs
+++ b/esp-metadata-generated/src/_generated_esp32c5.rs
@@ -358,6 +358,9 @@ macro_rules! property {
     ("uart.peripheral_controls_mem_clk") => {
         true
     };
+    ("uart.has_sclk_divider") => {
+        false
+    };
     ("uhci.combined_uart_selector_field") => {
         true
     };
@@ -1212,6 +1215,20 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
+/// // UART0_BAUD_RATE_GENERATOR
+///
+/// fn enable_uart0_baud_rate_generator_impl(_clocks: &mut ClockTree, _en: bool) {
+///     todo!()
+/// }
+///
+/// fn configure_uart0_baud_rate_generator_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<Uart0BaudRateGeneratorConfig>,
+///     _new_config: Uart0BaudRateGeneratorConfig,
+/// ) {
+///     todo!()
+/// }
+///
 /// // UART1_FUNCTION_CLOCK
 ///
 /// fn enable_uart1_function_clock_impl(_clocks: &mut ClockTree, _en: bool) {
@@ -1222,6 +1239,20 @@ macro_rules! for_each_sha_algorithm {
 ///     _clocks: &mut ClockTree,
 ///     _old_config: Option<Uart0FunctionClockConfig>,
 ///     _new_config: Uart0FunctionClockConfig,
+/// ) {
+///     todo!()
+/// }
+///
+/// // UART1_BAUD_RATE_GENERATOR
+///
+/// fn enable_uart1_baud_rate_generator_impl(_clocks: &mut ClockTree, _en: bool) {
+///     todo!()
+/// }
+///
+/// fn configure_uart1_baud_rate_generator_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<Uart0BaudRateGeneratorConfig>,
+///     _new_config: Uart0BaudRateGeneratorConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1442,10 +1473,9 @@ macro_rules! define_clock_tree_types {
             /// Selects `RC_FAST_CLK`.
             RcFastClk,
         }
-        /// The list of clock signals that the `UART0_FUNCTION_CLOCK` multiplexer can output.
         #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-        pub enum Uart0FunctionClockConfig {
+        pub enum Uart0FunctionClockSclk {
             #[default]
             /// Selects `XTAL_CLK`.
             Xtal,
@@ -1453,6 +1483,77 @@ macro_rules! define_clock_tree_types {
             PllF80m,
             /// Selects `RC_FAST_CLK`.
             RcFast,
+        }
+        /// Configures the `UART0_FUNCTION_CLOCK` clock node.
+        ///
+        /// The output is calculated as `OUTPUT = sclk / (div_num + 1)`.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+        pub struct Uart0FunctionClockConfig {
+            sclk: Uart0FunctionClockSclk,
+            div_num: u32,
+        }
+        impl Uart0FunctionClockConfig {
+            /// Creates a new configuration for the FUNCTION_CLOCK clock node.
+            ///
+            /// ## Panics
+            ///
+            /// Panics if the div_num value is outside the
+            /// valid range (0 ..= 255).
+            pub const fn new(sclk: Uart0FunctionClockSclk, div_num: u32) -> Self {
+                ::core::assert!(
+                    div_num <= 255,
+                    "`UART0_FUNCTION_CLOCK` div_num must be between 0 and 255 (inclusive)."
+                );
+                Self { sclk, div_num }
+            }
+            fn sclk(self) -> Uart0FunctionClockSclk {
+                self.sclk
+            }
+            fn div_num(self) -> u32 {
+                self.div_num as u32
+            }
+        }
+        /// Configures the `UART0_BAUD_RATE_GENERATOR` clock node.
+        ///
+        /// The output is calculated as `OUTPUT = (FUNCTION_CLOCK * 16) / (integral * 16 +
+        /// fractional)`.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+        pub struct Uart0BaudRateGeneratorConfig {
+            fractional: u32,
+            integral: u32,
+        }
+        impl Uart0BaudRateGeneratorConfig {
+            /// Creates a new configuration for the BAUD_RATE_GENERATOR clock node.
+            ///
+            /// ## Panics
+            ///
+            /// Panics if the fractional value is outside the
+            /// valid range (0 ..= 15).
+            ///
+            /// Panics if the integral value is outside the
+            /// valid range (0 ..= 4095).
+            pub const fn new(fractional: u32, integral: u32) -> Self {
+                ::core::assert!(
+                    fractional <= 15,
+                    "`UART0_BAUD_RATE_GENERATOR` fractional must be between 0 and 15 (inclusive)."
+                );
+                ::core::assert!(
+                    integral <= 4095,
+                    "`UART0_BAUD_RATE_GENERATOR` integral must be between 0 and 4095 (inclusive)."
+                );
+                Self {
+                    fractional,
+                    integral,
+                }
+            }
+            fn fractional(self) -> u32 {
+                self.fractional as u32
+            }
+            fn integral(self) -> u32 {
+                self.integral as u32
+            }
         }
         /// Represents the device's clock tree.
         pub struct ClockTree {
@@ -1473,7 +1574,9 @@ macro_rules! define_clock_tree_types {
             timg1_function_clock: Option<Timg0FunctionClockConfig>,
             timg1_wdt_clock: Option<Timg0WdtClockConfig>,
             uart0_function_clock: Option<Uart0FunctionClockConfig>,
+            uart0_baud_rate_generator: Option<Uart0BaudRateGeneratorConfig>,
             uart1_function_clock: Option<Uart0FunctionClockConfig>,
+            uart1_baud_rate_generator: Option<Uart0BaudRateGeneratorConfig>,
             pll_clk_refcount: u32,
             rc_fast_clk_refcount: u32,
             xtal32k_clk_refcount: u32,
@@ -1502,7 +1605,9 @@ macro_rules! define_clock_tree_types {
             timg1_function_clock_refcount: u32,
             timg1_wdt_clock_refcount: u32,
             uart0_function_clock_refcount: u32,
+            uart0_baud_rate_generator_refcount: u32,
             uart1_function_clock_refcount: u32,
+            uart1_baud_rate_generator_refcount: u32,
         }
         impl ClockTree {
             /// Locks the clock tree for exclusive access.
@@ -1577,9 +1682,17 @@ macro_rules! define_clock_tree_types {
             pub fn uart0_function_clock(&self) -> Option<Uart0FunctionClockConfig> {
                 self.uart0_function_clock
             }
+            /// Returns the current configuration of the UART0_BAUD_RATE_GENERATOR clock tree node
+            pub fn uart0_baud_rate_generator(&self) -> Option<Uart0BaudRateGeneratorConfig> {
+                self.uart0_baud_rate_generator
+            }
             /// Returns the current configuration of the UART1_FUNCTION_CLOCK clock tree node
             pub fn uart1_function_clock(&self) -> Option<Uart0FunctionClockConfig> {
                 self.uart1_function_clock
+            }
+            /// Returns the current configuration of the UART1_BAUD_RATE_GENERATOR clock tree node
+            pub fn uart1_baud_rate_generator(&self) -> Option<Uart0BaudRateGeneratorConfig> {
+                self.uart1_baud_rate_generator
             }
         }
         static CLOCK_TREE: ::esp_sync::NonReentrantMutex<ClockTree> =
@@ -1601,7 +1714,9 @@ macro_rules! define_clock_tree_types {
                 timg1_function_clock: None,
                 timg1_wdt_clock: None,
                 uart0_function_clock: None,
+                uart0_baud_rate_generator: None,
                 uart1_function_clock: None,
+                uart1_baud_rate_generator: None,
                 pll_clk_refcount: 0,
                 rc_fast_clk_refcount: 0,
                 xtal32k_clk_refcount: 0,
@@ -1630,7 +1745,9 @@ macro_rules! define_clock_tree_types {
                 timg1_function_clock_refcount: 0,
                 timg1_wdt_clock_refcount: 0,
                 uart0_function_clock_refcount: 0,
+                uart0_baud_rate_generator_refcount: 0,
                 uart1_function_clock_refcount: 0,
+                uart1_baud_rate_generator_refcount: 0,
             });
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
             let old_config = clocks.xtal_clk.replace(config);
@@ -2832,25 +2949,25 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_uart0_function_clock(
             clocks: &mut ClockTree,
-            new_selector: Uart0FunctionClockConfig,
+            config: Uart0FunctionClockConfig,
         ) {
-            let old_selector = clocks.uart0_function_clock.replace(new_selector);
+            let old_config = clocks.uart0_function_clock.replace(config);
             if clocks.uart0_function_clock_refcount > 0 {
-                match new_selector {
-                    Uart0FunctionClockConfig::Xtal => request_xtal_clk(clocks),
-                    Uart0FunctionClockConfig::PllF80m => request_pll_f80m(clocks),
-                    Uart0FunctionClockConfig::RcFast => request_rc_fast_clk(clocks),
+                match config.sclk {
+                    Uart0FunctionClockSclk::Xtal => request_xtal_clk(clocks),
+                    Uart0FunctionClockSclk::PllF80m => request_pll_f80m(clocks),
+                    Uart0FunctionClockSclk::RcFast => request_rc_fast_clk(clocks),
                 }
-                configure_uart0_function_clock_impl(clocks, old_selector, new_selector);
-                if let Some(old_selector) = old_selector {
-                    match old_selector {
-                        Uart0FunctionClockConfig::Xtal => release_xtal_clk(clocks),
-                        Uart0FunctionClockConfig::PllF80m => release_pll_f80m(clocks),
-                        Uart0FunctionClockConfig::RcFast => release_rc_fast_clk(clocks),
+                configure_uart0_function_clock_impl(clocks, old_config, config);
+                if let Some(old_config) = old_config {
+                    match old_config.sclk {
+                        Uart0FunctionClockSclk::Xtal => release_xtal_clk(clocks),
+                        Uart0FunctionClockSclk::PllF80m => release_pll_f80m(clocks),
+                        Uart0FunctionClockSclk::RcFast => release_rc_fast_clk(clocks),
                     }
                 }
             } else {
-                configure_uart0_function_clock_impl(clocks, old_selector, new_selector);
+                configure_uart0_function_clock_impl(clocks, old_config, config);
             }
         }
         pub fn uart0_function_clock_config(
@@ -2862,10 +2979,10 @@ macro_rules! define_clock_tree_types {
             trace!("Requesting UART0_FUNCTION_CLOCK");
             if increment_reference_count(&mut clocks.uart0_function_clock_refcount) {
                 trace!("Enabling UART0_FUNCTION_CLOCK");
-                match unwrap!(clocks.uart0_function_clock) {
-                    Uart0FunctionClockConfig::Xtal => request_xtal_clk(clocks),
-                    Uart0FunctionClockConfig::PllF80m => request_pll_f80m(clocks),
-                    Uart0FunctionClockConfig::RcFast => request_rc_fast_clk(clocks),
+                match unwrap!(clocks.uart0_function_clock).sclk {
+                    Uart0FunctionClockSclk::Xtal => request_xtal_clk(clocks),
+                    Uart0FunctionClockSclk::PllF80m => request_pll_f80m(clocks),
+                    Uart0FunctionClockSclk::RcFast => request_rc_fast_clk(clocks),
                 }
                 enable_uart0_function_clock_impl(clocks, true);
             }
@@ -2875,10 +2992,10 @@ macro_rules! define_clock_tree_types {
             if decrement_reference_count(&mut clocks.uart0_function_clock_refcount) {
                 trace!("Disabling UART0_FUNCTION_CLOCK");
                 enable_uart0_function_clock_impl(clocks, false);
-                match unwrap!(clocks.uart0_function_clock) {
-                    Uart0FunctionClockConfig::Xtal => release_xtal_clk(clocks),
-                    Uart0FunctionClockConfig::PllF80m => release_pll_f80m(clocks),
-                    Uart0FunctionClockConfig::RcFast => release_rc_fast_clk(clocks),
+                match unwrap!(clocks.uart0_function_clock).sclk {
+                    Uart0FunctionClockSclk::Xtal => release_xtal_clk(clocks),
+                    Uart0FunctionClockSclk::PllF80m => release_pll_f80m(clocks),
+                    Uart0FunctionClockSclk::RcFast => release_rc_fast_clk(clocks),
                 }
             }
         }
@@ -2887,11 +3004,11 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: Uart0FunctionClockConfig,
         ) -> u32 {
-            match config {
-                Uart0FunctionClockConfig::Xtal => xtal_clk_frequency(clocks),
-                Uart0FunctionClockConfig::PllF80m => pll_f80m_frequency(clocks),
-                Uart0FunctionClockConfig::RcFast => rc_fast_clk_frequency(clocks),
-            }
+            (match config.sclk {
+                Uart0FunctionClockSclk::Xtal => xtal_clk_frequency(clocks),
+                Uart0FunctionClockSclk::PllF80m => pll_f80m_frequency(clocks),
+                Uart0FunctionClockSclk::RcFast => rc_fast_clk_frequency(clocks),
+            } / (config.div_num() + 1))
         }
         pub fn uart0_function_clock_frequency(clocks: &mut ClockTree) -> u32 {
             if let Some(config) = clocks.uart0_function_clock {
@@ -2900,27 +3017,70 @@ macro_rules! define_clock_tree_types {
                 0
             }
         }
+        pub fn configure_uart0_baud_rate_generator(
+            clocks: &mut ClockTree,
+            config: Uart0BaudRateGeneratorConfig,
+        ) {
+            let old_config = clocks.uart0_baud_rate_generator.replace(config);
+            configure_uart0_baud_rate_generator_impl(clocks, old_config, config);
+        }
+        pub fn uart0_baud_rate_generator_config(
+            clocks: &mut ClockTree,
+        ) -> Option<Uart0BaudRateGeneratorConfig> {
+            clocks.uart0_baud_rate_generator
+        }
+        pub fn request_uart0_baud_rate_generator(clocks: &mut ClockTree) {
+            trace!("Requesting UART0_BAUD_RATE_GENERATOR");
+            if increment_reference_count(&mut clocks.uart0_baud_rate_generator_refcount) {
+                trace!("Enabling UART0_BAUD_RATE_GENERATOR");
+                request_uart0_function_clock(clocks);
+                enable_uart0_baud_rate_generator_impl(clocks, true);
+            }
+        }
+        pub fn release_uart0_baud_rate_generator(clocks: &mut ClockTree) {
+            trace!("Releasing UART0_BAUD_RATE_GENERATOR");
+            if decrement_reference_count(&mut clocks.uart0_baud_rate_generator_refcount) {
+                trace!("Disabling UART0_BAUD_RATE_GENERATOR");
+                enable_uart0_baud_rate_generator_impl(clocks, false);
+                release_uart0_function_clock(clocks);
+            }
+        }
+        #[allow(unused_variables)]
+        pub fn uart0_baud_rate_generator_config_frequency(
+            clocks: &mut ClockTree,
+            config: Uart0BaudRateGeneratorConfig,
+        ) -> u32 {
+            ((uart0_function_clock_frequency(clocks) * 16)
+                / ((config.integral() * 16) + config.fractional()))
+        }
+        pub fn uart0_baud_rate_generator_frequency(clocks: &mut ClockTree) -> u32 {
+            if let Some(config) = clocks.uart0_baud_rate_generator {
+                uart0_baud_rate_generator_config_frequency(clocks, config)
+            } else {
+                0
+            }
+        }
         pub fn configure_uart1_function_clock(
             clocks: &mut ClockTree,
-            new_selector: Uart0FunctionClockConfig,
+            config: Uart0FunctionClockConfig,
         ) {
-            let old_selector = clocks.uart1_function_clock.replace(new_selector);
+            let old_config = clocks.uart1_function_clock.replace(config);
             if clocks.uart1_function_clock_refcount > 0 {
-                match new_selector {
-                    Uart0FunctionClockConfig::Xtal => request_xtal_clk(clocks),
-                    Uart0FunctionClockConfig::PllF80m => request_pll_f80m(clocks),
-                    Uart0FunctionClockConfig::RcFast => request_rc_fast_clk(clocks),
+                match config.sclk {
+                    Uart0FunctionClockSclk::Xtal => request_xtal_clk(clocks),
+                    Uart0FunctionClockSclk::PllF80m => request_pll_f80m(clocks),
+                    Uart0FunctionClockSclk::RcFast => request_rc_fast_clk(clocks),
                 }
-                configure_uart1_function_clock_impl(clocks, old_selector, new_selector);
-                if let Some(old_selector) = old_selector {
-                    match old_selector {
-                        Uart0FunctionClockConfig::Xtal => release_xtal_clk(clocks),
-                        Uart0FunctionClockConfig::PllF80m => release_pll_f80m(clocks),
-                        Uart0FunctionClockConfig::RcFast => release_rc_fast_clk(clocks),
+                configure_uart1_function_clock_impl(clocks, old_config, config);
+                if let Some(old_config) = old_config {
+                    match old_config.sclk {
+                        Uart0FunctionClockSclk::Xtal => release_xtal_clk(clocks),
+                        Uart0FunctionClockSclk::PllF80m => release_pll_f80m(clocks),
+                        Uart0FunctionClockSclk::RcFast => release_rc_fast_clk(clocks),
                     }
                 }
             } else {
-                configure_uart1_function_clock_impl(clocks, old_selector, new_selector);
+                configure_uart1_function_clock_impl(clocks, old_config, config);
             }
         }
         pub fn uart1_function_clock_config(
@@ -2932,10 +3092,10 @@ macro_rules! define_clock_tree_types {
             trace!("Requesting UART1_FUNCTION_CLOCK");
             if increment_reference_count(&mut clocks.uart1_function_clock_refcount) {
                 trace!("Enabling UART1_FUNCTION_CLOCK");
-                match unwrap!(clocks.uart1_function_clock) {
-                    Uart0FunctionClockConfig::Xtal => request_xtal_clk(clocks),
-                    Uart0FunctionClockConfig::PllF80m => request_pll_f80m(clocks),
-                    Uart0FunctionClockConfig::RcFast => request_rc_fast_clk(clocks),
+                match unwrap!(clocks.uart1_function_clock).sclk {
+                    Uart0FunctionClockSclk::Xtal => request_xtal_clk(clocks),
+                    Uart0FunctionClockSclk::PllF80m => request_pll_f80m(clocks),
+                    Uart0FunctionClockSclk::RcFast => request_rc_fast_clk(clocks),
                 }
                 enable_uart1_function_clock_impl(clocks, true);
             }
@@ -2945,10 +3105,10 @@ macro_rules! define_clock_tree_types {
             if decrement_reference_count(&mut clocks.uart1_function_clock_refcount) {
                 trace!("Disabling UART1_FUNCTION_CLOCK");
                 enable_uart1_function_clock_impl(clocks, false);
-                match unwrap!(clocks.uart1_function_clock) {
-                    Uart0FunctionClockConfig::Xtal => release_xtal_clk(clocks),
-                    Uart0FunctionClockConfig::PllF80m => release_pll_f80m(clocks),
-                    Uart0FunctionClockConfig::RcFast => release_rc_fast_clk(clocks),
+                match unwrap!(clocks.uart1_function_clock).sclk {
+                    Uart0FunctionClockSclk::Xtal => release_xtal_clk(clocks),
+                    Uart0FunctionClockSclk::PllF80m => release_pll_f80m(clocks),
+                    Uart0FunctionClockSclk::RcFast => release_rc_fast_clk(clocks),
                 }
             }
         }
@@ -2957,15 +3117,58 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: Uart0FunctionClockConfig,
         ) -> u32 {
-            match config {
-                Uart0FunctionClockConfig::Xtal => xtal_clk_frequency(clocks),
-                Uart0FunctionClockConfig::PllF80m => pll_f80m_frequency(clocks),
-                Uart0FunctionClockConfig::RcFast => rc_fast_clk_frequency(clocks),
-            }
+            (match config.sclk {
+                Uart0FunctionClockSclk::Xtal => xtal_clk_frequency(clocks),
+                Uart0FunctionClockSclk::PllF80m => pll_f80m_frequency(clocks),
+                Uart0FunctionClockSclk::RcFast => rc_fast_clk_frequency(clocks),
+            } / (config.div_num() + 1))
         }
         pub fn uart1_function_clock_frequency(clocks: &mut ClockTree) -> u32 {
             if let Some(config) = clocks.uart1_function_clock {
                 uart1_function_clock_config_frequency(clocks, config)
+            } else {
+                0
+            }
+        }
+        pub fn configure_uart1_baud_rate_generator(
+            clocks: &mut ClockTree,
+            config: Uart0BaudRateGeneratorConfig,
+        ) {
+            let old_config = clocks.uart1_baud_rate_generator.replace(config);
+            configure_uart1_baud_rate_generator_impl(clocks, old_config, config);
+        }
+        pub fn uart1_baud_rate_generator_config(
+            clocks: &mut ClockTree,
+        ) -> Option<Uart0BaudRateGeneratorConfig> {
+            clocks.uart1_baud_rate_generator
+        }
+        pub fn request_uart1_baud_rate_generator(clocks: &mut ClockTree) {
+            trace!("Requesting UART1_BAUD_RATE_GENERATOR");
+            if increment_reference_count(&mut clocks.uart1_baud_rate_generator_refcount) {
+                trace!("Enabling UART1_BAUD_RATE_GENERATOR");
+                request_uart1_function_clock(clocks);
+                enable_uart1_baud_rate_generator_impl(clocks, true);
+            }
+        }
+        pub fn release_uart1_baud_rate_generator(clocks: &mut ClockTree) {
+            trace!("Releasing UART1_BAUD_RATE_GENERATOR");
+            if decrement_reference_count(&mut clocks.uart1_baud_rate_generator_refcount) {
+                trace!("Disabling UART1_BAUD_RATE_GENERATOR");
+                enable_uart1_baud_rate_generator_impl(clocks, false);
+                release_uart1_function_clock(clocks);
+            }
+        }
+        #[allow(unused_variables)]
+        pub fn uart1_baud_rate_generator_config_frequency(
+            clocks: &mut ClockTree,
+            config: Uart0BaudRateGeneratorConfig,
+        ) -> u32 {
+            ((uart1_function_clock_frequency(clocks) * 16)
+                / ((config.integral() * 16) + config.fractional()))
+        }
+        pub fn uart1_baud_rate_generator_frequency(clocks: &mut ClockTree) -> u32 {
+            if let Some(config) = clocks.uart1_baud_rate_generator {
+                uart1_baud_rate_generator_config_frequency(clocks, config)
             } else {
                 0
             }

--- a/esp-metadata-generated/src/_generated_esp32c6.rs
+++ b/esp-metadata-generated/src/_generated_esp32c6.rs
@@ -364,6 +364,9 @@ macro_rules! property {
     ("uart.peripheral_controls_mem_clk") => {
         true
     };
+    ("uart.has_sclk_divider") => {
+        false
+    };
     ("uhci.combined_uart_selector_field") => {
         false
     };
@@ -1266,6 +1269,20 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
+/// // UART0_BAUD_RATE_GENERATOR
+///
+/// fn enable_uart0_baud_rate_generator_impl(_clocks: &mut ClockTree, _en: bool) {
+///     todo!()
+/// }
+///
+/// fn configure_uart0_baud_rate_generator_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<Uart0BaudRateGeneratorConfig>,
+///     _new_config: Uart0BaudRateGeneratorConfig,
+/// ) {
+///     todo!()
+/// }
+///
 /// // UART1_FUNCTION_CLOCK
 ///
 /// fn enable_uart1_function_clock_impl(_clocks: &mut ClockTree, _en: bool) {
@@ -1276,6 +1293,20 @@ macro_rules! for_each_sha_algorithm {
 ///     _clocks: &mut ClockTree,
 ///     _old_config: Option<Uart0FunctionClockConfig>,
 ///     _new_config: Uart0FunctionClockConfig,
+/// ) {
+///     todo!()
+/// }
+///
+/// // UART1_BAUD_RATE_GENERATOR
+///
+/// fn enable_uart1_baud_rate_generator_impl(_clocks: &mut ClockTree, _en: bool) {
+///     todo!()
+/// }
+///
+/// fn configure_uart1_baud_rate_generator_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<Uart0BaudRateGeneratorConfig>,
+///     _new_config: Uart0BaudRateGeneratorConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1767,10 +1798,9 @@ macro_rules! define_clock_tree_types {
             /// Selects `RC_FAST_CLK`.
             RcFastClk,
         }
-        /// The list of clock signals that the `UART0_FUNCTION_CLOCK` multiplexer can output.
         #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-        pub enum Uart0FunctionClockConfig {
+        pub enum Uart0FunctionClockSclk {
             /// Selects `PLL_F80M`.
             PllF80m,
             /// Selects `RC_FAST_CLK`.
@@ -1778,6 +1808,77 @@ macro_rules! define_clock_tree_types {
             #[default]
             /// Selects `XTAL_CLK`.
             Xtal,
+        }
+        /// Configures the `UART0_FUNCTION_CLOCK` clock node.
+        ///
+        /// The output is calculated as `OUTPUT = sclk / (div_num + 1)`.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+        pub struct Uart0FunctionClockConfig {
+            sclk: Uart0FunctionClockSclk,
+            div_num: u32,
+        }
+        impl Uart0FunctionClockConfig {
+            /// Creates a new configuration for the FUNCTION_CLOCK clock node.
+            ///
+            /// ## Panics
+            ///
+            /// Panics if the div_num value is outside the
+            /// valid range (0 ..= 255).
+            pub const fn new(sclk: Uart0FunctionClockSclk, div_num: u32) -> Self {
+                ::core::assert!(
+                    div_num <= 255,
+                    "`UART0_FUNCTION_CLOCK` div_num must be between 0 and 255 (inclusive)."
+                );
+                Self { sclk, div_num }
+            }
+            fn sclk(self) -> Uart0FunctionClockSclk {
+                self.sclk
+            }
+            fn div_num(self) -> u32 {
+                self.div_num as u32
+            }
+        }
+        /// Configures the `UART0_BAUD_RATE_GENERATOR` clock node.
+        ///
+        /// The output is calculated as `OUTPUT = (FUNCTION_CLOCK * 16) / (integral * 16 +
+        /// fractional)`.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+        pub struct Uart0BaudRateGeneratorConfig {
+            fractional: u32,
+            integral: u32,
+        }
+        impl Uart0BaudRateGeneratorConfig {
+            /// Creates a new configuration for the BAUD_RATE_GENERATOR clock node.
+            ///
+            /// ## Panics
+            ///
+            /// Panics if the fractional value is outside the
+            /// valid range (0 ..= 15).
+            ///
+            /// Panics if the integral value is outside the
+            /// valid range (0 ..= 4095).
+            pub const fn new(fractional: u32, integral: u32) -> Self {
+                ::core::assert!(
+                    fractional <= 15,
+                    "`UART0_BAUD_RATE_GENERATOR` fractional must be between 0 and 15 (inclusive)."
+                );
+                ::core::assert!(
+                    integral <= 4095,
+                    "`UART0_BAUD_RATE_GENERATOR` integral must be between 0 and 4095 (inclusive)."
+                );
+                Self {
+                    fractional,
+                    integral,
+                }
+            }
+            fn fractional(self) -> u32 {
+                self.fractional as u32
+            }
+            fn integral(self) -> u32 {
+                self.integral as u32
+            }
         }
         /// Represents the device's clock tree.
         pub struct ClockTree {
@@ -1808,7 +1909,9 @@ macro_rules! define_clock_tree_types {
             timg1_calibration_clock: Option<Timg0CalibrationClockConfig>,
             timg1_wdt_clock: Option<Timg0WdtClockConfig>,
             uart0_function_clock: Option<Uart0FunctionClockConfig>,
+            uart0_baud_rate_generator: Option<Uart0BaudRateGeneratorConfig>,
             uart1_function_clock: Option<Uart0FunctionClockConfig>,
+            uart1_baud_rate_generator: Option<Uart0BaudRateGeneratorConfig>,
             pll_clk_refcount: u32,
             rc_fast_clk_refcount: u32,
             xtal32k_clk_refcount: u32,
@@ -1832,7 +1935,9 @@ macro_rules! define_clock_tree_types {
             timg1_calibration_clock_refcount: u32,
             timg1_wdt_clock_refcount: u32,
             uart0_function_clock_refcount: u32,
+            uart0_baud_rate_generator_refcount: u32,
             uart1_function_clock_refcount: u32,
+            uart1_baud_rate_generator_refcount: u32,
         }
         impl ClockTree {
             /// Locks the clock tree for exclusive access.
@@ -1947,9 +2052,17 @@ macro_rules! define_clock_tree_types {
             pub fn uart0_function_clock(&self) -> Option<Uart0FunctionClockConfig> {
                 self.uart0_function_clock
             }
+            /// Returns the current configuration of the UART0_BAUD_RATE_GENERATOR clock tree node
+            pub fn uart0_baud_rate_generator(&self) -> Option<Uart0BaudRateGeneratorConfig> {
+                self.uart0_baud_rate_generator
+            }
             /// Returns the current configuration of the UART1_FUNCTION_CLOCK clock tree node
             pub fn uart1_function_clock(&self) -> Option<Uart0FunctionClockConfig> {
                 self.uart1_function_clock
+            }
+            /// Returns the current configuration of the UART1_BAUD_RATE_GENERATOR clock tree node
+            pub fn uart1_baud_rate_generator(&self) -> Option<Uart0BaudRateGeneratorConfig> {
+                self.uart1_baud_rate_generator
             }
         }
         static CLOCK_TREE: ::esp_sync::NonReentrantMutex<ClockTree> =
@@ -1981,7 +2094,9 @@ macro_rules! define_clock_tree_types {
                 timg1_calibration_clock: None,
                 timg1_wdt_clock: None,
                 uart0_function_clock: None,
+                uart0_baud_rate_generator: None,
                 uart1_function_clock: None,
+                uart1_baud_rate_generator: None,
                 pll_clk_refcount: 0,
                 rc_fast_clk_refcount: 0,
                 xtal32k_clk_refcount: 0,
@@ -2005,7 +2120,9 @@ macro_rules! define_clock_tree_types {
                 timg1_calibration_clock_refcount: 0,
                 timg1_wdt_clock_refcount: 0,
                 uart0_function_clock_refcount: 0,
+                uart0_baud_rate_generator_refcount: 0,
                 uart1_function_clock_refcount: 0,
+                uart1_baud_rate_generator_refcount: 0,
             });
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
             let old_config = clocks.xtal_clk.replace(config);
@@ -3529,25 +3646,25 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_uart0_function_clock(
             clocks: &mut ClockTree,
-            new_selector: Uart0FunctionClockConfig,
+            config: Uart0FunctionClockConfig,
         ) {
-            let old_selector = clocks.uart0_function_clock.replace(new_selector);
+            let old_config = clocks.uart0_function_clock.replace(config);
             if clocks.uart0_function_clock_refcount > 0 {
-                match new_selector {
-                    Uart0FunctionClockConfig::PllF80m => request_pll_f80m(clocks),
-                    Uart0FunctionClockConfig::RcFast => request_rc_fast_clk(clocks),
-                    Uart0FunctionClockConfig::Xtal => request_xtal_clk(clocks),
+                match config.sclk {
+                    Uart0FunctionClockSclk::PllF80m => request_pll_f80m(clocks),
+                    Uart0FunctionClockSclk::RcFast => request_rc_fast_clk(clocks),
+                    Uart0FunctionClockSclk::Xtal => request_xtal_clk(clocks),
                 }
-                configure_uart0_function_clock_impl(clocks, old_selector, new_selector);
-                if let Some(old_selector) = old_selector {
-                    match old_selector {
-                        Uart0FunctionClockConfig::PllF80m => release_pll_f80m(clocks),
-                        Uart0FunctionClockConfig::RcFast => release_rc_fast_clk(clocks),
-                        Uart0FunctionClockConfig::Xtal => release_xtal_clk(clocks),
+                configure_uart0_function_clock_impl(clocks, old_config, config);
+                if let Some(old_config) = old_config {
+                    match old_config.sclk {
+                        Uart0FunctionClockSclk::PllF80m => release_pll_f80m(clocks),
+                        Uart0FunctionClockSclk::RcFast => release_rc_fast_clk(clocks),
+                        Uart0FunctionClockSclk::Xtal => release_xtal_clk(clocks),
                     }
                 }
             } else {
-                configure_uart0_function_clock_impl(clocks, old_selector, new_selector);
+                configure_uart0_function_clock_impl(clocks, old_config, config);
             }
         }
         pub fn uart0_function_clock_config(
@@ -3559,10 +3676,10 @@ macro_rules! define_clock_tree_types {
             trace!("Requesting UART0_FUNCTION_CLOCK");
             if increment_reference_count(&mut clocks.uart0_function_clock_refcount) {
                 trace!("Enabling UART0_FUNCTION_CLOCK");
-                match unwrap!(clocks.uart0_function_clock) {
-                    Uart0FunctionClockConfig::PllF80m => request_pll_f80m(clocks),
-                    Uart0FunctionClockConfig::RcFast => request_rc_fast_clk(clocks),
-                    Uart0FunctionClockConfig::Xtal => request_xtal_clk(clocks),
+                match unwrap!(clocks.uart0_function_clock).sclk {
+                    Uart0FunctionClockSclk::PllF80m => request_pll_f80m(clocks),
+                    Uart0FunctionClockSclk::RcFast => request_rc_fast_clk(clocks),
+                    Uart0FunctionClockSclk::Xtal => request_xtal_clk(clocks),
                 }
                 enable_uart0_function_clock_impl(clocks, true);
             }
@@ -3572,10 +3689,10 @@ macro_rules! define_clock_tree_types {
             if decrement_reference_count(&mut clocks.uart0_function_clock_refcount) {
                 trace!("Disabling UART0_FUNCTION_CLOCK");
                 enable_uart0_function_clock_impl(clocks, false);
-                match unwrap!(clocks.uart0_function_clock) {
-                    Uart0FunctionClockConfig::PllF80m => release_pll_f80m(clocks),
-                    Uart0FunctionClockConfig::RcFast => release_rc_fast_clk(clocks),
-                    Uart0FunctionClockConfig::Xtal => release_xtal_clk(clocks),
+                match unwrap!(clocks.uart0_function_clock).sclk {
+                    Uart0FunctionClockSclk::PllF80m => release_pll_f80m(clocks),
+                    Uart0FunctionClockSclk::RcFast => release_rc_fast_clk(clocks),
+                    Uart0FunctionClockSclk::Xtal => release_xtal_clk(clocks),
                 }
             }
         }
@@ -3584,11 +3701,11 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: Uart0FunctionClockConfig,
         ) -> u32 {
-            match config {
-                Uart0FunctionClockConfig::PllF80m => pll_f80m_frequency(clocks),
-                Uart0FunctionClockConfig::RcFast => rc_fast_clk_frequency(clocks),
-                Uart0FunctionClockConfig::Xtal => xtal_clk_frequency(clocks),
-            }
+            (match config.sclk {
+                Uart0FunctionClockSclk::PllF80m => pll_f80m_frequency(clocks),
+                Uart0FunctionClockSclk::RcFast => rc_fast_clk_frequency(clocks),
+                Uart0FunctionClockSclk::Xtal => xtal_clk_frequency(clocks),
+            } / (config.div_num() + 1))
         }
         pub fn uart0_function_clock_frequency(clocks: &mut ClockTree) -> u32 {
             if let Some(config) = clocks.uart0_function_clock {
@@ -3597,27 +3714,70 @@ macro_rules! define_clock_tree_types {
                 0
             }
         }
+        pub fn configure_uart0_baud_rate_generator(
+            clocks: &mut ClockTree,
+            config: Uart0BaudRateGeneratorConfig,
+        ) {
+            let old_config = clocks.uart0_baud_rate_generator.replace(config);
+            configure_uart0_baud_rate_generator_impl(clocks, old_config, config);
+        }
+        pub fn uart0_baud_rate_generator_config(
+            clocks: &mut ClockTree,
+        ) -> Option<Uart0BaudRateGeneratorConfig> {
+            clocks.uart0_baud_rate_generator
+        }
+        pub fn request_uart0_baud_rate_generator(clocks: &mut ClockTree) {
+            trace!("Requesting UART0_BAUD_RATE_GENERATOR");
+            if increment_reference_count(&mut clocks.uart0_baud_rate_generator_refcount) {
+                trace!("Enabling UART0_BAUD_RATE_GENERATOR");
+                request_uart0_function_clock(clocks);
+                enable_uart0_baud_rate_generator_impl(clocks, true);
+            }
+        }
+        pub fn release_uart0_baud_rate_generator(clocks: &mut ClockTree) {
+            trace!("Releasing UART0_BAUD_RATE_GENERATOR");
+            if decrement_reference_count(&mut clocks.uart0_baud_rate_generator_refcount) {
+                trace!("Disabling UART0_BAUD_RATE_GENERATOR");
+                enable_uart0_baud_rate_generator_impl(clocks, false);
+                release_uart0_function_clock(clocks);
+            }
+        }
+        #[allow(unused_variables)]
+        pub fn uart0_baud_rate_generator_config_frequency(
+            clocks: &mut ClockTree,
+            config: Uart0BaudRateGeneratorConfig,
+        ) -> u32 {
+            ((uart0_function_clock_frequency(clocks) * 16)
+                / ((config.integral() * 16) + config.fractional()))
+        }
+        pub fn uart0_baud_rate_generator_frequency(clocks: &mut ClockTree) -> u32 {
+            if let Some(config) = clocks.uart0_baud_rate_generator {
+                uart0_baud_rate_generator_config_frequency(clocks, config)
+            } else {
+                0
+            }
+        }
         pub fn configure_uart1_function_clock(
             clocks: &mut ClockTree,
-            new_selector: Uart0FunctionClockConfig,
+            config: Uart0FunctionClockConfig,
         ) {
-            let old_selector = clocks.uart1_function_clock.replace(new_selector);
+            let old_config = clocks.uart1_function_clock.replace(config);
             if clocks.uart1_function_clock_refcount > 0 {
-                match new_selector {
-                    Uart0FunctionClockConfig::PllF80m => request_pll_f80m(clocks),
-                    Uart0FunctionClockConfig::RcFast => request_rc_fast_clk(clocks),
-                    Uart0FunctionClockConfig::Xtal => request_xtal_clk(clocks),
+                match config.sclk {
+                    Uart0FunctionClockSclk::PllF80m => request_pll_f80m(clocks),
+                    Uart0FunctionClockSclk::RcFast => request_rc_fast_clk(clocks),
+                    Uart0FunctionClockSclk::Xtal => request_xtal_clk(clocks),
                 }
-                configure_uart1_function_clock_impl(clocks, old_selector, new_selector);
-                if let Some(old_selector) = old_selector {
-                    match old_selector {
-                        Uart0FunctionClockConfig::PllF80m => release_pll_f80m(clocks),
-                        Uart0FunctionClockConfig::RcFast => release_rc_fast_clk(clocks),
-                        Uart0FunctionClockConfig::Xtal => release_xtal_clk(clocks),
+                configure_uart1_function_clock_impl(clocks, old_config, config);
+                if let Some(old_config) = old_config {
+                    match old_config.sclk {
+                        Uart0FunctionClockSclk::PllF80m => release_pll_f80m(clocks),
+                        Uart0FunctionClockSclk::RcFast => release_rc_fast_clk(clocks),
+                        Uart0FunctionClockSclk::Xtal => release_xtal_clk(clocks),
                     }
                 }
             } else {
-                configure_uart1_function_clock_impl(clocks, old_selector, new_selector);
+                configure_uart1_function_clock_impl(clocks, old_config, config);
             }
         }
         pub fn uart1_function_clock_config(
@@ -3629,10 +3789,10 @@ macro_rules! define_clock_tree_types {
             trace!("Requesting UART1_FUNCTION_CLOCK");
             if increment_reference_count(&mut clocks.uart1_function_clock_refcount) {
                 trace!("Enabling UART1_FUNCTION_CLOCK");
-                match unwrap!(clocks.uart1_function_clock) {
-                    Uart0FunctionClockConfig::PllF80m => request_pll_f80m(clocks),
-                    Uart0FunctionClockConfig::RcFast => request_rc_fast_clk(clocks),
-                    Uart0FunctionClockConfig::Xtal => request_xtal_clk(clocks),
+                match unwrap!(clocks.uart1_function_clock).sclk {
+                    Uart0FunctionClockSclk::PllF80m => request_pll_f80m(clocks),
+                    Uart0FunctionClockSclk::RcFast => request_rc_fast_clk(clocks),
+                    Uart0FunctionClockSclk::Xtal => request_xtal_clk(clocks),
                 }
                 enable_uart1_function_clock_impl(clocks, true);
             }
@@ -3642,10 +3802,10 @@ macro_rules! define_clock_tree_types {
             if decrement_reference_count(&mut clocks.uart1_function_clock_refcount) {
                 trace!("Disabling UART1_FUNCTION_CLOCK");
                 enable_uart1_function_clock_impl(clocks, false);
-                match unwrap!(clocks.uart1_function_clock) {
-                    Uart0FunctionClockConfig::PllF80m => release_pll_f80m(clocks),
-                    Uart0FunctionClockConfig::RcFast => release_rc_fast_clk(clocks),
-                    Uart0FunctionClockConfig::Xtal => release_xtal_clk(clocks),
+                match unwrap!(clocks.uart1_function_clock).sclk {
+                    Uart0FunctionClockSclk::PllF80m => release_pll_f80m(clocks),
+                    Uart0FunctionClockSclk::RcFast => release_rc_fast_clk(clocks),
+                    Uart0FunctionClockSclk::Xtal => release_xtal_clk(clocks),
                 }
             }
         }
@@ -3654,15 +3814,58 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: Uart0FunctionClockConfig,
         ) -> u32 {
-            match config {
-                Uart0FunctionClockConfig::PllF80m => pll_f80m_frequency(clocks),
-                Uart0FunctionClockConfig::RcFast => rc_fast_clk_frequency(clocks),
-                Uart0FunctionClockConfig::Xtal => xtal_clk_frequency(clocks),
-            }
+            (match config.sclk {
+                Uart0FunctionClockSclk::PllF80m => pll_f80m_frequency(clocks),
+                Uart0FunctionClockSclk::RcFast => rc_fast_clk_frequency(clocks),
+                Uart0FunctionClockSclk::Xtal => xtal_clk_frequency(clocks),
+            } / (config.div_num() + 1))
         }
         pub fn uart1_function_clock_frequency(clocks: &mut ClockTree) -> u32 {
             if let Some(config) = clocks.uart1_function_clock {
                 uart1_function_clock_config_frequency(clocks, config)
+            } else {
+                0
+            }
+        }
+        pub fn configure_uart1_baud_rate_generator(
+            clocks: &mut ClockTree,
+            config: Uart0BaudRateGeneratorConfig,
+        ) {
+            let old_config = clocks.uart1_baud_rate_generator.replace(config);
+            configure_uart1_baud_rate_generator_impl(clocks, old_config, config);
+        }
+        pub fn uart1_baud_rate_generator_config(
+            clocks: &mut ClockTree,
+        ) -> Option<Uart0BaudRateGeneratorConfig> {
+            clocks.uart1_baud_rate_generator
+        }
+        pub fn request_uart1_baud_rate_generator(clocks: &mut ClockTree) {
+            trace!("Requesting UART1_BAUD_RATE_GENERATOR");
+            if increment_reference_count(&mut clocks.uart1_baud_rate_generator_refcount) {
+                trace!("Enabling UART1_BAUD_RATE_GENERATOR");
+                request_uart1_function_clock(clocks);
+                enable_uart1_baud_rate_generator_impl(clocks, true);
+            }
+        }
+        pub fn release_uart1_baud_rate_generator(clocks: &mut ClockTree) {
+            trace!("Releasing UART1_BAUD_RATE_GENERATOR");
+            if decrement_reference_count(&mut clocks.uart1_baud_rate_generator_refcount) {
+                trace!("Disabling UART1_BAUD_RATE_GENERATOR");
+                enable_uart1_baud_rate_generator_impl(clocks, false);
+                release_uart1_function_clock(clocks);
+            }
+        }
+        #[allow(unused_variables)]
+        pub fn uart1_baud_rate_generator_config_frequency(
+            clocks: &mut ClockTree,
+            config: Uart0BaudRateGeneratorConfig,
+        ) -> u32 {
+            ((uart1_function_clock_frequency(clocks) * 16)
+                / ((config.integral() * 16) + config.fractional()))
+        }
+        pub fn uart1_baud_rate_generator_frequency(clocks: &mut ClockTree) -> u32 {
+            if let Some(config) = clocks.uart1_baud_rate_generator {
+                uart1_baud_rate_generator_config_frequency(clocks, config)
             } else {
                 0
             }

--- a/esp-metadata-generated/src/_generated_esp32h2.rs
+++ b/esp-metadata-generated/src/_generated_esp32h2.rs
@@ -352,6 +352,9 @@ macro_rules! property {
     ("uart.peripheral_controls_mem_clk") => {
         true
     };
+    ("uart.has_sclk_divider") => {
+        false
+    };
     ("uhci.combined_uart_selector_field") => {
         false
     };
@@ -1108,6 +1111,20 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
+/// // UART0_BAUD_RATE_GENERATOR
+///
+/// fn enable_uart0_baud_rate_generator_impl(_clocks: &mut ClockTree, _en: bool) {
+///     todo!()
+/// }
+///
+/// fn configure_uart0_baud_rate_generator_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<Uart0BaudRateGeneratorConfig>,
+///     _new_config: Uart0BaudRateGeneratorConfig,
+/// ) {
+///     todo!()
+/// }
+///
 /// // UART1_FUNCTION_CLOCK
 ///
 /// fn enable_uart1_function_clock_impl(_clocks: &mut ClockTree, _en: bool) {
@@ -1118,6 +1135,20 @@ macro_rules! for_each_sha_algorithm {
 ///     _clocks: &mut ClockTree,
 ///     _old_config: Option<Uart0FunctionClockConfig>,
 ///     _new_config: Uart0FunctionClockConfig,
+/// ) {
+///     todo!()
+/// }
+///
+/// // UART1_BAUD_RATE_GENERATOR
+///
+/// fn enable_uart1_baud_rate_generator_impl(_clocks: &mut ClockTree, _en: bool) {
+///     todo!()
+/// }
+///
+/// fn configure_uart1_baud_rate_generator_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<Uart0BaudRateGeneratorConfig>,
+///     _new_config: Uart0BaudRateGeneratorConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1332,10 +1363,9 @@ macro_rules! define_clock_tree_types {
             /// Selects `PLL_F48M_CLK`.
             PllF48m,
         }
-        /// The list of clock signals that the `UART0_FUNCTION_CLOCK` multiplexer can output.
         #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-        pub enum Uart0FunctionClockConfig {
+        pub enum Uart0FunctionClockSclk {
             /// Selects `PLL_F48M_CLK`.
             PllF48m,
             /// Selects `RC_FAST_CLK`.
@@ -1343,6 +1373,77 @@ macro_rules! define_clock_tree_types {
             #[default]
             /// Selects `XTAL_CLK`.
             Xtal,
+        }
+        /// Configures the `UART0_FUNCTION_CLOCK` clock node.
+        ///
+        /// The output is calculated as `OUTPUT = sclk / (div_num + 1)`.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+        pub struct Uart0FunctionClockConfig {
+            sclk: Uart0FunctionClockSclk,
+            div_num: u32,
+        }
+        impl Uart0FunctionClockConfig {
+            /// Creates a new configuration for the FUNCTION_CLOCK clock node.
+            ///
+            /// ## Panics
+            ///
+            /// Panics if the div_num value is outside the
+            /// valid range (0 ..= 255).
+            pub const fn new(sclk: Uart0FunctionClockSclk, div_num: u32) -> Self {
+                ::core::assert!(
+                    div_num <= 255,
+                    "`UART0_FUNCTION_CLOCK` div_num must be between 0 and 255 (inclusive)."
+                );
+                Self { sclk, div_num }
+            }
+            fn sclk(self) -> Uart0FunctionClockSclk {
+                self.sclk
+            }
+            fn div_num(self) -> u32 {
+                self.div_num as u32
+            }
+        }
+        /// Configures the `UART0_BAUD_RATE_GENERATOR` clock node.
+        ///
+        /// The output is calculated as `OUTPUT = (FUNCTION_CLOCK * 16) / (integral * 16 +
+        /// fractional)`.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+        pub struct Uart0BaudRateGeneratorConfig {
+            fractional: u32,
+            integral: u32,
+        }
+        impl Uart0BaudRateGeneratorConfig {
+            /// Creates a new configuration for the BAUD_RATE_GENERATOR clock node.
+            ///
+            /// ## Panics
+            ///
+            /// Panics if the fractional value is outside the
+            /// valid range (0 ..= 15).
+            ///
+            /// Panics if the integral value is outside the
+            /// valid range (0 ..= 4095).
+            pub const fn new(fractional: u32, integral: u32) -> Self {
+                ::core::assert!(
+                    fractional <= 15,
+                    "`UART0_BAUD_RATE_GENERATOR` fractional must be between 0 and 15 (inclusive)."
+                );
+                ::core::assert!(
+                    integral <= 4095,
+                    "`UART0_BAUD_RATE_GENERATOR` integral must be between 0 and 4095 (inclusive)."
+                );
+                Self {
+                    fractional,
+                    integral,
+                }
+            }
+            fn fractional(self) -> u32 {
+                self.fractional as u32
+            }
+            fn integral(self) -> u32 {
+                self.integral as u32
+            }
         }
         /// Represents the device's clock tree.
         pub struct ClockTree {
@@ -1364,7 +1465,9 @@ macro_rules! define_clock_tree_types {
             timg1_calibration_clock: Option<Timg0CalibrationClockConfig>,
             timg1_wdt_clock: Option<Timg0WdtClockConfig>,
             uart0_function_clock: Option<Uart0FunctionClockConfig>,
+            uart0_baud_rate_generator: Option<Uart0BaudRateGeneratorConfig>,
             uart1_function_clock: Option<Uart0FunctionClockConfig>,
+            uart1_baud_rate_generator: Option<Uart0BaudRateGeneratorConfig>,
             pll_f96m_clk_refcount: u32,
             pll_f48m_clk_refcount: u32,
             rc_fast_clk_refcount: u32,
@@ -1384,7 +1487,9 @@ macro_rules! define_clock_tree_types {
             timg1_calibration_clock_refcount: u32,
             timg1_wdt_clock_refcount: u32,
             uart0_function_clock_refcount: u32,
+            uart0_baud_rate_generator_refcount: u32,
             uart1_function_clock_refcount: u32,
+            uart1_baud_rate_generator_refcount: u32,
         }
         impl ClockTree {
             /// Locks the clock tree for exclusive access.
@@ -1463,9 +1568,17 @@ macro_rules! define_clock_tree_types {
             pub fn uart0_function_clock(&self) -> Option<Uart0FunctionClockConfig> {
                 self.uart0_function_clock
             }
+            /// Returns the current configuration of the UART0_BAUD_RATE_GENERATOR clock tree node
+            pub fn uart0_baud_rate_generator(&self) -> Option<Uart0BaudRateGeneratorConfig> {
+                self.uart0_baud_rate_generator
+            }
             /// Returns the current configuration of the UART1_FUNCTION_CLOCK clock tree node
             pub fn uart1_function_clock(&self) -> Option<Uart0FunctionClockConfig> {
                 self.uart1_function_clock
+            }
+            /// Returns the current configuration of the UART1_BAUD_RATE_GENERATOR clock tree node
+            pub fn uart1_baud_rate_generator(&self) -> Option<Uart0BaudRateGeneratorConfig> {
+                self.uart1_baud_rate_generator
             }
         }
         static CLOCK_TREE: ::esp_sync::NonReentrantMutex<ClockTree> =
@@ -1488,7 +1601,9 @@ macro_rules! define_clock_tree_types {
                 timg1_calibration_clock: None,
                 timg1_wdt_clock: None,
                 uart0_function_clock: None,
+                uart0_baud_rate_generator: None,
                 uart1_function_clock: None,
+                uart1_baud_rate_generator: None,
                 pll_f96m_clk_refcount: 0,
                 pll_f48m_clk_refcount: 0,
                 rc_fast_clk_refcount: 0,
@@ -1508,7 +1623,9 @@ macro_rules! define_clock_tree_types {
                 timg1_calibration_clock_refcount: 0,
                 timg1_wdt_clock_refcount: 0,
                 uart0_function_clock_refcount: 0,
+                uart0_baud_rate_generator_refcount: 0,
                 uart1_function_clock_refcount: 0,
+                uart1_baud_rate_generator_refcount: 0,
             });
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
             let old_config = clocks.xtal_clk.replace(config);
@@ -2628,25 +2745,25 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_uart0_function_clock(
             clocks: &mut ClockTree,
-            new_selector: Uart0FunctionClockConfig,
+            config: Uart0FunctionClockConfig,
         ) {
-            let old_selector = clocks.uart0_function_clock.replace(new_selector);
+            let old_config = clocks.uart0_function_clock.replace(config);
             if clocks.uart0_function_clock_refcount > 0 {
-                match new_selector {
-                    Uart0FunctionClockConfig::PllF48m => request_pll_f48m_clk(clocks),
-                    Uart0FunctionClockConfig::RcFast => request_rc_fast_clk(clocks),
-                    Uart0FunctionClockConfig::Xtal => request_xtal_clk(clocks),
+                match config.sclk {
+                    Uart0FunctionClockSclk::PllF48m => request_pll_f48m_clk(clocks),
+                    Uart0FunctionClockSclk::RcFast => request_rc_fast_clk(clocks),
+                    Uart0FunctionClockSclk::Xtal => request_xtal_clk(clocks),
                 }
-                configure_uart0_function_clock_impl(clocks, old_selector, new_selector);
-                if let Some(old_selector) = old_selector {
-                    match old_selector {
-                        Uart0FunctionClockConfig::PllF48m => release_pll_f48m_clk(clocks),
-                        Uart0FunctionClockConfig::RcFast => release_rc_fast_clk(clocks),
-                        Uart0FunctionClockConfig::Xtal => release_xtal_clk(clocks),
+                configure_uart0_function_clock_impl(clocks, old_config, config);
+                if let Some(old_config) = old_config {
+                    match old_config.sclk {
+                        Uart0FunctionClockSclk::PllF48m => release_pll_f48m_clk(clocks),
+                        Uart0FunctionClockSclk::RcFast => release_rc_fast_clk(clocks),
+                        Uart0FunctionClockSclk::Xtal => release_xtal_clk(clocks),
                     }
                 }
             } else {
-                configure_uart0_function_clock_impl(clocks, old_selector, new_selector);
+                configure_uart0_function_clock_impl(clocks, old_config, config);
             }
         }
         pub fn uart0_function_clock_config(
@@ -2658,10 +2775,10 @@ macro_rules! define_clock_tree_types {
             trace!("Requesting UART0_FUNCTION_CLOCK");
             if increment_reference_count(&mut clocks.uart0_function_clock_refcount) {
                 trace!("Enabling UART0_FUNCTION_CLOCK");
-                match unwrap!(clocks.uart0_function_clock) {
-                    Uart0FunctionClockConfig::PllF48m => request_pll_f48m_clk(clocks),
-                    Uart0FunctionClockConfig::RcFast => request_rc_fast_clk(clocks),
-                    Uart0FunctionClockConfig::Xtal => request_xtal_clk(clocks),
+                match unwrap!(clocks.uart0_function_clock).sclk {
+                    Uart0FunctionClockSclk::PllF48m => request_pll_f48m_clk(clocks),
+                    Uart0FunctionClockSclk::RcFast => request_rc_fast_clk(clocks),
+                    Uart0FunctionClockSclk::Xtal => request_xtal_clk(clocks),
                 }
                 enable_uart0_function_clock_impl(clocks, true);
             }
@@ -2671,10 +2788,10 @@ macro_rules! define_clock_tree_types {
             if decrement_reference_count(&mut clocks.uart0_function_clock_refcount) {
                 trace!("Disabling UART0_FUNCTION_CLOCK");
                 enable_uart0_function_clock_impl(clocks, false);
-                match unwrap!(clocks.uart0_function_clock) {
-                    Uart0FunctionClockConfig::PllF48m => release_pll_f48m_clk(clocks),
-                    Uart0FunctionClockConfig::RcFast => release_rc_fast_clk(clocks),
-                    Uart0FunctionClockConfig::Xtal => release_xtal_clk(clocks),
+                match unwrap!(clocks.uart0_function_clock).sclk {
+                    Uart0FunctionClockSclk::PllF48m => release_pll_f48m_clk(clocks),
+                    Uart0FunctionClockSclk::RcFast => release_rc_fast_clk(clocks),
+                    Uart0FunctionClockSclk::Xtal => release_xtal_clk(clocks),
                 }
             }
         }
@@ -2683,11 +2800,11 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: Uart0FunctionClockConfig,
         ) -> u32 {
-            match config {
-                Uart0FunctionClockConfig::PllF48m => pll_f48m_clk_frequency(clocks),
-                Uart0FunctionClockConfig::RcFast => rc_fast_clk_frequency(clocks),
-                Uart0FunctionClockConfig::Xtal => xtal_clk_frequency(clocks),
-            }
+            (match config.sclk {
+                Uart0FunctionClockSclk::PllF48m => pll_f48m_clk_frequency(clocks),
+                Uart0FunctionClockSclk::RcFast => rc_fast_clk_frequency(clocks),
+                Uart0FunctionClockSclk::Xtal => xtal_clk_frequency(clocks),
+            } / (config.div_num() + 1))
         }
         pub fn uart0_function_clock_frequency(clocks: &mut ClockTree) -> u32 {
             if let Some(config) = clocks.uart0_function_clock {
@@ -2696,27 +2813,70 @@ macro_rules! define_clock_tree_types {
                 0
             }
         }
+        pub fn configure_uart0_baud_rate_generator(
+            clocks: &mut ClockTree,
+            config: Uart0BaudRateGeneratorConfig,
+        ) {
+            let old_config = clocks.uart0_baud_rate_generator.replace(config);
+            configure_uart0_baud_rate_generator_impl(clocks, old_config, config);
+        }
+        pub fn uart0_baud_rate_generator_config(
+            clocks: &mut ClockTree,
+        ) -> Option<Uart0BaudRateGeneratorConfig> {
+            clocks.uart0_baud_rate_generator
+        }
+        pub fn request_uart0_baud_rate_generator(clocks: &mut ClockTree) {
+            trace!("Requesting UART0_BAUD_RATE_GENERATOR");
+            if increment_reference_count(&mut clocks.uart0_baud_rate_generator_refcount) {
+                trace!("Enabling UART0_BAUD_RATE_GENERATOR");
+                request_uart0_function_clock(clocks);
+                enable_uart0_baud_rate_generator_impl(clocks, true);
+            }
+        }
+        pub fn release_uart0_baud_rate_generator(clocks: &mut ClockTree) {
+            trace!("Releasing UART0_BAUD_RATE_GENERATOR");
+            if decrement_reference_count(&mut clocks.uart0_baud_rate_generator_refcount) {
+                trace!("Disabling UART0_BAUD_RATE_GENERATOR");
+                enable_uart0_baud_rate_generator_impl(clocks, false);
+                release_uart0_function_clock(clocks);
+            }
+        }
+        #[allow(unused_variables)]
+        pub fn uart0_baud_rate_generator_config_frequency(
+            clocks: &mut ClockTree,
+            config: Uart0BaudRateGeneratorConfig,
+        ) -> u32 {
+            ((uart0_function_clock_frequency(clocks) * 16)
+                / ((config.integral() * 16) + config.fractional()))
+        }
+        pub fn uart0_baud_rate_generator_frequency(clocks: &mut ClockTree) -> u32 {
+            if let Some(config) = clocks.uart0_baud_rate_generator {
+                uart0_baud_rate_generator_config_frequency(clocks, config)
+            } else {
+                0
+            }
+        }
         pub fn configure_uart1_function_clock(
             clocks: &mut ClockTree,
-            new_selector: Uart0FunctionClockConfig,
+            config: Uart0FunctionClockConfig,
         ) {
-            let old_selector = clocks.uart1_function_clock.replace(new_selector);
+            let old_config = clocks.uart1_function_clock.replace(config);
             if clocks.uart1_function_clock_refcount > 0 {
-                match new_selector {
-                    Uart0FunctionClockConfig::PllF48m => request_pll_f48m_clk(clocks),
-                    Uart0FunctionClockConfig::RcFast => request_rc_fast_clk(clocks),
-                    Uart0FunctionClockConfig::Xtal => request_xtal_clk(clocks),
+                match config.sclk {
+                    Uart0FunctionClockSclk::PllF48m => request_pll_f48m_clk(clocks),
+                    Uart0FunctionClockSclk::RcFast => request_rc_fast_clk(clocks),
+                    Uart0FunctionClockSclk::Xtal => request_xtal_clk(clocks),
                 }
-                configure_uart1_function_clock_impl(clocks, old_selector, new_selector);
-                if let Some(old_selector) = old_selector {
-                    match old_selector {
-                        Uart0FunctionClockConfig::PllF48m => release_pll_f48m_clk(clocks),
-                        Uart0FunctionClockConfig::RcFast => release_rc_fast_clk(clocks),
-                        Uart0FunctionClockConfig::Xtal => release_xtal_clk(clocks),
+                configure_uart1_function_clock_impl(clocks, old_config, config);
+                if let Some(old_config) = old_config {
+                    match old_config.sclk {
+                        Uart0FunctionClockSclk::PllF48m => release_pll_f48m_clk(clocks),
+                        Uart0FunctionClockSclk::RcFast => release_rc_fast_clk(clocks),
+                        Uart0FunctionClockSclk::Xtal => release_xtal_clk(clocks),
                     }
                 }
             } else {
-                configure_uart1_function_clock_impl(clocks, old_selector, new_selector);
+                configure_uart1_function_clock_impl(clocks, old_config, config);
             }
         }
         pub fn uart1_function_clock_config(
@@ -2728,10 +2888,10 @@ macro_rules! define_clock_tree_types {
             trace!("Requesting UART1_FUNCTION_CLOCK");
             if increment_reference_count(&mut clocks.uart1_function_clock_refcount) {
                 trace!("Enabling UART1_FUNCTION_CLOCK");
-                match unwrap!(clocks.uart1_function_clock) {
-                    Uart0FunctionClockConfig::PllF48m => request_pll_f48m_clk(clocks),
-                    Uart0FunctionClockConfig::RcFast => request_rc_fast_clk(clocks),
-                    Uart0FunctionClockConfig::Xtal => request_xtal_clk(clocks),
+                match unwrap!(clocks.uart1_function_clock).sclk {
+                    Uart0FunctionClockSclk::PllF48m => request_pll_f48m_clk(clocks),
+                    Uart0FunctionClockSclk::RcFast => request_rc_fast_clk(clocks),
+                    Uart0FunctionClockSclk::Xtal => request_xtal_clk(clocks),
                 }
                 enable_uart1_function_clock_impl(clocks, true);
             }
@@ -2741,10 +2901,10 @@ macro_rules! define_clock_tree_types {
             if decrement_reference_count(&mut clocks.uart1_function_clock_refcount) {
                 trace!("Disabling UART1_FUNCTION_CLOCK");
                 enable_uart1_function_clock_impl(clocks, false);
-                match unwrap!(clocks.uart1_function_clock) {
-                    Uart0FunctionClockConfig::PllF48m => release_pll_f48m_clk(clocks),
-                    Uart0FunctionClockConfig::RcFast => release_rc_fast_clk(clocks),
-                    Uart0FunctionClockConfig::Xtal => release_xtal_clk(clocks),
+                match unwrap!(clocks.uart1_function_clock).sclk {
+                    Uart0FunctionClockSclk::PllF48m => release_pll_f48m_clk(clocks),
+                    Uart0FunctionClockSclk::RcFast => release_rc_fast_clk(clocks),
+                    Uart0FunctionClockSclk::Xtal => release_xtal_clk(clocks),
                 }
             }
         }
@@ -2753,15 +2913,58 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: Uart0FunctionClockConfig,
         ) -> u32 {
-            match config {
-                Uart0FunctionClockConfig::PllF48m => pll_f48m_clk_frequency(clocks),
-                Uart0FunctionClockConfig::RcFast => rc_fast_clk_frequency(clocks),
-                Uart0FunctionClockConfig::Xtal => xtal_clk_frequency(clocks),
-            }
+            (match config.sclk {
+                Uart0FunctionClockSclk::PllF48m => pll_f48m_clk_frequency(clocks),
+                Uart0FunctionClockSclk::RcFast => rc_fast_clk_frequency(clocks),
+                Uart0FunctionClockSclk::Xtal => xtal_clk_frequency(clocks),
+            } / (config.div_num() + 1))
         }
         pub fn uart1_function_clock_frequency(clocks: &mut ClockTree) -> u32 {
             if let Some(config) = clocks.uart1_function_clock {
                 uart1_function_clock_config_frequency(clocks, config)
+            } else {
+                0
+            }
+        }
+        pub fn configure_uart1_baud_rate_generator(
+            clocks: &mut ClockTree,
+            config: Uart0BaudRateGeneratorConfig,
+        ) {
+            let old_config = clocks.uart1_baud_rate_generator.replace(config);
+            configure_uart1_baud_rate_generator_impl(clocks, old_config, config);
+        }
+        pub fn uart1_baud_rate_generator_config(
+            clocks: &mut ClockTree,
+        ) -> Option<Uart0BaudRateGeneratorConfig> {
+            clocks.uart1_baud_rate_generator
+        }
+        pub fn request_uart1_baud_rate_generator(clocks: &mut ClockTree) {
+            trace!("Requesting UART1_BAUD_RATE_GENERATOR");
+            if increment_reference_count(&mut clocks.uart1_baud_rate_generator_refcount) {
+                trace!("Enabling UART1_BAUD_RATE_GENERATOR");
+                request_uart1_function_clock(clocks);
+                enable_uart1_baud_rate_generator_impl(clocks, true);
+            }
+        }
+        pub fn release_uart1_baud_rate_generator(clocks: &mut ClockTree) {
+            trace!("Releasing UART1_BAUD_RATE_GENERATOR");
+            if decrement_reference_count(&mut clocks.uart1_baud_rate_generator_refcount) {
+                trace!("Disabling UART1_BAUD_RATE_GENERATOR");
+                enable_uart1_baud_rate_generator_impl(clocks, false);
+                release_uart1_function_clock(clocks);
+            }
+        }
+        #[allow(unused_variables)]
+        pub fn uart1_baud_rate_generator_config_frequency(
+            clocks: &mut ClockTree,
+            config: Uart0BaudRateGeneratorConfig,
+        ) -> u32 {
+            ((uart1_function_clock_frequency(clocks) * 16)
+                / ((config.integral() * 16) + config.fractional()))
+        }
+        pub fn uart1_baud_rate_generator_frequency(clocks: &mut ClockTree) -> u32 {
+            if let Some(config) = clocks.uart1_baud_rate_generator {
+                uart1_baud_rate_generator_config_frequency(clocks, config)
             } else {
                 0
             }

--- a/esp-metadata-generated/src/_generated_esp32s2.rs
+++ b/esp-metadata-generated/src/_generated_esp32s2.rs
@@ -301,6 +301,9 @@ macro_rules! property {
     ("uart.peripheral_controls_mem_clk") => {
         false
     };
+    ("uart.has_sclk_divider") => {
+        false
+    };
     ("uhci.combined_uart_selector_field") => {
         false
     };
@@ -987,6 +990,20 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
+/// // UART0_BAUD_RATE_GENERATOR
+///
+/// fn enable_uart0_baud_rate_generator_impl(_clocks: &mut ClockTree, _en: bool) {
+///     todo!()
+/// }
+///
+/// fn configure_uart0_baud_rate_generator_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<Uart0BaudRateGeneratorConfig>,
+///     _new_config: Uart0BaudRateGeneratorConfig,
+/// ) {
+///     todo!()
+/// }
+///
 /// // UART0_MEM_CLOCK
 ///
 /// fn enable_uart0_mem_clock_impl(_clocks: &mut ClockTree, _en: bool) {
@@ -1011,6 +1028,20 @@ macro_rules! for_each_sha_algorithm {
 ///     _clocks: &mut ClockTree,
 ///     _old_config: Option<Uart0FunctionClockConfig>,
 ///     _new_config: Uart0FunctionClockConfig,
+/// ) {
+///     todo!()
+/// }
+///
+/// // UART1_BAUD_RATE_GENERATOR
+///
+/// fn enable_uart1_baud_rate_generator_impl(_clocks: &mut ClockTree, _en: bool) {
+///     todo!()
+/// }
+///
+/// fn configure_uart1_baud_rate_generator_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<Uart0BaudRateGeneratorConfig>,
+///     _new_config: Uart0BaudRateGeneratorConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1305,23 +1336,85 @@ macro_rules! define_clock_tree_types {
             /// Selects `XTAL32K_CLK`.
             Xtal32kClk,
         }
-        /// The list of clock signals that the `UART0_FUNCTION_CLOCK` multiplexer can output.
         #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-        pub enum Uart0FunctionClockConfig {
+        pub enum Uart0FunctionClockSclk {
             #[default]
             /// Selects `APB_CLK`.
             Apb,
             /// Selects `REF_TICK`.
             RefTick,
         }
-        /// The list of clock signals that the `UART0_MEM_CLOCK` multiplexer can output.
-        #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+        /// Configures the `UART0_FUNCTION_CLOCK` clock node.
+        ///
+        /// The output is calculated as `OUTPUT = sclk`.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-        pub enum Uart0MemClockConfig {
-            #[default]
-            /// Selects `UART_MEM_CLK`.
-            Mem,
+        pub struct Uart0FunctionClockConfig {
+            sclk: Uart0FunctionClockSclk,
+        }
+        impl Uart0FunctionClockConfig {
+            /// Creates a new configuration for the FUNCTION_CLOCK clock node.
+            pub const fn new(sclk: Uart0FunctionClockSclk) -> Self {
+                Self { sclk }
+            }
+            fn sclk(self) -> Uart0FunctionClockSclk {
+                self.sclk
+            }
+        }
+        /// Configures the `UART0_BAUD_RATE_GENERATOR` clock node.
+        ///
+        /// The output is calculated as `OUTPUT = (FUNCTION_CLOCK * 16) / (integral * 16 +
+        /// fractional)`.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+        pub struct Uart0BaudRateGeneratorConfig {
+            fractional: u32,
+            integral: u32,
+        }
+        impl Uart0BaudRateGeneratorConfig {
+            /// Creates a new configuration for the BAUD_RATE_GENERATOR clock node.
+            ///
+            /// ## Panics
+            ///
+            /// Panics if the fractional value is outside the
+            /// valid range (0 ..= 15).
+            ///
+            /// Panics if the integral value is outside the
+            /// valid range (0 ..= 1048575).
+            pub const fn new(fractional: u32, integral: u32) -> Self {
+                ::core::assert!(
+                    fractional <= 15,
+                    "`UART0_BAUD_RATE_GENERATOR` fractional must be between 0 and 15 (inclusive)."
+                );
+                ::core::assert!(
+                    integral <= 1048575,
+                    "`UART0_BAUD_RATE_GENERATOR` integral must be between 0 and 1048575 \
+                     (inclusive)."
+                );
+                Self {
+                    fractional,
+                    integral,
+                }
+            }
+            fn fractional(self) -> u32 {
+                self.fractional as u32
+            }
+            fn integral(self) -> u32 {
+                self.integral as u32
+            }
+        }
+        /// Configures the `UART0_MEM_CLOCK` clock node.
+        ///
+        /// The output is calculated as `OUTPUT = UART_MEM_CLK`.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+        pub struct Uart0MemClockConfig {}
+        impl Uart0MemClockConfig {
+            /// Creates a new configuration for the MEM_CLOCK clock node.
+            pub const fn new() -> Self {
+                Self {}
+            }
         }
         /// Represents the device's clock tree.
         pub struct ClockTree {
@@ -1344,8 +1437,10 @@ macro_rules! define_clock_tree_types {
             timg1_function_clock: Option<Timg0FunctionClockConfig>,
             timg1_calibration_clock: Option<Timg0CalibrationClockConfig>,
             uart0_function_clock: Option<Uart0FunctionClockConfig>,
+            uart0_baud_rate_generator: Option<Uart0BaudRateGeneratorConfig>,
             uart0_mem_clock: Option<Uart0MemClockConfig>,
             uart1_function_clock: Option<Uart0FunctionClockConfig>,
+            uart1_baud_rate_generator: Option<Uart0BaudRateGeneratorConfig>,
             uart1_mem_clock: Option<Uart0MemClockConfig>,
             pll_clk_refcount: u32,
             rc_fast_clk_refcount: u32,
@@ -1361,8 +1456,10 @@ macro_rules! define_clock_tree_types {
             timg1_function_clock_refcount: u32,
             timg1_calibration_clock_refcount: u32,
             uart0_function_clock_refcount: u32,
+            uart0_baud_rate_generator_refcount: u32,
             uart0_mem_clock_refcount: u32,
             uart1_function_clock_refcount: u32,
+            uart1_baud_rate_generator_refcount: u32,
             uart1_mem_clock_refcount: u32,
         }
         impl ClockTree {
@@ -1446,6 +1543,10 @@ macro_rules! define_clock_tree_types {
             pub fn uart0_function_clock(&self) -> Option<Uart0FunctionClockConfig> {
                 self.uart0_function_clock
             }
+            /// Returns the current configuration of the UART0_BAUD_RATE_GENERATOR clock tree node
+            pub fn uart0_baud_rate_generator(&self) -> Option<Uart0BaudRateGeneratorConfig> {
+                self.uart0_baud_rate_generator
+            }
             /// Returns the current configuration of the UART0_MEM_CLOCK clock tree node
             pub fn uart0_mem_clock(&self) -> Option<Uart0MemClockConfig> {
                 self.uart0_mem_clock
@@ -1453,6 +1554,10 @@ macro_rules! define_clock_tree_types {
             /// Returns the current configuration of the UART1_FUNCTION_CLOCK clock tree node
             pub fn uart1_function_clock(&self) -> Option<Uart0FunctionClockConfig> {
                 self.uart1_function_clock
+            }
+            /// Returns the current configuration of the UART1_BAUD_RATE_GENERATOR clock tree node
+            pub fn uart1_baud_rate_generator(&self) -> Option<Uart0BaudRateGeneratorConfig> {
+                self.uart1_baud_rate_generator
             }
             /// Returns the current configuration of the UART1_MEM_CLOCK clock tree node
             pub fn uart1_mem_clock(&self) -> Option<Uart0MemClockConfig> {
@@ -1480,8 +1585,10 @@ macro_rules! define_clock_tree_types {
                 timg1_function_clock: None,
                 timg1_calibration_clock: None,
                 uart0_function_clock: None,
+                uart0_baud_rate_generator: None,
                 uart0_mem_clock: None,
                 uart1_function_clock: None,
+                uart1_baud_rate_generator: None,
                 uart1_mem_clock: None,
                 pll_clk_refcount: 0,
                 rc_fast_clk_refcount: 0,
@@ -1497,8 +1604,10 @@ macro_rules! define_clock_tree_types {
                 timg1_function_clock_refcount: 0,
                 timg1_calibration_clock_refcount: 0,
                 uart0_function_clock_refcount: 0,
+                uart0_baud_rate_generator_refcount: 0,
                 uart0_mem_clock_refcount: 0,
                 uart1_function_clock_refcount: 0,
+                uart1_baud_rate_generator_refcount: 0,
                 uart1_mem_clock_refcount: 0,
             });
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
@@ -2562,23 +2671,23 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_uart0_function_clock(
             clocks: &mut ClockTree,
-            new_selector: Uart0FunctionClockConfig,
+            config: Uart0FunctionClockConfig,
         ) {
-            let old_selector = clocks.uart0_function_clock.replace(new_selector);
+            let old_config = clocks.uart0_function_clock.replace(config);
             if clocks.uart0_function_clock_refcount > 0 {
-                match new_selector {
-                    Uart0FunctionClockConfig::Apb => request_apb_clk(clocks),
-                    Uart0FunctionClockConfig::RefTick => request_ref_tick(clocks),
+                match config.sclk {
+                    Uart0FunctionClockSclk::Apb => request_apb_clk(clocks),
+                    Uart0FunctionClockSclk::RefTick => request_ref_tick(clocks),
                 }
-                configure_uart0_function_clock_impl(clocks, old_selector, new_selector);
-                if let Some(old_selector) = old_selector {
-                    match old_selector {
-                        Uart0FunctionClockConfig::Apb => release_apb_clk(clocks),
-                        Uart0FunctionClockConfig::RefTick => release_ref_tick(clocks),
+                configure_uart0_function_clock_impl(clocks, old_config, config);
+                if let Some(old_config) = old_config {
+                    match old_config.sclk {
+                        Uart0FunctionClockSclk::Apb => release_apb_clk(clocks),
+                        Uart0FunctionClockSclk::RefTick => release_ref_tick(clocks),
                     }
                 }
             } else {
-                configure_uart0_function_clock_impl(clocks, old_selector, new_selector);
+                configure_uart0_function_clock_impl(clocks, old_config, config);
             }
         }
         pub fn uart0_function_clock_config(
@@ -2590,9 +2699,9 @@ macro_rules! define_clock_tree_types {
             trace!("Requesting UART0_FUNCTION_CLOCK");
             if increment_reference_count(&mut clocks.uart0_function_clock_refcount) {
                 trace!("Enabling UART0_FUNCTION_CLOCK");
-                match unwrap!(clocks.uart0_function_clock) {
-                    Uart0FunctionClockConfig::Apb => request_apb_clk(clocks),
-                    Uart0FunctionClockConfig::RefTick => request_ref_tick(clocks),
+                match unwrap!(clocks.uart0_function_clock).sclk {
+                    Uart0FunctionClockSclk::Apb => request_apb_clk(clocks),
+                    Uart0FunctionClockSclk::RefTick => request_ref_tick(clocks),
                 }
                 enable_uart0_function_clock_impl(clocks, true);
             }
@@ -2602,9 +2711,9 @@ macro_rules! define_clock_tree_types {
             if decrement_reference_count(&mut clocks.uart0_function_clock_refcount) {
                 trace!("Disabling UART0_FUNCTION_CLOCK");
                 enable_uart0_function_clock_impl(clocks, false);
-                match unwrap!(clocks.uart0_function_clock) {
-                    Uart0FunctionClockConfig::Apb => release_apb_clk(clocks),
-                    Uart0FunctionClockConfig::RefTick => release_ref_tick(clocks),
+                match unwrap!(clocks.uart0_function_clock).sclk {
+                    Uart0FunctionClockSclk::Apb => release_apb_clk(clocks),
+                    Uart0FunctionClockSclk::RefTick => release_ref_tick(clocks),
                 }
             }
         }
@@ -2613,9 +2722,9 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: Uart0FunctionClockConfig,
         ) -> u32 {
-            match config {
-                Uart0FunctionClockConfig::Apb => apb_clk_frequency(clocks),
-                Uart0FunctionClockConfig::RefTick => ref_tick_frequency(clocks),
+            match config.sclk {
+                Uart0FunctionClockSclk::Apb => apb_clk_frequency(clocks),
+                Uart0FunctionClockSclk::RefTick => ref_tick_frequency(clocks),
             }
         }
         pub fn uart0_function_clock_frequency(clocks: &mut ClockTree) -> u32 {
@@ -2625,20 +2734,52 @@ macro_rules! define_clock_tree_types {
                 0
             }
         }
-        pub fn configure_uart0_mem_clock(
+        pub fn configure_uart0_baud_rate_generator(
             clocks: &mut ClockTree,
-            new_selector: Uart0MemClockConfig,
+            config: Uart0BaudRateGeneratorConfig,
         ) {
-            let old_selector = clocks.uart0_mem_clock.replace(new_selector);
-            if clocks.uart0_mem_clock_refcount > 0 {
-                request_uart_mem_clk(clocks);
-                configure_uart0_mem_clock_impl(clocks, old_selector, new_selector);
-                if let Some(old_selector) = old_selector {
-                    release_uart_mem_clk(clocks);
-                }
-            } else {
-                configure_uart0_mem_clock_impl(clocks, old_selector, new_selector);
+            let old_config = clocks.uart0_baud_rate_generator.replace(config);
+            configure_uart0_baud_rate_generator_impl(clocks, old_config, config);
+        }
+        pub fn uart0_baud_rate_generator_config(
+            clocks: &mut ClockTree,
+        ) -> Option<Uart0BaudRateGeneratorConfig> {
+            clocks.uart0_baud_rate_generator
+        }
+        pub fn request_uart0_baud_rate_generator(clocks: &mut ClockTree) {
+            trace!("Requesting UART0_BAUD_RATE_GENERATOR");
+            if increment_reference_count(&mut clocks.uart0_baud_rate_generator_refcount) {
+                trace!("Enabling UART0_BAUD_RATE_GENERATOR");
+                request_uart0_function_clock(clocks);
+                enable_uart0_baud_rate_generator_impl(clocks, true);
             }
+        }
+        pub fn release_uart0_baud_rate_generator(clocks: &mut ClockTree) {
+            trace!("Releasing UART0_BAUD_RATE_GENERATOR");
+            if decrement_reference_count(&mut clocks.uart0_baud_rate_generator_refcount) {
+                trace!("Disabling UART0_BAUD_RATE_GENERATOR");
+                enable_uart0_baud_rate_generator_impl(clocks, false);
+                release_uart0_function_clock(clocks);
+            }
+        }
+        #[allow(unused_variables)]
+        pub fn uart0_baud_rate_generator_config_frequency(
+            clocks: &mut ClockTree,
+            config: Uart0BaudRateGeneratorConfig,
+        ) -> u32 {
+            ((uart0_function_clock_frequency(clocks) * 16)
+                / ((config.integral() * 16) + config.fractional()))
+        }
+        pub fn uart0_baud_rate_generator_frequency(clocks: &mut ClockTree) -> u32 {
+            if let Some(config) = clocks.uart0_baud_rate_generator {
+                uart0_baud_rate_generator_config_frequency(clocks, config)
+            } else {
+                0
+            }
+        }
+        pub fn configure_uart0_mem_clock(clocks: &mut ClockTree, config: Uart0MemClockConfig) {
+            let old_config = clocks.uart0_mem_clock.replace(config);
+            configure_uart0_mem_clock_impl(clocks, old_config, config);
         }
         pub fn uart0_mem_clock_config(clocks: &mut ClockTree) -> Option<Uart0MemClockConfig> {
             clocks.uart0_mem_clock
@@ -2675,23 +2816,23 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_uart1_function_clock(
             clocks: &mut ClockTree,
-            new_selector: Uart0FunctionClockConfig,
+            config: Uart0FunctionClockConfig,
         ) {
-            let old_selector = clocks.uart1_function_clock.replace(new_selector);
+            let old_config = clocks.uart1_function_clock.replace(config);
             if clocks.uart1_function_clock_refcount > 0 {
-                match new_selector {
-                    Uart0FunctionClockConfig::Apb => request_apb_clk(clocks),
-                    Uart0FunctionClockConfig::RefTick => request_ref_tick(clocks),
+                match config.sclk {
+                    Uart0FunctionClockSclk::Apb => request_apb_clk(clocks),
+                    Uart0FunctionClockSclk::RefTick => request_ref_tick(clocks),
                 }
-                configure_uart1_function_clock_impl(clocks, old_selector, new_selector);
-                if let Some(old_selector) = old_selector {
-                    match old_selector {
-                        Uart0FunctionClockConfig::Apb => release_apb_clk(clocks),
-                        Uart0FunctionClockConfig::RefTick => release_ref_tick(clocks),
+                configure_uart1_function_clock_impl(clocks, old_config, config);
+                if let Some(old_config) = old_config {
+                    match old_config.sclk {
+                        Uart0FunctionClockSclk::Apb => release_apb_clk(clocks),
+                        Uart0FunctionClockSclk::RefTick => release_ref_tick(clocks),
                     }
                 }
             } else {
-                configure_uart1_function_clock_impl(clocks, old_selector, new_selector);
+                configure_uart1_function_clock_impl(clocks, old_config, config);
             }
         }
         pub fn uart1_function_clock_config(
@@ -2703,9 +2844,9 @@ macro_rules! define_clock_tree_types {
             trace!("Requesting UART1_FUNCTION_CLOCK");
             if increment_reference_count(&mut clocks.uart1_function_clock_refcount) {
                 trace!("Enabling UART1_FUNCTION_CLOCK");
-                match unwrap!(clocks.uart1_function_clock) {
-                    Uart0FunctionClockConfig::Apb => request_apb_clk(clocks),
-                    Uart0FunctionClockConfig::RefTick => request_ref_tick(clocks),
+                match unwrap!(clocks.uart1_function_clock).sclk {
+                    Uart0FunctionClockSclk::Apb => request_apb_clk(clocks),
+                    Uart0FunctionClockSclk::RefTick => request_ref_tick(clocks),
                 }
                 enable_uart1_function_clock_impl(clocks, true);
             }
@@ -2715,9 +2856,9 @@ macro_rules! define_clock_tree_types {
             if decrement_reference_count(&mut clocks.uart1_function_clock_refcount) {
                 trace!("Disabling UART1_FUNCTION_CLOCK");
                 enable_uart1_function_clock_impl(clocks, false);
-                match unwrap!(clocks.uart1_function_clock) {
-                    Uart0FunctionClockConfig::Apb => release_apb_clk(clocks),
-                    Uart0FunctionClockConfig::RefTick => release_ref_tick(clocks),
+                match unwrap!(clocks.uart1_function_clock).sclk {
+                    Uart0FunctionClockSclk::Apb => release_apb_clk(clocks),
+                    Uart0FunctionClockSclk::RefTick => release_ref_tick(clocks),
                 }
             }
         }
@@ -2726,9 +2867,9 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: Uart0FunctionClockConfig,
         ) -> u32 {
-            match config {
-                Uart0FunctionClockConfig::Apb => apb_clk_frequency(clocks),
-                Uart0FunctionClockConfig::RefTick => ref_tick_frequency(clocks),
+            match config.sclk {
+                Uart0FunctionClockSclk::Apb => apb_clk_frequency(clocks),
+                Uart0FunctionClockSclk::RefTick => ref_tick_frequency(clocks),
             }
         }
         pub fn uart1_function_clock_frequency(clocks: &mut ClockTree) -> u32 {
@@ -2738,20 +2879,52 @@ macro_rules! define_clock_tree_types {
                 0
             }
         }
-        pub fn configure_uart1_mem_clock(
+        pub fn configure_uart1_baud_rate_generator(
             clocks: &mut ClockTree,
-            new_selector: Uart0MemClockConfig,
+            config: Uart0BaudRateGeneratorConfig,
         ) {
-            let old_selector = clocks.uart1_mem_clock.replace(new_selector);
-            if clocks.uart1_mem_clock_refcount > 0 {
-                request_uart_mem_clk(clocks);
-                configure_uart1_mem_clock_impl(clocks, old_selector, new_selector);
-                if let Some(old_selector) = old_selector {
-                    release_uart_mem_clk(clocks);
-                }
-            } else {
-                configure_uart1_mem_clock_impl(clocks, old_selector, new_selector);
+            let old_config = clocks.uart1_baud_rate_generator.replace(config);
+            configure_uart1_baud_rate_generator_impl(clocks, old_config, config);
+        }
+        pub fn uart1_baud_rate_generator_config(
+            clocks: &mut ClockTree,
+        ) -> Option<Uart0BaudRateGeneratorConfig> {
+            clocks.uart1_baud_rate_generator
+        }
+        pub fn request_uart1_baud_rate_generator(clocks: &mut ClockTree) {
+            trace!("Requesting UART1_BAUD_RATE_GENERATOR");
+            if increment_reference_count(&mut clocks.uart1_baud_rate_generator_refcount) {
+                trace!("Enabling UART1_BAUD_RATE_GENERATOR");
+                request_uart1_function_clock(clocks);
+                enable_uart1_baud_rate_generator_impl(clocks, true);
             }
+        }
+        pub fn release_uart1_baud_rate_generator(clocks: &mut ClockTree) {
+            trace!("Releasing UART1_BAUD_RATE_GENERATOR");
+            if decrement_reference_count(&mut clocks.uart1_baud_rate_generator_refcount) {
+                trace!("Disabling UART1_BAUD_RATE_GENERATOR");
+                enable_uart1_baud_rate_generator_impl(clocks, false);
+                release_uart1_function_clock(clocks);
+            }
+        }
+        #[allow(unused_variables)]
+        pub fn uart1_baud_rate_generator_config_frequency(
+            clocks: &mut ClockTree,
+            config: Uart0BaudRateGeneratorConfig,
+        ) -> u32 {
+            ((uart1_function_clock_frequency(clocks) * 16)
+                / ((config.integral() * 16) + config.fractional()))
+        }
+        pub fn uart1_baud_rate_generator_frequency(clocks: &mut ClockTree) -> u32 {
+            if let Some(config) = clocks.uart1_baud_rate_generator {
+                uart1_baud_rate_generator_config_frequency(clocks, config)
+            } else {
+                0
+            }
+        }
+        pub fn configure_uart1_mem_clock(clocks: &mut ClockTree, config: Uart0MemClockConfig) {
+            let old_config = clocks.uart1_mem_clock.replace(config);
+            configure_uart1_mem_clock_impl(clocks, old_config, config);
         }
         pub fn uart1_mem_clock_config(clocks: &mut ClockTree) -> Option<Uart0MemClockConfig> {
             clocks.uart1_mem_clock

--- a/esp-metadata-generated/src/_generated_esp32s3.rs
+++ b/esp-metadata-generated/src/_generated_esp32s3.rs
@@ -322,6 +322,9 @@ macro_rules! property {
     ("uart.peripheral_controls_mem_clk") => {
         false
     };
+    ("uart.has_sclk_divider") => {
+        true
+    };
     ("uhci.combined_uart_selector_field") => {
         false
     };
@@ -1038,6 +1041,20 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
+/// // UART0_BAUD_RATE_GENERATOR
+///
+/// fn enable_uart0_baud_rate_generator_impl(_clocks: &mut ClockTree, _en: bool) {
+///     todo!()
+/// }
+///
+/// fn configure_uart0_baud_rate_generator_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<Uart0BaudRateGeneratorConfig>,
+///     _new_config: Uart0BaudRateGeneratorConfig,
+/// ) {
+///     todo!()
+/// }
+///
 /// // UART0_MEM_CLOCK
 ///
 /// fn enable_uart0_mem_clock_impl(_clocks: &mut ClockTree, _en: bool) {
@@ -1066,6 +1083,20 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
+/// // UART1_BAUD_RATE_GENERATOR
+///
+/// fn enable_uart1_baud_rate_generator_impl(_clocks: &mut ClockTree, _en: bool) {
+///     todo!()
+/// }
+///
+/// fn configure_uart1_baud_rate_generator_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<Uart0BaudRateGeneratorConfig>,
+///     _new_config: Uart0BaudRateGeneratorConfig,
+/// ) {
+///     todo!()
+/// }
+///
 /// // UART1_MEM_CLOCK
 ///
 /// fn enable_uart1_mem_clock_impl(_clocks: &mut ClockTree, _en: bool) {
@@ -1090,6 +1121,20 @@ macro_rules! for_each_sha_algorithm {
 ///     _clocks: &mut ClockTree,
 ///     _old_config: Option<Uart0FunctionClockConfig>,
 ///     _new_config: Uart0FunctionClockConfig,
+/// ) {
+///     todo!()
+/// }
+///
+/// // UART2_BAUD_RATE_GENERATOR
+///
+/// fn enable_uart2_baud_rate_generator_impl(_clocks: &mut ClockTree, _en: bool) {
+///     todo!()
+/// }
+///
+/// fn configure_uart2_baud_rate_generator_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<Uart0BaudRateGeneratorConfig>,
+///     _new_config: Uart0BaudRateGeneratorConfig,
 /// ) {
 ///     todo!()
 /// }
@@ -1325,10 +1370,9 @@ macro_rules! define_clock_tree_types {
             /// Selects `XTAL32K_CLK`.
             Xtal32kClk,
         }
-        /// The list of clock signals that the `UART0_FUNCTION_CLOCK` multiplexer can output.
         #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-        pub enum Uart0FunctionClockConfig {
+        pub enum Uart0FunctionClockSclk {
             /// Selects `APB_CLK`.
             Apb,
             /// Selects `RC_FAST_CLK`.
@@ -1337,13 +1381,88 @@ macro_rules! define_clock_tree_types {
             /// Selects `XTAL_CLK`.
             Xtal,
         }
-        /// The list of clock signals that the `UART0_MEM_CLOCK` multiplexer can output.
-        #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+        /// Configures the `UART0_FUNCTION_CLOCK` clock node.
+        ///
+        /// The output is calculated as `OUTPUT = sclk / (div_num + 1)`.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-        pub enum Uart0MemClockConfig {
-            #[default]
-            /// Selects `UART_MEM_CLK`.
-            Mem,
+        pub struct Uart0FunctionClockConfig {
+            sclk: Uart0FunctionClockSclk,
+            div_num: u32,
+        }
+        impl Uart0FunctionClockConfig {
+            /// Creates a new configuration for the FUNCTION_CLOCK clock node.
+            ///
+            /// ## Panics
+            ///
+            /// Panics if the div_num value is outside the
+            /// valid range (0 ..= 255).
+            pub const fn new(sclk: Uart0FunctionClockSclk, div_num: u32) -> Self {
+                ::core::assert!(
+                    div_num <= 255,
+                    "`UART0_FUNCTION_CLOCK` div_num must be between 0 and 255 (inclusive)."
+                );
+                Self { sclk, div_num }
+            }
+            fn sclk(self) -> Uart0FunctionClockSclk {
+                self.sclk
+            }
+            fn div_num(self) -> u32 {
+                self.div_num as u32
+            }
+        }
+        /// Configures the `UART0_BAUD_RATE_GENERATOR` clock node.
+        ///
+        /// The output is calculated as `OUTPUT = (FUNCTION_CLOCK * 16) / (integral * 16 +
+        /// fractional)`.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+        pub struct Uart0BaudRateGeneratorConfig {
+            fractional: u32,
+            integral: u32,
+        }
+        impl Uart0BaudRateGeneratorConfig {
+            /// Creates a new configuration for the BAUD_RATE_GENERATOR clock node.
+            ///
+            /// ## Panics
+            ///
+            /// Panics if the fractional value is outside the
+            /// valid range (0 ..= 15).
+            ///
+            /// Panics if the integral value is outside the
+            /// valid range (0 ..= 4095).
+            pub const fn new(fractional: u32, integral: u32) -> Self {
+                ::core::assert!(
+                    fractional <= 15,
+                    "`UART0_BAUD_RATE_GENERATOR` fractional must be between 0 and 15 (inclusive)."
+                );
+                ::core::assert!(
+                    integral <= 4095,
+                    "`UART0_BAUD_RATE_GENERATOR` integral must be between 0 and 4095 (inclusive)."
+                );
+                Self {
+                    fractional,
+                    integral,
+                }
+            }
+            fn fractional(self) -> u32 {
+                self.fractional as u32
+            }
+            fn integral(self) -> u32 {
+                self.integral as u32
+            }
+        }
+        /// Configures the `UART0_MEM_CLOCK` clock node.
+        ///
+        /// The output is calculated as `OUTPUT = UART_MEM_CLK`.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+        pub struct Uart0MemClockConfig {}
+        impl Uart0MemClockConfig {
+            /// Creates a new configuration for the MEM_CLOCK clock node.
+            pub const fn new() -> Self {
+                Self {}
+            }
         }
         /// Represents the device's clock tree.
         pub struct ClockTree {
@@ -1367,10 +1486,13 @@ macro_rules! define_clock_tree_types {
             timg1_function_clock: Option<Timg0FunctionClockConfig>,
             timg1_calibration_clock: Option<Timg0CalibrationClockConfig>,
             uart0_function_clock: Option<Uart0FunctionClockConfig>,
+            uart0_baud_rate_generator: Option<Uart0BaudRateGeneratorConfig>,
             uart0_mem_clock: Option<Uart0MemClockConfig>,
             uart1_function_clock: Option<Uart0FunctionClockConfig>,
+            uart1_baud_rate_generator: Option<Uart0BaudRateGeneratorConfig>,
             uart1_mem_clock: Option<Uart0MemClockConfig>,
             uart2_function_clock: Option<Uart0FunctionClockConfig>,
+            uart2_baud_rate_generator: Option<Uart0BaudRateGeneratorConfig>,
             uart2_mem_clock: Option<Uart0MemClockConfig>,
             pll_clk_refcount: u32,
             rc_fast_clk_refcount: u32,
@@ -1391,10 +1513,13 @@ macro_rules! define_clock_tree_types {
             timg1_function_clock_refcount: u32,
             timg1_calibration_clock_refcount: u32,
             uart0_function_clock_refcount: u32,
+            uart0_baud_rate_generator_refcount: u32,
             uart0_mem_clock_refcount: u32,
             uart1_function_clock_refcount: u32,
+            uart1_baud_rate_generator_refcount: u32,
             uart1_mem_clock_refcount: u32,
             uart2_function_clock_refcount: u32,
+            uart2_baud_rate_generator_refcount: u32,
             uart2_mem_clock_refcount: u32,
         }
         impl ClockTree {
@@ -1482,6 +1607,10 @@ macro_rules! define_clock_tree_types {
             pub fn uart0_function_clock(&self) -> Option<Uart0FunctionClockConfig> {
                 self.uart0_function_clock
             }
+            /// Returns the current configuration of the UART0_BAUD_RATE_GENERATOR clock tree node
+            pub fn uart0_baud_rate_generator(&self) -> Option<Uart0BaudRateGeneratorConfig> {
+                self.uart0_baud_rate_generator
+            }
             /// Returns the current configuration of the UART0_MEM_CLOCK clock tree node
             pub fn uart0_mem_clock(&self) -> Option<Uart0MemClockConfig> {
                 self.uart0_mem_clock
@@ -1490,6 +1619,10 @@ macro_rules! define_clock_tree_types {
             pub fn uart1_function_clock(&self) -> Option<Uart0FunctionClockConfig> {
                 self.uart1_function_clock
             }
+            /// Returns the current configuration of the UART1_BAUD_RATE_GENERATOR clock tree node
+            pub fn uart1_baud_rate_generator(&self) -> Option<Uart0BaudRateGeneratorConfig> {
+                self.uart1_baud_rate_generator
+            }
             /// Returns the current configuration of the UART1_MEM_CLOCK clock tree node
             pub fn uart1_mem_clock(&self) -> Option<Uart0MemClockConfig> {
                 self.uart1_mem_clock
@@ -1497,6 +1630,10 @@ macro_rules! define_clock_tree_types {
             /// Returns the current configuration of the UART2_FUNCTION_CLOCK clock tree node
             pub fn uart2_function_clock(&self) -> Option<Uart0FunctionClockConfig> {
                 self.uart2_function_clock
+            }
+            /// Returns the current configuration of the UART2_BAUD_RATE_GENERATOR clock tree node
+            pub fn uart2_baud_rate_generator(&self) -> Option<Uart0BaudRateGeneratorConfig> {
+                self.uart2_baud_rate_generator
             }
             /// Returns the current configuration of the UART2_MEM_CLOCK clock tree node
             pub fn uart2_mem_clock(&self) -> Option<Uart0MemClockConfig> {
@@ -1525,10 +1662,13 @@ macro_rules! define_clock_tree_types {
                 timg1_function_clock: None,
                 timg1_calibration_clock: None,
                 uart0_function_clock: None,
+                uart0_baud_rate_generator: None,
                 uart0_mem_clock: None,
                 uart1_function_clock: None,
+                uart1_baud_rate_generator: None,
                 uart1_mem_clock: None,
                 uart2_function_clock: None,
+                uart2_baud_rate_generator: None,
                 uart2_mem_clock: None,
                 pll_clk_refcount: 0,
                 rc_fast_clk_refcount: 0,
@@ -1549,10 +1689,13 @@ macro_rules! define_clock_tree_types {
                 timg1_function_clock_refcount: 0,
                 timg1_calibration_clock_refcount: 0,
                 uart0_function_clock_refcount: 0,
+                uart0_baud_rate_generator_refcount: 0,
                 uart0_mem_clock_refcount: 0,
                 uart1_function_clock_refcount: 0,
+                uart1_baud_rate_generator_refcount: 0,
                 uart1_mem_clock_refcount: 0,
                 uart2_function_clock_refcount: 0,
+                uart2_baud_rate_generator_refcount: 0,
                 uart2_mem_clock_refcount: 0,
             });
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
@@ -2721,25 +2864,25 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_uart0_function_clock(
             clocks: &mut ClockTree,
-            new_selector: Uart0FunctionClockConfig,
+            config: Uart0FunctionClockConfig,
         ) {
-            let old_selector = clocks.uart0_function_clock.replace(new_selector);
+            let old_config = clocks.uart0_function_clock.replace(config);
             if clocks.uart0_function_clock_refcount > 0 {
-                match new_selector {
-                    Uart0FunctionClockConfig::Apb => request_apb_clk(clocks),
-                    Uart0FunctionClockConfig::RcFast => request_rc_fast_clk(clocks),
-                    Uart0FunctionClockConfig::Xtal => request_xtal_clk(clocks),
+                match config.sclk {
+                    Uart0FunctionClockSclk::Apb => request_apb_clk(clocks),
+                    Uart0FunctionClockSclk::RcFast => request_rc_fast_clk(clocks),
+                    Uart0FunctionClockSclk::Xtal => request_xtal_clk(clocks),
                 }
-                configure_uart0_function_clock_impl(clocks, old_selector, new_selector);
-                if let Some(old_selector) = old_selector {
-                    match old_selector {
-                        Uart0FunctionClockConfig::Apb => release_apb_clk(clocks),
-                        Uart0FunctionClockConfig::RcFast => release_rc_fast_clk(clocks),
-                        Uart0FunctionClockConfig::Xtal => release_xtal_clk(clocks),
+                configure_uart0_function_clock_impl(clocks, old_config, config);
+                if let Some(old_config) = old_config {
+                    match old_config.sclk {
+                        Uart0FunctionClockSclk::Apb => release_apb_clk(clocks),
+                        Uart0FunctionClockSclk::RcFast => release_rc_fast_clk(clocks),
+                        Uart0FunctionClockSclk::Xtal => release_xtal_clk(clocks),
                     }
                 }
             } else {
-                configure_uart0_function_clock_impl(clocks, old_selector, new_selector);
+                configure_uart0_function_clock_impl(clocks, old_config, config);
             }
         }
         pub fn uart0_function_clock_config(
@@ -2751,10 +2894,10 @@ macro_rules! define_clock_tree_types {
             trace!("Requesting UART0_FUNCTION_CLOCK");
             if increment_reference_count(&mut clocks.uart0_function_clock_refcount) {
                 trace!("Enabling UART0_FUNCTION_CLOCK");
-                match unwrap!(clocks.uart0_function_clock) {
-                    Uart0FunctionClockConfig::Apb => request_apb_clk(clocks),
-                    Uart0FunctionClockConfig::RcFast => request_rc_fast_clk(clocks),
-                    Uart0FunctionClockConfig::Xtal => request_xtal_clk(clocks),
+                match unwrap!(clocks.uart0_function_clock).sclk {
+                    Uart0FunctionClockSclk::Apb => request_apb_clk(clocks),
+                    Uart0FunctionClockSclk::RcFast => request_rc_fast_clk(clocks),
+                    Uart0FunctionClockSclk::Xtal => request_xtal_clk(clocks),
                 }
                 enable_uart0_function_clock_impl(clocks, true);
             }
@@ -2764,10 +2907,10 @@ macro_rules! define_clock_tree_types {
             if decrement_reference_count(&mut clocks.uart0_function_clock_refcount) {
                 trace!("Disabling UART0_FUNCTION_CLOCK");
                 enable_uart0_function_clock_impl(clocks, false);
-                match unwrap!(clocks.uart0_function_clock) {
-                    Uart0FunctionClockConfig::Apb => release_apb_clk(clocks),
-                    Uart0FunctionClockConfig::RcFast => release_rc_fast_clk(clocks),
-                    Uart0FunctionClockConfig::Xtal => release_xtal_clk(clocks),
+                match unwrap!(clocks.uart0_function_clock).sclk {
+                    Uart0FunctionClockSclk::Apb => release_apb_clk(clocks),
+                    Uart0FunctionClockSclk::RcFast => release_rc_fast_clk(clocks),
+                    Uart0FunctionClockSclk::Xtal => release_xtal_clk(clocks),
                 }
             }
         }
@@ -2776,11 +2919,11 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: Uart0FunctionClockConfig,
         ) -> u32 {
-            match config {
-                Uart0FunctionClockConfig::Apb => apb_clk_frequency(clocks),
-                Uart0FunctionClockConfig::RcFast => rc_fast_clk_frequency(clocks),
-                Uart0FunctionClockConfig::Xtal => xtal_clk_frequency(clocks),
-            }
+            (match config.sclk {
+                Uart0FunctionClockSclk::Apb => apb_clk_frequency(clocks),
+                Uart0FunctionClockSclk::RcFast => rc_fast_clk_frequency(clocks),
+                Uart0FunctionClockSclk::Xtal => xtal_clk_frequency(clocks),
+            } / (config.div_num() + 1))
         }
         pub fn uart0_function_clock_frequency(clocks: &mut ClockTree) -> u32 {
             if let Some(config) = clocks.uart0_function_clock {
@@ -2789,20 +2932,52 @@ macro_rules! define_clock_tree_types {
                 0
             }
         }
-        pub fn configure_uart0_mem_clock(
+        pub fn configure_uart0_baud_rate_generator(
             clocks: &mut ClockTree,
-            new_selector: Uart0MemClockConfig,
+            config: Uart0BaudRateGeneratorConfig,
         ) {
-            let old_selector = clocks.uart0_mem_clock.replace(new_selector);
-            if clocks.uart0_mem_clock_refcount > 0 {
-                request_uart_mem_clk(clocks);
-                configure_uart0_mem_clock_impl(clocks, old_selector, new_selector);
-                if let Some(old_selector) = old_selector {
-                    release_uart_mem_clk(clocks);
-                }
-            } else {
-                configure_uart0_mem_clock_impl(clocks, old_selector, new_selector);
+            let old_config = clocks.uart0_baud_rate_generator.replace(config);
+            configure_uart0_baud_rate_generator_impl(clocks, old_config, config);
+        }
+        pub fn uart0_baud_rate_generator_config(
+            clocks: &mut ClockTree,
+        ) -> Option<Uart0BaudRateGeneratorConfig> {
+            clocks.uart0_baud_rate_generator
+        }
+        pub fn request_uart0_baud_rate_generator(clocks: &mut ClockTree) {
+            trace!("Requesting UART0_BAUD_RATE_GENERATOR");
+            if increment_reference_count(&mut clocks.uart0_baud_rate_generator_refcount) {
+                trace!("Enabling UART0_BAUD_RATE_GENERATOR");
+                request_uart0_function_clock(clocks);
+                enable_uart0_baud_rate_generator_impl(clocks, true);
             }
+        }
+        pub fn release_uart0_baud_rate_generator(clocks: &mut ClockTree) {
+            trace!("Releasing UART0_BAUD_RATE_GENERATOR");
+            if decrement_reference_count(&mut clocks.uart0_baud_rate_generator_refcount) {
+                trace!("Disabling UART0_BAUD_RATE_GENERATOR");
+                enable_uart0_baud_rate_generator_impl(clocks, false);
+                release_uart0_function_clock(clocks);
+            }
+        }
+        #[allow(unused_variables)]
+        pub fn uart0_baud_rate_generator_config_frequency(
+            clocks: &mut ClockTree,
+            config: Uart0BaudRateGeneratorConfig,
+        ) -> u32 {
+            ((uart0_function_clock_frequency(clocks) * 16)
+                / ((config.integral() * 16) + config.fractional()))
+        }
+        pub fn uart0_baud_rate_generator_frequency(clocks: &mut ClockTree) -> u32 {
+            if let Some(config) = clocks.uart0_baud_rate_generator {
+                uart0_baud_rate_generator_config_frequency(clocks, config)
+            } else {
+                0
+            }
+        }
+        pub fn configure_uart0_mem_clock(clocks: &mut ClockTree, config: Uart0MemClockConfig) {
+            let old_config = clocks.uart0_mem_clock.replace(config);
+            configure_uart0_mem_clock_impl(clocks, old_config, config);
         }
         pub fn uart0_mem_clock_config(clocks: &mut ClockTree) -> Option<Uart0MemClockConfig> {
             clocks.uart0_mem_clock
@@ -2839,25 +3014,25 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_uart1_function_clock(
             clocks: &mut ClockTree,
-            new_selector: Uart0FunctionClockConfig,
+            config: Uart0FunctionClockConfig,
         ) {
-            let old_selector = clocks.uart1_function_clock.replace(new_selector);
+            let old_config = clocks.uart1_function_clock.replace(config);
             if clocks.uart1_function_clock_refcount > 0 {
-                match new_selector {
-                    Uart0FunctionClockConfig::Apb => request_apb_clk(clocks),
-                    Uart0FunctionClockConfig::RcFast => request_rc_fast_clk(clocks),
-                    Uart0FunctionClockConfig::Xtal => request_xtal_clk(clocks),
+                match config.sclk {
+                    Uart0FunctionClockSclk::Apb => request_apb_clk(clocks),
+                    Uart0FunctionClockSclk::RcFast => request_rc_fast_clk(clocks),
+                    Uart0FunctionClockSclk::Xtal => request_xtal_clk(clocks),
                 }
-                configure_uart1_function_clock_impl(clocks, old_selector, new_selector);
-                if let Some(old_selector) = old_selector {
-                    match old_selector {
-                        Uart0FunctionClockConfig::Apb => release_apb_clk(clocks),
-                        Uart0FunctionClockConfig::RcFast => release_rc_fast_clk(clocks),
-                        Uart0FunctionClockConfig::Xtal => release_xtal_clk(clocks),
+                configure_uart1_function_clock_impl(clocks, old_config, config);
+                if let Some(old_config) = old_config {
+                    match old_config.sclk {
+                        Uart0FunctionClockSclk::Apb => release_apb_clk(clocks),
+                        Uart0FunctionClockSclk::RcFast => release_rc_fast_clk(clocks),
+                        Uart0FunctionClockSclk::Xtal => release_xtal_clk(clocks),
                     }
                 }
             } else {
-                configure_uart1_function_clock_impl(clocks, old_selector, new_selector);
+                configure_uart1_function_clock_impl(clocks, old_config, config);
             }
         }
         pub fn uart1_function_clock_config(
@@ -2869,10 +3044,10 @@ macro_rules! define_clock_tree_types {
             trace!("Requesting UART1_FUNCTION_CLOCK");
             if increment_reference_count(&mut clocks.uart1_function_clock_refcount) {
                 trace!("Enabling UART1_FUNCTION_CLOCK");
-                match unwrap!(clocks.uart1_function_clock) {
-                    Uart0FunctionClockConfig::Apb => request_apb_clk(clocks),
-                    Uart0FunctionClockConfig::RcFast => request_rc_fast_clk(clocks),
-                    Uart0FunctionClockConfig::Xtal => request_xtal_clk(clocks),
+                match unwrap!(clocks.uart1_function_clock).sclk {
+                    Uart0FunctionClockSclk::Apb => request_apb_clk(clocks),
+                    Uart0FunctionClockSclk::RcFast => request_rc_fast_clk(clocks),
+                    Uart0FunctionClockSclk::Xtal => request_xtal_clk(clocks),
                 }
                 enable_uart1_function_clock_impl(clocks, true);
             }
@@ -2882,10 +3057,10 @@ macro_rules! define_clock_tree_types {
             if decrement_reference_count(&mut clocks.uart1_function_clock_refcount) {
                 trace!("Disabling UART1_FUNCTION_CLOCK");
                 enable_uart1_function_clock_impl(clocks, false);
-                match unwrap!(clocks.uart1_function_clock) {
-                    Uart0FunctionClockConfig::Apb => release_apb_clk(clocks),
-                    Uart0FunctionClockConfig::RcFast => release_rc_fast_clk(clocks),
-                    Uart0FunctionClockConfig::Xtal => release_xtal_clk(clocks),
+                match unwrap!(clocks.uart1_function_clock).sclk {
+                    Uart0FunctionClockSclk::Apb => release_apb_clk(clocks),
+                    Uart0FunctionClockSclk::RcFast => release_rc_fast_clk(clocks),
+                    Uart0FunctionClockSclk::Xtal => release_xtal_clk(clocks),
                 }
             }
         }
@@ -2894,11 +3069,11 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: Uart0FunctionClockConfig,
         ) -> u32 {
-            match config {
-                Uart0FunctionClockConfig::Apb => apb_clk_frequency(clocks),
-                Uart0FunctionClockConfig::RcFast => rc_fast_clk_frequency(clocks),
-                Uart0FunctionClockConfig::Xtal => xtal_clk_frequency(clocks),
-            }
+            (match config.sclk {
+                Uart0FunctionClockSclk::Apb => apb_clk_frequency(clocks),
+                Uart0FunctionClockSclk::RcFast => rc_fast_clk_frequency(clocks),
+                Uart0FunctionClockSclk::Xtal => xtal_clk_frequency(clocks),
+            } / (config.div_num() + 1))
         }
         pub fn uart1_function_clock_frequency(clocks: &mut ClockTree) -> u32 {
             if let Some(config) = clocks.uart1_function_clock {
@@ -2907,20 +3082,52 @@ macro_rules! define_clock_tree_types {
                 0
             }
         }
-        pub fn configure_uart1_mem_clock(
+        pub fn configure_uart1_baud_rate_generator(
             clocks: &mut ClockTree,
-            new_selector: Uart0MemClockConfig,
+            config: Uart0BaudRateGeneratorConfig,
         ) {
-            let old_selector = clocks.uart1_mem_clock.replace(new_selector);
-            if clocks.uart1_mem_clock_refcount > 0 {
-                request_uart_mem_clk(clocks);
-                configure_uart1_mem_clock_impl(clocks, old_selector, new_selector);
-                if let Some(old_selector) = old_selector {
-                    release_uart_mem_clk(clocks);
-                }
-            } else {
-                configure_uart1_mem_clock_impl(clocks, old_selector, new_selector);
+            let old_config = clocks.uart1_baud_rate_generator.replace(config);
+            configure_uart1_baud_rate_generator_impl(clocks, old_config, config);
+        }
+        pub fn uart1_baud_rate_generator_config(
+            clocks: &mut ClockTree,
+        ) -> Option<Uart0BaudRateGeneratorConfig> {
+            clocks.uart1_baud_rate_generator
+        }
+        pub fn request_uart1_baud_rate_generator(clocks: &mut ClockTree) {
+            trace!("Requesting UART1_BAUD_RATE_GENERATOR");
+            if increment_reference_count(&mut clocks.uart1_baud_rate_generator_refcount) {
+                trace!("Enabling UART1_BAUD_RATE_GENERATOR");
+                request_uart1_function_clock(clocks);
+                enable_uart1_baud_rate_generator_impl(clocks, true);
             }
+        }
+        pub fn release_uart1_baud_rate_generator(clocks: &mut ClockTree) {
+            trace!("Releasing UART1_BAUD_RATE_GENERATOR");
+            if decrement_reference_count(&mut clocks.uart1_baud_rate_generator_refcount) {
+                trace!("Disabling UART1_BAUD_RATE_GENERATOR");
+                enable_uart1_baud_rate_generator_impl(clocks, false);
+                release_uart1_function_clock(clocks);
+            }
+        }
+        #[allow(unused_variables)]
+        pub fn uart1_baud_rate_generator_config_frequency(
+            clocks: &mut ClockTree,
+            config: Uart0BaudRateGeneratorConfig,
+        ) -> u32 {
+            ((uart1_function_clock_frequency(clocks) * 16)
+                / ((config.integral() * 16) + config.fractional()))
+        }
+        pub fn uart1_baud_rate_generator_frequency(clocks: &mut ClockTree) -> u32 {
+            if let Some(config) = clocks.uart1_baud_rate_generator {
+                uart1_baud_rate_generator_config_frequency(clocks, config)
+            } else {
+                0
+            }
+        }
+        pub fn configure_uart1_mem_clock(clocks: &mut ClockTree, config: Uart0MemClockConfig) {
+            let old_config = clocks.uart1_mem_clock.replace(config);
+            configure_uart1_mem_clock_impl(clocks, old_config, config);
         }
         pub fn uart1_mem_clock_config(clocks: &mut ClockTree) -> Option<Uart0MemClockConfig> {
             clocks.uart1_mem_clock
@@ -2957,25 +3164,25 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_uart2_function_clock(
             clocks: &mut ClockTree,
-            new_selector: Uart0FunctionClockConfig,
+            config: Uart0FunctionClockConfig,
         ) {
-            let old_selector = clocks.uart2_function_clock.replace(new_selector);
+            let old_config = clocks.uart2_function_clock.replace(config);
             if clocks.uart2_function_clock_refcount > 0 {
-                match new_selector {
-                    Uart0FunctionClockConfig::Apb => request_apb_clk(clocks),
-                    Uart0FunctionClockConfig::RcFast => request_rc_fast_clk(clocks),
-                    Uart0FunctionClockConfig::Xtal => request_xtal_clk(clocks),
+                match config.sclk {
+                    Uart0FunctionClockSclk::Apb => request_apb_clk(clocks),
+                    Uart0FunctionClockSclk::RcFast => request_rc_fast_clk(clocks),
+                    Uart0FunctionClockSclk::Xtal => request_xtal_clk(clocks),
                 }
-                configure_uart2_function_clock_impl(clocks, old_selector, new_selector);
-                if let Some(old_selector) = old_selector {
-                    match old_selector {
-                        Uart0FunctionClockConfig::Apb => release_apb_clk(clocks),
-                        Uart0FunctionClockConfig::RcFast => release_rc_fast_clk(clocks),
-                        Uart0FunctionClockConfig::Xtal => release_xtal_clk(clocks),
+                configure_uart2_function_clock_impl(clocks, old_config, config);
+                if let Some(old_config) = old_config {
+                    match old_config.sclk {
+                        Uart0FunctionClockSclk::Apb => release_apb_clk(clocks),
+                        Uart0FunctionClockSclk::RcFast => release_rc_fast_clk(clocks),
+                        Uart0FunctionClockSclk::Xtal => release_xtal_clk(clocks),
                     }
                 }
             } else {
-                configure_uart2_function_clock_impl(clocks, old_selector, new_selector);
+                configure_uart2_function_clock_impl(clocks, old_config, config);
             }
         }
         pub fn uart2_function_clock_config(
@@ -2987,10 +3194,10 @@ macro_rules! define_clock_tree_types {
             trace!("Requesting UART2_FUNCTION_CLOCK");
             if increment_reference_count(&mut clocks.uart2_function_clock_refcount) {
                 trace!("Enabling UART2_FUNCTION_CLOCK");
-                match unwrap!(clocks.uart2_function_clock) {
-                    Uart0FunctionClockConfig::Apb => request_apb_clk(clocks),
-                    Uart0FunctionClockConfig::RcFast => request_rc_fast_clk(clocks),
-                    Uart0FunctionClockConfig::Xtal => request_xtal_clk(clocks),
+                match unwrap!(clocks.uart2_function_clock).sclk {
+                    Uart0FunctionClockSclk::Apb => request_apb_clk(clocks),
+                    Uart0FunctionClockSclk::RcFast => request_rc_fast_clk(clocks),
+                    Uart0FunctionClockSclk::Xtal => request_xtal_clk(clocks),
                 }
                 enable_uart2_function_clock_impl(clocks, true);
             }
@@ -3000,10 +3207,10 @@ macro_rules! define_clock_tree_types {
             if decrement_reference_count(&mut clocks.uart2_function_clock_refcount) {
                 trace!("Disabling UART2_FUNCTION_CLOCK");
                 enable_uart2_function_clock_impl(clocks, false);
-                match unwrap!(clocks.uart2_function_clock) {
-                    Uart0FunctionClockConfig::Apb => release_apb_clk(clocks),
-                    Uart0FunctionClockConfig::RcFast => release_rc_fast_clk(clocks),
-                    Uart0FunctionClockConfig::Xtal => release_xtal_clk(clocks),
+                match unwrap!(clocks.uart2_function_clock).sclk {
+                    Uart0FunctionClockSclk::Apb => release_apb_clk(clocks),
+                    Uart0FunctionClockSclk::RcFast => release_rc_fast_clk(clocks),
+                    Uart0FunctionClockSclk::Xtal => release_xtal_clk(clocks),
                 }
             }
         }
@@ -3012,11 +3219,11 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: Uart0FunctionClockConfig,
         ) -> u32 {
-            match config {
-                Uart0FunctionClockConfig::Apb => apb_clk_frequency(clocks),
-                Uart0FunctionClockConfig::RcFast => rc_fast_clk_frequency(clocks),
-                Uart0FunctionClockConfig::Xtal => xtal_clk_frequency(clocks),
-            }
+            (match config.sclk {
+                Uart0FunctionClockSclk::Apb => apb_clk_frequency(clocks),
+                Uart0FunctionClockSclk::RcFast => rc_fast_clk_frequency(clocks),
+                Uart0FunctionClockSclk::Xtal => xtal_clk_frequency(clocks),
+            } / (config.div_num() + 1))
         }
         pub fn uart2_function_clock_frequency(clocks: &mut ClockTree) -> u32 {
             if let Some(config) = clocks.uart2_function_clock {
@@ -3025,20 +3232,52 @@ macro_rules! define_clock_tree_types {
                 0
             }
         }
-        pub fn configure_uart2_mem_clock(
+        pub fn configure_uart2_baud_rate_generator(
             clocks: &mut ClockTree,
-            new_selector: Uart0MemClockConfig,
+            config: Uart0BaudRateGeneratorConfig,
         ) {
-            let old_selector = clocks.uart2_mem_clock.replace(new_selector);
-            if clocks.uart2_mem_clock_refcount > 0 {
-                request_uart_mem_clk(clocks);
-                configure_uart2_mem_clock_impl(clocks, old_selector, new_selector);
-                if let Some(old_selector) = old_selector {
-                    release_uart_mem_clk(clocks);
-                }
-            } else {
-                configure_uart2_mem_clock_impl(clocks, old_selector, new_selector);
+            let old_config = clocks.uart2_baud_rate_generator.replace(config);
+            configure_uart2_baud_rate_generator_impl(clocks, old_config, config);
+        }
+        pub fn uart2_baud_rate_generator_config(
+            clocks: &mut ClockTree,
+        ) -> Option<Uart0BaudRateGeneratorConfig> {
+            clocks.uart2_baud_rate_generator
+        }
+        pub fn request_uart2_baud_rate_generator(clocks: &mut ClockTree) {
+            trace!("Requesting UART2_BAUD_RATE_GENERATOR");
+            if increment_reference_count(&mut clocks.uart2_baud_rate_generator_refcount) {
+                trace!("Enabling UART2_BAUD_RATE_GENERATOR");
+                request_uart2_function_clock(clocks);
+                enable_uart2_baud_rate_generator_impl(clocks, true);
             }
+        }
+        pub fn release_uart2_baud_rate_generator(clocks: &mut ClockTree) {
+            trace!("Releasing UART2_BAUD_RATE_GENERATOR");
+            if decrement_reference_count(&mut clocks.uart2_baud_rate_generator_refcount) {
+                trace!("Disabling UART2_BAUD_RATE_GENERATOR");
+                enable_uart2_baud_rate_generator_impl(clocks, false);
+                release_uart2_function_clock(clocks);
+            }
+        }
+        #[allow(unused_variables)]
+        pub fn uart2_baud_rate_generator_config_frequency(
+            clocks: &mut ClockTree,
+            config: Uart0BaudRateGeneratorConfig,
+        ) -> u32 {
+            ((uart2_function_clock_frequency(clocks) * 16)
+                / ((config.integral() * 16) + config.fractional()))
+        }
+        pub fn uart2_baud_rate_generator_frequency(clocks: &mut ClockTree) -> u32 {
+            if let Some(config) = clocks.uart2_baud_rate_generator {
+                uart2_baud_rate_generator_config_frequency(clocks, config)
+            } else {
+                0
+            }
+        }
+        pub fn configure_uart2_mem_clock(clocks: &mut ClockTree, config: Uart0MemClockConfig) {
+            let old_config = clocks.uart2_mem_clock.replace(config);
+            configure_uart2_mem_clock_impl(clocks, old_config, config);
         }
         pub fn uart2_mem_clock_config(clocks: &mut ClockTree) -> Option<Uart0MemClockConfig> {
             clocks.uart2_mem_clock

--- a/esp-metadata/devices/esp32.toml
+++ b/esp-metadata/devices/esp32.toml
@@ -293,13 +293,12 @@ clocks = { system_clocks = { clock_tree = [
     { name = "Uart1", clocks = "Uart0" },
     { name = "I2s0" },
     { name = "Uart0", template_params = { peripheral = "uart" }, keep_enabled = true, clocks = [
-        { name = "FUNCTION_CLOCK", type = "mux", variants = [
+        { name = "FUNCTION_CLOCK", type = "generic", output = "sclk", params = { sclk = [
             { name = "APB",      outputs = "APB_CLK", default = true },
             { name = "REF_TICK", outputs = "REF_TICK" }
-        ] },
-        { name = "MEM_CLOCK", type = "mux", variants = [
-            { name = "MEM", outputs = "UART_MEM_CLK", default = true },
-        ] },
+        ] } },
+        { name = "MEM_CLOCK", type = "generic", output = "UART_MEM_CLK" },
+        { name = "BAUD_RATE_GENERATOR", type = "generic", output = "(FUNCTION_CLOCK * 16) / (integral * 16 + fractional)", params = { fractional = "0..16", integral = "0..0x100000" } },
     ] },
     #{ name = "Spi01" },
 

--- a/esp-metadata/devices/esp32c2.toml
+++ b/esp-metadata/devices/esp32c2.toml
@@ -193,14 +193,13 @@ clocks = { system_clocks = { clock_tree = [
     { name = "Spi2" },
     { name = "Uart1", clocks = "Uart0" },
     { name = "Uart0", template_params = { peripheral = "uart" }, keep_enabled = true, clocks = [
-        { name = "FUNCTION_CLOCK", type = "mux", variants = [ # UART_SCLK
+        { name = "FUNCTION_CLOCK", type = "generic", output = "sclk / (div_num + 1)", params = { sclk = [
             { name = "PLL_F40M", outputs = "PLL_40M" },
             { name = "RC_FAST",  outputs = "RC_FAST_CLK" },
             { name = "XTAL",     outputs = "XTAL_CLK", default = true },
-        ] },
-        { name = "MEM_CLOCK", type = "mux", variants = [
-            { name = "MEM", outputs = "UART_MEM_CLK", default = true },
-        ] },
+        ], div_num = "0 .. 0x100" } },
+        { name = "MEM_CLOCK", type = "generic", output = "UART_MEM_CLK" },
+        { name = "BAUD_RATE_GENERATOR", type = "generic", output = "(FUNCTION_CLOCK * 16) / (integral * 16 + fractional)", params = { fractional = "0..16", integral = "0..0x1000" } },
     ] },
     #{ name = "Spi01" },
     #{ name = "Timers" },
@@ -436,6 +435,7 @@ instances = [
     { name = "uart1", sys_instance = "Uart1", tx = "U1TXD", rx = "U1RXD", cts = "U1CTS", rts = "U1RTS" },
 ]
 ram_size = 128
+has_sclk_divider = true
 
 [device.rng]
 support_status = "partial"

--- a/esp-metadata/devices/esp32c3.toml
+++ b/esp-metadata/devices/esp32c3.toml
@@ -219,14 +219,13 @@ clocks = { system_clocks = { clock_tree = [
     { name = "Spi2" },
     { name = "Uart1", clocks = "Uart0" },
     { name = "Uart0", template_params = { peripheral = "uart" }, keep_enabled = true, clocks = [
-        { name = "FUNCTION_CLOCK", type = "mux", variants = [ # UART_SCLK
+        { name = "FUNCTION_CLOCK", type = "generic", output = "sclk / (div_num + 1)", params = { sclk = [
             { name = "APB",      outputs = "APB_CLK" },
             { name = "RC_FAST",  outputs = "RC_FAST_CLK" },
             { name = "XTAL",     outputs = "XTAL_CLK", default = true },
-        ] },
-        { name = "MEM_CLOCK", type = "mux", variants = [
-            { name = "MEM", outputs = "UART_MEM_CLK", default = true },
-        ] },
+        ], div_num = "0 .. 0x100" } },
+        { name = "MEM_CLOCK", type = "generic", output = "UART_MEM_CLK" },
+        { name = "BAUD_RATE_GENERATOR", type = "generic", output = "(FUNCTION_CLOCK * 16) / (integral * 16 + fractional)", params = { fractional = "0..16", integral = "0..0x1000" } },
     ] },
     #{ name = "Spi01" },
     
@@ -506,6 +505,7 @@ instances = [
     { name = "uart1", sys_instance = "Uart1", tx = "U1TXD", rx = "U1RXD", cts = "U1CTS", rts = "U1RTS" },
 ]
 ram_size = 128
+has_sclk_divider = true
 
 [device.uhci]
 support_status = "partial"

--- a/esp-metadata/devices/esp32c5.toml
+++ b/esp-metadata/devices/esp32c5.toml
@@ -218,11 +218,12 @@ clocks = { system_clocks = { clock_tree = [
     { name = "rst_field", value = "{{peripheral}}_rst_en" },
 ], peripheral_clocks = [
     { name = "Uart0", template_params = { conf_register = "uart(0).conf", clk_en_field = "clk_en", rst_field = "rst_en" }, keep_enabled = true, clocks = [
-        { name = "FUNCTION_CLOCK", type = "mux", variants = [ # UART_SCLK
+        { name = "FUNCTION_CLOCK", type = "generic", output = "sclk / (div_num + 1)", params = { sclk = [
             { name = "XTAL",     outputs = "XTAL_CLK", default = true },
             { name = "PLL_F80M", outputs = "PLL_F80M" },
             { name = "RC_FAST",  outputs = "RC_FAST_CLK" },
-        ] },
+        ], div_num = "0 .. 0x100" } },
+        { name = "BAUD_RATE_GENERATOR", type = "generic", output = "(FUNCTION_CLOCK * 16) / (integral * 16 + fractional)", params = { fractional = "0..16", integral = "0..0x1000" } },
     ] },
     { name = "Uart1", template_params = { conf_register = "uart(1).conf", clk_en_field = "clk_en", rst_field = "rst_en" }, keep_enabled = true, clocks = "Uart0" },
     { name = "Timg0", template_params = { conf_register = "timergroup(0).conf", clk_en_field = "clk_en", rst_field = "rst_en" }, keep_enabled = true, clocks = [

--- a/esp-metadata/devices/esp32c6.toml
+++ b/esp-metadata/devices/esp32c6.toml
@@ -216,11 +216,12 @@ clocks = { system_clocks = { clock_tree = [
 ], peripheral_clocks = [
     # This list is based on TRM (v1.1) - 8.4.1 PCR Registers
     { name = "Uart0", template_params = { conf_register = "uart(0).conf", clk_en_field = "clk_en", rst_field = "rst_en" }, keep_enabled = true, clocks = [
-        { name = "FUNCTION_CLOCK", type = "mux", variants = [ # UART_SCLK
+        { name = "FUNCTION_CLOCK", type = "generic", output = "sclk / (div_num + 1)", params = { sclk = [
             { name = "PLL_F80M", outputs = "PLL_F80M" },
             { name = "RC_FAST",  outputs = "RC_FAST_CLK" },
             { name = "XTAL",     outputs = "XTAL_CLK", default = true },
-        ] },
+        ], div_num = "0 .. 0x100" } },
+        { name = "BAUD_RATE_GENERATOR", type = "generic", output = "(FUNCTION_CLOCK * 16) / (integral * 16 + fractional)", params = { fractional = "0..16", integral = "0..0x1000" } },
     ] },
     { name = "Uart1", template_params = { conf_register = "uart(1).conf", clk_en_field = "clk_en", rst_field = "rst_en" }, clocks = "Uart0" },
     { name = "I2cExt0", template_params = { peripheral = "i2c0" } },

--- a/esp-metadata/devices/esp32h2.toml
+++ b/esp-metadata/devices/esp32h2.toml
@@ -170,11 +170,12 @@ clocks = { system_clocks = { clock_tree = [
 ], peripheral_clocks = [
     # This list is based on TRM (v1.5) - 7.4.1 PCR Register Summary
     { name = "Uart0", template_params = { conf_register = "uart(0).conf", clk_en_field = "clk_en", rst_field = "rst_en" }, keep_enabled = true, clocks = [
-        { name = "FUNCTION_CLOCK", type = "mux", variants = [ # UART_SCLK
+        { name = "FUNCTION_CLOCK", type = "generic", output = "sclk / (div_num + 1)", params = { sclk = [
             { name = "PLL_F48M", outputs = "PLL_F48M_CLK" },
             { name = "RC_FAST",  outputs = "RC_FAST_CLK" },
             { name = "XTAL",     outputs = "XTAL_CLK", default = true },
-        ] },
+        ], div_num = "0 .. 0x100" } },
+        { name = "BAUD_RATE_GENERATOR", type = "generic", output = "(FUNCTION_CLOCK * 16) / (integral * 16 + fractional)", params = { fractional = "0..16", integral = "0..0x1000" } },
     ] },
     { name = "Uart1", template_params = { conf_register = "uart(1).conf", clk_en_field = "clk_en", rst_field = "rst_en" }, clocks = "Uart0" },
     { name = "I2cExt0", template_params = { peripheral = "i2c0" } },

--- a/esp-metadata/devices/esp32s2.toml
+++ b/esp-metadata/devices/esp32s2.toml
@@ -237,13 +237,12 @@ clocks = { system_clocks = { clock_tree = [
     { name = "I2s0" },
     { name = "Wdg" },
     { name = "Uart0", template_params = { peripheral = "uart" }, keep_enabled = true, clocks = [
-        { name = "FUNCTION_CLOCK", type = "mux", variants = [
+        { name = "FUNCTION_CLOCK", type = "generic", output = "sclk", params = { sclk = [
             { name = "APB",      outputs = "APB_CLK", default = true },
             { name = "REF_TICK", outputs = "REF_TICK" }
-        ] },
-        { name = "MEM_CLOCK", type = "mux", variants = [
-            { name = "MEM", outputs = "UART_MEM_CLK", default = true },
-        ] },
+        ] } },
+        { name = "BAUD_RATE_GENERATOR", type = "generic", output = "(FUNCTION_CLOCK * 16) / (integral * 16 + fractional)", params = { fractional = "0..16", integral = "0..0x100000" } },
+        { name = "MEM_CLOCK", type = "generic", output = "UART_MEM_CLK" },
     ] },
     #{ name = "Spi01" },
     #{ name = "Timers" },

--- a/esp-metadata/devices/esp32s3.toml
+++ b/esp-metadata/devices/esp32s3.toml
@@ -255,14 +255,13 @@ clocks = { system_clocks = { clock_tree = [
     { name = "Uart1", clocks = "Uart0" },
     { name = "I2s0" },
     { name = "Uart0", template_params = { peripheral = "uart" }, keep_enabled = true, clocks = [
-        { name = "FUNCTION_CLOCK", type = "mux", variants = [ # UART_SCLK
+        { name = "FUNCTION_CLOCK", type = "generic", output = "sclk / (div_num + 1)", params = { sclk = [
             { name = "APB",      outputs = "APB_CLK" },
             { name = "RC_FAST",  outputs = "RC_FAST_CLK" },
             { name = "XTAL",     outputs = "XTAL_CLK", default = true },
-        ] },
-        { name = "MEM_CLOCK", type = "mux", variants = [
-            { name = "MEM", outputs = "UART_MEM_CLK", default = true },
-        ] },
+        ], div_num = "0 .. 0x100" } },
+        { name = "BAUD_RATE_GENERATOR", type = "generic", output = "(FUNCTION_CLOCK * 16) / (integral * 16 + fractional)", params = { fractional = "0..16", integral = "0..0x1000" } },
+        { name = "MEM_CLOCK", type = "generic", output = "UART_MEM_CLK" },
     ] },
     #{ name = "Spi01" },
     #{ name = "Timers" },
@@ -831,6 +830,7 @@ instances = [
     { name = "uart2", sys_instance = "Uart2", tx = "U2TXD", rx = "U2RXD", cts = "U2CTS", rts = "U2RTS" },
 ]
 ram_size = 128
+has_sclk_divider = true
 
 [device.uhci]
 support_status = "partial"

--- a/esp-metadata/src/cfg.rs
+++ b/esp-metadata/src/cfg.rs
@@ -693,6 +693,9 @@ driver_configs![
             ram_size: u32,
             #[serde(default)]
             peripheral_controls_mem_clk: bool,
+            // Whether the MCU has a CLK_CONF register _in_ the UART peripheral.
+            #[serde(default)]
+            has_sclk_divider: bool,
         }
     },
     UhciProperties {

--- a/esp-metadata/src/cfg/soc.rs
+++ b/esp-metadata/src/cfg/soc.rs
@@ -1014,7 +1014,10 @@ impl DeviceClocks {
             // managed. In the current model, manually managed clocks have 0 consumers.
             let has_one_direct_dependent = tree.dependency_graph.users(node.name_str()).len() == 1;
 
-            let refcounted = !(node.always_on() || has_one_direct_dependent);
+            // Peripheral nodes are always refcounted, because we can't assume which node is
+            // referred to by the drivers.
+            let is_peripheral_node = !node.group.is_empty();
+            let refcounted = is_peripheral_node || !(node.always_on() || has_one_direct_dependent);
 
             let properties = ManagementProperties {
                 name: format_ident!("{}", node.name().to_case(Case::Snake)),

--- a/hil-test/src/bin/uart.rs
+++ b/hil-test/src/bin/uart.rs
@@ -15,7 +15,7 @@ mod tests {
         delay::Delay,
         gpio::{AnyPin, Pin},
         time::Duration,
-        uart::{self, ClockSource, Uart},
+        uart::{self, BaudrateTolerance, ClockSource, Uart},
     };
 
     struct Context {
@@ -103,7 +103,8 @@ mod tests {
         ];
 
         for config in configs {
-            uart.apply_config(&config).unwrap();
+            uart.apply_config(&config)
+                .unwrap_or_else(|e| panic!("{:?}: {:?}", e, config));
 
             uart.write(&[0x42]).unwrap();
             let mut byte = [0u8; 1];
@@ -192,16 +193,15 @@ mod tests {
             (5_000_000, fastest_clock_source),
         ];
 
-        // TODO: we need a way to verify these baud rates are actually what we want.
-
         let mut byte_to_write = 0xA5;
         for (baudrate, clock_source) in configs {
             uart.apply_config(
                 &uart::Config::default()
                     .with_baudrate(baudrate)
-                    .with_clock_source(clock_source),
+                    .with_clock_source(clock_source)
+                    .with_baudrate_tolerance(BaudrateTolerance::ErrorPercent(5)),
             )
-            .unwrap();
+            .unwrap_or_else(|e| panic!("{:?}: Failed to apply {:?}@{}", e, clock_source, baudrate));
             uart.write(&[byte_to_write]).unwrap();
             let mut byte = [0u8; 1];
             uart.read(&mut byte).unwrap();


### PR DESCRIPTION
This PR remodels the UART SCLK as a mux-divider (where applicable) and the baud rate generator as a clock node. This lets us to rely on the clock tree codegen to calculate the actual baud rate, cleaning up config validation nicely. This also allows us to abstract away device-specific clock divider setup from the UART driver into the clock tree impl.