### PR TITLE
Make sure to call enable for a few BLE functions on later NPL based chips

### DIFF
--- a/esp-radio/CHANGELOG.md
+++ b/esp-radio/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a crash when using advanced BLE scanning on certain chips (C6,H2,C5,C61) (#5458)
 
 ### Removed
 

--- a/esp-radio/src/ble/npl.rs
+++ b/esp-radio/src/ble/npl.rs
@@ -1182,13 +1182,16 @@ pub(crate) fn ble_init(config: &Config) -> PhyInitGuard<'static> {
                 fn adv_stack_initEnv() -> i32;
                 fn extAdv_stack_initEnv() -> i32;
                 fn sync_stack_initEnv() -> i32;
+
+                fn base_stack_enable() -> i32;
+                fn adv_stack_enable() -> i32;
+                fn extAdv_stack_enable() -> i32;
+                fn scan_stack_enable() -> i32;
+                fn sync_stack_enable() -> i32;
             }
 
             let res = base_stack_initEnv();
             assert!(res == 0, "base_stack_initEnv returned {}", res);
-
-            let res = conn_stack_initEnv();
-            assert!(res == 0, "conn_stack_initEnv returned {}", res);
 
             let res = adv_stack_initEnv();
             assert!(res == 0, "adv_stack_initEnv returned {}", res);
@@ -1202,11 +1205,29 @@ pub(crate) fn ble_init(config: &Config) -> PhyInitGuard<'static> {
                 assert!(res == 0, "scan_stack_initEnv returned {}", res);
             }
 
+            let res = conn_stack_initEnv();
+            assert!(res == 0, "conn_stack_initEnv returned {}", res);
+
             let res = sync_stack_initEnv();
             assert!(res == 0, "sync_stack_initEnv returned {}", res);
 
             let res = r_esp_ble_msys_init(256, 320, 12, 24, 1);
             assert!(res == 0, "esp_ble_msys_init returned {}", res);
+
+            let res = base_stack_enable();
+            assert!(res == 0, "base_stack_enable returned {}", res);
+
+            let res = adv_stack_enable();
+            assert!(res == 0, "adv_stack_enable returned {}", res);
+
+            let res = extAdv_stack_enable();
+            assert!(res == 0, "extAdv_stack_enable returned {}", res);
+
+            let res = scan_stack_enable();
+            assert!(res == 0, "scan_stack_enable returned {}", res);
+
+            let res = sync_stack_enable();
+            assert!(res == 0, "sync_stack_enable returned {}", res);
         }
 
         #[cfg(feature = "coex")]
@@ -1263,6 +1284,12 @@ pub(crate) fn ble_deinit() {
         fn adv_stack_deinitEnv() -> i32;
         fn extAdv_stack_deinitEnv() -> i32;
         fn sync_stack_deinitEnv() -> i32;
+
+        fn base_stack_disable() -> i32;
+        fn adv_stack_disable() -> i32;
+        fn extAdv_stack_disable() -> i32;
+        fn scan_stack_disable() -> i32;
+        fn sync_stack_disable() -> i32;
     }
 
     #[cfg(esp32c2)]
@@ -1277,6 +1304,11 @@ pub(crate) fn ble_deinit() {
         #[cfg(not(esp32c2))]
         {
             npl::r_ble_controller_disable();
+            sync_stack_disable();
+            scan_stack_disable();
+            extAdv_stack_disable();
+            adv_stack_disable();
+            base_stack_disable();
             conn_stack_deinitEnv();
             sync_stack_deinitEnv();
             scan_stack_deinitEnv();

--- a/qa-test/Cargo.toml
+++ b/qa-test/Cargo.toml
@@ -38,6 +38,11 @@ lis3dh-async = "0.9.3"
 ssd1306 = "0.10.0"
 static_cell = "2.1.1"
 rtos-trace = { version = "0.2.0", optional = true }
+trouble-host = { version = "0.6.0", features = [
+    "default-packet-pool-mtu-255",
+    "derive",
+    "scan",
+] }
 
 [features]
 unstable = []

--- a/qa-test/Cargo.toml
+++ b/qa-test/Cargo.toml
@@ -30,7 +30,6 @@ esp-println = { path = "../esp-println", features = ["log-04"] }
 esp-radio = { path = "../esp-radio", features = [
     "log-04",
     "unstable",
-    "wifi",
 ], optional = true }
 esp-storage = { path = "../esp-storage", optional = true }
 embedded-storage = "0.3.1"

--- a/qa-test/src/bin/ext_adv_scan.rs
+++ b/qa-test/src/bin/ext_adv_scan.rs
@@ -1,0 +1,98 @@
+//! A check that extended-advertisement scanning works.
+//!
+//! To really test this you need a way to have large advertisements received.
+//!
+//! e.g. on Windows use `Bluetooth LE Explorer` - use `Advertisement Beacon`,
+//! make sure to enable "Use Extended Format" and some payload.
+//! Enable advertising.
+
+//% FEATURES: esp-radio esp-radio/ble esp-hal/unstable
+//% CHIPS: esp32 esp32s3 esp32h2 esp32c2 esp32c3 esp32c5 esp32c6 esp32c61
+
+#![no_std]
+#![no_main]
+use embassy_executor::Spawner;
+use embassy_futures::join::join;
+use embassy_time::{Duration, Timer};
+use esp_alloc as _;
+use esp_backtrace as _;
+use esp_hal::{
+    clock::CpuClock,
+    interrupt::software::SoftwareInterruptControl,
+    timer::timg::TimerGroup,
+};
+use esp_println::println;
+use esp_radio::ble::controller::BleConnector;
+use trouble_host::prelude::*;
+
+esp_bootloader_esp_idf::esp_app_desc!();
+
+#[esp_rtos::main]
+async fn main(_s: Spawner) {
+    esp_println::logger::init_logger_from_env();
+    let peripherals = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));
+
+    esp_alloc::heap_allocator!(size: 72 * 1024);
+
+    let sw_int = SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
+    let timg0 = TimerGroup::new(peripherals.TIMG0);
+    esp_rtos::start(timg0.timer0, sw_int.software_interrupt0);
+
+    let bluetooth = peripherals.BT;
+    let connector = BleConnector::new(
+        bluetooth,
+        esp_radio::ble::Config::default().with_ext_adv_max_size(1650),
+    )
+    .unwrap();
+    let controller: ExternalController<_, 1> = ExternalController::new(connector);
+
+    // Using a fixed "random" address can be useful for testing. In real scenarios, one would
+    // use e.g. the MAC 6 byte array as the address (how to get that varies by the platform).
+    let address: Address = Address::random([0xff, 0x8f, 0x1b, 0x05, 0xe4, 0xff]);
+
+    println!("Our address = {:?}", address);
+
+    let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> =
+        HostResources::new();
+    let stack = trouble_host::new(controller, &mut resources).set_random_address(address);
+
+    let Host {
+        central,
+        mut runner,
+        ..
+    } = stack.build();
+
+    let printer = Printer {};
+    let mut scanner = Scanner::new(central);
+    let _ = join(runner.run_with_handler(&printer), async {
+        let config = ScanConfig {
+            active: false,
+            phys: PhySet::M1,
+            interval: Duration::from_millis(500),
+            window: Duration::from_millis(100),
+            timeout: Duration::from_secs(0),
+            ..Default::default()
+        };
+        let mut _session = scanner.scan_ext(&config).await.unwrap();
+        // Scan forever
+        loop {
+            Timer::after(Duration::from_secs(1)).await;
+        }
+    })
+    .await;
+}
+
+/// Max number of connections
+const CONNECTIONS_MAX: usize = 1;
+const L2CAP_CHANNELS_MAX: usize = 1;
+
+struct Printer {}
+
+impl EventHandler for Printer {
+    fn on_ext_adv_reports(&self, reports: LeExtAdvReportsIter<'_>) {
+        for report in reports {
+            let report = report.unwrap();
+            println!("ext adv {:?} {}", report.addr, report.data.len());
+        }
+    }
+}

--- a/qa-test/src/bin/ext_adv_scan.rs
+++ b/qa-test/src/bin/ext_adv_scan.rs
@@ -5,6 +5,8 @@
 //! e.g. on Windows use `Bluetooth LE Explorer` - use `Advertisement Beacon`,
 //! make sure to enable "Use Extended Format" and some payload.
 //! Enable advertising.
+//!
+//! Not supported on ESP32 since this feature needs BLE 5.0+ (and ESP32 is 4.2)
 
 //% FEATURES: esp-radio esp-radio/ble esp-hal/unstable
 //% CHIPS: esp32s3 esp32h2 esp32c2 esp32c3 esp32c5 esp32c6 esp32c61

--- a/qa-test/src/bin/ext_adv_scan.rs
+++ b/qa-test/src/bin/ext_adv_scan.rs
@@ -7,7 +7,7 @@
 //! Enable advertising.
 
 //% FEATURES: esp-radio esp-radio/ble esp-hal/unstable
-//% CHIPS: esp32 esp32s3 esp32h2 esp32c2 esp32c3 esp32c5 esp32c6 esp32c61
+//% CHIPS: esp32s3 esp32h2 esp32c2 esp32c3 esp32c5 esp32c6 esp32c61
 
 #![no_std]
 #![no_main]
@@ -39,11 +39,7 @@ async fn main(_s: Spawner) {
     esp_rtos::start(timg0.timer0, sw_int.software_interrupt0);
 
     let bluetooth = peripherals.BT;
-    let connector = BleConnector::new(
-        bluetooth,
-        esp_radio::ble::Config::default().with_ext_adv_max_size(1650),
-    )
-    .unwrap();
+    let connector = BleConnector::new(bluetooth, esp_radio::ble::Config::default()).unwrap();
     let controller: ExternalController<_, 1> = ExternalController::new(connector);
 
     // Using a fixed "random" address can be useful for testing. In real scenarios, one would


### PR DESCRIPTION
Fixes #5454 for H2, C6, C61, C5

I guess in #3071 we should make sure to cover this (noting it here to get this linked to the issue so we don't forget about it)
