### PR TITLE
Add range-based stack overflow checks

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -85,6 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - It's no longer possible to pass `esp_hal::gpio::Output` to bidirectional peripheral signals (half-duplex SPI, I2C) (#5093)
 - S3: SPI1 is no longer initialized if PSRAM is not correctly detected. The warning message now includes PSRAM mode config (#5122)
 - `Rng`, `Rng::{random, read}` have been marked stable (#5098)
+- `esp_hal::init` now verifies that the initial stack pointer is in range (#5227)
 
 ### Fixed
 

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -777,6 +777,7 @@ pub fn init(config: Config) -> Peripherals {
         }
     }
 
+    crate::soc::ensure_stack_pointer_in_range();
     #[cfg(stack_guard_monitoring)]
     crate::soc::enable_main_stack_guard_monitoring();
 

--- a/esp-hal/src/soc/mod.rs
+++ b/esp-hal/src/soc/mod.rs
@@ -254,6 +254,31 @@ fn setup_stack_guard() {
     }
 }
 
+#[cfg(feature = "rt")]
+pub(crate) fn ensure_stack_pointer_in_range() {
+    unsafe extern "C" {
+        static _stack_end_cpu0: u32;
+        static _stack_start_cpu0: u32;
+    }
+    let current_sp: usize;
+    cfg_if::cfg_if! {
+        if #[cfg(xtensa)] {
+            unsafe { core::arch::asm!("mov {0}, sp", out(reg) current_sp); }
+        } else {
+            unsafe { core::arch::asm!("mv {0}, sp", out(reg) current_sp); }
+        }
+    }
+    let stack_bottom = (&raw const _stack_end_cpu0) as usize;
+    let stack_top = (&raw const _stack_start_cpu0) as usize;
+    assert!(
+        current_sp > stack_bottom && current_sp <= stack_top,
+        "stack pointer out of range: sp=0x{:x}, bottom=0x{:x}, top=0x{:x}",
+        current_sp,
+        stack_bottom,
+        stack_top
+    );
+}
+
 #[cfg(all(feature = "rt", stack_guard_monitoring))]
 pub(crate) fn enable_main_stack_guard_monitoring() {
     unsafe {

--- a/esp-rtos/CHANGELOG.md
+++ b/esp-rtos/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Provide implementation for the `_getreent` syscall when the `alloc` feature is enabled (#4473)
 - Provide implementation for the `_malloc_r` and `_free_r` syscalls when the `alloc` feature is enabled (#4484)
 - Support for ESP32-C5 (#4884)
+- `ESP_RTOS_CONFIG_STACK_POINTER_RANGE_CHECK` to enable another way of stack-overflow detection. Enabled by default (#5227)
 
 ### Changed
 

--- a/esp-rtos/esp_config.yml
+++ b/esp-rtos/esp_config.yml
@@ -14,6 +14,11 @@ options:
     default:
       - value: false
 
+  - name: stack-pointer-range-check
+    description: "Enable range-check based stack overflow detection."
+    default:
+      - value: true
+
   - name: hw-task-overflow-detection
     description: "Enable hardware-based stack overflow detection. The stack watermark is based on the esp-hal stack-guard-offset configuration."
     default:

--- a/esp-rtos/src/scheduler.rs
+++ b/esp-rtos/src/scheduler.rs
@@ -234,9 +234,22 @@ impl SchedulerState {
         let cpu = Cpu::current();
         let current_cpu = cpu as usize;
 
+        let current_sp: u32;
+        cfg_if::cfg_if! {
+            if #[cfg(xtensa)] {
+                unsafe { core::arch::asm!("mov {0}, sp", out(reg) current_sp); }
+            } else {
+                unsafe { core::arch::asm!("mv {0}, sp", out(reg) current_sp); }
+            }
+        }
+
         let current_task = NonNull::new(read_thread_pointer());
         if let Some(current_task) = current_task {
-            unsafe { current_task.as_ref().ensure_no_stack_overflow() };
+            unsafe {
+                current_task
+                    .as_ref()
+                    .ensure_no_stack_overflow(current_sp as usize)
+            };
 
             if current_task.state() == TaskState::Ready {
                 // Current task is still ready, mark it as such.
@@ -297,15 +310,6 @@ impl SchedulerState {
                 {
                     // We're using the current task's stack, for which the watchpoint is already set
                     // up.
-
-                    let current_sp;
-                    cfg_if::cfg_if! {
-                        if #[cfg(xtensa)] {
-                            unsafe { core::arch::asm!("mov {0}, sp", out(reg) current_sp); }
-                        } else {
-                            unsafe { core::arch::asm!("mv {0}, sp", out(reg) current_sp); }
-                        }
-                    }
                     current_sp
                 } else {
                     // We're using the main task's stack.
@@ -392,7 +396,16 @@ impl SchedulerState {
     }
 
     fn delete_task(&mut self, mut to_delete: TaskPtr) {
-        unsafe { to_delete.as_ref().ensure_no_stack_overflow() };
+        unsafe {
+            cfg_if::cfg_if! {
+                if #[cfg(xtensa)] {
+                    let saved_sp = to_delete.as_ref().cpu_context.A1 as usize;
+                } else {
+                    let saved_sp = to_delete.as_ref().cpu_context.sp;
+                }
+            }
+            to_delete.as_ref().ensure_no_stack_overflow(saved_sp)
+        };
 
         debug!("Dropping task: {:x}", to_delete.as_ptr() as usize);
         unsafe {

--- a/esp-rtos/src/task/mod.rs
+++ b/esp-rtos/src/task/mod.rs
@@ -537,7 +537,7 @@ impl Task {
         }
     }
 
-    pub(crate) fn ensure_no_stack_overflow(&self) {
+    pub(crate) fn ensure_no_stack_overflow(&self, _sp: usize) {
         #[cfg(sw_task_overflow_detection)]
         assert_eq!(
             // This cast is safe to do from MaybeUninit<u32> because this is the word we've written
@@ -547,6 +547,22 @@ impl Task {
             "Stack overflow detected in {:?}",
             self as *const Task
         );
+
+        #[cfg(stack_pointer_range_check)]
+        {
+            let len = self.stack.len();
+            let data_ptr = self.stack.cast::<MaybeUninit<u32>>();
+            let stack_bottom = data_ptr as usize;
+            let stack_top = data_ptr.wrapping_add(len) as usize;
+            assert!(
+                _sp > stack_bottom && _sp <= stack_top,
+                "Stack overflow detected in {:?}. Stack pointer: {:x}, Task stack range: {:x} ..= {:x}",
+                self as *const Task,
+                _sp,
+                stack_bottom,
+                stack_top
+            );
+        }
     }
 
     pub(crate) fn set_up_stack_watchpoint(&self) {


### PR DESCRIPTION
This PR is supposed to resolve an issue where stack-overflow check may miss overflows due to using large MaybeUninit arrays, potentially in the main function. This is done by checking the stack pointer against its limits, unconditionally in `esp_hal::init`, and as an opt-out feature in esp-rtos.

Modifying the `embassy_multicore` example to use `16 *8192` bytes of stack results in this:

<img width="617" height="72" alt="image" src="https://github.com/user-attachments/assets/c7b52678-f9f6-41d4-a7d2-acd8b1c8694e" />
