### PR TITLE
Remove Default trait from Trng

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- The `Trng::default()` which is insecure (#5403)
 
 ## [v1.1.0-rc.0] - 2026-04-16
 

--- a/esp-hal/src/rng/trng.rs
+++ b/esp-hal/src/rng/trng.rs
@@ -181,7 +181,7 @@ pub enum TrngError {
 /// let pin_value: u16 = adc1.read_oneshot(&mut adc1_pin)?;
 /// # {after_snippet}
 /// ```
-#[derive(Default, Debug)]
+#[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 #[instability::unstable]


### PR DESCRIPTION
The `Trng::try_new` ensures load `TrngSource` and throws error if failed, but `Trng::default()` just skip the logic and fill the internal `Rng`. Which is insecure.

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.