### PR TITLE
Skip migration guide placeholder replacement for pre-releases

### DIFF
--- a/xtask/src/commands/release/bump_version.rs
+++ b/xtask/src/commands/release/bump_version.rs
@@ -440,7 +440,21 @@ fn finalize_placeholders(
         }
     }
 
+    let is_prerelease = !new_version.pre.is_empty();
+
     walk_dir(&bumped_package.package_path(), &skip_paths, &mut |path| {
+        if is_prerelease {
+            if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
+                if name.starts_with("MIGRATING-") && name.ends_with(".md") {
+                    log::info!(
+                        "  Skipping migration guide {} (pre-release)",
+                        path.display()
+                    );
+                    return;
+                }
+            }
+        }
+
         let content = match fs::read_to_string(path) {
             Ok(content) => content,
             Err(e) => {


### PR DESCRIPTION
During pre-release bumps (e.g. 1.1.0-rc.0), `finalize_placeholders` was replacing `{{currentVersion}}` in migration guide titles with the pre-release version. When the stable release later ran, the placeholder was already consumed, leaving the title stuck at the RC version.

Fix by skipping `MIGRATING-*.md` files during placeholder replacement when the target version is a pre-release. The placeholder is preserved until the stable release finalizes it correctly.

I toyed with trying to update the already written header, but this just seems cleaner. We add the migration guides to the actual GH release, so its not like this info isn't available, we just don't commit to it until the full release in the repo.

Closes #5452
