### PR TITLE
Link checker tweaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,9 +314,6 @@ jobs:
   # Check links in .rs, .md, and .toml files
 
   link-check:
-    needs: get-labels
-    if: ${{ github.event_name != 'pull_request' ||
-      !contains(needs.get-labels.outputs.labels, 'skip-ci-non-code-change') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -3,6 +3,7 @@
 ^https?://localhost
 ^https?://127\.0\.0\.1
 ^https?://0\.0\.0\.0
+^https?://1\.1\.1\.1
 .*\.local
 ^https?://192\.168\..*
 ^https?://10\..*

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,13 +1,9 @@
-# Local/private network addresses
-# Local/private network addresses (protocol-aware)
+# IPv4 addresses
+^https?://\d+\.\d+\.\d+\.\d+
+
+# localhost and .local domains
 ^https?://localhost
-^https?://127\.0\.0\.1
-^https?://0\.0\.0\.0
-^https?://1\.1\.1\.1
 .*\.local
-^https?://192\.168\..*
-^https?://10\..*
-^https?://172\.(1[6-9]|2[0-9]|3[0-1])\..*
 
 # Template placeholders
 %7B[^%]+%7D
@@ -21,10 +17,3 @@ releases/tag/$
 
 # Shield.io badges
 img\.shields\.io/badge/MSRV-
-
-# TODO: remove once released
-docs\.espressif\.com/projects/rust/esp-phy/latest/
-docs\.espressif\.com/projects/rust/esp-rtos/latest/
-docs\.espressif\.com/projects/rust/esp-radio-rtos-driver/latest/
-docs\.espressif\.com/projects/rust/esp-radio/latest/
-docs\.espressif\.com/projects/rust/esp-sync/latest/

--- a/esp-hal/src/soc/esp32s3/mod.rs
+++ b/esp-hal/src/soc/esp32s3/mod.rs
@@ -33,7 +33,7 @@ pub(crate) mod constants {
 pub(crate) unsafe fn configure_cpu_caches() {
     // this is just the bare minimum we need to run code from flash
     // consider implementing more advanced configurations
-    // see https://github.com/apache/incubator-nuttx/blob/master/arch/xtensa/src/esp32s3/esp32s3_start.c
+    // see https://github.com/apache/nuttx/blob/f25db331136351dbf8ebe6925a98d3b77e1ca983/arch/xtensa/src/esp32s3/esp32s3_start.c#L213
 
     unsafe extern "C" {
         fn Cache_Suspend_DCache();


### PR DESCRIPTION
We have one of the examples mention `http://1.1.1.1:8080/` but it's supposed to be the MCU's address in the example. This PR ignores all IPs, stops ignoring TODO-marked links, and runs the link checker even if the skip-ci-non-code-change label is set.