### PR TITLE
Enable C5/C61 for more qa-tests

### DIFF
--- a/qa-test/src/bin/embassy_executor_benchmark.rs
+++ b/qa-test/src/bin/embassy_executor_benchmark.rs
@@ -1,6 +1,6 @@
 //! Embassy executor benchmark, used to try out optimization ideas.
 
-//% CHIPS: esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+//% CHIPS: esp32c2 esp32c3 esp32c5 esp32c6 esp32c61 esp32h2 esp32s2 esp32s3
 //% FEATURES: rtos-trace
 
 #![no_std]

--- a/qa-test/src/bin/embassy_i2c.rs
+++ b/qa-test/src/bin/embassy_i2c.rs
@@ -10,7 +10,7 @@
 //! - SDA => GPIO4
 //! - SCL => GPIO5
 
-//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+//% CHIPS: esp32 esp32c2 esp32c3 esp32c5 esp32c6 esp32c61 esp32h2 esp32s2 esp32s3
 
 #![no_std]
 #![no_main]

--- a/qa-test/src/bin/embassy_i2c_bmp180_calibration_data.rs
+++ b/qa-test/src/bin/embassy_i2c_bmp180_calibration_data.rs
@@ -10,7 +10,7 @@
 //! Depending on your target and the board you are using you have to change the
 //! pins.
 
-//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+//% CHIPS: esp32 esp32c2 esp32c3 esp32c5 esp32c6 esp32c61 esp32h2 esp32s2 esp32s3
 //% TAG: bmp180
 
 #![no_std]

--- a/qa-test/src/bin/gpio_interrupt_latency.rs
+++ b/qa-test/src/bin/gpio_interrupt_latency.rs
@@ -13,7 +13,7 @@
 //! generated square waves are 90 degrees out of phase. DO NOT CONNECT GPIO2 and
 //! GPIO4 - they read back themselves.
 
-//% CHIPS: esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c5 esp32c6 esp32h2
+//% CHIPS: esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c5 esp32c6 esp32c61 esp32h2
 
 #![no_std]
 #![no_main]

--- a/qa-test/src/bin/i2c_bmp180_calibration_data.rs
+++ b/qa-test/src/bin/i2c_bmp180_calibration_data.rs
@@ -6,7 +6,7 @@
 //! - SDA => GPIO4
 //! - SCL => GPIO5
 
-//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+//% CHIPS: esp32 esp32c2 esp32c3 esp32c5 esp32c6 esp32c61 esp32h2 esp32s2 esp32s3
 //% TAG: bmp180
 
 #![no_std]

--- a/qa-test/src/bin/i2c_display.rs
+++ b/qa-test/src/bin/i2c_display.rs
@@ -7,7 +7,7 @@
 //! - SDA => GPIO4
 //! - SCL => GPIO5
 
-//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+//% CHIPS: esp32 esp32c2 esp32c3 esp32c5 esp32c6 esp32c61 esp32h2 esp32s2 esp32s3
 
 #![no_std]
 #![no_main]

--- a/qa-test/src/bin/i2c_ssd1306_length_test.rs
+++ b/qa-test/src/bin/i2c_ssd1306_length_test.rs
@@ -4,7 +4,7 @@
 //! - SDA => GPIO4
 //! - SCL => GPIO5
 
-//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+//% CHIPS: esp32 esp32c2 esp32c3 esp32c5 esp32c6 esp32c61 esp32h2 esp32s2 esp32s3
 //% TAG: ssd1306
 
 #![no_std]

--- a/qa-test/src/bin/qspi_flash.rs
+++ b/qa-test/src/bin/qspi_flash.rs
@@ -22,7 +22,7 @@
 //! Connect a flash chip (GD25Q64C was used) and make sure QE in the status
 //! register is set.
 
-//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+//% CHIPS: esp32 esp32c2 esp32c3 esp32c5 esp32c6 esp32c61 esp32h2 esp32s2 esp32s3
 //% TAG: flashchip
 
 #![no_std]

--- a/qa-test/src/bin/spi_halfduplex_read_manufacturer_id.rs
+++ b/qa-test/src/bin/spi_halfduplex_read_manufacturer_id.rs
@@ -22,7 +22,7 @@
 //! Connect a flash chip (GD25Q64C was used) and make sure QE in the status
 //! register is set.
 
-//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+//% CHIPS: esp32 esp32c2 esp32c3 esp32c5 esp32c6 esp32c61 esp32h2 esp32s2 esp32s3
 //% TAG: flashchip
 
 #![no_std]

--- a/qa-test/src/bin/wifi_survives_ble_drop.rs
+++ b/qa-test/src/bin/wifi_survives_ble_drop.rs
@@ -6,7 +6,7 @@
 //! - performs an HTTP get request to some "random" server
 
 //% FEATURES: esp-radio esp-radio/wifi esp-radio/ble esp-radio/unstable esp-hal/unstable
-//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32s3
+//% CHIPS: esp32 esp32c2 esp32c3 esp32c5 esp32c6 esp32c61 esp32s3
 
 #![no_std]
 #![no_main]


### PR DESCRIPTION
We forgot to enable a few qa-tests for ESP32-C5/C61
