### PR TITLE
Bump MSRV to 1.95.0 and replace cfg_if with cfg_select

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # esp-hal agent instructions
 
-Bare-metal `no_std` Rust HAL for Espressif SoCs. MSRV: **1.88.0** (source: `MSRV` env in `.github/workflows/ci.yml`).
+Bare-metal `no_std` Rust HAL for Espressif SoCs. MSRV: **1.95.0** (source: `MSRV` env in `.github/workflows/ci.yml`).
 
 ## Chip reference
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  MSRV: "1.88.0"
+  MSRV: "1.95.0"
   DEFMT_LOG: trace
 
 # Cancel any currently running workflows from the same PR, branch, or
@@ -161,7 +161,7 @@ jobs:
       # Install the Rust toolchain for Xtensa devices:
       - uses: esp-rs/xtensa-toolchain@v1.6
         with:
-          version: 1.88.0.0
+          version: 1.95.0.0
 
       # Install the Rust stable toolchain for RISC-V devices:
       - uses: dtolnay/rust-toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,21 +93,21 @@ jobs:
         shell: bash
         run: |
           # lints and docs are checked separately
-          cargo xcheck ci esp32 --toolchain esp --no-lint --no-docs
-          cargo xcheck ci esp32s2 --toolchain esp --no-lint --no-docs
-          cargo xcheck ci esp32s3 --toolchain esp --no-lint --no-docs
-          cargo xcheck ci esp32c2 --toolchain $MSRV --no-lint --no-docs
-          cargo xcheck ci esp32c3 --toolchain $MSRV --no-lint --no-docs
+          cargo +$MSRV xcheck ci esp32 --toolchain esp --no-lint --no-docs
+          cargo +$MSRV xcheck ci esp32s2 --toolchain esp --no-lint --no-docs
+          cargo +$MSRV xcheck ci esp32s3 --toolchain esp --no-lint --no-docs
+          cargo +$MSRV xcheck ci esp32c2 --toolchain $MSRV --no-lint --no-docs
+          cargo +$MSRV xcheck ci esp32c3 --toolchain $MSRV --no-lint --no-docs
 
       - name: Build and Check RISC-V
         if: env.SKIP_CI != 'true' && matrix.group == 'riscv'
         shell: bash
         run: |
           # lints and docs are checked separately
-          cargo xcheck ci esp32c5 --toolchain $MSRV --no-lint --no-docs
-          cargo xcheck ci esp32c6 --toolchain $MSRV --no-lint --no-docs
-          cargo xcheck ci esp32c61 --toolchain $MSRV --no-lint --no-docs
-          cargo xcheck ci esp32h2 --toolchain $MSRV --no-lint --no-docs
+          cargo +$MSRV xcheck ci esp32c5 --toolchain $MSRV --no-lint --no-docs
+          cargo +$MSRV xcheck ci esp32c6 --toolchain $MSRV --no-lint --no-docs
+          cargo +$MSRV xcheck ci esp32c61 --toolchain $MSRV --no-lint --no-docs
+          cargo +$MSRV xcheck ci esp32h2 --toolchain $MSRV --no-lint --no-docs
 
   detect-extras-runner:
     needs: get-labels

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,12 +73,12 @@ jobs:
         with:
           version: 1.95.0.0
 
-      # Install the Rust stable toolchain for RISC-V devices:
+      # Install the Rust toolchain for RISC-V devices:
       - uses: dtolnay/rust-toolchain@v1
         if: env.SKIP_CI != 'true'
         with:
           target: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf
-          toolchain: stable
+          toolchain: ${{ env.MSRV }}
           components: rust-src
 
       - name: Setup cargo-batch
@@ -96,18 +96,18 @@ jobs:
           cargo xcheck ci esp32 --toolchain esp --no-lint --no-docs
           cargo xcheck ci esp32s2 --toolchain esp --no-lint --no-docs
           cargo xcheck ci esp32s3 --toolchain esp --no-lint --no-docs
-          cargo xcheck ci esp32c2 --toolchain stable --no-lint --no-docs
-          cargo xcheck ci esp32c3 --toolchain stable --no-lint --no-docs
+          cargo xcheck ci esp32c2 --toolchain $MSRV --no-lint --no-docs
+          cargo xcheck ci esp32c3 --toolchain $MSRV --no-lint --no-docs
 
       - name: Build and Check RISC-V
         if: env.SKIP_CI != 'true' && matrix.group == 'riscv'
         shell: bash
         run: |
           # lints and docs are checked separately
-          cargo xcheck ci esp32c5 --toolchain stable --no-lint --no-docs
-          cargo xcheck ci esp32c6 --toolchain stable --no-lint --no-docs
-          cargo xcheck ci esp32c61 --toolchain stable --no-lint --no-docs
-          cargo xcheck ci esp32h2 --toolchain stable --no-lint --no-docs
+          cargo xcheck ci esp32c5 --toolchain $MSRV --no-lint --no-docs
+          cargo xcheck ci esp32c6 --toolchain $MSRV --no-lint --no-docs
+          cargo xcheck ci esp32c61 --toolchain $MSRV --no-lint --no-docs
+          cargo xcheck ci esp32h2 --toolchain $MSRV --no-lint --no-docs
 
   detect-extras-runner:
     needs: get-labels

--- a/esp-alloc/Cargo.toml
+++ b/esp-alloc/Cargo.toml
@@ -2,7 +2,7 @@
 name          = "esp-alloc"
 version       = "0.10.0"
 edition       = "2024"
-rust-version  = "1.88.0"
+rust-version  = "1.95.0"
 description   = "A heap allocator for Espressif devices"
 documentation = "https://docs.espressif.com/projects/rust/esp-alloc/latest/"
 keywords      = ["allocator", "embedded", "esp32", "espressif", "memory"]
@@ -34,7 +34,6 @@ test = false
 [dependencies]
 allocator-api2        = { version = "0.3.0", default-features = false }
 defmt                 = { version = "1.0.1", optional = true }
-cfg-if                = "1"
 enumset               = "1"
 esp-sync              = { version = "0.2.1", path = "../esp-sync" }
 document-features     = "0.2"

--- a/esp-alloc/src/lib.rs
+++ b/esp-alloc/src/lib.rs
@@ -474,8 +474,8 @@ impl EspHeapInner {
             }
         }
 
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "internal-heap-stats")] {
+        cfg_select! {
+            feature = "internal-heap-stats" => {
                 HeapStats {
                     region_stats,
                     size: free + used,
@@ -484,7 +484,8 @@ impl EspHeapInner {
                     total_allocated: self.internal_heap_stats.total_allocated,
                     total_freed: self.internal_heap_stats.total_freed,
                 }
-            } else {
+            }
+            _ => {
                 HeapStats {
                     region_stats,
                     size: free + used,

--- a/esp-alloc/src/lib.rs
+++ b/esp-alloc/src/lib.rs
@@ -483,14 +483,14 @@ impl EspHeapInner {
                     max_usage: self.internal_heap_stats.max_usage,
                     total_allocated: self.internal_heap_stats.total_allocated,
                     total_freed: self.internal_heap_stats.total_freed,
-                }
+            }
             }
             _ => {
                 HeapStats {
                     region_stats,
                     size: free + used,
                     current_usage: used,
-                }
+            }
             }
         }
     }

--- a/esp-backtrace/Cargo.toml
+++ b/esp-backtrace/Cargo.toml
@@ -2,7 +2,7 @@
 name          = "esp-backtrace"
 version       = "0.19.0"
 edition       = "2024"
-rust-version  = "1.88.0"
+rust-version  = "1.95.0"
 description   = "Bare-metal backtrace support for Espressif devices"
 documentation = "https://docs.espressif.com/projects/rust/esp-backtrace/latest/"
 keywords      = ["backtrace", "embedded", "esp32", "espressif"]
@@ -32,7 +32,6 @@ bench = false
 test  = false
 
 [dependencies]
-cfg-if      = "1"
 defmt       = { version = "1", optional = true }
 esp-config  = { version = "0.7.0", path = "../esp-config" }
 esp-metadata-generated = { version = "0.4.0", path = "../esp-metadata-generated" }

--- a/esp-backtrace/src/lib.rs
+++ b/esp-backtrace/src/lib.rs
@@ -127,10 +127,10 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
                 println!(
                     "No backtrace available - make sure to force frame-pointers. (see https://crates.io/crates/esp-backtrace)"
                 );
-            }
+        }
             for frame in backtrace.frames() {
                 println!("0x{:x}", frame.program_counter());
-            }
+        }
         }
         _ => {
             arch::dump_stack();
@@ -214,7 +214,7 @@ fn abort() -> ! {
             // call custom code
             unsafe extern "Rust" {
                 fn custom_halt() -> !;
-            }
+        }
             unsafe { custom_halt() }
         }
 

--- a/esp-backtrace/src/lib.rs
+++ b/esp-backtrace/src/lib.rs
@@ -115,9 +115,8 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
     println!("{}", info);
     set_color_code(RESET);
 
-    cfg_if::cfg_if! {
-        if #[cfg(not(stack_dump))]
-        {
+    cfg_select! {
+        not(stack_dump) => {
             println!("");
             println!("Backtrace:");
             println!("");
@@ -132,7 +131,8 @@ fn panic_handler(info: &core::panic::PanicInfo) -> ! {
             for frame in backtrace.frames() {
                 println!("0x{:x}", frame.program_counter());
             }
-        } else {
+        }
+        _ => {
             arch::dump_stack();
         }
     }
@@ -201,20 +201,24 @@ fn abort() -> ! {
     println!("");
     println!("");
 
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "semihosting")] {
+    cfg_select! {
+        feature = "semihosting" => {
             arch::interrupt_free(|| {
                 semihosting::process::abort();
             });
-        } else if #[cfg(feature = "halt-cores")] {
+        }
+        feature = "halt-cores" => {
             halt();
-        } else if #[cfg(feature = "custom-halt")] {
+        }
+        feature = "custom-halt" => {
             // call custom code
             unsafe extern "Rust" {
                 fn custom_halt() -> !;
             }
             unsafe { custom_halt() }
         }
+
+        _ => {}
     }
 
     #[allow(unreachable_code)]

--- a/esp-backtrace/src/riscv.rs
+++ b/esp-backtrace/src/riscv.rs
@@ -65,8 +65,8 @@ pub(crate) fn backtrace_internal(fp: u32, suppress: u32) -> Backtrace {
 
 #[cfg(all(stack_dump, feature = "panic-handler"))]
 pub(super) fn dump_stack() {
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "println")] {
+    cfg_select! {
+        feature = "println" => {
             const MAX_STACK_DUMP_SIZE: u32 = match () {
                 _ if cfg!(stack_dump_max_size_4k) => 4 * 1024,
                 _ if cfg!(stack_dump_max_size_8k) => 8 * 1024,
@@ -99,7 +99,8 @@ pub(super) fn dump_stack() {
                 esp_println::print!("{:02x}", byte);
             }
             esp_println::println!();
-        } else {
+        }
+        _ => {
             super::println!("Stack dumps are not supported with DEFMT.");
         }
     }

--- a/esp-backtrace/src/riscv.rs
+++ b/esp-backtrace/src/riscv.rs
@@ -86,7 +86,7 @@ pub(super) fn dump_stack() {
 
             unsafe extern "C" {
                 static _stack_start: u32;
-            }
+        }
 
             let end = u32::min(
                 core::ptr::addr_of!(_stack_start) as u32,
@@ -97,7 +97,7 @@ pub(super) fn dump_stack() {
             for address in sp..end {
                 let byte = unsafe { (address as *const u8).read_volatile() };
                 esp_println::print!("{:02x}", byte);
-            }
+        }
             esp_println::println!();
         }
         _ => {

--- a/esp-bootloader-esp-idf/Cargo.toml
+++ b/esp-bootloader-esp-idf/Cargo.toml
@@ -2,7 +2,7 @@
 name = "esp-bootloader-esp-idf"
 version = "0.5.0"
 edition = "2024"
-rust-version = "1.88.0"
+rust-version = "1.95.0"
 description = "Functionality related to the esp-idf bootloader"
 documentation = "https://docs.espressif.com/projects/rust/esp-bootloader-esp-idf/latest/"
 keywords = ["esp32", "espressif", "no-std"]
@@ -29,7 +29,6 @@ bench = false
 test  = true
 
 [dependencies]
-cfg-if = "1"
 defmt = { version = "1.0.1", optional = true }
 document-features = "0.2"
 esp-config = { version = "0.7.0", path = "../esp-config" }

--- a/esp-bootloader-esp-idf/README.md
+++ b/esp-bootloader-esp-idf/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/esp-bootloader-esp-idf?labelColor=1C2C2E&color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/esp-bootloader-esp-idf)
 [![docs.rs](https://img.shields.io/docsrs/esp-bootloader-esp-idf?labelColor=1C2C2E&color=C96329&logo=rust&style=flat-square)](https://docs.espressif.com/projects/rust/esp-bootloader-esp-idf/latest/)
-![MSRV](https://img.shields.io/badge/MSRV-1.88.0-blue?labelColor=1C2C2E&style=flat-square)
+![MSRV](https://img.shields.io/badge/MSRV-1.95.0-blue?labelColor=1C2C2E&style=flat-square)
 ![Crates.io](https://img.shields.io/crates/l/esp-bootloader-esp-idf?labelColor=1C2C2E&style=flat-square)
 [![Matrix](https://img.shields.io/matrix/esp-rs:matrix.org?label=join%20matrix&labelColor=1C2C2E&color=BEC5C9&logo=matrix&style=flat-square)](https://matrix.to/#/#esp-rs:matrix.org)
 

--- a/esp-bootloader-esp-idf/src/fmt.rs
+++ b/esp-bootloader-esp-idf/src/fmt.rs
@@ -7,10 +7,11 @@ use core::fmt::{Debug, Display, LowerHex};
 macro_rules! assert {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::assert!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::assert!($($x)*);
                 }
             }
@@ -22,10 +23,11 @@ macro_rules! assert {
 macro_rules! assert_eq {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::assert_eq!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::assert_eq!($($x)*);
                 }
             }
@@ -37,10 +39,11 @@ macro_rules! assert_eq {
 macro_rules! assert_ne {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::assert_ne!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::assert_ne!($($x)*);
                 }
             }
@@ -52,10 +55,11 @@ macro_rules! assert_ne {
 macro_rules! debug_assert {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::debug_assert!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::debug_assert!($($x)*);
                 }
             }
@@ -67,10 +71,11 @@ macro_rules! debug_assert {
 macro_rules! debug_assert_eq {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::debug_assert_eq!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::debug_assert_eq!($($x)*);
                 }
             }
@@ -82,10 +87,11 @@ macro_rules! debug_assert_eq {
 macro_rules! debug_assert_ne {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::debug_assert_ne!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::debug_assert_ne!($($x)*);
                 }
             }
@@ -97,10 +103,11 @@ macro_rules! debug_assert_ne {
 macro_rules! todo {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::todo!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::todo!($($x)*);
                 }
             }
@@ -112,10 +119,11 @@ macro_rules! todo {
 macro_rules! unreachable {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::unreachable!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::unreachable!($($x)*);
                 }
             }
@@ -127,10 +135,11 @@ macro_rules! unreachable {
 macro_rules! panic {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::panic!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::panic!($($x)*);
                 }
             }
@@ -142,12 +151,14 @@ macro_rules! panic {
 macro_rules! trace {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::trace!($s $(, $x)*);
-                } else if #[cfg(feature = "log-04")] {
+                }
+                feature = "log-04" => {
                     ::log_04::trace!($s $(, $x)*);
-                } else {
+                }
+                _ => {
                     let _ = ($( & $x ),*);
                 }
             }
@@ -159,12 +170,14 @@ macro_rules! trace {
 macro_rules! debug {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::debug!($s $(, $x)*);
-                } else if #[cfg(feature = "log-04")] {
+                }
+                feature = "log-04" => {
                     ::log_04::debug!($s $(, $x)*);
-                } else {
+                }
+                _ => {
                     let _ = ($( & $x ),*);
                 }
             }
@@ -176,12 +189,14 @@ macro_rules! debug {
 macro_rules! info {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::info!($s $(, $x)*);
-                } else if #[cfg(feature = "log-04")] {
+                }
+                feature = "log-04" => {
                     ::log_04::info!($s $(, $x)*);
-                } else {
+                }
+                _ => {
                     let _ = ($( & $x ),*);
                 }
             }
@@ -193,12 +208,14 @@ macro_rules! info {
 macro_rules! warn {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::warn!($s $(, $x)*);
-                } else if #[cfg(feature = "log-04")] {
+                }
+                feature = "log-04" => {
                     ::log_04::warn!($s $(, $x)*);
-                } else {
+                }
+                _ => {
                     let _ = ($( & $x ),*);
                 }
             }
@@ -210,12 +227,14 @@ macro_rules! warn {
 macro_rules! error {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::error!($s $(, $x)*);
-                } else if #[cfg(feature = "log-04")] {
+                }
+                feature = "log-04" => {
                     ::log_04::error!($s $(, $x)*);
-                } else {
+                }
+                _ => {
                     let _ = ($( & $x ),*);
                 }
             }

--- a/esp-bootloader-esp-idf/src/partitions.rs
+++ b/esp-bootloader-esp-idf/src/partitions.rs
@@ -318,30 +318,36 @@ impl<'a> PartitionTable<'a> {
         // Read entry 0 from MMU to know which partition is mapped
         //
         // See <https://github.com/espressif/esp-idf/blob/758939caecb16e5542b3adfba0bc85025517db45/components/hal/mmu_hal.c#L124>
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "esp32")] {
+        cfg_select! {
+            feature = "esp32" => {
                 let paddr = unsafe {
                     ((0x3FF10000 as *const u32).read_volatile() & 0xff) << 16
                 };
-            } else if #[cfg(feature = "esp32s2")] {
+            }
+            feature = "esp32s2" => {
                 let paddr = unsafe {
                     (((0x61801000 + 128 * 4) as *const u32).read_volatile() & 0xff) << 16
                 };
-            } else if #[cfg(feature = "esp32s3")] {
+            }
+            feature = "esp32s3" => {
                 // Revisit this once we support XiP from PSRAM for ESP32-S3
                 let paddr = unsafe {
                     ((0x600C5000 as *const u32).read_volatile() & 0xff) << 16
                 };
-            } else if #[cfg(any(feature = "esp32c2", feature = "esp32c3"))] {
+            }
+            any(feature = "esp32c2", feature = "esp32c3") => {
                 let paddr = unsafe {
                     ((0x600c5000 as *const u32).read_volatile() & 0xff) << 16
                 };
-            } else if #[cfg(any(feature = "esp32c5", feature = "esp32c6", feature = "esp32c61", feature = "esp32h2"))] {
+            }
+            any(feature = "esp32c5", feature = "esp32c6", feature = "esp32c61", feature = "esp32h2") => {
                 let paddr = unsafe {
                     ((0x60002000 + 0x380) as *mut u32).write_volatile(0);
                     (((0x60002000 + 0x37c) as *const u32).read_volatile() & 0xff) << 16
                 };
             }
+
+            _ => {}
         }
 
         for id in 0..self.len() {

--- a/esp-config/Cargo.toml
+++ b/esp-config/Cargo.toml
@@ -2,7 +2,7 @@
 name          = "esp-config"
 version       = "0.7.0"
 edition       = "2024"
-rust-version  = "1.88.0"
+rust-version  = "1.95.0"
 description   = "Configure projects using esp-hal and related packages"
 documentation = "https://docs.espressif.com/projects/rust/esp-config/latest/"
 repository    = "https://github.com/esp-rs/esp-hal"

--- a/esp-hal-procmacros/Cargo.toml
+++ b/esp-hal-procmacros/Cargo.toml
@@ -2,7 +2,7 @@
 name          = "esp-hal-procmacros"
 version       = "0.22.0"
 edition       = "2024"
-rust-version  = "1.88.0"
+rust-version  = "1.95.0"
 description   = "Procedural macros for esp-hal"
 documentation = "https://docs.espressif.com/projects/rust/esp-hal-procmacros/latest/"
 repository    = "https://github.com/esp-rs/esp-hal"

--- a/esp-hal-procmacros/README.md
+++ b/esp-hal-procmacros/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/esp-hal-procmacros?labelColor=1C2C2E&color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/esp-hal-procmacros)
 [![docs.rs](https://img.shields.io/docsrs/esp-hal-procmacros?labelColor=1C2C2E&color=C96329&logo=rust&style=flat-square)](https://docs.espressif.com/projects/rust/esp-hal-procmacros/latest/)
-![MSRV](https://img.shields.io/badge/MSRV-1.88.0-blue?labelColor=1C2C2E&style=flat-square)
+![MSRV](https://img.shields.io/badge/MSRV-1.95.0-blue?labelColor=1C2C2E&style=flat-square)
 ![Crates.io](https://img.shields.io/crates/l/esp-hal-procmacros?labelColor=1C2C2E&style=flat-square)
 [![Matrix](https://img.shields.io/matrix/esp-rs:matrix.org?label=join%20matrix&labelColor=1C2C2E&color=BEC5C9&logo=matrix&style=flat-square)](https://matrix.to/#/#esp-rs:matrix.org)
 

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -2,7 +2,7 @@
 name          = "esp-hal"
 version       = "1.1.0"
 edition       = "2024"
-rust-version  = "1.88.0"
+rust-version  = "1.95.0"
 description   = "Bare-metal HAL for Espressif devices"
 documentation = "https://docs.espressif.com/projects/rust/esp-hal/latest/"
 keywords      = ["embedded", "embedded-hal", "esp32", "espressif", "hal"]
@@ -44,7 +44,6 @@ test  = false
 [dependencies]
 bitflags                 = "2.9"
 bytemuck                 = "1.24"
-cfg-if                   = "1"
 critical-section         = { version = "1", features = ["restore-state-u32"], optional = true }
 embedded-hal             = "1.0.0"
 embedded-hal-async       = "1.0.0"

--- a/esp-hal/README.md
+++ b/esp-hal/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/esp-hal?labelColor=1C2C2E&color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/esp-hal)
 [![docs.rs](https://img.shields.io/docsrs/esp-hal?labelColor=1C2C2E&color=C96329&logo=rust&style=flat-square)](https://docs.espressif.com/projects/rust/esp-hal/latest/)
-![MSRV](https://img.shields.io/badge/MSRV-1.88.0-blue?labelColor=1C2C2E&style=flat-square)
+![MSRV](https://img.shields.io/badge/MSRV-1.95.0-blue?labelColor=1C2C2E&style=flat-square)
 ![Crates.io](https://img.shields.io/crates/l/esp-hal?labelColor=1C2C2E&style=flat-square)
 [![Matrix](https://img.shields.io/matrix/esp-rs:matrix.org?label=join%20matrix&labelColor=1C2C2E&color=BEC5C9&logo=matrix&style=flat-square)](https://matrix.to/#/#esp-rs:matrix.org)
 

--- a/esp-hal/src/aes/mod.rs
+++ b/esp-hal/src/aes/mod.rs
@@ -191,20 +191,22 @@ impl<'d> Aes<'d> {
     }
 
     fn start(&self) {
-        cfg_if::cfg_if! {
-            if #[cfg(esp32)] {
+        cfg_select! {
+            esp32 => {
                 self.regs().start().write(|w| w.start().set_bit());
-            } else {
+            }
+            _ => {
                 self.regs().trigger().write(|w| w.trigger().set_bit());
             }
         }
     }
 
     fn is_idle(&mut self) -> bool {
-        cfg_if::cfg_if! {
-            if #[cfg(esp32)] {
+        cfg_select! {
+            esp32 => {
                 self.regs().idle().read().idle().bit_is_set()
-            } else {
+            }
+            _ => {
                 self.regs().state().read().state().bits() == 0
             }
         }
@@ -218,10 +220,11 @@ impl<'d> Aes<'d> {
 
     fn write_block(&mut self, block: &[u8]) {
         for (i, word) in read_words(block).enumerate() {
-            cfg_if::cfg_if! {
-                if #[cfg(aes_has_split_text_registers)] {
+            cfg_select! {
+                aes_has_split_text_registers => {
                     self.regs().text_in(i).write(|w| unsafe { w.bits(word) });
-                } else {
+                }
+                _ => {
                     self.regs().text(i).write(|w| unsafe { w.bits(word) });
                 }
             }
@@ -229,10 +232,11 @@ impl<'d> Aes<'d> {
     }
 
     fn read_block(&self, block: &mut [u8]) {
-        cfg_if::cfg_if! {
-            if #[cfg(aes_has_split_text_registers)] {
+        cfg_select! {
+            aes_has_split_text_registers => {
                 write_words(block, |i| self.regs().text_out(i).read().bits());
-            } else {
+            }
+            _ => {
                 write_words(block, |i| self.regs().text(i).read().bits());
             }
         }

--- a/esp-hal/src/analog/adc/riscv.rs
+++ b/esp-hal/src/analog/adc/riscv.rs
@@ -1,9 +1,10 @@
 use core::marker::PhantomData;
 
-cfg_if::cfg_if! {
-    if #[cfg(esp32c6)] {
+cfg_select! {
+    esp32c6 => {
         use Interrupt::APB_SARADC as InterruptSource;
-    } else {
+    }
+    _ => {
         use Interrupt::APB_ADC as InterruptSource;
     }
 }
@@ -39,22 +40,26 @@ mod calibration;
 // https://github.com/espressif/esp-idf/blob/903af13e8/components/soc/esp32c3/include/soc/regi2c_saradc.h
 // https://github.com/espressif/esp-idf/blob/903af13e8/components/soc/esp32c6/include/soc/regi2c_saradc.h
 // https://github.com/espressif/esp-idf/blob/903af13e8/components/soc/esp32h2/include/soc/regi2c_saradc.h
-cfg_if::cfg_if! {
-    if #[cfg(adc_adc1)] {
+cfg_select! {
+    adc_adc1 => {
         const ADC_VAL_MASK: u16 = 0xfff;
         const ADC_CAL_CNT_MAX: u16 = 32;
         const ADC_CAL_CHANNEL: u16 = 15;
     }
+
+    _ => {}
 }
 
 // The number of analog IO pins, and in turn the number of attentuations,
 // depends on which chip is being used
-cfg_if::cfg_if! {
-    if #[cfg(esp32c6)] {
+cfg_select! {
+    esp32c6 => {
         pub(super) const NUM_ATTENS: usize = 7;
-    } else if #[cfg(esp32c5)] {
+    }
+    esp32c5 => {
         pub(super) const NUM_ATTENS: usize = 6;
-    } else {
+    }
+    _ => {
         pub(super) const NUM_ATTENS: usize = 5;
     }
 }
@@ -540,10 +545,11 @@ pub(super) fn acquire_async_adc() {
 }
 
 pub(super) fn release_async_adc() -> bool {
-    cfg_if::cfg_if! {
-        if #[cfg(all(adc_adc1, adc_adc2))] {
+    cfg_select! {
+        all(adc_adc1, adc_adc2) => {
             ASYNC_ADC_COUNT.fetch_sub(1, Ordering::Relaxed) == 1
-        } else {
+        }
+        _ => {
             true
         }
     }

--- a/esp-hal/src/analog/adc/xtensa.rs
+++ b/esp-hal/src/analog/adc/xtensa.rs
@@ -15,12 +15,14 @@ mod calibration;
 
 pub(super) const NUM_ATTENS: usize = 10;
 
-cfg_if::cfg_if! {
-    if #[cfg(esp32s3)] {
+cfg_select! {
+    esp32s3 => {
         const ADC_VAL_MASK: u16 = 0xfff;
         const ADC_CAL_CNT_MAX: u16 = 32;
         const ADC_CAL_CHANNEL: u16 = 15;
     }
+
+    _ => {}
 }
 
 impl<ADCI> AdcConfig<ADCI>

--- a/esp-hal/src/analog/dac.rs
+++ b/esp-hal/src/analog/dac.rs
@@ -47,14 +47,17 @@ use crate::gpio::AnalogPin;
 // Only specific pins can be used with each DAC peripheral, and of course
 // these pins are different depending on which chip you are using; for this
 // reason, we will type alias the pins for ease of use later in this module:
-cfg_if::cfg_if! {
-    if #[cfg(esp32)] {
+cfg_select! {
+    esp32 => {
         type Dac1Gpio<'d> = crate::peripherals::GPIO25<'d>;
         type Dac2Gpio<'d> = crate::peripherals::GPIO26<'d>;
-    } else if #[cfg(esp32s2)] {
+    }
+    esp32s2 => {
         type Dac1Gpio<'d> = crate::peripherals::GPIO17<'d>;
         type Dac2Gpio<'d> = crate::peripherals::GPIO18<'d>;
     }
+
+    _ => {}
 }
 
 /// Digital-to-Analog Converter (DAC) Channel

--- a/esp-hal/src/clock/mod.rs
+++ b/esp-hal/src/clock/mod.rs
@@ -93,14 +93,17 @@ impl CpuClock {
     /// # {after_snippet}
     /// ```
     pub const fn max() -> Self {
-        cfg_if::cfg_if! {
-            if #[cfg(esp32c2)] {
+        cfg_select! {
+            esp32c2 => {
                 Self::_120MHz
-            } else if #[cfg(any(esp32c3, esp32c6, esp32c61))] {
+            }
+            any(esp32c3, esp32c6, esp32c61) => {
                 Self::_160MHz
-            } else if #[cfg(esp32h2)] {
+            }
+            esp32h2 => {
                 Self::_96MHz
-            } else {
+            }
+            _ => {
                 Self::_240MHz
             }
         }
@@ -122,10 +125,11 @@ impl RtcClock {
     #[instability::unstable]
     #[cfg(any(soc_has_clock_node_lp_slow_clk, soc_has_clock_node_rtc_slow_clk))]
     pub fn slow_freq() -> Rate {
-        cfg_if::cfg_if! {
-            if #[cfg(soc_has_clock_node_rtc_slow_clk)] {
+        cfg_select! {
+            soc_has_clock_node_rtc_slow_clk => {
                 let getter = clocks::rtc_slow_clk_frequency;
-            } else {
+            }
+            _ => {
                 let getter = clocks::lp_slow_clk_frequency;
             }
         }
@@ -351,12 +355,14 @@ impl Clocks {
             .modify(|_, w| w.rtc_cali_start().clear_bit());
 
         // Make sure we measure the crystal.
-        cfg_if::cfg_if! {
-            if #[cfg(soc_has_clock_node_timg_function_clock)] {
+        cfg_select! {
+            soc_has_clock_node_timg_function_clock => {
                 let current_function_clock = clocks::TimgInstance::Timg0.function_clock_config(clocks);
                 clocks::TimgInstance::Timg0.configure_function_clock(clocks, function_clock);
                 clocks::TimgInstance::Timg0.request_function_clock(clocks);
             }
+
+            _ => {}
         }
 
         let current_calib_clock = clocks::timg_calibration_clock_config(clocks);
@@ -481,11 +487,12 @@ impl Clocks {
     pub(crate) fn calibrate_rtc_slow_clock() {
         // Unfortunate device specific mapping.
         // TODO: fix it by generating cfgs for each mux input?
-        cfg_if::cfg_if! {
-            if #[cfg(esp32s2)] {
+        cfg_select! {
+            esp32s2 => {
                 // Can directly measure output of the RTC_SLOW mux
                 let slow_clk = TimgCalibrationClockConfig::RtcClk;
-            } else if #[cfg(soc_has_clock_node_rtc_slow_clk)] {
+            }
+            soc_has_clock_node_rtc_slow_clk => {
                 let slow_clk = match unwrap!(ClockTree::with(clocks::rtc_slow_clk_config)) {
                     RtcSlowClkConfig::RcFast => TimgCalibrationClockConfig::RcFastDivClk,
                     RtcSlowClkConfig::RcSlow => TimgCalibrationClockConfig::RcSlowClk,
@@ -494,21 +501,25 @@ impl Clocks {
                     #[cfg(esp32c2)]
                     RtcSlowClkConfig::OscSlow => TimgCalibrationClockConfig::Osc32kClk,
                 };
-            } else if #[cfg(soc_has_clock_node_lp_slow_clk)]{
+            }
+            soc_has_clock_node_lp_slow_clk => {
                 let slow_clk = match unwrap!(ClockTree::with(clocks::lp_slow_clk_config)) {
                     LpSlowClkConfig::OscSlow => TimgCalibrationClockConfig::Xtal32kClk, //?
                     LpSlowClkConfig::Xtal32k => TimgCalibrationClockConfig::Xtal32kClk,
                     LpSlowClkConfig::RcSlow => TimgCalibrationClockConfig::RcSlowClk,
                 };
             }
+
+            _ => {}
         }
 
         let cal_val = RtcClock::calibrate(slow_clk, 1024);
 
-        cfg_if::cfg_if! {
-            if #[cfg(soc_has_lp_aon)] {
+        cfg_select! {
+            soc_has_lp_aon => {
                 use crate::peripherals::LP_AON;
-            } else {
+            }
+            _ => {
                 use crate::peripherals::LPWR as LP_AON;
             }
         }
@@ -537,10 +548,11 @@ pub fn xtal_clock() -> Rate {
 /// Written by [`Clocks::calibrate_rtc_slow_clock`] during clock
 /// initialization.
 fn rtc_slow_cal_period() -> u64 {
-    cfg_if::cfg_if! {
-        if #[cfg(soc_has_lp_aon)] {
+    cfg_select! {
+        soc_has_lp_aon => {
             use crate::peripherals::LP_AON;
-        } else {
+        }
+        _ => {
             use crate::peripherals::LPWR as LP_AON;
         }
     }

--- a/esp-hal/src/debugger.rs
+++ b/esp-hal/src/debugger.rs
@@ -2,17 +2,19 @@
 
 /// Checks if a debugger is connected.
 pub fn debugger_connected() -> bool {
-    cfg_if::cfg_if! {
-        if #[cfg(xtensa)] {
+    cfg_select! {
+        xtensa => {
             xtensa_lx::is_debugger_attached()
-        } else if #[cfg(all(riscv, soc_has_assist_debug))] {
+        }
+        all(riscv, soc_has_assist_debug) => {
             crate::peripherals::ASSIST_DEBUG::regs()
                 .cpu(0)
                 .debug_mode()
                 .read()
                 .debug_module_active()
                 .bit_is_set()
-        } else {
+        }
+        _ => {
             false
         }
     }
@@ -32,8 +34,8 @@ pub unsafe fn set_stack_watchpoint(addr: usize) {
     if cfg!(stack_guard_monitoring_with_debugger_connected)
         || !crate::debugger::debugger_connected()
     {
-        cfg_if::cfg_if! {
-            if #[cfg(xtensa)] {
+        cfg_select! {
+            xtensa => {
                 let addr = addr & !0b11;
                 let dbreakc = 0b1111100 | (1 << 31); // bit 31 = STORE
 
@@ -47,7 +49,8 @@ pub unsafe fn set_stack_watchpoint(addr: usize) {
                         dbreakc = in(reg) dbreakc,
                     );
                 }
-            } else {
+            }
+            _ => {
                 unsafe { set_watchpoint(0, addr, 4); }
             }
         }

--- a/esp-hal/src/debugger.rs
+++ b/esp-hal/src/debugger.rs
@@ -48,7 +48,7 @@ pub unsafe fn set_stack_watchpoint(addr: usize) {
                         addr = in(reg) addr,
                         dbreakc = in(reg) dbreakc,
                     );
-                }
+            }
             }
             _ => {
                 unsafe { set_watchpoint(0, addr, 4); }

--- a/esp-hal/src/dma/buffers.rs
+++ b/esp-hal/src/dma/buffers.rs
@@ -47,8 +47,8 @@ impl From<DmaAlignmentError> for DmaBufError {
     }
 }
 
-cfg_if::cfg_if! {
-    if #[cfg(dma_can_access_psram)] {
+cfg_select! {
+    dma_can_access_psram => {
         /// Burst size used when transferring to and from external memory.
         #[derive(Clone, Copy, PartialEq, Eq, Debug)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -142,7 +142,8 @@ cfg_if::cfg_if! {
                 }
             }
         }
-    } else {
+    }
+    _ => {
         /// Burst transfer configuration.
         #[derive(Clone, Copy, PartialEq, Eq, Debug)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -278,13 +279,15 @@ impl BurstConfig {
     fn min_alignment(self, _buffer: &[u8], direction: TransferDirection) -> usize {
         let alignment = self.min_dram_alignment(direction);
 
-        cfg_if::cfg_if! {
-            if #[cfg(dma_can_access_psram)] {
+        cfg_select! {
+            dma_can_access_psram => {
                 let mut alignment = alignment;
                 if is_valid_psram_address(_buffer.as_ptr() as usize) {
                     alignment = max(alignment, self.external_memory.min_psram_alignment(direction));
                 }
             }
+
+            _ => {}
         }
 
         alignment
@@ -326,10 +329,11 @@ impl BurstConfig {
         }
         // buffer can be either DRAM or PSRAM (if supported)
         let is_in_dram = is_slice_in_dram(buffer);
-        cfg_if::cfg_if! {
-            if #[cfg(dma_can_access_psram)]{
+        cfg_select! {
+            dma_can_access_psram => {
                 let is_in_psram = is_slice_in_psram(buffer);
-            } else {
+            }
+            _ => {
                 let is_in_psram = false;
             }
         }
@@ -641,8 +645,8 @@ unsafe impl DmaTxBuffer for DmaTxBuf {
     type Final = DmaTxBuf;
 
     fn prepare(&mut self) -> Preparation {
-        cfg_if::cfg_if! {
-            if #[cfg(dma_can_access_psram)] {
+        cfg_select! {
+            dma_can_access_psram => {
                 let is_data_in_psram = !is_valid_ram_address(self.buffer.as_ptr() as usize);
                 if is_data_in_psram {
                     unsafe {
@@ -653,6 +657,8 @@ unsafe impl DmaTxBuffer for DmaTxBuf {
                     };
                 }
             }
+
+            _ => {}
         }
 
         Preparation {
@@ -852,8 +858,8 @@ unsafe impl DmaRxBuffer for DmaRxBuf {
             desc.reset_for_rx();
         }
 
-        cfg_if::cfg_if! {
-            if #[cfg(dma_can_access_psram)] {
+        cfg_select! {
+            dma_can_access_psram => {
                 // Optimization: avoid locking for PSRAM range.
                 let is_data_in_psram = !is_valid_ram_address(self.buffer.as_ptr() as usize);
                 if is_data_in_psram {
@@ -865,6 +871,8 @@ unsafe impl DmaRxBuffer for DmaRxBuf {
                     };
                 }
             }
+
+            _ => {}
         }
 
         Preparation {
@@ -1035,8 +1043,8 @@ unsafe impl DmaTxBuffer for DmaRxTxBuf {
             desc.reset_for_tx(desc.next.is_null());
         }
 
-        cfg_if::cfg_if! {
-            if #[cfg(dma_can_access_psram)] {
+        cfg_select! {
+            dma_can_access_psram => {
                 // Optimization: avoid locking for PSRAM range.
                 let is_data_in_psram = !is_valid_ram_address(self.buffer.as_ptr() as usize);
                 if is_data_in_psram {
@@ -1048,6 +1056,8 @@ unsafe impl DmaTxBuffer for DmaRxTxBuf {
                     };
                 }
             }
+
+            _ => {}
         }
 
         Preparation {
@@ -1079,8 +1089,8 @@ unsafe impl DmaRxBuffer for DmaRxTxBuf {
             desc.reset_for_rx();
         }
 
-        cfg_if::cfg_if! {
-            if #[cfg(dma_can_access_psram)] {
+        cfg_select! {
+            dma_can_access_psram => {
                 // Optimization: avoid locking for PSRAM range.
                 let is_data_in_psram = !is_valid_ram_address(self.buffer.as_ptr() as usize);
                 if is_data_in_psram {
@@ -1092,6 +1102,8 @@ unsafe impl DmaRxBuffer for DmaRxTxBuf {
                     };
                 }
             }
+
+            _ => {}
         }
 
         Preparation {
@@ -1664,8 +1676,8 @@ pub(crate) unsafe fn prepare_for_tx(
 
     let data_len = data.len().min(chunk_size * descriptors.len());
 
-    cfg_if::cfg_if! {
-        if #[cfg(dma_can_access_psram)] {
+    cfg_select! {
+        dma_can_access_psram => {
             let data_addr = data.addr().get();
             let data_in_psram = crate::psram::psram_range().contains(&data_addr);
 
@@ -1674,6 +1686,8 @@ pub(crate) unsafe fn prepare_for_tx(
                 unsafe { crate::soc::cache_writeback_addr(data_addr as u32, data_len as u32) };
             }
         }
+
+        _ => {}
     }
 
     let mut descriptors = unwrap!(DescriptorSet::new(descriptors));
@@ -1721,19 +1735,20 @@ pub(crate) unsafe fn prepare_for_rx(
     // - it may be improperly aligned for PSRAM
     // - it may not have a length that is a multiple of the external memory block size
 
-    cfg_if::cfg_if! {
-        if #[cfg(dma_can_access_psram)] {
+    cfg_select! {
+        dma_can_access_psram => {
             let data_addr = data.addr().get();
             let data_in_psram = crate::psram::psram_range().contains(&data_addr);
-        } else {
+        }
+        _ => {
             let data_in_psram = false;
         }
     }
 
     let mut descriptors = unwrap!(DescriptorSet::new(descriptors));
     let data_len = if data_in_psram {
-        cfg_if::cfg_if! {
-            if #[cfg(dma_can_access_psram)] {
+        cfg_select! {
+            dma_can_access_psram => {
                 // This could use a better API, but right now we'll have to build the descriptor list by
                 // hand.
                 let consumed_bytes = build_descriptor_list_for_psram(
@@ -1749,7 +1764,8 @@ pub(crate) unsafe fn prepare_for_rx(
                 }
 
                 consumed_bytes
-            } else {
+            }
+            _ => {
                 unreachable!()
             }
         }

--- a/esp-hal/src/dma/buffers.rs
+++ b/esp-hal/src/dma/buffers.rs
@@ -61,18 +61,18 @@ cfg_select! {
 
             /// 64 bytes
             Size64 = 64,
-        }
+    }
 
         impl ExternalBurstConfig {
             /// The default external memory burst length.
             pub const DEFAULT: Self = Self::Size16;
-        }
+    }
 
         impl Default for ExternalBurstConfig {
             fn default() -> Self {
                 Self::DEFAULT
             }
-        }
+    }
 
         /// Internal memory access burst mode.
         #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -83,18 +83,18 @@ cfg_select! {
 
             /// Burst mode is enabled.
             Enabled,
-        }
+    }
 
         impl InternalBurstConfig {
             /// The default internal burst mode configuration.
             pub const DEFAULT: Self = Self::Disabled;
-        }
+    }
 
         impl Default for InternalBurstConfig {
             fn default() -> Self {
                 Self::DEFAULT
             }
-        }
+    }
 
         /// Burst transfer configuration.
         #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -109,7 +109,7 @@ cfg_select! {
             ///
             /// The burst size is not configurable.
             pub internal_memory: InternalBurstConfig,
-        }
+    }
 
         impl BurstConfig {
             /// The default burst mode configuration.
@@ -117,13 +117,13 @@ cfg_select! {
                 external_memory: ExternalBurstConfig::DEFAULT,
                 internal_memory: InternalBurstConfig::DEFAULT,
             };
-        }
+    }
 
         impl Default for BurstConfig {
             fn default() -> Self {
                 Self::DEFAULT
             }
-        }
+    }
 
         impl From<InternalBurstConfig> for BurstConfig {
             fn from(internal_memory: InternalBurstConfig) -> Self {
@@ -132,7 +132,7 @@ cfg_select! {
                     internal_memory,
                 }
             }
-        }
+    }
 
         impl From<ExternalBurstConfig> for BurstConfig {
             fn from(external_memory: ExternalBurstConfig) -> Self {
@@ -141,7 +141,7 @@ cfg_select! {
                     internal_memory: InternalBurstConfig::DEFAULT,
                 }
             }
-        }
+    }
     }
     _ => {
         /// Burst transfer configuration.
@@ -153,18 +153,18 @@ cfg_select! {
 
             /// Burst mode is enabled.
             Enabled,
-        }
+    }
 
         impl BurstConfig {
             /// The default burst mode configuration.
             pub const DEFAULT: Self = Self::Disabled;
-        }
+    }
 
         impl Default for BurstConfig {
             fn default() -> Self {
                 Self::DEFAULT
             }
-        }
+    }
 
         type InternalBurstConfig = BurstConfig;
     }
@@ -284,7 +284,7 @@ impl BurstConfig {
                 let mut alignment = alignment;
                 if is_valid_psram_address(_buffer.as_ptr() as usize) {
                     alignment = max(alignment, self.external_memory.min_psram_alignment(direction));
-                }
+            }
             }
 
             _ => {}
@@ -655,7 +655,7 @@ unsafe impl DmaTxBuffer for DmaTxBuf {
                             self.buffer.len() as u32,
                         )
                     };
-                }
+            }
             }
 
             _ => {}
@@ -869,7 +869,7 @@ unsafe impl DmaRxBuffer for DmaRxBuf {
                             self.buffer.len() as u32,
                         )
                     };
-                }
+            }
             }
 
             _ => {}
@@ -1054,7 +1054,7 @@ unsafe impl DmaTxBuffer for DmaRxTxBuf {
                             self.buffer.len() as u32,
                         )
                     };
-                }
+            }
             }
 
             _ => {}
@@ -1100,7 +1100,7 @@ unsafe impl DmaRxBuffer for DmaRxTxBuf {
                             self.buffer.len() as u32,
                         )
                     };
-                }
+            }
             }
 
             _ => {}
@@ -1684,7 +1684,7 @@ pub(crate) unsafe fn prepare_for_tx(
             // Make sure input data is in PSRAM instead of cache
             if data_in_psram {
                 unsafe { crate::soc::cache_writeback_addr(data_addr as u32, data_len as u32) };
-            }
+        }
         }
 
         _ => {}
@@ -1761,7 +1761,7 @@ pub(crate) unsafe fn prepare_for_rx(
                 unsafe {
                     crate::soc::cache_writeback_addr(data_addr as u32, consumed_bytes as u32);
                     crate::soc::cache_invalidate_addr(data_addr as u32, consumed_bytes as u32);
-                }
+            }
 
                 consumed_bytes
             }

--- a/esp-hal/src/dma/gdma/ahb_v1.rs
+++ b/esp-hal/src/dma/gdma/ahb_v1.rs
@@ -100,10 +100,11 @@ impl RegisterAccess for AnyGdmaTxChannel<'_> {
 
 impl TxRegisterAccess for AnyGdmaTxChannel<'_> {
     fn is_fifo_empty(&self) -> bool {
-        cfg_if::cfg_if! {
-            if #[cfg(esp32s3)] {
+        cfg_select! {
+            esp32s3 => {
                  self.ch().outfifo_status().read().outfifo_empty_l3().bit_is_set()
-            } else {
+            }
+            _ => {
                  self.ch().outfifo_status().read().outfifo_empty().bit_is_set()
             }
         }
@@ -230,20 +231,23 @@ impl InterruptAccess<DmaTxInterrupt> for AnyGdmaTxChannel<'_> {
     }
 
     fn is_async(&self) -> bool {
-        cfg_if::cfg_if! {
-            if #[cfg(any(esp32c2, esp32c3))] {
+        cfg_select! {
+            any(esp32c2, esp32c3) => {
                 TX_IS_ASYNC[self.channel as usize].load(portable_atomic::Ordering::Acquire)
-            } else {
+            }
+            _ => {
                 true
             }
         }
     }
 
     fn set_async(&self, _is_async: bool) {
-        cfg_if::cfg_if! {
-            if #[cfg(any(esp32c2, esp32c3))] {
+        cfg_select! {
+            any(esp32c2, esp32c3) => {
                 TX_IS_ASYNC[self.channel as usize].store(_is_async, portable_atomic::Ordering::Release);
             }
+
+            _ => {}
         }
     }
 }
@@ -465,20 +469,23 @@ impl InterruptAccess<DmaRxInterrupt> for AnyGdmaRxChannel<'_> {
     }
 
     fn is_async(&self) -> bool {
-        cfg_if::cfg_if! {
-            if #[cfg(any(esp32c2, esp32c3))] {
+        cfg_select! {
+            any(esp32c2, esp32c3) => {
                 RX_IS_ASYNC[self.channel as usize].load(portable_atomic::Ordering::Acquire)
-            } else {
+            }
+            _ => {
                 true
             }
         }
     }
 
     fn set_async(&self, _is_async: bool) {
-        cfg_if::cfg_if! {
-            if #[cfg(any(esp32c2, esp32c3))] {
+        cfg_select! {
+            any(esp32c2, esp32c3) => {
                 RX_IS_ASYNC[self.channel as usize].store(_is_async, portable_atomic::Ordering::Release);
             }
+
+            _ => {}
         }
     }
 }

--- a/esp-hal/src/dma/gdma/mod.rs
+++ b/esp-hal/src/dma/gdma/mod.rs
@@ -91,12 +91,14 @@ use crate::asynch::AtomicWaker;
 static TX_WAKERS: [AtomicWaker; CHANNEL_COUNT] = [const { AtomicWaker::new() }; CHANNEL_COUNT];
 static RX_WAKERS: [AtomicWaker; CHANNEL_COUNT] = [const { AtomicWaker::new() }; CHANNEL_COUNT];
 
-cfg_if::cfg_if! {
-    if #[cfg(any(esp32c2, esp32c3))] {
+cfg_select! {
+    any(esp32c2, esp32c3) => {
         use portable_atomic::AtomicBool;
         static TX_IS_ASYNC: [AtomicBool; CHANNEL_COUNT] = [const { AtomicBool::new(false) }; CHANNEL_COUNT];
         static RX_IS_ASYNC: [AtomicBool; CHANNEL_COUNT] = [const { AtomicBool::new(false) }; CHANNEL_COUNT];
     }
+
+    _ => {}
 }
 
 impl crate::private::Sealed for AnyGdmaTxChannel<'_> {}
@@ -232,8 +234,8 @@ const CHANNEL_COUNT: usize = cfg!(soc_has_dma_ch0) as usize
     + cfg!(soc_has_dma_ch3) as usize
     + cfg!(soc_has_dma_ch4) as usize;
 
-cfg_if::cfg_if! {
-    if #[cfg(dma_separate_in_out_interrupts)] {
+cfg_select! {
+    dma_separate_in_out_interrupts => {
         #[cfg(soc_has_dma_ch0)]
         impl_channel!(0, DMA_IN_CH0, DMA_OUT_CH0);
         #[cfg(soc_has_dma_ch1)]
@@ -244,7 +246,8 @@ cfg_if::cfg_if! {
         impl_channel!(3, DMA_IN_CH3, DMA_OUT_CH3);
         #[cfg(soc_has_dma_ch4)]
         impl_channel!(4, DMA_IN_CH4, DMA_OUT_CH4);
-    } else {
+    }
+    _ => {
         #[cfg(soc_has_dma_ch0)]
         impl_channel!(0, DMA_CH0);
         #[cfg(soc_has_dma_ch1)]

--- a/esp-hal/src/dma/m2m.rs
+++ b/esp-hal/src/dma/m2m.rs
@@ -32,12 +32,13 @@ use crate::{
     peripherals::DMA_COPY,
 };
 
-cfg_if::cfg_if! {
-    if #[cfg(esp32s2)] {
+cfg_select! {
+    esp32s2 => {
         type Mem2MemChannel<'d> = DMA_COPY<'d>;
         type Mem2MemRxChannel<'d> = CopyDmaRxChannel<'d>;
         type Mem2MemTxChannel<'d> = CopyDmaTxChannel<'d>;
-    } else {
+    }
+    _ => {
         type Mem2MemChannel<'d> = AnyGdmaChannel<'d>;
         type Mem2MemRxChannel<'d> = AnyGdmaRxChannel<'d>;
         type Mem2MemTxChannel<'d> = AnyGdmaTxChannel<'d>;
@@ -86,11 +87,12 @@ impl<'d> Mem2Mem<'d, Blocking> {
     ) -> Self {
         let channel = Channel::new(channel.degrade());
 
-        cfg_if::cfg_if! {
-            if #[cfg(dma_kind = "gdma")] {
+        cfg_select! {
+            dma_kind = "gdma" => {
                 let mut channel = channel;
                 channel.rx.set_mem2mem_mode(true);
-            } else {
+            }
+            _ => {
                 // The S2's COPY DMA channel doesn't care about this. Once support for other
                 // channels are added, this will need updating.
                 let peripheral = DmaPeripheral::Spi2;

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -377,12 +377,14 @@ impl DmaDescriptor {
 unsafe impl Send for DmaDescriptor {}
 
 mod buffers;
-cfg_if::cfg_if! {
-    if #[cfg(dma_kind = "gdma")] {
+cfg_select! {
+    dma_kind = "gdma" => {
         mod gdma;
-    } else if #[cfg(dma_kind = "pdma")] {
+    }
+    dma_kind = "pdma" => {
         mod pdma;
-    } else {
+    }
+    _ => {
         compile_error!("Unsupported DMA kind");
     }
 }
@@ -1697,19 +1699,21 @@ where
 
 // NOTE(p4): because the P4 has two different GDMAs, we won't be able to use
 // `GenericPeripheralGuard`.
-cfg_if::cfg_if! {
-    if #[cfg(dma_kind = "pdma")] {
+cfg_select! {
+    dma_kind = "pdma" => {
         type PeripheralGuard = Option<system::PeripheralGuard>;
-    } else {
+    }
+    _ => {
         type PeripheralGuard = system::GenericPeripheralGuard<{ system::Peripheral::Dma as u8}>;
     }
 }
 
 fn create_guard(_ch: &impl RegisterAccess) -> PeripheralGuard {
-    cfg_if::cfg_if! {
-        if #[cfg(dma_kind = "pdma")] {
+    cfg_select! {
+        dma_kind = "pdma" => {
             _ch.peripheral_clock().map(|peri_clock| system::PeripheralGuard::new_with(peri_clock, init_dma_racey))
-        } else {
+        }
+        _ => {
             // NOTE(p4): this function will read the channel's DMA peripheral from `_ch`
             system::GenericPeripheralGuard::new_with(init_dma_racey)
         }
@@ -1869,8 +1873,8 @@ where
         // NOTE: for RX the `buffer` and `size` need to be aligned but the `len` does
         // not. TRM section 3.4.9
         // Note that DmaBuffer implementations are required to do this for us.
-        cfg_if::cfg_if! {
-            if #[cfg(dma_can_access_psram)] {
+        cfg_select! {
+            dma_can_access_psram => {
                 let mut uses_psram = false;
                 let psram_range = crate::psram::psram_range();
                 for des in chain.descriptors.iter() {
@@ -1890,6 +1894,8 @@ where
                     }
                 }
             }
+
+            _ => {}
         }
 
         let preparation = Preparation {
@@ -2134,8 +2140,8 @@ where
         // alignment and writeback the cache for that buffer.
         // Note that DmaBuffer implementations are required to do this for us.
         #[cfg(dma_can_access_psram)]
-        cfg_if::cfg_if! {
-            if #[cfg(dma_can_access_psram)] {
+        cfg_select! {
+            dma_can_access_psram => {
                 let mut uses_psram = false;
                 let psram_range = crate::psram::psram_range();
                 for des in chain.descriptors.iter() {
@@ -2155,6 +2161,8 @@ where
                     }
                 }
             }
+
+            _ => {}
         }
 
         let preparation = Preparation {

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1892,7 +1892,7 @@ where
                         }
                         unsafe {crate::soc::cache_invalidate_addr(des.buffer as u32, des.size() as u32); }
                     }
-                }
+            }
             }
 
             _ => {}
@@ -2159,7 +2159,7 @@ where
                         }
                         unsafe { crate::soc::cache_writeback_addr(des.buffer as u32, des.size() as u32); }
                     }
-                }
+            }
             }
 
             _ => {}

--- a/esp-hal/src/dma/pdma/i2s.rs
+++ b/esp-hal/src/dma/pdma/i2s.rs
@@ -127,10 +127,11 @@ impl RegisterAccess for AnyI2sDmaTxChannel<'_> {
 
 impl TxRegisterAccess for AnyI2sDmaTxChannel<'_> {
     fn is_fifo_empty(&self) -> bool {
-        cfg_if::cfg_if! {
-            if #[cfg(esp32)] {
+        cfg_select! {
+            esp32 => {
                 self.regs().lc_state0().read().bits() & 0x80000000 != 0
-            } else {
+            }
+            _ => {
                 self.regs().lc_state0().read().out_empty().bit_is_set()
             }
         }

--- a/esp-hal/src/dma/pdma/spi.rs
+++ b/esp-hal/src/dma/pdma/spi.rs
@@ -63,7 +63,7 @@ impl RegisterAccess for AnySpiDmaTxChannel<'_> {
                 match self.0 {
                     AnySpiDmaChannel(any::Inner::Spi2(_)) => Some(Peripheral::Spi2Dma),
                     AnySpiDmaChannel(any::Inner::Spi3(_)) => Some(Peripheral::Spi3Dma),
-                }
+            }
             }
         }
     }
@@ -261,7 +261,7 @@ impl RegisterAccess for AnySpiDmaRxChannel<'_> {
                 match self.0 {
                     AnySpiDmaChannel(any::Inner::Spi2(_)) => Some(Peripheral::Spi2Dma),
                     AnySpiDmaChannel(any::Inner::Spi3(_)) => Some(Peripheral::Spi3Dma),
-                }
+            }
             }
         }
     }

--- a/esp-hal/src/dma/pdma/spi.rs
+++ b/esp-hal/src/dma/pdma/spi.rs
@@ -55,10 +55,11 @@ impl DmaTxChannel for AnySpiDmaTxChannel<'_> {}
 
 impl RegisterAccess for AnySpiDmaTxChannel<'_> {
     fn peripheral_clock(&self) -> Option<Peripheral> {
-        cfg_if::cfg_if! {
-            if #[cfg(esp32)] {
+        cfg_select! {
+            esp32 => {
                 Some(Peripheral::SpiDma)
-            } else {
+            }
+            _ => {
                 match self.0 {
                     AnySpiDmaChannel(any::Inner::Spi2(_)) => Some(Peripheral::Spi2Dma),
                     AnySpiDmaChannel(any::Inner::Spi3(_)) => Some(Peripheral::Spi3Dma),
@@ -136,10 +137,11 @@ impl RegisterAccess for AnySpiDmaTxChannel<'_> {
 
 impl TxRegisterAccess for AnySpiDmaTxChannel<'_> {
     fn is_fifo_empty(&self) -> bool {
-        cfg_if::cfg_if! {
-            if #[cfg(esp32)] {
+        cfg_select! {
+            esp32 => {
                 self.regs().dma_rstatus().read().dma_out_status().bits() & 0x80000000 != 0
-            } else {
+            }
+            _ => {
                 self.regs().dma_outstatus().read().dma_outfifo_empty().bit_is_set()
             }
         }
@@ -251,10 +253,11 @@ impl InterruptAccess<DmaTxInterrupt> for AnySpiDmaTxChannel<'_> {
 
 impl RegisterAccess for AnySpiDmaRxChannel<'_> {
     fn peripheral_clock(&self) -> Option<Peripheral> {
-        cfg_if::cfg_if! {
-            if #[cfg(esp32)] {
+        cfg_select! {
+            esp32 => {
                 Some(Peripheral::SpiDma)
-            } else {
+            }
+            _ => {
                 match self.0 {
                     AnySpiDmaChannel(any::Inner::Spi2(_)) => Some(Peripheral::Spi2Dma),
                     AnySpiDmaChannel(any::Inner::Spi3(_)) => Some(Peripheral::Spi3Dma),

--- a/esp-hal/src/ecc.rs
+++ b/esp-hal/src/ecc.rs
@@ -617,30 +617,33 @@ impl Info {
     }
 
     fn qx_mem(&self) -> *mut u32 {
-        cfg_if::cfg_if! {
-            if #[cfg(ecc_separate_jacobian_point_memory)] {
+        cfg_select! {
+            ecc_separate_jacobian_point_memory => {
                 self.regs.qx_mem(0).as_ptr()
-            } else {
+            }
+            _ => {
                 self.regs.px_mem(0).as_ptr()
             }
         }
     }
 
     fn qy_mem(&self) -> *mut u32 {
-        cfg_if::cfg_if! {
-            if #[cfg(ecc_separate_jacobian_point_memory)] {
+        cfg_select! {
+            ecc_separate_jacobian_point_memory => {
                 self.regs.qy_mem(0).as_ptr()
-            } else {
+            }
+            _ => {
                 self.regs.py_mem(0).as_ptr()
             }
         }
     }
 
     fn qz_mem(&self) -> *mut u32 {
-        cfg_if::cfg_if! {
-            if #[cfg(ecc_separate_jacobian_point_memory)] {
+        cfg_select! {
+            ecc_separate_jacobian_point_memory => {
                 self.regs.qz_mem(0).as_ptr()
-            } else {
+            }
+            _ => {
                 self.regs.k_mem(0).as_ptr()
             }
         }
@@ -954,30 +957,33 @@ impl MemoryPointers {
     }
 
     fn set_qx(&mut self, ptr: NonNull<[u8]>) {
-        cfg_if::cfg_if! {
-            if #[cfg(ecc_separate_jacobian_point_memory)] {
+        cfg_select! {
+            ecc_separate_jacobian_point_memory => {
                 self.qx = Some(ptr.cast());
-            } else {
+            }
+            _ => {
                 self.px = Some(ptr.cast());
             }
         }
     }
 
     fn set_qy(&mut self, ptr: NonNull<[u8]>) {
-        cfg_if::cfg_if! {
-            if #[cfg(ecc_separate_jacobian_point_memory)] {
+        cfg_select! {
+            ecc_separate_jacobian_point_memory => {
                 self.qy = Some(ptr.cast());
-            } else {
+            }
+            _ => {
                 self.py = Some(ptr.cast());
             }
         }
     }
 
     fn set_qz(&mut self, ptr: NonNull<[u8]>) {
-        cfg_if::cfg_if! {
-            if #[cfg(ecc_separate_jacobian_point_memory)] {
+        cfg_select! {
+            ecc_separate_jacobian_point_memory => {
                 self.qz = Some(ptr.cast());
-            } else {
+            }
+            _ => {
                 self.k = Some(ptr.cast());
             }
         }
@@ -1172,10 +1178,11 @@ fn ecc_work_queue_handler() {
     if !ECC_WORK_QUEUE.process() {
         // The queue may indicate that it needs to be polled again. In this case, we do not clear
         // the interrupt bit, which causes the interrupt to be re-handled.
-        cfg_if::cfg_if! {
-            if #[cfg(any(esp32c5, esp32c61))] {
+        cfg_select! {
+            any(esp32c5, esp32c61) => {
                 let reg = ECC::regs().int_clr();
-            } else {
+            }
+            _ => {
                 let reg = ECC::regs().mult_int_clr();
             }
         }

--- a/esp-hal/src/fmt.rs
+++ b/esp-hal/src/fmt.rs
@@ -7,10 +7,11 @@ use core::fmt::{Debug, Display, LowerHex};
 macro_rules! assert {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::assert!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::assert!($($x)*);
                 }
             }
@@ -22,10 +23,11 @@ macro_rules! assert {
 macro_rules! assert_eq {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::assert_eq!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::assert_eq!($($x)*);
                 }
             }
@@ -37,10 +39,11 @@ macro_rules! assert_eq {
 macro_rules! assert_ne {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::assert_ne!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::assert_ne!($($x)*);
                 }
             }
@@ -52,10 +55,11 @@ macro_rules! assert_ne {
 macro_rules! debug_assert {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::debug_assert!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::debug_assert!($($x)*);
                 }
             }
@@ -67,10 +71,11 @@ macro_rules! debug_assert {
 macro_rules! debug_assert_eq {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::debug_assert_eq!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::debug_assert_eq!($($x)*);
                 }
             }
@@ -82,10 +87,11 @@ macro_rules! debug_assert_eq {
 macro_rules! debug_assert_ne {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::debug_assert_ne!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::debug_assert_ne!($($x)*);
                 }
             }
@@ -97,10 +103,11 @@ macro_rules! debug_assert_ne {
 macro_rules! todo {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::todo!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::todo!($($x)*);
                 }
             }
@@ -112,10 +119,11 @@ macro_rules! todo {
 macro_rules! unreachable {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::unreachable!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::unreachable!($($x)*);
                 }
             }
@@ -127,10 +135,11 @@ macro_rules! unreachable {
 macro_rules! panic {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::panic!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::panic!($($x)*);
                 }
             }
@@ -142,12 +151,14 @@ macro_rules! panic {
 macro_rules! trace {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::trace!($s $(, $x)*);
-                } else if #[cfg(feature = "log-04")] {
+                }
+                feature = "log-04" => {
                     ::log_04::trace!($s $(, $x)*);
-                } else {
+                }
+                _ => {
                     let _ = ($( & $x ),*);
                 }
             }
@@ -159,12 +170,14 @@ macro_rules! trace {
 macro_rules! debug {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::debug!($s $(, $x)*);
-                } else if #[cfg(feature = "log-04")] {
+                }
+                feature = "log-04" => {
                     ::log_04::debug!($s $(, $x)*);
-                } else {
+                }
+                _ => {
                     let _ = ($( & $x ),*);
                 }
             }
@@ -176,12 +189,14 @@ macro_rules! debug {
 macro_rules! info {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::info!($s $(, $x)*);
-                } else if #[cfg(feature = "log-04")] {
+                }
+                feature = "log-04" => {
                     ::log_04::info!($s $(, $x)*);
-                } else {
+                }
+                _ => {
                     let _ = ($( & $x ),*);
                 }
             }
@@ -193,12 +208,14 @@ macro_rules! info {
 macro_rules! warn {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::warn!($s $(, $x)*);
-                } else if #[cfg(feature = "log-04")] {
+                }
+                feature = "log-04" => {
                     ::log_04::warn!($s $(, $x)*);
-                } else {
+                }
+                _ => {
                     let _ = ($( & $x ),*);
                 }
             }
@@ -210,12 +227,14 @@ macro_rules! warn {
 macro_rules! error {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::error!($s $(, $x)*);
-                } else if #[cfg(feature = "log-04")] {
+                }
+                feature = "log-04" => {
                     ::log_04::error!($s $(, $x)*);
-                } else {
+                }
+                _ => {
                     let _ = ($( & $x ),*);
                 }
             }

--- a/esp-hal/src/gpio/interrupt.rs
+++ b/esp-hal/src/gpio/interrupt.rs
@@ -130,12 +130,12 @@ cfg_select! {
         // On ESP32, the interrupt fires on the core that started listening for a pin event.
         fn cores() -> impl Iterator<Item = crate::system::Cpu> {
             crate::system::Cpu::all()
-        }
+    }
     }
     _ => {
         fn cores() -> [crate::system::Cpu; 1] {
             [crate::system::Cpu::current()]
-        }
+    }
     }
 }
 
@@ -231,14 +231,14 @@ impl InterruptStatusRegisterAccess {
                 match self {
                     Self::Bank0 => GPIO::regs().status().read().bits(),
                     Self::Bank1 => GPIO::regs().status1().read().bits(),
-                }
+            }
             }
             _ => {
                 match self {
                     Self::Bank0 => GPIO::regs().pcpu_int().read().bits(),
                     #[cfg(gpio_has_bank_1)]
                     Self::Bank1 => GPIO::regs().pcpu_int1().read().bits(),
-                }
+            }
             }
         }
     }

--- a/esp-hal/src/gpio/interrupt.rs
+++ b/esp-hal/src/gpio/interrupt.rs
@@ -125,13 +125,14 @@ pub(crate) fn bind_default_interrupt_handler() {
     );
 }
 
-cfg_if::cfg_if! {
-    if #[cfg(esp32)] {
+cfg_select! {
+    esp32 => {
         // On ESP32, the interrupt fires on the core that started listening for a pin event.
         fn cores() -> impl Iterator<Item = crate::system::Cpu> {
             crate::system::Cpu::all()
         }
-    } else {
+    }
+    _ => {
         fn cores() -> [crate::system::Cpu; 1] {
             [crate::system::Cpu::current()]
         }
@@ -225,13 +226,14 @@ pub(crate) enum InterruptStatusRegisterAccess {
 
 impl InterruptStatusRegisterAccess {
     pub(crate) fn interrupt_status_read(self) -> u32 {
-        cfg_if::cfg_if! {
-            if #[cfg(esp32)] {
+        cfg_select! {
+            esp32 => {
                 match self {
                     Self::Bank0 => GPIO::regs().status().read().bits(),
                     Self::Bank1 => GPIO::regs().status1().read().bits(),
                 }
-            } else {
+            }
+            _ => {
                 match self {
                     Self::Bank0 => GPIO::regs().pcpu_int().read().bits(),
                     #[cfg(gpio_has_bank_1)]

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -1900,13 +1900,14 @@ impl<'lt> AnyPin<'lt> {
     ) -> Result<(), WakeConfigError> {
         /// Assembles a valid value for the int_ena pin register field.
         fn gpio_intr_enable(int_enable: bool, nmi_enable: bool) -> u8 {
-            cfg_if::cfg_if! {
-                if #[cfg(esp32)] {
+            cfg_select! {
+                esp32 => {
                     match crate::system::Cpu::current() {
                         crate::system::Cpu::AppCpu => int_enable as u8 | ((nmi_enable as u8) << 1),
                         crate::system::Cpu::ProCpu => ((int_enable as u8) << 2) | ((nmi_enable as u8) << 3),
                     }
-                } else {
+                }
+                _ => {
                     // ESP32 and ESP32-C3 have separate bits for maskable and NMI interrupts.
                     int_enable as u8 | ((nmi_enable as u8) << 1)
                 }

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -1905,7 +1905,7 @@ impl<'lt> AnyPin<'lt> {
                     match crate::system::Cpu::current() {
                         crate::system::Cpu::AppCpu => int_enable as u8 | ((nmi_enable as u8) << 1),
                         crate::system::Cpu::ProCpu => ((int_enable as u8) << 2) | ((nmi_enable as u8) << 3),
-                    }
+                }
                 }
                 _ => {
                     // ESP32 and ESP32-C3 have separate bits for maskable and NMI interrupts.

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -1444,8 +1444,8 @@ fn set_filter(
     sda_threshold: Option<u8>,
     scl_threshold: Option<u8>,
 ) {
-    cfg_if::cfg_if! {
-        if #[cfg(i2c_master_separate_filter_config_registers)] {
+    cfg_select! {
+        i2c_master_separate_filter_config_registers => {
             register_block.sda_filter_cfg().modify(|_, w| {
                 if let Some(threshold) = sda_threshold {
                     unsafe { w.sda_filter_thres().bits(threshold) };
@@ -1458,7 +1458,8 @@ fn set_filter(
                 }
                 w.scl_filter_en().bit(scl_threshold.is_some())
             });
-        } else {
+        }
+        _ => {
             register_block.filter_cfg().modify(|_, w| {
                 if let Some(threshold) = sda_threshold {
                     unsafe { w.sda_filter_thres().bits(threshold) };
@@ -1491,25 +1492,29 @@ fn configure_clock(
     timeout: Option<u32>,
 ) -> Result<(), ConfigError> {
     unsafe {
-        cfg_if::cfg_if! {
-            if #[cfg(all(soc_has_pcr, soc_has_i2c1))] {
+        cfg_select! {
+            all(soc_has_pcr, soc_has_i2c1) => {
                 crate::peripherals::PCR::regs().i2c_sclk_conf(info.id as usize).modify(|_, w| {
                     w.i2c_sclk_sel().clear_bit();
                     w.i2c_sclk_div_num().bits((sclk_div - 1) as u8);
                     w.i2c_sclk_en().set_bit()
                 });
-            } else if #[cfg(soc_has_pcr)] {
+            }
+            soc_has_pcr => {
                 crate::peripherals::PCR::regs().i2c_sclk_conf().modify(|_, w| {
                     w.i2c_sclk_sel().clear_bit();
                     w.i2c_sclk_div_num().bits((sclk_div - 1) as u8);
                     w.i2c_sclk_en().set_bit()
                 });
-            } else if #[cfg(not(any(esp32, esp32s2)))] { // TODO have a better cfg for this
+            }
+            not(any(esp32, esp32s2)) => { // TODO have a better cfg for this
                 info.regs().clk_conf().modify(|_, w| {
                     w.sclk_sel().clear_bit();
                     w.sclk_div_num().bits((sclk_div - 1) as u8)
                 });
             }
+
+            _ => {}
         }
 
         // scl period
@@ -1552,13 +1557,14 @@ fn configure_clock(
             .scl_stop_hold()
             .write(|w| w.time().bits(scl_stop_hold_time as u16));
 
-        cfg_if::cfg_if! {
-            if #[cfg(i2c_master_has_bus_timeout_enable)] {
+        cfg_select! {
+            i2c_master_has_bus_timeout_enable => {
                 info.regs().to().write(|w| {
                     w.time_out_en().bit(timeout.is_some());
                     w.time_out_value().bits(timeout.unwrap_or(1) as _)
                 });
-            } else {
+            }
+            _ => {
                 info.regs()
                     .to()
                     .write(|w| w.time_out().bits(timeout.unwrap_or(1)));
@@ -1773,11 +1779,12 @@ impl Driver<'_> {
     }
 
     fn do_fsm_reset(&self) {
-        cfg_if::cfg_if! {
-            if #[cfg(i2c_master_has_reliable_fsm_reset)] {
+        cfg_select! {
+            i2c_master_has_reliable_fsm_reset => {
                 // Device has a working FSM reset mechanism
                 self.regs().ctr().modify(|_, w| w.fsm_rst().set_bit());
-            } else {
+            }
+            _ => {
                 // Even though C2 and C3 have a FSM reset bit, esp-idf does not
                 // define I2C_LL_SUPPORT_HW_FSM_RST for them, so include them in the fallback impl.
 
@@ -3345,28 +3352,30 @@ where
 }
 
 fn read_fifo(register_block: &RegisterBlock) -> u8 {
-    cfg_if::cfg_if! {
-        if #[cfg(esp32s2)] {
+    cfg_select! {
+        esp32s2 => {
             // Apparently the ESO can read just fine using DPORT,
             // so use this workaround on S2 only.
             let peri_offset = register_block as *const _ as usize - crate::peripherals::I2C0::ptr() as usize;
             let fifo_ptr = (property!("i2c_master.i2c0_data_register_ahb_address") + peri_offset) as *mut u32;
             unsafe { (fifo_ptr.read_volatile() & 0xff) as u8 }
-        } else {
+        }
+        _ => {
             register_block.data().read().fifo_rdata().bits()
         }
     }
 }
 
 fn write_fifo(register_block: &RegisterBlock, data: u8) {
-    cfg_if::cfg_if! {
-        if #[cfg(any(esp32, esp32s2))] {
+    cfg_select! {
+        any(esp32, esp32s2) => {
             let peri_offset = register_block as *const _ as usize - crate::peripherals::I2C0::ptr() as usize;
             let fifo_ptr = (property!("i2c_master.i2c0_data_register_ahb_address") + peri_offset) as *mut u32;
             unsafe {
                 fifo_ptr.write_volatile(data as u32);
             }
-        } else {
+        }
+        _ => {
             register_block
                 .data()
                 .write(|w| unsafe { w.fifo_rdata().bits(data) });
@@ -3377,15 +3386,16 @@ fn write_fifo(register_block: &RegisterBlock, data: u8) {
 // Estimate the reason for an acknowledge check failure on a best effort basis.
 // When in doubt it's better to return `Unknown` than to return a wrong reason.
 fn estimate_ack_failed_reason(_register_block: &RegisterBlock) -> AcknowledgeCheckFailedReason {
-    cfg_if::cfg_if! {
-        if #[cfg(i2c_master_can_estimate_nack_reason)] {
+    cfg_select! {
+        i2c_master_can_estimate_nack_reason => {
             // this is based on observations rather than documented behavior
             if _register_block.fifo_st().read().txfifo_raddr().bits() <= 1 {
                 AcknowledgeCheckFailedReason::Address
             } else {
                 AcknowledgeCheckFailedReason::Data
             }
-        } else {
+        }
+        _ => {
             AcknowledgeCheckFailedReason::Unknown
         }
     }

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -3373,7 +3373,7 @@ fn write_fifo(register_block: &RegisterBlock, data: u8) {
             let fifo_ptr = (property!("i2c_master.i2c0_data_register_ahb_address") + peri_offset) as *mut u32;
             unsafe {
                 fifo_ptr.write_volatile(data as u32);
-            }
+        }
         }
         _ => {
             register_block
@@ -3393,7 +3393,7 @@ fn estimate_ack_failed_reason(_register_block: &RegisterBlock) -> AcknowledgeChe
                 AcknowledgeCheckFailedReason::Address
             } else {
                 AcknowledgeCheckFailedReason::Data
-            }
+        }
         }
         _ => {
             AcknowledgeCheckFailedReason::Unknown

--- a/esp-hal/src/i2s/master.rs
+++ b/esp-hal/src/i2s/master.rs
@@ -1078,10 +1078,11 @@ where
 
     /// Change the I2S Tx unit configuration.
     pub fn apply_config(&mut self, tx_config: &UnitConfig) -> Result<(), ConfigError> {
-        cfg_if::cfg_if! {
-            if #[cfg(any(esp32, esp32s2))] {
+        cfg_select! {
+            any(esp32, esp32s2) => {
                 self.i2s.configure_tx(tx_config, self.data_format)
-            } else {
+            }
+            _ => {
                 self.i2s.configure_tx(tx_config)
             }
         }
@@ -1222,10 +1223,11 @@ where
 
     /// Change the I2S Rx unit configuration.
     pub fn apply_config(&mut self, rx_config: &UnitConfig) -> Result<(), ConfigError> {
-        cfg_if::cfg_if! {
-            if #[cfg(any(esp32, esp32s2))] {
+        cfg_select! {
+            any(esp32, esp32s2) => {
                 self.i2s.configure_rx(rx_config, self.data_format)
-            } else {
+            }
+            _ => {
                 self.i2s.configure_rx(rx_config)
             }
         }
@@ -1731,11 +1733,12 @@ mod private {
                 .int_clr()
                 .write(|w| w.in_suc_eof().clear_bit_by_one());
 
-            cfg_if::cfg_if! {
-                if #[cfg(esp32)] {
+            cfg_select! {
+                esp32 => {
                     // On ESP32, the eof_num count in words.
                     let eof_num = len / 4;
-                } else {
+                }
+                _ => {
                     let eof_num = len - 1;
                 }
             }
@@ -2180,80 +2183,92 @@ mod private {
     impl Signals for crate::peripherals::I2S0<'_> {
         #[cfg(not(esp32))] // MCLK on ESP32 requires special handling
         fn mclk_signal(&self) -> OutputSignal {
-            cfg_if::cfg_if! {
-                if #[cfg(esp32s2)] {
+            cfg_select! {
+                esp32s2 => {
                     OutputSignal::CLK_I2S
-                } else if #[cfg(esp32s3)] {
+                }
+                esp32s3 => {
                     OutputSignal::I2S0_MCLK
-                } else {
+                }
+                _ => {
                     OutputSignal::I2S_MCLK
                 }
             }
         }
 
         fn bclk_signal(&self) -> OutputSignal {
-            cfg_if::cfg_if! {
-                if #[cfg(any(esp32, esp32s2, esp32s3))] {
+            cfg_select! {
+                any(esp32, esp32s2, esp32s3) => {
                     OutputSignal::I2S0O_BCK
-                } else {
+                }
+                _ => {
                     OutputSignal::I2SO_BCK
                 }
             }
         }
 
         fn ws_signal(&self) -> OutputSignal {
-            cfg_if::cfg_if! {
-                if #[cfg(any(esp32, esp32s2, esp32s3))] {
+            cfg_select! {
+                any(esp32, esp32s2, esp32s3) => {
                     OutputSignal::I2S0O_WS
-                } else {
+                }
+                _ => {
                     OutputSignal::I2SO_WS
                 }
             }
         }
 
         fn dout_signal(&self) -> OutputSignal {
-            cfg_if::cfg_if! {
-                if #[cfg(esp32)] {
+            cfg_select! {
+                esp32 => {
                     OutputSignal::I2S0O_DATA_23
-                } else if #[cfg(esp32s2)] {
+                }
+                esp32s2 => {
                     OutputSignal::I2S0O_DATA_OUT23
-                } else if #[cfg(esp32s3)] {
+                }
+                esp32s3 => {
                     OutputSignal::I2S0O_SD
-                } else {
+                }
+                _ => {
                     OutputSignal::I2SO_SD
                 }
             }
         }
 
         fn bclk_rx_signal(&self) -> OutputSignal {
-            cfg_if::cfg_if! {
-                if #[cfg(any(esp32, esp32s2, esp32s3))] {
+            cfg_select! {
+                any(esp32, esp32s2, esp32s3) => {
                     OutputSignal::I2S0I_BCK
-                } else {
+                }
+                _ => {
                     OutputSignal::I2SI_BCK
                 }
             }
         }
 
         fn ws_rx_signal(&self) -> OutputSignal {
-            cfg_if::cfg_if! {
-                if #[cfg(any(esp32, esp32s2, esp32s3))] {
+            cfg_select! {
+                any(esp32, esp32s2, esp32s3) => {
                     OutputSignal::I2S0I_WS
-                } else {
+                }
+                _ => {
                     OutputSignal::I2SI_WS
                 }
             }
         }
 
         fn din_signal(&self) -> InputSignal {
-            cfg_if::cfg_if! {
-                if #[cfg(esp32)] {
+            cfg_select! {
+                esp32 => {
                     InputSignal::I2S0I_DATA_15
-                } else if #[cfg(esp32s2)] {
+                }
+                esp32s2 => {
                     InputSignal::I2S0I_DATA_IN15
-                } else if #[cfg(esp32s3)] {
+                }
+                esp32s3 => {
                     InputSignal::I2S0I_SD
-                } else {
+                }
+                _ => {
                     InputSignal::I2SI_SD
                 }
             }
@@ -2290,10 +2305,11 @@ mod private {
         }
 
         fn dout_signal(&self) -> OutputSignal {
-            cfg_if::cfg_if! {
-                if #[cfg(esp32)] {
+            cfg_select! {
+                esp32 => {
                     OutputSignal::I2S1O_DATA_23
-                } else {
+                }
+                _ => {
                     OutputSignal::I2S1O_SD
                 }
             }
@@ -2308,10 +2324,11 @@ mod private {
         }
 
         fn din_signal(&self) -> InputSignal {
-            cfg_if::cfg_if! {
-                if #[cfg(esp32)] {
+            cfg_select! {
+                esp32 => {
                     InputSignal::I2S1I_DATA_15
-                } else {
+                }
+                _ => {
                     InputSignal::I2S1I_SD
                 }
             }

--- a/esp-hal/src/interrupt/mod.rs
+++ b/esp-hal/src/interrupt/mod.rs
@@ -47,11 +47,12 @@ pub use self::riscv::*;
 pub use self::xtensa::*;
 use crate::{peripherals::Interrupt, system::Cpu};
 
-cfg_if::cfg_if! {
-    if #[cfg(esp32)] {
+cfg_select! {
+    esp32 => {
         use crate::peripherals::DPORT as INTERRUPT_CORE0;
         use crate::peripherals::DPORT as INTERRUPT_CORE1;
-    } else {
+    }
+    _ => {
         use crate::peripherals::INTERRUPT_CORE0;
         #[cfg(esp32s3)]
         use crate::peripherals::INTERRUPT_CORE1;
@@ -266,10 +267,11 @@ impl Iterator for InterruptStatusIterator {
 // Peripheral interrupt API.
 
 fn vector_entry(interrupt: Interrupt) -> &'static pac::Vector {
-    cfg_if::cfg_if! {
-        if #[cfg(xtensa)] {
+    cfg_select! {
+        xtensa => {
             &pac::__INTERRUPTS[interrupt as usize]
-        } else {
+        }
+        _ => {
             &pac::__EXTERNAL_INTERRUPTS[interrupt as usize]
         }
     }

--- a/esp-hal/src/interrupt/riscv.rs
+++ b/esp-hal/src/interrupt/riscv.rs
@@ -307,8 +307,8 @@ pub fn enable_direct(
     cpu_interrupt: DirectBindableCpuInterrupt,
     handler: unsafe extern "C" fn(),
 ) {
-    cfg_if::cfg_if! {
-        if #[cfg(interrupt_controller = "clic")] {
+    cfg_select! {
+        interrupt_controller = "clic" => {
             let clic = unsafe { crate::soc::pac::CLIC::steal() };
 
             // Enable hardware vectoring
@@ -325,7 +325,8 @@ pub fn enable_direct(
                 .wrapping_add(cpu_interrupt as usize);
 
             let instr = handler as usize as u32;
-        } else {
+        }
+        _ => {
             use riscv::register::mtvec;
             let mt = mtvec::read();
 
@@ -406,10 +407,11 @@ pub(crate) unsafe fn change_current_runlevel(level: RunLevel) -> RunLevel {
 }
 
 fn cpu_wait_mode_on() -> bool {
-    cfg_if::cfg_if! {
-        if #[cfg(soc_has_pcr)] {
+    cfg_select! {
+        soc_has_pcr => {
             crate::peripherals::PCR::regs().cpu_waiti_conf().read().cpu_wait_mode_force_on().bit_is_set()
-        } else {
+        }
+        _ => {
             crate::peripherals::SYSTEM::regs()
                 .cpu_per_conf()
                 .read()
@@ -566,11 +568,12 @@ pub(crate) mod rt {
         // so we clear it anyway
         cpu_intr.clear();
 
-        cfg_if::cfg_if! {
-            if #[cfg(interrupt_controller = "clic")] {
+        cfg_select! {
+            interrupt_controller = "clic" => {
                 let prio = cpu_int::current_runlevel();
                 let mcause = riscv::register::mcause::read();
-            } else {
+            }
+            _ => {
                 // Change the current runlevel so that interrupt handlers can access the correct runlevel.
                 let prio = unwrap!(INTERRUPT_TO_PRIORITY[cpu_intr as usize]);
                 let level = unsafe { change_current_runlevel(RunLevel::Interrupt(ElevatedRunLevel::from(prio))) };
@@ -600,8 +603,8 @@ pub(crate) mod rt {
             handle_interrupts();
         }
 
-        cfg_if::cfg_if! {
-            if #[cfg(interrupt_controller = "clic")] {
+        cfg_select! {
+            interrupt_controller = "clic" => {
                 // In case the target uses the CLIC, it is mandatory to restore `mcause` register
                 // since it contains the former CPU priority. When executing `mret`,
                 // the hardware will restore the former threshold, from `mcause` to
@@ -609,7 +612,8 @@ pub(crate) mod rt {
                 unsafe {
                     core::arch::asm!("csrw 0x342, {}", in(reg) mcause.bits())
                 }
-            } else {
+            }
+            _ => {
                 unsafe { change_current_runlevel(level) };
             }
         }

--- a/esp-hal/src/interrupt/riscv.rs
+++ b/esp-hal/src/interrupt/riscv.rs
@@ -611,7 +611,7 @@ pub(crate) mod rt {
                 // `mintstatus` CSR
                 unsafe {
                     core::arch::asm!("csrw 0x342, {}", in(reg) mcause.bits())
-                }
+            }
             }
             _ => {
                 unsafe { change_current_runlevel(level) };

--- a/esp-hal/src/interrupt/software.rs
+++ b/esp-hal/src/interrupt/software.rs
@@ -108,10 +108,11 @@ impl<const NUM: u8> SoftwareInterrupt<'_, NUM> {
 
     /// Trigger this software-interrupt
     pub fn raise(&self) {
-        cfg_if::cfg_if! {
-            if #[cfg(soc_has_intpri)] {
+        cfg_select! {
+            soc_has_intpri => {
                 let regs = crate::peripherals::INTPRI::regs();
-            } else {
+            }
+            _ => {
                 let regs = crate::peripherals::SYSTEM::regs();
             }
         }
@@ -135,10 +136,11 @@ impl<const NUM: u8> SoftwareInterrupt<'_, NUM> {
 
     /// Resets this software-interrupt
     pub fn reset(&self) {
-        cfg_if::cfg_if! {
-            if #[cfg(soc_has_intpri)] {
+        cfg_select! {
+            soc_has_intpri => {
                 let regs = crate::peripherals::INTPRI::regs();
-            } else {
+            }
+            _ => {
                 let regs = crate::peripherals::SYSTEM::regs();
             }
         }

--- a/esp-hal/src/interrupt/xtensa.rs
+++ b/esp-hal/src/interrupt/xtensa.rs
@@ -361,8 +361,8 @@ pub(crate) fn priority_to_cpu_interrupt(interrupt: Interrupt, level: Priority) -
     }
 }
 
-cfg_if::cfg_if! {
-    if #[cfg(esp32)] {
+cfg_select! {
+    esp32 => {
         pub(crate) const EDGE_INTERRUPTS: [Interrupt; 8] = [
             Interrupt::TG0_T0_EDGE,
             Interrupt::TG0_T1_EDGE,
@@ -373,7 +373,8 @@ cfg_if::cfg_if! {
             Interrupt::TG1_WDT_EDGE,
             Interrupt::TG1_LACT_EDGE,
         ];
-    } else if #[cfg(esp32s2)] {
+    }
+    esp32s2 => {
         pub(crate) const EDGE_INTERRUPTS: [Interrupt; 11] = [
             Interrupt::TG0_T0_EDGE,
             Interrupt::TG0_T1_EDGE,
@@ -387,9 +388,11 @@ cfg_if::cfg_if! {
             Interrupt::SYSTIMER_TARGET1,
             Interrupt::SYSTIMER_TARGET2,
         ];
-    } else if #[cfg(esp32s3)] {
+    }
+    esp32s3 => {
         pub(crate) const EDGE_INTERRUPTS: [Interrupt; 0] = [];
-    } else {
+    }
+    _ => {
         compile_error!("Unsupported chip");
     }
 }
@@ -580,10 +583,11 @@ pub(crate) mod rt {
     #[unsafe(no_mangle)]
     #[ram]
     unsafe fn __level_6_interrupt(save_frame: &mut Context) {
-        cfg_if::cfg_if! {
-            if #[cfg(all(feature = "rt", feature = "exception-handler", stack_guard_monitoring))] {
+        cfg_select! {
+            all(feature = "rt", feature = "exception-handler", stack_guard_monitoring) => {
                 crate::exception_handler::breakpoint_interrupt(save_frame);
-            } else {
+            }
+            _ => {
                 unsafe { level6_interrupt(save_frame) }
             }
         }

--- a/esp-hal/src/ledc/timer.rs
+++ b/esp-hal/src/ledc/timer.rs
@@ -359,10 +359,11 @@ impl TimerHW<LowSpeed> for Timer<'_, LowSpeed> {
 
     /// Update the timer in HW
     fn update_hw(&self) {
-        cfg_if::cfg_if! {
-            if #[cfg(esp32)] {
+        cfg_select! {
+            esp32 => {
                 let tmr = self.ledc.lstimer(self.number as usize);
-            } else {
+            }
+            _ => {
                 let tmr = self.ledc.timer(self.number as usize);
             }
         }

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -1927,10 +1927,11 @@ mod private {
         }
 
         pub fn tx_valid_pin_signal() -> OutputSignal {
-            cfg_if::cfg_if! {
-                if #[cfg(esp32c5)] {
+            cfg_select! {
+                esp32c5 => {
                     OutputSignal::PARL_TX_CS
-                } else {
+                }
+                _ => {
                     OutputSignal::PARL_TX_DATA7
                 }
             }

--- a/esp-hal/src/psram/esp32c5_c61.rs
+++ b/esp-hal/src/psram/esp32c5_c61.rs
@@ -14,18 +14,21 @@ use quad::CommandMode;
 const FUNC_SPICS1_SPICS1: u8 = 0;
 const PIN_FUNC_GPIO: u8 = 1;
 
-cfg_if::cfg_if! {
-    if #[cfg(esp32c61)] {
+cfg_select! {
+    esp32c61 => {
         const PSRAM_CS_IO: u8 = 14;
         const SPI_CS1_GPIO_NUM: u8 = 14;
         const SPICS1_OUT_IDX: u8 = 102;
         const PSRAM_SPIWP_SD3_IO: u8 = 17;
-    } else if #[cfg(esp32c5)] {
+    }
+    esp32c5 => {
         const PSRAM_CS_IO: u8 = 15;
         const SPI_CS1_GPIO_NUM: u8 = 15;
         const SPICS1_OUT_IDX: u8 = 101;
         const PSRAM_SPIWP_SD3_IO: u8 = 18;
     }
+
+    _ => {}
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -2376,13 +2376,14 @@ mod chip_specific {
 
             PCR::regs().rmt_sclk_conf().modify(|_, w| unsafe {
                 #[cfg(not(soc_has_clock_node_rmt_sclk))]
-                cfg_if::cfg_if!(
-                    if #[cfg(any(esp32c5, esp32c6))] {
+                cfg_select! {
+                    any(esp32c5, esp32c6) => {
                         w.sclk_sel().bits(source.bits());
-                    } else {
+                    }
+                    _ => {
                         w.sclk_sel().bit(source.bit());
                     }
-                );
+                }
 
                 w.sclk_div_num().bits(div);
                 w.sclk_div_a().bits(0);

--- a/esp-hal/src/rng/ll.rs
+++ b/esp-hal/src/rng/ll.rs
@@ -30,7 +30,7 @@ fn current_cpu_cycles() -> usize {
                         return r;
                     }
                 }
-            }
+        }
 
             read_csr_fn!(read_pccr_machine, "0x7e2");
             read_csr_fn!(read_pccr_user, "0x802");
@@ -43,13 +43,13 @@ fn current_cpu_cycles() -> usize {
                 }
 
                 PRV_M
-            }
+        }
 
             if read_prv_mode() == PRV_M {
                 read_pccr_machine()
             } else {
                 read_pccr_user()
-            }
+        }
         }
         _ => {
             riscv::register::mcycle::read()

--- a/esp-hal/src/rng/ll.rs
+++ b/esp-hal/src/rng/ll.rs
@@ -11,10 +11,11 @@ fn tee_enabled() -> bool {
 
 #[inline]
 fn current_cpu_cycles() -> usize {
-    cfg_if::cfg_if! {
-        if #[cfg(xtensa)] {
+    cfg_select! {
+        xtensa => {
             xtensa_lx::timer::get_cycle_count() as usize
-        } else if #[cfg(soc_cpu_has_csr_pc)] {
+        }
+        soc_cpu_has_csr_pc => {
             const PRV_M: usize = 3;
             macro_rules! read_csr_fn {
                 ($fnname:ident, $csr:expr) => {
@@ -49,7 +50,8 @@ fn current_cpu_cycles() -> usize {
             } else {
                 read_pccr_user()
             }
-        } else {
+        }
+        _ => {
             riscv::register::mcycle::read()
         }
     }

--- a/esp-hal/src/rsa/mod.rs
+++ b/esp-hal/src/rsa/mod.rs
@@ -168,11 +168,12 @@ impl<'d> Rsa<'d, Async> {
 
 impl<'d, Dm: DriverMode> Rsa<'d, Dm> {
     fn internal_enable_disable_interrupt(&self, enable: bool) {
-        cfg_if::cfg_if! {
-            if #[cfg(esp32)] {
+        cfg_select! {
+            esp32 => {
                 // Can't seem to actually disable the interrupt, but esp-idf still writes the register
                 self.regs().interrupt().write(|w| w.interrupt().bit(enable));
-            } else {
+            }
+            _ => {
                 self.regs().int_ena().write(|w| w.int_ena().bit(enable));
             }
         }
@@ -187,10 +188,11 @@ impl<'d, Dm: DriverMode> Rsa<'d, Dm> {
     /// This function would return without an error if the memory is
     /// initialized.
     fn ready(&self) -> bool {
-        cfg_if::cfg_if! {
-            if #[cfg(any(esp32, esp32s2, esp32s3))] {
+        cfg_select! {
+            any(esp32, esp32s2, esp32s3) => {
                 self.regs().clean().read().clean().bit_is_set()
-            } else {
+            }
+            _ => {
                 self.regs().query_clean().read().query_clean().bit_is_set()
             }
         }
@@ -198,12 +200,13 @@ impl<'d, Dm: DriverMode> Rsa<'d, Dm> {
 
     /// Starts the modular exponentiation operation.
     fn start_modexp(&self) {
-        cfg_if::cfg_if! {
-            if #[cfg(any(esp32, esp32s2, esp32s3))] {
+        cfg_select! {
+            any(esp32, esp32s2, esp32s3) => {
                 self.regs()
                     .modexp_start()
                     .write(|w| w.modexp_start().set_bit());
-            } else {
+            }
+            _ => {
                 self.regs()
                     .set_start_modexp()
                     .write(|w| w.set_start_modexp().set_bit());
@@ -213,10 +216,11 @@ impl<'d, Dm: DriverMode> Rsa<'d, Dm> {
 
     /// Starts the multiplication operation.
     fn start_multi(&self) {
-        cfg_if::cfg_if! {
-            if #[cfg(any(esp32, esp32s2, esp32s3))] {
+        cfg_select! {
+            any(esp32, esp32s2, esp32s3) => {
                 self.regs().mult_start().write(|w| w.mult_start().set_bit());
-            } else {
+            }
+            _ => {
                 self.regs()
                     .set_start_mult()
                     .write(|w| w.set_start_mult().set_bit());
@@ -226,15 +230,17 @@ impl<'d, Dm: DriverMode> Rsa<'d, Dm> {
 
     /// Starts the modular multiplication operation.
     fn start_modmulti(&self) {
-        cfg_if::cfg_if! {
-            if #[cfg(esp32)] {
+        cfg_select! {
+            esp32 => {
                 // modular-ness is encoded in the multi_mode register value
                 self.start_multi();
-            } else if #[cfg(any(esp32s2, esp32s3))] {
+            }
+            any(esp32s2, esp32s3) => {
                 self.regs()
                     .modmult_start()
                     .write(|w| w.modmult_start().set_bit());
-            } else {
+            }
+            _ => {
                 self.regs()
                     .set_start_modmult()
                     .write(|w| w.set_start_modmult().set_bit());
@@ -244,10 +250,11 @@ impl<'d, Dm: DriverMode> Rsa<'d, Dm> {
 
     /// Clears the RSA interrupt flag.
     fn clear_interrupt(&mut self) {
-        cfg_if::cfg_if! {
-            if #[cfg(esp32)] {
+        cfg_select! {
+            esp32 => {
                 self.regs().interrupt().write(|w| w.interrupt().set_bit());
-            } else {
+            }
+            _ => {
                 self.regs().int_clr().write(|w| w.int_clr().set_bit());
             }
         }
@@ -255,12 +262,14 @@ impl<'d, Dm: DriverMode> Rsa<'d, Dm> {
 
     /// Checks if the RSA peripheral is idle.
     fn is_idle(&self) -> bool {
-        cfg_if::cfg_if! {
-            if #[cfg(esp32)] {
+        cfg_select! {
+            esp32 => {
                 self.regs().interrupt().read().interrupt().bit_is_set()
-            } else if #[cfg(any(esp32s2, esp32s3))] {
+            }
+            any(esp32s2, esp32s3) => {
                 self.regs().idle().read().idle().bit_is_set()
-            } else {
+            }
+            _ => {
                 self.regs().query_idle().read().query_idle().bit_is_set()
             }
         }
@@ -280,10 +289,11 @@ impl<'d, Dm: DriverMode> Rsa<'d, Dm> {
             mode
         };
 
-        cfg_if::cfg_if! {
-            if #[cfg(esp32)] {
+        cfg_select! {
+            esp32 => {
                 self.regs().mult_mode().write(|w| unsafe { w.bits(mode) });
-            } else {
+            }
+            _ => {
                 self.regs().mode().write(|w| unsafe { w.bits(mode) });
             }
         }
@@ -291,10 +301,11 @@ impl<'d, Dm: DriverMode> Rsa<'d, Dm> {
 
     /// Writes the result size of the modular exponentiation.
     fn write_modexp_mode(&mut self, mode: u32) {
-        cfg_if::cfg_if! {
-            if #[cfg(esp32)] {
+        cfg_select! {
+            esp32 => {
                 self.regs().modexp_mode().write(|w| unsafe { w.bits(mode) });
-            } else {
+            }
+            _ => {
                 self.regs().mode().write(|w| unsafe { w.bits(mode) });
             }
         }
@@ -771,10 +782,11 @@ where
 pub(super) fn rsa_interrupt_handler() {
     let rsa = RSA::regs();
     SIGNALED.store(true, Ordering::Release);
-    cfg_if::cfg_if! {
-        if #[cfg(esp32)] {
+    cfg_select! {
+        esp32 => {
             rsa.interrupt().write(|w| w.interrupt().set_bit());
-        } else  {
+        }
+        _ => {
             rsa.int_clr().write(|w| w.int_clr().set_bit());
         }
     }
@@ -1121,10 +1133,11 @@ fn rsa_work_queue_handler() {
     if !RSA_WORK_QUEUE.process() {
         // The queue may indicate that it needs to be polled again. In this case, we do not clear
         // the interrupt bit, which causes the interrupt to be re-handled.
-        cfg_if::cfg_if! {
-            if #[cfg(esp32)] {
+        cfg_select! {
+            esp32 => {
                 RSA::regs().interrupt().write(|w| w.interrupt().set_bit());
-            } else {
+            }
+            _ => {
                 RSA::regs().int_clr().write(|w| w.int_clr().set_bit());
             }
         }

--- a/esp-hal/src/rtc_cntl/mod.rs
+++ b/esp-hal/src/rtc_cntl/mod.rs
@@ -229,7 +229,7 @@ impl<'d> Rtc<'d> {
                 while rtc_cntl.time_update().read().time_valid().bit_is_clear() {
                     // Might take 1 RTC slowclk period, don't flood RTC bus
                     crate::rom::ets_delay_us(1);
-                }
+            }
 
                 let h = rtc_cntl.time1().read().time_hi().bits();
                 let l = rtc_cntl.time0().read().time_lo().bits();

--- a/esp-hal/src/rtc_cntl/mod.rs
+++ b/esp-hal/src/rtc_cntl/mod.rs
@@ -140,13 +140,14 @@ pub mod sleep;
 #[cfg_attr(esp32s3, path = "rtc/esp32s3.rs")]
 pub(crate) mod rtc;
 
-cfg_if::cfg_if! {
-    if #[cfg(soc_has_lp_wdt)] {
+cfg_select! {
+    soc_has_lp_wdt => {
         use crate::peripherals::LP_WDT;
         #[cfg(lp_timer_driver_supported)]
         use crate::peripherals::LP_TIMER;
         use crate::peripherals::LP_AON;
-    } else {
+    }
+    _ => {
         use crate::peripherals::LPWR as LP_WDT;
         use crate::peripherals::LPWR as LP_TIMER;
         use crate::peripherals::LPWR as LP_AON;
@@ -222,8 +223,8 @@ impl<'d> Rtc<'d> {
     fn time_since_boot_raw(&self) -> u64 {
         let rtc_cntl = LP_TIMER::regs();
 
-        cfg_if::cfg_if! {
-            if #[cfg(esp32)] {
+        cfg_select! {
+            esp32 => {
                 rtc_cntl.time_update().write(|w| w.time_update().set_bit());
                 while rtc_cntl.time_update().read().time_valid().bit_is_clear() {
                     // Might take 1 RTC slowclk period, don't flood RTC bus
@@ -232,7 +233,8 @@ impl<'d> Rtc<'d> {
 
                 let h = rtc_cntl.time1().read().time_hi().bits();
                 let l = rtc_cntl.time0().read().time_lo().bits();
-            } else if #[cfg(any(esp32c5, esp32c6, esp32c61, esp32h2))] {
+            }
+            any(esp32c5, esp32c6, esp32c61, esp32h2) => {
                 rtc_cntl.update().write(|w| w.main_timer_update().set_bit());
 
                 let h = rtc_cntl
@@ -241,7 +243,8 @@ impl<'d> Rtc<'d> {
                     .main_timer_buf0_high()
                     .bits();
                 let l = rtc_cntl.main_buf0_low().read().main_timer_buf0_low().bits();
-            } else {
+            }
+            _ => {
                 rtc_cntl.time_update().write(|w| w.time_update().set_bit());
 
                 let h = rtc_cntl.time_high0().read().timer_value0_high().bits();
@@ -426,10 +429,11 @@ impl<'d> Rtc<'d> {
     #[instability::unstable]
     #[cfg(lp_timer_driver_supported)]
     pub fn set_interrupt_handler(&mut self, handler: InterruptHandler) {
-        cfg_if::cfg_if! {
-            if #[cfg(any(esp32c5, esp32c6, esp32c61, esp32h2))] {
+        cfg_select! {
+            any(esp32c5, esp32c6, esp32c61, esp32h2) => {
                 let interrupt = Interrupt::LP_WDT;
-            } else {
+            }
+            _ => {
                 let interrupt = Interrupt::RTC_CORE;
             }
         }
@@ -688,16 +692,18 @@ pub fn wakeup_cause() -> SleepSource {
         return SleepSource::Undefined;
     }
 
-    cfg_if::cfg_if! {
-        if #[cfg(esp32)] {
+    cfg_select! {
+        esp32 => {
             let wakeup_cause_bits = LPWR::regs().wakeup_state().read().wakeup_cause().bits() as u32;
-        } else if #[cfg(soc_has_intpri)] {
+        }
+        soc_has_intpri => {
             let wakeup_cause_bits = crate::peripherals::PMU::regs()
                 .slp_wakeup_status0()
                 .read()
                 .wakeup_cause()
                 .bits();
-        } else {
+        }
+        _ => {
             let wakeup_cause_bits = LPWR::regs().slp_wakeup_cause().read().wakeup_cause().bits();
         }
     }

--- a/esp-hal/src/sha.rs
+++ b/esp-hal/src/sha.rs
@@ -633,15 +633,16 @@ for_each_sha_algorithm! {
 impl ShaAlgorithmKind {
     fn start(self, sha: &crate::peripherals::SHA<'_>) {
         let regs = sha.register_block();
-        cfg_if::cfg_if! {
-            if #[cfg(esp32)] {
+        cfg_select! {
+            esp32 => {
                 match self {
                     ShaAlgorithmKind::Sha1 => regs.sha1_start().write(|w| w.sha1_start().set_bit()),
                     ShaAlgorithmKind::Sha256 => regs.sha256_start().write(|w| w.sha256_start().set_bit()),
                     ShaAlgorithmKind::Sha384 => regs.sha384_start().write(|w| w.sha384_start().set_bit()),
                     ShaAlgorithmKind::Sha512 => regs.sha512_start().write(|w| w.sha512_start().set_bit()),
                 };
-            } else {
+            }
+            _ => {
                 regs.start().write(|w| w.start().set_bit());
             }
         }
@@ -649,15 +650,16 @@ impl ShaAlgorithmKind {
 
     fn r#continue(self, sha: &crate::peripherals::SHA<'_>) {
         let regs = sha.register_block();
-        cfg_if::cfg_if! {
-            if #[cfg(esp32)] {
+        cfg_select! {
+            esp32 => {
                 match self {
                     ShaAlgorithmKind::Sha1 => regs.sha1_continue().write(|w| w.sha1_continue().set_bit()),
                     ShaAlgorithmKind::Sha256 => regs.sha256_continue().write(|w| w.sha256_continue().set_bit()),
                     ShaAlgorithmKind::Sha384 => regs.sha384_continue().write(|w| w.sha384_continue().set_bit()),
                     ShaAlgorithmKind::Sha512 => regs.sha512_continue().write(|w| w.sha512_continue().set_bit()),
                 };
-            } else {
+            }
+            _ => {
                 regs.continue_().write(|w| w.continue_().set_bit());
             }
         }
@@ -667,8 +669,8 @@ impl ShaAlgorithmKind {
     ///
     /// Returns whether the caller needs to wait for the hash to be loaded.
     fn load(self, _sha: &crate::peripherals::SHA<'_>) -> bool {
-        cfg_if::cfg_if! {
-            if #[cfg(esp32)] {
+        cfg_select! {
+            esp32 => {
                 let regs = _sha.register_block();
                 match self {
                     ShaAlgorithmKind::Sha1 => regs.sha1_load().write(|w| w.sha1_load().set_bit()),
@@ -678,7 +680,8 @@ impl ShaAlgorithmKind {
                 };
 
                 true
-            } else {
+            }
+            _ => {
                 // Return that no waiting is necessary
                 false
             }
@@ -687,15 +690,16 @@ impl ShaAlgorithmKind {
 
     fn is_busy(self, sha: &crate::peripherals::SHA<'_>) -> bool {
         let regs = sha.register_block();
-        cfg_if::cfg_if! {
-            if #[cfg(esp32)] {
+        cfg_select! {
+            esp32 => {
                 let bit = match self {
                     ShaAlgorithmKind::Sha1 => regs.sha1_busy().read().sha1_busy(),
                     ShaAlgorithmKind::Sha256 => regs.sha256_busy().read().sha256_busy(),
                     ShaAlgorithmKind::Sha384 => regs.sha384_busy().read().sha384_busy(),
                     ShaAlgorithmKind::Sha512 => regs.sha512_busy().read().sha512_busy(),
                 };
-            } else {
+            }
+            _ => {
                 let bit = regs.busy().read().state();
             }
         }
@@ -738,10 +742,11 @@ for_each_sha_algorithm! {
 
 fn h_mem(sha: &crate::peripherals::SHA<'_>, index: usize) -> *mut u32 {
     let sha = sha.register_block();
-    cfg_if::cfg_if! {
-        if #[cfg(esp32)] {
+    cfg_select! {
+        esp32 => {
             sha.text(index).as_ptr()
-        } else {
+        }
+        _ => {
             sha.h_mem(index).as_ptr()
         }
     }
@@ -749,10 +754,11 @@ fn h_mem(sha: &crate::peripherals::SHA<'_>, index: usize) -> *mut u32 {
 
 fn m_mem(sha: &crate::peripherals::SHA<'_>, index: usize) -> *mut u32 {
     let sha = sha.register_block();
-    cfg_if::cfg_if! {
-        if #[cfg(esp32)] {
+    cfg_select! {
+        esp32 => {
             sha.text(index).as_ptr()
-        } else {
+        }
+        _ => {
             sha.m_mem(index).as_ptr()
         }
     }

--- a/esp-hal/src/soc/mod.rs
+++ b/esp-hal/src/soc/mod.rs
@@ -262,10 +262,11 @@ pub(crate) fn ensure_stack_pointer_in_range() {
         static _stack_start_cpu0: u32;
     }
     let current_sp: usize;
-    cfg_if::cfg_if! {
-        if #[cfg(xtensa)] {
+    cfg_select! {
+        xtensa => {
             unsafe { core::arch::asm!("mov {0}, sp", out(reg) current_sp); }
-        } else {
+        }
+        _ => {
             unsafe { core::arch::asm!("mv {0}, sp", out(reg) current_sp); }
         }
     }

--- a/esp-hal/src/spi/master/dma.rs
+++ b/esp-hal/src/spi/master/dma.rs
@@ -163,12 +163,13 @@ impl<'d> SpiDma<'d, Blocking> {
 
         let empty_rx_buffer = unwrap!(DmaRxBuf::new(unsafe { &mut RX_DESCRIPTORS[id] }, &mut []));
 
-        cfg_if::cfg_if! {
-            if #[cfg(all(esp32, spi_address_workaround))] {
+        cfg_select! {
+            all(esp32, spi_address_workaround) => {
                 static mut BUFFERS: [[u32; 1]; SPI_NUM] = [[0]; SPI_NUM];
                 let buffer = crate::dma::as_mut_byte_array!(BUFFERS[id], 4);
                 let empty_tx_buffer = unwrap!(DmaTxBuf::new(unsafe { &mut TX_DESCRIPTORS[id] }, buffer));
-            } else {
+            }
+            _ => {
                 let empty_tx_buffer = unwrap!(DmaTxBuf::new(unsafe { &mut TX_DESCRIPTORS[id] }, &mut []));
             }
         }

--- a/esp-hal/src/spi/master/mod.rs
+++ b/esp-hal/src/spi/master/mod.rs
@@ -514,22 +514,25 @@ impl Config {
         let clocks = Clocks::get();
 
         // FIXME: take clock source into account
-        cfg_if::cfg_if! {
-            if #[cfg(esp32h2)] {
+        cfg_select! {
+            esp32h2 => {
                 // ESP32-H2 is using PLL_48M_CLK source instead of APB_CLK
                 let _clocks = clocks;
                 Rate::from_mhz(48)
-            } else if #[cfg(any(esp32c5, esp32c61))] {
+            }
+            any(esp32c5, esp32c61) => {
                 // We select the 160MHz PLL as the clock source in the driver. There is a by-2 divider
                 // configured between the PLL and the SPI clock (spi2_clkm_div_num).
                 let _clocks = clocks;
                 Rate::from_mhz(80) // clk_spi2_mst must be <= 80MHz
-            } else if #[cfg(esp32c6)] {
+            }
+            esp32c6 => {
                 // We select the 80MHz PLL as the clock source in the driver
                 // FIXME we state that the default clock source is APB, which just isn't true
                 let _clocks = clocks;
                 Rate::from_mhz(80)
-            } else {
+            }
+            _ => {
                 clocks.apb_clock
             }
         }
@@ -1353,8 +1356,8 @@ where
 
         self.flush()?;
 
-        cfg_if::cfg_if! {
-            if #[cfg(all(esp32, spi_address_workaround))] {
+        cfg_select! {
+            all(esp32, spi_address_workaround) => {
                 let mut buffer = buffer;
                 let mut data_mode = data_mode;
                 let mut address = address;
@@ -1377,6 +1380,8 @@ where
                     return Err(Error::Unsupported);
                 }
             }
+
+            _ => {}
         }
 
         self.driver().setup_half_duplex(
@@ -1593,10 +1598,11 @@ impl Driver {
         // function works for DMA so I have left it unchanged, but does not work
         // for CPU-controlled transfers on the ESP32. Toggling slave mode works on
         // ESP32, but not on later chips.
-        cfg_if::cfg_if! {
-            if #[cfg(esp32)] {
+        cfg_select! {
+            esp32 => {
                 self.regs().slave().toggle(|w, en| w.mode().bit(en));
-            } else {
+            }
+            _ => {
                 self.configure_datalen(1, 1);
             }
         }
@@ -1637,10 +1643,11 @@ impl Driver {
                 });
         }
 
-        cfg_if::cfg_if! {
-            if #[cfg(esp32)] {
+        cfg_select! {
+            esp32 => {
                 self.regs().ctrl().modify(|_, w| w.wp().clear_bit());
-            } else {
+            }
+            _ => {
                 self.regs().ctrl().modify(|_, w| {
                     w.q_pol().clear_bit();
                     w.d_pol().clear_bit();
@@ -1744,8 +1751,8 @@ impl Driver {
     /// Enable or disable listening for the given interrupts.
     #[cfg_attr(not(feature = "unstable"), allow(dead_code))]
     fn enable_listen(&self, interrupts: EnumSet<SpiInterrupt>, enable: bool) {
-        cfg_if::cfg_if! {
-            if #[cfg(esp32)] {
+        cfg_select! {
+            esp32 => {
                 self.regs().slave().modify(|_, w| {
                     for interrupt in interrupts {
                         match interrupt {
@@ -1754,7 +1761,8 @@ impl Driver {
                     }
                     w
                 });
-            } else if #[cfg(esp32s2)] {
+            }
+            esp32s2 => {
                 self.regs().slave().modify(|_, w| {
                     for interrupt in interrupts {
                         match interrupt {
@@ -1764,7 +1772,8 @@ impl Driver {
                     }
                     w
                 });
-            } else {
+            }
+            _ => {
                 self.regs().dma_int_ena().modify(|_, w| {
                     for interrupt in interrupts {
                         match interrupt {
@@ -1788,19 +1797,21 @@ impl Driver {
     fn interrupts(&self) -> EnumSet<SpiInterrupt> {
         let mut res = EnumSet::new();
 
-        cfg_if::cfg_if! {
-            if #[cfg(esp32)] {
+        cfg_select! {
+            esp32 => {
                 if self.regs().slave().read().trans_done().bit() {
                     res.insert(SpiInterrupt::TransferDone);
                 }
-            } else if #[cfg(esp32s2)] {
+            }
+            esp32s2 => {
                 if self.regs().slave().read().trans_done().bit() {
                     res.insert(SpiInterrupt::TransferDone);
                 }
                 if self.regs().hold().read().dma_seg_trans_done().bit() {
                     res.insert(SpiInterrupt::DmaSegmentedTransferDone);
                 }
-            } else {
+            }
+            _ => {
                 let ints = self.regs().dma_int_raw().read();
 
                 if ints.trans_done().bit() {
@@ -1826,8 +1837,8 @@ impl Driver {
 
     /// Resets asserted interrupts
     fn clear_interrupts(&self, interrupts: EnumSet<SpiInterrupt>) {
-        cfg_if::cfg_if! {
-            if #[cfg(esp32)] {
+        cfg_select! {
+            esp32 => {
                 for interrupt in interrupts {
                     match interrupt {
                         SpiInterrupt::TransferDone => {
@@ -1835,7 +1846,8 @@ impl Driver {
                         }
                     }
                 }
-            } else if #[cfg(esp32s2)] {
+            }
+            esp32s2 => {
                 for interrupt in interrupts {
                     match interrupt {
                         SpiInterrupt::TransferDone => {
@@ -1849,7 +1861,8 @@ impl Driver {
                         }
                     }
                 }
-            } else {
+            }
+            _ => {
                 self.regs().dma_int_clr().write(|w| {
                     for interrupt in interrupts {
                         match interrupt {
@@ -1928,10 +1941,11 @@ impl Driver {
     }
 
     fn set_data_mode(&self, data_mode: Mode) {
-        cfg_if::cfg_if! {
-            if #[cfg(esp32)] {
+        cfg_select! {
+            esp32 => {
                 let pin_reg = self.regs().pin();
-            } else {
+            }
+            _ => {
                 let pin_reg = self.regs().misc();
             }
         };
@@ -2394,8 +2408,8 @@ impl Driver {
     }
 
     fn update(&self) {
-        cfg_if::cfg_if! {
-            if #[cfg(not(any(esp32, esp32s2)))] {
+        cfg_select! {
+            not(any(esp32, esp32s2)) => {
                 let reg_block = self.regs();
 
                 reg_block.cmd().modify(|_, w| w.update().set_bit());
@@ -2403,7 +2417,8 @@ impl Driver {
                 while reg_block.cmd().read().update().bit_is_set() {
                     // wait
                 }
-            } else {
+            }
+            _ => {
                 // Doesn't seem to be needed for ESP32 and ESP32-S2
             }
         }
@@ -2418,8 +2433,8 @@ impl Driver {
         let rx_len = rx_len.saturating_sub(1);
         let tx_len = tx_len.saturating_sub(1);
 
-        cfg_if::cfg_if! {
-            if #[cfg(esp32)] {
+        cfg_select! {
+            esp32 => {
                 let len = rx_len.max(tx_len);
                 reg_block
                     .mosi_dlen()
@@ -2428,7 +2443,8 @@ impl Driver {
                 reg_block
                     .miso_dlen()
                     .write(|w| unsafe { w.usr_miso_dbitlen().bits(len) });
-            } else if #[cfg(esp32s2)] {
+            }
+            esp32s2 => {
                 reg_block
                     .mosi_dlen()
                     .write(|w| unsafe { w.usr_mosi_dbitlen().bits(tx_len) });
@@ -2436,7 +2452,8 @@ impl Driver {
                 reg_block
                     .miso_dlen()
                     .write(|w| unsafe { w.usr_miso_dbitlen().bits(rx_len) });
-            } else {
+            }
+            _ => {
                 reg_block
                     .ms_dlen()
                     .write(|w| unsafe { w.ms_data_bitlen().bits(rx_len.max(tx_len)) });

--- a/esp-hal/src/spi/master/mod.rs
+++ b/esp-hal/src/spi/master/mod.rs
@@ -1372,13 +1372,13 @@ where
                     buffer = &addr_bytes[4 - bytes_to_write..][..bytes_to_write];
                     data_mode = address.mode();
                     address = Address::None;
-                }
+            }
 
                 if dummy > 0 {
                     // FIXME: https://github.com/esp-rs/esp-hal/issues/2240
                     error!("Dummy bits are not supported without data");
                     return Err(Error::Unsupported);
-                }
+            }
             }
 
             _ => {}
@@ -1801,34 +1801,34 @@ impl Driver {
             esp32 => {
                 if self.regs().slave().read().trans_done().bit() {
                     res.insert(SpiInterrupt::TransferDone);
-                }
+            }
             }
             esp32s2 => {
                 if self.regs().slave().read().trans_done().bit() {
                     res.insert(SpiInterrupt::TransferDone);
-                }
+            }
                 if self.regs().hold().read().dma_seg_trans_done().bit() {
                     res.insert(SpiInterrupt::DmaSegmentedTransferDone);
-                }
+            }
             }
             _ => {
                 let ints = self.regs().dma_int_raw().read();
 
                 if ints.trans_done().bit() {
                     res.insert(SpiInterrupt::TransferDone);
-                }
+            }
                 #[cfg(spi_master_has_dma_segmented_transfer)]
                 if ints.dma_seg_trans_done().bit() {
                     res.insert(SpiInterrupt::DmaSegmentedTransferDone);
-                }
+            }
                 #[cfg(spi_master_has_app_interrupts)]
                 if ints.app2().bit() {
                     res.insert(SpiInterrupt::App2);
-                }
+            }
                 #[cfg(spi_master_has_app_interrupts)]
                 if ints.app1().bit() {
                     res.insert(SpiInterrupt::App1);
-                }
+            }
             }
         }
 
@@ -1845,7 +1845,7 @@ impl Driver {
                             self.regs().slave().modify(|_, w| w.trans_done().clear_bit());
                         }
                     }
-                }
+            }
             }
             esp32s2 => {
                 for interrupt in interrupts {
@@ -1860,7 +1860,7 @@ impl Driver {
                                 .modify(|_, w| w.dma_seg_trans_done().clear_bit());
                         }
                     }
-                }
+            }
             }
             _ => {
                 self.regs().dma_int_clr().write(|w| {
@@ -2416,7 +2416,7 @@ impl Driver {
 
                 while reg_block.cmd().read().update().bit_is_set() {
                     // wait
-                }
+            }
             }
             _ => {
                 // Doesn't seem to be needed for ESP32 and ESP32-S2

--- a/esp-hal/src/spi/slave.rs
+++ b/esp-hal/src/spi/slave.rs
@@ -760,10 +760,11 @@ impl Info {
                 w.rsck_i_edge()
                     .bit(matches!(data_mode, Mode::_1 | Mode::_2))
             });
-            cfg_if::cfg_if! {
-                if #[cfg(esp32s2)] {
+            cfg_select! {
+                esp32s2 => {
                     let ctrl1_reg = self.regs().ctrl1();
-                } else {
+                }
+                _ => {
                     let ctrl1_reg = self.regs().slave();
                 }
             }

--- a/esp-hal/src/system.rs
+++ b/esp-hal/src/system.rs
@@ -2,12 +2,13 @@
 
 use esp_sync::NonReentrantMutex;
 
-cfg_if::cfg_if! {
-    if #[cfg(all(soc_multi_core_enabled, feature = "unstable"))] {
+cfg_select! {
+    all(soc_multi_core_enabled, feature = "unstable") => {
         pub(crate) mod multi_core;
         #[cfg(feature = "unstable")]
         pub use multi_core::*;
     }
+    _ => {}
 }
 
 // Implements the Peripheral enum based on esp-metadata/device.soc/peripheral_clocks
@@ -269,13 +270,14 @@ impl Cpu {
     #[inline(always)]
     #[instability::unstable]
     pub fn other() -> impl Iterator<Item = Self> {
-        cfg_if::cfg_if! {
-            if #[cfg(multi_core)] {
+        cfg_select! {
+            multi_core => {
                 match Self::current() {
                     Cpu::ProCpu => [Cpu::AppCpu].into_iter(),
                     Cpu::AppCpu => [Cpu::ProCpu].into_iter(),
                 }
-            } else {
+            }
+            _ => {
                 [].into_iter()
             }
         }
@@ -284,10 +286,11 @@ impl Cpu {
     /// Returns an iterator over all cores.
     #[inline(always)]
     pub fn all() -> impl Iterator<Item = Self> {
-        cfg_if::cfg_if! {
-            if #[cfg(multi_core)] {
+        cfg_select! {
+            multi_core => {
                 [Cpu::ProCpu, Cpu::AppCpu].into_iter()
-            } else {
+            }
+            _ => {
                 [Cpu::ProCpu].into_iter()
             }
         }
@@ -304,12 +307,14 @@ impl Cpu {
 #[inline(always)]
 pub(crate) fn raw_core() -> usize {
     // This method must never return UNUSED_THREAD_ID_VALUE
-    cfg_if::cfg_if! {
-        if #[cfg(all(multi_core, riscv))] {
+    cfg_select! {
+        all(multi_core, riscv) => {
             riscv::register::mhartid::read()
-        } else if #[cfg(all(multi_core, xtensa))] {
+        }
+        all(multi_core, xtensa) => {
             (xtensa_lx::get_processor_id() & 0x2000) as usize
-        } else {
+        }
+        _ => {
             0
         }
     }

--- a/esp-hal/src/system.rs
+++ b/esp-hal/src/system.rs
@@ -275,7 +275,7 @@ impl Cpu {
                 match Self::current() {
                     Cpu::ProCpu => [Cpu::AppCpu].into_iter(),
                     Cpu::AppCpu => [Cpu::ProCpu].into_iter(),
-                }
+            }
             }
             _ => {
                 [].into_iter()

--- a/esp-hal/src/system/multi_core.rs
+++ b/esp-hal/src/system/multi_core.rs
@@ -210,13 +210,14 @@ impl<'d> CpuControl<'d> {
         F: FnOnce(),
         F: Send + 'a,
     {
-        cfg_if::cfg_if! {
-            if #[cfg(all(stack_guard_monitoring))] {
+        cfg_select! {
+            all(stack_guard_monitoring) => {
                 let stack_guard_offset = Some(esp_config::esp_config_int!(
                     usize,
                     "ESP_HAL_CONFIG_STACK_GUARD_OFFSET"
                 ));
-            } else {
+            }
+            _ => {
                 let stack_guard_offset = None;
             }
         };

--- a/esp-hal/src/timer/systimer.rs
+++ b/esp-hal/src/timer/systimer.rs
@@ -95,13 +95,14 @@ pub struct SystemTimer<'d> {
 }
 
 impl<'d> SystemTimer<'d> {
-    cfg_if::cfg_if! {
-        if #[cfg(esp32s2)] {
+    cfg_select! {
+        esp32s2 => {
             /// Bitmask to be applied to the raw register value.
             pub const BIT_MASK: u64 = u64::MAX;
             // Bitmask to be applied to the raw period register value.
             const PERIOD_MASK: u64 = 0x1FFF_FFFF;
-        } else {
+        }
+        _ => {
             /// Bitmask to be applied to the raw register value.
             pub const BIT_MASK: u64 = 0xF_FFFF_FFFF_FFFF;
             // Bitmask to be applied to the raw period register value.
@@ -195,20 +196,23 @@ impl<'d> SystemTimer<'d> {
     pub fn ticks_per_second() -> u64 {
         // FIXME: this requires a critical section. We can probably do better, if we can formulate
         // invariants well.
-        cfg_if::cfg_if! {
-            if #[cfg(esp32c5)] {
+        cfg_select! {
+            esp32c5 => {
                 // Assuming SYSTIMER runs from XTAL, the hardware always runs at 16 MHz.
                 16_000_000
-            } else {
+            }
+            _ => {
                 crate::soc::clocks::ClockTree::with(|clocks| {
-                    cfg_if::cfg_if! {
-                        if #[cfg(esp32s2)] {
+                    cfg_select! {
+                        esp32s2 => {
                             crate::soc::clocks::apb_clk_frequency(clocks) as u64
-                        } else if #[cfg(esp32h2)] {
+                        }
+                        esp32h2 => {
                             // The counters and comparators are driven using `XTAL_CLK`.
                             // The average clock frequency is fXTAL_CLK/2, (16 MHz for XTAL = 32 MHz)
                             (crate::soc::clocks::xtal_clk_frequency(clocks) / 2) as u64
-                        } else {
+                        }
+                        _ => {
                             // The counters and comparators are driven using `XTAL_CLK`.
                             // The average clock frequency is fXTAL_CLK/2.5 (16 MHz for XTAL = 40 MHz)
                             (crate::soc::clocks::xtal_clk_frequency(clocks) * 10 / 25) as u64

--- a/esp-hal/src/timer/timg.rs
+++ b/esp-hal/src/timer/timg.rs
@@ -88,14 +88,16 @@ use crate::{
 
 const NUM_TIMG: usize = 1 + cfg!(timergroup_timg1) as usize;
 
-cfg_if::cfg_if! {
+cfg_select! {
     // We need no locks when a TIMG has a single timer, and we don't need locks for ESP32
     // and S2 where the effective interrupt enable register (config) is not shared between
     // the timers.
-    if #[cfg(all(timergroup_timg_has_timer1, not(any(esp32, esp32s2))))] {
+    all(timergroup_timg_has_timer1, not(any(esp32, esp32s2))) => {
         use esp_sync::RawMutex;
         static INT_ENA_LOCK: [RawMutex; NUM_TIMG] = [const { RawMutex::new() }; NUM_TIMG];
     }
+
+    _ => {}
 }
 
 #[procmacros::doc_replace(
@@ -423,8 +425,8 @@ impl Timer<'_> {
 
     fn source_frequency(&self) -> Rate {
         let hz = clocks::ClockTree::with(|clocks| {
-            cfg_if::cfg_if! {
-                if #[cfg(soc_has_clock_node_timg_function_clock)] {
+            cfg_select! {
+                soc_has_clock_node_timg_function_clock => {
                     let timg = match self.timer_group() {
                         0 => crate::soc::clocks::TimgInstance::Timg0,
                         #[cfg(soc_has_timg1)]
@@ -433,7 +435,8 @@ impl Timer<'_> {
                     };
 
                     timg.function_clock_frequency(clocks)
-                } else {
+                }
+                _ => {
                     crate::soc::clocks::apb_clk_frequency(clocks)
                 }
             }
@@ -515,21 +518,23 @@ impl Timer<'_> {
     }
 
     fn set_interrupt_enabled(&self, state: bool) {
-        cfg_if::cfg_if! {
-            if #[cfg(any(esp32, esp32s2))] {
+        cfg_select! {
+            any(esp32, esp32s2) => {
                 // On ESP32 and S2, the `int_ena` register is ineffective - interrupts fire even
                 // without int_ena enabling them. We use level interrupts so that we have a status
                 // bit available.
                 self.t()
                     .config()
                     .modify(|_, w| w.level_int_en().bit(state));
-            } else if #[cfg(timergroup_timg_has_timer1)] {
+            }
+            timergroup_timg_has_timer1 => {
                 INT_ENA_LOCK[self.timer_group() as usize].lock(|| {
                     self.register_block()
                         .int_ena()
                         .modify(|_, w| w.t(self.timer_number()).bit(state));
                 });
-            } else {
+            }
+            _ => {
                 self.register_block()
                     .int_ena()
                     .modify(|_, w| w.t(0).bit(state));
@@ -691,10 +696,11 @@ where
     /// Set the timeout, in microseconds, of the watchdog timer
     pub fn set_timeout(&mut self, stage: MwdtStage, timeout: Duration) {
         let clk_src = clocks::ClockTree::with(|clocks| {
-            cfg_if::cfg_if! {
-                if #[cfg(soc_has_clock_node_timg_wdt_clock)] {
+            cfg_select! {
+                soc_has_clock_node_timg_wdt_clock => {
                     Rate::from_hz(TG::clock_instance().wdt_clock_frequency(clocks))
-                } else {
+                }
+                _ => {
                     Rate::from_hz(clocks::apb_clk_frequency(clocks))
                 }
             }

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -1498,20 +1498,22 @@ impl PrivateInstance for crate::peripherals::TWAI0<'_> {
     }
 
     fn input_signal(&self) -> InputSignal {
-        cfg_if::cfg_if! {
-            if #[cfg(any(esp32, esp32c3, esp32s2, esp32s3))] {
+        cfg_select! {
+            any(esp32, esp32c3, esp32s2, esp32s3) => {
                 InputSignal::TWAI_RX
-            } else {
+            }
+            _ => {
                 InputSignal::TWAI0_RX
             }
         }
     }
 
     fn output_signal(&self) -> OutputSignal {
-        cfg_if::cfg_if! {
-            if #[cfg(any(esp32, esp32c3, esp32s2, esp32s3))] {
+        cfg_select! {
+            any(esp32, esp32c3, esp32s2, esp32s3) => {
                 OutputSignal::TWAI_TX
-            } else {
+            }
+            _ => {
                 OutputSignal::TWAI0_TX
             }
         }

--- a/esp-hal/src/uart/mod.rs
+++ b/esp-hal/src/uart/mod.rs
@@ -942,10 +942,11 @@ where
 fn sync_regs(_register_block: &RegisterBlock) {
     #[cfg(not(any(esp32, esp32s2)))]
     {
-        cfg_if::cfg_if! {
-            if #[cfg(any(esp32c2, esp32c3, esp32s3))] {
+        cfg_select! {
+            any(esp32c2, esp32c3, esp32s3) => {
                 let update_reg = _register_block.id();
-            } else {
+            }
+            _ => {
                 let update_reg = _register_block.reg_update();
             }
         }
@@ -1099,10 +1100,11 @@ impl<'d> UartRx<'d, Async> {
                 events |= RxEvent::CmdCharDetected;
             }
 
-            cfg_if::cfg_if! {
-                if #[cfg(any(esp32c5, esp32c6, esp32c61, esp32h2))] {
+            cfg_select! {
+                any(esp32c5, esp32c6, esp32c61, esp32h2) => {
                     let reg_en = self.regs().tout_conf();
-                } else {
+                }
+                _ => {
                     let reg_en = self.regs().conf1();
                 }
             };
@@ -3281,10 +3283,11 @@ impl Info {
     /// - `esp32c2`, `esp32c3`, `esp32c6`, `esp32h2`, esp32s2`, esp32s3`: The value you pass times
     ///   the symbol size must be <= **0x3FF**
     fn set_rx_timeout(&self, timeout: Option<u8>, _symbol_len: u8) -> Result<(), ConfigError> {
-        cfg_if::cfg_if! {
-            if #[cfg(esp32)] {
+        cfg_select! {
+            esp32 => {
                 const MAX_THRHD: u8 = 0x7F; // 7 bits
-            } else {
+            }
+            _ => {
                 const MAX_THRHD: u16 = 0x3FF; // 10 bits
             }
         }
@@ -3303,22 +3306,25 @@ impl Info {
                 return Err(ConfigError::TimeoutTooLong);
             }
 
-            cfg_if::cfg_if! {
-                if #[cfg(esp32)] {
+            cfg_select! {
+                esp32 => {
                     let reg_thrhd = register_block.conf1();
-                } else if #[cfg(any(esp32c5, esp32c6, esp32c61, esp32h2))] {
+                }
+                any(esp32c5, esp32c6, esp32c61, esp32h2) => {
                     let reg_thrhd = register_block.tout_conf();
-                } else {
+                }
+                _ => {
                     let reg_thrhd = register_block.mem_conf();
                 }
             }
             reg_thrhd.modify(|_, w| unsafe { w.rx_tout_thrhd().bits(timeout_reg) });
         }
 
-        cfg_if::cfg_if! {
-            if #[cfg(any(esp32c5, esp32c6, esp32c61, esp32h2))] {
+        cfg_select! {
+            any(esp32c5, esp32c6, esp32c61, esp32h2) => {
                 let reg_en = register_block.tout_conf();
-            } else {
+            }
+            _ => {
                 let reg_en = register_block.conf1();
             }
         }
@@ -3356,15 +3362,16 @@ impl Info {
 
             // TODO: this block should only prepare the new clock config, and it should
             // be applied only after validating the resulting baud rate.
-            cfg_if::cfg_if! {
-                if #[cfg(any(uart_has_sclk_divider, soc_has_pcr))] {
+            cfg_select! {
+                any(uart_has_sclk_divider, soc_has_pcr) => {
                     const MAX_DIV: u32 = property!("clock_tree.uart.baud_rate_generator.integral").1;
                     let clk_div = clk.div_ceil(MAX_DIV).div_ceil(config.baudrate);
                     debug!("SCLK: {} divider: {}", clk, clk_div);
 
                     let conf = ClockConfig::new(config.clock_source, clk_div - 1);
                     let divider = (clk << FRAC_BITS) / (config.baudrate * clk_div);
-                } else {
+                }
+                _ => {
                     debug!("SCLK: {}", clk);
                     let conf = ClockConfig::new(config.clock_source);
                     let divider = (clk << FRAC_BITS) / config.baudrate;
@@ -3458,16 +3465,18 @@ impl Info {
                 xon_threshold,
                 xoff_threshold,
             } => {
-                cfg_if::cfg_if! {
-                    if #[cfg(any(esp32c5, esp32c6, esp32c61, esp32h2))] {
+                cfg_select! {
+                    any(esp32c5, esp32c6, esp32c61, esp32h2) => {
                         self.regs().swfc_conf0().modify(|_, w| w.xonoff_del().set_bit().sw_flow_con_en().set_bit());
                         self.regs().swfc_conf1().modify(|_, w| unsafe { w.xon_threshold().bits(xon_threshold).xoff_threshold().bits(xoff_threshold)});
                         self.regs().swfc_conf0().modify(|_, w| unsafe { w.xon_char().bits(xon_char).xoff_char().bits(xoff_char) });
-                    } else if #[cfg(esp32)]{
+                    }
+                    esp32 => {
                         self.regs().flow_conf().modify(|_, w| w.xonoff_del().set_bit().sw_flow_con_en().set_bit());
                         self.regs().swfc_conf().modify(|_, w| unsafe { w.xon_threshold().bits(xon_threshold).xoff_threshold().bits(xoff_threshold) });
                         self.regs().swfc_conf().modify(|_, w| unsafe { w.xon_char().bits(xon_char).xoff_char().bits(xoff_char) });
-                    } else {
+                    }
+                    _ => {
                         self.regs().flow_conf().modify(|_, w| w.xonoff_del().set_bit().sw_flow_con_en().set_bit());
                         self.regs().swfc_conf1().modify(|_, w| unsafe { w.xon_threshold().bits(xon_threshold as u16) });
                         self.regs().swfc_conf0().modify(|_, w| unsafe { w.xoff_threshold().bits(xoff_threshold as u16) });
@@ -3477,10 +3486,11 @@ impl Info {
                 }
             }
             SwFlowControl::Disabled => {
-                cfg_if::cfg_if! {
-                    if #[cfg(any(esp32c5, esp32c6, esp32c61, esp32h2))] {
+                cfg_select! {
+                    any(esp32c5, esp32c6, esp32c61, esp32h2) => {
                         let reg = self.regs().swfc_conf0();
-                    } else {
+                    }
+                    _ => {
                         let reg = self.regs().flow_conf();
                     }
                 }
@@ -3505,23 +3515,26 @@ impl Info {
 
     fn configure_rts_flow_ctrl(&self, enable: bool, threshold: Option<u8>) {
         if let Some(threshold) = threshold {
-            cfg_if::cfg_if! {
-                if #[cfg(esp32)] {
+            cfg_select! {
+                esp32 => {
                     self.regs().conf1().modify(|_, w| unsafe { w.rx_flow_thrhd().bits(threshold) });
-                } else if #[cfg(any(esp32c5, esp32c6, esp32c61, esp32h2))] {
+                }
+                any(esp32c5, esp32c6, esp32c61, esp32h2) => {
                     self.regs().hwfc_conf().modify(|_, w| unsafe { w.rx_flow_thrhd().bits(threshold) });
-                } else {
+                }
+                _ => {
                     self.regs().mem_conf().modify(|_, w| unsafe { w.rx_flow_thrhd().bits(threshold as u16) });
                 }
             }
         }
 
-        cfg_if::cfg_if! {
-            if #[cfg(any(esp32c5, esp32c6, esp32c61, esp32h2))] {
+        cfg_select! {
+            any(esp32c5, esp32c6, esp32c61, esp32h2) => {
                 self.regs().hwfc_conf().modify(|_, w| {
                     w.rx_flow_en().bit(enable)
                 });
-            } else {
+            }
+            _ => {
                 self.regs().conf1().modify(|_, w| {
                     w.rx_flow_en().bit(enable)
                 });
@@ -3576,23 +3589,26 @@ impl Info {
     fn read_next_from_fifo(&self) -> u8 {
         fn access_fifo_register<R>(f: impl Fn() -> R) -> R {
             // https://docs.espressif.com/projects/esp-chip-errata/en/latest/esp32/03-errata-description/esp32/cpu-subsequent-access-halted-when-get-interrupted.html
-            cfg_if::cfg_if! {
-                if #[cfg(esp32)] {
+            cfg_select! {
+                esp32 => {
                     crate::interrupt::free(f)
-                } else {
+                }
+                _ => {
                     f()
                 }
             }
         }
 
         let fifo_reg = self.regs().fifo();
-        cfg_if::cfg_if! {
-            if #[cfg(esp32s2)] {
+        cfg_select! {
+            esp32s2 => {
                 // On the ESP32-S2 we need to use PeriBus2 to read the FIFO:
                 let fifo_reg = unsafe {
                     &*fifo_reg.as_ptr().cast::<u8>().add(0x20C00000).cast::<crate::pac::uart0::FIFO>()
                 };
             }
+
+            _ => {}
         }
 
         access_fifo_register(|| fifo_reg.read().rxfifo_rd_byte().bits())

--- a/esp-hal/src/uart/uhci.rs
+++ b/esp-hal/src/uart/uhci.rs
@@ -314,8 +314,8 @@ where
         for_each_uart! {
             (all $( ($id:literal, $peri:ident, $variant:ident, $($pins:ident),*) ),*) => {
                 reg.conf0().modify(|_, w| {
-                    cfg_if::cfg_if! {
-                        if #[cfg(uhci_combined_uart_selector_field)] {
+                    cfg_select! {
+                        uhci_combined_uart_selector_field => {
                             unsafe {
                                 w.uart_sel().bits(
                                     match &self.uart.tx.uart.0 {
@@ -326,7 +326,8 @@ where
                                     }
                                 )
                             }
-                        } else {
+                        }
+                        _ => {
                             paste::paste! {
                                 // Clear any previous selection
                                 $(

--- a/esp-hal/src/uart/uhci.rs
+++ b/esp-hal/src/uart/uhci.rs
@@ -325,7 +325,7 @@ where
                                         })*
                                     }
                                 )
-                            }
+                        }
                         }
                         _ => {
                             paste::paste! {
@@ -341,7 +341,7 @@ where
                                         w.[< $peri:lower _ce >]().set_bit()
                                     })*
                                 }
-                            }
+                        }
                         }
                     }
                 });

--- a/esp-lp-hal/Cargo.toml
+++ b/esp-lp-hal/Cargo.toml
@@ -2,7 +2,7 @@
 name          = "esp-lp-hal"
 version       = "0.3.0"
 edition       = "2024"
-rust-version  = "1.88.0"
+rust-version  = "1.95.0"
 description   = "HAL for low-power RISC-V coprocessors found in ESP32 devices"
 documentation = "https://docs.espressif.com/projects/rust/esp-lp-hal/latest/"
 keywords      = ["embedded", "embedded-hal", "esp32", "espressif", "hal"]
@@ -35,7 +35,6 @@ bench = false
 test  = false
 
 [dependencies]
-cfg-if            = "1"
 document-features = "0.2"
 embedded-hal      = { version = "1.0.0",  optional = true }
 embedded-hal-nb   = { version = "1.0.0",  optional = true }

--- a/esp-lp-hal/examples/blinky.rs
+++ b/esp-lp-hal/examples/blinky.rs
@@ -14,12 +14,15 @@ use embedded_hal::{delay::DelayNs, digital::OutputPin};
 use esp_lp_hal::{delay::Delay, gpio::Output, prelude::*};
 use panic_halt as _;
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "esp32c6")] {
+cfg_select! {
+    feature = "esp32c6" => {
         const ADDRESS: u32 = 0x5000_2000;
-    } else if #[cfg(any(feature = "esp32s2", feature = "esp32s3"))] {
+    }
+    any(feature = "esp32s2", feature = "esp32s3") => {
         const ADDRESS: u32 = 0x400;
     }
+
+    _ => {}
 }
 
 #[entry]

--- a/esp-lp-hal/src/gpio.rs
+++ b/esp-lp-hal/src/gpio.rs
@@ -23,11 +23,12 @@
 //! }
 //! ```
 
-cfg_if::cfg_if! {
-    if #[cfg(esp32c6)] {
+cfg_select! {
+    esp32c6 => {
         type LpIo = crate::pac::LP_IO;
         const MAX_GPIO_PIN: u8 = 7;
-    } else {
+    }
+    _ => {
         type LpIo = crate::pac::RTC_IO;
         const MAX_GPIO_PIN: u8 = 21;
     }
@@ -103,14 +104,18 @@ impl<const PIN: u8> Flex<PIN> {
 
     /// Get the current pin input level.
     pub fn level(&self) -> Level {
-        cfg_if::cfg_if! {
-            if #[cfg(esp32c6)] {
+        cfg_select! {
+            esp32c6 => {
                 ((unsafe { &*LpIo::PTR }.in_().read().bits() >> PIN) & 0x1 != 0).into()
-            } else if #[cfg(esp32s2)] {
+            }
+            esp32s2 => {
                 ((unsafe { &*LpIo::PTR }.in_().read().gpio_in_next().bits() >> PIN) & 0x1 != 0).into()
-            } else if #[cfg(esp32s3)] {
+            }
+            esp32s3 => {
                 ((unsafe { &*LpIo::PTR }.in_().read().next().bits() >> PIN) & 0x1 != 0).into()
             }
+
+            _ => {}
         }
     }
 
@@ -131,14 +136,18 @@ impl<const PIN: u8> Flex<PIN> {
 
     /// What level output is set to
     pub fn output_level(&self) -> Level {
-        cfg_if::cfg_if! {
-            if #[cfg(esp32c6)] {
+        cfg_select! {
+            esp32c6 => {
                 ((unsafe { &*LpIo::PTR }.out().read().bits() >> PIN) & 0x1 != 0).into()
-            } else if #[cfg(esp32s2)] {
+            }
+            esp32s2 => {
                 ((unsafe { &*LpIo::PTR }.out().read().gpio_out_data().bits() >> PIN) & 0x1 != 0).into()
-            } else if #[cfg(esp32s3)] {
+            }
+            esp32s3 => {
                 ((unsafe { &*LpIo::PTR }.out().read().data().bits() >> PIN) & 0x1 != 0).into()
             }
+
+            _ => {}
         }
     }
 

--- a/esp-lp-hal/src/gpio.rs
+++ b/esp-lp-hal/src/gpio.rs
@@ -114,8 +114,6 @@ impl<const PIN: u8> Flex<PIN> {
             esp32s3 => {
                 ((unsafe { &*LpIo::PTR }.in_().read().next().bits() >> PIN) & 0x1 != 0).into()
             }
-
-            _ => {}
         }
     }
 
@@ -146,8 +144,6 @@ impl<const PIN: u8> Flex<PIN> {
             esp32s3 => {
                 ((unsafe { &*LpIo::PTR }.out().read().data().bits() >> PIN) & 0x1 != 0).into()
             }
-
-            _ => {}
         }
     }
 

--- a/esp-lp-hal/src/lib.rs
+++ b/esp-lp-hal/src/lib.rs
@@ -43,16 +43,20 @@ pub mod prelude {
     pub use procmacros::entry;
 }
 
-cfg_if::cfg_if! {
-    if #[cfg(esp32c6)] {
+cfg_select! {
+    esp32c6 => {
         // LP_FAST_CLK is not very accurate, for now use a rough estimate
         const LP_FAST_CLK_HZ: u32 = 16_000_000;
         const XTAL_D2_CLK_HZ: u32 = 20_000_000;
-    } else if #[cfg(esp32s2)] {
+    }
+    esp32s2 => {
         const LP_FAST_CLK_HZ: u32 = 8_000_000;
-    } else if #[cfg(esp32s3)] {
+    }
+    esp32s3 => {
         const LP_FAST_CLK_HZ: u32 = 17_500_000;
     }
+
+    _ => {}
 }
 
 pub(crate) static mut CPU_CLOCK: u32 = LP_FAST_CLK_HZ;

--- a/esp-metadata-generated/Cargo.toml
+++ b/esp-metadata-generated/Cargo.toml
@@ -2,7 +2,7 @@
 name          = "esp-metadata-generated"
 version       = "0.4.0"
 edition       = "2024"
-rust-version  = "1.88.0"
+rust-version  = "1.95.0"
 description   = "Generated metadata for Espressif devices"
 documentation = "https://docs.espressif.com/projects/rust/esp-metadata-generated/latest/"
 repository    = "https://github.com/esp-rs/esp-hal"

--- a/esp-metadata-generated/Cargo.toml
+++ b/esp-metadata-generated/Cargo.toml
@@ -2,7 +2,7 @@
 name          = "esp-metadata-generated"
 version       = "0.4.0"
 edition       = "2024"
-rust-version  = "1.95.0"
+rust-version  = "1.88.0"
 description   = "Generated metadata for Espressif devices"
 documentation = "https://docs.espressif.com/projects/rust/esp-metadata-generated/latest/"
 repository    = "https://github.com/esp-rs/esp-hal"

--- a/esp-metadata/Cargo.toml
+++ b/esp-metadata/Cargo.toml
@@ -2,7 +2,7 @@
 name          = "esp-metadata"
 version       = "0.10.1"
 edition       = "2024"
-rust-version  = "1.88.0"
+rust-version  = "1.95.0"
 description   = "Metadata for Espressif devices"
 documentation = "https://docs.espressif.com/projects/rust/esp-metadata/latest/"
 repository    = "https://github.com/esp-rs/esp-hal"

--- a/esp-metadata/Cargo.toml
+++ b/esp-metadata/Cargo.toml
@@ -2,7 +2,7 @@
 name          = "esp-metadata"
 version       = "0.10.1"
 edition       = "2024"
-rust-version  = "1.95.0"
+rust-version  = "1.88.0"
 description   = "Metadata for Espressif devices"
 documentation = "https://docs.espressif.com/projects/rust/esp-metadata/latest/"
 repository    = "https://github.com/esp-rs/esp-hal"

--- a/esp-phy/Cargo.toml
+++ b/esp-phy/Cargo.toml
@@ -26,8 +26,6 @@ features       = ["esp32c6"]
 bench = false
 
 [dependencies]
-cfg-if = "1"
-
 document-features = "0.2"
 esp-hal = { version = "~1.1.0", path = "../esp-hal", default-features = false }
 esp-metadata-generated = { version = "0.4.0", path = "../esp-metadata-generated" }

--- a/esp-phy/src/fmt.rs
+++ b/esp-phy/src/fmt.rs
@@ -7,10 +7,11 @@ use core::fmt::{Debug, Display, LowerHex};
 macro_rules! assert {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::assert!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::assert!($($x)*);
                 }
             }
@@ -22,10 +23,11 @@ macro_rules! assert {
 macro_rules! assert_eq {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::assert_eq!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::assert_eq!($($x)*);
                 }
             }
@@ -37,10 +39,11 @@ macro_rules! assert_eq {
 macro_rules! assert_ne {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::assert_ne!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::assert_ne!($($x)*);
                 }
             }
@@ -52,10 +55,11 @@ macro_rules! assert_ne {
 macro_rules! debug_assert {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::debug_assert!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::debug_assert!($($x)*);
                 }
             }
@@ -67,10 +71,11 @@ macro_rules! debug_assert {
 macro_rules! debug_assert_eq {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::debug_assert_eq!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::debug_assert_eq!($($x)*);
                 }
             }
@@ -82,10 +87,11 @@ macro_rules! debug_assert_eq {
 macro_rules! debug_assert_ne {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::debug_assert_ne!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::debug_assert_ne!($($x)*);
                 }
             }
@@ -97,10 +103,11 @@ macro_rules! debug_assert_ne {
 macro_rules! todo {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::todo!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::todo!($($x)*);
                 }
             }
@@ -112,10 +119,11 @@ macro_rules! todo {
 macro_rules! unreachable {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::unreachable!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::unreachable!($($x)*);
                 }
             }
@@ -127,10 +135,11 @@ macro_rules! unreachable {
 macro_rules! panic {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::panic!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::panic!($($x)*);
                 }
             }
@@ -142,12 +151,14 @@ macro_rules! panic {
 macro_rules! trace {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::trace!($s $(, $x)*);
-                } else if #[cfg(feature = "log-04")] {
+                }
+                feature = "log-04" => {
                     ::log_04::trace!($s $(, $x)*);
-                } else {
+                }
+                _ => {
                     let _ = ($( & $x ),*);
                 }
             }
@@ -159,12 +170,14 @@ macro_rules! trace {
 macro_rules! debug {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::debug!($s $(, $x)*);
-                } else if #[cfg(feature = "log-04")] {
+                }
+                feature = "log-04" => {
                     ::log_04::debug!($s $(, $x)*);
-                } else {
+                }
+                _ => {
                     let _ = ($( & $x ),*);
                 }
             }
@@ -176,12 +189,14 @@ macro_rules! debug {
 macro_rules! info {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::info!($s $(, $x)*);
-                } else if #[cfg(feature = "log-04")] {
+                }
+                feature = "log-04" => {
                     ::log_04::info!($s $(, $x)*);
-                } else {
+                }
+                _ => {
                     let _ = ($( & $x ),*);
                 }
             }
@@ -193,12 +208,14 @@ macro_rules! info {
 macro_rules! warn {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::warn!($s $(, $x)*);
-                } else if #[cfg(feature = "log-04")] {
+                }
+                feature = "log-04" => {
                     ::log_04::warn!($s $(, $x)*);
-                } else {
+                }
+                _ => {
                     let _ = ($( & $x ),*);
                 }
             }
@@ -210,12 +227,14 @@ macro_rules! warn {
 macro_rules! error {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::error!($s $(, $x)*);
-                } else if #[cfg(feature = "log-04")] {
+                }
+                feature = "log-04" => {
                     ::log_04::error!($s $(, $x)*);
-                } else {
+                }
+                _ => {
                     let _ = ($( & $x ),*);
                 }
             }

--- a/esp-println/Cargo.toml
+++ b/esp-println/Cargo.toml
@@ -2,7 +2,7 @@
 name          = "esp-println"
 version       = "0.17.0"
 edition       = "2024"
-rust-version  = "1.88.0"
+rust-version  = "1.95.0"
 description   = "Provides `print!` and `println!` implementations for various Espressif devices"
 documentation = "https://docs.espressif.com/projects/rust/esp-println/latest/"
 keywords      = ["defmt", "embedded", "esp32", "espressif", "logging"]

--- a/esp-radio-rtos-driver/Cargo.toml
+++ b/esp-radio-rtos-driver/Cargo.toml
@@ -2,7 +2,7 @@
 name          = "esp-radio-rtos-driver"
 version       = "0.3.0"
 edition       = "2024"
-rust-version  = "1.88.0"
+rust-version  = "1.95.0"
 description   = "Task scheduler interface for esp-radio"
 documentation = "https://docs.espressif.com/projects/rust/esp-radio-rtos-driver/latest/"
 keywords      = ["esp32", "espressif", "no-std"]
@@ -24,7 +24,6 @@ portable-atomic = { version = "1", features = ["unsafe-assume-single-core"] }
 
 [dependencies]
 esp-sync = { version = "0.2.1", path = "../esp-sync", optional = true }
-cfg-if = "1"
 
 # Logging interfaces, they are mutually exclusive so they need to be behind separate features.
 defmt  = { version = "1.0", optional = true }

--- a/esp-radio-rtos-driver/src/fmt.rs
+++ b/esp-radio-rtos-driver/src/fmt.rs
@@ -7,10 +7,11 @@ use core::fmt::{Debug, Display, LowerHex};
 macro_rules! assert {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::assert!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::assert!($($x)*);
                 }
             }
@@ -22,10 +23,11 @@ macro_rules! assert {
 macro_rules! assert_eq {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::assert_eq!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::assert_eq!($($x)*);
                 }
             }
@@ -37,10 +39,11 @@ macro_rules! assert_eq {
 macro_rules! assert_ne {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::assert_ne!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::assert_ne!($($x)*);
                 }
             }
@@ -52,10 +55,11 @@ macro_rules! assert_ne {
 macro_rules! debug_assert {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::debug_assert!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::debug_assert!($($x)*);
                 }
             }
@@ -67,10 +71,11 @@ macro_rules! debug_assert {
 macro_rules! debug_assert_eq {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::debug_assert_eq!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::debug_assert_eq!($($x)*);
                 }
             }
@@ -82,10 +87,11 @@ macro_rules! debug_assert_eq {
 macro_rules! debug_assert_ne {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::debug_assert_ne!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::debug_assert_ne!($($x)*);
                 }
             }
@@ -97,10 +103,11 @@ macro_rules! debug_assert_ne {
 macro_rules! todo {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::todo!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::todo!($($x)*);
                 }
             }
@@ -112,10 +119,11 @@ macro_rules! todo {
 macro_rules! unreachable {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::unreachable!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::unreachable!($($x)*);
                 }
             }
@@ -127,10 +135,11 @@ macro_rules! unreachable {
 macro_rules! panic {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::panic!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::panic!($($x)*);
                 }
             }
@@ -142,12 +151,14 @@ macro_rules! panic {
 macro_rules! trace {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::trace!($s $(, $x)*);
-                } else if #[cfg(feature = "log-04")] {
+                }
+                feature = "log-04" => {
                     ::log_04::trace!($s $(, $x)*);
-                } else {
+                }
+                _ => {
                     let _ = ($( & $x ),*);
                 }
             }
@@ -159,12 +170,14 @@ macro_rules! trace {
 macro_rules! debug {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::debug!($s $(, $x)*);
-                } else if #[cfg(feature = "log-04")] {
+                }
+                feature = "log-04" => {
                     ::log_04::debug!($s $(, $x)*);
-                } else {
+                }
+                _ => {
                     let _ = ($( & $x ),*);
                 }
             }
@@ -176,12 +189,14 @@ macro_rules! debug {
 macro_rules! info {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::info!($s $(, $x)*);
-                } else if #[cfg(feature = "log-04")] {
+                }
+                feature = "log-04" => {
                     ::log_04::info!($s $(, $x)*);
-                } else {
+                }
+                _ => {
                     let _ = ($( & $x ),*);
                 }
             }
@@ -193,12 +208,14 @@ macro_rules! info {
 macro_rules! warn {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::warn!($s $(, $x)*);
-                } else if #[cfg(feature = "log-04")] {
+                }
+                feature = "log-04" => {
                     ::log_04::warn!($s $(, $x)*);
-                } else {
+                }
+                _ => {
                     let _ = ($( & $x ),*);
                 }
             }
@@ -210,12 +227,14 @@ macro_rules! warn {
 macro_rules! error {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::error!($s $(, $x)*);
-                } else if #[cfg(feature = "log-04")] {
+                }
+                feature = "log-04" => {
                     ::log_04::error!($s $(, $x)*);
-                } else {
+                }
+                _ => {
                     let _ = ($( & $x ),*);
                 }
             }

--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -2,7 +2,7 @@
 name = "esp-radio"
 version = "0.18.0"
 edition = "2024"
-rust-version  = "1.88.0"
+rust-version  = "1.95.0"
 description = "A WiFi, Bluetooth and ESP-NOW driver for use with Espressif chips and bare-metal Rust"
 documentation = "https://docs.espressif.com/projects/rust/esp-radio/latest/"
 keywords = ["wifi", "bluetooth", "esp-now", "esp32", "no-std"]
@@ -43,7 +43,6 @@ bench = false
 test  = false
 
 [dependencies]
-cfg-if  = "1"
 esp-hal = { version = "~1.1.0", path = "../esp-hal", default-features = false }
 portable-atomic = { version = "1.11", default-features = false }
 enumset = { version = "1.1", default-features = false, optional = true }

--- a/esp-radio/README.md
+++ b/esp-radio/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/esp-radio?labelColor=1C2C2E&color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/esp-radio)
 [![docs.rs](https://img.shields.io/docsrs/esp-radio?labelColor=1C2C2E&color=C96329&logo=rust&style=flat-square)](https://docs.espressif.com/projects/rust/esp-radio/latest/)
-![MSRV](https://img.shields.io/badge/MSRV-1.88.0-blue?labelColor=1C2C2E&style=flat-square)
+![MSRV](https://img.shields.io/badge/MSRV-1.95.0-blue?labelColor=1C2C2E&style=flat-square)
 ![Crates.io](https://img.shields.io/crates/l/esp-radio?labelColor=1C2C2E&style=flat-square)
 [![Matrix](https://img.shields.io/matrix/esp-rs:matrix.org?label=join%20matrix&labelColor=1C2C2E&color=BEC5C9&logo=matrix&style=flat-square)](https://matrix.to/#/#esp-rs:matrix.org)
 

--- a/esp-radio/src/ble/btdm.rs
+++ b/esp-radio/src/ble/btdm.rs
@@ -352,15 +352,16 @@ pub(crate) fn ble_init(config: &Config) -> PhyInitGuard<'static> {
 
         phy_init_guard = esp_phy::enable_phy();
 
-        cfg_if::cfg_if! {
-            if #[cfg(esp32)] {
+        cfg_select! {
+            esp32 => {
                 unsafe extern "C" {
                     fn btdm_rf_bb_init_phase2();
                 }
 
                 btdm_rf_bb_init_phase2();
                 coex_bt_high_prio();
-            } else {
+            }
+            _ => {
                 coex_pti_v2();
             }
         }

--- a/esp-radio/src/ble/btdm.rs
+++ b/esp-radio/src/ble/btdm.rs
@@ -356,7 +356,7 @@ pub(crate) fn ble_init(config: &Config) -> PhyInitGuard<'static> {
             esp32 => {
                 unsafe extern "C" {
                     fn btdm_rf_bb_init_phase2();
-                }
+            }
 
                 btdm_rf_bb_init_phase2();
                 coex_bt_high_prio();

--- a/esp-radio/src/ble/os_adapter_esp32.rs
+++ b/esp-radio/src/ble/os_adapter_esp32.rs
@@ -513,14 +513,15 @@ pub(crate) unsafe extern "C" fn coex_schm_register_btdm_callback_wrapper(
 ) -> i32 {
     trace!("coex_schm_register_btdm_callback {:?}", callback);
 
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "coex")] {
+    cfg_select! {
+        feature = "coex" => {
             unsafe extern "C" {
                 fn coex_schm_register_callback(kind: u32, callback: unsafe extern "C" fn()) -> i32;
             }
             const COEX_SCHM_CALLBACK_TYPE_BT: u32 = 1;
             unsafe { coex_schm_register_callback(COEX_SCHM_CALLBACK_TYPE_BT, callback) }
-        } else {
+        }
+        _ => {
             0
         }
     }
@@ -533,13 +534,14 @@ pub(crate) unsafe extern "C" fn coex_wifi_channel_get(
 ) -> i32 {
     trace!("coex_wifi_channel_get");
 
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "coex")] {
+    cfg_select! {
+        feature = "coex" => {
             unsafe extern "C" {
                 fn coex_wifi_channel_get(_primary: *mut u8, _secondary: *mut u8) -> i32;
             }
             unsafe { coex_wifi_channel_get(_primary, _secondary) }
-        } else {
+        }
+        _ => {
             -1
         }
     }

--- a/esp-radio/src/ble/os_adapter_esp32.rs
+++ b/esp-radio/src/ble/os_adapter_esp32.rs
@@ -517,7 +517,7 @@ pub(crate) unsafe extern "C" fn coex_schm_register_btdm_callback_wrapper(
         feature = "coex" => {
             unsafe extern "C" {
                 fn coex_schm_register_callback(kind: u32, callback: unsafe extern "C" fn()) -> i32;
-            }
+        }
             const COEX_SCHM_CALLBACK_TYPE_BT: u32 = 1;
             unsafe { coex_schm_register_callback(COEX_SCHM_CALLBACK_TYPE_BT, callback) }
         }
@@ -538,7 +538,7 @@ pub(crate) unsafe extern "C" fn coex_wifi_channel_get(
         feature = "coex" => {
             unsafe extern "C" {
                 fn coex_wifi_channel_get(_primary: *mut u8, _secondary: *mut u8) -> i32;
-            }
+        }
             unsafe { coex_wifi_channel_get(_primary, _secondary) }
         }
         _ => {

--- a/esp-radio/src/ble/os_adapter_esp32c3_s3.rs
+++ b/esp-radio/src/ble/os_adapter_esp32c3_s3.rs
@@ -178,13 +178,14 @@ coex_fns! {
 extern "C" fn coex_schm_register_btdm_callback(_callback: *mut c_void) -> i32 {
     trace!("coex_schm_register_btdm_callback");
 
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "coex")] {
+    cfg_select! {
+        feature = "coex" => {
             unsafe {
                 const COEX_SCHM_CALLBACK_TYPE_BT: u32 = 1;
                 coex_schm_register_callback(COEX_SCHM_CALLBACK_TYPE_BT, _callback)
             }
-        } else {
+        }
+        _ => {
             0
         }
     }

--- a/esp-radio/src/ble/os_adapter_esp32c3_s3.rs
+++ b/esp-radio/src/ble/os_adapter_esp32c3_s3.rs
@@ -183,7 +183,7 @@ extern "C" fn coex_schm_register_btdm_callback(_callback: *mut c_void) -> i32 {
             unsafe {
                 const COEX_SCHM_CALLBACK_TYPE_BT: u32 = 1;
                 coex_schm_register_callback(COEX_SCHM_CALLBACK_TYPE_BT, _callback)
-            }
+        }
         }
         _ => {
             0

--- a/esp-radio/src/coex_utils.rs
+++ b/esp-radio/src/coex_utils.rs
@@ -34,13 +34,14 @@ macro_rules! extern_coex_fns {
             $(#[$meta])?
             #[allow(unused_variables)]
             pub(crate) unsafe extern "C" fn $name ($($arg: $arg_ty),*) $(-> $ret)? {
-                cfg_if::cfg_if! {
-                    if #[cfg(feature = "coex")] {
+                cfg_select! {
+                    feature = "coex" => {
                         unsafe extern "C" {
                             fn $name($($arg: $arg_ty),*) $(-> $ret)?;
                         }
                         unsafe { $name ($($arg),*) }
-                    } else {
+                    }
+                    _ => {
                         $(<$ret>::default())?
                     }
                 }

--- a/esp-radio/src/coex_utils.rs
+++ b/esp-radio/src/coex_utils.rs
@@ -38,7 +38,7 @@ macro_rules! extern_coex_fns {
                     feature = "coex" => {
                         unsafe extern "C" {
                             fn $name($($arg: $arg_ty),*) $(-> $ret)?;
-                        }
+                    }
                         unsafe { $name ($($arg),*) }
                     }
                     _ => {

--- a/esp-radio/src/common_adapter.rs
+++ b/esp-radio/src/common_adapter.rs
@@ -243,10 +243,11 @@ pub unsafe extern "C" fn __esp_radio_esp_timer_get_time() -> i64 {
     trace!("esp_timer_get_time");
     // Just using IEEE802.15.4 doesn't need the current time. If we don't use `preempt::now`, users
     // will not need to have a scheduler in their firmware.
-    cfg_if::cfg_if! {
-        if #[cfg(any(feature = "wifi", feature = "ble"))] {
+    cfg_select! {
+        any(feature = "wifi", feature = "ble") => {
             crate::preempt::now() as i64
-        } else {
+        }
+        _ => {
             // In this case we don't have a scheduler, we can return esp-hal's timestamp.
             esp_hal::time::Instant::now().duration_since_epoch().as_micros() as i64
         }
@@ -328,10 +329,11 @@ pub(crate) fn enable_wifi_power_domain() {
             .modify(|_, w| w.wifi_force_pd().clear_bit());
 
         #[cfg(not(esp32))]
-        cfg_if::cfg_if! {
-            if #[cfg(soc_has_apb_ctrl)] {
+        cfg_select! {
+            soc_has_apb_ctrl => {
                 let syscon = regs!(APB_CTRL);
-            } else { // S2
+            }
+            _ => { // S2
                 let syscon = regs!(SYSCON);
             }
         }

--- a/esp-radio/src/fmt.rs
+++ b/esp-radio/src/fmt.rs
@@ -9,10 +9,11 @@ use docsplay::Display;
 macro_rules! assert {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::assert!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::assert!($($x)*);
                 }
             }
@@ -24,10 +25,11 @@ macro_rules! assert {
 macro_rules! assert_eq {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::assert_eq!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::assert_eq!($($x)*);
                 }
             }
@@ -39,10 +41,11 @@ macro_rules! assert_eq {
 macro_rules! assert_ne {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::assert_ne!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::assert_ne!($($x)*);
                 }
             }
@@ -54,10 +57,11 @@ macro_rules! assert_ne {
 macro_rules! debug_assert {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::debug_assert!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::debug_assert!($($x)*);
                 }
             }
@@ -69,10 +73,11 @@ macro_rules! debug_assert {
 macro_rules! debug_assert_eq {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::debug_assert_eq!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::debug_assert_eq!($($x)*);
                 }
             }
@@ -84,10 +89,11 @@ macro_rules! debug_assert_eq {
 macro_rules! debug_assert_ne {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::debug_assert_ne!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::debug_assert_ne!($($x)*);
                 }
             }
@@ -99,10 +105,11 @@ macro_rules! debug_assert_ne {
 macro_rules! todo {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::todo!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::todo!($($x)*);
                 }
             }
@@ -114,10 +121,11 @@ macro_rules! todo {
 macro_rules! unreachable {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::unreachable!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::unreachable!($($x)*);
                 }
             }
@@ -129,10 +137,11 @@ macro_rules! unreachable {
 macro_rules! panic {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::panic!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::panic!($($x)*);
                 }
             }
@@ -144,12 +153,14 @@ macro_rules! panic {
 macro_rules! trace {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::trace!($s $(, $x)*);
-                } else if #[cfg(feature = "log-04")] {
+                }
+                feature = "log-04" => {
                     ::log_04::trace!($s $(, $x)*);
-                } else {
+                }
+                _ => {
                     let _ = ($( & $x ),*);
                 }
             }
@@ -161,12 +172,14 @@ macro_rules! trace {
 macro_rules! debug {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::debug!($s $(, $x)*);
-                } else if #[cfg(feature = "log-04")] {
+                }
+                feature = "log-04" => {
                     ::log_04::debug!($s $(, $x)*);
-                } else {
+                }
+                _ => {
                     let _ = ($( & $x ),*);
                 }
             }
@@ -178,12 +191,14 @@ macro_rules! debug {
 macro_rules! info {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::info!($s $(, $x)*);
-                } else if #[cfg(feature = "log-04")] {
+                }
+                feature = "log-04" => {
                     ::log_04::info!($s $(, $x)*);
-                } else {
+                }
+                _ => {
                     let _ = ($( & $x ),*);
                 }
             }
@@ -195,12 +210,14 @@ macro_rules! info {
 macro_rules! warn {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::warn!($s $(, $x)*);
-                } else if #[cfg(feature = "log-04")] {
+                }
+                feature = "log-04" => {
                     ::log_04::warn!($s $(, $x)*);
-                } else {
+                }
+                _ => {
                     let _ = ($( & $x ),*);
                 }
             }
@@ -212,12 +229,14 @@ macro_rules! warn {
 macro_rules! error {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::error!($s $(, $x)*);
-                } else if #[cfg(feature = "log-04")] {
+                }
+                feature = "log-04" => {
                     ::log_04::error!($s $(, $x)*);
-                } else {
+                }
+                _ => {
                     let _ = ($( & $x ),*);
                 }
             }

--- a/esp-radio/src/ieee802154/pib.rs
+++ b/esp-radio/src/ieee802154/pib.rs
@@ -216,18 +216,21 @@ fn ieee802154_set_multipan_hal(pib: &Pib) {
 
 // https://github.com/espressif/esp-idf/blob/v5.3/components/ieee802154/driver/esp_ieee802154_pib.c#L48
 fn ieee802154_txpower_convert(txpower: i8) -> u8 {
-    cfg_if::cfg_if! {
-        if #[cfg(esp32h2)] {
+    cfg_select! {
+        esp32h2 => {
             // https://github.com/espressif/esp-idf/blob/v5.3/components/hal/esp32h2/include/hal/ieee802154_ll.h
             const IEEE802154_TXPOWER_VALUE_MAX: i8 = 20;
             const IEEE802154_TXPOWER_VALUE_MIN: i8 = -24;
             const IEEE802154_TXPOWER_INDEX_MIN: i8 = 0;
-        } else if #[cfg(any(esp32c6, esp32c5))] {
+        }
+        any(esp32c6, esp32c5) => {
             // https://github.com/espressif/esp-idf/blob/v5.3/components/hal/esp32c6/include/hal/ieee802154_ll.h
             const IEEE802154_TXPOWER_VALUE_MAX: i8 = 20;
             const IEEE802154_TXPOWER_VALUE_MIN: i8 = -15;
             const IEEE802154_TXPOWER_INDEX_MIN: i8 = 3;
         }
+
+        _ => {}
     }
     if txpower >= IEEE802154_TXPOWER_VALUE_MAX {
         15

--- a/esp-radio/src/lib.rs
+++ b/esp-radio/src/lib.rs
@@ -236,8 +236,8 @@ pub(crate) static ESP_RADIO_LOCK: esp_sync::RawMutex = esp_sync::RawMutex::new()
 // this is just to verify that we use the correct defaults in `build.rs`
 #[allow(clippy::assertions_on_constants)] // TODO: try assert_eq once it's usable in const context
 const _: () = {
-    cfg_if::cfg_if! {
-        if #[cfg(wifi_driver_supported)] {
+    cfg_select! {
+        wifi_driver_supported => {
             core::assert!(sys::include::CONFIG_ESP_WIFI_STATIC_RX_BUFFER_NUM == 10);
             core::assert!(sys::include::CONFIG_ESP_WIFI_DYNAMIC_RX_BUFFER_NUM == 32);
             core::assert!(sys::include::WIFI_STATIC_TX_BUFFER_NUM == 0);
@@ -247,6 +247,8 @@ const _: () = {
             core::assert!(sys::include::WIFI_AMSDU_TX_ENABLED == 0);
             core::assert!(sys::include::CONFIG_ESP32_WIFI_RX_BA_WIN == 6);
         }
+
+        _ => {}
     };
 };
 

--- a/esp-radio/src/wifi/csi.rs
+++ b/esp-radio/src/wifi/csi.rs
@@ -138,12 +138,13 @@ impl<'a> WifiCsiInfo<'_> {
     /// [`SecondaryChannel`] on which this packet is received.
     #[instability::unstable]
     pub fn secondary_channel(&self) -> SecondaryChannel {
-        cfg_if::cfg_if! {
-            if #[cfg(wifi_mac_version = "1")] {
+        cfg_select! {
+            wifi_mac_version = "1" => {
                 SecondaryChannel::from_raw(unsafe {
                     (*self.inner).rx_ctrl.secondary_channel()
                 })
-            } else {
+            }
+            _ => {
                 SecondaryChannel::from_raw(unsafe {
                     (*self.inner).rx_ctrl.second()
                 })

--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -1056,10 +1056,11 @@ pub(crate) fn coex_initialize() -> i32 {
 pub(crate) unsafe extern "C" fn coex_init() -> i32 {
     debug!("coex-init");
 
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "coex")] {
+    cfg_select! {
+        feature = "coex" => {
             unsafe { crate::sys::include::coex_init() }
-        } else {
+        }
+        _ => {
             0
         }
     }

--- a/esp-radio/src/wifi/os_adapter/mod.rs
+++ b/esp-radio/src/wifi/os_adapter/mod.rs
@@ -1429,11 +1429,12 @@ extern_coex_fns! {
 pub unsafe extern "C" fn coex_status_get() -> u32 {
     trace!("coex_status_get");
 
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "coex")] {
+    cfg_select! {
+        feature = "coex" => {
             const COEX_STATUS_GET_WIFI_BITMAP: u8 = 1;
             unsafe { crate::sys::include::coex_status_get(COEX_STATUS_GET_WIFI_BITMAP) }
-        } else {
+        }
+        _ => {
             0
         }
     }
@@ -1452,15 +1453,16 @@ pub unsafe extern "C" fn coex_schm_register_cb_wrapper(
 ) -> c_int {
     trace!("coex_schm_register_cb_wrapper {} {:?}", arg1, cb);
 
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "coex")] {
+    cfg_select! {
+        feature = "coex" => {
             unsafe {
                 crate::sys::include::coex_schm_register_callback(
                     arg1 as u32,
                     unwrap!(cb) as *mut c_void,
                 )
             }
-        } else {
+        }
+        _ => {
             0
         }
     }

--- a/esp-radio/src/wifi/os_adapter/mod.rs
+++ b/esp-radio/src/wifi/os_adapter/mod.rs
@@ -1460,7 +1460,7 @@ pub unsafe extern "C" fn coex_schm_register_cb_wrapper(
                     arg1 as u32,
                     unwrap!(cb) as *mut c_void,
                 )
-            }
+        }
         }
         _ => {
             0

--- a/esp-riscv-rt/Cargo.toml
+++ b/esp-riscv-rt/Cargo.toml
@@ -2,7 +2,7 @@
 name          = "esp-riscv-rt"
 version       = "0.14.0"
 edition       = "2024"
-rust-version  = "1.88.0"
+rust-version  = "1.95.0"
 description   = "Minimal runtime / startup for RISC-V CPUs from Espressif"
 documentation = "https://docs.espressif.com/projects/rust/esp-riscv-rt/latest/"
 keywords      = ["esp32", "espressif", "riscv", "runtime", "startup"]

--- a/esp-rom-sys/Cargo.toml
+++ b/esp-rom-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name          = "esp-rom-sys"
 version       = "0.1.4"
 edition       = "2024"
-rust-version  = "1.88.0"
+rust-version  = "1.95.0"
 description   = "ROM code support"
 documentation = "https://docs.espressif.com/projects/rust/esp-rom-sys/latest/"
 keywords      = ["embedded", "esp32", "espressif"]
@@ -27,7 +27,6 @@ bench = false
 test  = false
 
 [dependencies]
-cfg-if              = "1"
 document-features   = "0.2"
 esp32   = { version = "0.40", features = ["critical-section"], optional = true }
 esp32c2 = { version = "0.29", features = ["critical-section"], optional = true }

--- a/esp-rom-sys/src/rom/mod.rs
+++ b/esp-rom-sys/src/rom/mod.rs
@@ -76,24 +76,28 @@ pub fn ets_set_appcpu_boot_addr(boot_addr: u32) {
 // so that either ieee or esp-radio gets it for free without duplicating in both
 #[unsafe(no_mangle)]
 extern "C" fn rtc_clk_xtal_freq_get() -> i32 {
-    cfg_if::cfg_if! {
-        if #[cfg(any(esp32c6, esp32h2))] {
+    cfg_select! {
+        any(esp32c6, esp32h2) => {
             unsafe extern "C" {
                 fn ets_clk_get_xtal_freq() -> i32;
             }
             (unsafe { ets_clk_get_xtal_freq() }) / 1_000_000
-        } else if #[cfg(any(esp32s2, esp32s3, esp32c3))] {
+        }
+        any(esp32s2, esp32s3, esp32c3) => {
             unsafe extern "C" {
                 fn ets_get_xtal_freq() -> i32;
             }
             (unsafe { ets_get_xtal_freq() }) / 1_000_000
-        } else if #[cfg(any(esp32, esp32c2))] {
+        }
+        any(esp32, esp32c2) => {
             // just rely on RTC_CNTL_STORE4
             (regs!(RTC_CNTL).store4().read().bits() & 0xff) as i32
-        } else if #[cfg(any(esp32c5, esp32c61))]  {
+        }
+        any(esp32c5, esp32c61) => {
             // PCR_CLK_XTAL_FREQ updates its value based on EFUSE_XTAL_48M_SEL.
             regs!(PCR).sysclk_conf().read().clk_xtal_freq().bits() as i32
-        } else {
+        }
+        _ => {
             compile_error!("rtc_clk_xtal_freq_get not implemented for this chip");
         }
     }

--- a/esp-rom-sys/src/rom/mod.rs
+++ b/esp-rom-sys/src/rom/mod.rs
@@ -80,13 +80,13 @@ extern "C" fn rtc_clk_xtal_freq_get() -> i32 {
         any(esp32c6, esp32h2) => {
             unsafe extern "C" {
                 fn ets_clk_get_xtal_freq() -> i32;
-            }
+        }
             (unsafe { ets_clk_get_xtal_freq() }) / 1_000_000
         }
         any(esp32s2, esp32s3, esp32c3) => {
             unsafe extern "C" {
                 fn ets_get_xtal_freq() -> i32;
-            }
+        }
             (unsafe { ets_get_xtal_freq() }) / 1_000_000
         }
         any(esp32, esp32c2) => {

--- a/esp-rom-sys/src/syscall/mod.rs
+++ b/esp-rom-sys/src/syscall/mod.rs
@@ -176,8 +176,8 @@ unsafe extern "C" fn abort_wrapper() {
 /// Should only get called once.
 #[allow(clippy::missing_transmute_annotations)]
 pub unsafe fn init_syscall_table() {
-    cfg_if::cfg_if! {
-        if #[cfg(esp32)] {
+    cfg_select! {
+        esp32 => {
             unsafe extern "C" {
                 static mut syscall_table_ptr_pro: *const chip_specific::syscall_stub_table;
                 static mut syscall_table_ptr_app: *const chip_specific::syscall_stub_table;
@@ -186,12 +186,14 @@ pub unsafe fn init_syscall_table() {
                 syscall_table_ptr_pro = &raw const SYSCALL_TABLE;
                 syscall_table_ptr_app = &raw const SYSCALL_TABLE;
             }
-        } else if #[cfg(esp32s2)] {
+        }
+        esp32s2 => {
             unsafe extern "C" {
                 static mut syscall_table_ptr_pro: *const chip_specific::syscall_stub_table;
             }
             unsafe { syscall_table_ptr_pro = &raw const SYSCALL_TABLE; }
-        } else {
+        }
+        _ => {
             unsafe extern "C" {
                 static mut syscall_table_ptr: *const chip_specific::syscall_stub_table;
             }

--- a/esp-rom-sys/src/syscall/mod.rs
+++ b/esp-rom-sys/src/syscall/mod.rs
@@ -181,22 +181,22 @@ pub unsafe fn init_syscall_table() {
             unsafe extern "C" {
                 static mut syscall_table_ptr_pro: *const chip_specific::syscall_stub_table;
                 static mut syscall_table_ptr_app: *const chip_specific::syscall_stub_table;
-            }
+        }
             unsafe {
                 syscall_table_ptr_pro = &raw const SYSCALL_TABLE;
                 syscall_table_ptr_app = &raw const SYSCALL_TABLE;
-            }
+        }
         }
         esp32s2 => {
             unsafe extern "C" {
                 static mut syscall_table_ptr_pro: *const chip_specific::syscall_stub_table;
-            }
+        }
             unsafe { syscall_table_ptr_pro = &raw const SYSCALL_TABLE; }
         }
         _ => {
             unsafe extern "C" {
                 static mut syscall_table_ptr: *const chip_specific::syscall_stub_table;
-            }
+        }
             unsafe { syscall_table_ptr = &raw const SYSCALL_TABLE; }
         }
     };

--- a/esp-rtos/Cargo.toml
+++ b/esp-rtos/Cargo.toml
@@ -2,7 +2,7 @@
 name          = "esp-rtos"
 version       = "0.3.0"
 edition       = "2024"
-rust-version  = "1.88.0"
+rust-version  = "1.95.0"
 description   = "A task scheduler for Espressif devices"
 documentation = "https://docs.espressif.com/projects/rust/esp-rtos/latest/"
 keywords      = ["esp32", "espressif", "no-std"]
@@ -38,7 +38,6 @@ esp-hal = { version = "~1.1.0", path = "../esp-hal", default-features = false, f
 ] }
 esp-rom-sys = { version = "~0.1", path = "../esp-rom-sys" }
 
-cfg-if = "1"
 rtos-trace = { version = "0.2.0", optional = true }
 
 # Unstable dependencies that are not (strictly) part of the public API

--- a/esp-rtos/src/fmt.rs
+++ b/esp-rtos/src/fmt.rs
@@ -7,10 +7,11 @@ use core::fmt::{Debug, Display, LowerHex};
 macro_rules! assert {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::assert!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::assert!($($x)*);
                 }
             }
@@ -22,10 +23,11 @@ macro_rules! assert {
 macro_rules! assert_eq {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::assert_eq!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::assert_eq!($($x)*);
                 }
             }
@@ -37,10 +39,11 @@ macro_rules! assert_eq {
 macro_rules! assert_ne {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::assert_ne!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::assert_ne!($($x)*);
                 }
             }
@@ -52,10 +55,11 @@ macro_rules! assert_ne {
 macro_rules! debug_assert {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::debug_assert!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::debug_assert!($($x)*);
                 }
             }
@@ -67,10 +71,11 @@ macro_rules! debug_assert {
 macro_rules! debug_assert_eq {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::debug_assert_eq!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::debug_assert_eq!($($x)*);
                 }
             }
@@ -82,10 +87,11 @@ macro_rules! debug_assert_eq {
 macro_rules! debug_assert_ne {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::debug_assert_ne!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::debug_assert_ne!($($x)*);
                 }
             }
@@ -97,10 +103,11 @@ macro_rules! debug_assert_ne {
 macro_rules! todo {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::todo!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::todo!($($x)*);
                 }
             }
@@ -112,10 +119,11 @@ macro_rules! todo {
 macro_rules! unreachable {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::unreachable!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::unreachable!($($x)*);
                 }
             }
@@ -127,10 +135,11 @@ macro_rules! unreachable {
 macro_rules! panic {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::panic!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::panic!($($x)*);
                 }
             }
@@ -142,12 +151,14 @@ macro_rules! panic {
 macro_rules! trace {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::trace!($s $(, $x)*);
-                } else if #[cfg(feature = "log-04")] {
+                }
+                feature = "log-04" => {
                     ::log_04::trace!($s $(, $x)*);
-                } else {
+                }
+                _ => {
                     let _ = ($( & $x ),*);
                 }
             }
@@ -159,12 +170,14 @@ macro_rules! trace {
 macro_rules! debug {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::debug!($s $(, $x)*);
-                } else if #[cfg(feature = "log-04")] {
+                }
+                feature = "log-04" => {
                     ::log_04::debug!($s $(, $x)*);
-                } else {
+                }
+                _ => {
                     let _ = ($( & $x ),*);
                 }
             }
@@ -176,12 +189,14 @@ macro_rules! debug {
 macro_rules! info {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::info!($s $(, $x)*);
-                } else if #[cfg(feature = "log-04")] {
+                }
+                feature = "log-04" => {
                     ::log_04::info!($s $(, $x)*);
-                } else {
+                }
+                _ => {
                     let _ = ($( & $x ),*);
                 }
             }
@@ -193,12 +208,14 @@ macro_rules! info {
 macro_rules! warn {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::warn!($s $(, $x)*);
-                } else if #[cfg(feature = "log-04")] {
+                }
+                feature = "log-04" => {
                     ::log_04::warn!($s $(, $x)*);
-                } else {
+                }
+                _ => {
                     let _ = ($( & $x ),*);
                 }
             }
@@ -210,12 +227,14 @@ macro_rules! warn {
 macro_rules! error {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::error!($s $(, $x)*);
-                } else if #[cfg(feature = "log-04")] {
+                }
+                feature = "log-04" => {
                     ::log_04::error!($s $(, $x)*);
-                } else {
+                }
+                _ => {
                     let _ = ($( & $x ),*);
                 }
             }

--- a/esp-rtos/src/run_queue.rs
+++ b/esp-rtos/src/run_queue.rs
@@ -177,14 +177,15 @@ impl RunQueue {
         }
         self.ready_tasks[priority_n].push(ready_task);
 
-        cfg_if::cfg_if! {
-            if #[cfg(multi_core)] {
+        cfg_select! {
+            multi_core => {
                 let run_on = if _state[1].initialized {
                     self.select_scheduler_trigger_multi_core(_state, ready_task)
                 } else {
                     self.select_scheduler_trigger_single_core(priority_n)
                 };
-            } else {
+            }
+            _ => {
                 let run_on = self.select_scheduler_trigger_single_core(priority_n);
             }
         }
@@ -254,8 +255,8 @@ impl RunQueue {
         let current_prio = self.ready_priority.ready();
         trace!("pop - from level: {}", current_prio);
 
-        cfg_if::cfg_if! {
-            if #[cfg(multi_core)] {
+        cfg_select! {
+            multi_core => {
                 use esp_hal::system::Cpu;
 
                 let other = match Cpu::current() {
@@ -283,7 +284,8 @@ impl RunQueue {
                     break;
                 }
 
-            } else {
+            }
+            _ => {
                 let popped = self.ready_tasks[current_prio].pop();
             }
         }

--- a/esp-rtos/src/run_queue.rs
+++ b/esp-rtos/src/run_queue.rs
@@ -282,7 +282,7 @@ impl RunQueue {
                     }
 
                     break;
-                }
+            }
 
             }
             _ => {

--- a/esp-rtos/src/scheduler.rs
+++ b/esp-rtos/src/scheduler.rs
@@ -235,10 +235,11 @@ impl SchedulerState {
         let current_cpu = cpu as usize;
 
         let current_sp: u32;
-        cfg_if::cfg_if! {
-            if #[cfg(xtensa)] {
+        cfg_select! {
+            xtensa => {
                 unsafe { core::arch::asm!("mov {0}, sp", out(reg) current_sp); }
-            } else {
+            }
+            _ => {
                 unsafe { core::arch::asm!("mv {0}, sp", out(reg) current_sp); }
             }
         }
@@ -397,10 +398,11 @@ impl SchedulerState {
 
     fn delete_task(&mut self, mut to_delete: TaskPtr) {
         unsafe {
-            cfg_if::cfg_if! {
-                if #[cfg(xtensa)] {
+            cfg_select! {
+                xtensa => {
                     let saved_sp = to_delete.as_ref().cpu_context.A1 as usize;
-                } else {
+                }
+                _ => {
                     let saved_sp = to_delete.as_ref().cpu_context.sp;
                 }
             }
@@ -438,10 +440,11 @@ impl SchedulerState {
             let task = unsafe { task.as_ref() };
             let in_queue = task.in_run_or_wait_queue;
 
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "esp-radio")] {
+            cfg_select! {
+                feature = "esp-radio" => {
                     let in_waitqueue = task.current_wait_queue.is_some();
-                } else {
+                }
+                _ => {
                     let in_waitqueue = false;
                 }
             }

--- a/esp-rtos/src/task/mod.rs
+++ b/esp-rtos/src/task/mod.rs
@@ -400,30 +400,35 @@ pub(crate) trait ContextExt {
 
 impl ContextExt for CpuContext {
     fn set_tp(&mut self, tp: u32) {
-        cfg_if::cfg_if! {
-            if #[cfg(xtensa)] {
+        cfg_select! {
+            xtensa => {
                 self.THREADPTR = tp;
-            } else if #[cfg(riscv)] {
+            }
+            riscv => {
                 self.tp = tp as usize;
             }
+
+            _ => {}
         }
     }
 
     fn sp(&self) -> u32 {
-        cfg_if::cfg_if! {
-            if #[cfg(xtensa)] {
+        cfg_select! {
+            xtensa => {
                 self.A1
-            } else {
+            }
+            _ => {
                 self.sp as u32
             }
         }
     }
 
     fn set_sp(&mut self, sp: u32) {
-        cfg_if::cfg_if! {
-            if #[cfg(xtensa)] {
+        cfg_select! {
+            xtensa => {
                 self.A1 = sp;
-            } else {
+            }
+            _ => {
                 self.sp = sp as usize;
             }
         }
@@ -706,14 +711,15 @@ pub(crate) fn trigger_scheduler(run_scheduler: RunSchedulerOn) {
     match run_scheduler {
         RunSchedulerOn::DontRun => {}
         RunSchedulerOn::RunOnCore(_core) => {
-            cfg_if::cfg_if! {
-                if #[cfg(multi_core)] {
+            cfg_select! {
+                multi_core => {
                     if _core == Cpu::current() {
                         yield_task()
                     } else {
                         schedule_other_core()
                     }
-                } else {
+                }
+                _ => {
                     yield_task()
                 }
             }

--- a/esp-rtos/src/task/mod.rs
+++ b/esp-rtos/src/task/mod.rs
@@ -717,7 +717,7 @@ pub(crate) fn trigger_scheduler(run_scheduler: RunSchedulerOn) {
                         yield_task()
                     } else {
                         schedule_other_core()
-                    }
+                }
                 }
                 _ => {
                     yield_task()

--- a/esp-storage/Cargo.toml
+++ b/esp-storage/Cargo.toml
@@ -2,7 +2,7 @@
 name          = "esp-storage"
 version       = "0.9.0"
 edition       = "2024"
-rust-version  = "1.88.0"
+rust-version  = "1.95.0"
 description   = "Implementation of embedded-storage traits to access unencrypted ESP32 flash"
 documentation = "https://docs.espressif.com/projects/rust/esp-storage/latest/"
 keywords      = ["embedded-storage", "esp32", "espressif", "no-std"]

--- a/esp-sync/Cargo.toml
+++ b/esp-sync/Cargo.toml
@@ -2,7 +2,7 @@
 name          = "esp-sync"
 version       = "0.2.1"
 edition       = "2024"
-rust-version  = "1.88.0"
+rust-version  = "1.95.0"
 description   = "Synchronization primitives for Espressif devices"
 documentation = "https://docs.espressif.com/projects/rust/esp-sync/latest/"
 categories    = ["no-std", "embedded", "concurrency"]
@@ -19,7 +19,6 @@ check-configs = [
 clippy-configs = [{ features = ["defmt"] }]
 
 [dependencies]
-cfg-if = "1"
 document-features = "0.2"
 esp-metadata-generated = { version = "0.4.0", path = "../esp-metadata-generated" }
 embassy-sync-06 = { package = "embassy-sync", version = "0.6" }

--- a/esp-sync/src/fmt.rs
+++ b/esp-sync/src/fmt.rs
@@ -7,10 +7,11 @@ use core::fmt::{Debug, Display, LowerHex};
 macro_rules! assert {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::assert!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::assert!($($x)*);
                 }
             }
@@ -22,10 +23,11 @@ macro_rules! assert {
 macro_rules! assert_eq {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::assert_eq!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::assert_eq!($($x)*);
                 }
             }
@@ -37,10 +39,11 @@ macro_rules! assert_eq {
 macro_rules! assert_ne {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::assert_ne!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::assert_ne!($($x)*);
                 }
             }
@@ -52,10 +55,11 @@ macro_rules! assert_ne {
 macro_rules! debug_assert {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::debug_assert!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::debug_assert!($($x)*);
                 }
             }
@@ -67,10 +71,11 @@ macro_rules! debug_assert {
 macro_rules! debug_assert_eq {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::debug_assert_eq!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::debug_assert_eq!($($x)*);
                 }
             }
@@ -82,10 +87,11 @@ macro_rules! debug_assert_eq {
 macro_rules! debug_assert_ne {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::debug_assert_ne!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::debug_assert_ne!($($x)*);
                 }
             }
@@ -97,10 +103,11 @@ macro_rules! debug_assert_ne {
 macro_rules! todo {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::todo!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::todo!($($x)*);
                 }
             }
@@ -112,10 +119,11 @@ macro_rules! todo {
 macro_rules! unreachable {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::unreachable!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::unreachable!($($x)*);
                 }
             }
@@ -127,10 +135,11 @@ macro_rules! unreachable {
 macro_rules! panic {
     ($($x:tt)*) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::panic!($($x)*);
-                } else {
+                }
+                _ => {
                     ::core::panic!($($x)*);
                 }
             }
@@ -142,12 +151,14 @@ macro_rules! panic {
 macro_rules! trace {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::trace!($s $(, $x)*);
-                } else if #[cfg(feature = "log-04")] {
+                }
+                feature = "log-04" => {
                     ::log_04::trace!($s $(, $x)*);
-                } else {
+                }
+                _ => {
                     let _ = ($( & $x ),*);
                 }
             }
@@ -159,12 +170,14 @@ macro_rules! trace {
 macro_rules! debug {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::debug!($s $(, $x)*);
-                } else if #[cfg(feature = "log-04")] {
+                }
+                feature = "log-04" => {
                     ::log_04::debug!($s $(, $x)*);
-                } else {
+                }
+                _ => {
                     let _ = ($( & $x ),*);
                 }
             }
@@ -176,12 +189,14 @@ macro_rules! debug {
 macro_rules! info {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::info!($s $(, $x)*);
-                } else if #[cfg(feature = "log-04")] {
+                }
+                feature = "log-04" => {
                     ::log_04::info!($s $(, $x)*);
-                } else {
+                }
+                _ => {
                     let _ = ($( & $x ),*);
                 }
             }
@@ -193,12 +208,14 @@ macro_rules! info {
 macro_rules! warn {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::warn!($s $(, $x)*);
-                } else if #[cfg(feature = "log-04")] {
+                }
+                feature = "log-04" => {
                     ::log_04::warn!($s $(, $x)*);
-                } else {
+                }
+                _ => {
                     let _ = ($( & $x ),*);
                 }
             }
@@ -210,12 +227,14 @@ macro_rules! warn {
 macro_rules! error {
     ($s:literal $(, $x:expr)* $(,)?) => {
         {
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "defmt")] {
+            cfg_select! {
+                feature = "defmt" => {
                     ::defmt::error!($s $(, $x)*);
-                } else if #[cfg(feature = "log-04")] {
+                }
+                feature = "log-04" => {
                     ::log_04::error!($s $(, $x)*);
-                } else {
+                }
+                _ => {
                     let _ = ($( & $x ),*);
                 }
             }

--- a/esp-sync/src/lib.rs
+++ b/esp-sync/src/lib.rs
@@ -123,12 +123,14 @@ mod multi_core {
     #[inline]
     fn thread_id() -> usize {
         // This method must never return UNUSED_THREAD_ID_VALUE
-        cfg_if::cfg_if! {
-            if #[cfg(all(multi_core, riscv))] {
+        cfg_select! {
+            all(multi_core, riscv) => {
                 riscv::register::mhartid::read()
-            } else if #[cfg(all(multi_core, xtensa))] {
+            }
+            all(multi_core, xtensa) => {
                 (xtensa_lx::get_processor_id() & 0x2000) as usize
-            } else {
+            }
+            _ => {
                 0
             }
         }

--- a/esp-sync/src/raw.rs
+++ b/esp-sync/src/raw.rs
@@ -34,17 +34,19 @@ const RESERVED_MASK: u32 = 0b1111_1111_1111_1000_1111_0000_0000_0000;
 impl RawLock for SingleCoreInterruptLock {
     #[inline]
     unsafe fn enter(&self) -> RestoreState {
-        cfg_if::cfg_if! {
-            if #[cfg(riscv)] {
+        cfg_select! {
+            riscv => {
                 let mut mstatus = 0u32;
                 unsafe { core::arch::asm!("csrrci {0}, mstatus, 8", inout(reg) mstatus); }
                 let token = mstatus & 0b1000;
-            } else if #[cfg(xtensa)] {
+            }
+            xtensa => {
                 let token: u32;
                 unsafe { core::arch::asm!("rsil {0}, 5", out(reg) token); }
                 #[cfg(debug_assertions)]
                 let token = token & !RESERVED_MASK;
-            } else {
+            }
+            _ => {
                 compile_error!("Unsupported architecture")
             }
         };
@@ -64,14 +66,15 @@ impl RawLock for SingleCoreInterruptLock {
 
         let token = token.inner();
 
-        cfg_if::cfg_if! {
-            if #[cfg(riscv)] {
+        cfg_select! {
+            riscv => {
                 if token != 0 {
                     unsafe {
                         riscv::interrupt::enable();
                     }
                 }
-            } else if #[cfg(xtensa)] {
+            }
+            xtensa => {
                 #[cfg(debug_assertions)]
                 if token & RESERVED_MASK != 0 {
                     // We could do this transformation in fmt.rs automatically, but experiments
@@ -90,7 +93,8 @@ impl RawLock for SingleCoreInterruptLock {
                         "wsr.ps {0}",
                         "rsync", in(reg) token)
                 }
-            } else {
+            }
+            _ => {
                 compile_error!("Unsupported architecture")
             }
         }

--- a/esp-sync/src/raw.rs
+++ b/esp-sync/src/raw.rs
@@ -72,7 +72,7 @@ impl RawLock for SingleCoreInterruptLock {
                     unsafe {
                         riscv::interrupt::enable();
                     }
-                }
+            }
             }
             xtensa => {
                 #[cfg(debug_assertions)]
@@ -86,13 +86,13 @@ impl RawLock for SingleCoreInterruptLock {
                     }
 
                     __assert_failed();
-                }
+            }
 
                 unsafe {
                     core::arch::asm!(
                         "wsr.ps {0}",
                         "rsync", in(reg) token)
-                }
+            }
             }
             _ => {
                 compile_error!("Unsupported architecture")

--- a/examples/async/embassy_rmt_rx/Cargo.toml
+++ b/examples/async/embassy_rmt_rx/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2024"
 publish = false
 
 [dependencies]
-cfg-if = "1"
 embassy-executor = "0.10.0"
 embassy-time = "0.5.0"
 esp-backtrace = { path = "../../../esp-backtrace", features = [

--- a/examples/async/embassy_rmt_rx/src/main.rs
+++ b/examples/async/embassy_rmt_rx/src/main.rs
@@ -48,13 +48,13 @@ async fn main(spawner: Spawner) {
     esp_rtos::start(timg0.timer0, sw_int.software_interrupt0);
 
     cfg_select! {
-    feature = "esp32h2" => {
+        feature = "esp32h2" => {
             let freq = Rate::from_mhz(32);
         }
-    _ => {
+        _ => {
             let freq = Rate::from_mhz(80);
         }
-}
+    }
 
     let rmt = Rmt::new(peripherals.RMT, freq).unwrap().into_async();
     let rx_config = RxChannelConfig::default()
@@ -62,16 +62,16 @@ async fn main(spawner: Spawner) {
         .with_idle_threshold(10000);
 
     cfg_select! {
-    any(feature = "esp32", feature = "esp32s2") => {
+        any(feature = "esp32", feature = "esp32s2") => {
             let channel = rmt.channel0.configure_rx(&rx_config).unwrap();
         }
-    feature = "esp32s3" => {
+        feature = "esp32s3" => {
             let channel = rmt.channel7.configure_rx(&rx_config).unwrap();
         }
-    _ => {
+        _ => {
             let channel = rmt.channel2.configure_rx(&rx_config).unwrap();
         }
-}
+    }
 
     let mut channel = channel.with_pin(peripherals.GPIO4);
 

--- a/examples/async/embassy_rmt_rx/src/main.rs
+++ b/examples/async/embassy_rmt_rx/src/main.rs
@@ -47,28 +47,31 @@ async fn main(spawner: Spawner) {
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     esp_rtos::start(timg0.timer0, sw_int.software_interrupt0);
 
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "esp32h2")] {
+    cfg_select! {
+    feature = "esp32h2" => {
             let freq = Rate::from_mhz(32);
-        } else {
+        }
+    _ => {
             let freq = Rate::from_mhz(80);
         }
-    };
+}
 
     let rmt = Rmt::new(peripherals.RMT, freq).unwrap().into_async();
     let rx_config = RxChannelConfig::default()
         .with_clk_divider(255)
         .with_idle_threshold(10000);
 
-    cfg_if::cfg_if! {
-        if #[cfg(any(feature = "esp32", feature = "esp32s2"))] {
+    cfg_select! {
+    any(feature = "esp32", feature = "esp32s2") => {
             let channel = rmt.channel0.configure_rx(&rx_config).unwrap();
-        } else if #[cfg(feature = "esp32s3")] {
+        }
+    feature = "esp32s3" => {
             let channel = rmt.channel7.configure_rx(&rx_config).unwrap();
-        } else {
+        }
+    _ => {
             let channel = rmt.channel2.configure_rx(&rx_config).unwrap();
         }
-    }
+}
 
     let mut channel = channel.with_pin(peripherals.GPIO4);
 

--- a/examples/async/embassy_rmt_tx/Cargo.toml
+++ b/examples/async/embassy_rmt_tx/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2024"
 publish = false
 
 [dependencies]
-cfg-if = "1"
 embassy-executor = "0.10.0"
 embassy-time = "0.5.0"
 esp-backtrace = { path = "../../../esp-backtrace", features = [

--- a/examples/async/embassy_rmt_tx/src/main.rs
+++ b/examples/async/embassy_rmt_tx/src/main.rs
@@ -34,13 +34,13 @@ async fn main(_spawner: Spawner) {
     esp_rtos::start(timg0.timer0, sw_int.software_interrupt0);
 
     cfg_select! {
-    feature = "esp32h2" => {
+        feature = "esp32h2" => {
             let freq = Rate::from_mhz(32);
         }
-    _ => {
+        _ => {
             let freq = Rate::from_mhz(80);
         }
-}
+    }
 
     let rmt = Rmt::new(peripherals.RMT, freq).unwrap().into_async();
 

--- a/examples/async/embassy_rmt_tx/src/main.rs
+++ b/examples/async/embassy_rmt_tx/src/main.rs
@@ -33,13 +33,14 @@ async fn main(_spawner: Spawner) {
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     esp_rtos::start(timg0.timer0, sw_int.software_interrupt0);
 
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "esp32h2")] {
+    cfg_select! {
+    feature = "esp32h2" => {
             let freq = Rate::from_mhz(32);
-        } else {
+        }
+    _ => {
             let freq = Rate::from_mhz(80);
         }
-    };
+}
 
     let rmt = Rmt::new(peripherals.RMT, freq).unwrap().into_async();
 

--- a/examples/async/embassy_serial/Cargo.toml
+++ b/examples/async/embassy_serial/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2024"
 publish = false
 
 [dependencies]
-cfg-if = "1"
 embassy-executor = "0.10.0"
 embassy-sync = "0.8"
 embedded-io-async = "0.7.0"

--- a/examples/async/embassy_serial/src/main.rs
+++ b/examples/async/embassy_serial/src/main.rs
@@ -75,27 +75,27 @@ async fn main(spawner: Spawner) {
 
     // Default pins for Uart communication
     cfg_select! {
-    feature = "esp32" => {
+        feature = "esp32" => {
             let (tx_pin, rx_pin) = (peripherals.GPIO1, peripherals.GPIO3);
         }
-    feature = "esp32c2" => {
+        feature = "esp32c2" => {
             let (tx_pin, rx_pin) = (peripherals.GPIO20, peripherals.GPIO19);
         }
-    feature = "esp32c3" => {
+        feature = "esp32c3" => {
             let (tx_pin, rx_pin) = (peripherals.GPIO21, peripherals.GPIO20);
         }
-    feature = "esp32c6" => {
+        feature = "esp32c6" => {
             let (tx_pin, rx_pin) = (peripherals.GPIO16, peripherals.GPIO17);
         }
-    feature = "esp32h2" => {
+        feature = "esp32h2" => {
             let (tx_pin, rx_pin) = (peripherals.GPIO24, peripherals.GPIO23);
         }
-    any(feature = "esp32s2", feature = "esp32s3") => {
+        any(feature = "esp32s2", feature = "esp32s3") => {
             let (tx_pin, rx_pin) = (peripherals.GPIO43, peripherals.GPIO44);
         }
 
-    _ => {}
-}
+        _ => {}
+    }
 
     let config = Config::default()
         .with_rx(RxConfig::default().with_fifo_full_threshold(READ_BUF_SIZE as u16));

--- a/examples/async/embassy_serial/src/main.rs
+++ b/examples/async/embassy_serial/src/main.rs
@@ -74,21 +74,28 @@ async fn main(spawner: Spawner) {
     esp_rtos::start(timg0.timer0, sw_int.software_interrupt0);
 
     // Default pins for Uart communication
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "esp32")] {
+    cfg_select! {
+    feature = "esp32" => {
             let (tx_pin, rx_pin) = (peripherals.GPIO1, peripherals.GPIO3);
-        } else if #[cfg(feature = "esp32c2")] {
+        }
+    feature = "esp32c2" => {
             let (tx_pin, rx_pin) = (peripherals.GPIO20, peripherals.GPIO19);
-        } else if #[cfg(feature = "esp32c3")] {
+        }
+    feature = "esp32c3" => {
             let (tx_pin, rx_pin) = (peripherals.GPIO21, peripherals.GPIO20);
-        } else if #[cfg(feature = "esp32c6")] {
+        }
+    feature = "esp32c6" => {
             let (tx_pin, rx_pin) = (peripherals.GPIO16, peripherals.GPIO17);
-        } else if #[cfg(feature = "esp32h2")] {
+        }
+    feature = "esp32h2" => {
             let (tx_pin, rx_pin) = (peripherals.GPIO24, peripherals.GPIO23);
-        } else if #[cfg(any(feature = "esp32s2", feature = "esp32s3"))] {
+        }
+    any(feature = "esp32s2", feature = "esp32s3") => {
             let (tx_pin, rx_pin) = (peripherals.GPIO43, peripherals.GPIO44);
         }
-    }
+
+    _ => {}
+}
 
     let config = Config::default()
         .with_rx(RxConfig::default().with_fifo_full_threshold(READ_BUF_SIZE as u16));

--- a/examples/async/embassy_spi/Cargo.toml
+++ b/examples/async/embassy_spi/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2024"
 publish = false
 
 [dependencies]
-cfg-if = "1"
 embassy-executor = "0.10.0"
 embassy-time = "0.5.0"
 embedded-hal-async = "1.0.0"

--- a/examples/async/embassy_spi/src/main.rs
+++ b/examples/async/embassy_spi/src/main.rs
@@ -48,13 +48,14 @@ async fn main(_spawner: Spawner) {
     let mosi = peripherals.GPIO4;
     let cs = peripherals.GPIO5;
 
-    cfg_if::cfg_if! {
-        if #[cfg(any(feature = "esp32", feature = "esp32s2"))] {
+    cfg_select! {
+    any(feature = "esp32", feature = "esp32s2") => {
             let dma_channel = peripherals.DMA_SPI2;
-        } else {
+        }
+    _ => {
             let dma_channel = peripherals.DMA_CH0;
         }
-    }
+}
 
     let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(32000);
     let dma_rx_buf = DmaRxBuf::new(rx_descriptors, rx_buffer).unwrap();

--- a/examples/async/embassy_spi/src/main.rs
+++ b/examples/async/embassy_spi/src/main.rs
@@ -49,13 +49,13 @@ async fn main(_spawner: Spawner) {
     let cs = peripherals.GPIO5;
 
     cfg_select! {
-    any(feature = "esp32", feature = "esp32s2") => {
+        any(feature = "esp32", feature = "esp32s2") => {
             let dma_channel = peripherals.DMA_SPI2;
         }
-    _ => {
+        _ => {
             let dma_channel = peripherals.DMA_CH0;
         }
-}
+    }
 
     let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(32000);
     let dma_rx_buf = DmaRxBuf::new(rx_descriptors, rx_buffer).unwrap();

--- a/examples/ieee802154/ieee802154_sniffer/Cargo.toml
+++ b/examples/ieee802154/ieee802154_sniffer/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2024"
 publish = false
 
 [dependencies]
-cfg-if = "1"
 esp-alloc = { path = "../../../esp-alloc" }
 esp-backtrace = { path = "../../../esp-backtrace", features = [
     "panic-handler",

--- a/examples/ieee802154/ieee802154_sniffer/src/main.rs
+++ b/examples/ieee802154/ieee802154_sniffer/src/main.rs
@@ -27,15 +27,19 @@ fn main() -> ! {
     esp_alloc::heap_allocator!(size: 24 * 1024);
 
     // Default pins for Uart communication
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "esp32c6")] {
+    cfg_select! {
+    feature = "esp32c6" => {
             let (tx_pin, rx_pin) = (peripherals.GPIO16, peripherals.GPIO17);
-        } else if #[cfg(feature = "esp32h2")] {
+        }
+    feature = "esp32h2" => {
             let (tx_pin, rx_pin) = (peripherals.GPIO24, peripherals.GPIO23);
-        } else if #[cfg(feature = "esp32c5")] {
+        }
+    feature = "esp32c5" => {
             let (tx_pin, rx_pin) = (peripherals.GPIO11, peripherals.GPIO12);
         }
-    }
+
+    _ => {}
+}
 
     let mut uart0 = Uart::new(peripherals.UART0, uart::Config::default())
         .unwrap()

--- a/examples/ieee802154/ieee802154_sniffer/src/main.rs
+++ b/examples/ieee802154/ieee802154_sniffer/src/main.rs
@@ -28,18 +28,18 @@ fn main() -> ! {
 
     // Default pins for Uart communication
     cfg_select! {
-    feature = "esp32c6" => {
+        feature = "esp32c6" => {
             let (tx_pin, rx_pin) = (peripherals.GPIO16, peripherals.GPIO17);
         }
-    feature = "esp32h2" => {
+        feature = "esp32h2" => {
             let (tx_pin, rx_pin) = (peripherals.GPIO24, peripherals.GPIO23);
         }
-    feature = "esp32c5" => {
+        feature = "esp32c5" => {
             let (tx_pin, rx_pin) = (peripherals.GPIO11, peripherals.GPIO12);
         }
 
-    _ => {}
-}
+        _ => {}
+    }
 
     let mut uart0 = Uart::new(peripherals.UART0, uart::Config::default())
         .unwrap()

--- a/examples/interrupt/gpio/Cargo.toml
+++ b/examples/interrupt/gpio/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2024"
 publish = false
 
 [dependencies]
-cfg-if = "1"
 critical-section = "1"
 esp-backtrace = { path = "../../../esp-backtrace", features = [
     "panic-handler",

--- a/examples/interrupt/gpio/src/main.rs
+++ b/examples/interrupt/gpio/src/main.rs
@@ -38,16 +38,16 @@ fn main() -> ! {
     let mut led = Output::new(peripherals.GPIO2, Level::Low, OutputConfig::default());
 
     cfg_select! {
-    any(feature = "esp32", feature = "esp32s2", feature = "esp32s3") => {
+        any(feature = "esp32", feature = "esp32s2", feature = "esp32s3") => {
             let button = peripherals.GPIO0;
         }
-    any(feature = "esp32c5") => {
+        any(feature = "esp32c5") => {
             let button = peripherals.GPIO28;
         }
-    _ => {
+        _ => {
             let button = peripherals.GPIO9;
         }
-}
+    }
 
     let config = InputConfig::default().with_pull(Pull::Up);
     let mut button = Input::new(button, config);
@@ -70,16 +70,16 @@ fn main() -> ! {
 #[ram]
 fn handler() {
     cfg_select! {
-    any(feature = "esp32", feature = "esp32s2", feature = "esp32s3") => {
+        any(feature = "esp32", feature = "esp32s2", feature = "esp32s3") => {
             esp_println::println!(
                 "GPIO Interrupt with priority {}",
                 esp_hal::xtensa_lx::interrupt::get_level()
             );
         }
-    _ => {
+        _ => {
             esp_println::println!("GPIO Interrupt");
         }
-}
+    }
 
     if critical_section::with(|cs| {
         BUTTON

--- a/examples/interrupt/gpio/src/main.rs
+++ b/examples/interrupt/gpio/src/main.rs
@@ -37,15 +37,17 @@ fn main() -> ! {
 
     let mut led = Output::new(peripherals.GPIO2, Level::Low, OutputConfig::default());
 
-    cfg_if::cfg_if! {
-        if #[cfg(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3"))] {
+    cfg_select! {
+    any(feature = "esp32", feature = "esp32s2", feature = "esp32s3") => {
             let button = peripherals.GPIO0;
-        } else if #[cfg(any(feature = "esp32c5"))] {
+        }
+    any(feature = "esp32c5") => {
             let button = peripherals.GPIO28;
-        }else {
+        }
+    _ => {
             let button = peripherals.GPIO9;
         }
-    }
+}
 
     let config = InputConfig::default().with_pull(Pull::Up);
     let mut button = Input::new(button, config);
@@ -67,16 +69,17 @@ fn main() -> ! {
 #[handler]
 #[ram]
 fn handler() {
-    cfg_if::cfg_if! {
-        if #[cfg(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3"))] {
+    cfg_select! {
+    any(feature = "esp32", feature = "esp32s2", feature = "esp32s3") => {
             esp_println::println!(
                 "GPIO Interrupt with priority {}",
                 esp_hal::xtensa_lx::interrupt::get_level()
             );
-        } else {
+        }
+    _ => {
             esp_println::println!("GPIO Interrupt");
         }
-    }
+}
 
     if critical_section::with(|cs| {
         BUTTON

--- a/examples/interrupt/uart/Cargo.toml
+++ b/examples/interrupt/uart/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2024"
 publish = false
 
 [dependencies]
-cfg-if = "1.0.0"
 critical-section = "1.1.3"
 esp-backtrace = { path = "../../../esp-backtrace", features = [
     "panic-handler",

--- a/examples/interrupt/uart/src/main.rs
+++ b/examples/interrupt/uart/src/main.rs
@@ -39,21 +39,28 @@ static SERIAL: Mutex<RefCell<Option<Uart<Blocking>>>> = Mutex::new(RefCell::new(
 fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "esp32")] {
+    cfg_select! {
+    feature = "esp32" => {
             let (tx_pin, rx_pin) = (peripherals.GPIO1, peripherals.GPIO3);
-        } else if #[cfg(feature = "esp32c2")] {
+        }
+    feature = "esp32c2" => {
             let (tx_pin, rx_pin) = (peripherals.GPIO20, peripherals.GPIO19);
-        } else if #[cfg(feature = "esp32c3")] {
+        }
+    feature = "esp32c3" => {
             let (tx_pin, rx_pin) = (peripherals.GPIO21, peripherals.GPIO20);
-        } else if #[cfg(feature = "esp32c6")] {
+        }
+    feature = "esp32c6" => {
             let (tx_pin, rx_pin) = (peripherals.GPIO16, peripherals.GPIO17);
-        } else if #[cfg(feature = "esp32h2")] {
+        }
+    feature = "esp32h2" => {
             let (tx_pin, rx_pin) = (peripherals.GPIO24, peripherals.GPIO23);
-        } else if #[cfg(any(feature = "esp32s2", feature = "esp32s3"))] {
+        }
+    any(feature = "esp32s2", feature = "esp32s3") => {
             let (tx_pin, rx_pin) = (peripherals.GPIO43, peripherals.GPIO44);
         }
-    }
+
+    _ => {}
+}
 
     let uart_config = UartConfig::default()
         .with_baudrate(19200)

--- a/examples/interrupt/uart/src/main.rs
+++ b/examples/interrupt/uart/src/main.rs
@@ -40,27 +40,27 @@ fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
     cfg_select! {
-    feature = "esp32" => {
+        feature = "esp32" => {
             let (tx_pin, rx_pin) = (peripherals.GPIO1, peripherals.GPIO3);
         }
-    feature = "esp32c2" => {
+        feature = "esp32c2" => {
             let (tx_pin, rx_pin) = (peripherals.GPIO20, peripherals.GPIO19);
         }
-    feature = "esp32c3" => {
+        feature = "esp32c3" => {
             let (tx_pin, rx_pin) = (peripherals.GPIO21, peripherals.GPIO20);
         }
-    feature = "esp32c6" => {
+        feature = "esp32c6" => {
             let (tx_pin, rx_pin) = (peripherals.GPIO16, peripherals.GPIO17);
         }
-    feature = "esp32h2" => {
+        feature = "esp32h2" => {
             let (tx_pin, rx_pin) = (peripherals.GPIO24, peripherals.GPIO23);
         }
-    any(feature = "esp32s2", feature = "esp32s3") => {
+        any(feature = "esp32s2", feature = "esp32s3") => {
             let (tx_pin, rx_pin) = (peripherals.GPIO43, peripherals.GPIO44);
         }
 
-    _ => {}
-}
+        _ => {}
+    }
 
     let uart_config = UartConfig::default()
         .with_baudrate(19200)

--- a/examples/ota/update/Cargo.toml
+++ b/examples/ota/update/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2024"
 publish = false
 
 [dependencies]
-cfg-if = "1"
 embedded-storage = "0.3.1"
 esp-backtrace = { path = "../../../esp-backtrace", features = [
     "panic-handler",

--- a/examples/ota/update/src/main.rs
+++ b/examples/ota/update/src/main.rs
@@ -89,16 +89,16 @@ fn main() -> ! {
     }
 
     cfg_select! {
-    any(feature = "esp32", feature = "esp32s2", feature = "esp32s3") => {
+        any(feature = "esp32", feature = "esp32s2", feature = "esp32s3") => {
             let button = peripherals.GPIO0;
         }
-    any(feature = "esp32c5") => {
+        any(feature = "esp32c5") => {
             let button = peripherals.GPIO28;
         }
-    _ => {
+        _ => {
             let button = peripherals.GPIO9;
         }
-}
+    }
 
     let boot_button = Input::new(button, InputConfig::default().with_pull(Pull::Up));
 

--- a/examples/ota/update/src/main.rs
+++ b/examples/ota/update/src/main.rs
@@ -88,15 +88,17 @@ fn main() -> ! {
         }
     }
 
-    cfg_if::cfg_if! {
-        if #[cfg(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3"))] {
+    cfg_select! {
+    any(feature = "esp32", feature = "esp32s2", feature = "esp32s3") => {
             let button = peripherals.GPIO0;
-        } else if #[cfg(any(feature = "esp32c5"))] {
+        }
+    any(feature = "esp32c5") => {
             let button = peripherals.GPIO28;
-        }else {
+        }
+    _ => {
             let button = peripherals.GPIO9;
         }
-    }
+}
 
     let boot_button = Input::new(button, InputConfig::default().with_pull(Pull::Up));
 

--- a/examples/peripheral/debug_assist/Cargo.toml
+++ b/examples/peripheral/debug_assist/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2024"
 publish = false
 
 [dependencies]
-cfg-if = "1"
 critical-section = "1"
 esp-backtrace = { path = "../../../esp-backtrace", features = [
     "panic-handler",

--- a/examples/peripheral/debug_assist/src/main.rs
+++ b/examples/peripheral/debug_assist/src/main.rs
@@ -25,7 +25,7 @@ fn main() -> ! {
     da.set_interrupt_handler(interrupt_handler);
 
     cfg_select! {
-    not(feature = "esp32s3") => {
+        not(feature = "esp32s3") => {
             use core::ptr::addr_of_mut;
 
             unsafe extern "C" {
@@ -33,7 +33,7 @@ fn main() -> ! {
                 static mut _stack_start: u32;
                 // bottom of stack
                 static mut _stack_end: u32;
-            }
+        }
 
             #[allow(unused_unsafe)]
             let stack_top = unsafe { addr_of_mut!(_stack_start) } as *mut _ as u32;
@@ -42,12 +42,12 @@ fn main() -> ! {
 
             let size = 4096;
         }
-    _ => {
+        _ => {
             let stack_bottom = 0x3fcce000;
 
             let size = 256;
         }
-}
+    }
 
     // Monitor the SP so as to prevent stack overflow or erroneous push/pop.
     // When the SP exceeds the minimum or maximum threshold, the module will

--- a/examples/peripheral/debug_assist/src/main.rs
+++ b/examples/peripheral/debug_assist/src/main.rs
@@ -24,8 +24,8 @@ fn main() -> ! {
     let mut da = DebugAssist::new(peripherals.ASSIST_DEBUG);
     da.set_interrupt_handler(interrupt_handler);
 
-    cfg_if::cfg_if! {
-        if #[cfg(not(feature = "esp32s3"))] {
+    cfg_select! {
+    not(feature = "esp32s3") => {
             use core::ptr::addr_of_mut;
 
             unsafe extern "C" {
@@ -41,12 +41,13 @@ fn main() -> ! {
             let stack_bottom = unsafe { addr_of_mut!(_stack_end) } as *mut _ as u32;
 
             let size = 4096;
-        } else {
+        }
+    _ => {
             let stack_bottom = 0x3fcce000;
 
             let size = 256;
         }
-    }
+}
 
     // Monitor the SP so as to prevent stack overflow or erroneous push/pop.
     // When the SP exceeds the minimum or maximum threshold, the module will

--- a/examples/peripheral/dma/mem2mem/Cargo.toml
+++ b/examples/peripheral/dma/mem2mem/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2024"
 publish = false
 
 [dependencies]
-cfg-if = "1"
 esp-backtrace = { path = "../../../../esp-backtrace", features = [
     "panic-handler",
     "println",

--- a/examples/peripheral/dma/mem2mem/src/main.rs
+++ b/examples/peripheral/dma/mem2mem/src/main.rs
@@ -27,15 +27,17 @@ fn main() -> ! {
 
     let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(DATA_SIZE);
 
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "esp32s2")] {
+    cfg_select! {
+    feature = "esp32s2" => {
             let mem2mem = Mem2Mem::new(peripherals.DMA_COPY);
-        } else if #[cfg(any(feature = "esp32c2", feature = "esp32c3", feature = "esp32s3"))] {
+        }
+    any(feature = "esp32c2", feature = "esp32c3", feature = "esp32s3") => {
             let mem2mem = Mem2Mem::new(peripherals.DMA_CH0, peripherals.SPI2);
-        } else {
+        }
+    _ => {
             let mem2mem = Mem2Mem::new(peripherals.DMA_CH0, peripherals.MEM2MEM1);
         }
-    }
+}
 
     let mut mem2mem = mem2mem
         .with_descriptors(rx_descriptors, tx_descriptors, BurstConfig::default())

--- a/examples/peripheral/dma/mem2mem/src/main.rs
+++ b/examples/peripheral/dma/mem2mem/src/main.rs
@@ -28,16 +28,16 @@ fn main() -> ! {
     let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(DATA_SIZE);
 
     cfg_select! {
-    feature = "esp32s2" => {
+        feature = "esp32s2" => {
             let mem2mem = Mem2Mem::new(peripherals.DMA_COPY);
         }
-    any(feature = "esp32c2", feature = "esp32c3", feature = "esp32s3") => {
+        any(feature = "esp32c2", feature = "esp32c3", feature = "esp32s3") => {
             let mem2mem = Mem2Mem::new(peripherals.DMA_CH0, peripherals.SPI2);
         }
-    _ => {
+        _ => {
             let mem2mem = Mem2Mem::new(peripherals.DMA_CH0, peripherals.MEM2MEM1);
         }
-}
+    }
 
     let mut mem2mem = mem2mem
         .with_descriptors(rx_descriptors, tx_descriptors, BurstConfig::default())

--- a/examples/peripheral/spi/slave_dma/Cargo.toml
+++ b/examples/peripheral/spi/slave_dma/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2024"
 publish = false
 
 [dependencies]
-cfg-if = "1"
 esp-backtrace = { path = "../../../../esp-backtrace", features = [
     "panic-handler",
     "println",

--- a/examples/peripheral/spi/slave_dma/src/main.rs
+++ b/examples/peripheral/spi/slave_dma/src/main.rs
@@ -58,13 +58,14 @@ fn main() -> ! {
     let slave_mosi = peripherals.GPIO2;
     let slave_cs = peripherals.GPIO3;
 
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "esp32s2")] {
+    cfg_select! {
+    feature = "esp32s2" => {
             let dma_channel = peripherals.DMA_SPI2;
-        } else {
+        }
+    _ => {
             let dma_channel = peripherals.DMA_CH0;
         }
-    }
+}
 
     let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(32000);
     let mut slave_receive = DmaRxBuf::new(rx_descriptors, rx_buffer).unwrap();

--- a/examples/peripheral/spi/slave_dma/src/main.rs
+++ b/examples/peripheral/spi/slave_dma/src/main.rs
@@ -59,13 +59,13 @@ fn main() -> ! {
     let slave_cs = peripherals.GPIO3;
 
     cfg_select! {
-    feature = "esp32s2" => {
+        feature = "esp32s2" => {
             let dma_channel = peripherals.DMA_SPI2;
         }
-    _ => {
+        _ => {
             let dma_channel = peripherals.DMA_CH0;
         }
-}
+    }
 
     let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(32000);
     let mut slave_receive = DmaRxBuf::new(rx_descriptors, rx_buffer).unwrap();

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -88,7 +88,6 @@ harness           = false
 
 [dependencies]
 allocator-api2    = { version = "0.3.0", default-features = false, features = ["alloc"] }
-cfg-if             = "1"
 critical-section   = "1"
 defmt              = "1.0.1"
 defmt-rtt          = { version = "1.0.0", optional = true }

--- a/hil-test/src/bin/crypto/aes.rs
+++ b/hil-test/src/bin/crypto/aes.rs
@@ -419,13 +419,14 @@ mod tests {
         }
         let peripherals = esp_hal::init(Config::default().with_cpu_clock(CpuClock::max()));
 
-        cfg_if::cfg_if! {
-            if #[cfg(esp32s2)] {
+        cfg_select! {
+    esp32s2 => {
                 let dma_channel = peripherals.DMA_CRYPTO;
-            } else {
+            }
+    _ => {
                 let dma_channel = peripherals.DMA_CH0;
             }
-        }
+}
 
         let aes = Aes::new(peripherals.AES).with_dma(dma_channel);
 
@@ -467,13 +468,14 @@ mod tests {
 
         esp_alloc::heap_allocator!(size: 32 * 1024);
 
-        cfg_if::cfg_if! {
-            if #[cfg(esp32s2)] {
+        cfg_select! {
+    esp32s2 => {
                 let mut aes = AesDmaBackend::new(p.AES, p.DMA_CRYPTO);
-            } else {
+            }
+    _ => {
                 let mut aes = AesDmaBackend::new(p.AES, p.DMA_CH0);
             }
-        }
+}
         let _backend = aes.start();
 
         const MAX_SHIFT: usize = 15;
@@ -494,13 +496,14 @@ mod tests {
         let p = esp_hal::init(Config::default().with_cpu_clock(CpuClock::max()));
         esp_alloc::psram_allocator!(p.PSRAM, esp_hal::psram);
 
-        cfg_if::cfg_if! {
-            if #[cfg(esp32s2)] {
+        cfg_select! {
+    esp32s2 => {
                 let mut aes = AesDmaBackend::new(p.AES, p.DMA_CRYPTO);
-            } else {
+            }
+    _ => {
                 let mut aes = AesDmaBackend::new(p.AES, p.DMA_CH0);
             }
-        }
+}
         let _backend = aes.start();
 
         let mut plaintext = [0; PLAINTEXT_BUF_SIZE];

--- a/hil-test/src/bin/crypto/aes.rs
+++ b/hil-test/src/bin/crypto/aes.rs
@@ -420,13 +420,13 @@ mod tests {
         let peripherals = esp_hal::init(Config::default().with_cpu_clock(CpuClock::max()));
 
         cfg_select! {
-    esp32s2 => {
+            esp32s2 => {
                 let dma_channel = peripherals.DMA_CRYPTO;
             }
-    _ => {
+            _ => {
                 let dma_channel = peripherals.DMA_CH0;
             }
-}
+        }
 
         let aes = Aes::new(peripherals.AES).with_dma(dma_channel);
 
@@ -469,13 +469,13 @@ mod tests {
         esp_alloc::heap_allocator!(size: 32 * 1024);
 
         cfg_select! {
-    esp32s2 => {
+            esp32s2 => {
                 let mut aes = AesDmaBackend::new(p.AES, p.DMA_CRYPTO);
             }
-    _ => {
+            _ => {
                 let mut aes = AesDmaBackend::new(p.AES, p.DMA_CH0);
             }
-}
+        }
         let _backend = aes.start();
 
         const MAX_SHIFT: usize = 15;
@@ -497,13 +497,13 @@ mod tests {
         esp_alloc::psram_allocator!(p.PSRAM, esp_hal::psram);
 
         cfg_select! {
-    esp32s2 => {
+            esp32s2 => {
                 let mut aes = AesDmaBackend::new(p.AES, p.DMA_CRYPTO);
             }
-    _ => {
+            _ => {
                 let mut aes = AesDmaBackend::new(p.AES, p.DMA_CH0);
             }
-}
+        }
         let _backend = aes.start();
 
         let mut plaintext = [0; PLAINTEXT_BUF_SIZE];

--- a/hil-test/src/bin/embassy_timers_executors.rs
+++ b/hil-test/src/bin/embassy_timers_executors.rs
@@ -506,15 +506,15 @@ mod interrupt_spi_dma {
         esp_rtos::start(timg0.timer0, sw_int.software_interrupt0);
 
         cfg_select! {
-    any(feature = "esp32", feature = "esp32s2") => {
+            any(feature = "esp32", feature = "esp32s2") => {
                 let dma_channel1 = peripherals.DMA_SPI2;
                 let dma_channel2 = peripherals.DMA_SPI3;
             }
-    _ => {
+            _ => {
                 let dma_channel1 = peripherals.DMA_CH0;
                 let dma_channel2 = peripherals.DMA_CH1;
             }
-}
+        }
 
         let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(1024);
         let dma_rx_buf = DmaRxBuf::new(rx_descriptors, rx_buffer).unwrap();
@@ -599,13 +599,13 @@ mod interrupt_spi_dma {
         };
 
         cfg_select! {
-    dma_kind = "pdma" => {
+            dma_kind = "pdma" => {
                 type DmaChannel<'a> = esp_hal::peripherals::DMA_SPI2<'a>;
             }
-    _ => {
+            _ => {
                 type DmaChannel<'a> = esp_hal::peripherals::DMA_CH0<'a>;
             }
-}
+        }
 
         const BUFFER_SIZE: usize = 256;
 
@@ -651,13 +651,13 @@ mod interrupt_spi_dma {
         esp_rtos::start(timg0.timer0, sw_int.software_interrupt0);
 
         cfg_select! {
-    dma_kind = "pdma" => {
+            dma_kind = "pdma" => {
                 let dma_channel = peripherals.DMA_SPI2;
             }
-    _ => {
+            _ => {
                 let dma_channel = peripherals.DMA_CH0;
             }
-}
+        }
 
         let transfer_finished = &*mk_static!(Signal<CriticalSectionRawMutex, ()>, Signal::new());
 

--- a/hil-test/src/bin/embassy_timers_executors.rs
+++ b/hil-test/src/bin/embassy_timers_executors.rs
@@ -505,15 +505,16 @@ mod interrupt_spi_dma {
         let timg0 = TimerGroup::new(peripherals.TIMG0);
         esp_rtos::start(timg0.timer0, sw_int.software_interrupt0);
 
-        cfg_if::cfg_if! {
-            if #[cfg(any(feature = "esp32", feature = "esp32s2"))] {
+        cfg_select! {
+    any(feature = "esp32", feature = "esp32s2") => {
                 let dma_channel1 = peripherals.DMA_SPI2;
                 let dma_channel2 = peripherals.DMA_SPI3;
-            } else {
+            }
+    _ => {
                 let dma_channel1 = peripherals.DMA_CH0;
                 let dma_channel2 = peripherals.DMA_CH1;
             }
-        }
+}
 
         let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(1024);
         let dma_rx_buf = DmaRxBuf::new(rx_descriptors, rx_buffer).unwrap();
@@ -597,13 +598,14 @@ mod interrupt_spi_dma {
             system::{Cpu, CpuControl, Stack},
         };
 
-        cfg_if::cfg_if! {
-            if #[cfg(dma_kind = "pdma")] {
+        cfg_select! {
+    dma_kind = "pdma" => {
                 type DmaChannel<'a> = esp_hal::peripherals::DMA_SPI2<'a>;
-            } else {
+            }
+    _ => {
                 type DmaChannel<'a> = esp_hal::peripherals::DMA_CH0<'a>;
             }
-        }
+}
 
         const BUFFER_SIZE: usize = 256;
 
@@ -648,13 +650,14 @@ mod interrupt_spi_dma {
         let timg0 = TimerGroup::new(peripherals.TIMG0);
         esp_rtos::start(timg0.timer0, sw_int.software_interrupt0);
 
-        cfg_if::cfg_if! {
-            if #[cfg(dma_kind = "pdma")] {
+        cfg_select! {
+    dma_kind = "pdma" => {
                 let dma_channel = peripherals.DMA_SPI2;
-            } else {
+            }
+    _ => {
                 let dma_channel = peripherals.DMA_CH0;
             }
-        }
+}
 
         let transfer_finished = &*mk_static!(Signal<CriticalSectionRawMutex, ()>, Signal::new());
 

--- a/hil-test/src/bin/esp_radio.rs
+++ b/hil-test/src/bin/esp_radio.rs
@@ -25,15 +25,18 @@ use hil_test as _;
 extern crate alloc;
 
 fn init_heap() {
-    cfg_if::cfg_if! {
-        if #[cfg(any(esp32, esp32s2, esp32s3, esp32c3, esp32c2, esp32c5, esp32c6, esp32c61))] {
+    cfg_select! {
+    any(esp32, esp32s2, esp32s3, esp32c3, esp32c2, esp32c5, esp32c6, esp32c61) => {
             use esp_hal::ram;
             esp_alloc::heap_allocator!(#[ram(reclaimed)] size: 64 * 1024);
             esp_alloc::heap_allocator!(size: 48 * 1024);
-        } else if #[cfg(esp32h2)] {
+        }
+    esp32h2 => {
             esp_alloc::heap_allocator!(size: 72 * 1024);
         }
-    }
+
+    _ => {}
+}
 }
 
 #[cfg(multi_core)]

--- a/hil-test/src/bin/esp_radio.rs
+++ b/hil-test/src/bin/esp_radio.rs
@@ -26,17 +26,17 @@ extern crate alloc;
 
 fn init_heap() {
     cfg_select! {
-    any(esp32, esp32s2, esp32s3, esp32c3, esp32c2, esp32c5, esp32c6, esp32c61) => {
+        any(esp32, esp32s2, esp32s3, esp32c3, esp32c2, esp32c5, esp32c6, esp32c61) => {
             use esp_hal::ram;
             esp_alloc::heap_allocator!(#[ram(reclaimed)] size: 64 * 1024);
             esp_alloc::heap_allocator!(size: 48 * 1024);
         }
-    esp32h2 => {
+        esp32h2 => {
             esp_alloc::heap_allocator!(size: 72 * 1024);
         }
 
-    _ => {}
-}
+        _ => {}
+    }
 }
 
 #[cfg(multi_core)]

--- a/hil-test/src/bin/gpio.rs
+++ b/hil-test/src/bin/gpio.rs
@@ -11,8 +11,8 @@
 use esp_hal::gpio::{AnyPin, Input, InputConfig, Level, Output, OutputConfig, Pin, Pull};
 use hil_test as _;
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "unstable")] {
+cfg_select! {
+    feature = "unstable" => {
         use core::cell::RefCell;
         use critical_section::Mutex;
         use embassy_time::{Duration, Timer};
@@ -28,12 +28,16 @@ cfg_if::cfg_if! {
         static COUNTER: Mutex<RefCell<u32>> = Mutex::new(RefCell::new(0));
         static INPUT_PIN: Mutex<RefCell<Option<Input>>> = Mutex::new(RefCell::new(None));
     }
+
+    _ => {}
 }
 
-cfg_if::cfg_if! {
-    if #[cfg(all(multi_core, feature = "unstable"))] {
+cfg_select! {
+    all(multi_core, feature = "unstable") => {
         use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
     }
+
+    _ => {}
 }
 
 #[cfg(all(dedicated_gpio_driver_supported, feature = "unstable"))]

--- a/hil-test/src/bin/i2s.rs
+++ b/hil-test/src/bin/i2s.rs
@@ -24,13 +24,13 @@ mod tests {
     };
 
     cfg_select! {
-    any(esp32, esp32s2) => {
+        any(esp32, esp32s2) => {
             type DmaChannel0<'d> = esp_hal::peripherals::DMA_I2S0<'d>;
         }
-    _ => {
+        _ => {
             type DmaChannel0<'d> = esp_hal::peripherals::DMA_CH0<'d>;
         }
-}
+    }
 
     const BUFFER_SIZE: usize = 2000;
 
@@ -94,13 +94,13 @@ mod tests {
         );
 
         cfg_select! {
-    dma_kind = "pdma" => {
+            dma_kind = "pdma" => {
                 let dma_channel = peripherals.DMA_I2S0;
             }
-    _ => {
+            _ => {
                 let dma_channel = peripherals.DMA_CH0;
             }
-}
+        }
 
         let (_, dout) = hil_test::common_test_pins!(peripherals);
 

--- a/hil-test/src/bin/i2s.rs
+++ b/hil-test/src/bin/i2s.rs
@@ -23,13 +23,14 @@ mod tests {
         time::Rate,
     };
 
-    cfg_if::cfg_if! {
-        if #[cfg(any(esp32, esp32s2))] {
+    cfg_select! {
+    any(esp32, esp32s2) => {
             type DmaChannel0<'d> = esp_hal::peripherals::DMA_I2S0<'d>;
-        } else {
+        }
+    _ => {
             type DmaChannel0<'d> = esp_hal::peripherals::DMA_CH0<'d>;
         }
-    }
+}
 
     const BUFFER_SIZE: usize = 2000;
 
@@ -92,13 +93,14 @@ mod tests {
             esp_hal::Config::default().with_cpu_clock(esp_hal::clock::CpuClock::max()),
         );
 
-        cfg_if::cfg_if! {
-            if #[cfg(dma_kind = "pdma")] {
+        cfg_select! {
+    dma_kind = "pdma" => {
                 let dma_channel = peripherals.DMA_I2S0;
-            } else {
+            }
+    _ => {
                 let dma_channel = peripherals.DMA_CH0;
             }
-        }
+}
 
         let (_, dout) = hil_test::common_test_pins!(peripherals);
 

--- a/hil-test/src/bin/interrupt.rs
+++ b/hil-test/src/bin/interrupt.rs
@@ -77,13 +77,14 @@ mod tests {
         let peripherals = esp_hal::init(config);
         let sw_ints = SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
 
-        cfg_if::cfg_if! {
-            if #[cfg(any(feature = "esp32c6", feature = "esp32h2"))] {
+        cfg_select! {
+    any(feature = "esp32c6", feature = "esp32h2") => {
                 let cpu_intr = &peripherals.INTPRI;
-            } else {
+            }
+    _ => {
                 let cpu_intr = &peripherals.SYSTEM;
             }
-        }
+}
 
         let sw0_trigger_addr = cpu_intr.register_block().cpu_intr_from_cpu(0) as *const _ as u32;
         unsafe {
@@ -139,12 +140,13 @@ mod tests {
         defmt::info!("Performance counter: {}", perf_counter);
 
         // TODO c3/c2 values should be adjusted to catch smaller regressions
-        cfg_if::cfg_if! {
-        if #[cfg(any(feature = "esp32c3", feature = "esp32c2"))] {
+        cfg_select! {
+    any(feature = "esp32c3", feature = "esp32c2") => {
             assert!(perf_counter < 400);
-        } else {
+        }
+    _ => {
             assert!(perf_counter < 155);
         }
-    }
+}
     }
 }

--- a/hil-test/src/bin/interrupt.rs
+++ b/hil-test/src/bin/interrupt.rs
@@ -78,13 +78,13 @@ mod tests {
         let sw_ints = SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
 
         cfg_select! {
-    any(feature = "esp32c6", feature = "esp32h2") => {
+            any(feature = "esp32c6", feature = "esp32h2") => {
                 let cpu_intr = &peripherals.INTPRI;
             }
-    _ => {
+            _ => {
                 let cpu_intr = &peripherals.SYSTEM;
             }
-}
+        }
 
         let sw0_trigger_addr = cpu_intr.register_block().cpu_intr_from_cpu(0) as *const _ as u32;
         unsafe {
@@ -141,12 +141,12 @@ mod tests {
 
         // TODO c3/c2 values should be adjusted to catch smaller regressions
         cfg_select! {
-    any(feature = "esp32c3", feature = "esp32c2") => {
+            any(feature = "esp32c3", feature = "esp32c2") => {
             assert!(perf_counter < 400);
-        }
-    _ => {
+            }
+            _ => {
             assert!(perf_counter < 155);
+            }
         }
-}
     }
 }

--- a/hil-test/src/bin/misc_non_drivers/dma_mem2mem.rs
+++ b/hil-test/src/bin/misc_non_drivers/dma_mem2mem.rs
@@ -16,16 +16,16 @@ mod tests {
         let peripherals = esp_hal::init(esp_hal::Config::default());
 
         cfg_select! {
-    esp32s2 => {
+            esp32s2 => {
                 let mem2mem = Mem2Mem::new(peripherals.DMA_COPY);
             }
-    soc_has_mem2mem1 => {
+            soc_has_mem2mem1 => {
                 let mem2mem = Mem2Mem::new(peripherals.DMA_CH0, peripherals.MEM2MEM1);
             }
-    _ => {
+            _ => {
                 let mem2mem = Mem2Mem::new(peripherals.DMA_CH0, peripherals.SPI2);
             }
-}
+        }
 
         Context { mem2mem }
     }

--- a/hil-test/src/bin/misc_non_drivers/dma_mem2mem.rs
+++ b/hil-test/src/bin/misc_non_drivers/dma_mem2mem.rs
@@ -15,15 +15,17 @@ mod tests {
     fn init() -> Context {
         let peripherals = esp_hal::init(esp_hal::Config::default());
 
-        cfg_if::cfg_if! {
-            if #[cfg(esp32s2)] {
+        cfg_select! {
+    esp32s2 => {
                 let mem2mem = Mem2Mem::new(peripherals.DMA_COPY);
-            } else if #[cfg(soc_has_mem2mem1)] {
+            }
+    soc_has_mem2mem1 => {
                 let mem2mem = Mem2Mem::new(peripherals.DMA_CH0, peripherals.MEM2MEM1);
-            } else {
+            }
+    _ => {
                 let mem2mem = Mem2Mem::new(peripherals.DMA_CH0, peripherals.SPI2);
             }
-        }
+}
 
         Context { mem2mem }
     }

--- a/hil-test/src/bin/parl_io.rs
+++ b/hil-test/src/bin/parl_io.rs
@@ -62,8 +62,8 @@ mod tests {
 
         let parl_io = peripherals.PARL_IO;
 
-        cfg_if::cfg_if! {
-            if #[cfg(esp32c5)] {
+        cfg_select! {
+    esp32c5 => {
                 // 27 is RGB, 9 and 10 are connected, 13 and 14 is USB
                 let valid_pin = peripherals.GPIO0.degrade();
                 let clock_pin = peripherals.GPIO1.degrade();
@@ -77,7 +77,8 @@ mod tests {
                     peripherals.GPIO8.degrade(),
                     peripherals.GPIO9.degrade(),
                 ];
-            } else if #[cfg(esp32c6)] {
+            }
+    esp32c6 => {
                 // 8 is RGB, 2 and 3 are connected, 12 and 13 is USB
                 let valid_pin = peripherals.GPIO0.degrade();
                 let clock_pin = peripherals.GPIO1.degrade();
@@ -91,7 +92,8 @@ mod tests {
                     peripherals.GPIO9.degrade(),
                     peripherals.GPIO10.degrade(),
                 ];
-            } else if #[cfg(esp32h2)] {
+            }
+    esp32h2 => {
                 // 8 is RGB, 2 and 3 are connected, 26 and 27 is USB
                 let valid_pin = peripherals.GPIO0.degrade();
                 let clock_pin = peripherals.GPIO1.degrade();
@@ -106,7 +108,9 @@ mod tests {
                     peripherals.GPIO23.degrade(),
                 ];
             }
-        }
+
+    _ => {}
+}
 
         Context {
             parl_io,

--- a/hil-test/src/bin/parl_io.rs
+++ b/hil-test/src/bin/parl_io.rs
@@ -63,7 +63,7 @@ mod tests {
         let parl_io = peripherals.PARL_IO;
 
         cfg_select! {
-    esp32c5 => {
+            esp32c5 => {
                 // 27 is RGB, 9 and 10 are connected, 13 and 14 is USB
                 let valid_pin = peripherals.GPIO0.degrade();
                 let clock_pin = peripherals.GPIO1.degrade();
@@ -78,7 +78,7 @@ mod tests {
                     peripherals.GPIO9.degrade(),
                 ];
             }
-    esp32c6 => {
+            esp32c6 => {
                 // 8 is RGB, 2 and 3 are connected, 12 and 13 is USB
                 let valid_pin = peripherals.GPIO0.degrade();
                 let clock_pin = peripherals.GPIO1.degrade();
@@ -93,7 +93,7 @@ mod tests {
                     peripherals.GPIO10.degrade(),
                 ];
             }
-    esp32h2 => {
+            esp32h2 => {
                 // 8 is RGB, 2 and 3 are connected, 26 and 27 is USB
                 let valid_pin = peripherals.GPIO0.degrade();
                 let clock_pin = peripherals.GPIO1.degrade();
@@ -109,8 +109,8 @@ mod tests {
                 ];
             }
 
-    _ => {}
-}
+            _ => {}
+        }
 
         Context {
             parl_io,

--- a/hil-test/src/bin/rmt.rs
+++ b/hil-test/src/bin/rmt.rs
@@ -58,11 +58,12 @@ use esp_hal::{
 use hil_test::{assert, assert_eq};
 
 // RMT channel clock = 500kHz
-cfg_if::cfg_if! {
-    if #[cfg(esp32h2)] {
+cfg_select! {
+    esp32h2 => {
         const FREQ: Rate = Rate::from_mhz(32);
         const DIV: u8 = 64;
-    } else {
+    }
+    _ => {
         const FREQ: Rate = Rate::from_mhz(80);
         const DIV: u8 = 160;
     }
@@ -440,21 +441,22 @@ macro_rules! pins {
     };
 }
 
-cfg_if::cfg_if!(
-    if #[cfg(any(esp32, esp32s3))] {
+cfg_select! {
+    any(esp32, esp32s3) => {
         macro_rules! rx_channel_creator {
             ($rmt:expr) => {
                 $rmt.channel4
             };
         }
-    } else {
+    }
+    _ => {
         macro_rules! rx_channel_creator {
             ($rmt:expr) => {
                 $rmt.channel2
             };
         }
     }
-);
+}
 
 struct Context {
     rmt: RMT<'static>,

--- a/hil-test/src/bin/rmt.rs
+++ b/hil-test/src/bin/rmt.rs
@@ -447,14 +447,14 @@ cfg_select! {
             ($rmt:expr) => {
                 $rmt.channel4
             };
-        }
+    }
     }
     _ => {
         macro_rules! rx_channel_creator {
             ($rmt:expr) => {
                 $rmt.channel2
             };
-        }
+    }
     }
 }
 

--- a/hil-test/src/bin/spi_full_duplex.rs
+++ b/hil-test/src/bin/spi_full_duplex.rs
@@ -19,8 +19,8 @@ use esp_hal::{
 };
 use hil_test as _;
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "unstable")] {
+cfg_select! {
+    feature = "unstable" => {
         use esp_hal::peripherals::SPI2;
         use esp_hal::spi::master::{Address, Command, DataMode};
 
@@ -33,13 +33,16 @@ cfg_if::cfg_if! {
         #[cfg(pcnt_driver_supported)]
         use esp_hal::pcnt::{channel::EdgeMode, unit::Unit, Pcnt};
     }
+
+    _ => {}
 }
 
 #[cfg(all(spi_master_supports_dma, feature = "unstable"))]
-cfg_if::cfg_if! {
-    if #[cfg(any(esp32, esp32s2))] {
+cfg_select! {
+    any(esp32, esp32s2) => {
         type DmaChannel<'d> = esp_hal::peripherals::DMA_SPI2<'d>;
-    } else {
+    }
+    _ => {
         type DmaChannel<'d> = esp_hal::peripherals::DMA_CH0<'d>;
     }
 }
@@ -94,25 +97,27 @@ mod tests {
         let sclk_input = Input::new(sclk_input, Default::default());
 
         #[cfg(all(spi_master_supports_dma, feature = "unstable"))]
-        cfg_if::cfg_if! {
-            if #[cfg(dma_kind = "pdma")] {
+        cfg_select! {
+    dma_kind = "pdma" => {
                 let dma_channel = peripherals.DMA_SPI2;
-            } else {
+            }
+    _ => {
                 let dma_channel = peripherals.DMA_CH0;
             }
-        }
+}
 
-        cfg_if::cfg_if! {
-            if #[cfg(all(spi_master_supports_dma, feature = "unstable"))] {
+        cfg_select! {
+    all(spi_master_supports_dma, feature = "unstable") => {
                 let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(32000);
-            } else {
+            }
+    _ => {
                 static mut TX_BUFFER: [u8; 4096] = [0; 4096];
                 static mut RX_BUFFER: [u8; 4096] = [0; 4096];
 
                 let tx_buffer = unsafe { (&raw mut TX_BUFFER).as_mut().unwrap() };
                 let rx_buffer = unsafe { (&raw mut RX_BUFFER).as_mut().unwrap() };
             }
-        }
+}
 
         // Need to set miso first so that mosi can overwrite the
         // output connection (because we are using the same pin to loop back)
@@ -125,8 +130,8 @@ mod tests {
         .with_miso(miso)
         .with_mosi(mosi);
 
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "unstable")] {
+        cfg_select! {
+    feature = "unstable" => {
                 #[cfg(pcnt_driver_supported)]
                 let pcnt = Pcnt::new(peripherals.PCNT);
 
@@ -146,7 +151,8 @@ mod tests {
                     #[cfg(pcnt_driver_supported)]
                     pcnt_unit: pcnt.unit0,
                 }
-            } else {
+            }
+    _ => {
                 Context {
                     spi,
                     rx_buffer,
@@ -154,7 +160,7 @@ mod tests {
                     miso_input,
                 }
             }
-        }
+}
     }
 
     #[test]
@@ -184,15 +190,17 @@ mod tests {
         let write = [0xde, 0xad, 0xbe, 0xef];
         let mut read = [0x00; 2];
 
-        cfg_if::cfg_if! {
-            if #[cfg(all(pcnt_driver_supported, feature = "unstable"))] {
+        cfg_select! {
+    all(pcnt_driver_supported, feature = "unstable") => {
                 let unit = ctx.pcnt_unit;
                 unit.channel0
                     .set_edge_signal(ctx.sclk_input.peripheral_input());
                 unit.channel0
                     .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
             }
-        }
+
+    _ => {}
+}
 
         SpiBus::transfer(&mut ctx.spi, &mut read, &write).expect("Asymmetric transfer failed");
         assert_eq!(read[0], write[0]);
@@ -207,15 +215,17 @@ mod tests {
         let write = [0xde, 0xad];
         let mut read = [0x00; 4];
 
-        cfg_if::cfg_if! {
-            if #[cfg(all(pcnt_driver_supported, feature = "unstable"))] {
+        cfg_select! {
+    all(pcnt_driver_supported, feature = "unstable") => {
                 let unit = ctx.pcnt_unit;
                 unit.channel0
                     .set_edge_signal(ctx.sclk_input.peripheral_input());
                 unit.channel0
                     .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
             }
-        }
+
+    _ => {}
+}
 
         SpiBus::transfer(&mut ctx.spi, &mut read, &write).expect("Asymmetric transfer failed");
         assert_eq!(read[0], write[0]);
@@ -232,15 +242,17 @@ mod tests {
         let write = [0xde, 0xad, 0xbe, 0xef];
         let mut read = [0x00; 2];
 
-        cfg_if::cfg_if! {
-            if #[cfg(all(pcnt_driver_supported, feature = "unstable"))] {
+        cfg_select! {
+    all(pcnt_driver_supported, feature = "unstable") => {
                 let unit = ctx.pcnt_unit;
                 unit.channel0
                     .set_edge_signal(ctx.sclk_input.peripheral_input());
                 unit.channel0
                     .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
             }
-        }
+
+    _ => {}
+}
 
         let mut spi = ctx.spi.into_async();
         SpiBusAsync::transfer(&mut spi, &mut read, &write)
@@ -258,15 +270,17 @@ mod tests {
         let write = [0xde, 0xad];
         let mut read = [0x00; 4];
 
-        cfg_if::cfg_if! {
-            if #[cfg(all(pcnt_driver_supported, feature = "unstable"))] {
+        cfg_select! {
+    all(pcnt_driver_supported, feature = "unstable") => {
                 let unit = ctx.pcnt_unit;
                 unit.channel0
                     .set_edge_signal(ctx.sclk_input.peripheral_input());
                 unit.channel0
                     .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
             }
-        }
+
+    _ => {}
+}
 
         let mut spi = ctx.spi.into_async();
         SpiBusAsync::transfer(&mut spi, &mut read, &write)

--- a/hil-test/src/bin/spi_full_duplex.rs
+++ b/hil-test/src/bin/spi_full_duplex.rs
@@ -98,26 +98,26 @@ mod tests {
 
         #[cfg(all(spi_master_supports_dma, feature = "unstable"))]
         cfg_select! {
-    dma_kind = "pdma" => {
+            dma_kind = "pdma" => {
                 let dma_channel = peripherals.DMA_SPI2;
             }
-    _ => {
+            _ => {
                 let dma_channel = peripherals.DMA_CH0;
             }
-}
+        }
 
         cfg_select! {
-    all(spi_master_supports_dma, feature = "unstable") => {
+            all(spi_master_supports_dma, feature = "unstable") => {
                 let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(32000);
             }
-    _ => {
+            _ => {
                 static mut TX_BUFFER: [u8; 4096] = [0; 4096];
                 static mut RX_BUFFER: [u8; 4096] = [0; 4096];
 
                 let tx_buffer = unsafe { (&raw mut TX_BUFFER).as_mut().unwrap() };
                 let rx_buffer = unsafe { (&raw mut RX_BUFFER).as_mut().unwrap() };
             }
-}
+        }
 
         // Need to set miso first so that mosi can overwrite the
         // output connection (because we are using the same pin to loop back)
@@ -131,7 +131,7 @@ mod tests {
         .with_mosi(mosi);
 
         cfg_select! {
-    feature = "unstable" => {
+            feature = "unstable" => {
                 #[cfg(pcnt_driver_supported)]
                 let pcnt = Pcnt::new(peripherals.PCNT);
 
@@ -150,17 +150,17 @@ mod tests {
                     tx_descriptors,
                     #[cfg(pcnt_driver_supported)]
                     pcnt_unit: pcnt.unit0,
-                }
             }
-    _ => {
+            }
+            _ => {
                 Context {
                     spi,
                     rx_buffer,
                     tx_buffer,
                     miso_input,
-                }
             }
-}
+            }
+        }
     }
 
     #[test]
@@ -191,7 +191,7 @@ mod tests {
         let mut read = [0x00; 2];
 
         cfg_select! {
-    all(pcnt_driver_supported, feature = "unstable") => {
+            all(pcnt_driver_supported, feature = "unstable") => {
                 let unit = ctx.pcnt_unit;
                 unit.channel0
                     .set_edge_signal(ctx.sclk_input.peripheral_input());
@@ -199,8 +199,8 @@ mod tests {
                     .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
             }
 
-    _ => {}
-}
+            _ => {}
+        }
 
         SpiBus::transfer(&mut ctx.spi, &mut read, &write).expect("Asymmetric transfer failed");
         assert_eq!(read[0], write[0]);
@@ -216,7 +216,7 @@ mod tests {
         let mut read = [0x00; 4];
 
         cfg_select! {
-    all(pcnt_driver_supported, feature = "unstable") => {
+            all(pcnt_driver_supported, feature = "unstable") => {
                 let unit = ctx.pcnt_unit;
                 unit.channel0
                     .set_edge_signal(ctx.sclk_input.peripheral_input());
@@ -224,8 +224,8 @@ mod tests {
                     .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
             }
 
-    _ => {}
-}
+            _ => {}
+        }
 
         SpiBus::transfer(&mut ctx.spi, &mut read, &write).expect("Asymmetric transfer failed");
         assert_eq!(read[0], write[0]);
@@ -243,7 +243,7 @@ mod tests {
         let mut read = [0x00; 2];
 
         cfg_select! {
-    all(pcnt_driver_supported, feature = "unstable") => {
+            all(pcnt_driver_supported, feature = "unstable") => {
                 let unit = ctx.pcnt_unit;
                 unit.channel0
                     .set_edge_signal(ctx.sclk_input.peripheral_input());
@@ -251,8 +251,8 @@ mod tests {
                     .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
             }
 
-    _ => {}
-}
+            _ => {}
+        }
 
         let mut spi = ctx.spi.into_async();
         SpiBusAsync::transfer(&mut spi, &mut read, &write)
@@ -271,7 +271,7 @@ mod tests {
         let mut read = [0x00; 4];
 
         cfg_select! {
-    all(pcnt_driver_supported, feature = "unstable") => {
+            all(pcnt_driver_supported, feature = "unstable") => {
                 let unit = ctx.pcnt_unit;
                 unit.channel0
                     .set_edge_signal(ctx.sclk_input.peripheral_input());
@@ -279,8 +279,8 @@ mod tests {
                     .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
             }
 
-    _ => {}
-}
+            _ => {}
+        }
 
         let mut spi = ctx.spi.into_async();
         SpiBusAsync::transfer(&mut spi, &mut read, &write)

--- a/hil-test/src/bin/spi_half_duplex_slave_qspi.rs
+++ b/hil-test/src/bin/spi_half_duplex_slave_qspi.rs
@@ -27,13 +27,13 @@ mod read {
 
     #[cfg(spi_master_supports_dma)]
     cfg_select! {
-    dma_kind = "pdma" => {
+        dma_kind = "pdma" => {
             type DmaChannel<'d> = esp_hal::peripherals::DMA_SPI2<'d>;
         }
-    _ => {
+        _ => {
             type DmaChannel<'d> = esp_hal::peripherals::DMA_CH0<'d>;
         }
-}
+    }
 
     struct Context {
         spi: Spi<'static, Blocking>,
@@ -53,13 +53,13 @@ mod read {
 
         #[cfg(spi_master_supports_dma)]
         cfg_select! {
-    dma_kind = "pdma" => {
+            dma_kind = "pdma" => {
                 let dma_channel = peripherals.DMA_SPI2;
             }
-    _ => {
+            _ => {
                 let dma_channel = peripherals.DMA_CH0;
             }
-}
+        }
 
         let spi = Spi::new(
             peripherals.SPI2,
@@ -289,13 +289,13 @@ mod write {
 
     #[cfg(spi_master_supports_dma)]
     cfg_select! {
-    dma_kind = "pdma" => {
+        dma_kind = "pdma" => {
             type DmaChannel<'d> = esp_hal::peripherals::DMA_SPI2<'d>;
         }
-    _ => {
+        _ => {
             type DmaChannel<'d> = esp_hal::peripherals::DMA_CH0<'d>;
         }
-}
+    }
 
     struct Context {
         spi: Spi<'static, Blocking>,
@@ -317,13 +317,13 @@ mod write {
 
         #[cfg(spi_master_supports_dma)]
         cfg_select! {
-    dma_kind = "pdma" => {
+            dma_kind = "pdma" => {
                 let dma_channel = peripherals.DMA_SPI2;
             }
-    _ => {
+            _ => {
                 let dma_channel = peripherals.DMA_CH0;
             }
-}
+        }
 
         let mut mosi = Flex::new(mosi);
 
@@ -526,13 +526,13 @@ mod spi_slave {
 
     #[cfg(spi_slave_supports_dma)]
     cfg_select! {
-    any(esp32, esp32s2) => {
+        any(esp32, esp32s2) => {
             type DmaChannel<'d> = esp_hal::peripherals::DMA_SPI2<'d>;
         }
-    _ => {
+        _ => {
             type DmaChannel<'d> = esp_hal::peripherals::DMA_CH0<'d>;
         }
-}
+    }
 
     struct Context {
         spi: Spi<'static, Blocking>,
@@ -613,13 +613,13 @@ mod spi_slave {
 
         #[cfg(spi_slave_supports_dma)]
         cfg_select! {
-    dma_kind = "pdma" => {
+            dma_kind = "pdma" => {
                 let dma_channel = peripherals.DMA_SPI2;
             }
-    _ => {
+            _ => {
                 let dma_channel = peripherals.DMA_CH0;
             }
-}
+        }
 
         let mut mosi_gpio = Flex::new(mosi_pin);
         mosi_gpio.apply_output_config(&OutputConfig::default());
@@ -714,22 +714,22 @@ mod qspi_dma {
     };
 
     cfg_select! {
-    dma_kind = "pdma" => {
+        dma_kind = "pdma" => {
             type DmaChannel0<'d> = esp_hal::peripherals::DMA_SPI2<'d>;
         }
-    _ => {
+        _ => {
             type DmaChannel0<'d> = esp_hal::peripherals::DMA_CH0<'d>;
         }
-}
+    }
 
     cfg_select! {
-    esp32 => {
+        esp32 => {
             const COMMAND_DATA_MODES: [DataMode; 1] = [DataMode::SingleTwoDataLines];
         }
-    _ => {
+        _ => {
             const COMMAND_DATA_MODES: [DataMode; 2] = [DataMode::SingleTwoDataLines, DataMode::Quad];
         }
-}
+    }
 
     type SpiUnderTest<'a> = SpiDma<'a, Blocking>;
 
@@ -960,13 +960,13 @@ mod qspi_dma {
         let _ = Input::new(unconnected_pin.reborrow(), config);
 
         cfg_select! {
-    dma_kind = "pdma" => {
+            dma_kind = "pdma" => {
                 let dma_channel = peripherals.DMA_SPI2;
             }
-    _ => {
+            _ => {
                 let dma_channel = peripherals.DMA_CH0;
             }
-}
+        }
 
         let spi = Spi::new(
             peripherals.SPI2,

--- a/hil-test/src/bin/spi_half_duplex_slave_qspi.rs
+++ b/hil-test/src/bin/spi_half_duplex_slave_qspi.rs
@@ -26,13 +26,14 @@ mod read {
     };
 
     #[cfg(spi_master_supports_dma)]
-    cfg_if::cfg_if! {
-        if #[cfg(dma_kind = "pdma")] {
+    cfg_select! {
+    dma_kind = "pdma" => {
             type DmaChannel<'d> = esp_hal::peripherals::DMA_SPI2<'d>;
-        } else {
+        }
+    _ => {
             type DmaChannel<'d> = esp_hal::peripherals::DMA_CH0<'d>;
         }
-    }
+}
 
     struct Context {
         spi: Spi<'static, Blocking>,
@@ -51,13 +52,14 @@ mod read {
         let miso_mirror = Output::new(miso_mirror, Level::High, OutputConfig::default());
 
         #[cfg(spi_master_supports_dma)]
-        cfg_if::cfg_if! {
-            if #[cfg(dma_kind = "pdma")] {
+        cfg_select! {
+    dma_kind = "pdma" => {
                 let dma_channel = peripherals.DMA_SPI2;
-            } else {
+            }
+    _ => {
                 let dma_channel = peripherals.DMA_CH0;
             }
-        }
+}
 
         let spi = Spi::new(
             peripherals.SPI2,
@@ -286,13 +288,14 @@ mod write {
     };
 
     #[cfg(spi_master_supports_dma)]
-    cfg_if::cfg_if! {
-        if #[cfg(dma_kind = "pdma")] {
+    cfg_select! {
+    dma_kind = "pdma" => {
             type DmaChannel<'d> = esp_hal::peripherals::DMA_SPI2<'d>;
-        } else {
+        }
+    _ => {
             type DmaChannel<'d> = esp_hal::peripherals::DMA_CH0<'d>;
         }
-    }
+}
 
     struct Context {
         spi: Spi<'static, Blocking>,
@@ -313,13 +316,14 @@ mod write {
         let pcnt = Pcnt::new(peripherals.PCNT);
 
         #[cfg(spi_master_supports_dma)]
-        cfg_if::cfg_if! {
-            if #[cfg(dma_kind = "pdma")] {
+        cfg_select! {
+    dma_kind = "pdma" => {
                 let dma_channel = peripherals.DMA_SPI2;
-            } else {
+            }
+    _ => {
                 let dma_channel = peripherals.DMA_CH0;
             }
-        }
+}
 
         let mut mosi = Flex::new(mosi);
 
@@ -521,13 +525,14 @@ mod spi_slave {
     };
 
     #[cfg(spi_slave_supports_dma)]
-    cfg_if::cfg_if! {
-        if #[cfg(any(esp32, esp32s2))] {
+    cfg_select! {
+    any(esp32, esp32s2) => {
             type DmaChannel<'d> = esp_hal::peripherals::DMA_SPI2<'d>;
-        } else {
+        }
+    _ => {
             type DmaChannel<'d> = esp_hal::peripherals::DMA_CH0<'d>;
         }
-    }
+}
 
     struct Context {
         spi: Spi<'static, Blocking>,
@@ -607,13 +612,14 @@ mod spi_slave {
         let cs_pin = hil_test::unconnected_pin!(peripherals);
 
         #[cfg(spi_slave_supports_dma)]
-        cfg_if::cfg_if! {
-            if #[cfg(dma_kind = "pdma")] {
+        cfg_select! {
+    dma_kind = "pdma" => {
                 let dma_channel = peripherals.DMA_SPI2;
-            } else {
+            }
+    _ => {
                 let dma_channel = peripherals.DMA_CH0;
             }
-        }
+}
 
         let mut mosi_gpio = Flex::new(mosi_pin);
         mosi_gpio.apply_output_config(&OutputConfig::default());
@@ -707,21 +713,23 @@ mod qspi_dma {
         peripherals::PCNT,
     };
 
-    cfg_if::cfg_if! {
-        if #[cfg(dma_kind = "pdma")] {
+    cfg_select! {
+    dma_kind = "pdma" => {
             type DmaChannel0<'d> = esp_hal::peripherals::DMA_SPI2<'d>;
-        } else {
+        }
+    _ => {
             type DmaChannel0<'d> = esp_hal::peripherals::DMA_CH0<'d>;
         }
-    }
+}
 
-    cfg_if::cfg_if! {
-        if #[cfg(esp32)] {
+    cfg_select! {
+    esp32 => {
             const COMMAND_DATA_MODES: [DataMode; 1] = [DataMode::SingleTwoDataLines];
-        } else {
+        }
+    _ => {
             const COMMAND_DATA_MODES: [DataMode; 2] = [DataMode::SingleTwoDataLines, DataMode::Quad];
         }
-    }
+}
 
     type SpiUnderTest<'a> = SpiDma<'a, Blocking>;
 
@@ -951,13 +959,14 @@ mod qspi_dma {
         let _ = Input::new(pin_mirror.reborrow(), config);
         let _ = Input::new(unconnected_pin.reborrow(), config);
 
-        cfg_if::cfg_if! {
-            if #[cfg(dma_kind = "pdma")] {
+        cfg_select! {
+    dma_kind = "pdma" => {
                 let dma_channel = peripherals.DMA_SPI2;
-            } else {
+            }
+    _ => {
                 let dma_channel = peripherals.DMA_CH0;
             }
-        }
+}
 
         let spi = Spi::new(
             peripherals.SPI2,

--- a/hil-test/src/bin/uart.rs
+++ b/hil-test/src/bin/uart.rs
@@ -169,19 +169,19 @@ mod tests {
         // while we're at it.
 
         cfg_select! {
-    esp32c2 => {
+            esp32c2 => {
                 let fastest_clock_source = ClockSource::PllF40m;
             }
-    any(esp32c5, esp32c6, esp32c61) => {
+            any(esp32c5, esp32c6, esp32c61) => {
                 let fastest_clock_source = ClockSource::PllF80m;
             }
-    esp32h2 => {
+            esp32h2 => {
                 let fastest_clock_source = ClockSource::PllF48m;
             }
-    _ => {
+            _ => {
                 let fastest_clock_source = ClockSource::Apb;
             }
-}
+        }
 
         let configs = [
             #[cfg(not(soc_has_clock_node_ref_tick))]

--- a/hil-test/src/bin/uart.rs
+++ b/hil-test/src/bin/uart.rs
@@ -168,17 +168,20 @@ mod tests {
         // working as expected. We will also using different clock sources
         // while we're at it.
 
-        cfg_if::cfg_if! {
-            if #[cfg(esp32c2)] {
+        cfg_select! {
+    esp32c2 => {
                 let fastest_clock_source = ClockSource::PllF40m;
-            } else if #[cfg(any(esp32c5, esp32c6, esp32c61))] {
+            }
+    any(esp32c5, esp32c6, esp32c61) => {
                 let fastest_clock_source = ClockSource::PllF80m;
-            } else if #[cfg(esp32h2)] {
+            }
+    esp32h2 => {
                 let fastest_clock_source = ClockSource::PllF48m;
-            } else {
+            }
+    _ => {
                 let fastest_clock_source = ClockSource::Apb;
             }
-        }
+}
 
         let configs = [
             #[cfg(not(soc_has_clock_node_ref_tick))]

--- a/hil-test/src/lib.rs
+++ b/hil-test/src/lib.rs
@@ -54,28 +54,28 @@ macro_rules! i2c_pins {
     ($peripherals:expr) => {{
         // Order: (SDA, SCL)
         cfg_select! {
-    any(esp32s2, esp32s3) => {
+            any(esp32s2, esp32s3) => {
                 ($peripherals.GPIO3, $peripherals.GPIO2)
             }
-    esp32 => {
+            esp32 => {
                 ($peripherals.GPIO32, $peripherals.GPIO33)
             }
-    any(esp32c6, esp32c61) => {
+            any(esp32c6, esp32c61) => {
                 ($peripherals.GPIO6, $peripherals.GPIO7)
             }
-    esp32h2 => {
+            esp32h2 => {
                 ($peripherals.GPIO12, $peripherals.GPIO22)
             }
-    esp32c2 => {
+            esp32c2 => {
                 ($peripherals.GPIO18, $peripherals.GPIO9)
             }
-    esp32c5 => {
+            esp32c5 => {
                 ($peripherals.GPIO2, $peripherals.GPIO3)
             }
-    _ => { // esp32c3
+            _ => { // esp32c3
                 ($peripherals.GPIO4, $peripherals.GPIO5)
             }
-}
+        }
     }};
 }
 
@@ -83,16 +83,16 @@ macro_rules! i2c_pins {
 macro_rules! common_test_pins {
     ($peripherals:expr) => {{
         cfg_select! {
-    any(esp32s2, esp32s3, esp32c5) => {
+            any(esp32s2, esp32s3, esp32c5) => {
                 ($peripherals.GPIO9, $peripherals.GPIO10)
             }
-    esp32 => {
+            esp32 => {
                 ($peripherals.GPIO2, $peripherals.GPIO4)
             }
-    _ => { // esp32c6, esp32c61, esp32h2, esp32c2, esp32c3
+            _ => { // esp32c6, esp32c61, esp32h2, esp32c2, esp32c3
                 ($peripherals.GPIO2, $peripherals.GPIO3)
             }
-}
+        }
     }};
 }
 
@@ -102,19 +102,19 @@ macro_rules! common_test_pins {
 macro_rules! unconnected_pin {
     ($peripherals:expr) => {{
         cfg_select! {
-    any(esp32, esp32s2, esp32s3) => {
+            any(esp32, esp32s2, esp32s3) => {
                 $peripherals.GPIO0
             }
-    esp32c2 => {
+            esp32c2 => {
                 $peripherals.GPIO8
             }
-    esp32c5 => {
+            esp32c5 => {
                 $peripherals.GPIO28
             }
-    _ => { // esp32c3, esp32c6, esp32c61, esp32h2
+            _ => { // esp32c3, esp32c6, esp32c61, esp32h2
                 $peripherals.GPIO9
             }
-}
+        }
     }};
 }
 

--- a/hil-test/src/lib.rs
+++ b/hil-test/src/lib.rs
@@ -53,38 +53,46 @@ macro_rules! assert_eq {
 macro_rules! i2c_pins {
     ($peripherals:expr) => {{
         // Order: (SDA, SCL)
-        cfg_if::cfg_if! {
-            if #[cfg(any(esp32s2, esp32s3))] {
+        cfg_select! {
+    any(esp32s2, esp32s3) => {
                 ($peripherals.GPIO3, $peripherals.GPIO2)
-            } else if #[cfg(esp32)] {
+            }
+    esp32 => {
                 ($peripherals.GPIO32, $peripherals.GPIO33)
-            } else if #[cfg(any(esp32c6, esp32c61))] {
+            }
+    any(esp32c6, esp32c61) => {
                 ($peripherals.GPIO6, $peripherals.GPIO7)
-            } else if #[cfg(esp32h2)] {
+            }
+    esp32h2 => {
                 ($peripherals.GPIO12, $peripherals.GPIO22)
-            } else if #[cfg(esp32c2)] {
+            }
+    esp32c2 => {
                 ($peripherals.GPIO18, $peripherals.GPIO9)
-            } else if #[cfg(esp32c5)] {
+            }
+    esp32c5 => {
                 ($peripherals.GPIO2, $peripherals.GPIO3)
-            } else { // esp32c3
+            }
+    _ => { // esp32c3
                 ($peripherals.GPIO4, $peripherals.GPIO5)
             }
-        }
+}
     }};
 }
 
 #[macro_export]
 macro_rules! common_test_pins {
     ($peripherals:expr) => {{
-        cfg_if::cfg_if! {
-            if #[cfg(any(esp32s2, esp32s3, esp32c5))] {
+        cfg_select! {
+    any(esp32s2, esp32s3, esp32c5) => {
                 ($peripherals.GPIO9, $peripherals.GPIO10)
-            } else if #[cfg(esp32)] {
+            }
+    esp32 => {
                 ($peripherals.GPIO2, $peripherals.GPIO4)
-            } else { // esp32c6, esp32c61, esp32h2, esp32c2, esp32c3
+            }
+    _ => { // esp32c6, esp32c61, esp32h2, esp32c2, esp32c3
                 ($peripherals.GPIO2, $peripherals.GPIO3)
             }
-        }
+}
     }};
 }
 
@@ -93,17 +101,20 @@ macro_rules! common_test_pins {
 #[macro_export]
 macro_rules! unconnected_pin {
     ($peripherals:expr) => {{
-        cfg_if::cfg_if! {
-            if #[cfg(any(esp32, esp32s2, esp32s3))] {
+        cfg_select! {
+    any(esp32, esp32s2, esp32s3) => {
                 $peripherals.GPIO0
-            } else if #[cfg(esp32c2)] {
+            }
+    esp32c2 => {
                 $peripherals.GPIO8
-            } else if #[cfg(esp32c5)] {
+            }
+    esp32c5 => {
                 $peripherals.GPIO28
-            } else { // esp32c3, esp32c6, esp32c61, esp32h2
+            }
+    _ => { // esp32c3, esp32c6, esp32c61, esp32h2
                 $peripherals.GPIO9
             }
-        }
+}
     }};
 }
 

--- a/init-local-registry/Cargo.toml
+++ b/init-local-registry/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "basic-c6"
-rust-version = "1.88.0"
+rust-version = "1.95.0"
 version = "0.1.0"
 
 [dependencies]

--- a/init-local-registry/Cargo.toml
+++ b/init-local-registry/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "basic-c6"
-rust-version = "1.95.0"
+rust-version = "1.88.0"
 version = "0.1.0"
 
 [dependencies]

--- a/qa-test/Cargo.toml
+++ b/qa-test/Cargo.toml
@@ -6,7 +6,6 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
-cfg-if = "1"
 embassy-executor = "0.10.0"
 embassy-time = "0.5.0"
 embassy-futures = "0.1"

--- a/qa-test/src/bin/embassy_adc.rs
+++ b/qa-test/src/bin/embassy_adc.rs
@@ -38,26 +38,30 @@ async fn main(_spawner: Spawner) {
         );
     let mut adc1 = Adc::new(peripherals.ADC1, adc1_config).into_async();
 
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "esp32c3")] {
+    cfg_select! {
+    feature = "esp32c3" => {
             let mut adc2_config = AdcConfig::new();
             let analog_pin2 = peripherals.GPIO5;
             let mut pin2 = adc2_config.enable_pin(analog_pin2, Attenuation::_11dB);
             let mut adc2 = Adc::new(peripherals.ADC2, adc2_config).into_async();
         }
-    }
+
+    _ => {}
+}
 
     let delay = Delay::new();
 
     loop {
         let adc1_value: u16 = adc1.read_oneshot(&mut pin1).await;
         println!("ADC1 value: {}", adc1_value);
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "esp32c3")] {
+        cfg_select! {
+    feature = "esp32c3" => {
                 let adc2_value: u16 = adc2.read_oneshot(&mut pin2).await;
                 println!("ADC2 value: {}", adc2_value);
             }
-        }
+
+    _ => {}
+}
         delay.delay_millis(1000);
     }
 }

--- a/qa-test/src/bin/embassy_adc.rs
+++ b/qa-test/src/bin/embassy_adc.rs
@@ -39,15 +39,15 @@ async fn main(_spawner: Spawner) {
     let mut adc1 = Adc::new(peripherals.ADC1, adc1_config).into_async();
 
     cfg_select! {
-    feature = "esp32c3" => {
+        feature = "esp32c3" => {
             let mut adc2_config = AdcConfig::new();
             let analog_pin2 = peripherals.GPIO5;
             let mut pin2 = adc2_config.enable_pin(analog_pin2, Attenuation::_11dB);
             let mut adc2 = Adc::new(peripherals.ADC2, adc2_config).into_async();
         }
 
-    _ => {}
-}
+        _ => {}
+    }
 
     let delay = Delay::new();
 
@@ -55,13 +55,13 @@ async fn main(_spawner: Spawner) {
         let adc1_value: u16 = adc1.read_oneshot(&mut pin1).await;
         println!("ADC1 value: {}", adc1_value);
         cfg_select! {
-    feature = "esp32c3" => {
+            feature = "esp32c3" => {
                 let adc2_value: u16 = adc2.read_oneshot(&mut pin2).await;
                 println!("ADC2 value: {}", adc2_value);
             }
 
-    _ => {}
-}
+            _ => {}
+        }
         delay.delay_millis(1000);
     }
 }

--- a/qa-test/src/bin/embassy_i2s_read.rs
+++ b/qa-test/src/bin/embassy_i2s_read.rs
@@ -37,13 +37,14 @@ async fn main(_spawner: Spawner) {
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     esp_rtos::start(timg0.timer0, sw_int.software_interrupt0);
 
-    cfg_if::cfg_if! {
-        if #[cfg(any(feature = "esp32", feature = "esp32s2"))] {
+    cfg_select! {
+    any(feature = "esp32", feature = "esp32s2") => {
             let dma_channel = peripherals.DMA_I2S0;
-        } else {
+        }
+    _ => {
             let dma_channel = peripherals.DMA_CH0;
         }
-    }
+}
 
     let (rx_buffer, rx_descriptors, _, _) = dma_buffers!(4092 * 4, 0);
 

--- a/qa-test/src/bin/embassy_i2s_read.rs
+++ b/qa-test/src/bin/embassy_i2s_read.rs
@@ -38,13 +38,13 @@ async fn main(_spawner: Spawner) {
     esp_rtos::start(timg0.timer0, sw_int.software_interrupt0);
 
     cfg_select! {
-    any(feature = "esp32", feature = "esp32s2") => {
+        any(feature = "esp32", feature = "esp32s2") => {
             let dma_channel = peripherals.DMA_I2S0;
         }
-    _ => {
+        _ => {
             let dma_channel = peripherals.DMA_CH0;
         }
-}
+    }
 
     let (rx_buffer, rx_descriptors, _, _) = dma_buffers!(4092 * 4, 0);
 

--- a/qa-test/src/bin/embassy_i2s_sound.rs
+++ b/qa-test/src/bin/embassy_i2s_sound.rs
@@ -60,13 +60,13 @@ async fn main(_spawner: Spawner) {
     esp_rtos::start(timg0.timer0, sw_int.software_interrupt0);
 
     cfg_select! {
-    any(feature = "esp32", feature = "esp32s2") => {
+        any(feature = "esp32", feature = "esp32s2") => {
             let dma_channel = peripherals.DMA_I2S0;
         }
-    _ => {
+        _ => {
             let dma_channel = peripherals.DMA_CH0;
         }
-}
+    }
 
     let (_, _, tx_buffer, tx_descriptors) = dma_buffers!(0, 32000);
 

--- a/qa-test/src/bin/embassy_i2s_sound.rs
+++ b/qa-test/src/bin/embassy_i2s_sound.rs
@@ -59,13 +59,14 @@ async fn main(_spawner: Spawner) {
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     esp_rtos::start(timg0.timer0, sw_int.software_interrupt0);
 
-    cfg_if::cfg_if! {
-        if #[cfg(any(feature = "esp32", feature = "esp32s2"))] {
+    cfg_select! {
+    any(feature = "esp32", feature = "esp32s2") => {
             let dma_channel = peripherals.DMA_I2S0;
-        } else {
+        }
+    _ => {
             let dma_channel = peripherals.DMA_CH0;
         }
-    }
+}
 
     let (_, _, tx_buffer, tx_descriptors) = dma_buffers!(0, 32000);
 

--- a/qa-test/src/bin/mcpwm.rs
+++ b/qa-test/src/bin/mcpwm.rs
@@ -25,15 +25,18 @@ fn main() -> ! {
     let peripherals: Peripherals = esp_hal::init(esp_hal::Config::default());
     let pin = peripherals.GPIO0;
 
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "esp32h2")] {
+    cfg_select! {
+    feature = "esp32h2" => {
             let clock_cfg =
                 PeripheralClockConfig::with_frequency(Rate::from_mhz(40)).unwrap();
-        } else if #[cfg(not(feature = "esp32h2"))] {
+        }
+    not(feature = "esp32h2") => {
             let clock_cfg =
                 PeripheralClockConfig::with_frequency(Rate::from_mhz(32)).unwrap();
         }
-    }
+
+    _ => {}
+}
 
     let mut mcpwm = McPwm::new(peripherals.MCPWM0, clock_cfg);
     mcpwm.operator0.set_timer(&mcpwm.timer0);

--- a/qa-test/src/bin/mcpwm.rs
+++ b/qa-test/src/bin/mcpwm.rs
@@ -26,17 +26,17 @@ fn main() -> ! {
     let pin = peripherals.GPIO0;
 
     cfg_select! {
-    feature = "esp32h2" => {
+        feature = "esp32h2" => {
             let clock_cfg =
                 PeripheralClockConfig::with_frequency(Rate::from_mhz(40)).unwrap();
         }
-    not(feature = "esp32h2") => {
+        not(feature = "esp32h2") => {
             let clock_cfg =
                 PeripheralClockConfig::with_frequency(Rate::from_mhz(32)).unwrap();
         }
 
-    _ => {}
-}
+        _ => {}
+    }
 
     let mut mcpwm = McPwm::new(peripherals.MCPWM0, clock_cfg);
     mcpwm.operator0.set_timer(&mcpwm.timer0);

--- a/qa-test/src/bin/qspi_flash.rs
+++ b/qa-test/src/bin/qspi_flash.rs
@@ -48,15 +48,16 @@ esp_bootloader_esp_idf::esp_app_desc!();
 fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "esp32")] {
+    cfg_select! {
+    feature = "esp32" => {
             let sclk = peripherals.GPIO12;
             let miso = peripherals.GPIO2;
             let mosi = peripherals.GPIO4;
             let sio2 = peripherals.GPIO5;
             let sio3 = peripherals.GPIO13;
             let cs = peripherals.GPIO14;
-        } else {
+        }
+    _ => {
             let sclk = peripherals.GPIO0;
             let miso = peripherals.GPIO1;
             let mosi = peripherals.GPIO2;
@@ -64,15 +65,16 @@ fn main() -> ! {
             let sio3 = peripherals.GPIO4;
             let cs = peripherals.GPIO5;
         }
-    }
+}
 
-    cfg_if::cfg_if! {
-        if #[cfg(any(feature = "esp32", feature = "esp32s2"))] {
+    cfg_select! {
+    any(feature = "esp32", feature = "esp32s2") => {
             let dma_channel = peripherals.DMA_SPI2;
-        } else {
+        }
+    _ => {
             let dma_channel = peripherals.DMA_CH0;
         }
-    }
+}
 
     let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(320, 256);
     let mut dma_rx_buf = DmaRxBuf::new(rx_descriptors, rx_buffer).unwrap();

--- a/qa-test/src/bin/qspi_flash.rs
+++ b/qa-test/src/bin/qspi_flash.rs
@@ -49,7 +49,7 @@ fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
     cfg_select! {
-    feature = "esp32" => {
+        feature = "esp32" => {
             let sclk = peripherals.GPIO12;
             let miso = peripherals.GPIO2;
             let mosi = peripherals.GPIO4;
@@ -57,7 +57,7 @@ fn main() -> ! {
             let sio3 = peripherals.GPIO13;
             let cs = peripherals.GPIO14;
         }
-    _ => {
+        _ => {
             let sclk = peripherals.GPIO0;
             let miso = peripherals.GPIO1;
             let mosi = peripherals.GPIO2;
@@ -65,16 +65,16 @@ fn main() -> ! {
             let sio3 = peripherals.GPIO4;
             let cs = peripherals.GPIO5;
         }
-}
+    }
 
     cfg_select! {
-    any(feature = "esp32", feature = "esp32s2") => {
+        any(feature = "esp32", feature = "esp32s2") => {
             let dma_channel = peripherals.DMA_SPI2;
         }
-    _ => {
+        _ => {
             let dma_channel = peripherals.DMA_CH0;
         }
-}
+    }
 
     let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(320, 256);
     let mut dma_rx_buf = DmaRxBuf::new(rx_descriptors, rx_buffer).unwrap();

--- a/qa-test/src/bin/sleep_timer_lpio.rs
+++ b/qa-test/src/bin/sleep_timer_lpio.rs
@@ -38,7 +38,7 @@ fn main() -> ! {
     let mut rtc = Rtc::new(peripherals.LPWR);
 
     cfg_select! {
-    feature = "esp32c6" => {
+        feature = "esp32c6" => {
             use esp_hal::gpio::{Input, InputConfig, Pull};
 
             let mut pin_low = peripherals.GPIO2;
@@ -49,13 +49,13 @@ fn main() -> ! {
             );
             core::mem::drop(input);
         }
-    feature = "esp32h2" => {
+        feature = "esp32h2" => {
             let mut pin_low = peripherals.GPIO9; // typically a boot mode button, low when pressed
             let mut pin_high = peripherals.GPIO10;
         }
 
-    _ => {}
-}
+        _ => {}
+    }
 
     println!("up and runnning!");
     let reason = reset_reason(Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);

--- a/qa-test/src/bin/sleep_timer_lpio.rs
+++ b/qa-test/src/bin/sleep_timer_lpio.rs
@@ -37,8 +37,8 @@ fn main() -> ! {
 
     let mut rtc = Rtc::new(peripherals.LPWR);
 
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "esp32c6")] {
+    cfg_select! {
+    feature = "esp32c6" => {
             use esp_hal::gpio::{Input, InputConfig, Pull};
 
             let mut pin_low = peripherals.GPIO2;
@@ -48,11 +48,14 @@ fn main() -> ! {
                 InputConfig::default().with_pull(Pull::None),
             );
             core::mem::drop(input);
-        } else if #[cfg(feature = "esp32h2")] {
+        }
+    feature = "esp32h2" => {
             let mut pin_low = peripherals.GPIO9; // typically a boot mode button, low when pressed
             let mut pin_high = peripherals.GPIO10;
         }
-    }
+
+    _ => {}
+}
 
     println!("up and runnning!");
     let reason = reset_reason(Cpu::ProCpu).unwrap_or(SocResetReason::ChipPowerOn);

--- a/qa-test/src/bin/sleep_timer_oversleeping.rs
+++ b/qa-test/src/bin/sleep_timer_oversleeping.rs
@@ -100,14 +100,14 @@ async fn main(_spawner: Spawner) {
     }
 
     cfg_select! {
-    any(feature = "esp32c6", feature = "esp32h2", feature = "esp32s3") => {
+        any(feature = "esp32c6", feature = "esp32h2", feature = "esp32s3") => {
             let config = RtcSleepConfig::deep();
         }
-    _ => { //esp32/c3/s2
+        _ => { //esp32/c3/s2
             let mut config = RtcSleepConfig::deep();
             config.set_rtc_fastmem_pd_en(false);
         }
-}
+    }
 
     let delay = esp_hal::delay::Delay::new();
 

--- a/qa-test/src/bin/sleep_timer_oversleeping.rs
+++ b/qa-test/src/bin/sleep_timer_oversleeping.rs
@@ -99,14 +99,15 @@ async fn main(_spawner: Spawner) {
         PRE_SLEEP_US = rtc.current_time_us();
     }
 
-    cfg_if::cfg_if! {
-        if #[cfg(any(feature = "esp32c6", feature = "esp32h2", feature = "esp32s3"))] {
+    cfg_select! {
+    any(feature = "esp32c6", feature = "esp32h2", feature = "esp32s3") => {
             let config = RtcSleepConfig::deep();
-        } else { //esp32/c3/s2
+        }
+    _ => { //esp32/c3/s2
             let mut config = RtcSleepConfig::deep();
             config.set_rtc_fastmem_pd_en(false);
         }
-    }
+}
 
     let delay = esp_hal::delay::Delay::new();
 

--- a/qa-test/src/bin/sleep_timer_rtcio.rs
+++ b/qa-test/src/bin/sleep_timer_rtcio.rs
@@ -51,7 +51,7 @@ fn main() -> ! {
 
     let config = InputConfig::default().with_pull(Pull::None);
     cfg_select! {
-    any(feature = "esp32c3", feature = "esp32c2") => {
+        any(feature = "esp32c3", feature = "esp32c2") => {
             let mut pin2 = peripherals.GPIO2;
             let mut pin3 = peripherals.GPIO3;
             let _pin2_input = Input::new(pin2.reborrow(), config);
@@ -61,7 +61,7 @@ fn main() -> ! {
                 (&mut pin3, WakeupLevel::High),
             ];
         }
-    any(feature = "esp32s2", feature = "esp32s3") => {
+        any(feature = "esp32s2", feature = "esp32s3") => {
             let mut pin17 = peripherals.GPIO17;
             let mut pin18 = peripherals.GPIO18;
             let _pin17_input = Input::new(pin17.reborrow(), config);
@@ -72,8 +72,8 @@ fn main() -> ! {
             ];
         }
 
-    _ => {}
-}
+        _ => {}
+    }
 
     let rtcio = RtcioWakeupSource::new(wakeup_pins);
     println!("sleeping!");

--- a/qa-test/src/bin/sleep_timer_rtcio.rs
+++ b/qa-test/src/bin/sleep_timer_rtcio.rs
@@ -50,8 +50,8 @@ fn main() -> ! {
     let timer = TimerWakeupSource::new(Duration::from_secs(10));
 
     let config = InputConfig::default().with_pull(Pull::None);
-    cfg_if::cfg_if! {
-        if #[cfg(any(feature = "esp32c3", feature = "esp32c2"))] {
+    cfg_select! {
+    any(feature = "esp32c3", feature = "esp32c2") => {
             let mut pin2 = peripherals.GPIO2;
             let mut pin3 = peripherals.GPIO3;
             let _pin2_input = Input::new(pin2.reborrow(), config);
@@ -60,7 +60,8 @@ fn main() -> ! {
                 (&mut pin2, WakeupLevel::Low),
                 (&mut pin3, WakeupLevel::High),
             ];
-        } else if #[cfg(any(feature = "esp32s2", feature = "esp32s3"))] {
+        }
+    any(feature = "esp32s2", feature = "esp32s3") => {
             let mut pin17 = peripherals.GPIO17;
             let mut pin18 = peripherals.GPIO18;
             let _pin17_input = Input::new(pin17.reborrow(), config);
@@ -70,7 +71,9 @@ fn main() -> ! {
                 (&mut pin18, WakeupLevel::High),
             ];
         }
-    }
+
+    _ => {}
+}
 
     let rtcio = RtcioWakeupSource::new(wakeup_pins);
     println!("sleeping!");

--- a/qa-test/src/bin/spi_halfduplex_read_manufacturer_id.rs
+++ b/qa-test/src/bin/spi_halfduplex_read_manufacturer_id.rs
@@ -47,15 +47,16 @@ fn main() -> ! {
     esp_println::logger::init_logger_from_env();
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "esp32")] {
+    cfg_select! {
+    feature = "esp32" => {
             let sclk = peripherals.GPIO12;
             let miso = peripherals.GPIO2;
             let mosi = peripherals.GPIO4;
             let sio2 = peripherals.GPIO5;
             let sio3 = peripherals.GPIO13;
             let cs = peripherals.GPIO14;
-        } else {
+        }
+    _ => {
             let sclk = peripherals.GPIO0;
             let miso = peripherals.GPIO1;
             let mosi = peripherals.GPIO2;
@@ -63,7 +64,7 @@ fn main() -> ! {
             let sio3 = peripherals.GPIO4;
             let cs = peripherals.GPIO5;
         }
-    }
+}
 
     let mut spi = Spi::new(
         peripherals.SPI2,

--- a/qa-test/src/bin/spi_halfduplex_read_manufacturer_id.rs
+++ b/qa-test/src/bin/spi_halfduplex_read_manufacturer_id.rs
@@ -48,7 +48,7 @@ fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
     cfg_select! {
-    feature = "esp32" => {
+        feature = "esp32" => {
             let sclk = peripherals.GPIO12;
             let miso = peripherals.GPIO2;
             let mosi = peripherals.GPIO4;
@@ -56,7 +56,7 @@ fn main() -> ! {
             let sio3 = peripherals.GPIO13;
             let cs = peripherals.GPIO14;
         }
-    _ => {
+        _ => {
             let sclk = peripherals.GPIO0;
             let miso = peripherals.GPIO1;
             let mosi = peripherals.GPIO2;
@@ -64,7 +64,7 @@ fn main() -> ! {
             let sio3 = peripherals.GPIO4;
             let cs = peripherals.GPIO5;
         }
-}
+    }
 
     let mut spi = Spi::new(
         peripherals.SPI2,

--- a/xtensa-lx-rt-proc-macros/Cargo.toml
+++ b/xtensa-lx-rt-proc-macros/Cargo.toml
@@ -2,7 +2,7 @@
 name = "xtensa-lx-rt-proc-macros"
 version = "0.5.0"
 edition = "2024"
-rust-version = "1.88.0"
+rust-version = "1.95.0"
 description = "Attributes re-exported in `xtensa-lx-rt`"
 documentation = "https://docs.espressif.com/projects/rust/xtensa-lx-rt-proc-macros/latest/"
 repository = "https://github.com/esp-rs/esp-hal"

--- a/xtensa-lx-rt/Cargo.toml
+++ b/xtensa-lx-rt/Cargo.toml
@@ -2,7 +2,7 @@
 name          = "xtensa-lx-rt"
 version       = "0.22.0"
 edition       = "2024"
-rust-version  = "1.88.0"
+rust-version  = "1.95.0"
 description   = "Minimal startup/runtime for Xtensa LX CPUs"
 documentation = "https://docs.espressif.com/projects/rust/xtensa-lx-rt/latest/"
 repository    = "https://github.com/esp-rs/esp-hal"

--- a/xtensa-lx-rt/README.md
+++ b/xtensa-lx-rt/README.md
@@ -2,7 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/xtensa-lx-rt?labelColor=1C2C2E&color=C96329&logo=Rust&style=flat-square)](https://crates.io/crates/xtensa-lx-rt)
 [![docs.rs](https://img.shields.io/docsrs/xtensa-lx-rt?labelColor=1C2C2E&color=C96329&logo=rust&style=flat-square)](https://docs.espressif.com/projects/rust/xtensa-lx-rt/latest/)
-![MSRV](https://img.shields.io/badge/MSRV-1.88.0-blue?labelColor=1C2C2E&style=flat-square)
+![MSRV](https://img.shields.io/badge/MSRV-1.95.0-blue?labelColor=1C2C2E&style=flat-square)
 ![Crates.io](https://img.shields.io/crates/l/xtensa-lx-rt?labelColor=1C2C2E&style=flat-square)
 [![Matrix](https://img.shields.io/matrix/esp-rs:matrix.org?label=join%20matrix&labelColor=1C2C2E&color=BEC5C9&logo=matrix&style=flat-square)](https://matrix.to/#/#esp-rs:matrix.org)
 

--- a/xtensa-lx/Cargo.toml
+++ b/xtensa-lx/Cargo.toml
@@ -2,7 +2,7 @@
 name          = "xtensa-lx"
 version       = "0.13.0"
 edition       = "2024"
-rust-version  = "1.88.0"
+rust-version  = "1.95.0"
 description   = "Low-level access to Xtensa LX processors and peripherals"
 documentation = "https://docs.espressif.com/projects/rust/xtensa-lx/latest/"
 repository    = "https://github.com/esp-rs/esp-hal"


### PR DESCRIPTION
cfg_select! was stabilized in Rust 1.95.0 and is available in the prelude, removing the need for the cfg-if crate dependency.

Disclaimer: this is claude's work here, I'm essentially relying on our CI checks to ensure no change in behavior here.

Closes #5371
