### PR TITLE
xtask: Only accept packages that have examples

### DIFF
--- a/xtask/src/commands/build.rs
+++ b/xtask/src/commands/build.rs
@@ -149,7 +149,7 @@ pub fn build_examples(
     let chip = args.chip.unwrap();
 
     // Determine the appropriate build target for the given package and chip:
-    let target = args.package.target_triple(&chip)?;
+    let target = args.package.as_package().target_triple(&chip)?;
 
     // Attempt to build each supported example, with all required features enabled:
 

--- a/xtask/src/commands/mod.rs
+++ b/xtask/src/commands/mod.rs
@@ -191,8 +191,8 @@ pub struct ExamplesArgs {
     #[arg(value_enum, long)]
     pub chip: Option<Chip>,
     /// Package whose examples we wish to act on.
-    #[arg(value_enum, long, default_value_t = Package::Examples)]
-    pub package: Package,
+    #[arg(value_enum, long, default_value_t = ExamplesPackage::Examples)]
+    pub package: ExamplesPackage,
     /// Build examples in debug mode only
     #[arg(long)]
     pub debug: bool,
@@ -204,6 +204,31 @@ pub struct ExamplesArgs {
     /// Emit crate build timings
     #[arg(long)]
     pub timings: bool,
+}
+
+/// The different packages which contain examples, and which the `examples` subcommand can act on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum ExamplesPackage {
+    Examples,
+    QaTest,
+    EspLpHal,
+}
+
+impl From<ExamplesPackage> for Package {
+    fn from(ep: ExamplesPackage) -> Self {
+        match ep {
+            ExamplesPackage::Examples => Package::Examples,
+            ExamplesPackage::QaTest => Package::QaTest,
+            ExamplesPackage::EspLpHal => Package::EspLpHal,
+        }
+    }
+}
+
+impl ExamplesPackage {
+    /// Get the underlying Package
+    pub fn as_package(self) -> Package {
+        Package::from(self)
+    }
 }
 
 /// Arguments common to commands which act on doctests.
@@ -265,7 +290,7 @@ pub struct TestsArgs {
 pub fn examples(workspace: &Path, mut args: ExamplesArgs, action: CargoAction) -> Result<()> {
     log::debug!(
         "Running examples for '{}' on '{:?}'",
-        args.package,
+        args.package.as_package(),
         args.chip
     );
     if args.chip.is_none() {
@@ -279,33 +304,26 @@ pub fn examples(workspace: &Path, mut args: ExamplesArgs, action: CargoAction) -
     let chip = args.chip.unwrap();
 
     // Ensure that the package/chip combination provided are valid:
-    args.package.validate_package_chip(&chip).with_context(|| {
-        format!(
-            "The package '{0}' does not support the chip '{chip:?}'",
-            args.package
-        )
-    })?;
-
-    // If the 'esp-hal' package is specified, what we *really* want is the
-    // 'examples' package instead:
-    if args.package != Package::QaTest {
-        log::warn!(
-            "Package '{}' specified, using '{}' instead",
-            args.package,
-            Package::Examples
-        );
-        args.package = Package::Examples;
-    }
+    args.package
+        .as_package()
+        .validate_package_chip(&chip)
+        .with_context(|| {
+            format!(
+                "The package '{0}' does not support the chip '{chip:?}'",
+                args.package.as_package()
+            )
+        })?;
 
     // Absolute path of the package's root:
-    let package_path = crate::windows_safe_path(&workspace.join(args.package.to_string()));
+    let package_path =
+        crate::windows_safe_path(&workspace.join(args.package.as_package().to_string()));
 
     // Load all examples which support the specified chip and parse their metadata.
     //
     // The `examples` directory contains a number of individual projects, and does not rely on
     // metadata comments in the source files. As such, it needs to load its metadata differently
     // than other packages.
-    let examples = if args.package == Package::Examples {
+    let examples = if args.package.as_package() == Package::Examples {
         crate::firmware::load_cargo_toml(&package_path).with_context(|| {
             format!(
                 "Failed to load specified examples from {}",
@@ -313,9 +331,8 @@ pub fn examples(workspace: &Path, mut args: ExamplesArgs, action: CargoAction) -
             )
         })?
     } else {
-        let example_path = match args.package {
+        let example_path = match args.package.as_package() {
             Package::QaTest => package_path.join("src").join("bin"),
-            Package::HilTest => package_path.join("tests"),
             _ => package_path.join("examples"),
         };
 

--- a/xtask/src/commands/run.rs
+++ b/xtask/src/commands/run.rs
@@ -208,7 +208,7 @@ pub fn run_examples(
 
     // At this point, chip can never be `None`, so we can safely unwrap it.
     let chip = args.chip.unwrap();
-    let target = args.package.target_triple(&chip)?;
+    let target = args.package.as_package().target_triple(&chip)?;
 
     examples.sort_by_key(|ex| ex.tag());
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -78,7 +78,6 @@ struct CheckChangelogArgs {
     normalize: bool,
 }
 
-
 // ----------------------------------------------------------------------------
 // Application
 
@@ -556,7 +555,7 @@ fn run_ci_checks(workspace: &Path, args: CiArgs) -> Result<()> {
             let result = examples(
                 workspace,
                 ExamplesArgs {
-                    package: Package::EspLpHal,
+                    package: ExamplesPackage::EspLpHal,
                     chip: Some(args.chip),
                     example: Some("all".to_string()),
                     debug: false,
@@ -645,7 +644,7 @@ fn run_ci_checks(workspace: &Path, args: CiArgs) -> Result<()> {
         examples(
             workspace,
             ExamplesArgs {
-                package: Package::Examples,
+                package: ExamplesPackage::Examples,
                 chip: Some(args.chip),
                 example: Some("all".to_string()),
                 debug: true,
@@ -660,7 +659,7 @@ fn run_ci_checks(workspace: &Path, args: CiArgs) -> Result<()> {
         examples(
             workspace,
             ExamplesArgs {
-                package: Package::QaTest,
+                package: ExamplesPackage::QaTest,
                 chip: Some(args.chip),
                 example: Some("all".to_string()),
                 debug: true,


### PR DESCRIPTION
We should only use `examples` or `qa-test` - when other package is specified, use `examples` as a fallback.

Without this PR
`cargo xtask build examples --chip esp32c6 --package hil-test` gives:
```rust
Error: Failed to read {path}

Caused by:
    No such file or directory (os error 2)
```

