### PR TITLE
fix(ci): /test-size loses last chip when comment has trailing newline

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -583,8 +583,16 @@ jobs:
         run: |
           # Expected format: /test-size example_name chip(s)
           COMMENT="${{ github.event.comment.body }}"
+          # Use only the line that holds the command (let users add free-form
+          # text in the rest of the comment) and strip any CR characters that
+          # GitHub may include on CRLF line endings.
+          COMMAND_LINE=$(printf '%s' "$COMMENT" | tr -d '\r' | grep -m1 -E '^/test-size' || true)
+          if [ -z "$COMMAND_LINE" ]; then
+            echo "Error: Could not find /test-size command line in comment."
+            exit 1
+          fi
           # Strip the /test-size prefix
-          ARGS=$(echo "$COMMENT" | sed 's|/test-size[[:space:]]*||')
+          ARGS=$(printf '%s' "$COMMAND_LINE" | sed 's|/test-size[[:space:]]*||')
 
           # Extract --package value if present
           PACKAGE=""


### PR DESCRIPTION
## Thank you for your contribution!

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [ ] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
- [ ] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

(Submission Checklist boxes left unchecked because this PR only touches `.github/workflows/dispatch.yml` — no examples, no Rust formatting target, and CHANGELOG.md is for esp-hal user-facing changes which a CI workflow isn't. PR #5469 is the precedent for "CI-only PRs don't add a changelog entry.")

### Pull Request Details 📖

#### Description

Fixes #5472.

The `/test-size` slash-command handler in `.github/workflows/dispatch.yml` reads `github.event.comment.body` and feeds the entire comment (with whatever line endings GitHub delivers) into a `for token in $ARGS` loop. When the comment ends with `\r\n` — which is what GitHub returns when the user hit Enter after the command line — the last chip token ends up as `esp32s3\r` and fails the `KNOWN_CHIPS` whitelist match. The handler silently drops it. Result: typing `/test-size loopback esp32c3 esp32c6 esp32s3` followed by Enter only runs analysis on `esp32c3` and `esp32c6`.

The same root cause affects free-form text after the command line — the issue body explicitly asks for "let me ramble on in the rest of the comment without affecting the command."

#### Fix

Pick only the line that starts with `/test-size` and strip CR characters before the existing parser runs:

```yaml
COMMAND_LINE=$(printf '%s' "$COMMENT" | tr -d '\r' | grep -m1 -E '^/test-size' || true)
ARGS=$(printf '%s' "$COMMAND_LINE" | sed 's|/test-size[[:space:]]*||')
```

Bail with an explicit error if the line isn't found. The outer `if` already gates on `startsWith(github.event.comment.body, '/test-size')`, so the bail path should be unreachable in practice — it's defensive for the case where someone has a multi-paragraph comment whose first line isn't the command.

#### Testing

- Manually traced the bash logic against the issue's input (`/test-size loopback esp32c3 esp32c6 esp32s3\r\n`): with the fix, `ARGS` becomes the chip list with no trailing `\r`, the `for token in $ARGS` loop matches all three chips, and `CHIPS_JSON` is `["esp32c3","esp32c6","esp32s3"]`.
- The `--package` extraction path still works because it operates on the now-clean `ARGS`.
- The error path (no `/test-size` line found) was added as a guard but should not fire under normal use.