### PR TITLE
Build chip specific esp-storage docs

### DIFF
--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -223,6 +223,7 @@ impl Package {
                 | EspBootloaderEspIdf
                 | EspMetadataGenerated
                 | EspRtos
+                | EspStorage
         )
     }
 


### PR DESCRIPTION
Previously esp-storage's docs were not chip dependent but we need at least specific docs for multi-core chips
