### PR TITLE
fix(exception): RISC-V exception code descriptions for 14 and 15 are swapped

### DIFF
--- a/esp-hal/src/exception_handler/mod.rs
+++ b/esp-hal/src/exception_handler/mod.rs
@@ -104,8 +104,8 @@ unsafe extern "C" fn ExceptionHandler(context: &TrapFrame) -> ! {
         11 => "Environment call from M-mode",
         12 => "Instruction page fault",
         13 => "Load page fault",
-        14 => "Reserved",
-        15 => "Store/AMO page fault",
+        14 => "Store/AMO page fault",
+        15 => "Reserved",
         _ => "UNKNOWN",
     };
 


### PR DESCRIPTION
## Summary
- Per the RISC-V Privileged Specification: code 14 is "Store/AMO page fault" and code 15 is "Reserved"
- The descriptions were in the wrong order
- The stack overflow detection at line 56 correctly treats code 14 as a store page fault, confirming the table was wrong