### PR TITLE
Add rand_core 0.10.0

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - C61: Add GPIO support (#5248)
 - C61: Add UART support (#5251)
 - C61: Add I2C support (#5258)
+- Added support for `rand_core 0.10.0` (#5280)
 
 ### Changed
 

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -99,6 +99,7 @@ embedded-io-07           = { package = "embedded-io", version = "0.7", optional 
 embedded-io-async-07     = { package = "embedded-io-async", version = "0.7", optional = true }
 rand_core-06             = { package = "rand_core", version = "0.6", optional = true }
 rand_core-09             = { package = "rand_core", version = "0.9", optional = true }
+rand_core-010            = { package = "rand_core", version = "0.10", optional = true }
 ufmt-write               = { version = "0.1", optional = true }
 
 # IMPORTANT:
@@ -322,6 +323,7 @@ unstable = [
     "dep:embedded-io-async-07",
     "dep:rand_core-06",
     "dep:rand_core-09",
+    "dep:rand_core-010",
     "dep:nb",
     "dep:ufmt-write",
 ]

--- a/esp-hal/src/rng/mod.rs
+++ b/esp-hal/src/rng/mod.rs
@@ -155,6 +155,8 @@ impl Rng {
 
 // Implement RngCore traits
 
+/// Compatibility with `rand_core 0.6`. Documentation can be found at
+/// <https://docs.rs/rand_core/0.6.4/rand_core/trait.RngCore.html>.
 #[instability::unstable]
 impl rand_core_06::RngCore for Rng {
     fn next_u32(&mut self) -> u32 {
@@ -163,7 +165,7 @@ impl rand_core_06::RngCore for Rng {
 
     fn next_u64(&mut self) -> u64 {
         let mut bytes = [0; 8];
-        self.fill_bytes(&mut bytes);
+        self.read(&mut bytes);
         u64::from_le_bytes(bytes)
     }
 
@@ -177,6 +179,8 @@ impl rand_core_06::RngCore for Rng {
     }
 }
 
+/// Compatibility with `rand_core 0.9`. Documentation can be found at
+/// <https://docs.rs/rand_core/0.9.5/rand_core/trait.RngCore.html>.
 #[instability::unstable]
 impl rand_core_09::RngCore for Rng {
     fn next_u32(&mut self) -> u32 {
@@ -184,10 +188,28 @@ impl rand_core_09::RngCore for Rng {
     }
     fn next_u64(&mut self) -> u64 {
         let mut bytes = [0; 8];
-        self.fill_bytes(&mut bytes);
+        self.read(&mut bytes);
         u64::from_le_bytes(bytes)
     }
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         self.read(dest);
+    }
+}
+
+/// Compatibility with `rand_core 0.10`
+#[instability::unstable]
+impl rand_core_010::TryRng for Rng {
+    type Error = core::convert::Infallible;
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        Ok(self.random())
+    }
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        let mut bytes = [0; 8];
+        self.read(&mut bytes);
+        Ok(u64::from_le_bytes(bytes))
+    }
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
+        self.read(dest);
+        Ok(())
     }
 }

--- a/esp-hal/src/rng/trng.rs
+++ b/esp-hal/src/rng/trng.rs
@@ -243,39 +243,68 @@ impl Drop for Trng {
     }
 }
 
+/// Compatibility with `rand_core 0.6`. Documentation can be found at
+/// <https://docs.rs/rand_core/0.6.4/rand_core/trait.RngCore.html>.
 #[instability::unstable]
 impl rand_core_06::RngCore for Trng {
     fn next_u32(&mut self) -> u32 {
-        self.rng.next_u32()
+        <Rng as rand_core_06::RngCore>::next_u32(&mut self.rng)
     }
 
     fn next_u64(&mut self) -> u64 {
-        self.rng.next_u64()
+        <Rng as rand_core_06::RngCore>::next_u64(&mut self.rng)
     }
 
     fn fill_bytes(&mut self, dest: &mut [u8]) {
-        self.rng.fill_bytes(dest)
+        <Rng as rand_core_06::RngCore>::fill_bytes(&mut self.rng, dest)
     }
 
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core_06::Error> {
-        self.rng.try_fill_bytes(dest)
+        <Rng as rand_core_06::RngCore>::try_fill_bytes(&mut self.rng, dest)
     }
 }
 
+/// Compatibility with `rand_core 0.9`. Documentation can be found at
+/// <https://docs.rs/rand_core/0.9.5/rand_core/trait.RngCore.html>.
 #[instability::unstable]
 impl rand_core_09::RngCore for Trng {
     fn next_u32(&mut self) -> u32 {
-        self.rng.next_u32()
+        <Rng as rand_core_09::RngCore>::next_u32(&mut self.rng)
     }
     fn next_u64(&mut self) -> u64 {
-        self.rng.next_u64()
+        <Rng as rand_core_09::RngCore>::next_u64(&mut self.rng)
     }
     fn fill_bytes(&mut self, dest: &mut [u8]) {
-        self.rng.fill_bytes(dest)
+        <Rng as rand_core_09::RngCore>::fill_bytes(&mut self.rng, dest)
     }
 }
 
+/// Compatibility with `rand_core 0.6`. Documentation can be found at
+/// <https://docs.rs/rand_core/0.6.4/rand_core/trait.CryptoRng.html>.
 #[instability::unstable]
 impl rand_core_06::CryptoRng for Trng {}
+/// Compatibility with `rand_core 0.9`. Documentation can be found at
+/// <https://docs.rs/rand_core/0.9.5/rand_core/trait.CryptoRng.html>.
 #[instability::unstable]
 impl rand_core_09::CryptoRng for Trng {}
+
+// Non-try variants are blanket-implemented when `Error = Infallible`.
+
+/// Compatibility with `rand_core 0.10`
+#[instability::unstable]
+impl rand_core_010::TryRng for Trng {
+    type Error = core::convert::Infallible;
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        <Rng as rand_core_010::TryRng>::try_next_u32(&mut self.rng)
+    }
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        <Rng as rand_core_010::TryRng>::try_next_u64(&mut self.rng)
+    }
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
+        <Rng as rand_core_010::TryRng>::try_fill_bytes(&mut self.rng, dest)
+    }
+}
+
+/// Compatibility with `rand_core 0.10`
+#[instability::unstable]
+impl rand_core_010::TryCryptoRng for Trng {}

--- a/xtask/src/documentation.rs
+++ b/xtask/src/documentation.rs
@@ -260,13 +260,25 @@ fn cargo_doc_without_pre_processing(
     // Special case: `esp-metadata` requires `std`, and we get some really confusing
     // errors if we try to pass `-Zbuild-std=core`:
     if package.needs_build_std() {
-        builder = builder.arg("-Zbuild-std=alloc,core");
+        builder.add_arg("-Zbuild-std=alloc,core");
     }
 
     let args = builder.build();
     log::debug!("{args:#?}");
 
-    let mut envs = vec![("RUSTDOCFLAGS", "--cfg docsrs --cfg not_really_docsrs")];
+    let rustdocflags = vec![
+        "--cfg docsrs",
+        "--cfg not_really_docsrs",
+        // Activating this would redirect *all* rand_core version to 0.10.0, which is wrong.
+        // "--extern-html-root-takes-precedence",
+        // While we could use --extern-html-root-url to remap rand_core links, it doesn't seem to
+        // support multiple versions of the same crate. We could redirect everything to 0.10.0,
+        // which isn't ideal.
+        // "--extern-html-root-url rand_core-09=https://docs.rs/rand_core/0.9.5/",
+    ];
+
+    let rustdocflags = rustdocflags.join(" ");
+    let mut envs = vec![("RUSTDOCFLAGS", rustdocflags.as_str())];
     // Special case: `esp-storage` requires the optimization level to be 2 or 3:
     if package == Package::EspStorage {
         envs.push(("CARGO_PROFILE_DEBUG_OPT_LEVEL", "3"));


### PR DESCRIPTION
Closes #5276 - we now provide an implementation for rand_core 0.10.0 traits, and their documentation points at the right place. We don't have a way to fix the old traits - `--extern-html-root-url` does not know about crate versions, and we can't use search-and-replace either without logic to infer which trait version we're looking at. The best I could do is to add the links by hand, which unfortunately doesn't apply to the blanket implementations...