### PR TITLE
Fix I2S DMA edge cases

### DIFF
--- a/esp-hal/src/i2s/master.rs
+++ b/esp-hal/src/i2s/master.rs
@@ -2146,8 +2146,6 @@ mod private {
         }
 
         fn rx_start(&self, len: usize) {
-            let len = len - 1;
-
             self.regs()
                 .rxeof_num()
                 .write(|w| unsafe { w.rx_eof_num().bits(len as u16) });

--- a/esp-hal/src/i2s/master.rs
+++ b/esp-hal/src/i2s/master.rs
@@ -2667,7 +2667,7 @@ pub mod asynch {
             }
 
             // start: set I2S_RX_START
-            self.i2s.rx_start(len);
+            self.i2s.rx_start(0xFFF);
 
             let state = RxCircularState::new(&mut self.rx_chain);
             Ok(I2sReadDmaTransferAsync {


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

While working with I2S on the ESP32-C6 I found two small problems concerning edge cases in less common I2S configurations (8-bit mode, weird DMA buffer sizes). Both problems are related to the I2S_RX_EOF_NUM register, which esp-hal is currently setting to the **total** size of all DMA buffers allocated for the transfer minus one, which appears to be just wrong according to my observations.

[In ESP-IDF](https://github.com/espressif/esp-idf/blob/e1b81f0aad6e78f275a504282a548beb227fb4e4/components/esp_driver_i2s/i2s_common.c#L553) the value of this register is always set to the size of **one** DMA buffer. However they also ensure that each buffer has the same size, unlike in esp-hal where the last buffer may be shorter than the others.

I'm not sure how to deal with this or if you're willing to accept it at all, considering that the observed behavior here directly contradicts the TRM as I understand it, so I did not bother writing a changelog just yet. I'm not too familiar with these low-level details, so it's also entirely possible that I am just totally mistaken here.

#### Testing
Tested on ESP32-C6 with NAU88C22 in 16-bit 48kHz mode and in 8-bit A-Law 8kHz mode.