### PR TITLE
Small TWAI tweaks

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -130,6 +130,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `SpiBus::transfer` (both from `embedded_hal` and `embedded_hal_async`) implementations of `esp_hal::spi::master::Spi` no longer write more data than they need to (#5245)
 - Fixed a bug in `Spi::half_duplex_{read, write}` where calling these functions aborted previously running writes (#5247)
 - LP I2C: prevent spurious I2C start during the initialization of LpI2c (#5311)
+- Fixed a bug in `TWAI` that may cause the driver to hang (#5318)
 
 ### Removed
 

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -1622,18 +1622,15 @@ impl Instance for AnyTwai<'_> {}
 mod asynch {
     use core::{future::poll_fn, task::Poll};
 
-    use embassy_sync::{
-        blocking_mutex::raw::CriticalSectionRawMutex,
-        channel::Channel,
-        waitqueue::AtomicWaker,
-    };
+    use embassy_sync::{channel::Channel, waitqueue::AtomicWaker};
+    use esp_sync::RawMutex;
 
     use super::*;
 
     pub struct TwaiAsyncState {
         pub tx_waker: AtomicWaker,
         pub err_waker: AtomicWaker,
-        pub rx_queue: Channel<CriticalSectionRawMutex, Result<EspTwaiFrame, EspTwaiError>, 32>,
+        pub rx_queue: Channel<RawMutex, Result<EspTwaiFrame, EspTwaiError>, 32>,
     }
 
     impl Default for TwaiAsyncState {

--- a/hil-test/src/bin/misc_drivers.rs
+++ b/hil-test/src/bin/misc_drivers.rs
@@ -5,7 +5,7 @@
 //! System Timer Tests
 //! TWAI Tests
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c5 esp32c6 esp32c61 esp32h2 esp32s2 esp32s3
-//% FEATURES: unstable embassy defmt
+//% FEATURES: unstable embassy
 
 #![no_std]
 #![no_main]


### PR DESCRIPTION
This PR makes two changes:
- Replaces the global critical section with a core-local spinlock.
- Fixes a race condition in `transmit_async` and similarly adjusts `receive_async`.

The blocking `transmit` function just pushes a message into the queue and returns without waiting for the message to be sent. This is fine, and the strategy could be used to make `transfer_async` cancel-safe as well, but that is out of scope for this PR. That pending message can, then, trigger an interrupt after `transfer_async` has subscribed to the interrupt, but haven't yet registered its waker. If the interrupt occurs before registering the waker, the CPU unlistens the interrupt signal. The end result is, that `TransmitFuture` can return Pending, waiting for an interrupt that it isn't listening for.