### PR TITLE
Fix typo, remove hall sensor code

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -19,9 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - RSA: the driver should no longer cause unhandled interrupts to fire (#5443)
+- ESP32: attenuation is now correctly set for ADC2 (#5463)
 
 ### Removed
 
+- ESP32: removed unsupported Hall-effect sensor API (#5463)
 
 ## [v1.1.0] - 2026-04-24
 

--- a/esp-hal/src/analog/adc/calibration/basic.rs
+++ b/esp-hal/src/analog/adc/calibration/basic.rs
@@ -20,32 +20,32 @@ use crate::analog::adc::{
 /// range because bias correction is done *before* the ADC's output is truncated
 /// to 12 bits.
 #[derive(Clone, Copy)]
-pub struct AdcCalBasic<ADCI> {
+pub struct AdcCalBasic<ADCX> {
     /// Calibration value to set to ADC unit
     cal_val: u16,
 
     #[cfg(esp32c5)]
     chan_compens: i32,
 
-    _phantom: PhantomData<ADCI>,
+    _phantom: PhantomData<ADCX>,
 }
 
-impl<ADCI> crate::private::Sealed for AdcCalBasic<ADCI> {}
+impl<ADCX> crate::private::Sealed for AdcCalBasic<ADCX> {}
 
-impl<ADCI> AdcCalScheme<ADCI> for AdcCalBasic<ADCI>
+impl<ADCX> AdcCalScheme<ADCX> for AdcCalBasic<ADCX>
 where
-    ADCI: AdcCalEfuse + CalibrationAccess,
+    ADCX: AdcCalEfuse + CalibrationAccess,
 {
     fn new_cal(atten: Attenuation) -> Self {
         // Try to get init code (Dout0) from efuse
         // Dout0 means mean raw ADC value when zero voltage applied to input.
-        let cal_val = ADCI::init_code(atten).unwrap_or_else(|| {
+        let cal_val = ADCX::init_code(atten).unwrap_or_else(|| {
             // As a fallback try to calibrate via connecting input to ground internally.
-            AdcConfig::<ADCI>::adc_calibrate(atten, AdcCalSource::Gnd)
+            AdcConfig::<ADCX>::adc_calibrate(atten, AdcCalSource::Gnd)
         });
 
         #[cfg(esp32c5)]
-        let chan_compens = ADCI::cal_chan_compens(atten, ADCI::ADC_CAL_CHANNEL).unwrap_or(0);
+        let chan_compens = ADCX::cal_chan_compens(atten, ADCX::ADC_CAL_CHANNEL).unwrap_or(0);
 
         Self {
             cal_val,
@@ -63,6 +63,6 @@ where
     #[cfg(esp32c5)]
     fn adc_val(&self, val: u16) -> u16 {
         val.saturating_sub(self.chan_compens as u16)
-            .clamp(0, ADCI::ADC_VAL_MASK)
+            .clamp(0, ADCX::ADC_VAL_MASK)
     }
 }

--- a/esp-hal/src/analog/adc/calibration/curve.rs
+++ b/esp-hal/src/analog/adc/calibration/curve.rs
@@ -43,8 +43,8 @@ pub trait AdcHasCurveCal {
 /// This scheme also includes basic calibration ([`super::AdcCalBasic`]) and
 /// line fitting ([`AdcCalLine`]).
 #[derive(Clone, Copy)]
-pub struct AdcCalCurve<ADCI> {
-    line: AdcCalLine<ADCI>,
+pub struct AdcCalCurve<ADCX> {
+    line: AdcCalLine<ADCX>,
 
     /// Coefficients of the error estimation polynomial.
     ///
@@ -57,19 +57,19 @@ pub struct AdcCalCurve<ADCI> {
     /// subtracted from linear calibration's output to get the final reading.
     coeff: &'static [CurveCoeff],
 
-    _phantom: PhantomData<ADCI>,
+    _phantom: PhantomData<ADCX>,
 }
 
-impl<ADCI> crate::private::Sealed for AdcCalCurve<ADCI> {}
+impl<ADCX> crate::private::Sealed for AdcCalCurve<ADCX> {}
 
-impl<ADCI> AdcCalScheme<ADCI> for AdcCalCurve<ADCI>
+impl<ADCX> AdcCalScheme<ADCX> for AdcCalCurve<ADCX>
 where
-    ADCI: AdcCalEfuse + AdcHasLineCal + AdcHasCurveCal + CalibrationAccess,
+    ADCX: AdcCalEfuse + AdcHasLineCal + AdcHasCurveCal + CalibrationAccess,
 {
     fn new_cal(atten: Attenuation) -> Self {
-        let line = AdcCalLine::<ADCI>::new_cal(atten);
+        let line = AdcCalLine::<ADCX>::new_cal(atten);
 
-        let coeff = ADCI::CURVES_COEFFS
+        let coeff = ADCX::CURVES_COEFFS
             .iter()
             .find(|item| item.atten == atten)
             .expect("No curve coefficients for given attenuation")

--- a/esp-hal/src/analog/adc/calibration/line.rs
+++ b/esp-hal/src/analog/adc/calibration/line.rs
@@ -35,8 +35,8 @@ const GAIN_SCALE: u32 = 1 << 16;
 ///
 /// This scheme also includes basic calibration ([`AdcCalBasic`]).
 #[derive(Clone, Copy)]
-pub struct AdcCalLine<ADCI> {
-    basic: AdcCalBasic<ADCI>,
+pub struct AdcCalLine<ADCX> {
+    basic: AdcCalBasic<ADCX>,
 
     /// ADC gain.
     ///
@@ -45,28 +45,28 @@ pub struct AdcCalLine<ADCI> {
     /// number with 16 fractional bits.
     gain: u32,
 
-    _phantom: PhantomData<ADCI>,
+    _phantom: PhantomData<ADCX>,
 }
 
-impl<ADCI> crate::private::Sealed for AdcCalLine<ADCI> {}
+impl<ADCX> crate::private::Sealed for AdcCalLine<ADCX> {}
 
-impl<ADCI> AdcCalScheme<ADCI> for AdcCalLine<ADCI>
+impl<ADCX> AdcCalScheme<ADCX> for AdcCalLine<ADCX>
 where
-    ADCI: AdcCalEfuse + AdcHasLineCal + CalibrationAccess,
+    ADCX: AdcCalEfuse + AdcHasLineCal + CalibrationAccess,
 {
     fn new_cal(atten: Attenuation) -> Self {
-        let basic = AdcCalBasic::<ADCI>::new_cal(atten);
+        let basic = AdcCalBasic::<ADCX>::new_cal(atten);
 
         // Try get the reference point (Dout, Vin) from efuse
         // Dout means mean raw ADC value when specified Vin applied to input.
-        let (code, mv) = ADCI::cal_code(atten)
-            .map(|code| (code, ADCI::cal_mv(atten)))
+        let (code, mv) = ADCX::cal_code(atten)
+            .map(|code| (code, ADCX::cal_mv(atten)))
             .unwrap_or_else(|| {
                 // As a fallback try to calibrate using reference voltage source.
                 // This method is not too good because actual reference voltage may varies
                 // in range 1000..=1200 mV and this value currently cannot be read from efuse.
                 (
-                    AdcConfig::<ADCI>::adc_calibrate(atten, AdcCalSource::Ref),
+                    AdcConfig::<ADCX>::adc_calibrate(atten, AdcCalSource::Ref),
                     1100, // use 1100 mV as a middle of typical reference voltage range
                 )
             });

--- a/esp-hal/src/analog/adc/esp32.rs
+++ b/esp-hal/src/analog/adc/esp32.rs
@@ -5,8 +5,8 @@ use core::{
 
 use super::{AdcConfig, Attenuation};
 use crate::{
-    peripherals::{ADC1, ADC2, RTC_IO, SENS},
-    private::{self},
+    peripherals::{ADC1, ADC2, SENS},
+    private,
 };
 
 pub(super) const NUM_ATTENS: usize = 10;

--- a/esp-hal/src/analog/adc/esp32.rs
+++ b/esp-hal/src/analog/adc/esp32.rs
@@ -267,7 +267,7 @@ where
 
         for (channel, attentuation) in attenuations.iter().enumerate() {
             if let Some(attenuation) = attentuation {
-                ADC1::set_attenuation(channel, *attenuation as u8);
+                ADCI::set_attenuation(channel, *attenuation as u8);
             }
         }
 
@@ -362,22 +362,6 @@ where
         self.active_channel = None;
 
         Ok(converted_value)
-    }
-}
-
-impl<ADC1> Adc<'_, ADC1, crate::Blocking> {
-    /// Enable the Hall sensor
-    pub fn enable_hall_sensor() {
-        RTC_IO::regs()
-            .hall_sens()
-            .modify(|_, w| w.xpd_hall().set_bit());
-    }
-
-    /// Disable the Hall sensor
-    pub fn disable_hall_sensor() {
-        RTC_IO::regs()
-            .hall_sens()
-            .modify(|_, w| w.xpd_hall().clear_bit());
     }
 }
 

--- a/esp-hal/src/analog/adc/esp32.rs
+++ b/esp-hal/src/analog/adc/esp32.rs
@@ -239,9 +239,9 @@ pub struct Adc<'d, ADC, Dm: crate::DriverMode> {
     _phantom: PhantomData<(Dm, &'d mut ())>,
 }
 
-impl<'d, ADCI> Adc<'d, ADCI, crate::Blocking>
+impl<'d, ADCX> Adc<'d, ADCX, crate::Blocking>
 where
-    ADCI: RegisterAccess + 'd,
+    ADCX: RegisterAccess + 'd,
 {
     /// Configure a given ADC instance using the provided configuration, and
     /// initialize the ADC for use
@@ -250,8 +250,8 @@ where
     ///
     /// `ADC2` cannot be used simultaneously with `radio` functionalities, otherwise this function
     /// will panic.
-    pub fn new(adc_instance: ADCI, config: AdcConfig<ADCI>) -> Self {
-        if ADCI::instance_number() == 2 && try_claim_adc2(private::Internal).is_err() {
+    pub fn new(adc_instance: ADCX, config: AdcConfig<ADCX>) -> Self {
+        if ADCX::instance_number() == 2 && try_claim_adc2(private::Internal).is_err() {
             panic!(
                 "ADC2 is already in use by Radio. On ESP32, ADC2 cannot be used simultaneously with Wi-Fi or Bluetooth."
             );
@@ -260,21 +260,21 @@ where
         let sensors = SENS::regs();
 
         // Set reading and sampling resolution
-        ADCI::set_resolution(config.resolution as u8);
+        ADCX::set_resolution(config.resolution as u8);
 
         // Set attenuation for pins
         let attenuations = config.attenuations;
 
         for (channel, attenuation) in attenuations.iter().enumerate() {
             if let Some(attenuation) = attenuation {
-                ADCI::set_attenuation(channel, *attenuation as u8);
+                ADCX::set_attenuation(channel, *attenuation as u8);
             }
         }
 
         // Set controller to RTC
-        ADCI::clear_dig_force();
-        ADCI::set_start_force();
-        ADCI::set_en_pad_force();
+        ADCX::clear_dig_force();
+        ADCX::set_start_force();
+        ADCX::set_en_pad_force();
         sensors.sar_touch_ctrl1().modify(|_, w| {
             w.xpd_hall_force().set_bit();
             w.hall_phase_force().set_bit()
@@ -321,7 +321,7 @@ where
     /// This method takes an [AdcPin](super::AdcPin) reference, as it is
     /// expected that the ADC will be able to sample whatever channel
     /// underlies the pin.
-    pub fn read_oneshot<PIN>(&mut self, pin: &mut super::AdcPin<PIN, ADCI>) -> nb::Result<u16, ()>
+    pub fn read_oneshot<PIN>(&mut self, pin: &mut super::AdcPin<PIN, ADCX>) -> nb::Result<u16, ()>
     where
         PIN: super::AdcChannel,
     {
@@ -343,20 +343,20 @@ where
             // If no conversions are in progress, start a new one for given channel
             self.active_channel = Some(pin.pin.adc_channel());
 
-            ADCI::set_en_pad(pin.pin.adc_channel());
+            ADCX::set_en_pad(pin.pin.adc_channel());
 
-            ADCI::clear_start_sar();
-            ADCI::set_start_sar();
+            ADCX::clear_start_sar();
+            ADCX::set_start_sar();
         }
 
         // Wait for ADC to finish conversion
-        let conversion_finished = ADCI::read_done_sar();
+        let conversion_finished = ADCX::read_done_sar();
         if !conversion_finished {
             return Err(nb::Error::WouldBlock);
         }
 
         // Get converted value
-        let converted_value = ADCI::read_data_sar();
+        let converted_value = ADCX::read_data_sar();
 
         // Mark that no conversions are currently in progress
         self.active_channel = None;

--- a/esp-hal/src/analog/adc/esp32.rs
+++ b/esp-hal/src/analog/adc/esp32.rs
@@ -265,8 +265,8 @@ where
         // Set attenuation for pins
         let attenuations = config.attenuations;
 
-        for (channel, attentuation) in attenuations.iter().enumerate() {
-            if let Some(attenuation) = attentuation {
+        for (channel, attenuation) in attenuations.iter().enumerate() {
+            if let Some(attenuation) = attenuation {
                 ADCI::set_attenuation(channel, *attenuation as u8);
             }
         }

--- a/esp-hal/src/analog/adc/mod.rs
+++ b/esp-hal/src/analog/adc/mod.rs
@@ -97,15 +97,15 @@ pub enum AdcCalSource {
 }
 
 /// An I/O pin which can be read using the ADC.
-pub struct AdcPin<PIN, ADCI, CS = ()> {
+pub struct AdcPin<PIN, ADCX, CS = ()> {
     /// The underlying GPIO pin
     pub pin: PIN,
     /// Calibration scheme used for the configured ADC pin
     pub cal_scheme: CS,
-    _phantom: PhantomData<ADCI>,
+    _phantom: PhantomData<ADCX>,
 }
 
-impl<PIN: core::fmt::Debug, ADCI, CS: core::fmt::Debug> core::fmt::Debug for AdcPin<PIN, ADCI, CS> {
+impl<PIN: core::fmt::Debug, ADCX, CS: core::fmt::Debug> core::fmt::Debug for AdcPin<PIN, ADCX, CS> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("AdcPin")
             .field("pin", &self.pin)
@@ -115,7 +115,7 @@ impl<PIN: core::fmt::Debug, ADCI, CS: core::fmt::Debug> core::fmt::Debug for Adc
 }
 
 #[cfg(feature = "defmt")]
-impl<PIN: defmt::Format, ADCI, CS: defmt::Format> defmt::Format for AdcPin<PIN, ADCI, CS> {
+impl<PIN: defmt::Format, ADCX, CS: defmt::Format> defmt::Format for AdcPin<PIN, ADCX, CS> {
     fn format(&self, fmt: defmt::Formatter<'_>) {
         defmt::write!(
             fmt,
@@ -128,22 +128,22 @@ impl<PIN: defmt::Format, ADCI, CS: defmt::Format> defmt::Format for AdcPin<PIN, 
 
 /// Configuration for the ADC.
 #[cfg(feature = "unstable")]
-pub struct AdcConfig<ADCI> {
+pub struct AdcConfig<ADCX> {
     #[cfg(esp32)]
     resolution: Resolution,
     attenuations: [Option<Attenuation>; NUM_ATTENS],
-    _phantom: PhantomData<ADCI>,
+    _phantom: PhantomData<ADCX>,
 }
 
 #[cfg(feature = "unstable")]
-impl<ADCI> AdcConfig<ADCI> {
+impl<ADCX> AdcConfig<ADCX> {
     /// Create a new configuration struct with its default values
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Enable the specified pin with the given attenuation
-    pub fn enable_pin<PIN>(&mut self, pin: PIN, attenuation: Attenuation) -> AdcPin<PIN, ADCI>
+    pub fn enable_pin<PIN>(&mut self, pin: PIN, attenuation: Attenuation) -> AdcPin<PIN, ADCX>
     where
         PIN: AdcChannel + AnalogPin,
     {
@@ -166,11 +166,11 @@ impl<ADCI> AdcConfig<ADCI> {
         &mut self,
         pin: PIN,
         attenuation: Attenuation,
-    ) -> AdcPin<PIN, ADCI, CS>
+    ) -> AdcPin<PIN, ADCX, CS>
     where
-        ADCI: CalibrationAccess,
+        ADCX: CalibrationAccess,
         PIN: AdcChannel + AnalogPin,
-        CS: AdcCalScheme<ADCI>,
+        CS: AdcCalScheme<ADCX>,
     {
         // TODO revert this on drop
         pin.set_analog(crate::private::Internal);
@@ -185,7 +185,7 @@ impl<ADCI> AdcConfig<ADCI> {
 }
 
 #[cfg(feature = "unstable")]
-impl<ADCI> Default for AdcConfig<ADCI> {
+impl<ADCX> Default for AdcConfig<ADCX> {
     fn default() -> Self {
         Self {
             #[cfg(esp32)]
@@ -221,7 +221,7 @@ pub trait AdcChannel {
 /// The methods in this trait are mostly for internal use. To get
 /// calibrated ADC reads, all you need to do is call `enable_pin_with_cal`
 /// and specify some implementor of this trait.
-pub trait AdcCalScheme<ADCI>: Sized + crate::private::Sealed {
+pub trait AdcCalScheme<ADCX>: Sized + crate::private::Sealed {
     /// Create a new calibration scheme for the given attenuation.
     fn new_cal(atten: Attenuation) -> Self;
 
@@ -238,7 +238,7 @@ pub trait AdcCalScheme<ADCI>: Sized + crate::private::Sealed {
 
 impl crate::private::Sealed for () {}
 
-impl<ADCI> AdcCalScheme<ADCI> for () {
+impl<ADCX> AdcCalScheme<ADCX> for () {
     fn new_cal(_atten: Attenuation) -> Self {}
 }
 

--- a/esp-hal/src/analog/adc/riscv.rs
+++ b/esp-hal/src/analog/adc/riscv.rs
@@ -59,40 +59,40 @@ cfg_if::cfg_if! {
     }
 }
 
-impl<ADCI> AdcConfig<ADCI>
+impl<ADCX> AdcConfig<ADCX>
 where
-    ADCI: RegisterAccess,
+    ADCX: RegisterAccess,
 {
     /// Calibrate ADC with specified attenuation and voltage source
     pub fn adc_calibrate(atten: Attenuation, source: AdcCalSource) -> u16
     where
-        ADCI: super::CalibrationAccess,
+        ADCX: super::CalibrationAccess,
     {
         let mut adc_max: u16 = 0;
         let mut adc_min: u16 = u16::MAX;
         let mut adc_sum: u32 = 0;
 
-        ADCI::enable_vdef(true);
+        ADCX::enable_vdef(true);
 
         // Start sampling
-        ADCI::config_onetime_sample(ADC_CAL_CHANNEL as u8, atten as u8);
+        ADCX::config_onetime_sample(ADC_CAL_CHANNEL as u8, atten as u8);
 
         // Connect calibration source
-        ADCI::connect_cal(source, true);
+        ADCX::connect_cal(source, true);
 
-        ADCI::calibration_init();
+        ADCX::calibration_init();
         for _ in 0..ADC_CAL_CNT_MAX {
-            ADCI::set_init_code(0);
+            ADCX::set_init_code(0);
 
             // Trigger ADC sampling
-            ADCI::start_onetime_sample();
+            ADCX::start_onetime_sample();
 
             // Wait until ADC sampling is done
-            while !ADCI::is_done() {}
+            while !ADCX::is_done() {}
 
-            let adc = ADCI::read_data() & ADC_VAL_MASK;
+            let adc = ADCX::read_data() & ADC_VAL_MASK;
 
-            ADCI::reset();
+            ADCX::reset();
 
             adc_sum += adc as u32;
             adc_max = adc.max(adc_max);
@@ -102,7 +102,7 @@ where
         let cal_val = (adc_sum - adc_max as u32 - adc_min as u32) as u16 / (ADC_CAL_CNT_MAX - 2);
 
         // Disconnect calibration source
-        ADCI::connect_cal(source, false);
+        ADCX::connect_cal(source, false);
 
         cal_val
     }
@@ -287,21 +287,21 @@ impl super::CalibrationAccess for crate::peripherals::ADC2<'_> {
 }
 
 /// Analog-to-Digital Converter peripheral driver.
-pub struct Adc<'d, ADCI, Dm: crate::DriverMode> {
-    _adc: ADCI,
+pub struct Adc<'d, ADCX, Dm: crate::DriverMode> {
+    _adc: ADCX,
     attenuations: [Option<Attenuation>; NUM_ATTENS],
     active_channel: Option<u8>,
     _guard: GenericPeripheralGuard<{ Peripheral::ApbSarAdc as u8 }>,
     _phantom: PhantomData<(Dm, &'d mut ())>,
 }
 
-impl<'d, ADCI> Adc<'d, ADCI, Blocking>
+impl<'d, ADCX> Adc<'d, ADCX, Blocking>
 where
-    ADCI: RegisterAccess + 'd,
+    ADCX: RegisterAccess + 'd,
 {
     /// Configure a given ADC instance using the provided configuration, and
     /// initialize the ADC for use
-    pub fn new(adc_instance: ADCI, config: AdcConfig<ADCI>) -> Self {
+    pub fn new(adc_instance: ADCX, config: AdcConfig<ADCX>) -> Self {
         let guard = GenericPeripheralGuard::new();
 
         APB_SARADC::regs().ctrl().modify(|_, w| unsafe {
@@ -321,14 +321,14 @@ where
     }
 
     /// Reconfigures the ADC driver to operate in asynchronous mode.
-    pub fn into_async(mut self) -> Adc<'d, ADCI, Async> {
+    pub fn into_async(mut self) -> Adc<'d, ADCX, Async> {
         acquire_async_adc();
         self.set_interrupt_handler(adc_interrupt_handler);
 
         // Reset interrupt flags and disable oneshot reading to normalize state before
         // entering async mode, otherwise there can be '0' readings, happening initially
         // using ADC2
-        ADCI::reset();
+        ADCX::reset();
 
         Adc {
             _adc: self._adc,
@@ -346,11 +346,11 @@ where
     /// underlies the pin.
     pub fn read_oneshot<PIN, CS>(
         &mut self,
-        pin: &mut super::AdcPin<PIN, ADCI, CS>,
+        pin: &mut super::AdcPin<PIN, ADCX, CS>,
     ) -> nb::Result<u16, ()>
     where
         PIN: super::AdcChannel,
-        CS: super::AdcCalScheme<ADCI>,
+        CS: super::AdcCalScheme<ADCX>,
     {
         if self.attenuations[pin.pin.adc_channel() as usize].is_none() {
             panic!(
@@ -371,32 +371,32 @@ where
             self.active_channel = Some(pin.pin.adc_channel());
 
             // Set ADC unit calibration according used scheme for pin
-            ADCI::calibration_init();
-            ADCI::set_init_code(pin.cal_scheme.adc_cal());
+            ADCX::calibration_init();
+            ADCX::set_init_code(pin.cal_scheme.adc_cal());
 
             let channel = self.active_channel.unwrap();
             let attenuation = self.attenuations[channel as usize].unwrap() as u8;
-            ADCI::config_onetime_sample(channel, attenuation);
-            ADCI::start_onetime_sample();
+            ADCX::config_onetime_sample(channel, attenuation);
+            ADCX::start_onetime_sample();
 
             // see https://github.com/espressif/esp-idf/blob/b4268c874a4cf8fcf7c0c4153cffb76ad2ddda4e/components/hal/adc_oneshot_hal.c#L105-L107
             // the delay might be a bit generous but longer delay seem to not cause problems
             #[cfg(esp32c6)]
             {
                 crate::rom::ets_delay_us(40);
-                ADCI::start_onetime_sample();
+                ADCX::start_onetime_sample();
             }
         }
 
         // Wait for ADC to finish conversion
-        let conversion_finished = ADCI::is_done();
+        let conversion_finished = ADCX::is_done();
         if !conversion_finished {
             return Err(nb::Error::WouldBlock);
         }
 
         // Get converted value
-        let converted_value = ADCI::read_data();
-        ADCI::reset();
+        let converted_value = ADCX::read_data();
+        ADCX::reset();
 
         // Postprocess converted value according to calibration scheme used for pin
         let converted_value = pin.cal_scheme.adc_val(converted_value);
@@ -418,9 +418,9 @@ where
     }
 }
 
-impl<ADCI> crate::private::Sealed for Adc<'_, ADCI, Blocking> {}
+impl<ADCX> crate::private::Sealed for Adc<'_, ADCX, Blocking> {}
 
-impl<ADCI> InterruptConfigurable for Adc<'_, ADCI, Blocking> {
+impl<ADCX> InterruptConfigurable for Adc<'_, ADCX, Blocking> {
     fn set_interrupt_handler(&mut self, handler: InterruptHandler) {
         for core in crate::system::Cpu::other() {
             crate::interrupt::disable(core, InterruptSource);
@@ -464,12 +464,12 @@ impl super::AdcCalEfuse for crate::peripherals::ADC2<'_> {
     }
 }
 
-impl<'d, ADCI> Adc<'d, ADCI, Async>
+impl<'d, ADCX> Adc<'d, ADCX, Async>
 where
-    ADCI: RegisterAccess + 'd,
+    ADCX: RegisterAccess + 'd,
 {
     /// Create a new instance in [crate::Blocking] mode.
-    pub fn into_blocking(self) -> Adc<'d, ADCI, Blocking> {
+    pub fn into_blocking(self) -> Adc<'d, ADCX, Blocking> {
         if release_async_adc() {
             // Disable ADC interrupt on all cores if the last async ADC instance is disabled
             for cpu in crate::system::Cpu::all() {
@@ -490,11 +490,11 @@ where
     /// This method takes an [AdcPin](super::AdcPin) reference, as it is
     /// expected that the ADC will be able to sample whatever channel
     /// underlies the pin.
-    pub async fn read_oneshot<PIN, CS>(&mut self, pin: &mut super::AdcPin<PIN, ADCI, CS>) -> u16
+    pub async fn read_oneshot<PIN, CS>(&mut self, pin: &mut super::AdcPin<PIN, ADCX, CS>) -> u16
     where
-        ADCI: Instance,
+        ADCX: Instance,
         PIN: super::AdcChannel,
-        CS: super::AdcCalScheme<ADCI>,
+        CS: super::AdcCalScheme<ADCX>,
     {
         let channel = pin.pin.adc_channel();
         if self.attenuations[channel as usize].is_none() {
@@ -502,17 +502,17 @@ where
         }
 
         // Set ADC unit calibration according used scheme for pin
-        ADCI::calibration_init();
-        ADCI::set_init_code(pin.cal_scheme.adc_cal());
+        ADCX::calibration_init();
+        ADCX::set_init_code(pin.cal_scheme.adc_cal());
 
         let attenuation = self.attenuations[channel as usize].unwrap() as u8;
-        ADCI::config_onetime_sample(channel, attenuation);
-        ADCI::start_onetime_sample();
+        ADCX::config_onetime_sample(channel, attenuation);
+        ADCX::start_onetime_sample();
 
         // Wait for ADC to finish conversion and get value
         let adc_ready_future = AdcFuture::new(self);
         adc_ready_future.await;
-        let converted_value = ADCI::read_data();
+        let converted_value = ADCX::read_data();
 
         // There is a hardware limitation. If the APB clock frequency is high, the step
         // of this reg signal: ``onetime_start`` may not be captured by the
@@ -524,7 +524,7 @@ where
         // We reset ``onetime_start`` in `reset` and assume enough time has passed until
         // the next sample is requested.
 
-        ADCI::reset();
+        ADCX::reset();
 
         // Postprocess converted value according to calibration scheme used for pin
         pin.cal_scheme.adc_val(converted_value)
@@ -565,9 +565,9 @@ pub(crate) fn adc_interrupt_handler() {
     }
 }
 
-fn handle_async<ADCI: Instance>(_instance: ADCI) {
-    ADCI::waker().wake();
-    ADCI::unlisten();
+fn handle_async<ADCX: Instance>(_instance: ADCX) {
+    ADCX::waker().wake();
+    ADCX::unlisten();
 }
 
 /// Enable asynchronous access.
@@ -640,35 +640,35 @@ impl Instance for crate::peripherals::ADC2<'_> {
 }
 
 #[must_use = "futures do nothing unless you `.await` or poll them"]
-pub(crate) struct AdcFuture<ADCI: Instance> {
-    phantom: PhantomData<ADCI>,
+pub(crate) struct AdcFuture<ADCX: Instance> {
+    phantom: PhantomData<ADCX>,
 }
 
-impl<ADCI: Instance> AdcFuture<ADCI> {
-    pub fn new(_self: &super::Adc<'_, ADCI, Async>) -> Self {
+impl<ADCX: Instance> AdcFuture<ADCX> {
+    pub fn new(_self: &super::Adc<'_, ADCX, Async>) -> Self {
         Self {
             phantom: PhantomData,
         }
     }
 }
 
-impl<ADCI: Instance + super::RegisterAccess> core::future::Future for AdcFuture<ADCI> {
+impl<ADCX: Instance + super::RegisterAccess> core::future::Future for AdcFuture<ADCX> {
     type Output = ();
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        if ADCI::is_done() {
-            ADCI::clear_interrupt();
+        if ADCX::is_done() {
+            ADCX::clear_interrupt();
             Poll::Ready(())
         } else {
-            ADCI::waker().register(cx.waker());
-            ADCI::listen();
+            ADCX::waker().register(cx.waker());
+            ADCX::listen();
             Poll::Pending
         }
     }
 }
 
-impl<ADCI: Instance> Drop for AdcFuture<ADCI> {
+impl<ADCX: Instance> Drop for AdcFuture<ADCX> {
     fn drop(&mut self) {
-        ADCI::unlisten();
+        ADCX::unlisten();
     }
 }

--- a/esp-hal/src/analog/adc/riscv.rs
+++ b/esp-hal/src/analog/adc/riscv.rs
@@ -87,7 +87,7 @@ where
             // Trigger ADC sampling
             ADCI::start_onetime_sample();
 
-            // Wait until ADC1 sampling is done
+            // Wait until ADC sampling is done
             while !ADCI::is_done() {}
 
             let adc = ADCI::read_data() & ADC_VAL_MASK;

--- a/esp-hal/src/analog/adc/xtensa.rs
+++ b/esp-hal/src/analog/adc/xtensa.rs
@@ -23,41 +23,41 @@ cfg_if::cfg_if! {
     }
 }
 
-impl<ADCI> AdcConfig<ADCI>
+impl<ADCX> AdcConfig<ADCX>
 where
-    ADCI: RegisterAccess,
+    ADCX: RegisterAccess,
 {
     /// Calibrate ADC with specified attenuation and voltage source
     pub fn adc_calibrate(atten: Attenuation, source: AdcCalSource) -> u16
     where
-        ADCI: super::CalibrationAccess,
+        ADCX: super::CalibrationAccess,
     {
         let mut adc_max: u16 = 0;
         let mut adc_min: u16 = u16::MAX;
         let mut adc_sum: u32 = 0;
 
-        ADCI::enable_vdef(true);
+        ADCX::enable_vdef(true);
 
         // Start sampling
-        ADCI::set_en_pad(ADCI::ADC_CAL_CHANNEL as u8);
-        ADCI::set_attenuation(ADCI::ADC_CAL_CHANNEL as usize, atten as u8);
+        ADCX::set_en_pad(ADCX::ADC_CAL_CHANNEL as u8);
+        ADCX::set_attenuation(ADCX::ADC_CAL_CHANNEL as usize, atten as u8);
 
         // Connect calibration source
-        ADCI::connect_cal(source, true);
+        ADCX::connect_cal(source, true);
 
-        ADCI::calibration_init();
-        ADCI::set_init_code(0);
+        ADCX::calibration_init();
+        ADCX::set_init_code(0);
 
-        for _ in 0..ADCI::ADC_CAL_CNT_MAX {
+        for _ in 0..ADCX::ADC_CAL_CNT_MAX {
             // Trigger ADC sampling
-            ADCI::start_sample();
+            ADCX::start_sample();
 
             // Wait until ADC sampling is done
-            while !ADCI::is_done() {}
+            while !ADCX::is_done() {}
 
-            let adc = ADCI::read_data() & ADCI::ADC_VAL_MASK;
+            let adc = ADCX::read_data() & ADCX::ADC_VAL_MASK;
 
-            ADCI::reset();
+            ADCX::reset();
 
             adc_sum += adc as u32;
             adc_max = adc.max(adc_max);
@@ -65,10 +65,10 @@ where
         }
 
         let cal_val =
-            (adc_sum - adc_max as u32 - adc_min as u32) as u16 / (ADCI::ADC_CAL_CNT_MAX - 2);
+            (adc_sum - adc_max as u32 - adc_min as u32) as u16 / (ADCX::ADC_CAL_CNT_MAX - 2);
 
         // Disconnect calibration source
-        ADCI::connect_cal(source, false);
+        ADCX::connect_cal(source, false);
 
         cal_val
     }
@@ -329,13 +329,13 @@ pub struct Adc<'d, ADC, Dm: crate::DriverMode> {
     _phantom: PhantomData<(Dm, &'d mut ())>,
 }
 
-impl<'d, ADCI> Adc<'d, ADCI, crate::Blocking>
+impl<'d, ADCX> Adc<'d, ADCX, crate::Blocking>
 where
-    ADCI: RegisterAccess + 'd,
+    ADCX: RegisterAccess + 'd,
 {
     /// Configure a given ADC instance using the provided configuration, and
     /// initialize the ADC for use
-    pub fn new(adc_instance: ADCI, config: AdcConfig<ADCI>) -> Self {
+    pub fn new(adc_instance: ADCX, config: AdcConfig<ADCX>) -> Self {
         let guard = GenericPeripheralGuard::new();
         let sensors = SENS::regs();
 
@@ -344,14 +344,14 @@ where
 
         for (channel, attenuation) in attenuations.iter().enumerate() {
             if let Some(attenuation) = attenuation {
-                ADCI::set_attenuation(channel, *attenuation as u8);
+                ADCX::set_attenuation(channel, *attenuation as u8);
             }
         }
 
         // Set controller to RTC
-        ADCI::clear_dig_force();
-        ADCI::set_start_force();
-        ADCI::set_en_pad_force();
+        ADCX::clear_dig_force();
+        ADCX::set_start_force();
+        ADCX::set_en_pad_force();
         sensors.sar_hall_ctrl().modify(|_, w| {
             w.xpd_hall_force().set_bit();
             w.hall_phase_force().set_bit()
@@ -401,19 +401,19 @@ where
 
     /// Start and wait for a conversion on the specified pin and return the
     /// result
-    pub fn read_blocking<PIN, CS>(&mut self, pin: &mut AdcPin<PIN, ADCI, CS>) -> u16
+    pub fn read_blocking<PIN, CS>(&mut self, pin: &mut AdcPin<PIN, ADCX, CS>) -> u16
     where
         PIN: AdcChannel,
-        CS: AdcCalScheme<ADCI>,
+        CS: AdcCalScheme<ADCX>,
     {
         self.start_sample(pin);
 
         // Wait for ADC to finish conversion
-        while !ADCI::is_done() {}
+        while !ADCX::is_done() {}
 
         // Get converted value
-        let converted_value = ADCI::read_data();
-        ADCI::reset();
+        let converted_value = ADCX::read_data();
+        ADCX::reset();
 
         // Postprocess converted value according to calibration scheme used for pin
         pin.cal_scheme.adc_val(converted_value)
@@ -426,11 +426,11 @@ where
     /// underlies the pin.
     pub fn read_oneshot<PIN, CS>(
         &mut self,
-        pin: &mut super::AdcPin<PIN, ADCI, CS>,
+        pin: &mut super::AdcPin<PIN, ADCX, CS>,
     ) -> nb::Result<u16, ()>
     where
         PIN: super::AdcChannel,
-        CS: super::AdcCalScheme<ADCI>,
+        CS: super::AdcCalScheme<ADCX>,
     {
         if let Some(active_channel) = self.active_channel {
             // There is conversion in progress:
@@ -447,14 +447,14 @@ where
         }
 
         // Wait for ADC to finish conversion
-        let conversion_finished = ADCI::is_done();
+        let conversion_finished = ADCX::is_done();
         if !conversion_finished {
             return Err(nb::Error::WouldBlock);
         }
 
         // Get converted value
-        let converted_value = ADCI::read_data();
-        ADCI::reset();
+        let converted_value = ADCX::read_data();
+        ADCX::reset();
 
         // Postprocess converted value according to calibration scheme used for pin
         let converted_value = pin.cal_scheme.adc_val(converted_value);
@@ -465,23 +465,23 @@ where
         Ok(converted_value)
     }
 
-    fn start_sample<PIN, CS>(&mut self, pin: &mut AdcPin<PIN, ADCI, CS>)
+    fn start_sample<PIN, CS>(&mut self, pin: &mut AdcPin<PIN, ADCX, CS>)
     where
         PIN: AdcChannel,
-        CS: AdcCalScheme<ADCI>,
+        CS: AdcCalScheme<ADCX>,
     {
         // Set ADC unit calibration according used scheme for pin
         let init_code = pin.cal_scheme.adc_cal();
         if self.last_init_code != init_code {
-            ADCI::calibration_init();
-            ADCI::set_init_code(init_code);
+            ADCX::calibration_init();
+            ADCX::set_init_code(init_code);
             self.last_init_code = init_code;
         }
 
-        ADCI::set_en_pad(pin.pin.adc_channel());
+        ADCX::set_en_pad(pin.pin.adc_channel());
 
-        ADCI::clear_start_sample();
-        ADCI::start_sample();
+        ADCX::clear_start_sample();
+        ADCX::start_sample();
     }
 }
 

--- a/esp-hal/src/analog/adc/xtensa.rs
+++ b/esp-hal/src/analog/adc/xtensa.rs
@@ -52,7 +52,7 @@ where
             // Trigger ADC sampling
             ADCI::start_sample();
 
-            // Wait until ADC1 sampling is done
+            // Wait until ADC sampling is done
             while !ADCI::is_done() {}
 
             let adc = ADCI::read_data() & ADCI::ADC_VAL_MASK;

--- a/qa-test/src/bin/embassy_adc_async_abstraction.rs
+++ b/qa-test/src/bin/embassy_adc_async_abstraction.rs
@@ -43,24 +43,24 @@ trait Converter {
     fn raw_to_metering(raw_value: u16) -> u16;
 }
 
-pub struct AdcSensor<'d, ADCI, PIN, CS, MC> {
-    adc: Adc<'d, ADCI, Async>,
-    pin: AdcPin<PIN, ADCI, CS>,
+pub struct AdcSensor<'d, ADCX, PIN, CS, MC> {
+    adc: Adc<'d, ADCX, Async>,
+    pin: AdcPin<PIN, ADCX, CS>,
     _phantom: PhantomData<MC>,
 }
 
-impl<'d, ADCI, PIN, CS, MC> AdcSensor<'d, ADCI, PIN, CS, MC> {
-    pub fn new(adc: Adc<'d, ADCI, Async>, pin: AdcPin<PIN, ADCI, CS>) -> Self {
+impl<'d, ADCX, PIN, CS, MC> AdcSensor<'d, ADCX, PIN, CS, MC> {
+    pub fn new(adc: Adc<'d, ADCX, Async>, pin: AdcPin<PIN, ADCX, CS>) -> Self {
         let _phantom = PhantomData::<MC> {};
         Self { adc, pin, _phantom }
     }
 }
 
-impl<'d, ADCI, PIN, CS, MC> Sensor for AdcSensor<'d, ADCI, PIN, CS, MC>
+impl<'d, ADCX, PIN, CS, MC> Sensor for AdcSensor<'d, ADCX, PIN, CS, MC>
 where
-    ADCI: RegisterAccess + Instance + 'd,
+    ADCX: RegisterAccess + Instance + 'd,
     PIN: AdcChannel,
-    CS: AdcCalScheme<ADCI>,
+    CS: AdcCalScheme<ADCX>,
     MC: Converter,
 {
     async fn measure(&mut self) -> u16 {


### PR DESCRIPTION
Closes #5460
Closes #5459

Hall sensor mentions have been removed from the TRM so I doubt we can support the hardware in a reliable way, especially considering which chip is in question.

# Changelog

## esp-hal/ADC

- Removed: ESP32: removed non-functional Hall-sensor code
- Fixed: Corrected a typo that accidentally configured the incorrect ADC instance