### PR TITLE
Fix excessive write issue in SpiBus impl

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -115,6 +115,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve LP timer accuracy (#5105, #5115)
 - Increase the size of `irom_seg`/`drom_seg` from 4 MB to 32 MB for the ESP32-S3 (#5121)
 - UART and I2C inputs are now correctly defined when creating drivers (#5214)
+- The `SpiBus::transfer` (both from `embedded_hal` and `embedded_hal_async`) implementations of `esp_hal::spi::master::Spi` no longer write more data than they need to (#5245)
 
 ### Removed
 

--- a/esp-hal/src/spi/master.rs
+++ b/esp-hal/src/spi/master.rs
@@ -2908,10 +2908,8 @@ mod ehal1 {
             loop {
                 // How many bytes we write in this chunk
                 let write_inc = core::cmp::min(FIFO_SIZE, write.len() - write_from);
-                let write_to = write_from + write_inc;
                 // How many bytes we read in this chunk
                 let read_inc = core::cmp::min(FIFO_SIZE, read.len() - read_from);
-                let read_to = read_from + read_inc;
 
                 if (write_inc == 0) && (read_inc == 0) {
                     break;
@@ -2919,23 +2917,23 @@ mod ehal1 {
 
                 // No need to flush here, `SpiBus::write` will do it for us
 
-                if write_to < read_to {
+                if write_inc < read_inc {
                     // Read more than we write, must pad writing part with zeros
                     let mut empty = [EMPTY_WRITE_PAD; FIFO_SIZE];
-                    empty[0..write_inc].copy_from_slice(&write[write_from..write_to]);
-                    SpiBus::write(self, &empty)?;
+                    empty[0..write_inc].copy_from_slice(&write[write_from..][..write_inc]);
+                    SpiBus::write(self, &empty[..read_inc])?;
                 } else {
-                    SpiBus::write(self, &write[write_from..write_to])?;
+                    SpiBus::write(self, &write[write_from..][..write_inc])?;
                 }
 
                 if read_inc > 0 {
                     SpiBus::flush(self)?;
                     self.driver()
-                        .read_from_fifo(&mut read[read_from..read_to])?;
+                        .read_from_fifo(&mut read[read_from..][..read_inc])?;
                 }
 
-                write_from = write_to;
-                read_from = read_to;
+                write_from += write_inc;
+                read_from += read_inc;
             }
             Ok(())
         }
@@ -2980,10 +2978,8 @@ mod ehal1 {
             loop {
                 // How many bytes we write in this chunk
                 let write_inc = core::cmp::min(FIFO_SIZE, write.len() - write_from);
-                let write_to = write_from + write_inc;
                 // How many bytes we read in this chunk
                 let read_inc = core::cmp::min(FIFO_SIZE, read.len() - read_from);
-                let read_to = read_from + read_inc;
 
                 if (write_inc == 0) && (read_inc == 0) {
                     break;
@@ -2991,22 +2987,22 @@ mod ehal1 {
 
                 // No need to flush here, `SpiBusAsync::write` will do it for us
 
-                if write_to < read_to {
+                if write_inc < read_inc {
                     // Read more than we write, must pad writing part with zeros
                     let mut empty = [EMPTY_WRITE_PAD; FIFO_SIZE];
-                    empty[0..write_inc].copy_from_slice(&write[write_from..write_to]);
-                    SpiBusAsync::write(self, &empty).await?;
+                    empty[0..write_inc].copy_from_slice(&write[write_from..][..write_inc]);
+                    SpiBusAsync::write(self, &empty[..read_inc]).await?;
                 } else {
-                    SpiBusAsync::write(self, &write[write_from..write_to]).await?;
+                    SpiBusAsync::write(self, &write[write_from..][..write_inc]).await?;
                 }
 
                 if read_inc > 0 {
                     self.driver()
-                        .read_from_fifo(&mut read[read_from..read_to])?;
+                        .read_from_fifo(&mut read[read_from..][..read_inc])?;
                 }
 
-                write_from = write_to;
-                read_from = read_to;
+                write_from += write_inc;
+                read_from += read_inc;
             }
             Ok(())
         }

--- a/hil-test/src/bin/spi_full_duplex.rs
+++ b/hil-test/src/bin/spi_full_duplex.rs
@@ -46,16 +46,24 @@ cfg_if::cfg_if! {
 
 struct Context {
     spi: Spi<'static, Blocking>,
+
     #[cfg(all(spi_master_supports_dma, feature = "unstable"))]
     dma_channel: DmaChannel<'static>,
+
     // Reuse the really large buffer so we don't run out of DRAM with many tests
     rx_buffer: &'static mut [u8],
+
     #[cfg(all(spi_master_supports_dma, feature = "unstable"))]
     rx_descriptors: &'static mut [DmaDescriptor],
     tx_buffer: &'static mut [u8],
+
     #[cfg(all(spi_master_supports_dma, feature = "unstable"))]
     tx_descriptors: &'static mut [DmaDescriptor],
+
     miso_input: Input<'static>,
+    #[cfg(all(pcnt_driver_supported, feature = "unstable"))]
+    sclk_input: Input<'static>,
+
     #[cfg(all(pcnt_driver_supported, feature = "unstable"))]
     pcnt_unit: Unit<'static, 0>,
 }
@@ -71,13 +79,19 @@ mod tests {
         );
 
         let (_, miso) = hil_test::common_test_pins!(peripherals);
+        let sclk = hil_test::unconnected_pin!(peripherals);
 
         // A bit ugly but the peripheral interconnect APIs aren't yet stable.
         let mosi = unsafe { miso.clone_unchecked() };
         let miso_input = unsafe { miso.clone_unchecked() };
+        #[cfg(all(pcnt_driver_supported, feature = "unstable"))]
+        let sclk_input = unsafe { sclk.clone_unchecked() };
 
         // Will be used later to detect edges directly or through PCNT.
         let miso_input = Input::new(miso_input, Default::default());
+
+        #[cfg(all(pcnt_driver_supported, feature = "unstable"))]
+        let sclk_input = Input::new(sclk_input, Default::default());
 
         #[cfg(all(spi_master_supports_dma, feature = "unstable"))]
         cfg_if::cfg_if! {
@@ -107,7 +121,7 @@ mod tests {
             Config::default().with_frequency(Rate::from_mhz(10)),
         )
         .unwrap()
-        .with_sck(peripherals.GPIO0)
+        .with_sck(sclk)
         .with_miso(miso)
         .with_mosi(mosi);
 
@@ -121,6 +135,8 @@ mod tests {
                     rx_buffer,
                     tx_buffer,
                     miso_input,
+                    #[cfg(pcnt_driver_supported)]
+                    sclk_input,
                     #[cfg(spi_master_supports_dma)]
                     dma_channel,
                     #[cfg(spi_master_supports_dma)]
@@ -166,25 +182,103 @@ mod tests {
     #[test]
     fn test_asymmetric_transfer(mut ctx: Context) {
         let write = [0xde, 0xad, 0xbe, 0xef];
-        let mut read: [u8; 4] = [0x00; 4];
+        let mut read = [0x00; 2];
 
-        SpiBus::transfer(&mut ctx.spi, &mut read[0..2], &write[..])
-            .expect("Asymmetric transfer failed");
-        assert_eq!(write[0], read[0]);
-        assert_eq!(read[2], 0x00u8);
+        cfg_if::cfg_if! {
+            if #[cfg(all(pcnt_driver_supported, feature = "unstable"))] {
+                let unit = ctx.pcnt_unit;
+                unit.channel0
+                    .set_edge_signal(ctx.sclk_input.peripheral_input());
+                unit.channel0
+                    .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
+            }
+        }
+
+        SpiBus::transfer(&mut ctx.spi, &mut read, &write).expect("Asymmetric transfer failed");
+        assert_eq!(read[0], write[0]);
+        assert_eq!(read[1], write[1]);
+
+        #[cfg(all(pcnt_driver_supported, feature = "unstable"))]
+        assert_eq!(unit.value(), 4 * 8);
+    }
+
+    #[test]
+    fn test_asymmetric_transfer_read_more(mut ctx: Context) {
+        let write = [0xde, 0xad];
+        let mut read = [0x00; 4];
+
+        cfg_if::cfg_if! {
+            if #[cfg(all(pcnt_driver_supported, feature = "unstable"))] {
+                let unit = ctx.pcnt_unit;
+                unit.channel0
+                    .set_edge_signal(ctx.sclk_input.peripheral_input());
+                unit.channel0
+                    .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
+            }
+        }
+
+        SpiBus::transfer(&mut ctx.spi, &mut read, &write).expect("Asymmetric transfer failed");
+        assert_eq!(read[0], write[0]);
+        assert_eq!(read[1], write[1]);
+        assert_eq!(read[2], 0x00);
+        assert_eq!(read[3], 0x00);
+
+        #[cfg(all(pcnt_driver_supported, feature = "unstable"))]
+        assert_eq!(unit.value(), 4 * 8);
     }
 
     #[test]
     async fn test_async_asymmetric_transfer(ctx: Context) {
         let write = [0xde, 0xad, 0xbe, 0xef];
-        let mut read: [u8; 4] = [0x00; 4];
+        let mut read = [0x00; 2];
+
+        cfg_if::cfg_if! {
+            if #[cfg(all(pcnt_driver_supported, feature = "unstable"))] {
+                let unit = ctx.pcnt_unit;
+                unit.channel0
+                    .set_edge_signal(ctx.sclk_input.peripheral_input());
+                unit.channel0
+                    .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
+            }
+        }
 
         let mut spi = ctx.spi.into_async();
-        SpiBusAsync::transfer(&mut spi, &mut read[0..2], &write[..])
+        SpiBusAsync::transfer(&mut spi, &mut read, &write)
             .await
             .expect("Asymmetric transfer failed");
-        assert_eq!(write[0], read[0]);
-        assert_eq!(read[2], 0x00u8);
+        assert_eq!(read[0], write[0]);
+        assert_eq!(read[1], write[1]);
+
+        #[cfg(all(pcnt_driver_supported, feature = "unstable"))]
+        assert_eq!(unit.value(), 4 * 8);
+    }
+
+    #[test]
+    async fn test_async_asymmetric_transfer_read_more(ctx: Context) {
+        let write = [0xde, 0xad];
+        let mut read = [0x00; 4];
+
+        cfg_if::cfg_if! {
+            if #[cfg(all(pcnt_driver_supported, feature = "unstable"))] {
+                let unit = ctx.pcnt_unit;
+                unit.channel0
+                    .set_edge_signal(ctx.sclk_input.peripheral_input());
+                unit.channel0
+                    .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
+            }
+        }
+
+        let mut spi = ctx.spi.into_async();
+        SpiBusAsync::transfer(&mut spi, &mut read, &write)
+            .await
+            .expect("Asymmetric transfer failed");
+        assert_eq!(read[0], write[0]);
+        assert_eq!(read[1], write[1]);
+        assert_eq!(read[2], 0x00);
+        assert_eq!(read[3], 0x00);
+
+        #[cfg(all(pcnt_driver_supported, feature = "unstable"))]
+        assert_eq!(unit.value(), 4 * 8);
     }
 
     #[test]


### PR DESCRIPTION
Previously, if `transfer` needed to read more than it had data to write, the function output an entire FIFO's worth of zeroes.