### PR TITLE
fix(esp32/adc): use generic `ADCI` for set_attenuation, not hard-coded `ADC1` (#5459)

### DIFF
--- a/esp-hal/src/analog/adc/esp32.rs
+++ b/esp-hal/src/analog/adc/esp32.rs
@@ -267,7 +267,15 @@ where
 
         for (channel, attentuation) in attenuations.iter().enumerate() {
             if let Some(attenuation) = attentuation {
-                ADC1::set_attenuation(channel, *attenuation as u8);
+                // Use the generic type parameter `ADCI` instead of the
+                // hard-coded `ADC1` so per-channel attenuation lands on
+                // the actual peripheral the caller passed to
+                // `Adc::new`. With the previous `ADC1::set_attenuation`,
+                // an `Adc::<ADC2>::new(...)` invocation silently wrote
+                // to the matching channel of ADC1 and the ADC2 reading
+                // stayed at the 11 dB hardware default. See
+                // https://github.com/esp-rs/esp-hal/issues/5459.
+                ADCI::set_attenuation(channel, *attenuation as u8);
             }
         }
 


### PR DESCRIPTION
Closes #5459.

## Summary
The per-channel attenuation loop in \`Adc::new()\` (esp-hal/src/analog/adc/esp32.rs:270) hard-codes the ADC1 type:
```rust
for (channel, attentuation) in attenuations.iter().enumerate() {
    if let Some(attenuation) = attentuation {
        ADC1::set_attenuation(channel, *attenuation as u8);   // <-- bug
    }
}
```
So an \`Adc::<ADC2>::new(...)\` invocation silently wrote to the matching channel of ADC1, and the ADC2 reading stayed at the 11 dB hardware default regardless of the requested attenuation. Setting ADC2 to anything other than 11 dB was a no-op at the user level.

## Fix
Single-token swap: use \`ADCI\` (the generic type parameter, constrained to \`RegisterAccess\` at line 244) instead of the hard-coded \`ADC1\`. Both \`ADC1\` and \`ADC2\` implement \`RegisterAccess\` (lines 82 and 158), so trait dispatch lands on the right peripheral at compile time.

```diff
- ADC1::set_attenuation(channel, *attenuation as u8);
+ ADCI::set_attenuation(channel, *attenuation as u8);
```

Added a comment so the next reader doesn't \"helpfully\" change \`ADCI\` back to \`ADC1\` thinking the loop only ever runs against ADC1.

## Test plan
- I do not have an ESP32 + xtensa toolchain set up locally and cannot run the reporter's reproducer end-to-end. The fix is type-system-verified: \`ADCI: RegisterAccess + 'd\` is enforced at the surrounding \`impl\` block (line 244), \`RegisterAccess::set_attenuation\` is the trait method (line 61), and both ADC peripherals implement it (lines 82, 158).
- Reporter confirmed the manual register-write workaround in their bug report produces the correct reading, which is functionally equivalent to what \`ADCI::set_attenuation\` resolves to under the trait dispatch when the user passes \`p.ADC2\` to \`Adc::new\`.
- Should be safe to land alongside an integration smoke test on hardware.

## Notes
- Found by Claude Code review of an existing project; confirmed experimentally by the reporter.
- This is the same single-token bug pattern that occasionally crops up in other generic-over-peripheral sites — worth a quick \`grep ADC1::\\|ADC2::\` audit at some point, but I couldn't find any other call sites in this file.