### PR TITLE
S3: auto-detect PSRAM mode

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -60,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cache configuration options for ESP32-S2 (#5306)
 - C5: Add PSRAM support (#5317)
 - C61: Add PSRAM support (#5325)
+- A `PsramMode` option has been introduced for ESP32-S3. The default mode is `Auto` which will try to detect if PSRAM works via Octal or Quad SPI and configure it accordingly. (#5334)
 
 ### Changed
 
@@ -139,6 +140,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The `Efuse` struct has been removed. Use free-standing functions in the `efuse` module instead. (#5104)
 - The `ESP_HAL_CONFIG_XTAL_FREQUENCY` configuration option has been removed (#4517)
+- The `ESP_HAL_CONFIG_PSRAM_MODE` configuration option has been removed (#5334)
 - `Clocks::{i2c_clock, pwm_clock, crypto_clock}` fields (#4636, #4647)
 - `RtcClock::xtal_freq()` and the `XtalClock` enum (#4724)
 - `Rtc::estimate_xtal_frequency()` (#4851)

--- a/esp-hal/MIGRATING-1.0.0.md
+++ b/esp-hal/MIGRATING-1.0.0.md
@@ -179,3 +179,87 @@ expensive.
 -let revision = chip_revision();
 +let revision = chip_revision().combined();
 ```
+
+## PSRAM configuration changes
+
+The PSRAM configuration has been moved out of `esp_hal::Config`. Instead, PSRAM configuration is now done
+when creating the `Psram` driver. If you are using the `esp_alloc::psram_allocator!` macro, a default
+configuration is applied for you. However, sometimes you may want to customize this configuration.
+
+```rust
+let psram_config = esp_hal::psram::PsramConfig {
+    // Set custom configuration options here
+    // e.g. (ESP32-S3): `mode: esp_hal::psram::PsramMode::OctalSpi,`
+    ..Default::default()
+};
+```
+
+You have the following options to apply this configuration:
+
+### Pass a `PsramConfig` struct to the macro
+
+```rust
+let p = esp_hal::init(Default::default());
+esp_alloc::psram_allocator!(p.PSRAM, esp_hal::psram, psram_config);
+```
+
+### Initialize the driver explicitly and pass it to the macro
+
+```rust
+use esp_hal::psram::Psram;
+
+let p = esp_hal::init(Default::default());
+let psram = Psram::new(p.PSRAM, psram_config);
+esp_alloc::psram_allocator!(&psram);
+```
+
+### Initialize the driver explicitly and set up the PSRAM heap without the macro
+
+```rust
+use esp_hal::psram::Psram;
+
+let p = esp_hal::init(Default::default());
+let psram = Psram::new(p.PSRAM, psram_config);
+let (start, size) = psram.raw_parts();
+unsafe {
+    esp_alloc::HEAP.add_region(esp_alloc::HeapRegion::new(
+        start,
+        size,
+        esp_alloc::MemoryCapability::External.into(),
+    ));
+}
+```
+
+## Build configuration changes
+
+The following options have been removed:
+
+- `ESP_HAL_CONFIG_XTAL_FREQUENCY`
+- `ESP_HAL_CONFIG_PSRAM_MODE`
+
+Instead, runtime configuration is available.
+
+### Configuring crystal frequency
+
+The crystal frequency can be configured when initializing `esp-hal`, by providing a custom clock configuration.
+
+```rust
+use esp_hal::clock::{CpuClock, ll};
+
+// Obtain a configuration preset for a given CPU clock frequency.
+let mut cpu_clock_config: ll::ClockConfig = CpuClock::default().into();
+
+// Change the XTAL frequency in the configuration.
+cpu_clock_config.xtal_clk = Some(ll::XtalClkConfig::_40);
+
+// Initialize esp-hal with the custom clock configuration.
+let peripherals = esp_hal::init(esp_hal::Config::default().with_cpu_clock(cpu_clock_config));
+```
+
+### Configuring the PSRAM interface (ESP32-S3)
+
+`esp-hal` will try to auto-detect the PSRAM mode. However, this may not work in all cases. Also, you
+may already know exactly what mode your chip's PSRAM can operate in, and want to configure it directly
+to save on time or code size.
+
+You can now specify the PSRAM mode via the `mode` field of the `PsramConfig` struct. Read the "PSRAM configuration changes" section for more information on how you need to apply this configuration.

--- a/esp-hal/esp_config.yml
+++ b/esp-hal/esp_config.yml
@@ -35,24 +35,6 @@ options:
       - value: true
     active: 'chip == "esp32"'
 
-  - name: psram-mode
-    description: SPIRAM chip mode
-    default:
-      - value: '"quad"'
-    constraints:
-      - if: 'feature("psram_octal_spi")'
-        type:
-          validator: enumeration
-          value:
-            - "quad"
-            - "octal"
-      - if: '!feature("psram_octal_spi")'
-        type:
-          validator: enumeration
-          value:
-            - "quad"
-    active: 'feature("soc_has_psram")'
-
   - name: stack-guard-offset
     description: The stack guard variable will be placed this many bytes from the stack's end. Needs to be a multiple of 4.
     default:

--- a/esp-hal/src/psram/esp32.rs
+++ b/esp-hal/src/psram/esp32.rs
@@ -49,8 +49,6 @@ pub struct PsramConfig {
 }
 
 /// Initializes the PSRAM memory on supported devices.
-///
-/// Returns the start of the mapped memory and the size
 pub(crate) fn init_psram(config: PsramConfig) {
     let mut config = config;
 

--- a/esp-hal/src/psram/esp32c5_c61.rs
+++ b/esp-hal/src/psram/esp32c5_c61.rs
@@ -129,8 +129,6 @@ impl Default for PsramConfig {
 }
 
 /// Initialize PSRAM to be used for data.
-///
-/// Returns the start of the mapped memory and the size
 #[procmacros::ram]
 pub(crate) fn init_psram(config: PsramConfig) {
     let mut config = config;

--- a/esp-hal/src/psram/esp32s2.rs
+++ b/esp-hal/src/psram/esp32s2.rs
@@ -27,8 +27,6 @@ pub struct PsramConfig {
 }
 
 /// Initialize PSRAM to be used for data.
-///
-/// Returns the start of the mapped memory and the size
 #[procmacros::ram]
 pub(crate) fn init_psram(config: PsramConfig) {
     let mut config = config;

--- a/esp-hal/src/psram/esp32s3.rs
+++ b/esp-hal/src/psram/esp32s3.rs
@@ -3,6 +3,21 @@ use crate::peripherals::{EXTMEM, IO_MUX, SPI0, SPI1};
 
 const EXTMEM_ORIGIN: u32 = 0x3C000000;
 
+/// PSRAM interface mode
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PsramMode {
+    /// Try to detect the PSRAM mode. While convenient, not entirely reliable.
+    #[default]
+    Auto,
+
+    /// The PSRAM is connected via Quad SPI.
+    QuadSpi,
+
+    /// The PSRAM is connected via Octal SPI.
+    OctalSpi,
+}
+
 /// Frequency of flash memory
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -52,6 +67,8 @@ pub enum SpiTimingConfigCoreClock {
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct PsramConfig {
+    /// PSRAM interface mode
+    pub mode: PsramMode,
     /// PSRAM size
     pub size: PsramSize,
     /// Core timing configuration
@@ -63,33 +80,28 @@ pub struct PsramConfig {
 }
 
 /// Initialize PSRAM to be used for data.
-///
-/// Returns the start of the mapped memory and the size
 #[procmacros::ram]
-pub(crate) fn init_psram(config: PsramConfig) {
-    let mut config = config;
+pub(crate) fn init_psram(mut config: PsramConfig) {
+    let success = match config.mode {
+        PsramMode::Auto => {
+            let mut success = octal_spi_impl::psram_init(&mut config);
 
-    if config.core_clock.is_none() {
-        cfg_if::cfg_if! {
-            if #[cfg(psram_mode_octal)] {
-                config.core_clock = Some(if config.ram_frequency == SpiRamFreq::Freq80m {
-                    SpiTimingConfigCoreClock::SpiTimingConfigCoreClock160m
-                } else if config.ram_frequency == SpiRamFreq::Freq120m {
-                    SpiTimingConfigCoreClock::SpiTimingConfigCoreClock240m
-                } else {
-                    SpiTimingConfigCoreClock::SpiTimingConfigCoreClock80m
-                });
-            } else {
-                config.core_clock = Some( if config.ram_frequency == SpiRamFreq::Freq120m {
-                    SpiTimingConfigCoreClock::SpiTimingConfigCoreClock120m
-                } else {
-                    SpiTimingConfigCoreClock::SpiTimingConfigCoreClock80m
-                });
+            if !success {
+                success = quad_spi_impl::psram_init(&mut config);
             }
-        }
-    }
 
-    utils::psram_init(&mut config);
+            success
+        }
+        PsramMode::QuadSpi => quad_spi_impl::psram_init(&mut config),
+        PsramMode::OctalSpi => octal_spi_impl::psram_init(&mut config),
+    };
+
+    if !success {
+        warn!(
+            "Failed to configure PSRAM. This may indicate a missing/inoperable PSRAM chip, or an incorrect PSRAM configuration. Check if the PSRAM chip is present and the configuration is correct."
+        );
+        return;
+    }
 
     const MMU_ACCESS_SPIRAM: u32 = 1 << 15;
     const START_PAGE: u32 = 0;
@@ -179,8 +191,7 @@ pub(crate) fn init_psram(config: PsramConfig) {
     }
 }
 
-#[cfg(psram_mode_quad)]
-pub(crate) mod utils {
+pub(crate) mod quad_spi_impl {
     use procmacros::ram;
 
     use super::*;
@@ -191,7 +202,7 @@ pub(crate) mod utils {
     const CS_PSRAM_SEL: u8 = 1 << 1;
 
     #[ram]
-    pub(crate) fn psram_init(config: &mut super::PsramConfig) {
+    pub(crate) fn psram_init(config: &mut PsramConfig) -> bool {
         psram_gpio_config();
         psram_set_cs_timing();
 
@@ -215,11 +226,11 @@ pub(crate) mod utils {
                 false,
             );
             if dev_id == 0xffffff {
-                warn!(
-                    "Unknown PSRAM chip ID: {:x}. PSRAM chip not found or not supported. Check if ESP_HAL_CONFIG_PSRAM_MODE is configured correctly.",
+                debug!(
+                    "Unknown PSRAM chip ID: {:x}. PSRAM chip not found or not supported. Check if the interface mode is configured correctly.",
                     dev_id
                 );
-                return;
+                return false;
             }
 
             info!("chip id = {:x}", dev_id);
@@ -246,6 +257,14 @@ pub(crate) mod utils {
             config.size = PsramSize::Size(size);
         }
 
+        if config.core_clock.is_none() {
+            config.core_clock = Some(if config.ram_frequency == SpiRamFreq::Freq120m {
+                SpiTimingConfigCoreClock::SpiTimingConfigCoreClock120m
+            } else {
+                SpiTimingConfigCoreClock::SpiTimingConfigCoreClock80m
+            });
+        }
+
         // SPI1: send psram reset command
         psram_reset_mode_spi1();
         // SPI1: send QPI enable command
@@ -260,6 +279,9 @@ pub(crate) mod utils {
         // Back to the high speed mode. Flash/PSRAM clocks are set to the clock that
         // user selected. SPI0/1 registers are all set correctly
         mspi_timing_enter_high_speed_mode(true, config);
+
+        info!("PSRAM initialized successfully in Quad SPI mode");
+        true
     }
 
     const PSRAM_CS_IO: u8 = 26;
@@ -765,8 +787,7 @@ pub(crate) mod utils {
     }
 }
 
-#[cfg(psram_mode_octal)]
-pub(crate) mod utils {
+pub(crate) mod octal_spi_impl {
     use procmacros::ram;
 
     use super::*;
@@ -1056,7 +1077,7 @@ pub(crate) mod utils {
     }
 
     #[ram]
-    pub(crate) fn psram_init(config: &mut PsramConfig) {
+    pub(crate) fn psram_init(config: &mut PsramConfig) -> bool {
         mspi_pin_init();
         init_psram_pins();
         set_psram_cs_timing();
@@ -1090,11 +1111,11 @@ pub(crate) mod utils {
         print_psram_info(&mode_reg);
 
         if mode_reg.vendor_id() != OCT_PSRAM_VENDOR_ID {
-            warn!(
-                "Unknown PSRAM vendor ID: {:x}. PSRAM chip not found or not supported. Check if ESP_HAL_CONFIG_PSRAM_MODE is configured correctly.",
+            debug!(
+                "Unknown PSRAM vendor ID: {:x}. PSRAM chip not found or not supported. Check if the interface mode is configured correctly.",
                 mode_reg.vendor_id()
             );
-            return;
+            return false;
         }
 
         let psram_size = match mode_reg.density() {
@@ -1107,6 +1128,15 @@ pub(crate) mod utils {
         };
         info!("{} bytes of PSRAM", psram_size);
 
+        if config.core_clock.is_none() {
+            config.core_clock = Some(if config.ram_frequency == SpiRamFreq::Freq80m {
+                SpiTimingConfigCoreClock::SpiTimingConfigCoreClock160m
+            } else if config.ram_frequency == SpiRamFreq::Freq120m {
+                SpiTimingConfigCoreClock::SpiTimingConfigCoreClock240m
+            } else {
+                SpiTimingConfigCoreClock::SpiTimingConfigCoreClock80m
+            });
+        }
         if config.size.is_auto() {
             config.size = PsramSize::Size(psram_size);
         }
@@ -1129,6 +1159,9 @@ pub(crate) mod utils {
         // spi_flash_set_vendor_required_regs();
 
         config_psram_spi_phases();
+
+        info!("PSRAM initialized successfully in Octal SPI mode");
+        true
     }
 
     // Configure PSRAM SPI0 phase related registers here according to the PSRAM chip

--- a/esp-hal/src/psram/mod.rs
+++ b/esp-hal/src/psram/mod.rs
@@ -10,7 +10,7 @@
 #![cfg_attr(
     psram_octal_spi,
     doc = concat!("The ", chip_pretty!(), " can use either Quad SPI or Octal SPI to interface with PSRAM.
-        You need to configure the correct interface type using `ESP_HAL_CONFIG_PSRAM_MODE`.")
+        `esp-hal` will try to automatically detect the best option, but manual configuration is also possible and more reliable.")
 )]
 #![doc = ""]
 //! ## Examples

--- a/examples/peripheral/dma/extmem2mem/src/main.rs
+++ b/examples/peripheral/dma/extmem2mem/src/main.rs
@@ -1,7 +1,4 @@
 //! Uses DMA to copy psram to internal memory.
-//!
-//! If your module is octal PSRAM then you need to set
-//! `ESP_HAL_CONFIG_PSRAM_MODE` to `octal`.
 
 #![no_std]
 #![no_main]

--- a/examples/peripheral/spi/loopback_dma_psram/src/main.rs
+++ b/examples/peripheral/spi/loopback_dma_psram/src/main.rs
@@ -12,9 +12,6 @@
 //! This example transfers data via SPI.
 //! Connect MISO and MOSI pins to see the outgoing data is read as incoming
 //! data.
-//!
-//! If your module is octal PSRAM then you need to set
-//! `ESP_HAL_CONFIG_PSRAM_MODE` to `octal`.
 
 #![no_std]
 #![no_main]

--- a/hil-test/src/bin/alloc_psram.rs
+++ b/hil-test/src/bin/alloc_psram.rs
@@ -1,12 +1,9 @@
 //! Allocator and PSRAM-related tests
 
 //% CHIPS:
-//% CHIPS(llff_quad, tlsf_quad): esp32 esp32s2 esp32c5 esp32c61
-// The S3 dev kit in the HIL-tester has octal PSRAM.
-//% CHIPS(llff_octal, tlsf_octal): esp32s3
-//% ENV(llff_octal, tlsf_octal): ESP_HAL_CONFIG_PSRAM_MODE=octal
-//% ENV(llff_octal, llff_quad): ESP_ALLOC_CONFIG_HEAP_ALGORITHM=LLFF
-//% ENV(tlsf_octal, tlsf_quad): ESP_ALLOC_CONFIG_HEAP_ALGORITHM=TLSF
+//% CHIPS(llff, tlsf): esp32 esp32s2 esp32c5 esp32c61 esp32s3
+//% ENV(llff): ESP_ALLOC_CONFIG_HEAP_ALGORITHM=LLFF
+//% ENV(tlsf): ESP_ALLOC_CONFIG_HEAP_ALGORITHM=TLSF
 //% FEATURES: unstable esp-storage esp-alloc/nightly
 
 #![no_std]

--- a/hil-test/src/bin/crypto.rs
+++ b/hil-test/src/bin/crypto.rs
@@ -1,15 +1,11 @@
 //! Crypto hardware tests
 
-//% CHIPS(quad): esp32s2
-// The S3 dev kit in the HIL-tester has octal PSRAM.
-//% CHIPS(octal): esp32s3
+//% CHIPS(quad): esp32s2 esp32s3
 // ESP32 has no AES-DMA, no point in setting up PSRAM
-// TODO: enable PSRAM for ESP32-C5
+// TODO: enable PSRAM for ESP32-C5, C61
 //% CHIPS(no_psram): esp32 esp32c2 esp32c3 esp32c5 esp32c6 esp32h2
 
-//% ENV(octal): ESP_HAL_CONFIG_PSRAM_MODE=octal
-//% FEATURES(quad, octal):
-//% FEATURES: unstable esp-alloc/nightly
+//% FEATURES: unstable esp-alloc/nightly defmt
 
 #![no_std]
 #![no_main]

--- a/hil-test/src/bin/spi_half_duplex_write_psram.rs
+++ b/hil-test/src/bin/spi_half_duplex_write_psram.rs
@@ -2,8 +2,6 @@
 
 //% CHIPS: esp32s3
 //% FEATURES: unstable
-// The dev kit in the HIL-tester has octal PSRAM.
-//% ENV: ESP_HAL_CONFIG_PSRAM_MODE=octal
 
 #![no_std]
 #![no_main]

--- a/qa-test/src/bin/psram.rs
+++ b/qa-test/src/bin/psram.rs
@@ -1,9 +1,6 @@
 //! This shows how to use PSRAM as heap-memory via esp-alloc
 //!
 //! You need a supported target with at least 2 MB of PSRAM memory.
-//!
-//! On ESP32-S3 you might want to set `ESP_HAL_CONFIG_PSRAM_MODE` to `octal` if
-//! the device comes with octal-SPIRAM
 
 //% CHIPS: esp32 esp32s2 esp32s3 esp32c5 esp32c61
 //% FEATURES: esp-alloc/internal-heap-stats


### PR DESCRIPTION
We can just try octal SPI, and try quad SPI again if it fails. This allows us to remove a common enough pain point, and a build-time config option. Just in case, this PR adds `PsramConfig::mode` to maintain control over the exact interface used.