### PR TITLE
Prepare esp-hal@1.1-rc.0

### DIFF
--- a/esp-alloc/CHANGELOG.md
+++ b/esp-alloc/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+
+### Changed
+
+
+### Fixed
+
+
+### Removed
+
+
+## [v0.10.0] - 2026-04-14
+
+### Added
+
 - `global-allocator` Cargo feature to opt in to the `#[global_allocator]`, this feature is enabled by default. (#4703)
 - Support for ESP32-C5 (#4884)
 - Support for ESP32-C61 (#5240)
@@ -22,9 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed arithmetic overflow in tracking total amount of allocated/freed memory (#4783)
-
-### Removed
-
 
 ## [v0.9.0] - 2025-10-13
 
@@ -96,4 +107,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.7.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-alloc-v0.7.0
 [v0.8.0]: https://github.com/esp-rs/esp-hal/compare/esp-alloc-v0.7.0...esp-alloc-v0.8.0
 [v0.9.0]: https://github.com/esp-rs/esp-hal/compare/esp-alloc-v0.8.0...esp-alloc-v0.9.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-alloc-v0.9.0...HEAD
+[v0.10.0]: https://github.com/esp-rs/esp-hal/compare/esp-alloc-v0.9.0...esp-alloc-v0.10.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-alloc-v0.10.0...HEAD

--- a/esp-alloc/Cargo.toml
+++ b/esp-alloc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-alloc"
-version       = "0.9.0"
+version       = "0.10.0"
 edition       = "2024"
 rust-version  = "1.86.0"
 description   = "A heap allocator for Espressif devices"
@@ -36,14 +36,14 @@ allocator-api2        = { version = "0.3.0", default-features = false }
 defmt                 = { version = "1.0.1", optional = true }
 cfg-if                = "1"
 enumset               = "1"
-esp-sync              = { version = "0.1.1", path = "../esp-sync" }
+esp-sync              = { version = "0.2.0", path = "../esp-sync" }
 document-features     = "0.2"
 
 linked_list_allocator = { version = "0.10.5", default-features = false, features = ["const_mut_refs"] }
 rlsf = { version = "0.2", features = ["unstable"] }
 
 [build-dependencies]
-esp-config   = { version = "0.6.1", path = "../esp-config", features = ["build"] }
+esp-config   = { version = "0.7.0", path = "../esp-config", features = ["build"] }
 
 [features]
 default = ["compat", "global-allocator"]

--- a/esp-backtrace/Cargo.toml
+++ b/esp-backtrace/Cargo.toml
@@ -34,8 +34,8 @@ test  = false
 [dependencies]
 cfg-if      = "1"
 defmt       = { version = "1", optional = true }
-esp-config  = { version = "0.6.1", path = "../esp-config" }
-esp-metadata-generated = { version = "0.3.0", path = "../esp-metadata-generated" }
+esp-config  = { version = "0.7.0", path = "../esp-config" }
+esp-metadata-generated = { version = "0.4.0", path = "../esp-metadata-generated" }
 esp-println = { version = "0.16.1", optional = true, default-features = false, path = "../esp-println" }
 heapless    = "0.9"
 semihosting = { version = "0.1.20", optional = true }
@@ -45,11 +45,11 @@ document-features = "0.2"
 riscv            = { version = "0.15.0" }
 
 [target.'cfg(target_arch = "xtensa")'.dependencies]
-xtensa-lx        = { version = "0.13.0", path = "../xtensa-lx" }
+xtensa-lx        = { version = "0.14.0", path = "../xtensa-lx" }
 
 [build-dependencies]
-esp-config   = { version = "0.6.1", path = "../esp-config", features = ["build"] }
-esp-metadata-generated = { version = "0.3.0", path = "../esp-metadata-generated", features = ["build-script"] }
+esp-config   = { version = "0.7.0", path = "../esp-config", features = ["build"] }
+esp-metadata-generated = { version = "0.4.0", path = "../esp-metadata-generated", features = ["build-script"] }
 
 [features]
 default = ["colors"]

--- a/esp-bootloader-esp-idf/Cargo.toml
+++ b/esp-bootloader-esp-idf/Cargo.toml
@@ -32,10 +32,10 @@ test  = true
 cfg-if = "1"
 defmt = { version = "1.0.1", optional = true }
 document-features = "0.2"
-esp-config = { version = "0.6.1", path = "../esp-config" }
-esp-hal-procmacros = { version = "0.21.0", path = "../esp-hal-procmacros", features = ["__esp_idf_bootloader"] }
-esp-metadata-generated = { version = "0.3.0", path = "../esp-metadata-generated" }
-esp-rom-sys = { version = "0.1.3", path = "../esp-rom-sys", optional = true }
+esp-config = { version = "0.7.0", path = "../esp-config" }
+esp-hal-procmacros = { version = "0.22.0", path = "../esp-hal-procmacros", features = ["__esp_idf_bootloader"] }
+esp-metadata-generated = { version = "0.4.0", path = "../esp-metadata-generated" }
+esp-rom-sys = { version = "0.1.4", path = "../esp-rom-sys", optional = true }
 embedded-storage = "0.3.1"
 log-04 = { package = "log", version = "0.4", optional = true }
 strum = { version = "0.27", default-features = false, features = ["derive"] }
@@ -45,12 +45,12 @@ md-5 = { version = "0.10.6", default-features = false, optional = true }
 
 [build-dependencies]
 jiff       = { version = "0.2.13", default-features = false, features = ["std"] }
-esp-config = { version = "0.6.1", path = "../esp-config", features = ["build"] }
-esp-metadata-generated = { version = "0.3.0", path = "../esp-metadata-generated", features = ["build-script"] }
+esp-config = { version = "0.7.0", path = "../esp-config", features = ["build"] }
+esp-metadata-generated = { version = "0.4.0", path = "../esp-metadata-generated", features = ["build-script"] }
 
 # Make doctests & host-tests work together:
 [target.'cfg(any(target_arch = "riscv32", target_arch = "xtensa"))'.dev-dependencies]
-esp-hal = { version = "~1.0", path = "../esp-hal" }
+esp-hal = { version = "~1.1.0-rc.0", path = "../esp-hal" }
 
 [features]
 default = ["validation"]

--- a/esp-config/CHANGELOG.md
+++ b/esp-config/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 
+## [v0.7.0] - 2026-04-14
+
 ## [v0.6.1] - 2025-10-30
 
 ## [v0.6.0] - 2025-10-13
@@ -77,4 +79,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v0.5.0]: https://github.com/esp-rs/esp-hal/compare/esp-config-v0.4.0...esp-config-v0.5.0
 [v0.6.0]: https://github.com/esp-rs/esp-hal/compare/esp-config-v0.5.0...esp-config-v0.6.0
 [v0.6.1]: https://github.com/esp-rs/esp-hal/compare/esp-config-v0.6.0...esp-config-v0.6.1
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-config-v0.6.1...HEAD
+[v0.7.0]: https://github.com/esp-rs/esp-hal/compare/esp-config-v0.6.1...esp-config-v0.7.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-config-v0.7.0...HEAD

--- a/esp-config/Cargo.toml
+++ b/esp-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-config"
-version       = "0.6.1"
+version       = "0.7.0"
 edition       = "2024"
 rust-version  = "1.86.0"
 description   = "Configure projects using esp-hal and related packages"
@@ -33,7 +33,7 @@ document-features = "0.2"
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 serde_yaml = { version =  "0.9", optional = true }
 somni-expr = { version = "0.2.0", optional = true }
-esp-metadata-generated = { version = "0.3.0", path = "../esp-metadata-generated", features = ["build-script"], optional = true }
+esp-metadata-generated = { version = "0.4.0", path = "../esp-metadata-generated", features = ["build-script"], optional = true }
 
 # used by the `tui` feature
 clap            = { version = "4.5", features = ["derive"], optional = true }

--- a/esp-hal-procmacros/CHANGELOG.md
+++ b/esp-hal-procmacros/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+
+### Changed
+
+
+### Fixed
+
+
+### Removed
+
+
+## [v0.22.0] - 2026-04-14
+
+### Added
+
 - `doc_replace` can now replace `__placeholders__` in-line (#5119)
 
 ### Changed
@@ -21,10 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed the logic for determining which sections should be loaded in `load_lp_code!` macro (#4612)
-
-
-### Removed
-
 
 ## [v0.21.0] - 2025-10-30
 
@@ -129,4 +139,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v0.19.0]: https://github.com/esp-rs/esp-hal/compare/esp-hal-procmacros-v0.18.0...esp-hal-procmacros-v0.19.0
 [v0.20.0]: https://github.com/esp-rs/esp-hal/compare/esp-hal-procmacros-v0.19.0...esp-hal-procmacros-v0.20.0
 [v0.21.0]: https://github.com/esp-rs/esp-hal/compare/esp-hal-procmacros-v0.20.0...esp-hal-procmacros-v0.21.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-hal-procmacros-v0.21.0...HEAD
+[v0.22.0]: https://github.com/esp-rs/esp-hal/compare/esp-hal-procmacros-v0.21.0...esp-hal-procmacros-v0.22.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-hal-procmacros-v0.22.0...HEAD

--- a/esp-hal-procmacros/Cargo.toml
+++ b/esp-hal-procmacros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-hal-procmacros"
-version       = "0.21.0"
+version       = "0.22.0"
 edition       = "2024"
 rust-version  = "1.88.0"
 description   = "Procedural macros for esp-hal"

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+
+### Changed
+
+
+### Fixed
+
+
+### Removed
+
+
+## [v1.1.0-rc.0] - 2026-04-14
+
+### Added
+
 - `AdcPin` now implements `Debug` and `defmt::Format`. (#5194)
 - RMT: All public types now derive `Debug` and `defmt::Format`. (#4302)
 - RMT: `Channel::apply_config` has been added. (#4302)
@@ -1592,4 +1606,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v1.0.0-rc.0]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.0.0-beta.1...esp-hal-v1.0.0-rc.0
 [v1.0.0-rc.1]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.0.0-rc.0...esp-hal-v1.0.0-rc.1
 [v1.0.0]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.0.0-rc.1...esp-hal-v1.0.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.0.0...HEAD
+[v1.1.0-rc.0]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.0.0...esp-hal-v1.1.0-rc.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.1.0-rc.0...HEAD

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-hal"
-version       = "1.0.0"
+version       = "1.1.0-rc.0"
 edition       = "2024"
 rust-version  = "1.88.0"
 description   = "Bare-metal HAL for Espressif devices"
@@ -52,7 +52,7 @@ enumset                  = "1.1"
 paste                    = "1.0.15"
 portable-atomic          = { version = "1.11", default-features = false }
 
-esp-rom-sys              = { version = "0.1.3", path = "../esp-rom-sys" }
+esp-rom-sys              = { version = "0.1.4", path = "../esp-rom-sys" }
 
 # Unstable dependencies that are not (strictly) part of the public API
 bitfield                 = "0.19"
@@ -64,10 +64,10 @@ fugit                    = "0.3.7"
 instability              = "0.3.12"
 strum                    = { version = "0.27.1", default-features = false, features = ["derive"] }
 
-esp-config               = { version = "0.6.1", path = "../esp-config" }
-esp-metadata-generated   = { version = "0.3.0", path = "../esp-metadata-generated" }
-esp-sync                 = { version = "0.1.1", path = "../esp-sync" }
-procmacros               = { version = "0.21.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
+esp-config               = { version = "0.7.0", path = "../esp-config" }
+esp-metadata-generated   = { version = "0.4.0", path = "../esp-metadata-generated" }
+esp-sync                 = { version = "0.2.0", path = "../esp-sync" }
+procmacros               = { version = "0.22.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
 
 # Dependencies that are optional because they are used by unstable drivers.
 # They are needed when using the `unstable` feature.
@@ -114,15 +114,15 @@ esp32s3 = { version = "0.35", features = ["critical-section", "rt"], optional = 
 
 [target.'cfg(target_arch = "riscv32")'.dependencies]
 riscv            = { version = "0.15.0" }
-esp-riscv-rt     = { version = "0.13.0", path = "../esp-riscv-rt", optional = true }
+esp-riscv-rt     = { version = "0.14.0", path = "../esp-riscv-rt", optional = true }
 
 [target.'cfg(target_arch = "xtensa")'.dependencies]
-xtensa-lx        = { version = "0.13.0", path = "../xtensa-lx" }
-xtensa-lx-rt     = { version = "0.21.0", path = "../xtensa-lx-rt", optional = true }
+xtensa-lx        = { version = "0.14.0", path = "../xtensa-lx" }
+xtensa-lx-rt     = { version = "0.22.0", path = "../xtensa-lx-rt", optional = true }
 
 [build-dependencies]
-esp-metadata-generated = { version = "0.3.0", path = "../esp-metadata-generated", features = ["build-script"] }
-esp-config   = { version = "0.6.1", path = "../esp-config", features = ["build"] }
+esp-metadata-generated = { version = "0.4.0", path = "../esp-metadata-generated", features = ["build-script"] }
+esp-config   = { version = "0.7.0", path = "../esp-config", features = ["build"] }
 
 [dev-dependencies]
 crypto-bigint = { version = "0.5.5", default-features = false }

--- a/esp-hal/MIGRATING-1.0.0.md
+++ b/esp-hal/MIGRATING-1.0.0.md
@@ -1,4 +1,4 @@
-# Migration Guide from 1.0.0 to {{currentVersion}}
+# Migration Guide from 1.0.0 to 1.1.0-rc.0
 
 ## RMT Changes
 

--- a/esp-lp-hal/Cargo.toml
+++ b/esp-lp-hal/Cargo.toml
@@ -42,9 +42,9 @@ embedded-hal-nb   = { version = "1.0.0",  optional = true }
 embedded-io-06    = { package = "embedded-io", version = "0.6",  optional = true }
 embedded-io-07    = { package = "embedded-io", version = "0.7",  optional = true }
 nb                = { version = "1.1.0",  optional = true }
-procmacros        = { version = "0.21.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
+procmacros        = { version = "0.22.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
 riscv             = { version = "0.15", features = ["critical-section-single-hart"] }
-esp-metadata-generated = { version = "0.3.0", path = "../esp-metadata-generated" }
+esp-metadata-generated = { version = "0.4.0", path = "../esp-metadata-generated" }
 esp32c6-lp        = { version = "0.3.0", features = ["critical-section"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "fc3e6d4" }
 esp32s2-ulp       = { version = "0.3.0", features = ["critical-section"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "fc3e6d4" }
 esp32s3-ulp       = { version = "0.3.0", features = ["critical-section"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "fc3e6d4" }
@@ -53,7 +53,7 @@ esp32s3-ulp       = { version = "0.3.0", features = ["critical-section"], option
 panic-halt = "0.2.0"
 
 [build-dependencies]
-esp-metadata-generated = { version = "0.3.0", path = "../esp-metadata-generated", features = ["build-script"] }
+esp-metadata-generated = { version = "0.4.0", path = "../esp-metadata-generated", features = ["build-script"] }
 
 [features]
 default = ["embedded-hal"]

--- a/esp-metadata-generated/Cargo.toml
+++ b/esp-metadata-generated/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-metadata-generated"
-version       = "0.3.0"
+version       = "0.4.0"
 edition       = "2024"
 rust-version  = "1.86.0"
 description   = "Generated metadata for Espressif devices"

--- a/esp-phy/Cargo.toml
+++ b/esp-phy/Cargo.toml
@@ -29,9 +29,9 @@ bench = false
 cfg-if = "1"
 
 document-features = "0.2"
-esp-hal = { version = "~1.0", path = "../esp-hal", default-features = false }
-esp-metadata-generated = { version = "0.3.0", path = "../esp-metadata-generated" }
-esp-sync = { version = "0.1.1", path = "../esp-sync" }
+esp-hal = { version = "~1.1.0-rc.0", path = "../esp-hal", default-features = false }
+esp-metadata-generated = { version = "0.4.0", path = "../esp-metadata-generated" }
+esp-sync = { version = "0.2.0", path = "../esp-sync" }
 
 # Make sure these are aligned with esp-radio's dependencies, too!
 esp-wifi-sys-esp32 = { version = "0.2.0", optional = true }
@@ -60,8 +60,8 @@ defmt = { version = "1.0.1", optional = true }
 log-04 = { version = "0.4.27", package = "log", optional = true }
 
 [build-dependencies]
-esp-config   = { version = "0.6.1", path = "../esp-config", features = ["build"] }
-esp-metadata-generated = { version = "0.3.0", path = "../esp-metadata-generated", features = ["build-script"] }
+esp-config   = { version = "0.7.0", path = "../esp-config", features = ["build"] }
+esp-metadata-generated = { version = "0.4.0", path = "../esp-metadata-generated", features = ["build-script"] }
 
 [features]
 #! ### Logging Feature Flags

--- a/esp-println/Cargo.toml
+++ b/esp-println/Cargo.toml
@@ -39,7 +39,7 @@ test  = false
 document-features = "0.2"
 
 # Unstable dependencies that are not (strictly) part of the public API
-esp-sync = { version = "0.1.1", path = "../esp-sync", optional = true }
+esp-sync = { version = "0.2.0", path = "../esp-sync", optional = true }
 
 # Optional dependencies
 portable-atomic  = { version = "1.11", optional = true, default-features = false }
@@ -49,7 +49,7 @@ defmt  = { version = "1.0.1", optional = true }
 log-04 = { package = "log", version = "0.4", optional = true }
 
 [build-dependencies]
-esp-metadata-generated = { version = "0.3.0", path = "../esp-metadata-generated", features = ["build-script"] }
+esp-metadata-generated = { version = "0.4.0", path = "../esp-metadata-generated", features = ["build-script"] }
 log-04 = { package = "log", version = "0.4" }
 
 [features]

--- a/esp-radio-rtos-driver/CHANGELOG.md
+++ b/esp-radio-rtos-driver/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+
+### Changed
+
+
+### Fixed
+
+
+### Removed
+
+
+## [v0.3.0] - 2026-04-14
+
+### Added
+
 - `usleep_until` and `Scheduler::usleep_until` to put the current task to sleep until the specified timestamp. (#4555)
 - `SemaphoreHandle::take_with_deadline` to take a semaphore with a deadline. (#4555)
 - `QueueHandle::{send_to_front_with_deadline, send_to_back_with_deadline, receive_with_deadline}` for queue operations with a deadline. (#4555)
@@ -33,9 +47,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `register_queue_implementation` no longer requires `QueuePtr` to be in scope (#4559)
 - `task_create` now saturates the priority to the maximum supported by the OS (#5074)
 
-### Removed
-
-
 ## [v0.2.0] - 2025-10-30
 
 ### Added
@@ -50,4 +61,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [v0.1.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-radio-rtos-driver-v0.1.0
 [v0.2.0]: https://github.com/esp-rs/esp-hal/compare/esp-radio-rtos-driver-v0.1.0...esp-radio-rtos-driver-v0.2.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-radio-rtos-driver-v0.2.0...HEAD
+[v0.3.0]: https://github.com/esp-rs/esp-hal/compare/esp-radio-rtos-driver-v0.2.0...esp-radio-rtos-driver-v0.3.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-radio-rtos-driver-v0.3.0...HEAD

--- a/esp-radio-rtos-driver/Cargo.toml
+++ b/esp-radio-rtos-driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-radio-rtos-driver"
-version       = "0.2.0"
+version       = "0.3.0"
 edition       = "2024"
 rust-version  = "1.86.0"
 description   = "Task scheduler interface for esp-radio"
@@ -23,7 +23,7 @@ portable-atomic = "1"
 portable-atomic = { version = "1", features = ["unsafe-assume-single-core"] }
 
 [dependencies]
-esp-sync = { version = "0.1.1", path = "../esp-sync", optional = true }
+esp-sync = { version = "0.2.0", path = "../esp-sync", optional = true }
 cfg-if = "1"
 
 # Logging interfaces, they are mutually exclusive so they need to be behind separate features.

--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -43,28 +43,28 @@ test  = false
 
 [dependencies]
 cfg-if  = "1"
-esp-hal = { version = "~1.0", path = "../esp-hal", default-features = false }
+esp-hal = { version = "~1.1.0-rc.0", path = "../esp-hal", default-features = false }
 portable-atomic = { version = "1.11", default-features = false }
 enumset = { version = "1.1", default-features = false, optional = true }
 
 # ⚠️ Unstable dependencies
-esp-radio-rtos-driver = { version = "0.2.0", path = "../esp-radio-rtos-driver" }
+esp-radio-rtos-driver = { version = "0.3.0", path = "../esp-radio-rtos-driver" }
 instability = "0.3.12"
 
 # Unstable dependencies that are not (strictly) part of the public API
 allocator-api2 = { version = "0.3.0", default-features = false, features = ["alloc"] }
 docsplay = { version = "0.1", default-features = false }
 document-features  = "0.2"
-esp-alloc = { version = "0.9.0", path = "../esp-alloc", optional = true, default-features = false }
-esp-config = { version = "0.6.1", path = "../esp-config" }
-esp-metadata-generated = { version = "0.3.0", path = "../esp-metadata-generated" }
-esp-sync = { version = "0.1.1", path = "../esp-sync" }
+esp-alloc = { version = "0.10.0", path = "../esp-alloc", optional = true, default-features = false }
+esp-config = { version = "0.7.0", path = "../esp-config" }
+esp-metadata-generated = { version = "0.4.0", path = "../esp-metadata-generated" }
+esp-sync = { version = "0.2.0", path = "../esp-sync" }
 esp-phy = { version = "0.1.1", path = "../esp-phy/" }
 num-derive = "0.4.2"
 num-traits = { version = "0.2.19", default-features = false }
 portable_atomic_enum = { version = "0.3.1", features = ["portable-atomic"] }
-procmacros = { version = "0.21.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
-xtensa-lx-rt = { version = "0.21.0", path = "../xtensa-lx-rt", optional = true }
+procmacros = { version = "0.22.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
+xtensa-lx-rt = { version = "0.22.0", path = "../xtensa-lx-rt", optional = true }
 byte = { version = "0.2.7", optional = true }
 ieee802154 = { version = "0.6.1", optional = true }
 heapless = "0.9"
@@ -103,11 +103,11 @@ defmt = { version = "1.0.1", optional = true }
 log-04 = { package = "log", version = "0.4.27", optional = true }
 
 [build-dependencies]
-esp-config = { version = "0.6.1", path = "../esp-config", features = ["build"] }
-esp-metadata-generated = { version = "0.3.0", path = "../esp-metadata-generated", features = ["build-script"] }
+esp-config = { version = "0.7.0", path = "../esp-config", features = ["build"] }
+esp-metadata-generated = { version = "0.4.0", path = "../esp-metadata-generated", features = ["build-script"] }
 
 [dev-dependencies]
-esp-rtos = { version = "0.2.0", path = "../esp-rtos" }
+esp-rtos = { version = "0.3.0", path = "../esp-rtos" }
 
 [features]
 default = ["esp-alloc"]

--- a/esp-riscv-rt/CHANGELOG.md
+++ b/esp-riscv-rt/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `clic-48` feature to generate more trap handlers (#4883)
 
 ### Changed
 
@@ -19,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+
+## [v0.14.0] - 2026-04-14
+
+### Added
+
+- Added `clic-48` feature to generate more trap handlers (#4883)
 
 ## [v0.13.0] - 2025-10-13
 
@@ -118,4 +123,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v0.11.0]: https://github.com/esp-rs/esp-hal/compare/esp-riscv-rt-v0.10.0...esp-riscv-rt-v0.11.0
 [v0.12.0]: https://github.com/esp-rs/esp-hal/compare/esp-riscv-rt-v0.11.0...esp-riscv-rt-v0.12.0
 [v0.13.0]: https://github.com/esp-rs/esp-hal/compare/esp-riscv-rt-v0.12.0...esp-riscv-rt-v0.13.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-riscv-rt-v0.13.0...HEAD
+[v0.14.0]: https://github.com/esp-rs/esp-hal/compare/esp-riscv-rt-v0.13.0...esp-riscv-rt-v0.14.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-riscv-rt-v0.14.0...HEAD

--- a/esp-riscv-rt/Cargo.toml
+++ b/esp-riscv-rt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-riscv-rt"
-version       = "0.13.0"
+version       = "0.14.0"
 edition       = "2024"
 rust-version  = "1.88.0"
 description   = "Minimal runtime / startup for RISC-V CPUs from Espressif"

--- a/esp-rom-sys/CHANGELOG.md
+++ b/esp-rom-sys/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+
+### Changed
+
+
+### Fixed
+
+
+### Removed
+
+
+## [v0.1.4] - 2026-04-14
+
+### Added
+
 - Initial ESP32-C5 support (#4859)
 - Initial ESP32-C61 support (#5187)
 
@@ -19,9 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed `ets_update_cpu_frequency_rom` not linking on ESP32 (#4500)
-
-### Removed
-
 
 ## [v0.1.3] - 2025-10-30
 
@@ -47,4 +58,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v0.1.1]: https://github.com/esp-rs/esp-hal/compare/esp-rom-sys-v0.1.0...esp-rom-sys-v0.1.1
 [v0.1.2]: https://github.com/esp-rs/esp-hal/compare/esp-rom-sys-v0.1.1...esp-rom-sys-v0.1.2
 [v0.1.3]: https://github.com/esp-rs/esp-hal/compare/esp-rom-sys-v0.1.2...esp-rom-sys-v0.1.3
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-rom-sys-v0.1.3...HEAD
+[v0.1.4]: https://github.com/esp-rs/esp-hal/compare/esp-rom-sys-v0.1.3...esp-rom-sys-v0.1.4
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-rom-sys-v0.1.4...HEAD

--- a/esp-rom-sys/Cargo.toml
+++ b/esp-rom-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-rom-sys"
-version       = "0.1.3"
+version       = "0.1.4"
 edition       = "2024"
 rust-version  = "1.87.0"
 description   = "ROM code support"
@@ -40,7 +40,7 @@ esp32s2 = { version = "0.31", features = ["critical-section"], optional = true }
 esp32s3 = { version = "0.35", features = ["critical-section"], optional = true }
 
 [build-dependencies]
-esp-metadata-generated = { version = "0.3.0", path = "../esp-metadata-generated", features = ["build-script"] }
+esp-metadata-generated = { version = "0.4.0", path = "../esp-metadata-generated", features = ["build-script"] }
 
 [features]
 __internal_rom_symbols = []

--- a/esp-rtos/CHANGELOG.md
+++ b/esp-rtos/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+
+### Changed
+
+
+### Fixed
+
+
+### Removed
+
+
+## [v0.3.0] - 2026-04-14
+
+### Added
+
 - Provide implementation for the `_getreent` syscall when the `alloc` feature is enabled (#4473)
 - Provide implementation for the `_malloc_r` and `_free_r` syscalls when the `alloc` feature is enabled (#4484)
 - Support for ESP32-C5 (#4884)
@@ -70,4 +84,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v0.1.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-rtos-v0.1.0
 [v0.1.1]: https://github.com/esp-rs/esp-hal/compare/esp-rtos-v0.1.0...esp-rtos-v0.1.1
 [v0.2.0]: https://github.com/esp-rs/esp-hal/compare/esp-rtos-v0.1.1...esp-rtos-v0.2.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-rtos-v0.2.0...HEAD
+[v0.3.0]: https://github.com/esp-rs/esp-hal/compare/esp-rtos-v0.2.0...esp-rtos-v0.3.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-rtos-v0.3.0...HEAD

--- a/esp-rtos/Cargo.toml
+++ b/esp-rtos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-rtos"
-version       = "0.2.0"
+version       = "0.3.0"
 edition       = "2024"
 rust-version  = "1.86.0"
 description   = "A task scheduler for Espressif devices"
@@ -31,12 +31,12 @@ features       = ["esp32c6", "embassy", "esp-radio"]
 bench = false
 
 [dependencies]
-esp-hal = { version = "~1.0", path = "../esp-hal", default-features = false, features = [
+esp-hal = { version = "~1.1.0-rc.0", path = "../esp-hal", default-features = false, features = [
     # FIXME: rt technically shouldn't be enabled, but rtos requires `TrapFrame`
     # and uses reexported riscv/xtensa-lx from esp-hal
     "requires-unstable", "rt"
 ] }
-esp-rom-sys = { version = "0.1.3", path = "../esp-rom-sys" }
+esp-rom-sys = { version = "0.1.4", path = "../esp-rom-sys" }
 
 cfg-if = "1"
 rtos-trace = { version = "0.2.0", optional = true }
@@ -45,11 +45,11 @@ rtos-trace = { version = "0.2.0", optional = true }
 allocator-api2 = { version = "0.3.0", default-features = false, features = ["alloc"], optional = true }
 document-features  = "0.2"
 embassy-sync = "0.8"
-esp-alloc = { version = "0.9.0", path = "../esp-alloc", optional = true, default-features = false }
-esp-config = { version = "0.6.1", path = "../esp-config" }
-esp-sync = { version = "0.1.1", path = "../esp-sync" }
-esp-radio-rtos-driver = { version = "0.2.0", path = "../esp-radio-rtos-driver", features = ["ipc-implementations"], optional = true }
-macros = { version = "0.21.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
+esp-alloc = { version = "0.10.0", path = "../esp-alloc", optional = true, default-features = false }
+esp-config = { version = "0.7.0", path = "../esp-config" }
+esp-sync = { version = "0.2.0", path = "../esp-sync" }
+esp-radio-rtos-driver = { version = "0.3.0", path = "../esp-radio-rtos-driver", features = ["ipc-implementations"], optional = true }
+macros = { version = "0.22.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
 portable-atomic = { version = "1.11", default-features = false }
 
 # Optional dependencies that enable ecosystem support.
@@ -65,14 +65,14 @@ log-04           = { package = "log", version = "0.4", optional = true }
 riscv            = { version = "0.15.0" }
 
 [target.'cfg(target_arch = "xtensa")'.dependencies]
-xtensa-lx        = { version = "0.13.0", path = "../xtensa-lx" }
+xtensa-lx        = { version = "0.14.0", path = "../xtensa-lx" }
 
 [build-dependencies]
-esp-config             = { version = "0.6.1", path = "../esp-config", features = ["build"] }
-esp-metadata-generated = { version = "0.3.0", path = "../esp-metadata-generated", features = ["build-script"] }
+esp-config             = { version = "0.7.0", path = "../esp-config", features = ["build"] }
+esp-metadata-generated = { version = "0.4.0", path = "../esp-metadata-generated", features = ["build-script"] }
 
 [dev-dependencies]
-esp-hal = { version = "~1.0", path = "../esp-hal", features = ["unstable"] }
+esp-hal = { version = "~1.1.0-rc.0", path = "../esp-hal", features = ["unstable"] }
 
 [features]
 default = []

--- a/esp-storage/Cargo.toml
+++ b/esp-storage/Cargo.toml
@@ -28,19 +28,19 @@ bench = false
 
 [dependencies]
 embedded-storage = "0.3.1"
-procmacros       = { version = "0.21.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
-esp-hal = { version = "~1.0", path = "../esp-hal", default-features = false, optional = true}
+procmacros       = { version = "0.22.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
+esp-hal = { version = "~1.1.0-rc.0", path = "../esp-hal", default-features = false, optional = true}
 
 # Optional dependencies
-esp-sync         = { version = "0.1.1", path = "../esp-sync", optional = true }
-esp-rom-sys      = { version = "0.1.3", path = "../esp-rom-sys", optional = true }
+esp-sync         = { version = "0.2.0", path = "../esp-sync", optional = true }
+esp-rom-sys      = { version = "0.1.4", path = "../esp-rom-sys", optional = true }
 defmt  = { version = "1.0.1", optional = true }
 
 # Unstable dependencies that are not (strictly) part of the public API
 document-features = "0.2"
 
 [build-dependencies]
-esp-metadata-generated = { version = "0.3.0", path = "../esp-metadata-generated", features = ["build-script"] }
+esp-metadata-generated = { version = "0.4.0", path = "../esp-metadata-generated", features = ["build-script"] }
 
 [features]
 default = ["critical-section"]

--- a/esp-sync/CHANGELOG.md
+++ b/esp-sync/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+
+### Changed
+
+
+### Fixed
+
+
+### Removed
+
+
+## [v0.2.0] - 2026-04-14
+
+### Added
+
 - Initial ESP32-C5 support (#4859)
 - Initial ESP32-C61 support (#5187)
 - Added support for embassy-sync 0.8 (#5249)
@@ -16,12 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Added `#[inline]` attributes to ensure better codegen (#4627)
-
-### Fixed
-
-
-### Removed
-
 
 ## [v0.1.1] - 2025-10-30
 
@@ -33,4 +41,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [v0.1.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-sync-v0.1.0
 [v0.1.1]: https://github.com/esp-rs/esp-hal/compare/esp-sync-v0.1.0...esp-sync-v0.1.1
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-sync-v0.1.1...HEAD
+[v0.2.0]: https://github.com/esp-rs/esp-hal/compare/esp-sync-v0.1.1...esp-sync-v0.2.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-sync-v0.2.0...HEAD

--- a/esp-sync/Cargo.toml
+++ b/esp-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-sync"
-version       = "0.1.1"
+version       = "0.2.0"
 edition       = "2024"
 rust-version  = "1.88.0"
 description   = "Synchronization primitives for Espressif devices"
@@ -21,7 +21,7 @@ clippy-configs = [{ features = ["defmt"] }]
 [dependencies]
 cfg-if = "1"
 document-features = "0.2"
-esp-metadata-generated = { version = "0.3.0", path = "../esp-metadata-generated" }
+esp-metadata-generated = { version = "0.4.0", path = "../esp-metadata-generated" }
 embassy-sync-06 = { package = "embassy-sync", version = "0.6" }
 embassy-sync-07 = { package = "embassy-sync", version = "0.7" }
 embassy-sync-08 = { package = "embassy-sync", version = "0.8" }
@@ -34,10 +34,10 @@ log-04 = { package = "log", version = "0.4", optional = true }
 riscv            = { version = "0.15" }
 
 [target.'cfg(target_arch = "xtensa")'.dependencies]
-xtensa-lx        = { version = "0.13.0", path = "../xtensa-lx" }
+xtensa-lx        = { version = "0.14.0", path = "../xtensa-lx" }
 
 [build-dependencies]
-esp-metadata-generated = { version = "0.3.0", path = "../esp-metadata-generated", features = ["build-script"] }
+esp-metadata-generated = { version = "0.4.0", path = "../esp-metadata-generated", features = ["build-script"] }
 
 [features]
 #! ### Chip Support Feature Flags

--- a/xtensa-lx-rt/CHANGELOG.md
+++ b/xtensa-lx-rt/CHANGELOG.md
@@ -12,14 +12,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+
+### Fixed
+
+
+### Removed
+
+
+## [v0.22.0] - 2026-04-14
+
+### Changed
+
 - `CpuInterruptLevel::mask` is now a const function. (#4437)
 
 ### Fixed
 
 - Fixed offset of `DoubleException` handler (#4580)
-
-### Removed
-
 
 ## [v0.21.0] - 2025-10-13
 
@@ -75,4 +83,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v0.19.0]: https://github.com/esp-rs/esp-hal/compare/xtensa-lx-rt-v0.18.0...xtensa-lx-rt-v0.19.0
 [v0.20.0]: https://github.com/esp-rs/esp-hal/compare/xtensa-lx-rt-v0.19.0...xtensa-lx-rt-v0.20.0
 [v0.21.0]: https://github.com/esp-rs/esp-hal/compare/xtensa-lx-rt-v0.20.0...xtensa-lx-rt-v0.21.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/xtensa-lx-rt-v0.21.0...HEAD
+[v0.22.0]: https://github.com/esp-rs/esp-hal/compare/xtensa-lx-rt-v0.21.0...xtensa-lx-rt-v0.22.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/xtensa-lx-rt-v0.22.0...HEAD

--- a/xtensa-lx-rt/Cargo.toml
+++ b/xtensa-lx-rt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "xtensa-lx-rt"
-version       = "0.21.0"
+version       = "0.22.0"
 edition       = "2024"
 rust-version  = "1.88.0"
 description   = "Minimal startup/runtime for Xtensa LX CPUs"
@@ -22,7 +22,7 @@ test  = false
 document-features = "0.2"
 defmt             = {version = "1.0.1", optional = true}
 macros            = { version = "0.5.0", package = "xtensa-lx-rt-proc-macros", path = "../xtensa-lx-rt-proc-macros" }
-xtensa-lx         = { version = "0.13.0", path = "../xtensa-lx" }
+xtensa-lx         = { version = "0.14.0", path = "../xtensa-lx" }
 
 [build-dependencies]
 

--- a/xtensa-lx/CHANGELOG.md
+++ b/xtensa-lx/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 
+## [v0.14.0] - 2026-04-14
+
 ## [v0.13.0] - 2025-10-13
 
 ## [v0.12.0] - 2025-07-16
@@ -67,4 +69,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v0.11.0]: https://github.com/esp-rs/esp-hal/compare/xtensa-lx-v0.10.0...xtensa-lx-v0.11.0
 [v0.12.0]: https://github.com/esp-rs/esp-hal/compare/xtensa-lx-v0.11.0...xtensa-lx-v0.12.0
 [v0.13.0]: https://github.com/esp-rs/esp-hal/compare/xtensa-lx-v0.12.0...xtensa-lx-v0.13.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/xtensa-lx-v0.13.0...HEAD
+[v0.14.0]: https://github.com/esp-rs/esp-hal/compare/xtensa-lx-v0.13.0...xtensa-lx-v0.14.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/xtensa-lx-v0.14.0...HEAD

--- a/xtensa-lx/Cargo.toml
+++ b/xtensa-lx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "xtensa-lx"
-version       = "0.13.0"
+version       = "0.14.0"
 edition       = "2024"
 rust-version  = "1.86.0"
 description   = "Low-level access to Xtensa LX processors and peripherals"


### PR DESCRIPTION
This pull request prepares the following packages for release:

- esp-riscv-rt: 0.14.0
- esp-metadata-generated: 0.4.0
- esp-hal-procmacros: 0.22.0
- esp-rom-sys: 0.1.4
- xtensa-lx: 0.14.0
- esp-config: 0.7.0
- xtensa-lx-rt: 0.22.0
- esp-sync: 0.2.0
- esp-hal: 1.1.0-rc.0
- esp-alloc: 0.10.0
- esp-radio-rtos-driver: 0.3.0
- esp-rtos: 0.3.0

The release plan used for this release:

```json
{
  "base": "main",
  "packages": [
    {
      "package": "esp-riscv-rt",
      "semver_checked": false,
      "current_version": "0.13.0",
      "new_version": "0.14.0",
      "tag_name": "esp-riscv-rt-v0.14.0",
      "bump": {
        "base": "Minor",
        "pre": null
      }
    },
    {
      "package": "esp-metadata-generated",
      "semver_checked": false,
      "current_version": "0.3.0",
      "new_version": "0.4.0",
      "tag_name": "esp-metadata-generated-v0.4.0",
      "bump": {
        "base": "Minor",
        "pre": null
      }
    },
    {
      "package": "esp-hal-procmacros",
      "semver_checked": false,
      "current_version": "0.21.0",
      "new_version": "0.22.0",
      "tag_name": "esp-hal-procmacros-v0.22.0",
      "bump": {
        "base": "Minor",
        "pre": null
      }
    },
    {
      "package": "esp-rom-sys",
      "semver_checked": false,
      "current_version": "0.1.3",
      "new_version": "0.1.4",
      "tag_name": "esp-rom-sys-v0.1.4",
      "bump": {
        "base": "Patch",
        "pre": null
      }
    },
    {
      "package": "xtensa-lx",
      "semver_checked": false,
      "current_version": "0.13.0",
      "new_version": "0.14.0",
      "tag_name": "xtensa-lx-v0.14.0",
      "bump": {
        "base": "Minor",
        "pre": null
      }
    },
    {
      "package": "esp-config",
      "semver_checked": false,
      "current_version": "0.6.1",
      "new_version": "0.7.0",
      "tag_name": "esp-config-v0.7.0",
      "bump": {
        "base": "Minor",
        "pre": null
      }
    },
    {
      "package": "xtensa-lx-rt",
      "semver_checked": false,
      "current_version": "0.21.0",
      "new_version": "0.22.0",
      "tag_name": "xtensa-lx-rt-v0.22.0",
      "bump": {
        "base": "Minor",
        "pre": null
      }
    },
    {
      "package": "esp-sync",
      "semver_checked": false,
      "current_version": "0.1.1",
      "new_version": "0.2.0",
      "tag_name": "esp-sync-v0.2.0",
      "bump": {
        "base": "Minor",
        "pre": null
      }
    },
    {
      "package": "esp-hal",
      "semver_checked": true,
      "current_version": "1.0.0",
      "new_version": "1.1.0-rc.0",
      "tag_name": "esp-hal-v1.1.0-rc.0",
      "bump": {
        "base": "Minor",
        "pre": "rc"
      }
    },
    {
      "package": "esp-alloc",
      "semver_checked": false,
      "current_version": "0.9.0",
      "new_version": "0.10.0",
      "tag_name": "esp-alloc-v0.10.0",
      "bump": {
        "base": "Minor",
        "pre": null
      }
    },
    {
      "package": "esp-radio-rtos-driver",
      "semver_checked": false,
      "current_version": "0.2.0",
      "new_version": "0.3.0",
      "tag_name": "esp-radio-rtos-driver-v0.3.0",
      "bump": {
        "base": "Minor",
        "pre": null
      }
    },
    {
      "package": "esp-rtos",
      "semver_checked": false,
      "current_version": "0.2.0",
      "new_version": "0.3.0",
      "tag_name": "esp-rtos-v0.3.0",
      "bump": {
        "base": "Minor",
        "pre": null
      }
    }
  ]
}
```

Please review the changes and merge them into the `main` branch.

After merging, please make sure you have this release plan in the repo root,
then run the following command on the `main` branch to tag and publish the packages:

```
cargo xrelease publish-plan --no-dry-run
```
