### PR TITLE
C5: define start address of `dram2_uninit` correctly

### DIFF
--- a/esp-metadata-generated/src/_build_script_utils.rs
+++ b/esp-metadata-generated/src/_build_script_utils.rs
@@ -2186,7 +2186,7 @@ impl Chip {
                         (
                             "dram2_uninit",
                             MemoryRegion {
-                                address_range: 0x4084BBA0..0x4085C5A0,
+                                address_range: 0x4084E5A0..0x4085E5A0,
                             },
                         ),
                     ],

--- a/esp-metadata-generated/src/_generated_esp32c5.rs
+++ b/esp-metadata-generated/src/_generated_esp32c5.rs
@@ -3145,10 +3145,10 @@ macro_rules! memory_range {
         "393216"
     };
     ("DRAM2_UNINIT") => {
-        0x4084BBA0..0x4085C5A0
+        0x4084E5A0..0x4085E5A0
     };
     (size as str, "DRAM2_UNINIT") => {
-        "68096"
+        "65536"
     };
 }
 /// This macro can be used to generate code for each peripheral instance of the I2C master driver.

--- a/esp-metadata/devices/esp32c5.toml
+++ b/esp-metadata/devices/esp32c5.toml
@@ -136,8 +136,8 @@ rc_fast_clk_default = 17_500_000
 
 memory_map = { ranges = [
     { name = "dram", start = 0x4080_0000, end = 0x4086_0000 },
-    # start address from correct bootloader commit: https://github.com/espressif/esp-idf/blob/d66ebb8/components/bootloader/subproject/main/ld/esp32c5/bootloader.ld#L33
-    { name = "dram2_uninit", start = 0x4084_BBA0, end = 0x4085_C5A0 },
+    # start address from correct bootloader commit: https://github.com/espressif/esp-idf/blob/d66ebb8/components/bootloader/subproject/main/ld/esp32c5/bootloader.ld#L32
+    { name = "dram2_uninit", start = 0x4084_E5A0, end = 0x4085_E5A0 },
 ] }
 
 clocks = { system_clocks = { clock_tree = [


### PR DESCRIPTION
closes #5196 