### PR TITLE
fix(mcpwm): set_timestamp_b incorrectly sets pin_a instead of pin_b

### DIFF
--- a/esp-hal/src/mcpwm/operator.rs
+++ b/esp-hal/src/mcpwm/operator.rs
@@ -540,7 +540,7 @@ impl<'d, PWM: PwmPeripheral, const OP: u8> LinkedPins<'d, PWM, OP> {
     /// The written value will take effect according to the set
     /// [`PwmUpdateMethod`].
     pub fn set_timestamp_b(&mut self, value: u16) {
-        self.pin_a.set_timestamp(value)
+        self.pin_b.set_timestamp(value)
     }
 
     /// Configure the deadtime generator


### PR DESCRIPTION
## Summary

- `LinkedPins::set_timestamp_b()` was a copy-paste of `set_timestamp_a()` and wrote the timestamp value to `self.pin_a` instead of `self.pin_b`
- This silently produced wrong PWM output on the wrong pin

## Fix

Changed `self.pin_a.set_timestamp(value)` to `self.pin_b.set_timestamp(value)` in `esp-hal/src/mcpwm/operator.rs:543`