### PR TITLE
Split UART generations into versions in metadata

### DIFF
--- a/esp-hal/src/uart/mod.rs
+++ b/esp-hal/src/uart/mod.rs
@@ -3267,6 +3267,19 @@ impl Info {
         Ok(())
     }
 
+    #[procmacros::doc_replace(
+        "rx_timeout_limit" => {
+            cfg(esp32) => "- `esp32`: Symbol size is fixed to 8, do not pass a value > **0x7F**.",
+            cfg(esp32c2) => "- `esp32c2`: The value you pass times the symbol size must be <= **0x3FF**.",
+            cfg(esp32c3) => "- `esp32c3`: The value you pass times the symbol size must be <= **0x3FF**.",
+            cfg(esp32c5) => "- `esp32c5`: The value you pass times the symbol size must be <= **0x3FF**.",
+            cfg(esp32c6) => "- `esp32c6`: The value you pass times the symbol size must be <= **0x3FF**.",
+            cfg(esp32c61) => "- `esp32c61`: The value you pass times the symbol size must be <= **0x3FF**.",
+            cfg(esp32h2) => "- `esp32h2`: The value you pass times the symbol size must be <= **0x3FF**.",
+            cfg(esp32s2) => "- `esp32s2`: The value you pass times the symbol size must be <= **0x3FF**.",
+            cfg(esp32s3) => "- `esp32s3`: The value you pass times the symbol size must be <= **0x3FF**.",
+        }
+    )]
     /// Configures the Receive Timeout detection setting
     ///
     /// ## Arguments
@@ -3278,9 +3291,7 @@ impl Info {
     ///
     /// [`ConfigError::TimeoutTooLong`] if the provided value exceeds
     /// the maximum value for SOC:
-    /// - `esp32`: Symbol size is fixed to 8, do not pass a value > **0x7F**.
-    /// - `esp32c2`, `esp32c3`, `esp32c5`, `esp32c6`, `esp32c61`, `esp32h2`, `esp32s2`, `esp32s3`:
-    ///   The value you pass times the symbol size must be <= **0x3FF**
+    /// {rx_timeout_limit}
     fn set_rx_timeout(&self, timeout: Option<u8>, _symbol_len: u8) -> Result<(), ConfigError> {
         cfg_if::cfg_if! {
             if #[cfg(esp32)] {

--- a/esp-hal/src/uart/mod.rs
+++ b/esp-hal/src/uart/mod.rs
@@ -1101,9 +1101,9 @@ impl<'d> UartRx<'d, Async> {
             }
 
             cfg_if::cfg_if! {
-                if #[cfg(uart_v2)] {
+                if #[cfg(uart_version = "2")] {
                     let reg_en = self.regs().tout_conf();
-                } else if #[cfg(uart_v1)] {
+                } else if #[cfg(uart_version = "1")] {
                     let reg_en = self.regs().conf1();
                 }
             };
@@ -3307,9 +3307,9 @@ impl Info {
             cfg_if::cfg_if! {
                 if #[cfg(esp32)] {
                     let reg_thrhd = register_block.conf1();
-                } else if #[cfg(uart_v2)] {
+                } else if #[cfg(uart_version = "2")] {
                     let reg_thrhd = register_block.tout_conf();
-                } else if #[cfg(uart_v1)] {
+                } else if #[cfg(uart_version = "1")] {
                     let reg_thrhd = register_block.mem_conf();
                 }
             }
@@ -3317,9 +3317,9 @@ impl Info {
         }
 
         cfg_if::cfg_if! {
-            if #[cfg(uart_v2)] {
+            if #[cfg(uart_version = "2")] {
                 let reg_en = register_block.tout_conf();
-            } else if #[cfg(uart_v1)] {
+            } else if #[cfg(uart_version = "1")] {
                 let reg_en = register_block.conf1();
             }
         }
@@ -3460,7 +3460,7 @@ impl Info {
                 xoff_threshold,
             } => {
                 cfg_if::cfg_if! {
-                    if #[cfg(uart_v2)] {
+                    if #[cfg(uart_version = "2")] {
                         self.regs().swfc_conf0().modify(|_, w| w.xonoff_del().set_bit().sw_flow_con_en().set_bit());
                         self.regs().swfc_conf1().modify(|_, w| unsafe { w.xon_threshold().bits(xon_threshold).xoff_threshold().bits(xoff_threshold)});
                         self.regs().swfc_conf0().modify(|_, w| unsafe { w.xon_char().bits(xon_char).xoff_char().bits(xoff_char) });
@@ -3468,7 +3468,7 @@ impl Info {
                         self.regs().flow_conf().modify(|_, w| w.xonoff_del().set_bit().sw_flow_con_en().set_bit());
                         self.regs().swfc_conf().modify(|_, w| unsafe { w.xon_threshold().bits(xon_threshold).xoff_threshold().bits(xoff_threshold) });
                         self.regs().swfc_conf().modify(|_, w| unsafe { w.xon_char().bits(xon_char).xoff_char().bits(xoff_char) });
-                    } else if #[cfg(uart_v1)] {
+                    } else if #[cfg(uart_version = "1")] {
                         self.regs().flow_conf().modify(|_, w| w.xonoff_del().set_bit().sw_flow_con_en().set_bit());
                         self.regs().swfc_conf1().modify(|_, w| unsafe { w.xon_threshold().bits(xon_threshold as u16) });
                         self.regs().swfc_conf0().modify(|_, w| unsafe { w.xoff_threshold().bits(xoff_threshold as u16) });
@@ -3479,9 +3479,9 @@ impl Info {
             }
             SwFlowControl::Disabled => {
                 cfg_if::cfg_if! {
-                    if #[cfg(uart_v2)] {
+                    if #[cfg(uart_version = "2")] {
                         let reg = self.regs().swfc_conf0();
-                    } else if #[cfg(uart_v1)] {
+                    } else if #[cfg(uart_version = "1")] {
                         let reg = self.regs().flow_conf();
                     }
                 }
@@ -3509,20 +3509,20 @@ impl Info {
             cfg_if::cfg_if! {
                 if #[cfg(esp32)] {
                     self.regs().conf1().modify(|_, w| unsafe { w.rx_flow_thrhd().bits(threshold) });
-                } else if #[cfg(uart_v2)] {
+                } else if #[cfg(uart_version = "2")] {
                     self.regs().hwfc_conf().modify(|_, w| unsafe { w.rx_flow_thrhd().bits(threshold) });
-                } else if #[cfg(uart_v1)] {
+                } else if #[cfg(uart_version = "1")] {
                     self.regs().mem_conf().modify(|_, w| unsafe { w.rx_flow_thrhd().bits(threshold as u16) });
                 }
             }
         }
 
         cfg_if::cfg_if! {
-            if #[cfg(uart_v2)] {
+            if #[cfg(uart_version = "2")] {
                 self.regs().hwfc_conf().modify(|_, w| {
                     w.rx_flow_en().bit(enable)
                 });
-            } else if #[cfg(uart_v1)] {
+            } else if #[cfg(uart_version = "1")] {
                 self.regs().conf1().modify(|_, w| {
                     w.rx_flow_en().bit(enable)
                 });

--- a/esp-hal/src/uart/mod.rs
+++ b/esp-hal/src/uart/mod.rs
@@ -3269,15 +3269,8 @@ impl Info {
 
     #[procmacros::doc_replace(
         "rx_timeout_limit" => {
-            cfg(esp32) => "- `esp32`: Symbol size is fixed to 8, do not pass a value > **0x7F**.",
-            cfg(esp32c2) => "- `esp32c2`: The value you pass times the symbol size must be <= **0x3FF**.",
-            cfg(esp32c3) => "- `esp32c3`: The value you pass times the symbol size must be <= **0x3FF**.",
-            cfg(esp32c5) => "- `esp32c5`: The value you pass times the symbol size must be <= **0x3FF**.",
-            cfg(esp32c6) => "- `esp32c6`: The value you pass times the symbol size must be <= **0x3FF**.",
-            cfg(esp32c61) => "- `esp32c61`: The value you pass times the symbol size must be <= **0x3FF**.",
-            cfg(esp32h2) => "- `esp32h2`: The value you pass times the symbol size must be <= **0x3FF**.",
-            cfg(esp32s2) => "- `esp32s2`: The value you pass times the symbol size must be <= **0x3FF**.",
-            cfg(esp32s3) => "- `esp32s3`: The value you pass times the symbol size must be <= **0x3FF**.",
+            cfg(esp32) => "- Symbol size is fixed to 8, do not pass a value > **0x7F**.",
+            _ => "- The value you pass times the symbol size must be <= **0x3FF**.",
         }
     )]
     /// Configures the Receive Timeout detection setting

--- a/esp-hal/src/uart/mod.rs
+++ b/esp-hal/src/uart/mod.rs
@@ -1101,9 +1101,9 @@ impl<'d> UartRx<'d, Async> {
             }
 
             cfg_if::cfg_if! {
-                if #[cfg(any(esp32c5, esp32c6, esp32c61, esp32h2))] {
+                if #[cfg(uart_v2)] {
                     let reg_en = self.regs().tout_conf();
-                } else {
+                } else if #[cfg(uart_v1)] {
                     let reg_en = self.regs().conf1();
                 }
             };
@@ -3279,8 +3279,8 @@ impl Info {
     /// [`ConfigError::TimeoutTooLong`] if the provided value exceeds
     /// the maximum value for SOC:
     /// - `esp32`: Symbol size is fixed to 8, do not pass a value > **0x7F**.
-    /// - `esp32c2`, `esp32c3`, `esp32c6`, `esp32h2`, esp32s2`, esp32s3`: The value you pass times
-    ///   the symbol size must be <= **0x3FF**
+    /// - `esp32c2`, `esp32c3`, `esp32c5`, `esp32c6`, `esp32c61`, `esp32h2`, `esp32s2`, `esp32s3`:
+    ///   The value you pass times the symbol size must be <= **0x3FF**
     fn set_rx_timeout(&self, timeout: Option<u8>, _symbol_len: u8) -> Result<(), ConfigError> {
         cfg_if::cfg_if! {
             if #[cfg(esp32)] {
@@ -3307,9 +3307,9 @@ impl Info {
             cfg_if::cfg_if! {
                 if #[cfg(esp32)] {
                     let reg_thrhd = register_block.conf1();
-                } else if #[cfg(any(esp32c5, esp32c6, esp32c61, esp32h2))] {
+                } else if #[cfg(uart_v2)] {
                     let reg_thrhd = register_block.tout_conf();
-                } else {
+                } else if #[cfg(uart_v1)] {
                     let reg_thrhd = register_block.mem_conf();
                 }
             }
@@ -3317,9 +3317,9 @@ impl Info {
         }
 
         cfg_if::cfg_if! {
-            if #[cfg(any(esp32c5, esp32c6, esp32c61, esp32h2))] {
+            if #[cfg(uart_v2)] {
                 let reg_en = register_block.tout_conf();
-            } else {
+            } else if #[cfg(uart_v1)] {
                 let reg_en = register_block.conf1();
             }
         }
@@ -3460,7 +3460,7 @@ impl Info {
                 xoff_threshold,
             } => {
                 cfg_if::cfg_if! {
-                    if #[cfg(any(esp32c5, esp32c6, esp32c61, esp32h2))] {
+                    if #[cfg(uart_v2)] {
                         self.regs().swfc_conf0().modify(|_, w| w.xonoff_del().set_bit().sw_flow_con_en().set_bit());
                         self.regs().swfc_conf1().modify(|_, w| unsafe { w.xon_threshold().bits(xon_threshold).xoff_threshold().bits(xoff_threshold)});
                         self.regs().swfc_conf0().modify(|_, w| unsafe { w.xon_char().bits(xon_char).xoff_char().bits(xoff_char) });
@@ -3468,7 +3468,7 @@ impl Info {
                         self.regs().flow_conf().modify(|_, w| w.xonoff_del().set_bit().sw_flow_con_en().set_bit());
                         self.regs().swfc_conf().modify(|_, w| unsafe { w.xon_threshold().bits(xon_threshold).xoff_threshold().bits(xoff_threshold) });
                         self.regs().swfc_conf().modify(|_, w| unsafe { w.xon_char().bits(xon_char).xoff_char().bits(xoff_char) });
-                    } else {
+                    } else if #[cfg(uart_v1)] {
                         self.regs().flow_conf().modify(|_, w| w.xonoff_del().set_bit().sw_flow_con_en().set_bit());
                         self.regs().swfc_conf1().modify(|_, w| unsafe { w.xon_threshold().bits(xon_threshold as u16) });
                         self.regs().swfc_conf0().modify(|_, w| unsafe { w.xoff_threshold().bits(xoff_threshold as u16) });
@@ -3479,9 +3479,9 @@ impl Info {
             }
             SwFlowControl::Disabled => {
                 cfg_if::cfg_if! {
-                    if #[cfg(any(esp32c5, esp32c6, esp32c61, esp32h2))] {
+                    if #[cfg(uart_v2)] {
                         let reg = self.regs().swfc_conf0();
-                    } else {
+                    } else if #[cfg(uart_v1)] {
                         let reg = self.regs().flow_conf();
                     }
                 }
@@ -3509,20 +3509,20 @@ impl Info {
             cfg_if::cfg_if! {
                 if #[cfg(esp32)] {
                     self.regs().conf1().modify(|_, w| unsafe { w.rx_flow_thrhd().bits(threshold) });
-                } else if #[cfg(any(esp32c5, esp32c6, esp32c61, esp32h2))] {
+                } else if #[cfg(uart_v2)] {
                     self.regs().hwfc_conf().modify(|_, w| unsafe { w.rx_flow_thrhd().bits(threshold) });
-                } else {
+                } else if #[cfg(uart_v1)] {
                     self.regs().mem_conf().modify(|_, w| unsafe { w.rx_flow_thrhd().bits(threshold as u16) });
                 }
             }
         }
 
         cfg_if::cfg_if! {
-            if #[cfg(any(esp32c5, esp32c6, esp32c61, esp32h2))] {
+            if #[cfg(uart_v2)] {
                 self.regs().hwfc_conf().modify(|_, w| {
                     w.rx_flow_en().bit(enable)
                 });
-            } else {
+            } else if #[cfg(uart_v1)] {
                 self.regs().conf1().modify(|_, w| {
                     w.rx_flow_en().bit(enable)
                 });

--- a/esp-metadata-generated/src/_build_script_utils.rs
+++ b/esp-metadata-generated/src/_build_script_utils.rs
@@ -386,7 +386,7 @@ impl Chip {
                     "timergroup_timg_has_timer1",
                     "timergroup_rc_fast_calibration_is_set",
                     "uart_ram_size=\"128\"",
-                    "uart_v1",
+                    "uart_version=\"1\"",
                     "wifi_mac_version=\"1\"",
                     "wifi_csi_supported",
                 ],
@@ -586,7 +586,7 @@ impl Chip {
                     "cargo:rustc-cfg=timergroup_timg_has_timer1",
                     "cargo:rustc-cfg=timergroup_rc_fast_calibration_is_set",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
-                    "cargo:rustc-cfg=uart_v1",
+                    "cargo:rustc-cfg=uart_version=\"1\"",
                     "cargo:rustc-cfg=wifi_mac_version=\"1\"",
                     "cargo:rustc-cfg=wifi_csi_supported",
                 ],
@@ -908,7 +908,7 @@ impl Chip {
                     "timergroup_timg_has_divcnt_rst",
                     "timergroup_rc_fast_calibration_is_set",
                     "uart_ram_size=\"128\"",
-                    "uart_v1",
+                    "uart_version=\"1\"",
                     "uart_has_sclk_divider",
                     "wifi_mac_version=\"1\"",
                 ],
@@ -1068,7 +1068,7 @@ impl Chip {
                     "cargo:rustc-cfg=timergroup_timg_has_divcnt_rst",
                     "cargo:rustc-cfg=timergroup_rc_fast_calibration_is_set",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
-                    "cargo:rustc-cfg=uart_v1",
+                    "cargo:rustc-cfg=uart_version=\"1\"",
                     "cargo:rustc-cfg=uart_has_sclk_divider",
                     "cargo:rustc-cfg=wifi_mac_version=\"1\"",
                 ],
@@ -1378,7 +1378,7 @@ impl Chip {
                     "timergroup_timg_has_divcnt_rst",
                     "timergroup_rc_fast_calibration_is_set",
                     "uart_ram_size=\"128\"",
-                    "uart_v1",
+                    "uart_version=\"1\"",
                     "uart_has_sclk_divider",
                     "wifi_mac_version=\"1\"",
                     "wifi_csi_supported",
@@ -1583,7 +1583,7 @@ impl Chip {
                     "cargo:rustc-cfg=timergroup_timg_has_divcnt_rst",
                     "cargo:rustc-cfg=timergroup_rc_fast_calibration_is_set",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
-                    "cargo:rustc-cfg=uart_v1",
+                    "cargo:rustc-cfg=uart_version=\"1\"",
                     "cargo:rustc-cfg=uart_has_sclk_divider",
                     "cargo:rustc-cfg=wifi_mac_version=\"1\"",
                     "cargo:rustc-cfg=wifi_csi_supported",
@@ -1941,7 +1941,7 @@ impl Chip {
                     "timergroup_timg_has_divcnt_rst",
                     "timergroup_rc_fast_calibration_is_set",
                     "uart_ram_size=\"128\"",
-                    "uart_v2",
+                    "uart_version=\"2\"",
                     "uart_peripheral_controls_mem_clk",
                     "uhci_combined_uart_selector_field",
                     "wifi_mac_version=\"3\"",
@@ -2191,7 +2191,7 @@ impl Chip {
                     "cargo:rustc-cfg=timergroup_timg_has_divcnt_rst",
                     "cargo:rustc-cfg=timergroup_rc_fast_calibration_is_set",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
-                    "cargo:rustc-cfg=uart_v2",
+                    "cargo:rustc-cfg=uart_version=\"2\"",
                     "cargo:rustc-cfg=uart_peripheral_controls_mem_clk",
                     "cargo:rustc-cfg=uhci_combined_uart_selector_field",
                     "cargo:rustc-cfg=wifi_mac_version=\"3\"",
@@ -2606,7 +2606,7 @@ impl Chip {
                     "timergroup_rc_fast_calibration_divider",
                     "timergroup_rc_fast_calibration_is_set",
                     "uart_ram_size=\"128\"",
-                    "uart_v2",
+                    "uart_version=\"2\"",
                     "uart_peripheral_controls_mem_clk",
                     "wifi_has_wifi6",
                     "wifi_mac_version=\"2\"",
@@ -2882,7 +2882,7 @@ impl Chip {
                     "cargo:rustc-cfg=timergroup_rc_fast_calibration_divider",
                     "cargo:rustc-cfg=timergroup_rc_fast_calibration_is_set",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
-                    "cargo:rustc-cfg=uart_v2",
+                    "cargo:rustc-cfg=uart_version=\"2\"",
                     "cargo:rustc-cfg=uart_peripheral_controls_mem_clk",
                     "cargo:rustc-cfg=wifi_has_wifi6",
                     "cargo:rustc-cfg=wifi_mac_version=\"2\"",
@@ -3218,7 +3218,7 @@ impl Chip {
                     "timergroup_timg_has_divcnt_rst",
                     "timergroup_rc_fast_calibration_is_set",
                     "uart_ram_size=\"128\"",
-                    "uart_v2",
+                    "uart_version=\"2\"",
                     "uart_peripheral_controls_mem_clk",
                     "wifi_has_wifi6",
                     "wifi_mac_version=\"3\"",
@@ -3408,7 +3408,7 @@ impl Chip {
                     "cargo:rustc-cfg=timergroup_timg_has_divcnt_rst",
                     "cargo:rustc-cfg=timergroup_rc_fast_calibration_is_set",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
-                    "cargo:rustc-cfg=uart_v2",
+                    "cargo:rustc-cfg=uart_version=\"2\"",
                     "cargo:rustc-cfg=uart_peripheral_controls_mem_clk",
                     "cargo:rustc-cfg=wifi_has_wifi6",
                     "cargo:rustc-cfg=wifi_mac_version=\"3\"",
@@ -3793,7 +3793,7 @@ impl Chip {
                     "timergroup_rc_fast_calibration_tick_enable",
                     "timergroup_rc_fast_calibration_is_set",
                     "uart_ram_size=\"128\"",
-                    "uart_v2",
+                    "uart_version=\"2\"",
                     "uart_peripheral_controls_mem_clk",
                 ],
                 cfgs: &[
@@ -4033,7 +4033,7 @@ impl Chip {
                     "cargo:rustc-cfg=timergroup_rc_fast_calibration_tick_enable",
                     "cargo:rustc-cfg=timergroup_rc_fast_calibration_is_set",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
-                    "cargo:rustc-cfg=uart_v2",
+                    "cargo:rustc-cfg=uart_version=\"2\"",
                     "cargo:rustc-cfg=uart_peripheral_controls_mem_clk",
                 ],
                 memory_layout: &MemoryLayout {
@@ -4352,7 +4352,7 @@ impl Chip {
                     "timergroup_timg_has_timer1",
                     "timergroup_rc_fast_calibration_is_set",
                     "uart_ram_size=\"128\"",
-                    "uart_v1",
+                    "uart_version=\"1\"",
                     "wifi_mac_version=\"1\"",
                     "wifi_csi_supported",
                 ],
@@ -4566,7 +4566,7 @@ impl Chip {
                     "cargo:rustc-cfg=timergroup_timg_has_timer1",
                     "cargo:rustc-cfg=timergroup_rc_fast_calibration_is_set",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
-                    "cargo:rustc-cfg=uart_v1",
+                    "cargo:rustc-cfg=uart_version=\"1\"",
                     "cargo:rustc-cfg=wifi_mac_version=\"1\"",
                     "cargo:rustc-cfg=wifi_csi_supported",
                 ],
@@ -5010,7 +5010,7 @@ impl Chip {
                     "timergroup_timg_has_timer1",
                     "timergroup_rc_fast_calibration_is_set",
                     "uart_ram_size=\"128\"",
-                    "uart_v1",
+                    "uart_version=\"1\"",
                     "uart_has_sclk_divider",
                     "wifi_mac_version=\"1\"",
                     "wifi_csi_supported",
@@ -5261,7 +5261,7 @@ impl Chip {
                     "cargo:rustc-cfg=timergroup_timg_has_timer1",
                     "cargo:rustc-cfg=timergroup_rc_fast_calibration_is_set",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
-                    "cargo:rustc-cfg=uart_v1",
+                    "cargo:rustc-cfg=uart_version=\"1\"",
                     "cargo:rustc-cfg=uart_has_sclk_divider",
                     "cargo:rustc-cfg=wifi_mac_version=\"1\"",
                     "cargo:rustc-cfg=wifi_csi_supported",
@@ -5697,7 +5697,6 @@ pub fn emit_check_cfg_directives() {
     println!("cargo:rustc-check-cfg=cfg(spi_slave_supports_dma)");
     println!("cargo:rustc-check-cfg=cfg(timergroup_timg_has_timer1)");
     println!("cargo:rustc-check-cfg=cfg(timergroup_rc_fast_calibration_is_set)");
-    println!("cargo:rustc-check-cfg=cfg(uart_v1)");
     println!("cargo:rustc-check-cfg=cfg(wifi_csi_supported)");
     println!("cargo:rustc-check-cfg=cfg(esp32c2)");
     println!("cargo:rustc-check-cfg=cfg(riscv)");
@@ -5868,7 +5867,6 @@ pub fn emit_check_cfg_directives() {
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_parl_io_rx_clock)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_parl_io_tx_clock)");
     println!("cargo:rustc-check-cfg=cfg(spi_master_has_clk_pre_div)");
-    println!("cargo:rustc-check-cfg=cfg(uart_v2)");
     println!("cargo:rustc-check-cfg=cfg(uart_peripheral_controls_mem_clk)");
     println!("cargo:rustc-check-cfg=cfg(uhci_combined_uart_selector_field)");
     println!("cargo:rustc-check-cfg=cfg(wifi_has_5g)");
@@ -5983,6 +5981,7 @@ pub fn emit_check_cfg_directives() {
         "cargo:rustc-check-cfg=cfg(soc_rc_fast_clk_default, values(\"8500000\",\"17500000\"))"
     );
     println!("cargo:rustc-check-cfg=cfg(uart_ram_size, values(\"128\"))");
+    println!("cargo:rustc-check-cfg=cfg(uart_version, values(\"1\",\"2\"))");
     println!("cargo:rustc-check-cfg=cfg(wifi_mac_version, values(\"1\",\"3\",\"2\"))");
     println!("cargo:rustc-check-cfg=cfg(dma_max_priority, values(\"9\",\"5\"))");
     println!("cargo:rustc-check-cfg=cfg(dma_gdma_version, values(\"1\",\"2\"))");

--- a/esp-metadata-generated/src/_build_script_utils.rs
+++ b/esp-metadata-generated/src/_build_script_utils.rs
@@ -386,6 +386,7 @@ impl Chip {
                     "timergroup_timg_has_timer1",
                     "timergroup_rc_fast_calibration_is_set",
                     "uart_ram_size=\"128\"",
+                    "uart_v1",
                     "wifi_mac_version=\"1\"",
                     "wifi_csi_supported",
                 ],
@@ -585,6 +586,7 @@ impl Chip {
                     "cargo:rustc-cfg=timergroup_timg_has_timer1",
                     "cargo:rustc-cfg=timergroup_rc_fast_calibration_is_set",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
+                    "cargo:rustc-cfg=uart_v1",
                     "cargo:rustc-cfg=wifi_mac_version=\"1\"",
                     "cargo:rustc-cfg=wifi_csi_supported",
                 ],
@@ -906,6 +908,7 @@ impl Chip {
                     "timergroup_timg_has_divcnt_rst",
                     "timergroup_rc_fast_calibration_is_set",
                     "uart_ram_size=\"128\"",
+                    "uart_v1",
                     "uart_has_sclk_divider",
                     "wifi_mac_version=\"1\"",
                 ],
@@ -1065,6 +1068,7 @@ impl Chip {
                     "cargo:rustc-cfg=timergroup_timg_has_divcnt_rst",
                     "cargo:rustc-cfg=timergroup_rc_fast_calibration_is_set",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
+                    "cargo:rustc-cfg=uart_v1",
                     "cargo:rustc-cfg=uart_has_sclk_divider",
                     "cargo:rustc-cfg=wifi_mac_version=\"1\"",
                 ],
@@ -1374,6 +1378,7 @@ impl Chip {
                     "timergroup_timg_has_divcnt_rst",
                     "timergroup_rc_fast_calibration_is_set",
                     "uart_ram_size=\"128\"",
+                    "uart_v1",
                     "uart_has_sclk_divider",
                     "wifi_mac_version=\"1\"",
                     "wifi_csi_supported",
@@ -1578,6 +1583,7 @@ impl Chip {
                     "cargo:rustc-cfg=timergroup_timg_has_divcnt_rst",
                     "cargo:rustc-cfg=timergroup_rc_fast_calibration_is_set",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
+                    "cargo:rustc-cfg=uart_v1",
                     "cargo:rustc-cfg=uart_has_sclk_divider",
                     "cargo:rustc-cfg=wifi_mac_version=\"1\"",
                     "cargo:rustc-cfg=wifi_csi_supported",
@@ -1935,6 +1941,7 @@ impl Chip {
                     "timergroup_timg_has_divcnt_rst",
                     "timergroup_rc_fast_calibration_is_set",
                     "uart_ram_size=\"128\"",
+                    "uart_v2",
                     "uart_peripheral_controls_mem_clk",
                     "uhci_combined_uart_selector_field",
                     "wifi_mac_version=\"3\"",
@@ -2184,6 +2191,7 @@ impl Chip {
                     "cargo:rustc-cfg=timergroup_timg_has_divcnt_rst",
                     "cargo:rustc-cfg=timergroup_rc_fast_calibration_is_set",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
+                    "cargo:rustc-cfg=uart_v2",
                     "cargo:rustc-cfg=uart_peripheral_controls_mem_clk",
                     "cargo:rustc-cfg=uhci_combined_uart_selector_field",
                     "cargo:rustc-cfg=wifi_mac_version=\"3\"",
@@ -2598,6 +2606,7 @@ impl Chip {
                     "timergroup_rc_fast_calibration_divider",
                     "timergroup_rc_fast_calibration_is_set",
                     "uart_ram_size=\"128\"",
+                    "uart_v2",
                     "uart_peripheral_controls_mem_clk",
                     "wifi_has_wifi6",
                     "wifi_mac_version=\"2\"",
@@ -2873,6 +2882,7 @@ impl Chip {
                     "cargo:rustc-cfg=timergroup_rc_fast_calibration_divider",
                     "cargo:rustc-cfg=timergroup_rc_fast_calibration_is_set",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
+                    "cargo:rustc-cfg=uart_v2",
                     "cargo:rustc-cfg=uart_peripheral_controls_mem_clk",
                     "cargo:rustc-cfg=wifi_has_wifi6",
                     "cargo:rustc-cfg=wifi_mac_version=\"2\"",
@@ -3208,6 +3218,7 @@ impl Chip {
                     "timergroup_timg_has_divcnt_rst",
                     "timergroup_rc_fast_calibration_is_set",
                     "uart_ram_size=\"128\"",
+                    "uart_v2",
                     "uart_peripheral_controls_mem_clk",
                     "wifi_has_wifi6",
                     "wifi_mac_version=\"3\"",
@@ -3397,6 +3408,7 @@ impl Chip {
                     "cargo:rustc-cfg=timergroup_timg_has_divcnt_rst",
                     "cargo:rustc-cfg=timergroup_rc_fast_calibration_is_set",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
+                    "cargo:rustc-cfg=uart_v2",
                     "cargo:rustc-cfg=uart_peripheral_controls_mem_clk",
                     "cargo:rustc-cfg=wifi_has_wifi6",
                     "cargo:rustc-cfg=wifi_mac_version=\"3\"",
@@ -3781,6 +3793,7 @@ impl Chip {
                     "timergroup_rc_fast_calibration_tick_enable",
                     "timergroup_rc_fast_calibration_is_set",
                     "uart_ram_size=\"128\"",
+                    "uart_v2",
                     "uart_peripheral_controls_mem_clk",
                 ],
                 cfgs: &[
@@ -4020,6 +4033,7 @@ impl Chip {
                     "cargo:rustc-cfg=timergroup_rc_fast_calibration_tick_enable",
                     "cargo:rustc-cfg=timergroup_rc_fast_calibration_is_set",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
+                    "cargo:rustc-cfg=uart_v2",
                     "cargo:rustc-cfg=uart_peripheral_controls_mem_clk",
                 ],
                 memory_layout: &MemoryLayout {
@@ -4338,6 +4352,7 @@ impl Chip {
                     "timergroup_timg_has_timer1",
                     "timergroup_rc_fast_calibration_is_set",
                     "uart_ram_size=\"128\"",
+                    "uart_v1",
                     "wifi_mac_version=\"1\"",
                     "wifi_csi_supported",
                 ],
@@ -4551,6 +4566,7 @@ impl Chip {
                     "cargo:rustc-cfg=timergroup_timg_has_timer1",
                     "cargo:rustc-cfg=timergroup_rc_fast_calibration_is_set",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
+                    "cargo:rustc-cfg=uart_v1",
                     "cargo:rustc-cfg=wifi_mac_version=\"1\"",
                     "cargo:rustc-cfg=wifi_csi_supported",
                 ],
@@ -4994,6 +5010,7 @@ impl Chip {
                     "timergroup_timg_has_timer1",
                     "timergroup_rc_fast_calibration_is_set",
                     "uart_ram_size=\"128\"",
+                    "uart_v1",
                     "uart_has_sclk_divider",
                     "wifi_mac_version=\"1\"",
                     "wifi_csi_supported",
@@ -5244,6 +5261,7 @@ impl Chip {
                     "cargo:rustc-cfg=timergroup_timg_has_timer1",
                     "cargo:rustc-cfg=timergroup_rc_fast_calibration_is_set",
                     "cargo:rustc-cfg=uart_ram_size=\"128\"",
+                    "cargo:rustc-cfg=uart_v1",
                     "cargo:rustc-cfg=uart_has_sclk_divider",
                     "cargo:rustc-cfg=wifi_mac_version=\"1\"",
                     "cargo:rustc-cfg=wifi_csi_supported",
@@ -5679,6 +5697,7 @@ pub fn emit_check_cfg_directives() {
     println!("cargo:rustc-check-cfg=cfg(spi_slave_supports_dma)");
     println!("cargo:rustc-check-cfg=cfg(timergroup_timg_has_timer1)");
     println!("cargo:rustc-check-cfg=cfg(timergroup_rc_fast_calibration_is_set)");
+    println!("cargo:rustc-check-cfg=cfg(uart_v1)");
     println!("cargo:rustc-check-cfg=cfg(wifi_csi_supported)");
     println!("cargo:rustc-check-cfg=cfg(esp32c2)");
     println!("cargo:rustc-check-cfg=cfg(riscv)");
@@ -5849,6 +5868,7 @@ pub fn emit_check_cfg_directives() {
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_parl_io_rx_clock)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_parl_io_tx_clock)");
     println!("cargo:rustc-check-cfg=cfg(spi_master_has_clk_pre_div)");
+    println!("cargo:rustc-check-cfg=cfg(uart_v2)");
     println!("cargo:rustc-check-cfg=cfg(uart_peripheral_controls_mem_clk)");
     println!("cargo:rustc-check-cfg=cfg(uhci_combined_uart_selector_field)");
     println!("cargo:rustc-check-cfg=cfg(wifi_has_5g)");

--- a/esp-metadata-generated/src/_generated_esp32.rs
+++ b/esp-metadata-generated/src/_generated_esp32.rs
@@ -328,10 +328,10 @@ macro_rules! property {
     ("uart.ram_size", str) => {
         stringify!(128)
     };
-    ("uart.register_map_version") => {
+    ("uart.version") => {
         1
     };
-    ("uart.register_map_version", str) => {
+    ("uart.version", str) => {
         stringify!(1)
     };
     ("uart.peripheral_controls_mem_clk") => {

--- a/esp-metadata-generated/src/_generated_esp32.rs
+++ b/esp-metadata-generated/src/_generated_esp32.rs
@@ -328,6 +328,12 @@ macro_rules! property {
     ("uart.ram_size", str) => {
         stringify!(128)
     };
+    ("uart.register_map_version") => {
+        1
+    };
+    ("uart.register_map_version", str) => {
+        stringify!(1)
+    };
     ("uart.peripheral_controls_mem_clk") => {
         false
     };

--- a/esp-metadata-generated/src/_generated_esp32c2.rs
+++ b/esp-metadata-generated/src/_generated_esp32c2.rs
@@ -292,10 +292,10 @@ macro_rules! property {
     ("uart.ram_size", str) => {
         stringify!(128)
     };
-    ("uart.register_map_version") => {
+    ("uart.version") => {
         1
     };
-    ("uart.register_map_version", str) => {
+    ("uart.version", str) => {
         stringify!(1)
     };
     ("uart.peripheral_controls_mem_clk") => {

--- a/esp-metadata-generated/src/_generated_esp32c2.rs
+++ b/esp-metadata-generated/src/_generated_esp32c2.rs
@@ -292,6 +292,12 @@ macro_rules! property {
     ("uart.ram_size", str) => {
         stringify!(128)
     };
+    ("uart.register_map_version") => {
+        1
+    };
+    ("uart.register_map_version", str) => {
+        stringify!(1)
+    };
     ("uart.peripheral_controls_mem_clk") => {
         false
     };

--- a/esp-metadata-generated/src/_generated_esp32c3.rs
+++ b/esp-metadata-generated/src/_generated_esp32c3.rs
@@ -343,6 +343,12 @@ macro_rules! property {
     ("uart.ram_size", str) => {
         stringify!(128)
     };
+    ("uart.register_map_version") => {
+        1
+    };
+    ("uart.register_map_version", str) => {
+        stringify!(1)
+    };
     ("uart.peripheral_controls_mem_clk") => {
         false
     };

--- a/esp-metadata-generated/src/_generated_esp32c3.rs
+++ b/esp-metadata-generated/src/_generated_esp32c3.rs
@@ -343,10 +343,10 @@ macro_rules! property {
     ("uart.ram_size", str) => {
         stringify!(128)
     };
-    ("uart.register_map_version") => {
+    ("uart.version") => {
         1
     };
-    ("uart.register_map_version", str) => {
+    ("uart.version", str) => {
         stringify!(1)
     };
     ("uart.peripheral_controls_mem_clk") => {

--- a/esp-metadata-generated/src/_generated_esp32c5.rs
+++ b/esp-metadata-generated/src/_generated_esp32c5.rs
@@ -388,10 +388,10 @@ macro_rules! property {
     ("uart.ram_size", str) => {
         stringify!(128)
     };
-    ("uart.register_map_version") => {
+    ("uart.version") => {
         2
     };
-    ("uart.register_map_version", str) => {
+    ("uart.version", str) => {
         stringify!(2)
     };
     ("uart.peripheral_controls_mem_clk") => {

--- a/esp-metadata-generated/src/_generated_esp32c5.rs
+++ b/esp-metadata-generated/src/_generated_esp32c5.rs
@@ -388,6 +388,12 @@ macro_rules! property {
     ("uart.ram_size", str) => {
         stringify!(128)
     };
+    ("uart.register_map_version") => {
+        2
+    };
+    ("uart.register_map_version", str) => {
+        stringify!(2)
+    };
     ("uart.peripheral_controls_mem_clk") => {
         true
     };

--- a/esp-metadata-generated/src/_generated_esp32c6.rs
+++ b/esp-metadata-generated/src/_generated_esp32c6.rs
@@ -379,10 +379,10 @@ macro_rules! property {
     ("uart.ram_size", str) => {
         stringify!(128)
     };
-    ("uart.register_map_version") => {
+    ("uart.version") => {
         2
     };
-    ("uart.register_map_version", str) => {
+    ("uart.version", str) => {
         stringify!(2)
     };
     ("uart.peripheral_controls_mem_clk") => {

--- a/esp-metadata-generated/src/_generated_esp32c6.rs
+++ b/esp-metadata-generated/src/_generated_esp32c6.rs
@@ -379,6 +379,12 @@ macro_rules! property {
     ("uart.ram_size", str) => {
         stringify!(128)
     };
+    ("uart.register_map_version") => {
+        2
+    };
+    ("uart.register_map_version", str) => {
+        stringify!(2)
+    };
     ("uart.peripheral_controls_mem_clk") => {
         true
     };

--- a/esp-metadata-generated/src/_generated_esp32c61.rs
+++ b/esp-metadata-generated/src/_generated_esp32c61.rs
@@ -304,10 +304,10 @@ macro_rules! property {
     ("uart.ram_size", str) => {
         stringify!(128)
     };
-    ("uart.register_map_version") => {
+    ("uart.version") => {
         2
     };
-    ("uart.register_map_version", str) => {
+    ("uart.version", str) => {
         stringify!(2)
     };
     ("uart.peripheral_controls_mem_clk") => {

--- a/esp-metadata-generated/src/_generated_esp32c61.rs
+++ b/esp-metadata-generated/src/_generated_esp32c61.rs
@@ -304,6 +304,12 @@ macro_rules! property {
     ("uart.ram_size", str) => {
         stringify!(128)
     };
+    ("uart.register_map_version") => {
+        2
+    };
+    ("uart.register_map_version", str) => {
+        stringify!(2)
+    };
     ("uart.peripheral_controls_mem_clk") => {
         true
     };

--- a/esp-metadata-generated/src/_generated_esp32h2.rs
+++ b/esp-metadata-generated/src/_generated_esp32h2.rs
@@ -376,10 +376,10 @@ macro_rules! property {
     ("uart.ram_size", str) => {
         stringify!(128)
     };
-    ("uart.register_map_version") => {
+    ("uart.version") => {
         2
     };
-    ("uart.register_map_version", str) => {
+    ("uart.version", str) => {
         stringify!(2)
     };
     ("uart.peripheral_controls_mem_clk") => {

--- a/esp-metadata-generated/src/_generated_esp32h2.rs
+++ b/esp-metadata-generated/src/_generated_esp32h2.rs
@@ -376,6 +376,12 @@ macro_rules! property {
     ("uart.ram_size", str) => {
         stringify!(128)
     };
+    ("uart.register_map_version") => {
+        2
+    };
+    ("uart.register_map_version", str) => {
+        stringify!(2)
+    };
     ("uart.peripheral_controls_mem_clk") => {
         true
     };

--- a/esp-metadata-generated/src/_generated_esp32s2.rs
+++ b/esp-metadata-generated/src/_generated_esp32s2.rs
@@ -328,10 +328,10 @@ macro_rules! property {
     ("uart.ram_size", str) => {
         stringify!(128)
     };
-    ("uart.register_map_version") => {
+    ("uart.version") => {
         1
     };
-    ("uart.register_map_version", str) => {
+    ("uart.version", str) => {
         stringify!(1)
     };
     ("uart.peripheral_controls_mem_clk") => {

--- a/esp-metadata-generated/src/_generated_esp32s2.rs
+++ b/esp-metadata-generated/src/_generated_esp32s2.rs
@@ -328,6 +328,12 @@ macro_rules! property {
     ("uart.ram_size", str) => {
         stringify!(128)
     };
+    ("uart.register_map_version") => {
+        1
+    };
+    ("uart.register_map_version", str) => {
+        stringify!(1)
+    };
     ("uart.peripheral_controls_mem_clk") => {
         false
     };

--- a/esp-metadata-generated/src/_generated_esp32s3.rs
+++ b/esp-metadata-generated/src/_generated_esp32s3.rs
@@ -349,10 +349,10 @@ macro_rules! property {
     ("uart.ram_size", str) => {
         stringify!(128)
     };
-    ("uart.register_map_version") => {
+    ("uart.version") => {
         1
     };
-    ("uart.register_map_version", str) => {
+    ("uart.version", str) => {
         stringify!(1)
     };
     ("uart.peripheral_controls_mem_clk") => {

--- a/esp-metadata-generated/src/_generated_esp32s3.rs
+++ b/esp-metadata-generated/src/_generated_esp32s3.rs
@@ -349,6 +349,12 @@ macro_rules! property {
     ("uart.ram_size", str) => {
         stringify!(128)
     };
+    ("uart.register_map_version") => {
+        1
+    };
+    ("uart.register_map_version", str) => {
+        stringify!(1)
+    };
     ("uart.peripheral_controls_mem_clk") => {
         false
     };

--- a/esp-metadata/devices/esp32.toml
+++ b/esp-metadata/devices/esp32.toml
@@ -852,7 +852,7 @@ instances = [
     { name = "uart2", sys_instance = "Uart2", tx = "U2TXD", rx = "U2RXD", cts = "U2CTS", rts = "U2RTS" },
 ]
 ram_size = 128
-register_map_version = 1
+version = 1
 
 [device.uhci]
 support_status = "not_supported"

--- a/esp-metadata/devices/esp32.toml
+++ b/esp-metadata/devices/esp32.toml
@@ -852,6 +852,7 @@ instances = [
     { name = "uart2", sys_instance = "Uart2", tx = "U2TXD", rx = "U2RXD", cts = "U2CTS", rts = "U2RTS" },
 ]
 ram_size = 128
+register_map_version = 1
 
 [device.uhci]
 support_status = "not_supported"

--- a/esp-metadata/devices/esp32c2.toml
+++ b/esp-metadata/devices/esp32c2.toml
@@ -438,7 +438,7 @@ instances = [
     { name = "uart1", sys_instance = "Uart1", tx = "U1TXD", rx = "U1RXD", cts = "U1CTS", rts = "U1RTS" },
 ]
 ram_size = 128
-register_map_version = 1
+version = 1
 has_sclk_divider = true
 
 [device.rng]

--- a/esp-metadata/devices/esp32c2.toml
+++ b/esp-metadata/devices/esp32c2.toml
@@ -438,6 +438,7 @@ instances = [
     { name = "uart1", sys_instance = "Uart1", tx = "U1TXD", rx = "U1RXD", cts = "U1CTS", rts = "U1RTS" },
 ]
 ram_size = 128
+register_map_version = 1
 has_sclk_divider = true
 
 [device.rng]

--- a/esp-metadata/devices/esp32c3.toml
+++ b/esp-metadata/devices/esp32c3.toml
@@ -511,6 +511,7 @@ instances = [
     { name = "uart1", sys_instance = "Uart1", tx = "U1TXD", rx = "U1RXD", cts = "U1CTS", rts = "U1RTS" },
 ]
 ram_size = 128
+register_map_version = 1
 has_sclk_divider = true
 
 [device.uhci]

--- a/esp-metadata/devices/esp32c3.toml
+++ b/esp-metadata/devices/esp32c3.toml
@@ -511,7 +511,7 @@ instances = [
     { name = "uart1", sys_instance = "Uart1", tx = "U1TXD", rx = "U1RXD", cts = "U1CTS", rts = "U1RTS" },
 ]
 ram_size = 128
-register_map_version = 1
+version = 1
 has_sclk_divider = true
 
 [device.uhci]

--- a/esp-metadata/devices/esp32c5.toml
+++ b/esp-metadata/devices/esp32c5.toml
@@ -620,7 +620,7 @@ instances = [
     { name = "uart1", sys_instance = "Uart1", tx = "U1TXD", rx = "U1RXD", cts = "U1CTS", rts = "U1RTS" },
 ]
 ram_size = 128
-register_map_version = 2
+version = 2
 peripheral_controls_mem_clk = true
 
 [device.uhci]

--- a/esp-metadata/devices/esp32c5.toml
+++ b/esp-metadata/devices/esp32c5.toml
@@ -620,6 +620,7 @@ instances = [
     { name = "uart1", sys_instance = "Uart1", tx = "U1TXD", rx = "U1RXD", cts = "U1CTS", rts = "U1RTS" },
 ]
 ram_size = 128
+register_map_version = 2
 peripheral_controls_mem_clk = true
 
 [device.uhci]

--- a/esp-metadata/devices/esp32c6.toml
+++ b/esp-metadata/devices/esp32c6.toml
@@ -718,6 +718,7 @@ instances = [
     { name = "uart1", sys_instance = "Uart1", tx = "U1TXD", rx = "U1RXD", cts = "U1CTS", rts = "U1RTS" },
 ]
 ram_size = 128
+register_map_version = 2
 peripheral_controls_mem_clk = true
 
 [device.uhci]

--- a/esp-metadata/devices/esp32c6.toml
+++ b/esp-metadata/devices/esp32c6.toml
@@ -718,7 +718,7 @@ instances = [
     { name = "uart1", sys_instance = "Uart1", tx = "U1TXD", rx = "U1RXD", cts = "U1CTS", rts = "U1RTS" },
 ]
 ram_size = 128
-register_map_version = 2
+version = 2
 peripheral_controls_mem_clk = true
 
 [device.uhci]

--- a/esp-metadata/devices/esp32c61.toml
+++ b/esp-metadata/devices/esp32c61.toml
@@ -428,7 +428,7 @@ instances = [
     { name = "uart1", sys_instance = "Uart1", tx = "U1TXD", rx = "U1RXD", cts = "U1CTS", rts = "U1RTS" },
 ]
 ram_size = 128
-register_map_version = 2
+version = 2
 peripheral_controls_mem_clk = true
 
 [device.i2c_master]

--- a/esp-metadata/devices/esp32c61.toml
+++ b/esp-metadata/devices/esp32c61.toml
@@ -428,6 +428,7 @@ instances = [
     { name = "uart1", sys_instance = "Uart1", tx = "U1TXD", rx = "U1RXD", cts = "U1CTS", rts = "U1RTS" },
 ]
 ram_size = 128
+register_map_version = 2
 peripheral_controls_mem_clk = true
 
 [device.i2c_master]

--- a/esp-metadata/devices/esp32h2.toml
+++ b/esp-metadata/devices/esp32h2.toml
@@ -620,7 +620,7 @@ instances = [
     { name = "uart1", sys_instance = "Uart1", tx = "U1TXD", rx = "U1RXD", cts = "U1CTS", rts = "U1RTS" },
 ]
 ram_size = 128
-register_map_version = 2
+version = 2
 peripheral_controls_mem_clk = true
 
 [device.uhci]

--- a/esp-metadata/devices/esp32h2.toml
+++ b/esp-metadata/devices/esp32h2.toml
@@ -620,6 +620,7 @@ instances = [
     { name = "uart1", sys_instance = "Uart1", tx = "U1TXD", rx = "U1RXD", cts = "U1CTS", rts = "U1RTS" },
 ]
 ram_size = 128
+register_map_version = 2
 peripheral_controls_mem_clk = true
 
 [device.uhci]

--- a/esp-metadata/devices/esp32s2.toml
+++ b/esp-metadata/devices/esp32s2.toml
@@ -638,6 +638,7 @@ instances = [
     { name = "uart1", sys_instance = "Uart1", tx = "U1TXD", rx = "U1RXD", cts = "U1CTS", rts = "U1RTS" },
 ]
 ram_size = 128
+register_map_version = 1
 
 [device.uhci]
 support_status = "not_supported"

--- a/esp-metadata/devices/esp32s2.toml
+++ b/esp-metadata/devices/esp32s2.toml
@@ -638,7 +638,7 @@ instances = [
     { name = "uart1", sys_instance = "Uart1", tx = "U1TXD", rx = "U1RXD", cts = "U1CTS", rts = "U1RTS" },
 ]
 ram_size = 128
-register_map_version = 1
+version = 1
 
 [device.uhci]
 support_status = "not_supported"

--- a/esp-metadata/devices/esp32s3.toml
+++ b/esp-metadata/devices/esp32s3.toml
@@ -837,7 +837,7 @@ instances = [
     { name = "uart2", sys_instance = "Uart2", tx = "U2TXD", rx = "U2RXD", cts = "U2CTS", rts = "U2RTS" },
 ]
 ram_size = 128
-register_map_version = 1
+version = 1
 has_sclk_divider = true
 
 [device.uhci]

--- a/esp-metadata/devices/esp32s3.toml
+++ b/esp-metadata/devices/esp32s3.toml
@@ -837,6 +837,7 @@ instances = [
     { name = "uart2", sys_instance = "Uart2", tx = "U2TXD", rx = "U2RXD", cts = "U2CTS", rts = "U2RTS" },
 ]
 ram_size = 128
+register_map_version = 1
 has_sclk_divider = true
 
 [device.uhci]

--- a/esp-metadata/src/cfg.rs
+++ b/esp-metadata/src/cfg.rs
@@ -703,7 +703,7 @@ driver_configs![
         name: "UART",
         properties: {
             ram_size: u32,
-            register_map_version: UartRegisterMapVersion,
+            version: u32,
             #[serde(default)]
             peripheral_controls_mem_clk: bool,
             // Whether the MCU has a CLK_CONF register _in_ the UART peripheral.

--- a/esp-metadata/src/cfg.rs
+++ b/esp-metadata/src/cfg.rs
@@ -703,6 +703,7 @@ driver_configs![
         name: "UART",
         properties: {
             ram_size: u32,
+            register_map_version: UartRegisterMapVersion,
             #[serde(default)]
             peripheral_controls_mem_clk: bool,
             // Whether the MCU has a CLK_CONF register _in_ the UART peripheral.

--- a/esp-metadata/src/cfg/uart.rs
+++ b/esp-metadata/src/cfg/uart.rs
@@ -1,38 +1,7 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
-use crate::{
-    cfg::{GenericProperty, UartProperties},
-    generate_for_each_macro,
-    number,
-};
-
-/// UART register map version (HAL `cfg(uart_v1)` / `cfg(uart_v2)`).
-///
-/// Version 2 matches peripherals that expose `HWFC_CONF`, split software flow
-/// control registers, and RX timeout fields in `TOUT_CONF` as used in esp-hal.
-/// Usually uart_v1 is used on older chips, and uart_v2 is used on newer ones.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
-#[repr(transparent)]
-pub(crate) struct UartRegisterMapVersion(pub u32);
-
-impl GenericProperty for UartRegisterMapVersion {
-    fn cfgs(&self) -> Option<Vec<String>> {
-        match self.0 {
-            1 => Some(vec!["uart_v1".to_string()]),
-            2 => Some(vec!["uart_v2".to_string()]),
-            _ => None,
-        }
-    }
-
-    fn property_macro_branches(&self) -> proc_macro2::TokenStream {
-        let v = number(self.0);
-        quote! {
-            ("uart.register_map_version") => { #v };
-            ("uart.register_map_version", str) => { stringify!(#v) };
-        }
-    }
-}
+use crate::{cfg::UartProperties, generate_for_each_macro};
 
 /// Instance configuration, used in [device.uart.instances]
 #[derive(Debug, Default, Clone, serde::Deserialize, serde::Serialize)]

--- a/esp-metadata/src/cfg/uart.rs
+++ b/esp-metadata/src/cfg/uart.rs
@@ -1,7 +1,38 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
-use crate::{cfg::UartProperties, generate_for_each_macro};
+use crate::{
+    cfg::{GenericProperty, UartProperties},
+    generate_for_each_macro,
+    number,
+};
+
+/// UART register map version (HAL `cfg(uart_v1)` / `cfg(uart_v2)`).
+///
+/// Version 2 matches peripherals that expose `HWFC_CONF`, split software flow
+/// control registers, and RX timeout fields in `TOUT_CONF` as used in esp-hal.
+/// Usually uart_v1 is used on older chips, and uart_v2 is used on newer ones.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[repr(transparent)]
+pub(crate) struct UartRegisterMapVersion(pub u32);
+
+impl GenericProperty for UartRegisterMapVersion {
+    fn cfgs(&self) -> Option<Vec<String>> {
+        match self.0 {
+            1 => Some(vec!["uart_v1".to_string()]),
+            2 => Some(vec!["uart_v2".to_string()]),
+            _ => None,
+        }
+    }
+
+    fn property_macro_branches(&self) -> proc_macro2::TokenStream {
+        let v = number(self.0);
+        quote! {
+            ("uart.register_map_version") => { #v };
+            ("uart.register_map_version", str) => { stringify!(#v) };
+        }
+    }
+}
 
 /// Instance configuration, used in [device.uart.instances]
 #[derive(Debug, Default, Clone, serde::Deserialize, serde::Serialize)]

--- a/esp-metadata/src/lib.rs
+++ b/esp-metadata/src/lib.rs
@@ -388,6 +388,14 @@ impl Config {
             );
         }
 
+        if let Some(uart) = &self.device.peri_config.uart {
+            ensure!(
+                matches!(uart.register_map_version.0, 1 | 2),
+                "uart.register_map_version must be 1 or 2 for device '{}'",
+                self.device.name
+            );
+        }
+
         Ok(())
     }
 

--- a/esp-metadata/src/lib.rs
+++ b/esp-metadata/src/lib.rs
@@ -388,14 +388,6 @@ impl Config {
             );
         }
 
-        if let Some(uart) = &self.device.peri_config.uart {
-            ensure!(
-                matches!(uart.register_map_version.0, 1 | 2),
-                "uart.register_map_version must be 1 or 2 for device '{}'",
-                self.device.name
-            );
-        }
-
         Ok(())
     }
 


### PR DESCRIPTION
closes https://github.com/esp-rs/esp-hal/issues/5250

This PR introduces a small internal UART “generation/version” split in metadata (uart_v1 / uart_v2) and switches UART register-layout cfgs to use that instead of repeating long chip lists.

We kept seeing the same gates like `#[cfg(any(esp32c5, esp32c6, esp32c61, esp32h2))]` in many places where the behaviour difference is really about register layout. This PR groups chips by practical UART register-map behaviour and makes those branches easier to read and maintain.

There is no official Espressif “UART version” naming used here, these generations are an internal abstraction which makes sense only in `esp-hal` based on practical observation of PAC/TRM register layout differences.

If this concept survives through review, I will revisit all the peripherals and try to unify things in the same way there as well


DISCLAIMER: `esp32` still remains "special" in many cases (surprise, right?), even though it is matched to `uart_v1`, sometimes we still need to create a cfg-gate specifically for this chip. I didn't want to create a `uart_v0` for one only chip, so this is still using `cfg(esp32)` where esp32 needs special treatment