### PR TITLE
Embassy net driver impls

### DIFF
--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -97,7 +97,7 @@ embedded-io-06 = { package = "embedded-io", version = "0.6", default-features = 
 embedded-io-async-06 = { package = "embedded-io-async", version = "0.6", default-features = false, optional = true }
 embedded-io-07 = { package = "embedded-io", version = "0.7", default-features = false, optional = true }
 embedded-io-async-07 = { package = "embedded-io-async", version = "0.7", default-features = false, optional = true }
-embassy-net-driver = { version = "0.2.0", optional = true }
+embassy-net-driver-02 = { package = "embassy-net-driver", version = "0.2.0", optional = true }
 bt-hci = { version = "0.8.0", optional = true }
 
 # Logging interfaces, they are mutually exclusive so they need to be behind separate features.
@@ -250,7 +250,7 @@ esp32s3 = [
 
 #DOC_IF has("wifi_driver_supported")
 ## Enable Wi-Fi support.
-wifi = ["dep:enumset", "dep:embassy-net-driver"]
+wifi = ["dep:enumset", "dep:embassy-net-driver-02"]
 
 ## Enable Wi-Fi Enterprise Authentication Protocol (EAP) support.
 ##

--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -113,7 +113,7 @@ const MTU: usize = esp_config_int!(usize, "ESP_RADIO_CONFIG_WIFI_MTU");
 /// The link state of a network device.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, PartialOrd, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum LinkState {
+enum LinkState {
     /// The link is down.
     #[default]
     Down,
@@ -1351,6 +1351,10 @@ impl InterfaceType {
 }
 
 /// Wi-Fi interface.
+///
+/// This implements the `embassy-net-driver` trait for up to three latest versions of that crate.
+/// While that crate isn't stable we make an exception here from the [API Guidelines](https://rust-lang.github.io/api-guidelines/necessities.html#c-stable)
+/// in exposing unstable dependencies.
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]

--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -81,6 +81,7 @@ use self::{
 };
 use crate::{
     RadioRefGuard,
+    asynch::AtomicWaker,
     hal::ram,
     sys::{
         c_types,
@@ -1837,12 +1838,10 @@ pub(crate) use esp_wifi_result;
 
 // We can get away with a single tx waker because the transmit queue is shared
 // between interfaces.
-pub(crate) static TRANSMIT_WAKER: crate::asynch::AtomicWaker = crate::asynch::AtomicWaker::new();
+static TRANSMIT_WAKER: AtomicWaker = AtomicWaker::new();
 
-pub(crate) static AP_LINK_STATE_WAKER: crate::asynch::AtomicWaker =
-    crate::asynch::AtomicWaker::new();
-pub(crate) static STA_LINK_STATE_WAKER: crate::asynch::AtomicWaker =
-    crate::asynch::AtomicWaker::new();
+static AP_LINK_STATE_WAKER: AtomicWaker = AtomicWaker::new();
+static STA_LINK_STATE_WAKER: AtomicWaker = AtomicWaker::new();
 
 // we implement up to three latest versions of the embassy-net-driver
 // (but 0.1 clashes with embassy-time-driver)

--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -1840,9 +1840,17 @@ pub(crate) static AP_LINK_STATE_WAKER: crate::asynch::AtomicWaker =
 pub(crate) static STA_LINK_STATE_WAKER: crate::asynch::AtomicWaker =
     crate::asynch::AtomicWaker::new();
 
-// we implement the (max) latest three versions of the embassy-net-driver
+// we implement up to three latest versions of the embassy-net-driver
+// (but 0.1 clashes with embassy-time-driver)
 pub(crate) mod embassy_02 {
-    use embassy_net_driver_02::{Capabilities, Driver, HardwareAddress, RxToken, TxToken};
+    use embassy_net_driver_02::{
+        Capabilities,
+        Driver,
+        HardwareAddress,
+        LinkState,
+        RxToken,
+        TxToken,
+    };
 
     use super::*;
 
@@ -1888,14 +1896,11 @@ pub(crate) mod embassy_02 {
             self.mode.tx_token()
         }
 
-        fn link_state(
-            &mut self,
-            cx: &mut core::task::Context<'_>,
-        ) -> embassy_net_driver_02::LinkState {
+        fn link_state(&mut self, cx: &mut core::task::Context<'_>) -> LinkState {
             self.mode.register_link_state_waker(cx);
             match self.mode.link_state() {
-                LinkState::Down => embassy_net_driver_02::LinkState::Down,
-                LinkState::Up => embassy_net_driver_02::LinkState::Up,
+                super::LinkState::Down => LinkState::Down,
+                super::LinkState::Up => LinkState::Up,
             }
         }
 

--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -110,6 +110,17 @@ mod internal;
 
 const MTU: usize = esp_config_int!(usize, "ESP_RADIO_CONFIG_WIFI_MTU");
 
+/// The link state of a network device.
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, PartialOrd, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum LinkState {
+    /// The link is down.
+    #[default]
+    Down,
+    /// The link is up.
+    Up,
+}
+
 /// Supported Wi-Fi authentication methods.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, PartialOrd, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -1123,7 +1134,7 @@ unsafe extern "C" fn esp_wifi_tx_done_cb(
 
     decrement_inflight_counter();
 
-    embassy::TRANSMIT_WAKER.wake();
+    TRANSMIT_WAKER.wake();
 }
 
 pub(crate) fn wifi_start_scan(
@@ -1275,7 +1286,7 @@ impl InterfaceType {
 
         if self.can_send() {
             // even checking for !Uninitialized would be enough to not crash
-            if self.link_state() == embassy_net_driver::LinkState::Up {
+            if self.link_state() == LinkState::Up {
                 return Some(WifiTxToken { mode: *self });
             }
         }
@@ -1307,7 +1318,7 @@ impl InterfaceType {
     }
 
     fn register_transmit_waker(&self, cx: &mut core::task::Context<'_>) {
-        embassy::TRANSMIT_WAKER.register(cx.waker())
+        TRANSMIT_WAKER.register(cx.waker())
     }
 
     fn register_receive_waker(&self, cx: &mut core::task::Context<'_>) {
@@ -1316,12 +1327,12 @@ impl InterfaceType {
 
     fn register_link_state_waker(&self, cx: &mut core::task::Context<'_>) {
         match self {
-            InterfaceType::Station => embassy::STA_LINK_STATE_WAKER.register(cx.waker()),
-            InterfaceType::AccessPoint => embassy::AP_LINK_STATE_WAKER.register(cx.waker()),
+            InterfaceType::Station => STA_LINK_STATE_WAKER.register(cx.waker()),
+            InterfaceType::AccessPoint => AP_LINK_STATE_WAKER.register(cx.waker()),
         }
     }
 
-    fn link_state(&self) -> embassy_net_driver::LinkState {
+    fn link_state(&self) -> LinkState {
         let is_up = match self {
             InterfaceType::Station => {
                 matches!(station_state(), WifiStationState::Connected)
@@ -1332,9 +1343,9 @@ impl InterfaceType {
         };
 
         if is_up {
-            embassy_net_driver::LinkState::Up
+            LinkState::Up
         } else {
-            embassy_net_driver::LinkState::Down
+            LinkState::Down
         }
     }
 }
@@ -1820,18 +1831,20 @@ macro_rules! esp_wifi_result {
 }
 pub(crate) use esp_wifi_result;
 
-pub(crate) mod embassy {
-    use embassy_net_driver::{Capabilities, Driver, HardwareAddress, RxToken, TxToken};
+// We can get away with a single tx waker because the transmit queue is shared
+// between interfaces.
+pub(crate) static TRANSMIT_WAKER: crate::asynch::AtomicWaker = crate::asynch::AtomicWaker::new();
+
+pub(crate) static AP_LINK_STATE_WAKER: crate::asynch::AtomicWaker =
+    crate::asynch::AtomicWaker::new();
+pub(crate) static STA_LINK_STATE_WAKER: crate::asynch::AtomicWaker =
+    crate::asynch::AtomicWaker::new();
+
+// we implement the (max) latest three versions of the embassy-net-driver
+pub(crate) mod embassy_02 {
+    use embassy_net_driver_02::{Capabilities, Driver, HardwareAddress, RxToken, TxToken};
 
     use super::*;
-    use crate::asynch::AtomicWaker;
-
-    // We can get away with a single tx waker because the transmit queue is shared
-    // between interfaces.
-    pub(crate) static TRANSMIT_WAKER: AtomicWaker = AtomicWaker::new();
-
-    pub(crate) static AP_LINK_STATE_WAKER: AtomicWaker = AtomicWaker::new();
-    pub(crate) static STA_LINK_STATE_WAKER: AtomicWaker = AtomicWaker::new();
 
     impl RxToken for WifiRxToken {
         fn consume<R, F>(self, f: F) -> R
@@ -1878,9 +1891,12 @@ pub(crate) mod embassy {
         fn link_state(
             &mut self,
             cx: &mut core::task::Context<'_>,
-        ) -> embassy_net_driver::LinkState {
+        ) -> embassy_net_driver_02::LinkState {
             self.mode.register_link_state_waker(cx);
-            self.mode.link_state()
+            match self.mode.link_state() {
+                LinkState::Down => embassy_net_driver_02::LinkState::Down,
+                LinkState::Up => embassy_net_driver_02::LinkState::Up,
+            }
         }
 
         fn capabilities(&self) -> Capabilities {

--- a/esp-radio/src/wifi/os_adapter/mod.rs
+++ b/esp-radio/src/wifi/os_adapter/mod.rs
@@ -684,11 +684,11 @@ pub unsafe extern "C" fn event_post(
 
         match event {
             WifiEvent::StationConnected | WifiEvent::StationDisconnected => {
-                crate::wifi::embassy::STA_LINK_STATE_WAKER.wake();
+                crate::wifi::STA_LINK_STATE_WAKER.wake();
             }
 
             WifiEvent::AccessPointStart | WifiEvent::AccessPointStop => {
-                crate::wifi::embassy::AP_LINK_STATE_WAKER.wake();
+                crate::wifi::AP_LINK_STATE_WAKER.wake();
             }
 
             _ => {}


### PR DESCRIPTION
Closes #5268

`skip-changelog` since technically this doesn't change anything

We could implement embassy-net-driver 0.1.0, too - but since we don't support older embassy-time-drivers no one could use it - so I decided to not implement it

