### PR TITLE
fix(ble): btdm_hus_2_lpcycles has << and / operators swapped

### DIFF
--- a/esp-radio/src/ble/btdm.rs
+++ b/esp-radio/src/ble/btdm.rs
@@ -222,7 +222,7 @@ unsafe extern "C" fn btdm_hus_2_lpcycles(us: u32) -> u32 {
     let g_btdm_lpcycle_us = 2 << (g_btdm_lpcycle_us_frac);
 
     // Converts a duration in half us into a number of low power clock cycles.
-    let cycles: u64 = (us as u64) << (g_btdm_lpcycle_us_frac as u64 / g_btdm_lpcycle_us as u64);
+    let cycles: u64 = ((us as u64) << g_btdm_lpcycle_us_frac) / (g_btdm_lpcycle_us as u64);
     trace!("btdm_hus_2_lpcycles {} {}", us, cycles);
 
     cycles as u32


### PR DESCRIPTION
## Summary
- With `g_btdm_lpcycle_us_frac = 19` and `g_btdm_lpcycle_us = 2 << 19 = 1048576`, the old code computed `us << (19 / 1048576) = us << 0 = us`
- The ESP-IDF C source computes `(us << 19) / 1048576` for the half-microseconds to low-power-cycles conversion
- The `<<` and `/` operators were swapped

# Changelog

## esp-radio

- Fixed: Fixed incorrect formula in `btdm_hus_2_lpcycles`