### PR TITLE
fix(dma): copy DMA is_listening checks wrong interrupt flag for DescriptorEmpty

### DIFF
--- a/esp-hal/src/dma/pdma/copy.rs
+++ b/esp-hal/src/dma/pdma/copy.rs
@@ -324,7 +324,7 @@ impl InterruptAccess<DmaRxInterrupt> for CopyDmaRxChannel<'_> {
         if int_ena.in_dscr_err().bit_is_set() {
             result |= DmaRxInterrupt::DescriptorError;
         }
-        if int_ena.in_dscr_err().bit_is_set() {
+        if int_ena.in_dscr_empty().bit_is_set() {
             result |= DmaRxInterrupt::DescriptorEmpty;
         }
         if int_ena.in_suc_eof().bit_is_set() {


### PR DESCRIPTION
## Summary
- `CopyDmaRxChannel::is_listening()` checked `in_dscr_err()` instead of `in_dscr_empty()` for the `DescriptorEmpty` interrupt — a copy-paste from the `DescriptorError` check above it
- `DescriptorEmpty` events could never be detected as "listening"
- All other methods in the same file (`enable_listen`, `clear`, `pending_interrupts`) correctly use `in_dscr_empty()`