### PR TITLE
xtask: Format `xtask` and `xtask-mcp-macros`

### DIFF
--- a/xtask-mcp-macros/src/lib.rs
+++ b/xtask-mcp-macros/src/lib.rs
@@ -2,7 +2,14 @@ use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
 use syn::{
-    Attribute, Expr, Ident, ItemStruct, Lit, Meta, Token, Type,
+    Attribute,
+    Expr,
+    Ident,
+    ItemStruct,
+    Lit,
+    Meta,
+    Token,
+    Type,
     parse::Parser,
     parse_macro_input,
     punctuated::Punctuated,
@@ -183,9 +190,7 @@ enum CliKind {
     RequiredPositional,
 }
 
-fn build_field_desc(
-    field: &syn::Field,
-) -> Option<FieldDesc> {
+fn build_field_desc(field: &syn::Field) -> Option<FieldDesc> {
     let ident = field.ident.as_ref()?.clone();
     let arg = parse_arg_attrs(&field.attrs);
     let doc = extract_doc(&field.attrs);
@@ -208,10 +213,7 @@ fn build_field_desc(
     let flag = format!("--{flag_name}");
 
     let (mcp_ty, cli_kind) = match tc {
-        TypeClass::Bool => (
-            quote! { Option<bool> },
-            CliKind::BoolFlag,
-        ),
+        TypeClass::Bool => (quote! { Option<bool> }, CliKind::BoolFlag),
         TypeClass::Option => {
             if arg.has_long {
                 (quote! { Option<String> }, CliKind::NamedOpt)
@@ -368,8 +370,8 @@ fn gen_cli_push(fd: &FieldDesc) -> TokenStream2 {
 ///
 /// The macro generates:
 /// 1. A `MyArgsMcpInput` struct (`Deserialize` + `JsonSchema`)
-/// 2. A helper function `my_args_mcp_to_cli_args` that converts the input to
-///    a `Vec<String>` of CLI arguments.
+/// 2. A helper function `my_args_mcp_to_cli_args` that converts the input to a `Vec<String>` of CLI
+///    arguments.
 /// 3. An `inventory::submit!` block that registers the tool.
 #[proc_macro_attribute]
 pub fn mcp_tool(attrs: TokenStream, input: TokenStream) -> TokenStream {
@@ -420,13 +422,13 @@ fn parse_mcp_tool_attrs(attrs: TokenStream2) -> syn::Result<McpToolAttrs> {
         )
     })?;
 
-    Ok(McpToolAttrs { description, command })
+    Ok(McpToolAttrs {
+        description,
+        command,
+    })
 }
 
-fn expand_mcp_tool(
-    attrs: McpToolAttrs,
-    item: &ItemStruct,
-) -> syn::Result<TokenStream2> {
+fn expand_mcp_tool(attrs: McpToolAttrs, item: &ItemStruct) -> syn::Result<TokenStream2> {
     let struct_name = &item.ident;
     let input_type_name = format_ident!("{}McpInput", struct_name);
 
@@ -434,11 +436,18 @@ fn expand_mcp_tool(
     let tool_name = attrs.command.replace(' ', "_").replace('-', "_");
 
     // Split the command string into individual CLI tokens.
-    let command_parts: Vec<String> = attrs.command.split_whitespace().map(str::to_string).collect();
+    let command_parts: Vec<String> = attrs
+        .command
+        .split_whitespace()
+        .map(str::to_string)
+        .collect();
     let command_parts_lit = command_parts.iter().map(|p| quote! { #p.to_string(), });
 
     let syn::Fields::Named(fields) = &item.fields else {
-        return Err(syn::Error::new_spanned(struct_name, "mcp_tool only supports structs with named fields"));
+        return Err(syn::Error::new_spanned(
+            struct_name,
+            "mcp_tool only supports structs with named fields",
+        ));
     };
 
     let mut mcp_fields = Vec::new();

--- a/xtask/src/commands/build.rs
+++ b/xtask/src/commands/build.rs
@@ -36,10 +36,13 @@ pub enum Build {
 // Subcommand Arguments
 
 /// Arguments for building documentation.
-#[cfg_attr(feature = "mcp", xtask_mcp_macros::mcp_tool(
-    description = "Build documentation for the specified packages and chips",
-    command = "build documentation"
-))]
+#[cfg_attr(
+    feature = "mcp",
+    xtask_mcp_macros::mcp_tool(
+        description = "Build documentation for the specified packages and chips",
+        command = "build documentation"
+    )
+)]
 #[derive(Debug, Default, Args)]
 pub struct BuildDocumentationArgs {
     /// Package(s) to document.
@@ -57,10 +60,13 @@ pub struct BuildDocumentationArgs {
 }
 
 /// Arguments for building a package.
-#[cfg_attr(feature = "mcp", xtask_mcp_macros::mcp_tool(
-    description = "Build the specified package with the given options",
-    command = "build package"
-))]
+#[cfg_attr(
+    feature = "mcp",
+    xtask_mcp_macros::mcp_tool(
+        description = "Build the specified package with the given options",
+        command = "build package"
+    )
+)]
 #[derive(Debug, Args)]
 pub struct BuildPackageArgs {
     /// Package to build.

--- a/xtask/src/commands/mcp.rs
+++ b/xtask/src/commands/mcp.rs
@@ -108,9 +108,7 @@ impl ServerHandler for EspHalServer {
 
         ServerInfo {
             instructions: Some(instructions.into()),
-            capabilities: ServerCapabilities::builder()
-                .enable_tools()
-                .build(),
+            capabilities: ServerCapabilities::builder().enable_tools().build(),
             ..Default::default()
         }
     }
@@ -138,12 +136,7 @@ impl ServerHandler for EspHalServer {
         let tool_name = request.name.as_ref();
         let reg = inventory::iter::<crate::McpToolRegistration>()
             .find(|r| r.name == tool_name)
-            .ok_or_else(|| {
-                ErrorData::invalid_params(
-                    format!("Unknown tool: {tool_name}"),
-                    None,
-                )
-            })?;
+            .ok_or_else(|| ErrorData::invalid_params(format!("Unknown tool: {tool_name}"), None))?;
 
         let json = Value::Object(request.arguments.unwrap_or_default());
         match (reg.execute_fn)(json) {

--- a/xtask/src/commands/relcheck.rs
+++ b/xtask/src/commands/relcheck.rs
@@ -97,7 +97,10 @@ fn toolchain_folder(toolchain: &str) -> Result<PathBuf> {
 
     match parsed.iter().find(|(name, _)| name == toolchain) {
         Some((_, folder)) => Ok(PathBuf::from(folder)),
-        None => Err(anyhow::anyhow!("Toolchain {toolchain} not found. Found {:?}", parsed)),
+        None => Err(anyhow::anyhow!(
+            "Toolchain {toolchain} not found. Found {:?}",
+            parsed
+        )),
     }
 }
 

--- a/xtask/src/commands/run.rs
+++ b/xtask/src/commands/run.rs
@@ -34,10 +34,13 @@ pub enum Run {
 // Subcommand Arguments
 
 /// Arguments for running ELFs.
-#[cfg_attr(feature = "mcp", xtask_mcp_macros::mcp_tool(
-    description = "Run all ELFs in a folder using probe-rs",
-    command = "run elfs"
-))]
+#[cfg_attr(
+    feature = "mcp",
+    xtask_mcp_macros::mcp_tool(
+        description = "Run all ELFs in a folder using probe-rs",
+        command = "run elfs"
+    )
+)]
 #[derive(Debug, Args)]
 pub struct RunElfsArgs {
     /// Which chip to run the tests for.

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -883,7 +883,8 @@ pub fn run_host_tests(workspace: &Path, package: Package) -> Result<()> {
     }
 }
 
-fn format_package_path(
+/// Format a package directory in the workspace using `cargo fmt`.
+pub fn format_package_path(
     workspace: &Path,
     package_path: &Path,
     check: bool,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -181,6 +181,13 @@ fn fmt_packages(workspace: &Path, args: FmtPackagesArgs) -> Result<()> {
         xtask::format_package(workspace, package, args.check, None)?;
     }
 
+    // Keep formatting "helper" crates that are intentionally not in
+    // the Package enum.
+    for package_path in ["xtask", "xtask-mcp-macros"] {
+        log::info!("Formatting package: {}", package_path);
+        xtask::format_package_path(workspace, &workspace.join(package_path), args.check, None)?;
+    }
+
     // format ymls in .github/
     xtask::format_yml(args.check, "./.github")?;
 


### PR DESCRIPTION
Those 2 packages were not formatted with `xfmt`.
closes https://github.com/esp-rs/esp-hal/issues/5337