### PR TITLE
H2: Fix ECO2+ RcFast clock calibration

### DIFF
--- a/esp-hal/src/clock/mod.rs
+++ b/esp-hal/src/clock/mod.rs
@@ -69,8 +69,7 @@ pub mod ll {
 use crate::efuse::ChipRevision;
 #[cfg(all(
     soc_has_clock_node_timg_calibration_clock,
-    timergroup_rc_fast_calibration_divider,
-    esp32h2
+    timergroup_rc_fast_calibration_tick_enable
 ))]
 use crate::peripherals::PCR;
 #[instability::unstable]
@@ -331,7 +330,10 @@ impl Clocks {
         #[cfg(not(timergroup_rc_fast_calibration_divider))]
         let calibration_divider = 1;
 
-        #[cfg(all(timergroup_rc_fast_calibration_divider, esp32h2))]
+        #[cfg(all(
+            timergroup_rc_fast_calibration_divider,
+            timergroup_rc_fast_calibration_tick_enable
+        ))]
         let use_rc_fast_calibration_divider = rtc_clock == TimgCalibrationClockConfig::RcFastDivClk
             && crate::soc::chip_revision_above(ChipRevision::from_combined(property!(
                 "timergroup.rc_fast_calibration_divider_min_rev"
@@ -365,7 +367,10 @@ impl Clocks {
         clocks::request_timg_calibration_clock(clocks);
 
         // Align with IDF ECO2+ RC_FAST calibration flow.
-        #[cfg(all(timergroup_rc_fast_calibration_divider, esp32h2))]
+        #[cfg(all(
+            timergroup_rc_fast_calibration_divider,
+            timergroup_rc_fast_calibration_tick_enable
+        ))]
         if use_rc_fast_calibration_divider {
             PCR::regs()
                 .ctrl_tick_conf()
@@ -446,7 +451,10 @@ impl Clocks {
             .modify(|_, w| w.rtc_cali_start().clear_bit());
 
         // Align with IDF ECO2+ RC_FAST calibration flow.
-        #[cfg(all(timergroup_rc_fast_calibration_divider, esp32h2))]
+        #[cfg(all(
+            timergroup_rc_fast_calibration_divider,
+            timergroup_rc_fast_calibration_tick_enable
+        ))]
         if use_rc_fast_calibration_divider {
             PCR::regs()
                 .ctrl_tick_conf()

--- a/esp-hal/src/clock/mod.rs
+++ b/esp-hal/src/clock/mod.rs
@@ -67,6 +67,12 @@ pub mod ll {
 
 #[cfg(timergroup_rc_fast_calibration_divider)]
 use crate::efuse::ChipRevision;
+#[cfg(all(
+    soc_has_clock_node_timg_calibration_clock,
+    timergroup_rc_fast_calibration_divider,
+    esp32h2
+))]
+use crate::peripherals::PCR;
 #[instability::unstable]
 pub use crate::soc::clocks::ClockConfig;
 pub use crate::soc::clocks::CpuClock;
@@ -325,6 +331,12 @@ impl Clocks {
         #[cfg(not(timergroup_rc_fast_calibration_divider))]
         let calibration_divider = 1;
 
+        #[cfg(all(timergroup_rc_fast_calibration_divider, esp32h2))]
+        let use_rc_fast_calibration_divider = rtc_clock == TimgCalibrationClockConfig::RcFastDivClk
+            && crate::soc::chip_revision_above(ChipRevision::from_combined(property!(
+                "timergroup.rc_fast_calibration_divider_min_rev"
+            )));
+
         // On some revisions calibration uses a divided RC_FAST tick.
         let calibration_cycles = (slow_cycles / calibration_divider).max(1);
 
@@ -351,6 +363,14 @@ impl Clocks {
         let current_calib_clock = clocks::timg_calibration_clock_config(clocks);
         clocks::configure_timg_calibration_clock(clocks, rtc_clock);
         clocks::request_timg_calibration_clock(clocks);
+
+        // Align with IDF ECO2+ RC_FAST calibration flow.
+        #[cfg(all(timergroup_rc_fast_calibration_divider, esp32h2))]
+        if use_rc_fast_calibration_divider {
+            PCR::regs()
+                .ctrl_tick_conf()
+                .modify(|_, w| w.tick_enable().set_bit());
+        }
 
         let calibration_clock_frequency = clocks::timg_calibration_clock_frequency(clocks);
 
@@ -424,6 +444,14 @@ impl Clocks {
         TIMG0::regs()
             .rtccalicfg()
             .modify(|_, w| w.rtc_cali_start().clear_bit());
+
+        // Align with IDF ECO2+ RC_FAST calibration flow.
+        #[cfg(all(timergroup_rc_fast_calibration_divider, esp32h2))]
+        if use_rc_fast_calibration_divider {
+            PCR::regs()
+                .ctrl_tick_conf()
+                .modify(|_, w| w.tick_enable().clear_bit());
+        }
 
         if let Some(calib_clock) = current_calib_clock
             && calib_clock != rtc_clock

--- a/esp-hal/src/clock/mod.rs
+++ b/esp-hal/src/clock/mod.rs
@@ -330,10 +330,7 @@ impl Clocks {
         #[cfg(not(timergroup_rc_fast_calibration_divider))]
         let calibration_divider = 1;
 
-        #[cfg(all(
-            timergroup_rc_fast_calibration_divider,
-            timergroup_rc_fast_calibration_tick_enable
-        ))]
+        #[cfg(timergroup_rc_fast_calibration_tick_enable)]
         let use_rc_fast_calibration_divider = rtc_clock == TimgCalibrationClockConfig::RcFastDivClk
             && crate::soc::chip_revision_above(ChipRevision::from_combined(property!(
                 "timergroup.rc_fast_calibration_divider_min_rev"
@@ -367,10 +364,7 @@ impl Clocks {
         clocks::request_timg_calibration_clock(clocks);
 
         // Align with IDF ECO2+ RC_FAST calibration flow.
-        #[cfg(all(
-            timergroup_rc_fast_calibration_divider,
-            timergroup_rc_fast_calibration_tick_enable
-        ))]
+        #[cfg(timergroup_rc_fast_calibration_tick_enable)]
         if use_rc_fast_calibration_divider {
             PCR::regs()
                 .ctrl_tick_conf()
@@ -451,10 +445,7 @@ impl Clocks {
             .modify(|_, w| w.rtc_cali_start().clear_bit());
 
         // Align with IDF ECO2+ RC_FAST calibration flow.
-        #[cfg(all(
-            timergroup_rc_fast_calibration_divider,
-            timergroup_rc_fast_calibration_tick_enable
-        ))]
+        #[cfg(timergroup_rc_fast_calibration_tick_enable)]
         if use_rc_fast_calibration_divider {
             PCR::regs()
                 .ctrl_tick_conf()

--- a/esp-hal/src/rtc_cntl/rtc/esp32h2.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32h2.rs
@@ -1,6 +1,9 @@
 use strum::FromRepr;
 
-use crate::{peripherals::PMU, soc::regi2c};
+use crate::{
+    peripherals::{PCR, PMU},
+    soc::regi2c,
+};
 
 pub(crate) fn init() {
     // * No peripheral reg i2c power up required on the target */
@@ -69,6 +72,10 @@ pub(crate) fn init() {
         pmu.slp_wakeup_cntl7()
             .modify(|_, w| w.ana_wait_target().bits(1700));
     }
+
+    PCR::regs()
+        .ctrl_tick_conf()
+        .modify(|_, w| unsafe { w.fosc_tick_num().bits(255) });
 }
 
 // Terminology:

--- a/esp-metadata-generated/src/_build_script_utils.rs
+++ b/esp-metadata-generated/src/_build_script_utils.rs
@@ -3632,6 +3632,7 @@ impl Chip {
                     "spi_slave_supports_dma",
                     "timergroup_timg_has_divcnt_rst",
                     "timergroup_rc_fast_calibration_divider",
+                    "timergroup_rc_fast_calibration_tick_enable",
                     "timergroup_rc_fast_calibration_is_set",
                     "uart_ram_size=\"128\"",
                     "uart_peripheral_controls_mem_clk",
@@ -3870,6 +3871,7 @@ impl Chip {
                     "cargo:rustc-cfg=spi_slave_supports_dma",
                     "cargo:rustc-cfg=timergroup_timg_has_divcnt_rst",
                     "cargo:rustc-cfg=timergroup_rc_fast_calibration_divider",
+                    "cargo:rustc-cfg=timergroup_rc_fast_calibration_tick_enable",
                     "cargo:rustc-cfg=timergroup_rc_fast_calibration_is_set",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
                     "cargo:rustc-cfg=uart_peripheral_controls_mem_clk",
@@ -5720,6 +5722,7 @@ pub fn emit_check_cfg_directives() {
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_pll_f64m_clk)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_pll_f48m_clk)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_pll_lp_clk)");
+    println!("cargo:rustc-check-cfg=cfg(timergroup_rc_fast_calibration_tick_enable)");
     println!("cargo:rustc-check-cfg=cfg(esp32s2)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_dedicated_gpio)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_pms)");

--- a/esp-metadata-generated/src/_generated_esp32c6.rs
+++ b/esp-metadata-generated/src/_generated_esp32c6.rs
@@ -367,6 +367,9 @@ macro_rules! property {
     ("timergroup.rc_fast_calibration_divider") => {
         32
     };
+    ("timergroup.rc_fast_calibration_tick_enable") => {
+        false
+    };
     ("uart.ram_size") => {
         128
     };

--- a/esp-metadata-generated/src/_generated_esp32h2.rs
+++ b/esp-metadata-generated/src/_generated_esp32h2.rs
@@ -364,6 +364,9 @@ macro_rules! property {
     ("timergroup.rc_fast_calibration_divider") => {
         32
     };
+    ("timergroup.rc_fast_calibration_tick_enable") => {
+        true
+    };
     ("uart.ram_size") => {
         128
     };

--- a/esp-metadata/devices/esp32h2.toml
+++ b/esp-metadata/devices/esp32h2.toml
@@ -608,7 +608,7 @@ instances = [
 support_status = "partial"
 instances = [{ name = "timg0" }, { name = "timg1" }]
 timg_has_divcnt_rst = true
-rc_fast_calibration = { divider = 32, min_rev = 2 }
+rc_fast_calibration = { divider = 32, min_rev = 2, tick_enable = true }
 
 [device.uart]
 support_status = "supported"

--- a/esp-metadata/src/cfg/timergroup.rs
+++ b/esp-metadata/src/cfg/timergroup.rs
@@ -7,22 +7,32 @@ pub struct RcFastCalibrationProperties {
     divider: u32,
     #[serde(default)]
     min_rev: u32,
+    #[serde(default)]
+    tick_enable: bool,
 }
 
 impl GenericProperty for RcFastCalibrationProperties {
     fn cfgs(&self) -> Option<Vec<String>> {
-        Some(vec![String::from("timergroup_rc_fast_calibration_divider")])
+        let mut cfgs = vec![String::from("timergroup_rc_fast_calibration_divider")];
+        if self.tick_enable {
+            cfgs.push(String::from("timergroup_rc_fast_calibration_tick_enable"));
+        }
+        Some(cfgs)
     }
 
     fn property_macro_branches(&self) -> proc_macro2::TokenStream {
         let divider = number(self.divider);
         let min_rev = number(self.min_rev);
+        let tick_enable = self.tick_enable;
         quote! {
             ("timergroup.rc_fast_calibration_divider_min_rev") => {
                 #min_rev
             };
             ("timergroup.rc_fast_calibration_divider") => {
                 #divider
+            };
+            ("timergroup.rc_fast_calibration_tick_enable") => {
+                #tick_enable
             };
         }
     }


### PR DESCRIPTION
This PR addresses necessary calibration steps for ECO2+ H2.

closes https://github.com/esp-rs/esp-hal/issues/5321