### PR TITLE
Bump e-sync to 0.2.1, as we have a yanked 0.2 release

### DIFF
--- a/esp-sync/CHANGELOG.md
+++ b/esp-sync/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 
-## [v0.2.0] - 2026-04-16
+## [v0.2.1] - 2026-04-16
 
 ### Added
 
@@ -41,5 +41,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [v0.1.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-sync-v0.1.0
 [v0.1.1]: https://github.com/esp-rs/esp-hal/compare/esp-sync-v0.1.0...esp-sync-v0.1.1
-[v0.2.0]: https://github.com/esp-rs/esp-hal/compare/esp-sync-v0.1.1...esp-sync-v0.2.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-sync-v0.2.0...HEAD
+[v0.2.1]: https://github.com/esp-rs/esp-hal/compare/esp-sync-v0.1.1...esp-sync-v0.2.1
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-sync-v0.2.1...HEAD

--- a/esp-sync/Cargo.toml
+++ b/esp-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-sync"
-version       = "0.2.0"
+version       = "0.2.1"
 edition       = "2024"
 rust-version  = "1.88.0"
 description   = "Synchronization primitives for Espressif devices"


### PR DESCRIPTION
The release tooling failed on this, in the future we can add a check for this.