### PR TITLE
Use clock tree code to track current frequencies

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The clock frequency accessor functions no longer need to lock the clock tree (#5461)
 
 ### Fixed
 
@@ -22,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ESP32: attenuation is now correctly set for ADC2 (#5463)
 - UART: disallow 0 as the RX FIFO full threshold (#5451)
 - UART: prevent returning 0 from `read_async` (#5451)
+- The `Clocks` struct has been removed (#5461)
 
 ### Removed
 

--- a/esp-hal/MIGRATING-1.1.0.md
+++ b/esp-hal/MIGRATING-1.1.0.md
@@ -1,1 +1,25 @@
 # Migration Guide from 1.1.0 to {{currentVersion}}
+
+## `Clocks` struct removed
+
+The `Clocks` struct and `Clocks::get()` have been removed. The clock frequencies
+they provided are now available as lockless free functions from `esp_hal::clock`
+and (for chip-specific clocks) `esp_hal::clock::ll`.
+
+| Old | New |
+|---|---|
+| `Clocks::get().cpu_clock` | `clock::cpu_clock()` |
+| `Clocks::get().apb_clock` | `Rate::from_hz(clock::ll::apb_clk_frequency())` |
+| `Clocks::get().xtal_clock` | `clock::xtal_clock()` |
+
+```diff
+-use esp_hal::clock::Clocks;
++use esp_hal::clock;
+
+-let cpu_freq = Clocks::get().cpu_clock;
+-let apb_freq = Clocks::get().apb_clock;
+-let xtal_freq = Clocks::get().xtal_clock;
++let cpu_freq = clock::cpu_clock();
++let apb_freq = Rate::from_hz(clock::ll::apb_clk_frequency());
++let xtal_freq = clock::xtal_clock();
+```

--- a/esp-hal/src/clock/mod.rs
+++ b/esp-hal/src/clock/mod.rs
@@ -129,7 +129,7 @@ impl RtcClock {
                 let getter = clocks::lp_slow_clk_frequency;
             }
         }
-        Rate::from_hz(ClockTree::with(getter))
+        Rate::from_hz(getter())
     }
 
     /// Measure the frequency of one of the TIMG0 calibration clocks,
@@ -143,7 +143,7 @@ impl RtcClock {
     #[cfg(soc_has_clock_node_timg_calibration_clock)]
     pub(crate) fn calibrate(cal_clk: TimgCalibrationClockConfig, slowclk_cycles: u32) -> u32 {
         ClockTree::with(|clocks| {
-            let xtal_freq = Rate::from_hz(clocks::xtal_clk_frequency(clocks));
+            let xtal_freq = Rate::from_hz(clocks::xtal_clk_frequency());
 
             let (xtal_cycles, _) = Clocks::measure_rtc_clock(
                 clocks,
@@ -259,11 +259,11 @@ impl Clocks {
             // code
             Self {
                 #[cfg(soc_has_clock_node_cpu_clk)]
-                cpu_clock: Rate::from_hz(clocks::cpu_clk_frequency(clocks)),
+                cpu_clock: Rate::from_hz(clocks::cpu_clk_frequency()),
                 #[cfg(soc_has_clock_node_apb_clk)]
-                apb_clock: Rate::from_hz(clocks::apb_clk_frequency(clocks)),
+                apb_clock: Rate::from_hz(clocks::apb_clk_frequency()),
                 #[cfg(soc_has_clock_node_xtal_clk)]
-                xtal_clock: Rate::from_hz(clocks::xtal_clk_frequency(clocks)),
+                xtal_clock: Rate::from_hz(clocks::xtal_clk_frequency()),
             }
         })
     }
@@ -371,7 +371,7 @@ impl Clocks {
                 .modify(|_, w| w.tick_enable().set_bit());
         }
 
-        let calibration_clock_frequency = clocks::timg_calibration_clock_frequency(clocks);
+        let calibration_clock_frequency = clocks::timg_calibration_clock_frequency();
 
         let effective_calibration_clock_frequency =
             calibration_clock_frequency / calibration_divider;
@@ -381,7 +381,7 @@ impl Clocks {
         #[cfg(not(esp32))]
         {
             let function_clk_freq =
-                clocks::TimgInstance::Timg0.function_clock_frequency(clocks) as u64;
+                clocks::TimgInstance::Timg0.function_clock_frequency() as u64;
             let expected_function_clock_cycles = (function_clk_freq * slow_cycles as u64
                 / effective_calibration_clock_frequency as u64)
                 as u32;

--- a/esp-hal/src/clock/mod.rs
+++ b/esp-hal/src/clock/mod.rs
@@ -521,12 +521,12 @@ impl Clocks {
 
 /// The CPU clock frequency.
 pub fn cpu_clock() -> Rate {
-    Clocks::get().cpu_clock
+    Rate::from_hz(crate::soc::clocks::cpu_clk_frequency())
 }
 
 /// The XTAL clock frequency.
 pub fn xtal_clock() -> Rate {
-    Clocks::get().xtal_clock
+    Rate::from_hz(crate::soc::clocks::xtal_clk_frequency())
 }
 
 /// Read the calibrated RTC slow clock period from the STORE1 register.

--- a/esp-hal/src/clock/mod.rs
+++ b/esp-hal/src/clock/mod.rs
@@ -145,7 +145,7 @@ impl RtcClock {
         ClockTree::with(|clocks| {
             let xtal_freq = Rate::from_hz(clocks::xtal_clk_frequency());
 
-            let (xtal_cycles, _) = Clocks::measure_rtc_clock(
+            let (xtal_cycles, _) = RtcClock::measure_rtc_clock(
                 clocks,
                 cal_clk,
                 #[cfg(soc_has_clock_node_timg_function_clock)]
@@ -175,99 +175,48 @@ impl RtcClock {
     }
 }
 
-/// Clock frequencies.
-#[derive(Debug, Clone, Copy)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[non_exhaustive]
-#[doc(hidden)]
-#[instability::unstable]
-pub struct Clocks {
-    /// CPU clock frequency
-    #[cfg(soc_has_clock_node_cpu_clk)]
-    pub cpu_clock: Rate,
+pub(crate) fn init(cpu_clock_config: ClockConfig) {
+    ESP_HAL_LOCK.lock(|| {
+        crate::rtc_cntl::rtc::init();
+        configure(cpu_clock_config);
+    });
 
-    /// APB clock frequency
-    #[cfg(soc_has_clock_node_apb_clk)]
-    pub apb_clock: Rate,
-
-    /// XTAL clock frequency
-    #[cfg(soc_has_clock_node_xtal_clk)]
-    pub xtal_clock: Rate,
+    calibrate_rtc_slow_clock();
 }
 
-static mut ACTIVE_CLOCKS: Option<Clocks> = None;
+fn configure(clock_config: ClockConfig) {
+    use crate::soc::clocks::ClockTree;
 
-impl Clocks {
-    pub(crate) fn init(cpu_clock_config: ClockConfig) {
-        ESP_HAL_LOCK.lock(|| {
-            crate::rtc_cntl::rtc::init();
+    clock_config.configure();
 
-            let config = Self::configure(cpu_clock_config);
-            unsafe { ACTIVE_CLOCKS = Some(config) };
-        });
-
-        Clocks::calibrate_rtc_slow_clock();
-    }
-
-    fn try_get<'a>() -> Option<&'a Clocks> {
-        unsafe {
-            // Safety: ACTIVE_CLOCKS is only set in `init` and never modified after that.
-            let clocks = &*core::ptr::addr_of!(ACTIVE_CLOCKS);
-            clocks.as_ref()
+    ClockTree::with(|clocks| {
+        // FIXME: MCPWM clock configuration needs to know about the active clock source
+        // frequency. In the future, we should turn the MCPWM config structs into
+        // plain old data structures and remove this pre-configuration, otherwise we will not be
+        // able to select a different clock source.
+        #[cfg(soc_has_clock_node_mcpwm_function_clock)]
+        {
+            clocks::McpwmInstance::Mcpwm0.configure_function_clock(clocks, Default::default());
+            #[cfg(soc_has_mcpwm1)]
+            clocks::McpwmInstance::Mcpwm1.configure_function_clock(clocks, Default::default());
         }
-    }
-
-    /// Get the active clock configuration.
-    pub fn get<'a>() -> &'a Clocks {
-        unwrap!(Self::try_get())
-    }
+        // Until we have every clock consumer modelled, we should manually keep clocks alive
+        #[cfg(soc_has_clock_node_rc_fast_clk)]
+        clocks::request_rc_fast_clk(clocks);
+        #[cfg(soc_has_clock_node_rc_slow_clk)]
+        clocks::request_rc_slow_clk(clocks);
+        #[cfg(soc_has_clock_node_pll_clk)]
+        clocks::request_pll_clk(clocks);
+        #[cfg(soc_has_clock_node_pll_f96m_clk)]
+        clocks::request_pll_f96m_clk(clocks);
+        #[cfg(soc_has_clock_node_pll_f240m)]
+        clocks::request_pll_f240m(clocks);
+        #[cfg(soc_has_clock_node_rc_fast_div_clk)]
+        clocks::request_rc_fast_div_clk(clocks);
+    });
 }
 
-impl Clocks {
-    /// Configure the CPU clock speed.
-    pub(crate) fn configure(clock_config: ClockConfig) -> Self {
-        use crate::soc::clocks::ClockTree;
-
-        clock_config.configure();
-
-        ClockTree::with(|clocks| {
-            // FIXME: MCPWM clock configuration needs to know about the active clock source
-            // frequency. In the future, we should turn the MCPWM config structs into
-            // plain old data structures and remove this pre-configuration, otherwise we will not be
-            // able to select a different clock source.
-            #[cfg(soc_has_clock_node_mcpwm_function_clock)]
-            {
-                clocks::McpwmInstance::Mcpwm0.configure_function_clock(clocks, Default::default());
-                #[cfg(soc_has_mcpwm1)]
-                clocks::McpwmInstance::Mcpwm1.configure_function_clock(clocks, Default::default());
-            }
-            // Until we have every clock consumer modelled, we should manually keep clocks alive
-            #[cfg(soc_has_clock_node_rc_fast_clk)]
-            clocks::request_rc_fast_clk(clocks);
-            #[cfg(soc_has_clock_node_rc_slow_clk)]
-            clocks::request_rc_slow_clk(clocks);
-            #[cfg(soc_has_clock_node_pll_clk)]
-            clocks::request_pll_clk(clocks);
-            #[cfg(soc_has_clock_node_pll_f96m_clk)]
-            clocks::request_pll_f96m_clk(clocks);
-            #[cfg(soc_has_clock_node_pll_f240m)]
-            clocks::request_pll_f240m(clocks);
-            #[cfg(soc_has_clock_node_rc_fast_div_clk)]
-            clocks::request_rc_fast_div_clk(clocks);
-
-            // TODO: this struct can be removed once everything uses the new internal clock tree
-            // code
-            Self {
-                #[cfg(soc_has_clock_node_cpu_clk)]
-                cpu_clock: Rate::from_hz(clocks::cpu_clk_frequency()),
-                #[cfg(soc_has_clock_node_apb_clk)]
-                apb_clock: Rate::from_hz(clocks::apb_clk_frequency()),
-                #[cfg(soc_has_clock_node_xtal_clk)]
-                xtal_clock: Rate::from_hz(clocks::xtal_clk_frequency()),
-            }
-        })
-    }
-
+impl RtcClock {
     /// Uses a TIMG0 feature to count clock cycles of a high-frequency clock, for a period of time
     /// that is measured by a low-frequency clock. This function can be used to calibrate two
     /// clocks to each other, e.g. to determine a rough value of the XTAL clock, or to determine
@@ -380,8 +329,7 @@ impl Clocks {
         // cycles.
         #[cfg(not(esp32))]
         {
-            let function_clk_freq =
-                clocks::TimgInstance::Timg0.function_clock_frequency() as u64;
+            let function_clk_freq = clocks::TimgInstance::Timg0.function_clock_frequency() as u64;
             let expected_function_clock_cycles = (function_clk_freq * slow_cycles as u64
                 / effective_calibration_clock_frequency as u64)
                 as u32;
@@ -471,62 +419,62 @@ impl Clocks {
 
         (cali_value, Rate::from_hz(calibration_clock_frequency))
     }
+}
 
-    #[cfg(not(soc_has_clock_node_timg_calibration_clock))]
-    pub(crate) fn calibrate_rtc_slow_clock() {
-        // Do nothing until TIMG_CALIBRATION_CLOCK is added to device metadata.
+#[cfg(not(soc_has_clock_node_timg_calibration_clock))]
+fn calibrate_rtc_slow_clock() {
+    // Do nothing until TIMG_CALIBRATION_CLOCK is added to device metadata.
+}
+
+#[cfg(soc_has_clock_node_timg_calibration_clock)]
+fn calibrate_rtc_slow_clock() {
+    // Unfortunate device specific mapping.
+    // TODO: fix it by generating cfgs for each mux input?
+    cfg_if::cfg_if! {
+        if #[cfg(esp32s2)] {
+            // Can directly measure output of the RTC_SLOW mux
+            let slow_clk = TimgCalibrationClockConfig::RtcClk;
+        } else if #[cfg(soc_has_clock_node_rtc_slow_clk)] {
+            let slow_clk = match unwrap!(ClockTree::with(clocks::rtc_slow_clk_config)) {
+                RtcSlowClkConfig::RcFast => TimgCalibrationClockConfig::RcFastDivClk,
+                RtcSlowClkConfig::RcSlow => TimgCalibrationClockConfig::RcSlowClk,
+                #[cfg(not(esp32c2))]
+                RtcSlowClkConfig::Xtal32k => TimgCalibrationClockConfig::Xtal32kClk,
+                #[cfg(esp32c2)]
+                RtcSlowClkConfig::OscSlow => TimgCalibrationClockConfig::Osc32kClk,
+            };
+        } else if #[cfg(soc_has_clock_node_lp_slow_clk)]{
+            let slow_clk = match unwrap!(ClockTree::with(clocks::lp_slow_clk_config)) {
+                LpSlowClkConfig::OscSlow => TimgCalibrationClockConfig::Xtal32kClk, //?
+                LpSlowClkConfig::Xtal32k => TimgCalibrationClockConfig::Xtal32kClk,
+                LpSlowClkConfig::RcSlow => TimgCalibrationClockConfig::RcSlowClk,
+            };
+        }
     }
 
-    #[cfg(soc_has_clock_node_timg_calibration_clock)]
-    pub(crate) fn calibrate_rtc_slow_clock() {
-        // Unfortunate device specific mapping.
-        // TODO: fix it by generating cfgs for each mux input?
-        cfg_if::cfg_if! {
-            if #[cfg(esp32s2)] {
-                // Can directly measure output of the RTC_SLOW mux
-                let slow_clk = TimgCalibrationClockConfig::RtcClk;
-            } else if #[cfg(soc_has_clock_node_rtc_slow_clk)] {
-                let slow_clk = match unwrap!(ClockTree::with(clocks::rtc_slow_clk_config)) {
-                    RtcSlowClkConfig::RcFast => TimgCalibrationClockConfig::RcFastDivClk,
-                    RtcSlowClkConfig::RcSlow => TimgCalibrationClockConfig::RcSlowClk,
-                    #[cfg(not(esp32c2))]
-                    RtcSlowClkConfig::Xtal32k => TimgCalibrationClockConfig::Xtal32kClk,
-                    #[cfg(esp32c2)]
-                    RtcSlowClkConfig::OscSlow => TimgCalibrationClockConfig::Osc32kClk,
-                };
-            } else if #[cfg(soc_has_clock_node_lp_slow_clk)]{
-                let slow_clk = match unwrap!(ClockTree::with(clocks::lp_slow_clk_config)) {
-                    LpSlowClkConfig::OscSlow => TimgCalibrationClockConfig::Xtal32kClk, //?
-                    LpSlowClkConfig::Xtal32k => TimgCalibrationClockConfig::Xtal32kClk,
-                    LpSlowClkConfig::RcSlow => TimgCalibrationClockConfig::RcSlowClk,
-                };
-            }
+    let cal_val = RtcClock::calibrate(slow_clk, 1024);
+
+    cfg_if::cfg_if! {
+        if #[cfg(soc_has_lp_aon)] {
+            use crate::peripherals::LP_AON;
+        } else {
+            use crate::peripherals::LPWR as LP_AON;
         }
-
-        let cal_val = RtcClock::calibrate(slow_clk, 1024);
-
-        cfg_if::cfg_if! {
-            if #[cfg(soc_has_lp_aon)] {
-                use crate::peripherals::LP_AON;
-            } else {
-                use crate::peripherals::LPWR as LP_AON;
-            }
-        }
-
-        LP_AON::regs()
-            .store1()
-            .write(|w| unsafe { w.bits(cal_val) });
     }
+
+    LP_AON::regs()
+        .store1()
+        .write(|w| unsafe { w.bits(cal_val) });
 }
 
 /// The CPU clock frequency.
 pub fn cpu_clock() -> Rate {
-    Rate::from_hz(crate::soc::clocks::cpu_clk_frequency())
+    Rate::from_hz(ll::cpu_clk_frequency())
 }
 
 /// The XTAL clock frequency.
 pub fn xtal_clock() -> Rate {
-    Rate::from_hz(crate::soc::clocks::xtal_clk_frequency())
+    Rate::from_hz(ll::xtal_clk_frequency())
 }
 
 /// Read the calibrated RTC slow clock period from the STORE1 register.
@@ -534,8 +482,7 @@ pub fn xtal_clock() -> Rate {
 /// The period is in unit of microseconds, represented as a fixed-point number
 /// with `RtcClock::CAL_FRACT` fractional bits.
 ///
-/// Written by [`Clocks::calibrate_rtc_slow_clock`] during clock
-/// initialization.
+/// Written by [`calibrate_rtc_slow_clock`] during clock initialization.
 fn rtc_slow_cal_period() -> u64 {
     cfg_if::cfg_if! {
         if #[cfg(soc_has_lp_aon)] {

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -1875,9 +1875,7 @@ impl Driver<'_> {
     fn set_frequency(&self, clock_config: &Config) -> Result<(), ConfigError> {
         let timeout = clock_config.timeout;
 
-        let source_clk = crate::soc::clocks::ClockTree::with(|clocks| {
-            crate::soc::clocks::apb_clk_frequency(clocks)
-        });
+        let source_clk = crate::soc::clocks::apb_clk_frequency();
 
         let bus_freq = clock_config.frequency.as_hz();
 
@@ -1954,9 +1952,7 @@ impl Driver<'_> {
         let timeout = clock_config.timeout;
 
         // TODO: could be REF_TICK
-        let source_clk = crate::soc::clocks::ClockTree::with(|clocks| {
-            crate::soc::clocks::apb_clk_frequency(clocks)
-        });
+        let source_clk = crate::soc::clocks::apb_clk_frequency();
 
         let bus_freq = clock_config.frequency.as_hz();
 
@@ -2011,9 +2007,7 @@ impl Driver<'_> {
     fn set_frequency(&self, clock_config: &Config) -> Result<(), ConfigError> {
         let timeout = clock_config.timeout;
 
-        let source_clk = crate::soc::clocks::ClockTree::with(|clocks| {
-            crate::soc::clocks::xtal_clk_frequency(clocks)
-        });
+        let source_clk = crate::soc::clocks::xtal_clk_frequency();
 
         let bus_freq = clock_config.frequency.as_hz();
 

--- a/esp-hal/src/lcd_cam/cam.rs
+++ b/esp-hal/src/lcd_cam/cam.rs
@@ -67,7 +67,6 @@ use crate::{
     lcd_cam::{BitOrder, ByteOrder, ClockError, calculate_clkm},
     pac,
     peripherals::LCD_CAM,
-    soc::clocks::ClockTree,
     system::{self, GenericPeripheralGuard},
     time::Rate,
 };
@@ -178,16 +177,14 @@ impl<'d> Camera<'d> {
     /// [`ConfigError::Clock`] will be returned if the frequency passed in
     /// `Config` is too low.
     pub fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError> {
-        let (i, divider) = ClockTree::with(|clocks| {
-            calculate_clkm(
-                config.frequency.as_hz() as _,
-                &[
-                    crate::soc::clocks::xtal_clk_frequency(clocks) as usize,
-                    crate::soc::clocks::pll_d2_frequency(clocks) as usize,
-                    crate::soc::clocks::crypto_pwm_clk_frequency(clocks) as usize,
-                ],
-            )
-        })
+        let (i, divider) = calculate_clkm(
+            config.frequency.as_hz() as _,
+            &[
+                crate::soc::clocks::xtal_clk_frequency() as usize,
+                crate::soc::clocks::pll_d2_frequency() as usize,
+                crate::soc::clocks::crypto_pwm_clk_frequency() as usize,
+            ],
+        )
         .map_err(ConfigError::Clock)?;
 
         if let Some(value) = config.line_interrupt

--- a/esp-hal/src/lcd_cam/lcd/dpi.rs
+++ b/esp-hal/src/lcd_cam/lcd/dpi.rs
@@ -115,7 +115,6 @@ use crate::{
     },
     pac,
     peripherals::LCD_CAM,
-    soc::clocks::ClockTree,
     system::{self, GenericPeripheralGuard},
     time::Rate,
 };
@@ -174,16 +173,14 @@ where
         // Due to https://www.espressif.com/sites/default/files/documentation/esp32-s3_errata_en.pdf
         // the LCD_PCLK divider must be at least 2. To make up for this the user
         // provided frequency is doubled to match.
-        let (i, divider) = ClockTree::with(|clocks| {
-            calculate_clkm(
-                (config.frequency.as_hz() * 2) as _,
-                &[
-                    crate::soc::clocks::xtal_clk_frequency(clocks) as usize,
-                    crate::soc::clocks::pll_d2_frequency(clocks) as usize,
-                    crate::soc::clocks::crypto_pwm_clk_frequency(clocks) as usize,
-                ],
-            )
-        })
+        let (i, divider) = calculate_clkm(
+            (config.frequency.as_hz() * 2) as _,
+            &[
+                crate::soc::clocks::xtal_clk_frequency() as usize,
+                crate::soc::clocks::pll_d2_frequency() as usize,
+                crate::soc::clocks::crypto_pwm_clk_frequency() as usize,
+            ],
+        )
         .map_err(ConfigError::Clock)?;
 
         self.regs().lcd_clock().write(|w| unsafe {

--- a/esp-hal/src/lcd_cam/lcd/i8080.rs
+++ b/esp-hal/src/lcd_cam/lcd/i8080.rs
@@ -68,7 +68,6 @@ use crate::{
     },
     pac,
     peripherals::LCD_CAM,
-    soc::clocks::ClockTree,
     system::{self, GenericPeripheralGuard},
     time::Rate,
 };
@@ -127,16 +126,14 @@ where
         // Due to https://www.espressif.com/sites/default/files/documentation/esp32-s3_errata_en.pdf
         // the LCD_PCLK divider must be at least 2. To make up for this the user
         // provided frequency is doubled to match.
-        let (i, divider) = ClockTree::with(|clocks| {
-            calculate_clkm(
-                (config.frequency.as_hz() * 2) as _,
-                &[
-                    crate::soc::clocks::xtal_clk_frequency(clocks) as usize,
-                    crate::soc::clocks::pll_d2_frequency(clocks) as usize,
-                    crate::soc::clocks::crypto_pwm_clk_frequency(clocks) as usize,
-                ],
-            )
-        })
+        let (i, divider) = calculate_clkm(
+            (config.frequency.as_hz() * 2) as _,
+            &[
+                crate::soc::clocks::xtal_clk_frequency() as usize,
+                crate::soc::clocks::pll_d2_frequency() as usize,
+                crate::soc::clocks::crypto_pwm_clk_frequency() as usize,
+            ],
+        )
         .map_err(ConfigError::Clock)?;
 
         self.regs().lcd_clock().write(|w| unsafe {

--- a/esp-hal/src/ledc/timer.rs
+++ b/esp-hal/src/ledc/timer.rs
@@ -14,7 +14,7 @@
 #[cfg(esp32)]
 use super::HighSpeed;
 use super::{LowSpeed, Speed};
-use crate::{clock::Clocks, pac, time::Rate};
+use crate::{pac, soc::clocks, time::Rate};
 
 const LEDC_TIMER_DIV_NUM_MAX: u64 = 0x3FFFF;
 
@@ -314,10 +314,7 @@ impl TimerHW<LowSpeed> for Timer<'_, LowSpeed> {
     /// Get the current source timer frequency from the HW
     fn freq_hw(&self) -> Option<Rate> {
         self.clock_source.map(|source| match source {
-            LSClockSource::APBClk => {
-                let clocks = Clocks::get();
-                clocks.apb_clock
-            }
+            LSClockSource::APBClk => Rate::from_hz(clocks::apb_clk_frequency()),
         })
     }
 
@@ -377,10 +374,7 @@ impl TimerHW<HighSpeed> for Timer<'_, HighSpeed> {
     /// Get the current source timer frequency from the HW
     fn freq_hw(&self) -> Option<Rate> {
         self.clock_source.map(|source| match source {
-            HSClockSource::APBClk => {
-                let clocks = Clocks::get();
-                clocks.apb_clock
-            }
+            HSClockSource::APBClk => Rate::from_hz(clocks::apb_clk_frequency()),
         })
     }
 

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -613,7 +613,7 @@ pub mod __macro_implementation {
 
 use crate::clock::{ClockConfig, CpuClock};
 #[cfg(feature = "rt")]
-use crate::{clock::Clocks, peripherals::Peripherals};
+use crate::peripherals::Peripherals;
 
 /// A spinlock for seldom called stuff. Users assume that lock contention is not an issue.
 pub(crate) static ESP_HAL_LOCK: RawMutex = RawMutex::new();
@@ -740,7 +740,7 @@ pub fn init(config: Config) -> Peripherals {
 
     let mut peripherals = Peripherals::take();
 
-    Clocks::init(config.clock_config());
+    crate::clock::init(config.clock_config());
 
     // RTC domain must be enabled before we try to disable
     let mut rtc = crate::rtc_cntl::Rtc::new(peripherals.LPWR.reborrow());

--- a/esp-hal/src/mcpwm/mod.rs
+++ b/esp-hal/src/mcpwm/mod.rs
@@ -181,9 +181,7 @@ impl PeripheralClockConfig {
     fn source_clock() -> Rate {
         // FIXME: this works right now because we configure the default clock source during startup.
         // Needs to be revisited when refactoring the MCPWM driver before stabilization.
-        ClockTree::with(|clocks| {
-            Rate::from_hz(clocks::McpwmInstance::Mcpwm0.function_clock_frequency(clocks))
-        })
+        Rate::from_hz(clocks::McpwmInstance::Mcpwm0.function_clock_frequency())
     }
 
     /// Get a clock configuration with the given prescaler.

--- a/esp-hal/src/parl_io.rs
+++ b/esp-hal/src/parl_io.rs
@@ -1222,7 +1222,7 @@ where
             return Err(ConfigError::UnreachableClockRate);
         }
 
-        let frequency = ClockTree::with(|clocks| ParlIoInstance::ParlIo.tx_clock_frequency(clocks));
+        let frequency = ParlIoInstance::ParlIo.tx_clock_frequency();
         let divider = frequency / config.frequency.as_hz();
         if divider > 0xFFFF {
             return Err(ConfigError::UnreachableClockRate);
@@ -1385,7 +1385,7 @@ where
             return Err(ConfigError::UnreachableClockRate);
         }
 
-        let frequency = ClockTree::with(|clocks| ParlIoInstance::ParlIo.rx_clock_frequency(clocks));
+        let frequency = ParlIoInstance::ParlIo.rx_clock_frequency();
         let divider = frequency / config.frequency.as_hz();
         if divider > 0xffff {
             return Err(ConfigError::UnreachableClockRate);

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -213,7 +213,6 @@ use portable_atomic::Ordering;
 #[cfg(place_rmt_driver_in_ram)]
 use procmacros::ram;
 
-use crate::soc::clocks;
 use crate::{
     Async,
     Blocking,
@@ -227,6 +226,7 @@ use crate::{
         interconnect::{PeripheralInput, PeripheralOutput},
     },
     peripherals::{Interrupt, RMT},
+    soc::clocks,
     system::GenericPeripheralGuard,
     time::Rate,
 };

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -2257,9 +2257,7 @@ for_each_rmt_clock_source!(
 
                     #[cfg(rmt_supports_rcfast_clock)]
                     ClockSource::RcFast => {
-                        Rate::from_hz(clocks::ClockTree::with(
-                            clocks::rc_fast_clk_frequency,
-                        ))
+                        Rate::from_hz(clocks::rc_fast_clk_frequency())
                     }
 
                     #[cfg(rmt_supports_xtal_clock)]

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -213,13 +213,11 @@ use portable_atomic::Ordering;
 #[cfg(place_rmt_driver_in_ram)]
 use procmacros::ram;
 
-#[cfg(soc_has_clock_node_rmt_sclk)]
 use crate::soc::clocks;
 use crate::{
     Async,
     Blocking,
     asynch::AtomicWaker,
-    clock::Clocks,
     gpio::{
         self,
         InputConfig,
@@ -2253,15 +2251,13 @@ for_each_rmt_clock_source!(
             fn freq(self) -> crate::time::Rate {
                 match self {
                     #[cfg(rmt_supports_apb_clock)]
-                    ClockSource::Apb => Clocks::get().apb_clock,
+                    ClockSource::Apb => Rate::from_hz(clocks::apb_clk_frequency()),
 
                     #[cfg(rmt_supports_rcfast_clock)]
-                    ClockSource::RcFast => {
-                        Rate::from_hz(clocks::rc_fast_clk_frequency())
-                    }
+                    ClockSource::RcFast => Rate::from_hz(clocks::rc_fast_clk_frequency()),
 
                     #[cfg(rmt_supports_xtal_clock)]
-                    ClockSource::Xtal => Clocks::get().xtal_clock,
+                    ClockSource::Xtal => Rate::from_hz(clocks::xtal_clk_frequency()),
 
                     #[cfg(rmt_supports_pll80mhz_clock)]
                     ClockSource::Pll80MHz => Rate::from_mhz(80),

--- a/esp-hal/src/rng/ll.rs
+++ b/esp-hal/src/rng/ll.rs
@@ -1,6 +1,6 @@
 use esp_sync::NonReentrantMutex;
 
-use crate::{clock::Clocks, peripherals::RNG};
+use crate::{peripherals::RNG, soc::clocks};
 
 // TODO: find a better place for these
 #[inline]
@@ -76,8 +76,7 @@ fn read_one(wait_cycles: usize) -> u32 {
 }
 
 pub(super) fn fill_ptr_range(data: *mut u8, len: usize) {
-    let clocks = Clocks::get();
-    let cpu_to_apb_freq_ratio = clocks.cpu_clock / clocks.apb_clock;
+    let cpu_to_apb_freq_ratio = clocks::cpu_clk_frequency() / clocks::apb_clk_frequency();
     let wait_cycles = cpu_to_apb_freq_ratio as usize * property!("rng.apb_cycle_wait_num");
 
     let mut remaining = len;

--- a/esp-hal/src/soc/esp32/clocks.rs
+++ b/esp-hal/src/soc/esp32/clocks.rs
@@ -568,10 +568,10 @@ fn configure_cpu_clk_impl(
     });
 
     // Store frequencies in expected places.
-    let cpu_freq = Rate::from_hz(cpu_clk_frequency(clocks));
+    let cpu_freq = Rate::from_hz(cpu_clk_frequency());
     ets_update_cpu_frequency_rom(cpu_freq.as_mhz());
 
-    let apb_freq = Rate::from_hz(apb_clk_frequency(clocks));
+    let apb_freq = Rate::from_hz(apb_clk_frequency());
     update_apb_frequency(apb_freq);
 }
 

--- a/esp-hal/src/soc/esp32/clocks.rs
+++ b/esp-hal/src/soc/esp32/clocks.rs
@@ -18,7 +18,7 @@
 use esp_rom_sys::rom::{ets_delay_us, ets_update_cpu_frequency_rom};
 
 use crate::{
-    clock::Clocks,
+    clock::RtcClock,
     efuse::VOL_LEVEL_HP_INV,
     peripherals::{APB_CTRL, LPWR, RTC_IO, SYSTEM, TIMG0, UART0, UART1, UART2},
     rtc_cntl::Rtc,
@@ -143,7 +143,7 @@ fn detect_xtal_freq(clocks: &mut ClockTree) -> XtalClkConfig {
         .clk_conf()
         .modify(|_, w| w.dig_clk8m_d256_en().set_bit());
 
-    let (xtal_cycles, calibration_clock_frequency) = Clocks::measure_rtc_clock(
+    let (xtal_cycles, calibration_clock_frequency) = RtcClock::measure_rtc_clock(
         clocks,
         TimgCalibrationClockConfig::RcFastDivClk,
         CALIBRATION_CYCLES,

--- a/esp-hal/src/soc/esp32c2/clocks.rs
+++ b/esp-hal/src/soc/esp32c2/clocks.rs
@@ -452,10 +452,10 @@ fn configure_cpu_clk_impl(
         })
     });
 
-    let apb_freq = Rate::from_hz(apb_clk_frequency(clocks));
+    let apb_freq = Rate::from_hz(apb_clk_frequency());
     update_apb_frequency(apb_freq);
 
-    let cpu_freq = Rate::from_hz(cpu_clk_frequency(clocks));
+    let cpu_freq = Rate::from_hz(cpu_clk_frequency());
     ets_update_cpu_frequency_rom(cpu_freq.as_mhz());
 }
 

--- a/esp-hal/src/soc/esp32c2/clocks.rs
+++ b/esp-hal/src/soc/esp32c2/clocks.rs
@@ -18,7 +18,7 @@
 use esp_rom_sys::rom::{ets_delay_us, ets_update_cpu_frequency_rom};
 
 use crate::{
-    clock::Clocks,
+    clock::RtcClock,
     peripherals::{I2C_ANA_MST, LPWR, SYSTEM, TIMG0, UART0, UART1},
     rtc_cntl::Rtc,
     soc::regi2c,
@@ -127,7 +127,7 @@ fn detect_xtal_freq(clocks: &mut ClockTree) -> XtalClkConfig {
         .clk_conf()
         .modify(|_, w| w.dig_clk8m_d256_en().set_bit());
 
-    let (xtal_cycles, calibration_clock_frequency) = Clocks::measure_rtc_clock(
+    let (xtal_cycles, calibration_clock_frequency) = RtcClock::measure_rtc_clock(
         clocks,
         TimgCalibrationClockConfig::RcFastDivClk,
         TimgFunctionClockConfig::XtalClk,

--- a/esp-hal/src/soc/esp32c3/clocks.rs
+++ b/esp-hal/src/soc/esp32c3/clocks.rs
@@ -416,10 +416,10 @@ fn configure_cpu_clk_impl(
         })
     });
 
-    let apb_freq = Rate::from_hz(apb_clk_frequency(clocks));
+    let apb_freq = Rate::from_hz(apb_clk_frequency());
     update_apb_frequency(apb_freq);
 
-    let cpu_freq = Rate::from_hz(cpu_clk_frequency(clocks));
+    let cpu_freq = Rate::from_hz(cpu_clk_frequency());
     ets_update_cpu_frequency_rom(cpu_freq.as_mhz());
 }
 

--- a/esp-hal/src/soc/esp32s2/clocks.rs
+++ b/esp-hal/src/soc/esp32s2/clocks.rs
@@ -430,10 +430,10 @@ fn configure_cpu_clk_impl(
         .modify(|_, w| unsafe { w.soc_clk_sel().bits(clock_source_sel0_bit) });
 
     // Store frequencies in expected places.
-    let cpu_freq = Rate::from_hz(cpu_clk_frequency(clocks));
+    let cpu_freq = Rate::from_hz(cpu_clk_frequency());
     ets_update_cpu_frequency_rom(cpu_freq.as_mhz());
 
-    let apb_freq = Rate::from_hz(apb_clk_frequency(clocks));
+    let apb_freq = Rate::from_hz(apb_clk_frequency());
     update_apb_frequency(apb_freq);
 
     ensure_voltage_minimal(clocks);

--- a/esp-hal/src/soc/esp32s3/clocks.rs
+++ b/esp-hal/src/soc/esp32s3/clocks.rs
@@ -157,7 +157,7 @@ fn enable_pll_clk_impl(clocks: &mut ClockTree, en: bool) {
         return;
     }
 
-    ensure_voltage_raised(clocks);
+    ensure_voltage_raised();
 
     // Analog part
     let pll_freq = unwrap!(clocks.pll_clk);
@@ -246,7 +246,7 @@ fn enable_pll_clk_impl(clocks: &mut ClockTree, en: bool) {
         w.bbpll_stop_force_low().clear_bit()
     });
 
-    ensure_voltage_minimal(clocks);
+    ensure_voltage_minimal();
 }
 
 fn configure_pll_clk_impl(
@@ -438,7 +438,7 @@ fn configure_cpu_clk_impl(
         _ => 0,
     };
 
-    ensure_voltage_raised(clocks);
+    ensure_voltage_raised();
     if new_config == CpuClkConfig::Pll {
         SYSTEM::regs().cpu_per_conf().modify(|_, w| {
             unsafe { w.cpuperiod_sel().bits(clock_source_sel2_bit) };
@@ -454,7 +454,7 @@ fn configure_cpu_clk_impl(
     let cpu_freq = Rate::from_hz(cpu_clk_frequency());
     ets_update_cpu_frequency_rom(cpu_freq.as_mhz());
 
-    ensure_voltage_minimal(clocks);
+    ensure_voltage_minimal();
 }
 
 // There are totally 6 LDO slaves(all on by default). At the moment of switching LDO slave, LDO
@@ -561,7 +561,7 @@ fn pvt_supported() -> bool {
     (blk_major == 0 && blk_minor == 1) || (blk_major == 1 && blk_minor >= 2) || blk_major > 1
 }
 
-fn ensure_voltage_raised(_clocks: &mut ClockTree) {
+fn ensure_voltage_raised() {
     let cpu_freq = cpu_clk_frequency();
     let pd_slave = cpu_freq / 80_000_000;
 
@@ -590,7 +590,7 @@ fn ensure_voltage_raised(_clocks: &mut ClockTree) {
         .modify(|_, w| unsafe { w.ldo_slave().bits(0x7 >> pd_slave) });
 }
 
-fn ensure_voltage_minimal(_clocks: &mut ClockTree) {
+fn ensure_voltage_minimal() {
     let cpu_freq = cpu_clk_frequency();
     let pd_slave = cpu_freq / 80_000_000;
 

--- a/esp-hal/src/soc/esp32s3/clocks.rs
+++ b/esp-hal/src/soc/esp32s3/clocks.rs
@@ -451,7 +451,7 @@ fn configure_cpu_clk_impl(
         w.soc_clk_sel().bits(clock_source_sel0_bit)
     });
 
-    let cpu_freq = Rate::from_hz(cpu_clk_frequency(clocks));
+    let cpu_freq = Rate::from_hz(cpu_clk_frequency());
     ets_update_cpu_frequency_rom(cpu_freq.as_mhz());
 
     ensure_voltage_minimal(clocks);
@@ -561,8 +561,8 @@ fn pvt_supported() -> bool {
     (blk_major == 0 && blk_minor == 1) || (blk_major == 1 && blk_minor >= 2) || blk_major > 1
 }
 
-fn ensure_voltage_raised(clocks: &mut ClockTree) {
-    let cpu_freq = cpu_clk_frequency(clocks);
+fn ensure_voltage_raised(_clocks: &mut ClockTree) {
+    let cpu_freq = cpu_clk_frequency();
     let pd_slave = cpu_freq / 80_000_000;
 
     if cpu_freq == 240_000_000 {
@@ -590,8 +590,8 @@ fn ensure_voltage_raised(clocks: &mut ClockTree) {
         .modify(|_, w| unsafe { w.ldo_slave().bits(0x7 >> pd_slave) });
 }
 
-fn ensure_voltage_minimal(clocks: &mut ClockTree) {
-    let cpu_freq = cpu_clk_frequency(clocks);
+fn ensure_voltage_minimal(_clocks: &mut ClockTree) {
+    let cpu_freq = cpu_clk_frequency();
     let pd_slave = cpu_freq / 80_000_000;
 
     if cpu_freq < 240_000_000 {

--- a/esp-hal/src/spi/master/mod.rs
+++ b/esp-hal/src/spi/master/mod.rs
@@ -63,7 +63,6 @@ use crate::{
     DriverMode,
     RegisterToggle,
     asynch::AtomicWaker,
-    clock::Clocks,
     gpio::{
         InputConfig,
         InputSignal,
@@ -511,26 +510,21 @@ impl Config {
     }
 
     fn clock_source_freq_hz(&self) -> Rate {
-        let clocks = Clocks::get();
-
         // FIXME: take clock source into account
         cfg_if::cfg_if! {
             if #[cfg(esp32h2)] {
                 // ESP32-H2 is using PLL_48M_CLK source instead of APB_CLK
-                let _clocks = clocks;
                 Rate::from_mhz(48)
             } else if #[cfg(any(esp32c5, esp32c61))] {
                 // We select the 160MHz PLL as the clock source in the driver. There is a by-2 divider
                 // configured between the PLL and the SPI clock (spi2_clkm_div_num).
-                let _clocks = clocks;
                 Rate::from_mhz(80) // clk_spi2_mst must be <= 80MHz
             } else if #[cfg(esp32c6)] {
                 // We select the 80MHz PLL as the clock source in the driver
                 // FIXME we state that the default clock source is APB, which just isn't true
-                let _clocks = clocks;
                 Rate::from_mhz(80)
             } else {
-                clocks.apb_clock
+                Rate::from_hz(crate::soc::clocks::apb_clk_frequency())
             }
         }
     }

--- a/esp-hal/src/time.rs
+++ b/esp-hal/src/time.rs
@@ -717,7 +717,8 @@ pub(crate) mod implem {
 
     #[cfg(feature = "rt")]
     pub(crate) fn time_init() {
-        let apb = crate::Clocks::get().apb_clock.as_hz();
+        // FIXME: does this imply that clock management needs to be "rt", too?
+        let apb = crate::soc::clocks::apb_clk_frequency();
 
         let tg0 = TIMG0::regs();
 

--- a/esp-hal/src/timer/systimer.rs
+++ b/esp-hal/src/timer/systimer.rs
@@ -200,21 +200,15 @@ impl<'d> SystemTimer<'d> {
                 // Assuming SYSTIMER runs from XTAL, the hardware always runs at 16 MHz.
                 16_000_000
             } else {
-                crate::soc::clocks::ClockTree::with(|clocks| {
-                    cfg_if::cfg_if! {
-                        if #[cfg(esp32s2)] {
-                            crate::soc::clocks::apb_clk_frequency(clocks) as u64
-                        } else if #[cfg(esp32h2)] {
-                            // The counters and comparators are driven using `XTAL_CLK`.
-                            // The average clock frequency is fXTAL_CLK/2, (16 MHz for XTAL = 32 MHz)
-                            (crate::soc::clocks::xtal_clk_frequency(clocks) / 2) as u64
-                        } else {
-                            // The counters and comparators are driven using `XTAL_CLK`.
-                            // The average clock frequency is fXTAL_CLK/2.5 (16 MHz for XTAL = 40 MHz)
-                            (crate::soc::clocks::xtal_clk_frequency(clocks) * 10 / 25) as u64
-                        }
+                cfg_if::cfg_if! {
+                    if #[cfg(esp32s2)] {
+                        crate::soc::clocks::apb_clk_frequency() as u64
+                    } else if #[cfg(esp32h2)] {
+                        (crate::soc::clocks::xtal_clk_frequency() / 2) as u64
+                    } else {
+                        (crate::soc::clocks::xtal_clk_frequency() * 10 / 25) as u64
                     }
-                })
+                }
             }
         }
     }

--- a/esp-hal/src/timer/timg.rs
+++ b/esp-hal/src/timer/timg.rs
@@ -422,7 +422,6 @@ impl Timer<'_> {
     }
 
     fn source_frequency(&self) -> Rate {
-        let hz;
         cfg_if::cfg_if! {
             if #[cfg(soc_has_clock_node_timg_function_clock)] {
                 let timg = match self.timer_group() {
@@ -431,9 +430,9 @@ impl Timer<'_> {
                     1 => crate::soc::clocks::TimgInstance::Timg1,
                     _ => unreachable!()
                 };
-                hz = timg.function_clock_frequency();
+                let hz = timg.function_clock_frequency();
             } else {
-                hz = crate::soc::clocks::apb_clk_frequency();
+                let hz = crate::soc::clocks::apb_clk_frequency();
             }
         }
         Rate::from_hz(hz)
@@ -688,12 +687,11 @@ where
 
     /// Set the timeout, in microseconds, of the watchdog timer
     pub fn set_timeout(&mut self, stage: MwdtStage, timeout: Duration) {
-        let clk_src;
         cfg_if::cfg_if! {
             if #[cfg(soc_has_clock_node_timg_wdt_clock)] {
-                clk_src = Rate::from_hz(TG::clock_instance().wdt_clock_frequency());
+                let clk_src = Rate::from_hz(TG::clock_instance().wdt_clock_frequency());
             } else {
-                clk_src = Rate::from_hz(clocks::apb_clk_frequency());
+                let clk_src = Rate::from_hz(clocks::apb_clk_frequency());
             }
         }
 

--- a/esp-hal/src/timer/timg.rs
+++ b/esp-hal/src/timer/timg.rs
@@ -422,22 +422,20 @@ impl Timer<'_> {
     }
 
     fn source_frequency(&self) -> Rate {
-        let hz = clocks::ClockTree::with(|clocks| {
-            cfg_if::cfg_if! {
-                if #[cfg(soc_has_clock_node_timg_function_clock)] {
-                    let timg = match self.timer_group() {
-                        0 => crate::soc::clocks::TimgInstance::Timg0,
-                        #[cfg(soc_has_timg1)]
-                        1 => crate::soc::clocks::TimgInstance::Timg1,
-                        _ => unreachable!()
-                    };
-
-                    timg.function_clock_frequency(clocks)
-                } else {
-                    crate::soc::clocks::apb_clk_frequency(clocks)
-                }
+        let hz;
+        cfg_if::cfg_if! {
+            if #[cfg(soc_has_clock_node_timg_function_clock)] {
+                let timg = match self.timer_group() {
+                    0 => crate::soc::clocks::TimgInstance::Timg0,
+                    #[cfg(soc_has_timg1)]
+                    1 => crate::soc::clocks::TimgInstance::Timg1,
+                    _ => unreachable!()
+                };
+                hz = timg.function_clock_frequency();
+            } else {
+                hz = crate::soc::clocks::apb_clk_frequency();
             }
-        });
+        }
         Rate::from_hz(hz)
     }
 
@@ -690,15 +688,14 @@ where
 
     /// Set the timeout, in microseconds, of the watchdog timer
     pub fn set_timeout(&mut self, stage: MwdtStage, timeout: Duration) {
-        let clk_src = clocks::ClockTree::with(|clocks| {
-            cfg_if::cfg_if! {
-                if #[cfg(soc_has_clock_node_timg_wdt_clock)] {
-                    Rate::from_hz(TG::clock_instance().wdt_clock_frequency(clocks))
-                } else {
-                    Rate::from_hz(clocks::apb_clk_frequency(clocks))
-                }
+        let clk_src;
+        cfg_if::cfg_if! {
+            if #[cfg(soc_has_clock_node_timg_wdt_clock)] {
+                clk_src = Rate::from_hz(TG::clock_instance().wdt_clock_frequency());
+            } else {
+                clk_src = Rate::from_hz(clocks::apb_clk_frequency());
             }
-        });
+        }
 
         let timeout_ticks = timeout.as_micros() * clk_src.as_mhz() as u64;
 

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -773,8 +773,7 @@ where
         // Included timings are all for 80MHz so assert that we are running at 80MHz.
         #[cfg(not(any(esp32h2, esp32c6)))]
         {
-            let apb_clock = crate::clock::Clocks::get().apb_clock;
-            assert!(apb_clock.as_mhz() == 80);
+            assert!(crate::soc::clocks::apb_clk_frequency() / 1_000_000 == 80);
         }
 
         // Unpack the baud rate timings and convert them to the values needed for the

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -773,7 +773,7 @@ where
         // Included timings are all for 80MHz so assert that we are running at 80MHz.
         #[cfg(not(any(esp32h2, esp32c6)))]
         {
-            assert!(crate::soc::clocks::apb_clk_frequency() / 1_000_000 == 80);
+            assert!(crate::soc::clocks::apb_clk_frequency() == 80_000_000);
         }
 
         // Unpack the baud rate timings and convert them to the values needed for the

--- a/esp-hal/src/uart/mod.rs
+++ b/esp-hal/src/uart/mod.rs
@@ -2712,7 +2712,6 @@ pub mod lp_uart {
     use crate::{
         gpio::lp_io::{LowPowerInput, LowPowerOutput},
         peripherals::{LP_AON, LP_CLKRST, LP_IO, LP_UART, LPWR},
-        soc::clocks::ClockTree,
         uart::{DataBits, Parity, StopBits},
     };
 
@@ -2873,10 +2872,10 @@ pub mod lp_uart {
         }
 
         fn change_baud_internal(&mut self, config: &Config) {
-            let clk = ClockTree::with(|clocks| match config.clock_source {
-                ClockSource::RcFast => crate::soc::clocks::rc_fast_clk_frequency(clocks),
-                ClockSource::Xtal => crate::soc::clocks::xtal_d2_clk_frequency(clocks),
-            });
+            let clk = match config.clock_source {
+                ClockSource::RcFast => crate::soc::clocks::rc_fast_clk_frequency(),
+                ClockSource::Xtal => crate::soc::clocks::xtal_d2_clk_frequency(),
+            };
 
             LP_CLKRST::regs().lpperi().modify(|_, w| {
                 w.lp_uart_clk_sel().bit(match config.clock_source {
@@ -3395,7 +3394,7 @@ impl Info {
                     _ => return Ok(()),
                 };
 
-                let actual_baud = clock.baud_rate_generator_frequency(clocks);
+                let actual_baud = clock.baud_rate_generator_frequency();
                 if actual_baud == 0 {
                     return Err(ConfigError::BaudrateNotAchievable);
                 }

--- a/esp-metadata-generated/src/_generated_esp32.rs
+++ b/esp-metadata-generated/src/_generated_esp32.rs
@@ -1509,7 +1509,7 @@ macro_rules! define_clock_tree_types {
         pub fn xtal_clk_config_frequency(clocks: &mut ClockTree, config: XtalClkConfig) -> u32 {
             config.value()
         }
-        pub fn xtal_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn xtal_clk_frequency() -> u32 {
             XTAL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_pll_clk(clocks: &mut ClockTree, config: PllClkConfig) {
@@ -1546,7 +1546,7 @@ macro_rules! define_clock_tree_types {
         pub fn pll_clk_config_frequency(clocks: &mut ClockTree, config: PllClkConfig) -> u32 {
             config.value()
         }
-        pub fn pll_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn pll_clk_frequency() -> u32 {
             PLL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_apll_clk(clocks: &mut ClockTree, config: ApllClkConfig) {
@@ -1573,7 +1573,7 @@ macro_rules! define_clock_tree_types {
         pub fn apll_clk_config_frequency(clocks: &mut ClockTree, config: ApllClkConfig) -> u32 {
             config.value()
         }
-        pub fn apll_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn apll_clk_frequency() -> u32 {
             APLL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_rc_fast_clk(clocks: &mut ClockTree) {
@@ -1590,7 +1590,7 @@ macro_rules! define_clock_tree_types {
                 enable_rc_fast_clk_impl(clocks, false);
             }
         }
-        pub fn rc_fast_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn rc_fast_clk_frequency() -> u32 {
             8000000
         }
         pub fn request_pll_f160m_clk(clocks: &mut ClockTree) {
@@ -1609,7 +1609,7 @@ macro_rules! define_clock_tree_types {
                 release_pll_clk(clocks);
             }
         }
-        pub fn pll_f160m_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn pll_f160m_clk_frequency() -> u32 {
             160000000
         }
         pub fn configure_cpu_pll_div_in(clocks: &mut ClockTree, new_selector: CpuPllDivInConfig) {
@@ -1654,16 +1654,16 @@ macro_rules! define_clock_tree_types {
             config: CpuPllDivInConfig,
         ) -> u32 {
             match config {
-                CpuPllDivInConfig::Pll => pll_clk_frequency(clocks),
-                CpuPllDivInConfig::Apll => apll_clk_frequency(clocks),
+                CpuPllDivInConfig::Pll => pll_clk_frequency(),
+                CpuPllDivInConfig::Apll => apll_clk_frequency(),
             }
         }
-        pub fn cpu_pll_div_in_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn cpu_pll_div_in_frequency() -> u32 {
             CPU_PLL_DIV_IN_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_cpu_pll_div(clocks: &mut ClockTree, config: CpuPllDivConfig) {
             if clocks.pll_clk.is_some() {
-                assert!(!((pll_clk_frequency(clocks) == 480000000) && (config.divisor() == 4)));
+                assert!(!((pll_clk_frequency() == 480000000) && (config.divisor() == 4)));
             }
             let old_config = clocks.cpu_pll_div.replace(config);
             configure_cpu_pll_div_impl(clocks, old_config, config);
@@ -1689,9 +1689,9 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: CpuPllDivConfig,
         ) -> u32 {
-            (cpu_pll_div_in_frequency(clocks) / config.divisor())
+            (cpu_pll_div_in_frequency() / config.divisor())
         }
-        pub fn cpu_pll_div_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn cpu_pll_div_frequency() -> u32 {
             CPU_PLL_DIV_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_syscon_pre_div_in(
@@ -1739,11 +1739,11 @@ macro_rules! define_clock_tree_types {
             config: SysconPreDivInConfig,
         ) -> u32 {
             match config {
-                SysconPreDivInConfig::Xtal => xtal_clk_frequency(clocks),
-                SysconPreDivInConfig::RcFast => rc_fast_clk_frequency(clocks),
+                SysconPreDivInConfig::Xtal => xtal_clk_frequency(),
+                SysconPreDivInConfig::RcFast => rc_fast_clk_frequency(),
             }
         }
-        pub fn syscon_pre_div_in_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn syscon_pre_div_in_frequency() -> u32 {
             SYSCON_PRE_DIV_IN_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_syscon_pre_div(clocks: &mut ClockTree, config: SysconPreDivConfig) {
@@ -1771,9 +1771,9 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: SysconPreDivConfig,
         ) -> u32 {
-            (syscon_pre_div_in_frequency(clocks) / (config.divisor() + 1))
+            (syscon_pre_div_in_frequency() / (config.divisor() + 1))
         }
-        pub fn syscon_pre_div_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn syscon_pre_div_frequency() -> u32 {
             SYSCON_PRE_DIV_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, new_selector: ApbClkConfig) {
@@ -1827,12 +1827,12 @@ macro_rules! define_clock_tree_types {
         #[allow(unused_variables)]
         pub fn apb_clk_config_frequency(clocks: &mut ClockTree, config: ApbClkConfig) -> u32 {
             match config {
-                ApbClkConfig::Pll80m => apb_clk_80m_frequency(clocks),
-                ApbClkConfig::CpuDiv2 => apb_clk_cpu_div2_frequency(clocks),
-                ApbClkConfig::Cpu => cpu_clk_frequency(clocks),
+                ApbClkConfig::Pll80m => apb_clk_80m_frequency(),
+                ApbClkConfig::CpuDiv2 => apb_clk_cpu_div2_frequency(),
+                ApbClkConfig::Cpu => cpu_clk_frequency(),
             }
         }
-        pub fn apb_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn apb_clk_frequency() -> u32 {
             APB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_ref_tick(clocks: &mut ClockTree, new_selector: RefTickConfig) {
@@ -1890,13 +1890,13 @@ macro_rules! define_clock_tree_types {
         #[allow(unused_variables)]
         pub fn ref_tick_config_frequency(clocks: &mut ClockTree, config: RefTickConfig) -> u32 {
             match config {
-                RefTickConfig::Pll => ref_tick_pll_frequency(clocks),
-                RefTickConfig::Apll => ref_tick_apll_frequency(clocks),
-                RefTickConfig::Xtal => ref_tick_xtal_frequency(clocks),
-                RefTickConfig::Fosc => ref_tick_fosc_frequency(clocks),
+                RefTickConfig::Pll => ref_tick_pll_frequency(),
+                RefTickConfig::Apll => ref_tick_apll_frequency(),
+                RefTickConfig::Xtal => ref_tick_xtal_frequency(),
+                RefTickConfig::Fosc => ref_tick_fosc_frequency(),
             }
         }
-        pub fn ref_tick_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn ref_tick_frequency() -> u32 {
             REF_TICK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_ref_tick_xtal(clocks: &mut ClockTree, config: RefTickXtalConfig) {
@@ -1924,9 +1924,9 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: RefTickXtalConfig,
         ) -> u32 {
-            (apb_clk_frequency(clocks) / (config.divisor() + 1))
+            (apb_clk_frequency() / (config.divisor() + 1))
         }
-        pub fn ref_tick_xtal_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn ref_tick_xtal_frequency() -> u32 {
             REF_TICK_XTAL_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_ref_tick_fosc(clocks: &mut ClockTree, config: RefTickFoscConfig) {
@@ -1954,9 +1954,9 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: RefTickFoscConfig,
         ) -> u32 {
-            (apb_clk_frequency(clocks) / (config.divisor() + 1))
+            (apb_clk_frequency() / (config.divisor() + 1))
         }
-        pub fn ref_tick_fosc_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn ref_tick_fosc_frequency() -> u32 {
             REF_TICK_FOSC_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_ref_tick_apll(clocks: &mut ClockTree, config: RefTickApllConfig) {
@@ -1984,9 +1984,9 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: RefTickApllConfig,
         ) -> u32 {
-            (apb_clk_frequency(clocks) / (config.divisor() + 1))
+            (apb_clk_frequency() / (config.divisor() + 1))
         }
-        pub fn ref_tick_apll_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn ref_tick_apll_frequency() -> u32 {
             REF_TICK_APLL_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_ref_tick_pll(clocks: &mut ClockTree, config: RefTickPllConfig) {
@@ -2014,9 +2014,9 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: RefTickPllConfig,
         ) -> u32 {
-            (apb_clk_frequency(clocks) / (config.divisor() + 1))
+            (apb_clk_frequency() / (config.divisor() + 1))
         }
-        pub fn ref_tick_pll_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn ref_tick_pll_frequency() -> u32 {
             REF_TICK_PLL_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, new_selector: CpuClkConfig) {
@@ -2027,7 +2027,7 @@ macro_rules! define_clock_tree_types {
                     configure_syscon_pre_div_in(clocks, SysconPreDivInConfig::Xtal);
                     configure_ref_tick(clocks, RefTickConfig::Xtal);
                     let config_value =
-                        RefTickXtalConfig::new(((apb_clk_frequency(clocks) / 1000000) - 1));
+                        RefTickXtalConfig::new(((apb_clk_frequency() / 1000000) - 1));
                     configure_ref_tick_xtal(clocks, config_value);
                 }
                 CpuClkConfig::RcFast => {
@@ -2035,7 +2035,7 @@ macro_rules! define_clock_tree_types {
                     configure_syscon_pre_div_in(clocks, SysconPreDivInConfig::RcFast);
                     configure_ref_tick(clocks, RefTickConfig::Fosc);
                     let config_value =
-                        RefTickFoscConfig::new(((apb_clk_frequency(clocks) / 1000000) - 1));
+                        RefTickFoscConfig::new(((apb_clk_frequency() / 1000000) - 1));
                     configure_ref_tick_fosc(clocks, config_value);
                 }
                 CpuClkConfig::Apll => {
@@ -2043,15 +2043,14 @@ macro_rules! define_clock_tree_types {
                     configure_cpu_pll_div_in(clocks, CpuPllDivInConfig::Apll);
                     configure_ref_tick(clocks, RefTickConfig::Apll);
                     let config_value =
-                        RefTickApllConfig::new(((apb_clk_frequency(clocks) / 1000000) - 1));
+                        RefTickApllConfig::new(((apb_clk_frequency() / 1000000) - 1));
                     configure_ref_tick_apll(clocks, config_value);
                 }
                 CpuClkConfig::Pll => {
                     configure_apb_clk(clocks, ApbClkConfig::Pll80m);
                     configure_cpu_pll_div_in(clocks, CpuPllDivInConfig::Pll);
                     configure_ref_tick(clocks, RefTickConfig::Pll);
-                    let config_value =
-                        RefTickPllConfig::new(((apb_clk_frequency(clocks) / 1000000) - 1));
+                    let config_value = RefTickPllConfig::new(((apb_clk_frequency() / 1000000) - 1));
                     configure_ref_tick_pll(clocks, config_value);
                 }
             }
@@ -2080,13 +2079,13 @@ macro_rules! define_clock_tree_types {
         #[allow(unused_variables)]
         pub fn cpu_clk_config_frequency(clocks: &mut ClockTree, config: CpuClkConfig) -> u32 {
             match config {
-                CpuClkConfig::Xtal => syscon_pre_div_frequency(clocks),
-                CpuClkConfig::RcFast => syscon_pre_div_frequency(clocks),
-                CpuClkConfig::Apll => cpu_pll_div_frequency(clocks),
-                CpuClkConfig::Pll => cpu_pll_div_frequency(clocks),
+                CpuClkConfig::Xtal => syscon_pre_div_frequency(),
+                CpuClkConfig::RcFast => syscon_pre_div_frequency(),
+                CpuClkConfig::Apll => cpu_pll_div_frequency(),
+                CpuClkConfig::Pll => cpu_pll_div_frequency(),
             }
         }
-        pub fn cpu_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn cpu_clk_frequency() -> u32 {
             CPU_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_apb_clk_cpu_div2(clocks: &mut ClockTree) {
@@ -2101,8 +2100,8 @@ macro_rules! define_clock_tree_types {
             enable_apb_clk_cpu_div2_impl(clocks, false);
             release_cpu_clk(clocks);
         }
-        pub fn apb_clk_cpu_div2_frequency(clocks: &mut ClockTree) -> u32 {
-            (cpu_clk_frequency(clocks) / 2)
+        pub fn apb_clk_cpu_div2_frequency() -> u32 {
+            (cpu_clk_frequency() / 2)
         }
         pub fn request_apb_clk_80m(clocks: &mut ClockTree) {
             trace!("Requesting APB_CLK_80M");
@@ -2116,7 +2115,7 @@ macro_rules! define_clock_tree_types {
             enable_apb_clk_80m_impl(clocks, false);
             release_cpu_clk(clocks);
         }
-        pub fn apb_clk_80m_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn apb_clk_80m_frequency() -> u32 {
             80000000
         }
         pub fn request_xtal32k_clk(clocks: &mut ClockTree) {
@@ -2133,7 +2132,7 @@ macro_rules! define_clock_tree_types {
                 enable_xtal32k_clk_impl(clocks, false);
             }
         }
-        pub fn xtal32k_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn xtal32k_clk_frequency() -> u32 {
             32768
         }
         pub fn request_rc_slow_clk(clocks: &mut ClockTree) {
@@ -2150,7 +2149,7 @@ macro_rules! define_clock_tree_types {
                 enable_rc_slow_clk_impl(clocks, false);
             }
         }
-        pub fn rc_slow_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn rc_slow_clk_frequency() -> u32 {
             150000
         }
         pub fn request_rc_fast_div_clk(clocks: &mut ClockTree) {
@@ -2169,8 +2168,8 @@ macro_rules! define_clock_tree_types {
                 release_rc_fast_clk(clocks);
             }
         }
-        pub fn rc_fast_div_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            (rc_fast_clk_frequency(clocks) / 256)
+        pub fn rc_fast_div_clk_frequency() -> u32 {
+            (rc_fast_clk_frequency() / 256)
         }
         pub fn request_xtal_div_clk(clocks: &mut ClockTree) {
             trace!("Requesting XTAL_DIV_CLK");
@@ -2184,8 +2183,8 @@ macro_rules! define_clock_tree_types {
             enable_xtal_div_clk_impl(clocks, false);
             release_xtal_clk(clocks);
         }
-        pub fn xtal_div_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            (xtal_clk_frequency(clocks) / 4)
+        pub fn xtal_div_clk_frequency() -> u32 {
+            (xtal_clk_frequency() / 4)
         }
         pub fn configure_rtc_slow_clk(clocks: &mut ClockTree, new_selector: RtcSlowClkConfig) {
             let old_selector = clocks.rtc_slow_clk.replace(new_selector);
@@ -2241,12 +2240,12 @@ macro_rules! define_clock_tree_types {
             config: RtcSlowClkConfig,
         ) -> u32 {
             match config {
-                RtcSlowClkConfig::Xtal32k => xtal32k_clk_frequency(clocks),
-                RtcSlowClkConfig::RcSlow => rc_slow_clk_frequency(clocks),
-                RtcSlowClkConfig::RcFast => rc_fast_div_clk_frequency(clocks),
+                RtcSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
+                RtcSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
+                RtcSlowClkConfig::RcFast => rc_fast_div_clk_frequency(),
             }
         }
-        pub fn rtc_slow_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn rtc_slow_clk_frequency() -> u32 {
             RTC_SLOW_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_rtc_fast_clk(clocks: &mut ClockTree, new_selector: RtcFastClkConfig) {
@@ -2299,11 +2298,11 @@ macro_rules! define_clock_tree_types {
             config: RtcFastClkConfig,
         ) -> u32 {
             match config {
-                RtcFastClkConfig::Xtal => xtal_div_clk_frequency(clocks),
-                RtcFastClkConfig::Rc => rc_fast_clk_frequency(clocks),
+                RtcFastClkConfig::Xtal => xtal_div_clk_frequency(),
+                RtcFastClkConfig::Rc => rc_fast_clk_frequency(),
             }
         }
-        pub fn rtc_fast_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn rtc_fast_clk_frequency() -> u32 {
             RTC_FAST_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_uart_mem_clk(clocks: &mut ClockTree) {
@@ -2322,8 +2321,8 @@ macro_rules! define_clock_tree_types {
                 release_xtal_clk(clocks);
             }
         }
-        pub fn uart_mem_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            xtal_clk_frequency(clocks)
+        pub fn uart_mem_clk_frequency() -> u32 {
+            xtal_clk_frequency()
         }
         pub fn configure_timg_calibration_clock(
             clocks: &mut ClockTree,
@@ -2384,12 +2383,12 @@ macro_rules! define_clock_tree_types {
             config: TimgCalibrationClockConfig,
         ) -> u32 {
             match config {
-                TimgCalibrationClockConfig::RcSlowClk => rc_slow_clk_frequency(clocks),
-                TimgCalibrationClockConfig::RcFastDivClk => rc_fast_div_clk_frequency(clocks),
-                TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(clocks),
+                TimgCalibrationClockConfig::RcSlowClk => rc_slow_clk_frequency(),
+                TimgCalibrationClockConfig::RcFastDivClk => rc_fast_div_clk_frequency(),
+                TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
             }
         }
-        pub fn timg_calibration_clock_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn timg_calibration_clock_frequency() -> u32 {
             TIMG_CALIBRATION_CLOCK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         impl McpwmInstance {
@@ -2442,9 +2441,9 @@ macro_rules! define_clock_tree_types {
                 clocks: &mut ClockTree,
                 config: McpwmFunctionClockConfig,
             ) -> u32 {
-                pll_f160m_clk_frequency(clocks)
+                pll_f160m_clk_frequency()
             }
-            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn function_clock_frequency(self) -> u32 {
                 MCPWM_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -2512,11 +2511,11 @@ macro_rules! define_clock_tree_types {
                 config: UartFunctionClockConfig,
             ) -> u32 {
                 match config.sclk {
-                    UartFunctionClockSclk::Apb => apb_clk_frequency(clocks),
-                    UartFunctionClockSclk::RefTick => ref_tick_frequency(clocks),
+                    UartFunctionClockSclk::Apb => apb_clk_frequency(),
+                    UartFunctionClockSclk::RefTick => ref_tick_frequency(),
                 }
             }
-            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn function_clock_frequency(self) -> u32 {
                 UART_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -2550,9 +2549,9 @@ macro_rules! define_clock_tree_types {
                 clocks: &mut ClockTree,
                 config: UartMemClockConfig,
             ) -> u32 {
-                uart_mem_clk_frequency(clocks)
+                uart_mem_clk_frequency()
             }
-            pub fn mem_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn mem_clock_frequency(self) -> u32 {
                 UART_MEM_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -2597,10 +2596,10 @@ macro_rules! define_clock_tree_types {
                 clocks: &mut ClockTree,
                 config: UartBaudRateGeneratorConfig,
             ) -> u32 {
-                ((self.function_clock_frequency(clocks) * 16)
+                ((self.function_clock_frequency() * 16)
                     / ((config.integral() * 16) + config.fractional()))
             }
-            pub fn baud_rate_generator_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn baud_rate_generator_frequency(self) -> u32 {
                 UART_BAUD_RATE_GENERATOR_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }

--- a/esp-metadata-generated/src/_generated_esp32.rs
+++ b/esp-metadata-generated/src/_generated_esp32.rs
@@ -1498,7 +1498,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
             let old_config = clocks.xtal_clk.replace(config);
             configure_xtal_clk_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_xtal_clk_downstream(clocks);
         }
         pub fn xtal_clk_config(clocks: &mut ClockTree) -> Option<XtalClkConfig> {
             clocks.xtal_clk
@@ -1521,7 +1521,7 @@ macro_rules! define_clock_tree_types {
             }
             let old_config = clocks.pll_clk.replace(config);
             configure_pll_clk_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_pll_clk_downstream(clocks);
         }
         pub fn pll_clk_config(clocks: &mut ClockTree) -> Option<PllClkConfig> {
             clocks.pll_clk
@@ -1552,7 +1552,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_apll_clk(clocks: &mut ClockTree, config: ApllClkConfig) {
             let old_config = clocks.apll_clk.replace(config);
             configure_apll_clk_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_apll_clk_downstream(clocks);
         }
         pub fn apll_clk_config(clocks: &mut ClockTree) -> Option<ApllClkConfig> {
             clocks.apll_clk
@@ -1625,7 +1625,7 @@ macro_rules! define_clock_tree_types {
                     CpuPllDivInConfig::Apll => release_apll_clk(clocks),
                 }
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_cpu_pll_div_in_downstream(clocks);
         }
         pub fn cpu_pll_div_in_config(clocks: &mut ClockTree) -> Option<CpuPllDivInConfig> {
             clocks.cpu_pll_div_in
@@ -1667,7 +1667,7 @@ macro_rules! define_clock_tree_types {
             }
             let old_config = clocks.cpu_pll_div.replace(config);
             configure_cpu_pll_div_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_cpu_pll_div_downstream(clocks);
         }
         pub fn cpu_pll_div_config(clocks: &mut ClockTree) -> Option<CpuPllDivConfig> {
             clocks.cpu_pll_div
@@ -1710,7 +1710,7 @@ macro_rules! define_clock_tree_types {
                     SysconPreDivInConfig::RcFast => release_rc_fast_clk(clocks),
                 }
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_syscon_pre_div_in_downstream(clocks);
         }
         pub fn syscon_pre_div_in_config(clocks: &mut ClockTree) -> Option<SysconPreDivInConfig> {
             clocks.syscon_pre_div_in
@@ -1749,7 +1749,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_syscon_pre_div(clocks: &mut ClockTree, config: SysconPreDivConfig) {
             let old_config = clocks.syscon_pre_div.replace(config);
             configure_syscon_pre_div_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_syscon_pre_div_downstream(clocks);
         }
         pub fn syscon_pre_div_config(clocks: &mut ClockTree) -> Option<SysconPreDivConfig> {
             clocks.syscon_pre_div
@@ -1795,7 +1795,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_apb_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_apb_clk_downstream(clocks);
         }
         pub fn apb_clk_config(clocks: &mut ClockTree) -> Option<ApbClkConfig> {
             clocks.apb_clk
@@ -1856,7 +1856,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_ref_tick_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_ref_tick_downstream(clocks);
         }
         pub fn ref_tick_config(clocks: &mut ClockTree) -> Option<RefTickConfig> {
             clocks.ref_tick
@@ -1902,7 +1902,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_ref_tick_xtal(clocks: &mut ClockTree, config: RefTickXtalConfig) {
             let old_config = clocks.ref_tick_xtal.replace(config);
             configure_ref_tick_xtal_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_ref_tick_xtal_downstream(clocks);
         }
         pub fn ref_tick_xtal_config(clocks: &mut ClockTree) -> Option<RefTickXtalConfig> {
             clocks.ref_tick_xtal
@@ -1932,7 +1932,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_ref_tick_fosc(clocks: &mut ClockTree, config: RefTickFoscConfig) {
             let old_config = clocks.ref_tick_fosc.replace(config);
             configure_ref_tick_fosc_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_ref_tick_fosc_downstream(clocks);
         }
         pub fn ref_tick_fosc_config(clocks: &mut ClockTree) -> Option<RefTickFoscConfig> {
             clocks.ref_tick_fosc
@@ -1962,7 +1962,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_ref_tick_apll(clocks: &mut ClockTree, config: RefTickApllConfig) {
             let old_config = clocks.ref_tick_apll.replace(config);
             configure_ref_tick_apll_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_ref_tick_apll_downstream(clocks);
         }
         pub fn ref_tick_apll_config(clocks: &mut ClockTree) -> Option<RefTickApllConfig> {
             clocks.ref_tick_apll
@@ -1992,7 +1992,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_ref_tick_pll(clocks: &mut ClockTree, config: RefTickPllConfig) {
             let old_config = clocks.ref_tick_pll.replace(config);
             configure_ref_tick_pll_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_ref_tick_pll_downstream(clocks);
         }
         pub fn ref_tick_pll_config(clocks: &mut ClockTree) -> Option<RefTickPllConfig> {
             clocks.ref_tick_pll
@@ -2069,7 +2069,7 @@ macro_rules! define_clock_tree_types {
                     CpuClkConfig::Pll => release_cpu_pll_div(clocks),
                 }
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_cpu_clk_downstream(clocks);
         }
         pub fn cpu_clk_config(clocks: &mut ClockTree) -> Option<CpuClkConfig> {
             clocks.cpu_clk
@@ -2205,7 +2205,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_rtc_slow_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_rtc_slow_clk_downstream(clocks);
         }
         pub fn rtc_slow_clk_config(clocks: &mut ClockTree) -> Option<RtcSlowClkConfig> {
             clocks.rtc_slow_clk
@@ -2265,7 +2265,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_rtc_fast_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_rtc_fast_clk_downstream(clocks);
         }
         pub fn rtc_fast_clk_config(clocks: &mut ClockTree) -> Option<RtcFastClkConfig> {
             clocks.rtc_fast_clk
@@ -2346,7 +2346,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_timg_calibration_clock_downstream(clocks);
         }
         pub fn timg_calibration_clock_config(
             clocks: &mut ClockTree,
@@ -2407,7 +2407,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_mcpwm_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -2470,7 +2470,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_config, config);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_uart_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -2522,7 +2522,7 @@ macro_rules! define_clock_tree_types {
             pub fn configure_mem_clock(self, clocks: &mut ClockTree, config: UartMemClockConfig) {
                 let old_config = clocks.uart_mem_clock[self as usize].replace(config);
                 self.configure_mem_clock_impl(clocks, old_config, config);
-                refresh_all_frequency_caches(clocks);
+                refresh_uart_mem_clock_downstream(clocks, self);
             }
             pub fn mem_clock_config(self, clocks: &mut ClockTree) -> Option<UartMemClockConfig> {
                 clocks.uart_mem_clock[self as usize]
@@ -2562,7 +2562,7 @@ macro_rules! define_clock_tree_types {
             ) {
                 let old_config = clocks.uart_baud_rate_generator[self as usize].replace(config);
                 self.configure_baud_rate_generator_impl(clocks, old_config, config);
-                refresh_all_frequency_caches(clocks);
+                refresh_uart_baud_rate_generator_downstream(clocks, self);
             }
             pub fn baud_rate_generator_config(
                 self,
@@ -2677,152 +2677,267 @@ macro_rules! define_clock_tree_types {
             let last = *refcount == 0;
             last
         }
-        fn refresh_all_frequency_caches(clocks: &mut ClockTree) {
+        fn refresh_xtal_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.xtal_clk {
                 XTAL_CLK_FREQ_CACHE.store(
                     xtal_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_pll_clk_downstream(clocks);
+            refresh_syscon_pre_div_in_downstream(clocks);
+            refresh_rtc_fast_clk_downstream(clocks);
+            for child_instance in [
+                UartInstance::Uart0,
+                UartInstance::Uart1,
+                UartInstance::Uart2,
+            ] {
+                refresh_uart_mem_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [
+                UartInstance::Uart0,
+                UartInstance::Uart1,
+                UartInstance::Uart2,
+            ] {
+                refresh_uart_mem_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [
+                UartInstance::Uart0,
+                UartInstance::Uart1,
+                UartInstance::Uart2,
+            ] {
+                refresh_uart_mem_clock_downstream(clocks, child_instance);
+            }
+        }
+        fn refresh_pll_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.pll_clk {
                 PLL_CLK_FREQ_CACHE.store(
                     pll_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_apll_clk_downstream(clocks);
+            refresh_cpu_pll_div_in_downstream(clocks);
+            for child_instance in [McpwmInstance::Mcpwm0, McpwmInstance::Mcpwm1] {
+                refresh_mcpwm_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [McpwmInstance::Mcpwm0, McpwmInstance::Mcpwm1] {
+                refresh_mcpwm_function_clock_downstream(clocks, child_instance);
+            }
+        }
+        fn refresh_apll_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.apll_clk {
                 APLL_CLK_FREQ_CACHE.store(
                     apll_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_cpu_pll_div_in_downstream(clocks);
+        }
+        fn refresh_cpu_pll_div_in_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.cpu_pll_div_in {
                 CPU_PLL_DIV_IN_FREQ_CACHE.store(
                     cpu_pll_div_in_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_cpu_pll_div_downstream(clocks);
+        }
+        fn refresh_cpu_pll_div_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.cpu_pll_div {
                 CPU_PLL_DIV_FREQ_CACHE.store(
                     cpu_pll_div_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_cpu_clk_downstream(clocks);
+        }
+        fn refresh_syscon_pre_div_in_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.syscon_pre_div_in {
                 SYSCON_PRE_DIV_IN_FREQ_CACHE.store(
                     syscon_pre_div_in_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_syscon_pre_div_downstream(clocks);
+        }
+        fn refresh_syscon_pre_div_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.syscon_pre_div {
                 SYSCON_PRE_DIV_FREQ_CACHE.store(
                     syscon_pre_div_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_cpu_clk_downstream(clocks);
+        }
+        fn refresh_cpu_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.cpu_clk {
                 CPU_CLK_FREQ_CACHE.store(
                     cpu_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_apb_clk_downstream(clocks);
+        }
+        fn refresh_rtc_slow_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.rtc_slow_clk {
                 RTC_SLOW_CLK_FREQ_CACHE.store(
                     rtc_slow_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+        }
+        fn refresh_rtc_fast_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.rtc_fast_clk {
                 RTC_FAST_CLK_FREQ_CACHE.store(
                     rtc_fast_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+        }
+        fn refresh_timg_calibration_clock_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.timg_calibration_clock {
                 TIMG_CALIBRATION_CLOCK_FREQ_CACHE.store(
                     timg_calibration_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
-            for instance in [McpwmInstance::Mcpwm0, McpwmInstance::Mcpwm1] {
-                if let Some(config) = clocks.mcpwm_function_clock[instance as usize] {
-                    MCPWM_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.function_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_mcpwm_function_clock_downstream(
+            clocks: &mut ClockTree,
+            instance: McpwmInstance,
+        ) {
+            if let Some(config) = clocks.mcpwm_function_clock[instance as usize] {
+                MCPWM_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.function_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
-            for instance in [
-                UartInstance::Uart0,
-                UartInstance::Uart1,
-                UartInstance::Uart2,
-            ] {
-                if let Some(config) = clocks.uart_mem_clock[instance as usize] {
-                    UART_MEM_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.mem_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_uart_mem_clock_downstream(clocks: &mut ClockTree, instance: UartInstance) {
+            if let Some(config) = clocks.uart_mem_clock[instance as usize] {
+                UART_MEM_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.mem_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
+        }
+        fn refresh_apb_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.apb_clk {
                 APB_CLK_FREQ_CACHE.store(
                     apb_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_ref_tick_xtal_downstream(clocks);
+            refresh_ref_tick_fosc_downstream(clocks);
+            refresh_ref_tick_apll_downstream(clocks);
+            refresh_ref_tick_pll_downstream(clocks);
+            for child_instance in [
+                UartInstance::Uart0,
+                UartInstance::Uart1,
+                UartInstance::Uart2,
+            ] {
+                refresh_uart_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [
+                UartInstance::Uart0,
+                UartInstance::Uart1,
+                UartInstance::Uart2,
+            ] {
+                refresh_uart_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [
+                UartInstance::Uart0,
+                UartInstance::Uart1,
+                UartInstance::Uart2,
+            ] {
+                refresh_uart_function_clock_downstream(clocks, child_instance);
+            }
+        }
+        fn refresh_ref_tick_xtal_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.ref_tick_xtal {
                 REF_TICK_XTAL_FREQ_CACHE.store(
                     ref_tick_xtal_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_ref_tick_downstream(clocks);
+        }
+        fn refresh_ref_tick_fosc_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.ref_tick_fosc {
                 REF_TICK_FOSC_FREQ_CACHE.store(
                     ref_tick_fosc_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_ref_tick_downstream(clocks);
+        }
+        fn refresh_ref_tick_apll_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.ref_tick_apll {
                 REF_TICK_APLL_FREQ_CACHE.store(
                     ref_tick_apll_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_ref_tick_downstream(clocks);
+        }
+        fn refresh_ref_tick_pll_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.ref_tick_pll {
                 REF_TICK_PLL_FREQ_CACHE.store(
                     ref_tick_pll_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_ref_tick_downstream(clocks);
+        }
+        fn refresh_ref_tick_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.ref_tick {
                 REF_TICK_FREQ_CACHE.store(
                     ref_tick_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
-            for instance in [
+            for child_instance in [
                 UartInstance::Uart0,
                 UartInstance::Uart1,
                 UartInstance::Uart2,
             ] {
-                if let Some(config) = clocks.uart_function_clock[instance as usize] {
-                    UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.function_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+                refresh_uart_function_clock_downstream(clocks, child_instance);
             }
-            for instance in [
+            for child_instance in [
                 UartInstance::Uart0,
                 UartInstance::Uart1,
                 UartInstance::Uart2,
             ] {
-                if let Some(config) = clocks.uart_baud_rate_generator[instance as usize] {
-                    UART_BAUD_RATE_GENERATOR_FREQ_CACHE[instance as usize].store(
-                        instance.baud_rate_generator_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+                refresh_uart_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [
+                UartInstance::Uart0,
+                UartInstance::Uart1,
+                UartInstance::Uart2,
+            ] {
+                refresh_uart_function_clock_downstream(clocks, child_instance);
+            }
+        }
+        fn refresh_uart_function_clock_downstream(clocks: &mut ClockTree, instance: UartInstance) {
+            if let Some(config) = clocks.uart_function_clock[instance as usize] {
+                UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.function_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            refresh_uart_baud_rate_generator_downstream(clocks, instance);
+        }
+        fn refresh_uart_baud_rate_generator_downstream(
+            clocks: &mut ClockTree,
+            instance: UartInstance,
+        ) {
+            if let Some(config) = clocks.uart_baud_rate_generator[instance as usize] {
+                UART_BAUD_RATE_GENERATOR_FREQ_CACHE[instance as usize].store(
+                    instance.baud_rate_generator_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
         }
     };

--- a/esp-metadata-generated/src/_generated_esp32.rs
+++ b/esp-metadata-generated/src/_generated_esp32.rs
@@ -2694,20 +2694,6 @@ macro_rules! define_clock_tree_types {
             ] {
                 refresh_uart_mem_clock_downstream(clocks, child_instance);
             }
-            for child_instance in [
-                UartInstance::Uart0,
-                UartInstance::Uart1,
-                UartInstance::Uart2,
-            ] {
-                refresh_uart_mem_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [
-                UartInstance::Uart0,
-                UartInstance::Uart1,
-                UartInstance::Uart2,
-            ] {
-                refresh_uart_mem_clock_downstream(clocks, child_instance);
-            }
         }
         fn refresh_pll_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.pll_clk {
@@ -2718,9 +2704,6 @@ macro_rules! define_clock_tree_types {
             }
             refresh_apll_clk_downstream(clocks);
             refresh_cpu_pll_div_in_downstream(clocks);
-            for child_instance in [McpwmInstance::Mcpwm0, McpwmInstance::Mcpwm1] {
-                refresh_mcpwm_function_clock_downstream(clocks, child_instance);
-            }
             for child_instance in [McpwmInstance::Mcpwm0, McpwmInstance::Mcpwm1] {
                 refresh_mcpwm_function_clock_downstream(clocks, child_instance);
             }
@@ -2840,20 +2823,6 @@ macro_rules! define_clock_tree_types {
             ] {
                 refresh_uart_function_clock_downstream(clocks, child_instance);
             }
-            for child_instance in [
-                UartInstance::Uart0,
-                UartInstance::Uart1,
-                UartInstance::Uart2,
-            ] {
-                refresh_uart_function_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [
-                UartInstance::Uart0,
-                UartInstance::Uart1,
-                UartInstance::Uart2,
-            ] {
-                refresh_uart_function_clock_downstream(clocks, child_instance);
-            }
         }
         fn refresh_ref_tick_xtal_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.ref_tick_xtal {
@@ -2897,20 +2866,6 @@ macro_rules! define_clock_tree_types {
                     ref_tick_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
-            }
-            for child_instance in [
-                UartInstance::Uart0,
-                UartInstance::Uart1,
-                UartInstance::Uart2,
-            ] {
-                refresh_uart_function_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [
-                UartInstance::Uart0,
-                UartInstance::Uart1,
-                UartInstance::Uart2,
-            ] {
-                refresh_uart_function_clock_downstream(clocks, child_instance);
             }
             for child_instance in [
                 UartInstance::Uart0,

--- a/esp-metadata-generated/src/_generated_esp32.rs
+++ b/esp-metadata-generated/src/_generated_esp32.rs
@@ -1453,9 +1453,52 @@ macro_rules! define_clock_tree_types {
                 uart_mem_clock_refcount: [0; 3],
                 uart_baud_rate_generator_refcount: [0; 3],
             });
+        static XTAL_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static PLL_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static APLL_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static CPU_PLL_DIV_IN_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static CPU_PLL_DIV_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static SYSCON_PRE_DIV_IN_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static SYSCON_PRE_DIV_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static CPU_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static RTC_SLOW_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static RTC_FAST_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static TIMG_CALIBRATION_CLOCK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static MCPWM_FUNCTION_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 2] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
+        static UART_MEM_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 3] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 3];
+        static APB_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static REF_TICK_XTAL_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static REF_TICK_FOSC_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static REF_TICK_APLL_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static REF_TICK_PLL_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static REF_TICK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static UART_FUNCTION_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 3] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 3];
+        static UART_BAUD_RATE_GENERATOR_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 3] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 3];
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
             let old_config = clocks.xtal_clk.replace(config);
             configure_xtal_clk_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn xtal_clk_config(clocks: &mut ClockTree) -> Option<XtalClkConfig> {
             clocks.xtal_clk
@@ -1466,12 +1509,8 @@ macro_rules! define_clock_tree_types {
         pub fn xtal_clk_config_frequency(clocks: &mut ClockTree, config: XtalClkConfig) -> u32 {
             config.value()
         }
-        pub fn xtal_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.xtal_clk {
-                xtal_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn xtal_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            XTAL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_pll_clk(clocks: &mut ClockTree, config: PllClkConfig) {
             if clocks.cpu_pll_div.is_some() {
@@ -1482,6 +1521,7 @@ macro_rules! define_clock_tree_types {
             }
             let old_config = clocks.pll_clk.replace(config);
             configure_pll_clk_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn pll_clk_config(clocks: &mut ClockTree) -> Option<PllClkConfig> {
             clocks.pll_clk
@@ -1506,16 +1546,13 @@ macro_rules! define_clock_tree_types {
         pub fn pll_clk_config_frequency(clocks: &mut ClockTree, config: PllClkConfig) -> u32 {
             config.value()
         }
-        pub fn pll_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.pll_clk {
-                pll_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn pll_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            PLL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_apll_clk(clocks: &mut ClockTree, config: ApllClkConfig) {
             let old_config = clocks.apll_clk.replace(config);
             configure_apll_clk_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn apll_clk_config(clocks: &mut ClockTree) -> Option<ApllClkConfig> {
             clocks.apll_clk
@@ -1536,12 +1573,8 @@ macro_rules! define_clock_tree_types {
         pub fn apll_clk_config_frequency(clocks: &mut ClockTree, config: ApllClkConfig) -> u32 {
             config.value()
         }
-        pub fn apll_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.apll_clk {
-                apll_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn apll_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            APLL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_rc_fast_clk(clocks: &mut ClockTree) {
             trace!("Requesting RC_FAST_CLK");
@@ -1592,6 +1625,7 @@ macro_rules! define_clock_tree_types {
                     CpuPllDivInConfig::Apll => release_apll_clk(clocks),
                 }
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn cpu_pll_div_in_config(clocks: &mut ClockTree) -> Option<CpuPllDivInConfig> {
             clocks.cpu_pll_div_in
@@ -1624,12 +1658,8 @@ macro_rules! define_clock_tree_types {
                 CpuPllDivInConfig::Apll => apll_clk_frequency(clocks),
             }
         }
-        pub fn cpu_pll_div_in_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.cpu_pll_div_in {
-                cpu_pll_div_in_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn cpu_pll_div_in_frequency(_clocks: &mut ClockTree) -> u32 {
+            CPU_PLL_DIV_IN_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_cpu_pll_div(clocks: &mut ClockTree, config: CpuPllDivConfig) {
             if clocks.pll_clk.is_some() {
@@ -1637,6 +1667,7 @@ macro_rules! define_clock_tree_types {
             }
             let old_config = clocks.cpu_pll_div.replace(config);
             configure_cpu_pll_div_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn cpu_pll_div_config(clocks: &mut ClockTree) -> Option<CpuPllDivConfig> {
             clocks.cpu_pll_div
@@ -1660,12 +1691,8 @@ macro_rules! define_clock_tree_types {
         ) -> u32 {
             (cpu_pll_div_in_frequency(clocks) / config.divisor())
         }
-        pub fn cpu_pll_div_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.cpu_pll_div {
-                cpu_pll_div_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn cpu_pll_div_frequency(_clocks: &mut ClockTree) -> u32 {
+            CPU_PLL_DIV_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_syscon_pre_div_in(
             clocks: &mut ClockTree,
@@ -1683,6 +1710,7 @@ macro_rules! define_clock_tree_types {
                     SysconPreDivInConfig::RcFast => release_rc_fast_clk(clocks),
                 }
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn syscon_pre_div_in_config(clocks: &mut ClockTree) -> Option<SysconPreDivInConfig> {
             clocks.syscon_pre_div_in
@@ -1715,16 +1743,13 @@ macro_rules! define_clock_tree_types {
                 SysconPreDivInConfig::RcFast => rc_fast_clk_frequency(clocks),
             }
         }
-        pub fn syscon_pre_div_in_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.syscon_pre_div_in {
-                syscon_pre_div_in_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn syscon_pre_div_in_frequency(_clocks: &mut ClockTree) -> u32 {
+            SYSCON_PRE_DIV_IN_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_syscon_pre_div(clocks: &mut ClockTree, config: SysconPreDivConfig) {
             let old_config = clocks.syscon_pre_div.replace(config);
             configure_syscon_pre_div_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn syscon_pre_div_config(clocks: &mut ClockTree) -> Option<SysconPreDivConfig> {
             clocks.syscon_pre_div
@@ -1748,12 +1773,8 @@ macro_rules! define_clock_tree_types {
         ) -> u32 {
             (syscon_pre_div_in_frequency(clocks) / (config.divisor() + 1))
         }
-        pub fn syscon_pre_div_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.syscon_pre_div {
-                syscon_pre_div_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn syscon_pre_div_frequency(_clocks: &mut ClockTree) -> u32 {
+            SYSCON_PRE_DIV_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, new_selector: ApbClkConfig) {
             let old_selector = clocks.apb_clk.replace(new_selector);
@@ -1774,6 +1795,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_apb_clk_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn apb_clk_config(clocks: &mut ClockTree) -> Option<ApbClkConfig> {
             clocks.apb_clk
@@ -1810,12 +1832,8 @@ macro_rules! define_clock_tree_types {
                 ApbClkConfig::Cpu => cpu_clk_frequency(clocks),
             }
         }
-        pub fn apb_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.apb_clk {
-                apb_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn apb_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            APB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_ref_tick(clocks: &mut ClockTree, new_selector: RefTickConfig) {
             let old_selector = clocks.ref_tick.replace(new_selector);
@@ -1838,6 +1856,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_ref_tick_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn ref_tick_config(clocks: &mut ClockTree) -> Option<RefTickConfig> {
             clocks.ref_tick
@@ -1877,16 +1896,13 @@ macro_rules! define_clock_tree_types {
                 RefTickConfig::Fosc => ref_tick_fosc_frequency(clocks),
             }
         }
-        pub fn ref_tick_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.ref_tick {
-                ref_tick_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn ref_tick_frequency(_clocks: &mut ClockTree) -> u32 {
+            REF_TICK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_ref_tick_xtal(clocks: &mut ClockTree, config: RefTickXtalConfig) {
             let old_config = clocks.ref_tick_xtal.replace(config);
             configure_ref_tick_xtal_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn ref_tick_xtal_config(clocks: &mut ClockTree) -> Option<RefTickXtalConfig> {
             clocks.ref_tick_xtal
@@ -1910,16 +1926,13 @@ macro_rules! define_clock_tree_types {
         ) -> u32 {
             (apb_clk_frequency(clocks) / (config.divisor() + 1))
         }
-        pub fn ref_tick_xtal_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.ref_tick_xtal {
-                ref_tick_xtal_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn ref_tick_xtal_frequency(_clocks: &mut ClockTree) -> u32 {
+            REF_TICK_XTAL_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_ref_tick_fosc(clocks: &mut ClockTree, config: RefTickFoscConfig) {
             let old_config = clocks.ref_tick_fosc.replace(config);
             configure_ref_tick_fosc_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn ref_tick_fosc_config(clocks: &mut ClockTree) -> Option<RefTickFoscConfig> {
             clocks.ref_tick_fosc
@@ -1943,16 +1956,13 @@ macro_rules! define_clock_tree_types {
         ) -> u32 {
             (apb_clk_frequency(clocks) / (config.divisor() + 1))
         }
-        pub fn ref_tick_fosc_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.ref_tick_fosc {
-                ref_tick_fosc_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn ref_tick_fosc_frequency(_clocks: &mut ClockTree) -> u32 {
+            REF_TICK_FOSC_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_ref_tick_apll(clocks: &mut ClockTree, config: RefTickApllConfig) {
             let old_config = clocks.ref_tick_apll.replace(config);
             configure_ref_tick_apll_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn ref_tick_apll_config(clocks: &mut ClockTree) -> Option<RefTickApllConfig> {
             clocks.ref_tick_apll
@@ -1976,16 +1986,13 @@ macro_rules! define_clock_tree_types {
         ) -> u32 {
             (apb_clk_frequency(clocks) / (config.divisor() + 1))
         }
-        pub fn ref_tick_apll_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.ref_tick_apll {
-                ref_tick_apll_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn ref_tick_apll_frequency(_clocks: &mut ClockTree) -> u32 {
+            REF_TICK_APLL_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_ref_tick_pll(clocks: &mut ClockTree, config: RefTickPllConfig) {
             let old_config = clocks.ref_tick_pll.replace(config);
             configure_ref_tick_pll_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn ref_tick_pll_config(clocks: &mut ClockTree) -> Option<RefTickPllConfig> {
             clocks.ref_tick_pll
@@ -2009,12 +2016,8 @@ macro_rules! define_clock_tree_types {
         ) -> u32 {
             (apb_clk_frequency(clocks) / (config.divisor() + 1))
         }
-        pub fn ref_tick_pll_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.ref_tick_pll {
-                ref_tick_pll_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn ref_tick_pll_frequency(_clocks: &mut ClockTree) -> u32 {
+            REF_TICK_PLL_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, new_selector: CpuClkConfig) {
             let old_selector = clocks.cpu_clk.replace(new_selector);
@@ -2067,6 +2070,7 @@ macro_rules! define_clock_tree_types {
                     CpuClkConfig::Pll => release_cpu_pll_div(clocks),
                 }
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn cpu_clk_config(clocks: &mut ClockTree) -> Option<CpuClkConfig> {
             clocks.cpu_clk
@@ -2082,12 +2086,8 @@ macro_rules! define_clock_tree_types {
                 CpuClkConfig::Pll => cpu_pll_div_frequency(clocks),
             }
         }
-        pub fn cpu_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.cpu_clk {
-                cpu_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn cpu_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            CPU_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_apb_clk_cpu_div2(clocks: &mut ClockTree) {
             trace!("Requesting APB_CLK_CPU_DIV2");
@@ -2206,6 +2206,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_rtc_slow_clk_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn rtc_slow_clk_config(clocks: &mut ClockTree) -> Option<RtcSlowClkConfig> {
             clocks.rtc_slow_clk
@@ -2245,12 +2246,8 @@ macro_rules! define_clock_tree_types {
                 RtcSlowClkConfig::RcFast => rc_fast_div_clk_frequency(clocks),
             }
         }
-        pub fn rtc_slow_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.rtc_slow_clk {
-                rtc_slow_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn rtc_slow_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            RTC_SLOW_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_rtc_fast_clk(clocks: &mut ClockTree, new_selector: RtcFastClkConfig) {
             let old_selector = clocks.rtc_fast_clk.replace(new_selector);
@@ -2269,6 +2266,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_rtc_fast_clk_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn rtc_fast_clk_config(clocks: &mut ClockTree) -> Option<RtcFastClkConfig> {
             clocks.rtc_fast_clk
@@ -2305,12 +2303,8 @@ macro_rules! define_clock_tree_types {
                 RtcFastClkConfig::Rc => rc_fast_clk_frequency(clocks),
             }
         }
-        pub fn rtc_fast_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.rtc_fast_clk {
-                rtc_fast_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn rtc_fast_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            RTC_FAST_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_uart_mem_clk(clocks: &mut ClockTree) {
             trace!("Requesting UART_MEM_CLK");
@@ -2353,6 +2347,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn timg_calibration_clock_config(
             clocks: &mut ClockTree,
@@ -2394,12 +2389,8 @@ macro_rules! define_clock_tree_types {
                 TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(clocks),
             }
         }
-        pub fn timg_calibration_clock_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.timg_calibration_clock {
-                timg_calibration_clock_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn timg_calibration_clock_frequency(_clocks: &mut ClockTree) -> u32 {
+            TIMG_CALIBRATION_CLOCK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         impl McpwmInstance {
             pub fn configure_function_clock(
@@ -2417,6 +2408,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn function_clock_config(
                 self,
@@ -2452,12 +2444,9 @@ macro_rules! define_clock_tree_types {
             ) -> u32 {
                 pll_f160m_clk_frequency(clocks)
             }
-            pub fn function_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.mcpwm_function_clock[self as usize] {
-                    self.function_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                MCPWM_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
         }
         impl UartInstance {
@@ -2482,6 +2471,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_config, config);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn function_clock_config(
                 self,
@@ -2526,16 +2516,14 @@ macro_rules! define_clock_tree_types {
                     UartFunctionClockSclk::RefTick => ref_tick_frequency(clocks),
                 }
             }
-            pub fn function_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.uart_function_clock[self as usize] {
-                    self.function_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                UART_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
             pub fn configure_mem_clock(self, clocks: &mut ClockTree, config: UartMemClockConfig) {
                 let old_config = clocks.uart_mem_clock[self as usize].replace(config);
                 self.configure_mem_clock_impl(clocks, old_config, config);
+                refresh_all_frequency_caches(clocks);
             }
             pub fn mem_clock_config(self, clocks: &mut ClockTree) -> Option<UartMemClockConfig> {
                 clocks.uart_mem_clock[self as usize]
@@ -2564,12 +2552,9 @@ macro_rules! define_clock_tree_types {
             ) -> u32 {
                 uart_mem_clk_frequency(clocks)
             }
-            pub fn mem_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.uart_mem_clock[self as usize] {
-                    self.mem_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn mem_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                UART_MEM_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
             pub fn configure_baud_rate_generator(
                 self,
@@ -2578,6 +2563,7 @@ macro_rules! define_clock_tree_types {
             ) {
                 let old_config = clocks.uart_baud_rate_generator[self as usize].replace(config);
                 self.configure_baud_rate_generator_impl(clocks, old_config, config);
+                refresh_all_frequency_caches(clocks);
             }
             pub fn baud_rate_generator_config(
                 self,
@@ -2614,12 +2600,9 @@ macro_rules! define_clock_tree_types {
                 ((self.function_clock_frequency(clocks) * 16)
                     / ((config.integral() * 16) + config.fractional()))
             }
-            pub fn baud_rate_generator_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.uart_baud_rate_generator[self as usize] {
-                    self.baud_rate_generator_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn baud_rate_generator_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                UART_BAUD_RATE_GENERATOR_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
         }
         /// Clock tree configuration.
@@ -2694,6 +2677,154 @@ macro_rules! define_clock_tree_types {
             *refcount = refcount.saturating_sub(1);
             let last = *refcount == 0;
             last
+        }
+        fn refresh_all_frequency_caches(clocks: &mut ClockTree) {
+            if let Some(config) = clocks.xtal_clk {
+                XTAL_CLK_FREQ_CACHE.store(
+                    xtal_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.pll_clk {
+                PLL_CLK_FREQ_CACHE.store(
+                    pll_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.apll_clk {
+                APLL_CLK_FREQ_CACHE.store(
+                    apll_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.cpu_pll_div_in {
+                CPU_PLL_DIV_IN_FREQ_CACHE.store(
+                    cpu_pll_div_in_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.cpu_pll_div {
+                CPU_PLL_DIV_FREQ_CACHE.store(
+                    cpu_pll_div_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.syscon_pre_div_in {
+                SYSCON_PRE_DIV_IN_FREQ_CACHE.store(
+                    syscon_pre_div_in_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.syscon_pre_div {
+                SYSCON_PRE_DIV_FREQ_CACHE.store(
+                    syscon_pre_div_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.cpu_clk {
+                CPU_CLK_FREQ_CACHE.store(
+                    cpu_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.rtc_slow_clk {
+                RTC_SLOW_CLK_FREQ_CACHE.store(
+                    rtc_slow_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.rtc_fast_clk {
+                RTC_FAST_CLK_FREQ_CACHE.store(
+                    rtc_fast_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.timg_calibration_clock {
+                TIMG_CALIBRATION_CLOCK_FREQ_CACHE.store(
+                    timg_calibration_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            for instance in [McpwmInstance::Mcpwm0, McpwmInstance::Mcpwm1] {
+                if let Some(config) = clocks.mcpwm_function_clock[instance as usize] {
+                    MCPWM_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.function_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [
+                UartInstance::Uart0,
+                UartInstance::Uart1,
+                UartInstance::Uart2,
+            ] {
+                if let Some(config) = clocks.uart_mem_clock[instance as usize] {
+                    UART_MEM_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.mem_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            if let Some(config) = clocks.apb_clk {
+                APB_CLK_FREQ_CACHE.store(
+                    apb_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.ref_tick_xtal {
+                REF_TICK_XTAL_FREQ_CACHE.store(
+                    ref_tick_xtal_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.ref_tick_fosc {
+                REF_TICK_FOSC_FREQ_CACHE.store(
+                    ref_tick_fosc_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.ref_tick_apll {
+                REF_TICK_APLL_FREQ_CACHE.store(
+                    ref_tick_apll_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.ref_tick_pll {
+                REF_TICK_PLL_FREQ_CACHE.store(
+                    ref_tick_pll_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.ref_tick {
+                REF_TICK_FREQ_CACHE.store(
+                    ref_tick_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            for instance in [
+                UartInstance::Uart0,
+                UartInstance::Uart1,
+                UartInstance::Uart2,
+            ] {
+                if let Some(config) = clocks.uart_function_clock[instance as usize] {
+                    UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.function_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [
+                UartInstance::Uart0,
+                UartInstance::Uart1,
+                UartInstance::Uart2,
+            ] {
+                if let Some(config) = clocks.uart_baud_rate_generator[instance as usize] {
+                    UART_BAUD_RATE_GENERATOR_FREQ_CACHE[instance as usize].store(
+                        instance.baud_rate_generator_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
         }
     };
 }

--- a/esp-metadata-generated/src/_generated_esp32.rs
+++ b/esp-metadata-generated/src/_generated_esp32.rs
@@ -1497,8 +1497,8 @@ macro_rules! define_clock_tree_types {
             [const { ::core::sync::atomic::AtomicU32::new(0) }; 3];
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
             let old_config = clocks.xtal_clk.replace(config);
-            configure_xtal_clk_impl(clocks, old_config, config);
             refresh_xtal_clk_downstream(clocks);
+            configure_xtal_clk_impl(clocks, old_config, config);
         }
         pub fn xtal_clk_config(clocks: &mut ClockTree) -> Option<XtalClkConfig> {
             clocks.xtal_clk
@@ -1520,8 +1520,8 @@ macro_rules! define_clock_tree_types {
                 );
             }
             let old_config = clocks.pll_clk.replace(config);
-            configure_pll_clk_impl(clocks, old_config, config);
             refresh_pll_clk_downstream(clocks);
+            configure_pll_clk_impl(clocks, old_config, config);
         }
         pub fn pll_clk_config(clocks: &mut ClockTree) -> Option<PllClkConfig> {
             clocks.pll_clk
@@ -1551,8 +1551,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_apll_clk(clocks: &mut ClockTree, config: ApllClkConfig) {
             let old_config = clocks.apll_clk.replace(config);
-            configure_apll_clk_impl(clocks, old_config, config);
             refresh_apll_clk_downstream(clocks);
+            configure_apll_clk_impl(clocks, old_config, config);
         }
         pub fn apll_clk_config(clocks: &mut ClockTree) -> Option<ApllClkConfig> {
             clocks.apll_clk
@@ -1614,6 +1614,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_cpu_pll_div_in(clocks: &mut ClockTree, new_selector: CpuPllDivInConfig) {
             let old_selector = clocks.cpu_pll_div_in.replace(new_selector);
+            refresh_cpu_pll_div_in_downstream(clocks);
             match new_selector {
                 CpuPllDivInConfig::Pll => request_pll_clk(clocks),
                 CpuPllDivInConfig::Apll => request_apll_clk(clocks),
@@ -1625,7 +1626,6 @@ macro_rules! define_clock_tree_types {
                     CpuPllDivInConfig::Apll => release_apll_clk(clocks),
                 }
             }
-            refresh_cpu_pll_div_in_downstream(clocks);
         }
         pub fn cpu_pll_div_in_config(clocks: &mut ClockTree) -> Option<CpuPllDivInConfig> {
             clocks.cpu_pll_div_in
@@ -1666,8 +1666,8 @@ macro_rules! define_clock_tree_types {
                 assert!(!((pll_clk_frequency() == 480000000) && (config.divisor() == 4)));
             }
             let old_config = clocks.cpu_pll_div.replace(config);
-            configure_cpu_pll_div_impl(clocks, old_config, config);
             refresh_cpu_pll_div_downstream(clocks);
+            configure_cpu_pll_div_impl(clocks, old_config, config);
         }
         pub fn cpu_pll_div_config(clocks: &mut ClockTree) -> Option<CpuPllDivConfig> {
             clocks.cpu_pll_div
@@ -1699,6 +1699,7 @@ macro_rules! define_clock_tree_types {
             new_selector: SysconPreDivInConfig,
         ) {
             let old_selector = clocks.syscon_pre_div_in.replace(new_selector);
+            refresh_syscon_pre_div_in_downstream(clocks);
             match new_selector {
                 SysconPreDivInConfig::Xtal => request_xtal_clk(clocks),
                 SysconPreDivInConfig::RcFast => request_rc_fast_clk(clocks),
@@ -1710,7 +1711,6 @@ macro_rules! define_clock_tree_types {
                     SysconPreDivInConfig::RcFast => release_rc_fast_clk(clocks),
                 }
             }
-            refresh_syscon_pre_div_in_downstream(clocks);
         }
         pub fn syscon_pre_div_in_config(clocks: &mut ClockTree) -> Option<SysconPreDivInConfig> {
             clocks.syscon_pre_div_in
@@ -1748,8 +1748,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_syscon_pre_div(clocks: &mut ClockTree, config: SysconPreDivConfig) {
             let old_config = clocks.syscon_pre_div.replace(config);
-            configure_syscon_pre_div_impl(clocks, old_config, config);
             refresh_syscon_pre_div_downstream(clocks);
+            configure_syscon_pre_div_impl(clocks, old_config, config);
         }
         pub fn syscon_pre_div_config(clocks: &mut ClockTree) -> Option<SysconPreDivConfig> {
             clocks.syscon_pre_div
@@ -1778,6 +1778,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, new_selector: ApbClkConfig) {
             let old_selector = clocks.apb_clk.replace(new_selector);
+            refresh_apb_clk_downstream(clocks);
             if clocks.apb_clk_refcount > 0 {
                 match new_selector {
                     ApbClkConfig::Pll80m => request_apb_clk_80m(clocks),
@@ -1795,7 +1796,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_apb_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_apb_clk_downstream(clocks);
         }
         pub fn apb_clk_config(clocks: &mut ClockTree) -> Option<ApbClkConfig> {
             clocks.apb_clk
@@ -1837,6 +1837,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_ref_tick(clocks: &mut ClockTree, new_selector: RefTickConfig) {
             let old_selector = clocks.ref_tick.replace(new_selector);
+            refresh_ref_tick_downstream(clocks);
             if clocks.ref_tick_refcount > 0 {
                 match new_selector {
                     RefTickConfig::Pll => request_ref_tick_pll(clocks),
@@ -1856,7 +1857,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_ref_tick_impl(clocks, old_selector, new_selector);
             }
-            refresh_ref_tick_downstream(clocks);
         }
         pub fn ref_tick_config(clocks: &mut ClockTree) -> Option<RefTickConfig> {
             clocks.ref_tick
@@ -1901,8 +1901,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_ref_tick_xtal(clocks: &mut ClockTree, config: RefTickXtalConfig) {
             let old_config = clocks.ref_tick_xtal.replace(config);
-            configure_ref_tick_xtal_impl(clocks, old_config, config);
             refresh_ref_tick_xtal_downstream(clocks);
+            configure_ref_tick_xtal_impl(clocks, old_config, config);
         }
         pub fn ref_tick_xtal_config(clocks: &mut ClockTree) -> Option<RefTickXtalConfig> {
             clocks.ref_tick_xtal
@@ -1931,8 +1931,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_ref_tick_fosc(clocks: &mut ClockTree, config: RefTickFoscConfig) {
             let old_config = clocks.ref_tick_fosc.replace(config);
-            configure_ref_tick_fosc_impl(clocks, old_config, config);
             refresh_ref_tick_fosc_downstream(clocks);
+            configure_ref_tick_fosc_impl(clocks, old_config, config);
         }
         pub fn ref_tick_fosc_config(clocks: &mut ClockTree) -> Option<RefTickFoscConfig> {
             clocks.ref_tick_fosc
@@ -1961,8 +1961,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_ref_tick_apll(clocks: &mut ClockTree, config: RefTickApllConfig) {
             let old_config = clocks.ref_tick_apll.replace(config);
-            configure_ref_tick_apll_impl(clocks, old_config, config);
             refresh_ref_tick_apll_downstream(clocks);
+            configure_ref_tick_apll_impl(clocks, old_config, config);
         }
         pub fn ref_tick_apll_config(clocks: &mut ClockTree) -> Option<RefTickApllConfig> {
             clocks.ref_tick_apll
@@ -1991,8 +1991,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_ref_tick_pll(clocks: &mut ClockTree, config: RefTickPllConfig) {
             let old_config = clocks.ref_tick_pll.replace(config);
-            configure_ref_tick_pll_impl(clocks, old_config, config);
             refresh_ref_tick_pll_downstream(clocks);
+            configure_ref_tick_pll_impl(clocks, old_config, config);
         }
         pub fn ref_tick_pll_config(clocks: &mut ClockTree) -> Option<RefTickPllConfig> {
             clocks.ref_tick_pll
@@ -2021,6 +2021,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, new_selector: CpuClkConfig) {
             let old_selector = clocks.cpu_clk.replace(new_selector);
+            refresh_cpu_clk_downstream(clocks);
             match new_selector {
                 CpuClkConfig::Xtal => {
                     configure_apb_clk(clocks, ApbClkConfig::Cpu);
@@ -2069,7 +2070,6 @@ macro_rules! define_clock_tree_types {
                     CpuClkConfig::Pll => release_cpu_pll_div(clocks),
                 }
             }
-            refresh_cpu_clk_downstream(clocks);
         }
         pub fn cpu_clk_config(clocks: &mut ClockTree) -> Option<CpuClkConfig> {
             clocks.cpu_clk
@@ -2188,6 +2188,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_rtc_slow_clk(clocks: &mut ClockTree, new_selector: RtcSlowClkConfig) {
             let old_selector = clocks.rtc_slow_clk.replace(new_selector);
+            refresh_rtc_slow_clk_downstream(clocks);
             if clocks.rtc_slow_clk_refcount > 0 {
                 match new_selector {
                     RtcSlowClkConfig::Xtal32k => request_xtal32k_clk(clocks),
@@ -2205,7 +2206,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_rtc_slow_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_rtc_slow_clk_downstream(clocks);
         }
         pub fn rtc_slow_clk_config(clocks: &mut ClockTree) -> Option<RtcSlowClkConfig> {
             clocks.rtc_slow_clk
@@ -2250,6 +2250,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_rtc_fast_clk(clocks: &mut ClockTree, new_selector: RtcFastClkConfig) {
             let old_selector = clocks.rtc_fast_clk.replace(new_selector);
+            refresh_rtc_fast_clk_downstream(clocks);
             if clocks.rtc_fast_clk_refcount > 0 {
                 match new_selector {
                     RtcFastClkConfig::Xtal => request_xtal_div_clk(clocks),
@@ -2265,7 +2266,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_rtc_fast_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_rtc_fast_clk_downstream(clocks);
         }
         pub fn rtc_fast_clk_config(clocks: &mut ClockTree) -> Option<RtcFastClkConfig> {
             clocks.rtc_fast_clk
@@ -2329,6 +2329,7 @@ macro_rules! define_clock_tree_types {
             new_selector: TimgCalibrationClockConfig,
         ) {
             let old_selector = clocks.timg_calibration_clock.replace(new_selector);
+            refresh_timg_calibration_clock_downstream(clocks);
             if clocks.timg_calibration_clock_refcount > 0 {
                 match new_selector {
                     TimgCalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
@@ -2346,7 +2347,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
             }
-            refresh_timg_calibration_clock_downstream(clocks);
         }
         pub fn timg_calibration_clock_config(
             clocks: &mut ClockTree,
@@ -2398,6 +2398,7 @@ macro_rules! define_clock_tree_types {
                 new_selector: McpwmFunctionClockConfig,
             ) {
                 let old_selector = clocks.mcpwm_function_clock[self as usize].replace(new_selector);
+                refresh_mcpwm_function_clock_downstream(clocks, self);
                 if clocks.mcpwm_function_clock_refcount[self as usize] > 0 {
                     request_pll_f160m_clk(clocks);
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
@@ -2407,7 +2408,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_mcpwm_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -2455,6 +2455,7 @@ macro_rules! define_clock_tree_types {
                 config: UartFunctionClockConfig,
             ) {
                 let old_config = clocks.uart_function_clock[self as usize].replace(config);
+                refresh_uart_function_clock_downstream(clocks, self);
                 if clocks.uart_function_clock_refcount[self as usize] > 0 {
                     match config.sclk {
                         UartFunctionClockSclk::Apb => request_apb_clk(clocks),
@@ -2470,7 +2471,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_config, config);
                 }
-                refresh_uart_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -2521,8 +2521,8 @@ macro_rules! define_clock_tree_types {
             }
             pub fn configure_mem_clock(self, clocks: &mut ClockTree, config: UartMemClockConfig) {
                 let old_config = clocks.uart_mem_clock[self as usize].replace(config);
-                self.configure_mem_clock_impl(clocks, old_config, config);
                 refresh_uart_mem_clock_downstream(clocks, self);
+                self.configure_mem_clock_impl(clocks, old_config, config);
             }
             pub fn mem_clock_config(self, clocks: &mut ClockTree) -> Option<UartMemClockConfig> {
                 clocks.uart_mem_clock[self as usize]
@@ -2561,8 +2561,8 @@ macro_rules! define_clock_tree_types {
                 config: UartBaudRateGeneratorConfig,
             ) {
                 let old_config = clocks.uart_baud_rate_generator[self as usize].replace(config);
-                self.configure_baud_rate_generator_impl(clocks, old_config, config);
                 refresh_uart_baud_rate_generator_downstream(clocks, self);
+                self.configure_baud_rate_generator_impl(clocks, old_config, config);
             }
             pub fn baud_rate_generator_config(
                 self,

--- a/esp-metadata-generated/src/_generated_esp32c2.rs
+++ b/esp-metadata-generated/src/_generated_esp32c2.rs
@@ -1343,9 +1343,46 @@ macro_rules! define_clock_tree_types {
                 uart_mem_clock_refcount: [0; 2],
                 uart_baud_rate_generator_refcount: [0; 2],
             });
+        static XTAL_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static SYSTEM_PRE_DIV_IN_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static SYSTEM_PRE_DIV_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static CPU_PLL_DIV_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static CPU_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static RC_FAST_CLK_DIV_N_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static RTC_SLOW_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static RTC_FAST_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static LOW_POWER_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static TIMG_CALIBRATION_CLOCK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static TIMG_FUNCTION_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 1] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 1];
+        static TIMG_WDT_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 1] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 1];
+        static UART_FUNCTION_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 2] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
+        static UART_MEM_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 2] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
+        static UART_BAUD_RATE_GENERATOR_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 2] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
+        static APB_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static CRYPTO_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static MSPI_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
             let old_config = clocks.xtal_clk.replace(config);
             configure_xtal_clk_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn xtal_clk_config(clocks: &mut ClockTree) -> Option<XtalClkConfig> {
             clocks.xtal_clk
@@ -1356,12 +1393,8 @@ macro_rules! define_clock_tree_types {
         pub fn xtal_clk_config_frequency(clocks: &mut ClockTree, config: XtalClkConfig) -> u32 {
             config.value()
         }
-        pub fn xtal_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.xtal_clk {
-                xtal_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn xtal_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            XTAL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_pll_clk(clocks: &mut ClockTree) {
             trace!("Requesting PLL_CLK");
@@ -1464,6 +1497,7 @@ macro_rules! define_clock_tree_types {
                     SystemPreDivInConfig::RcFast => release_rc_fast_clk(clocks),
                 }
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn system_pre_div_in_config(clocks: &mut ClockTree) -> Option<SystemPreDivInConfig> {
             clocks.system_pre_div_in
@@ -1496,16 +1530,13 @@ macro_rules! define_clock_tree_types {
                 SystemPreDivInConfig::RcFast => rc_fast_clk_frequency(clocks),
             }
         }
-        pub fn system_pre_div_in_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.system_pre_div_in {
-                system_pre_div_in_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn system_pre_div_in_frequency(_clocks: &mut ClockTree) -> u32 {
+            SYSTEM_PRE_DIV_IN_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_system_pre_div(clocks: &mut ClockTree, config: SystemPreDivConfig) {
             let old_config = clocks.system_pre_div.replace(config);
             configure_system_pre_div_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn system_pre_div_config(clocks: &mut ClockTree) -> Option<SystemPreDivConfig> {
             clocks.system_pre_div
@@ -1529,16 +1560,13 @@ macro_rules! define_clock_tree_types {
         ) -> u32 {
             (system_pre_div_in_frequency(clocks) / (config.divisor() + 1))
         }
-        pub fn system_pre_div_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.system_pre_div {
-                system_pre_div_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn system_pre_div_frequency(_clocks: &mut ClockTree) -> u32 {
+            SYSTEM_PRE_DIV_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_cpu_pll_div(clocks: &mut ClockTree, config: CpuPllDivConfig) {
             let old_config = clocks.cpu_pll_div.replace(config);
             configure_cpu_pll_div_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn cpu_pll_div_config(clocks: &mut ClockTree) -> Option<CpuPllDivConfig> {
             clocks.cpu_pll_div
@@ -1562,12 +1590,8 @@ macro_rules! define_clock_tree_types {
         ) -> u32 {
             (pll_clk_frequency(clocks) / config.divisor())
         }
-        pub fn cpu_pll_div_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.cpu_pll_div {
-                cpu_pll_div_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn cpu_pll_div_frequency(_clocks: &mut ClockTree) -> u32 {
+            CPU_PLL_DIV_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, new_selector: ApbClkConfig) {
             let old_selector = clocks.apb_clk.replace(new_selector);
@@ -1586,6 +1610,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_apb_clk_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn apb_clk_config(clocks: &mut ClockTree) -> Option<ApbClkConfig> {
             clocks.apb_clk
@@ -1619,12 +1644,8 @@ macro_rules! define_clock_tree_types {
                 ApbClkConfig::Cpu => cpu_clk_frequency(clocks),
             }
         }
-        pub fn apb_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.apb_clk {
-                apb_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn apb_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            APB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_crypto_clk(clocks: &mut ClockTree, new_selector: CryptoClkConfig) {
             let old_selector = clocks.crypto_clk.replace(new_selector);
@@ -1643,6 +1664,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_crypto_clk_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn crypto_clk_config(clocks: &mut ClockTree) -> Option<CryptoClkConfig> {
             clocks.crypto_clk
@@ -1676,12 +1698,8 @@ macro_rules! define_clock_tree_types {
                 CryptoClkConfig::Cpu => cpu_clk_frequency(clocks),
             }
         }
-        pub fn crypto_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.crypto_clk {
-                crypto_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn crypto_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            CRYPTO_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_mspi_clk(clocks: &mut ClockTree, new_selector: MspiClkConfig) {
             let old_selector = clocks.mspi_clk.replace(new_selector);
@@ -1700,6 +1718,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_mspi_clk_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn mspi_clk_config(clocks: &mut ClockTree) -> Option<MspiClkConfig> {
             clocks.mspi_clk
@@ -1733,12 +1752,8 @@ macro_rules! define_clock_tree_types {
                 MspiClkConfig::Cpu => cpu_clk_frequency(clocks),
             }
         }
-        pub fn mspi_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.mspi_clk {
-                mspi_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn mspi_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            MSPI_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, new_selector: CpuClkConfig) {
             let old_selector = clocks.cpu_clk.replace(new_selector);
@@ -1774,6 +1789,7 @@ macro_rules! define_clock_tree_types {
                     CpuClkConfig::Pll => release_cpu_pll_div(clocks),
                 }
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn cpu_clk_config(clocks: &mut ClockTree) -> Option<CpuClkConfig> {
             clocks.cpu_clk
@@ -1788,12 +1804,8 @@ macro_rules! define_clock_tree_types {
                 CpuClkConfig::Pll => cpu_pll_div_frequency(clocks),
             }
         }
-        pub fn cpu_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.cpu_clk {
-                cpu_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn cpu_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            CPU_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_pll_40m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_40M");
@@ -1866,6 +1878,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_rc_fast_clk_div_n(clocks: &mut ClockTree, config: RcFastClkDivNConfig) {
             let old_config = clocks.rc_fast_clk_div_n.replace(config);
             configure_rc_fast_clk_div_n_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn rc_fast_clk_div_n_config(clocks: &mut ClockTree) -> Option<RcFastClkDivNConfig> {
             clocks.rc_fast_clk_div_n
@@ -1889,12 +1902,8 @@ macro_rules! define_clock_tree_types {
         ) -> u32 {
             (rc_fast_clk_frequency(clocks) / (config.divisor() + 1))
         }
-        pub fn rc_fast_clk_div_n_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.rc_fast_clk_div_n {
-                rc_fast_clk_div_n_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn rc_fast_clk_div_n_frequency(_clocks: &mut ClockTree) -> u32 {
+            RC_FAST_CLK_DIV_N_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_xtal_div_clk(clocks: &mut ClockTree) {
             trace!("Requesting XTAL_DIV_CLK");
@@ -1926,6 +1935,7 @@ macro_rules! define_clock_tree_types {
                     RtcSlowClkConfig::RcFast => release_rc_fast_div_clk(clocks),
                 }
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn rtc_slow_clk_config(clocks: &mut ClockTree) -> Option<RtcSlowClkConfig> {
             clocks.rtc_slow_clk
@@ -1961,12 +1971,8 @@ macro_rules! define_clock_tree_types {
                 RtcSlowClkConfig::RcFast => rc_fast_div_clk_frequency(clocks),
             }
         }
-        pub fn rtc_slow_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.rtc_slow_clk {
-                rtc_slow_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn rtc_slow_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            RTC_SLOW_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_rtc_fast_clk(clocks: &mut ClockTree, new_selector: RtcFastClkConfig) {
             let old_selector = clocks.rtc_fast_clk.replace(new_selector);
@@ -1985,6 +1991,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_rtc_fast_clk_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn rtc_fast_clk_config(clocks: &mut ClockTree) -> Option<RtcFastClkConfig> {
             clocks.rtc_fast_clk
@@ -2021,12 +2028,8 @@ macro_rules! define_clock_tree_types {
                 RtcFastClkConfig::Rc => rc_fast_clk_div_n_frequency(clocks),
             }
         }
-        pub fn rtc_fast_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.rtc_fast_clk {
-                rtc_fast_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn rtc_fast_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            RTC_FAST_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_low_power_clk(clocks: &mut ClockTree, new_selector: LowPowerClkConfig) {
             let old_selector = clocks.low_power_clk.replace(new_selector);
@@ -2049,6 +2052,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_low_power_clk_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn low_power_clk_config(clocks: &mut ClockTree) -> Option<LowPowerClkConfig> {
             clocks.low_power_clk
@@ -2091,12 +2095,8 @@ macro_rules! define_clock_tree_types {
                 LowPowerClkConfig::RtcSlow => rtc_slow_clk_frequency(clocks),
             }
         }
-        pub fn low_power_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.low_power_clk {
-                low_power_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn low_power_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            LOW_POWER_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_uart_mem_clk(clocks: &mut ClockTree) {
             trace!("Requesting UART_MEM_CLK");
@@ -2139,6 +2139,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn timg_calibration_clock_config(
             clocks: &mut ClockTree,
@@ -2180,12 +2181,8 @@ macro_rules! define_clock_tree_types {
                 TimgCalibrationClockConfig::Osc32kClk => osc_slow_clk_frequency(clocks),
             }
         }
-        pub fn timg_calibration_clock_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.timg_calibration_clock {
-                timg_calibration_clock_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn timg_calibration_clock_frequency(_clocks: &mut ClockTree) -> u32 {
+            TIMG_CALIBRATION_CLOCK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         impl TimgInstance {
             pub fn configure_function_clock(
@@ -2209,6 +2206,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn function_clock_config(
                 self,
@@ -2253,12 +2251,9 @@ macro_rules! define_clock_tree_types {
                     TimgFunctionClockConfig::Pll40m => pll_40m_frequency(clocks),
                 }
             }
-            pub fn function_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.timg_function_clock[self as usize] {
-                    self.function_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                TIMG_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
             pub fn configure_wdt_clock(
                 self,
@@ -2281,6 +2276,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_wdt_clock_impl(clocks, old_selector, new_selector);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn wdt_clock_config(self, clocks: &mut ClockTree) -> Option<TimgWdtClockConfig> {
                 clocks.timg_wdt_clock[self as usize]
@@ -2318,12 +2314,9 @@ macro_rules! define_clock_tree_types {
                     TimgWdtClockConfig::XtalClk => xtal_clk_frequency(clocks),
                 }
             }
-            pub fn wdt_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.timg_wdt_clock[self as usize] {
-                    self.wdt_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn wdt_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                TIMG_WDT_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
         }
         impl UartInstance {
@@ -2350,6 +2343,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_config, config);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn function_clock_config(
                 self,
@@ -2397,16 +2391,14 @@ macro_rules! define_clock_tree_types {
                     UartFunctionClockSclk::Xtal => xtal_clk_frequency(clocks),
                 } / (config.div_num() + 1))
             }
-            pub fn function_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.uart_function_clock[self as usize] {
-                    self.function_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                UART_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
             pub fn configure_mem_clock(self, clocks: &mut ClockTree, config: UartMemClockConfig) {
                 let old_config = clocks.uart_mem_clock[self as usize].replace(config);
                 self.configure_mem_clock_impl(clocks, old_config, config);
+                refresh_all_frequency_caches(clocks);
             }
             pub fn mem_clock_config(self, clocks: &mut ClockTree) -> Option<UartMemClockConfig> {
                 clocks.uart_mem_clock[self as usize]
@@ -2435,12 +2427,9 @@ macro_rules! define_clock_tree_types {
             ) -> u32 {
                 uart_mem_clk_frequency(clocks)
             }
-            pub fn mem_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.uart_mem_clock[self as usize] {
-                    self.mem_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn mem_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                UART_MEM_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
             pub fn configure_baud_rate_generator(
                 self,
@@ -2449,6 +2438,7 @@ macro_rules! define_clock_tree_types {
             ) {
                 let old_config = clocks.uart_baud_rate_generator[self as usize].replace(config);
                 self.configure_baud_rate_generator_impl(clocks, old_config, config);
+                refresh_all_frequency_caches(clocks);
             }
             pub fn baud_rate_generator_config(
                 self,
@@ -2485,12 +2475,9 @@ macro_rules! define_clock_tree_types {
                 ((self.function_clock_frequency(clocks) * 16)
                     / ((config.integral() * 16) + config.fractional()))
             }
-            pub fn baud_rate_generator_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.uart_baud_rate_generator[self as usize] {
-                    self.baud_rate_generator_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn baud_rate_generator_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                UART_BAUD_RATE_GENERATOR_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
         }
         /// Clock tree configuration.
@@ -2565,6 +2552,126 @@ macro_rules! define_clock_tree_types {
             *refcount = refcount.saturating_sub(1);
             let last = *refcount == 0;
             last
+        }
+        fn refresh_all_frequency_caches(clocks: &mut ClockTree) {
+            if let Some(config) = clocks.xtal_clk {
+                XTAL_CLK_FREQ_CACHE.store(
+                    xtal_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.system_pre_div_in {
+                SYSTEM_PRE_DIV_IN_FREQ_CACHE.store(
+                    system_pre_div_in_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.system_pre_div {
+                SYSTEM_PRE_DIV_FREQ_CACHE.store(
+                    system_pre_div_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.cpu_pll_div {
+                CPU_PLL_DIV_FREQ_CACHE.store(
+                    cpu_pll_div_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.cpu_clk {
+                CPU_CLK_FREQ_CACHE.store(
+                    cpu_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.rc_fast_clk_div_n {
+                RC_FAST_CLK_DIV_N_FREQ_CACHE.store(
+                    rc_fast_clk_div_n_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.rtc_slow_clk {
+                RTC_SLOW_CLK_FREQ_CACHE.store(
+                    rtc_slow_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.rtc_fast_clk {
+                RTC_FAST_CLK_FREQ_CACHE.store(
+                    rtc_fast_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.low_power_clk {
+                LOW_POWER_CLK_FREQ_CACHE.store(
+                    low_power_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.timg_calibration_clock {
+                TIMG_CALIBRATION_CLOCK_FREQ_CACHE.store(
+                    timg_calibration_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            for instance in [TimgInstance::Timg0] {
+                if let Some(config) = clocks.timg_function_clock[instance as usize] {
+                    TIMG_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.function_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [TimgInstance::Timg0] {
+                if let Some(config) = clocks.timg_wdt_clock[instance as usize] {
+                    TIMG_WDT_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.wdt_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                if let Some(config) = clocks.uart_function_clock[instance as usize] {
+                    UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.function_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                if let Some(config) = clocks.uart_mem_clock[instance as usize] {
+                    UART_MEM_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.mem_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                if let Some(config) = clocks.uart_baud_rate_generator[instance as usize] {
+                    UART_BAUD_RATE_GENERATOR_FREQ_CACHE[instance as usize].store(
+                        instance.baud_rate_generator_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            if let Some(config) = clocks.apb_clk {
+                APB_CLK_FREQ_CACHE.store(
+                    apb_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.crypto_clk {
+                CRYPTO_CLK_FREQ_CACHE.store(
+                    crypto_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.mspi_clk {
+                MSPI_CLK_FREQ_CACHE.store(
+                    mspi_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
         }
     };
 }

--- a/esp-metadata-generated/src/_generated_esp32c2.rs
+++ b/esp-metadata-generated/src/_generated_esp32c2.rs
@@ -1381,8 +1381,8 @@ macro_rules! define_clock_tree_types {
             ::core::sync::atomic::AtomicU32::new(0);
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
             let old_config = clocks.xtal_clk.replace(config);
-            configure_xtal_clk_impl(clocks, old_config, config);
             refresh_xtal_clk_downstream(clocks);
+            configure_xtal_clk_impl(clocks, old_config, config);
         }
         pub fn xtal_clk_config(clocks: &mut ClockTree) -> Option<XtalClkConfig> {
             clocks.xtal_clk
@@ -1486,6 +1486,7 @@ macro_rules! define_clock_tree_types {
             new_selector: SystemPreDivInConfig,
         ) {
             let old_selector = clocks.system_pre_div_in.replace(new_selector);
+            refresh_system_pre_div_in_downstream(clocks);
             match new_selector {
                 SystemPreDivInConfig::Xtal => request_xtal_clk(clocks),
                 SystemPreDivInConfig::RcFast => request_rc_fast_clk(clocks),
@@ -1497,7 +1498,6 @@ macro_rules! define_clock_tree_types {
                     SystemPreDivInConfig::RcFast => release_rc_fast_clk(clocks),
                 }
             }
-            refresh_system_pre_div_in_downstream(clocks);
         }
         pub fn system_pre_div_in_config(clocks: &mut ClockTree) -> Option<SystemPreDivInConfig> {
             clocks.system_pre_div_in
@@ -1535,8 +1535,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_system_pre_div(clocks: &mut ClockTree, config: SystemPreDivConfig) {
             let old_config = clocks.system_pre_div.replace(config);
-            configure_system_pre_div_impl(clocks, old_config, config);
             refresh_system_pre_div_downstream(clocks);
+            configure_system_pre_div_impl(clocks, old_config, config);
         }
         pub fn system_pre_div_config(clocks: &mut ClockTree) -> Option<SystemPreDivConfig> {
             clocks.system_pre_div
@@ -1565,8 +1565,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_cpu_pll_div(clocks: &mut ClockTree, config: CpuPllDivConfig) {
             let old_config = clocks.cpu_pll_div.replace(config);
-            configure_cpu_pll_div_impl(clocks, old_config, config);
             refresh_cpu_pll_div_downstream(clocks);
+            configure_cpu_pll_div_impl(clocks, old_config, config);
         }
         pub fn cpu_pll_div_config(clocks: &mut ClockTree) -> Option<CpuPllDivConfig> {
             clocks.cpu_pll_div
@@ -1595,6 +1595,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, new_selector: ApbClkConfig) {
             let old_selector = clocks.apb_clk.replace(new_selector);
+            refresh_apb_clk_downstream(clocks);
             if clocks.apb_clk_refcount > 0 {
                 match new_selector {
                     ApbClkConfig::Pll40m => request_pll_40m(clocks),
@@ -1610,7 +1611,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_apb_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_apb_clk_downstream(clocks);
         }
         pub fn apb_clk_config(clocks: &mut ClockTree) -> Option<ApbClkConfig> {
             clocks.apb_clk
@@ -1649,6 +1649,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_crypto_clk(clocks: &mut ClockTree, new_selector: CryptoClkConfig) {
             let old_selector = clocks.crypto_clk.replace(new_selector);
+            refresh_crypto_clk_downstream(clocks);
             if clocks.crypto_clk_refcount > 0 {
                 match new_selector {
                     CryptoClkConfig::Pll80m => request_pll_80m(clocks),
@@ -1664,7 +1665,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_crypto_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_crypto_clk_downstream(clocks);
         }
         pub fn crypto_clk_config(clocks: &mut ClockTree) -> Option<CryptoClkConfig> {
             clocks.crypto_clk
@@ -1703,6 +1703,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_mspi_clk(clocks: &mut ClockTree, new_selector: MspiClkConfig) {
             let old_selector = clocks.mspi_clk.replace(new_selector);
+            refresh_mspi_clk_downstream(clocks);
             if clocks.mspi_clk_refcount > 0 {
                 match new_selector {
                     MspiClkConfig::CpuDiv2 => request_cpu_div2(clocks),
@@ -1718,7 +1719,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_mspi_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_mspi_clk_downstream(clocks);
         }
         pub fn mspi_clk_config(clocks: &mut ClockTree) -> Option<MspiClkConfig> {
             clocks.mspi_clk
@@ -1757,6 +1757,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, new_selector: CpuClkConfig) {
             let old_selector = clocks.cpu_clk.replace(new_selector);
+            refresh_cpu_clk_downstream(clocks);
             match new_selector {
                 CpuClkConfig::Xtal => {
                     configure_apb_clk(clocks, ApbClkConfig::Cpu);
@@ -1789,7 +1790,6 @@ macro_rules! define_clock_tree_types {
                     CpuClkConfig::Pll => release_cpu_pll_div(clocks),
                 }
             }
-            refresh_cpu_clk_downstream(clocks);
         }
         pub fn cpu_clk_config(clocks: &mut ClockTree) -> Option<CpuClkConfig> {
             clocks.cpu_clk
@@ -1877,8 +1877,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_rc_fast_clk_div_n(clocks: &mut ClockTree, config: RcFastClkDivNConfig) {
             let old_config = clocks.rc_fast_clk_div_n.replace(config);
-            configure_rc_fast_clk_div_n_impl(clocks, old_config, config);
             refresh_rc_fast_clk_div_n_downstream(clocks);
+            configure_rc_fast_clk_div_n_impl(clocks, old_config, config);
         }
         pub fn rc_fast_clk_div_n_config(clocks: &mut ClockTree) -> Option<RcFastClkDivNConfig> {
             clocks.rc_fast_clk_div_n
@@ -1922,6 +1922,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_rtc_slow_clk(clocks: &mut ClockTree, new_selector: RtcSlowClkConfig) {
             let old_selector = clocks.rtc_slow_clk.replace(new_selector);
+            refresh_rtc_slow_clk_downstream(clocks);
             match new_selector {
                 RtcSlowClkConfig::OscSlow => request_osc_slow_clk(clocks),
                 RtcSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
@@ -1935,7 +1936,6 @@ macro_rules! define_clock_tree_types {
                     RtcSlowClkConfig::RcFast => release_rc_fast_div_clk(clocks),
                 }
             }
-            refresh_rtc_slow_clk_downstream(clocks);
         }
         pub fn rtc_slow_clk_config(clocks: &mut ClockTree) -> Option<RtcSlowClkConfig> {
             clocks.rtc_slow_clk
@@ -1976,6 +1976,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_rtc_fast_clk(clocks: &mut ClockTree, new_selector: RtcFastClkConfig) {
             let old_selector = clocks.rtc_fast_clk.replace(new_selector);
+            refresh_rtc_fast_clk_downstream(clocks);
             if clocks.rtc_fast_clk_refcount > 0 {
                 match new_selector {
                     RtcFastClkConfig::Xtal => request_xtal_div_clk(clocks),
@@ -1991,7 +1992,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_rtc_fast_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_rtc_fast_clk_downstream(clocks);
         }
         pub fn rtc_fast_clk_config(clocks: &mut ClockTree) -> Option<RtcFastClkConfig> {
             clocks.rtc_fast_clk
@@ -2033,6 +2033,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_low_power_clk(clocks: &mut ClockTree, new_selector: LowPowerClkConfig) {
             let old_selector = clocks.low_power_clk.replace(new_selector);
+            refresh_low_power_clk_downstream(clocks);
             if clocks.low_power_clk_refcount > 0 {
                 match new_selector {
                     LowPowerClkConfig::Xtal => request_xtal_clk(clocks),
@@ -2052,7 +2053,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_low_power_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_low_power_clk_downstream(clocks);
         }
         pub fn low_power_clk_config(clocks: &mut ClockTree) -> Option<LowPowerClkConfig> {
             clocks.low_power_clk
@@ -2122,6 +2122,7 @@ macro_rules! define_clock_tree_types {
             new_selector: TimgCalibrationClockConfig,
         ) {
             let old_selector = clocks.timg_calibration_clock.replace(new_selector);
+            refresh_timg_calibration_clock_downstream(clocks);
             if clocks.timg_calibration_clock_refcount > 0 {
                 match new_selector {
                     TimgCalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
@@ -2139,7 +2140,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
             }
-            refresh_timg_calibration_clock_downstream(clocks);
         }
         pub fn timg_calibration_clock_config(
             clocks: &mut ClockTree,
@@ -2191,6 +2191,7 @@ macro_rules! define_clock_tree_types {
                 new_selector: TimgFunctionClockConfig,
             ) {
                 let old_selector = clocks.timg_function_clock[self as usize].replace(new_selector);
+                refresh_timg_function_clock_downstream(clocks, self);
                 if clocks.timg_function_clock_refcount[self as usize] > 0 {
                     match new_selector {
                         TimgFunctionClockConfig::XtalClk => request_xtal_clk(clocks),
@@ -2206,7 +2207,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_timg_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -2261,6 +2261,7 @@ macro_rules! define_clock_tree_types {
                 new_selector: TimgWdtClockConfig,
             ) {
                 let old_selector = clocks.timg_wdt_clock[self as usize].replace(new_selector);
+                refresh_timg_wdt_clock_downstream(clocks, self);
                 if clocks.timg_wdt_clock_refcount[self as usize] > 0 {
                     match new_selector {
                         TimgWdtClockConfig::Pll40m => request_pll_40m(clocks),
@@ -2276,7 +2277,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_wdt_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_timg_wdt_clock_downstream(clocks, self);
             }
             pub fn wdt_clock_config(self, clocks: &mut ClockTree) -> Option<TimgWdtClockConfig> {
                 clocks.timg_wdt_clock[self as usize]
@@ -2326,6 +2326,7 @@ macro_rules! define_clock_tree_types {
                 config: UartFunctionClockConfig,
             ) {
                 let old_config = clocks.uart_function_clock[self as usize].replace(config);
+                refresh_uart_function_clock_downstream(clocks, self);
                 if clocks.uart_function_clock_refcount[self as usize] > 0 {
                     match config.sclk {
                         UartFunctionClockSclk::PllF40m => request_pll_40m(clocks),
@@ -2343,7 +2344,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_config, config);
                 }
-                refresh_uart_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -2397,8 +2397,8 @@ macro_rules! define_clock_tree_types {
             }
             pub fn configure_mem_clock(self, clocks: &mut ClockTree, config: UartMemClockConfig) {
                 let old_config = clocks.uart_mem_clock[self as usize].replace(config);
-                self.configure_mem_clock_impl(clocks, old_config, config);
                 refresh_uart_mem_clock_downstream(clocks, self);
+                self.configure_mem_clock_impl(clocks, old_config, config);
             }
             pub fn mem_clock_config(self, clocks: &mut ClockTree) -> Option<UartMemClockConfig> {
                 clocks.uart_mem_clock[self as usize]
@@ -2437,8 +2437,8 @@ macro_rules! define_clock_tree_types {
                 config: UartBaudRateGeneratorConfig,
             ) {
                 let old_config = clocks.uart_baud_rate_generator[self as usize].replace(config);
-                self.configure_baud_rate_generator_impl(clocks, old_config, config);
                 refresh_uart_baud_rate_generator_downstream(clocks, self);
+                self.configure_baud_rate_generator_impl(clocks, old_config, config);
             }
             pub fn baud_rate_generator_config(
                 self,

--- a/esp-metadata-generated/src/_generated_esp32c2.rs
+++ b/esp-metadata-generated/src/_generated_esp32c2.rs
@@ -2566,20 +2566,10 @@ macro_rules! define_clock_tree_types {
             refresh_low_power_clk_downstream(clocks);
             for child_instance in [TimgInstance::Timg0] {
                 refresh_timg_function_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [TimgInstance::Timg0] {
                 refresh_timg_wdt_clock_downstream(clocks, child_instance);
             }
             for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
                 refresh_uart_function_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
-                refresh_uart_mem_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
-                refresh_uart_function_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
                 refresh_uart_mem_clock_downstream(clocks, child_instance);
             }
         }
@@ -2617,21 +2607,16 @@ macro_rules! define_clock_tree_types {
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_apb_clk_downstream(clocks);
+            refresh_crypto_clk_downstream(clocks);
+            refresh_mspi_clk_downstream(clocks);
             for child_instance in [TimgInstance::Timg0] {
                 refresh_timg_function_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [TimgInstance::Timg0] {
                 refresh_timg_wdt_clock_downstream(clocks, child_instance);
             }
             for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
                 refresh_uart_function_clock_downstream(clocks, child_instance);
             }
-            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
-                refresh_uart_function_clock_downstream(clocks, child_instance);
-            }
-            refresh_apb_clk_downstream(clocks);
-            refresh_crypto_clk_downstream(clocks);
-            refresh_mspi_clk_downstream(clocks);
         }
         fn refresh_rc_fast_clk_div_n_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.rc_fast_clk_div_n {

--- a/esp-metadata-generated/src/_generated_esp32c2.rs
+++ b/esp-metadata-generated/src/_generated_esp32c2.rs
@@ -1382,7 +1382,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
             let old_config = clocks.xtal_clk.replace(config);
             configure_xtal_clk_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_xtal_clk_downstream(clocks);
         }
         pub fn xtal_clk_config(clocks: &mut ClockTree) -> Option<XtalClkConfig> {
             clocks.xtal_clk
@@ -1497,7 +1497,7 @@ macro_rules! define_clock_tree_types {
                     SystemPreDivInConfig::RcFast => release_rc_fast_clk(clocks),
                 }
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_system_pre_div_in_downstream(clocks);
         }
         pub fn system_pre_div_in_config(clocks: &mut ClockTree) -> Option<SystemPreDivInConfig> {
             clocks.system_pre_div_in
@@ -1536,7 +1536,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_system_pre_div(clocks: &mut ClockTree, config: SystemPreDivConfig) {
             let old_config = clocks.system_pre_div.replace(config);
             configure_system_pre_div_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_system_pre_div_downstream(clocks);
         }
         pub fn system_pre_div_config(clocks: &mut ClockTree) -> Option<SystemPreDivConfig> {
             clocks.system_pre_div
@@ -1566,7 +1566,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_cpu_pll_div(clocks: &mut ClockTree, config: CpuPllDivConfig) {
             let old_config = clocks.cpu_pll_div.replace(config);
             configure_cpu_pll_div_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_cpu_pll_div_downstream(clocks);
         }
         pub fn cpu_pll_div_config(clocks: &mut ClockTree) -> Option<CpuPllDivConfig> {
             clocks.cpu_pll_div
@@ -1610,7 +1610,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_apb_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_apb_clk_downstream(clocks);
         }
         pub fn apb_clk_config(clocks: &mut ClockTree) -> Option<ApbClkConfig> {
             clocks.apb_clk
@@ -1664,7 +1664,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_crypto_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_crypto_clk_downstream(clocks);
         }
         pub fn crypto_clk_config(clocks: &mut ClockTree) -> Option<CryptoClkConfig> {
             clocks.crypto_clk
@@ -1718,7 +1718,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_mspi_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_mspi_clk_downstream(clocks);
         }
         pub fn mspi_clk_config(clocks: &mut ClockTree) -> Option<MspiClkConfig> {
             clocks.mspi_clk
@@ -1789,7 +1789,7 @@ macro_rules! define_clock_tree_types {
                     CpuClkConfig::Pll => release_cpu_pll_div(clocks),
                 }
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_cpu_clk_downstream(clocks);
         }
         pub fn cpu_clk_config(clocks: &mut ClockTree) -> Option<CpuClkConfig> {
             clocks.cpu_clk
@@ -1878,7 +1878,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_rc_fast_clk_div_n(clocks: &mut ClockTree, config: RcFastClkDivNConfig) {
             let old_config = clocks.rc_fast_clk_div_n.replace(config);
             configure_rc_fast_clk_div_n_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_rc_fast_clk_div_n_downstream(clocks);
         }
         pub fn rc_fast_clk_div_n_config(clocks: &mut ClockTree) -> Option<RcFastClkDivNConfig> {
             clocks.rc_fast_clk_div_n
@@ -1935,7 +1935,7 @@ macro_rules! define_clock_tree_types {
                     RtcSlowClkConfig::RcFast => release_rc_fast_div_clk(clocks),
                 }
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_rtc_slow_clk_downstream(clocks);
         }
         pub fn rtc_slow_clk_config(clocks: &mut ClockTree) -> Option<RtcSlowClkConfig> {
             clocks.rtc_slow_clk
@@ -1991,7 +1991,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_rtc_fast_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_rtc_fast_clk_downstream(clocks);
         }
         pub fn rtc_fast_clk_config(clocks: &mut ClockTree) -> Option<RtcFastClkConfig> {
             clocks.rtc_fast_clk
@@ -2052,7 +2052,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_low_power_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_low_power_clk_downstream(clocks);
         }
         pub fn low_power_clk_config(clocks: &mut ClockTree) -> Option<LowPowerClkConfig> {
             clocks.low_power_clk
@@ -2139,7 +2139,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_timg_calibration_clock_downstream(clocks);
         }
         pub fn timg_calibration_clock_config(
             clocks: &mut ClockTree,
@@ -2206,7 +2206,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_timg_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -2276,7 +2276,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_wdt_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_timg_wdt_clock_downstream(clocks, self);
             }
             pub fn wdt_clock_config(self, clocks: &mut ClockTree) -> Option<TimgWdtClockConfig> {
                 clocks.timg_wdt_clock[self as usize]
@@ -2343,7 +2343,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_config, config);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_uart_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -2398,7 +2398,7 @@ macro_rules! define_clock_tree_types {
             pub fn configure_mem_clock(self, clocks: &mut ClockTree, config: UartMemClockConfig) {
                 let old_config = clocks.uart_mem_clock[self as usize].replace(config);
                 self.configure_mem_clock_impl(clocks, old_config, config);
-                refresh_all_frequency_caches(clocks);
+                refresh_uart_mem_clock_downstream(clocks, self);
             }
             pub fn mem_clock_config(self, clocks: &mut ClockTree) -> Option<UartMemClockConfig> {
                 clocks.uart_mem_clock[self as usize]
@@ -2438,7 +2438,7 @@ macro_rules! define_clock_tree_types {
             ) {
                 let old_config = clocks.uart_baud_rate_generator[self as usize].replace(config);
                 self.configure_baud_rate_generator_impl(clocks, old_config, config);
-                refresh_all_frequency_caches(clocks);
+                refresh_uart_baud_rate_generator_downstream(clocks, self);
             }
             pub fn baud_rate_generator_config(
                 self,
@@ -2553,119 +2553,189 @@ macro_rules! define_clock_tree_types {
             let last = *refcount == 0;
             last
         }
-        fn refresh_all_frequency_caches(clocks: &mut ClockTree) {
+        fn refresh_xtal_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.xtal_clk {
                 XTAL_CLK_FREQ_CACHE.store(
                     xtal_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_system_pre_div_in_downstream(clocks);
+            refresh_cpu_pll_div_downstream(clocks);
+            refresh_rtc_fast_clk_downstream(clocks);
+            refresh_low_power_clk_downstream(clocks);
+            for child_instance in [TimgInstance::Timg0] {
+                refresh_timg_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [TimgInstance::Timg0] {
+                refresh_timg_wdt_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                refresh_uart_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                refresh_uart_mem_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                refresh_uart_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                refresh_uart_mem_clock_downstream(clocks, child_instance);
+            }
+        }
+        fn refresh_system_pre_div_in_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.system_pre_div_in {
                 SYSTEM_PRE_DIV_IN_FREQ_CACHE.store(
                     system_pre_div_in_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_system_pre_div_downstream(clocks);
+        }
+        fn refresh_system_pre_div_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.system_pre_div {
                 SYSTEM_PRE_DIV_FREQ_CACHE.store(
                     system_pre_div_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_cpu_clk_downstream(clocks);
+        }
+        fn refresh_cpu_pll_div_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.cpu_pll_div {
                 CPU_PLL_DIV_FREQ_CACHE.store(
                     cpu_pll_div_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_cpu_clk_downstream(clocks);
+        }
+        fn refresh_cpu_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.cpu_clk {
                 CPU_CLK_FREQ_CACHE.store(
                     cpu_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            for child_instance in [TimgInstance::Timg0] {
+                refresh_timg_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [TimgInstance::Timg0] {
+                refresh_timg_wdt_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                refresh_uart_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                refresh_uart_function_clock_downstream(clocks, child_instance);
+            }
+            refresh_apb_clk_downstream(clocks);
+            refresh_crypto_clk_downstream(clocks);
+            refresh_mspi_clk_downstream(clocks);
+        }
+        fn refresh_rc_fast_clk_div_n_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.rc_fast_clk_div_n {
                 RC_FAST_CLK_DIV_N_FREQ_CACHE.store(
                     rc_fast_clk_div_n_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_rtc_fast_clk_downstream(clocks);
+        }
+        fn refresh_rtc_slow_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.rtc_slow_clk {
                 RTC_SLOW_CLK_FREQ_CACHE.store(
                     rtc_slow_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_low_power_clk_downstream(clocks);
+        }
+        fn refresh_rtc_fast_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.rtc_fast_clk {
                 RTC_FAST_CLK_FREQ_CACHE.store(
                     rtc_fast_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+        }
+        fn refresh_low_power_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.low_power_clk {
                 LOW_POWER_CLK_FREQ_CACHE.store(
                     low_power_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+        }
+        fn refresh_timg_calibration_clock_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.timg_calibration_clock {
                 TIMG_CALIBRATION_CLOCK_FREQ_CACHE.store(
                     timg_calibration_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
-            for instance in [TimgInstance::Timg0] {
-                if let Some(config) = clocks.timg_function_clock[instance as usize] {
-                    TIMG_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.function_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_timg_function_clock_downstream(clocks: &mut ClockTree, instance: TimgInstance) {
+            if let Some(config) = clocks.timg_function_clock[instance as usize] {
+                TIMG_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.function_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
-            for instance in [TimgInstance::Timg0] {
-                if let Some(config) = clocks.timg_wdt_clock[instance as usize] {
-                    TIMG_WDT_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.wdt_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_timg_wdt_clock_downstream(clocks: &mut ClockTree, instance: TimgInstance) {
+            if let Some(config) = clocks.timg_wdt_clock[instance as usize] {
+                TIMG_WDT_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.wdt_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
-            for instance in [UartInstance::Uart0, UartInstance::Uart1] {
-                if let Some(config) = clocks.uart_function_clock[instance as usize] {
-                    UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.function_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_uart_function_clock_downstream(clocks: &mut ClockTree, instance: UartInstance) {
+            if let Some(config) = clocks.uart_function_clock[instance as usize] {
+                UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.function_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
-            for instance in [UartInstance::Uart0, UartInstance::Uart1] {
-                if let Some(config) = clocks.uart_mem_clock[instance as usize] {
-                    UART_MEM_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.mem_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+            refresh_uart_baud_rate_generator_downstream(clocks, instance);
+        }
+        fn refresh_uart_mem_clock_downstream(clocks: &mut ClockTree, instance: UartInstance) {
+            if let Some(config) = clocks.uart_mem_clock[instance as usize] {
+                UART_MEM_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.mem_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
-            for instance in [UartInstance::Uart0, UartInstance::Uart1] {
-                if let Some(config) = clocks.uart_baud_rate_generator[instance as usize] {
-                    UART_BAUD_RATE_GENERATOR_FREQ_CACHE[instance as usize].store(
-                        instance.baud_rate_generator_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_uart_baud_rate_generator_downstream(
+            clocks: &mut ClockTree,
+            instance: UartInstance,
+        ) {
+            if let Some(config) = clocks.uart_baud_rate_generator[instance as usize] {
+                UART_BAUD_RATE_GENERATOR_FREQ_CACHE[instance as usize].store(
+                    instance.baud_rate_generator_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
+        }
+        fn refresh_apb_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.apb_clk {
                 APB_CLK_FREQ_CACHE.store(
                     apb_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+        }
+        fn refresh_crypto_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.crypto_clk {
                 CRYPTO_CLK_FREQ_CACHE.store(
                     crypto_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+        }
+        fn refresh_mspi_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.mspi_clk {
                 MSPI_CLK_FREQ_CACHE.store(
                     mspi_clk_config_frequency(clocks, config),

--- a/esp-metadata-generated/src/_generated_esp32c2.rs
+++ b/esp-metadata-generated/src/_generated_esp32c2.rs
@@ -1393,7 +1393,7 @@ macro_rules! define_clock_tree_types {
         pub fn xtal_clk_config_frequency(clocks: &mut ClockTree, config: XtalClkConfig) -> u32 {
             config.value()
         }
-        pub fn xtal_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn xtal_clk_frequency() -> u32 {
             XTAL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_pll_clk(clocks: &mut ClockTree) {
@@ -1408,7 +1408,7 @@ macro_rules! define_clock_tree_types {
             enable_pll_clk_impl(clocks, false);
             release_xtal_clk(clocks);
         }
-        pub fn pll_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn pll_clk_frequency() -> u32 {
             480000000
         }
         pub fn request_rc_fast_clk(clocks: &mut ClockTree) {
@@ -1425,7 +1425,7 @@ macro_rules! define_clock_tree_types {
                 enable_rc_fast_clk_impl(clocks, false);
             }
         }
-        pub fn rc_fast_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn rc_fast_clk_frequency() -> u32 {
             17500000
         }
         pub fn request_osc_slow_clk(clocks: &mut ClockTree) {
@@ -1442,7 +1442,7 @@ macro_rules! define_clock_tree_types {
                 enable_osc_slow_clk_impl(clocks, false);
             }
         }
-        pub fn osc_slow_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn osc_slow_clk_frequency() -> u32 {
             32768
         }
         pub fn request_rc_slow_clk(clocks: &mut ClockTree) {
@@ -1459,7 +1459,7 @@ macro_rules! define_clock_tree_types {
                 enable_rc_slow_clk_impl(clocks, false);
             }
         }
-        pub fn rc_slow_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn rc_slow_clk_frequency() -> u32 {
             136000
         }
         pub fn request_rc_fast_div_clk(clocks: &mut ClockTree) {
@@ -1478,8 +1478,8 @@ macro_rules! define_clock_tree_types {
                 release_rc_fast_clk(clocks);
             }
         }
-        pub fn rc_fast_div_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            (rc_fast_clk_frequency(clocks) / 256)
+        pub fn rc_fast_div_clk_frequency() -> u32 {
+            (rc_fast_clk_frequency() / 256)
         }
         pub fn configure_system_pre_div_in(
             clocks: &mut ClockTree,
@@ -1526,11 +1526,11 @@ macro_rules! define_clock_tree_types {
             config: SystemPreDivInConfig,
         ) -> u32 {
             match config {
-                SystemPreDivInConfig::Xtal => xtal_clk_frequency(clocks),
-                SystemPreDivInConfig::RcFast => rc_fast_clk_frequency(clocks),
+                SystemPreDivInConfig::Xtal => xtal_clk_frequency(),
+                SystemPreDivInConfig::RcFast => rc_fast_clk_frequency(),
             }
         }
-        pub fn system_pre_div_in_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn system_pre_div_in_frequency() -> u32 {
             SYSTEM_PRE_DIV_IN_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_system_pre_div(clocks: &mut ClockTree, config: SystemPreDivConfig) {
@@ -1558,9 +1558,9 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: SystemPreDivConfig,
         ) -> u32 {
-            (system_pre_div_in_frequency(clocks) / (config.divisor() + 1))
+            (system_pre_div_in_frequency() / (config.divisor() + 1))
         }
-        pub fn system_pre_div_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn system_pre_div_frequency() -> u32 {
             SYSTEM_PRE_DIV_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_cpu_pll_div(clocks: &mut ClockTree, config: CpuPllDivConfig) {
@@ -1588,9 +1588,9 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: CpuPllDivConfig,
         ) -> u32 {
-            (pll_clk_frequency(clocks) / config.divisor())
+            (pll_clk_frequency() / config.divisor())
         }
-        pub fn cpu_pll_div_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn cpu_pll_div_frequency() -> u32 {
             CPU_PLL_DIV_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, new_selector: ApbClkConfig) {
@@ -1640,11 +1640,11 @@ macro_rules! define_clock_tree_types {
         #[allow(unused_variables)]
         pub fn apb_clk_config_frequency(clocks: &mut ClockTree, config: ApbClkConfig) -> u32 {
             match config {
-                ApbClkConfig::Pll40m => pll_40m_frequency(clocks),
-                ApbClkConfig::Cpu => cpu_clk_frequency(clocks),
+                ApbClkConfig::Pll40m => pll_40m_frequency(),
+                ApbClkConfig::Cpu => cpu_clk_frequency(),
             }
         }
-        pub fn apb_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn apb_clk_frequency() -> u32 {
             APB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_crypto_clk(clocks: &mut ClockTree, new_selector: CryptoClkConfig) {
@@ -1694,11 +1694,11 @@ macro_rules! define_clock_tree_types {
         #[allow(unused_variables)]
         pub fn crypto_clk_config_frequency(clocks: &mut ClockTree, config: CryptoClkConfig) -> u32 {
             match config {
-                CryptoClkConfig::Pll80m => pll_80m_frequency(clocks),
-                CryptoClkConfig::Cpu => cpu_clk_frequency(clocks),
+                CryptoClkConfig::Pll80m => pll_80m_frequency(),
+                CryptoClkConfig::Cpu => cpu_clk_frequency(),
             }
         }
-        pub fn crypto_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn crypto_clk_frequency() -> u32 {
             CRYPTO_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_mspi_clk(clocks: &mut ClockTree, new_selector: MspiClkConfig) {
@@ -1748,11 +1748,11 @@ macro_rules! define_clock_tree_types {
         #[allow(unused_variables)]
         pub fn mspi_clk_config_frequency(clocks: &mut ClockTree, config: MspiClkConfig) -> u32 {
             match config {
-                MspiClkConfig::CpuDiv2 => cpu_div2_frequency(clocks),
-                MspiClkConfig::Cpu => cpu_clk_frequency(clocks),
+                MspiClkConfig::CpuDiv2 => cpu_div2_frequency(),
+                MspiClkConfig::Cpu => cpu_clk_frequency(),
             }
         }
-        pub fn mspi_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn mspi_clk_frequency() -> u32 {
             MSPI_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, new_selector: CpuClkConfig) {
@@ -1799,12 +1799,12 @@ macro_rules! define_clock_tree_types {
         #[allow(unused_variables)]
         pub fn cpu_clk_config_frequency(clocks: &mut ClockTree, config: CpuClkConfig) -> u32 {
             match config {
-                CpuClkConfig::Xtal => system_pre_div_frequency(clocks),
-                CpuClkConfig::RcFast => system_pre_div_frequency(clocks),
-                CpuClkConfig::Pll => cpu_pll_div_frequency(clocks),
+                CpuClkConfig::Xtal => system_pre_div_frequency(),
+                CpuClkConfig::RcFast => system_pre_div_frequency(),
+                CpuClkConfig::Pll => cpu_pll_div_frequency(),
             }
         }
-        pub fn cpu_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn cpu_clk_frequency() -> u32 {
             CPU_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_pll_40m(clocks: &mut ClockTree) {
@@ -1823,7 +1823,7 @@ macro_rules! define_clock_tree_types {
                 release_cpu_clk(clocks);
             }
         }
-        pub fn pll_40m_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn pll_40m_frequency() -> u32 {
             40000000
         }
         pub fn request_pll_60m(clocks: &mut ClockTree) {
@@ -1842,7 +1842,7 @@ macro_rules! define_clock_tree_types {
                 release_cpu_clk(clocks);
             }
         }
-        pub fn pll_60m_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn pll_60m_frequency() -> u32 {
             60000000
         }
         pub fn request_pll_80m(clocks: &mut ClockTree) {
@@ -1857,7 +1857,7 @@ macro_rules! define_clock_tree_types {
             enable_pll_80m_impl(clocks, false);
             release_cpu_clk(clocks);
         }
-        pub fn pll_80m_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn pll_80m_frequency() -> u32 {
             80000000
         }
         pub fn request_cpu_div2(clocks: &mut ClockTree) {
@@ -1872,8 +1872,8 @@ macro_rules! define_clock_tree_types {
             enable_cpu_div2_impl(clocks, false);
             release_cpu_clk(clocks);
         }
-        pub fn cpu_div2_frequency(clocks: &mut ClockTree) -> u32 {
-            (cpu_clk_frequency(clocks) / 2)
+        pub fn cpu_div2_frequency() -> u32 {
+            (cpu_clk_frequency() / 2)
         }
         pub fn configure_rc_fast_clk_div_n(clocks: &mut ClockTree, config: RcFastClkDivNConfig) {
             let old_config = clocks.rc_fast_clk_div_n.replace(config);
@@ -1900,9 +1900,9 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: RcFastClkDivNConfig,
         ) -> u32 {
-            (rc_fast_clk_frequency(clocks) / (config.divisor() + 1))
+            (rc_fast_clk_frequency() / (config.divisor() + 1))
         }
-        pub fn rc_fast_clk_div_n_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn rc_fast_clk_div_n_frequency() -> u32 {
             RC_FAST_CLK_DIV_N_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_xtal_div_clk(clocks: &mut ClockTree) {
@@ -1917,8 +1917,8 @@ macro_rules! define_clock_tree_types {
             enable_xtal_div_clk_impl(clocks, false);
             release_xtal_clk(clocks);
         }
-        pub fn xtal_div_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            (xtal_clk_frequency(clocks) / 2)
+        pub fn xtal_div_clk_frequency() -> u32 {
+            (xtal_clk_frequency() / 2)
         }
         pub fn configure_rtc_slow_clk(clocks: &mut ClockTree, new_selector: RtcSlowClkConfig) {
             let old_selector = clocks.rtc_slow_clk.replace(new_selector);
@@ -1966,12 +1966,12 @@ macro_rules! define_clock_tree_types {
             config: RtcSlowClkConfig,
         ) -> u32 {
             match config {
-                RtcSlowClkConfig::OscSlow => osc_slow_clk_frequency(clocks),
-                RtcSlowClkConfig::RcSlow => rc_slow_clk_frequency(clocks),
-                RtcSlowClkConfig::RcFast => rc_fast_div_clk_frequency(clocks),
+                RtcSlowClkConfig::OscSlow => osc_slow_clk_frequency(),
+                RtcSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
+                RtcSlowClkConfig::RcFast => rc_fast_div_clk_frequency(),
             }
         }
-        pub fn rtc_slow_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn rtc_slow_clk_frequency() -> u32 {
             RTC_SLOW_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_rtc_fast_clk(clocks: &mut ClockTree, new_selector: RtcFastClkConfig) {
@@ -2024,11 +2024,11 @@ macro_rules! define_clock_tree_types {
             config: RtcFastClkConfig,
         ) -> u32 {
             match config {
-                RtcFastClkConfig::Xtal => xtal_div_clk_frequency(clocks),
-                RtcFastClkConfig::Rc => rc_fast_clk_div_n_frequency(clocks),
+                RtcFastClkConfig::Xtal => xtal_div_clk_frequency(),
+                RtcFastClkConfig::Rc => rc_fast_clk_div_n_frequency(),
             }
         }
-        pub fn rtc_fast_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn rtc_fast_clk_frequency() -> u32 {
             RTC_FAST_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_low_power_clk(clocks: &mut ClockTree, new_selector: LowPowerClkConfig) {
@@ -2089,13 +2089,13 @@ macro_rules! define_clock_tree_types {
             config: LowPowerClkConfig,
         ) -> u32 {
             match config {
-                LowPowerClkConfig::Xtal => xtal_clk_frequency(clocks),
-                LowPowerClkConfig::RcFast => rc_fast_clk_frequency(clocks),
-                LowPowerClkConfig::OscSlow => osc_slow_clk_frequency(clocks),
-                LowPowerClkConfig::RtcSlow => rtc_slow_clk_frequency(clocks),
+                LowPowerClkConfig::Xtal => xtal_clk_frequency(),
+                LowPowerClkConfig::RcFast => rc_fast_clk_frequency(),
+                LowPowerClkConfig::OscSlow => osc_slow_clk_frequency(),
+                LowPowerClkConfig::RtcSlow => rtc_slow_clk_frequency(),
             }
         }
-        pub fn low_power_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn low_power_clk_frequency() -> u32 {
             LOW_POWER_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_uart_mem_clk(clocks: &mut ClockTree) {
@@ -2114,8 +2114,8 @@ macro_rules! define_clock_tree_types {
                 release_xtal_clk(clocks);
             }
         }
-        pub fn uart_mem_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            xtal_clk_frequency(clocks)
+        pub fn uart_mem_clk_frequency() -> u32 {
+            xtal_clk_frequency()
         }
         pub fn configure_timg_calibration_clock(
             clocks: &mut ClockTree,
@@ -2176,12 +2176,12 @@ macro_rules! define_clock_tree_types {
             config: TimgCalibrationClockConfig,
         ) -> u32 {
             match config {
-                TimgCalibrationClockConfig::RcSlowClk => rc_slow_clk_frequency(clocks),
-                TimgCalibrationClockConfig::RcFastDivClk => rc_fast_div_clk_frequency(clocks),
-                TimgCalibrationClockConfig::Osc32kClk => osc_slow_clk_frequency(clocks),
+                TimgCalibrationClockConfig::RcSlowClk => rc_slow_clk_frequency(),
+                TimgCalibrationClockConfig::RcFastDivClk => rc_fast_div_clk_frequency(),
+                TimgCalibrationClockConfig::Osc32kClk => osc_slow_clk_frequency(),
             }
         }
-        pub fn timg_calibration_clock_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn timg_calibration_clock_frequency() -> u32 {
             TIMG_CALIBRATION_CLOCK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         impl TimgInstance {
@@ -2247,11 +2247,11 @@ macro_rules! define_clock_tree_types {
                 config: TimgFunctionClockConfig,
             ) -> u32 {
                 match config {
-                    TimgFunctionClockConfig::XtalClk => xtal_clk_frequency(clocks),
-                    TimgFunctionClockConfig::Pll40m => pll_40m_frequency(clocks),
+                    TimgFunctionClockConfig::XtalClk => xtal_clk_frequency(),
+                    TimgFunctionClockConfig::Pll40m => pll_40m_frequency(),
                 }
             }
-            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn function_clock_frequency(self) -> u32 {
                 TIMG_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -2310,11 +2310,11 @@ macro_rules! define_clock_tree_types {
                 config: TimgWdtClockConfig,
             ) -> u32 {
                 match config {
-                    TimgWdtClockConfig::Pll40m => pll_40m_frequency(clocks),
-                    TimgWdtClockConfig::XtalClk => xtal_clk_frequency(clocks),
+                    TimgWdtClockConfig::Pll40m => pll_40m_frequency(),
+                    TimgWdtClockConfig::XtalClk => xtal_clk_frequency(),
                 }
             }
-            pub fn wdt_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn wdt_clock_frequency(self) -> u32 {
                 TIMG_WDT_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -2386,12 +2386,12 @@ macro_rules! define_clock_tree_types {
                 config: UartFunctionClockConfig,
             ) -> u32 {
                 (match config.sclk {
-                    UartFunctionClockSclk::PllF40m => pll_40m_frequency(clocks),
-                    UartFunctionClockSclk::RcFast => rc_fast_clk_frequency(clocks),
-                    UartFunctionClockSclk::Xtal => xtal_clk_frequency(clocks),
+                    UartFunctionClockSclk::PllF40m => pll_40m_frequency(),
+                    UartFunctionClockSclk::RcFast => rc_fast_clk_frequency(),
+                    UartFunctionClockSclk::Xtal => xtal_clk_frequency(),
                 } / (config.div_num() + 1))
             }
-            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn function_clock_frequency(self) -> u32 {
                 UART_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -2425,9 +2425,9 @@ macro_rules! define_clock_tree_types {
                 clocks: &mut ClockTree,
                 config: UartMemClockConfig,
             ) -> u32 {
-                uart_mem_clk_frequency(clocks)
+                uart_mem_clk_frequency()
             }
-            pub fn mem_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn mem_clock_frequency(self) -> u32 {
                 UART_MEM_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -2472,10 +2472,10 @@ macro_rules! define_clock_tree_types {
                 clocks: &mut ClockTree,
                 config: UartBaudRateGeneratorConfig,
             ) -> u32 {
-                ((self.function_clock_frequency(clocks) * 16)
+                ((self.function_clock_frequency() * 16)
                     / ((config.integral() * 16) + config.fractional()))
             }
-            pub fn baud_rate_generator_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn baud_rate_generator_frequency(self) -> u32 {
                 UART_BAUD_RATE_GENERATOR_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }

--- a/esp-metadata-generated/src/_generated_esp32c3.rs
+++ b/esp-metadata-generated/src/_generated_esp32c3.rs
@@ -1653,8 +1653,8 @@ macro_rules! define_clock_tree_types {
             [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
             let old_config = clocks.xtal_clk.replace(config);
-            configure_xtal_clk_impl(clocks, old_config, config);
             refresh_xtal_clk_downstream(clocks);
+            configure_xtal_clk_impl(clocks, old_config, config);
         }
         pub fn xtal_clk_config(clocks: &mut ClockTree) -> Option<XtalClkConfig> {
             clocks.xtal_clk
@@ -1670,8 +1670,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_pll_clk(clocks: &mut ClockTree, config: PllClkConfig) {
             let old_config = clocks.pll_clk.replace(config);
-            configure_pll_clk_impl(clocks, old_config, config);
             refresh_pll_clk_downstream(clocks);
+            configure_pll_clk_impl(clocks, old_config, config);
         }
         pub fn pll_clk_config(clocks: &mut ClockTree) -> Option<PllClkConfig> {
             clocks.pll_clk
@@ -1770,6 +1770,7 @@ macro_rules! define_clock_tree_types {
             new_selector: SystemPreDivInConfig,
         ) {
             let old_selector = clocks.system_pre_div_in.replace(new_selector);
+            refresh_system_pre_div_in_downstream(clocks);
             match new_selector {
                 SystemPreDivInConfig::Xtal => request_xtal_clk(clocks),
                 SystemPreDivInConfig::RcFast => request_rc_fast_clk(clocks),
@@ -1781,7 +1782,6 @@ macro_rules! define_clock_tree_types {
                     SystemPreDivInConfig::RcFast => release_rc_fast_clk(clocks),
                 }
             }
-            refresh_system_pre_div_in_downstream(clocks);
         }
         pub fn system_pre_div_in_config(clocks: &mut ClockTree) -> Option<SystemPreDivInConfig> {
             clocks.system_pre_div_in
@@ -1819,8 +1819,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_system_pre_div(clocks: &mut ClockTree, config: SystemPreDivConfig) {
             let old_config = clocks.system_pre_div.replace(config);
-            configure_system_pre_div_impl(clocks, old_config, config);
             refresh_system_pre_div_downstream(clocks);
+            configure_system_pre_div_impl(clocks, old_config, config);
         }
         pub fn system_pre_div_config(clocks: &mut ClockTree) -> Option<SystemPreDivConfig> {
             clocks.system_pre_div
@@ -1849,8 +1849,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_cpu_pll_div_out(clocks: &mut ClockTree, config: CpuPllDivOutConfig) {
             let old_config = clocks.cpu_pll_div_out.replace(config);
-            configure_cpu_pll_div_out_impl(clocks, old_config, config);
             refresh_cpu_pll_div_out_downstream(clocks);
+            configure_cpu_pll_div_out_impl(clocks, old_config, config);
         }
         pub fn cpu_pll_div_out_config(clocks: &mut ClockTree) -> Option<CpuPllDivOutConfig> {
             clocks.cpu_pll_div_out
@@ -1879,6 +1879,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, new_selector: ApbClkConfig) {
             let old_selector = clocks.apb_clk.replace(new_selector);
+            refresh_apb_clk_downstream(clocks);
             if clocks.apb_clk_refcount > 0 {
                 match new_selector {
                     ApbClkConfig::Pll80m => request_pll_80m(clocks),
@@ -1894,7 +1895,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_apb_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_apb_clk_downstream(clocks);
         }
         pub fn apb_clk_config(clocks: &mut ClockTree) -> Option<ApbClkConfig> {
             clocks.apb_clk
@@ -1933,6 +1933,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_crypto_clk(clocks: &mut ClockTree, new_selector: CryptoClkConfig) {
             let old_selector = clocks.crypto_clk.replace(new_selector);
+            refresh_crypto_clk_downstream(clocks);
             if clocks.crypto_clk_refcount > 0 {
                 match new_selector {
                     CryptoClkConfig::Pll160m => request_pll_160m(clocks),
@@ -1948,7 +1949,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_crypto_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_crypto_clk_downstream(clocks);
         }
         pub fn crypto_clk_config(clocks: &mut ClockTree) -> Option<CryptoClkConfig> {
             clocks.crypto_clk
@@ -1987,6 +1987,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, new_selector: CpuClkConfig) {
             let old_selector = clocks.cpu_clk.replace(new_selector);
+            refresh_cpu_clk_downstream(clocks);
             match new_selector {
                 CpuClkConfig::Xtal => {
                     configure_apb_clk(clocks, ApbClkConfig::Cpu);
@@ -2016,7 +2017,6 @@ macro_rules! define_clock_tree_types {
                     CpuClkConfig::Pll => release_cpu_pll_div_out(clocks),
                 }
             }
-            refresh_cpu_clk_downstream(clocks);
         }
         pub fn cpu_clk_config(clocks: &mut ClockTree) -> Option<CpuClkConfig> {
             clocks.cpu_clk
@@ -2066,8 +2066,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_rc_fast_clk_div_n(clocks: &mut ClockTree, config: RcFastClkDivNConfig) {
             let old_config = clocks.rc_fast_clk_div_n.replace(config);
-            configure_rc_fast_clk_div_n_impl(clocks, old_config, config);
             refresh_rc_fast_clk_div_n_downstream(clocks);
+            configure_rc_fast_clk_div_n_impl(clocks, old_config, config);
         }
         pub fn rc_fast_clk_div_n_config(clocks: &mut ClockTree) -> Option<RcFastClkDivNConfig> {
             clocks.rc_fast_clk_div_n
@@ -2111,6 +2111,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_rtc_slow_clk(clocks: &mut ClockTree, new_selector: RtcSlowClkConfig) {
             let old_selector = clocks.rtc_slow_clk.replace(new_selector);
+            refresh_rtc_slow_clk_downstream(clocks);
             match new_selector {
                 RtcSlowClkConfig::Xtal32k => request_xtal32k_clk(clocks),
                 RtcSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
@@ -2124,7 +2125,6 @@ macro_rules! define_clock_tree_types {
                     RtcSlowClkConfig::RcFast => release_rc_fast_div_clk(clocks),
                 }
             }
-            refresh_rtc_slow_clk_downstream(clocks);
         }
         pub fn rtc_slow_clk_config(clocks: &mut ClockTree) -> Option<RtcSlowClkConfig> {
             clocks.rtc_slow_clk
@@ -2165,6 +2165,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_rtc_fast_clk(clocks: &mut ClockTree, new_selector: RtcFastClkConfig) {
             let old_selector = clocks.rtc_fast_clk.replace(new_selector);
+            refresh_rtc_fast_clk_downstream(clocks);
             if clocks.rtc_fast_clk_refcount > 0 {
                 match new_selector {
                     RtcFastClkConfig::Xtal => request_xtal_div_clk(clocks),
@@ -2180,7 +2181,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_rtc_fast_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_rtc_fast_clk_downstream(clocks);
         }
         pub fn rtc_fast_clk_config(clocks: &mut ClockTree) -> Option<RtcFastClkConfig> {
             clocks.rtc_fast_clk
@@ -2222,6 +2222,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_low_power_clk(clocks: &mut ClockTree, new_selector: LowPowerClkConfig) {
             let old_selector = clocks.low_power_clk.replace(new_selector);
+            refresh_low_power_clk_downstream(clocks);
             if clocks.low_power_clk_refcount > 0 {
                 match new_selector {
                     LowPowerClkConfig::Xtal => request_xtal_clk(clocks),
@@ -2241,7 +2242,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_low_power_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_low_power_clk_downstream(clocks);
         }
         pub fn low_power_clk_config(clocks: &mut ClockTree) -> Option<LowPowerClkConfig> {
             clocks.low_power_clk
@@ -2311,6 +2311,7 @@ macro_rules! define_clock_tree_types {
             new_selector: TimgCalibrationClockConfig,
         ) {
             let old_selector = clocks.timg_calibration_clock.replace(new_selector);
+            refresh_timg_calibration_clock_downstream(clocks);
             if clocks.timg_calibration_clock_refcount > 0 {
                 match new_selector {
                     TimgCalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
@@ -2328,7 +2329,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
             }
-            refresh_timg_calibration_clock_downstream(clocks);
         }
         pub fn timg_calibration_clock_config(
             clocks: &mut ClockTree,
@@ -2376,6 +2376,7 @@ macro_rules! define_clock_tree_types {
         impl RmtInstance {
             pub fn configure_sclk(self, clocks: &mut ClockTree, new_selector: RmtSclkConfig) {
                 let old_selector = clocks.rmt_sclk[self as usize].replace(new_selector);
+                refresh_rmt_sclk_downstream(clocks, self);
                 if clocks.rmt_sclk_refcount[self as usize] > 0 {
                     match new_selector {
                         RmtSclkConfig::ApbClk => request_apb_clk(clocks),
@@ -2393,7 +2394,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_sclk_impl(clocks, old_selector, new_selector);
                 }
-                refresh_rmt_sclk_downstream(clocks, self);
             }
             pub fn sclk_config(self, clocks: &mut ClockTree) -> Option<RmtSclkConfig> {
                 clocks.rmt_sclk[self as usize]
@@ -2445,6 +2445,7 @@ macro_rules! define_clock_tree_types {
                 new_selector: TimgFunctionClockConfig,
             ) {
                 let old_selector = clocks.timg_function_clock[self as usize].replace(new_selector);
+                refresh_timg_function_clock_downstream(clocks, self);
                 if clocks.timg_function_clock_refcount[self as usize] > 0 {
                     match new_selector {
                         TimgFunctionClockConfig::XtalClk => request_xtal_clk(clocks),
@@ -2460,7 +2461,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_timg_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -2515,6 +2515,7 @@ macro_rules! define_clock_tree_types {
                 new_selector: TimgWdtClockConfig,
             ) {
                 let old_selector = clocks.timg_wdt_clock[self as usize].replace(new_selector);
+                refresh_timg_wdt_clock_downstream(clocks, self);
                 if clocks.timg_wdt_clock_refcount[self as usize] > 0 {
                     match new_selector {
                         TimgWdtClockConfig::ApbClk => request_apb_clk(clocks),
@@ -2530,7 +2531,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_wdt_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_timg_wdt_clock_downstream(clocks, self);
             }
             pub fn wdt_clock_config(self, clocks: &mut ClockTree) -> Option<TimgWdtClockConfig> {
                 clocks.timg_wdt_clock[self as usize]
@@ -2580,6 +2580,7 @@ macro_rules! define_clock_tree_types {
                 config: UartFunctionClockConfig,
             ) {
                 let old_config = clocks.uart_function_clock[self as usize].replace(config);
+                refresh_uart_function_clock_downstream(clocks, self);
                 if clocks.uart_function_clock_refcount[self as usize] > 0 {
                     match config.sclk {
                         UartFunctionClockSclk::Apb => request_apb_clk(clocks),
@@ -2597,7 +2598,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_config, config);
                 }
-                refresh_uart_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -2651,8 +2651,8 @@ macro_rules! define_clock_tree_types {
             }
             pub fn configure_mem_clock(self, clocks: &mut ClockTree, config: UartMemClockConfig) {
                 let old_config = clocks.uart_mem_clock[self as usize].replace(config);
-                self.configure_mem_clock_impl(clocks, old_config, config);
                 refresh_uart_mem_clock_downstream(clocks, self);
+                self.configure_mem_clock_impl(clocks, old_config, config);
             }
             pub fn mem_clock_config(self, clocks: &mut ClockTree) -> Option<UartMemClockConfig> {
                 clocks.uart_mem_clock[self as usize]
@@ -2691,8 +2691,8 @@ macro_rules! define_clock_tree_types {
                 config: UartBaudRateGeneratorConfig,
             ) {
                 let old_config = clocks.uart_baud_rate_generator[self as usize].replace(config);
-                self.configure_baud_rate_generator_impl(clocks, old_config, config);
                 refresh_uart_baud_rate_generator_downstream(clocks, self);
+                self.configure_baud_rate_generator_impl(clocks, old_config, config);
             }
             pub fn baud_rate_generator_config(
                 self,

--- a/esp-metadata-generated/src/_generated_esp32c3.rs
+++ b/esp-metadata-generated/src/_generated_esp32c3.rs
@@ -1654,7 +1654,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
             let old_config = clocks.xtal_clk.replace(config);
             configure_xtal_clk_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_xtal_clk_downstream(clocks);
         }
         pub fn xtal_clk_config(clocks: &mut ClockTree) -> Option<XtalClkConfig> {
             clocks.xtal_clk
@@ -1671,7 +1671,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_pll_clk(clocks: &mut ClockTree, config: PllClkConfig) {
             let old_config = clocks.pll_clk.replace(config);
             configure_pll_clk_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_pll_clk_downstream(clocks);
         }
         pub fn pll_clk_config(clocks: &mut ClockTree) -> Option<PllClkConfig> {
             clocks.pll_clk
@@ -1781,7 +1781,7 @@ macro_rules! define_clock_tree_types {
                     SystemPreDivInConfig::RcFast => release_rc_fast_clk(clocks),
                 }
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_system_pre_div_in_downstream(clocks);
         }
         pub fn system_pre_div_in_config(clocks: &mut ClockTree) -> Option<SystemPreDivInConfig> {
             clocks.system_pre_div_in
@@ -1820,7 +1820,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_system_pre_div(clocks: &mut ClockTree, config: SystemPreDivConfig) {
             let old_config = clocks.system_pre_div.replace(config);
             configure_system_pre_div_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_system_pre_div_downstream(clocks);
         }
         pub fn system_pre_div_config(clocks: &mut ClockTree) -> Option<SystemPreDivConfig> {
             clocks.system_pre_div
@@ -1850,7 +1850,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_cpu_pll_div_out(clocks: &mut ClockTree, config: CpuPllDivOutConfig) {
             let old_config = clocks.cpu_pll_div_out.replace(config);
             configure_cpu_pll_div_out_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_cpu_pll_div_out_downstream(clocks);
         }
         pub fn cpu_pll_div_out_config(clocks: &mut ClockTree) -> Option<CpuPllDivOutConfig> {
             clocks.cpu_pll_div_out
@@ -1894,7 +1894,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_apb_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_apb_clk_downstream(clocks);
         }
         pub fn apb_clk_config(clocks: &mut ClockTree) -> Option<ApbClkConfig> {
             clocks.apb_clk
@@ -1948,7 +1948,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_crypto_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_crypto_clk_downstream(clocks);
         }
         pub fn crypto_clk_config(clocks: &mut ClockTree) -> Option<CryptoClkConfig> {
             clocks.crypto_clk
@@ -2016,7 +2016,7 @@ macro_rules! define_clock_tree_types {
                     CpuClkConfig::Pll => release_cpu_pll_div_out(clocks),
                 }
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_cpu_clk_downstream(clocks);
         }
         pub fn cpu_clk_config(clocks: &mut ClockTree) -> Option<CpuClkConfig> {
             clocks.cpu_clk
@@ -2067,7 +2067,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_rc_fast_clk_div_n(clocks: &mut ClockTree, config: RcFastClkDivNConfig) {
             let old_config = clocks.rc_fast_clk_div_n.replace(config);
             configure_rc_fast_clk_div_n_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_rc_fast_clk_div_n_downstream(clocks);
         }
         pub fn rc_fast_clk_div_n_config(clocks: &mut ClockTree) -> Option<RcFastClkDivNConfig> {
             clocks.rc_fast_clk_div_n
@@ -2124,7 +2124,7 @@ macro_rules! define_clock_tree_types {
                     RtcSlowClkConfig::RcFast => release_rc_fast_div_clk(clocks),
                 }
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_rtc_slow_clk_downstream(clocks);
         }
         pub fn rtc_slow_clk_config(clocks: &mut ClockTree) -> Option<RtcSlowClkConfig> {
             clocks.rtc_slow_clk
@@ -2180,7 +2180,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_rtc_fast_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_rtc_fast_clk_downstream(clocks);
         }
         pub fn rtc_fast_clk_config(clocks: &mut ClockTree) -> Option<RtcFastClkConfig> {
             clocks.rtc_fast_clk
@@ -2241,7 +2241,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_low_power_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_low_power_clk_downstream(clocks);
         }
         pub fn low_power_clk_config(clocks: &mut ClockTree) -> Option<LowPowerClkConfig> {
             clocks.low_power_clk
@@ -2328,7 +2328,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_timg_calibration_clock_downstream(clocks);
         }
         pub fn timg_calibration_clock_config(
             clocks: &mut ClockTree,
@@ -2393,7 +2393,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_sclk_impl(clocks, old_selector, new_selector);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_rmt_sclk_downstream(clocks, self);
             }
             pub fn sclk_config(self, clocks: &mut ClockTree) -> Option<RmtSclkConfig> {
                 clocks.rmt_sclk[self as usize]
@@ -2460,7 +2460,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_timg_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -2530,7 +2530,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_wdt_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_timg_wdt_clock_downstream(clocks, self);
             }
             pub fn wdt_clock_config(self, clocks: &mut ClockTree) -> Option<TimgWdtClockConfig> {
                 clocks.timg_wdt_clock[self as usize]
@@ -2597,7 +2597,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_config, config);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_uart_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -2652,7 +2652,7 @@ macro_rules! define_clock_tree_types {
             pub fn configure_mem_clock(self, clocks: &mut ClockTree, config: UartMemClockConfig) {
                 let old_config = clocks.uart_mem_clock[self as usize].replace(config);
                 self.configure_mem_clock_impl(clocks, old_config, config);
-                refresh_all_frequency_caches(clocks);
+                refresh_uart_mem_clock_downstream(clocks, self);
             }
             pub fn mem_clock_config(self, clocks: &mut ClockTree) -> Option<UartMemClockConfig> {
                 clocks.uart_mem_clock[self as usize]
@@ -2692,7 +2692,7 @@ macro_rules! define_clock_tree_types {
             ) {
                 let old_config = clocks.uart_baud_rate_generator[self as usize].replace(config);
                 self.configure_baud_rate_generator_impl(clocks, old_config, config);
-                refresh_all_frequency_caches(clocks);
+                refresh_uart_baud_rate_generator_downstream(clocks, self);
             }
             pub fn baud_rate_generator_config(
                 self,
@@ -2812,132 +2812,220 @@ macro_rules! define_clock_tree_types {
             let last = *refcount == 0;
             last
         }
-        fn refresh_all_frequency_caches(clocks: &mut ClockTree) {
+        fn refresh_xtal_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.xtal_clk {
                 XTAL_CLK_FREQ_CACHE.store(
                     xtal_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_pll_clk_downstream(clocks);
+            refresh_system_pre_div_in_downstream(clocks);
+            refresh_rtc_fast_clk_downstream(clocks);
+            refresh_low_power_clk_downstream(clocks);
+            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                refresh_uart_mem_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                refresh_uart_mem_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [RmtInstance::Rmt] {
+                refresh_rmt_sclk_downstream(clocks, child_instance);
+            }
+            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                refresh_timg_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                refresh_timg_wdt_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                refresh_timg_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                refresh_timg_wdt_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                refresh_uart_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                refresh_uart_function_clock_downstream(clocks, child_instance);
+            }
+        }
+        fn refresh_pll_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.pll_clk {
                 PLL_CLK_FREQ_CACHE.store(
                     pll_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_cpu_pll_div_out_downstream(clocks);
+        }
+        fn refresh_system_pre_div_in_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.system_pre_div_in {
                 SYSTEM_PRE_DIV_IN_FREQ_CACHE.store(
                     system_pre_div_in_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_system_pre_div_downstream(clocks);
+        }
+        fn refresh_system_pre_div_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.system_pre_div {
                 SYSTEM_PRE_DIV_FREQ_CACHE.store(
                     system_pre_div_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_cpu_clk_downstream(clocks);
+        }
+        fn refresh_cpu_pll_div_out_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.cpu_pll_div_out {
                 CPU_PLL_DIV_OUT_FREQ_CACHE.store(
                     cpu_pll_div_out_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_cpu_clk_downstream(clocks);
+        }
+        fn refresh_cpu_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.cpu_clk {
                 CPU_CLK_FREQ_CACHE.store(
                     cpu_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_apb_clk_downstream(clocks);
+            refresh_crypto_clk_downstream(clocks);
+        }
+        fn refresh_rc_fast_clk_div_n_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.rc_fast_clk_div_n {
                 RC_FAST_CLK_DIV_N_FREQ_CACHE.store(
                     rc_fast_clk_div_n_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_rtc_fast_clk_downstream(clocks);
+        }
+        fn refresh_rtc_slow_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.rtc_slow_clk {
                 RTC_SLOW_CLK_FREQ_CACHE.store(
                     rtc_slow_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_low_power_clk_downstream(clocks);
+        }
+        fn refresh_rtc_fast_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.rtc_fast_clk {
                 RTC_FAST_CLK_FREQ_CACHE.store(
                     rtc_fast_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+        }
+        fn refresh_low_power_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.low_power_clk {
                 LOW_POWER_CLK_FREQ_CACHE.store(
                     low_power_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+        }
+        fn refresh_timg_calibration_clock_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.timg_calibration_clock {
                 TIMG_CALIBRATION_CLOCK_FREQ_CACHE.store(
                     timg_calibration_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
-            for instance in [UartInstance::Uart0, UartInstance::Uart1] {
-                if let Some(config) = clocks.uart_mem_clock[instance as usize] {
-                    UART_MEM_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.mem_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_uart_mem_clock_downstream(clocks: &mut ClockTree, instance: UartInstance) {
+            if let Some(config) = clocks.uart_mem_clock[instance as usize] {
+                UART_MEM_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.mem_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
+        }
+        fn refresh_apb_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.apb_clk {
                 APB_CLK_FREQ_CACHE.store(
                     apb_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            for child_instance in [RmtInstance::Rmt] {
+                refresh_rmt_sclk_downstream(clocks, child_instance);
+            }
+            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                refresh_timg_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                refresh_timg_wdt_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                refresh_timg_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                refresh_timg_wdt_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                refresh_uart_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                refresh_uart_function_clock_downstream(clocks, child_instance);
+            }
+        }
+        fn refresh_crypto_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.crypto_clk {
                 CRYPTO_CLK_FREQ_CACHE.store(
                     crypto_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
-            for instance in [RmtInstance::Rmt] {
-                if let Some(config) = clocks.rmt_sclk[instance as usize] {
-                    RMT_SCLK_FREQ_CACHE[instance as usize].store(
-                        instance.sclk_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_rmt_sclk_downstream(clocks: &mut ClockTree, instance: RmtInstance) {
+            if let Some(config) = clocks.rmt_sclk[instance as usize] {
+                RMT_SCLK_FREQ_CACHE[instance as usize].store(
+                    instance.sclk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
-            for instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
-                if let Some(config) = clocks.timg_function_clock[instance as usize] {
-                    TIMG_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.function_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_timg_function_clock_downstream(clocks: &mut ClockTree, instance: TimgInstance) {
+            if let Some(config) = clocks.timg_function_clock[instance as usize] {
+                TIMG_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.function_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
-            for instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
-                if let Some(config) = clocks.timg_wdt_clock[instance as usize] {
-                    TIMG_WDT_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.wdt_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_timg_wdt_clock_downstream(clocks: &mut ClockTree, instance: TimgInstance) {
+            if let Some(config) = clocks.timg_wdt_clock[instance as usize] {
+                TIMG_WDT_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.wdt_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
-            for instance in [UartInstance::Uart0, UartInstance::Uart1] {
-                if let Some(config) = clocks.uart_function_clock[instance as usize] {
-                    UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.function_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_uart_function_clock_downstream(clocks: &mut ClockTree, instance: UartInstance) {
+            if let Some(config) = clocks.uart_function_clock[instance as usize] {
+                UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.function_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
-            for instance in [UartInstance::Uart0, UartInstance::Uart1] {
-                if let Some(config) = clocks.uart_baud_rate_generator[instance as usize] {
-                    UART_BAUD_RATE_GENERATOR_FREQ_CACHE[instance as usize].store(
-                        instance.baud_rate_generator_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+            refresh_uart_baud_rate_generator_downstream(clocks, instance);
+        }
+        fn refresh_uart_baud_rate_generator_downstream(
+            clocks: &mut ClockTree,
+            instance: UartInstance,
+        ) {
+            if let Some(config) = clocks.uart_baud_rate_generator[instance as usize] {
+                UART_BAUD_RATE_GENERATOR_FREQ_CACHE[instance as usize].store(
+                    instance.baud_rate_generator_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
         }
     };

--- a/esp-metadata-generated/src/_generated_esp32c3.rs
+++ b/esp-metadata-generated/src/_generated_esp32c3.rs
@@ -1613,9 +1613,48 @@ macro_rules! define_clock_tree_types {
                 uart_mem_clock_refcount: [0; 2],
                 uart_baud_rate_generator_refcount: [0; 2],
             });
+        static XTAL_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static PLL_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static SYSTEM_PRE_DIV_IN_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static SYSTEM_PRE_DIV_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static CPU_PLL_DIV_OUT_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static CPU_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static RC_FAST_CLK_DIV_N_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static RTC_SLOW_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static RTC_FAST_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static LOW_POWER_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static TIMG_CALIBRATION_CLOCK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static UART_MEM_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 2] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
+        static APB_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static CRYPTO_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static RMT_SCLK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 1] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 1];
+        static TIMG_FUNCTION_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 2] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
+        static TIMG_WDT_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 2] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
+        static UART_FUNCTION_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 2] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
+        static UART_BAUD_RATE_GENERATOR_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 2] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
             let old_config = clocks.xtal_clk.replace(config);
             configure_xtal_clk_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn xtal_clk_config(clocks: &mut ClockTree) -> Option<XtalClkConfig> {
             clocks.xtal_clk
@@ -1626,16 +1665,13 @@ macro_rules! define_clock_tree_types {
         pub fn xtal_clk_config_frequency(clocks: &mut ClockTree, config: XtalClkConfig) -> u32 {
             config.value()
         }
-        pub fn xtal_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.xtal_clk {
-                xtal_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn xtal_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            XTAL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_pll_clk(clocks: &mut ClockTree, config: PllClkConfig) {
             let old_config = clocks.pll_clk.replace(config);
             configure_pll_clk_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn pll_clk_config(clocks: &mut ClockTree) -> Option<PllClkConfig> {
             clocks.pll_clk
@@ -1656,12 +1692,8 @@ macro_rules! define_clock_tree_types {
         pub fn pll_clk_config_frequency(clocks: &mut ClockTree, config: PllClkConfig) -> u32 {
             config.value()
         }
-        pub fn pll_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.pll_clk {
-                pll_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn pll_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            PLL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_rc_fast_clk(clocks: &mut ClockTree) {
             trace!("Requesting RC_FAST_CLK");
@@ -1749,6 +1781,7 @@ macro_rules! define_clock_tree_types {
                     SystemPreDivInConfig::RcFast => release_rc_fast_clk(clocks),
                 }
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn system_pre_div_in_config(clocks: &mut ClockTree) -> Option<SystemPreDivInConfig> {
             clocks.system_pre_div_in
@@ -1781,16 +1814,13 @@ macro_rules! define_clock_tree_types {
                 SystemPreDivInConfig::RcFast => rc_fast_clk_frequency(clocks),
             }
         }
-        pub fn system_pre_div_in_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.system_pre_div_in {
-                system_pre_div_in_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn system_pre_div_in_frequency(_clocks: &mut ClockTree) -> u32 {
+            SYSTEM_PRE_DIV_IN_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_system_pre_div(clocks: &mut ClockTree, config: SystemPreDivConfig) {
             let old_config = clocks.system_pre_div.replace(config);
             configure_system_pre_div_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn system_pre_div_config(clocks: &mut ClockTree) -> Option<SystemPreDivConfig> {
             clocks.system_pre_div
@@ -1814,16 +1844,13 @@ macro_rules! define_clock_tree_types {
         ) -> u32 {
             (system_pre_div_in_frequency(clocks) / (config.divisor() + 1))
         }
-        pub fn system_pre_div_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.system_pre_div {
-                system_pre_div_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn system_pre_div_frequency(_clocks: &mut ClockTree) -> u32 {
+            SYSTEM_PRE_DIV_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_cpu_pll_div_out(clocks: &mut ClockTree, config: CpuPllDivOutConfig) {
             let old_config = clocks.cpu_pll_div_out.replace(config);
             configure_cpu_pll_div_out_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn cpu_pll_div_out_config(clocks: &mut ClockTree) -> Option<CpuPllDivOutConfig> {
             clocks.cpu_pll_div_out
@@ -1847,12 +1874,8 @@ macro_rules! define_clock_tree_types {
         ) -> u32 {
             config.value()
         }
-        pub fn cpu_pll_div_out_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.cpu_pll_div_out {
-                cpu_pll_div_out_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn cpu_pll_div_out_frequency(_clocks: &mut ClockTree) -> u32 {
+            CPU_PLL_DIV_OUT_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, new_selector: ApbClkConfig) {
             let old_selector = clocks.apb_clk.replace(new_selector);
@@ -1871,6 +1894,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_apb_clk_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn apb_clk_config(clocks: &mut ClockTree) -> Option<ApbClkConfig> {
             clocks.apb_clk
@@ -1904,12 +1928,8 @@ macro_rules! define_clock_tree_types {
                 ApbClkConfig::Cpu => cpu_clk_frequency(clocks),
             }
         }
-        pub fn apb_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.apb_clk {
-                apb_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn apb_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            APB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_crypto_clk(clocks: &mut ClockTree, new_selector: CryptoClkConfig) {
             let old_selector = clocks.crypto_clk.replace(new_selector);
@@ -1928,6 +1948,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_crypto_clk_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn crypto_clk_config(clocks: &mut ClockTree) -> Option<CryptoClkConfig> {
             clocks.crypto_clk
@@ -1961,12 +1982,8 @@ macro_rules! define_clock_tree_types {
                 CryptoClkConfig::Cpu => cpu_clk_frequency(clocks),
             }
         }
-        pub fn crypto_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.crypto_clk {
-                crypto_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn crypto_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            CRYPTO_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, new_selector: CpuClkConfig) {
             let old_selector = clocks.cpu_clk.replace(new_selector);
@@ -1999,6 +2016,7 @@ macro_rules! define_clock_tree_types {
                     CpuClkConfig::Pll => release_cpu_pll_div_out(clocks),
                 }
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn cpu_clk_config(clocks: &mut ClockTree) -> Option<CpuClkConfig> {
             clocks.cpu_clk
@@ -2013,12 +2031,8 @@ macro_rules! define_clock_tree_types {
                 CpuClkConfig::Pll => cpu_pll_div_out_frequency(clocks),
             }
         }
-        pub fn cpu_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.cpu_clk {
-                cpu_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn cpu_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            CPU_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_pll_80m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_80M");
@@ -2053,6 +2067,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_rc_fast_clk_div_n(clocks: &mut ClockTree, config: RcFastClkDivNConfig) {
             let old_config = clocks.rc_fast_clk_div_n.replace(config);
             configure_rc_fast_clk_div_n_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn rc_fast_clk_div_n_config(clocks: &mut ClockTree) -> Option<RcFastClkDivNConfig> {
             clocks.rc_fast_clk_div_n
@@ -2076,12 +2091,8 @@ macro_rules! define_clock_tree_types {
         ) -> u32 {
             (rc_fast_clk_frequency(clocks) / (config.divisor() + 1))
         }
-        pub fn rc_fast_clk_div_n_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.rc_fast_clk_div_n {
-                rc_fast_clk_div_n_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn rc_fast_clk_div_n_frequency(_clocks: &mut ClockTree) -> u32 {
+            RC_FAST_CLK_DIV_N_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_xtal_div_clk(clocks: &mut ClockTree) {
             trace!("Requesting XTAL_DIV_CLK");
@@ -2113,6 +2124,7 @@ macro_rules! define_clock_tree_types {
                     RtcSlowClkConfig::RcFast => release_rc_fast_div_clk(clocks),
                 }
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn rtc_slow_clk_config(clocks: &mut ClockTree) -> Option<RtcSlowClkConfig> {
             clocks.rtc_slow_clk
@@ -2148,12 +2160,8 @@ macro_rules! define_clock_tree_types {
                 RtcSlowClkConfig::RcFast => rc_fast_div_clk_frequency(clocks),
             }
         }
-        pub fn rtc_slow_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.rtc_slow_clk {
-                rtc_slow_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn rtc_slow_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            RTC_SLOW_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_rtc_fast_clk(clocks: &mut ClockTree, new_selector: RtcFastClkConfig) {
             let old_selector = clocks.rtc_fast_clk.replace(new_selector);
@@ -2172,6 +2180,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_rtc_fast_clk_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn rtc_fast_clk_config(clocks: &mut ClockTree) -> Option<RtcFastClkConfig> {
             clocks.rtc_fast_clk
@@ -2208,12 +2217,8 @@ macro_rules! define_clock_tree_types {
                 RtcFastClkConfig::Rc => rc_fast_clk_div_n_frequency(clocks),
             }
         }
-        pub fn rtc_fast_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.rtc_fast_clk {
-                rtc_fast_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn rtc_fast_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            RTC_FAST_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_low_power_clk(clocks: &mut ClockTree, new_selector: LowPowerClkConfig) {
             let old_selector = clocks.low_power_clk.replace(new_selector);
@@ -2236,6 +2241,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_low_power_clk_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn low_power_clk_config(clocks: &mut ClockTree) -> Option<LowPowerClkConfig> {
             clocks.low_power_clk
@@ -2278,12 +2284,8 @@ macro_rules! define_clock_tree_types {
                 LowPowerClkConfig::RtcSlow => rtc_slow_clk_frequency(clocks),
             }
         }
-        pub fn low_power_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.low_power_clk {
-                low_power_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn low_power_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            LOW_POWER_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_uart_mem_clk(clocks: &mut ClockTree) {
             trace!("Requesting UART_MEM_CLK");
@@ -2326,6 +2328,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn timg_calibration_clock_config(
             clocks: &mut ClockTree,
@@ -2367,12 +2370,8 @@ macro_rules! define_clock_tree_types {
                 TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(clocks),
             }
         }
-        pub fn timg_calibration_clock_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.timg_calibration_clock {
-                timg_calibration_clock_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn timg_calibration_clock_frequency(_clocks: &mut ClockTree) -> u32 {
+            TIMG_CALIBRATION_CLOCK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         impl RmtInstance {
             pub fn configure_sclk(self, clocks: &mut ClockTree, new_selector: RmtSclkConfig) {
@@ -2394,6 +2393,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_sclk_impl(clocks, old_selector, new_selector);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn sclk_config(self, clocks: &mut ClockTree) -> Option<RmtSclkConfig> {
                 clocks.rmt_sclk[self as usize]
@@ -2434,12 +2434,8 @@ macro_rules! define_clock_tree_types {
                     RmtSclkConfig::XtalClk => xtal_clk_frequency(clocks),
                 }
             }
-            pub fn sclk_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.rmt_sclk[self as usize] {
-                    self.sclk_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn sclk_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                RMT_SCLK_FREQ_CACHE[self as usize].load(::core::sync::atomic::Ordering::Acquire)
             }
         }
         impl TimgInstance {
@@ -2464,6 +2460,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn function_clock_config(
                 self,
@@ -2508,12 +2505,9 @@ macro_rules! define_clock_tree_types {
                     TimgFunctionClockConfig::ApbClk => apb_clk_frequency(clocks),
                 }
             }
-            pub fn function_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.timg_function_clock[self as usize] {
-                    self.function_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                TIMG_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
             pub fn configure_wdt_clock(
                 self,
@@ -2536,6 +2530,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_wdt_clock_impl(clocks, old_selector, new_selector);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn wdt_clock_config(self, clocks: &mut ClockTree) -> Option<TimgWdtClockConfig> {
                 clocks.timg_wdt_clock[self as usize]
@@ -2573,12 +2568,9 @@ macro_rules! define_clock_tree_types {
                     TimgWdtClockConfig::XtalClk => xtal_clk_frequency(clocks),
                 }
             }
-            pub fn wdt_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.timg_wdt_clock[self as usize] {
-                    self.wdt_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn wdt_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                TIMG_WDT_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
         }
         impl UartInstance {
@@ -2605,6 +2597,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_config, config);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn function_clock_config(
                 self,
@@ -2652,16 +2645,14 @@ macro_rules! define_clock_tree_types {
                     UartFunctionClockSclk::Xtal => xtal_clk_frequency(clocks),
                 } / (config.div_num() + 1))
             }
-            pub fn function_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.uart_function_clock[self as usize] {
-                    self.function_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                UART_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
             pub fn configure_mem_clock(self, clocks: &mut ClockTree, config: UartMemClockConfig) {
                 let old_config = clocks.uart_mem_clock[self as usize].replace(config);
                 self.configure_mem_clock_impl(clocks, old_config, config);
+                refresh_all_frequency_caches(clocks);
             }
             pub fn mem_clock_config(self, clocks: &mut ClockTree) -> Option<UartMemClockConfig> {
                 clocks.uart_mem_clock[self as usize]
@@ -2690,12 +2681,9 @@ macro_rules! define_clock_tree_types {
             ) -> u32 {
                 uart_mem_clk_frequency(clocks)
             }
-            pub fn mem_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.uart_mem_clock[self as usize] {
-                    self.mem_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn mem_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                UART_MEM_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
             pub fn configure_baud_rate_generator(
                 self,
@@ -2704,6 +2692,7 @@ macro_rules! define_clock_tree_types {
             ) {
                 let old_config = clocks.uart_baud_rate_generator[self as usize].replace(config);
                 self.configure_baud_rate_generator_impl(clocks, old_config, config);
+                refresh_all_frequency_caches(clocks);
             }
             pub fn baud_rate_generator_config(
                 self,
@@ -2740,12 +2729,9 @@ macro_rules! define_clock_tree_types {
                 ((self.function_clock_frequency(clocks) * 16)
                     / ((config.integral() * 16) + config.fractional()))
             }
-            pub fn baud_rate_generator_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.uart_baud_rate_generator[self as usize] {
-                    self.baud_rate_generator_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn baud_rate_generator_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                UART_BAUD_RATE_GENERATOR_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
         }
         /// Clock tree configuration.
@@ -2825,6 +2811,134 @@ macro_rules! define_clock_tree_types {
             *refcount = refcount.saturating_sub(1);
             let last = *refcount == 0;
             last
+        }
+        fn refresh_all_frequency_caches(clocks: &mut ClockTree) {
+            if let Some(config) = clocks.xtal_clk {
+                XTAL_CLK_FREQ_CACHE.store(
+                    xtal_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.pll_clk {
+                PLL_CLK_FREQ_CACHE.store(
+                    pll_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.system_pre_div_in {
+                SYSTEM_PRE_DIV_IN_FREQ_CACHE.store(
+                    system_pre_div_in_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.system_pre_div {
+                SYSTEM_PRE_DIV_FREQ_CACHE.store(
+                    system_pre_div_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.cpu_pll_div_out {
+                CPU_PLL_DIV_OUT_FREQ_CACHE.store(
+                    cpu_pll_div_out_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.cpu_clk {
+                CPU_CLK_FREQ_CACHE.store(
+                    cpu_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.rc_fast_clk_div_n {
+                RC_FAST_CLK_DIV_N_FREQ_CACHE.store(
+                    rc_fast_clk_div_n_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.rtc_slow_clk {
+                RTC_SLOW_CLK_FREQ_CACHE.store(
+                    rtc_slow_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.rtc_fast_clk {
+                RTC_FAST_CLK_FREQ_CACHE.store(
+                    rtc_fast_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.low_power_clk {
+                LOW_POWER_CLK_FREQ_CACHE.store(
+                    low_power_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.timg_calibration_clock {
+                TIMG_CALIBRATION_CLOCK_FREQ_CACHE.store(
+                    timg_calibration_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            for instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                if let Some(config) = clocks.uart_mem_clock[instance as usize] {
+                    UART_MEM_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.mem_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            if let Some(config) = clocks.apb_clk {
+                APB_CLK_FREQ_CACHE.store(
+                    apb_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.crypto_clk {
+                CRYPTO_CLK_FREQ_CACHE.store(
+                    crypto_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            for instance in [RmtInstance::Rmt] {
+                if let Some(config) = clocks.rmt_sclk[instance as usize] {
+                    RMT_SCLK_FREQ_CACHE[instance as usize].store(
+                        instance.sclk_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                if let Some(config) = clocks.timg_function_clock[instance as usize] {
+                    TIMG_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.function_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                if let Some(config) = clocks.timg_wdt_clock[instance as usize] {
+                    TIMG_WDT_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.wdt_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                if let Some(config) = clocks.uart_function_clock[instance as usize] {
+                    UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.function_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                if let Some(config) = clocks.uart_baud_rate_generator[instance as usize] {
+                    UART_BAUD_RATE_GENERATOR_FREQ_CACHE[instance as usize].store(
+                        instance.baud_rate_generator_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
         }
     };
 }

--- a/esp-metadata-generated/src/_generated_esp32c3.rs
+++ b/esp-metadata-generated/src/_generated_esp32c3.rs
@@ -2825,30 +2825,14 @@ macro_rules! define_clock_tree_types {
             refresh_low_power_clk_downstream(clocks);
             for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
                 refresh_uart_mem_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
-                refresh_uart_mem_clock_downstream(clocks, child_instance);
+                refresh_uart_function_clock_downstream(clocks, child_instance);
             }
             for child_instance in [RmtInstance::Rmt] {
                 refresh_rmt_sclk_downstream(clocks, child_instance);
             }
             for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
                 refresh_timg_function_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
                 refresh_timg_wdt_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
-                refresh_timg_function_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
-                refresh_timg_wdt_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
-                refresh_uart_function_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
-                refresh_uart_function_clock_downstream(clocks, child_instance);
             }
         }
         fn refresh_pll_clk_downstream(clocks: &mut ClockTree) {
@@ -2959,18 +2943,7 @@ macro_rules! define_clock_tree_types {
             }
             for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
                 refresh_timg_function_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
                 refresh_timg_wdt_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
-                refresh_timg_function_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
-                refresh_timg_wdt_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
-                refresh_uart_function_clock_downstream(clocks, child_instance);
             }
             for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
                 refresh_uart_function_clock_downstream(clocks, child_instance);

--- a/esp-metadata-generated/src/_generated_esp32c3.rs
+++ b/esp-metadata-generated/src/_generated_esp32c3.rs
@@ -1665,7 +1665,7 @@ macro_rules! define_clock_tree_types {
         pub fn xtal_clk_config_frequency(clocks: &mut ClockTree, config: XtalClkConfig) -> u32 {
             config.value()
         }
-        pub fn xtal_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn xtal_clk_frequency() -> u32 {
             XTAL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_pll_clk(clocks: &mut ClockTree, config: PllClkConfig) {
@@ -1692,7 +1692,7 @@ macro_rules! define_clock_tree_types {
         pub fn pll_clk_config_frequency(clocks: &mut ClockTree, config: PllClkConfig) -> u32 {
             config.value()
         }
-        pub fn pll_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn pll_clk_frequency() -> u32 {
             PLL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_rc_fast_clk(clocks: &mut ClockTree) {
@@ -1709,7 +1709,7 @@ macro_rules! define_clock_tree_types {
                 enable_rc_fast_clk_impl(clocks, false);
             }
         }
-        pub fn rc_fast_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn rc_fast_clk_frequency() -> u32 {
             17500000
         }
         pub fn request_xtal32k_clk(clocks: &mut ClockTree) {
@@ -1726,7 +1726,7 @@ macro_rules! define_clock_tree_types {
                 enable_xtal32k_clk_impl(clocks, false);
             }
         }
-        pub fn xtal32k_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn xtal32k_clk_frequency() -> u32 {
             32768
         }
         pub fn request_rc_slow_clk(clocks: &mut ClockTree) {
@@ -1743,7 +1743,7 @@ macro_rules! define_clock_tree_types {
                 enable_rc_slow_clk_impl(clocks, false);
             }
         }
-        pub fn rc_slow_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn rc_slow_clk_frequency() -> u32 {
             136000
         }
         pub fn request_rc_fast_div_clk(clocks: &mut ClockTree) {
@@ -1762,8 +1762,8 @@ macro_rules! define_clock_tree_types {
                 release_rc_fast_clk(clocks);
             }
         }
-        pub fn rc_fast_div_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            (rc_fast_clk_frequency(clocks) / 256)
+        pub fn rc_fast_div_clk_frequency() -> u32 {
+            (rc_fast_clk_frequency() / 256)
         }
         pub fn configure_system_pre_div_in(
             clocks: &mut ClockTree,
@@ -1810,11 +1810,11 @@ macro_rules! define_clock_tree_types {
             config: SystemPreDivInConfig,
         ) -> u32 {
             match config {
-                SystemPreDivInConfig::Xtal => xtal_clk_frequency(clocks),
-                SystemPreDivInConfig::RcFast => rc_fast_clk_frequency(clocks),
+                SystemPreDivInConfig::Xtal => xtal_clk_frequency(),
+                SystemPreDivInConfig::RcFast => rc_fast_clk_frequency(),
             }
         }
-        pub fn system_pre_div_in_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn system_pre_div_in_frequency() -> u32 {
             SYSTEM_PRE_DIV_IN_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_system_pre_div(clocks: &mut ClockTree, config: SystemPreDivConfig) {
@@ -1842,9 +1842,9 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: SystemPreDivConfig,
         ) -> u32 {
-            (system_pre_div_in_frequency(clocks) / (config.divisor() + 1))
+            (system_pre_div_in_frequency() / (config.divisor() + 1))
         }
-        pub fn system_pre_div_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn system_pre_div_frequency() -> u32 {
             SYSTEM_PRE_DIV_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_cpu_pll_div_out(clocks: &mut ClockTree, config: CpuPllDivOutConfig) {
@@ -1874,7 +1874,7 @@ macro_rules! define_clock_tree_types {
         ) -> u32 {
             config.value()
         }
-        pub fn cpu_pll_div_out_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn cpu_pll_div_out_frequency() -> u32 {
             CPU_PLL_DIV_OUT_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, new_selector: ApbClkConfig) {
@@ -1924,11 +1924,11 @@ macro_rules! define_clock_tree_types {
         #[allow(unused_variables)]
         pub fn apb_clk_config_frequency(clocks: &mut ClockTree, config: ApbClkConfig) -> u32 {
             match config {
-                ApbClkConfig::Pll80m => pll_80m_frequency(clocks),
-                ApbClkConfig::Cpu => cpu_clk_frequency(clocks),
+                ApbClkConfig::Pll80m => pll_80m_frequency(),
+                ApbClkConfig::Cpu => cpu_clk_frequency(),
             }
         }
-        pub fn apb_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn apb_clk_frequency() -> u32 {
             APB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_crypto_clk(clocks: &mut ClockTree, new_selector: CryptoClkConfig) {
@@ -1978,11 +1978,11 @@ macro_rules! define_clock_tree_types {
         #[allow(unused_variables)]
         pub fn crypto_clk_config_frequency(clocks: &mut ClockTree, config: CryptoClkConfig) -> u32 {
             match config {
-                CryptoClkConfig::Pll160m => pll_160m_frequency(clocks),
-                CryptoClkConfig::Cpu => cpu_clk_frequency(clocks),
+                CryptoClkConfig::Pll160m => pll_160m_frequency(),
+                CryptoClkConfig::Cpu => cpu_clk_frequency(),
             }
         }
-        pub fn crypto_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn crypto_clk_frequency() -> u32 {
             CRYPTO_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, new_selector: CpuClkConfig) {
@@ -2026,12 +2026,12 @@ macro_rules! define_clock_tree_types {
         #[allow(unused_variables)]
         pub fn cpu_clk_config_frequency(clocks: &mut ClockTree, config: CpuClkConfig) -> u32 {
             match config {
-                CpuClkConfig::Xtal => system_pre_div_frequency(clocks),
-                CpuClkConfig::RcFast => system_pre_div_frequency(clocks),
-                CpuClkConfig::Pll => cpu_pll_div_out_frequency(clocks),
+                CpuClkConfig::Xtal => system_pre_div_frequency(),
+                CpuClkConfig::RcFast => system_pre_div_frequency(),
+                CpuClkConfig::Pll => cpu_pll_div_out_frequency(),
             }
         }
-        pub fn cpu_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn cpu_clk_frequency() -> u32 {
             CPU_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_pll_80m(clocks: &mut ClockTree) {
@@ -2046,7 +2046,7 @@ macro_rules! define_clock_tree_types {
             enable_pll_80m_impl(clocks, false);
             release_cpu_clk(clocks);
         }
-        pub fn pll_80m_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn pll_80m_frequency() -> u32 {
             80000000
         }
         pub fn request_pll_160m(clocks: &mut ClockTree) {
@@ -2061,7 +2061,7 @@ macro_rules! define_clock_tree_types {
             enable_pll_160m_impl(clocks, false);
             release_cpu_clk(clocks);
         }
-        pub fn pll_160m_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn pll_160m_frequency() -> u32 {
             160000000
         }
         pub fn configure_rc_fast_clk_div_n(clocks: &mut ClockTree, config: RcFastClkDivNConfig) {
@@ -2089,9 +2089,9 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: RcFastClkDivNConfig,
         ) -> u32 {
-            (rc_fast_clk_frequency(clocks) / (config.divisor() + 1))
+            (rc_fast_clk_frequency() / (config.divisor() + 1))
         }
-        pub fn rc_fast_clk_div_n_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn rc_fast_clk_div_n_frequency() -> u32 {
             RC_FAST_CLK_DIV_N_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_xtal_div_clk(clocks: &mut ClockTree) {
@@ -2106,8 +2106,8 @@ macro_rules! define_clock_tree_types {
             enable_xtal_div_clk_impl(clocks, false);
             release_xtal_clk(clocks);
         }
-        pub fn xtal_div_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            (xtal_clk_frequency(clocks) / 2)
+        pub fn xtal_div_clk_frequency() -> u32 {
+            (xtal_clk_frequency() / 2)
         }
         pub fn configure_rtc_slow_clk(clocks: &mut ClockTree, new_selector: RtcSlowClkConfig) {
             let old_selector = clocks.rtc_slow_clk.replace(new_selector);
@@ -2155,12 +2155,12 @@ macro_rules! define_clock_tree_types {
             config: RtcSlowClkConfig,
         ) -> u32 {
             match config {
-                RtcSlowClkConfig::Xtal32k => xtal32k_clk_frequency(clocks),
-                RtcSlowClkConfig::RcSlow => rc_slow_clk_frequency(clocks),
-                RtcSlowClkConfig::RcFast => rc_fast_div_clk_frequency(clocks),
+                RtcSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
+                RtcSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
+                RtcSlowClkConfig::RcFast => rc_fast_div_clk_frequency(),
             }
         }
-        pub fn rtc_slow_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn rtc_slow_clk_frequency() -> u32 {
             RTC_SLOW_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_rtc_fast_clk(clocks: &mut ClockTree, new_selector: RtcFastClkConfig) {
@@ -2213,11 +2213,11 @@ macro_rules! define_clock_tree_types {
             config: RtcFastClkConfig,
         ) -> u32 {
             match config {
-                RtcFastClkConfig::Xtal => xtal_div_clk_frequency(clocks),
-                RtcFastClkConfig::Rc => rc_fast_clk_div_n_frequency(clocks),
+                RtcFastClkConfig::Xtal => xtal_div_clk_frequency(),
+                RtcFastClkConfig::Rc => rc_fast_clk_div_n_frequency(),
             }
         }
-        pub fn rtc_fast_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn rtc_fast_clk_frequency() -> u32 {
             RTC_FAST_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_low_power_clk(clocks: &mut ClockTree, new_selector: LowPowerClkConfig) {
@@ -2278,13 +2278,13 @@ macro_rules! define_clock_tree_types {
             config: LowPowerClkConfig,
         ) -> u32 {
             match config {
-                LowPowerClkConfig::Xtal => xtal_clk_frequency(clocks),
-                LowPowerClkConfig::RcFast => rc_fast_clk_frequency(clocks),
-                LowPowerClkConfig::Xtal32k => xtal32k_clk_frequency(clocks),
-                LowPowerClkConfig::RtcSlow => rtc_slow_clk_frequency(clocks),
+                LowPowerClkConfig::Xtal => xtal_clk_frequency(),
+                LowPowerClkConfig::RcFast => rc_fast_clk_frequency(),
+                LowPowerClkConfig::Xtal32k => xtal32k_clk_frequency(),
+                LowPowerClkConfig::RtcSlow => rtc_slow_clk_frequency(),
             }
         }
-        pub fn low_power_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn low_power_clk_frequency() -> u32 {
             LOW_POWER_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_uart_mem_clk(clocks: &mut ClockTree) {
@@ -2303,8 +2303,8 @@ macro_rules! define_clock_tree_types {
                 release_xtal_clk(clocks);
             }
         }
-        pub fn uart_mem_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            xtal_clk_frequency(clocks)
+        pub fn uart_mem_clk_frequency() -> u32 {
+            xtal_clk_frequency()
         }
         pub fn configure_timg_calibration_clock(
             clocks: &mut ClockTree,
@@ -2365,12 +2365,12 @@ macro_rules! define_clock_tree_types {
             config: TimgCalibrationClockConfig,
         ) -> u32 {
             match config {
-                TimgCalibrationClockConfig::RcSlowClk => rc_slow_clk_frequency(clocks),
-                TimgCalibrationClockConfig::RcFastDivClk => rc_fast_div_clk_frequency(clocks),
-                TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(clocks),
+                TimgCalibrationClockConfig::RcSlowClk => rc_slow_clk_frequency(),
+                TimgCalibrationClockConfig::RcFastDivClk => rc_fast_div_clk_frequency(),
+                TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
             }
         }
-        pub fn timg_calibration_clock_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn timg_calibration_clock_frequency() -> u32 {
             TIMG_CALIBRATION_CLOCK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         impl RmtInstance {
@@ -2429,12 +2429,12 @@ macro_rules! define_clock_tree_types {
                 config: RmtSclkConfig,
             ) -> u32 {
                 match config {
-                    RmtSclkConfig::ApbClk => apb_clk_frequency(clocks),
-                    RmtSclkConfig::RcFastClk => rc_fast_clk_frequency(clocks),
-                    RmtSclkConfig::XtalClk => xtal_clk_frequency(clocks),
+                    RmtSclkConfig::ApbClk => apb_clk_frequency(),
+                    RmtSclkConfig::RcFastClk => rc_fast_clk_frequency(),
+                    RmtSclkConfig::XtalClk => xtal_clk_frequency(),
                 }
             }
-            pub fn sclk_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn sclk_frequency(self) -> u32 {
                 RMT_SCLK_FREQ_CACHE[self as usize].load(::core::sync::atomic::Ordering::Acquire)
             }
         }
@@ -2501,11 +2501,11 @@ macro_rules! define_clock_tree_types {
                 config: TimgFunctionClockConfig,
             ) -> u32 {
                 match config {
-                    TimgFunctionClockConfig::XtalClk => xtal_clk_frequency(clocks),
-                    TimgFunctionClockConfig::ApbClk => apb_clk_frequency(clocks),
+                    TimgFunctionClockConfig::XtalClk => xtal_clk_frequency(),
+                    TimgFunctionClockConfig::ApbClk => apb_clk_frequency(),
                 }
             }
-            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn function_clock_frequency(self) -> u32 {
                 TIMG_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -2564,11 +2564,11 @@ macro_rules! define_clock_tree_types {
                 config: TimgWdtClockConfig,
             ) -> u32 {
                 match config {
-                    TimgWdtClockConfig::ApbClk => apb_clk_frequency(clocks),
-                    TimgWdtClockConfig::XtalClk => xtal_clk_frequency(clocks),
+                    TimgWdtClockConfig::ApbClk => apb_clk_frequency(),
+                    TimgWdtClockConfig::XtalClk => xtal_clk_frequency(),
                 }
             }
-            pub fn wdt_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn wdt_clock_frequency(self) -> u32 {
                 TIMG_WDT_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -2640,12 +2640,12 @@ macro_rules! define_clock_tree_types {
                 config: UartFunctionClockConfig,
             ) -> u32 {
                 (match config.sclk {
-                    UartFunctionClockSclk::Apb => apb_clk_frequency(clocks),
-                    UartFunctionClockSclk::RcFast => rc_fast_clk_frequency(clocks),
-                    UartFunctionClockSclk::Xtal => xtal_clk_frequency(clocks),
+                    UartFunctionClockSclk::Apb => apb_clk_frequency(),
+                    UartFunctionClockSclk::RcFast => rc_fast_clk_frequency(),
+                    UartFunctionClockSclk::Xtal => xtal_clk_frequency(),
                 } / (config.div_num() + 1))
             }
-            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn function_clock_frequency(self) -> u32 {
                 UART_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -2679,9 +2679,9 @@ macro_rules! define_clock_tree_types {
                 clocks: &mut ClockTree,
                 config: UartMemClockConfig,
             ) -> u32 {
-                uart_mem_clk_frequency(clocks)
+                uart_mem_clk_frequency()
             }
-            pub fn mem_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn mem_clock_frequency(self) -> u32 {
                 UART_MEM_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -2726,10 +2726,10 @@ macro_rules! define_clock_tree_types {
                 clocks: &mut ClockTree,
                 config: UartBaudRateGeneratorConfig,
             ) -> u32 {
-                ((self.function_clock_frequency(clocks) * 16)
+                ((self.function_clock_frequency() * 16)
                     / ((config.integral() * 16) + config.fractional()))
             }
-            pub fn baud_rate_generator_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn baud_rate_generator_frequency(self) -> u32 {
                 UART_BAUD_RATE_GENERATOR_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }

--- a/esp-metadata-generated/src/_generated_esp32c5.rs
+++ b/esp-metadata-generated/src/_generated_esp32c5.rs
@@ -1747,9 +1747,42 @@ macro_rules! define_clock_tree_types {
                 uart_function_clock_refcount: [0; 2],
                 uart_baud_rate_generator_refcount: [0; 2],
             });
+        static XTAL_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static HP_ROOT_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static CPU_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static AHB_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static APB_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static LP_FAST_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static LP_SLOW_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static CRYPTO_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static TIMG_CALIBRATION_CLOCK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static PARL_IO_RX_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 1] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 1];
+        static PARL_IO_TX_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 1] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 1];
+        static RMT_SCLK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 1] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 1];
+        static TIMG_FUNCTION_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 2] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
+        static TIMG_WDT_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 2] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
+        static UART_FUNCTION_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 2] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
+        static UART_BAUD_RATE_GENERATOR_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 2] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
             let old_config = clocks.xtal_clk.replace(config);
             configure_xtal_clk_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn xtal_clk_config(clocks: &mut ClockTree) -> Option<XtalClkConfig> {
             clocks.xtal_clk
@@ -1760,12 +1793,8 @@ macro_rules! define_clock_tree_types {
         pub fn xtal_clk_config_frequency(clocks: &mut ClockTree, config: XtalClkConfig) -> u32 {
             config.value()
         }
-        pub fn xtal_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.xtal_clk {
-                xtal_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn xtal_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            XTAL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_pll_clk(clocks: &mut ClockTree) {
             trace!("Requesting PLL_CLK");
@@ -2042,6 +2071,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_hp_root_clk_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn hp_root_clk_config(clocks: &mut ClockTree) -> Option<HpRootClkConfig> {
             clocks.hp_root_clk
@@ -2084,16 +2114,13 @@ macro_rules! define_clock_tree_types {
                 HpRootClkConfig::PllF240m => pll_f240m_frequency(clocks),
             }
         }
-        pub fn hp_root_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.hp_root_clk {
-                hp_root_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn hp_root_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            HP_ROOT_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, config: CpuClkConfig) {
             let old_config = clocks.cpu_clk.replace(config);
             configure_cpu_clk_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn cpu_clk_config(clocks: &mut ClockTree) -> Option<CpuClkConfig> {
             clocks.cpu_clk
@@ -2118,16 +2145,13 @@ macro_rules! define_clock_tree_types {
         pub fn cpu_clk_config_frequency(clocks: &mut ClockTree, config: CpuClkConfig) -> u32 {
             (hp_root_clk_frequency(clocks) / (config.divisor() + 1))
         }
-        pub fn cpu_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.cpu_clk {
-                cpu_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn cpu_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            CPU_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_ahb_clk(clocks: &mut ClockTree, config: AhbClkConfig) {
             let old_config = clocks.ahb_clk.replace(config);
             configure_ahb_clk_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn ahb_clk_config(clocks: &mut ClockTree) -> Option<AhbClkConfig> {
             clocks.ahb_clk
@@ -2148,16 +2172,13 @@ macro_rules! define_clock_tree_types {
         pub fn ahb_clk_config_frequency(clocks: &mut ClockTree, config: AhbClkConfig) -> u32 {
             (hp_root_clk_frequency(clocks) / (config.divisor() + 1))
         }
-        pub fn ahb_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.ahb_clk {
-                ahb_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn ahb_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            AHB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, config: ApbClkConfig) {
             let old_config = clocks.apb_clk.replace(config);
             configure_apb_clk_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn apb_clk_config(clocks: &mut ClockTree) -> Option<ApbClkConfig> {
             clocks.apb_clk
@@ -2182,12 +2203,8 @@ macro_rules! define_clock_tree_types {
         pub fn apb_clk_config_frequency(clocks: &mut ClockTree, config: ApbClkConfig) -> u32 {
             (ahb_clk_frequency(clocks) / (config.divisor() + 1))
         }
-        pub fn apb_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.apb_clk {
-                apb_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn apb_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            APB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_xtal_d2_clk(clocks: &mut ClockTree) {
             trace!("Requesting XTAL_D2_CLK");
@@ -2223,6 +2240,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_lp_fast_clk_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn lp_fast_clk_config(clocks: &mut ClockTree) -> Option<LpFastClkConfig> {
             clocks.lp_fast_clk
@@ -2262,12 +2280,8 @@ macro_rules! define_clock_tree_types {
                 LpFastClkConfig::Xtal => xtal_clk_frequency(clocks),
             }
         }
-        pub fn lp_fast_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.lp_fast_clk {
-                lp_fast_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn lp_fast_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            LP_FAST_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_lp_slow_clk(clocks: &mut ClockTree, new_selector: LpSlowClkConfig) {
             let old_selector = clocks.lp_slow_clk.replace(new_selector);
@@ -2288,6 +2302,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_lp_slow_clk_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn lp_slow_clk_config(clocks: &mut ClockTree) -> Option<LpSlowClkConfig> {
             clocks.lp_slow_clk
@@ -2327,12 +2342,8 @@ macro_rules! define_clock_tree_types {
                 LpSlowClkConfig::OscSlow => osc_slow_clk_frequency(clocks),
             }
         }
-        pub fn lp_slow_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.lp_slow_clk {
-                lp_slow_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn lp_slow_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            LP_SLOW_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_crypto_clk(clocks: &mut ClockTree, new_selector: CryptoClkConfig) {
             let old_selector = clocks.crypto_clk.replace(new_selector);
@@ -2353,6 +2364,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_crypto_clk_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn crypto_clk_config(clocks: &mut ClockTree) -> Option<CryptoClkConfig> {
             clocks.crypto_clk
@@ -2389,12 +2401,8 @@ macro_rules! define_clock_tree_types {
                 CryptoClkConfig::PllF480m => pll_clk_frequency(clocks),
             }
         }
-        pub fn crypto_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.crypto_clk {
-                crypto_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn crypto_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            CRYPTO_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_timg_calibration_clock(
             clocks: &mut ClockTree,
@@ -2420,6 +2428,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn timg_calibration_clock_config(
             clocks: &mut ClockTree,
@@ -2464,12 +2473,8 @@ macro_rules! define_clock_tree_types {
                 TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(clocks),
             }
         }
-        pub fn timg_calibration_clock_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.timg_calibration_clock {
-                timg_calibration_clock_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn timg_calibration_clock_frequency(_clocks: &mut ClockTree) -> u32 {
+            TIMG_CALIBRATION_CLOCK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         impl ParlIoInstance {
             pub fn configure_rx_clock(
@@ -2495,6 +2500,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_rx_clock_impl(clocks, old_selector, new_selector);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn rx_clock_config(self, clocks: &mut ClockTree) -> Option<ParlIoRxClockConfig> {
                 clocks.parl_io_rx_clock[self as usize]
@@ -2535,12 +2541,9 @@ macro_rules! define_clock_tree_types {
                     ParlIoRxClockConfig::PllF240m => pll_f240m_frequency(clocks),
                 }
             }
-            pub fn rx_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.parl_io_rx_clock[self as usize] {
-                    self.rx_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn rx_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                PARL_IO_RX_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
             pub fn configure_tx_clock(
                 self,
@@ -2565,6 +2568,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_tx_clock_impl(clocks, old_selector, new_selector);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn tx_clock_config(self, clocks: &mut ClockTree) -> Option<ParlIoTxClockConfig> {
                 clocks.parl_io_tx_clock[self as usize]
@@ -2605,12 +2609,9 @@ macro_rules! define_clock_tree_types {
                     ParlIoTxClockConfig::PllF240m => pll_f240m_frequency(clocks),
                 }
             }
-            pub fn tx_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.parl_io_tx_clock[self as usize] {
-                    self.tx_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn tx_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                PARL_IO_TX_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
         }
         impl RmtInstance {
@@ -2633,6 +2634,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_sclk_impl(clocks, old_selector, new_selector);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn sclk_config(self, clocks: &mut ClockTree) -> Option<RmtSclkConfig> {
                 clocks.rmt_sclk[self as usize]
@@ -2673,12 +2675,8 @@ macro_rules! define_clock_tree_types {
                     RmtSclkConfig::PllF80m => pll_f80m_frequency(clocks),
                 }
             }
-            pub fn sclk_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.rmt_sclk[self as usize] {
-                    self.sclk_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn sclk_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                RMT_SCLK_FREQ_CACHE[self as usize].load(::core::sync::atomic::Ordering::Acquire)
             }
         }
         impl TimgInstance {
@@ -2705,6 +2703,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn function_clock_config(
                 self,
@@ -2752,12 +2751,9 @@ macro_rules! define_clock_tree_types {
                     TimgFunctionClockConfig::PllF80m => pll_f80m_frequency(clocks),
                 }
             }
-            pub fn function_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.timg_function_clock[self as usize] {
-                    self.function_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                TIMG_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
             pub fn configure_wdt_clock(
                 self,
@@ -2782,6 +2778,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_wdt_clock_impl(clocks, old_selector, new_selector);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn wdt_clock_config(self, clocks: &mut ClockTree) -> Option<TimgWdtClockConfig> {
                 clocks.timg_wdt_clock[self as usize]
@@ -2822,12 +2819,9 @@ macro_rules! define_clock_tree_types {
                     TimgWdtClockConfig::RcFastClk => rc_fast_clk_frequency(clocks),
                 }
             }
-            pub fn wdt_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.timg_wdt_clock[self as usize] {
-                    self.wdt_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn wdt_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                TIMG_WDT_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
         }
         impl UartInstance {
@@ -2854,6 +2848,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_config, config);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn function_clock_config(
                 self,
@@ -2901,12 +2896,9 @@ macro_rules! define_clock_tree_types {
                     UartFunctionClockSclk::RcFast => rc_fast_clk_frequency(clocks),
                 } / (config.div_num() + 1))
             }
-            pub fn function_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.uart_function_clock[self as usize] {
-                    self.function_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                UART_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
             pub fn configure_baud_rate_generator(
                 self,
@@ -2915,6 +2907,7 @@ macro_rules! define_clock_tree_types {
             ) {
                 let old_config = clocks.uart_baud_rate_generator[self as usize].replace(config);
                 self.configure_baud_rate_generator_impl(clocks, old_config, config);
+                refresh_all_frequency_caches(clocks);
             }
             pub fn baud_rate_generator_config(
                 self,
@@ -2951,12 +2944,9 @@ macro_rules! define_clock_tree_types {
                 ((self.function_clock_frequency(clocks) * 16)
                     / ((config.integral() * 16) + config.fractional()))
             }
-            pub fn baud_rate_generator_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.uart_baud_rate_generator[self as usize] {
-                    self.baud_rate_generator_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn baud_rate_generator_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                UART_BAUD_RATE_GENERATOR_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
         }
         /// Clock tree configuration.
@@ -3031,6 +3021,118 @@ macro_rules! define_clock_tree_types {
             *refcount = refcount.saturating_sub(1);
             let last = *refcount == 0;
             last
+        }
+        fn refresh_all_frequency_caches(clocks: &mut ClockTree) {
+            if let Some(config) = clocks.xtal_clk {
+                XTAL_CLK_FREQ_CACHE.store(
+                    xtal_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.hp_root_clk {
+                HP_ROOT_CLK_FREQ_CACHE.store(
+                    hp_root_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.cpu_clk {
+                CPU_CLK_FREQ_CACHE.store(
+                    cpu_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.ahb_clk {
+                AHB_CLK_FREQ_CACHE.store(
+                    ahb_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.apb_clk {
+                APB_CLK_FREQ_CACHE.store(
+                    apb_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.lp_fast_clk {
+                LP_FAST_CLK_FREQ_CACHE.store(
+                    lp_fast_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.lp_slow_clk {
+                LP_SLOW_CLK_FREQ_CACHE.store(
+                    lp_slow_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.crypto_clk {
+                CRYPTO_CLK_FREQ_CACHE.store(
+                    crypto_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.timg_calibration_clock {
+                TIMG_CALIBRATION_CLOCK_FREQ_CACHE.store(
+                    timg_calibration_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            for instance in [ParlIoInstance::ParlIo] {
+                if let Some(config) = clocks.parl_io_rx_clock[instance as usize] {
+                    PARL_IO_RX_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.rx_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [ParlIoInstance::ParlIo] {
+                if let Some(config) = clocks.parl_io_tx_clock[instance as usize] {
+                    PARL_IO_TX_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.tx_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [RmtInstance::Rmt] {
+                if let Some(config) = clocks.rmt_sclk[instance as usize] {
+                    RMT_SCLK_FREQ_CACHE[instance as usize].store(
+                        instance.sclk_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                if let Some(config) = clocks.timg_function_clock[instance as usize] {
+                    TIMG_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.function_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                if let Some(config) = clocks.timg_wdt_clock[instance as usize] {
+                    TIMG_WDT_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.wdt_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                if let Some(config) = clocks.uart_function_clock[instance as usize] {
+                    UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.function_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                if let Some(config) = clocks.uart_baud_rate_generator[instance as usize] {
+                    UART_BAUD_RATE_GENERATOR_FREQ_CACHE[instance as usize].store(
+                        instance.baud_rate_generator_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
         }
     };
 }

--- a/esp-metadata-generated/src/_generated_esp32c5.rs
+++ b/esp-metadata-generated/src/_generated_esp32c5.rs
@@ -3034,8 +3034,6 @@ macro_rules! define_clock_tree_types {
             refresh_crypto_clk_downstream(clocks);
             for child_instance in [ParlIoInstance::ParlIo] {
                 refresh_parl_io_rx_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [ParlIoInstance::ParlIo] {
                 refresh_parl_io_tx_clock_downstream(clocks, child_instance);
             }
             for child_instance in [RmtInstance::Rmt] {
@@ -3043,18 +3041,7 @@ macro_rules! define_clock_tree_types {
             }
             for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
                 refresh_timg_function_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
                 refresh_timg_wdt_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
-                refresh_timg_function_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
-                refresh_timg_wdt_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
-                refresh_uart_function_clock_downstream(clocks, child_instance);
             }
             for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
                 refresh_uart_function_clock_downstream(clocks, child_instance);

--- a/esp-metadata-generated/src/_generated_esp32c5.rs
+++ b/esp-metadata-generated/src/_generated_esp32c5.rs
@@ -1781,8 +1781,8 @@ macro_rules! define_clock_tree_types {
             [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
             let old_config = clocks.xtal_clk.replace(config);
-            configure_xtal_clk_impl(clocks, old_config, config);
             refresh_xtal_clk_downstream(clocks);
+            configure_xtal_clk_impl(clocks, old_config, config);
         }
         pub fn xtal_clk_config(clocks: &mut ClockTree) -> Option<XtalClkConfig> {
             clocks.xtal_clk
@@ -2052,6 +2052,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_hp_root_clk(clocks: &mut ClockTree, new_selector: HpRootClkConfig) {
             let old_selector = clocks.hp_root_clk.replace(new_selector);
+            refresh_hp_root_clk_downstream(clocks);
             if clocks.hp_root_clk_refcount > 0 {
                 match new_selector {
                     HpRootClkConfig::Xtal => request_xtal_clk(clocks),
@@ -2071,7 +2072,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_hp_root_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_hp_root_clk_downstream(clocks);
         }
         pub fn hp_root_clk_config(clocks: &mut ClockTree) -> Option<HpRootClkConfig> {
             clocks.hp_root_clk
@@ -2119,8 +2119,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, config: CpuClkConfig) {
             let old_config = clocks.cpu_clk.replace(config);
-            configure_cpu_clk_impl(clocks, old_config, config);
             refresh_cpu_clk_downstream(clocks);
+            configure_cpu_clk_impl(clocks, old_config, config);
         }
         pub fn cpu_clk_config(clocks: &mut ClockTree) -> Option<CpuClkConfig> {
             clocks.cpu_clk
@@ -2150,8 +2150,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_ahb_clk(clocks: &mut ClockTree, config: AhbClkConfig) {
             let old_config = clocks.ahb_clk.replace(config);
-            configure_ahb_clk_impl(clocks, old_config, config);
             refresh_ahb_clk_downstream(clocks);
+            configure_ahb_clk_impl(clocks, old_config, config);
         }
         pub fn ahb_clk_config(clocks: &mut ClockTree) -> Option<AhbClkConfig> {
             clocks.ahb_clk
@@ -2177,8 +2177,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, config: ApbClkConfig) {
             let old_config = clocks.apb_clk.replace(config);
-            configure_apb_clk_impl(clocks, old_config, config);
             refresh_apb_clk_downstream(clocks);
+            configure_apb_clk_impl(clocks, old_config, config);
         }
         pub fn apb_clk_config(clocks: &mut ClockTree) -> Option<ApbClkConfig> {
             clocks.apb_clk
@@ -2223,6 +2223,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_lp_fast_clk(clocks: &mut ClockTree, new_selector: LpFastClkConfig) {
             let old_selector = clocks.lp_fast_clk.replace(new_selector);
+            refresh_lp_fast_clk_downstream(clocks);
             if clocks.lp_fast_clk_refcount > 0 {
                 match new_selector {
                     LpFastClkConfig::RcFast => request_rc_fast_clk(clocks),
@@ -2240,7 +2241,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_lp_fast_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_lp_fast_clk_downstream(clocks);
         }
         pub fn lp_fast_clk_config(clocks: &mut ClockTree) -> Option<LpFastClkConfig> {
             clocks.lp_fast_clk
@@ -2285,6 +2285,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_lp_slow_clk(clocks: &mut ClockTree, new_selector: LpSlowClkConfig) {
             let old_selector = clocks.lp_slow_clk.replace(new_selector);
+            refresh_lp_slow_clk_downstream(clocks);
             if clocks.lp_slow_clk_refcount > 0 {
                 match new_selector {
                     LpSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
@@ -2302,7 +2303,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_lp_slow_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_lp_slow_clk_downstream(clocks);
         }
         pub fn lp_slow_clk_config(clocks: &mut ClockTree) -> Option<LpSlowClkConfig> {
             clocks.lp_slow_clk
@@ -2347,6 +2347,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_crypto_clk(clocks: &mut ClockTree, new_selector: CryptoClkConfig) {
             let old_selector = clocks.crypto_clk.replace(new_selector);
+            refresh_crypto_clk_downstream(clocks);
             if clocks.crypto_clk_refcount > 0 {
                 match new_selector {
                     CryptoClkConfig::Xtal => request_xtal_clk(clocks),
@@ -2364,7 +2365,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_crypto_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_crypto_clk_downstream(clocks);
         }
         pub fn crypto_clk_config(clocks: &mut ClockTree) -> Option<CryptoClkConfig> {
             clocks.crypto_clk
@@ -2409,6 +2409,7 @@ macro_rules! define_clock_tree_types {
             new_selector: TimgCalibrationClockConfig,
         ) {
             let old_selector = clocks.timg_calibration_clock.replace(new_selector);
+            refresh_timg_calibration_clock_downstream(clocks);
             if clocks.timg_calibration_clock_refcount > 0 {
                 match new_selector {
                     TimgCalibrationClockConfig::OscSlowClk => request_osc_slow_clk(clocks),
@@ -2428,7 +2429,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
             }
-            refresh_timg_calibration_clock_downstream(clocks);
         }
         pub fn timg_calibration_clock_config(
             clocks: &mut ClockTree,
@@ -2483,6 +2483,7 @@ macro_rules! define_clock_tree_types {
                 new_selector: ParlIoRxClockConfig,
             ) {
                 let old_selector = clocks.parl_io_rx_clock[self as usize].replace(new_selector);
+                refresh_parl_io_rx_clock_downstream(clocks, self);
                 if clocks.parl_io_rx_clock_refcount[self as usize] > 0 {
                     match new_selector {
                         ParlIoRxClockConfig::XtalClk => request_xtal_clk(clocks),
@@ -2500,7 +2501,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_rx_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_parl_io_rx_clock_downstream(clocks, self);
             }
             pub fn rx_clock_config(self, clocks: &mut ClockTree) -> Option<ParlIoRxClockConfig> {
                 clocks.parl_io_rx_clock[self as usize]
@@ -2551,6 +2551,7 @@ macro_rules! define_clock_tree_types {
                 new_selector: ParlIoTxClockConfig,
             ) {
                 let old_selector = clocks.parl_io_tx_clock[self as usize].replace(new_selector);
+                refresh_parl_io_tx_clock_downstream(clocks, self);
                 if clocks.parl_io_tx_clock_refcount[self as usize] > 0 {
                     match new_selector {
                         ParlIoTxClockConfig::XtalClk => request_xtal_clk(clocks),
@@ -2568,7 +2569,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_tx_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_parl_io_tx_clock_downstream(clocks, self);
             }
             pub fn tx_clock_config(self, clocks: &mut ClockTree) -> Option<ParlIoTxClockConfig> {
                 clocks.parl_io_tx_clock[self as usize]
@@ -2617,6 +2617,7 @@ macro_rules! define_clock_tree_types {
         impl RmtInstance {
             pub fn configure_sclk(self, clocks: &mut ClockTree, new_selector: RmtSclkConfig) {
                 let old_selector = clocks.rmt_sclk[self as usize].replace(new_selector);
+                refresh_rmt_sclk_downstream(clocks, self);
                 if clocks.rmt_sclk_refcount[self as usize] > 0 {
                     match new_selector {
                         RmtSclkConfig::XtalClk => request_xtal_clk(clocks),
@@ -2634,7 +2635,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_sclk_impl(clocks, old_selector, new_selector);
                 }
-                refresh_rmt_sclk_downstream(clocks, self);
             }
             pub fn sclk_config(self, clocks: &mut ClockTree) -> Option<RmtSclkConfig> {
                 clocks.rmt_sclk[self as usize]
@@ -2686,6 +2686,7 @@ macro_rules! define_clock_tree_types {
                 new_selector: TimgFunctionClockConfig,
             ) {
                 let old_selector = clocks.timg_function_clock[self as usize].replace(new_selector);
+                refresh_timg_function_clock_downstream(clocks, self);
                 if clocks.timg_function_clock_refcount[self as usize] > 0 {
                     match new_selector {
                         TimgFunctionClockConfig::XtalClk => request_xtal_clk(clocks),
@@ -2703,7 +2704,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_timg_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -2761,6 +2761,7 @@ macro_rules! define_clock_tree_types {
                 new_selector: TimgWdtClockConfig,
             ) {
                 let old_selector = clocks.timg_wdt_clock[self as usize].replace(new_selector);
+                refresh_timg_wdt_clock_downstream(clocks, self);
                 if clocks.timg_wdt_clock_refcount[self as usize] > 0 {
                     match new_selector {
                         TimgWdtClockConfig::XtalClk => request_xtal_clk(clocks),
@@ -2778,7 +2779,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_wdt_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_timg_wdt_clock_downstream(clocks, self);
             }
             pub fn wdt_clock_config(self, clocks: &mut ClockTree) -> Option<TimgWdtClockConfig> {
                 clocks.timg_wdt_clock[self as usize]
@@ -2831,6 +2831,7 @@ macro_rules! define_clock_tree_types {
                 config: UartFunctionClockConfig,
             ) {
                 let old_config = clocks.uart_function_clock[self as usize].replace(config);
+                refresh_uart_function_clock_downstream(clocks, self);
                 if clocks.uart_function_clock_refcount[self as usize] > 0 {
                     match config.sclk {
                         UartFunctionClockSclk::Xtal => request_xtal_clk(clocks),
@@ -2848,7 +2849,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_config, config);
                 }
-                refresh_uart_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -2906,8 +2906,8 @@ macro_rules! define_clock_tree_types {
                 config: UartBaudRateGeneratorConfig,
             ) {
                 let old_config = clocks.uart_baud_rate_generator[self as usize].replace(config);
-                self.configure_baud_rate_generator_impl(clocks, old_config, config);
                 refresh_uart_baud_rate_generator_downstream(clocks, self);
+                self.configure_baud_rate_generator_impl(clocks, old_config, config);
             }
             pub fn baud_rate_generator_config(
                 self,

--- a/esp-metadata-generated/src/_generated_esp32c5.rs
+++ b/esp-metadata-generated/src/_generated_esp32c5.rs
@@ -1782,7 +1782,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
             let old_config = clocks.xtal_clk.replace(config);
             configure_xtal_clk_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_xtal_clk_downstream(clocks);
         }
         pub fn xtal_clk_config(clocks: &mut ClockTree) -> Option<XtalClkConfig> {
             clocks.xtal_clk
@@ -2071,7 +2071,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_hp_root_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_hp_root_clk_downstream(clocks);
         }
         pub fn hp_root_clk_config(clocks: &mut ClockTree) -> Option<HpRootClkConfig> {
             clocks.hp_root_clk
@@ -2120,7 +2120,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_cpu_clk(clocks: &mut ClockTree, config: CpuClkConfig) {
             let old_config = clocks.cpu_clk.replace(config);
             configure_cpu_clk_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_cpu_clk_downstream(clocks);
         }
         pub fn cpu_clk_config(clocks: &mut ClockTree) -> Option<CpuClkConfig> {
             clocks.cpu_clk
@@ -2151,7 +2151,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_ahb_clk(clocks: &mut ClockTree, config: AhbClkConfig) {
             let old_config = clocks.ahb_clk.replace(config);
             configure_ahb_clk_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_ahb_clk_downstream(clocks);
         }
         pub fn ahb_clk_config(clocks: &mut ClockTree) -> Option<AhbClkConfig> {
             clocks.ahb_clk
@@ -2178,7 +2178,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_apb_clk(clocks: &mut ClockTree, config: ApbClkConfig) {
             let old_config = clocks.apb_clk.replace(config);
             configure_apb_clk_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_apb_clk_downstream(clocks);
         }
         pub fn apb_clk_config(clocks: &mut ClockTree) -> Option<ApbClkConfig> {
             clocks.apb_clk
@@ -2240,7 +2240,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_lp_fast_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_lp_fast_clk_downstream(clocks);
         }
         pub fn lp_fast_clk_config(clocks: &mut ClockTree) -> Option<LpFastClkConfig> {
             clocks.lp_fast_clk
@@ -2302,7 +2302,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_lp_slow_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_lp_slow_clk_downstream(clocks);
         }
         pub fn lp_slow_clk_config(clocks: &mut ClockTree) -> Option<LpSlowClkConfig> {
             clocks.lp_slow_clk
@@ -2364,7 +2364,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_crypto_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_crypto_clk_downstream(clocks);
         }
         pub fn crypto_clk_config(clocks: &mut ClockTree) -> Option<CryptoClkConfig> {
             clocks.crypto_clk
@@ -2428,7 +2428,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_timg_calibration_clock_downstream(clocks);
         }
         pub fn timg_calibration_clock_config(
             clocks: &mut ClockTree,
@@ -2500,7 +2500,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_rx_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_parl_io_rx_clock_downstream(clocks, self);
             }
             pub fn rx_clock_config(self, clocks: &mut ClockTree) -> Option<ParlIoRxClockConfig> {
                 clocks.parl_io_rx_clock[self as usize]
@@ -2568,7 +2568,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_tx_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_parl_io_tx_clock_downstream(clocks, self);
             }
             pub fn tx_clock_config(self, clocks: &mut ClockTree) -> Option<ParlIoTxClockConfig> {
                 clocks.parl_io_tx_clock[self as usize]
@@ -2634,7 +2634,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_sclk_impl(clocks, old_selector, new_selector);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_rmt_sclk_downstream(clocks, self);
             }
             pub fn sclk_config(self, clocks: &mut ClockTree) -> Option<RmtSclkConfig> {
                 clocks.rmt_sclk[self as usize]
@@ -2703,7 +2703,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_timg_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -2778,7 +2778,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_wdt_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_timg_wdt_clock_downstream(clocks, self);
             }
             pub fn wdt_clock_config(self, clocks: &mut ClockTree) -> Option<TimgWdtClockConfig> {
                 clocks.timg_wdt_clock[self as usize]
@@ -2848,7 +2848,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_config, config);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_uart_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -2907,7 +2907,7 @@ macro_rules! define_clock_tree_types {
             ) {
                 let old_config = clocks.uart_baud_rate_generator[self as usize].replace(config);
                 self.configure_baud_rate_generator_impl(clocks, old_config, config);
-                refresh_all_frequency_caches(clocks);
+                refresh_uart_baud_rate_generator_downstream(clocks, self);
             }
             pub fn baud_rate_generator_config(
                 self,
@@ -3022,116 +3022,169 @@ macro_rules! define_clock_tree_types {
             let last = *refcount == 0;
             last
         }
-        fn refresh_all_frequency_caches(clocks: &mut ClockTree) {
+        fn refresh_xtal_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.xtal_clk {
                 XTAL_CLK_FREQ_CACHE.store(
                     xtal_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_hp_root_clk_downstream(clocks);
+            refresh_lp_fast_clk_downstream(clocks);
+            refresh_crypto_clk_downstream(clocks);
+            for child_instance in [ParlIoInstance::ParlIo] {
+                refresh_parl_io_rx_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [ParlIoInstance::ParlIo] {
+                refresh_parl_io_tx_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [RmtInstance::Rmt] {
+                refresh_rmt_sclk_downstream(clocks, child_instance);
+            }
+            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                refresh_timg_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                refresh_timg_wdt_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                refresh_timg_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                refresh_timg_wdt_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                refresh_uart_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                refresh_uart_function_clock_downstream(clocks, child_instance);
+            }
+        }
+        fn refresh_hp_root_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.hp_root_clk {
                 HP_ROOT_CLK_FREQ_CACHE.store(
                     hp_root_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_cpu_clk_downstream(clocks);
+            refresh_ahb_clk_downstream(clocks);
+        }
+        fn refresh_cpu_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.cpu_clk {
                 CPU_CLK_FREQ_CACHE.store(
                     cpu_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+        }
+        fn refresh_ahb_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.ahb_clk {
                 AHB_CLK_FREQ_CACHE.store(
                     ahb_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_apb_clk_downstream(clocks);
+        }
+        fn refresh_apb_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.apb_clk {
                 APB_CLK_FREQ_CACHE.store(
                     apb_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+        }
+        fn refresh_lp_fast_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.lp_fast_clk {
                 LP_FAST_CLK_FREQ_CACHE.store(
                     lp_fast_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+        }
+        fn refresh_lp_slow_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.lp_slow_clk {
                 LP_SLOW_CLK_FREQ_CACHE.store(
                     lp_slow_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+        }
+        fn refresh_crypto_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.crypto_clk {
                 CRYPTO_CLK_FREQ_CACHE.store(
                     crypto_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+        }
+        fn refresh_timg_calibration_clock_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.timg_calibration_clock {
                 TIMG_CALIBRATION_CLOCK_FREQ_CACHE.store(
                     timg_calibration_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
-            for instance in [ParlIoInstance::ParlIo] {
-                if let Some(config) = clocks.parl_io_rx_clock[instance as usize] {
-                    PARL_IO_RX_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.rx_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_parl_io_rx_clock_downstream(clocks: &mut ClockTree, instance: ParlIoInstance) {
+            if let Some(config) = clocks.parl_io_rx_clock[instance as usize] {
+                PARL_IO_RX_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.rx_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
-            for instance in [ParlIoInstance::ParlIo] {
-                if let Some(config) = clocks.parl_io_tx_clock[instance as usize] {
-                    PARL_IO_TX_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.tx_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_parl_io_tx_clock_downstream(clocks: &mut ClockTree, instance: ParlIoInstance) {
+            if let Some(config) = clocks.parl_io_tx_clock[instance as usize] {
+                PARL_IO_TX_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.tx_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
-            for instance in [RmtInstance::Rmt] {
-                if let Some(config) = clocks.rmt_sclk[instance as usize] {
-                    RMT_SCLK_FREQ_CACHE[instance as usize].store(
-                        instance.sclk_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_rmt_sclk_downstream(clocks: &mut ClockTree, instance: RmtInstance) {
+            if let Some(config) = clocks.rmt_sclk[instance as usize] {
+                RMT_SCLK_FREQ_CACHE[instance as usize].store(
+                    instance.sclk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
-            for instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
-                if let Some(config) = clocks.timg_function_clock[instance as usize] {
-                    TIMG_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.function_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_timg_function_clock_downstream(clocks: &mut ClockTree, instance: TimgInstance) {
+            if let Some(config) = clocks.timg_function_clock[instance as usize] {
+                TIMG_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.function_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
-            for instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
-                if let Some(config) = clocks.timg_wdt_clock[instance as usize] {
-                    TIMG_WDT_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.wdt_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_timg_wdt_clock_downstream(clocks: &mut ClockTree, instance: TimgInstance) {
+            if let Some(config) = clocks.timg_wdt_clock[instance as usize] {
+                TIMG_WDT_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.wdt_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
-            for instance in [UartInstance::Uart0, UartInstance::Uart1] {
-                if let Some(config) = clocks.uart_function_clock[instance as usize] {
-                    UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.function_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_uart_function_clock_downstream(clocks: &mut ClockTree, instance: UartInstance) {
+            if let Some(config) = clocks.uart_function_clock[instance as usize] {
+                UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.function_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
-            for instance in [UartInstance::Uart0, UartInstance::Uart1] {
-                if let Some(config) = clocks.uart_baud_rate_generator[instance as usize] {
-                    UART_BAUD_RATE_GENERATOR_FREQ_CACHE[instance as usize].store(
-                        instance.baud_rate_generator_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+            refresh_uart_baud_rate_generator_downstream(clocks, instance);
+        }
+        fn refresh_uart_baud_rate_generator_downstream(
+            clocks: &mut ClockTree,
+            instance: UartInstance,
+        ) {
+            if let Some(config) = clocks.uart_baud_rate_generator[instance as usize] {
+                UART_BAUD_RATE_GENERATOR_FREQ_CACHE[instance as usize].store(
+                    instance.baud_rate_generator_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
         }
     };

--- a/esp-metadata-generated/src/_generated_esp32c5.rs
+++ b/esp-metadata-generated/src/_generated_esp32c5.rs
@@ -1793,7 +1793,7 @@ macro_rules! define_clock_tree_types {
         pub fn xtal_clk_config_frequency(clocks: &mut ClockTree, config: XtalClkConfig) -> u32 {
             config.value()
         }
-        pub fn xtal_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn xtal_clk_frequency() -> u32 {
             XTAL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_pll_clk(clocks: &mut ClockTree) {
@@ -1812,7 +1812,7 @@ macro_rules! define_clock_tree_types {
                 release_xtal_clk(clocks);
             }
         }
-        pub fn pll_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn pll_clk_frequency() -> u32 {
             480000000
         }
         pub fn request_rc_fast_clk(clocks: &mut ClockTree) {
@@ -1829,7 +1829,7 @@ macro_rules! define_clock_tree_types {
                 enable_rc_fast_clk_impl(clocks, false);
             }
         }
-        pub fn rc_fast_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn rc_fast_clk_frequency() -> u32 {
             20000000
         }
         pub fn request_xtal32k_clk(clocks: &mut ClockTree) {
@@ -1846,7 +1846,7 @@ macro_rules! define_clock_tree_types {
                 enable_xtal32k_clk_impl(clocks, false);
             }
         }
-        pub fn xtal32k_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn xtal32k_clk_frequency() -> u32 {
             32768
         }
         pub fn request_osc_slow_clk(clocks: &mut ClockTree) {
@@ -1863,7 +1863,7 @@ macro_rules! define_clock_tree_types {
                 enable_osc_slow_clk_impl(clocks, false);
             }
         }
-        pub fn osc_slow_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn osc_slow_clk_frequency() -> u32 {
             32768
         }
         pub fn request_rc_slow_clk(clocks: &mut ClockTree) {
@@ -1880,7 +1880,7 @@ macro_rules! define_clock_tree_types {
                 enable_rc_slow_clk_impl(clocks, false);
             }
         }
-        pub fn rc_slow_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn rc_slow_clk_frequency() -> u32 {
             130000
         }
         pub fn request_pll_f12m(clocks: &mut ClockTree) {
@@ -1899,8 +1899,8 @@ macro_rules! define_clock_tree_types {
                 release_pll_clk(clocks);
             }
         }
-        pub fn pll_f12m_frequency(clocks: &mut ClockTree) -> u32 {
-            (pll_clk_frequency(clocks) / 40)
+        pub fn pll_f12m_frequency() -> u32 {
+            (pll_clk_frequency() / 40)
         }
         pub fn request_pll_f20m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F20M");
@@ -1918,8 +1918,8 @@ macro_rules! define_clock_tree_types {
                 release_pll_clk(clocks);
             }
         }
-        pub fn pll_f20m_frequency(clocks: &mut ClockTree) -> u32 {
-            (pll_clk_frequency(clocks) / 24)
+        pub fn pll_f20m_frequency() -> u32 {
+            (pll_clk_frequency() / 24)
         }
         pub fn request_pll_f40m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F40M");
@@ -1937,8 +1937,8 @@ macro_rules! define_clock_tree_types {
                 release_pll_clk(clocks);
             }
         }
-        pub fn pll_f40m_frequency(clocks: &mut ClockTree) -> u32 {
-            (pll_clk_frequency(clocks) / 12)
+        pub fn pll_f40m_frequency() -> u32 {
+            (pll_clk_frequency() / 12)
         }
         pub fn request_pll_f48m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F48M");
@@ -1956,8 +1956,8 @@ macro_rules! define_clock_tree_types {
                 release_pll_clk(clocks);
             }
         }
-        pub fn pll_f48m_frequency(clocks: &mut ClockTree) -> u32 {
-            (pll_clk_frequency(clocks) / 10)
+        pub fn pll_f48m_frequency() -> u32 {
+            (pll_clk_frequency() / 10)
         }
         pub fn request_pll_f60m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F60M");
@@ -1975,8 +1975,8 @@ macro_rules! define_clock_tree_types {
                 release_pll_clk(clocks);
             }
         }
-        pub fn pll_f60m_frequency(clocks: &mut ClockTree) -> u32 {
-            (pll_clk_frequency(clocks) / 8)
+        pub fn pll_f60m_frequency() -> u32 {
+            (pll_clk_frequency() / 8)
         }
         pub fn request_pll_f80m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F80M");
@@ -1994,8 +1994,8 @@ macro_rules! define_clock_tree_types {
                 release_pll_clk(clocks);
             }
         }
-        pub fn pll_f80m_frequency(clocks: &mut ClockTree) -> u32 {
-            (pll_clk_frequency(clocks) / 6)
+        pub fn pll_f80m_frequency() -> u32 {
+            (pll_clk_frequency() / 6)
         }
         pub fn request_pll_f120m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F120M");
@@ -2013,8 +2013,8 @@ macro_rules! define_clock_tree_types {
                 release_pll_clk(clocks);
             }
         }
-        pub fn pll_f120m_frequency(clocks: &mut ClockTree) -> u32 {
-            (pll_clk_frequency(clocks) / 4)
+        pub fn pll_f120m_frequency() -> u32 {
+            (pll_clk_frequency() / 4)
         }
         pub fn request_pll_f160m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F160M");
@@ -2028,8 +2028,8 @@ macro_rules! define_clock_tree_types {
             enable_pll_f160m_impl(clocks, false);
             release_pll_clk(clocks);
         }
-        pub fn pll_f160m_frequency(clocks: &mut ClockTree) -> u32 {
-            (pll_clk_frequency(clocks) / 3)
+        pub fn pll_f160m_frequency() -> u32 {
+            (pll_clk_frequency() / 3)
         }
         pub fn request_pll_f240m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F240M");
@@ -2047,8 +2047,8 @@ macro_rules! define_clock_tree_types {
                 release_pll_clk(clocks);
             }
         }
-        pub fn pll_f240m_frequency(clocks: &mut ClockTree) -> u32 {
-            (pll_clk_frequency(clocks) / 2)
+        pub fn pll_f240m_frequency() -> u32 {
+            (pll_clk_frequency() / 2)
         }
         pub fn configure_hp_root_clk(clocks: &mut ClockTree, new_selector: HpRootClkConfig) {
             let old_selector = clocks.hp_root_clk.replace(new_selector);
@@ -2108,13 +2108,13 @@ macro_rules! define_clock_tree_types {
             config: HpRootClkConfig,
         ) -> u32 {
             match config {
-                HpRootClkConfig::Xtal => xtal_clk_frequency(clocks),
-                HpRootClkConfig::RcFast => rc_fast_clk_frequency(clocks),
-                HpRootClkConfig::PllF160m => pll_f160m_frequency(clocks),
-                HpRootClkConfig::PllF240m => pll_f240m_frequency(clocks),
+                HpRootClkConfig::Xtal => xtal_clk_frequency(),
+                HpRootClkConfig::RcFast => rc_fast_clk_frequency(),
+                HpRootClkConfig::PllF160m => pll_f160m_frequency(),
+                HpRootClkConfig::PllF240m => pll_f240m_frequency(),
             }
         }
-        pub fn hp_root_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn hp_root_clk_frequency() -> u32 {
             HP_ROOT_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, config: CpuClkConfig) {
@@ -2143,9 +2143,9 @@ macro_rules! define_clock_tree_types {
         }
         #[allow(unused_variables)]
         pub fn cpu_clk_config_frequency(clocks: &mut ClockTree, config: CpuClkConfig) -> u32 {
-            (hp_root_clk_frequency(clocks) / (config.divisor() + 1))
+            (hp_root_clk_frequency() / (config.divisor() + 1))
         }
-        pub fn cpu_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn cpu_clk_frequency() -> u32 {
             CPU_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_ahb_clk(clocks: &mut ClockTree, config: AhbClkConfig) {
@@ -2170,9 +2170,9 @@ macro_rules! define_clock_tree_types {
         }
         #[allow(unused_variables)]
         pub fn ahb_clk_config_frequency(clocks: &mut ClockTree, config: AhbClkConfig) -> u32 {
-            (hp_root_clk_frequency(clocks) / (config.divisor() + 1))
+            (hp_root_clk_frequency() / (config.divisor() + 1))
         }
-        pub fn ahb_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn ahb_clk_frequency() -> u32 {
             AHB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, config: ApbClkConfig) {
@@ -2201,9 +2201,9 @@ macro_rules! define_clock_tree_types {
         }
         #[allow(unused_variables)]
         pub fn apb_clk_config_frequency(clocks: &mut ClockTree, config: ApbClkConfig) -> u32 {
-            (ahb_clk_frequency(clocks) / (config.divisor() + 1))
+            (ahb_clk_frequency() / (config.divisor() + 1))
         }
-        pub fn apb_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn apb_clk_frequency() -> u32 {
             APB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_xtal_d2_clk(clocks: &mut ClockTree) {
@@ -2218,8 +2218,8 @@ macro_rules! define_clock_tree_types {
             enable_xtal_d2_clk_impl(clocks, false);
             release_xtal_clk(clocks);
         }
-        pub fn xtal_d2_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            (xtal_clk_frequency(clocks) / 2)
+        pub fn xtal_d2_clk_frequency() -> u32 {
+            (xtal_clk_frequency() / 2)
         }
         pub fn configure_lp_fast_clk(clocks: &mut ClockTree, new_selector: LpFastClkConfig) {
             let old_selector = clocks.lp_fast_clk.replace(new_selector);
@@ -2275,12 +2275,12 @@ macro_rules! define_clock_tree_types {
             config: LpFastClkConfig,
         ) -> u32 {
             match config {
-                LpFastClkConfig::RcFast => rc_fast_clk_frequency(clocks),
-                LpFastClkConfig::XtalD2 => xtal_d2_clk_frequency(clocks),
-                LpFastClkConfig::Xtal => xtal_clk_frequency(clocks),
+                LpFastClkConfig::RcFast => rc_fast_clk_frequency(),
+                LpFastClkConfig::XtalD2 => xtal_d2_clk_frequency(),
+                LpFastClkConfig::Xtal => xtal_clk_frequency(),
             }
         }
-        pub fn lp_fast_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn lp_fast_clk_frequency() -> u32 {
             LP_FAST_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_lp_slow_clk(clocks: &mut ClockTree, new_selector: LpSlowClkConfig) {
@@ -2337,12 +2337,12 @@ macro_rules! define_clock_tree_types {
             config: LpSlowClkConfig,
         ) -> u32 {
             match config {
-                LpSlowClkConfig::RcSlow => rc_slow_clk_frequency(clocks),
-                LpSlowClkConfig::Xtal32k => xtal32k_clk_frequency(clocks),
-                LpSlowClkConfig::OscSlow => osc_slow_clk_frequency(clocks),
+                LpSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
+                LpSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
+                LpSlowClkConfig::OscSlow => osc_slow_clk_frequency(),
             }
         }
-        pub fn lp_slow_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn lp_slow_clk_frequency() -> u32 {
             LP_SLOW_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_crypto_clk(clocks: &mut ClockTree, new_selector: CryptoClkConfig) {
@@ -2396,12 +2396,12 @@ macro_rules! define_clock_tree_types {
         #[allow(unused_variables)]
         pub fn crypto_clk_config_frequency(clocks: &mut ClockTree, config: CryptoClkConfig) -> u32 {
             match config {
-                CryptoClkConfig::Xtal => xtal_clk_frequency(clocks),
-                CryptoClkConfig::Fosc => rc_fast_clk_frequency(clocks),
-                CryptoClkConfig::PllF480m => pll_clk_frequency(clocks),
+                CryptoClkConfig::Xtal => xtal_clk_frequency(),
+                CryptoClkConfig::Fosc => rc_fast_clk_frequency(),
+                CryptoClkConfig::PllF480m => pll_clk_frequency(),
             }
         }
-        pub fn crypto_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn crypto_clk_frequency() -> u32 {
             CRYPTO_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_timg_calibration_clock(
@@ -2467,13 +2467,13 @@ macro_rules! define_clock_tree_types {
             config: TimgCalibrationClockConfig,
         ) -> u32 {
             match config {
-                TimgCalibrationClockConfig::OscSlowClk => osc_slow_clk_frequency(clocks),
-                TimgCalibrationClockConfig::RcSlowClk => rc_slow_clk_frequency(clocks),
-                TimgCalibrationClockConfig::RcFastDivClk => rc_fast_clk_frequency(clocks),
-                TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(clocks),
+                TimgCalibrationClockConfig::OscSlowClk => osc_slow_clk_frequency(),
+                TimgCalibrationClockConfig::RcSlowClk => rc_slow_clk_frequency(),
+                TimgCalibrationClockConfig::RcFastDivClk => rc_fast_clk_frequency(),
+                TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
             }
         }
-        pub fn timg_calibration_clock_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn timg_calibration_clock_frequency() -> u32 {
             TIMG_CALIBRATION_CLOCK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         impl ParlIoInstance {
@@ -2536,12 +2536,12 @@ macro_rules! define_clock_tree_types {
                 config: ParlIoRxClockConfig,
             ) -> u32 {
                 match config {
-                    ParlIoRxClockConfig::XtalClk => xtal_clk_frequency(clocks),
-                    ParlIoRxClockConfig::RcFastClk => rc_fast_clk_frequency(clocks),
-                    ParlIoRxClockConfig::PllF240m => pll_f240m_frequency(clocks),
+                    ParlIoRxClockConfig::XtalClk => xtal_clk_frequency(),
+                    ParlIoRxClockConfig::RcFastClk => rc_fast_clk_frequency(),
+                    ParlIoRxClockConfig::PllF240m => pll_f240m_frequency(),
                 }
             }
-            pub fn rx_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn rx_clock_frequency(self) -> u32 {
                 PARL_IO_RX_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -2604,12 +2604,12 @@ macro_rules! define_clock_tree_types {
                 config: ParlIoTxClockConfig,
             ) -> u32 {
                 match config {
-                    ParlIoTxClockConfig::XtalClk => xtal_clk_frequency(clocks),
-                    ParlIoTxClockConfig::RcFastClk => rc_fast_clk_frequency(clocks),
-                    ParlIoTxClockConfig::PllF240m => pll_f240m_frequency(clocks),
+                    ParlIoTxClockConfig::XtalClk => xtal_clk_frequency(),
+                    ParlIoTxClockConfig::RcFastClk => rc_fast_clk_frequency(),
+                    ParlIoTxClockConfig::PllF240m => pll_f240m_frequency(),
                 }
             }
-            pub fn tx_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn tx_clock_frequency(self) -> u32 {
                 PARL_IO_TX_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -2670,12 +2670,12 @@ macro_rules! define_clock_tree_types {
                 config: RmtSclkConfig,
             ) -> u32 {
                 match config {
-                    RmtSclkConfig::XtalClk => xtal_clk_frequency(clocks),
-                    RmtSclkConfig::RcFastClk => rc_fast_clk_frequency(clocks),
-                    RmtSclkConfig::PllF80m => pll_f80m_frequency(clocks),
+                    RmtSclkConfig::XtalClk => xtal_clk_frequency(),
+                    RmtSclkConfig::RcFastClk => rc_fast_clk_frequency(),
+                    RmtSclkConfig::PllF80m => pll_f80m_frequency(),
                 }
             }
-            pub fn sclk_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn sclk_frequency(self) -> u32 {
                 RMT_SCLK_FREQ_CACHE[self as usize].load(::core::sync::atomic::Ordering::Acquire)
             }
         }
@@ -2746,12 +2746,12 @@ macro_rules! define_clock_tree_types {
                 config: TimgFunctionClockConfig,
             ) -> u32 {
                 match config {
-                    TimgFunctionClockConfig::XtalClk => xtal_clk_frequency(clocks),
-                    TimgFunctionClockConfig::RcFastClk => rc_fast_clk_frequency(clocks),
-                    TimgFunctionClockConfig::PllF80m => pll_f80m_frequency(clocks),
+                    TimgFunctionClockConfig::XtalClk => xtal_clk_frequency(),
+                    TimgFunctionClockConfig::RcFastClk => rc_fast_clk_frequency(),
+                    TimgFunctionClockConfig::PllF80m => pll_f80m_frequency(),
                 }
             }
-            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn function_clock_frequency(self) -> u32 {
                 TIMG_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -2814,12 +2814,12 @@ macro_rules! define_clock_tree_types {
                 config: TimgWdtClockConfig,
             ) -> u32 {
                 match config {
-                    TimgWdtClockConfig::XtalClk => xtal_clk_frequency(clocks),
-                    TimgWdtClockConfig::PllF80m => pll_f80m_frequency(clocks),
-                    TimgWdtClockConfig::RcFastClk => rc_fast_clk_frequency(clocks),
+                    TimgWdtClockConfig::XtalClk => xtal_clk_frequency(),
+                    TimgWdtClockConfig::PllF80m => pll_f80m_frequency(),
+                    TimgWdtClockConfig::RcFastClk => rc_fast_clk_frequency(),
                 }
             }
-            pub fn wdt_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn wdt_clock_frequency(self) -> u32 {
                 TIMG_WDT_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -2891,12 +2891,12 @@ macro_rules! define_clock_tree_types {
                 config: UartFunctionClockConfig,
             ) -> u32 {
                 (match config.sclk {
-                    UartFunctionClockSclk::Xtal => xtal_clk_frequency(clocks),
-                    UartFunctionClockSclk::PllF80m => pll_f80m_frequency(clocks),
-                    UartFunctionClockSclk::RcFast => rc_fast_clk_frequency(clocks),
+                    UartFunctionClockSclk::Xtal => xtal_clk_frequency(),
+                    UartFunctionClockSclk::PllF80m => pll_f80m_frequency(),
+                    UartFunctionClockSclk::RcFast => rc_fast_clk_frequency(),
                 } / (config.div_num() + 1))
             }
-            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn function_clock_frequency(self) -> u32 {
                 UART_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -2941,10 +2941,10 @@ macro_rules! define_clock_tree_types {
                 clocks: &mut ClockTree,
                 config: UartBaudRateGeneratorConfig,
             ) -> u32 {
-                ((self.function_clock_frequency(clocks) * 16)
+                ((self.function_clock_frequency() * 16)
                     / ((config.integral() * 16) + config.fractional()))
             }
-            pub fn baud_rate_generator_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn baud_rate_generator_frequency(self) -> u32 {
                 UART_BAUD_RATE_GENERATOR_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }

--- a/esp-metadata-generated/src/_generated_esp32c6.rs
+++ b/esp-metadata-generated/src/_generated_esp32c6.rs
@@ -2154,7 +2154,7 @@ macro_rules! define_clock_tree_types {
         pub fn xtal_clk_config_frequency(clocks: &mut ClockTree, config: XtalClkConfig) -> u32 {
             config.value()
         }
-        pub fn xtal_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn xtal_clk_frequency() -> u32 {
             XTAL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_pll_clk(clocks: &mut ClockTree) {
@@ -2173,7 +2173,7 @@ macro_rules! define_clock_tree_types {
                 release_xtal_clk(clocks);
             }
         }
-        pub fn pll_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn pll_clk_frequency() -> u32 {
             480000000
         }
         pub fn request_rc_fast_clk(clocks: &mut ClockTree) {
@@ -2190,7 +2190,7 @@ macro_rules! define_clock_tree_types {
                 enable_rc_fast_clk_impl(clocks, false);
             }
         }
-        pub fn rc_fast_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn rc_fast_clk_frequency() -> u32 {
             17500000
         }
         pub fn request_xtal32k_clk(clocks: &mut ClockTree) {
@@ -2207,7 +2207,7 @@ macro_rules! define_clock_tree_types {
                 enable_xtal32k_clk_impl(clocks, false);
             }
         }
-        pub fn xtal32k_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn xtal32k_clk_frequency() -> u32 {
             32768
         }
         pub fn request_osc_slow_clk(clocks: &mut ClockTree) {
@@ -2220,7 +2220,7 @@ macro_rules! define_clock_tree_types {
             trace!("Disabling OSC_SLOW_CLK");
             enable_osc_slow_clk_impl(clocks, false);
         }
-        pub fn osc_slow_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn osc_slow_clk_frequency() -> u32 {
             32768
         }
         pub fn request_rc_slow_clk(clocks: &mut ClockTree) {
@@ -2233,7 +2233,7 @@ macro_rules! define_clock_tree_types {
             trace!("Disabling RC_SLOW_CLK");
             enable_rc_slow_clk_impl(clocks, false);
         }
-        pub fn rc_slow_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn rc_slow_clk_frequency() -> u32 {
             136000
         }
         pub fn configure_hp_root_clk(clocks: &mut ClockTree, config: HpRootClkConfig) {
@@ -2265,9 +2265,9 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: HpRootClkConfig,
         ) -> u32 {
-            (soc_root_clk_frequency(clocks) / config.divisor())
+            (soc_root_clk_frequency() / config.divisor())
         }
-        pub fn hp_root_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn hp_root_clk_frequency() -> u32 {
             HP_ROOT_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, new_selector: CpuClkConfig) {
@@ -2293,11 +2293,11 @@ macro_rules! define_clock_tree_types {
         #[allow(unused_variables)]
         pub fn cpu_clk_config_frequency(clocks: &mut ClockTree, config: CpuClkConfig) -> u32 {
             match config {
-                CpuClkConfig::Hs => cpu_hs_div_frequency(clocks),
-                CpuClkConfig::Ls => cpu_ls_div_frequency(clocks),
+                CpuClkConfig::Hs => cpu_hs_div_frequency(),
+                CpuClkConfig::Ls => cpu_ls_div_frequency(),
             }
         }
-        pub fn cpu_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn cpu_clk_frequency() -> u32 {
             CPU_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_ahb_clk(clocks: &mut ClockTree, new_selector: AhbClkConfig) {
@@ -2323,11 +2323,11 @@ macro_rules! define_clock_tree_types {
         #[allow(unused_variables)]
         pub fn ahb_clk_config_frequency(clocks: &mut ClockTree, config: AhbClkConfig) -> u32 {
             match config {
-                AhbClkConfig::Hs => ahb_hs_div_frequency(clocks),
-                AhbClkConfig::Ls => ahb_ls_div_frequency(clocks),
+                AhbClkConfig::Hs => ahb_hs_div_frequency(),
+                AhbClkConfig::Ls => ahb_ls_div_frequency(),
             }
         }
-        pub fn ahb_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn ahb_clk_frequency() -> u32 {
             AHB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_mspi_fast_clk(clocks: &mut ClockTree, new_selector: MspiFastClkConfig) {
@@ -2380,11 +2380,11 @@ macro_rules! define_clock_tree_types {
             config: MspiFastClkConfig,
         ) -> u32 {
             match config {
-                MspiFastClkConfig::Hs => mspi_fast_hs_clk_frequency(clocks),
-                MspiFastClkConfig::Ls => mspi_fast_ls_clk_frequency(clocks),
+                MspiFastClkConfig::Hs => mspi_fast_hs_clk_frequency(),
+                MspiFastClkConfig::Ls => mspi_fast_ls_clk_frequency(),
             }
         }
-        pub fn mspi_fast_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn mspi_fast_clk_frequency() -> u32 {
             MSPI_FAST_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_soc_root_clk(clocks: &mut ClockTree, new_selector: SocRootClkConfig) {
@@ -2456,12 +2456,12 @@ macro_rules! define_clock_tree_types {
             config: SocRootClkConfig,
         ) -> u32 {
             match config {
-                SocRootClkConfig::Xtal => xtal_clk_frequency(clocks),
-                SocRootClkConfig::RcFast => rc_fast_clk_frequency(clocks),
-                SocRootClkConfig::Pll => pll_clk_frequency(clocks),
+                SocRootClkConfig::Xtal => xtal_clk_frequency(),
+                SocRootClkConfig::RcFast => rc_fast_clk_frequency(),
+                SocRootClkConfig::Pll => pll_clk_frequency(),
             }
         }
-        pub fn soc_root_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn soc_root_clk_frequency() -> u32 {
             SOC_ROOT_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_cpu_hs_div(clocks: &mut ClockTree, config: CpuHsDivConfig) {
@@ -2486,9 +2486,9 @@ macro_rules! define_clock_tree_types {
         }
         #[allow(unused_variables)]
         pub fn cpu_hs_div_config_frequency(clocks: &mut ClockTree, config: CpuHsDivConfig) -> u32 {
-            (hp_root_clk_frequency(clocks) / (config.divisor() + 1))
+            (hp_root_clk_frequency() / (config.divisor() + 1))
         }
-        pub fn cpu_hs_div_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn cpu_hs_div_frequency() -> u32 {
             CPU_HS_DIV_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_cpu_ls_div(clocks: &mut ClockTree, config: CpuLsDivConfig) {
@@ -2513,9 +2513,9 @@ macro_rules! define_clock_tree_types {
         }
         #[allow(unused_variables)]
         pub fn cpu_ls_div_config_frequency(clocks: &mut ClockTree, config: CpuLsDivConfig) -> u32 {
-            (hp_root_clk_frequency(clocks) / (config.divisor() + 1))
+            (hp_root_clk_frequency() / (config.divisor() + 1))
         }
-        pub fn cpu_ls_div_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn cpu_ls_div_frequency() -> u32 {
             CPU_LS_DIV_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_ahb_hs_div(clocks: &mut ClockTree, config: AhbHsDivConfig) {
@@ -2540,9 +2540,9 @@ macro_rules! define_clock_tree_types {
         }
         #[allow(unused_variables)]
         pub fn ahb_hs_div_config_frequency(clocks: &mut ClockTree, config: AhbHsDivConfig) -> u32 {
-            (hp_root_clk_frequency(clocks) / (config.divisor() + 1))
+            (hp_root_clk_frequency() / (config.divisor() + 1))
         }
-        pub fn ahb_hs_div_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn ahb_hs_div_frequency() -> u32 {
             AHB_HS_DIV_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_ahb_ls_div(clocks: &mut ClockTree, config: AhbLsDivConfig) {
@@ -2567,9 +2567,9 @@ macro_rules! define_clock_tree_types {
         }
         #[allow(unused_variables)]
         pub fn ahb_ls_div_config_frequency(clocks: &mut ClockTree, config: AhbLsDivConfig) -> u32 {
-            (hp_root_clk_frequency(clocks) / (config.divisor() + 1))
+            (hp_root_clk_frequency() / (config.divisor() + 1))
         }
-        pub fn ahb_ls_div_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn ahb_ls_div_frequency() -> u32 {
             AHB_LS_DIV_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, config: ApbClkConfig) {
@@ -2598,9 +2598,9 @@ macro_rules! define_clock_tree_types {
         }
         #[allow(unused_variables)]
         pub fn apb_clk_config_frequency(clocks: &mut ClockTree, config: ApbClkConfig) -> u32 {
-            (ahb_clk_frequency(clocks) / (config.divisor() + 1))
+            (ahb_clk_frequency() / (config.divisor() + 1))
         }
-        pub fn apb_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn apb_clk_frequency() -> u32 {
             APB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_mspi_fast_hs_clk(clocks: &mut ClockTree, config: MspiFastHsClkConfig) {
@@ -2628,9 +2628,9 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: MspiFastHsClkConfig,
         ) -> u32 {
-            (hp_root_clk_frequency(clocks) / (config.divisor() + 1))
+            (hp_root_clk_frequency() / (config.divisor() + 1))
         }
-        pub fn mspi_fast_hs_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn mspi_fast_hs_clk_frequency() -> u32 {
             MSPI_FAST_HS_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_mspi_fast_ls_clk(clocks: &mut ClockTree, config: MspiFastLsClkConfig) {
@@ -2658,9 +2658,9 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: MspiFastLsClkConfig,
         ) -> u32 {
-            (hp_root_clk_frequency(clocks) / (config.divisor() + 1))
+            (hp_root_clk_frequency() / (config.divisor() + 1))
         }
-        pub fn mspi_fast_ls_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn mspi_fast_ls_clk_frequency() -> u32 {
             MSPI_FAST_LS_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_pll_f48m(clocks: &mut ClockTree) {
@@ -2679,7 +2679,7 @@ macro_rules! define_clock_tree_types {
                 release_pll_clk(clocks);
             }
         }
-        pub fn pll_f48m_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn pll_f48m_frequency() -> u32 {
             48000000
         }
         pub fn request_pll_f80m(clocks: &mut ClockTree) {
@@ -2698,7 +2698,7 @@ macro_rules! define_clock_tree_types {
                 release_pll_clk(clocks);
             }
         }
-        pub fn pll_f80m_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn pll_f80m_frequency() -> u32 {
             80000000
         }
         pub fn request_pll_f160m(clocks: &mut ClockTree) {
@@ -2713,7 +2713,7 @@ macro_rules! define_clock_tree_types {
             enable_pll_f160m_impl(clocks, false);
             release_pll_clk(clocks);
         }
-        pub fn pll_f160m_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn pll_f160m_frequency() -> u32 {
             160000000
         }
         pub fn request_pll_f240m(clocks: &mut ClockTree) {
@@ -2732,7 +2732,7 @@ macro_rules! define_clock_tree_types {
                 release_pll_clk(clocks);
             }
         }
-        pub fn pll_f240m_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn pll_f240m_frequency() -> u32 {
             240000000
         }
         pub fn configure_ledc_sclk(clocks: &mut ClockTree, new_selector: LedcSclkConfig) {
@@ -2786,12 +2786,12 @@ macro_rules! define_clock_tree_types {
         #[allow(unused_variables)]
         pub fn ledc_sclk_config_frequency(clocks: &mut ClockTree, config: LedcSclkConfig) -> u32 {
             match config {
-                LedcSclkConfig::PllF80m => pll_f80m_frequency(clocks),
-                LedcSclkConfig::RcFastClk => rc_fast_clk_frequency(clocks),
-                LedcSclkConfig::XtalClk => xtal_clk_frequency(clocks),
+                LedcSclkConfig::PllF80m => pll_f80m_frequency(),
+                LedcSclkConfig::RcFastClk => rc_fast_clk_frequency(),
+                LedcSclkConfig::XtalClk => xtal_clk_frequency(),
             }
         }
-        pub fn ledc_sclk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn ledc_sclk_frequency() -> u32 {
             LEDC_SCLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_xtal_d2_clk(clocks: &mut ClockTree) {
@@ -2806,8 +2806,8 @@ macro_rules! define_clock_tree_types {
             enable_xtal_d2_clk_impl(clocks, false);
             release_xtal_clk(clocks);
         }
-        pub fn xtal_d2_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            (xtal_clk_frequency(clocks) / 2)
+        pub fn xtal_d2_clk_frequency() -> u32 {
+            (xtal_clk_frequency() / 2)
         }
         pub fn configure_lp_fast_clk(clocks: &mut ClockTree, new_selector: LpFastClkConfig) {
             let old_selector = clocks.lp_fast_clk.replace(new_selector);
@@ -2859,11 +2859,11 @@ macro_rules! define_clock_tree_types {
             config: LpFastClkConfig,
         ) -> u32 {
             match config {
-                LpFastClkConfig::RcFastClk => rc_fast_clk_frequency(clocks),
-                LpFastClkConfig::XtalD2Clk => xtal_d2_clk_frequency(clocks),
+                LpFastClkConfig::RcFastClk => rc_fast_clk_frequency(),
+                LpFastClkConfig::XtalD2Clk => xtal_d2_clk_frequency(),
             }
         }
-        pub fn lp_fast_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn lp_fast_clk_frequency() -> u32 {
             LP_FAST_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_lp_slow_clk(clocks: &mut ClockTree, new_selector: LpSlowClkConfig) {
@@ -2912,12 +2912,12 @@ macro_rules! define_clock_tree_types {
             config: LpSlowClkConfig,
         ) -> u32 {
             match config {
-                LpSlowClkConfig::Xtal32k => xtal32k_clk_frequency(clocks),
-                LpSlowClkConfig::RcSlow => rc_slow_clk_frequency(clocks),
-                LpSlowClkConfig::OscSlow => osc_slow_clk_frequency(clocks),
+                LpSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
+                LpSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
+                LpSlowClkConfig::OscSlow => osc_slow_clk_frequency(),
             }
         }
-        pub fn lp_slow_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn lp_slow_clk_frequency() -> u32 {
             LP_SLOW_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_timg_calibration_clock(
@@ -2979,12 +2979,12 @@ macro_rules! define_clock_tree_types {
             config: TimgCalibrationClockConfig,
         ) -> u32 {
             match config {
-                TimgCalibrationClockConfig::RcSlowClk => lp_slow_clk_frequency(clocks),
-                TimgCalibrationClockConfig::RcFastDivClk => rc_fast_clk_frequency(clocks),
-                TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(clocks),
+                TimgCalibrationClockConfig::RcSlowClk => lp_slow_clk_frequency(),
+                TimgCalibrationClockConfig::RcFastDivClk => rc_fast_clk_frequency(),
+                TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
             }
         }
-        pub fn timg_calibration_clock_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn timg_calibration_clock_frequency() -> u32 {
             TIMG_CALIBRATION_CLOCK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         impl McpwmInstance {
@@ -3054,12 +3054,12 @@ macro_rules! define_clock_tree_types {
                 config: McpwmFunctionClockConfig,
             ) -> u32 {
                 match config {
-                    McpwmFunctionClockConfig::PllF160m => pll_f160m_frequency(clocks),
-                    McpwmFunctionClockConfig::RcFastClk => rc_fast_clk_frequency(clocks),
-                    McpwmFunctionClockConfig::XtalClk => xtal_clk_frequency(clocks),
+                    McpwmFunctionClockConfig::PllF160m => pll_f160m_frequency(),
+                    McpwmFunctionClockConfig::RcFastClk => rc_fast_clk_frequency(),
+                    McpwmFunctionClockConfig::XtalClk => xtal_clk_frequency(),
                 }
             }
-            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn function_clock_frequency(self) -> u32 {
                 MCPWM_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -3124,12 +3124,12 @@ macro_rules! define_clock_tree_types {
                 config: ParlIoRxClockConfig,
             ) -> u32 {
                 match config {
-                    ParlIoRxClockConfig::XtalClk => xtal_clk_frequency(clocks),
-                    ParlIoRxClockConfig::RcFastClk => rc_fast_clk_frequency(clocks),
-                    ParlIoRxClockConfig::PllF240m => pll_f240m_frequency(clocks),
+                    ParlIoRxClockConfig::XtalClk => xtal_clk_frequency(),
+                    ParlIoRxClockConfig::RcFastClk => rc_fast_clk_frequency(),
+                    ParlIoRxClockConfig::PllF240m => pll_f240m_frequency(),
                 }
             }
-            pub fn rx_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn rx_clock_frequency(self) -> u32 {
                 PARL_IO_RX_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -3192,12 +3192,12 @@ macro_rules! define_clock_tree_types {
                 config: ParlIoTxClockConfig,
             ) -> u32 {
                 match config {
-                    ParlIoTxClockConfig::XtalClk => xtal_clk_frequency(clocks),
-                    ParlIoTxClockConfig::RcFastClk => rc_fast_clk_frequency(clocks),
-                    ParlIoTxClockConfig::PllF240m => pll_f240m_frequency(clocks),
+                    ParlIoTxClockConfig::XtalClk => xtal_clk_frequency(),
+                    ParlIoTxClockConfig::RcFastClk => rc_fast_clk_frequency(),
+                    ParlIoTxClockConfig::PllF240m => pll_f240m_frequency(),
                 }
             }
-            pub fn tx_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn tx_clock_frequency(self) -> u32 {
                 PARL_IO_TX_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -3258,12 +3258,12 @@ macro_rules! define_clock_tree_types {
                 config: RmtSclkConfig,
             ) -> u32 {
                 match config {
-                    RmtSclkConfig::PllF80m => pll_f80m_frequency(clocks),
-                    RmtSclkConfig::RcFastClk => rc_fast_clk_frequency(clocks),
-                    RmtSclkConfig::XtalClk => xtal_clk_frequency(clocks),
+                    RmtSclkConfig::PllF80m => pll_f80m_frequency(),
+                    RmtSclkConfig::RcFastClk => rc_fast_clk_frequency(),
+                    RmtSclkConfig::XtalClk => xtal_clk_frequency(),
                 }
             }
-            pub fn sclk_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn sclk_frequency(self) -> u32 {
                 RMT_SCLK_FREQ_CACHE[self as usize].load(::core::sync::atomic::Ordering::Acquire)
             }
         }
@@ -3334,12 +3334,12 @@ macro_rules! define_clock_tree_types {
                 config: TimgFunctionClockConfig,
             ) -> u32 {
                 match config {
-                    TimgFunctionClockConfig::XtalClk => xtal_clk_frequency(clocks),
-                    TimgFunctionClockConfig::RcFastClk => rc_fast_clk_frequency(clocks),
-                    TimgFunctionClockConfig::PllF80m => pll_f80m_frequency(clocks),
+                    TimgFunctionClockConfig::XtalClk => xtal_clk_frequency(),
+                    TimgFunctionClockConfig::RcFastClk => rc_fast_clk_frequency(),
+                    TimgFunctionClockConfig::PllF80m => pll_f80m_frequency(),
                 }
             }
-            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn function_clock_frequency(self) -> u32 {
                 TIMG_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -3402,12 +3402,12 @@ macro_rules! define_clock_tree_types {
                 config: TimgWdtClockConfig,
             ) -> u32 {
                 match config {
-                    TimgWdtClockConfig::XtalClk => xtal_clk_frequency(clocks),
-                    TimgWdtClockConfig::PllF80m => pll_f80m_frequency(clocks),
-                    TimgWdtClockConfig::RcFastClk => rc_fast_clk_frequency(clocks),
+                    TimgWdtClockConfig::XtalClk => xtal_clk_frequency(),
+                    TimgWdtClockConfig::PllF80m => pll_f80m_frequency(),
+                    TimgWdtClockConfig::RcFastClk => rc_fast_clk_frequency(),
                 }
             }
-            pub fn wdt_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn wdt_clock_frequency(self) -> u32 {
                 TIMG_WDT_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -3479,12 +3479,12 @@ macro_rules! define_clock_tree_types {
                 config: UartFunctionClockConfig,
             ) -> u32 {
                 (match config.sclk {
-                    UartFunctionClockSclk::PllF80m => pll_f80m_frequency(clocks),
-                    UartFunctionClockSclk::RcFast => rc_fast_clk_frequency(clocks),
-                    UartFunctionClockSclk::Xtal => xtal_clk_frequency(clocks),
+                    UartFunctionClockSclk::PllF80m => pll_f80m_frequency(),
+                    UartFunctionClockSclk::RcFast => rc_fast_clk_frequency(),
+                    UartFunctionClockSclk::Xtal => xtal_clk_frequency(),
                 } / (config.div_num() + 1))
             }
-            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn function_clock_frequency(self) -> u32 {
                 UART_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -3529,10 +3529,10 @@ macro_rules! define_clock_tree_types {
                 clocks: &mut ClockTree,
                 config: UartBaudRateGeneratorConfig,
             ) -> u32 {
-                ((self.function_clock_frequency(clocks) * 16)
+                ((self.function_clock_frequency() * 16)
                     / ((config.integral() * 16) + config.fractional()))
             }
-            pub fn baud_rate_generator_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn baud_rate_generator_frequency(self) -> u32 {
                 UART_BAUD_RATE_GENERATOR_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }

--- a/esp-metadata-generated/src/_generated_esp32c6.rs
+++ b/esp-metadata-generated/src/_generated_esp32c6.rs
@@ -2143,7 +2143,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
             let old_config = clocks.xtal_clk.replace(config);
             configure_xtal_clk_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_xtal_clk_downstream(clocks);
         }
         pub fn xtal_clk_config(clocks: &mut ClockTree) -> Option<XtalClkConfig> {
             clocks.xtal_clk
@@ -2239,7 +2239,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_hp_root_clk(clocks: &mut ClockTree, config: HpRootClkConfig) {
             let old_config = clocks.hp_root_clk.replace(config);
             configure_hp_root_clk_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_hp_root_clk_downstream(clocks);
         }
         pub fn hp_root_clk_config(clocks: &mut ClockTree) -> Option<HpRootClkConfig> {
             clocks.hp_root_clk
@@ -2283,7 +2283,7 @@ macro_rules! define_clock_tree_types {
                     CpuClkConfig::Ls => release_cpu_ls_div(clocks),
                 }
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_cpu_clk_downstream(clocks);
         }
         pub fn cpu_clk_config(clocks: &mut ClockTree) -> Option<CpuClkConfig> {
             clocks.cpu_clk
@@ -2313,7 +2313,7 @@ macro_rules! define_clock_tree_types {
                     AhbClkConfig::Ls => release_ahb_ls_div(clocks),
                 }
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_ahb_clk_downstream(clocks);
         }
         pub fn ahb_clk_config(clocks: &mut ClockTree) -> Option<AhbClkConfig> {
             clocks.ahb_clk
@@ -2347,7 +2347,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_mspi_fast_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_mspi_fast_clk_downstream(clocks);
         }
         pub fn mspi_fast_clk_config(clocks: &mut ClockTree) -> Option<MspiFastClkConfig> {
             clocks.mspi_fast_clk
@@ -2425,7 +2425,7 @@ macro_rules! define_clock_tree_types {
                     SocRootClkConfig::Pll => release_pll_clk(clocks),
                 }
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_soc_root_clk_downstream(clocks);
         }
         pub fn soc_root_clk_config(clocks: &mut ClockTree) -> Option<SocRootClkConfig> {
             clocks.soc_root_clk
@@ -2467,7 +2467,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_cpu_hs_div(clocks: &mut ClockTree, config: CpuHsDivConfig) {
             let old_config = clocks.cpu_hs_div.replace(config);
             configure_cpu_hs_div_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_cpu_hs_div_downstream(clocks);
         }
         pub fn cpu_hs_div_config(clocks: &mut ClockTree) -> Option<CpuHsDivConfig> {
             clocks.cpu_hs_div
@@ -2494,7 +2494,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_cpu_ls_div(clocks: &mut ClockTree, config: CpuLsDivConfig) {
             let old_config = clocks.cpu_ls_div.replace(config);
             configure_cpu_ls_div_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_cpu_ls_div_downstream(clocks);
         }
         pub fn cpu_ls_div_config(clocks: &mut ClockTree) -> Option<CpuLsDivConfig> {
             clocks.cpu_ls_div
@@ -2521,7 +2521,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_ahb_hs_div(clocks: &mut ClockTree, config: AhbHsDivConfig) {
             let old_config = clocks.ahb_hs_div.replace(config);
             configure_ahb_hs_div_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_ahb_hs_div_downstream(clocks);
         }
         pub fn ahb_hs_div_config(clocks: &mut ClockTree) -> Option<AhbHsDivConfig> {
             clocks.ahb_hs_div
@@ -2548,7 +2548,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_ahb_ls_div(clocks: &mut ClockTree, config: AhbLsDivConfig) {
             let old_config = clocks.ahb_ls_div.replace(config);
             configure_ahb_ls_div_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_ahb_ls_div_downstream(clocks);
         }
         pub fn ahb_ls_div_config(clocks: &mut ClockTree) -> Option<AhbLsDivConfig> {
             clocks.ahb_ls_div
@@ -2575,7 +2575,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_apb_clk(clocks: &mut ClockTree, config: ApbClkConfig) {
             let old_config = clocks.apb_clk.replace(config);
             configure_apb_clk_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_apb_clk_downstream(clocks);
         }
         pub fn apb_clk_config(clocks: &mut ClockTree) -> Option<ApbClkConfig> {
             clocks.apb_clk
@@ -2606,7 +2606,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_mspi_fast_hs_clk(clocks: &mut ClockTree, config: MspiFastHsClkConfig) {
             let old_config = clocks.mspi_fast_hs_clk.replace(config);
             configure_mspi_fast_hs_clk_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_mspi_fast_hs_clk_downstream(clocks);
         }
         pub fn mspi_fast_hs_clk_config(clocks: &mut ClockTree) -> Option<MspiFastHsClkConfig> {
             clocks.mspi_fast_hs_clk
@@ -2636,7 +2636,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_mspi_fast_ls_clk(clocks: &mut ClockTree, config: MspiFastLsClkConfig) {
             let old_config = clocks.mspi_fast_ls_clk.replace(config);
             configure_mspi_fast_ls_clk_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_mspi_fast_ls_clk_downstream(clocks);
         }
         pub fn mspi_fast_ls_clk_config(clocks: &mut ClockTree) -> Option<MspiFastLsClkConfig> {
             clocks.mspi_fast_ls_clk
@@ -2754,7 +2754,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_ledc_sclk_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_ledc_sclk_downstream(clocks);
         }
         pub fn ledc_sclk_config(clocks: &mut ClockTree) -> Option<LedcSclkConfig> {
             clocks.ledc_sclk
@@ -2826,7 +2826,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_lp_fast_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_lp_fast_clk_downstream(clocks);
         }
         pub fn lp_fast_clk_config(clocks: &mut ClockTree) -> Option<LpFastClkConfig> {
             clocks.lp_fast_clk
@@ -2881,7 +2881,7 @@ macro_rules! define_clock_tree_types {
                     LpSlowClkConfig::OscSlow => release_osc_slow_clk(clocks),
                 }
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_lp_slow_clk_downstream(clocks);
         }
         pub fn lp_slow_clk_config(clocks: &mut ClockTree) -> Option<LpSlowClkConfig> {
             clocks.lp_slow_clk
@@ -2942,7 +2942,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_timg_calibration_clock_downstream(clocks);
         }
         pub fn timg_calibration_clock_config(
             clocks: &mut ClockTree,
@@ -3011,7 +3011,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_mcpwm_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -3088,7 +3088,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_rx_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_parl_io_rx_clock_downstream(clocks, self);
             }
             pub fn rx_clock_config(self, clocks: &mut ClockTree) -> Option<ParlIoRxClockConfig> {
                 clocks.parl_io_rx_clock[self as usize]
@@ -3156,7 +3156,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_tx_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_parl_io_tx_clock_downstream(clocks, self);
             }
             pub fn tx_clock_config(self, clocks: &mut ClockTree) -> Option<ParlIoTxClockConfig> {
                 clocks.parl_io_tx_clock[self as usize]
@@ -3222,7 +3222,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_sclk_impl(clocks, old_selector, new_selector);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_rmt_sclk_downstream(clocks, self);
             }
             pub fn sclk_config(self, clocks: &mut ClockTree) -> Option<RmtSclkConfig> {
                 clocks.rmt_sclk[self as usize]
@@ -3291,7 +3291,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_timg_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -3366,7 +3366,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_wdt_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_timg_wdt_clock_downstream(clocks, self);
             }
             pub fn wdt_clock_config(self, clocks: &mut ClockTree) -> Option<TimgWdtClockConfig> {
                 clocks.timg_wdt_clock[self as usize]
@@ -3436,7 +3436,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_config, config);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_uart_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -3495,7 +3495,7 @@ macro_rules! define_clock_tree_types {
             ) {
                 let old_config = clocks.uart_baud_rate_generator[self as usize].replace(config);
                 self.configure_baud_rate_generator_impl(clocks, old_config, config);
-                refresh_all_frequency_caches(clocks);
+                refresh_uart_baud_rate_generator_downstream(clocks, self);
             }
             pub fn baud_rate_generator_config(
                 self,
@@ -3630,167 +3630,254 @@ macro_rules! define_clock_tree_types {
             let last = *refcount == 0;
             last
         }
-        fn refresh_all_frequency_caches(clocks: &mut ClockTree) {
+        fn refresh_xtal_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.xtal_clk {
                 XTAL_CLK_FREQ_CACHE.store(
                     xtal_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_soc_root_clk_downstream(clocks);
+            refresh_ledc_sclk_downstream(clocks);
+            refresh_lp_fast_clk_downstream(clocks);
+            for child_instance in [McpwmInstance::Mcpwm0] {
+                refresh_mcpwm_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [ParlIoInstance::ParlIo] {
+                refresh_parl_io_rx_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [ParlIoInstance::ParlIo] {
+                refresh_parl_io_tx_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [RmtInstance::Rmt] {
+                refresh_rmt_sclk_downstream(clocks, child_instance);
+            }
+            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                refresh_timg_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                refresh_timg_wdt_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                refresh_timg_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                refresh_timg_wdt_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                refresh_uart_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                refresh_uart_function_clock_downstream(clocks, child_instance);
+            }
+        }
+        fn refresh_soc_root_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.soc_root_clk {
                 SOC_ROOT_CLK_FREQ_CACHE.store(
                     soc_root_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_hp_root_clk_downstream(clocks);
+        }
+        fn refresh_ledc_sclk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.ledc_sclk {
                 LEDC_SCLK_FREQ_CACHE.store(
                     ledc_sclk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+        }
+        fn refresh_lp_fast_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.lp_fast_clk {
                 LP_FAST_CLK_FREQ_CACHE.store(
                     lp_fast_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+        }
+        fn refresh_lp_slow_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.lp_slow_clk {
                 LP_SLOW_CLK_FREQ_CACHE.store(
                     lp_slow_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_timg_calibration_clock_downstream(clocks);
+        }
+        fn refresh_timg_calibration_clock_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.timg_calibration_clock {
                 TIMG_CALIBRATION_CLOCK_FREQ_CACHE.store(
                     timg_calibration_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
-            for instance in [McpwmInstance::Mcpwm0] {
-                if let Some(config) = clocks.mcpwm_function_clock[instance as usize] {
-                    MCPWM_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.function_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_mcpwm_function_clock_downstream(
+            clocks: &mut ClockTree,
+            instance: McpwmInstance,
+        ) {
+            if let Some(config) = clocks.mcpwm_function_clock[instance as usize] {
+                MCPWM_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.function_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
-            for instance in [ParlIoInstance::ParlIo] {
-                if let Some(config) = clocks.parl_io_rx_clock[instance as usize] {
-                    PARL_IO_RX_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.rx_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_parl_io_rx_clock_downstream(clocks: &mut ClockTree, instance: ParlIoInstance) {
+            if let Some(config) = clocks.parl_io_rx_clock[instance as usize] {
+                PARL_IO_RX_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.rx_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
-            for instance in [ParlIoInstance::ParlIo] {
-                if let Some(config) = clocks.parl_io_tx_clock[instance as usize] {
-                    PARL_IO_TX_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.tx_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_parl_io_tx_clock_downstream(clocks: &mut ClockTree, instance: ParlIoInstance) {
+            if let Some(config) = clocks.parl_io_tx_clock[instance as usize] {
+                PARL_IO_TX_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.tx_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
-            for instance in [RmtInstance::Rmt] {
-                if let Some(config) = clocks.rmt_sclk[instance as usize] {
-                    RMT_SCLK_FREQ_CACHE[instance as usize].store(
-                        instance.sclk_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_rmt_sclk_downstream(clocks: &mut ClockTree, instance: RmtInstance) {
+            if let Some(config) = clocks.rmt_sclk[instance as usize] {
+                RMT_SCLK_FREQ_CACHE[instance as usize].store(
+                    instance.sclk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
-            for instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
-                if let Some(config) = clocks.timg_function_clock[instance as usize] {
-                    TIMG_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.function_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_timg_function_clock_downstream(clocks: &mut ClockTree, instance: TimgInstance) {
+            if let Some(config) = clocks.timg_function_clock[instance as usize] {
+                TIMG_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.function_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
-            for instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
-                if let Some(config) = clocks.timg_wdt_clock[instance as usize] {
-                    TIMG_WDT_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.wdt_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_timg_wdt_clock_downstream(clocks: &mut ClockTree, instance: TimgInstance) {
+            if let Some(config) = clocks.timg_wdt_clock[instance as usize] {
+                TIMG_WDT_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.wdt_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
-            for instance in [UartInstance::Uart0, UartInstance::Uart1] {
-                if let Some(config) = clocks.uart_function_clock[instance as usize] {
-                    UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.function_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_uart_function_clock_downstream(clocks: &mut ClockTree, instance: UartInstance) {
+            if let Some(config) = clocks.uart_function_clock[instance as usize] {
+                UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.function_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
-            for instance in [UartInstance::Uart0, UartInstance::Uart1] {
-                if let Some(config) = clocks.uart_baud_rate_generator[instance as usize] {
-                    UART_BAUD_RATE_GENERATOR_FREQ_CACHE[instance as usize].store(
-                        instance.baud_rate_generator_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+            refresh_uart_baud_rate_generator_downstream(clocks, instance);
+        }
+        fn refresh_uart_baud_rate_generator_downstream(
+            clocks: &mut ClockTree,
+            instance: UartInstance,
+        ) {
+            if let Some(config) = clocks.uart_baud_rate_generator[instance as usize] {
+                UART_BAUD_RATE_GENERATOR_FREQ_CACHE[instance as usize].store(
+                    instance.baud_rate_generator_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
+        }
+        fn refresh_hp_root_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.hp_root_clk {
                 HP_ROOT_CLK_FREQ_CACHE.store(
                     hp_root_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_cpu_hs_div_downstream(clocks);
+            refresh_cpu_ls_div_downstream(clocks);
+            refresh_ahb_hs_div_downstream(clocks);
+            refresh_ahb_ls_div_downstream(clocks);
+            refresh_mspi_fast_hs_clk_downstream(clocks);
+            refresh_mspi_fast_ls_clk_downstream(clocks);
+        }
+        fn refresh_cpu_hs_div_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.cpu_hs_div {
                 CPU_HS_DIV_FREQ_CACHE.store(
                     cpu_hs_div_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_cpu_clk_downstream(clocks);
+        }
+        fn refresh_cpu_ls_div_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.cpu_ls_div {
                 CPU_LS_DIV_FREQ_CACHE.store(
                     cpu_ls_div_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_cpu_clk_downstream(clocks);
+        }
+        fn refresh_ahb_hs_div_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.ahb_hs_div {
                 AHB_HS_DIV_FREQ_CACHE.store(
                     ahb_hs_div_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_ahb_clk_downstream(clocks);
+        }
+        fn refresh_ahb_ls_div_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.ahb_ls_div {
                 AHB_LS_DIV_FREQ_CACHE.store(
                     ahb_ls_div_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_ahb_clk_downstream(clocks);
+        }
+        fn refresh_mspi_fast_hs_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.mspi_fast_hs_clk {
                 MSPI_FAST_HS_CLK_FREQ_CACHE.store(
                     mspi_fast_hs_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_mspi_fast_clk_downstream(clocks);
+        }
+        fn refresh_mspi_fast_ls_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.mspi_fast_ls_clk {
                 MSPI_FAST_LS_CLK_FREQ_CACHE.store(
                     mspi_fast_ls_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_mspi_fast_clk_downstream(clocks);
+        }
+        fn refresh_cpu_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.cpu_clk {
                 CPU_CLK_FREQ_CACHE.store(
                     cpu_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+        }
+        fn refresh_ahb_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.ahb_clk {
                 AHB_CLK_FREQ_CACHE.store(
                     ahb_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_apb_clk_downstream(clocks);
+        }
+        fn refresh_mspi_fast_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.mspi_fast_clk {
                 MSPI_FAST_CLK_FREQ_CACHE.store(
                     mspi_fast_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+        }
+        fn refresh_apb_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.apb_clk {
                 APB_CLK_FREQ_CACHE.store(
                     apb_clk_config_frequency(clocks, config),

--- a/esp-metadata-generated/src/_generated_esp32c6.rs
+++ b/esp-metadata-generated/src/_generated_esp32c6.rs
@@ -2090,9 +2090,60 @@ macro_rules! define_clock_tree_types {
                 uart_function_clock_refcount: [0; 2],
                 uart_baud_rate_generator_refcount: [0; 2],
             });
+        static XTAL_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static SOC_ROOT_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static LEDC_SCLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static LP_FAST_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static LP_SLOW_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static TIMG_CALIBRATION_CLOCK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static MCPWM_FUNCTION_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 1] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 1];
+        static PARL_IO_RX_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 1] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 1];
+        static PARL_IO_TX_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 1] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 1];
+        static RMT_SCLK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 1] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 1];
+        static TIMG_FUNCTION_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 2] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
+        static TIMG_WDT_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 2] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
+        static UART_FUNCTION_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 2] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
+        static UART_BAUD_RATE_GENERATOR_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 2] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
+        static HP_ROOT_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static CPU_HS_DIV_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static CPU_LS_DIV_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static AHB_HS_DIV_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static AHB_LS_DIV_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static MSPI_FAST_HS_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static MSPI_FAST_LS_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static CPU_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static AHB_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static MSPI_FAST_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static APB_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
             let old_config = clocks.xtal_clk.replace(config);
             configure_xtal_clk_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn xtal_clk_config(clocks: &mut ClockTree) -> Option<XtalClkConfig> {
             clocks.xtal_clk
@@ -2103,12 +2154,8 @@ macro_rules! define_clock_tree_types {
         pub fn xtal_clk_config_frequency(clocks: &mut ClockTree, config: XtalClkConfig) -> u32 {
             config.value()
         }
-        pub fn xtal_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.xtal_clk {
-                xtal_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn xtal_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            XTAL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_pll_clk(clocks: &mut ClockTree) {
             trace!("Requesting PLL_CLK");
@@ -2192,6 +2239,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_hp_root_clk(clocks: &mut ClockTree, config: HpRootClkConfig) {
             let old_config = clocks.hp_root_clk.replace(config);
             configure_hp_root_clk_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn hp_root_clk_config(clocks: &mut ClockTree) -> Option<HpRootClkConfig> {
             clocks.hp_root_clk
@@ -2219,12 +2267,8 @@ macro_rules! define_clock_tree_types {
         ) -> u32 {
             (soc_root_clk_frequency(clocks) / config.divisor())
         }
-        pub fn hp_root_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.hp_root_clk {
-                hp_root_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn hp_root_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            HP_ROOT_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, new_selector: CpuClkConfig) {
             let old_selector = clocks.cpu_clk.replace(new_selector);
@@ -2239,6 +2283,7 @@ macro_rules! define_clock_tree_types {
                     CpuClkConfig::Ls => release_cpu_ls_div(clocks),
                 }
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn cpu_clk_config(clocks: &mut ClockTree) -> Option<CpuClkConfig> {
             clocks.cpu_clk
@@ -2252,12 +2297,8 @@ macro_rules! define_clock_tree_types {
                 CpuClkConfig::Ls => cpu_ls_div_frequency(clocks),
             }
         }
-        pub fn cpu_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.cpu_clk {
-                cpu_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn cpu_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            CPU_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_ahb_clk(clocks: &mut ClockTree, new_selector: AhbClkConfig) {
             let old_selector = clocks.ahb_clk.replace(new_selector);
@@ -2272,6 +2313,7 @@ macro_rules! define_clock_tree_types {
                     AhbClkConfig::Ls => release_ahb_ls_div(clocks),
                 }
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn ahb_clk_config(clocks: &mut ClockTree) -> Option<AhbClkConfig> {
             clocks.ahb_clk
@@ -2285,12 +2327,8 @@ macro_rules! define_clock_tree_types {
                 AhbClkConfig::Ls => ahb_ls_div_frequency(clocks),
             }
         }
-        pub fn ahb_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.ahb_clk {
-                ahb_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn ahb_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            AHB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_mspi_fast_clk(clocks: &mut ClockTree, new_selector: MspiFastClkConfig) {
             let old_selector = clocks.mspi_fast_clk.replace(new_selector);
@@ -2309,6 +2347,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_mspi_fast_clk_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn mspi_fast_clk_config(clocks: &mut ClockTree) -> Option<MspiFastClkConfig> {
             clocks.mspi_fast_clk
@@ -2345,12 +2384,8 @@ macro_rules! define_clock_tree_types {
                 MspiFastClkConfig::Ls => mspi_fast_ls_clk_frequency(clocks),
             }
         }
-        pub fn mspi_fast_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.mspi_fast_clk {
-                mspi_fast_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn mspi_fast_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            MSPI_FAST_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_soc_root_clk(clocks: &mut ClockTree, new_selector: SocRootClkConfig) {
             let old_selector = clocks.soc_root_clk.replace(new_selector);
@@ -2390,6 +2425,7 @@ macro_rules! define_clock_tree_types {
                     SocRootClkConfig::Pll => release_pll_clk(clocks),
                 }
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn soc_root_clk_config(clocks: &mut ClockTree) -> Option<SocRootClkConfig> {
             clocks.soc_root_clk
@@ -2425,16 +2461,13 @@ macro_rules! define_clock_tree_types {
                 SocRootClkConfig::Pll => pll_clk_frequency(clocks),
             }
         }
-        pub fn soc_root_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.soc_root_clk {
-                soc_root_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn soc_root_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            SOC_ROOT_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_cpu_hs_div(clocks: &mut ClockTree, config: CpuHsDivConfig) {
             let old_config = clocks.cpu_hs_div.replace(config);
             configure_cpu_hs_div_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn cpu_hs_div_config(clocks: &mut ClockTree) -> Option<CpuHsDivConfig> {
             clocks.cpu_hs_div
@@ -2455,16 +2488,13 @@ macro_rules! define_clock_tree_types {
         pub fn cpu_hs_div_config_frequency(clocks: &mut ClockTree, config: CpuHsDivConfig) -> u32 {
             (hp_root_clk_frequency(clocks) / (config.divisor() + 1))
         }
-        pub fn cpu_hs_div_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.cpu_hs_div {
-                cpu_hs_div_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn cpu_hs_div_frequency(_clocks: &mut ClockTree) -> u32 {
+            CPU_HS_DIV_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_cpu_ls_div(clocks: &mut ClockTree, config: CpuLsDivConfig) {
             let old_config = clocks.cpu_ls_div.replace(config);
             configure_cpu_ls_div_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn cpu_ls_div_config(clocks: &mut ClockTree) -> Option<CpuLsDivConfig> {
             clocks.cpu_ls_div
@@ -2485,16 +2515,13 @@ macro_rules! define_clock_tree_types {
         pub fn cpu_ls_div_config_frequency(clocks: &mut ClockTree, config: CpuLsDivConfig) -> u32 {
             (hp_root_clk_frequency(clocks) / (config.divisor() + 1))
         }
-        pub fn cpu_ls_div_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.cpu_ls_div {
-                cpu_ls_div_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn cpu_ls_div_frequency(_clocks: &mut ClockTree) -> u32 {
+            CPU_LS_DIV_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_ahb_hs_div(clocks: &mut ClockTree, config: AhbHsDivConfig) {
             let old_config = clocks.ahb_hs_div.replace(config);
             configure_ahb_hs_div_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn ahb_hs_div_config(clocks: &mut ClockTree) -> Option<AhbHsDivConfig> {
             clocks.ahb_hs_div
@@ -2515,16 +2542,13 @@ macro_rules! define_clock_tree_types {
         pub fn ahb_hs_div_config_frequency(clocks: &mut ClockTree, config: AhbHsDivConfig) -> u32 {
             (hp_root_clk_frequency(clocks) / (config.divisor() + 1))
         }
-        pub fn ahb_hs_div_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.ahb_hs_div {
-                ahb_hs_div_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn ahb_hs_div_frequency(_clocks: &mut ClockTree) -> u32 {
+            AHB_HS_DIV_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_ahb_ls_div(clocks: &mut ClockTree, config: AhbLsDivConfig) {
             let old_config = clocks.ahb_ls_div.replace(config);
             configure_ahb_ls_div_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn ahb_ls_div_config(clocks: &mut ClockTree) -> Option<AhbLsDivConfig> {
             clocks.ahb_ls_div
@@ -2545,16 +2569,13 @@ macro_rules! define_clock_tree_types {
         pub fn ahb_ls_div_config_frequency(clocks: &mut ClockTree, config: AhbLsDivConfig) -> u32 {
             (hp_root_clk_frequency(clocks) / (config.divisor() + 1))
         }
-        pub fn ahb_ls_div_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.ahb_ls_div {
-                ahb_ls_div_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn ahb_ls_div_frequency(_clocks: &mut ClockTree) -> u32 {
+            AHB_LS_DIV_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, config: ApbClkConfig) {
             let old_config = clocks.apb_clk.replace(config);
             configure_apb_clk_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn apb_clk_config(clocks: &mut ClockTree) -> Option<ApbClkConfig> {
             clocks.apb_clk
@@ -2579,16 +2600,13 @@ macro_rules! define_clock_tree_types {
         pub fn apb_clk_config_frequency(clocks: &mut ClockTree, config: ApbClkConfig) -> u32 {
             (ahb_clk_frequency(clocks) / (config.divisor() + 1))
         }
-        pub fn apb_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.apb_clk {
-                apb_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn apb_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            APB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_mspi_fast_hs_clk(clocks: &mut ClockTree, config: MspiFastHsClkConfig) {
             let old_config = clocks.mspi_fast_hs_clk.replace(config);
             configure_mspi_fast_hs_clk_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn mspi_fast_hs_clk_config(clocks: &mut ClockTree) -> Option<MspiFastHsClkConfig> {
             clocks.mspi_fast_hs_clk
@@ -2612,16 +2630,13 @@ macro_rules! define_clock_tree_types {
         ) -> u32 {
             (hp_root_clk_frequency(clocks) / (config.divisor() + 1))
         }
-        pub fn mspi_fast_hs_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.mspi_fast_hs_clk {
-                mspi_fast_hs_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn mspi_fast_hs_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            MSPI_FAST_HS_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_mspi_fast_ls_clk(clocks: &mut ClockTree, config: MspiFastLsClkConfig) {
             let old_config = clocks.mspi_fast_ls_clk.replace(config);
             configure_mspi_fast_ls_clk_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn mspi_fast_ls_clk_config(clocks: &mut ClockTree) -> Option<MspiFastLsClkConfig> {
             clocks.mspi_fast_ls_clk
@@ -2645,12 +2660,8 @@ macro_rules! define_clock_tree_types {
         ) -> u32 {
             (hp_root_clk_frequency(clocks) / (config.divisor() + 1))
         }
-        pub fn mspi_fast_ls_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.mspi_fast_ls_clk {
-                mspi_fast_ls_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn mspi_fast_ls_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            MSPI_FAST_LS_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_pll_f48m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F48M");
@@ -2743,6 +2754,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_ledc_sclk_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn ledc_sclk_config(clocks: &mut ClockTree) -> Option<LedcSclkConfig> {
             clocks.ledc_sclk
@@ -2779,12 +2791,8 @@ macro_rules! define_clock_tree_types {
                 LedcSclkConfig::XtalClk => xtal_clk_frequency(clocks),
             }
         }
-        pub fn ledc_sclk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.ledc_sclk {
-                ledc_sclk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn ledc_sclk_frequency(_clocks: &mut ClockTree) -> u32 {
+            LEDC_SCLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_xtal_d2_clk(clocks: &mut ClockTree) {
             trace!("Requesting XTAL_D2_CLK");
@@ -2818,6 +2826,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_lp_fast_clk_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn lp_fast_clk_config(clocks: &mut ClockTree) -> Option<LpFastClkConfig> {
             clocks.lp_fast_clk
@@ -2854,12 +2863,8 @@ macro_rules! define_clock_tree_types {
                 LpFastClkConfig::XtalD2Clk => xtal_d2_clk_frequency(clocks),
             }
         }
-        pub fn lp_fast_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.lp_fast_clk {
-                lp_fast_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn lp_fast_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            LP_FAST_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_lp_slow_clk(clocks: &mut ClockTree, new_selector: LpSlowClkConfig) {
             let old_selector = clocks.lp_slow_clk.replace(new_selector);
@@ -2876,6 +2881,7 @@ macro_rules! define_clock_tree_types {
                     LpSlowClkConfig::OscSlow => release_osc_slow_clk(clocks),
                 }
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn lp_slow_clk_config(clocks: &mut ClockTree) -> Option<LpSlowClkConfig> {
             clocks.lp_slow_clk
@@ -2911,12 +2917,8 @@ macro_rules! define_clock_tree_types {
                 LpSlowClkConfig::OscSlow => osc_slow_clk_frequency(clocks),
             }
         }
-        pub fn lp_slow_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.lp_slow_clk {
-                lp_slow_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn lp_slow_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            LP_SLOW_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_timg_calibration_clock(
             clocks: &mut ClockTree,
@@ -2940,6 +2942,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn timg_calibration_clock_config(
             clocks: &mut ClockTree,
@@ -2981,12 +2984,8 @@ macro_rules! define_clock_tree_types {
                 TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(clocks),
             }
         }
-        pub fn timg_calibration_clock_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.timg_calibration_clock {
-                timg_calibration_clock_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn timg_calibration_clock_frequency(_clocks: &mut ClockTree) -> u32 {
+            TIMG_CALIBRATION_CLOCK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         impl McpwmInstance {
             pub fn configure_function_clock(
@@ -3012,6 +3011,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn function_clock_config(
                 self,
@@ -3059,12 +3059,9 @@ macro_rules! define_clock_tree_types {
                     McpwmFunctionClockConfig::XtalClk => xtal_clk_frequency(clocks),
                 }
             }
-            pub fn function_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.mcpwm_function_clock[self as usize] {
-                    self.function_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                MCPWM_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
         }
         impl ParlIoInstance {
@@ -3091,6 +3088,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_rx_clock_impl(clocks, old_selector, new_selector);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn rx_clock_config(self, clocks: &mut ClockTree) -> Option<ParlIoRxClockConfig> {
                 clocks.parl_io_rx_clock[self as usize]
@@ -3131,12 +3129,9 @@ macro_rules! define_clock_tree_types {
                     ParlIoRxClockConfig::PllF240m => pll_f240m_frequency(clocks),
                 }
             }
-            pub fn rx_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.parl_io_rx_clock[self as usize] {
-                    self.rx_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn rx_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                PARL_IO_RX_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
             pub fn configure_tx_clock(
                 self,
@@ -3161,6 +3156,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_tx_clock_impl(clocks, old_selector, new_selector);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn tx_clock_config(self, clocks: &mut ClockTree) -> Option<ParlIoTxClockConfig> {
                 clocks.parl_io_tx_clock[self as usize]
@@ -3201,12 +3197,9 @@ macro_rules! define_clock_tree_types {
                     ParlIoTxClockConfig::PllF240m => pll_f240m_frequency(clocks),
                 }
             }
-            pub fn tx_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.parl_io_tx_clock[self as usize] {
-                    self.tx_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn tx_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                PARL_IO_TX_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
         }
         impl RmtInstance {
@@ -3229,6 +3222,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_sclk_impl(clocks, old_selector, new_selector);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn sclk_config(self, clocks: &mut ClockTree) -> Option<RmtSclkConfig> {
                 clocks.rmt_sclk[self as usize]
@@ -3269,12 +3263,8 @@ macro_rules! define_clock_tree_types {
                     RmtSclkConfig::XtalClk => xtal_clk_frequency(clocks),
                 }
             }
-            pub fn sclk_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.rmt_sclk[self as usize] {
-                    self.sclk_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn sclk_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                RMT_SCLK_FREQ_CACHE[self as usize].load(::core::sync::atomic::Ordering::Acquire)
             }
         }
         impl TimgInstance {
@@ -3301,6 +3291,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn function_clock_config(
                 self,
@@ -3348,12 +3339,9 @@ macro_rules! define_clock_tree_types {
                     TimgFunctionClockConfig::PllF80m => pll_f80m_frequency(clocks),
                 }
             }
-            pub fn function_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.timg_function_clock[self as usize] {
-                    self.function_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                TIMG_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
             pub fn configure_wdt_clock(
                 self,
@@ -3378,6 +3366,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_wdt_clock_impl(clocks, old_selector, new_selector);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn wdt_clock_config(self, clocks: &mut ClockTree) -> Option<TimgWdtClockConfig> {
                 clocks.timg_wdt_clock[self as usize]
@@ -3418,12 +3407,9 @@ macro_rules! define_clock_tree_types {
                     TimgWdtClockConfig::RcFastClk => rc_fast_clk_frequency(clocks),
                 }
             }
-            pub fn wdt_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.timg_wdt_clock[self as usize] {
-                    self.wdt_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn wdt_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                TIMG_WDT_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
         }
         impl UartInstance {
@@ -3450,6 +3436,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_config, config);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn function_clock_config(
                 self,
@@ -3497,12 +3484,9 @@ macro_rules! define_clock_tree_types {
                     UartFunctionClockSclk::Xtal => xtal_clk_frequency(clocks),
                 } / (config.div_num() + 1))
             }
-            pub fn function_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.uart_function_clock[self as usize] {
-                    self.function_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                UART_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
             pub fn configure_baud_rate_generator(
                 self,
@@ -3511,6 +3495,7 @@ macro_rules! define_clock_tree_types {
             ) {
                 let old_config = clocks.uart_baud_rate_generator[self as usize].replace(config);
                 self.configure_baud_rate_generator_impl(clocks, old_config, config);
+                refresh_all_frequency_caches(clocks);
             }
             pub fn baud_rate_generator_config(
                 self,
@@ -3547,12 +3532,9 @@ macro_rules! define_clock_tree_types {
                 ((self.function_clock_frequency(clocks) * 16)
                     / ((config.integral() * 16) + config.fractional()))
             }
-            pub fn baud_rate_generator_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.uart_baud_rate_generator[self as usize] {
-                    self.baud_rate_generator_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn baud_rate_generator_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                UART_BAUD_RATE_GENERATOR_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
         }
         /// Clock tree configuration.
@@ -3647,6 +3629,174 @@ macro_rules! define_clock_tree_types {
             *refcount = refcount.saturating_sub(1);
             let last = *refcount == 0;
             last
+        }
+        fn refresh_all_frequency_caches(clocks: &mut ClockTree) {
+            if let Some(config) = clocks.xtal_clk {
+                XTAL_CLK_FREQ_CACHE.store(
+                    xtal_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.soc_root_clk {
+                SOC_ROOT_CLK_FREQ_CACHE.store(
+                    soc_root_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.ledc_sclk {
+                LEDC_SCLK_FREQ_CACHE.store(
+                    ledc_sclk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.lp_fast_clk {
+                LP_FAST_CLK_FREQ_CACHE.store(
+                    lp_fast_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.lp_slow_clk {
+                LP_SLOW_CLK_FREQ_CACHE.store(
+                    lp_slow_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.timg_calibration_clock {
+                TIMG_CALIBRATION_CLOCK_FREQ_CACHE.store(
+                    timg_calibration_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            for instance in [McpwmInstance::Mcpwm0] {
+                if let Some(config) = clocks.mcpwm_function_clock[instance as usize] {
+                    MCPWM_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.function_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [ParlIoInstance::ParlIo] {
+                if let Some(config) = clocks.parl_io_rx_clock[instance as usize] {
+                    PARL_IO_RX_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.rx_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [ParlIoInstance::ParlIo] {
+                if let Some(config) = clocks.parl_io_tx_clock[instance as usize] {
+                    PARL_IO_TX_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.tx_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [RmtInstance::Rmt] {
+                if let Some(config) = clocks.rmt_sclk[instance as usize] {
+                    RMT_SCLK_FREQ_CACHE[instance as usize].store(
+                        instance.sclk_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                if let Some(config) = clocks.timg_function_clock[instance as usize] {
+                    TIMG_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.function_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                if let Some(config) = clocks.timg_wdt_clock[instance as usize] {
+                    TIMG_WDT_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.wdt_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                if let Some(config) = clocks.uart_function_clock[instance as usize] {
+                    UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.function_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                if let Some(config) = clocks.uart_baud_rate_generator[instance as usize] {
+                    UART_BAUD_RATE_GENERATOR_FREQ_CACHE[instance as usize].store(
+                        instance.baud_rate_generator_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            if let Some(config) = clocks.hp_root_clk {
+                HP_ROOT_CLK_FREQ_CACHE.store(
+                    hp_root_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.cpu_hs_div {
+                CPU_HS_DIV_FREQ_CACHE.store(
+                    cpu_hs_div_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.cpu_ls_div {
+                CPU_LS_DIV_FREQ_CACHE.store(
+                    cpu_ls_div_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.ahb_hs_div {
+                AHB_HS_DIV_FREQ_CACHE.store(
+                    ahb_hs_div_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.ahb_ls_div {
+                AHB_LS_DIV_FREQ_CACHE.store(
+                    ahb_ls_div_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.mspi_fast_hs_clk {
+                MSPI_FAST_HS_CLK_FREQ_CACHE.store(
+                    mspi_fast_hs_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.mspi_fast_ls_clk {
+                MSPI_FAST_LS_CLK_FREQ_CACHE.store(
+                    mspi_fast_ls_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.cpu_clk {
+                CPU_CLK_FREQ_CACHE.store(
+                    cpu_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.ahb_clk {
+                AHB_CLK_FREQ_CACHE.store(
+                    ahb_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.mspi_fast_clk {
+                MSPI_FAST_CLK_FREQ_CACHE.store(
+                    mspi_fast_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.apb_clk {
+                APB_CLK_FREQ_CACHE.store(
+                    apb_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
         }
     };
 }

--- a/esp-metadata-generated/src/_generated_esp32c6.rs
+++ b/esp-metadata-generated/src/_generated_esp32c6.rs
@@ -3645,8 +3645,6 @@ macro_rules! define_clock_tree_types {
             }
             for child_instance in [ParlIoInstance::ParlIo] {
                 refresh_parl_io_rx_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [ParlIoInstance::ParlIo] {
                 refresh_parl_io_tx_clock_downstream(clocks, child_instance);
             }
             for child_instance in [RmtInstance::Rmt] {
@@ -3654,18 +3652,7 @@ macro_rules! define_clock_tree_types {
             }
             for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
                 refresh_timg_function_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
                 refresh_timg_wdt_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
-                refresh_timg_function_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
-                refresh_timg_wdt_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
-                refresh_uart_function_clock_downstream(clocks, child_instance);
             }
             for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
                 refresh_uart_function_clock_downstream(clocks, child_instance);

--- a/esp-metadata-generated/src/_generated_esp32c6.rs
+++ b/esp-metadata-generated/src/_generated_esp32c6.rs
@@ -2142,8 +2142,8 @@ macro_rules! define_clock_tree_types {
             ::core::sync::atomic::AtomicU32::new(0);
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
             let old_config = clocks.xtal_clk.replace(config);
-            configure_xtal_clk_impl(clocks, old_config, config);
             refresh_xtal_clk_downstream(clocks);
+            configure_xtal_clk_impl(clocks, old_config, config);
         }
         pub fn xtal_clk_config(clocks: &mut ClockTree) -> Option<XtalClkConfig> {
             clocks.xtal_clk
@@ -2238,8 +2238,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_hp_root_clk(clocks: &mut ClockTree, config: HpRootClkConfig) {
             let old_config = clocks.hp_root_clk.replace(config);
-            configure_hp_root_clk_impl(clocks, old_config, config);
             refresh_hp_root_clk_downstream(clocks);
+            configure_hp_root_clk_impl(clocks, old_config, config);
         }
         pub fn hp_root_clk_config(clocks: &mut ClockTree) -> Option<HpRootClkConfig> {
             clocks.hp_root_clk
@@ -2272,6 +2272,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, new_selector: CpuClkConfig) {
             let old_selector = clocks.cpu_clk.replace(new_selector);
+            refresh_cpu_clk_downstream(clocks);
             match new_selector {
                 CpuClkConfig::Hs => request_cpu_hs_div(clocks),
                 CpuClkConfig::Ls => request_cpu_ls_div(clocks),
@@ -2283,7 +2284,6 @@ macro_rules! define_clock_tree_types {
                     CpuClkConfig::Ls => release_cpu_ls_div(clocks),
                 }
             }
-            refresh_cpu_clk_downstream(clocks);
         }
         pub fn cpu_clk_config(clocks: &mut ClockTree) -> Option<CpuClkConfig> {
             clocks.cpu_clk
@@ -2302,6 +2302,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_ahb_clk(clocks: &mut ClockTree, new_selector: AhbClkConfig) {
             let old_selector = clocks.ahb_clk.replace(new_selector);
+            refresh_ahb_clk_downstream(clocks);
             match new_selector {
                 AhbClkConfig::Hs => request_ahb_hs_div(clocks),
                 AhbClkConfig::Ls => request_ahb_ls_div(clocks),
@@ -2313,7 +2314,6 @@ macro_rules! define_clock_tree_types {
                     AhbClkConfig::Ls => release_ahb_ls_div(clocks),
                 }
             }
-            refresh_ahb_clk_downstream(clocks);
         }
         pub fn ahb_clk_config(clocks: &mut ClockTree) -> Option<AhbClkConfig> {
             clocks.ahb_clk
@@ -2332,6 +2332,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_mspi_fast_clk(clocks: &mut ClockTree, new_selector: MspiFastClkConfig) {
             let old_selector = clocks.mspi_fast_clk.replace(new_selector);
+            refresh_mspi_fast_clk_downstream(clocks);
             if clocks.mspi_fast_clk_refcount > 0 {
                 match new_selector {
                     MspiFastClkConfig::Hs => request_mspi_fast_hs_clk(clocks),
@@ -2347,7 +2348,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_mspi_fast_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_mspi_fast_clk_downstream(clocks);
         }
         pub fn mspi_fast_clk_config(clocks: &mut ClockTree) -> Option<MspiFastClkConfig> {
             clocks.mspi_fast_clk
@@ -2389,6 +2389,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_soc_root_clk(clocks: &mut ClockTree, new_selector: SocRootClkConfig) {
             let old_selector = clocks.soc_root_clk.replace(new_selector);
+            refresh_soc_root_clk_downstream(clocks);
             match new_selector {
                 SocRootClkConfig::Xtal => {
                     let config_value = HpRootClkConfig::new(HpRootClkDivisor::new(1));
@@ -2425,7 +2426,6 @@ macro_rules! define_clock_tree_types {
                     SocRootClkConfig::Pll => release_pll_clk(clocks),
                 }
             }
-            refresh_soc_root_clk_downstream(clocks);
         }
         pub fn soc_root_clk_config(clocks: &mut ClockTree) -> Option<SocRootClkConfig> {
             clocks.soc_root_clk
@@ -2466,8 +2466,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_cpu_hs_div(clocks: &mut ClockTree, config: CpuHsDivConfig) {
             let old_config = clocks.cpu_hs_div.replace(config);
-            configure_cpu_hs_div_impl(clocks, old_config, config);
             refresh_cpu_hs_div_downstream(clocks);
+            configure_cpu_hs_div_impl(clocks, old_config, config);
         }
         pub fn cpu_hs_div_config(clocks: &mut ClockTree) -> Option<CpuHsDivConfig> {
             clocks.cpu_hs_div
@@ -2493,8 +2493,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_cpu_ls_div(clocks: &mut ClockTree, config: CpuLsDivConfig) {
             let old_config = clocks.cpu_ls_div.replace(config);
-            configure_cpu_ls_div_impl(clocks, old_config, config);
             refresh_cpu_ls_div_downstream(clocks);
+            configure_cpu_ls_div_impl(clocks, old_config, config);
         }
         pub fn cpu_ls_div_config(clocks: &mut ClockTree) -> Option<CpuLsDivConfig> {
             clocks.cpu_ls_div
@@ -2520,8 +2520,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_ahb_hs_div(clocks: &mut ClockTree, config: AhbHsDivConfig) {
             let old_config = clocks.ahb_hs_div.replace(config);
-            configure_ahb_hs_div_impl(clocks, old_config, config);
             refresh_ahb_hs_div_downstream(clocks);
+            configure_ahb_hs_div_impl(clocks, old_config, config);
         }
         pub fn ahb_hs_div_config(clocks: &mut ClockTree) -> Option<AhbHsDivConfig> {
             clocks.ahb_hs_div
@@ -2547,8 +2547,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_ahb_ls_div(clocks: &mut ClockTree, config: AhbLsDivConfig) {
             let old_config = clocks.ahb_ls_div.replace(config);
-            configure_ahb_ls_div_impl(clocks, old_config, config);
             refresh_ahb_ls_div_downstream(clocks);
+            configure_ahb_ls_div_impl(clocks, old_config, config);
         }
         pub fn ahb_ls_div_config(clocks: &mut ClockTree) -> Option<AhbLsDivConfig> {
             clocks.ahb_ls_div
@@ -2574,8 +2574,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, config: ApbClkConfig) {
             let old_config = clocks.apb_clk.replace(config);
-            configure_apb_clk_impl(clocks, old_config, config);
             refresh_apb_clk_downstream(clocks);
+            configure_apb_clk_impl(clocks, old_config, config);
         }
         pub fn apb_clk_config(clocks: &mut ClockTree) -> Option<ApbClkConfig> {
             clocks.apb_clk
@@ -2605,8 +2605,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_mspi_fast_hs_clk(clocks: &mut ClockTree, config: MspiFastHsClkConfig) {
             let old_config = clocks.mspi_fast_hs_clk.replace(config);
-            configure_mspi_fast_hs_clk_impl(clocks, old_config, config);
             refresh_mspi_fast_hs_clk_downstream(clocks);
+            configure_mspi_fast_hs_clk_impl(clocks, old_config, config);
         }
         pub fn mspi_fast_hs_clk_config(clocks: &mut ClockTree) -> Option<MspiFastHsClkConfig> {
             clocks.mspi_fast_hs_clk
@@ -2635,8 +2635,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_mspi_fast_ls_clk(clocks: &mut ClockTree, config: MspiFastLsClkConfig) {
             let old_config = clocks.mspi_fast_ls_clk.replace(config);
-            configure_mspi_fast_ls_clk_impl(clocks, old_config, config);
             refresh_mspi_fast_ls_clk_downstream(clocks);
+            configure_mspi_fast_ls_clk_impl(clocks, old_config, config);
         }
         pub fn mspi_fast_ls_clk_config(clocks: &mut ClockTree) -> Option<MspiFastLsClkConfig> {
             clocks.mspi_fast_ls_clk
@@ -2737,6 +2737,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_ledc_sclk(clocks: &mut ClockTree, new_selector: LedcSclkConfig) {
             let old_selector = clocks.ledc_sclk.replace(new_selector);
+            refresh_ledc_sclk_downstream(clocks);
             if clocks.ledc_sclk_refcount > 0 {
                 match new_selector {
                     LedcSclkConfig::PllF80m => request_pll_f80m(clocks),
@@ -2754,7 +2755,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_ledc_sclk_impl(clocks, old_selector, new_selector);
             }
-            refresh_ledc_sclk_downstream(clocks);
         }
         pub fn ledc_sclk_config(clocks: &mut ClockTree) -> Option<LedcSclkConfig> {
             clocks.ledc_sclk
@@ -2811,6 +2811,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_lp_fast_clk(clocks: &mut ClockTree, new_selector: LpFastClkConfig) {
             let old_selector = clocks.lp_fast_clk.replace(new_selector);
+            refresh_lp_fast_clk_downstream(clocks);
             if clocks.lp_fast_clk_refcount > 0 {
                 match new_selector {
                     LpFastClkConfig::RcFastClk => request_rc_fast_clk(clocks),
@@ -2826,7 +2827,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_lp_fast_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_lp_fast_clk_downstream(clocks);
         }
         pub fn lp_fast_clk_config(clocks: &mut ClockTree) -> Option<LpFastClkConfig> {
             clocks.lp_fast_clk
@@ -2868,6 +2868,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_lp_slow_clk(clocks: &mut ClockTree, new_selector: LpSlowClkConfig) {
             let old_selector = clocks.lp_slow_clk.replace(new_selector);
+            refresh_lp_slow_clk_downstream(clocks);
             match new_selector {
                 LpSlowClkConfig::Xtal32k => request_xtal32k_clk(clocks),
                 LpSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
@@ -2881,7 +2882,6 @@ macro_rules! define_clock_tree_types {
                     LpSlowClkConfig::OscSlow => release_osc_slow_clk(clocks),
                 }
             }
-            refresh_lp_slow_clk_downstream(clocks);
         }
         pub fn lp_slow_clk_config(clocks: &mut ClockTree) -> Option<LpSlowClkConfig> {
             clocks.lp_slow_clk
@@ -2925,6 +2925,7 @@ macro_rules! define_clock_tree_types {
             new_selector: TimgCalibrationClockConfig,
         ) {
             let old_selector = clocks.timg_calibration_clock.replace(new_selector);
+            refresh_timg_calibration_clock_downstream(clocks);
             if clocks.timg_calibration_clock_refcount > 0 {
                 match new_selector {
                     TimgCalibrationClockConfig::RcSlowClk => request_lp_slow_clk(clocks),
@@ -2942,7 +2943,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
             }
-            refresh_timg_calibration_clock_downstream(clocks);
         }
         pub fn timg_calibration_clock_config(
             clocks: &mut ClockTree,
@@ -2994,6 +2994,7 @@ macro_rules! define_clock_tree_types {
                 new_selector: McpwmFunctionClockConfig,
             ) {
                 let old_selector = clocks.mcpwm_function_clock[self as usize].replace(new_selector);
+                refresh_mcpwm_function_clock_downstream(clocks, self);
                 if clocks.mcpwm_function_clock_refcount[self as usize] > 0 {
                     match new_selector {
                         McpwmFunctionClockConfig::PllF160m => request_pll_f160m(clocks),
@@ -3011,7 +3012,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_mcpwm_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -3071,6 +3071,7 @@ macro_rules! define_clock_tree_types {
                 new_selector: ParlIoRxClockConfig,
             ) {
                 let old_selector = clocks.parl_io_rx_clock[self as usize].replace(new_selector);
+                refresh_parl_io_rx_clock_downstream(clocks, self);
                 if clocks.parl_io_rx_clock_refcount[self as usize] > 0 {
                     match new_selector {
                         ParlIoRxClockConfig::XtalClk => request_xtal_clk(clocks),
@@ -3088,7 +3089,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_rx_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_parl_io_rx_clock_downstream(clocks, self);
             }
             pub fn rx_clock_config(self, clocks: &mut ClockTree) -> Option<ParlIoRxClockConfig> {
                 clocks.parl_io_rx_clock[self as usize]
@@ -3139,6 +3139,7 @@ macro_rules! define_clock_tree_types {
                 new_selector: ParlIoTxClockConfig,
             ) {
                 let old_selector = clocks.parl_io_tx_clock[self as usize].replace(new_selector);
+                refresh_parl_io_tx_clock_downstream(clocks, self);
                 if clocks.parl_io_tx_clock_refcount[self as usize] > 0 {
                     match new_selector {
                         ParlIoTxClockConfig::XtalClk => request_xtal_clk(clocks),
@@ -3156,7 +3157,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_tx_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_parl_io_tx_clock_downstream(clocks, self);
             }
             pub fn tx_clock_config(self, clocks: &mut ClockTree) -> Option<ParlIoTxClockConfig> {
                 clocks.parl_io_tx_clock[self as usize]
@@ -3205,6 +3205,7 @@ macro_rules! define_clock_tree_types {
         impl RmtInstance {
             pub fn configure_sclk(self, clocks: &mut ClockTree, new_selector: RmtSclkConfig) {
                 let old_selector = clocks.rmt_sclk[self as usize].replace(new_selector);
+                refresh_rmt_sclk_downstream(clocks, self);
                 if clocks.rmt_sclk_refcount[self as usize] > 0 {
                     match new_selector {
                         RmtSclkConfig::PllF80m => request_pll_f80m(clocks),
@@ -3222,7 +3223,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_sclk_impl(clocks, old_selector, new_selector);
                 }
-                refresh_rmt_sclk_downstream(clocks, self);
             }
             pub fn sclk_config(self, clocks: &mut ClockTree) -> Option<RmtSclkConfig> {
                 clocks.rmt_sclk[self as usize]
@@ -3274,6 +3274,7 @@ macro_rules! define_clock_tree_types {
                 new_selector: TimgFunctionClockConfig,
             ) {
                 let old_selector = clocks.timg_function_clock[self as usize].replace(new_selector);
+                refresh_timg_function_clock_downstream(clocks, self);
                 if clocks.timg_function_clock_refcount[self as usize] > 0 {
                     match new_selector {
                         TimgFunctionClockConfig::XtalClk => request_xtal_clk(clocks),
@@ -3291,7 +3292,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_timg_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -3349,6 +3349,7 @@ macro_rules! define_clock_tree_types {
                 new_selector: TimgWdtClockConfig,
             ) {
                 let old_selector = clocks.timg_wdt_clock[self as usize].replace(new_selector);
+                refresh_timg_wdt_clock_downstream(clocks, self);
                 if clocks.timg_wdt_clock_refcount[self as usize] > 0 {
                     match new_selector {
                         TimgWdtClockConfig::XtalClk => request_xtal_clk(clocks),
@@ -3366,7 +3367,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_wdt_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_timg_wdt_clock_downstream(clocks, self);
             }
             pub fn wdt_clock_config(self, clocks: &mut ClockTree) -> Option<TimgWdtClockConfig> {
                 clocks.timg_wdt_clock[self as usize]
@@ -3419,6 +3419,7 @@ macro_rules! define_clock_tree_types {
                 config: UartFunctionClockConfig,
             ) {
                 let old_config = clocks.uart_function_clock[self as usize].replace(config);
+                refresh_uart_function_clock_downstream(clocks, self);
                 if clocks.uart_function_clock_refcount[self as usize] > 0 {
                     match config.sclk {
                         UartFunctionClockSclk::PllF80m => request_pll_f80m(clocks),
@@ -3436,7 +3437,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_config, config);
                 }
-                refresh_uart_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -3494,8 +3494,8 @@ macro_rules! define_clock_tree_types {
                 config: UartBaudRateGeneratorConfig,
             ) {
                 let old_config = clocks.uart_baud_rate_generator[self as usize].replace(config);
-                self.configure_baud_rate_generator_impl(clocks, old_config, config);
                 refresh_uart_baud_rate_generator_downstream(clocks, self);
+                self.configure_baud_rate_generator_impl(clocks, old_config, config);
             }
             pub fn baud_rate_generator_config(
                 self,

--- a/esp-metadata-generated/src/_generated_esp32c61.rs
+++ b/esp-metadata-generated/src/_generated_esp32c61.rs
@@ -1238,8 +1238,8 @@ macro_rules! define_clock_tree_types {
             [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
             let old_config = clocks.xtal_clk.replace(config);
-            configure_xtal_clk_impl(clocks, old_config, config);
             refresh_xtal_clk_downstream(clocks);
+            configure_xtal_clk_impl(clocks, old_config, config);
         }
         pub fn xtal_clk_config(clocks: &mut ClockTree) -> Option<XtalClkConfig> {
             clocks.xtal_clk
@@ -1471,6 +1471,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_hp_root_clk(clocks: &mut ClockTree, new_selector: HpRootClkConfig) {
             let old_selector = clocks.hp_root_clk.replace(new_selector);
+            refresh_hp_root_clk_downstream(clocks);
             if clocks.hp_root_clk_refcount > 0 {
                 match new_selector {
                     HpRootClkConfig::Xtal => request_xtal_clk(clocks),
@@ -1488,7 +1489,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_hp_root_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_hp_root_clk_downstream(clocks);
         }
         pub fn hp_root_clk_config(clocks: &mut ClockTree) -> Option<HpRootClkConfig> {
             clocks.hp_root_clk
@@ -1533,8 +1533,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, config: CpuClkConfig) {
             let old_config = clocks.cpu_clk.replace(config);
-            configure_cpu_clk_impl(clocks, old_config, config);
             refresh_cpu_clk_downstream(clocks);
+            configure_cpu_clk_impl(clocks, old_config, config);
         }
         pub fn cpu_clk_config(clocks: &mut ClockTree) -> Option<CpuClkConfig> {
             clocks.cpu_clk
@@ -1564,8 +1564,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_ahb_clk(clocks: &mut ClockTree, config: AhbClkConfig) {
             let old_config = clocks.ahb_clk.replace(config);
-            configure_ahb_clk_impl(clocks, old_config, config);
             refresh_ahb_clk_downstream(clocks);
+            configure_ahb_clk_impl(clocks, old_config, config);
         }
         pub fn ahb_clk_config(clocks: &mut ClockTree) -> Option<AhbClkConfig> {
             clocks.ahb_clk
@@ -1591,8 +1591,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, config: ApbClkConfig) {
             let old_config = clocks.apb_clk.replace(config);
-            configure_apb_clk_impl(clocks, old_config, config);
             refresh_apb_clk_downstream(clocks);
+            configure_apb_clk_impl(clocks, old_config, config);
         }
         pub fn apb_clk_config(clocks: &mut ClockTree) -> Option<ApbClkConfig> {
             clocks.apb_clk
@@ -1637,6 +1637,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_lp_fast_clk(clocks: &mut ClockTree, new_selector: LpFastClkConfig) {
             let old_selector = clocks.lp_fast_clk.replace(new_selector);
+            refresh_lp_fast_clk_downstream(clocks);
             if clocks.lp_fast_clk_refcount > 0 {
                 match new_selector {
                     LpFastClkConfig::RcFast => request_rc_fast_clk(clocks),
@@ -1654,7 +1655,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_lp_fast_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_lp_fast_clk_downstream(clocks);
         }
         pub fn lp_fast_clk_config(clocks: &mut ClockTree) -> Option<LpFastClkConfig> {
             clocks.lp_fast_clk
@@ -1699,6 +1699,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_lp_slow_clk(clocks: &mut ClockTree, new_selector: LpSlowClkConfig) {
             let old_selector = clocks.lp_slow_clk.replace(new_selector);
+            refresh_lp_slow_clk_downstream(clocks);
             if clocks.lp_slow_clk_refcount > 0 {
                 match new_selector {
                     LpSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
@@ -1716,7 +1717,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_lp_slow_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_lp_slow_clk_downstream(clocks);
         }
         pub fn lp_slow_clk_config(clocks: &mut ClockTree) -> Option<LpSlowClkConfig> {
             clocks.lp_slow_clk
@@ -1764,6 +1764,7 @@ macro_rules! define_clock_tree_types {
             new_selector: TimgCalibrationClockConfig,
         ) {
             let old_selector = clocks.timg_calibration_clock.replace(new_selector);
+            refresh_timg_calibration_clock_downstream(clocks);
             if clocks.timg_calibration_clock_refcount > 0 {
                 match new_selector {
                     TimgCalibrationClockConfig::OscSlowClk => request_osc_slow_clk(clocks),
@@ -1783,7 +1784,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
             }
-            refresh_timg_calibration_clock_downstream(clocks);
         }
         pub fn timg_calibration_clock_config(
             clocks: &mut ClockTree,
@@ -1838,6 +1838,7 @@ macro_rules! define_clock_tree_types {
                 new_selector: TimgFunctionClockConfig,
             ) {
                 let old_selector = clocks.timg_function_clock[self as usize].replace(new_selector);
+                refresh_timg_function_clock_downstream(clocks, self);
                 if clocks.timg_function_clock_refcount[self as usize] > 0 {
                     match new_selector {
                         TimgFunctionClockConfig::XtalClk => request_xtal_clk(clocks),
@@ -1855,7 +1856,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_timg_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -1913,6 +1913,7 @@ macro_rules! define_clock_tree_types {
                 new_selector: TimgWdtClockConfig,
             ) {
                 let old_selector = clocks.timg_wdt_clock[self as usize].replace(new_selector);
+                refresh_timg_wdt_clock_downstream(clocks, self);
                 if clocks.timg_wdt_clock_refcount[self as usize] > 0 {
                     match new_selector {
                         TimgWdtClockConfig::XtalClk => request_xtal_clk(clocks),
@@ -1930,7 +1931,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_wdt_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_timg_wdt_clock_downstream(clocks, self);
             }
             pub fn wdt_clock_config(self, clocks: &mut ClockTree) -> Option<TimgWdtClockConfig> {
                 clocks.timg_wdt_clock[self as usize]
@@ -1983,6 +1983,7 @@ macro_rules! define_clock_tree_types {
                 config: UartFunctionClockConfig,
             ) {
                 let old_config = clocks.uart_function_clock[self as usize].replace(config);
+                refresh_uart_function_clock_downstream(clocks, self);
                 if clocks.uart_function_clock_refcount[self as usize] > 0 {
                     match config.sclk {
                         UartFunctionClockSclk::Xtal => request_xtal_clk(clocks),
@@ -2000,7 +2001,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_config, config);
                 }
-                refresh_uart_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -2058,8 +2058,8 @@ macro_rules! define_clock_tree_types {
                 config: UartBaudRateGeneratorConfig,
             ) {
                 let old_config = clocks.uart_baud_rate_generator[self as usize].replace(config);
-                self.configure_baud_rate_generator_impl(clocks, old_config, config);
                 refresh_uart_baud_rate_generator_downstream(clocks, self);
+                self.configure_baud_rate_generator_impl(clocks, old_config, config);
             }
             pub fn baud_rate_generator_config(
                 self,

--- a/esp-metadata-generated/src/_generated_esp32c61.rs
+++ b/esp-metadata-generated/src/_generated_esp32c61.rs
@@ -1212,9 +1212,34 @@ macro_rules! define_clock_tree_types {
                 uart_function_clock_refcount: [0; 2],
                 uart_baud_rate_generator_refcount: [0; 2],
             });
+        static XTAL_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static HP_ROOT_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static CPU_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static AHB_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static APB_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static LP_FAST_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static LP_SLOW_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static TIMG_CALIBRATION_CLOCK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static TIMG_FUNCTION_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 2] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
+        static TIMG_WDT_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 2] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
+        static UART_FUNCTION_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 2] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
+        static UART_BAUD_RATE_GENERATOR_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 2] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
             let old_config = clocks.xtal_clk.replace(config);
             configure_xtal_clk_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn xtal_clk_config(clocks: &mut ClockTree) -> Option<XtalClkConfig> {
             clocks.xtal_clk
@@ -1225,12 +1250,8 @@ macro_rules! define_clock_tree_types {
         pub fn xtal_clk_config_frequency(clocks: &mut ClockTree, config: XtalClkConfig) -> u32 {
             config.value()
         }
-        pub fn xtal_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.xtal_clk {
-                xtal_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn xtal_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            XTAL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_rc_fast_clk(clocks: &mut ClockTree) {
             trace!("Requesting RC_FAST_CLK");
@@ -1467,6 +1488,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_hp_root_clk_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn hp_root_clk_config(clocks: &mut ClockTree) -> Option<HpRootClkConfig> {
             clocks.hp_root_clk
@@ -1506,16 +1528,13 @@ macro_rules! define_clock_tree_types {
                 HpRootClkConfig::PllF160m => pll_f160m_frequency(clocks),
             }
         }
-        pub fn hp_root_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.hp_root_clk {
-                hp_root_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn hp_root_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            HP_ROOT_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, config: CpuClkConfig) {
             let old_config = clocks.cpu_clk.replace(config);
             configure_cpu_clk_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn cpu_clk_config(clocks: &mut ClockTree) -> Option<CpuClkConfig> {
             clocks.cpu_clk
@@ -1540,16 +1559,13 @@ macro_rules! define_clock_tree_types {
         pub fn cpu_clk_config_frequency(clocks: &mut ClockTree, config: CpuClkConfig) -> u32 {
             (hp_root_clk_frequency(clocks) / (config.divisor() + 1))
         }
-        pub fn cpu_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.cpu_clk {
-                cpu_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn cpu_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            CPU_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_ahb_clk(clocks: &mut ClockTree, config: AhbClkConfig) {
             let old_config = clocks.ahb_clk.replace(config);
             configure_ahb_clk_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn ahb_clk_config(clocks: &mut ClockTree) -> Option<AhbClkConfig> {
             clocks.ahb_clk
@@ -1570,16 +1586,13 @@ macro_rules! define_clock_tree_types {
         pub fn ahb_clk_config_frequency(clocks: &mut ClockTree, config: AhbClkConfig) -> u32 {
             (hp_root_clk_frequency(clocks) / (config.divisor() + 1))
         }
-        pub fn ahb_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.ahb_clk {
-                ahb_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn ahb_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            AHB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, config: ApbClkConfig) {
             let old_config = clocks.apb_clk.replace(config);
             configure_apb_clk_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn apb_clk_config(clocks: &mut ClockTree) -> Option<ApbClkConfig> {
             clocks.apb_clk
@@ -1604,12 +1617,8 @@ macro_rules! define_clock_tree_types {
         pub fn apb_clk_config_frequency(clocks: &mut ClockTree, config: ApbClkConfig) -> u32 {
             (ahb_clk_frequency(clocks) / (config.divisor() + 1))
         }
-        pub fn apb_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.apb_clk {
-                apb_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn apb_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            APB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_xtal_d2_clk(clocks: &mut ClockTree) {
             trace!("Requesting XTAL_D2_CLK");
@@ -1645,6 +1654,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_lp_fast_clk_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn lp_fast_clk_config(clocks: &mut ClockTree) -> Option<LpFastClkConfig> {
             clocks.lp_fast_clk
@@ -1684,12 +1694,8 @@ macro_rules! define_clock_tree_types {
                 LpFastClkConfig::Xtal => xtal_clk_frequency(clocks),
             }
         }
-        pub fn lp_fast_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.lp_fast_clk {
-                lp_fast_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn lp_fast_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            LP_FAST_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_lp_slow_clk(clocks: &mut ClockTree, new_selector: LpSlowClkConfig) {
             let old_selector = clocks.lp_slow_clk.replace(new_selector);
@@ -1710,6 +1716,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_lp_slow_clk_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn lp_slow_clk_config(clocks: &mut ClockTree) -> Option<LpSlowClkConfig> {
             clocks.lp_slow_clk
@@ -1749,12 +1756,8 @@ macro_rules! define_clock_tree_types {
                 LpSlowClkConfig::OscSlow => osc_slow_clk_frequency(clocks),
             }
         }
-        pub fn lp_slow_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.lp_slow_clk {
-                lp_slow_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn lp_slow_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            LP_SLOW_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_timg_calibration_clock(
             clocks: &mut ClockTree,
@@ -1780,6 +1783,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn timg_calibration_clock_config(
             clocks: &mut ClockTree,
@@ -1824,12 +1828,8 @@ macro_rules! define_clock_tree_types {
                 TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(clocks),
             }
         }
-        pub fn timg_calibration_clock_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.timg_calibration_clock {
-                timg_calibration_clock_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn timg_calibration_clock_frequency(_clocks: &mut ClockTree) -> u32 {
+            TIMG_CALIBRATION_CLOCK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         impl TimgInstance {
             pub fn configure_function_clock(
@@ -1855,6 +1855,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn function_clock_config(
                 self,
@@ -1902,12 +1903,9 @@ macro_rules! define_clock_tree_types {
                     TimgFunctionClockConfig::PllF80m => pll_f80m_frequency(clocks),
                 }
             }
-            pub fn function_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.timg_function_clock[self as usize] {
-                    self.function_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                TIMG_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
             pub fn configure_wdt_clock(
                 self,
@@ -1932,6 +1930,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_wdt_clock_impl(clocks, old_selector, new_selector);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn wdt_clock_config(self, clocks: &mut ClockTree) -> Option<TimgWdtClockConfig> {
                 clocks.timg_wdt_clock[self as usize]
@@ -1972,12 +1971,9 @@ macro_rules! define_clock_tree_types {
                     TimgWdtClockConfig::PllF80m => pll_f80m_frequency(clocks),
                 }
             }
-            pub fn wdt_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.timg_wdt_clock[self as usize] {
-                    self.wdt_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn wdt_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                TIMG_WDT_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
         }
         impl UartInstance {
@@ -2004,6 +2000,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_config, config);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn function_clock_config(
                 self,
@@ -2051,12 +2048,9 @@ macro_rules! define_clock_tree_types {
                     UartFunctionClockSclk::RcFast => rc_fast_clk_frequency(clocks),
                 } / (config.div_num() + 1))
             }
-            pub fn function_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.uart_function_clock[self as usize] {
-                    self.function_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                UART_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
             pub fn configure_baud_rate_generator(
                 self,
@@ -2065,6 +2059,7 @@ macro_rules! define_clock_tree_types {
             ) {
                 let old_config = clocks.uart_baud_rate_generator[self as usize].replace(config);
                 self.configure_baud_rate_generator_impl(clocks, old_config, config);
+                refresh_all_frequency_caches(clocks);
             }
             pub fn baud_rate_generator_config(
                 self,
@@ -2101,12 +2096,9 @@ macro_rules! define_clock_tree_types {
                 ((self.function_clock_frequency(clocks) * 16)
                     / ((config.integral() * 16) + config.fractional()))
             }
-            pub fn baud_rate_generator_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.uart_baud_rate_generator[self as usize] {
-                    self.baud_rate_generator_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn baud_rate_generator_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                UART_BAUD_RATE_GENERATOR_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
         }
         /// Clock tree configuration.
@@ -2176,6 +2168,88 @@ macro_rules! define_clock_tree_types {
             *refcount = refcount.saturating_sub(1);
             let last = *refcount == 0;
             last
+        }
+        fn refresh_all_frequency_caches(clocks: &mut ClockTree) {
+            if let Some(config) = clocks.xtal_clk {
+                XTAL_CLK_FREQ_CACHE.store(
+                    xtal_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.hp_root_clk {
+                HP_ROOT_CLK_FREQ_CACHE.store(
+                    hp_root_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.cpu_clk {
+                CPU_CLK_FREQ_CACHE.store(
+                    cpu_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.ahb_clk {
+                AHB_CLK_FREQ_CACHE.store(
+                    ahb_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.apb_clk {
+                APB_CLK_FREQ_CACHE.store(
+                    apb_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.lp_fast_clk {
+                LP_FAST_CLK_FREQ_CACHE.store(
+                    lp_fast_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.lp_slow_clk {
+                LP_SLOW_CLK_FREQ_CACHE.store(
+                    lp_slow_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.timg_calibration_clock {
+                TIMG_CALIBRATION_CLOCK_FREQ_CACHE.store(
+                    timg_calibration_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            for instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                if let Some(config) = clocks.timg_function_clock[instance as usize] {
+                    TIMG_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.function_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                if let Some(config) = clocks.timg_wdt_clock[instance as usize] {
+                    TIMG_WDT_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.wdt_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                if let Some(config) = clocks.uart_function_clock[instance as usize] {
+                    UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.function_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                if let Some(config) = clocks.uart_baud_rate_generator[instance as usize] {
+                    UART_BAUD_RATE_GENERATOR_FREQ_CACHE[instance as usize].store(
+                        instance.baud_rate_generator_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
         }
     };
 }

--- a/esp-metadata-generated/src/_generated_esp32c61.rs
+++ b/esp-metadata-generated/src/_generated_esp32c61.rs
@@ -1239,7 +1239,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
             let old_config = clocks.xtal_clk.replace(config);
             configure_xtal_clk_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_xtal_clk_downstream(clocks);
         }
         pub fn xtal_clk_config(clocks: &mut ClockTree) -> Option<XtalClkConfig> {
             clocks.xtal_clk
@@ -1488,7 +1488,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_hp_root_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_hp_root_clk_downstream(clocks);
         }
         pub fn hp_root_clk_config(clocks: &mut ClockTree) -> Option<HpRootClkConfig> {
             clocks.hp_root_clk
@@ -1534,7 +1534,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_cpu_clk(clocks: &mut ClockTree, config: CpuClkConfig) {
             let old_config = clocks.cpu_clk.replace(config);
             configure_cpu_clk_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_cpu_clk_downstream(clocks);
         }
         pub fn cpu_clk_config(clocks: &mut ClockTree) -> Option<CpuClkConfig> {
             clocks.cpu_clk
@@ -1565,7 +1565,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_ahb_clk(clocks: &mut ClockTree, config: AhbClkConfig) {
             let old_config = clocks.ahb_clk.replace(config);
             configure_ahb_clk_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_ahb_clk_downstream(clocks);
         }
         pub fn ahb_clk_config(clocks: &mut ClockTree) -> Option<AhbClkConfig> {
             clocks.ahb_clk
@@ -1592,7 +1592,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_apb_clk(clocks: &mut ClockTree, config: ApbClkConfig) {
             let old_config = clocks.apb_clk.replace(config);
             configure_apb_clk_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_apb_clk_downstream(clocks);
         }
         pub fn apb_clk_config(clocks: &mut ClockTree) -> Option<ApbClkConfig> {
             clocks.apb_clk
@@ -1654,7 +1654,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_lp_fast_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_lp_fast_clk_downstream(clocks);
         }
         pub fn lp_fast_clk_config(clocks: &mut ClockTree) -> Option<LpFastClkConfig> {
             clocks.lp_fast_clk
@@ -1716,7 +1716,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_lp_slow_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_lp_slow_clk_downstream(clocks);
         }
         pub fn lp_slow_clk_config(clocks: &mut ClockTree) -> Option<LpSlowClkConfig> {
             clocks.lp_slow_clk
@@ -1783,7 +1783,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_timg_calibration_clock_downstream(clocks);
         }
         pub fn timg_calibration_clock_config(
             clocks: &mut ClockTree,
@@ -1855,7 +1855,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_timg_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -1930,7 +1930,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_wdt_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_timg_wdt_clock_downstream(clocks, self);
             }
             pub fn wdt_clock_config(self, clocks: &mut ClockTree) -> Option<TimgWdtClockConfig> {
                 clocks.timg_wdt_clock[self as usize]
@@ -2000,7 +2000,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_config, config);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_uart_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -2059,7 +2059,7 @@ macro_rules! define_clock_tree_types {
             ) {
                 let old_config = clocks.uart_baud_rate_generator[self as usize].replace(config);
                 self.configure_baud_rate_generator_impl(clocks, old_config, config);
-                refresh_all_frequency_caches(clocks);
+                refresh_uart_baud_rate_generator_downstream(clocks, self);
             }
             pub fn baud_rate_generator_config(
                 self,
@@ -2169,86 +2169,127 @@ macro_rules! define_clock_tree_types {
             let last = *refcount == 0;
             last
         }
-        fn refresh_all_frequency_caches(clocks: &mut ClockTree) {
+        fn refresh_xtal_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.xtal_clk {
                 XTAL_CLK_FREQ_CACHE.store(
                     xtal_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_hp_root_clk_downstream(clocks);
+            refresh_lp_fast_clk_downstream(clocks);
+            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                refresh_timg_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                refresh_timg_wdt_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                refresh_timg_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                refresh_timg_wdt_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                refresh_uart_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                refresh_uart_function_clock_downstream(clocks, child_instance);
+            }
+        }
+        fn refresh_hp_root_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.hp_root_clk {
                 HP_ROOT_CLK_FREQ_CACHE.store(
                     hp_root_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_cpu_clk_downstream(clocks);
+            refresh_ahb_clk_downstream(clocks);
+        }
+        fn refresh_cpu_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.cpu_clk {
                 CPU_CLK_FREQ_CACHE.store(
                     cpu_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+        }
+        fn refresh_ahb_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.ahb_clk {
                 AHB_CLK_FREQ_CACHE.store(
                     ahb_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_apb_clk_downstream(clocks);
+        }
+        fn refresh_apb_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.apb_clk {
                 APB_CLK_FREQ_CACHE.store(
                     apb_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+        }
+        fn refresh_lp_fast_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.lp_fast_clk {
                 LP_FAST_CLK_FREQ_CACHE.store(
                     lp_fast_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+        }
+        fn refresh_lp_slow_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.lp_slow_clk {
                 LP_SLOW_CLK_FREQ_CACHE.store(
                     lp_slow_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+        }
+        fn refresh_timg_calibration_clock_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.timg_calibration_clock {
                 TIMG_CALIBRATION_CLOCK_FREQ_CACHE.store(
                     timg_calibration_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
-            for instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
-                if let Some(config) = clocks.timg_function_clock[instance as usize] {
-                    TIMG_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.function_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_timg_function_clock_downstream(clocks: &mut ClockTree, instance: TimgInstance) {
+            if let Some(config) = clocks.timg_function_clock[instance as usize] {
+                TIMG_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.function_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
-            for instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
-                if let Some(config) = clocks.timg_wdt_clock[instance as usize] {
-                    TIMG_WDT_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.wdt_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_timg_wdt_clock_downstream(clocks: &mut ClockTree, instance: TimgInstance) {
+            if let Some(config) = clocks.timg_wdt_clock[instance as usize] {
+                TIMG_WDT_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.wdt_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
-            for instance in [UartInstance::Uart0, UartInstance::Uart1] {
-                if let Some(config) = clocks.uart_function_clock[instance as usize] {
-                    UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.function_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_uart_function_clock_downstream(clocks: &mut ClockTree, instance: UartInstance) {
+            if let Some(config) = clocks.uart_function_clock[instance as usize] {
+                UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.function_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
-            for instance in [UartInstance::Uart0, UartInstance::Uart1] {
-                if let Some(config) = clocks.uart_baud_rate_generator[instance as usize] {
-                    UART_BAUD_RATE_GENERATOR_FREQ_CACHE[instance as usize].store(
-                        instance.baud_rate_generator_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+            refresh_uart_baud_rate_generator_downstream(clocks, instance);
+        }
+        fn refresh_uart_baud_rate_generator_downstream(
+            clocks: &mut ClockTree,
+            instance: UartInstance,
+        ) {
+            if let Some(config) = clocks.uart_baud_rate_generator[instance as usize] {
+                UART_BAUD_RATE_GENERATOR_FREQ_CACHE[instance as usize].store(
+                    instance.baud_rate_generator_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
         }
     };

--- a/esp-metadata-generated/src/_generated_esp32c61.rs
+++ b/esp-metadata-generated/src/_generated_esp32c61.rs
@@ -1250,7 +1250,7 @@ macro_rules! define_clock_tree_types {
         pub fn xtal_clk_config_frequency(clocks: &mut ClockTree, config: XtalClkConfig) -> u32 {
             config.value()
         }
-        pub fn xtal_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn xtal_clk_frequency() -> u32 {
             XTAL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_rc_fast_clk(clocks: &mut ClockTree) {
@@ -1267,7 +1267,7 @@ macro_rules! define_clock_tree_types {
                 enable_rc_fast_clk_impl(clocks, false);
             }
         }
-        pub fn rc_fast_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn rc_fast_clk_frequency() -> u32 {
             17500000
         }
         pub fn request_pll_clk(clocks: &mut ClockTree) {
@@ -1286,7 +1286,7 @@ macro_rules! define_clock_tree_types {
                 release_xtal_clk(clocks);
             }
         }
-        pub fn pll_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn pll_clk_frequency() -> u32 {
             480000000
         }
         pub fn request_xtal32k_clk(clocks: &mut ClockTree) {
@@ -1303,7 +1303,7 @@ macro_rules! define_clock_tree_types {
                 enable_xtal32k_clk_impl(clocks, false);
             }
         }
-        pub fn xtal32k_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn xtal32k_clk_frequency() -> u32 {
             32768
         }
         pub fn request_osc_slow_clk(clocks: &mut ClockTree) {
@@ -1320,7 +1320,7 @@ macro_rules! define_clock_tree_types {
                 enable_osc_slow_clk_impl(clocks, false);
             }
         }
-        pub fn osc_slow_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn osc_slow_clk_frequency() -> u32 {
             32768
         }
         pub fn request_rc_slow_clk(clocks: &mut ClockTree) {
@@ -1337,7 +1337,7 @@ macro_rules! define_clock_tree_types {
                 enable_rc_slow_clk_impl(clocks, false);
             }
         }
-        pub fn rc_slow_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn rc_slow_clk_frequency() -> u32 {
             136000
         }
         pub fn request_pll_f20m(clocks: &mut ClockTree) {
@@ -1356,8 +1356,8 @@ macro_rules! define_clock_tree_types {
                 release_pll_clk(clocks);
             }
         }
-        pub fn pll_f20m_frequency(clocks: &mut ClockTree) -> u32 {
-            (pll_clk_frequency(clocks) / 24)
+        pub fn pll_f20m_frequency() -> u32 {
+            (pll_clk_frequency() / 24)
         }
         pub fn request_pll_f40m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F40M");
@@ -1375,8 +1375,8 @@ macro_rules! define_clock_tree_types {
                 release_pll_clk(clocks);
             }
         }
-        pub fn pll_f40m_frequency(clocks: &mut ClockTree) -> u32 {
-            (pll_clk_frequency(clocks) / 12)
+        pub fn pll_f40m_frequency() -> u32 {
+            (pll_clk_frequency() / 12)
         }
         pub fn request_pll_f48m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F48M");
@@ -1394,8 +1394,8 @@ macro_rules! define_clock_tree_types {
                 release_pll_clk(clocks);
             }
         }
-        pub fn pll_f48m_frequency(clocks: &mut ClockTree) -> u32 {
-            (pll_clk_frequency(clocks) / 10)
+        pub fn pll_f48m_frequency() -> u32 {
+            (pll_clk_frequency() / 10)
         }
         pub fn request_pll_f60m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F60M");
@@ -1413,8 +1413,8 @@ macro_rules! define_clock_tree_types {
                 release_pll_clk(clocks);
             }
         }
-        pub fn pll_f60m_frequency(clocks: &mut ClockTree) -> u32 {
-            (pll_clk_frequency(clocks) / 8)
+        pub fn pll_f60m_frequency() -> u32 {
+            (pll_clk_frequency() / 8)
         }
         pub fn request_pll_f80m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F80M");
@@ -1432,8 +1432,8 @@ macro_rules! define_clock_tree_types {
                 release_pll_clk(clocks);
             }
         }
-        pub fn pll_f80m_frequency(clocks: &mut ClockTree) -> u32 {
-            (pll_clk_frequency(clocks) / 6)
+        pub fn pll_f80m_frequency() -> u32 {
+            (pll_clk_frequency() / 6)
         }
         pub fn request_pll_f120m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F120M");
@@ -1451,8 +1451,8 @@ macro_rules! define_clock_tree_types {
                 release_pll_clk(clocks);
             }
         }
-        pub fn pll_f120m_frequency(clocks: &mut ClockTree) -> u32 {
-            (pll_clk_frequency(clocks) / 4)
+        pub fn pll_f120m_frequency() -> u32 {
+            (pll_clk_frequency() / 4)
         }
         pub fn request_pll_f160m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F160M");
@@ -1466,8 +1466,8 @@ macro_rules! define_clock_tree_types {
             enable_pll_f160m_impl(clocks, false);
             release_pll_clk(clocks);
         }
-        pub fn pll_f160m_frequency(clocks: &mut ClockTree) -> u32 {
-            (pll_clk_frequency(clocks) / 3)
+        pub fn pll_f160m_frequency() -> u32 {
+            (pll_clk_frequency() / 3)
         }
         pub fn configure_hp_root_clk(clocks: &mut ClockTree, new_selector: HpRootClkConfig) {
             let old_selector = clocks.hp_root_clk.replace(new_selector);
@@ -1523,12 +1523,12 @@ macro_rules! define_clock_tree_types {
             config: HpRootClkConfig,
         ) -> u32 {
             match config {
-                HpRootClkConfig::Xtal => xtal_clk_frequency(clocks),
-                HpRootClkConfig::RcFast => rc_fast_clk_frequency(clocks),
-                HpRootClkConfig::PllF160m => pll_f160m_frequency(clocks),
+                HpRootClkConfig::Xtal => xtal_clk_frequency(),
+                HpRootClkConfig::RcFast => rc_fast_clk_frequency(),
+                HpRootClkConfig::PllF160m => pll_f160m_frequency(),
             }
         }
-        pub fn hp_root_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn hp_root_clk_frequency() -> u32 {
             HP_ROOT_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, config: CpuClkConfig) {
@@ -1557,9 +1557,9 @@ macro_rules! define_clock_tree_types {
         }
         #[allow(unused_variables)]
         pub fn cpu_clk_config_frequency(clocks: &mut ClockTree, config: CpuClkConfig) -> u32 {
-            (hp_root_clk_frequency(clocks) / (config.divisor() + 1))
+            (hp_root_clk_frequency() / (config.divisor() + 1))
         }
-        pub fn cpu_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn cpu_clk_frequency() -> u32 {
             CPU_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_ahb_clk(clocks: &mut ClockTree, config: AhbClkConfig) {
@@ -1584,9 +1584,9 @@ macro_rules! define_clock_tree_types {
         }
         #[allow(unused_variables)]
         pub fn ahb_clk_config_frequency(clocks: &mut ClockTree, config: AhbClkConfig) -> u32 {
-            (hp_root_clk_frequency(clocks) / (config.divisor() + 1))
+            (hp_root_clk_frequency() / (config.divisor() + 1))
         }
-        pub fn ahb_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn ahb_clk_frequency() -> u32 {
             AHB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, config: ApbClkConfig) {
@@ -1615,9 +1615,9 @@ macro_rules! define_clock_tree_types {
         }
         #[allow(unused_variables)]
         pub fn apb_clk_config_frequency(clocks: &mut ClockTree, config: ApbClkConfig) -> u32 {
-            (ahb_clk_frequency(clocks) / (config.divisor() + 1))
+            (ahb_clk_frequency() / (config.divisor() + 1))
         }
-        pub fn apb_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn apb_clk_frequency() -> u32 {
             APB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_xtal_d2_clk(clocks: &mut ClockTree) {
@@ -1632,8 +1632,8 @@ macro_rules! define_clock_tree_types {
             enable_xtal_d2_clk_impl(clocks, false);
             release_xtal_clk(clocks);
         }
-        pub fn xtal_d2_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            (xtal_clk_frequency(clocks) / 2)
+        pub fn xtal_d2_clk_frequency() -> u32 {
+            (xtal_clk_frequency() / 2)
         }
         pub fn configure_lp_fast_clk(clocks: &mut ClockTree, new_selector: LpFastClkConfig) {
             let old_selector = clocks.lp_fast_clk.replace(new_selector);
@@ -1689,12 +1689,12 @@ macro_rules! define_clock_tree_types {
             config: LpFastClkConfig,
         ) -> u32 {
             match config {
-                LpFastClkConfig::RcFast => rc_fast_clk_frequency(clocks),
-                LpFastClkConfig::XtalD2 => xtal_d2_clk_frequency(clocks),
-                LpFastClkConfig::Xtal => xtal_clk_frequency(clocks),
+                LpFastClkConfig::RcFast => rc_fast_clk_frequency(),
+                LpFastClkConfig::XtalD2 => xtal_d2_clk_frequency(),
+                LpFastClkConfig::Xtal => xtal_clk_frequency(),
             }
         }
-        pub fn lp_fast_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn lp_fast_clk_frequency() -> u32 {
             LP_FAST_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_lp_slow_clk(clocks: &mut ClockTree, new_selector: LpSlowClkConfig) {
@@ -1751,12 +1751,12 @@ macro_rules! define_clock_tree_types {
             config: LpSlowClkConfig,
         ) -> u32 {
             match config {
-                LpSlowClkConfig::RcSlow => rc_slow_clk_frequency(clocks),
-                LpSlowClkConfig::Xtal32k => xtal32k_clk_frequency(clocks),
-                LpSlowClkConfig::OscSlow => osc_slow_clk_frequency(clocks),
+                LpSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
+                LpSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
+                LpSlowClkConfig::OscSlow => osc_slow_clk_frequency(),
             }
         }
-        pub fn lp_slow_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn lp_slow_clk_frequency() -> u32 {
             LP_SLOW_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_timg_calibration_clock(
@@ -1822,13 +1822,13 @@ macro_rules! define_clock_tree_types {
             config: TimgCalibrationClockConfig,
         ) -> u32 {
             match config {
-                TimgCalibrationClockConfig::OscSlowClk => osc_slow_clk_frequency(clocks),
-                TimgCalibrationClockConfig::RcSlowClk => rc_slow_clk_frequency(clocks),
-                TimgCalibrationClockConfig::RcFastDivClk => rc_fast_clk_frequency(clocks),
-                TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(clocks),
+                TimgCalibrationClockConfig::OscSlowClk => osc_slow_clk_frequency(),
+                TimgCalibrationClockConfig::RcSlowClk => rc_slow_clk_frequency(),
+                TimgCalibrationClockConfig::RcFastDivClk => rc_fast_clk_frequency(),
+                TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
             }
         }
-        pub fn timg_calibration_clock_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn timg_calibration_clock_frequency() -> u32 {
             TIMG_CALIBRATION_CLOCK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         impl TimgInstance {
@@ -1898,12 +1898,12 @@ macro_rules! define_clock_tree_types {
                 config: TimgFunctionClockConfig,
             ) -> u32 {
                 match config {
-                    TimgFunctionClockConfig::XtalClk => xtal_clk_frequency(clocks),
-                    TimgFunctionClockConfig::RcFastClk => rc_fast_clk_frequency(clocks),
-                    TimgFunctionClockConfig::PllF80m => pll_f80m_frequency(clocks),
+                    TimgFunctionClockConfig::XtalClk => xtal_clk_frequency(),
+                    TimgFunctionClockConfig::RcFastClk => rc_fast_clk_frequency(),
+                    TimgFunctionClockConfig::PllF80m => pll_f80m_frequency(),
                 }
             }
-            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn function_clock_frequency(self) -> u32 {
                 TIMG_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -1966,12 +1966,12 @@ macro_rules! define_clock_tree_types {
                 config: TimgWdtClockConfig,
             ) -> u32 {
                 match config {
-                    TimgWdtClockConfig::XtalClk => xtal_clk_frequency(clocks),
-                    TimgWdtClockConfig::RcFastClk => rc_fast_clk_frequency(clocks),
-                    TimgWdtClockConfig::PllF80m => pll_f80m_frequency(clocks),
+                    TimgWdtClockConfig::XtalClk => xtal_clk_frequency(),
+                    TimgWdtClockConfig::RcFastClk => rc_fast_clk_frequency(),
+                    TimgWdtClockConfig::PllF80m => pll_f80m_frequency(),
                 }
             }
-            pub fn wdt_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn wdt_clock_frequency(self) -> u32 {
                 TIMG_WDT_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -2043,12 +2043,12 @@ macro_rules! define_clock_tree_types {
                 config: UartFunctionClockConfig,
             ) -> u32 {
                 (match config.sclk {
-                    UartFunctionClockSclk::Xtal => xtal_clk_frequency(clocks),
-                    UartFunctionClockSclk::PllF80m => pll_f80m_frequency(clocks),
-                    UartFunctionClockSclk::RcFast => rc_fast_clk_frequency(clocks),
+                    UartFunctionClockSclk::Xtal => xtal_clk_frequency(),
+                    UartFunctionClockSclk::PllF80m => pll_f80m_frequency(),
+                    UartFunctionClockSclk::RcFast => rc_fast_clk_frequency(),
                 } / (config.div_num() + 1))
             }
-            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn function_clock_frequency(self) -> u32 {
                 UART_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -2093,10 +2093,10 @@ macro_rules! define_clock_tree_types {
                 clocks: &mut ClockTree,
                 config: UartBaudRateGeneratorConfig,
             ) -> u32 {
-                ((self.function_clock_frequency(clocks) * 16)
+                ((self.function_clock_frequency() * 16)
                     / ((config.integral() * 16) + config.fractional()))
             }
-            pub fn baud_rate_generator_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn baud_rate_generator_frequency(self) -> u32 {
                 UART_BAUD_RATE_GENERATOR_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }

--- a/esp-metadata-generated/src/_generated_esp32c61.rs
+++ b/esp-metadata-generated/src/_generated_esp32c61.rs
@@ -2180,18 +2180,7 @@ macro_rules! define_clock_tree_types {
             refresh_lp_fast_clk_downstream(clocks);
             for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
                 refresh_timg_function_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
                 refresh_timg_wdt_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
-                refresh_timg_function_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
-                refresh_timg_wdt_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
-                refresh_uart_function_clock_downstream(clocks, child_instance);
             }
             for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
                 refresh_uart_function_clock_downstream(clocks, child_instance);

--- a/esp-metadata-generated/src/_generated_esp32h2.rs
+++ b/esp-metadata-generated/src/_generated_esp32h2.rs
@@ -1634,7 +1634,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
             let old_config = clocks.xtal_clk.replace(config);
             configure_xtal_clk_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_xtal_clk_downstream(clocks);
         }
         pub fn xtal_clk_config(clocks: &mut ClockTree) -> Option<XtalClkConfig> {
             clocks.xtal_clk
@@ -1797,7 +1797,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_hp_root_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_hp_root_clk_downstream(clocks);
         }
         pub fn hp_root_clk_config(clocks: &mut ClockTree) -> Option<HpRootClkConfig> {
             clocks.hp_root_clk
@@ -1846,7 +1846,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_cpu_clk(clocks: &mut ClockTree, config: CpuClkConfig) {
             let old_config = clocks.cpu_clk.replace(config);
             configure_cpu_clk_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_cpu_clk_downstream(clocks);
         }
         pub fn cpu_clk_config(clocks: &mut ClockTree) -> Option<CpuClkConfig> {
             clocks.cpu_clk
@@ -1863,7 +1863,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_ahb_clk(clocks: &mut ClockTree, config: AhbClkConfig) {
             let old_config = clocks.ahb_clk.replace(config);
             configure_ahb_clk_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_ahb_clk_downstream(clocks);
         }
         pub fn ahb_clk_config(clocks: &mut ClockTree) -> Option<AhbClkConfig> {
             clocks.ahb_clk
@@ -1880,7 +1880,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_apb_clk(clocks: &mut ClockTree, config: ApbClkConfig) {
             let old_config = clocks.apb_clk.replace(config);
             configure_apb_clk_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_apb_clk_downstream(clocks);
         }
         pub fn apb_clk_config(clocks: &mut ClockTree) -> Option<ApbClkConfig> {
             clocks.apb_clk
@@ -1942,7 +1942,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_lp_fast_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_lp_fast_clk_downstream(clocks);
         }
         pub fn lp_fast_clk_config(clocks: &mut ClockTree) -> Option<LpFastClkConfig> {
             clocks.lp_fast_clk
@@ -2000,7 +2000,7 @@ macro_rules! define_clock_tree_types {
                     LpSlowClkConfig::OscSlow => release_osc_slow_clk(clocks),
                 }
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_lp_slow_clk_downstream(clocks);
         }
         pub fn lp_slow_clk_config(clocks: &mut ClockTree) -> Option<LpSlowClkConfig> {
             clocks.lp_slow_clk
@@ -2061,7 +2061,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_timg_calibration_clock_downstream(clocks);
         }
         pub fn timg_calibration_clock_config(
             clocks: &mut ClockTree,
@@ -2130,7 +2130,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_mcpwm_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -2207,7 +2207,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_rx_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_parl_io_rx_clock_downstream(clocks, self);
             }
             pub fn rx_clock_config(self, clocks: &mut ClockTree) -> Option<ParlIoRxClockConfig> {
                 clocks.parl_io_rx_clock[self as usize]
@@ -2275,7 +2275,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_tx_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_parl_io_tx_clock_downstream(clocks, self);
             }
             pub fn tx_clock_config(self, clocks: &mut ClockTree) -> Option<ParlIoTxClockConfig> {
                 clocks.parl_io_tx_clock[self as usize]
@@ -2339,7 +2339,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_sclk_impl(clocks, old_selector, new_selector);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_rmt_sclk_downstream(clocks, self);
             }
             pub fn sclk_config(self, clocks: &mut ClockTree) -> Option<RmtSclkConfig> {
                 clocks.rmt_sclk[self as usize]
@@ -2405,7 +2405,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_timg_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -2480,7 +2480,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_wdt_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_timg_wdt_clock_downstream(clocks, self);
             }
             pub fn wdt_clock_config(self, clocks: &mut ClockTree) -> Option<TimgWdtClockConfig> {
                 clocks.timg_wdt_clock[self as usize]
@@ -2550,7 +2550,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_config, config);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_uart_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -2609,7 +2609,7 @@ macro_rules! define_clock_tree_types {
             ) {
                 let old_config = clocks.uart_baud_rate_generator[self as usize].replace(config);
                 self.configure_baud_rate_generator_impl(clocks, old_config, config);
-                refresh_all_frequency_caches(clocks);
+                refresh_uart_baud_rate_generator_downstream(clocks, self);
             }
             pub fn baud_rate_generator_config(
                 self,
@@ -2719,118 +2719,175 @@ macro_rules! define_clock_tree_types {
             let last = *refcount == 0;
             last
         }
-        fn refresh_all_frequency_caches(clocks: &mut ClockTree) {
+        fn refresh_xtal_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.xtal_clk {
                 XTAL_CLK_FREQ_CACHE.store(
                     xtal_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_hp_root_clk_downstream(clocks);
+            refresh_lp_fast_clk_downstream(clocks);
+            for child_instance in [McpwmInstance::Mcpwm0] {
+                refresh_mcpwm_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [ParlIoInstance::ParlIo] {
+                refresh_parl_io_rx_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [ParlIoInstance::ParlIo] {
+                refresh_parl_io_tx_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [RmtInstance::Rmt] {
+                refresh_rmt_sclk_downstream(clocks, child_instance);
+            }
+            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                refresh_timg_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                refresh_timg_wdt_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                refresh_timg_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                refresh_timg_wdt_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                refresh_uart_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                refresh_uart_function_clock_downstream(clocks, child_instance);
+            }
+        }
+        fn refresh_hp_root_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.hp_root_clk {
                 HP_ROOT_CLK_FREQ_CACHE.store(
                     hp_root_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_cpu_clk_downstream(clocks);
+            refresh_ahb_clk_downstream(clocks);
+        }
+        fn refresh_cpu_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.cpu_clk {
                 CPU_CLK_FREQ_CACHE.store(
                     cpu_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+        }
+        fn refresh_ahb_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.ahb_clk {
                 AHB_CLK_FREQ_CACHE.store(
                     ahb_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_apb_clk_downstream(clocks);
+        }
+        fn refresh_apb_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.apb_clk {
                 APB_CLK_FREQ_CACHE.store(
                     apb_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+        }
+        fn refresh_lp_fast_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.lp_fast_clk {
                 LP_FAST_CLK_FREQ_CACHE.store(
                     lp_fast_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+        }
+        fn refresh_lp_slow_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.lp_slow_clk {
                 LP_SLOW_CLK_FREQ_CACHE.store(
                     lp_slow_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_timg_calibration_clock_downstream(clocks);
+        }
+        fn refresh_timg_calibration_clock_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.timg_calibration_clock {
                 TIMG_CALIBRATION_CLOCK_FREQ_CACHE.store(
                     timg_calibration_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
-            for instance in [McpwmInstance::Mcpwm0] {
-                if let Some(config) = clocks.mcpwm_function_clock[instance as usize] {
-                    MCPWM_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.function_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_mcpwm_function_clock_downstream(
+            clocks: &mut ClockTree,
+            instance: McpwmInstance,
+        ) {
+            if let Some(config) = clocks.mcpwm_function_clock[instance as usize] {
+                MCPWM_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.function_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
-            for instance in [ParlIoInstance::ParlIo] {
-                if let Some(config) = clocks.parl_io_rx_clock[instance as usize] {
-                    PARL_IO_RX_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.rx_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_parl_io_rx_clock_downstream(clocks: &mut ClockTree, instance: ParlIoInstance) {
+            if let Some(config) = clocks.parl_io_rx_clock[instance as usize] {
+                PARL_IO_RX_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.rx_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
-            for instance in [ParlIoInstance::ParlIo] {
-                if let Some(config) = clocks.parl_io_tx_clock[instance as usize] {
-                    PARL_IO_TX_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.tx_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_parl_io_tx_clock_downstream(clocks: &mut ClockTree, instance: ParlIoInstance) {
+            if let Some(config) = clocks.parl_io_tx_clock[instance as usize] {
+                PARL_IO_TX_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.tx_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
-            for instance in [RmtInstance::Rmt] {
-                if let Some(config) = clocks.rmt_sclk[instance as usize] {
-                    RMT_SCLK_FREQ_CACHE[instance as usize].store(
-                        instance.sclk_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_rmt_sclk_downstream(clocks: &mut ClockTree, instance: RmtInstance) {
+            if let Some(config) = clocks.rmt_sclk[instance as usize] {
+                RMT_SCLK_FREQ_CACHE[instance as usize].store(
+                    instance.sclk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
-            for instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
-                if let Some(config) = clocks.timg_function_clock[instance as usize] {
-                    TIMG_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.function_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_timg_function_clock_downstream(clocks: &mut ClockTree, instance: TimgInstance) {
+            if let Some(config) = clocks.timg_function_clock[instance as usize] {
+                TIMG_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.function_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
-            for instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
-                if let Some(config) = clocks.timg_wdt_clock[instance as usize] {
-                    TIMG_WDT_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.wdt_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_timg_wdt_clock_downstream(clocks: &mut ClockTree, instance: TimgInstance) {
+            if let Some(config) = clocks.timg_wdt_clock[instance as usize] {
+                TIMG_WDT_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.wdt_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
-            for instance in [UartInstance::Uart0, UartInstance::Uart1] {
-                if let Some(config) = clocks.uart_function_clock[instance as usize] {
-                    UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.function_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_uart_function_clock_downstream(clocks: &mut ClockTree, instance: UartInstance) {
+            if let Some(config) = clocks.uart_function_clock[instance as usize] {
+                UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.function_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
-            for instance in [UartInstance::Uart0, UartInstance::Uart1] {
-                if let Some(config) = clocks.uart_baud_rate_generator[instance as usize] {
-                    UART_BAUD_RATE_GENERATOR_FREQ_CACHE[instance as usize].store(
-                        instance.baud_rate_generator_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+            refresh_uart_baud_rate_generator_downstream(clocks, instance);
+        }
+        fn refresh_uart_baud_rate_generator_downstream(
+            clocks: &mut ClockTree,
+            instance: UartInstance,
+        ) {
+            if let Some(config) = clocks.uart_baud_rate_generator[instance as usize] {
+                UART_BAUD_RATE_GENERATOR_FREQ_CACHE[instance as usize].store(
+                    instance.baud_rate_generator_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
         }
     };

--- a/esp-metadata-generated/src/_generated_esp32h2.rs
+++ b/esp-metadata-generated/src/_generated_esp32h2.rs
@@ -1645,7 +1645,7 @@ macro_rules! define_clock_tree_types {
         pub fn xtal_clk_config_frequency(clocks: &mut ClockTree, config: XtalClkConfig) -> u32 {
             config.value()
         }
-        pub fn xtal_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn xtal_clk_frequency() -> u32 {
             XTAL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_pll_f96m_clk(clocks: &mut ClockTree) {
@@ -1664,7 +1664,7 @@ macro_rules! define_clock_tree_types {
                 release_xtal_clk(clocks);
             }
         }
-        pub fn pll_f96m_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn pll_f96m_clk_frequency() -> u32 {
             96000000
         }
         pub fn request_pll_f64m_clk(clocks: &mut ClockTree) {
@@ -1679,8 +1679,8 @@ macro_rules! define_clock_tree_types {
             enable_pll_f64m_clk_impl(clocks, false);
             release_pll_f96m_clk(clocks);
         }
-        pub fn pll_f64m_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            ((pll_f96m_clk_frequency(clocks) * 2) / 3)
+        pub fn pll_f64m_clk_frequency() -> u32 {
+            ((pll_f96m_clk_frequency() * 2) / 3)
         }
         pub fn request_pll_f48m_clk(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F48M_CLK");
@@ -1698,8 +1698,8 @@ macro_rules! define_clock_tree_types {
                 release_pll_f96m_clk(clocks);
             }
         }
-        pub fn pll_f48m_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            (pll_f96m_clk_frequency(clocks) / 2)
+        pub fn pll_f48m_clk_frequency() -> u32 {
+            (pll_f96m_clk_frequency() / 2)
         }
         pub fn request_rc_fast_clk(clocks: &mut ClockTree) {
             trace!("Requesting RC_FAST_CLK");
@@ -1715,7 +1715,7 @@ macro_rules! define_clock_tree_types {
                 enable_rc_fast_clk_impl(clocks, false);
             }
         }
-        pub fn rc_fast_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn rc_fast_clk_frequency() -> u32 {
             8000000
         }
         pub fn request_xtal32k_clk(clocks: &mut ClockTree) {
@@ -1732,7 +1732,7 @@ macro_rules! define_clock_tree_types {
                 enable_xtal32k_clk_impl(clocks, false);
             }
         }
-        pub fn xtal32k_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn xtal32k_clk_frequency() -> u32 {
             32768
         }
         pub fn request_osc_slow_clk(clocks: &mut ClockTree) {
@@ -1745,7 +1745,7 @@ macro_rules! define_clock_tree_types {
             trace!("Disabling OSC_SLOW_CLK");
             enable_osc_slow_clk_impl(clocks, false);
         }
-        pub fn osc_slow_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn osc_slow_clk_frequency() -> u32 {
             32768
         }
         pub fn request_rc_slow_clk(clocks: &mut ClockTree) {
@@ -1758,7 +1758,7 @@ macro_rules! define_clock_tree_types {
             trace!("Disabling RC_SLOW_CLK");
             enable_rc_slow_clk_impl(clocks, false);
         }
-        pub fn rc_slow_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn rc_slow_clk_frequency() -> u32 {
             130000
         }
         pub fn request_pll_lp_clk(clocks: &mut ClockTree) {
@@ -1773,7 +1773,7 @@ macro_rules! define_clock_tree_types {
             enable_pll_lp_clk_impl(clocks, false);
             release_xtal32k_clk(clocks);
         }
-        pub fn pll_lp_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn pll_lp_clk_frequency() -> u32 {
             8000000
         }
         pub fn configure_hp_root_clk(clocks: &mut ClockTree, new_selector: HpRootClkConfig) {
@@ -1834,13 +1834,13 @@ macro_rules! define_clock_tree_types {
             config: HpRootClkConfig,
         ) -> u32 {
             match config {
-                HpRootClkConfig::Pll96 => pll_f96m_clk_frequency(clocks),
-                HpRootClkConfig::Pll64 => pll_f64m_clk_frequency(clocks),
-                HpRootClkConfig::Xtal => xtal_clk_frequency(clocks),
-                HpRootClkConfig::RcFast => rc_fast_clk_frequency(clocks),
+                HpRootClkConfig::Pll96 => pll_f96m_clk_frequency(),
+                HpRootClkConfig::Pll64 => pll_f64m_clk_frequency(),
+                HpRootClkConfig::Xtal => xtal_clk_frequency(),
+                HpRootClkConfig::RcFast => rc_fast_clk_frequency(),
             }
         }
-        pub fn hp_root_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn hp_root_clk_frequency() -> u32 {
             HP_ROOT_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, config: CpuClkConfig) {
@@ -1855,9 +1855,9 @@ macro_rules! define_clock_tree_types {
         fn release_cpu_clk(_clocks: &mut ClockTree) {}
         #[allow(unused_variables)]
         pub fn cpu_clk_config_frequency(clocks: &mut ClockTree, config: CpuClkConfig) -> u32 {
-            (hp_root_clk_frequency(clocks) / (config.divisor() + 1))
+            (hp_root_clk_frequency() / (config.divisor() + 1))
         }
-        pub fn cpu_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn cpu_clk_frequency() -> u32 {
             CPU_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_ahb_clk(clocks: &mut ClockTree, config: AhbClkConfig) {
@@ -1872,9 +1872,9 @@ macro_rules! define_clock_tree_types {
         fn release_ahb_clk(_clocks: &mut ClockTree) {}
         #[allow(unused_variables)]
         pub fn ahb_clk_config_frequency(clocks: &mut ClockTree, config: AhbClkConfig) -> u32 {
-            (hp_root_clk_frequency(clocks) / (config.divisor() + 1))
+            (hp_root_clk_frequency() / (config.divisor() + 1))
         }
-        pub fn ahb_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn ahb_clk_frequency() -> u32 {
             AHB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, config: ApbClkConfig) {
@@ -1903,9 +1903,9 @@ macro_rules! define_clock_tree_types {
         }
         #[allow(unused_variables)]
         pub fn apb_clk_config_frequency(clocks: &mut ClockTree, config: ApbClkConfig) -> u32 {
-            (ahb_clk_frequency(clocks) / (config.divisor() + 1))
+            (ahb_clk_frequency() / (config.divisor() + 1))
         }
-        pub fn apb_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn apb_clk_frequency() -> u32 {
             APB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_xtal_d2_clk(clocks: &mut ClockTree) {
@@ -1920,8 +1920,8 @@ macro_rules! define_clock_tree_types {
             enable_xtal_d2_clk_impl(clocks, false);
             release_xtal_clk(clocks);
         }
-        pub fn xtal_d2_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            (xtal_clk_frequency(clocks) / 2)
+        pub fn xtal_d2_clk_frequency() -> u32 {
+            (xtal_clk_frequency() / 2)
         }
         pub fn configure_lp_fast_clk(clocks: &mut ClockTree, new_selector: LpFastClkConfig) {
             let old_selector = clocks.lp_fast_clk.replace(new_selector);
@@ -1977,12 +1977,12 @@ macro_rules! define_clock_tree_types {
             config: LpFastClkConfig,
         ) -> u32 {
             match config {
-                LpFastClkConfig::RcFastClk => rc_fast_clk_frequency(clocks),
-                LpFastClkConfig::PllLpClk => pll_lp_clk_frequency(clocks),
-                LpFastClkConfig::XtalD2Clk => xtal_d2_clk_frequency(clocks),
+                LpFastClkConfig::RcFastClk => rc_fast_clk_frequency(),
+                LpFastClkConfig::PllLpClk => pll_lp_clk_frequency(),
+                LpFastClkConfig::XtalD2Clk => xtal_d2_clk_frequency(),
             }
         }
-        pub fn lp_fast_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn lp_fast_clk_frequency() -> u32 {
             LP_FAST_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_lp_slow_clk(clocks: &mut ClockTree, new_selector: LpSlowClkConfig) {
@@ -2031,12 +2031,12 @@ macro_rules! define_clock_tree_types {
             config: LpSlowClkConfig,
         ) -> u32 {
             match config {
-                LpSlowClkConfig::Xtal32k => xtal32k_clk_frequency(clocks),
-                LpSlowClkConfig::RcSlow => rc_slow_clk_frequency(clocks),
-                LpSlowClkConfig::OscSlow => osc_slow_clk_frequency(clocks),
+                LpSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
+                LpSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
+                LpSlowClkConfig::OscSlow => osc_slow_clk_frequency(),
             }
         }
-        pub fn lp_slow_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn lp_slow_clk_frequency() -> u32 {
             LP_SLOW_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_timg_calibration_clock(
@@ -2098,12 +2098,12 @@ macro_rules! define_clock_tree_types {
             config: TimgCalibrationClockConfig,
         ) -> u32 {
             match config {
-                TimgCalibrationClockConfig::RcSlowClk => lp_slow_clk_frequency(clocks),
-                TimgCalibrationClockConfig::RcFastDivClk => rc_fast_clk_frequency(clocks),
-                TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(clocks),
+                TimgCalibrationClockConfig::RcSlowClk => lp_slow_clk_frequency(),
+                TimgCalibrationClockConfig::RcFastDivClk => rc_fast_clk_frequency(),
+                TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
             }
         }
-        pub fn timg_calibration_clock_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn timg_calibration_clock_frequency() -> u32 {
             TIMG_CALIBRATION_CLOCK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         impl McpwmInstance {
@@ -2173,12 +2173,12 @@ macro_rules! define_clock_tree_types {
                 config: McpwmFunctionClockConfig,
             ) -> u32 {
                 match config {
-                    McpwmFunctionClockConfig::PllF96m => pll_f96m_clk_frequency(clocks),
-                    McpwmFunctionClockConfig::RcFastClk => rc_fast_clk_frequency(clocks),
-                    McpwmFunctionClockConfig::XtalClk => xtal_clk_frequency(clocks),
+                    McpwmFunctionClockConfig::PllF96m => pll_f96m_clk_frequency(),
+                    McpwmFunctionClockConfig::RcFastClk => rc_fast_clk_frequency(),
+                    McpwmFunctionClockConfig::XtalClk => xtal_clk_frequency(),
                 }
             }
-            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn function_clock_frequency(self) -> u32 {
                 MCPWM_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -2243,12 +2243,12 @@ macro_rules! define_clock_tree_types {
                 config: ParlIoRxClockConfig,
             ) -> u32 {
                 match config {
-                    ParlIoRxClockConfig::XtalClk => xtal_clk_frequency(clocks),
-                    ParlIoRxClockConfig::RcFastClk => rc_fast_clk_frequency(clocks),
-                    ParlIoRxClockConfig::PllF96m => pll_f96m_clk_frequency(clocks),
+                    ParlIoRxClockConfig::XtalClk => xtal_clk_frequency(),
+                    ParlIoRxClockConfig::RcFastClk => rc_fast_clk_frequency(),
+                    ParlIoRxClockConfig::PllF96m => pll_f96m_clk_frequency(),
                 }
             }
-            pub fn rx_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn rx_clock_frequency(self) -> u32 {
                 PARL_IO_RX_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -2311,12 +2311,12 @@ macro_rules! define_clock_tree_types {
                 config: ParlIoTxClockConfig,
             ) -> u32 {
                 match config {
-                    ParlIoTxClockConfig::XtalClk => xtal_clk_frequency(clocks),
-                    ParlIoTxClockConfig::RcFastClk => rc_fast_clk_frequency(clocks),
-                    ParlIoTxClockConfig::PllF96m => pll_f96m_clk_frequency(clocks),
+                    ParlIoTxClockConfig::XtalClk => xtal_clk_frequency(),
+                    ParlIoTxClockConfig::RcFastClk => rc_fast_clk_frequency(),
+                    ParlIoTxClockConfig::PllF96m => pll_f96m_clk_frequency(),
                 }
             }
-            pub fn tx_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn tx_clock_frequency(self) -> u32 {
                 PARL_IO_TX_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -2373,11 +2373,11 @@ macro_rules! define_clock_tree_types {
                 config: RmtSclkConfig,
             ) -> u32 {
                 match config {
-                    RmtSclkConfig::XtalClk => xtal_clk_frequency(clocks),
-                    RmtSclkConfig::RcFastClk => rc_fast_clk_frequency(clocks),
+                    RmtSclkConfig::XtalClk => xtal_clk_frequency(),
+                    RmtSclkConfig::RcFastClk => rc_fast_clk_frequency(),
                 }
             }
-            pub fn sclk_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn sclk_frequency(self) -> u32 {
                 RMT_SCLK_FREQ_CACHE[self as usize].load(::core::sync::atomic::Ordering::Acquire)
             }
         }
@@ -2448,12 +2448,12 @@ macro_rules! define_clock_tree_types {
                 config: TimgFunctionClockConfig,
             ) -> u32 {
                 match config {
-                    TimgFunctionClockConfig::XtalClk => xtal_clk_frequency(clocks),
-                    TimgFunctionClockConfig::RcFastClk => rc_fast_clk_frequency(clocks),
-                    TimgFunctionClockConfig::PllF48m => pll_f48m_clk_frequency(clocks),
+                    TimgFunctionClockConfig::XtalClk => xtal_clk_frequency(),
+                    TimgFunctionClockConfig::RcFastClk => rc_fast_clk_frequency(),
+                    TimgFunctionClockConfig::PllF48m => pll_f48m_clk_frequency(),
                 }
             }
-            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn function_clock_frequency(self) -> u32 {
                 TIMG_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -2516,12 +2516,12 @@ macro_rules! define_clock_tree_types {
                 config: TimgWdtClockConfig,
             ) -> u32 {
                 match config {
-                    TimgWdtClockConfig::XtalClk => xtal_clk_frequency(clocks),
-                    TimgWdtClockConfig::RcFastClk => rc_fast_clk_frequency(clocks),
-                    TimgWdtClockConfig::PllF48m => pll_f48m_clk_frequency(clocks),
+                    TimgWdtClockConfig::XtalClk => xtal_clk_frequency(),
+                    TimgWdtClockConfig::RcFastClk => rc_fast_clk_frequency(),
+                    TimgWdtClockConfig::PllF48m => pll_f48m_clk_frequency(),
                 }
             }
-            pub fn wdt_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn wdt_clock_frequency(self) -> u32 {
                 TIMG_WDT_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -2593,12 +2593,12 @@ macro_rules! define_clock_tree_types {
                 config: UartFunctionClockConfig,
             ) -> u32 {
                 (match config.sclk {
-                    UartFunctionClockSclk::PllF48m => pll_f48m_clk_frequency(clocks),
-                    UartFunctionClockSclk::RcFast => rc_fast_clk_frequency(clocks),
-                    UartFunctionClockSclk::Xtal => xtal_clk_frequency(clocks),
+                    UartFunctionClockSclk::PllF48m => pll_f48m_clk_frequency(),
+                    UartFunctionClockSclk::RcFast => rc_fast_clk_frequency(),
+                    UartFunctionClockSclk::Xtal => xtal_clk_frequency(),
                 } / (config.div_num() + 1))
             }
-            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn function_clock_frequency(self) -> u32 {
                 UART_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -2643,10 +2643,10 @@ macro_rules! define_clock_tree_types {
                 clocks: &mut ClockTree,
                 config: UartBaudRateGeneratorConfig,
             ) -> u32 {
-                ((self.function_clock_frequency(clocks) * 16)
+                ((self.function_clock_frequency() * 16)
                     / ((config.integral() * 16) + config.fractional()))
             }
-            pub fn baud_rate_generator_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn baud_rate_generator_frequency(self) -> u32 {
                 UART_BAUD_RATE_GENERATOR_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }

--- a/esp-metadata-generated/src/_generated_esp32h2.rs
+++ b/esp-metadata-generated/src/_generated_esp32h2.rs
@@ -1633,8 +1633,8 @@ macro_rules! define_clock_tree_types {
             [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
             let old_config = clocks.xtal_clk.replace(config);
-            configure_xtal_clk_impl(clocks, old_config, config);
             refresh_xtal_clk_downstream(clocks);
+            configure_xtal_clk_impl(clocks, old_config, config);
         }
         pub fn xtal_clk_config(clocks: &mut ClockTree) -> Option<XtalClkConfig> {
             clocks.xtal_clk
@@ -1778,6 +1778,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_hp_root_clk(clocks: &mut ClockTree, new_selector: HpRootClkConfig) {
             let old_selector = clocks.hp_root_clk.replace(new_selector);
+            refresh_hp_root_clk_downstream(clocks);
             if clocks.hp_root_clk_refcount > 0 {
                 match new_selector {
                     HpRootClkConfig::Pll96 => request_pll_f96m_clk(clocks),
@@ -1797,7 +1798,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_hp_root_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_hp_root_clk_downstream(clocks);
         }
         pub fn hp_root_clk_config(clocks: &mut ClockTree) -> Option<HpRootClkConfig> {
             clocks.hp_root_clk
@@ -1845,8 +1845,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, config: CpuClkConfig) {
             let old_config = clocks.cpu_clk.replace(config);
-            configure_cpu_clk_impl(clocks, old_config, config);
             refresh_cpu_clk_downstream(clocks);
+            configure_cpu_clk_impl(clocks, old_config, config);
         }
         pub fn cpu_clk_config(clocks: &mut ClockTree) -> Option<CpuClkConfig> {
             clocks.cpu_clk
@@ -1862,8 +1862,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_ahb_clk(clocks: &mut ClockTree, config: AhbClkConfig) {
             let old_config = clocks.ahb_clk.replace(config);
-            configure_ahb_clk_impl(clocks, old_config, config);
             refresh_ahb_clk_downstream(clocks);
+            configure_ahb_clk_impl(clocks, old_config, config);
         }
         pub fn ahb_clk_config(clocks: &mut ClockTree) -> Option<AhbClkConfig> {
             clocks.ahb_clk
@@ -1879,8 +1879,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, config: ApbClkConfig) {
             let old_config = clocks.apb_clk.replace(config);
-            configure_apb_clk_impl(clocks, old_config, config);
             refresh_apb_clk_downstream(clocks);
+            configure_apb_clk_impl(clocks, old_config, config);
         }
         pub fn apb_clk_config(clocks: &mut ClockTree) -> Option<ApbClkConfig> {
             clocks.apb_clk
@@ -1925,6 +1925,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_lp_fast_clk(clocks: &mut ClockTree, new_selector: LpFastClkConfig) {
             let old_selector = clocks.lp_fast_clk.replace(new_selector);
+            refresh_lp_fast_clk_downstream(clocks);
             if clocks.lp_fast_clk_refcount > 0 {
                 match new_selector {
                     LpFastClkConfig::RcFastClk => request_rc_fast_clk(clocks),
@@ -1942,7 +1943,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_lp_fast_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_lp_fast_clk_downstream(clocks);
         }
         pub fn lp_fast_clk_config(clocks: &mut ClockTree) -> Option<LpFastClkConfig> {
             clocks.lp_fast_clk
@@ -1987,6 +1987,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_lp_slow_clk(clocks: &mut ClockTree, new_selector: LpSlowClkConfig) {
             let old_selector = clocks.lp_slow_clk.replace(new_selector);
+            refresh_lp_slow_clk_downstream(clocks);
             match new_selector {
                 LpSlowClkConfig::Xtal32k => request_xtal32k_clk(clocks),
                 LpSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
@@ -2000,7 +2001,6 @@ macro_rules! define_clock_tree_types {
                     LpSlowClkConfig::OscSlow => release_osc_slow_clk(clocks),
                 }
             }
-            refresh_lp_slow_clk_downstream(clocks);
         }
         pub fn lp_slow_clk_config(clocks: &mut ClockTree) -> Option<LpSlowClkConfig> {
             clocks.lp_slow_clk
@@ -2044,6 +2044,7 @@ macro_rules! define_clock_tree_types {
             new_selector: TimgCalibrationClockConfig,
         ) {
             let old_selector = clocks.timg_calibration_clock.replace(new_selector);
+            refresh_timg_calibration_clock_downstream(clocks);
             if clocks.timg_calibration_clock_refcount > 0 {
                 match new_selector {
                     TimgCalibrationClockConfig::RcSlowClk => request_lp_slow_clk(clocks),
@@ -2061,7 +2062,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
             }
-            refresh_timg_calibration_clock_downstream(clocks);
         }
         pub fn timg_calibration_clock_config(
             clocks: &mut ClockTree,
@@ -2113,6 +2113,7 @@ macro_rules! define_clock_tree_types {
                 new_selector: McpwmFunctionClockConfig,
             ) {
                 let old_selector = clocks.mcpwm_function_clock[self as usize].replace(new_selector);
+                refresh_mcpwm_function_clock_downstream(clocks, self);
                 if clocks.mcpwm_function_clock_refcount[self as usize] > 0 {
                     match new_selector {
                         McpwmFunctionClockConfig::PllF96m => request_pll_f96m_clk(clocks),
@@ -2130,7 +2131,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_mcpwm_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -2190,6 +2190,7 @@ macro_rules! define_clock_tree_types {
                 new_selector: ParlIoRxClockConfig,
             ) {
                 let old_selector = clocks.parl_io_rx_clock[self as usize].replace(new_selector);
+                refresh_parl_io_rx_clock_downstream(clocks, self);
                 if clocks.parl_io_rx_clock_refcount[self as usize] > 0 {
                     match new_selector {
                         ParlIoRxClockConfig::XtalClk => request_xtal_clk(clocks),
@@ -2207,7 +2208,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_rx_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_parl_io_rx_clock_downstream(clocks, self);
             }
             pub fn rx_clock_config(self, clocks: &mut ClockTree) -> Option<ParlIoRxClockConfig> {
                 clocks.parl_io_rx_clock[self as usize]
@@ -2258,6 +2258,7 @@ macro_rules! define_clock_tree_types {
                 new_selector: ParlIoTxClockConfig,
             ) {
                 let old_selector = clocks.parl_io_tx_clock[self as usize].replace(new_selector);
+                refresh_parl_io_tx_clock_downstream(clocks, self);
                 if clocks.parl_io_tx_clock_refcount[self as usize] > 0 {
                     match new_selector {
                         ParlIoTxClockConfig::XtalClk => request_xtal_clk(clocks),
@@ -2275,7 +2276,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_tx_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_parl_io_tx_clock_downstream(clocks, self);
             }
             pub fn tx_clock_config(self, clocks: &mut ClockTree) -> Option<ParlIoTxClockConfig> {
                 clocks.parl_io_tx_clock[self as usize]
@@ -2324,6 +2324,7 @@ macro_rules! define_clock_tree_types {
         impl RmtInstance {
             pub fn configure_sclk(self, clocks: &mut ClockTree, new_selector: RmtSclkConfig) {
                 let old_selector = clocks.rmt_sclk[self as usize].replace(new_selector);
+                refresh_rmt_sclk_downstream(clocks, self);
                 if clocks.rmt_sclk_refcount[self as usize] > 0 {
                     match new_selector {
                         RmtSclkConfig::XtalClk => request_xtal_clk(clocks),
@@ -2339,7 +2340,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_sclk_impl(clocks, old_selector, new_selector);
                 }
-                refresh_rmt_sclk_downstream(clocks, self);
             }
             pub fn sclk_config(self, clocks: &mut ClockTree) -> Option<RmtSclkConfig> {
                 clocks.rmt_sclk[self as usize]
@@ -2388,6 +2388,7 @@ macro_rules! define_clock_tree_types {
                 new_selector: TimgFunctionClockConfig,
             ) {
                 let old_selector = clocks.timg_function_clock[self as usize].replace(new_selector);
+                refresh_timg_function_clock_downstream(clocks, self);
                 if clocks.timg_function_clock_refcount[self as usize] > 0 {
                     match new_selector {
                         TimgFunctionClockConfig::XtalClk => request_xtal_clk(clocks),
@@ -2405,7 +2406,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_timg_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -2463,6 +2463,7 @@ macro_rules! define_clock_tree_types {
                 new_selector: TimgWdtClockConfig,
             ) {
                 let old_selector = clocks.timg_wdt_clock[self as usize].replace(new_selector);
+                refresh_timg_wdt_clock_downstream(clocks, self);
                 if clocks.timg_wdt_clock_refcount[self as usize] > 0 {
                     match new_selector {
                         TimgWdtClockConfig::XtalClk => request_xtal_clk(clocks),
@@ -2480,7 +2481,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_wdt_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_timg_wdt_clock_downstream(clocks, self);
             }
             pub fn wdt_clock_config(self, clocks: &mut ClockTree) -> Option<TimgWdtClockConfig> {
                 clocks.timg_wdt_clock[self as usize]
@@ -2533,6 +2533,7 @@ macro_rules! define_clock_tree_types {
                 config: UartFunctionClockConfig,
             ) {
                 let old_config = clocks.uart_function_clock[self as usize].replace(config);
+                refresh_uart_function_clock_downstream(clocks, self);
                 if clocks.uart_function_clock_refcount[self as usize] > 0 {
                     match config.sclk {
                         UartFunctionClockSclk::PllF48m => request_pll_f48m_clk(clocks),
@@ -2550,7 +2551,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_config, config);
                 }
-                refresh_uart_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -2608,8 +2608,8 @@ macro_rules! define_clock_tree_types {
                 config: UartBaudRateGeneratorConfig,
             ) {
                 let old_config = clocks.uart_baud_rate_generator[self as usize].replace(config);
-                self.configure_baud_rate_generator_impl(clocks, old_config, config);
                 refresh_uart_baud_rate_generator_downstream(clocks, self);
+                self.configure_baud_rate_generator_impl(clocks, old_config, config);
             }
             pub fn baud_rate_generator_config(
                 self,

--- a/esp-metadata-generated/src/_generated_esp32h2.rs
+++ b/esp-metadata-generated/src/_generated_esp32h2.rs
@@ -2733,8 +2733,6 @@ macro_rules! define_clock_tree_types {
             }
             for child_instance in [ParlIoInstance::ParlIo] {
                 refresh_parl_io_rx_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [ParlIoInstance::ParlIo] {
                 refresh_parl_io_tx_clock_downstream(clocks, child_instance);
             }
             for child_instance in [RmtInstance::Rmt] {
@@ -2742,18 +2740,7 @@ macro_rules! define_clock_tree_types {
             }
             for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
                 refresh_timg_function_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
                 refresh_timg_wdt_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
-                refresh_timg_function_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
-                refresh_timg_wdt_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
-                refresh_uart_function_clock_downstream(clocks, child_instance);
             }
             for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
                 refresh_uart_function_clock_downstream(clocks, child_instance);

--- a/esp-metadata-generated/src/_generated_esp32h2.rs
+++ b/esp-metadata-generated/src/_generated_esp32h2.rs
@@ -1599,9 +1599,42 @@ macro_rules! define_clock_tree_types {
                 uart_function_clock_refcount: [0; 2],
                 uart_baud_rate_generator_refcount: [0; 2],
             });
+        static XTAL_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static HP_ROOT_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static CPU_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static AHB_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static APB_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static LP_FAST_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static LP_SLOW_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static TIMG_CALIBRATION_CLOCK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static MCPWM_FUNCTION_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 1] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 1];
+        static PARL_IO_RX_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 1] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 1];
+        static PARL_IO_TX_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 1] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 1];
+        static RMT_SCLK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 1] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 1];
+        static TIMG_FUNCTION_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 2] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
+        static TIMG_WDT_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 2] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
+        static UART_FUNCTION_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 2] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
+        static UART_BAUD_RATE_GENERATOR_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 2] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
             let old_config = clocks.xtal_clk.replace(config);
             configure_xtal_clk_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn xtal_clk_config(clocks: &mut ClockTree) -> Option<XtalClkConfig> {
             clocks.xtal_clk
@@ -1612,12 +1645,8 @@ macro_rules! define_clock_tree_types {
         pub fn xtal_clk_config_frequency(clocks: &mut ClockTree, config: XtalClkConfig) -> u32 {
             config.value()
         }
-        pub fn xtal_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.xtal_clk {
-                xtal_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn xtal_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            XTAL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_pll_f96m_clk(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F96M_CLK");
@@ -1768,6 +1797,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_hp_root_clk_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn hp_root_clk_config(clocks: &mut ClockTree) -> Option<HpRootClkConfig> {
             clocks.hp_root_clk
@@ -1810,16 +1840,13 @@ macro_rules! define_clock_tree_types {
                 HpRootClkConfig::RcFast => rc_fast_clk_frequency(clocks),
             }
         }
-        pub fn hp_root_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.hp_root_clk {
-                hp_root_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn hp_root_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            HP_ROOT_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, config: CpuClkConfig) {
             let old_config = clocks.cpu_clk.replace(config);
             configure_cpu_clk_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn cpu_clk_config(clocks: &mut ClockTree) -> Option<CpuClkConfig> {
             clocks.cpu_clk
@@ -1830,16 +1857,13 @@ macro_rules! define_clock_tree_types {
         pub fn cpu_clk_config_frequency(clocks: &mut ClockTree, config: CpuClkConfig) -> u32 {
             (hp_root_clk_frequency(clocks) / (config.divisor() + 1))
         }
-        pub fn cpu_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.cpu_clk {
-                cpu_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn cpu_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            CPU_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_ahb_clk(clocks: &mut ClockTree, config: AhbClkConfig) {
             let old_config = clocks.ahb_clk.replace(config);
             configure_ahb_clk_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn ahb_clk_config(clocks: &mut ClockTree) -> Option<AhbClkConfig> {
             clocks.ahb_clk
@@ -1850,16 +1874,13 @@ macro_rules! define_clock_tree_types {
         pub fn ahb_clk_config_frequency(clocks: &mut ClockTree, config: AhbClkConfig) -> u32 {
             (hp_root_clk_frequency(clocks) / (config.divisor() + 1))
         }
-        pub fn ahb_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.ahb_clk {
-                ahb_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn ahb_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            AHB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, config: ApbClkConfig) {
             let old_config = clocks.apb_clk.replace(config);
             configure_apb_clk_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn apb_clk_config(clocks: &mut ClockTree) -> Option<ApbClkConfig> {
             clocks.apb_clk
@@ -1884,12 +1905,8 @@ macro_rules! define_clock_tree_types {
         pub fn apb_clk_config_frequency(clocks: &mut ClockTree, config: ApbClkConfig) -> u32 {
             (ahb_clk_frequency(clocks) / (config.divisor() + 1))
         }
-        pub fn apb_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.apb_clk {
-                apb_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn apb_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            APB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_xtal_d2_clk(clocks: &mut ClockTree) {
             trace!("Requesting XTAL_D2_CLK");
@@ -1925,6 +1942,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_lp_fast_clk_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn lp_fast_clk_config(clocks: &mut ClockTree) -> Option<LpFastClkConfig> {
             clocks.lp_fast_clk
@@ -1964,12 +1982,8 @@ macro_rules! define_clock_tree_types {
                 LpFastClkConfig::XtalD2Clk => xtal_d2_clk_frequency(clocks),
             }
         }
-        pub fn lp_fast_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.lp_fast_clk {
-                lp_fast_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn lp_fast_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            LP_FAST_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_lp_slow_clk(clocks: &mut ClockTree, new_selector: LpSlowClkConfig) {
             let old_selector = clocks.lp_slow_clk.replace(new_selector);
@@ -1986,6 +2000,7 @@ macro_rules! define_clock_tree_types {
                     LpSlowClkConfig::OscSlow => release_osc_slow_clk(clocks),
                 }
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn lp_slow_clk_config(clocks: &mut ClockTree) -> Option<LpSlowClkConfig> {
             clocks.lp_slow_clk
@@ -2021,12 +2036,8 @@ macro_rules! define_clock_tree_types {
                 LpSlowClkConfig::OscSlow => osc_slow_clk_frequency(clocks),
             }
         }
-        pub fn lp_slow_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.lp_slow_clk {
-                lp_slow_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn lp_slow_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            LP_SLOW_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_timg_calibration_clock(
             clocks: &mut ClockTree,
@@ -2050,6 +2061,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn timg_calibration_clock_config(
             clocks: &mut ClockTree,
@@ -2091,12 +2103,8 @@ macro_rules! define_clock_tree_types {
                 TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(clocks),
             }
         }
-        pub fn timg_calibration_clock_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.timg_calibration_clock {
-                timg_calibration_clock_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn timg_calibration_clock_frequency(_clocks: &mut ClockTree) -> u32 {
+            TIMG_CALIBRATION_CLOCK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         impl McpwmInstance {
             pub fn configure_function_clock(
@@ -2122,6 +2130,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn function_clock_config(
                 self,
@@ -2169,12 +2178,9 @@ macro_rules! define_clock_tree_types {
                     McpwmFunctionClockConfig::XtalClk => xtal_clk_frequency(clocks),
                 }
             }
-            pub fn function_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.mcpwm_function_clock[self as usize] {
-                    self.function_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                MCPWM_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
         }
         impl ParlIoInstance {
@@ -2201,6 +2207,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_rx_clock_impl(clocks, old_selector, new_selector);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn rx_clock_config(self, clocks: &mut ClockTree) -> Option<ParlIoRxClockConfig> {
                 clocks.parl_io_rx_clock[self as usize]
@@ -2241,12 +2248,9 @@ macro_rules! define_clock_tree_types {
                     ParlIoRxClockConfig::PllF96m => pll_f96m_clk_frequency(clocks),
                 }
             }
-            pub fn rx_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.parl_io_rx_clock[self as usize] {
-                    self.rx_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn rx_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                PARL_IO_RX_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
             pub fn configure_tx_clock(
                 self,
@@ -2271,6 +2275,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_tx_clock_impl(clocks, old_selector, new_selector);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn tx_clock_config(self, clocks: &mut ClockTree) -> Option<ParlIoTxClockConfig> {
                 clocks.parl_io_tx_clock[self as usize]
@@ -2311,12 +2316,9 @@ macro_rules! define_clock_tree_types {
                     ParlIoTxClockConfig::PllF96m => pll_f96m_clk_frequency(clocks),
                 }
             }
-            pub fn tx_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.parl_io_tx_clock[self as usize] {
-                    self.tx_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn tx_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                PARL_IO_TX_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
         }
         impl RmtInstance {
@@ -2337,6 +2339,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_sclk_impl(clocks, old_selector, new_selector);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn sclk_config(self, clocks: &mut ClockTree) -> Option<RmtSclkConfig> {
                 clocks.rmt_sclk[self as usize]
@@ -2374,12 +2377,8 @@ macro_rules! define_clock_tree_types {
                     RmtSclkConfig::RcFastClk => rc_fast_clk_frequency(clocks),
                 }
             }
-            pub fn sclk_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.rmt_sclk[self as usize] {
-                    self.sclk_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn sclk_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                RMT_SCLK_FREQ_CACHE[self as usize].load(::core::sync::atomic::Ordering::Acquire)
             }
         }
         impl TimgInstance {
@@ -2406,6 +2405,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn function_clock_config(
                 self,
@@ -2453,12 +2453,9 @@ macro_rules! define_clock_tree_types {
                     TimgFunctionClockConfig::PllF48m => pll_f48m_clk_frequency(clocks),
                 }
             }
-            pub fn function_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.timg_function_clock[self as usize] {
-                    self.function_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                TIMG_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
             pub fn configure_wdt_clock(
                 self,
@@ -2483,6 +2480,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_wdt_clock_impl(clocks, old_selector, new_selector);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn wdt_clock_config(self, clocks: &mut ClockTree) -> Option<TimgWdtClockConfig> {
                 clocks.timg_wdt_clock[self as usize]
@@ -2523,12 +2521,9 @@ macro_rules! define_clock_tree_types {
                     TimgWdtClockConfig::PllF48m => pll_f48m_clk_frequency(clocks),
                 }
             }
-            pub fn wdt_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.timg_wdt_clock[self as usize] {
-                    self.wdt_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn wdt_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                TIMG_WDT_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
         }
         impl UartInstance {
@@ -2555,6 +2550,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_config, config);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn function_clock_config(
                 self,
@@ -2602,12 +2598,9 @@ macro_rules! define_clock_tree_types {
                     UartFunctionClockSclk::Xtal => xtal_clk_frequency(clocks),
                 } / (config.div_num() + 1))
             }
-            pub fn function_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.uart_function_clock[self as usize] {
-                    self.function_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                UART_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
             pub fn configure_baud_rate_generator(
                 self,
@@ -2616,6 +2609,7 @@ macro_rules! define_clock_tree_types {
             ) {
                 let old_config = clocks.uart_baud_rate_generator[self as usize].replace(config);
                 self.configure_baud_rate_generator_impl(clocks, old_config, config);
+                refresh_all_frequency_caches(clocks);
             }
             pub fn baud_rate_generator_config(
                 self,
@@ -2652,12 +2646,9 @@ macro_rules! define_clock_tree_types {
                 ((self.function_clock_frequency(clocks) * 16)
                     / ((config.integral() * 16) + config.fractional()))
             }
-            pub fn baud_rate_generator_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.uart_baud_rate_generator[self as usize] {
-                    self.baud_rate_generator_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn baud_rate_generator_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                UART_BAUD_RATE_GENERATOR_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
         }
         /// Clock tree configuration.
@@ -2727,6 +2718,120 @@ macro_rules! define_clock_tree_types {
             *refcount = refcount.saturating_sub(1);
             let last = *refcount == 0;
             last
+        }
+        fn refresh_all_frequency_caches(clocks: &mut ClockTree) {
+            if let Some(config) = clocks.xtal_clk {
+                XTAL_CLK_FREQ_CACHE.store(
+                    xtal_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.hp_root_clk {
+                HP_ROOT_CLK_FREQ_CACHE.store(
+                    hp_root_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.cpu_clk {
+                CPU_CLK_FREQ_CACHE.store(
+                    cpu_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.ahb_clk {
+                AHB_CLK_FREQ_CACHE.store(
+                    ahb_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.apb_clk {
+                APB_CLK_FREQ_CACHE.store(
+                    apb_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.lp_fast_clk {
+                LP_FAST_CLK_FREQ_CACHE.store(
+                    lp_fast_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.lp_slow_clk {
+                LP_SLOW_CLK_FREQ_CACHE.store(
+                    lp_slow_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.timg_calibration_clock {
+                TIMG_CALIBRATION_CLOCK_FREQ_CACHE.store(
+                    timg_calibration_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            for instance in [McpwmInstance::Mcpwm0] {
+                if let Some(config) = clocks.mcpwm_function_clock[instance as usize] {
+                    MCPWM_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.function_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [ParlIoInstance::ParlIo] {
+                if let Some(config) = clocks.parl_io_rx_clock[instance as usize] {
+                    PARL_IO_RX_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.rx_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [ParlIoInstance::ParlIo] {
+                if let Some(config) = clocks.parl_io_tx_clock[instance as usize] {
+                    PARL_IO_TX_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.tx_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [RmtInstance::Rmt] {
+                if let Some(config) = clocks.rmt_sclk[instance as usize] {
+                    RMT_SCLK_FREQ_CACHE[instance as usize].store(
+                        instance.sclk_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                if let Some(config) = clocks.timg_function_clock[instance as usize] {
+                    TIMG_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.function_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                if let Some(config) = clocks.timg_wdt_clock[instance as usize] {
+                    TIMG_WDT_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.wdt_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                if let Some(config) = clocks.uart_function_clock[instance as usize] {
+                    UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.function_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                if let Some(config) = clocks.uart_baud_rate_generator[instance as usize] {
+                    UART_BAUD_RATE_GENERATOR_FREQ_CACHE[instance as usize].store(
+                        instance.baud_rate_generator_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
         }
     };
 }

--- a/esp-metadata-generated/src/_generated_esp32s2.rs
+++ b/esp-metadata-generated/src/_generated_esp32s2.rs
@@ -1565,9 +1565,48 @@ macro_rules! define_clock_tree_types {
                 uart_baud_rate_generator_refcount: [0; 2],
                 uart_mem_clock_refcount: [0; 2],
             });
+        static XTAL_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static PLL_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static APLL_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static CPU_PLL_DIV_IN_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static CPU_PLL_DIV_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static SYSTEM_PRE_DIV_IN_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static SYSTEM_PRE_DIV_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static REF_TICK_XTAL_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static REF_TICK_CK8M_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static CPU_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static RTC_SLOW_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static RTC_FAST_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static TIMG_CALIBRATION_CLOCK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static UART_MEM_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 2] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
+        static APB_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static REF_TICK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static TIMG_FUNCTION_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 2] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
+        static UART_FUNCTION_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 2] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
+        static UART_BAUD_RATE_GENERATOR_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 2] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
             let old_config = clocks.xtal_clk.replace(config);
             configure_xtal_clk_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn xtal_clk_config(clocks: &mut ClockTree) -> Option<XtalClkConfig> {
             clocks.xtal_clk
@@ -1578,16 +1617,13 @@ macro_rules! define_clock_tree_types {
         pub fn xtal_clk_config_frequency(clocks: &mut ClockTree, config: XtalClkConfig) -> u32 {
             config.value()
         }
-        pub fn xtal_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.xtal_clk {
-                xtal_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn xtal_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            XTAL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_pll_clk(clocks: &mut ClockTree, config: PllClkConfig) {
             let old_config = clocks.pll_clk.replace(config);
             configure_pll_clk_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn pll_clk_config(clocks: &mut ClockTree) -> Option<PllClkConfig> {
             clocks.pll_clk
@@ -1612,16 +1648,13 @@ macro_rules! define_clock_tree_types {
         pub fn pll_clk_config_frequency(clocks: &mut ClockTree, config: PllClkConfig) -> u32 {
             config.value()
         }
-        pub fn pll_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.pll_clk {
-                pll_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn pll_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            PLL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_apll_clk(clocks: &mut ClockTree, config: ApllClkConfig) {
             let old_config = clocks.apll_clk.replace(config);
             configure_apll_clk_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn apll_clk_config(clocks: &mut ClockTree) -> Option<ApllClkConfig> {
             clocks.apll_clk
@@ -1642,12 +1675,8 @@ macro_rules! define_clock_tree_types {
         pub fn apll_clk_config_frequency(clocks: &mut ClockTree, config: ApllClkConfig) -> u32 {
             config.value()
         }
-        pub fn apll_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.apll_clk {
-                apll_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn apll_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            APLL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_rc_fast_clk(clocks: &mut ClockTree) {
             trace!("Requesting RC_FAST_CLK");
@@ -1679,6 +1708,7 @@ macro_rules! define_clock_tree_types {
                     CpuPllDivInConfig::Apll => release_apll_clk(clocks),
                 }
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn cpu_pll_div_in_config(clocks: &mut ClockTree) -> Option<CpuPllDivInConfig> {
             clocks.cpu_pll_div_in
@@ -1711,16 +1741,13 @@ macro_rules! define_clock_tree_types {
                 CpuPllDivInConfig::Apll => apll_clk_frequency(clocks),
             }
         }
-        pub fn cpu_pll_div_in_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.cpu_pll_div_in {
-                cpu_pll_div_in_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn cpu_pll_div_in_frequency(_clocks: &mut ClockTree) -> u32 {
+            CPU_PLL_DIV_IN_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_cpu_pll_div(clocks: &mut ClockTree, config: CpuPllDivConfig) {
             let old_config = clocks.cpu_pll_div.replace(config);
             configure_cpu_pll_div_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn cpu_pll_div_config(clocks: &mut ClockTree) -> Option<CpuPllDivConfig> {
             clocks.cpu_pll_div
@@ -1744,12 +1771,8 @@ macro_rules! define_clock_tree_types {
         ) -> u32 {
             (cpu_pll_div_in_frequency(clocks) / config.divisor())
         }
-        pub fn cpu_pll_div_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.cpu_pll_div {
-                cpu_pll_div_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn cpu_pll_div_frequency(_clocks: &mut ClockTree) -> u32 {
+            CPU_PLL_DIV_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_system_pre_div_in(
             clocks: &mut ClockTree,
@@ -1767,6 +1790,7 @@ macro_rules! define_clock_tree_types {
                     SystemPreDivInConfig::RcFast => release_rc_fast_clk(clocks),
                 }
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn system_pre_div_in_config(clocks: &mut ClockTree) -> Option<SystemPreDivInConfig> {
             clocks.system_pre_div_in
@@ -1799,16 +1823,13 @@ macro_rules! define_clock_tree_types {
                 SystemPreDivInConfig::RcFast => rc_fast_clk_frequency(clocks),
             }
         }
-        pub fn system_pre_div_in_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.system_pre_div_in {
-                system_pre_div_in_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn system_pre_div_in_frequency(_clocks: &mut ClockTree) -> u32 {
+            SYSTEM_PRE_DIV_IN_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_system_pre_div(clocks: &mut ClockTree, config: SystemPreDivConfig) {
             let old_config = clocks.system_pre_div.replace(config);
             configure_system_pre_div_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn system_pre_div_config(clocks: &mut ClockTree) -> Option<SystemPreDivConfig> {
             clocks.system_pre_div
@@ -1832,12 +1853,8 @@ macro_rules! define_clock_tree_types {
         ) -> u32 {
             (system_pre_div_in_frequency(clocks) / (config.divisor() + 1))
         }
-        pub fn system_pre_div_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.system_pre_div {
-                system_pre_div_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn system_pre_div_frequency(_clocks: &mut ClockTree) -> u32 {
+            SYSTEM_PRE_DIV_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, new_selector: ApbClkConfig) {
             let old_selector = clocks.apb_clk.replace(new_selector);
@@ -1860,6 +1877,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_apb_clk_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn apb_clk_config(clocks: &mut ClockTree) -> Option<ApbClkConfig> {
             clocks.apb_clk
@@ -1899,12 +1917,8 @@ macro_rules! define_clock_tree_types {
                 ApbClkConfig::RcFast => cpu_clk_frequency(clocks),
             }
         }
-        pub fn apb_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.apb_clk {
-                apb_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn apb_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            APB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_ref_tick(clocks: &mut ClockTree, new_selector: RefTickConfig) {
             let old_selector = clocks.ref_tick.replace(new_selector);
@@ -1927,6 +1941,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_ref_tick_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn ref_tick_config(clocks: &mut ClockTree) -> Option<RefTickConfig> {
             clocks.ref_tick
@@ -1966,16 +1981,13 @@ macro_rules! define_clock_tree_types {
                 RefTickConfig::RcFast => ref_tick_ck8m_frequency(clocks),
             }
         }
-        pub fn ref_tick_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.ref_tick {
-                ref_tick_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn ref_tick_frequency(_clocks: &mut ClockTree) -> u32 {
+            REF_TICK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_ref_tick_xtal(clocks: &mut ClockTree, config: RefTickXtalConfig) {
             let old_config = clocks.ref_tick_xtal.replace(config);
             configure_ref_tick_xtal_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn ref_tick_xtal_config(clocks: &mut ClockTree) -> Option<RefTickXtalConfig> {
             clocks.ref_tick_xtal
@@ -1999,16 +2011,13 @@ macro_rules! define_clock_tree_types {
         ) -> u32 {
             (xtal_clk_frequency(clocks) / (config.divisor() + 1))
         }
-        pub fn ref_tick_xtal_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.ref_tick_xtal {
-                ref_tick_xtal_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn ref_tick_xtal_frequency(_clocks: &mut ClockTree) -> u32 {
+            REF_TICK_XTAL_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_ref_tick_ck8m(clocks: &mut ClockTree, config: RefTickCk8mConfig) {
             let old_config = clocks.ref_tick_ck8m.replace(config);
             configure_ref_tick_ck8m_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn ref_tick_ck8m_config(clocks: &mut ClockTree) -> Option<RefTickCk8mConfig> {
             clocks.ref_tick_ck8m
@@ -2032,12 +2041,8 @@ macro_rules! define_clock_tree_types {
         ) -> u32 {
             (rc_fast_clk_frequency(clocks) / (config.divisor() + 1))
         }
-        pub fn ref_tick_ck8m_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.ref_tick_ck8m {
-                ref_tick_ck8m_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn ref_tick_ck8m_frequency(_clocks: &mut ClockTree) -> u32 {
+            REF_TICK_CK8M_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, new_selector: CpuClkConfig) {
             let old_selector = clocks.cpu_clk.replace(new_selector);
@@ -2090,6 +2095,7 @@ macro_rules! define_clock_tree_types {
                     CpuClkConfig::Pll => release_cpu_pll_div(clocks),
                 }
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn cpu_clk_config(clocks: &mut ClockTree) -> Option<CpuClkConfig> {
             clocks.cpu_clk
@@ -2105,12 +2111,8 @@ macro_rules! define_clock_tree_types {
                 CpuClkConfig::Pll => cpu_pll_div_frequency(clocks),
             }
         }
-        pub fn cpu_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.cpu_clk {
-                cpu_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn cpu_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            CPU_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_apb_clk_cpu_div2(clocks: &mut ClockTree) {
             trace!("Requesting APB_CLK_CPU_DIV2");
@@ -2221,6 +2223,7 @@ macro_rules! define_clock_tree_types {
                     RtcSlowClkConfig::RcFast => release_rc_fast_div_clk(clocks),
                 }
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn rtc_slow_clk_config(clocks: &mut ClockTree) -> Option<RtcSlowClkConfig> {
             clocks.rtc_slow_clk
@@ -2256,12 +2259,8 @@ macro_rules! define_clock_tree_types {
                 RtcSlowClkConfig::RcFast => rc_fast_div_clk_frequency(clocks),
             }
         }
-        pub fn rtc_slow_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.rtc_slow_clk {
-                rtc_slow_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn rtc_slow_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            RTC_SLOW_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_rtc_fast_clk(clocks: &mut ClockTree, new_selector: RtcFastClkConfig) {
             let old_selector = clocks.rtc_fast_clk.replace(new_selector);
@@ -2280,6 +2279,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_rtc_fast_clk_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn rtc_fast_clk_config(clocks: &mut ClockTree) -> Option<RtcFastClkConfig> {
             clocks.rtc_fast_clk
@@ -2316,12 +2316,8 @@ macro_rules! define_clock_tree_types {
                 RtcFastClkConfig::Rc => rc_fast_clk_frequency(clocks),
             }
         }
-        pub fn rtc_fast_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.rtc_fast_clk {
-                rtc_fast_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn rtc_fast_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            RTC_FAST_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_uart_mem_clk(clocks: &mut ClockTree) {
             trace!("Requesting UART_MEM_CLK");
@@ -2364,6 +2360,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn timg_calibration_clock_config(
             clocks: &mut ClockTree,
@@ -2405,12 +2402,8 @@ macro_rules! define_clock_tree_types {
                 TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(clocks),
             }
         }
-        pub fn timg_calibration_clock_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.timg_calibration_clock {
-                timg_calibration_clock_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn timg_calibration_clock_frequency(_clocks: &mut ClockTree) -> u32 {
+            TIMG_CALIBRATION_CLOCK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         impl TimgInstance {
             pub fn configure_function_clock(
@@ -2434,6 +2427,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn function_clock_config(
                 self,
@@ -2478,12 +2472,9 @@ macro_rules! define_clock_tree_types {
                     TimgFunctionClockConfig::ApbClk => apb_clk_frequency(clocks),
                 }
             }
-            pub fn function_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.timg_function_clock[self as usize] {
-                    self.function_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                TIMG_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
         }
         impl UartInstance {
@@ -2508,6 +2499,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_config, config);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn function_clock_config(
                 self,
@@ -2552,12 +2544,9 @@ macro_rules! define_clock_tree_types {
                     UartFunctionClockSclk::RefTick => ref_tick_frequency(clocks),
                 }
             }
-            pub fn function_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.uart_function_clock[self as usize] {
-                    self.function_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                UART_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
             pub fn configure_baud_rate_generator(
                 self,
@@ -2566,6 +2555,7 @@ macro_rules! define_clock_tree_types {
             ) {
                 let old_config = clocks.uart_baud_rate_generator[self as usize].replace(config);
                 self.configure_baud_rate_generator_impl(clocks, old_config, config);
+                refresh_all_frequency_caches(clocks);
             }
             pub fn baud_rate_generator_config(
                 self,
@@ -2602,16 +2592,14 @@ macro_rules! define_clock_tree_types {
                 ((self.function_clock_frequency(clocks) * 16)
                     / ((config.integral() * 16) + config.fractional()))
             }
-            pub fn baud_rate_generator_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.uart_baud_rate_generator[self as usize] {
-                    self.baud_rate_generator_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn baud_rate_generator_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                UART_BAUD_RATE_GENERATOR_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
             pub fn configure_mem_clock(self, clocks: &mut ClockTree, config: UartMemClockConfig) {
                 let old_config = clocks.uart_mem_clock[self as usize].replace(config);
                 self.configure_mem_clock_impl(clocks, old_config, config);
+                refresh_all_frequency_caches(clocks);
             }
             pub fn mem_clock_config(self, clocks: &mut ClockTree) -> Option<UartMemClockConfig> {
                 clocks.uart_mem_clock[self as usize]
@@ -2640,12 +2628,9 @@ macro_rules! define_clock_tree_types {
             ) -> u32 {
                 uart_mem_clk_frequency(clocks)
             }
-            pub fn mem_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.uart_mem_clock[self as usize] {
-                    self.mem_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn mem_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                UART_MEM_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
         }
         /// Clock tree configuration.
@@ -2720,6 +2705,130 @@ macro_rules! define_clock_tree_types {
             *refcount = refcount.saturating_sub(1);
             let last = *refcount == 0;
             last
+        }
+        fn refresh_all_frequency_caches(clocks: &mut ClockTree) {
+            if let Some(config) = clocks.xtal_clk {
+                XTAL_CLK_FREQ_CACHE.store(
+                    xtal_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.pll_clk {
+                PLL_CLK_FREQ_CACHE.store(
+                    pll_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.apll_clk {
+                APLL_CLK_FREQ_CACHE.store(
+                    apll_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.cpu_pll_div_in {
+                CPU_PLL_DIV_IN_FREQ_CACHE.store(
+                    cpu_pll_div_in_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.cpu_pll_div {
+                CPU_PLL_DIV_FREQ_CACHE.store(
+                    cpu_pll_div_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.system_pre_div_in {
+                SYSTEM_PRE_DIV_IN_FREQ_CACHE.store(
+                    system_pre_div_in_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.system_pre_div {
+                SYSTEM_PRE_DIV_FREQ_CACHE.store(
+                    system_pre_div_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.ref_tick_xtal {
+                REF_TICK_XTAL_FREQ_CACHE.store(
+                    ref_tick_xtal_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.ref_tick_ck8m {
+                REF_TICK_CK8M_FREQ_CACHE.store(
+                    ref_tick_ck8m_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.cpu_clk {
+                CPU_CLK_FREQ_CACHE.store(
+                    cpu_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.rtc_slow_clk {
+                RTC_SLOW_CLK_FREQ_CACHE.store(
+                    rtc_slow_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.rtc_fast_clk {
+                RTC_FAST_CLK_FREQ_CACHE.store(
+                    rtc_fast_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.timg_calibration_clock {
+                TIMG_CALIBRATION_CLOCK_FREQ_CACHE.store(
+                    timg_calibration_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            for instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                if let Some(config) = clocks.uart_mem_clock[instance as usize] {
+                    UART_MEM_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.mem_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            if let Some(config) = clocks.apb_clk {
+                APB_CLK_FREQ_CACHE.store(
+                    apb_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.ref_tick {
+                REF_TICK_FREQ_CACHE.store(
+                    ref_tick_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            for instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                if let Some(config) = clocks.timg_function_clock[instance as usize] {
+                    TIMG_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.function_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                if let Some(config) = clocks.uart_function_clock[instance as usize] {
+                    UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.function_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                if let Some(config) = clocks.uart_baud_rate_generator[instance as usize] {
+                    UART_BAUD_RATE_GENERATOR_FREQ_CACHE[instance as usize].store(
+                        instance.baud_rate_generator_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
         }
     };
 }

--- a/esp-metadata-generated/src/_generated_esp32s2.rs
+++ b/esp-metadata-generated/src/_generated_esp32s2.rs
@@ -1605,8 +1605,8 @@ macro_rules! define_clock_tree_types {
             [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
             let old_config = clocks.xtal_clk.replace(config);
-            configure_xtal_clk_impl(clocks, old_config, config);
             refresh_xtal_clk_downstream(clocks);
+            configure_xtal_clk_impl(clocks, old_config, config);
         }
         pub fn xtal_clk_config(clocks: &mut ClockTree) -> Option<XtalClkConfig> {
             clocks.xtal_clk
@@ -1622,8 +1622,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_pll_clk(clocks: &mut ClockTree, config: PllClkConfig) {
             let old_config = clocks.pll_clk.replace(config);
-            configure_pll_clk_impl(clocks, old_config, config);
             refresh_pll_clk_downstream(clocks);
+            configure_pll_clk_impl(clocks, old_config, config);
         }
         pub fn pll_clk_config(clocks: &mut ClockTree) -> Option<PllClkConfig> {
             clocks.pll_clk
@@ -1653,8 +1653,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_apll_clk(clocks: &mut ClockTree, config: ApllClkConfig) {
             let old_config = clocks.apll_clk.replace(config);
-            configure_apll_clk_impl(clocks, old_config, config);
             refresh_apll_clk_downstream(clocks);
+            configure_apll_clk_impl(clocks, old_config, config);
         }
         pub fn apll_clk_config(clocks: &mut ClockTree) -> Option<ApllClkConfig> {
             clocks.apll_clk
@@ -1697,6 +1697,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_cpu_pll_div_in(clocks: &mut ClockTree, new_selector: CpuPllDivInConfig) {
             let old_selector = clocks.cpu_pll_div_in.replace(new_selector);
+            refresh_cpu_pll_div_in_downstream(clocks);
             match new_selector {
                 CpuPllDivInConfig::Pll => request_pll_clk(clocks),
                 CpuPllDivInConfig::Apll => request_apll_clk(clocks),
@@ -1708,7 +1709,6 @@ macro_rules! define_clock_tree_types {
                     CpuPllDivInConfig::Apll => release_apll_clk(clocks),
                 }
             }
-            refresh_cpu_pll_div_in_downstream(clocks);
         }
         pub fn cpu_pll_div_in_config(clocks: &mut ClockTree) -> Option<CpuPllDivInConfig> {
             clocks.cpu_pll_div_in
@@ -1746,8 +1746,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_cpu_pll_div(clocks: &mut ClockTree, config: CpuPllDivConfig) {
             let old_config = clocks.cpu_pll_div.replace(config);
-            configure_cpu_pll_div_impl(clocks, old_config, config);
             refresh_cpu_pll_div_downstream(clocks);
+            configure_cpu_pll_div_impl(clocks, old_config, config);
         }
         pub fn cpu_pll_div_config(clocks: &mut ClockTree) -> Option<CpuPllDivConfig> {
             clocks.cpu_pll_div
@@ -1779,6 +1779,7 @@ macro_rules! define_clock_tree_types {
             new_selector: SystemPreDivInConfig,
         ) {
             let old_selector = clocks.system_pre_div_in.replace(new_selector);
+            refresh_system_pre_div_in_downstream(clocks);
             match new_selector {
                 SystemPreDivInConfig::Xtal => request_xtal_clk(clocks),
                 SystemPreDivInConfig::RcFast => request_rc_fast_clk(clocks),
@@ -1790,7 +1791,6 @@ macro_rules! define_clock_tree_types {
                     SystemPreDivInConfig::RcFast => release_rc_fast_clk(clocks),
                 }
             }
-            refresh_system_pre_div_in_downstream(clocks);
         }
         pub fn system_pre_div_in_config(clocks: &mut ClockTree) -> Option<SystemPreDivInConfig> {
             clocks.system_pre_div_in
@@ -1828,8 +1828,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_system_pre_div(clocks: &mut ClockTree, config: SystemPreDivConfig) {
             let old_config = clocks.system_pre_div.replace(config);
-            configure_system_pre_div_impl(clocks, old_config, config);
             refresh_system_pre_div_downstream(clocks);
+            configure_system_pre_div_impl(clocks, old_config, config);
         }
         pub fn system_pre_div_config(clocks: &mut ClockTree) -> Option<SystemPreDivConfig> {
             clocks.system_pre_div
@@ -1858,6 +1858,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, new_selector: ApbClkConfig) {
             let old_selector = clocks.apb_clk.replace(new_selector);
+            refresh_apb_clk_downstream(clocks);
             if clocks.apb_clk_refcount > 0 {
                 match new_selector {
                     ApbClkConfig::Pll => request_apb_clk_80m(clocks),
@@ -1877,7 +1878,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_apb_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_apb_clk_downstream(clocks);
         }
         pub fn apb_clk_config(clocks: &mut ClockTree) -> Option<ApbClkConfig> {
             clocks.apb_clk
@@ -1922,6 +1922,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_ref_tick(clocks: &mut ClockTree, new_selector: RefTickConfig) {
             let old_selector = clocks.ref_tick.replace(new_selector);
+            refresh_ref_tick_downstream(clocks);
             if clocks.ref_tick_refcount > 0 {
                 match new_selector {
                     RefTickConfig::Pll => request_ref_tick_xtal(clocks),
@@ -1941,7 +1942,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_ref_tick_impl(clocks, old_selector, new_selector);
             }
-            refresh_ref_tick_downstream(clocks);
         }
         pub fn ref_tick_config(clocks: &mut ClockTree) -> Option<RefTickConfig> {
             clocks.ref_tick
@@ -1986,8 +1986,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_ref_tick_xtal(clocks: &mut ClockTree, config: RefTickXtalConfig) {
             let old_config = clocks.ref_tick_xtal.replace(config);
-            configure_ref_tick_xtal_impl(clocks, old_config, config);
             refresh_ref_tick_xtal_downstream(clocks);
+            configure_ref_tick_xtal_impl(clocks, old_config, config);
         }
         pub fn ref_tick_xtal_config(clocks: &mut ClockTree) -> Option<RefTickXtalConfig> {
             clocks.ref_tick_xtal
@@ -2016,8 +2016,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_ref_tick_ck8m(clocks: &mut ClockTree, config: RefTickCk8mConfig) {
             let old_config = clocks.ref_tick_ck8m.replace(config);
-            configure_ref_tick_ck8m_impl(clocks, old_config, config);
             refresh_ref_tick_ck8m_downstream(clocks);
+            configure_ref_tick_ck8m_impl(clocks, old_config, config);
         }
         pub fn ref_tick_ck8m_config(clocks: &mut ClockTree) -> Option<RefTickCk8mConfig> {
             clocks.ref_tick_ck8m
@@ -2046,6 +2046,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, new_selector: CpuClkConfig) {
             let old_selector = clocks.cpu_clk.replace(new_selector);
+            refresh_cpu_clk_downstream(clocks);
             match new_selector {
                 CpuClkConfig::Xtal => {
                     configure_system_pre_div_in(clocks, SystemPreDivInConfig::Xtal);
@@ -2095,7 +2096,6 @@ macro_rules! define_clock_tree_types {
                     CpuClkConfig::Pll => release_cpu_pll_div(clocks),
                 }
             }
-            refresh_cpu_clk_downstream(clocks);
         }
         pub fn cpu_clk_config(clocks: &mut ClockTree) -> Option<CpuClkConfig> {
             clocks.cpu_clk
@@ -2210,6 +2210,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_rtc_slow_clk(clocks: &mut ClockTree, new_selector: RtcSlowClkConfig) {
             let old_selector = clocks.rtc_slow_clk.replace(new_selector);
+            refresh_rtc_slow_clk_downstream(clocks);
             match new_selector {
                 RtcSlowClkConfig::Xtal32k => request_xtal32k_clk(clocks),
                 RtcSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
@@ -2223,7 +2224,6 @@ macro_rules! define_clock_tree_types {
                     RtcSlowClkConfig::RcFast => release_rc_fast_div_clk(clocks),
                 }
             }
-            refresh_rtc_slow_clk_downstream(clocks);
         }
         pub fn rtc_slow_clk_config(clocks: &mut ClockTree) -> Option<RtcSlowClkConfig> {
             clocks.rtc_slow_clk
@@ -2264,6 +2264,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_rtc_fast_clk(clocks: &mut ClockTree, new_selector: RtcFastClkConfig) {
             let old_selector = clocks.rtc_fast_clk.replace(new_selector);
+            refresh_rtc_fast_clk_downstream(clocks);
             if clocks.rtc_fast_clk_refcount > 0 {
                 match new_selector {
                     RtcFastClkConfig::Xtal => request_xtal_div_clk(clocks),
@@ -2279,7 +2280,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_rtc_fast_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_rtc_fast_clk_downstream(clocks);
         }
         pub fn rtc_fast_clk_config(clocks: &mut ClockTree) -> Option<RtcFastClkConfig> {
             clocks.rtc_fast_clk
@@ -2343,6 +2343,7 @@ macro_rules! define_clock_tree_types {
             new_selector: TimgCalibrationClockConfig,
         ) {
             let old_selector = clocks.timg_calibration_clock.replace(new_selector);
+            refresh_timg_calibration_clock_downstream(clocks);
             if clocks.timg_calibration_clock_refcount > 0 {
                 match new_selector {
                     TimgCalibrationClockConfig::RtcClk => request_rtc_slow_clk(clocks),
@@ -2360,7 +2361,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
             }
-            refresh_timg_calibration_clock_downstream(clocks);
         }
         pub fn timg_calibration_clock_config(
             clocks: &mut ClockTree,
@@ -2412,6 +2412,7 @@ macro_rules! define_clock_tree_types {
                 new_selector: TimgFunctionClockConfig,
             ) {
                 let old_selector = clocks.timg_function_clock[self as usize].replace(new_selector);
+                refresh_timg_function_clock_downstream(clocks, self);
                 if clocks.timg_function_clock_refcount[self as usize] > 0 {
                     match new_selector {
                         TimgFunctionClockConfig::XtalClk => request_xtal_clk(clocks),
@@ -2427,7 +2428,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_timg_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -2484,6 +2484,7 @@ macro_rules! define_clock_tree_types {
                 config: UartFunctionClockConfig,
             ) {
                 let old_config = clocks.uart_function_clock[self as usize].replace(config);
+                refresh_uart_function_clock_downstream(clocks, self);
                 if clocks.uart_function_clock_refcount[self as usize] > 0 {
                     match config.sclk {
                         UartFunctionClockSclk::Apb => request_apb_clk(clocks),
@@ -2499,7 +2500,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_config, config);
                 }
-                refresh_uart_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -2554,8 +2554,8 @@ macro_rules! define_clock_tree_types {
                 config: UartBaudRateGeneratorConfig,
             ) {
                 let old_config = clocks.uart_baud_rate_generator[self as usize].replace(config);
-                self.configure_baud_rate_generator_impl(clocks, old_config, config);
                 refresh_uart_baud_rate_generator_downstream(clocks, self);
+                self.configure_baud_rate_generator_impl(clocks, old_config, config);
             }
             pub fn baud_rate_generator_config(
                 self,
@@ -2598,8 +2598,8 @@ macro_rules! define_clock_tree_types {
             }
             pub fn configure_mem_clock(self, clocks: &mut ClockTree, config: UartMemClockConfig) {
                 let old_config = clocks.uart_mem_clock[self as usize].replace(config);
-                self.configure_mem_clock_impl(clocks, old_config, config);
                 refresh_uart_mem_clock_downstream(clocks, self);
+                self.configure_mem_clock_impl(clocks, old_config, config);
             }
             pub fn mem_clock_config(self, clocks: &mut ClockTree) -> Option<UartMemClockConfig> {
                 clocks.uart_mem_clock[self as usize]

--- a/esp-metadata-generated/src/_generated_esp32s2.rs
+++ b/esp-metadata-generated/src/_generated_esp32s2.rs
@@ -1617,7 +1617,7 @@ macro_rules! define_clock_tree_types {
         pub fn xtal_clk_config_frequency(clocks: &mut ClockTree, config: XtalClkConfig) -> u32 {
             config.value()
         }
-        pub fn xtal_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn xtal_clk_frequency() -> u32 {
             XTAL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_pll_clk(clocks: &mut ClockTree, config: PllClkConfig) {
@@ -1648,7 +1648,7 @@ macro_rules! define_clock_tree_types {
         pub fn pll_clk_config_frequency(clocks: &mut ClockTree, config: PllClkConfig) -> u32 {
             config.value()
         }
-        pub fn pll_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn pll_clk_frequency() -> u32 {
             PLL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_apll_clk(clocks: &mut ClockTree, config: ApllClkConfig) {
@@ -1675,7 +1675,7 @@ macro_rules! define_clock_tree_types {
         pub fn apll_clk_config_frequency(clocks: &mut ClockTree, config: ApllClkConfig) -> u32 {
             config.value()
         }
-        pub fn apll_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn apll_clk_frequency() -> u32 {
             APLL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_rc_fast_clk(clocks: &mut ClockTree) {
@@ -1692,7 +1692,7 @@ macro_rules! define_clock_tree_types {
                 enable_rc_fast_clk_impl(clocks, false);
             }
         }
-        pub fn rc_fast_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn rc_fast_clk_frequency() -> u32 {
             8000000
         }
         pub fn configure_cpu_pll_div_in(clocks: &mut ClockTree, new_selector: CpuPllDivInConfig) {
@@ -1737,11 +1737,11 @@ macro_rules! define_clock_tree_types {
             config: CpuPllDivInConfig,
         ) -> u32 {
             match config {
-                CpuPllDivInConfig::Pll => pll_clk_frequency(clocks),
-                CpuPllDivInConfig::Apll => apll_clk_frequency(clocks),
+                CpuPllDivInConfig::Pll => pll_clk_frequency(),
+                CpuPllDivInConfig::Apll => apll_clk_frequency(),
             }
         }
-        pub fn cpu_pll_div_in_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn cpu_pll_div_in_frequency() -> u32 {
             CPU_PLL_DIV_IN_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_cpu_pll_div(clocks: &mut ClockTree, config: CpuPllDivConfig) {
@@ -1769,9 +1769,9 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: CpuPllDivConfig,
         ) -> u32 {
-            (cpu_pll_div_in_frequency(clocks) / config.divisor())
+            (cpu_pll_div_in_frequency() / config.divisor())
         }
-        pub fn cpu_pll_div_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn cpu_pll_div_frequency() -> u32 {
             CPU_PLL_DIV_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_system_pre_div_in(
@@ -1819,11 +1819,11 @@ macro_rules! define_clock_tree_types {
             config: SystemPreDivInConfig,
         ) -> u32 {
             match config {
-                SystemPreDivInConfig::Xtal => xtal_clk_frequency(clocks),
-                SystemPreDivInConfig::RcFast => rc_fast_clk_frequency(clocks),
+                SystemPreDivInConfig::Xtal => xtal_clk_frequency(),
+                SystemPreDivInConfig::RcFast => rc_fast_clk_frequency(),
             }
         }
-        pub fn system_pre_div_in_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn system_pre_div_in_frequency() -> u32 {
             SYSTEM_PRE_DIV_IN_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_system_pre_div(clocks: &mut ClockTree, config: SystemPreDivConfig) {
@@ -1851,9 +1851,9 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: SystemPreDivConfig,
         ) -> u32 {
-            (system_pre_div_in_frequency(clocks) / (config.divisor() + 1))
+            (system_pre_div_in_frequency() / (config.divisor() + 1))
         }
-        pub fn system_pre_div_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn system_pre_div_frequency() -> u32 {
             SYSTEM_PRE_DIV_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, new_selector: ApbClkConfig) {
@@ -1911,13 +1911,13 @@ macro_rules! define_clock_tree_types {
         #[allow(unused_variables)]
         pub fn apb_clk_config_frequency(clocks: &mut ClockTree, config: ApbClkConfig) -> u32 {
             match config {
-                ApbClkConfig::Pll => apb_clk_80m_frequency(clocks),
-                ApbClkConfig::Apll => apb_clk_cpu_div2_frequency(clocks),
-                ApbClkConfig::Xtal => cpu_clk_frequency(clocks),
-                ApbClkConfig::RcFast => cpu_clk_frequency(clocks),
+                ApbClkConfig::Pll => apb_clk_80m_frequency(),
+                ApbClkConfig::Apll => apb_clk_cpu_div2_frequency(),
+                ApbClkConfig::Xtal => cpu_clk_frequency(),
+                ApbClkConfig::RcFast => cpu_clk_frequency(),
             }
         }
-        pub fn apb_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn apb_clk_frequency() -> u32 {
             APB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_ref_tick(clocks: &mut ClockTree, new_selector: RefTickConfig) {
@@ -1975,13 +1975,13 @@ macro_rules! define_clock_tree_types {
         #[allow(unused_variables)]
         pub fn ref_tick_config_frequency(clocks: &mut ClockTree, config: RefTickConfig) -> u32 {
             match config {
-                RefTickConfig::Pll => ref_tick_xtal_frequency(clocks),
-                RefTickConfig::Apll => ref_tick_xtal_frequency(clocks),
-                RefTickConfig::Xtal => ref_tick_xtal_frequency(clocks),
-                RefTickConfig::RcFast => ref_tick_ck8m_frequency(clocks),
+                RefTickConfig::Pll => ref_tick_xtal_frequency(),
+                RefTickConfig::Apll => ref_tick_xtal_frequency(),
+                RefTickConfig::Xtal => ref_tick_xtal_frequency(),
+                RefTickConfig::RcFast => ref_tick_ck8m_frequency(),
             }
         }
-        pub fn ref_tick_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn ref_tick_frequency() -> u32 {
             REF_TICK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_ref_tick_xtal(clocks: &mut ClockTree, config: RefTickXtalConfig) {
@@ -2009,9 +2009,9 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: RefTickXtalConfig,
         ) -> u32 {
-            (xtal_clk_frequency(clocks) / (config.divisor() + 1))
+            (xtal_clk_frequency() / (config.divisor() + 1))
         }
-        pub fn ref_tick_xtal_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn ref_tick_xtal_frequency() -> u32 {
             REF_TICK_XTAL_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_ref_tick_ck8m(clocks: &mut ClockTree, config: RefTickCk8mConfig) {
@@ -2039,9 +2039,9 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: RefTickCk8mConfig,
         ) -> u32 {
-            (rc_fast_clk_frequency(clocks) / (config.divisor() + 1))
+            (rc_fast_clk_frequency() / (config.divisor() + 1))
         }
-        pub fn ref_tick_ck8m_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn ref_tick_ck8m_frequency() -> u32 {
             REF_TICK_CK8M_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, new_selector: CpuClkConfig) {
@@ -2052,7 +2052,7 @@ macro_rules! define_clock_tree_types {
                     configure_apb_clk(clocks, ApbClkConfig::Xtal);
                     configure_ref_tick(clocks, RefTickConfig::Xtal);
                     let config_value =
-                        RefTickXtalConfig::new(((xtal_clk_frequency(clocks) / 1000000) - 1));
+                        RefTickXtalConfig::new(((xtal_clk_frequency() / 1000000) - 1));
                     configure_ref_tick_xtal(clocks, config_value);
                 }
                 CpuClkConfig::RcFast => {
@@ -2060,7 +2060,7 @@ macro_rules! define_clock_tree_types {
                     configure_apb_clk(clocks, ApbClkConfig::RcFast);
                     configure_ref_tick(clocks, RefTickConfig::RcFast);
                     let config_value =
-                        RefTickCk8mConfig::new(((rc_fast_clk_frequency(clocks) / 1000000) - 1));
+                        RefTickCk8mConfig::new(((rc_fast_clk_frequency() / 1000000) - 1));
                     configure_ref_tick_ck8m(clocks, config_value);
                 }
                 CpuClkConfig::Apll => {
@@ -2068,7 +2068,7 @@ macro_rules! define_clock_tree_types {
                     configure_apb_clk(clocks, ApbClkConfig::Apll);
                     configure_ref_tick(clocks, RefTickConfig::Apll);
                     let config_value =
-                        RefTickXtalConfig::new(((xtal_clk_frequency(clocks) / 1000000) - 1));
+                        RefTickXtalConfig::new(((xtal_clk_frequency() / 1000000) - 1));
                     configure_ref_tick_xtal(clocks, config_value);
                 }
                 CpuClkConfig::Pll => {
@@ -2076,7 +2076,7 @@ macro_rules! define_clock_tree_types {
                     configure_apb_clk(clocks, ApbClkConfig::Pll);
                     configure_ref_tick(clocks, RefTickConfig::Pll);
                     let config_value =
-                        RefTickXtalConfig::new(((xtal_clk_frequency(clocks) / 1000000) - 1));
+                        RefTickXtalConfig::new(((xtal_clk_frequency() / 1000000) - 1));
                     configure_ref_tick_xtal(clocks, config_value);
                 }
             }
@@ -2105,13 +2105,13 @@ macro_rules! define_clock_tree_types {
         #[allow(unused_variables)]
         pub fn cpu_clk_config_frequency(clocks: &mut ClockTree, config: CpuClkConfig) -> u32 {
             match config {
-                CpuClkConfig::Xtal => system_pre_div_frequency(clocks),
-                CpuClkConfig::RcFast => system_pre_div_frequency(clocks),
-                CpuClkConfig::Apll => cpu_pll_div_frequency(clocks),
-                CpuClkConfig::Pll => cpu_pll_div_frequency(clocks),
+                CpuClkConfig::Xtal => system_pre_div_frequency(),
+                CpuClkConfig::RcFast => system_pre_div_frequency(),
+                CpuClkConfig::Apll => cpu_pll_div_frequency(),
+                CpuClkConfig::Pll => cpu_pll_div_frequency(),
             }
         }
-        pub fn cpu_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn cpu_clk_frequency() -> u32 {
             CPU_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_apb_clk_cpu_div2(clocks: &mut ClockTree) {
@@ -2126,8 +2126,8 @@ macro_rules! define_clock_tree_types {
             enable_apb_clk_cpu_div2_impl(clocks, false);
             release_cpu_clk(clocks);
         }
-        pub fn apb_clk_cpu_div2_frequency(clocks: &mut ClockTree) -> u32 {
-            (cpu_clk_frequency(clocks) / 2)
+        pub fn apb_clk_cpu_div2_frequency() -> u32 {
+            (cpu_clk_frequency() / 2)
         }
         pub fn request_apb_clk_80m(clocks: &mut ClockTree) {
             trace!("Requesting APB_CLK_80M");
@@ -2141,7 +2141,7 @@ macro_rules! define_clock_tree_types {
             enable_apb_clk_80m_impl(clocks, false);
             release_cpu_clk(clocks);
         }
-        pub fn apb_clk_80m_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn apb_clk_80m_frequency() -> u32 {
             80000000
         }
         pub fn request_xtal32k_clk(clocks: &mut ClockTree) {
@@ -2158,7 +2158,7 @@ macro_rules! define_clock_tree_types {
                 enable_xtal32k_clk_impl(clocks, false);
             }
         }
-        pub fn xtal32k_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn xtal32k_clk_frequency() -> u32 {
             32768
         }
         pub fn request_rc_slow_clk(clocks: &mut ClockTree) {
@@ -2171,7 +2171,7 @@ macro_rules! define_clock_tree_types {
             trace!("Disabling RC_SLOW_CLK");
             enable_rc_slow_clk_impl(clocks, false);
         }
-        pub fn rc_slow_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn rc_slow_clk_frequency() -> u32 {
             90000
         }
         pub fn request_rc_fast_div_clk(clocks: &mut ClockTree) {
@@ -2190,8 +2190,8 @@ macro_rules! define_clock_tree_types {
                 release_rc_fast_clk(clocks);
             }
         }
-        pub fn rc_fast_div_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            (rc_fast_clk_frequency(clocks) / 256)
+        pub fn rc_fast_div_clk_frequency() -> u32 {
+            (rc_fast_clk_frequency() / 256)
         }
         pub fn request_xtal_div_clk(clocks: &mut ClockTree) {
             trace!("Requesting XTAL_DIV_CLK");
@@ -2205,8 +2205,8 @@ macro_rules! define_clock_tree_types {
             enable_xtal_div_clk_impl(clocks, false);
             release_xtal_clk(clocks);
         }
-        pub fn xtal_div_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            (xtal_clk_frequency(clocks) / 4)
+        pub fn xtal_div_clk_frequency() -> u32 {
+            (xtal_clk_frequency() / 4)
         }
         pub fn configure_rtc_slow_clk(clocks: &mut ClockTree, new_selector: RtcSlowClkConfig) {
             let old_selector = clocks.rtc_slow_clk.replace(new_selector);
@@ -2254,12 +2254,12 @@ macro_rules! define_clock_tree_types {
             config: RtcSlowClkConfig,
         ) -> u32 {
             match config {
-                RtcSlowClkConfig::Xtal32k => xtal32k_clk_frequency(clocks),
-                RtcSlowClkConfig::RcSlow => rc_slow_clk_frequency(clocks),
-                RtcSlowClkConfig::RcFast => rc_fast_div_clk_frequency(clocks),
+                RtcSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
+                RtcSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
+                RtcSlowClkConfig::RcFast => rc_fast_div_clk_frequency(),
             }
         }
-        pub fn rtc_slow_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn rtc_slow_clk_frequency() -> u32 {
             RTC_SLOW_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_rtc_fast_clk(clocks: &mut ClockTree, new_selector: RtcFastClkConfig) {
@@ -2312,11 +2312,11 @@ macro_rules! define_clock_tree_types {
             config: RtcFastClkConfig,
         ) -> u32 {
             match config {
-                RtcFastClkConfig::Xtal => xtal_div_clk_frequency(clocks),
-                RtcFastClkConfig::Rc => rc_fast_clk_frequency(clocks),
+                RtcFastClkConfig::Xtal => xtal_div_clk_frequency(),
+                RtcFastClkConfig::Rc => rc_fast_clk_frequency(),
             }
         }
-        pub fn rtc_fast_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn rtc_fast_clk_frequency() -> u32 {
             RTC_FAST_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_uart_mem_clk(clocks: &mut ClockTree) {
@@ -2335,8 +2335,8 @@ macro_rules! define_clock_tree_types {
                 release_xtal_clk(clocks);
             }
         }
-        pub fn uart_mem_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            xtal_clk_frequency(clocks)
+        pub fn uart_mem_clk_frequency() -> u32 {
+            xtal_clk_frequency()
         }
         pub fn configure_timg_calibration_clock(
             clocks: &mut ClockTree,
@@ -2397,12 +2397,12 @@ macro_rules! define_clock_tree_types {
             config: TimgCalibrationClockConfig,
         ) -> u32 {
             match config {
-                TimgCalibrationClockConfig::RtcClk => rtc_slow_clk_frequency(clocks),
-                TimgCalibrationClockConfig::RcFastDivClk => rc_fast_div_clk_frequency(clocks),
-                TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(clocks),
+                TimgCalibrationClockConfig::RtcClk => rtc_slow_clk_frequency(),
+                TimgCalibrationClockConfig::RcFastDivClk => rc_fast_div_clk_frequency(),
+                TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
             }
         }
-        pub fn timg_calibration_clock_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn timg_calibration_clock_frequency() -> u32 {
             TIMG_CALIBRATION_CLOCK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         impl TimgInstance {
@@ -2468,11 +2468,11 @@ macro_rules! define_clock_tree_types {
                 config: TimgFunctionClockConfig,
             ) -> u32 {
                 match config {
-                    TimgFunctionClockConfig::XtalClk => xtal_clk_frequency(clocks),
-                    TimgFunctionClockConfig::ApbClk => apb_clk_frequency(clocks),
+                    TimgFunctionClockConfig::XtalClk => xtal_clk_frequency(),
+                    TimgFunctionClockConfig::ApbClk => apb_clk_frequency(),
                 }
             }
-            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn function_clock_frequency(self) -> u32 {
                 TIMG_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -2540,11 +2540,11 @@ macro_rules! define_clock_tree_types {
                 config: UartFunctionClockConfig,
             ) -> u32 {
                 match config.sclk {
-                    UartFunctionClockSclk::Apb => apb_clk_frequency(clocks),
-                    UartFunctionClockSclk::RefTick => ref_tick_frequency(clocks),
+                    UartFunctionClockSclk::Apb => apb_clk_frequency(),
+                    UartFunctionClockSclk::RefTick => ref_tick_frequency(),
                 }
             }
-            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn function_clock_frequency(self) -> u32 {
                 UART_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -2589,10 +2589,10 @@ macro_rules! define_clock_tree_types {
                 clocks: &mut ClockTree,
                 config: UartBaudRateGeneratorConfig,
             ) -> u32 {
-                ((self.function_clock_frequency(clocks) * 16)
+                ((self.function_clock_frequency() * 16)
                     / ((config.integral() * 16) + config.fractional()))
             }
-            pub fn baud_rate_generator_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn baud_rate_generator_frequency(self) -> u32 {
                 UART_BAUD_RATE_GENERATOR_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -2626,9 +2626,9 @@ macro_rules! define_clock_tree_types {
                 clocks: &mut ClockTree,
                 config: UartMemClockConfig,
             ) -> u32 {
-                uart_mem_clk_frequency(clocks)
+                uart_mem_clk_frequency()
             }
-            pub fn mem_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn mem_clock_frequency(self) -> u32 {
                 UART_MEM_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }

--- a/esp-metadata-generated/src/_generated_esp32s2.rs
+++ b/esp-metadata-generated/src/_generated_esp32s2.rs
@@ -2720,12 +2720,6 @@ macro_rules! define_clock_tree_types {
             for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
                 refresh_uart_mem_clock_downstream(clocks, child_instance);
             }
-            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
-                refresh_uart_mem_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
-                refresh_timg_function_clock_downstream(clocks, child_instance);
-            }
             for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
                 refresh_timg_function_clock_downstream(clocks, child_instance);
             }
@@ -2855,12 +2849,6 @@ macro_rules! define_clock_tree_types {
             for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
                 refresh_timg_function_clock_downstream(clocks, child_instance);
             }
-            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
-                refresh_timg_function_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
-                refresh_uart_function_clock_downstream(clocks, child_instance);
-            }
             for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
                 refresh_uart_function_clock_downstream(clocks, child_instance);
             }
@@ -2871,9 +2859,6 @@ macro_rules! define_clock_tree_types {
                     ref_tick_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
-            }
-            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
-                refresh_uart_function_clock_downstream(clocks, child_instance);
             }
             for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
                 refresh_uart_function_clock_downstream(clocks, child_instance);

--- a/esp-metadata-generated/src/_generated_esp32s2.rs
+++ b/esp-metadata-generated/src/_generated_esp32s2.rs
@@ -1606,7 +1606,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
             let old_config = clocks.xtal_clk.replace(config);
             configure_xtal_clk_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_xtal_clk_downstream(clocks);
         }
         pub fn xtal_clk_config(clocks: &mut ClockTree) -> Option<XtalClkConfig> {
             clocks.xtal_clk
@@ -1623,7 +1623,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_pll_clk(clocks: &mut ClockTree, config: PllClkConfig) {
             let old_config = clocks.pll_clk.replace(config);
             configure_pll_clk_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_pll_clk_downstream(clocks);
         }
         pub fn pll_clk_config(clocks: &mut ClockTree) -> Option<PllClkConfig> {
             clocks.pll_clk
@@ -1654,7 +1654,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_apll_clk(clocks: &mut ClockTree, config: ApllClkConfig) {
             let old_config = clocks.apll_clk.replace(config);
             configure_apll_clk_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_apll_clk_downstream(clocks);
         }
         pub fn apll_clk_config(clocks: &mut ClockTree) -> Option<ApllClkConfig> {
             clocks.apll_clk
@@ -1708,7 +1708,7 @@ macro_rules! define_clock_tree_types {
                     CpuPllDivInConfig::Apll => release_apll_clk(clocks),
                 }
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_cpu_pll_div_in_downstream(clocks);
         }
         pub fn cpu_pll_div_in_config(clocks: &mut ClockTree) -> Option<CpuPllDivInConfig> {
             clocks.cpu_pll_div_in
@@ -1747,7 +1747,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_cpu_pll_div(clocks: &mut ClockTree, config: CpuPllDivConfig) {
             let old_config = clocks.cpu_pll_div.replace(config);
             configure_cpu_pll_div_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_cpu_pll_div_downstream(clocks);
         }
         pub fn cpu_pll_div_config(clocks: &mut ClockTree) -> Option<CpuPllDivConfig> {
             clocks.cpu_pll_div
@@ -1790,7 +1790,7 @@ macro_rules! define_clock_tree_types {
                     SystemPreDivInConfig::RcFast => release_rc_fast_clk(clocks),
                 }
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_system_pre_div_in_downstream(clocks);
         }
         pub fn system_pre_div_in_config(clocks: &mut ClockTree) -> Option<SystemPreDivInConfig> {
             clocks.system_pre_div_in
@@ -1829,7 +1829,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_system_pre_div(clocks: &mut ClockTree, config: SystemPreDivConfig) {
             let old_config = clocks.system_pre_div.replace(config);
             configure_system_pre_div_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_system_pre_div_downstream(clocks);
         }
         pub fn system_pre_div_config(clocks: &mut ClockTree) -> Option<SystemPreDivConfig> {
             clocks.system_pre_div
@@ -1877,7 +1877,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_apb_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_apb_clk_downstream(clocks);
         }
         pub fn apb_clk_config(clocks: &mut ClockTree) -> Option<ApbClkConfig> {
             clocks.apb_clk
@@ -1941,7 +1941,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_ref_tick_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_ref_tick_downstream(clocks);
         }
         pub fn ref_tick_config(clocks: &mut ClockTree) -> Option<RefTickConfig> {
             clocks.ref_tick
@@ -1987,7 +1987,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_ref_tick_xtal(clocks: &mut ClockTree, config: RefTickXtalConfig) {
             let old_config = clocks.ref_tick_xtal.replace(config);
             configure_ref_tick_xtal_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_ref_tick_xtal_downstream(clocks);
         }
         pub fn ref_tick_xtal_config(clocks: &mut ClockTree) -> Option<RefTickXtalConfig> {
             clocks.ref_tick_xtal
@@ -2017,7 +2017,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_ref_tick_ck8m(clocks: &mut ClockTree, config: RefTickCk8mConfig) {
             let old_config = clocks.ref_tick_ck8m.replace(config);
             configure_ref_tick_ck8m_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_ref_tick_ck8m_downstream(clocks);
         }
         pub fn ref_tick_ck8m_config(clocks: &mut ClockTree) -> Option<RefTickCk8mConfig> {
             clocks.ref_tick_ck8m
@@ -2095,7 +2095,7 @@ macro_rules! define_clock_tree_types {
                     CpuClkConfig::Pll => release_cpu_pll_div(clocks),
                 }
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_cpu_clk_downstream(clocks);
         }
         pub fn cpu_clk_config(clocks: &mut ClockTree) -> Option<CpuClkConfig> {
             clocks.cpu_clk
@@ -2223,7 +2223,7 @@ macro_rules! define_clock_tree_types {
                     RtcSlowClkConfig::RcFast => release_rc_fast_div_clk(clocks),
                 }
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_rtc_slow_clk_downstream(clocks);
         }
         pub fn rtc_slow_clk_config(clocks: &mut ClockTree) -> Option<RtcSlowClkConfig> {
             clocks.rtc_slow_clk
@@ -2279,7 +2279,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_rtc_fast_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_rtc_fast_clk_downstream(clocks);
         }
         pub fn rtc_fast_clk_config(clocks: &mut ClockTree) -> Option<RtcFastClkConfig> {
             clocks.rtc_fast_clk
@@ -2360,7 +2360,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_timg_calibration_clock_downstream(clocks);
         }
         pub fn timg_calibration_clock_config(
             clocks: &mut ClockTree,
@@ -2427,7 +2427,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_timg_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -2499,7 +2499,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_config, config);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_uart_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -2555,7 +2555,7 @@ macro_rules! define_clock_tree_types {
             ) {
                 let old_config = clocks.uart_baud_rate_generator[self as usize].replace(config);
                 self.configure_baud_rate_generator_impl(clocks, old_config, config);
-                refresh_all_frequency_caches(clocks);
+                refresh_uart_baud_rate_generator_downstream(clocks, self);
             }
             pub fn baud_rate_generator_config(
                 self,
@@ -2599,7 +2599,7 @@ macro_rules! define_clock_tree_types {
             pub fn configure_mem_clock(self, clocks: &mut ClockTree, config: UartMemClockConfig) {
                 let old_config = clocks.uart_mem_clock[self as usize].replace(config);
                 self.configure_mem_clock_impl(clocks, old_config, config);
-                refresh_all_frequency_caches(clocks);
+                refresh_uart_mem_clock_downstream(clocks, self);
             }
             pub fn mem_clock_config(self, clocks: &mut ClockTree) -> Option<UartMemClockConfig> {
                 clocks.uart_mem_clock[self as usize]
@@ -2706,128 +2706,205 @@ macro_rules! define_clock_tree_types {
             let last = *refcount == 0;
             last
         }
-        fn refresh_all_frequency_caches(clocks: &mut ClockTree) {
+        fn refresh_xtal_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.xtal_clk {
                 XTAL_CLK_FREQ_CACHE.store(
                     xtal_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_pll_clk_downstream(clocks);
+            refresh_system_pre_div_in_downstream(clocks);
+            refresh_ref_tick_xtal_downstream(clocks);
+            refresh_rtc_fast_clk_downstream(clocks);
+            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                refresh_uart_mem_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                refresh_uart_mem_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                refresh_timg_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                refresh_timg_function_clock_downstream(clocks, child_instance);
+            }
+        }
+        fn refresh_pll_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.pll_clk {
                 PLL_CLK_FREQ_CACHE.store(
                     pll_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_apll_clk_downstream(clocks);
+            refresh_cpu_pll_div_in_downstream(clocks);
+        }
+        fn refresh_apll_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.apll_clk {
                 APLL_CLK_FREQ_CACHE.store(
                     apll_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_cpu_pll_div_in_downstream(clocks);
+        }
+        fn refresh_cpu_pll_div_in_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.cpu_pll_div_in {
                 CPU_PLL_DIV_IN_FREQ_CACHE.store(
                     cpu_pll_div_in_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_cpu_pll_div_downstream(clocks);
+        }
+        fn refresh_cpu_pll_div_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.cpu_pll_div {
                 CPU_PLL_DIV_FREQ_CACHE.store(
                     cpu_pll_div_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_cpu_clk_downstream(clocks);
+        }
+        fn refresh_system_pre_div_in_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.system_pre_div_in {
                 SYSTEM_PRE_DIV_IN_FREQ_CACHE.store(
                     system_pre_div_in_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_system_pre_div_downstream(clocks);
+        }
+        fn refresh_system_pre_div_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.system_pre_div {
                 SYSTEM_PRE_DIV_FREQ_CACHE.store(
                     system_pre_div_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_cpu_clk_downstream(clocks);
+        }
+        fn refresh_ref_tick_xtal_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.ref_tick_xtal {
                 REF_TICK_XTAL_FREQ_CACHE.store(
                     ref_tick_xtal_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_ref_tick_downstream(clocks);
+        }
+        fn refresh_ref_tick_ck8m_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.ref_tick_ck8m {
                 REF_TICK_CK8M_FREQ_CACHE.store(
                     ref_tick_ck8m_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_ref_tick_downstream(clocks);
+        }
+        fn refresh_cpu_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.cpu_clk {
                 CPU_CLK_FREQ_CACHE.store(
                     cpu_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_apb_clk_downstream(clocks);
+        }
+        fn refresh_rtc_slow_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.rtc_slow_clk {
                 RTC_SLOW_CLK_FREQ_CACHE.store(
                     rtc_slow_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_timg_calibration_clock_downstream(clocks);
+        }
+        fn refresh_rtc_fast_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.rtc_fast_clk {
                 RTC_FAST_CLK_FREQ_CACHE.store(
                     rtc_fast_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+        }
+        fn refresh_timg_calibration_clock_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.timg_calibration_clock {
                 TIMG_CALIBRATION_CLOCK_FREQ_CACHE.store(
                     timg_calibration_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
-            for instance in [UartInstance::Uart0, UartInstance::Uart1] {
-                if let Some(config) = clocks.uart_mem_clock[instance as usize] {
-                    UART_MEM_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.mem_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_uart_mem_clock_downstream(clocks: &mut ClockTree, instance: UartInstance) {
+            if let Some(config) = clocks.uart_mem_clock[instance as usize] {
+                UART_MEM_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.mem_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
+        }
+        fn refresh_apb_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.apb_clk {
                 APB_CLK_FREQ_CACHE.store(
                     apb_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                refresh_timg_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                refresh_timg_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                refresh_uart_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                refresh_uart_function_clock_downstream(clocks, child_instance);
+            }
+        }
+        fn refresh_ref_tick_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.ref_tick {
                 REF_TICK_FREQ_CACHE.store(
                     ref_tick_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
-            for instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
-                if let Some(config) = clocks.timg_function_clock[instance as usize] {
-                    TIMG_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.function_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                refresh_uart_function_clock_downstream(clocks, child_instance);
             }
-            for instance in [UartInstance::Uart0, UartInstance::Uart1] {
-                if let Some(config) = clocks.uart_function_clock[instance as usize] {
-                    UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.function_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+            for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
+                refresh_uart_function_clock_downstream(clocks, child_instance);
             }
-            for instance in [UartInstance::Uart0, UartInstance::Uart1] {
-                if let Some(config) = clocks.uart_baud_rate_generator[instance as usize] {
-                    UART_BAUD_RATE_GENERATOR_FREQ_CACHE[instance as usize].store(
-                        instance.baud_rate_generator_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_timg_function_clock_downstream(clocks: &mut ClockTree, instance: TimgInstance) {
+            if let Some(config) = clocks.timg_function_clock[instance as usize] {
+                TIMG_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.function_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+        }
+        fn refresh_uart_function_clock_downstream(clocks: &mut ClockTree, instance: UartInstance) {
+            if let Some(config) = clocks.uart_function_clock[instance as usize] {
+                UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.function_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            refresh_uart_baud_rate_generator_downstream(clocks, instance);
+        }
+        fn refresh_uart_baud_rate_generator_downstream(
+            clocks: &mut ClockTree,
+            instance: UartInstance,
+        ) {
+            if let Some(config) = clocks.uart_baud_rate_generator[instance as usize] {
+                UART_BAUD_RATE_GENERATOR_FREQ_CACHE[instance as usize].store(
+                    instance.baud_rate_generator_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
         }
     };

--- a/esp-metadata-generated/src/_generated_esp32s3.rs
+++ b/esp-metadata-generated/src/_generated_esp32s3.rs
@@ -1640,8 +1640,8 @@ macro_rules! define_clock_tree_types {
             [const { ::core::sync::atomic::AtomicU32::new(0) }; 3];
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
             let old_config = clocks.xtal_clk.replace(config);
-            configure_xtal_clk_impl(clocks, old_config, config);
             refresh_xtal_clk_downstream(clocks);
+            configure_xtal_clk_impl(clocks, old_config, config);
         }
         pub fn xtal_clk_config(clocks: &mut ClockTree) -> Option<XtalClkConfig> {
             clocks.xtal_clk
@@ -1662,8 +1662,8 @@ macro_rules! define_clock_tree_types {
                 );
             }
             let old_config = clocks.pll_clk.replace(config);
-            configure_pll_clk_impl(clocks, old_config, config);
             refresh_pll_clk_downstream(clocks);
+            configure_pll_clk_impl(clocks, old_config, config);
         }
         pub fn pll_clk_config(clocks: &mut ClockTree) -> Option<PllClkConfig> {
             clocks.pll_clk
@@ -1766,6 +1766,7 @@ macro_rules! define_clock_tree_types {
             new_selector: SystemPreDivInConfig,
         ) {
             let old_selector = clocks.system_pre_div_in.replace(new_selector);
+            refresh_system_pre_div_in_downstream(clocks);
             match new_selector {
                 SystemPreDivInConfig::Xtal => request_xtal_clk(clocks),
                 SystemPreDivInConfig::RcFast => request_rc_fast_clk(clocks),
@@ -1777,7 +1778,6 @@ macro_rules! define_clock_tree_types {
                     SystemPreDivInConfig::RcFast => release_rc_fast_clk(clocks),
                 }
             }
-            refresh_system_pre_div_in_downstream(clocks);
         }
         pub fn system_pre_div_in_config(clocks: &mut ClockTree) -> Option<SystemPreDivInConfig> {
             clocks.system_pre_div_in
@@ -1815,8 +1815,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_system_pre_div(clocks: &mut ClockTree, config: SystemPreDivConfig) {
             let old_config = clocks.system_pre_div.replace(config);
-            configure_system_pre_div_impl(clocks, old_config, config);
             refresh_system_pre_div_downstream(clocks);
+            configure_system_pre_div_impl(clocks, old_config, config);
         }
         pub fn system_pre_div_config(clocks: &mut ClockTree) -> Option<SystemPreDivConfig> {
             clocks.system_pre_div
@@ -1848,8 +1848,8 @@ macro_rules! define_clock_tree_types {
                 assert!(!((config.value() == 240000000) && (pll_clk_frequency() == 320000000)));
             }
             let old_config = clocks.cpu_pll_div_out.replace(config);
-            configure_cpu_pll_div_out_impl(clocks, old_config, config);
             refresh_cpu_pll_div_out_downstream(clocks);
+            configure_cpu_pll_div_out_impl(clocks, old_config, config);
         }
         pub fn cpu_pll_div_out_config(clocks: &mut ClockTree) -> Option<CpuPllDivOutConfig> {
             clocks.cpu_pll_div_out
@@ -1878,6 +1878,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, new_selector: ApbClkConfig) {
             let old_selector = clocks.apb_clk.replace(new_selector);
+            refresh_apb_clk_downstream(clocks);
             if clocks.apb_clk_refcount > 0 {
                 match new_selector {
                     ApbClkConfig::Pll => request_apb_80m(clocks),
@@ -1893,7 +1894,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_apb_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_apb_clk_downstream(clocks);
         }
         pub fn apb_clk_config(clocks: &mut ClockTree) -> Option<ApbClkConfig> {
             clocks.apb_clk
@@ -1932,6 +1932,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_crypto_pwm_clk(clocks: &mut ClockTree, new_selector: CryptoPwmClkConfig) {
             let old_selector = clocks.crypto_pwm_clk.replace(new_selector);
+            refresh_crypto_pwm_clk_downstream(clocks);
             if clocks.crypto_pwm_clk_refcount > 0 {
                 match new_selector {
                     CryptoPwmClkConfig::Pll => request_pll_160m(clocks),
@@ -1947,7 +1948,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_crypto_pwm_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_crypto_pwm_clk_downstream(clocks);
         }
         pub fn crypto_pwm_clk_config(clocks: &mut ClockTree) -> Option<CryptoPwmClkConfig> {
             clocks.crypto_pwm_clk
@@ -1989,6 +1989,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, new_selector: CpuClkConfig) {
             let old_selector = clocks.cpu_clk.replace(new_selector);
+            refresh_cpu_clk_downstream(clocks);
             match new_selector {
                 CpuClkConfig::Xtal => {
                     configure_apb_clk(clocks, ApbClkConfig::Cpu);
@@ -2018,7 +2019,6 @@ macro_rules! define_clock_tree_types {
                     CpuClkConfig::Pll => release_cpu_pll_div_out(clocks),
                 }
             }
-            refresh_cpu_clk_downstream(clocks);
         }
         pub fn cpu_clk_config(clocks: &mut ClockTree) -> Option<CpuClkConfig> {
             clocks.cpu_clk
@@ -2087,8 +2087,8 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_rc_fast_clk_div_n(clocks: &mut ClockTree, config: RcFastClkDivNConfig) {
             let old_config = clocks.rc_fast_clk_div_n.replace(config);
-            configure_rc_fast_clk_div_n_impl(clocks, old_config, config);
             refresh_rc_fast_clk_div_n_downstream(clocks);
+            configure_rc_fast_clk_div_n_impl(clocks, old_config, config);
         }
         pub fn rc_fast_clk_div_n_config(clocks: &mut ClockTree) -> Option<RcFastClkDivNConfig> {
             clocks.rc_fast_clk_div_n
@@ -2132,6 +2132,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_rtc_slow_clk(clocks: &mut ClockTree, new_selector: RtcSlowClkConfig) {
             let old_selector = clocks.rtc_slow_clk.replace(new_selector);
+            refresh_rtc_slow_clk_downstream(clocks);
             match new_selector {
                 RtcSlowClkConfig::Xtal32k => request_xtal32k_clk(clocks),
                 RtcSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
@@ -2145,7 +2146,6 @@ macro_rules! define_clock_tree_types {
                     RtcSlowClkConfig::RcFast => release_rc_fast_div_clk(clocks),
                 }
             }
-            refresh_rtc_slow_clk_downstream(clocks);
         }
         pub fn rtc_slow_clk_config(clocks: &mut ClockTree) -> Option<RtcSlowClkConfig> {
             clocks.rtc_slow_clk
@@ -2186,6 +2186,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_rtc_fast_clk(clocks: &mut ClockTree, new_selector: RtcFastClkConfig) {
             let old_selector = clocks.rtc_fast_clk.replace(new_selector);
+            refresh_rtc_fast_clk_downstream(clocks);
             if clocks.rtc_fast_clk_refcount > 0 {
                 match new_selector {
                     RtcFastClkConfig::Xtal => request_xtal_div_clk(clocks),
@@ -2201,7 +2202,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_rtc_fast_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_rtc_fast_clk_downstream(clocks);
         }
         pub fn rtc_fast_clk_config(clocks: &mut ClockTree) -> Option<RtcFastClkConfig> {
             clocks.rtc_fast_clk
@@ -2243,6 +2243,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn configure_low_power_clk(clocks: &mut ClockTree, new_selector: LowPowerClkConfig) {
             let old_selector = clocks.low_power_clk.replace(new_selector);
+            refresh_low_power_clk_downstream(clocks);
             if clocks.low_power_clk_refcount > 0 {
                 match new_selector {
                     LowPowerClkConfig::Xtal => request_xtal_clk(clocks),
@@ -2262,7 +2263,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_low_power_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_low_power_clk_downstream(clocks);
         }
         pub fn low_power_clk_config(clocks: &mut ClockTree) -> Option<LowPowerClkConfig> {
             clocks.low_power_clk
@@ -2332,6 +2332,7 @@ macro_rules! define_clock_tree_types {
             new_selector: TimgCalibrationClockConfig,
         ) {
             let old_selector = clocks.timg_calibration_clock.replace(new_selector);
+            refresh_timg_calibration_clock_downstream(clocks);
             if clocks.timg_calibration_clock_refcount > 0 {
                 match new_selector {
                     TimgCalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
@@ -2349,7 +2350,6 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
             }
-            refresh_timg_calibration_clock_downstream(clocks);
         }
         pub fn timg_calibration_clock_config(
             clocks: &mut ClockTree,
@@ -2401,6 +2401,7 @@ macro_rules! define_clock_tree_types {
                 new_selector: McpwmFunctionClockConfig,
             ) {
                 let old_selector = clocks.mcpwm_function_clock[self as usize].replace(new_selector);
+                refresh_mcpwm_function_clock_downstream(clocks, self);
                 if clocks.mcpwm_function_clock_refcount[self as usize] > 0 {
                     request_crypto_pwm_clk(clocks);
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
@@ -2410,7 +2411,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_mcpwm_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -2454,6 +2454,7 @@ macro_rules! define_clock_tree_types {
         impl RmtInstance {
             pub fn configure_sclk(self, clocks: &mut ClockTree, new_selector: RmtSclkConfig) {
                 let old_selector = clocks.rmt_sclk[self as usize].replace(new_selector);
+                refresh_rmt_sclk_downstream(clocks, self);
                 if clocks.rmt_sclk_refcount[self as usize] > 0 {
                     match new_selector {
                         RmtSclkConfig::ApbClk => request_apb_clk(clocks),
@@ -2471,7 +2472,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_sclk_impl(clocks, old_selector, new_selector);
                 }
-                refresh_rmt_sclk_downstream(clocks, self);
             }
             pub fn sclk_config(self, clocks: &mut ClockTree) -> Option<RmtSclkConfig> {
                 clocks.rmt_sclk[self as usize]
@@ -2523,6 +2523,7 @@ macro_rules! define_clock_tree_types {
                 new_selector: TimgFunctionClockConfig,
             ) {
                 let old_selector = clocks.timg_function_clock[self as usize].replace(new_selector);
+                refresh_timg_function_clock_downstream(clocks, self);
                 if clocks.timg_function_clock_refcount[self as usize] > 0 {
                     match new_selector {
                         TimgFunctionClockConfig::XtalClk => request_xtal_clk(clocks),
@@ -2538,7 +2539,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_timg_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -2595,6 +2595,7 @@ macro_rules! define_clock_tree_types {
                 config: UartFunctionClockConfig,
             ) {
                 let old_config = clocks.uart_function_clock[self as usize].replace(config);
+                refresh_uart_function_clock_downstream(clocks, self);
                 if clocks.uart_function_clock_refcount[self as usize] > 0 {
                     match config.sclk {
                         UartFunctionClockSclk::Apb => request_apb_clk(clocks),
@@ -2612,7 +2613,6 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_config, config);
                 }
-                refresh_uart_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -2670,8 +2670,8 @@ macro_rules! define_clock_tree_types {
                 config: UartBaudRateGeneratorConfig,
             ) {
                 let old_config = clocks.uart_baud_rate_generator[self as usize].replace(config);
-                self.configure_baud_rate_generator_impl(clocks, old_config, config);
                 refresh_uart_baud_rate_generator_downstream(clocks, self);
+                self.configure_baud_rate_generator_impl(clocks, old_config, config);
             }
             pub fn baud_rate_generator_config(
                 self,
@@ -2714,8 +2714,8 @@ macro_rules! define_clock_tree_types {
             }
             pub fn configure_mem_clock(self, clocks: &mut ClockTree, config: UartMemClockConfig) {
                 let old_config = clocks.uart_mem_clock[self as usize].replace(config);
-                self.configure_mem_clock_impl(clocks, old_config, config);
                 refresh_uart_mem_clock_downstream(clocks, self);
+                self.configure_mem_clock_impl(clocks, old_config, config);
             }
             pub fn mem_clock_config(self, clocks: &mut ClockTree) -> Option<UartMemClockConfig> {
                 clocks.uart_mem_clock[self as usize]

--- a/esp-metadata-generated/src/_generated_esp32s3.rs
+++ b/esp-metadata-generated/src/_generated_esp32s3.rs
@@ -1600,9 +1600,48 @@ macro_rules! define_clock_tree_types {
                 uart_baud_rate_generator_refcount: [0; 3],
                 uart_mem_clock_refcount: [0; 3],
             });
+        static XTAL_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static PLL_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static SYSTEM_PRE_DIV_IN_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static SYSTEM_PRE_DIV_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static CPU_PLL_DIV_OUT_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static CPU_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static RC_FAST_CLK_DIV_N_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static RTC_SLOW_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static RTC_FAST_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static LOW_POWER_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static TIMG_CALIBRATION_CLOCK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static UART_MEM_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 3] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 3];
+        static APB_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static CRYPTO_PWM_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static MCPWM_FUNCTION_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 2] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
+        static RMT_SCLK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 1] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 1];
+        static TIMG_FUNCTION_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 2] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
+        static UART_FUNCTION_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 3] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 3];
+        static UART_BAUD_RATE_GENERATOR_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 3] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 3];
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
             let old_config = clocks.xtal_clk.replace(config);
             configure_xtal_clk_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn xtal_clk_config(clocks: &mut ClockTree) -> Option<XtalClkConfig> {
             clocks.xtal_clk
@@ -1613,12 +1652,8 @@ macro_rules! define_clock_tree_types {
         pub fn xtal_clk_config_frequency(clocks: &mut ClockTree, config: XtalClkConfig) -> u32 {
             config.value()
         }
-        pub fn xtal_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.xtal_clk {
-                xtal_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn xtal_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            XTAL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_pll_clk(clocks: &mut ClockTree, config: PllClkConfig) {
             if clocks.cpu_pll_div_out.is_some() {
@@ -1629,6 +1664,7 @@ macro_rules! define_clock_tree_types {
             }
             let old_config = clocks.pll_clk.replace(config);
             configure_pll_clk_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn pll_clk_config(clocks: &mut ClockTree) -> Option<PllClkConfig> {
             clocks.pll_clk
@@ -1653,12 +1689,8 @@ macro_rules! define_clock_tree_types {
         pub fn pll_clk_config_frequency(clocks: &mut ClockTree, config: PllClkConfig) -> u32 {
             config.value()
         }
-        pub fn pll_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.pll_clk {
-                pll_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn pll_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            PLL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_rc_fast_clk(clocks: &mut ClockTree) {
             trace!("Requesting RC_FAST_CLK");
@@ -1746,6 +1778,7 @@ macro_rules! define_clock_tree_types {
                     SystemPreDivInConfig::RcFast => release_rc_fast_clk(clocks),
                 }
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn system_pre_div_in_config(clocks: &mut ClockTree) -> Option<SystemPreDivInConfig> {
             clocks.system_pre_div_in
@@ -1778,16 +1811,13 @@ macro_rules! define_clock_tree_types {
                 SystemPreDivInConfig::RcFast => rc_fast_clk_frequency(clocks),
             }
         }
-        pub fn system_pre_div_in_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.system_pre_div_in {
-                system_pre_div_in_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn system_pre_div_in_frequency(_clocks: &mut ClockTree) -> u32 {
+            SYSTEM_PRE_DIV_IN_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_system_pre_div(clocks: &mut ClockTree, config: SystemPreDivConfig) {
             let old_config = clocks.system_pre_div.replace(config);
             configure_system_pre_div_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn system_pre_div_config(clocks: &mut ClockTree) -> Option<SystemPreDivConfig> {
             clocks.system_pre_div
@@ -1811,12 +1841,8 @@ macro_rules! define_clock_tree_types {
         ) -> u32 {
             (system_pre_div_in_frequency(clocks) / (config.divisor() + 1))
         }
-        pub fn system_pre_div_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.system_pre_div {
-                system_pre_div_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn system_pre_div_frequency(_clocks: &mut ClockTree) -> u32 {
+            SYSTEM_PRE_DIV_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_cpu_pll_div_out(clocks: &mut ClockTree, config: CpuPllDivOutConfig) {
             if clocks.pll_clk.is_some() {
@@ -1826,6 +1852,7 @@ macro_rules! define_clock_tree_types {
             }
             let old_config = clocks.cpu_pll_div_out.replace(config);
             configure_cpu_pll_div_out_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn cpu_pll_div_out_config(clocks: &mut ClockTree) -> Option<CpuPllDivOutConfig> {
             clocks.cpu_pll_div_out
@@ -1849,12 +1876,8 @@ macro_rules! define_clock_tree_types {
         ) -> u32 {
             config.value()
         }
-        pub fn cpu_pll_div_out_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.cpu_pll_div_out {
-                cpu_pll_div_out_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn cpu_pll_div_out_frequency(_clocks: &mut ClockTree) -> u32 {
+            CPU_PLL_DIV_OUT_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, new_selector: ApbClkConfig) {
             let old_selector = clocks.apb_clk.replace(new_selector);
@@ -1873,6 +1896,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_apb_clk_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn apb_clk_config(clocks: &mut ClockTree) -> Option<ApbClkConfig> {
             clocks.apb_clk
@@ -1906,12 +1930,8 @@ macro_rules! define_clock_tree_types {
                 ApbClkConfig::Cpu => cpu_clk_frequency(clocks),
             }
         }
-        pub fn apb_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.apb_clk {
-                apb_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn apb_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            APB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_crypto_pwm_clk(clocks: &mut ClockTree, new_selector: CryptoPwmClkConfig) {
             let old_selector = clocks.crypto_pwm_clk.replace(new_selector);
@@ -1930,6 +1950,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_crypto_pwm_clk_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn crypto_pwm_clk_config(clocks: &mut ClockTree) -> Option<CryptoPwmClkConfig> {
             clocks.crypto_pwm_clk
@@ -1966,12 +1987,8 @@ macro_rules! define_clock_tree_types {
                 CryptoPwmClkConfig::Cpu => cpu_clk_frequency(clocks),
             }
         }
-        pub fn crypto_pwm_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.crypto_pwm_clk {
-                crypto_pwm_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn crypto_pwm_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            CRYPTO_PWM_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, new_selector: CpuClkConfig) {
             let old_selector = clocks.cpu_clk.replace(new_selector);
@@ -2004,6 +2021,7 @@ macro_rules! define_clock_tree_types {
                     CpuClkConfig::Pll => release_cpu_pll_div_out(clocks),
                 }
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn cpu_clk_config(clocks: &mut ClockTree) -> Option<CpuClkConfig> {
             clocks.cpu_clk
@@ -2018,12 +2036,8 @@ macro_rules! define_clock_tree_types {
                 CpuClkConfig::Pll => cpu_pll_div_out_frequency(clocks),
             }
         }
-        pub fn cpu_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.cpu_clk {
-                cpu_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn cpu_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            CPU_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_pll_d2(clocks: &mut ClockTree) {
             trace!("Requesting PLL_D2");
@@ -2077,6 +2091,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_rc_fast_clk_div_n(clocks: &mut ClockTree, config: RcFastClkDivNConfig) {
             let old_config = clocks.rc_fast_clk_div_n.replace(config);
             configure_rc_fast_clk_div_n_impl(clocks, old_config, config);
+            refresh_all_frequency_caches(clocks);
         }
         pub fn rc_fast_clk_div_n_config(clocks: &mut ClockTree) -> Option<RcFastClkDivNConfig> {
             clocks.rc_fast_clk_div_n
@@ -2100,12 +2115,8 @@ macro_rules! define_clock_tree_types {
         ) -> u32 {
             (rc_fast_clk_frequency(clocks) / (config.divisor() + 1))
         }
-        pub fn rc_fast_clk_div_n_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.rc_fast_clk_div_n {
-                rc_fast_clk_div_n_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn rc_fast_clk_div_n_frequency(_clocks: &mut ClockTree) -> u32 {
+            RC_FAST_CLK_DIV_N_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_xtal_div_clk(clocks: &mut ClockTree) {
             trace!("Requesting XTAL_DIV_CLK");
@@ -2137,6 +2148,7 @@ macro_rules! define_clock_tree_types {
                     RtcSlowClkConfig::RcFast => release_rc_fast_div_clk(clocks),
                 }
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn rtc_slow_clk_config(clocks: &mut ClockTree) -> Option<RtcSlowClkConfig> {
             clocks.rtc_slow_clk
@@ -2172,12 +2184,8 @@ macro_rules! define_clock_tree_types {
                 RtcSlowClkConfig::RcFast => rc_fast_div_clk_frequency(clocks),
             }
         }
-        pub fn rtc_slow_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.rtc_slow_clk {
-                rtc_slow_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn rtc_slow_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            RTC_SLOW_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_rtc_fast_clk(clocks: &mut ClockTree, new_selector: RtcFastClkConfig) {
             let old_selector = clocks.rtc_fast_clk.replace(new_selector);
@@ -2196,6 +2204,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_rtc_fast_clk_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn rtc_fast_clk_config(clocks: &mut ClockTree) -> Option<RtcFastClkConfig> {
             clocks.rtc_fast_clk
@@ -2232,12 +2241,8 @@ macro_rules! define_clock_tree_types {
                 RtcFastClkConfig::Rc => rc_fast_clk_div_n_frequency(clocks),
             }
         }
-        pub fn rtc_fast_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.rtc_fast_clk {
-                rtc_fast_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn rtc_fast_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            RTC_FAST_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_low_power_clk(clocks: &mut ClockTree, new_selector: LowPowerClkConfig) {
             let old_selector = clocks.low_power_clk.replace(new_selector);
@@ -2260,6 +2265,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_low_power_clk_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn low_power_clk_config(clocks: &mut ClockTree) -> Option<LowPowerClkConfig> {
             clocks.low_power_clk
@@ -2302,12 +2308,8 @@ macro_rules! define_clock_tree_types {
                 LowPowerClkConfig::RtcSlow => rtc_slow_clk_frequency(clocks),
             }
         }
-        pub fn low_power_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.low_power_clk {
-                low_power_clk_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn low_power_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+            LOW_POWER_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_uart_mem_clk(clocks: &mut ClockTree) {
             trace!("Requesting UART_MEM_CLK");
@@ -2350,6 +2352,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
             }
+            refresh_all_frequency_caches(clocks);
         }
         pub fn timg_calibration_clock_config(
             clocks: &mut ClockTree,
@@ -2391,12 +2394,8 @@ macro_rules! define_clock_tree_types {
                 TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(clocks),
             }
         }
-        pub fn timg_calibration_clock_frequency(clocks: &mut ClockTree) -> u32 {
-            if let Some(config) = clocks.timg_calibration_clock {
-                timg_calibration_clock_config_frequency(clocks, config)
-            } else {
-                0
-            }
+        pub fn timg_calibration_clock_frequency(_clocks: &mut ClockTree) -> u32 {
+            TIMG_CALIBRATION_CLOCK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         impl McpwmInstance {
             pub fn configure_function_clock(
@@ -2414,6 +2413,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn function_clock_config(
                 self,
@@ -2449,12 +2449,9 @@ macro_rules! define_clock_tree_types {
             ) -> u32 {
                 crypto_pwm_clk_frequency(clocks)
             }
-            pub fn function_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.mcpwm_function_clock[self as usize] {
-                    self.function_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                MCPWM_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
         }
         impl RmtInstance {
@@ -2477,6 +2474,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_sclk_impl(clocks, old_selector, new_selector);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn sclk_config(self, clocks: &mut ClockTree) -> Option<RmtSclkConfig> {
                 clocks.rmt_sclk[self as usize]
@@ -2517,12 +2515,8 @@ macro_rules! define_clock_tree_types {
                     RmtSclkConfig::XtalClk => xtal_clk_frequency(clocks),
                 }
             }
-            pub fn sclk_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.rmt_sclk[self as usize] {
-                    self.sclk_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn sclk_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                RMT_SCLK_FREQ_CACHE[self as usize].load(::core::sync::atomic::Ordering::Acquire)
             }
         }
         impl TimgInstance {
@@ -2547,6 +2541,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn function_clock_config(
                 self,
@@ -2591,12 +2586,9 @@ macro_rules! define_clock_tree_types {
                     TimgFunctionClockConfig::ApbClk => apb_clk_frequency(clocks),
                 }
             }
-            pub fn function_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.timg_function_clock[self as usize] {
-                    self.function_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                TIMG_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
         }
         impl UartInstance {
@@ -2623,6 +2615,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_config, config);
                 }
+                refresh_all_frequency_caches(clocks);
             }
             pub fn function_clock_config(
                 self,
@@ -2670,12 +2663,9 @@ macro_rules! define_clock_tree_types {
                     UartFunctionClockSclk::Xtal => xtal_clk_frequency(clocks),
                 } / (config.div_num() + 1))
             }
-            pub fn function_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.uart_function_clock[self as usize] {
-                    self.function_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                UART_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
             pub fn configure_baud_rate_generator(
                 self,
@@ -2684,6 +2674,7 @@ macro_rules! define_clock_tree_types {
             ) {
                 let old_config = clocks.uart_baud_rate_generator[self as usize].replace(config);
                 self.configure_baud_rate_generator_impl(clocks, old_config, config);
+                refresh_all_frequency_caches(clocks);
             }
             pub fn baud_rate_generator_config(
                 self,
@@ -2720,16 +2711,14 @@ macro_rules! define_clock_tree_types {
                 ((self.function_clock_frequency(clocks) * 16)
                     / ((config.integral() * 16) + config.fractional()))
             }
-            pub fn baud_rate_generator_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.uart_baud_rate_generator[self as usize] {
-                    self.baud_rate_generator_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn baud_rate_generator_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                UART_BAUD_RATE_GENERATOR_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
             pub fn configure_mem_clock(self, clocks: &mut ClockTree, config: UartMemClockConfig) {
                 let old_config = clocks.uart_mem_clock[self as usize].replace(config);
                 self.configure_mem_clock_impl(clocks, old_config, config);
+                refresh_all_frequency_caches(clocks);
             }
             pub fn mem_clock_config(self, clocks: &mut ClockTree) -> Option<UartMemClockConfig> {
                 clocks.uart_mem_clock[self as usize]
@@ -2758,12 +2747,9 @@ macro_rules! define_clock_tree_types {
             ) -> u32 {
                 uart_mem_clk_frequency(clocks)
             }
-            pub fn mem_clock_frequency(self, clocks: &mut ClockTree) -> u32 {
-                if let Some(config) = clocks.uart_mem_clock[self as usize] {
-                    self.mem_clock_config_frequency(clocks, config)
-                } else {
-                    0
-                }
+            pub fn mem_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+                UART_MEM_CLOCK_FREQ_CACHE[self as usize]
+                    .load(::core::sync::atomic::Ordering::Acquire)
             }
         }
         /// Clock tree configuration.
@@ -2843,6 +2829,146 @@ macro_rules! define_clock_tree_types {
             *refcount = refcount.saturating_sub(1);
             let last = *refcount == 0;
             last
+        }
+        fn refresh_all_frequency_caches(clocks: &mut ClockTree) {
+            if let Some(config) = clocks.xtal_clk {
+                XTAL_CLK_FREQ_CACHE.store(
+                    xtal_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.pll_clk {
+                PLL_CLK_FREQ_CACHE.store(
+                    pll_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.system_pre_div_in {
+                SYSTEM_PRE_DIV_IN_FREQ_CACHE.store(
+                    system_pre_div_in_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.system_pre_div {
+                SYSTEM_PRE_DIV_FREQ_CACHE.store(
+                    system_pre_div_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.cpu_pll_div_out {
+                CPU_PLL_DIV_OUT_FREQ_CACHE.store(
+                    cpu_pll_div_out_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.cpu_clk {
+                CPU_CLK_FREQ_CACHE.store(
+                    cpu_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.rc_fast_clk_div_n {
+                RC_FAST_CLK_DIV_N_FREQ_CACHE.store(
+                    rc_fast_clk_div_n_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.rtc_slow_clk {
+                RTC_SLOW_CLK_FREQ_CACHE.store(
+                    rtc_slow_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.rtc_fast_clk {
+                RTC_FAST_CLK_FREQ_CACHE.store(
+                    rtc_fast_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.low_power_clk {
+                LOW_POWER_CLK_FREQ_CACHE.store(
+                    low_power_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.timg_calibration_clock {
+                TIMG_CALIBRATION_CLOCK_FREQ_CACHE.store(
+                    timg_calibration_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            for instance in [
+                UartInstance::Uart0,
+                UartInstance::Uart1,
+                UartInstance::Uart2,
+            ] {
+                if let Some(config) = clocks.uart_mem_clock[instance as usize] {
+                    UART_MEM_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.mem_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            if let Some(config) = clocks.apb_clk {
+                APB_CLK_FREQ_CACHE.store(
+                    apb_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            if let Some(config) = clocks.crypto_pwm_clk {
+                CRYPTO_PWM_CLK_FREQ_CACHE.store(
+                    crypto_pwm_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            for instance in [McpwmInstance::Mcpwm0, McpwmInstance::Mcpwm1] {
+                if let Some(config) = clocks.mcpwm_function_clock[instance as usize] {
+                    MCPWM_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.function_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [RmtInstance::Rmt] {
+                if let Some(config) = clocks.rmt_sclk[instance as usize] {
+                    RMT_SCLK_FREQ_CACHE[instance as usize].store(
+                        instance.sclk_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                if let Some(config) = clocks.timg_function_clock[instance as usize] {
+                    TIMG_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.function_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [
+                UartInstance::Uart0,
+                UartInstance::Uart1,
+                UartInstance::Uart2,
+            ] {
+                if let Some(config) = clocks.uart_function_clock[instance as usize] {
+                    UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                        instance.function_clock_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
+            for instance in [
+                UartInstance::Uart0,
+                UartInstance::Uart1,
+                UartInstance::Uart2,
+            ] {
+                if let Some(config) = clocks.uart_baud_rate_generator[instance as usize] {
+                    UART_BAUD_RATE_GENERATOR_FREQ_CACHE[instance as usize].store(
+                        instance.baud_rate_generator_config_frequency(clocks, config),
+                        ::core::sync::atomic::Ordering::Release,
+                    );
+                }
+            }
         }
     };
 }

--- a/esp-metadata-generated/src/_generated_esp32s3.rs
+++ b/esp-metadata-generated/src/_generated_esp32s3.rs
@@ -1652,14 +1652,13 @@ macro_rules! define_clock_tree_types {
         pub fn xtal_clk_config_frequency(clocks: &mut ClockTree, config: XtalClkConfig) -> u32 {
             config.value()
         }
-        pub fn xtal_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn xtal_clk_frequency() -> u32 {
             XTAL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_pll_clk(clocks: &mut ClockTree, config: PllClkConfig) {
             if clocks.cpu_pll_div_out.is_some() {
                 assert!(
-                    !((config.value() == 320000000)
-                        && (cpu_pll_div_out_frequency(clocks) == 240000000))
+                    !((config.value() == 320000000) && (cpu_pll_div_out_frequency() == 240000000))
                 );
             }
             let old_config = clocks.pll_clk.replace(config);
@@ -1689,7 +1688,7 @@ macro_rules! define_clock_tree_types {
         pub fn pll_clk_config_frequency(clocks: &mut ClockTree, config: PllClkConfig) -> u32 {
             config.value()
         }
-        pub fn pll_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn pll_clk_frequency() -> u32 {
             PLL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_rc_fast_clk(clocks: &mut ClockTree) {
@@ -1706,7 +1705,7 @@ macro_rules! define_clock_tree_types {
                 enable_rc_fast_clk_impl(clocks, false);
             }
         }
-        pub fn rc_fast_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn rc_fast_clk_frequency() -> u32 {
             17500000
         }
         pub fn request_xtal32k_clk(clocks: &mut ClockTree) {
@@ -1723,7 +1722,7 @@ macro_rules! define_clock_tree_types {
                 enable_xtal32k_clk_impl(clocks, false);
             }
         }
-        pub fn xtal32k_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn xtal32k_clk_frequency() -> u32 {
             32768
         }
         pub fn request_rc_slow_clk(clocks: &mut ClockTree) {
@@ -1740,7 +1739,7 @@ macro_rules! define_clock_tree_types {
                 enable_rc_slow_clk_impl(clocks, false);
             }
         }
-        pub fn rc_slow_clk_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn rc_slow_clk_frequency() -> u32 {
             136000
         }
         pub fn request_rc_fast_div_clk(clocks: &mut ClockTree) {
@@ -1759,8 +1758,8 @@ macro_rules! define_clock_tree_types {
                 release_rc_fast_clk(clocks);
             }
         }
-        pub fn rc_fast_div_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            (rc_fast_clk_frequency(clocks) / 256)
+        pub fn rc_fast_div_clk_frequency() -> u32 {
+            (rc_fast_clk_frequency() / 256)
         }
         pub fn configure_system_pre_div_in(
             clocks: &mut ClockTree,
@@ -1807,11 +1806,11 @@ macro_rules! define_clock_tree_types {
             config: SystemPreDivInConfig,
         ) -> u32 {
             match config {
-                SystemPreDivInConfig::Xtal => xtal_clk_frequency(clocks),
-                SystemPreDivInConfig::RcFast => rc_fast_clk_frequency(clocks),
+                SystemPreDivInConfig::Xtal => xtal_clk_frequency(),
+                SystemPreDivInConfig::RcFast => rc_fast_clk_frequency(),
             }
         }
-        pub fn system_pre_div_in_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn system_pre_div_in_frequency() -> u32 {
             SYSTEM_PRE_DIV_IN_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_system_pre_div(clocks: &mut ClockTree, config: SystemPreDivConfig) {
@@ -1839,16 +1838,14 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: SystemPreDivConfig,
         ) -> u32 {
-            (system_pre_div_in_frequency(clocks) / (config.divisor() + 1))
+            (system_pre_div_in_frequency() / (config.divisor() + 1))
         }
-        pub fn system_pre_div_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn system_pre_div_frequency() -> u32 {
             SYSTEM_PRE_DIV_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_cpu_pll_div_out(clocks: &mut ClockTree, config: CpuPllDivOutConfig) {
             if clocks.pll_clk.is_some() {
-                assert!(
-                    !((config.value() == 240000000) && (pll_clk_frequency(clocks) == 320000000))
-                );
+                assert!(!((config.value() == 240000000) && (pll_clk_frequency() == 320000000)));
             }
             let old_config = clocks.cpu_pll_div_out.replace(config);
             configure_cpu_pll_div_out_impl(clocks, old_config, config);
@@ -1876,7 +1873,7 @@ macro_rules! define_clock_tree_types {
         ) -> u32 {
             config.value()
         }
-        pub fn cpu_pll_div_out_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn cpu_pll_div_out_frequency() -> u32 {
             CPU_PLL_DIV_OUT_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, new_selector: ApbClkConfig) {
@@ -1926,11 +1923,11 @@ macro_rules! define_clock_tree_types {
         #[allow(unused_variables)]
         pub fn apb_clk_config_frequency(clocks: &mut ClockTree, config: ApbClkConfig) -> u32 {
             match config {
-                ApbClkConfig::Pll => apb_80m_frequency(clocks),
-                ApbClkConfig::Cpu => cpu_clk_frequency(clocks),
+                ApbClkConfig::Pll => apb_80m_frequency(),
+                ApbClkConfig::Cpu => cpu_clk_frequency(),
             }
         }
-        pub fn apb_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn apb_clk_frequency() -> u32 {
             APB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_crypto_pwm_clk(clocks: &mut ClockTree, new_selector: CryptoPwmClkConfig) {
@@ -1983,11 +1980,11 @@ macro_rules! define_clock_tree_types {
             config: CryptoPwmClkConfig,
         ) -> u32 {
             match config {
-                CryptoPwmClkConfig::Pll => pll_160m_frequency(clocks),
-                CryptoPwmClkConfig::Cpu => cpu_clk_frequency(clocks),
+                CryptoPwmClkConfig::Pll => pll_160m_frequency(),
+                CryptoPwmClkConfig::Cpu => cpu_clk_frequency(),
             }
         }
-        pub fn crypto_pwm_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn crypto_pwm_clk_frequency() -> u32 {
             CRYPTO_PWM_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, new_selector: CpuClkConfig) {
@@ -2031,12 +2028,12 @@ macro_rules! define_clock_tree_types {
         #[allow(unused_variables)]
         pub fn cpu_clk_config_frequency(clocks: &mut ClockTree, config: CpuClkConfig) -> u32 {
             match config {
-                CpuClkConfig::Xtal => system_pre_div_frequency(clocks),
-                CpuClkConfig::RcFast => system_pre_div_frequency(clocks),
-                CpuClkConfig::Pll => cpu_pll_div_out_frequency(clocks),
+                CpuClkConfig::Xtal => system_pre_div_frequency(),
+                CpuClkConfig::RcFast => system_pre_div_frequency(),
+                CpuClkConfig::Pll => cpu_pll_div_out_frequency(),
             }
         }
-        pub fn cpu_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn cpu_clk_frequency() -> u32 {
             CPU_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_pll_d2(clocks: &mut ClockTree) {
@@ -2055,8 +2052,8 @@ macro_rules! define_clock_tree_types {
                 release_pll_clk(clocks);
             }
         }
-        pub fn pll_d2_frequency(clocks: &mut ClockTree) -> u32 {
-            (pll_clk_frequency(clocks) / 2)
+        pub fn pll_d2_frequency() -> u32 {
+            (pll_clk_frequency() / 2)
         }
         pub fn request_pll_160m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_160M");
@@ -2070,7 +2067,7 @@ macro_rules! define_clock_tree_types {
             enable_pll_160m_impl(clocks, false);
             release_cpu_clk(clocks);
         }
-        pub fn pll_160m_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn pll_160m_frequency() -> u32 {
             160000000
         }
         pub fn request_apb_80m(clocks: &mut ClockTree) {
@@ -2085,7 +2082,7 @@ macro_rules! define_clock_tree_types {
             enable_apb_80m_impl(clocks, false);
             release_cpu_clk(clocks);
         }
-        pub fn apb_80m_frequency(clocks: &mut ClockTree) -> u32 {
+        pub fn apb_80m_frequency() -> u32 {
             80000000
         }
         pub fn configure_rc_fast_clk_div_n(clocks: &mut ClockTree, config: RcFastClkDivNConfig) {
@@ -2113,9 +2110,9 @@ macro_rules! define_clock_tree_types {
             clocks: &mut ClockTree,
             config: RcFastClkDivNConfig,
         ) -> u32 {
-            (rc_fast_clk_frequency(clocks) / (config.divisor() + 1))
+            (rc_fast_clk_frequency() / (config.divisor() + 1))
         }
-        pub fn rc_fast_clk_div_n_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn rc_fast_clk_div_n_frequency() -> u32 {
             RC_FAST_CLK_DIV_N_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_xtal_div_clk(clocks: &mut ClockTree) {
@@ -2130,8 +2127,8 @@ macro_rules! define_clock_tree_types {
             enable_xtal_div_clk_impl(clocks, false);
             release_xtal_clk(clocks);
         }
-        pub fn xtal_div_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            (xtal_clk_frequency(clocks) / 2)
+        pub fn xtal_div_clk_frequency() -> u32 {
+            (xtal_clk_frequency() / 2)
         }
         pub fn configure_rtc_slow_clk(clocks: &mut ClockTree, new_selector: RtcSlowClkConfig) {
             let old_selector = clocks.rtc_slow_clk.replace(new_selector);
@@ -2179,12 +2176,12 @@ macro_rules! define_clock_tree_types {
             config: RtcSlowClkConfig,
         ) -> u32 {
             match config {
-                RtcSlowClkConfig::Xtal32k => xtal32k_clk_frequency(clocks),
-                RtcSlowClkConfig::RcSlow => rc_slow_clk_frequency(clocks),
-                RtcSlowClkConfig::RcFast => rc_fast_div_clk_frequency(clocks),
+                RtcSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
+                RtcSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
+                RtcSlowClkConfig::RcFast => rc_fast_div_clk_frequency(),
             }
         }
-        pub fn rtc_slow_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn rtc_slow_clk_frequency() -> u32 {
             RTC_SLOW_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_rtc_fast_clk(clocks: &mut ClockTree, new_selector: RtcFastClkConfig) {
@@ -2237,11 +2234,11 @@ macro_rules! define_clock_tree_types {
             config: RtcFastClkConfig,
         ) -> u32 {
             match config {
-                RtcFastClkConfig::Xtal => xtal_div_clk_frequency(clocks),
-                RtcFastClkConfig::Rc => rc_fast_clk_div_n_frequency(clocks),
+                RtcFastClkConfig::Xtal => xtal_div_clk_frequency(),
+                RtcFastClkConfig::Rc => rc_fast_clk_div_n_frequency(),
             }
         }
-        pub fn rtc_fast_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn rtc_fast_clk_frequency() -> u32 {
             RTC_FAST_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn configure_low_power_clk(clocks: &mut ClockTree, new_selector: LowPowerClkConfig) {
@@ -2302,13 +2299,13 @@ macro_rules! define_clock_tree_types {
             config: LowPowerClkConfig,
         ) -> u32 {
             match config {
-                LowPowerClkConfig::Xtal => xtal_clk_frequency(clocks),
-                LowPowerClkConfig::RcFast => rc_fast_clk_frequency(clocks),
-                LowPowerClkConfig::Xtal32k => xtal32k_clk_frequency(clocks),
-                LowPowerClkConfig::RtcSlow => rtc_slow_clk_frequency(clocks),
+                LowPowerClkConfig::Xtal => xtal_clk_frequency(),
+                LowPowerClkConfig::RcFast => rc_fast_clk_frequency(),
+                LowPowerClkConfig::Xtal32k => xtal32k_clk_frequency(),
+                LowPowerClkConfig::RtcSlow => rtc_slow_clk_frequency(),
             }
         }
-        pub fn low_power_clk_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn low_power_clk_frequency() -> u32 {
             LOW_POWER_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn request_uart_mem_clk(clocks: &mut ClockTree) {
@@ -2327,8 +2324,8 @@ macro_rules! define_clock_tree_types {
                 release_xtal_clk(clocks);
             }
         }
-        pub fn uart_mem_clk_frequency(clocks: &mut ClockTree) -> u32 {
-            xtal_clk_frequency(clocks)
+        pub fn uart_mem_clk_frequency() -> u32 {
+            xtal_clk_frequency()
         }
         pub fn configure_timg_calibration_clock(
             clocks: &mut ClockTree,
@@ -2389,12 +2386,12 @@ macro_rules! define_clock_tree_types {
             config: TimgCalibrationClockConfig,
         ) -> u32 {
             match config {
-                TimgCalibrationClockConfig::RcSlowClk => rc_slow_clk_frequency(clocks),
-                TimgCalibrationClockConfig::RcFastDivClk => rc_fast_div_clk_frequency(clocks),
-                TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(clocks),
+                TimgCalibrationClockConfig::RcSlowClk => rc_slow_clk_frequency(),
+                TimgCalibrationClockConfig::RcFastDivClk => rc_fast_div_clk_frequency(),
+                TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
             }
         }
-        pub fn timg_calibration_clock_frequency(_clocks: &mut ClockTree) -> u32 {
+        pub fn timg_calibration_clock_frequency() -> u32 {
             TIMG_CALIBRATION_CLOCK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         impl McpwmInstance {
@@ -2447,9 +2444,9 @@ macro_rules! define_clock_tree_types {
                 clocks: &mut ClockTree,
                 config: McpwmFunctionClockConfig,
             ) -> u32 {
-                crypto_pwm_clk_frequency(clocks)
+                crypto_pwm_clk_frequency()
             }
-            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn function_clock_frequency(self) -> u32 {
                 MCPWM_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -2510,12 +2507,12 @@ macro_rules! define_clock_tree_types {
                 config: RmtSclkConfig,
             ) -> u32 {
                 match config {
-                    RmtSclkConfig::ApbClk => apb_clk_frequency(clocks),
-                    RmtSclkConfig::RcFastClk => rc_fast_clk_frequency(clocks),
-                    RmtSclkConfig::XtalClk => xtal_clk_frequency(clocks),
+                    RmtSclkConfig::ApbClk => apb_clk_frequency(),
+                    RmtSclkConfig::RcFastClk => rc_fast_clk_frequency(),
+                    RmtSclkConfig::XtalClk => xtal_clk_frequency(),
                 }
             }
-            pub fn sclk_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn sclk_frequency(self) -> u32 {
                 RMT_SCLK_FREQ_CACHE[self as usize].load(::core::sync::atomic::Ordering::Acquire)
             }
         }
@@ -2582,11 +2579,11 @@ macro_rules! define_clock_tree_types {
                 config: TimgFunctionClockConfig,
             ) -> u32 {
                 match config {
-                    TimgFunctionClockConfig::XtalClk => xtal_clk_frequency(clocks),
-                    TimgFunctionClockConfig::ApbClk => apb_clk_frequency(clocks),
+                    TimgFunctionClockConfig::XtalClk => xtal_clk_frequency(),
+                    TimgFunctionClockConfig::ApbClk => apb_clk_frequency(),
                 }
             }
-            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn function_clock_frequency(self) -> u32 {
                 TIMG_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -2658,12 +2655,12 @@ macro_rules! define_clock_tree_types {
                 config: UartFunctionClockConfig,
             ) -> u32 {
                 (match config.sclk {
-                    UartFunctionClockSclk::Apb => apb_clk_frequency(clocks),
-                    UartFunctionClockSclk::RcFast => rc_fast_clk_frequency(clocks),
-                    UartFunctionClockSclk::Xtal => xtal_clk_frequency(clocks),
+                    UartFunctionClockSclk::Apb => apb_clk_frequency(),
+                    UartFunctionClockSclk::RcFast => rc_fast_clk_frequency(),
+                    UartFunctionClockSclk::Xtal => xtal_clk_frequency(),
                 } / (config.div_num() + 1))
             }
-            pub fn function_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn function_clock_frequency(self) -> u32 {
                 UART_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -2708,10 +2705,10 @@ macro_rules! define_clock_tree_types {
                 clocks: &mut ClockTree,
                 config: UartBaudRateGeneratorConfig,
             ) -> u32 {
-                ((self.function_clock_frequency(clocks) * 16)
+                ((self.function_clock_frequency() * 16)
                     / ((config.integral() * 16) + config.fractional()))
             }
-            pub fn baud_rate_generator_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn baud_rate_generator_frequency(self) -> u32 {
                 UART_BAUD_RATE_GENERATOR_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
@@ -2745,9 +2742,9 @@ macro_rules! define_clock_tree_types {
                 clocks: &mut ClockTree,
                 config: UartMemClockConfig,
             ) -> u32 {
-                uart_mem_clk_frequency(clocks)
+                uart_mem_clk_frequency()
             }
-            pub fn mem_clock_frequency(self, _clocks: &mut ClockTree) -> u32 {
+            pub fn mem_clock_frequency(self) -> u32 {
                 UART_MEM_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }

--- a/esp-metadata-generated/src/_generated_esp32s3.rs
+++ b/esp-metadata-generated/src/_generated_esp32s3.rs
@@ -2844,50 +2844,13 @@ macro_rules! define_clock_tree_types {
                 UartInstance::Uart2,
             ] {
                 refresh_uart_mem_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [
-                UartInstance::Uart0,
-                UartInstance::Uart1,
-                UartInstance::Uart2,
-            ] {
-                refresh_uart_mem_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [
-                UartInstance::Uart0,
-                UartInstance::Uart1,
-                UartInstance::Uart2,
-            ] {
-                refresh_uart_mem_clock_downstream(clocks, child_instance);
+                refresh_uart_function_clock_downstream(clocks, child_instance);
             }
             for child_instance in [RmtInstance::Rmt] {
                 refresh_rmt_sclk_downstream(clocks, child_instance);
             }
             for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
                 refresh_timg_function_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
-                refresh_timg_function_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [
-                UartInstance::Uart0,
-                UartInstance::Uart1,
-                UartInstance::Uart2,
-            ] {
-                refresh_uart_function_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [
-                UartInstance::Uart0,
-                UartInstance::Uart1,
-                UartInstance::Uart2,
-            ] {
-                refresh_uart_function_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [
-                UartInstance::Uart0,
-                UartInstance::Uart1,
-                UartInstance::Uart2,
-            ] {
-                refresh_uart_function_clock_downstream(clocks, child_instance);
             }
         }
         fn refresh_pll_clk_downstream(clocks: &mut ClockTree) {
@@ -2999,23 +2962,6 @@ macro_rules! define_clock_tree_types {
             for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
                 refresh_timg_function_clock_downstream(clocks, child_instance);
             }
-            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
-                refresh_timg_function_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [
-                UartInstance::Uart0,
-                UartInstance::Uart1,
-                UartInstance::Uart2,
-            ] {
-                refresh_uart_function_clock_downstream(clocks, child_instance);
-            }
-            for child_instance in [
-                UartInstance::Uart0,
-                UartInstance::Uart1,
-                UartInstance::Uart2,
-            ] {
-                refresh_uart_function_clock_downstream(clocks, child_instance);
-            }
             for child_instance in [
                 UartInstance::Uart0,
                 UartInstance::Uart1,
@@ -3030,9 +2976,6 @@ macro_rules! define_clock_tree_types {
                     crypto_pwm_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
-            }
-            for child_instance in [McpwmInstance::Mcpwm0, McpwmInstance::Mcpwm1] {
-                refresh_mcpwm_function_clock_downstream(clocks, child_instance);
             }
             for child_instance in [McpwmInstance::Mcpwm0, McpwmInstance::Mcpwm1] {
                 refresh_mcpwm_function_clock_downstream(clocks, child_instance);

--- a/esp-metadata-generated/src/_generated_esp32s3.rs
+++ b/esp-metadata-generated/src/_generated_esp32s3.rs
@@ -1641,7 +1641,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_xtal_clk(clocks: &mut ClockTree, config: XtalClkConfig) {
             let old_config = clocks.xtal_clk.replace(config);
             configure_xtal_clk_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_xtal_clk_downstream(clocks);
         }
         pub fn xtal_clk_config(clocks: &mut ClockTree) -> Option<XtalClkConfig> {
             clocks.xtal_clk
@@ -1663,7 +1663,7 @@ macro_rules! define_clock_tree_types {
             }
             let old_config = clocks.pll_clk.replace(config);
             configure_pll_clk_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_pll_clk_downstream(clocks);
         }
         pub fn pll_clk_config(clocks: &mut ClockTree) -> Option<PllClkConfig> {
             clocks.pll_clk
@@ -1777,7 +1777,7 @@ macro_rules! define_clock_tree_types {
                     SystemPreDivInConfig::RcFast => release_rc_fast_clk(clocks),
                 }
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_system_pre_div_in_downstream(clocks);
         }
         pub fn system_pre_div_in_config(clocks: &mut ClockTree) -> Option<SystemPreDivInConfig> {
             clocks.system_pre_div_in
@@ -1816,7 +1816,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_system_pre_div(clocks: &mut ClockTree, config: SystemPreDivConfig) {
             let old_config = clocks.system_pre_div.replace(config);
             configure_system_pre_div_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_system_pre_div_downstream(clocks);
         }
         pub fn system_pre_div_config(clocks: &mut ClockTree) -> Option<SystemPreDivConfig> {
             clocks.system_pre_div
@@ -1849,7 +1849,7 @@ macro_rules! define_clock_tree_types {
             }
             let old_config = clocks.cpu_pll_div_out.replace(config);
             configure_cpu_pll_div_out_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_cpu_pll_div_out_downstream(clocks);
         }
         pub fn cpu_pll_div_out_config(clocks: &mut ClockTree) -> Option<CpuPllDivOutConfig> {
             clocks.cpu_pll_div_out
@@ -1893,7 +1893,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_apb_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_apb_clk_downstream(clocks);
         }
         pub fn apb_clk_config(clocks: &mut ClockTree) -> Option<ApbClkConfig> {
             clocks.apb_clk
@@ -1947,7 +1947,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_crypto_pwm_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_crypto_pwm_clk_downstream(clocks);
         }
         pub fn crypto_pwm_clk_config(clocks: &mut ClockTree) -> Option<CryptoPwmClkConfig> {
             clocks.crypto_pwm_clk
@@ -2018,7 +2018,7 @@ macro_rules! define_clock_tree_types {
                     CpuClkConfig::Pll => release_cpu_pll_div_out(clocks),
                 }
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_cpu_clk_downstream(clocks);
         }
         pub fn cpu_clk_config(clocks: &mut ClockTree) -> Option<CpuClkConfig> {
             clocks.cpu_clk
@@ -2088,7 +2088,7 @@ macro_rules! define_clock_tree_types {
         pub fn configure_rc_fast_clk_div_n(clocks: &mut ClockTree, config: RcFastClkDivNConfig) {
             let old_config = clocks.rc_fast_clk_div_n.replace(config);
             configure_rc_fast_clk_div_n_impl(clocks, old_config, config);
-            refresh_all_frequency_caches(clocks);
+            refresh_rc_fast_clk_div_n_downstream(clocks);
         }
         pub fn rc_fast_clk_div_n_config(clocks: &mut ClockTree) -> Option<RcFastClkDivNConfig> {
             clocks.rc_fast_clk_div_n
@@ -2145,7 +2145,7 @@ macro_rules! define_clock_tree_types {
                     RtcSlowClkConfig::RcFast => release_rc_fast_div_clk(clocks),
                 }
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_rtc_slow_clk_downstream(clocks);
         }
         pub fn rtc_slow_clk_config(clocks: &mut ClockTree) -> Option<RtcSlowClkConfig> {
             clocks.rtc_slow_clk
@@ -2201,7 +2201,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_rtc_fast_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_rtc_fast_clk_downstream(clocks);
         }
         pub fn rtc_fast_clk_config(clocks: &mut ClockTree) -> Option<RtcFastClkConfig> {
             clocks.rtc_fast_clk
@@ -2262,7 +2262,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_low_power_clk_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_low_power_clk_downstream(clocks);
         }
         pub fn low_power_clk_config(clocks: &mut ClockTree) -> Option<LowPowerClkConfig> {
             clocks.low_power_clk
@@ -2349,7 +2349,7 @@ macro_rules! define_clock_tree_types {
             } else {
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
             }
-            refresh_all_frequency_caches(clocks);
+            refresh_timg_calibration_clock_downstream(clocks);
         }
         pub fn timg_calibration_clock_config(
             clocks: &mut ClockTree,
@@ -2410,7 +2410,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_mcpwm_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -2471,7 +2471,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_sclk_impl(clocks, old_selector, new_selector);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_rmt_sclk_downstream(clocks, self);
             }
             pub fn sclk_config(self, clocks: &mut ClockTree) -> Option<RmtSclkConfig> {
                 clocks.rmt_sclk[self as usize]
@@ -2538,7 +2538,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_selector, new_selector);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_timg_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -2612,7 +2612,7 @@ macro_rules! define_clock_tree_types {
                 } else {
                     self.configure_function_clock_impl(clocks, old_config, config);
                 }
-                refresh_all_frequency_caches(clocks);
+                refresh_uart_function_clock_downstream(clocks, self);
             }
             pub fn function_clock_config(
                 self,
@@ -2671,7 +2671,7 @@ macro_rules! define_clock_tree_types {
             ) {
                 let old_config = clocks.uart_baud_rate_generator[self as usize].replace(config);
                 self.configure_baud_rate_generator_impl(clocks, old_config, config);
-                refresh_all_frequency_caches(clocks);
+                refresh_uart_baud_rate_generator_downstream(clocks, self);
             }
             pub fn baud_rate_generator_config(
                 self,
@@ -2715,7 +2715,7 @@ macro_rules! define_clock_tree_types {
             pub fn configure_mem_clock(self, clocks: &mut ClockTree, config: UartMemClockConfig) {
                 let old_config = clocks.uart_mem_clock[self as usize].replace(config);
                 self.configure_mem_clock_impl(clocks, old_config, config);
-                refresh_all_frequency_caches(clocks);
+                refresh_uart_mem_clock_downstream(clocks, self);
             }
             pub fn mem_clock_config(self, clocks: &mut ClockTree) -> Option<UartMemClockConfig> {
                 clocks.uart_mem_clock[self as usize]
@@ -2827,144 +2827,262 @@ macro_rules! define_clock_tree_types {
             let last = *refcount == 0;
             last
         }
-        fn refresh_all_frequency_caches(clocks: &mut ClockTree) {
+        fn refresh_xtal_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.xtal_clk {
                 XTAL_CLK_FREQ_CACHE.store(
                     xtal_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_pll_clk_downstream(clocks);
+            refresh_system_pre_div_in_downstream(clocks);
+            refresh_rtc_fast_clk_downstream(clocks);
+            refresh_low_power_clk_downstream(clocks);
+            for child_instance in [
+                UartInstance::Uart0,
+                UartInstance::Uart1,
+                UartInstance::Uart2,
+            ] {
+                refresh_uart_mem_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [
+                UartInstance::Uart0,
+                UartInstance::Uart1,
+                UartInstance::Uart2,
+            ] {
+                refresh_uart_mem_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [
+                UartInstance::Uart0,
+                UartInstance::Uart1,
+                UartInstance::Uart2,
+            ] {
+                refresh_uart_mem_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [RmtInstance::Rmt] {
+                refresh_rmt_sclk_downstream(clocks, child_instance);
+            }
+            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                refresh_timg_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                refresh_timg_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [
+                UartInstance::Uart0,
+                UartInstance::Uart1,
+                UartInstance::Uart2,
+            ] {
+                refresh_uart_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [
+                UartInstance::Uart0,
+                UartInstance::Uart1,
+                UartInstance::Uart2,
+            ] {
+                refresh_uart_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [
+                UartInstance::Uart0,
+                UartInstance::Uart1,
+                UartInstance::Uart2,
+            ] {
+                refresh_uart_function_clock_downstream(clocks, child_instance);
+            }
+        }
+        fn refresh_pll_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.pll_clk {
                 PLL_CLK_FREQ_CACHE.store(
                     pll_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_cpu_pll_div_out_downstream(clocks);
+        }
+        fn refresh_system_pre_div_in_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.system_pre_div_in {
                 SYSTEM_PRE_DIV_IN_FREQ_CACHE.store(
                     system_pre_div_in_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_system_pre_div_downstream(clocks);
+        }
+        fn refresh_system_pre_div_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.system_pre_div {
                 SYSTEM_PRE_DIV_FREQ_CACHE.store(
                     system_pre_div_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_cpu_clk_downstream(clocks);
+        }
+        fn refresh_cpu_pll_div_out_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.cpu_pll_div_out {
                 CPU_PLL_DIV_OUT_FREQ_CACHE.store(
                     cpu_pll_div_out_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_cpu_clk_downstream(clocks);
+        }
+        fn refresh_cpu_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.cpu_clk {
                 CPU_CLK_FREQ_CACHE.store(
                     cpu_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_apb_clk_downstream(clocks);
+            refresh_crypto_pwm_clk_downstream(clocks);
+        }
+        fn refresh_rc_fast_clk_div_n_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.rc_fast_clk_div_n {
                 RC_FAST_CLK_DIV_N_FREQ_CACHE.store(
                     rc_fast_clk_div_n_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_rtc_fast_clk_downstream(clocks);
+        }
+        fn refresh_rtc_slow_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.rtc_slow_clk {
                 RTC_SLOW_CLK_FREQ_CACHE.store(
                     rtc_slow_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            refresh_low_power_clk_downstream(clocks);
+        }
+        fn refresh_rtc_fast_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.rtc_fast_clk {
                 RTC_FAST_CLK_FREQ_CACHE.store(
                     rtc_fast_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+        }
+        fn refresh_low_power_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.low_power_clk {
                 LOW_POWER_CLK_FREQ_CACHE.store(
                     low_power_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+        }
+        fn refresh_timg_calibration_clock_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.timg_calibration_clock {
                 TIMG_CALIBRATION_CLOCK_FREQ_CACHE.store(
                     timg_calibration_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
-            for instance in [
-                UartInstance::Uart0,
-                UartInstance::Uart1,
-                UartInstance::Uart2,
-            ] {
-                if let Some(config) = clocks.uart_mem_clock[instance as usize] {
-                    UART_MEM_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.mem_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_uart_mem_clock_downstream(clocks: &mut ClockTree, instance: UartInstance) {
+            if let Some(config) = clocks.uart_mem_clock[instance as usize] {
+                UART_MEM_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.mem_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
+        }
+        fn refresh_apb_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.apb_clk {
                 APB_CLK_FREQ_CACHE.store(
                     apb_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            for child_instance in [RmtInstance::Rmt] {
+                refresh_rmt_sclk_downstream(clocks, child_instance);
+            }
+            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                refresh_timg_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                refresh_timg_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [
+                UartInstance::Uart0,
+                UartInstance::Uart1,
+                UartInstance::Uart2,
+            ] {
+                refresh_uart_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [
+                UartInstance::Uart0,
+                UartInstance::Uart1,
+                UartInstance::Uart2,
+            ] {
+                refresh_uart_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [
+                UartInstance::Uart0,
+                UartInstance::Uart1,
+                UartInstance::Uart2,
+            ] {
+                refresh_uart_function_clock_downstream(clocks, child_instance);
+            }
+        }
+        fn refresh_crypto_pwm_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.crypto_pwm_clk {
                 CRYPTO_PWM_CLK_FREQ_CACHE.store(
                     crypto_pwm_clk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
-            for instance in [McpwmInstance::Mcpwm0, McpwmInstance::Mcpwm1] {
-                if let Some(config) = clocks.mcpwm_function_clock[instance as usize] {
-                    MCPWM_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.function_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+            for child_instance in [McpwmInstance::Mcpwm0, McpwmInstance::Mcpwm1] {
+                refresh_mcpwm_function_clock_downstream(clocks, child_instance);
             }
-            for instance in [RmtInstance::Rmt] {
-                if let Some(config) = clocks.rmt_sclk[instance as usize] {
-                    RMT_SCLK_FREQ_CACHE[instance as usize].store(
-                        instance.sclk_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+            for child_instance in [McpwmInstance::Mcpwm0, McpwmInstance::Mcpwm1] {
+                refresh_mcpwm_function_clock_downstream(clocks, child_instance);
             }
-            for instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
-                if let Some(config) = clocks.timg_function_clock[instance as usize] {
-                    TIMG_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.function_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_mcpwm_function_clock_downstream(
+            clocks: &mut ClockTree,
+            instance: McpwmInstance,
+        ) {
+            if let Some(config) = clocks.mcpwm_function_clock[instance as usize] {
+                MCPWM_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.function_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
-            for instance in [
-                UartInstance::Uart0,
-                UartInstance::Uart1,
-                UartInstance::Uart2,
-            ] {
-                if let Some(config) = clocks.uart_function_clock[instance as usize] {
-                    UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                        instance.function_clock_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_rmt_sclk_downstream(clocks: &mut ClockTree, instance: RmtInstance) {
+            if let Some(config) = clocks.rmt_sclk[instance as usize] {
+                RMT_SCLK_FREQ_CACHE[instance as usize].store(
+                    instance.sclk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
-            for instance in [
-                UartInstance::Uart0,
-                UartInstance::Uart1,
-                UartInstance::Uart2,
-            ] {
-                if let Some(config) = clocks.uart_baud_rate_generator[instance as usize] {
-                    UART_BAUD_RATE_GENERATOR_FREQ_CACHE[instance as usize].store(
-                        instance.baud_rate_generator_config_frequency(clocks, config),
-                        ::core::sync::atomic::Ordering::Release,
-                    );
-                }
+        }
+        fn refresh_timg_function_clock_downstream(clocks: &mut ClockTree, instance: TimgInstance) {
+            if let Some(config) = clocks.timg_function_clock[instance as usize] {
+                TIMG_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.function_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+        }
+        fn refresh_uart_function_clock_downstream(clocks: &mut ClockTree, instance: UartInstance) {
+            if let Some(config) = clocks.uart_function_clock[instance as usize] {
+                UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
+                    instance.function_clock_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            refresh_uart_baud_rate_generator_downstream(clocks, instance);
+        }
+        fn refresh_uart_baud_rate_generator_downstream(
+            clocks: &mut ClockTree,
+            instance: UartInstance,
+        ) {
+            if let Some(config) = clocks.uart_baud_rate_generator[instance as usize] {
+                UART_BAUD_RATE_GENERATOR_FREQ_CACHE[instance as usize].store(
+                    instance.baud_rate_generator_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
         }
     };

--- a/esp-metadata/src/cfg/soc.rs
+++ b/esp-metadata/src/cfg/soc.rs
@@ -839,28 +839,24 @@ impl SystemClocks {
             }
         }
 
-        // Helper: generates a `for child_instance in [...] { child_fn(clocks, child_instance); }`
-        // call for a template-group child node.
-        let template_child_call =
-            |tree: &ProcessedClockData, child: &ClockTreeNodeInstance, child_fn: &Ident| {
-                let instances = tree.group_instances.get(&child.group_template).unwrap();
-                let child_enum = format_ident!(
-                    "{}Instance",
-                    child
-                        .group_template
-                        .from_case(Case::Constant)
-                        .to_case(Case::Pascal)
-                );
-                let variants: Vec<_> = instances
-                    .iter()
-                    .map(|v| format_ident!("{}", v.from_case(Case::Constant).to_case(Case::Pascal)))
-                    .collect();
-                quote! {
-                    for child_instance in [#(#child_enum::#variants,)*] {
-                        #child_fn(clocks, child_instance);
-                    }
+        // Helper: generates a `for child_instance in [...] { fn1(...); fn2(...); ... }` loop
+        // for a template-group child node.
+        let template_group_loop = |tree: &ProcessedClockData, group: &str, fns: &[Ident]| {
+            let instances = tree.group_instances.get(group).unwrap();
+            let child_enum = format_ident!(
+                "{}Instance",
+                group.from_case(Case::Constant).to_case(Case::Pascal)
+            );
+            let variants: Vec<_> = instances
+                .iter()
+                .map(|v| format_ident!("{}", v.from_case(Case::Constant).to_case(Case::Pascal)))
+                .collect();
+            quote! {
+                for child_instance in [#(#child_enum::#variants,)*] {
+                    #(#fns(clocks, child_instance);)*
                 }
-            };
+            }
+        };
 
         // For each configurable node, emit a targeted downstream refresh function.
         // Each function refreshes itself and delegates to its direct configurable children's
@@ -899,7 +895,9 @@ impl SystemClocks {
                         .from_case(Case::Constant)
                         .to_case(Case::Pascal)
                 );
-                let child_calls: Vec<TokenStream> = children
+                // Group cross-template children by group_template for a single loop per group.
+                let mut cross_template_fns: IndexMap<String, IndexSet<String>> = IndexMap::new();
+                let mut child_calls: Vec<TokenStream> = children
                     .iter()
                     .filter_map(|child_name| {
                         let child = tree.try_get_node(child_name)?;
@@ -907,12 +905,20 @@ impl SystemClocks {
                         if child.group_template == node.group_template {
                             Some(quote! { #child_fn(clocks, instance); })
                         } else if child.properties.receiver.is_some() {
-                            Some(template_child_call(tree, child, &child_fn))
+                            cross_template_fns
+                                .entry(child.group_template.clone())
+                                .or_default()
+                                .insert(child_fn.to_string());
+                            None
                         } else {
                             Some(quote! { #child_fn(clocks); })
                         }
                     })
                     .collect();
+                for (group, fns) in &cross_template_fns {
+                    let fns: Vec<Ident> = fns.iter().map(|s| format_ident!("{s}")).collect();
+                    child_calls.push(template_group_loop(tree, group, &fns));
+                }
                 downstream_refresh_fns.push(quote! {
                     fn #fn_name(clocks: &mut ClockTree, instance: #enum_name) {
                         #self_stmt
@@ -921,18 +927,28 @@ impl SystemClocks {
                 });
             } else {
                 // System (scalar) node: no instance parameter.
-                let child_calls: Vec<TokenStream> = children
+                // Group template children by group_template for a single loop per group.
+                let mut template_group_fns: IndexMap<String, IndexSet<String>> = IndexMap::new();
+                let mut child_calls: Vec<TokenStream> = children
                     .iter()
                     .filter_map(|child_name| {
                         let child = tree.try_get_node(child_name)?;
                         let child_fn = child.refresh_downstream_function_name();
                         if child.properties.receiver.is_some() {
-                            Some(template_child_call(tree, child, &child_fn))
+                            template_group_fns
+                                .entry(child.group_template.clone())
+                                .or_default()
+                                .insert(child_fn.to_string());
+                            None
                         } else {
                             Some(quote! { #child_fn(clocks); })
                         }
                     })
                     .collect();
+                for (group, fns) in &template_group_fns {
+                    let fns: Vec<Ident> = fns.iter().map(|s| format_ident!("{s}")).collect();
+                    child_calls.push(template_group_loop(tree, group, &fns));
+                }
                 downstream_refresh_fns.push(quote! {
                     fn #fn_name(clocks: &mut ClockTree) {
                         #self_stmt

--- a/esp-metadata/src/cfg/soc.rs
+++ b/esp-metadata/src/cfg/soc.rs
@@ -475,13 +475,13 @@ impl ClockTreeNodeInstance {
                         pub fn #config_frequency_function_name(#(#receiver,)* clocks: &mut ClockTree, config: #ty_name) -> u32 {
                             #frequency_function_impl
                         }
-                        pub fn #frequency_function_name(#(#receiver,)* _clocks: &mut ClockTree) -> u32 {
+                        pub fn #frequency_function_name(#(#receiver)*) -> u32 {
                             #cache_load
                         }
                     }
                 } else {
                     quote! {
-                        pub fn #frequency_function_name(#(#receiver,)* clocks: &mut ClockTree) -> u32 {
+                        pub fn #frequency_function_name(#(#receiver)*) -> u32 {
                             #frequency_function_impl
                         }
                     }

--- a/esp-metadata/src/cfg/soc.rs
+++ b/esp-metadata/src/cfg/soc.rs
@@ -293,6 +293,15 @@ impl ClockTreeNodeInstance {
         self.prefix_function("configure")
     }
 
+    pub(super) fn freq_cache_static_name(&self) -> Ident {
+        let name = if self.group_template.is_empty() {
+            self.name.clone()
+        } else {
+            format!("{}_{}", self.group_template, self.node.name())
+        };
+        format_ident!("{}_FREQ_CACHE", name)
+    }
+
     fn current_config_function_name(&self) -> Ident {
         self.suffix_function("config")
     }
@@ -455,18 +464,19 @@ impl ClockTreeNodeInstance {
             frequency: Function {
                 _name: frequency_function_name.to_string(),
                 implementation: if self.is_configurable() {
-                    let config_field = self.properties.indexed_config_accessor();
+                    let cache_name = self.freq_cache_static_name();
+                    let cache_load = if self.properties.receiver.is_some() {
+                        quote! { #cache_name[self as usize].load(::core::sync::atomic::Ordering::Acquire) }
+                    } else {
+                        quote! { #cache_name.load(::core::sync::atomic::Ordering::Acquire) }
+                    };
                     quote! {
                         #[allow(unused_variables)]
                         pub fn #config_frequency_function_name(#(#receiver,)* clocks: &mut ClockTree, config: #ty_name) -> u32 {
                             #frequency_function_impl
                         }
-                        pub fn #frequency_function_name(#(#receiver,)* clocks: &mut ClockTree) -> u32 {
-                            if let Some(config) = #config_field {
-                                #(#receiver.)* #config_frequency_function_name(clocks, config)
-                            } else {
-                                0
-                            }
+                        pub fn #frequency_function_name(#(#receiver,)* _clocks: &mut ClockTree) -> u32 {
+                            #cache_load
                         }
                     }
                 } else {
@@ -752,6 +762,81 @@ impl SystemClocks {
             })
             .collect::<Vec<_>>();
 
+        // Build AtomicU32 cache statics and the refresh function body in topological order.
+        let mut freq_cache_statics: Vec<TokenStream> = vec![];
+        let mut refresh_cache_stmts: Vec<TokenStream> = vec![];
+        let mut seen_cache_templates: HashSet<String> = HashSet::new();
+
+        for node_name in tree.dependency_graph.iter() {
+            let Some(node) = tree.try_get_node(&node_name) else {
+                continue;
+            };
+            if !node.is_configurable() {
+                continue;
+            }
+
+            let template_key = if node.group_template.is_empty() {
+                node_name.clone()
+            } else {
+                format!("{}_{}", node.group_template, node.node.name())
+            };
+
+            if !seen_cache_templates.insert(template_key) {
+                continue;
+            }
+
+            let cache_name = node.freq_cache_static_name();
+            let config_freq_fn = node.config_frequency_function_name();
+
+            if node.properties.receiver.is_some() {
+                let instances = tree.group_instances.get(&node.group_template).unwrap();
+                let instance_count = number(instances.len());
+                let enum_name = format_ident!(
+                    "{}Instance",
+                    node.group_template
+                        .from_case(Case::Constant)
+                        .to_case(Case::Pascal)
+                );
+                let variants: Vec<_> = instances
+                    .iter()
+                    .map(|v| {
+                        format_ident!("{}", v.from_case(Case::Constant).to_case(Case::Pascal))
+                    })
+                    .collect();
+                let field_name = node.properties.field_name();
+
+                freq_cache_statics.push(quote! {
+                    static #cache_name: [::core::sync::atomic::AtomicU32; #instance_count] =
+                        [const { ::core::sync::atomic::AtomicU32::new(0) }; #instance_count];
+                });
+                refresh_cache_stmts.push(quote! {
+                    for instance in [#(#enum_name::#variants,)*] {
+                        if let Some(config) = clocks.#field_name[instance as usize] {
+                            #cache_name[instance as usize].store(
+                                instance.#config_freq_fn(clocks, config),
+                                ::core::sync::atomic::Ordering::Release,
+                            );
+                        }
+                    }
+                });
+            } else {
+                let config_field = node.properties.indexed_config_accessor();
+
+                freq_cache_statics.push(quote! {
+                    static #cache_name: ::core::sync::atomic::AtomicU32 =
+                        ::core::sync::atomic::AtomicU32::new(0);
+                });
+                refresh_cache_stmts.push(quote! {
+                    if let Some(config) = #config_field {
+                        #cache_name.store(
+                            #config_freq_fn(clocks, config),
+                            ::core::sync::atomic::Ordering::Release,
+                        );
+                    }
+                });
+            }
+        }
+
         Ok(quote! {
             #[macro_export]
             /// ESP-HAL must provide implementation for the following functions:
@@ -787,6 +872,8 @@ impl SystemClocks {
                             #(#clock_tree_state_field_names: #clock_tree_state_field_initializers,)*
                             #(#clock_tree_refcount_field_inits,)*
                         });
+
+                    #(#freq_cache_statics)*
 
                     #(#clock_tree_node_impls)*
 
@@ -824,6 +911,9 @@ impl SystemClocks {
                         let last = *refcount == 0;
                         // CLOCK_BITMAP.fetch_and(!clock_id, Ordering::Relaxed);
                         last
+                    }
+                    fn refresh_all_frequency_caches(clocks: &mut ClockTree) {
+                        #(#refresh_cache_stmts)*
                     }
                 };
             }

--- a/esp-metadata/src/cfg/soc.rs
+++ b/esp-metadata/src/cfg/soc.rs
@@ -302,6 +302,15 @@ impl ClockTreeNodeInstance {
         format_ident!("{}_FREQ_CACHE", name)
     }
 
+    pub(super) fn refresh_downstream_function_name(&self) -> Ident {
+        let name = if self.group_template.is_empty() {
+            self.name.clone()
+        } else {
+            format!("{}_{}", self.group_template, self.node.name())
+        };
+        format_ident!("refresh_{}_downstream", name.to_lowercase())
+    }
+
     fn current_config_function_name(&self) -> Ident {
         self.suffix_function("config")
     }
@@ -762,9 +771,12 @@ impl SystemClocks {
             })
             .collect::<Vec<_>>();
 
-        // Build AtomicU32 cache statics and the refresh function body in topological order.
+        // Build AtomicU32 cache statics and per-node downstream refresh functions.
+        // refresh_stmt_by_key holds the token stream that refreshes one configurable node:
+        //   - scalar nodes: refreshes that single node
+        //   - template nodes: refreshes `instance` (a local variable) of that template
         let mut freq_cache_statics: Vec<TokenStream> = vec![];
-        let mut refresh_cache_stmts: Vec<TokenStream> = vec![];
+        let mut refresh_stmt_by_key: IndexMap<String, TokenStream> = IndexMap::new();
         let mut seen_cache_templates: HashSet<String> = HashSet::new();
 
         for node_name in tree.dependency_graph.iter() {
@@ -781,7 +793,7 @@ impl SystemClocks {
                 format!("{}_{}", node.group_template, node.node.name())
             };
 
-            if !seen_cache_templates.insert(template_key) {
+            if !seen_cache_templates.insert(template_key.clone()) {
                 continue;
             }
 
@@ -791,30 +803,19 @@ impl SystemClocks {
             if node.properties.receiver.is_some() {
                 let instances = tree.group_instances.get(&node.group_template).unwrap();
                 let instance_count = number(instances.len());
-                let enum_name = format_ident!(
-                    "{}Instance",
-                    node.group_template
-                        .from_case(Case::Constant)
-                        .to_case(Case::Pascal)
-                );
-                let variants: Vec<_> = instances
-                    .iter()
-                    .map(|v| format_ident!("{}", v.from_case(Case::Constant).to_case(Case::Pascal)))
-                    .collect();
                 let field_name = node.properties.field_name();
 
                 freq_cache_statics.push(quote! {
                     static #cache_name: [::core::sync::atomic::AtomicU32; #instance_count] =
                         [const { ::core::sync::atomic::AtomicU32::new(0) }; #instance_count];
                 });
-                refresh_cache_stmts.push(quote! {
-                    for instance in [#(#enum_name::#variants,)*] {
-                        if let Some(config) = clocks.#field_name[instance as usize] {
-                            #cache_name[instance as usize].store(
-                                instance.#config_freq_fn(clocks, config),
-                                ::core::sync::atomic::Ordering::Release,
-                            );
-                        }
+                // Refresh stmt for template nodes uses an `instance` variable (passed by caller).
+                refresh_stmt_by_key.insert(template_key.clone(), quote! {
+                    if let Some(config) = clocks.#field_name[instance as usize] {
+                        #cache_name[instance as usize].store(
+                            instance.#config_freq_fn(clocks, config),
+                            ::core::sync::atomic::Ordering::Release,
+                        );
                     }
                 });
             } else {
@@ -824,12 +825,142 @@ impl SystemClocks {
                     static #cache_name: ::core::sync::atomic::AtomicU32 =
                         ::core::sync::atomic::AtomicU32::new(0);
                 });
-                refresh_cache_stmts.push(quote! {
+                refresh_stmt_by_key.insert(template_key, quote! {
                     if let Some(config) = #config_field {
                         #cache_name.store(
                             #config_freq_fn(clocks, config),
                             ::core::sync::atomic::Ordering::Release,
                         );
+                    }
+                });
+            }
+        }
+
+        // For each configurable node, emit a targeted downstream refresh function.
+        // Each function refreshes itself and delegates to its direct configurable children's
+        // refresh functions, forming a call chain instead of inlining everything.
+        let mut downstream_refresh_fns: Vec<TokenStream> = vec![];
+        let mut seen_refresh_fns: HashSet<String> = HashSet::new();
+
+        for node_name in tree.dependency_graph.iter() {
+            let Some(node) = tree.try_get_node(&node_name) else {
+                continue;
+            };
+            if !node.is_configurable() {
+                continue;
+            }
+
+            let template_key = if node.group_template.is_empty() {
+                node_name.clone()
+            } else {
+                format!("{}_{}", node.group_template, node.node.name())
+            };
+
+            if !seen_refresh_fns.insert(template_key.clone()) {
+                continue;
+            }
+
+            let fn_name = node.refresh_downstream_function_name();
+            let self_stmt = refresh_stmt_by_key.get(&template_key).cloned();
+
+            // Build calls to direct configurable children's refresh functions.
+            let children = tree
+                .dependency_graph
+                .configurable_children_of(&node_name, tree);
+
+            let child_calls: Vec<TokenStream> = children
+                .iter()
+                .filter_map(|child_name| {
+                    let child = tree.try_get_node(child_name)?;
+                    let child_fn = child.refresh_downstream_function_name();
+
+                    if child.properties.receiver.is_some() {
+                        // Template child — call for each instance.
+                        let instances =
+                            tree.group_instances.get(&child.group_template).unwrap();
+                        let child_enum = format_ident!(
+                            "{}Instance",
+                            child
+                                .group_template
+                                .from_case(Case::Constant)
+                                .to_case(Case::Pascal)
+                        );
+                        let variants: Vec<_> = instances
+                            .iter()
+                            .map(|v| {
+                                format_ident!(
+                                    "{}",
+                                    v.from_case(Case::Constant).to_case(Case::Pascal)
+                                )
+                            })
+                            .collect();
+                        Some(quote! {
+                            for child_instance in [#(#child_enum::#variants,)*] {
+                                #child_fn(clocks, child_instance);
+                            }
+                        })
+                    } else {
+                        Some(quote! { #child_fn(clocks); })
+                    }
+                })
+                .collect();
+
+            if node.properties.receiver.is_some() {
+                // Template node: function takes a typed instance parameter.
+                let enum_name = format_ident!(
+                    "{}Instance",
+                    node.group_template
+                        .from_case(Case::Constant)
+                        .to_case(Case::Pascal)
+                );
+                // For same-template children, pass the current instance instead of looping.
+                let child_calls: Vec<TokenStream> = children
+                    .iter()
+                    .filter_map(|child_name| {
+                        let child = tree.try_get_node(child_name)?;
+                        let child_fn = child.refresh_downstream_function_name();
+                        if child.group_template == node.group_template {
+                            Some(quote! { #child_fn(clocks, instance); })
+                        } else if child.properties.receiver.is_some() {
+                            let instances =
+                                tree.group_instances.get(&child.group_template).unwrap();
+                            let child_enum = format_ident!(
+                                "{}Instance",
+                                child
+                                    .group_template
+                                    .from_case(Case::Constant)
+                                    .to_case(Case::Pascal)
+                            );
+                            let variants: Vec<_> = instances
+                                .iter()
+                                .map(|v| {
+                                    format_ident!(
+                                        "{}",
+                                        v.from_case(Case::Constant).to_case(Case::Pascal)
+                                    )
+                                })
+                                .collect();
+                            Some(quote! {
+                                for child_instance in [#(#child_enum::#variants,)*] {
+                                    #child_fn(clocks, child_instance);
+                                }
+                            })
+                        } else {
+                            Some(quote! { #child_fn(clocks); })
+                        }
+                    })
+                    .collect();
+                downstream_refresh_fns.push(quote! {
+                    fn #fn_name(clocks: &mut ClockTree, instance: #enum_name) {
+                        #self_stmt
+                        #(#child_calls)*
+                    }
+                });
+            } else {
+                downstream_refresh_fns.push(quote! {
+                    fn #fn_name(clocks: &mut ClockTree) {
+                        #self_stmt
+                        #(#child_calls)*
                     }
                 });
             }
@@ -910,9 +1041,7 @@ impl SystemClocks {
                         // CLOCK_BITMAP.fetch_and(!clock_id, Ordering::Relaxed);
                         last
                     }
-                    fn refresh_all_frequency_caches(clocks: &mut ClockTree) {
-                        #(#refresh_cache_stmts)*
-                    }
+                    #(#downstream_refresh_fns)*
                 };
             }
         })

--- a/esp-metadata/src/cfg/soc.rs
+++ b/esp-metadata/src/cfg/soc.rs
@@ -799,9 +799,7 @@ impl SystemClocks {
                 );
                 let variants: Vec<_> = instances
                     .iter()
-                    .map(|v| {
-                        format_ident!("{}", v.from_case(Case::Constant).to_case(Case::Pascal))
-                    })
+                    .map(|v| format_ident!("{}", v.from_case(Case::Constant).to_case(Case::Pascal)))
                     .collect();
                 let field_name = node.properties.field_name();
 

--- a/esp-metadata/src/cfg/soc.rs
+++ b/esp-metadata/src/cfg/soc.rs
@@ -293,22 +293,20 @@ impl ClockTreeNodeInstance {
         self.prefix_function("configure")
     }
 
-    pub(super) fn freq_cache_static_name(&self) -> Ident {
-        let name = if self.group_template.is_empty() {
+    fn node_ident_base(&self) -> String {
+        if self.group_template.is_empty() {
             self.name.clone()
         } else {
             format!("{}_{}", self.group_template, self.node.name())
-        };
-        format_ident!("{}_FREQ_CACHE", name)
+        }
+    }
+
+    pub(super) fn freq_cache_static_name(&self) -> Ident {
+        format_ident!("{}_FREQ_CACHE", self.node_ident_base())
     }
 
     pub(super) fn refresh_downstream_function_name(&self) -> Ident {
-        let name = if self.group_template.is_empty() {
-            self.name.clone()
-        } else {
-            format!("{}_{}", self.group_template, self.node.name())
-        };
-        format_ident!("refresh_{}_downstream", name.to_lowercase())
+        format_ident!("refresh_{}_downstream", self.node_ident_base().to_lowercase())
     }
 
     fn current_config_function_name(&self) -> Ident {
@@ -787,11 +785,7 @@ impl SystemClocks {
                 continue;
             }
 
-            let template_key = if node.group_template.is_empty() {
-                node_name.clone()
-            } else {
-                format!("{}_{}", node.group_template, node.node.name())
-            };
+            let template_key = node.node_ident_base();
 
             if !seen_cache_templates.insert(template_key.clone()) {
                 continue;
@@ -836,6 +830,29 @@ impl SystemClocks {
             }
         }
 
+        // Helper: generates a `for child_instance in [...] { child_fn(clocks, child_instance); }`
+        // call for a template-group child node.
+        let template_child_call =
+            |tree: &ProcessedClockData, child: &ClockTreeNodeInstance, child_fn: &Ident| {
+                let instances = tree.group_instances.get(&child.group_template).unwrap();
+                let child_enum = format_ident!(
+                    "{}Instance",
+                    child
+                        .group_template
+                        .from_case(Case::Constant)
+                        .to_case(Case::Pascal)
+                );
+                let variants: Vec<_> = instances
+                    .iter()
+                    .map(|v| format_ident!("{}", v.from_case(Case::Constant).to_case(Case::Pascal)))
+                    .collect();
+                quote! {
+                    for child_instance in [#(#child_enum::#variants,)*] {
+                        #child_fn(clocks, child_instance);
+                    }
+                }
+            };
+
         // For each configurable node, emit a targeted downstream refresh function.
         // Each function refreshes itself and delegates to its direct configurable children's
         // refresh functions, forming a call chain instead of inlining everything.
@@ -850,11 +867,7 @@ impl SystemClocks {
                 continue;
             }
 
-            let template_key = if node.group_template.is_empty() {
-                node_name.clone()
-            } else {
-                format!("{}_{}", node.group_template, node.node.name())
-            };
+            let template_key = node.node_ident_base();
 
             if !seen_refresh_fns.insert(template_key.clone()) {
                 continue;
@@ -868,52 +881,15 @@ impl SystemClocks {
                 .dependency_graph
                 .configurable_children_of(&node_name, tree);
 
-            let child_calls: Vec<TokenStream> = children
-                .iter()
-                .filter_map(|child_name| {
-                    let child = tree.try_get_node(child_name)?;
-                    let child_fn = child.refresh_downstream_function_name();
-
-                    if child.properties.receiver.is_some() {
-                        // Template child — call for each instance.
-                        let instances =
-                            tree.group_instances.get(&child.group_template).unwrap();
-                        let child_enum = format_ident!(
-                            "{}Instance",
-                            child
-                                .group_template
-                                .from_case(Case::Constant)
-                                .to_case(Case::Pascal)
-                        );
-                        let variants: Vec<_> = instances
-                            .iter()
-                            .map(|v| {
-                                format_ident!(
-                                    "{}",
-                                    v.from_case(Case::Constant).to_case(Case::Pascal)
-                                )
-                            })
-                            .collect();
-                        Some(quote! {
-                            for child_instance in [#(#child_enum::#variants,)*] {
-                                #child_fn(clocks, child_instance);
-                            }
-                        })
-                    } else {
-                        Some(quote! { #child_fn(clocks); })
-                    }
-                })
-                .collect();
-
             if node.properties.receiver.is_some() {
                 // Template node: function takes a typed instance parameter.
+                // Same-template children receive the current instance; others loop over instances.
                 let enum_name = format_ident!(
                     "{}Instance",
                     node.group_template
                         .from_case(Case::Constant)
                         .to_case(Case::Pascal)
                 );
-                // For same-template children, pass the current instance instead of looping.
                 let child_calls: Vec<TokenStream> = children
                     .iter()
                     .filter_map(|child_name| {
@@ -922,29 +898,7 @@ impl SystemClocks {
                         if child.group_template == node.group_template {
                             Some(quote! { #child_fn(clocks, instance); })
                         } else if child.properties.receiver.is_some() {
-                            let instances =
-                                tree.group_instances.get(&child.group_template).unwrap();
-                            let child_enum = format_ident!(
-                                "{}Instance",
-                                child
-                                    .group_template
-                                    .from_case(Case::Constant)
-                                    .to_case(Case::Pascal)
-                            );
-                            let variants: Vec<_> = instances
-                                .iter()
-                                .map(|v| {
-                                    format_ident!(
-                                        "{}",
-                                        v.from_case(Case::Constant).to_case(Case::Pascal)
-                                    )
-                                })
-                                .collect();
-                            Some(quote! {
-                                for child_instance in [#(#child_enum::#variants,)*] {
-                                    #child_fn(clocks, child_instance);
-                                }
-                            })
+                            Some(template_child_call(tree, child, &child_fn))
                         } else {
                             Some(quote! { #child_fn(clocks); })
                         }
@@ -957,6 +911,19 @@ impl SystemClocks {
                     }
                 });
             } else {
+                // System (scalar) node: no instance parameter.
+                let child_calls: Vec<TokenStream> = children
+                    .iter()
+                    .filter_map(|child_name| {
+                        let child = tree.try_get_node(child_name)?;
+                        let child_fn = child.refresh_downstream_function_name();
+                        if child.properties.receiver.is_some() {
+                            Some(template_child_call(tree, child, &child_fn))
+                        } else {
+                            Some(quote! { #child_fn(clocks); })
+                        }
+                    })
+                    .collect();
                 downstream_refresh_fns.push(quote! {
                     fn #fn_name(clocks: &mut ClockTree) {
                         #self_stmt

--- a/esp-metadata/src/cfg/soc.rs
+++ b/esp-metadata/src/cfg/soc.rs
@@ -306,7 +306,10 @@ impl ClockTreeNodeInstance {
     }
 
     pub(super) fn refresh_downstream_function_name(&self) -> Ident {
-        format_ident!("refresh_{}_downstream", self.node_ident_base().to_lowercase())
+        format_ident!(
+            "refresh_{}_downstream",
+            self.node_ident_base().to_lowercase()
+        )
     }
 
     fn current_config_function_name(&self) -> Ident {
@@ -804,14 +807,17 @@ impl SystemClocks {
                         [const { ::core::sync::atomic::AtomicU32::new(0) }; #instance_count];
                 });
                 // Refresh stmt for template nodes uses an `instance` variable (passed by caller).
-                refresh_stmt_by_key.insert(template_key.clone(), quote! {
-                    if let Some(config) = clocks.#field_name[instance as usize] {
-                        #cache_name[instance as usize].store(
-                            instance.#config_freq_fn(clocks, config),
-                            ::core::sync::atomic::Ordering::Release,
-                        );
-                    }
-                });
+                refresh_stmt_by_key.insert(
+                    template_key.clone(),
+                    quote! {
+                        if let Some(config) = clocks.#field_name[instance as usize] {
+                            #cache_name[instance as usize].store(
+                                instance.#config_freq_fn(clocks, config),
+                                ::core::sync::atomic::Ordering::Release,
+                            );
+                        }
+                    },
+                );
             } else {
                 let config_field = node.properties.indexed_config_accessor();
 
@@ -819,14 +825,17 @@ impl SystemClocks {
                     static #cache_name: ::core::sync::atomic::AtomicU32 =
                         ::core::sync::atomic::AtomicU32::new(0);
                 });
-                refresh_stmt_by_key.insert(template_key, quote! {
-                    if let Some(config) = #config_field {
-                        #cache_name.store(
-                            #config_freq_fn(clocks, config),
-                            ::core::sync::atomic::Ordering::Release,
-                        );
-                    }
-                });
+                refresh_stmt_by_key.insert(
+                    template_key,
+                    quote! {
+                        if let Some(config) = #config_field {
+                            #cache_name.store(
+                                #config_freq_fn(clocks, config),
+                                ::core::sync::atomic::Ordering::Release,
+                            );
+                        }
+                    },
+                );
             }
         }
 

--- a/esp-metadata/src/cfg/soc/clock_tree.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree.rs
@@ -201,15 +201,17 @@ impl DependencyGraph {
         node: &str,
         tree: &ProcessedClockData,
     ) -> Vec<String> {
-        let mut result = Vec::new();
-        let mut visited = IndexSet::new();
+        let mut found: IndexSet<String> = IndexSet::new();
+        let mut visited: IndexSet<String> = IndexSet::new();
         let mut queue: Vec<String> = self.users(node).to_vec();
         while let Some(n) = queue.pop() {
             if !visited.insert(n.clone()) {
                 continue;
             }
             match tree.try_get_node(&n) {
-                Some(inst) if inst.is_configurable() => result.push(n),
+                Some(inst) if inst.is_configurable() => {
+                    found.insert(n);
+                }
                 _ => {
                     for user in self.users(&n) {
                         queue.push(user.clone());
@@ -217,37 +219,9 @@ impl DependencyGraph {
                 }
             }
         }
-        self.iter().filter(|n| result.contains(n)).collect()
+        self.iter().filter(|n| found.contains(n.as_str())).collect()
     }
 
-    /// Returns all configurable nodes that are transitively downstream of `node`
-    /// (including `node` itself), in topological order.
-    pub fn downstream_configurable_of(
-        &self,
-        node: &str,
-        tree: &ProcessedClockData,
-    ) -> Vec<String> {
-        // BFS forward through the graph (upstream → downstream direction).
-        let mut reachable = IndexSet::new();
-        let mut queue = vec![node.to_string()];
-        while let Some(n) = queue.pop() {
-            if !reachable.insert(n.clone()) {
-                continue;
-            }
-            for user in self.users(&n) {
-                queue.push(user.clone());
-            }
-        }
-        // Preserve topological order, keeping only configurable nodes.
-        self.iter()
-            .filter(|n| {
-                reachable.contains(n.as_str())
-                    && tree
-                        .try_get_node(n)
-                        .is_some_and(|inst| inst.is_configurable())
-            })
-            .collect()
-    }
 }
 
 fn topological_sort(dep_graph: &IndexMap<String, Vec<String>>) -> impl Iterator<Item = String> {

--- a/esp-metadata/src/cfg/soc/clock_tree.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree.rs
@@ -196,11 +196,7 @@ impl DependencyGraph {
 
     /// Returns the nearest configurable nodes directly downstream of `node`, in topological order.
     /// The search stops at each configurable node found (does not look through them).
-    pub fn configurable_children_of(
-        &self,
-        node: &str,
-        tree: &ProcessedClockData,
-    ) -> Vec<String> {
+    pub fn configurable_children_of(&self, node: &str, tree: &ProcessedClockData) -> Vec<String> {
         let mut found: IndexSet<String> = IndexSet::new();
         let mut visited: IndexSet<String> = IndexSet::new();
         let mut queue: Vec<String> = self.users(node).to_vec();
@@ -221,7 +217,6 @@ impl DependencyGraph {
         }
         self.iter().filter(|n| found.contains(n.as_str())).collect()
     }
-
 }
 
 fn topological_sort(dep_graph: &IndexMap<String, Vec<String>>) -> impl Iterator<Item = String> {

--- a/esp-metadata/src/cfg/soc/clock_tree.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree.rs
@@ -40,7 +40,7 @@
 use std::{any::Any, collections::HashMap, str::FromStr};
 
 use anyhow::{Context, Result};
-use indexmap::IndexMap;
+use indexmap::{IndexMap, IndexSet};
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
 use serde::{
@@ -192,6 +192,61 @@ impl DependencyGraph {
     /// Returns the names of nodes in a topological order.
     pub fn iter(&self) -> impl Iterator<Item = String> {
         topological_sort(&self.reverse_graph)
+    }
+
+    /// Returns the nearest configurable nodes directly downstream of `node`, in topological order.
+    /// The search stops at each configurable node found (does not look through them).
+    pub fn configurable_children_of(
+        &self,
+        node: &str,
+        tree: &ProcessedClockData,
+    ) -> Vec<String> {
+        let mut result = Vec::new();
+        let mut visited = IndexSet::new();
+        let mut queue: Vec<String> = self.users(node).to_vec();
+        while let Some(n) = queue.pop() {
+            if !visited.insert(n.clone()) {
+                continue;
+            }
+            match tree.try_get_node(&n) {
+                Some(inst) if inst.is_configurable() => result.push(n),
+                _ => {
+                    for user in self.users(&n) {
+                        queue.push(user.clone());
+                    }
+                }
+            }
+        }
+        self.iter().filter(|n| result.contains(n)).collect()
+    }
+
+    /// Returns all configurable nodes that are transitively downstream of `node`
+    /// (including `node` itself), in topological order.
+    pub fn downstream_configurable_of(
+        &self,
+        node: &str,
+        tree: &ProcessedClockData,
+    ) -> Vec<String> {
+        // BFS forward through the graph (upstream → downstream direction).
+        let mut reachable = IndexSet::new();
+        let mut queue = vec![node.to_string()];
+        while let Some(n) = queue.pop() {
+            if !reachable.insert(n.clone()) {
+                continue;
+            }
+            for user in self.users(&n) {
+                queue.push(user.clone());
+            }
+        }
+        // Preserve topological order, keeping only configurable nodes.
+        self.iter()
+            .filter(|n| {
+                reachable.contains(n.as_str())
+                    && tree
+                        .try_get_node(n)
+                        .is_some_and(|inst| inst.is_configurable())
+            })
+            .collect()
     }
 }
 

--- a/esp-metadata/src/cfg/soc/clock_tree.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree.rs
@@ -664,7 +664,7 @@ impl RejectExpression {
                 // Referring to a node by name resolves to its output frequency.
                 let node = instance.resolve_node(tree, var);
                 let freq_fn = node.frequency_function_name();
-                variables.insert(var, quote! { #freq_fn(clocks) });
+                variables.insert(var, quote! { #freq_fn() });
 
                 // Only run the assert if the referenced nodes have been configured
                 let config_field = node.properties.indexed_config_accessor();

--- a/esp-metadata/src/cfg/soc/clock_tree/generic.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/generic.rs
@@ -308,6 +308,8 @@ impl ClockTreeNodeType for Generic {
                 let old_config = #config_field.replace(config);
 
                 #func_body
+
+                refresh_all_frequency_caches(clocks);
             }
         }
     }

--- a/esp-metadata/src/cfg/soc/clock_tree/generic.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/generic.rs
@@ -313,9 +313,9 @@ impl ClockTreeNodeType for Generic {
                 #reject_exprs
                 let old_config = #config_field.replace(config);
 
-                #func_body
-
                 #refresh_call
+
+                #func_body
             }
         }
     }

--- a/esp-metadata/src/cfg/soc/clock_tree/generic.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/generic.rs
@@ -219,6 +219,12 @@ impl ClockTreeNodeType for Generic {
         let hal_impl = format_ident!("{apply_fn_name}_impl");
         let receiver = instance.properties.receiver();
         let hal_impl = quote! { #(#receiver.)* #hal_impl };
+        let refresh_fn = instance.refresh_downstream_function_name();
+        let refresh_call = if instance.properties.receiver.is_some() {
+            quote! { #refresh_fn(clocks, self); }
+        } else {
+            quote! { #refresh_fn(clocks); }
+        };
 
         // TODO: support reject exprs - implement `value(node, property)` in expressions
 
@@ -309,7 +315,7 @@ impl ClockTreeNodeType for Generic {
 
                 #func_body
 
-                refresh_all_frequency_caches(clocks);
+                #refresh_call
             }
         }
     }

--- a/esp-metadata/src/cfg/soc/clock_tree/generic.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/generic.rs
@@ -380,7 +380,7 @@ impl ClockTreeNodeType for Generic {
                     for clock in tree.clock_tree.values() {
                         let clock_name = clock.name_str().as_str();
                         let frequency_fn = clock.frequency_function_name();
-                        variables.insert(clock_name, quote! { #frequency_fn(clocks) });
+                        variables.insert(clock_name, quote! { #frequency_fn() });
                     }
 
                     let cfg_expr_code = ExprCompiler::new(&variables)
@@ -453,13 +453,13 @@ impl ClockTreeNodeType for Generic {
                 let source_node = instance.resolve_node(tree, &input);
                 let source_receiver = source_node.properties.receiver();
                 let freq_fn = source_node.frequency_function_name();
-                quote! { #(#source_receiver.)* #freq_fn(clocks) }
+                quote! { #(#source_receiver.)* #freq_fn() }
             }
             ClockSource::Mux(input) if input.len() == 1 => {
                 let source_node = instance.resolve_node(tree, &input[0].outputs);
                 let source_receiver = source_node.properties.receiver();
                 let freq_fn = source_node.frequency_function_name();
-                quote! { #(#source_receiver.)* #freq_fn(clocks) }
+                quote! { #(#source_receiver.)* #freq_fn() }
             }
             ClockSource::Mux(inputs) => {
                 let ty_name = self.param_type_name(instance, source_param_name);
@@ -475,7 +475,7 @@ impl ClockTreeNodeType for Generic {
 
                         (
                             quote! { #ty_name::#name },
-                            quote! { #(#source_receiver.)* #frequency_fn(clocks) },
+                            quote! { #(#source_receiver.)* #frequency_fn() },
                         )
                     })
                     .unzip::<_, _, Vec<_>, Vec<_>>();

--- a/esp-metadata/src/cfg/soc/clock_tree/mux.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/mux.rs
@@ -147,7 +147,6 @@ impl ClockTreeNodeType for Multiplexer {
             .iter()
             .map(|variant| {
                 let name = variant.config_enum_variant_name();
-
                 quote! { #ty_name::#name }
             })
             .collect::<Vec<_>>();
@@ -159,7 +158,6 @@ impl ClockTreeNodeType for Multiplexer {
                 let upstream_node = instance.resolve_node(tree, &variant.outputs);
                 let frequency_fn = upstream_node.frequency_function_name();
                 let receiver = upstream_node.properties.receiver();
-
                 quote! { #(#receiver.)* #frequency_fn() }
             })
             .collect::<Vec<_>>();
@@ -172,9 +170,7 @@ impl ClockTreeNodeType for Multiplexer {
             }
         } else {
             let variant_frequency = variant_frequencies.first().unwrap();
-            quote! {
-                #variant_frequency
-            }
+            quote! { #variant_frequency }
         }
     }
 
@@ -324,11 +320,11 @@ impl Multiplexer {
             pub fn #apply_fn_name(#(#receiver,)* clocks: &mut ClockTree, new_selector: #ty_name) {
                 let old_selector = #config_field.replace(new_selector);
 
+                #refresh_call
+
                 #configures
 
                 #apply_impl
-
-                #refresh_call
             }
         }
     }

--- a/esp-metadata/src/cfg/soc/clock_tree/mux.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/mux.rs
@@ -160,7 +160,7 @@ impl ClockTreeNodeType for Multiplexer {
                 let frequency_fn = upstream_node.frequency_function_name();
                 let receiver = upstream_node.properties.receiver();
 
-                quote! { #(#receiver.)* #frequency_fn(clocks) }
+                quote! { #(#receiver.)* #frequency_fn() }
             })
             .collect::<Vec<_>>();
 

--- a/esp-metadata/src/cfg/soc/clock_tree/mux.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/mux.rs
@@ -321,6 +321,8 @@ impl Multiplexer {
                 #configures
 
                 #apply_impl
+
+                refresh_all_frequency_caches(clocks);
             }
         }
     }

--- a/esp-metadata/src/cfg/soc/clock_tree/mux.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/mux.rs
@@ -249,6 +249,12 @@ impl Multiplexer {
         let hal_impl = format_ident!("{}_impl", apply_fn_name);
         let config_field = instance.properties.indexed_config_accessor();
         let receiver = instance.properties.receiver();
+        let refresh_fn = instance.refresh_downstream_function_name();
+        let refresh_call = if instance.properties.receiver.is_some() {
+            quote! { #refresh_fn(clocks, self); }
+        } else {
+            quote! { #refresh_fn(clocks); }
+        };
 
         let hal_impl = quote! { #(#receiver.)*#hal_impl };
 
@@ -322,7 +328,7 @@ impl Multiplexer {
 
                 #apply_impl
 
-                refresh_all_frequency_caches(clocks);
+                #refresh_call
             }
         }
     }

--- a/esp-metadata/src/cfg/soc/clock_tree/source.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/source.rs
@@ -115,8 +115,8 @@ impl ClockTreeNodeType for Source {
             pub fn #apply_fn_name(clocks: &mut ClockTree, config: #ty_name) {
                 #reject_exprs
                 let old_config = #config_field.replace(config);
-                #hal_impl(clocks, old_config, config);
                 #refresh_fn(clocks);
+                #hal_impl(clocks, old_config, config);
             }
         }
     }

--- a/esp-metadata/src/cfg/soc/clock_tree/source.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/source.rs
@@ -103,6 +103,7 @@ impl ClockTreeNodeType for Source {
         let config_field = instance.properties.indexed_config_accessor();
         let apply_fn_name = instance.config_apply_function_name();
         let hal_impl = format_ident!("{}_impl", apply_fn_name);
+        let refresh_fn = instance.refresh_downstream_function_name();
         let reject_exprs = self.reject.as_ref().map(|reject| {
             let mut variables = HashMap::new();
 
@@ -115,7 +116,7 @@ impl ClockTreeNodeType for Source {
                 #reject_exprs
                 let old_config = #config_field.replace(config);
                 #hal_impl(clocks, old_config, config);
-                refresh_all_frequency_caches(clocks);
+                #refresh_fn(clocks);
             }
         }
     }

--- a/esp-metadata/src/cfg/soc/clock_tree/source.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/source.rs
@@ -115,6 +115,7 @@ impl ClockTreeNodeType for Source {
                 #reject_exprs
                 let old_config = #config_field.replace(config);
                 #hal_impl(clocks, old_config, config);
+                refresh_all_frequency_caches(clocks);
             }
         }
     }


### PR DESCRIPTION
Claude-assisted PR, still in progress.

This PR aims to optimize access to the currently configured clock speeds. This is done by caching them in atomic variables, and updating them when a clock node or its upstream dependencies are updated. This change allows removing the `Clocks` struct entirely, which is also done in this PR.