### PR TITLE
Add ChipRevision, stabilise chip_revision

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - C61: Add I2C support (#5258)
 - C61: Add SPI support (#5261)
 - Added support for `rand_core 0.10.0` (#5280)
+- `esp_hal::efuse::ChipRevision` (#5287)
 
 ### Changed
 
@@ -93,6 +94,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Rng`, `Rng::{random, read}` have been marked stable (#5098)
 - `esp_hal::init` now verifies that the initial stack pointer is in range (#5227)
 - Updated embassy dependencies: embassy-sync to 0.8, embassy-embedded-hal to 0.6 (#5249)
+- `esp_hal::efuse::chip_revision` has been marked stable (#5287)
+- `esp_hal::efuse::chip_revision` now returns `ChipRevision` (#5287)
 
 ### Fixed
 

--- a/esp-hal/MIGRATING-1.0.0.md
+++ b/esp-hal/MIGRATING-1.0.0.md
@@ -150,6 +150,8 @@ can be read using the `success` method.
 
 ## eFuse Changes
 
+### Module structure change
+
 The `Efuse` struct has been removed. All methods are now free-standing functions
 in the `efuse` module. Some functions have been renamed:
 
@@ -162,3 +164,18 @@ in the `efuse` module. Some functions have been renamed:
 
 `Efuse::read_base_mac_address()` has been removed; use `efuse::base_mac_address()` instead.
 `MacAddress::as_bytes_mut()` has been removed; use `MacAddress::as_bytes()` for read access.
+
+### Chip revision change
+
+`chip_revision` now returns a `ChipRevision` structure. This structure allows more efficient
+operations compared to the old combined u16 - it does not require integer multiplication/division.
+
+The old `u16` revision number is equivalent to `ChipRevision`'s `combined` representation. You
+can use the `from_combined` and `combined` functions to keep working with this representation. A
+new, `packed` representation (also encoded as `u16`) is now available which is less computationally
+expensive.
+
+```diff
+-let revision = chip_revision();
++let revision = chip_revision().combined();
+```

--- a/esp-hal/src/clock/mod.rs
+++ b/esp-hal/src/clock/mod.rs
@@ -66,6 +66,8 @@ pub mod ll {
     pub use crate::soc::clocks::*;
 }
 
+#[cfg(timergroup_rc_fast_calibration_divider)]
+use crate::efuse::ChipRevision;
 #[cfg(feature = "unstable")]
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 pub use crate::soc::clocks::ClockConfig;
@@ -281,9 +283,9 @@ impl Clocks {
 
         #[cfg(timergroup_rc_fast_calibration_divider)]
         let calibration_divider = if rtc_clock == TimgCalibrationClockConfig::RcFastDivClk
-            && crate::soc::chip_revision_above(property!(
+            && crate::soc::chip_revision_above(ChipRevision::from_combined(property!(
                 "timergroup.rc_fast_calibration_divider_min_rev"
-            )) {
+            ))) {
             property!("timergroup.rc_fast_calibration_divider")
         } else {
             1

--- a/esp-hal/src/ecc.rs
+++ b/esp-hal/src/ecc.rs
@@ -14,6 +14,8 @@ use core::{marker::PhantomData, ptr::NonNull};
 
 use procmacros::BuilderLite;
 
+#[cfg(ecc_supports_enhanced_security)]
+use crate::efuse::ChipRevision;
 use crate::{
     Blocking,
     DriverMode,
@@ -547,7 +549,7 @@ impl Info {
                 .bit(config.force_enable_mem_clock);
 
             #[cfg(ecc_supports_enhanced_security)]
-            if !cfg!(esp32h2) || crate::soc::chip_revision_above(102) {
+            if !cfg!(esp32h2) || crate::soc::chip_revision_above(ChipRevision::from_combined(102)) {
                 w.security_mode().bit(config.enhanced_security);
             }
 

--- a/esp-hal/src/efuse/mod.rs
+++ b/esp-hal/src/efuse/mod.rs
@@ -50,6 +50,7 @@ pub(crate) mod implem;
 
 #[instability::unstable]
 pub use implem::*;
+use procmacros::doc_replace;
 
 /// The bit field for get access to efuse data
 #[derive(Debug, Clone, Copy)]
@@ -275,13 +276,134 @@ pub fn interface_mac_address(kind: InterfaceMacAddress) -> MacAddress {
     mac
 }
 
-/// Returns the hardware revision
+#[doc_replace]
+/// Returns the hardware revision.
 ///
-/// The chip version is calculated using the following
-/// formula: MAJOR * 100 + MINOR. (if the result is 1, then version is v0.1)
-#[instability::unstable]
-pub fn chip_revision() -> u16 {
-    major_chip_version() as u16 * 100 + minor_chip_version() as u16
+/// ## Examples
+///
+/// ```rust,no_run
+/// # {before_snippet}
+/// let rev = esp_hal::efuse::chip_revision();
+/// println!("Chip revision: {}.{}", rev.major, rev.minor);
+/// # {after_snippet}
+/// ```
+#[inline]
+pub fn chip_revision() -> ChipRevision {
+    ChipRevision {
+        major: major_chip_version(),
+        minor: minor_chip_version(),
+    }
+}
+
+#[doc_replace]
+/// Represents the hardware revision.
+///
+/// The type supports converting between two separate u16-based representations:
+///
+/// - Combined: a `u16` calculated as `major * 100 + minor`. The combined representation is more
+///   often used by ESP-IDF, and working with it involves integer division. Note that the combined
+///   representation assumes minor is less than 100.
+/// - Packed: a `u16` with the major revision in the high byte and the minor revision in the low
+///   byte.
+///
+/// ## Examples
+///
+/// ```rust,no_run
+/// # {before_snippet}
+/// use esp_hal::efuse::ChipRevision;
+///
+/// let rev = esp_hal::efuse::chip_revision();
+/// println!("Chip revision: {}.{}", rev.major, rev.minor);
+///
+/// // You can compare against other ChipRevision objects
+/// if rev < ChipRevision::from_combined(300) {
+///     // You can print a debug representation
+///     println!("Chip revision is too old: {:?}", rev);
+/// }
+/// if rev >= ChipRevision::from_packed(0x400) {
+///     println!("Chip revision is too new: {:?}", rev);
+/// }
+///
+/// // You can convert into two different numeric representations.
+/// assert!(rev.packed() >= 0x300);
+/// assert!(rev.combined() >= 300);
+/// # {after_snippet}
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct ChipRevision {
+    /// The major revision number.
+    pub major: u8,
+
+    /// The minor revision number.
+    pub minor: u8,
+}
+
+impl PartialOrd for ChipRevision {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for ChipRevision {
+    #[inline]
+    fn cmp(&self, other: &Self) -> cmp::Ordering {
+        match self.major.cmp(&other.major) {
+            cmp::Ordering::Equal => self.minor.cmp(&other.minor),
+            ord => ord,
+        }
+    }
+}
+
+impl ChipRevision {
+    /// Creates a new [`ChipRevision`] from a combined revision value.
+    #[inline]
+    pub const fn from_combined(revision: u16) -> Self {
+        let major = revision / 100;
+        let minor = revision % 100;
+        ::core::assert!(
+            major <= u8::MAX as u16 && minor <= u8::MAX as u16,
+            "`ChipRevision` cannot represent revision",
+        );
+        Self {
+            major: major as u8,
+            minor: minor as u8,
+        }
+    }
+
+    /// Returns the combined revision value as a `u16`.
+    ///
+    /// The combined revision value is a `u16` calculated as `major * 100 + minor`.
+    #[inline]
+    pub const fn combined(self) -> u16 {
+        ::core::assert!(
+            self.minor < 100,
+            "`ChipRevision` cannot be represented using the combined representation",
+        );
+        (self.major as u16) * 100 + (self.minor as u16)
+    }
+
+    /// Creates a new [`ChipRevision`] from a packed revision value.
+    ///
+    /// The packed revision value is a `u16` with the major revision in the high byte and the minor
+    /// revision in the low byte.
+    #[inline]
+    pub const fn from_packed(packed: u16) -> Self {
+        Self {
+            major: ((packed >> 8) & 0xFF) as u8,
+            minor: (packed & 0xFF) as u8,
+        }
+    }
+
+    /// Returns the packed revision value as a `u16`.
+    ///
+    /// The packed revision value is a `u16` with the major revision in the high byte and the minor
+    /// revision in the low byte.
+    #[inline]
+    pub const fn packed(self) -> u16 {
+        (self.major as u16) << 8 | (self.minor as u16)
+    }
 }
 
 // Indicates the state of setting the mac address

--- a/esp-hal/src/peripherals/overlay_h2.rs
+++ b/esp-hal/src/peripherals/overlay_h2.rs
@@ -1,6 +1,7 @@
 use core::ops::Deref;
 
 use super::*;
+use crate::efuse::ChipRevision;
 
 // RNG must be marked `virtual` for this to work.
 impl RNG<'_> {
@@ -37,7 +38,7 @@ impl RngRegisterBlock {
     #[instability::unstable]
     pub fn data(&self) -> &pac::rng::DATA {
         let ptr = unsafe { pac::RNG::steal().data() as *const pac::rng::DATA };
-        if crate::soc::chip_revision_above(102) {
+        if crate::soc::chip_revision_above(ChipRevision::from_combined(102)) {
             // On H2-ECO5+ the LPPERI peripherals contains an additional register inserted before
             // the `rng_data` register.
             // https://github.com/espressif/esp-idf/commit/4c5e1a03414a6d55be4b42ba071b30ad228414f6#diff-bc8f2eca37e32ee4ba21ac812e4934998e764132a400479c4d091eb6f7e2e444

--- a/esp-hal/src/soc/mod.rs
+++ b/esp-hal/src/soc/mod.rs
@@ -6,6 +6,7 @@ use portable_atomic::AtomicU32;
 use procmacros::ram;
 
 pub use self::implementation::*;
+use crate::efuse::ChipRevision;
 
 #[cfg_attr(esp32, path = "esp32/mod.rs")]
 #[cfg_attr(esp32c2, path = "esp32c2/mod.rs")]
@@ -332,26 +333,29 @@ pub(crate) fn setup_trap_section_protection() {
 
 static CHIP_REVISION: AtomicU32 = AtomicU32::new(0);
 const LOADED: u32 = 1 << 31;
+const MAX_REVISION: ChipRevision = ChipRevision::from_packed(0xFFFF);
 
 #[cold]
 fn load_chip_revision_from_efuse() -> u16 {
     let chip_revision = crate::efuse::chip_revision();
+    let chip_revision = chip_revision.packed();
     CHIP_REVISION.store(chip_revision as u32 | LOADED, Ordering::Release);
     chip_revision
 }
 
 #[ram]
-fn load_chip_revision() -> u16 {
+fn load_chip_revision() -> ChipRevision {
     let stored = CHIP_REVISION.load(Ordering::Acquire);
     if stored & LOADED == 0 {
-        return load_chip_revision_from_efuse();
+        return ChipRevision::from_packed(load_chip_revision_from_efuse());
     }
-    (stored & u16::MAX as u32) as u16
+    ChipRevision::from_packed((stored & u16::MAX as u32) as u16)
 }
 
-fn chip_revision_in_range(range: Range<u16>) -> bool {
-    const BUILD_TIME_MIN_REV: u16 =
-        esp_config::esp_config_int!(u16, "ESP_HAL_CONFIG_MIN_CHIP_REVISION");
+fn chip_revision_in_range(range: Range<ChipRevision>) -> bool {
+    const BUILD_TIME_MIN_REV: ChipRevision = ChipRevision::from_combined(
+        esp_config::esp_config_int!(u16, "ESP_HAL_CONFIG_MIN_CHIP_REVISION"),
+    );
 
     // Check to determine chip is obviously in or out of range, without reading efuse
     #[allow(
@@ -367,24 +371,27 @@ fn chip_revision_in_range(range: Range<u16>) -> bool {
         clippy::absurd_extreme_comparisons,
         reason = "Not absurd depending on configuration"
     )]
-    if range.start <= BUILD_TIME_MIN_REV && range.end == u16::MAX {
+    if range.start <= BUILD_TIME_MIN_REV && range.end == MAX_REVISION {
         return true;
     }
 
     let chip_revision = load_chip_revision();
 
-    range.contains(&chip_revision)
+    range.start <= chip_revision && chip_revision < range.end
 }
 
 /// Returns true if the chip revision is at least the given revision.
 #[allow(dead_code)]
-pub(crate) fn chip_revision_above(min: u16) -> bool {
-    chip_revision_in_range(min..u16::MAX)
+pub(crate) fn chip_revision_above(revision: ChipRevision) -> bool {
+    chip_revision_in_range(revision..MAX_REVISION)
 }
 
 /// Returns true if the chip is at least the given revision, in the same major version.
 #[allow(dead_code)]
-pub(crate) fn chip_minor_revision_above(rev: u16) -> bool {
-    let max = (rev + 1).next_multiple_of(100);
-    chip_revision_in_range(rev..max)
+pub(crate) fn chip_minor_revision_above(revision: ChipRevision) -> bool {
+    let next_major = ChipRevision {
+        major: revision.major + 1,
+        minor: 0,
+    };
+    chip_revision_in_range(revision..next_major)
 }


### PR DESCRIPTION
Closes #5271

One concern I have is that we may want to use the same type for the efuse block version, too, so the naming might be too specific. On the other hand, maybe we just want the same functionality in a different type there (as it makes not a lot of sense to compare chip revision to efuse block version) so it might be okay.

I've immediately marked the two u16 representations as stable, I don't see much that can go wrong with them.