### PR TITLE
Remove explicit cache writeback from AES driver

### DIFF
--- a/esp-hal/src/aes/mod.rs
+++ b/esp-hal/src/aes/mod.rs
@@ -937,15 +937,6 @@ pub mod dma {
                         }
                         *buffer = None;
                     }
-                    #[cfg(dma_can_access_psram)]
-                    if crate::psram::psram_range().contains(&item.buffers.output.addr().get()) {
-                        unsafe {
-                            crate::soc::cache_writeback_addr(
-                                item.buffers.output.addr().get() as u32,
-                                item.buffers.output.len() as u32,
-                            );
-                        }
-                    }
 
                     // Now process the remainder:
                     if remaining_bytes > 0 {


### PR DESCRIPTION
This PR removes this manual cache management operation, which is not the responsibility of the AES driver. In #4124 the underlying `prepare_for_rx` helper function has been modified to write back the affected cache lines _before_ starting the DMA transfer. This means it's not necessary to write back the cache after the transfer.