### PR TITLE
esp-rom-sys dep policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,6 +278,9 @@ jobs:
       # Check metadata generation for all packages:
       - run: cargo xtask update-metadata --check
 
+      # Enforce esp-rom-sys dependency requirement policy:
+      - run: cargo xrel-check check-rom-sys-policy
+
       # Run host tests for all applicable packages:
       - run: cargo xtask host-tests
 

--- a/esp-bootloader-esp-idf/Cargo.toml
+++ b/esp-bootloader-esp-idf/Cargo.toml
@@ -35,7 +35,7 @@ document-features = "0.2"
 esp-config = { version = "0.7.0", path = "../esp-config" }
 esp-hal-procmacros = { version = "0.22.0", path = "../esp-hal-procmacros", features = ["__esp_idf_bootloader"] }
 esp-metadata-generated = { version = "0.4.0", path = "../esp-metadata-generated" }
-esp-rom-sys = { version = "0.1.4", path = "../esp-rom-sys", optional = true }
+esp-rom-sys = { version = "~0.1", path = "../esp-rom-sys", optional = true }
 embedded-storage = "0.3.1"
 log-04 = { package = "log", version = "0.4", optional = true }
 strum = { version = "0.27", default-features = false, features = ["derive"] }

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -52,7 +52,7 @@ enumset                  = "1.1"
 paste                    = "1.0.15"
 portable-atomic          = { version = "1.11", default-features = false }
 
-esp-rom-sys              = { version = "0.1.4", path = "../esp-rom-sys" }
+esp-rom-sys              = { version = "~0.1", path = "../esp-rom-sys" }
 
 # Unstable dependencies that are not (strictly) part of the public API
 bitfield                 = "0.19"

--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -370,6 +370,6 @@ features = [
 ]
 default-target = "riscv32imac-unknown-none-elf"
 
-# `esp-alloc` and `xtensa-lx-rt` are hidden behind features so `cargo machete` incorrectly marks it as unused.
+# `esp-rom-sys` https://github.com/esp-rs/esp-hal/issues/4675#issuecomment-4267119170
 [package.metadata.cargo-machete]
-ignored = ["esp-alloc", "xtensa-lx-rt"]
+ignored = ["esp-rom-sys"]

--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -59,6 +59,7 @@ document-features  = "0.2"
 esp-alloc = { version = "0.10.0", path = "../esp-alloc", optional = true, default-features = false }
 esp-config = { version = "0.7.0", path = "../esp-config" }
 esp-metadata-generated = { version = "0.4.0", path = "../esp-metadata-generated" }
+esp-rom-sys = { version = "=0.1.4", path = "../esp-rom-sys" }
 esp-sync = { version = "0.2.1", path = "../esp-sync" }
 esp-phy = { version = "0.2.0", path = "../esp-phy/" }
 num-derive = "0.4.2"

--- a/esp-radio/README.md
+++ b/esp-radio/README.md
@@ -14,15 +14,6 @@ Note that this crate currently requires you to enable the `unstable` feature on 
 
 [IEEE 802.15.4]: https://en.wikipedia.org/wiki/IEEE_802.15.4
 
-## `esp-rom-sys` compatibility
-
-`esp-radio` depends directly on `esp-rom-sys` with an exact version pin (`=0.1.x`).
-This is intentional: radio blob compatibility is tied to a validated `esp-rom-sys`
-patch level, and Cargo must not silently float this dependency when `esp-radio` is
-in the graph.
-
-Only one exact `esp-rom-sys` pin is allowed in the dependency graph.
-
 ## Current support
 
 If a cell contains an em dash (&mdash;) this means that the particular feature is not present for a chip. A check mark (✓) means that some driver implementation exists.

--- a/esp-radio/README.md
+++ b/esp-radio/README.md
@@ -14,6 +14,15 @@ Note that this crate currently requires you to enable the `unstable` feature on 
 
 [IEEE 802.15.4]: https://en.wikipedia.org/wiki/IEEE_802.15.4
 
+## `esp-rom-sys` compatibility
+
+`esp-radio` depends directly on `esp-rom-sys` with an exact version pin (`=0.1.x`).
+This is intentional: radio blob compatibility is tied to a validated `esp-rom-sys`
+patch level, and Cargo must not silently float this dependency when `esp-radio` is
+in the graph.
+
+Only one exact `esp-rom-sys` pin is allowed in the dependency graph.
+
 ## Current support
 
 If a cell contains an em dash (&mdash;) this means that the particular feature is not present for a chip. A check mark (✓) means that some driver implementation exists.

--- a/esp-rom-sys/README.md
+++ b/esp-rom-sys/README.md
@@ -16,6 +16,19 @@ Since there can be only one version of this crate used in a dependency tree this
 
 That said, we cannot remove anything here. Degrading a symbol from hard linkage to weak linkage is allowed.
 
+## Dependency policy in the esp-hal workspace
+
+The workspace intentionally uses two dependency strategies for `esp-rom-sys`:
+
+- Most crates use a non-exact requirement on the `0.1.x` line (for example
+  `~0.1` / `~0.1.x`), so they can consume compatible patch updates.
+- Crates that are tightly coupled to a specific radio/blob behavior pin an exact
+  `esp-rom-sys` patch version (currently `esp-radio`).
+
+Only one exact `esp-rom-sys` pin should exist in the dependency graph at a
+time. This keeps Cargo resolution deterministic for radio stacks while
+preserving patch-level flexibility for other crates.
+
 ## [Documentation](https://docs.espressif.com/projects/rust/esp-rom-sys/latest/)
 
 ## Minimum Supported Rust Version (MSRV)

--- a/esp-rtos/Cargo.toml
+++ b/esp-rtos/Cargo.toml
@@ -36,7 +36,7 @@ esp-hal = { version = "~1.1.0-rc.0", path = "../esp-hal", default-features = fal
     # and uses reexported riscv/xtensa-lx from esp-hal
     "requires-unstable", "rt"
 ] }
-esp-rom-sys = { version = "0.1.4", path = "../esp-rom-sys" }
+esp-rom-sys = { version = "~0.1", path = "../esp-rom-sys" }
 
 cfg-if = "1"
 rtos-trace = { version = "0.2.0", optional = true }

--- a/esp-storage/Cargo.toml
+++ b/esp-storage/Cargo.toml
@@ -33,7 +33,7 @@ esp-hal = { version = "~1.1.0-rc.0", path = "../esp-hal", default-features = fal
 
 # Optional dependencies
 esp-sync         = { version = "0.2.1", path = "../esp-sync", optional = true }
-esp-rom-sys      = { version = "0.1.4", path = "../esp-rom-sys", optional = true }
+esp-rom-sys      = { version = "~0.1", path = "../esp-rom-sys", optional = true }
 defmt  = { version = "1.0.1", optional = true }
 
 # Unstable dependencies that are not (strictly) part of the public API

--- a/xtask/src/commands/relcheck.rs
+++ b/xtask/src/commands/relcheck.rs
@@ -6,7 +6,9 @@ use std::{
 
 use anyhow::{Result, bail};
 use clap::{Args, Subcommand};
+use semver::{Comparator, Op, Version, VersionReq};
 use strum::IntoEnumIterator;
+use toml_edit::Table;
 
 use crate::{Package, cargo::CargoToml, windows_safe_path};
 
@@ -24,6 +26,8 @@ pub enum RelCheckCmds {
     /// Remove the path-dependencies from examples and make sure the dependencies are available in
     /// the local registry.
     ReplacePathDeps,
+    /// Validate workspace esp-rom-sys dependency version policy.
+    CheckRomSysPolicy,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -40,6 +44,7 @@ pub fn run_rel_check(args: RelCheckCmds) -> Result<()> {
         RelCheckCmds::Deinit => deinit_rel_check()?,
         RelCheckCmds::Update(args) => update(args)?,
         RelCheckCmds::ReplacePathDeps => scrap_path_deps()?,
+        RelCheckCmds::CheckRomSysPolicy => check_rom_sys_policy(Path::new("."))?,
     }
 
     Ok(())
@@ -750,4 +755,89 @@ fn related_crates_cb(
     }
 
     packages
+}
+
+const EXPECTED: (u64, u64) = (0, 1);
+const EXACT_ALLOWLIST: [Package; 1] = [Package::EspRadio];
+
+/// Checks that the esp-rom-sys dependency policy is followed across the workspace.
+fn check_rom_sys_policy(workspace: &Path) -> Result<()> {
+    let mut errs = Vec::new();
+    let mut global_exact: Option<Version> = None;
+    let mut count = 0;
+
+    for pkg in Package::iter().filter(|&p| p != Package::Examples) {
+        let Ok(mut toml) = CargoToml::new(workspace, pkg) else {
+            continue;
+        };
+        let mut found = false;
+
+        toml.visit_dependencies(|path, _, table| {
+            let Some(raw) = get_ver(table, "esp-rom-sys") else {
+                return;
+            };
+            let Ok(req) = VersionReq::parse(&raw) else {
+                return errs.push(format!("Bad semver: {raw}"));
+            };
+
+            let exact = extract_exact(&req.comparators);
+            let is_allowed = EXACT_ALLOWLIST.contains(&pkg);
+            found = true;
+            count += 1;
+
+            if is_allowed != exact.is_some() {
+                errs.push(format!("{pkg}: pin policy mismatch for '{raw}'"));
+            }
+
+            if let Some(v) = exact {
+                if global_exact.get_or_insert(v.clone()) != &v {
+                    errs.push(format!("Conflicting pins: {raw}"));
+                }
+            }
+
+            let in_line = req
+                .comparators
+                .iter()
+                .all(|c| c.major == EXPECTED.0 && c.minor == Some(EXPECTED.1));
+            if !in_line || req.matches(&Version::new(EXPECTED.0, EXPECTED.1 + 1, 0)) {
+                errs.push(format!(
+                    "{path}: must stay on {}.{}.*",
+                    EXPECTED.0, EXPECTED.1
+                ));
+            }
+        });
+
+        if EXACT_ALLOWLIST.contains(&pkg) && !found {
+            errs.push(format!("Missing required pin for {pkg:?}"));
+        }
+    }
+
+    if errs.is_empty() {
+        Ok(log::info!("Checked {count} deps, all good."))
+    } else {
+        bail!("Policy failed:\n- {}", errs.join("\n- "))
+    }
+}
+
+fn get_ver(table: &Table, target: &str) -> Option<String> {
+    table.iter().find_map(|(name, item)| {
+        let pkg = item.get("package").and_then(|i| i.as_str()).unwrap_or(name);
+        if pkg != target {
+            return None;
+        }
+        item.as_str()
+            .or_else(|| item.get("version").and_then(|v| v.as_str()))
+            .map(Into::into)
+    })
+}
+
+fn extract_exact(comps: &[Comparator]) -> Option<Version> {
+    let c = comps.first()?;
+    (comps.len() == 1 && c.op == Op::Exact).then(|| Version {
+        major: c.major,
+        minor: c.minor.unwrap_or(0),
+        patch: c.patch.unwrap_or(0),
+        pre: c.pre.clone(),
+        build: Default::default(),
+    })
 }


### PR DESCRIPTION
This PR updates `Cargo.toml` dependency policy by adding a direct `esp-rom-sys = "=0.1.4"` pin to `esp-radio` (while keeping other crates on `~0.1` constraint), then added `cargo xrel-check check-rom-sys-policy` to enforce this rule and fail on missing/invalid or conflicting exact pins (not sure if we want to add this check or not).

closes https://github.com/esp-rs/esp-hal/issues/4675