### PR TITLE
Enable regi2c-related clocks in regi2c enable_block impls

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -152,6 +152,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug in `Spi::half_duplex_{read, write}` where calling these functions aborted previously running writes (#5247)
 - LP I2C: prevent spurious I2C start during the initialization of LpI2c (#5311)
 - Fixed a bug in `TWAI` that may cause the driver to hang (#5318)
+- ESP32-C6: Fixed an issue where the chip failed to enable a required clock signal before trying to use it (#5405)
 
 ### Removed
 

--- a/esp-hal/src/soc/esp32c5/clocks.rs
+++ b/esp-hal/src/soc/esp32c5/clocks.rs
@@ -16,7 +16,7 @@
 // TODO: This is a temporary place for this, should probably be moved into clocks_ll.
 
 use crate::{
-    peripherals::{I2C_ANA_MST, LP_CLKRST, MODEM_LPCON, PCR, PMU, UART0, UART1},
+    peripherals::{I2C_ANA_MST, LP_CLKRST, PCR, PMU, UART0, UART1},
     soc::regi2c,
 };
 
@@ -155,12 +155,6 @@ fn enable_pll_clk_impl(clocks: &mut ClockTree, en: bool) {
     // Digital part - nothing to do here, PLL always runs at 480MHz
 
     // Analog part
-    // TODO: reference count I2C_ANA_MST clock (also applies to other chips)
-    let old_clk_conf = MODEM_LPCON::regs().clk_conf().read();
-    MODEM_LPCON::regs().clk_conf().write(|w| {
-        unsafe { w.bits(old_clk_conf.bits()) };
-        w.clk_i2c_mst_en().set_bit()
-    });
 
     // BBPLL CALIBRATION START
     I2C_ANA_MST::regs().ana_conf0().modify(|_, w| {
@@ -218,10 +212,6 @@ fn enable_pll_clk_impl(clocks: &mut ClockTree, en: bool) {
         w.bbpll_stop_force_high().set_bit();
         w.bbpll_stop_force_low().clear_bit()
     });
-
-    MODEM_LPCON::regs()
-        .clk_conf()
-        .write(|w| unsafe { w.bits(old_clk_conf.bits()) });
 }
 
 // RC_FAST_CLK

--- a/esp-hal/src/soc/esp32c6/clocks.rs
+++ b/esp-hal/src/soc/esp32c6/clocks.rs
@@ -17,7 +17,7 @@
 // TODO: This is a temporary place for this, should probably be moved into clocks_ll.
 
 use crate::{
-    peripherals::{I2C_ANA_MST, LP_CLKRST, MODEM_LPCON, PCR, PMU, TIMG0, UART0, UART1},
+    peripherals::{I2C_ANA_MST, LP_CLKRST, PCR, PMU, TIMG0, UART0, UART1},
     soc::regi2c,
 };
 
@@ -152,17 +152,6 @@ fn enable_pll_clk_impl(_clocks: &mut ClockTree, en: bool) {
         return;
     }
 
-    // enable i2c mst clk by temporarily forcing on
-    let old_clk_conf = MODEM_LPCON::regs().clk_conf().read();
-    MODEM_LPCON::regs().clk_conf().write(|w| {
-        unsafe { w.bits(old_clk_conf.bits()) };
-        w.clk_i2c_mst_en().set_bit()
-    });
-
-    MODEM_LPCON::regs()
-        .i2c_mst_clk_conf()
-        .modify(|_, w| w.clk_i2c_mst_sel_160m().set_bit());
-
     // BBPLL CALIBRATION START
     I2C_ANA_MST::regs().ana_conf0().modify(|_, w| {
         w.bbpll_stop_force_high().clear_bit();
@@ -204,10 +193,6 @@ fn enable_pll_clk_impl(_clocks: &mut ClockTree, en: bool) {
         w.bbpll_stop_force_high().set_bit();
         w.bbpll_stop_force_low().clear_bit()
     });
-
-    MODEM_LPCON::regs()
-        .clk_conf()
-        .write(|w| unsafe { w.bits(old_clk_conf.bits()) });
 }
 
 // RC_FAST_CLK

--- a/esp-hal/src/soc/esp32c6/regi2c.rs
+++ b/esp-hal/src/soc/esp32c6/regi2c.rs
@@ -151,6 +151,10 @@ fn regi2c_enable_block(block: u8) -> usize {
         .clk_conf()
         .modify(|_, w| w.clk_i2c_mst_en().set_bit());
 
+    MODEM_LPCON::regs()
+        .i2c_mst_clk_conf()
+        .modify(|_, w| w.clk_i2c_mst_sel_160m().set_bit());
+
     // Before config I2C register, enable corresponding slave.
     let i2c_sel_bits = I2C_ANA_MST::regs().ana_conf2().read();
     let i2c_sel = match block {

--- a/esp-hal/src/soc/esp32c61/clocks.rs
+++ b/esp-hal/src/soc/esp32c61/clocks.rs
@@ -14,7 +14,7 @@
 #![allow(missing_docs, reason = "Experimental")]
 
 use crate::{
-    peripherals::{I2C_ANA_MST, LP_CLKRST, MODEM_LPCON, PCR, PMU, UART0, UART1},
+    peripherals::{I2C_ANA_MST, LP_CLKRST, PCR, PMU, UART0, UART1},
     soc::regi2c,
 };
 
@@ -129,12 +129,6 @@ fn enable_pll_clk_impl(_clocks: &mut ClockTree, en: bool) {
     // Digital part - The target SPLL is fixed to 480MHz, do nothing.
 
     // Analog part
-    let old_clk_conf = MODEM_LPCON::regs().clk_conf().read();
-    MODEM_LPCON::regs().clk_conf().write(|w| {
-        unsafe { w.bits(old_clk_conf.bits()) };
-        w.clk_i2c_mst_en().set_bit()
-    });
-
     I2C_ANA_MST::regs().ana_conf0().modify(|_, w| {
         w.bbpll_stop_force_high().clear_bit();
         w.bbpll_stop_force_low().set_bit()
@@ -173,10 +167,6 @@ fn enable_pll_clk_impl(_clocks: &mut ClockTree, en: bool) {
         w.bbpll_stop_force_high().set_bit();
         w.bbpll_stop_force_low().clear_bit()
     });
-
-    MODEM_LPCON::regs()
-        .clk_conf()
-        .write(|w| unsafe { w.bits(old_clk_conf.bits()) });
 }
 
 // RC_FAST_CLK

--- a/esp-hal/src/soc/esp32h2/clocks.rs
+++ b/esp-hal/src/soc/esp32h2/clocks.rs
@@ -15,7 +15,7 @@
 // TODO: This is a temporary place for this, should probably be moved into clocks_ll.
 
 use crate::{
-    peripherals::{I2C_ANA_MST, LP_CLKRST, MODEM_LPCON, PCR, PMU, TIMG0, UART0, UART1},
+    peripherals::{I2C_ANA_MST, LP_CLKRST, PCR, PMU, TIMG0, UART0, UART1},
     soc::regi2c,
 };
 
@@ -126,17 +126,6 @@ fn enable_pll_f96m_clk_impl(_clocks: &mut ClockTree, en: bool) {
 
         return;
     }
-
-    // Enable I2C master clock
-    MODEM_LPCON::regs()
-        .clk_conf_force_on()
-        .modify(|_, w| w.clk_i2c_mst_fo().set_bit());
-
-    // Set I2C clock to 96MHz
-    const MODEM_LPCON_CLK_I2C_SEL_96M: u32 = 1 << 0; // FIXME add to PAC
-    MODEM_LPCON::regs()
-        .clk_conf()
-        .modify(|r, w| unsafe { w.bits(r.bits() | MODEM_LPCON_CLK_I2C_SEL_96M) });
 
     // BPPLL calibration start
     I2C_ANA_MST::regs().ana_conf0().modify(|_, w| {

--- a/esp-hal/src/soc/esp32h2/regi2c.rs
+++ b/esp-hal/src/soc/esp32h2/regi2c.rs
@@ -83,9 +83,17 @@ define_regi2c! {
 }
 
 fn regi2c_enable_block(block: u8) -> usize {
+    // Enable I2C master clock
     MODEM_LPCON::regs()
-        .clk_conf()
-        .modify(|_, w| w.clk_i2c_mst_en().set_bit());
+        .clk_conf_force_on()
+        .modify(|_, w| w.clk_i2c_mst_fo().set_bit());
+
+    // Set I2C clock to 96MHz
+    const MODEM_LPCON_CLK_I2C_SEL_96M: u32 = 1 << 0; // FIXME add to PAC
+    MODEM_LPCON::regs().clk_conf().modify(|r, w| {
+        unsafe { w.bits(r.bits() | MODEM_LPCON_CLK_I2C_SEL_96M) };
+        w.clk_i2c_mst_en().set_bit()
+    });
 
     // Before config I2C register, enable corresponding slave.
     let i2c_sel_bits = I2C_ANA_MST::regs().ana_conf2().read();


### PR DESCRIPTION
Supposedly fixes #5366