### PR TITLE
esp-radio: Don't re-export `esp_wifi_result` macro & bunch of missed traits

### DIFF
--- a/esp-radio/src/wifi/csi.rs
+++ b/esp-radio/src/wifi/csi.rs
@@ -5,7 +5,7 @@ use core::marker::PhantomData;
 
 use esp_hal::time::{Duration, Instant};
 
-use super::{WifiError, c_types::c_void, esp_wifi_result};
+use super::{WifiError, c_types::c_void};
 #[cfg(any(wifi_mac_version = "2", wifi_mac_version = "3"))]
 use crate::sys::include::wifi_csi_acquire_config_t;
 use crate::{
@@ -16,7 +16,7 @@ use crate::{
         wifi_csi_config_t,
         wifi_csi_info_t,
     },
-    wifi::SecondaryChannel,
+    wifi::{SecondaryChannel, esp_wifi_result},
 };
 
 /// CSI (Channel State Information) packet metadata and associated packet details.

--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -80,7 +80,6 @@ use self::{
 };
 use crate::{
     RadioRefGuard,
-    esp_wifi_result,
     hal::ram,
     sys::{
         c_types,
@@ -1354,7 +1353,7 @@ impl Interface<'_> {
 }
 
 /// Supported Wi-Fi protocols for each band.
-#[derive(Debug, Clone, Copy, PartialEq, Hash, BuilderLite)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, BuilderLite)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub struct Bandwidths {
@@ -1772,8 +1771,6 @@ fn dump_packet_info(_buffer: &mut [u8]) {
     }
 }
 
-#[doc(hidden)]
-#[macro_export]
 macro_rules! esp_wifi_result {
     ($value:expr) => {{
         use num_traits::FromPrimitive;
@@ -1792,6 +1789,7 @@ macro_rules! esp_wifi_result {
         }
     }};
 }
+pub(crate) use esp_wifi_result;
 
 pub(crate) mod embassy {
     use embassy_net_driver::{Capabilities, Driver, HardwareAddress, RxToken, TxToken};

--- a/esp-radio/src/wifi/scan.rs
+++ b/esp-radio/src/wifi/scan.rs
@@ -6,13 +6,13 @@ use esp_hal::time::Duration;
 use procmacros::BuilderLite;
 
 use crate::{
-    esp_wifi_result,
     sys::include,
     wifi::{
         Ssid,
         WifiController,
         WifiError,
         ap::{AccessPointInfo, convert_ap_info},
+        esp_wifi_result,
     },
 };
 

--- a/esp-radio/src/wifi/sniffer.rs
+++ b/esp-radio/src/wifi/sniffer.rs
@@ -7,7 +7,6 @@ use esp_sync::NonReentrantMutex;
 use super::RxControlInfo;
 use crate::{
     WifiError,
-    esp_wifi_result,
     sys::include::{
         esp_wifi_80211_tx,
         esp_wifi_set_promiscuous,
@@ -19,6 +18,7 @@ use crate::{
         wifi_promiscuous_pkt_t,
         wifi_promiscuous_pkt_type_t,
     },
+    wifi::esp_wifi_result,
 };
 
 /// Represents a Wi-Fi packet in promiscuous mode.


### PR DESCRIPTION
Minor cleanup and another round cc https://github.com/esp-rs/esp-hal/issues/4712  - I think we can close it now 🤔 
closes https://github.com/esp-rs/esp-hal/issues/4712