### PR TITLE
fix(ieee802154): received() frame decoding has off-by-one causing potential panic

### DIFF
--- a/esp-radio/src/ieee802154/mod.rs
+++ b/esp-radio/src/ieee802154/mod.rs
@@ -198,9 +198,9 @@ impl<'a> Ieee802154<'a> {
     pub fn received(&mut self) -> Option<Result<ReceivedFrame, Error>> {
         raw::ensure_receive_enabled();
         if let Some(raw) = ieee802154_poll() {
-            let maybe_decoded = if raw.data[0] as usize > raw.data.len() {
-                // try to decode up to data.len()
-                mac::Frame::try_read(&raw.data[1..][..raw.data.len()], FooterMode::Explicit)
+            let maybe_decoded = if raw.data[0] as usize >= raw.data.len() {
+                // try to decode up to data.len() - 1 (since we skip byte 0)
+                mac::Frame::try_read(&raw.data[1..][..raw.data.len() - 1], FooterMode::Explicit)
             } else {
                 mac::Frame::try_read(&raw.data[1..][..raw.data[0] as usize], FooterMode::Explicit)
             };
@@ -208,7 +208,7 @@ impl<'a> Ieee802154<'a> {
             let result = match maybe_decoded {
                 Ok((decoded, _)) => {
                     // crc is not written to rx buffer
-                    let rssi = if (raw.data[0] as usize > raw.data.len()) || (raw.data[0] == 0) {
+                    let rssi = if (raw.data[0] as usize >= raw.data.len()) || (raw.data[0] == 0) {
                         raw.data[raw.data.len() - 1] as i8
                     } else {
                         raw.data[raw.data[0] as usize - 1] as i8


### PR DESCRIPTION
## Summary
Two bugs in `Ieee802154::received()`:
1. Used `>` instead of `>=` when comparing `data[0]` with `data.len()` — when `data[0] == data.len()`, the else branch ran with an incorrect slice
2. Used `raw.data.len()` instead of `raw.data.len() - 1` for the slice length after skipping byte 0, causing a panic since `raw.data[1..]` has one fewer element

The correct code in `raw.rs` uses `>= FRAME_SIZE` and `FRAME_SIZE - 1`.

# Changelog

## esp-radio/IEEE802.15.4

- Fixed: Fixed an issue that may cause a panic