### PR TITLE
Release esp-hal: 1.1.0-rc.0 → 1.1.0

### DIFF
--- a/esp-bootloader-esp-idf/Cargo.toml
+++ b/esp-bootloader-esp-idf/Cargo.toml
@@ -50,7 +50,7 @@ esp-metadata-generated = { version = "0.4.0", path = "../esp-metadata-generated"
 
 # Make doctests & host-tests work together:
 [target.'cfg(any(target_arch = "riscv32", target_arch = "xtensa"))'.dev-dependencies]
-esp-hal = { version = "~1.1.0-rc.0", path = "../esp-hal" }
+esp-hal = { version = "~1.1.0", path = "../esp-hal" }
 
 [features]
 default = ["validation"]

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+
+## [v1.1.0] - 2026-04-24
+
+### Removed
+
 - The `Trng::default()` which is insecure (#5403)
 
 ## [v1.1.0-rc.0] - 2026-04-16
@@ -1610,4 +1615,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v1.0.0-rc.1]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.0.0-rc.0...esp-hal-v1.0.0-rc.1
 [v1.0.0]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.0.0-rc.1...esp-hal-v1.0.0
 [v1.1.0-rc.0]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.0.0...esp-hal-v1.1.0-rc.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.1.0-rc.0...HEAD
+[v1.1.0]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.1.0-rc.0...esp-hal-v1.1.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.1.0...HEAD

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-hal"
-version       = "1.1.0-rc.0"
+version       = "1.1.0"
 edition       = "2024"
 rust-version  = "1.88.0"
 description   = "Bare-metal HAL for Espressif devices"

--- a/esp-phy/Cargo.toml
+++ b/esp-phy/Cargo.toml
@@ -29,7 +29,7 @@ bench = false
 cfg-if = "1"
 
 document-features = "0.2"
-esp-hal = { version = "~1.1.0-rc.0", path = "../esp-hal", default-features = false }
+esp-hal = { version = "~1.1.0", path = "../esp-hal", default-features = false }
 esp-metadata-generated = { version = "0.4.0", path = "../esp-metadata-generated" }
 esp-sync = { version = "0.2.1", path = "../esp-sync" }
 

--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -44,7 +44,7 @@ test  = false
 
 [dependencies]
 cfg-if  = "1"
-esp-hal = { version = "~1.1.0-rc.0", path = "../esp-hal", default-features = false }
+esp-hal = { version = "~1.1.0", path = "../esp-hal", default-features = false }
 portable-atomic = { version = "1.11", default-features = false }
 enumset = { version = "1.1", default-features = false, optional = true }
 

--- a/esp-rtos/Cargo.toml
+++ b/esp-rtos/Cargo.toml
@@ -31,7 +31,7 @@ features       = ["esp32c6", "embassy", "esp-radio"]
 bench = false
 
 [dependencies]
-esp-hal = { version = "~1.1.0-rc.0", path = "../esp-hal", default-features = false, features = [
+esp-hal = { version = "~1.1.0", path = "../esp-hal", default-features = false, features = [
     # FIXME: rt technically shouldn't be enabled, but rtos requires `TrapFrame`
     # and uses reexported riscv/xtensa-lx from esp-hal
     "requires-unstable", "rt"
@@ -72,7 +72,7 @@ esp-config             = { version = "0.7.0", path = "../esp-config", features =
 esp-metadata-generated = { version = "0.4.0", path = "../esp-metadata-generated", features = ["build-script"] }
 
 [dev-dependencies]
-esp-hal = { version = "~1.1.0-rc.0", path = "../esp-hal", features = ["unstable"] }
+esp-hal = { version = "~1.1.0", path = "../esp-hal", features = ["unstable"] }
 
 [features]
 default = []

--- a/esp-storage/Cargo.toml
+++ b/esp-storage/Cargo.toml
@@ -29,7 +29,7 @@ bench = false
 [dependencies]
 embedded-storage = "0.3.1"
 procmacros       = { version = "0.22.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
-esp-hal = { version = "~1.1.0-rc.0", path = "../esp-hal", default-features = false, optional = true}
+esp-hal = { version = "~1.1.0", path = "../esp-hal", default-features = false, optional = true}
 
 # Optional dependencies
 esp-sync         = { version = "0.2.1", path = "../esp-sync", optional = true }


### PR DESCRIPTION
This pull request prepares the following packages for release:

- esp-hal: 1.1.0-rc.0 → 1.1.0

<details>

<summary>Release plan (click to expand)</summary>

```jsonc
{
  "base": "main",
  "slug": "v4vwtp",
  "packages": [
    {
      "package": "esp-hal",
      "semver_checked": true,
      "current_version": "1.1.0-rc.0",
      "new_version": "1.1.0",
      "tag_name": "esp-hal-v1.1.0",
      "bump": {
        "base": "Minor",
        "pre": null
      }
    }
  ]
}
```

</details>

Please review the changes and merge them into the `main` branch.

After merging, please make sure you have this release plan in the repo root,
then run the following command on the `main` branch to tag and publish the packages:

```
cargo xrelease publish-plan --no-dry-run
```
