### PR TITLE
Reference the correct clock node

### DIFF
--- a/esp-metadata/src/cfg/soc.rs
+++ b/esp-metadata/src/cfg/soc.rs
@@ -912,9 +912,7 @@ impl DeviceClocks {
                         peri.name.from_case(Case::Ada).to_case(Case::Constant),
                         def.name()
                     ),
-                    group: template_peripheral
-                        .from_case(Case::Ada)
-                        .to_case(Case::Constant),
+                    group: peri.name.from_case(Case::Ada).to_case(Case::Constant),
                     template_name: format!(
                         "{}_{}",
                         template_peripheral

--- a/esp-metadata/src/cfg/soc/clock_tree.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree.rs
@@ -658,6 +658,7 @@ impl RejectExpression {
     fn to_rust<'a>(
         &'a self,
         mut variables: HashMap<&'a str, TokenStream>,
+        instance: &ClockTreeNodeInstance,
         tree: &ProcessedClockData,
     ) -> TokenStream {
         let mut patterns = vec![];
@@ -665,8 +666,8 @@ impl RejectExpression {
         self.0.visit_variables(|var| {
             if !variables.contains_key(var) {
                 // Referring to a node by name resolves to its output frequency.
-                let properties = tree.properties(var);
-                let node = tree.node(var);
+                let node = instance.resolve_node(tree, var);
+                let properties = tree.properties(node.name_str());
                 let freq_fn = node.frequency_function_name();
                 variables.insert(var, quote! { #freq_fn(clocks) });
 
@@ -676,7 +677,7 @@ impl RejectExpression {
             }
         });
 
-        let reject_expr = self.0.to_rust(variables, tree);
+        let reject_expr = self.0.to_rust(variables, instance, tree);
 
         let assert_reject = quote! {
             assert!(!(#reject_expr));
@@ -738,9 +739,10 @@ impl Expression {
     fn to_rust(
         &self,
         variables: HashMap<&str, TokenStream>,
+        instance: &ClockTreeNodeInstance,
         tree: &ProcessedClockData,
     ) -> TokenStream {
-        ExprCompiler::new(&variables).compile_expression(self, tree)
+        ExprCompiler::new(&variables).compile_expression(self, instance, tree)
     }
 }
 

--- a/esp-metadata/src/cfg/soc/clock_tree/divider.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/divider.rs
@@ -145,7 +145,7 @@ impl ClockTreeNodeType for Divider {
                 variables.insert(var.as_str(), quote! { config.#param_fn() });
             }
 
-            reject.to_rust(variables, tree)
+            reject.to_rust(variables, instance, tree)
         });
         quote! {
             pub fn #apply_fn_name(clocks: &mut ClockTree, config: #ty_name) {
@@ -203,6 +203,7 @@ impl ClockTreeNodeType for Divider {
         let cfg_expr_code = ExprCompiler::new(&variables).compile_right_hand_expression(
             &expr.source,
             &effect.value,
+            instance,
             tree,
         );
         let node_name = instance.name_str();
@@ -273,7 +274,7 @@ impl ClockTreeNodeType for Divider {
         for (var, param_value_accessor) in params {
             variables.insert(var.as_str(), param_value_accessor);
         }
-        let cfg_expr_code = self.output.to_rust(variables, tree);
+        let cfg_expr_code = self.output.to_rust(variables, instance, tree);
 
         cfg_expr_code
     }
@@ -522,8 +523,9 @@ impl DividerOutputExpression {
     fn to_rust(
         &self,
         variables: HashMap<&str, TokenStream>,
+        instance: &ClockTreeNodeInstance,
         tree: &ProcessedClockData,
     ) -> TokenStream {
-        self.0.to_rust(variables, tree)
+        self.0.to_rust(variables, instance, tree)
     }
 }

--- a/esp-metadata/src/cfg/soc/clock_tree/expr_compiler.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/expr_compiler.rs
@@ -6,7 +6,7 @@ use somni_expr::DefaultTypeSet;
 use somni_parser::{ast, lexer::Token};
 
 use crate::{
-    cfg::{ProcessedClockData, clock_tree::Expression},
+    cfg::{ClockTreeNodeInstance, ProcessedClockData, clock_tree::Expression},
     number,
 };
 
@@ -22,16 +22,18 @@ impl<'ctx> ExprCompiler<'ctx> {
     pub fn compile_expression(
         &self,
         expression: &Expression,
+        instance: &ClockTreeNodeInstance,
         tree: &ProcessedClockData,
     ) -> TokenStream {
         let source = expression.source.as_str();
-        self.compile_right_hand_expression(source, &expression.expr, tree)
+        self.compile_right_hand_expression(source, &expression.expr, instance, tree)
     }
 
     pub fn compile_right_hand_expression(
         &self,
         source: &str,
         expression: &ast::RightHandExpression<DefaultTypeSet>,
+        instance: &ClockTreeNodeInstance,
         tree: &ProcessedClockData,
     ) -> TokenStream {
         match expression {
@@ -40,13 +42,13 @@ impl<'ctx> ExprCompiler<'ctx> {
             }
             ast::RightHandExpression::Literal { value } => self.compile_literal(value),
             ast::RightHandExpression::UnaryOperator { name, operand } => {
-                self.compile_unary_operator(source, name, operand, tree)
+                self.compile_unary_operator(source, name, operand, instance, tree)
             }
             ast::RightHandExpression::BinaryOperator { name, operands } => {
-                self.compile_binary_operator(source, name, operands, tree)
+                self.compile_binary_operator(source, name, operands, instance, tree)
             }
             ast::RightHandExpression::FunctionCall { name, arguments } => {
-                self.compile_function_call(source, name, arguments, tree)
+                self.compile_function_call(source, name, arguments, instance, tree)
             }
         }
     }
@@ -64,6 +66,7 @@ impl<'ctx> ExprCompiler<'ctx> {
         source: &str,
         name: &Token,
         operand: &ast::RightHandExpression<DefaultTypeSet>,
+        instance: &ClockTreeNodeInstance,
         tree: &ProcessedClockData,
     ) -> TokenStream {
         let operator = match name.source(source) {
@@ -72,7 +75,7 @@ impl<'ctx> ExprCompiler<'ctx> {
             other => todo!("Unsupported unary operator: {other}"),
         };
 
-        let operand = self.compile_right_hand_expression(source, operand, tree);
+        let operand = self.compile_right_hand_expression(source, operand, instance, tree);
         quote! { #operator (#operand) }
     }
 
@@ -81,6 +84,7 @@ impl<'ctx> ExprCompiler<'ctx> {
         source: &str,
         name: &Token,
         operands: &[ast::RightHandExpression<DefaultTypeSet>; 2],
+        instance: &ClockTreeNodeInstance,
         tree: &ProcessedClockData,
     ) -> TokenStream {
         let operator = match name.source(source) {
@@ -94,8 +98,8 @@ impl<'ctx> ExprCompiler<'ctx> {
             other => todo!("Unsupported binary operator: {other}"),
         };
 
-        let lhs = self.compile_right_hand_expression(source, &operands[0], tree);
-        let rhs = self.compile_right_hand_expression(source, &operands[1], tree);
+        let lhs = self.compile_right_hand_expression(source, &operands[0], instance, tree);
+        let rhs = self.compile_right_hand_expression(source, &operands[1], instance, tree);
         quote! { (#lhs #operator #rhs) }
     }
 
@@ -113,6 +117,7 @@ impl<'ctx> ExprCompiler<'ctx> {
         source: &str,
         name: &Token,
         arguments: &[ast::RightHandExpression<DefaultTypeSet>],
+        instance: &ClockTreeNodeInstance,
         tree: &ProcessedClockData,
     ) -> TokenStream {
         // property(NODE)
@@ -120,8 +125,8 @@ impl<'ctx> ExprCompiler<'ctx> {
             panic!("Function calls must be of the form property(NODE)")
         };
 
-        // TODO: pass instance to resolve node
-        let node_props = tree.properties(variable.source(source));
+        let referred_node = instance.resolve_node(tree, variable.source(source));
+        let node_props = tree.properties(referred_node.name_str());
         let node_field = quote::format_ident!("{}", node_props.field_name());
         let name = quote::format_ident!("{}", name.source(source));
         quote! { unwrap!(clocks.#node_field).#name() }

--- a/esp-metadata/src/cfg/soc/clock_tree/source.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/source.rs
@@ -104,7 +104,7 @@ impl ClockTreeNodeType for Source {
 
             variables.insert("VALUE", quote! { config.value() });
 
-            reject.to_rust(variables, tree)
+            reject.to_rust(variables, instance, tree)
         });
         quote! {
             pub fn #apply_fn_name(clocks: &mut ClockTree, config: #ty_name) {
@@ -125,7 +125,7 @@ impl ClockTreeNodeType for Source {
         if self.values.is_some() {
             quote! { unwrap!(clocks.#state_field).value() }
         } else {
-            self.output.0.to_rust(HashMap::new(), tree)
+            self.output.0.to_rust(HashMap::new(), instance, tree)
         }
     }
 


### PR DESCRIPTION
A peripheral instance's "group" is supposed to be the peripheral it belongs to, not the peripheral it's inherited from. This causes bugs visible in #5186

This PR also implements a todo so that the expression compiler resolves the correct clock nodes