### PR TITLE
fix: OTA partition selection producing `ota_seq == 0`

### DIFF
--- a/esp-bootloader-esp-idf/CHANGELOG.md
+++ b/esp-bootloader-esp-idf/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fix `set_current_app_partition` producing `ota_seq == 0` when selecting from uninitialized otadata, which the bootloader ignores (#5346)
 
 ### Removed
 

--- a/esp-bootloader-esp-idf/src/ota.rs
+++ b/esp-bootloader-esp-idf/src/ota.rs
@@ -527,7 +527,9 @@ mod tests {
         );
 
         // The written ota_seq must be >= 1 (bootloader ignores seq == 0).
-        let seq = u32::from_le_bytes(mock_flash.data[0x0000..0x0004].try_into().unwrap());
+        let slot0_offset = SLOT0_DATA_OFFSET as usize;
+        let seq =
+            u32::from_le_bytes(mock_flash.data[slot0_offset..slot0_offset + 4].try_into().unwrap());
         assert!(seq >= 1, "ota_seq must be >= 1, got {seq}");
         // (seq - 1) % 2 must equal 1 to select Ota1.
         assert_eq!((seq - 1) % 2, 1, "ota_seq {seq} does not select Ota1");

--- a/esp-bootloader-esp-idf/src/ota.rs
+++ b/esp-bootloader-esp-idf/src/ota.rs
@@ -528,8 +528,11 @@ mod tests {
 
         // The written ota_seq must be >= 1 (bootloader ignores seq == 0).
         let slot0_offset = SLOT0_DATA_OFFSET as usize;
-        let seq =
-            u32::from_le_bytes(mock_flash.data[slot0_offset..slot0_offset + 4].try_into().unwrap());
+        let seq = u32::from_le_bytes(
+            mock_flash.data[slot0_offset..slot0_offset + 4]
+                .try_into()
+                .unwrap(),
+        );
         assert!(seq >= 1, "ota_seq must be >= 1, got {seq}");
         // (seq - 1) % 2 must equal 1 to select Ota1.
         assert_eq!((seq - 1) % 2, 1, "ota_seq {seq} does not select Ota1");

--- a/esp-bootloader-esp-idf/src/ota.rs
+++ b/esp-bootloader-esp-idf/src/ota.rs
@@ -220,8 +220,23 @@ where
         let mut buffer2 = OtaSelectEntry::default();
         self.flash.read(SLOT0_DATA_OFFSET, buffer1.as_bytes_mut())?;
         self.flash.read(SLOT1_DATA_OFFSET, buffer2.as_bytes_mut())?;
-        let seq0 = buffer1.ota_seq;
-        let seq1 = buffer2.ota_seq;
+        // The esp-idf C writer never produces ota_seq == 0 (see
+        // `esp_rewrite_ota_data` in esp-idf's `esp_ota_ops.c`), so if it
+        // appears on flash it was written by a buggy caller.  Normalize it
+        // to UNINITALIZED_SEQUENCE so the rest of the selection logic does
+        // not misinterpret it via unsigned underflow in `(0u32 - 1)`.
+        //
+        // Ref: https://github.com/espressif/esp-idf/blob/v5.4.1/components/app_update/esp_ota_ops.c#L390-L435
+        let seq0 = if buffer1.ota_seq == 0 {
+            UNINITALIZED_SEQUENCE
+        } else {
+            buffer1.ota_seq
+        };
+        let seq1 = if buffer2.ota_seq == 0 {
+            UNINITALIZED_SEQUENCE
+        } else {
+            buffer2.ota_seq
+        };
         Ok((seq0, seq1))
     }
 
@@ -264,8 +279,20 @@ where
             // calculate the needed increment of the sequence-number to select the requested OTA-app
             // partition
             let inc = if current == AppPartitionSubType::Factory {
-                (((app.ota_app_number()) as i32 + 1) + (self.ota_partition_count as i32)) as u32
-                    % self.ota_partition_count as u32
+                // Both slots are uninitialized when current == Factory, so
+                // new_seq = inc directly (not base + inc).  The bootloader
+                // selects partition (ota_seq - 1) % count, so the minimum
+                // valid ota_seq that selects `app` is app_number + 1.
+                //
+                // This matches the esp-idf C implementation which uses
+                // `SUB_TYPE_ID(subtype) + 1` for the uninitialized case:
+                // https://github.com/espressif/esp-idf/blob/v5.4.1/components/app_update/esp_ota_ops.c#L430-L434
+                //
+                // Note: the previous formula `((app_number + 1) + count) %
+                // count` produces 0 when (app_number + 1) is a multiple of
+                // count (e.g. Ota1 with 2 partitions), and the bootloader
+                // ignores ota_seq == 0.
+                app.ota_app_number() as u32 + 1
             } else {
                 ((((app.ota_app_number()) as i32) - ((current.ota_app_number()) as i32))
                     + (self.ota_partition_count as i32)) as u32
@@ -462,6 +489,48 @@ mod tests {
 
         assert_eq!(SLOT_COUNT_1_UNDEFINED, &mock_flash.data[0x0000..][..0x20],);
         assert_eq!(SLOT_INITIAL, &mock_flash.data[0x1000..][..0x20],);
+    }
+
+    /// Regression test: selecting Ota1 from uninitialized otadata (Factory
+    /// state) must produce ota_seq >= 1.  Previously the increment formula
+    /// `((app_number + 1) + count) % count` gave 0 for Ota1 with 2
+    /// partitions, and the bootloader treats ota_seq == 0 as unused.
+    #[test]
+    fn test_factory_to_ota1_produces_valid_seq() {
+        let mut binary = PARTITION_RAW;
+
+        let mock_entry = PartitionEntry {
+            binary: &mut binary,
+        };
+
+        let mut mock_flash = MockFlash {
+            data: [0xff; 0x2000],
+        };
+
+        let mock_region = FlashRegion {
+            raw: mock_entry,
+            flash: &mut mock_flash,
+        };
+
+        let mut sut = Ota::new(mock_region, 2).unwrap();
+        assert_eq!(
+            sut.current_app_partition().unwrap(),
+            AppPartitionSubType::Factory
+        );
+
+        // Select Ota1 directly from uninitialized (Factory) state.
+        sut.set_current_app_partition(AppPartitionSubType::Ota1)
+            .unwrap();
+        assert_eq!(
+            sut.current_app_partition().unwrap(),
+            AppPartitionSubType::Ota1
+        );
+
+        // The written ota_seq must be >= 1 (bootloader ignores seq == 0).
+        let seq = u32::from_le_bytes(mock_flash.data[0x0000..0x0004].try_into().unwrap());
+        assert!(seq >= 1, "ota_seq must be >= 1, got {seq}");
+        // (seq - 1) % 2 must equal 1 to select Ota1.
+        assert_eq!((seq - 1) % 2, 1, "ota_seq {seq} does not select Ota1");
     }
 
     #[test]

--- a/esp-bootloader-esp-idf/src/ota.rs
+++ b/esp-bootloader-esp-idf/src/ota.rs
@@ -223,17 +223,17 @@ where
         // The esp-idf C writer never produces ota_seq == 0 (see
         // `esp_rewrite_ota_data` in esp-idf's `esp_ota_ops.c`), so if it
         // appears on flash it was written by a buggy caller.  Normalize it
-        // to UNINITALIZED_SEQUENCE so the rest of the selection logic does
+        // to UNINITIALIZED_SEQUENCE so the rest of the selection logic does
         // not misinterpret it via unsigned underflow in `(0u32 - 1)`.
         //
         // Ref: https://github.com/espressif/esp-idf/blob/v5.4.1/components/app_update/esp_ota_ops.c#L390-L435
         let seq0 = if buffer1.ota_seq == 0 {
-            UNINITALIZED_SEQUENCE
+            UNINITIALIZED_SEQUENCE
         } else {
             buffer1.ota_seq
         };
         let seq1 = if buffer2.ota_seq == 0 {
-            UNINITALIZED_SEQUENCE
+            UNINITIALIZED_SEQUENCE
         } else {
             buffer2.ota_seq
         };


### PR DESCRIPTION
`Ota::set_current_app_partition` produces `ota_seq = 0` when selecting certain partitions from uninitialized `otadata`, for example the state `espflash` leaves after a direct flash. The esp-idf bootloader ignores `ota_seq == 0`, so the device boots the old firmware instead of the newly flashed OTA image.

This breaks the standard OTA workflow: flash via `espflash` -> trigger first OTA -> device stays on old firmware.

### Root cause

The Factory-case increment formula:

```rust
((app.ota_app_number() as i32 + 1) + count as i32) as u32 % count as u32
```

For `Ota1` with 2 partitions: `((1+1)+2) % 2 = 0`. With both otadata slots uninitialized, `new_seq = inc = 0`.

Once `ota_seq == 0` is on flash, `current_app_partition()` misinterprets it via unsigned underflow (`(0u32 - 1) % 2 = 1` → `Ota1`), making subsequent `set_current_app_partition(Ota1)` calls no-ops. The broken state is sticky across OTA retries.

### Fix

- **Increment formula**: replace the Factory-case formula with `app_number + 1`, matching the [esp-idf C implementation](https://github.com/espressif/esp-idf/blob/v5.4.1/components/app_update/esp_ota_ops.c#L430-L434) (`SUB_TYPE_ID(subtype) + 1`).
- **Sequence validation**: normalize `ota_seq == 0` to `UNINITALIZED_SEQUENCE` in `get_slot_seq()` so it is handled the same as an erased slot, preventing the sticky broken state.

### Affected configurations

Any device with:
- Two OTA app partitions (`ota_0`, `ota_1`) and no factory partition
- `otadata` left uninitialized (e.g. after `espflash flash`)
- First OTA targeting `ota_1` (the non-booted slot)

In those cases, using the `OtaUpdater` to activate the next partition does not work once the device is reboot, sample code:
```rs
fn activate_next_ota_partition(flash: &mut esp_storage::FlashStorage) {
    use esp_bootloader_esp_idf::ota::OtaImageState;
    use esp_bootloader_esp_idf::ota_updater::OtaUpdater;
    use esp_bootloader_esp_idf::partitions::PARTITION_TABLE_MAX_LEN;

    let mut pt_buf = [0u8; PARTITION_TABLE_MAX_LEN];
    let mut ota = OtaUpdater::new(flash, &mut pt_buf).expect("OtaUpdater init failed");
    ota.activate_next_partition().expect("activate failed");
    ota.set_current_ota_state(OtaImageState::New).expect("set state failed");
}
```

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

#### Testing
- [x] New regression test `test_factory_to_ota1_produces_valid_seq` — verifies `ota_seq >= 1` and correct partition selection for Factory → Ota1 with 2 partitions
- [x] All 16 existing `esp-bootloader-esp-idf` unit tests pass

