### PR TITLE
C61: Enable a small hil-test for the CI

### DIFF
--- a/.github/scripts/hil-parse.js
+++ b/.github/scripts/hil-parse.js
@@ -1,5 +1,5 @@
 const DEFAULT_ALLOWED = [
-  'esp32c2','esp32c3','esp32c5','esp32c6','esp32h2','esp32','esp32s2','esp32s3'
+  'esp32c2','esp32c3','esp32c5','esp32c6','esp32c61','esp32h2','esp32','esp32s2','esp32s3'
 ];
 
 function parseTests(body) {

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -140,6 +140,10 @@ jobs:
             rust-target: riscv32imac-unknown-none-elf
             runner: esp32c6-usb
             host: armv7
+          - soc: esp32c61
+            rust-target: riscv32imac-unknown-none-elf
+            runner: esp32c61-usb
+            host: aarch64
           - soc: esp32h2
             rust-target: riscv32imac-unknown-none-elf
             runner: esp32h2-usb
@@ -227,6 +231,10 @@ jobs:
             rust-target: riscv32imac-unknown-none-elf
             runner: esp32c6-usb
             host: armv7
+          - soc: esp32c61
+            rust-target: riscv32imac-unknown-none-elf
+            runner: esp32c61-usb
+            host: aarch64
           - soc: esp32h2
             rust-target: riscv32imac-unknown-none-elf
             runner: esp32h2-usb
@@ -371,6 +379,10 @@ jobs:
             rust-target: riscv32imac-unknown-none-elf
             runner: esp32c6-usb
             host: armv7
+          - soc: esp32c61
+            rust-target: riscv32imac-unknown-none-elf
+            runner: esp32c61-usb
+            host: aarch64
           - soc: esp32h2
             rust-target: riscv32imac-unknown-none-elf
             runner: esp32h2-usb
@@ -457,6 +469,10 @@ jobs:
             rust-target: riscv32imac-unknown-none-elf
             runner: esp32c6-usb
             host: armv7
+          - soc: esp32c61
+            rust-target: riscv32imac-unknown-none-elf
+            runner: esp32c61-usb
+            host: aarch64
           - soc: esp32h2
             rust-target: riscv32imac-unknown-none-elf
             runner: esp32h2-usb

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -195,6 +195,15 @@ esp32c6 = [
     "esp-metadata-generated/esp32c6",
     "esp-rtos?/esp32c6",
 ]
+esp32c61 = [
+    "esp-hal/esp32c61",
+    # "esp-alloc/esp32c61",
+    # "esp-radio?/esp32c61",
+    # "esp-storage?/esp32c61",
+    "esp-bootloader-esp-idf/esp32c61",
+    "esp-metadata-generated/esp32c61",
+    # "esp-rtos?/esp32c61",
+]
 esp32h2 = [
     "esp-hal/esp32h2",
     "esp-alloc/esp32h2",

--- a/hil-test/src/bin/misc_non_drivers.rs
+++ b/hil-test/src/bin/misc_non_drivers.rs
@@ -19,7 +19,7 @@
 //! The goal of this test suite is to collect smaller, simpler test cases, to keep the overall
 //! number of test suites low(er).
 
-//% CHIPS: esp32 esp32c2 esp32c3 esp32c5 esp32c6 esp32h2 esp32s2 esp32s3
+//% CHIPS: esp32 esp32c2 esp32c3 esp32c5 esp32c6 esp32c61 esp32h2 esp32s2 esp32s3
 //% FEATURES: unstable
 
 #![no_std]
@@ -28,10 +28,12 @@
 #[path = "misc_non_drivers/clock_monitor.rs"]
 mod clock_monitor;
 
+#[cfg(not(esp32c61))]
 #[path = "misc_non_drivers/critical_section.rs"]
 mod critical_section;
 
 #[path = "misc_non_drivers/delay_async.rs"]
+#[cfg(not(esp32c61))] // will be removed after the clocktree is finished for the C61
 #[cfg(timergroup_driver_supported)]
 mod delay_async;
 
@@ -43,9 +45,11 @@ mod dma_macros;
 #[cfg(all(dma_driver_supported, dma_supports_mem2mem))]
 mod dma_mem2mem;
 
+#[cfg(not(esp32c61))]
 #[path = "misc_non_drivers/init.rs"]
 mod init;
 
+#[cfg(not(esp32c61))]
 #[path = "misc_non_drivers/simple.rs"]
 mod simple;
 


### PR DESCRIPTION
We need to test if probe-rs is alive on the runner