### PR TITLE
[xtask] allow pre-release base bump

### DIFF
--- a/xtask/src/commands/release/bump_version.rs
+++ b/xtask/src/commands/release/bump_version.rs
@@ -77,7 +77,7 @@ pub struct BumpVersionArgs {
     ///   pre-release tag is dropped (finalizing the cycle) and `amount` is ignored.
     /// - With `--pre`: start (or restart) a pre-release cycle on the bumped base, e.g.
     ///   `bump-version minor --pre alpha` on `1.0.0` produces `1.1.0-alpha.0`.
-    #[arg(value_enum)]
+    #[arg(value_enum, required_unless_present = "pre")]
     amount: Option<Version>,
     /// Pre-release identifier to apply.
     ///
@@ -317,7 +317,10 @@ pub fn do_version_bump(version: &semver::Version, bump: &VersionBump) -> Result<
     // | None   | Some    | Continue a pre-release cycle on the current base. Bails if the    |
     // |        |         | current version is stable, as it would produce a lower version.   |
     match (bump.base, bump.pre.as_deref()) {
-        (None, None) => bail!("nothing to bump: specify an amount and/or --pre"),
+        (None, None) => bail!(
+            "invalid bump request: neither an amount nor `--pre` was specified; \
+             pass a bump amount (`major`/`minor`/`patch`) and/or `--pre <id>`"
+        ),
 
         // Stable bump. If currently a pre-release, finalize by dropping the
         // pre tag and ignore `amount` (matches historical behavior).
@@ -539,7 +542,7 @@ mod tests {
         };
         let err = do_version_bump(&version, &bump).unwrap_err();
         assert!(
-            err.to_string().contains("nothing to bump"),
+            err.to_string().contains("invalid bump request"),
             "unexpected error: {err}"
         );
     }

--- a/xtask/src/commands/release/bump_version.rs
+++ b/xtask/src/commands/release/bump_version.rs
@@ -29,9 +29,11 @@ use crate::{
 pub struct VersionBump {
     /// Bump the base `major.minor.patch` by this amount. `None` means keep
     /// the current base.
+    #[serde(default)]
     pub base: Option<Version>,
     /// Apply or continue this pre-release identifier (e.g. `"alpha"`).
     /// `None` means a stable release.
+    #[serde(default)]
     pub pre: Option<String>,
 }
 
@@ -522,13 +524,13 @@ mod tests {
             ),
         ];
 
-        for (version, amount, expected) in test_cases {
+        for (version, bump, expected) in test_cases {
             let version = semver::Version::parse(version).unwrap();
-            let new_version = do_version_bump(&version, &amount).unwrap();
+            let new_version = do_version_bump(&version, &bump).unwrap();
             assert_eq!(
                 new_version.to_string(),
                 expected,
-                "bump {amount:?} of {version}",
+                "bump {bump:?} of {version}",
             );
         }
     }

--- a/xtask/src/commands/release/bump_version.rs
+++ b/xtask/src/commands/release/bump_version.rs
@@ -21,28 +21,72 @@ use crate::{
 };
 
 /// How to bump the version of a package.
+///
+/// This is a direct reflection of the `bump-version` CLI arguments. The four
+/// combinations of `base` and `pre` each mean something different; see
+/// [`do_version_bump`] for the full state table.
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
-pub enum VersionBump {
-    PreRelease(String),
-    Patch,
-    Minor,
-    Major,
+pub struct VersionBump {
+    /// Bump the base `major.minor.patch` by this amount. `None` means keep
+    /// the current base.
+    pub base: Option<Version>,
+    /// Apply or continue this pre-release identifier (e.g. `"alpha"`).
+    /// `None` means a stable release.
+    pub pre: Option<String>,
+}
+
+impl VersionBump {
+    pub fn major() -> Self {
+        Self {
+            base: Some(Version::Major),
+            pre: None,
+        }
+    }
+    pub fn minor() -> Self {
+        Self {
+            base: Some(Version::Minor),
+            pre: None,
+        }
+    }
+    pub fn patch() -> Self {
+        Self {
+            base: Some(Version::Patch),
+            pre: None,
+        }
+    }
+    pub fn pre(id: impl Into<String>) -> Self {
+        Self {
+            base: None,
+            pre: Some(id.into()),
+        }
+    }
+    pub fn base_and_pre(base: Version, id: impl Into<String>) -> Self {
+        Self {
+            base: Some(base),
+            pre: Some(id.into()),
+        }
+    }
 }
 
 /// Arguments for bumping the version of packages.
 #[derive(Debug, Args)]
 pub struct BumpVersionArgs {
-    /// How much to bump the version by.
+    /// How much to bump the base version by.
     ///
-    /// If the version is a pre-release, this will just remove the pre-release
-    /// version tag.
+    /// - Without `--pre`: a regular stable bump. If the current version is a pre-release, the
+    ///   pre-release tag is dropped (finalizing the cycle) and `amount` is ignored.
+    /// - With `--pre`: start (or restart) a pre-release cycle on the bumped base, e.g.
+    ///   `bump-version minor --pre alpha` on `1.0.0` produces `1.1.0-alpha.0`.
     #[arg(value_enum)]
-    amount: Version,
-    /// Pre-release version to append to the version.
+    amount: Option<Version>,
+    /// Pre-release identifier to apply.
     ///
-    /// If the package is already a pre-release, this will ignore `amount`. If
-    /// the package is not a pre-release, this will bump the version by
-    /// `amount` and append the pre-release version as `<pre>.0`.
+    /// - Without `amount`: continue the pre-release cycle on the *current* base. If the current
+    ///   version already carries this identifier the counter is incremented; if it carries a
+    ///   different one the counter is reset to `<pre>.0`. Starting a pre-release cycle from a
+    ///   stable version without also passing `amount` is an error, as it would produce a version
+    ///   lower than the current one.
+    /// - With `amount`: bump the base then append `<pre>.0`.
     #[arg(long)]
     pre: Option<String>,
     /// Package(s) to target.
@@ -52,19 +96,15 @@ pub struct BumpVersionArgs {
 
 /// Bump the version of the specified packages by the specified amount.
 pub fn bump_version(workspace: &Path, args: BumpVersionArgs) -> Result<()> {
-    // Bump the version by the specified amount for each given package:
+    let bump = VersionBump {
+        base: args.amount,
+        pre: args.pre,
+    };
+
+    // Bump the version for each given package:
     for package in args.packages {
-        let version = if let Some(pre) = &args.pre {
-            VersionBump::PreRelease(pre.clone())
-        } else {
-            match args.amount {
-                Version::Major => VersionBump::Major,
-                Version::Minor => VersionBump::Minor,
-                Version::Patch => VersionBump::Patch,
-            }
-        };
         let mut package = CargoToml::new(workspace, package)?;
-        update_package(&mut package, &version, false)?;
+        update_package(&mut package, &bump, false)?;
     }
 
     Ok(())
@@ -244,47 +284,88 @@ fn bump_crate_version(
     Ok(version)
 }
 
-/// Perform the actual version bump logic.
-pub fn do_version_bump(version: &semver::Version, amount: &VersionBump) -> Result<semver::Version> {
-    fn bump_version_number(version: &mut semver::Version, amount: &VersionBump) {
-        log::debug!("Bumping version number: {version} by {amount:?}");
-        match amount {
-            VersionBump::Major => {
-                version.major += 1;
-                version.minor = 0;
-                version.patch = 0;
-            }
-            VersionBump::Minor => {
-                version.minor += 1;
-                version.patch = 0;
-            }
-            VersionBump::Patch => {
-                version.patch += 1;
-            }
-            VersionBump::PreRelease(_) => unreachable!(),
+/// Bump only the base version (`major.minor.patch`).
+fn bump_base(version: &mut semver::Version, amount: Version) {
+    log::debug!("Bumping base version: {version} by {amount:?}");
+    match amount {
+        Version::Major => {
+            version.major += 1;
+            version.minor = 0;
+            version.patch = 0;
+        }
+        Version::Minor => {
+            version.minor += 1;
+            version.patch = 0;
+        }
+        Version::Patch => {
+            version.patch += 1;
         }
     }
+}
+
+/// Perform the actual version bump logic.
+pub fn do_version_bump(version: &semver::Version, bump: &VersionBump) -> Result<semver::Version> {
     let mut version = version.clone();
 
-    match amount {
-        VersionBump::Major | VersionBump::Minor | VersionBump::Patch => {
-            // If the version is a pre-release, we need to remove it
+    // The four `(base, pre)` combinations each mean something different:
+    //
+    // | `base` | `pre`   | Behavior                                                          |
+    // |--------|---------|-------------------------------------------------------------------|
+    // | None   | None    | Error — nothing to do.                                            |
+    // | Some   | None    | Stable bump. If currently pre, drop the pre tag (finalize).       |
+    // | Some   | Some    | Start / restart a pre-release cycle on a freshly-bumped base.     |
+    // | None   | Some    | Continue a pre-release cycle on the current base. Bails if the    |
+    // |        |         | current version is stable, as it would produce a lower version.   |
+    match (bump.base, bump.pre.as_deref()) {
+        (None, None) => bail!("nothing to bump: specify an amount and/or --pre"),
+
+        // Stable bump. If currently a pre-release, finalize by dropping the
+        // pre tag and ignore `amount` (matches historical behavior).
+        (Some(amount), None) => {
             if !version.pre.is_empty() {
                 version.pre = Prerelease::EMPTY;
             } else {
-                // If the version is not a pre-release, we need to bump the version
-                bump_version_number(&mut version, &amount);
+                bump_base(&mut version, amount);
             }
         }
-        VersionBump::PreRelease(pre) => {
-            if let Some(pre_version) = version.pre.as_str().strip_prefix(&format!("{pre}.")) {
-                let pre_version = pre_version.parse::<u32>()?;
-                version.pre = Prerelease::new(&format!("{pre}.{}", pre_version + 1)).unwrap();
+
+        // Start / restart a pre-release cycle on a freshly-bumped base.
+        // e.g. 1.0.0 + (Minor, alpha) -> 1.1.0-alpha.0
+        //      1.1.0-alpha.5 + (Minor, alpha) -> 1.2.0-alpha.0
+        (Some(amount), Some(pre)) => {
+            version.pre = Prerelease::EMPTY;
+            bump_base(&mut version, amount);
+            version.pre = Prerelease::new(&format!("{pre}.0"))
+                .with_context(|| format!("invalid pre-release identifier {pre:?}"))?;
+        }
+
+        // Pre-release work on the *current* base.
+        (None, Some(pre)) => {
+            if version.pre.is_empty() {
+                bail!(
+                    "cannot start pre-release {pre:?} from stable version {version}: \
+                     the result would be semver-less than the current version. \
+                     Pass a bump amount as well, e.g. `bump-version minor --pre {pre}`."
+                );
+            } else if let Some(pre_version) = version.pre.as_str().strip_prefix(&format!("{pre}."))
+            {
+                // Same identifier -> increment counter.
+                let pre_version = pre_version.parse::<u32>().with_context(|| {
+                    format!(
+                        "could not parse pre-release counter from {:?}",
+                        version.pre.as_str()
+                    )
+                })?;
+                // This branch is structurally safe: the strip_prefix match above
+                // requires the current version's pre to already start with "{pre}.",
+                // so `pre` has already been accepted by `Prerelease::new` once.
+                version.pre = Prerelease::new(&format!("{pre}.{}", pre_version + 1))
+                    .with_context(|| format!("invalid pre-release identifier {pre:?}"))?;
             } else {
-                // if the pre version is _not_ the same as the one we had, it's a new pre-release
-                // use the new pre and reset the bump to 0
-                // equally, if the version is not a pre-release, we need to append the pre-release
-                version.pre = Prerelease::new(&format!("{pre}.0")).unwrap();
+                // Different identifier on same base -> reset counter.
+                // e.g. 1.1.0-alpha.5 + (None, beta) -> 1.1.0-beta.0
+                version.pre = Prerelease::new(&format!("{pre}.0"))
+                    .with_context(|| format!("invalid pre-release identifier {pre:?}"))?;
             }
         }
     }
@@ -383,33 +464,141 @@ mod tests {
     #[test]
     fn test_version_bump() {
         let test_cases = vec![
-            ("0.1.0", VersionBump::Patch, "0.1.1"),
-            ("0.1.0", VersionBump::Minor, "0.2.0"),
-            ("0.1.0", VersionBump::Major, "1.0.0"),
-            // amount is ignored, assuming same release cycle
-            ("0.1.0-beta.0", VersionBump::Minor, "0.1.0"),
-            ("0.1.0-beta.0", VersionBump::Major, "0.1.0"),
+            // --- Stable bumps from stable versions ---
+            ("0.1.0", VersionBump::patch(), "0.1.1"),
+            ("0.1.0", VersionBump::minor(), "0.2.0"),
+            ("0.1.0", VersionBump::major(), "1.0.0"),
+            ("1.0.0", VersionBump::patch(), "1.0.1"),
+            ("1.0.0", VersionBump::minor(), "1.1.0"),
+            ("1.0.0", VersionBump::major(), "2.0.0"),
+            // --- Finalizing a pre-release: amount is ignored, pre is dropped ---
+            ("0.1.0-beta.0", VersionBump::minor(), "0.1.0"),
+            ("0.1.0-beta.0", VersionBump::major(), "0.1.0"),
+            ("1.1.0-alpha.5", VersionBump::minor(), "1.1.0"),
+            // --- Continuing a pre-release cycle on the *same* base ---
+            // Same identifier -> increment counter.
+            ("0.1.0-beta.0", VersionBump::pre("beta"), "0.1.0-beta.1"),
+            ("0.1.0-beta.7", VersionBump::pre("beta"), "0.1.0-beta.8"),
+            ("1.1.0-alpha.0", VersionBump::pre("alpha"), "1.1.0-alpha.1"),
+            // Different identifier on same base -> reset counter.
+            ("0.1.0-beta.0", VersionBump::pre("rc"), "0.1.0-rc.0"),
+            ("1.1.0-alpha.5", VersionBump::pre("beta"), "1.1.0-beta.0"),
+            // --- Starting a new pre-release cycle on a freshly-bumped base ---
+            // This is the scenario from esp-rs/esp-hal#3801.
             (
-                "0.1.0-beta.0",
-                VersionBump::PreRelease("beta".to_string()),
-                "0.1.0-beta.1",
+                "1.0.0",
+                VersionBump::base_and_pre(Version::Minor, "alpha"),
+                "1.1.0-alpha.0",
             ),
             (
-                "0.1.0-beta.0",
-                VersionBump::PreRelease("beta".to_string()),
-                "0.1.0-beta.1",
+                "1.0.0",
+                VersionBump::base_and_pre(Version::Major, "alpha"),
+                "2.0.0-alpha.0",
             ),
             (
-                "0.1.0-beta.0",
-                VersionBump::PreRelease("rc".to_string()),
-                "0.1.0-rc.0",
+                "1.0.0",
+                VersionBump::base_and_pre(Version::Patch, "alpha"),
+                "1.0.1-alpha.0",
+            ),
+            // Restart a cycle from an existing pre-release onto a new base.
+            (
+                "1.1.0-alpha.5",
+                VersionBump::base_and_pre(Version::Minor, "alpha"),
+                "1.2.0-alpha.0",
+            ),
+            (
+                "1.1.0-alpha.5",
+                VersionBump::base_and_pre(Version::Major, "beta"),
+                "2.0.0-beta.0",
+            ),
+            // Starting a pre-release on a 0.x package.
+            (
+                "0.5.0",
+                VersionBump::base_and_pre(Version::Minor, "alpha"),
+                "0.6.0-alpha.0",
             ),
         ];
 
         for (version, amount, expected) in test_cases {
             let version = semver::Version::parse(version).unwrap();
             let new_version = do_version_bump(&version, &amount).unwrap();
-            assert_eq!(new_version.to_string(), expected);
+            assert_eq!(
+                new_version.to_string(),
+                expected,
+                "bump {amount:?} of {version}",
+            );
+        }
+    }
+
+    #[test]
+    fn test_version_bump_empty_is_error() {
+        let version = semver::Version::parse("1.0.0").unwrap();
+        let bump = VersionBump {
+            base: None,
+            pre: None,
+        };
+        let err = do_version_bump(&version, &bump).unwrap_err();
+        assert!(
+            err.to_string().contains("nothing to bump"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_pre_release_from_stable_without_base_is_error() {
+        // This is the exact bug from esp-rs/esp-hal#3801: producing `1.0.0-alpha.0`
+        // from `1.0.0` would be semver-less than the current version. The engine
+        // must refuse, pointing the user at the combined `amount + --pre` form.
+        let version = semver::Version::parse("1.0.0").unwrap();
+        let bump = VersionBump::pre("alpha");
+        let err = do_version_bump(&version, &bump).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("cannot start pre-release") && msg.contains("bump-version minor --pre"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_invalid_pre_identifier_is_error() {
+        // Valid identifiers should pass through `do_version_bump` cleanly.
+        let stable = semver::Version::parse("1.0.0").unwrap();
+        for ok in ["alpha", "rc1", "beta-2", "rc-0", "pre"] {
+            do_version_bump(&stable, &VersionBump::base_and_pre(Version::Minor, ok))
+                .unwrap_or_else(|e| panic!("expected {ok:?} to be valid: {e}"));
+        }
+
+        // Invalid identifiers must produce a clean error, not a panic.
+        //
+        // Two code paths construct a `Prerelease` from a user-supplied identifier:
+        //
+        //   1. `(Some(base), Some(pre))` — start / restart a cycle on a bumped base.
+        //   2. `(None, Some(pre))` with a different identifier on the current base — reset the
+        //      counter.
+        //
+        // The third site (same-identifier increment) is structurally safe: the
+        // strip_prefix match requires `pre` to already be present in the current
+        // version's pre-release, meaning `Prerelease::new` has accepted it before.
+        for bad in ["foo@bar", "has space", "trailing.", "", "dot..dot"] {
+            // Path 1: (Some, Some).
+            let err = do_version_bump(&stable, &VersionBump::base_and_pre(Version::Minor, bad))
+                .unwrap_err()
+                .to_string();
+            assert!(
+                err.contains("invalid pre-release identifier"),
+                "unexpected error for (Some, Some) with {bad:?}: {err}"
+            );
+
+            // Path 2: (None, Some) with a different identifier, forcing the
+            // reset-counter branch.
+            let pre_version = semver::Version::parse("1.0.0-alpha.0").unwrap();
+            let err = do_version_bump(&pre_version, &VersionBump::pre(bad))
+                .unwrap_err()
+                .to_string();
+            assert!(
+                err.contains("invalid pre-release identifier"),
+                "unexpected error for (None, Some) with {bad:?}: {err}"
+            );
         }
     }
 

--- a/xtask/src/commands/release/bump_version.rs
+++ b/xtask/src/commands/release/bump_version.rs
@@ -534,73 +534,31 @@ mod tests {
     }
 
     #[test]
-    fn test_version_bump_empty_is_error() {
-        let version = semver::Version::parse("1.0.0").unwrap();
-        let bump = VersionBump {
-            base: None,
-            pre: None,
-        };
-        let err = do_version_bump(&version, &bump).unwrap_err();
-        assert!(
-            err.to_string().contains("invalid bump request"),
-            "unexpected error: {err}"
-        );
-    }
+    fn test_version_bump_errors() {
+        let test_cases = vec![
+            // Nothing to bump.
+            (
+                "1.0.0",
+                VersionBump {
+                    base: None,
+                    pre: None,
+                },
+            ),
+            // Pre-release from stable without a base bump would go backwards (#3801).
+            ("1.0.0", VersionBump::pre("alpha")),
+            // Invalid pre-release identifiers, both construction paths.
+            (
+                "1.0.0",
+                VersionBump::base_and_pre(Version::Minor, "has space"),
+            ),
+            ("1.0.0-alpha.0", VersionBump::pre("has space")),
+        ];
 
-    #[test]
-    fn test_pre_release_from_stable_without_base_is_error() {
-        // This is the exact bug from esp-rs/esp-hal#3801: producing `1.0.0-alpha.0`
-        // from `1.0.0` would be semver-less than the current version. The engine
-        // must refuse, pointing the user at the combined `amount + --pre` form.
-        let version = semver::Version::parse("1.0.0").unwrap();
-        let bump = VersionBump::pre("alpha");
-        let err = do_version_bump(&version, &bump).unwrap_err();
-        let msg = err.to_string();
-        assert!(
-            msg.contains("cannot start pre-release") && msg.contains("bump-version minor --pre"),
-            "unexpected error: {msg}"
-        );
-    }
-
-    #[test]
-    fn test_invalid_pre_identifier_is_error() {
-        // Valid identifiers should pass through `do_version_bump` cleanly.
-        let stable = semver::Version::parse("1.0.0").unwrap();
-        for ok in ["alpha", "rc1", "beta-2", "rc-0", "pre"] {
-            do_version_bump(&stable, &VersionBump::base_and_pre(Version::Minor, ok))
-                .unwrap_or_else(|e| panic!("expected {ok:?} to be valid: {e}"));
-        }
-
-        // Invalid identifiers must produce a clean error, not a panic.
-        //
-        // Two code paths construct a `Prerelease` from a user-supplied identifier:
-        //
-        //   1. `(Some(base), Some(pre))` — start / restart a cycle on a bumped base.
-        //   2. `(None, Some(pre))` with a different identifier on the current base — reset the
-        //      counter.
-        //
-        // The third site (same-identifier increment) is structurally safe: the
-        // strip_prefix match requires `pre` to already be present in the current
-        // version's pre-release, meaning `Prerelease::new` has accepted it before.
-        for bad in ["foo@bar", "has space", "trailing.", "", "dot..dot"] {
-            // Path 1: (Some, Some).
-            let err = do_version_bump(&stable, &VersionBump::base_and_pre(Version::Minor, bad))
-                .unwrap_err()
-                .to_string();
+        for (version, bump) in test_cases {
+            let version = semver::Version::parse(version).unwrap();
             assert!(
-                err.contains("invalid pre-release identifier"),
-                "unexpected error for (Some, Some) with {bad:?}: {err}"
-            );
-
-            // Path 2: (None, Some) with a different identifier, forcing the
-            // reset-counter branch.
-            let pre_version = semver::Version::parse("1.0.0-alpha.0").unwrap();
-            let err = do_version_bump(&pre_version, &VersionBump::pre(bad))
-                .unwrap_err()
-                .to_string();
-            assert!(
-                err.contains("invalid pre-release identifier"),
-                "unexpected error for (None, Some) with {bad:?}: {err}"
+                do_version_bump(&version, &bump).is_err(),
+                "expected error for bump {bump:?} of {version}",
             );
         }
     }

--- a/xtask/src/commands/release/execute_plan.rs
+++ b/xtask/src/commands/release/execute_plan.rs
@@ -7,8 +7,9 @@ use strum::IntoEnumIterator;
 use toml_edit::{Item, Value};
 
 use crate::{
+    Version,
     cargo::CargoToml,
-    commands::{VersionBump, checker::generate_baseline, release::plan::Plan, update_package},
+    commands::{checker::generate_baseline, release::plan::Plan, update_package},
     git::{current_branch, ensure_workspace_clean, get_remote_name_for},
 };
 
@@ -79,7 +80,11 @@ pub fn execute_plan(workspace: &Path, args: ApplyPlanArgs) -> Result<()> {
                 true
             };
 
-            if forever_unstable && step.bump != VersionBump::Patch {
+            // Perma-unstable packages are stable-patch only: no major/minor and no
+            // pre-release cycles. (The previous code accidentally let pre-release
+            // bumps through; this is the stricter, intended rule.)
+            let is_stable_patch = step.bump.pre.is_none() && step.bump.base == Some(Version::Patch);
+            if forever_unstable && !is_stable_patch {
                 bail!(
                     "Cannot bump perma-unstable package {} to a non-patch version",
                     step.package

--- a/xtask/src/commands/release/execute_plan.rs
+++ b/xtask/src/commands/release/execute_plan.rs
@@ -7,9 +7,8 @@ use strum::IntoEnumIterator;
 use toml_edit::{Item, Value};
 
 use crate::{
-    Version,
     cargo::CargoToml,
-    commands::{checker::generate_baseline, release::plan::Plan, update_package},
+    commands::{VersionBump, checker::generate_baseline, release::plan::Plan, update_package},
     git::{current_branch, ensure_workspace_clean, get_remote_name_for},
 };
 
@@ -80,11 +79,7 @@ pub fn execute_plan(workspace: &Path, args: ApplyPlanArgs) -> Result<()> {
                 true
             };
 
-            // Perma-unstable packages are stable-patch only: no major/minor and no
-            // pre-release cycles. (The previous code accidentally let pre-release
-            // bumps through; this is the stricter, intended rule.)
-            let is_stable_patch = step.bump.pre.is_none() && step.bump.base == Some(Version::Patch);
-            if forever_unstable && !is_stable_patch {
+            if forever_unstable && step.bump != VersionBump::patch() {
                 bail!(
                     "Cannot bump perma-unstable package {} to a non-patch version",
                     step.package

--- a/xtask/src/commands/release/plan.rs
+++ b/xtask/src/commands/release/plan.rs
@@ -10,6 +10,7 @@ use toml_edit::{Item, Value};
 
 use crate::{
     Package,
+    Version,
     cargo::CargoToml,
     commands::{VersionBump, checker::min_package_update, do_version_bump},
     git::current_branch,
@@ -183,21 +184,32 @@ pub fn plan(workspace: &Path, args: PlanArgs) -> Result<()> {
                     let current_version = package_tomls[&package].package_version();
 
                     let bump = if !current_version.pre.is_empty() {
-                        VersionBump::PreRelease(
-                            current_version
-                                .pre
-                                .as_str()
-                                .split('.')
-                                .next()
-                                .unwrap()
-                                .to_string(),
-                        )
+                        // Package is already in a pre-release cycle — continue it
+                        // on the same base. Hand-edit the plan to start a new
+                        // cycle on a bumped base (e.g. `1.1.0-alpha.0` from
+                        // `1.0.0`) by also setting `base`.
+                        VersionBump {
+                            base: None,
+                            pre: Some(
+                                current_version
+                                    .pre
+                                    .as_str()
+                                    .split('.')
+                                    .next()
+                                    .unwrap()
+                                    .to_string(),
+                            ),
+                        }
                     } else {
-                        match b {
-                            ReleaseType::Major => VersionBump::Major,
-                            ReleaseType::Minor => VersionBump::Minor,
-                            ReleaseType::Patch => VersionBump::Patch,
+                        let base = match b {
+                            ReleaseType::Major => Version::Major,
+                            ReleaseType::Minor => Version::Minor,
+                            ReleaseType::Patch => Version::Patch,
                             _ => unreachable!(),
+                        };
+                        VersionBump {
+                            base: Some(base),
+                            pre: None,
                         }
                     };
 
@@ -241,11 +253,17 @@ pub fn plan(workspace: &Path, args: PlanArgs) -> Result<()> {
 // orchestrate the actual publishing process.
 //
 // For each package, this plan contains the version bump that will be applied.
-// The version bump is one of:
-// - PreRelease (`"bump": { "PreRelease": "beta" }`)
-// - Patch (`"bump": "Patch"`)
-// - Minor (`"bump": "Minor"`)
-// - Major (`"bump": "Major"`)
+// A bump has two orthogonal fields — `base` (how much to bump
+// major.minor.patch) and `pre` (the pre-release identifier):
+//
+// - Stable bump:               `"bump": { "base": "Minor", "pre": null }`
+// - Continue pre-release cycle:`"bump": { "base": null,    "pre": "beta" }`
+// - Start a new pre-release cycle on a bumped base (e.g. 1.0.0 -> 1.1.0-alpha.0):
+//                              `"bump": { "base": "Minor", "pre": "alpha" }`
+//
+// Starting a pre-release cycle from a stable version without also setting
+// `base` is an error, as it would produce a version lower than the current
+// one.
 "#,
     );
 

--- a/xtask/src/commands/release/post_release.rs
+++ b/xtask/src/commands/release/post_release.rs
@@ -72,13 +72,20 @@ pub fn post_release(workspace: &std::path::Path) -> Result<()> {
             );
         }
 
-        // Backport branch management: only for stable minor/major bumps on stable releases
-        // (**major** >= 1), we do not have and do not maintain backport branches for
-        // `0.{minor}.x` versions, and we do not create them for pre-releases.
+        // Backport branch management: only for minor/major bumps on stable releases (**major** >=
+        // 1), we do not have and do not maintain backport branches for `0.{minor}.x`
+        // versions. Pre-release cycles also don't get backport branches.
+        if package_plan.bump.pre.is_some() {
+            log::info!(
+                "Skipping backport branch creation for {} v{} (pre-release cycle)",
+                package,
+                version_str
+            );
+            continue;
+        }
+
         match package_plan.bump.base {
-            Some(crate::Version::Minor | crate::Version::Major)
-                if package_plan.bump.pre.is_none() =>
-            {
+            Some(crate::Version::Minor) | Some(crate::Version::Major) => {
                 if version.major >= 1 {
                     let branch_name = format!("{}-{}.{}.x", package, version.major, version.minor);
 
@@ -214,7 +221,7 @@ pub fn post_release(workspace: &std::path::Path) -> Result<()> {
             }
             _ => {
                 log::info!(
-                    "Skipping backport branch creation for {} v{} (bump is not a stable minor/major)",
+                    "Skipping backport branch creation for {} v{} (bump is not minor/major)",
                     package,
                     version_str
                 );

--- a/xtask/src/commands/release/post_release.rs
+++ b/xtask/src/commands/release/post_release.rs
@@ -73,48 +73,46 @@ pub fn post_release(workspace: &std::path::Path) -> Result<()> {
         }
 
         // Backport branch management: only for stable minor/major bumps on stable releases
-        // (**major** >= 1). We do not maintain backport branches for `0.{minor}.x` versions,
-        // and we do not create them for pre-releases.
-        let is_stable_minor_or_major = package_plan.bump.pre.is_none()
-            && matches!(
-                package_plan.bump.base,
-                Some(crate::Version::Minor | crate::Version::Major)
-            );
-        if is_stable_minor_or_major {
-            if version.major >= 1 {
-                let branch_name = format!("{}-{}.{}.x", package, version.major, version.minor);
+        // (**major** >= 1), we do not have and do not maintain backport branches for
+        // `0.{minor}.x` versions, and we do not create them for pre-releases.
+        match package_plan.bump.base {
+            Some(crate::Version::Minor | crate::Version::Major)
+                if package_plan.bump.pre.is_none() =>
+            {
+                if version.major >= 1 {
+                    let branch_name = format!("{}-{}.{}.x", package, version.major, version.minor);
 
-                // Check if branch already exists on origin
-                let branch_exists = Command::new("git")
-                    .args([
-                        "ls-remote",
-                        "--exit-code",
-                        "--heads",
-                        "origin",
-                        &branch_name,
-                    ])
-                    .current_dir(workspace)
-                    .status()
-                    .map(|status| status.success())
-                    .unwrap_or(false);
-
-                if branch_exists {
-                    log::info!(
-                        "Backport branch already exists on origin: {branch_name}, skipping creation"
-                    );
-                } else {
-                    // We want the backport branch to start at the released tag for this
-                    // package.
-                    let tag_name = &package_plan.tag_name;
-
-                    let tag_exists = Command::new("git")
-                        .args(["rev-parse", "--verify", "--quiet", tag_name])
+                    // Check if branch already exists on origin
+                    let branch_exists = Command::new("git")
+                        .args([
+                            "ls-remote",
+                            "--exit-code",
+                            "--heads",
+                            "origin",
+                            &branch_name,
+                        ])
                         .current_dir(workspace)
                         .status()
                         .map(|status| status.success())
                         .unwrap_or(false);
 
-                    let create_status = if tag_exists {
+                    if branch_exists {
+                        log::info!(
+                            "Backport branch already exists on origin: {branch_name}, skipping creation"
+                        );
+                    } else {
+                        // We want the backport branch to start at the released tag for this
+                        // package.
+                        let tag_name = &package_plan.tag_name;
+
+                        let tag_exists = Command::new("git")
+                            .args(["rev-parse", "--verify", "--quiet", tag_name])
+                            .current_dir(workspace)
+                            .status()
+                            .map(|status| status.success())
+                            .unwrap_or(false);
+
+                        let create_status = if tag_exists {
                             // Create branch from the release tag (preferred).
                             Command::new("git")
                                 .arg("branch")
@@ -135,85 +133,92 @@ pub fn post_release(workspace: &std::path::Path) -> Result<()> {
                         }
                         .with_context(|| format!("Failed to create backport branch {branch_name}"))?;
 
-                    if !create_status.success() {
-                        return Err(anyhow::anyhow!("`git branch {}` failed", branch_name));
+                        if !create_status.success() {
+                            return Err(anyhow::anyhow!("`git branch {}` failed", branch_name));
+                        }
+
+                        let push_status = Command::new("git")
+                            .arg("push")
+                            .arg("origin")
+                            .arg(&branch_name)
+                            .current_dir(workspace)
+                            .status()
+                            .with_context(|| {
+                                format!("Failed to push backport branch {branch_name}")
+                            })?;
+
+                        if !push_status.success() {
+                            return Err(anyhow::anyhow!(
+                                "`git push origin {}` failed",
+                                branch_name
+                            ));
+                        }
+
+                        log::info!(
+                            "Created backport branch {branch_name} for {} v{}",
+                            package,
+                            version_str
+                        );
                     }
 
-                    let push_status = Command::new("git")
-                        .arg("push")
-                        .arg("origin")
-                        .arg(&branch_name)
-                        .current_dir(workspace)
-                        .status()
-                        .with_context(|| format!("Failed to push backport branch {branch_name}"))?;
+                    // If there was a previous minor branch (e.g. 1.1.x when creating 1.2.x),
+                    // delete it on origin if it exists.
+                    if version.minor > 0 {
+                        let prev_branch_name =
+                            format!("{}-{}.{}.x", package, version.major, version.minor - 1);
 
-                    if !push_status.success() {
-                        return Err(anyhow::anyhow!("`git push origin {}` failed", branch_name));
+                        let prev_exists = Command::new("git")
+                            .args([
+                                "ls-remote",
+                                "--exit-code",
+                                "--heads",
+                                "origin",
+                                &prev_branch_name,
+                            ])
+                            .current_dir(workspace)
+                            .status()
+                            .map(|status| status.success())
+                            .unwrap_or(false);
+
+                        if prev_exists {
+                            let delete_status = Command::new("git")
+                                .arg("push")
+                                .arg("origin")
+                                .arg(format!(":{}", prev_branch_name))
+                                .current_dir(workspace)
+                                .status()
+                                .with_context(|| {
+                                    format!(
+                                        "Failed to delete previous backport branch {prev_branch_name}"
+                                    )
+                                })?;
+
+                            if delete_status.success() {
+                                log::info!(
+                                    "Deleted previous backport branch {prev_branch_name} on origin"
+                                );
+                            } else {
+                                log::warn!(
+                                    "Failed to delete previous backport branch {prev_branch_name} on origin"
+                                );
+                            }
+                        }
                     }
-
+                } else {
                     log::info!(
-                        "Created backport branch {branch_name} for {} v{}",
+                        "Skipping backport branch creation for {} v{} (major < 1)",
                         package,
                         version_str
                     );
                 }
-
-                // If there was a previous minor branch (e.g. 1.1.x when creating 1.2.x),
-                // delete it on origin if it exists.
-                if version.minor > 0 {
-                    let prev_branch_name =
-                        format!("{}-{}.{}.x", package, version.major, version.minor - 1);
-
-                    let prev_exists = Command::new("git")
-                        .args([
-                            "ls-remote",
-                            "--exit-code",
-                            "--heads",
-                            "origin",
-                            &prev_branch_name,
-                        ])
-                        .current_dir(workspace)
-                        .status()
-                        .map(|status| status.success())
-                        .unwrap_or(false);
-
-                    if prev_exists {
-                        let delete_status = Command::new("git")
-                            .arg("push")
-                            .arg("origin")
-                            .arg(format!(":{}", prev_branch_name))
-                            .current_dir(workspace)
-                            .status()
-                            .with_context(|| {
-                                format!(
-                                    "Failed to delete previous backport branch {prev_branch_name}"
-                                )
-                            })?;
-
-                        if delete_status.success() {
-                            log::info!(
-                                "Deleted previous backport branch {prev_branch_name} on origin"
-                            );
-                        } else {
-                            log::warn!(
-                                "Failed to delete previous backport branch {prev_branch_name} on origin"
-                            );
-                        }
-                    }
-                }
-            } else {
+            }
+            _ => {
                 log::info!(
-                    "Skipping backport branch creation for {} v{} (major < 1)",
+                    "Skipping backport branch creation for {} v{} (bump is not a stable minor/major)",
                     package,
                     version_str
                 );
             }
-        } else {
-            log::info!(
-                "Skipping backport branch creation for {} v{} (bump is not stable minor/major)",
-                package,
-                version_str
-            );
         }
     }
 

--- a/xtask/src/commands/release/post_release.rs
+++ b/xtask/src/commands/release/post_release.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use semver::Version;
 
 use super::{PLACEHOLDER, Plan, execute_plan::make_git_changes};
-use crate::commands::{VersionBump, comparison_url};
+use crate::commands::comparison_url;
 
 /// Perform post-release tasks such as creating migration guides for packages that have them.
 pub fn post_release(workspace: &std::path::Path) -> Result<()> {
@@ -72,45 +72,49 @@ pub fn post_release(workspace: &std::path::Path) -> Result<()> {
             );
         }
 
-        // Backport branch management: only for minor/major bumps on stable releases (**major** >=
-        // 1), we do not have and do not maintain backport branches for `0.{minor}.x`
-        // versions.
-        match package_plan.bump {
-            VersionBump::Minor | VersionBump::Major => {
-                if version.major >= 1 {
-                    let branch_name = format!("{}-{}.{}.x", package, version.major, version.minor);
+        // Backport branch management: only for stable minor/major bumps on stable releases
+        // (**major** >= 1). We do not maintain backport branches for `0.{minor}.x` versions,
+        // and we do not create them for pre-releases.
+        let is_stable_minor_or_major = package_plan.bump.pre.is_none()
+            && matches!(
+                package_plan.bump.base,
+                Some(crate::Version::Minor | crate::Version::Major)
+            );
+        if is_stable_minor_or_major {
+            if version.major >= 1 {
+                let branch_name = format!("{}-{}.{}.x", package, version.major, version.minor);
 
-                    // Check if branch already exists on origin
-                    let branch_exists = Command::new("git")
-                        .args([
-                            "ls-remote",
-                            "--exit-code",
-                            "--heads",
-                            "origin",
-                            &branch_name,
-                        ])
+                // Check if branch already exists on origin
+                let branch_exists = Command::new("git")
+                    .args([
+                        "ls-remote",
+                        "--exit-code",
+                        "--heads",
+                        "origin",
+                        &branch_name,
+                    ])
+                    .current_dir(workspace)
+                    .status()
+                    .map(|status| status.success())
+                    .unwrap_or(false);
+
+                if branch_exists {
+                    log::info!(
+                        "Backport branch already exists on origin: {branch_name}, skipping creation"
+                    );
+                } else {
+                    // We want the backport branch to start at the released tag for this
+                    // package.
+                    let tag_name = &package_plan.tag_name;
+
+                    let tag_exists = Command::new("git")
+                        .args(["rev-parse", "--verify", "--quiet", tag_name])
                         .current_dir(workspace)
                         .status()
                         .map(|status| status.success())
                         .unwrap_or(false);
 
-                    if branch_exists {
-                        log::info!(
-                            "Backport branch already exists on origin: {branch_name}, skipping creation"
-                        );
-                    } else {
-                        // We want the backport branch to start at the released tag for this
-                        // package.
-                        let tag_name = &package_plan.tag_name;
-
-                        let tag_exists = Command::new("git")
-                            .args(["rev-parse", "--verify", "--quiet", tag_name])
-                            .current_dir(workspace)
-                            .status()
-                            .map(|status| status.success())
-                            .unwrap_or(false);
-
-                        let create_status = if tag_exists {
+                    let create_status = if tag_exists {
                             // Create branch from the release tag (preferred).
                             Command::new("git")
                                 .arg("branch")
@@ -131,92 +135,85 @@ pub fn post_release(workspace: &std::path::Path) -> Result<()> {
                         }
                         .with_context(|| format!("Failed to create backport branch {branch_name}"))?;
 
-                        if !create_status.success() {
-                            return Err(anyhow::anyhow!("`git branch {}` failed", branch_name));
-                        }
-
-                        let push_status = Command::new("git")
-                            .arg("push")
-                            .arg("origin")
-                            .arg(&branch_name)
-                            .current_dir(workspace)
-                            .status()
-                            .with_context(|| {
-                                format!("Failed to push backport branch {branch_name}")
-                            })?;
-
-                        if !push_status.success() {
-                            return Err(anyhow::anyhow!(
-                                "`git push origin {}` failed",
-                                branch_name
-                            ));
-                        }
-
-                        log::info!(
-                            "Created backport branch {branch_name} for {} v{}",
-                            package,
-                            version_str
-                        );
+                    if !create_status.success() {
+                        return Err(anyhow::anyhow!("`git branch {}` failed", branch_name));
                     }
 
-                    // If there was a previous minor branch (e.g. 1.1.x when creating 1.2.x),
-                    // delete it on origin if it exists.
-                    if version.minor > 0 {
-                        let prev_branch_name =
-                            format!("{}-{}.{}.x", package, version.major, version.minor - 1);
+                    let push_status = Command::new("git")
+                        .arg("push")
+                        .arg("origin")
+                        .arg(&branch_name)
+                        .current_dir(workspace)
+                        .status()
+                        .with_context(|| format!("Failed to push backport branch {branch_name}"))?;
 
-                        let prev_exists = Command::new("git")
-                            .args([
-                                "ls-remote",
-                                "--exit-code",
-                                "--heads",
-                                "origin",
-                                &prev_branch_name,
-                            ])
-                            .current_dir(workspace)
-                            .status()
-                            .map(|status| status.success())
-                            .unwrap_or(false);
-
-                        if prev_exists {
-                            let delete_status = Command::new("git")
-                                .arg("push")
-                                .arg("origin")
-                                .arg(format!(":{}", prev_branch_name))
-                                .current_dir(workspace)
-                                .status()
-                                .with_context(|| {
-                                    format!(
-                                        "Failed to delete previous backport branch {prev_branch_name}"
-                                    )
-                                })?;
-
-                            if delete_status.success() {
-                                log::info!(
-                                    "Deleted previous backport branch {prev_branch_name} on origin"
-                                );
-                            } else {
-                                log::warn!(
-                                    "Failed to delete previous backport branch {prev_branch_name} on origin"
-                                );
-                            }
-                        }
+                    if !push_status.success() {
+                        return Err(anyhow::anyhow!("`git push origin {}` failed", branch_name));
                     }
-                } else {
+
                     log::info!(
-                        "Skipping backport branch creation for {} v{} (major < 1)",
+                        "Created backport branch {branch_name} for {} v{}",
                         package,
                         version_str
                     );
                 }
-            }
-            _ => {
+
+                // If there was a previous minor branch (e.g. 1.1.x when creating 1.2.x),
+                // delete it on origin if it exists.
+                if version.minor > 0 {
+                    let prev_branch_name =
+                        format!("{}-{}.{}.x", package, version.major, version.minor - 1);
+
+                    let prev_exists = Command::new("git")
+                        .args([
+                            "ls-remote",
+                            "--exit-code",
+                            "--heads",
+                            "origin",
+                            &prev_branch_name,
+                        ])
+                        .current_dir(workspace)
+                        .status()
+                        .map(|status| status.success())
+                        .unwrap_or(false);
+
+                    if prev_exists {
+                        let delete_status = Command::new("git")
+                            .arg("push")
+                            .arg("origin")
+                            .arg(format!(":{}", prev_branch_name))
+                            .current_dir(workspace)
+                            .status()
+                            .with_context(|| {
+                                format!(
+                                    "Failed to delete previous backport branch {prev_branch_name}"
+                                )
+                            })?;
+
+                        if delete_status.success() {
+                            log::info!(
+                                "Deleted previous backport branch {prev_branch_name} on origin"
+                            );
+                        } else {
+                            log::warn!(
+                                "Failed to delete previous backport branch {prev_branch_name} on origin"
+                            );
+                        }
+                    }
+                }
+            } else {
                 log::info!(
-                    "Skipping backport branch creation for {} v{} (bump is not minor/major)",
+                    "Skipping backport branch creation for {} v{} (major < 1)",
                     package,
                     version_str
                 );
             }
+        } else {
+            log::info!(
+                "Skipping backport branch creation for {} v{} (bump is not stable minor/major)",
+                package,
+                version_str
+            );
         }
     }
 

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -545,7 +545,9 @@ impl Package {
     }
 }
 
-#[derive(Debug, Clone, Copy, strum::Display, clap::ValueEnum, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, strum::Display, clap::ValueEnum, Serialize, Deserialize,
+)]
 #[strum(serialize_all = "lowercase")]
 /// Represents the versioning scheme for a package.
 pub enum Version {


### PR DESCRIPTION
Previously `bump-version <amount> --pre <id>` ignored `<amount>` whenever `--pre` was set, so there was no way to start e.g. a `1.1.0-alpha.0` cycle from `1.0.0` the tooling would only produce `1.0.0-alpha.0`, which is semver-less-than the current version.

Closes #3801