### PR TITLE
Remove push event triggers from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,6 @@ name: CI
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-  push:
-    branches-ignore:
-      - "gh-readonly-queue/**"
-      - "main"
-      - "backport-**"
-      - "release-branch-**"
   merge_group:
   workflow_dispatch:
 


### PR DESCRIPTION
I'm pretty sure we don't need this. It should save us doing double CI when pushing directly to esp-rs.

Historically I think this was needed for release tooling, but all the release steps can be handled by the pull request event now (I think we ran into the label limitation).