### PR TITLE
fix(spi): SpiDmaTransfer::drop leaks resources when transfer is complete

### DIFF
--- a/esp-hal/src/spi/master/dma.rs
+++ b/esp-hal/src/spi/master/dma.rs
@@ -230,7 +230,7 @@ impl<'d> SpiDma<'d, Blocking> {
 }
 
 impl<'d> SpiDma<'d, Async> {
-    /// Converts the SPI instance into async mode.
+    /// Converts the SPI instance into blocking mode.
     #[instability::unstable]
     pub fn into_blocking(self) -> SpiDma<'d, Blocking> {
         self.spi.disable_peri_interrupt_on_all_cores();
@@ -551,11 +551,11 @@ where
         if !self.is_done() {
             self.spi_dma.cancel_transfer();
             self.spi_dma.wait_for_idle();
+        }
 
-            unsafe {
-                ManuallyDrop::drop(&mut self.spi_dma);
-                ManuallyDrop::drop(&mut self.dma_buf);
-            }
+        unsafe {
+            ManuallyDrop::drop(&mut self.spi_dma);
+            ManuallyDrop::drop(&mut self.dma_buf);
         }
     }
 }
@@ -889,7 +889,7 @@ impl<'d> SpiDmaBus<'d, Blocking> {
 }
 
 impl<'d> SpiDmaBus<'d, Async> {
-    /// Converts the SPI instance into async mode.
+    /// Converts the SPI instance into blocking mode.
     #[instability::unstable]
     pub fn into_blocking(self) -> SpiDmaBus<'d, Blocking> {
         SpiDmaBus {


### PR DESCRIPTION
## Summary
- `SpiDmaTransfer::drop()` only called `ManuallyDrop::drop` inside the `if !is_done()` block, so `spi_dma` and `dma_buf` were leaked when the transfer had already completed
- Moved the `ManuallyDrop::drop` calls outside the `if` block so cleanup always happens
- Also fixed `into_blocking` doc comments on `SpiDma` and `SpiDmaBus` that incorrectly said "into async mode" instead of "into blocking mode"