### PR TITLE
misc improvements for the release tooling

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -45,7 +45,6 @@ cargo-semver-checks = { version = "0.46.0", optional = true }
 
 flate2 = { version = "1.1.1", optional = true }
 temp-file = { version = "0.1.9", optional = true }
-urlencoding = { version = "2.1.3", optional = true }
 
 # MCP server support
 inventory        = { version = "0.3", optional = true }
@@ -62,7 +61,7 @@ tempfile = "3"
 deploy-docs  = ["dep:reqwest", "dep:kuchikiki"]
 preview-docs = ["dep:opener", "dep:rocket"]
 semver-checks = [ "dep:cargo-semver-checks", "dep:flate2", "dep:temp-file", "dep:regex" ]
-release = ["semver-checks", "dep:opener", "dep:urlencoding", "dep:regex"]
+release = ["semver-checks", "dep:opener", "dep:regex"]
 report = ["dep:regex"]
 rel-check = ["dep:regex"]
 mcp = ["dep:inventory", "dep:rmcp", "dep:schemars", "dep:tokio", "dep:xtask-mcp-macros"]

--- a/xtask/src/commands/release/execute_plan.rs
+++ b/xtask/src/commands/release/execute_plan.rs
@@ -267,16 +267,12 @@ fn commit_message(plan: &Plan) -> String {
     format!("{subject}\n\n{body}\n")
 }
 
-fn open_pull_request(
-    branch: &Branch,
-    dry_run: bool,
-    manual_pull_request: bool,
-    release_plan_str: &str,
-    release_plan: &Plan,
-) -> Result<()> {
-    // Open a pull request
+const UPSTREAM_REPO: &str = "esp-rs/esp-hal";
+const PR_TITLE: &str = "Prepare release";
+const PR_LABELS: &str = "release-pr,skip-changelog";
 
-    let packages_to_release = release_plan
+fn build_pr_body(plan: &Plan, release_plan_str: &str) -> String {
+    let packages = plan
         .packages
         .iter()
         .map(|step| {
@@ -291,74 +287,216 @@ fn open_pull_request(
     let mut body = format!(
         r#"This pull request prepares the following packages for release:
 
-{packages_to_release}
+{packages}
 
-The release plan used for this release:
+<details>
+<summary>Release plan (click to expand)</summary>
 
-```json
+<pre>
 {release_plan_str}
-```
+</pre>
+</details>
 
-Please review the changes and merge them into the `{base_branch}` branch.
+Please review the changes and merge them into the `{base}` branch.
 
 After merging, please make sure you have this release plan in the repo root,
-then run the following command on the `{base_branch}` branch to tag and publish the packages:
+then run the following command on the `{base}` branch to tag and publish the packages:
 
 ```
 cargo xrelease publish-plan --no-dry-run
 ```
 "#,
-        base_branch = release_plan.base,
+        base = plan.base,
     );
 
-    if release_plan.base != "main" {
+    if plan.base != "main" {
         body = format!(
-            "⚠️ This pull request was branched off from `{current_branch}`. ⚠️\n\n{body}",
-            current_branch = release_plan.base
+            "⚠️ This pull request was branched off from `{}`. ⚠️\n\n{body}",
+            plan.base
         );
     }
 
-    // TODO: don't forget to update the PR text once we have the `publish` command
-    // updated.
+    body
+}
 
-    let pr_url_base = comparison_url(&release_plan.base, &branch.upstream, &branch.name)?;
-
-    // Query string options are documented at: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request
-    let mut open_pr_url = format!(
-        "{pr_url_base}?quick_pull=1&title=Prepare+release&labels={labels}&body={body}",
-        body = urlencoding::encode(&body),
-        labels = "release-pr,skip-changelog",
-    );
-
-    // https://stackoverflow.com/a/64565317
-    if manual_pull_request || open_pr_url.len() > 8201 {
-        println!();
-        println!("PR description begins here.");
-        println!();
-        eprintln!("{body}");
-        println!();
-
-        println!("The PR description is too long to be included in the URL.");
-        println!("Please copy the above text as the PR description.");
-        println!();
-
-        open_pr_url = format!(
-            "{pr_url_base}?quick_pull=1&title=Prepare+release&labels={labels}",
-            labels = "release-pr,skip-changelog",
-        );
-    }
+fn open_pull_request(
+    branch: &Branch,
+    dry_run: bool,
+    manual_pull_request: bool,
+    release_plan_str: &str,
+    release_plan: &Plan,
+) -> Result<()> {
+    let body = build_pr_body(release_plan, release_plan_str);
 
     if dry_run {
-        println!("Dry run: would open the following URL to create a pull request:");
-        println!("{open_pr_url}");
-    } else {
-        if opener::open(&open_pr_url).is_err() {
-            println!("Open the following URL to create a pull request:");
-            println!("{open_pr_url}");
-        }
+        println!("Dry run: would create/update the release PR with body:");
+        println!("----");
+        println!("{body}");
+        println!("----");
+        return Ok(());
     }
 
-    println!("Create the release PR and follow the next steps laid out there.");
+    if manual_pull_request || !gh_available() {
+        if !manual_pull_request {
+            log::warn!("`gh` CLI not available — falling back to manual PR instructions");
+        }
+        return print_manual_instructions(branch, release_plan, &body);
+    }
+
+    let pr_number = upsert_pull_request(branch, release_plan, &body)?;
+
+    println!(
+        "Release PR ready: https://github.com/{UPSTREAM_REPO}/pull/{pr_number} — review and merge to continue."
+    );
+    Ok(())
+}
+
+fn gh_available() -> bool {
+    Command::new("gh")
+        .arg("--version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn head_spec(upstream_url: &str, branch_name: &str) -> Result<String> {
+    if upstream_url.starts_with("https://github.com/esp-rs/") || upstream_url.is_empty() {
+        Ok(branch_name.to_string())
+    } else {
+        let user = upstream_url
+            .split('/')
+            .nth(3)
+            .with_context(|| format!("Failed to extract user from URL: {upstream_url}"))?;
+        Ok(format!("{user}:{branch_name}"))
+    }
+}
+
+fn gh_stdin(args: &[&str], stdin_data: &str) -> Result<String> {
+    use std::io::Write;
+
+    let mut child = Command::new("gh")
+        .args(args)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .with_context(|| format!("Failed to spawn `gh {}`", args.join(" ")))?;
+
+    child
+        .stdin
+        .as_mut()
+        .expect("stdin piped")
+        .write_all(stdin_data.as_bytes())
+        .context("Failed to write stdin to gh")?;
+
+    let out = child
+        .wait_with_output()
+        .with_context(|| format!("`gh {}` failed", args.join(" ")))?;
+    if !out.status.success() {
+        bail!(
+            "`gh {}` failed: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).to_string())
+}
+
+fn find_existing_pr(branch_name: &str) -> Result<Option<u64>> {
+    let output = Command::new("gh")
+        .args([
+            "pr",
+            "list",
+            "--state",
+            "open",
+            "--repo",
+            UPSTREAM_REPO,
+            "--head",
+        ])
+        .arg(branch_name)
+        .args(["--json", "number"])
+        .output()
+        .context("`gh pr list` failed")?;
+    if !output.status.success() {
+        bail!(
+            "`gh pr list` failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    let value: serde_json::Value =
+        serde_json::from_slice(&output.stdout).context("Failed to parse `gh pr list` output")?;
+    Ok(value
+        .as_array()
+        .and_then(|a| a.first())
+        .and_then(|o| o.get("number"))
+        .and_then(|n| n.as_u64()))
+}
+
+fn upsert_pull_request(branch: &Branch, plan: &Plan, body: &str) -> Result<u64> {
+    if let Some(num) = find_existing_pr(&branch.name)? {
+        log::info!("Updating existing release PR #{num}");
+        gh_stdin(
+            &[
+                "pr",
+                "edit",
+                &num.to_string(),
+                "--repo",
+                UPSTREAM_REPO,
+                "--title",
+                PR_TITLE,
+                "--body-file",
+                "-",
+            ],
+            body,
+        )?;
+        Ok(num)
+    } else {
+        let head = head_spec(&branch.upstream, &branch.name)?;
+        log::info!("Creating release PR (head: {head}, base: {})", plan.base);
+        let stdout = gh_stdin(
+            &[
+                "pr",
+                "create",
+                "--repo",
+                UPSTREAM_REPO,
+                "--base",
+                &plan.base,
+                "--head",
+                &head,
+                "--title",
+                PR_TITLE,
+                "--label",
+                PR_LABELS,
+                "--body-file",
+                "-",
+            ],
+            body,
+        )?;
+        // `gh pr create` prints the PR URL on stdout.
+        let url = stdout.trim();
+        let num = url
+            .rsplit('/')
+            .next()
+            .and_then(|s| s.parse::<u64>().ok())
+            .with_context(|| {
+                format!("Failed to parse PR number from `gh pr create` output: {url}")
+            })?;
+        Ok(num)
+    }
+}
+
+fn print_manual_instructions(branch: &Branch, plan: &Plan, body: &str) -> Result<()> {
+    let url = comparison_url(&plan.base, &branch.upstream, &branch.name)?;
+    println!();
+    println!("Open the following URL in a browser to create the PR:");
+    println!("  {url}");
+    println!();
+    println!("Paste this as the PR description:");
+    println!("----");
+    println!("{body}");
+    println!("----");
     Ok(())
 }
 

--- a/xtask/src/commands/release/execute_plan.rs
+++ b/xtask/src/commands/release/execute_plan.rs
@@ -199,8 +199,9 @@ pub(crate) fn make_git_changes(dry_run: bool, branch_name: &str, commit: &str) -
     }
 
     // Push the branch. If the remote branch already exists (e.g. this is a
-    // re-run), use --force-with-lease so we overwrite our own prior push but
-    // bail if someone else pushed in the meantime.
+    // re-run), fetch it first so the remote-tracking ref is current, then use
+    // --force-with-lease so we overwrite our own prior push but bail if
+    // someone else pushed in the meantime.
     let url = if dry_run {
         println!("Dry run: would push branch: {branch_name}");
         String::from("https://github.com/esp-rs/esp-hal/")
@@ -213,10 +214,23 @@ pub(crate) fn make_git_changes(dry_run: bool, branch_name: &str, commit: &str) -
             .context("Failed to query remote branches")?
             .success();
 
+        if remote_exists {
+            log::info!("Remote branch {branch_name} already exists — fetching before force-push");
+            let fetch_status = Command::new("git")
+                .arg("fetch")
+                .arg(&upstream)
+                .arg(&branch_name)
+                .status()
+                .context("Failed to fetch existing release branch before force-push")?;
+            if !fetch_status.success() {
+                bail!("Failed to fetch existing release branch {branch_name} from {upstream}");
+            }
+        }
+
         let mut push = Command::new("git");
         push.arg("push").arg(&upstream).arg(&branch_name);
         if remote_exists {
-            log::info!("Remote branch {branch_name} already exists — force-pushing with lease");
+            log::info!("Force-pushing {branch_name} with lease");
             push.arg("--force-with-lease");
         }
         let message = push.output().context("Failed to push branch")?;
@@ -240,8 +254,8 @@ pub(crate) fn make_git_changes(dry_run: bool, branch_name: &str, commit: &str) -
     })
 }
 
-fn commit_message(plan: &Plan) -> String {
-    let subject = match plan.packages.len() {
+fn release_subject(plan: &Plan) -> String {
+    match plan.packages.len() {
         1 => {
             let step = &plan.packages[0];
             format!(
@@ -250,10 +264,11 @@ fn commit_message(plan: &Plan) -> String {
             )
         }
         n => format!("Release {n} packages"),
-    };
+    }
+}
 
-    let body = plan
-        .packages
+fn format_package_list(plan: &Plan) -> String {
+    plan.packages
         .iter()
         .map(|step| {
             format!(
@@ -262,27 +277,20 @@ fn commit_message(plan: &Plan) -> String {
             )
         })
         .collect::<Vec<_>>()
-        .join("\n");
+        .join("\n")
+}
 
+fn commit_message(plan: &Plan) -> String {
+    let subject = release_subject(plan);
+    let body = format_package_list(plan);
     format!("{subject}\n\n{body}\n")
 }
 
 const UPSTREAM_REPO: &str = "esp-rs/esp-hal";
-const PR_TITLE: &str = "Prepare release";
-const PR_LABELS: &str = "release-pr,skip-changelog";
+const PR_LABELS: &[&str] = &["release-pr", "skip-changelog"];
 
 fn build_pr_body(plan: &Plan, release_plan_str: &str) -> String {
-    let packages = plan
-        .packages
-        .iter()
-        .map(|step| {
-            format!(
-                "- {}: {} → {}",
-                step.package, step.current_version, step.new_version
-            )
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
+    let packages = format_package_list(plan);
 
     let mut body = format!(
         r#"This pull request prepares the following packages for release:
@@ -435,17 +443,19 @@ fn find_existing_pr(branch_name: &str) -> Result<Option<u64>> {
 }
 
 fn upsert_pull_request(branch: &Branch, plan: &Plan, body: &str) -> Result<u64> {
+    let title = release_subject(plan);
     if let Some(num) = find_existing_pr(&branch.name)? {
         log::info!("Updating existing release PR #{num}");
+        let num_str = num.to_string();
         gh_stdin(
             &[
                 "pr",
                 "edit",
-                &num.to_string(),
+                &num_str,
                 "--repo",
                 UPSTREAM_REPO,
                 "--title",
-                PR_TITLE,
+                &title,
                 "--body-file",
                 "-",
             ],
@@ -455,27 +465,32 @@ fn upsert_pull_request(branch: &Branch, plan: &Plan, body: &str) -> Result<u64> 
     } else {
         let head = head_spec(&branch.upstream, &branch.name)?;
         log::info!("Creating release PR (head: {head}, base: {})", plan.base);
-        let stdout = gh_stdin(
-            &[
-                "pr",
-                "create",
-                "--repo",
-                UPSTREAM_REPO,
-                "--base",
-                &plan.base,
-                "--head",
-                &head,
-                "--title",
-                PR_TITLE,
-                "--label",
-                PR_LABELS,
-                "--body-file",
-                "-",
-            ],
-            body,
-        )?;
-        // `gh pr create` prints the PR URL on stdout.
-        let url = stdout.trim();
+        let mut args: Vec<&str> = vec![
+            "pr",
+            "create",
+            "--repo",
+            UPSTREAM_REPO,
+            "--base",
+            &plan.base,
+            "--head",
+            &head,
+            "--title",
+            &title,
+        ];
+        for l in PR_LABELS {
+            args.push("--label");
+            args.push(l);
+        }
+        args.push("--body-file");
+        args.push("-");
+        let stdout = gh_stdin(&args, body)?;
+        // `gh pr create` prints the PR URL as the last line of stdout.
+        let url = stdout
+            .lines()
+            .rev()
+            .map(str::trim)
+            .find(|l| !l.is_empty())
+            .unwrap_or("");
         let num = url
             .rsplit('/')
             .next()

--- a/xtask/src/commands/release/execute_plan.rs
+++ b/xtask/src/commands/release/execute_plan.rs
@@ -248,7 +248,12 @@ fn open_pull_request(
     let packages_to_release = release_plan
         .packages
         .iter()
-        .map(|step| format!("- {}: {}", step.package, step.new_version))
+        .map(|step| {
+            format!(
+                "- {}: {} → {}",
+                step.package, step.current_version, step.new_version
+            )
+        })
         .collect::<Vec<_>>()
         .join("\n");
 

--- a/xtask/src/commands/release/execute_plan.rs
+++ b/xtask/src/commands/release/execute_plan.rs
@@ -185,17 +185,24 @@ pub(crate) fn make_git_changes(dry_run: bool, branch_name: &str, commit: &str) -
     if dry_run {
         println!("Dry run: would commit changes to branch: {branch_name}");
     } else {
-        Command::new("git")
+        let status = Command::new("git")
             .arg("add")
             .arg(".")
             .status()
             .context("Failed to stage changes")?;
-        Command::new("git")
+        if !status.success() {
+            bail!("Failed to stage changes");
+        }
+
+        let status = Command::new("git")
             .arg("commit")
             .arg("-m")
             .arg(commit)
             .status()
             .context("Failed to commit changes")?;
+        if !status.success() {
+            bail!("Failed to commit changes to branch: {branch_name}");
+        }
     }
 
     // Push the branch. If the remote branch already exists (e.g. this is a
@@ -298,6 +305,7 @@ fn build_pr_body(plan: &Plan, release_plan_str: &str) -> String {
 {packages}
 
 <details>
+
 <summary>Release plan (click to expand)</summary>
 
 ```jsonc

--- a/xtask/src/commands/release/execute_plan.rs
+++ b/xtask/src/commands/release/execute_plan.rs
@@ -300,9 +300,10 @@ fn build_pr_body(plan: &Plan, release_plan_str: &str) -> String {
 <details>
 <summary>Release plan (click to expand)</summary>
 
-<pre>
+```jsonc
 {release_plan_str}
-</pre>
+```
+
 </details>
 
 Please review the changes and merge them into the `{base}` branch.

--- a/xtask/src/commands/release/execute_plan.rs
+++ b/xtask/src/commands/release/execute_plan.rs
@@ -132,11 +132,7 @@ pub fn execute_plan(workspace: &Path, args: ApplyPlanArgs) -> Result<()> {
         );
     }
 
-    let branch = make_git_changes(
-        !args.no_dry_run,
-        "release-branch",
-        "Finalize crate releases",
-    )?;
+    let branch = make_git_changes(!args.no_dry_run, "release-branch", &commit_message(&plan))?;
 
     open_pull_request(
         &branch,
@@ -234,6 +230,33 @@ pub(crate) fn make_git_changes(dry_run: bool, branch_name: &str, commit: &str) -
         name: branch_name,
         upstream: url,
     })
+}
+
+fn commit_message(plan: &Plan) -> String {
+    let subject = match plan.packages.len() {
+        1 => {
+            let step = &plan.packages[0];
+            format!(
+                "Release {}: {} → {}",
+                step.package, step.current_version, step.new_version
+            )
+        }
+        n => format!("Release {n} packages"),
+    };
+
+    let body = plan
+        .packages
+        .iter()
+        .map(|step| {
+            format!(
+                "- {}: {} → {}",
+                step.package, step.current_version, step.new_version
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!("{subject}\n\n{body}\n")
 }
 
 fn open_pull_request(

--- a/xtask/src/commands/release/execute_plan.rs
+++ b/xtask/src/commands/release/execute_plan.rs
@@ -132,7 +132,8 @@ pub fn execute_plan(workspace: &Path, args: ApplyPlanArgs) -> Result<()> {
         );
     }
 
-    let branch = make_git_changes(!args.no_dry_run, "release-branch", &commit_message(&plan))?;
+    let branch_name = format!("release-branch-{}", plan.slug);
+    let branch = make_git_changes(!args.no_dry_run, &branch_name, &commit_message(&plan))?;
 
     open_pull_request(
         &branch,
@@ -158,28 +159,25 @@ pub(crate) struct Branch {
 }
 
 pub(crate) fn make_git_changes(dry_run: bool, branch_name: &str, commit: &str) -> Result<Branch> {
-    // Find an available branch name
-    let branch_name = format!(
-        "{branch_name}-{}",
-        jiff::Timestamp::now().strftime("%Y-%m-%d"),
-    );
-
+    let branch_name = branch_name.to_string();
     let upstream = get_remote_name_for("esp-rs/esp-hal")?;
 
-    // Switch to the new branch
+    // `git switch -C` creates the branch, or resets it to HEAD if it already
+    // exists — carrying our uncommitted version-bump edits along. This is
+    // what makes re-running `execute-plan` idempotent: the branch simply
+    // snaps back to a single fresh commit off the base.
     if dry_run {
-        println!("Dry run: would create a new branch: {branch_name}");
+        println!("Dry run: would switch to branch: {branch_name}");
     } else {
-        // Create a new branch
         let status = Command::new("git")
             .arg("switch")
-            .arg("-c")
+            .arg("-C")
             .arg(&branch_name)
             .status()
-            .context("Failed to create new branch")?;
+            .context("Failed to switch to release branch")?;
 
         if !status.success() {
-            bail!("Failed to create new branch: {branch_name}");
+            bail!("Failed to switch to release branch: {branch_name}");
         }
     }
 
@@ -200,18 +198,28 @@ pub(crate) fn make_git_changes(dry_run: bool, branch_name: &str, commit: &str) -
             .context("Failed to commit changes")?;
     }
 
-    // Push the branch
+    // Push the branch. If the remote branch already exists (e.g. this is a
+    // re-run), use --force-with-lease so we overwrite our own prior push but
+    // bail if someone else pushed in the meantime.
     let url = if dry_run {
         println!("Dry run: would push branch: {branch_name}");
         String::from("https://github.com/esp-rs/esp-hal/")
     } else {
-        // git push origin <branch_name>
-        let message = Command::new("git")
-            .arg("push")
+        let remote_exists = Command::new("git")
+            .args(["ls-remote", "--exit-code", "--heads"])
             .arg(&upstream)
             .arg(&branch_name)
-            .output()
-            .context("Failed to push branch")?;
+            .status()
+            .context("Failed to query remote branches")?
+            .success();
+
+        let mut push = Command::new("git");
+        push.arg("push").arg(&upstream).arg(&branch_name);
+        if remote_exists {
+            log::info!("Remote branch {branch_name} already exists — force-pushing with lease");
+            push.arg("--force-with-lease");
+        }
+        let message = push.output().context("Failed to push branch")?;
 
         if !message.status.success() {
             bail!(

--- a/xtask/src/commands/release/plan.rs
+++ b/xtask/src/commands/release/plan.rs
@@ -73,14 +73,17 @@ fn generate_slug() -> String {
     slug
 }
 
-/// Read the slug from an existing plan file, tolerating the leading JSONC
-/// comment header that the freshly-generated plan carries until the user
-/// finalizes it.
-fn read_existing_slug(plan_path: &Path) -> Option<String> {
-    let source = std::fs::read_to_string(plan_path).ok()?;
-    let json_start = source.find('{')?;
-    let value: serde_json::Value = serde_json::from_str(&source[json_start..]).ok()?;
-    value.get("slug")?.as_str().map(str::to_string)
+/// Read the slug from an existing (finalized) plan file, so that re-running
+/// `plan` preserves the release branch name. Returns `Ok(None)` when no plan
+/// file exists yet. Bails with the same error as `Plan::from_path` if the
+/// file is present but still carries its JSONC comment header — the user is
+/// expected to finalize the plan before re-running.
+fn read_existing_slug(plan_path: &Path) -> Result<Option<String>> {
+    if !plan_path.exists() {
+        return Ok(None);
+    }
+    let plan = Plan::from_path(plan_path)?;
+    Ok(Some(plan.slug))
 }
 
 impl Plan {
@@ -209,7 +212,7 @@ pub fn plan(workspace: &Path, args: PlanArgs) -> Result<()> {
 
     // Preserve the slug from an existing plan file so that re-running `plan`
     // after tweaks keeps targeting the same release branch.
-    let slug = read_existing_slug(&plan_path).unwrap_or_else(generate_slug);
+    let slug = read_existing_slug(&plan_path)?.unwrap_or_else(generate_slug);
 
     let plan = Plan {
         base: current_branch,

--- a/xtask/src/commands/release/plan.rs
+++ b/xtask/src/commands/release/plan.rs
@@ -50,8 +50,37 @@ pub struct PackagePlan {
 pub struct Plan {
     /// The branch the release is made from.
     pub base: String,
+    /// Short random slug that pins this plan to its release branch
+    /// (`release-branch-<slug>`). Generated once when the plan is created and
+    /// preserved across re-plans so re-runs of `execute-plan` target the same
+    /// branch and PR.
+    pub slug: String,
     /// The packages to be released, in order.
     pub packages: Vec<PackagePlan>,
+}
+
+/// Generate a short base36 slug. Not cryptographically random — we only need
+/// uniqueness across release attempts, and the slug is persisted in the plan
+/// file so it survives re-runs.
+fn generate_slug() -> String {
+    let mut n = jiff::Timestamp::now().as_nanosecond() as u128;
+    const CHARS: &[u8] = b"0123456789abcdefghijklmnopqrstuvwxyz";
+    let mut slug = String::new();
+    for _ in 0..6 {
+        slug.push(CHARS[(n % 36) as usize] as char);
+        n /= 36;
+    }
+    slug
+}
+
+/// Read the slug from an existing plan file, tolerating the leading JSONC
+/// comment header that the freshly-generated plan carries until the user
+/// finalizes it.
+fn read_existing_slug(plan_path: &Path) -> Option<String> {
+    let source = std::fs::read_to_string(plan_path).ok()?;
+    let json_start = source.find('{')?;
+    let value: serde_json::Value = serde_json::from_str(&source[json_start..]).ok()?;
+    value.get("slug")?.as_str().map(str::to_string)
 }
 
 impl Plan {
@@ -175,8 +204,16 @@ pub fn plan(workspace: &Path, args: PlanArgs) -> Result<()> {
     // Generate plan file. The plan should include, as an ordered list, the packages
     // and their version increment.
 
+    let plan_path = workspace.join("release_plan.jsonc");
+    let plan_path = crate::windows_safe_path(&plan_path);
+
+    // Preserve the slug from an existing plan file so that re-running `plan`
+    // after tweaks keeps targeting the same release branch.
+    let slug = read_existing_slug(&plan_path).unwrap_or_else(generate_slug);
+
     let plan = Plan {
         base: current_branch,
+        slug,
         packages: update_amounts
             .into_iter()
             .filter_map(|(package, bump)| {
@@ -229,8 +266,6 @@ pub fn plan(workspace: &Path, args: PlanArgs) -> Result<()> {
             .collect(),
     };
 
-    let plan_path = workspace.join("release_plan.jsonc");
-    let plan_path = crate::windows_safe_path(&plan_path);
     log::debug!("Writing release plan to {}", plan_path.display());
 
     let plan_header = String::from(


### PR DESCRIPTION
This is mostly claude operating at my behest, though I have reviewed this myself:

- Pin the release branch to a short slug stored in the plan, so execute-plan is re-runnable: the branch is reset with git switch -C, and the push fetches + force-with-leases when the   
  remote already has it.
- Replace the browser-opened quick-PR URL with gh CLI upsert: gh pr list finds an existing release PR by head branch, then gh pr edit or gh pr create applies the new body via           
--body-file -. Falls back to printed manual instructions when gh is missing or --manual-pull-request is set.                                                                             
- Generate the commit subject and PR title dynamically from the plan (Release <pkg>: X → Y or Release N packages) instead of the hardcoded "Finalize crate releases" / "Prepare release".
- PR body now shows old → new per package and embeds the full plan JSON inside a collapsed details block.                                                                              
- Drop the unused urlencoding dependency from xtask.