### PR TITLE
fix(dma): DmaTransferTx::drop passes swapped rx/tx arguments

### DIFF
--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -2553,7 +2553,7 @@ where
     I: dma_private::DmaSupportTx,
 {
     fn drop(&mut self) {
-        self.instance.peripheral_wait_dma(true, false);
+        self.instance.peripheral_wait_dma(false, true);
     }
 }
 


### PR DESCRIPTION
## Summary
- `DmaTransferTx::drop()` called `peripheral_wait_dma(true, false)` which waits for RX instead of TX
- This was copy-pasted from `DmaTransferRx::drop()` without updating the arguments
- `DmaTransferTx::wait()` correctly calls `peripheral_wait_dma(false, true)`, confirming the drop is wrong