### PR TITLE
esp-wifi: Chore, pub api revisit

### DIFF
--- a/esp-radio/src/esp_now/mod.rs
+++ b/esp-radio/src/esp_now/mod.rs
@@ -349,6 +349,8 @@ impl EspNowWifiInterface {
 }
 
 /// Manages the `EspNow` instance lifecycle while ensuring it remains active.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[instability::unstable]
 pub struct EspNowManager<'d> {
     _rc: EspNowRc<'d>,
@@ -538,6 +540,8 @@ impl EspNowManager<'_> {
 /// **DO NOT USE** a lock implementation that disables interrupts since the
 /// completion of a sending requires waiting for a callback invoked in an
 /// interrupt.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[instability::unstable]
 pub struct EspNowSender<'d> {
     _rc: EspNowRc<'d>,
@@ -603,6 +607,8 @@ impl Drop for SendWaiter<'_> {
 
 /// This is the receiver part of ESP-NOW. You can get this receiver by splitting
 /// an `EspNow` instance.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[instability::unstable]
 pub struct EspNowReceiver<'d> {
     _rc: EspNowRc<'d>,
@@ -618,9 +624,21 @@ impl EspNowReceiver<'_> {
 
 /// The reference counter for properly deinit espnow after all parts are
 /// dropped.
+#[derive(Debug)]
 struct EspNowRc<'d> {
     rc: &'static AtomicU8,
     inner: PhantomData<EspNow<'d>>,
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for EspNowRc<'_> {
+    fn format(&self, f: defmt::Formatter<'_>) {
+        defmt::write!(
+            f,
+            "EspNowRc {{ rc: {}, inner: ... }}",
+            self.rc.load(Ordering::Relaxed)
+        );
+    }
 }
 
 impl EspNowRc<'_> {
@@ -667,6 +685,8 @@ impl Drop for EspNowRc<'_> {
 ///
 /// For convenience, by default there will be a broadcast peer added on the station
 /// interface.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[instability::unstable]
 pub struct EspNow<'d> {
     manager: EspNowManager<'d>,

--- a/esp-radio/src/ieee802154/frame.rs
+++ b/esp-radio/src/ieee802154/frame.rs
@@ -13,6 +13,7 @@ const FRAME_VERSION_MASK: u8 = 0x30;
 
 /// IEEE 802.15.4 MAC frame
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[instability::unstable]
 pub struct Frame {
     /// Header
     pub header: Header,
@@ -42,6 +43,7 @@ impl defmt::Format for Frame {
 /// IEEE 802.15.4 MAC frame which has been received
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[instability::unstable]
 pub struct ReceivedFrame {
     /// Frame
     pub frame: Frame,

--- a/esp-radio/src/ieee802154/mod.rs
+++ b/esp-radio/src/ieee802154/mod.rs
@@ -42,6 +42,7 @@ mod raw;
 /// IEEE 802.15.4 errors
 #[derive(Display, Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[instability::unstable]
 pub enum Error {
     /// The requested data is bigger than available range, and/or the offset is
     /// invalid.
@@ -65,6 +66,7 @@ impl From<byte::Error> for Error {
 /// IEEE 802.15.4 driver configuration
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[instability::unstable]
 pub struct Config {
     pub auto_ack_tx: bool,
     pub auto_ack_rx: bool,
@@ -106,6 +108,7 @@ impl Default for Config {
 /// IEEE 802.15.4 driver
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[instability::unstable]
 pub struct Ieee802154<'a> {
     _align: u32,
     transmit_buffer: [u8; FRAME_SIZE],
@@ -118,6 +121,7 @@ impl<'a> Ieee802154<'a> {
     ///
     /// NOTE: Coexistence with Wi-Fi or Bluetooth is currently not possible. If you do it anyway,
     /// things will break.
+    #[instability::unstable]
     pub fn new(radio: IEEE802154<'a>) -> Self {
         let (_phy_clock_guard, _phy_init_guard) = esp_ieee802154_enable(radio);
         Self {
@@ -129,6 +133,7 @@ impl<'a> Ieee802154<'a> {
     }
 
     /// Set the configuration for the driver
+    #[instability::unstable]
     pub fn set_config(&mut self, cfg: Config) {
         set_auto_ack_tx(cfg.auto_ack_tx);
         set_auto_ack_rx(cfg.auto_ack_rx);
@@ -160,11 +165,13 @@ impl<'a> Ieee802154<'a> {
     }
 
     /// Start receiving frames
+    #[instability::unstable]
     pub fn start_receive(&mut self) {
         ieee802154_receive();
     }
 
     /// Return the raw data of a received frame
+    #[instability::unstable]
     pub fn raw_received(&mut self) -> Option<RawReceived> {
         raw::ensure_receive_enabled();
         ieee802154_poll()
@@ -181,11 +188,13 @@ impl<'a> Ieee802154<'a> {
     /// ACK timed out, or no transmission has occurred).
     ///
     /// The ACK frame is cleared at the start of each new transmission.
+    #[instability::unstable]
     pub fn get_ack_frame(&self) -> Option<RawReceived> {
         raw::get_ack_frame()
     }
 
     /// Get a received frame, if available
+    #[instability::unstable]
     pub fn received(&mut self) -> Option<Result<ReceivedFrame, Error>> {
         raw::ensure_receive_enabled();
         if let Some(raw) = ieee802154_poll() {
@@ -230,6 +239,7 @@ impl<'a> Ieee802154<'a> {
     ///
     /// If `cca` is true, a Clear Channel Assessment is performed before
     /// transmitting. The transmission is aborted if the channel is busy.
+    #[instability::unstable]
     pub fn transmit(&mut self, frame: &Frame, cca: bool) -> Result<(), Error> {
         let frm = mac::Frame {
             header: frame.header,
@@ -257,6 +267,7 @@ impl<'a> Ieee802154<'a> {
     ///
     /// If `cca` is true, a Clear Channel Assessment is performed before
     /// transmitting. The transmission is aborted if the channel is busy.
+    #[instability::unstable]
     pub fn transmit_raw(&mut self, frame: &[u8], cca: bool) -> Result<(), Error> {
         self.transmit_buffer[1..][..frame.len()].copy_from_slice(frame);
         self.transmit_buffer[0] = frame.len() as u8;
@@ -267,6 +278,7 @@ impl<'a> Ieee802154<'a> {
     }
 
     /// Set the transmit done callback function.
+    #[instability::unstable]
     pub fn set_tx_done_callback(&mut self, callback: &'a mut (dyn FnMut() + Send)) {
         CALLBACKS.with(|cbs| {
             let cb: &'static mut (dyn FnMut() + Send) = unsafe { core::mem::transmute(callback) };
@@ -275,11 +287,13 @@ impl<'a> Ieee802154<'a> {
     }
 
     /// Clear the transmit done callback function.
+    #[instability::unstable]
     pub fn clear_tx_done_callback(&mut self) {
         CALLBACKS.with(|cbs| cbs.tx_done = None);
     }
 
     /// Set the receive available callback function.
+    #[instability::unstable]
     pub fn set_rx_available_callback(&mut self, callback: &'a mut (dyn FnMut() + Send)) {
         CALLBACKS.with(|cbs| {
             let cb: &'static mut (dyn FnMut() + Send) = unsafe { core::mem::transmute(callback) };
@@ -288,31 +302,37 @@ impl<'a> Ieee802154<'a> {
     }
 
     /// Clear the receive available callback function.
+    #[instability::unstable]
     pub fn clear_rx_available_callback(&mut self) {
         CALLBACKS.with(|cbs| cbs.rx_available = None);
     }
 
     /// Set the transmit done callback function.
+    #[instability::unstable]
     pub fn set_tx_done_callback_fn(&mut self, callback: fn()) {
         CALLBACKS.with(|cbs| cbs.tx_done_fn = Some(callback));
     }
 
     /// Clear the transmit done callback function.
+    #[instability::unstable]
     pub fn clear_tx_done_callback_fn(&mut self) {
         CALLBACKS.with(|cbs| cbs.tx_done_fn = None);
     }
 
     /// Set the receive available callback function.
+    #[instability::unstable]
     pub fn set_rx_available_callback_fn(&mut self, callback: fn()) {
         CALLBACKS.with(|cbs| cbs.rx_available_fn = Some(callback));
     }
 
     /// Clear the receive available callback function.
+    #[instability::unstable]
     pub fn clear_rx_available_callback_fn(&mut self) {
         CALLBACKS.with(|cbs| cbs.rx_available_fn = None);
     }
 
     /// Set the transmit failed callback function.
+    #[instability::unstable]
     pub fn set_tx_failed_callback(&mut self, callback: &'a mut (dyn FnMut() + Send)) {
         CALLBACKS.with(|cbs| {
             let cb: &'static mut (dyn FnMut() + Send) = unsafe { core::mem::transmute(callback) };
@@ -321,16 +341,19 @@ impl<'a> Ieee802154<'a> {
     }
 
     /// Clear the transmit failed callback function.
+    #[instability::unstable]
     pub fn clear_tx_failed_callback(&mut self) {
         CALLBACKS.with(|cbs| cbs.tx_failed = None);
     }
 
     /// Set the transmit failed callback function pointer.
+    #[instability::unstable]
     pub fn set_tx_failed_callback_fn(&mut self, callback: fn()) {
         CALLBACKS.with(|cbs| cbs.tx_failed_fn = Some(callback));
     }
 
     /// Clear the transmit failed callback function.
+    #[instability::unstable]
     pub fn clear_tx_failed_callback_fn(&mut self) {
         CALLBACKS.with(|cbs| cbs.tx_failed_fn = None);
     }
@@ -352,6 +375,7 @@ impl Drop for Ieee802154<'_> {
 ///
 /// RSSI is a measure of incoherent (raw) RF power in a channel. LQI is a
 /// cumulative value used in multi-hop networks to assess the cost of a link.
+#[instability::unstable]
 pub fn rssi_to_lqi(rssi: i8) -> u8 {
     if rssi < -80 {
         0

--- a/esp-radio/src/ieee802154/pib.rs
+++ b/esp-radio/src/ieee802154/pib.rs
@@ -26,6 +26,7 @@ const IEEE802154_MULTIPAN_MAX: usize = 4;
 /// Frame pending mode
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[instability::unstable]
 pub enum PendingMode {
     /// Frame pending bit always set to 1 in the ack to Data Request
     #[default]
@@ -43,6 +44,7 @@ pub enum PendingMode {
 /// CCA mode
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[instability::unstable]
 pub enum CcaMode {
     /// Carrier only
     #[default]

--- a/esp-radio/src/ieee802154/raw.rs
+++ b/esp-radio/src/ieee802154/raw.rs
@@ -96,6 +96,7 @@ enum Ieee802154TxRxScene {
 /// A raw payload received on some channel
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[instability::unstable]
 pub struct RawReceived {
     /// Payload
     pub data: [u8; FRAME_SIZE],
@@ -104,7 +105,7 @@ pub struct RawReceived {
 }
 
 pub(crate) fn esp_ieee802154_enable(
-    mut radio: IEEE802154<'_>,
+    radio: IEEE802154<'_>,
 ) -> (PhyClockGuard<'_>, PhyInitGuard<'_>) {
     init_radio_clocks();
     let phy_clock_guard = esp_phy::enable_phy_clock();

--- a/esp-radio/src/lib.rs
+++ b/esp-radio/src/lib.rs
@@ -331,6 +331,7 @@ pub(crate) fn deinit() {
 /// Management of the global reference count
 /// and conditional hardware initialization/deinitialization.
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(crate) struct RadioRefGuard {
     _private: PhantomData<()>,
 }

--- a/esp-radio/src/wifi/csi.rs
+++ b/esp-radio/src/wifi/csi.rs
@@ -24,6 +24,9 @@ use crate::{
 /// This structure contains the raw CSI data, along with necessary metadata
 /// from the received Wi-Fi packet (MAC addresses, sequence number, packet headers).
 #[repr(transparent)]
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[instability::unstable]
 pub struct WifiCsiInfo<'a> {
     inner: *const wifi_csi_info_t,
     _lt: PhantomData<&'a ()>,
@@ -31,21 +34,23 @@ pub struct WifiCsiInfo<'a> {
 
 impl<'a> WifiCsiInfo<'_> {
     /// Received Signal Strength Indicator (RSSI) of the packet.
+    #[instability::unstable]
     pub fn rssi(&self) -> i8 {
         // Signed bitfields are broken in rust-bingen, see https://github.com/esp-rs/esp-wifi-sys/issues/482
         // Hard-casting it from C-signed to i8 gives correct values, so no need for workaround
         // here.
-        // unsafe { (*self.inner.rx_ctrl.rssi()) as i8 }
         unsafe { (*self.inner).rx_ctrl.rssi() as i8 }
     }
 
     /// Data rate of the packet.
+    #[instability::unstable]
     pub fn rate(&self) -> u8 {
         unsafe { (*self.inner).rx_ctrl.rate() as u8 }
     }
 
     /// Protocol of the received packet, 0: non HT(11bg) packet; 1: HT(11n) packet; 3: VHT(11ac)
     /// packet.
+    #[instability::unstable]
     #[cfg(wifi_mac_version = "1")]
     pub fn packet_mode(&self) -> u8 {
         unsafe { (*self.inner).rx_ctrl.sig_mode() as u8 }
@@ -53,12 +58,14 @@ impl<'a> WifiCsiInfo<'_> {
 
     /// Modulation Coding Scheme. If is HT(11n) packet, shows the modulation, range from 0 to
     /// 76(MSC0 ~ MCS76).
+    #[instability::unstable]
     #[cfg(wifi_mac_version = "1")]
     pub fn modulation_coding_scheme(&self) -> u8 {
         unsafe { (*self.inner).rx_ctrl.mcs() as u8 }
     }
 
     /// Channel Bandwidth of the packet. 0: 20MHz; 1: 40MHz.
+    #[instability::unstable]
     #[cfg(wifi_mac_version = "1")]
     pub fn cwb(&self) -> bool {
         unsafe { (*self.inner).rx_ctrl.cwb() != 0 }
@@ -67,6 +74,7 @@ impl<'a> WifiCsiInfo<'_> {
     /// Set to 1 indicates that channel estimate smoothing is recommended.
     /// Set to 0 indicates that only per-carrier independent (unsmoothed) channel estimate is
     /// recommended.
+    #[instability::unstable]
     #[cfg(wifi_mac_version = "1")]
     pub fn smoothing(&self) -> bool {
         unsafe { (*self.inner).rx_ctrl.smoothing() != 0 }
@@ -74,52 +82,61 @@ impl<'a> WifiCsiInfo<'_> {
 
     /// Set to 1 indicates that the PPDU is not a sounding PPDU.
     /// Set to 0 indicates that PPDU is a sounding PPDU.
+    #[instability::unstable]
     #[cfg(wifi_mac_version = "1")]
     pub fn not_sounding(&self) -> bool {
         unsafe { (*self.inner).rx_ctrl.not_sounding() != 0 }
     }
 
     /// Aggregation. 0: MPDU packet; 1: AMPDU packet.
+    #[instability::unstable]
     #[cfg(wifi_mac_version = "1")]
     pub fn aggregation(&self) -> bool {
         unsafe { (*self.inner).rx_ctrl.aggregation() != 0 }
     }
 
     /// Space Time Block Code(STBC). 0: non STBC packet; 1: STBC packet.
+    #[instability::unstable]
     #[cfg(wifi_mac_version = "1")]
     pub fn space_time_block_code(&self) -> u8 {
         unsafe { (*self.inner).rx_ctrl.stbc() as u8 }
     }
 
     /// Forward Error Correction(FEC). Flag is set for 11n packets which are LDPC.
+    #[instability::unstable]
     #[cfg(wifi_mac_version = "1")]
     pub fn forward_error_correction_coding(&self) -> bool {
         unsafe { (*self.inner).rx_ctrl.fec_coding() != 0 }
     }
 
     /// Short Guide Interval(SGI). 0: Long GI; 1: Short GI.
+    #[instability::unstable]
     #[cfg(wifi_mac_version = "1")]
     pub fn short_guide_interval(&self) -> bool {
         unsafe { (*self.inner).rx_ctrl.sgi() != 0 }
     }
 
     /// Noise floor in dBm of Radio Frequency Module(RF).
+    #[instability::unstable]
     pub fn noise_floor(&self) -> i8 {
         unsafe { (*self.inner).rx_ctrl.noise_floor() as i8 }
     }
 
     /// The number of subframes aggregated in AMPDU.
+    #[instability::unstable]
     #[cfg(wifi_mac_version = "1")]
     pub fn ampdu_count(&self) -> u8 {
         unsafe { (*self.inner).rx_ctrl.ampdu_cnt() as u8 }
     }
 
     /// Primary channel on which this packet is received.
+    #[instability::unstable]
     pub fn channel(&self) -> u8 {
         unsafe { (*self.inner).rx_ctrl.channel() as u8 }
     }
 
     /// [`SecondaryChannel`] on which this packet is received.
+    #[instability::unstable]
     pub fn secondary_channel(&self) -> SecondaryChannel {
         cfg_if::cfg_if! {
             if #[cfg(wifi_mac_version = "1")] {
@@ -136,6 +153,7 @@ impl<'a> WifiCsiInfo<'_> {
 
     /// The local time in microseconds when this packet is received. It is precise only if modem
     /// sleep or light sleep is not enabled.
+    #[instability::unstable]
     pub fn timestamp(&self) -> Instant {
         let raw_ticks = unsafe { (*self.inner).rx_ctrl.timestamp() as u64 };
 
@@ -144,123 +162,144 @@ impl<'a> WifiCsiInfo<'_> {
 
     /// Antenna number from which this packet is received.
     /// 0: Wi-Fi antenna 0; 1: Wi-Fi antenna 1.
+    #[instability::unstable]
     #[cfg(wifi_mac_version = "1")]
     pub fn antenna(&self) -> u8 {
         unsafe { (*self.inner).rx_ctrl.ant() as u8 }
     }
 
     /// The length of the reception MPDU.
+    #[instability::unstable]
     pub fn signal_length(&self) -> u16 {
         unsafe { (*self.inner).rx_ctrl.sig_len() as u16 }
     }
 
     /// State of the packet.
     /// 0: no error; others: failure.
+    #[instability::unstable]
     pub fn rx_state(&self) -> u8 {
         unsafe { (*self.inner).rx_ctrl.rx_state() as u8 }
     }
 
     /// Indicate whether the reception frame is from interface 0.
+    #[instability::unstable]
     #[cfg(esp32c6)]
     pub fn rx_match0(&self) -> bool {
         unsafe { (*self.inner).rx_ctrl.rxmatch0() != 0 }
     }
 
     /// Indicate whether the reception frame is from interface 1.
+    #[instability::unstable]
     #[cfg(not(wifi_mac_version = "1"))]
     pub fn rx_match1(&self) -> bool {
         unsafe { (*self.inner).rx_ctrl.rxmatch1() != 0 }
     }
 
     /// Indicate whether the reception frame is from interface 2.
+    #[instability::unstable]
     #[cfg(not(wifi_mac_version = "1"))]
     pub fn rx_match2(&self) -> bool {
         unsafe { (*self.inner).rx_ctrl.rxmatch2() != 0 }
     }
 
     /// Indicate whether the reception frame is from interface 3.
+    #[instability::unstable]
     #[cfg(not(wifi_mac_version = "1"))]
     pub fn rx_match3(&self) -> bool {
         unsafe { (*self.inner).rx_ctrl.rxmatch3() != 0 }
     }
 
     /// HE-SIGA1 or HT-SIG.
+    #[instability::unstable]
     #[cfg(not(wifi_mac_version = "1"))]
     pub fn he_siga1(&self) -> u32 {
         unsafe { (*self.inner).rx_ctrl.he_siga1 }
     }
 
     /// Reception state, 0: successful, others: failure.
+    #[instability::unstable]
     #[cfg(not(wifi_mac_version = "1"))]
     pub fn rx_end_state(&self) -> u8 {
         unsafe { (*self.inner).rx_ctrl.rxend_state() as u8 }
     }
 
     /// HE-SIGA2.
+    #[instability::unstable]
     #[cfg(not(wifi_mac_version = "1"))]
     pub fn he_siga2(&self) -> u16 {
         unsafe { (*self.inner).rx_ctrl.he_siga2 }
     }
 
     /// Indicate whether the reception is a group addressed frame.
+    #[instability::unstable]
     #[cfg(not(wifi_mac_version = "1"))]
     pub fn is_group(&self) -> bool {
         unsafe { (*self.inner).rx_ctrl.is_group() != 0 }
     }
 
     /// The length of the channel information.
+    #[instability::unstable]
     #[cfg(not(wifi_mac_version = "1"))]
     pub fn rx_channel_estimate_length(&self) -> u32 {
         unsafe { (*self.inner).rx_ctrl.rx_channel_estimate_len() }
     }
 
     /// Indicate the channel information is valid.
+    #[instability::unstable]
     #[cfg(not(wifi_mac_version = "1"))]
     pub fn rx_channel_estimate_info_valid(&self) -> bool {
         unsafe { (*self.inner).rx_ctrl.rx_channel_estimate_info_vld() != 0 }
     }
 
     /// The format of the reception frame.
+    #[instability::unstable]
     #[cfg(not(wifi_mac_version = "1"))]
     pub fn cur_bb_format(&self) -> u8 {
         unsafe { (*self.inner).rx_ctrl.cur_bb_format() as u8 }
     }
 
     /// Indicate whether the reception MPDU is a S-MPDU.
+    #[instability::unstable]
     #[cfg(wifi_mac_version = "2")]
     pub fn cur_single_mpdu(&self) -> bool {
         unsafe { (*self.inner).rx_ctrl.cur_single_mpdu() != 0 }
     }
 
     /// The length of HE-SIGB.
+    #[instability::unstable]
     #[cfg(wifi_mac_version = "2")]
     pub fn he_sigb_length(&self) -> u8 {
         unsafe { (*self.inner).rx_ctrl.he_sigb_len() as u8 }
     }
 
     /// The length of the reception MPDU excluding the FCS.
+    #[instability::unstable]
     #[cfg(not(wifi_mac_version = "1"))]
     pub fn dump_length(&self) -> u32 {
         unsafe { (*self.inner).rx_ctrl.dump_len() }
     }
 
     /// Source MAC address of the CSI data.
+    #[instability::unstable]
     pub fn mac(&self) -> &[u8; 6] {
         unsafe { &(*self.inner).mac }
     }
 
     /// Destination MAC address of the CSI data.
+    #[instability::unstable]
     pub fn destination_mac(&self) -> &[u8; 6] {
         unsafe { &(*self.inner).dmac }
     }
 
     /// First four bytes of the CSI data is invalid or not, true indicates the first four bytes is
     /// invalid due to hardware limitation.
+    #[instability::unstable]
     pub fn first_word_invalid(&self) -> bool {
         unsafe { (*self.inner).first_word_invalid }
     }
 
     /// Valid buffer of CSI data.
+    #[instability::unstable]
     pub fn buf(&self) -> &[i8] {
         unsafe {
             if (*self.inner).buf.is_null() || (*self.inner).len == 0 {
@@ -272,6 +311,7 @@ impl<'a> WifiCsiInfo<'_> {
     }
 
     /// Header of the wifi packet.
+    #[instability::unstable]
     pub fn header(&self) -> &[u8] {
         unsafe {
             if (*self.inner).hdr.is_null() {
@@ -284,6 +324,7 @@ impl<'a> WifiCsiInfo<'_> {
     }
 
     /// Payload of the wifi packet.
+    #[instability::unstable]
     pub fn payload(&self) -> &[u8] {
         unsafe {
             if (*self.inner).payload.is_null() || (*self.inner).payload_len == 0 {
@@ -298,6 +339,7 @@ impl<'a> WifiCsiInfo<'_> {
     }
 
     /// Rx sequence number of the wifi packet.
+    #[instability::unstable]
     pub fn rx_sequence(&self) -> u16 {
         unsafe { (*self.inner).rx_seq }
     }
@@ -320,8 +362,10 @@ unsafe extern "C" fn csi_rx_cb<C: CsiCallback>(ctx: *mut c_void, data: *mut wifi
 }
 
 /// Channel state information (CSI) configuration.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg(wifi_mac_version = "1")]
+#[instability::unstable]
 pub struct CsiConfig {
     /// Enable to receive legacy long training field(lltf) data.
     pub lltf_en: bool,
@@ -348,8 +392,10 @@ pub struct CsiConfig {
 }
 
 /// Channel state information (CSI) configuration.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg(wifi_mac_version = "2")]
+#[instability::unstable]
 pub struct CsiConfig {
     /// Enable to acquire CSI.
     pub enable: u32,
@@ -380,8 +426,10 @@ pub struct CsiConfig {
 }
 
 /// Channel state information (CSI) configuration.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[cfg(wifi_mac_version = "3")]
+#[instability::unstable]
 pub struct CsiConfig {
     /// Enable to acquire CSI.
     pub enable: u32,

--- a/esp-radio/src/wifi/event.rs
+++ b/esp-radio/src/wifi/event.rs
@@ -146,6 +146,7 @@ macro_rules! impl_wifi_event {
     ($newtype:ident) => {
         /// See [`WifiEvent`].
         #[derive(Copy, Clone)]
+        #[instability::unstable]
         pub struct $newtype;
 
         impl Event for $newtype {
@@ -159,6 +160,7 @@ macro_rules! impl_wifi_event {
         use crate::sys::include::$data;
         /// See [`WifiEvent`].
         #[derive(Copy, Clone)]
+        #[instability::unstable]
         pub struct $newtype<'a>(&'a $data);
 
         impl Event for $newtype<'_> {
@@ -1340,6 +1342,7 @@ impl<'a> EventSubscriber<'a> {
     }
 
     /// Wait for a published event
+    #[instability::unstable]
     pub async fn next_event(&mut self) -> MessageResult {
         match self.inner.next_message().await {
             embassy_sync::pubsub::WaitResult::Lagged(missed) => MessageResult::Lagged(missed),
@@ -1348,6 +1351,7 @@ impl<'a> EventSubscriber<'a> {
     }
 
     /// Wait for a published event (ignoring lag results)
+    #[instability::unstable]
     pub async fn next_event_pure(&mut self) -> EventInfo {
         self.inner.next_message_pure().await
     }

--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -857,6 +857,8 @@ pub struct AccessPointStationDisconnectedInfo {
 }
 
 /// Either the [AccessPointStationConnectedInfo] or [AccessPointStationDisconnectedInfo].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum AccessPointStationEventInfo {
     /// Information about a station connected to the access point.
     Connected(AccessPointStationConnectedInfo),
@@ -1154,8 +1156,6 @@ pub(crate) fn wifi_start_scan(
 mod private {
     use super::*;
 
-    #[derive(Debug)]
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     /// Take care not to drop this while in a critical section.
     ///
     /// Dropping an PacketBuffer will call
@@ -1163,6 +1163,8 @@ mod private {
     /// internal mutex. If the mutex is already taken, the function will try
     /// to trigger a context switch, which will fail if we are in a critical
     /// section.
+    #[derive(Debug)]
+    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub struct PacketBuffer {
         pub(crate) buffer: *mut c_types::c_void,
         pub(crate) len: u16,
@@ -1186,7 +1188,7 @@ mod private {
 }
 
 /// Wi-Fi interface mode.
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 enum InterfaceType {
     /// Station mode.
@@ -1310,6 +1312,9 @@ impl InterfaceType {
 }
 
 /// Wi-Fi interface.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub struct Interface<'d> {
     _phantom: PhantomData<&'d ()>,
     mode: InterfaceType,
@@ -1876,10 +1881,10 @@ pub(crate) mod embassy {
 }
 
 /// Power saving mode settings for the modem.
-#[non_exhaustive]
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Default, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[instability::unstable]
+#[non_exhaustive]
 pub enum PowerSaveMode {
     /// No power saving.
     #[default]
@@ -1904,6 +1909,8 @@ pub(crate) fn apply_power_saving(ps: PowerSaveMode) -> Result<(), WifiError> {
 }
 
 /// Represents the Wi-Fi controller and its associated interfaces.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub struct Interfaces<'d> {
     /// Station mode Wi-Fi device.
@@ -2051,6 +2058,7 @@ impl CountryInfo {
 /// Wi-Fi configuration.
 #[derive(Clone, BuilderLite, Debug, Hash, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub struct ControllerConfig {
     /// Country info.
     #[builder_lite(into)]
@@ -2309,6 +2317,8 @@ pub fn new<'d>(
 ///
 /// When the controller is dropped, the Wi-Fi driver is
 /// deinitialized and Wi-Fi is stopped.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub struct WifiController<'d> {
     _guard: RadioRefGuard,

--- a/esp-radio/src/wifi/scan.rs
+++ b/esp-radio/src/wifi/scan.rs
@@ -76,7 +76,9 @@ impl ScanTypeConfig {
 }
 
 /// Scan configuration.
-#[derive(Clone, Copy, Default, PartialEq, Eq, BuilderLite)]
+#[derive(Clone, Copy, Default, Debug, PartialEq, Eq, BuilderLite)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub struct ScanConfig {
     /// SSID to filter for.
     /// If [`None`] is passed, all SSIDs will be returned.
@@ -119,6 +121,9 @@ impl ScanConfig {
 }
 
 /// Wi-Fi scan results.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub struct ScanResults<'d> {
     /// Number of APs to return
     remaining: usize,
@@ -172,6 +177,8 @@ impl Iterator for ScanResults<'_> {
 }
 
 /// AP list on-drop guard.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub(super) struct FreeApListOnDrop;
 
 impl FreeApListOnDrop {

--- a/esp-radio/src/wifi/sniffer.rs
+++ b/esp-radio/src/wifi/sniffer.rs
@@ -22,6 +22,8 @@ use crate::{
 };
 
 /// Represents a Wi-Fi packet in promiscuous mode.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[instability::unstable]
 pub struct PromiscuousPkt<'a> {
     /// Control information related to packet reception.
@@ -72,6 +74,8 @@ unsafe extern "C" fn promiscuous_rx_cb(buf: *mut core::ffi::c_void, frame_type: 
 }
 
 /// A Wi-Fi sniffer.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[instability::unstable]
 #[non_exhaustive]
 pub struct Sniffer<'d> {

--- a/esp-radio/src/wifi/sta/eap.rs
+++ b/esp-radio/src/wifi/sta/eap.rs
@@ -139,6 +139,7 @@ pub struct EapStationConfig {
 
 impl EapStationConfig {
     /// Set the SSID of the access point.
+    #[instability::unstable]
     pub fn with_ssid(mut self, ssid: impl Into<Ssid>) -> Self {
         self.ssid = ssid.into();
         self


### PR DESCRIPTION
This PR mainly adds missing `#[instability::unstable]` to the `unstable` modules (which is docs-only change). Also adds some missing derives to the pub items.
 
cc https://github.com/esp-rs/esp-hal/issues/4712

