### PR TITLE
Fix problem with `xtask ci` when NOT using cargo-batch

### DIFF
--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -652,6 +652,15 @@ fn run_ci_checks(workspace: &Path, args: CiArgs) -> Result<()> {
 
                     let dst = dir.join(without_fingerprint);
 
+                    if dst.exists() {
+                        std::fs::remove_file(&dst).with_context(|| {
+                            format!(
+                                "Failed to remove destination file {} before copying",
+                                dst.display()
+                            )
+                        })?;
+                    }
+
                     log::debug!("Copying {} to {}", example_path.display(), dst.display());
 
                     // Copy so we don't trigger a rebuild unnecessarily by deleting the original


### PR DESCRIPTION
This should fix the problem seen in https://github.com/esp-rs/esp-hal/actions/runs/24845894249/job/72738535533?pr=5396

Also locally I was able to repro the problem when not using cargo-batch (which we don't do in that workflow since it's run on a GitHub hosted runner)

On Windows it complained about a file being in use, on Linux it just truncated the target file.

It's not really clear to me why deleting the target file before trying to copy makes it work (for me locally at least) - but deleting the target file before trying to copy shouldn't hurt in any way
