### PR TITLE
Use write to initialize GPIO

### DIFF
--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -1710,7 +1710,7 @@ impl<'lt> AnyPin<'lt> {
 
         GPIO::regs()
             .func_out_sel_cfg(self.number() as usize)
-            .modify(|_, w| unsafe { w.out_sel().bits(OutputSignal::GPIO as _) });
+            .write(|w| unsafe { w.out_sel().bits(OutputSignal::GPIO as _) });
 
         // Use RMW to not overwrite sleep configuration
         io_mux_reg(self.number()).modify(|_, w| unsafe {


### PR DESCRIPTION
There is no reason to read-modify-write the `func_out_sel_cfg`. The fields only configure the output signal, output enable and signal inversion bits, all of them can be written to a default value.