### PR TITLE
ci(semver): Check semver per package

### DIFF
--- a/.github/workflows/api-baseline-check.yml
+++ b/.github/workflows/api-baseline-check.yml
@@ -23,8 +23,7 @@ jobs:
   baseline-check:
     needs: get-labels
     if: |
-      !contains(needs.get-labels.outputs.labels, 'skip-ci-non-code-change') &&
-      !contains(needs.get-labels.outputs.labels, 'breaking-change-esp-hal')
+      !contains(needs.get-labels.outputs.labels, 'skip-ci-non-code-change')
     runs-on: ubuntu-latest
     env:
       CARGO_TARGET_DIR: ${{ github.workspace }}/target
@@ -45,15 +44,11 @@ jobs:
           components: rust-src
 
       - name: Semver-Check
-        shell: bash
         run: |
           cargo xcheck semver-check download-baselines
-          cargo xcheck semver-check --chips esp32 check
-          cargo xcheck semver-check --chips esp32s2 check
-          cargo xcheck semver-check --chips esp32s3 check
-          cargo xcheck semver-check --chips esp32c2 check
-          cargo xcheck semver-check --chips esp32c3 check
-          # cargo xcheck semver-check --chips esp32c5 check # TODO: enable
-          # cargo xcheck semver-check --chips esp32c61 check # TODO: enable
-          cargo xcheck semver-check --chips esp32c6 check
-          cargo xcheck semver-check --chips esp32h2 check
+          PACKAGES="${{ needs.get-labels.outputs.packages }}"
+          if [ -n "$PACKAGES" ]; then
+            cargo xcheck semver-check --exclude-packages "$PACKAGES" check
+          else
+            cargo xcheck semver-check check
+          fi

--- a/xtask/src/commands/release/semver_check.rs
+++ b/xtask/src/commands/release/semver_check.rs
@@ -25,6 +25,10 @@ pub struct SemverCheckArgs {
     #[arg(long, value_enum, value_delimiter = ',', default_values_t = vec![Package::EspHal, Package::EspRomSys])]
     pub packages: Vec<Package>,
 
+    /// Default packages that are not supposed to run, used in CI.
+    #[arg(long, value_enum, value_delimiter = ' ')]
+    pub exclude_packages: Vec<Package>,
+
     /// Chip(s) to target.
     #[arg(long, value_enum, value_delimiter = ',', default_values_t = Chip::iter())]
     pub chips: Vec<Chip>,
@@ -47,9 +51,12 @@ pub fn semver_checks(workspace: &Path, args: SemverCheckArgs) -> anyhow::Result<
         SemverCheckCmd::GenerateBaseline => {
             checker::generate_baseline(&workspace, args.packages, args.chips)
         }
-        SemverCheckCmd::Check => {
-            checker::check_for_breaking_changes(&workspace, args.packages, args.chips)
-        }
+        SemverCheckCmd::Check => checker::check_for_breaking_changes(
+            &workspace,
+            args.packages,
+            args.exclude_packages,
+            args.chips,
+        ),
         SemverCheckCmd::DownloadBaselines => checker::download_baselines(&workspace, args.packages),
     }
 }
@@ -162,8 +169,19 @@ pub mod checker {
     pub fn check_for_breaking_changes(
         workspace: &Path,
         packages: Vec<Package>,
+        exclude_packages: Vec<Package>,
         chips: Vec<Chip>,
     ) -> anyhow::Result<()> {
+        let mut packages = packages;
+        packages.retain(|pkg| !exclude_packages.contains(pkg));
+
+        if packages.is_empty() {
+            log::info!(
+                "No packages for semver check.\nHint: Double-check the `--exclude-packages` flag"
+            );
+            return anyhow::Ok(());
+        }
+
         let mut semver_incompatible_packages = Vec::new();
 
         for package in packages {


### PR DESCRIPTION
I added `breaking-change-esp-rom-sys` label. ~~This PR now does `semver` checks _per_ package instead.~~

This PR introduced `--exclude-packages` flag for `xcheck semver` command that is used in Check semver CI. The idea is to get rid of `!contains(needs.get-labels.outputs.labels, 'breaking-change-esp-hal')` (which will be annoying when enabling new packages for semver checks) and would require us to type it on multiple places multiple times. 

The idea of this PR is:
If we have, for example a `breaking-change-esp-hal` label we could reuse the `get-label`'s output and pass it as `--exclude-packages` like:
(`get-label`s output would be `esp-hal` here)
`cargo xcheck semver-check check --exclude-packages esp-hal` -> and this will only run for `esp-rom-sys`. 

So when we need to enable another package for semver, we have to (A)create a GH label and (B) add it as a default package to the xtask and that should be it. 🤔 So we don't have to juggle with `!contains(needs.get-labels.outputs.labels, 'breaking-change-{package_name}` in the workflow.

closes https://github.com/esp-rs/esp-hal/issues/5228