### PR TITLE
UART: retry reading if not enough data has been read before a timeout

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - C5 and C61: Enable RTC timekeeping (#5449)
 - C61: usb-serial-jtag and debug-assist (#5427)
 - C61: dedicated gpio (#5426)
+- UART: unstably add and return RX timeout error (#5451)
 
 ### Changed
 
@@ -20,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - RSA: the driver should no longer cause unhandled interrupts to fire (#5443)
 - ESP32: attenuation is now correctly set for ADC2 (#5463)
+- UART: disallow 0 as the RX FIFO full threshold (#5451)
+- UART: disable default RX timeout (#5451)
 
 ### Removed
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - C5 and C61: Enable RTC timekeeping (#5449)
 - C61: usb-serial-jtag and debug-assist (#5427)
 - C61: dedicated gpio (#5426)
-- UART: unstably add and return RX timeout error (#5451)
 
 ### Changed
 
@@ -22,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - RSA: the driver should no longer cause unhandled interrupts to fire (#5443)
 - ESP32: attenuation is now correctly set for ADC2 (#5463)
 - UART: disallow 0 as the RX FIFO full threshold (#5451)
-- UART: disable default RX timeout (#5451)
+- UART: prevent returning 0 from `read_async` (#5451)
 
 ### Removed
 

--- a/esp-hal/src/uart/mod.rs
+++ b/esp-hal/src/uart/mod.rs
@@ -3228,10 +3228,10 @@ impl Info {
     ///
     /// ## Errors
     ///
-    /// [ConfigError::UnsupportedRxFifoThreshold] if the provided value exceeds
-    /// [`Info::RX_FIFO_MAX_THRHD`].
+    /// [`ConfigError::RxFifoThresholdNotSupported`] if the provided value is zero
+    /// or exceeds [`Info::RX_FIFO_MAX_THRHD`].
     fn set_rx_fifo_full_threshold(&self, threshold: u16) -> Result<(), ConfigError> {
-        if threshold > Self::RX_FIFO_MAX_THRHD {
+        if threshold == 0 || threshold > Self::RX_FIFO_MAX_THRHD {
             return Err(ConfigError::RxFifoThresholdNotSupported);
         }
 

--- a/esp-hal/src/uart/mod.rs
+++ b/esp-hal/src/uart/mod.rs
@@ -3252,7 +3252,7 @@ impl Info {
     ///
     /// ## Errors
     ///
-    /// [ConfigError::UnsupportedTxFifoThreshold] if the provided value exceeds
+    /// [`ConfigError::TxFifoThresholdNotSupported`] if the provided value exceeds
     /// [`Info::TX_FIFO_MAX_THRHD`].
     fn set_tx_fifo_empty_threshold(&self, threshold: u16) -> Result<(), ConfigError> {
         if threshold > Self::TX_FIFO_MAX_THRHD {
@@ -3275,7 +3275,7 @@ impl Info {
     ///
     /// ## Errors
     ///
-    /// [ConfigError::UnsupportedTimeout] if the provided value exceeds
+    /// [`ConfigError::TimeoutTooLong`] if the provided value exceeds
     /// the maximum value for SOC:
     /// - `esp32`: Symbol size is fixed to 8, do not pass a value > **0x7F**.
     /// - `esp32c2`, `esp32c3`, `esp32c6`, `esp32h2`, esp32s2`, esp32s3`: The value you pass times

--- a/esp-hal/src/uart/mod.rs
+++ b/esp-hal/src/uart/mod.rs
@@ -1078,7 +1078,8 @@ impl<'d> UartRx<'d, Async> {
         // of returnable bytes.
         let minimum = minimum.min(max_threshold);
 
-        if self.uart.info().rx_fifo_count() < minimum {
+        // loop to prevent returning 0 bytes
+        while self.uart.info().rx_fifo_count() < minimum {
             // We're ignoring the user configuration here to ensure that this is not waiting
             // for more data than the buffer. We'll restore the original value after the
             // future resolved.

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -142,7 +142,7 @@ default = []
 unstable = ["esp-hal/unstable"]
 
 # Add the `embedded-test/defmt` feature for more verbose testing
-defmt = ["dep:defmt-rtt", "embedded-test/defmt", "esp-hal/defmt", "esp-rtos/defmt", "esp-radio/defmt"]
+defmt = ["dep:defmt-rtt", "embedded-test/defmt", "esp-hal/defmt", "esp-rtos?/defmt", "esp-radio?/defmt"]
 esp-radio = ["dep:esp-radio", "dep:esp-rtos", "dep:esp-radio-rtos-driver", "esp-rtos/esp-radio"]
 esp-radio-unstable = ["esp-radio/unstable"]
 embassy = ["dep:esp-rtos", "esp-rtos/embassy"]
@@ -152,7 +152,7 @@ rtos-radio-driver = ["dep:esp-rtos", "esp-rtos/esp-radio", "dep:esp-radio-rtos-d
 esp32 = [
     "embedded-test/xtensa-semihosting",
     "esp-hal/esp32",
-    "esp-alloc/esp32",
+    "esp-alloc?/esp32",
     "esp-radio?/esp32",
     "esp-storage?/esp32",
     "esp-bootloader-esp-idf/esp32",
@@ -161,7 +161,7 @@ esp32 = [
 ]
 esp32c2 = [
     "esp-hal/esp32c2",
-    "esp-alloc/esp32c2",
+    "esp-alloc?/esp32c2",
     "esp-radio?/esp32c2",
     "esp-storage?/esp32c2",
     "esp-bootloader-esp-idf/esp32c2",
@@ -170,7 +170,7 @@ esp32c2 = [
 ]
 esp32c3 = [
     "esp-hal/esp32c3",
-    "esp-alloc/esp32c3",
+    "esp-alloc?/esp32c3",
     "esp-radio?/esp32c3",
     "esp-storage?/esp32c3",
     "esp-bootloader-esp-idf/esp32c3",
@@ -179,7 +179,7 @@ esp32c3 = [
 ]
 esp32c5 = [
     "esp-hal/esp32c5",
-    "esp-alloc/esp32c5",
+    "esp-alloc?/esp32c5",
     "esp-radio?/esp32c5",
     "esp-storage?/esp32c5",
     "esp-bootloader-esp-idf/esp32c5",
@@ -188,7 +188,7 @@ esp32c5 = [
 ]
 esp32c6 = [
     "esp-hal/esp32c6",
-    "esp-alloc/esp32c6",
+    "esp-alloc?/esp32c6",
     "esp-radio?/esp32c6",
     "esp-storage?/esp32c6",
     "esp-bootloader-esp-idf/esp32c6",
@@ -197,7 +197,7 @@ esp32c6 = [
 ]
 esp32c61 = [
     "esp-hal/esp32c61",
-    "esp-alloc/esp32c61",
+    "esp-alloc?/esp32c61",
     "esp-radio?/esp32c61",
     "esp-storage?/esp32c61",
     "esp-bootloader-esp-idf/esp32c61",
@@ -206,7 +206,7 @@ esp32c61 = [
 ]
 esp32h2 = [
     "esp-hal/esp32h2",
-    "esp-alloc/esp32h2",
+    "esp-alloc?/esp32h2",
     "esp-radio?/esp32h2",
     "esp-storage?/esp32h2",
     "esp-bootloader-esp-idf/esp32h2",
@@ -216,7 +216,7 @@ esp32h2 = [
 esp32s2 = [
     "embedded-test/xtensa-semihosting",
     "esp-hal/esp32s2",
-    "esp-alloc/esp32s2",
+    "esp-alloc?/esp32s2",
     "esp-radio?/esp32s2",
     "esp-storage?/esp32s2",
     "esp-bootloader-esp-idf/esp32s2",
@@ -226,7 +226,7 @@ esp32s2 = [
 esp32s3 = [
     "embedded-test/xtensa-semihosting",
     "esp-hal/esp32s3",
-    "esp-alloc/esp32s3",
+    "esp-alloc?/esp32s3",
     "esp-radio?/esp32s3",
     "esp-storage?/esp32s3",
     "esp-bootloader-esp-idf/esp32s3",

--- a/hil-test/src/bin/spi_half_duplex_write_psram.rs
+++ b/hil-test/src/bin/spi_half_duplex_write_psram.rs
@@ -1,7 +1,7 @@
 //! SPI Half Duplex Write Test
 
 //% CHIPS: esp32s3
-//% FEATURES: unstable
+//% FEATURES: unstable esp-alloc
 
 #![no_std]
 #![no_main]

--- a/hil-test/src/bin/uart.rs
+++ b/hil-test/src/bin/uart.rs
@@ -542,6 +542,7 @@ mod async_tx_rx {
         timer::timg::TimerGroup,
         uart::{self, RxConfig, RxError, UartRx, UartTx},
     };
+    use hil_test::{assert, assert_eq, assert_ne};
 
     struct Context {
         rx: UartRx<'static, Async>,
@@ -788,6 +789,125 @@ mod async_tx_rx {
 
         assert_eq!(read, Ok(3));
         assert_eq!(&data[..3], &[1, 2, 3]);
+    }
+
+    #[test]
+    async fn async_rx_does_not_return_0(mut ctx: Context) {
+        // Ensure we read at least once, regardless of the implementation details of `read`.
+        ctx.rx
+            .apply_config(
+                &uart::Config::default().with_rx(RxConfig::default().with_fifo_full_threshold(30)),
+            )
+            .unwrap();
+
+        let mut read_success = false;
+        select(
+            async {
+                for _ in 0..5 {
+                    use embedded_io_async::Write;
+
+                    let _ = Write::write(&mut ctx.tx, b"hello world")
+                        .await
+                        .expect("Failed to write data");
+
+                    Timer::after_millis(50).await;
+                }
+                ctx.tx.flush_async().await.unwrap();
+            },
+            async {
+                let mut buf = [0; 128];
+                loop {
+                    use embedded_io_async::Read;
+
+                    let read_bytes = Read::read(&mut ctx.rx, &mut buf)
+                        .await
+                        .expect("Failed to read data");
+                    assert_ne!(read_bytes, 0, "read_async returned 0 bytes read");
+                    read_success = true;
+                }
+            },
+        )
+        .await;
+
+        assert!(read_success);
+    }
+}
+
+#[embedded_test::tests(default_timeout = 3, executor = hil_test::Executor::new())]
+mod async_tx_rx_split {
+    use embassy_futures::select::select;
+    use embassy_time::Timer;
+    use esp_hal::{
+        Async,
+        interrupt::software::SoftwareInterruptControl,
+        timer::timg::TimerGroup,
+        uart::{self, RxConfig, Uart, UartRx, UartTx},
+    };
+    use hil_test::assert_ne;
+
+    struct Context {
+        rx: UartRx<'static, Async>,
+        tx: UartTx<'static, Async>,
+    }
+    #[init]
+    async fn init() -> Context {
+        let peripherals = esp_hal::init(esp_hal::Config::default());
+
+        let (rx, tx) = hil_test::common_test_pins!(peripherals);
+
+        let sw_int = SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
+        let timg0 = TimerGroup::new(peripherals.TIMG0);
+        esp_rtos::start(timg0.timer0, sw_int.software_interrupt0);
+
+        let (rx, tx) = Uart::new(peripherals.UART0, uart::Config::default())
+            .unwrap()
+            .with_tx(tx)
+            .with_rx(rx)
+            .into_async()
+            .split();
+
+        Context { rx, tx }
+    }
+
+    #[test]
+    async fn async_rx_does_not_return_0(mut ctx: Context) {
+        // Ensure we read at least once, regardless of the implementation details of `read`.
+        ctx.rx
+            .apply_config(
+                &uart::Config::default().with_rx(RxConfig::default().with_fifo_full_threshold(30)),
+            )
+            .unwrap();
+
+        let mut read_success = false;
+        select(
+            async {
+                for _ in 0..5 {
+                    use embedded_io_async::Write;
+
+                    let _ = Write::write(&mut ctx.tx, b"hello world")
+                        .await
+                        .expect("Failed to write data");
+
+                    Timer::after_millis(50).await;
+                }
+                ctx.tx.flush_async().await.unwrap();
+            },
+            async {
+                let mut buf = [0; 128];
+                loop {
+                    use embedded_io_async::Read;
+
+                    let read_bytes = Read::read(&mut ctx.rx, &mut buf)
+                        .await
+                        .expect("Failed to read data");
+                    assert_ne!(read_bytes, 0, "read_async returned 0 bytes read");
+                    read_success = true;
+                }
+            },
+        )
+        .await;
+
+        assert!(read_success);
     }
 }
 

--- a/hil-test/src/lib.rs
+++ b/hil-test/src/lib.rs
@@ -37,6 +37,12 @@ macro_rules! assert_eq {
     ($($t:tt)*) => { defmt::assert_eq!($($t)*) }
 }
 
+#[cfg(feature = "defmt")]
+#[macro_export]
+macro_rules! assert_ne {
+    ($($t:tt)*) => { defmt::assert_ne!($($t)*) }
+}
+
 #[cfg(not(feature = "defmt"))]
 #[macro_export]
 macro_rules! assert {
@@ -47,6 +53,12 @@ macro_rules! assert {
 #[macro_export]
 macro_rules! assert_eq {
     ($($t:tt)*) => { ::core::assert_eq!($($t)*) }
+}
+
+#[cfg(not(feature = "defmt"))]
+#[macro_export]
+macro_rules! assert_ne {
+    ($($t:tt)*) => { ::core::assert_ne!($($t)*) }
 }
 
 #[macro_export]


### PR DESCRIPTION
Fixes #5436
Closes #4869

Two changes are being made:
- `rx_fifo_full_treshold` of 0 is not a sensible value, so it's being disallowed
- `read_async` will now loop while there is no data to return