### PR TITLE
fix(ledc): timer divisor range excludes the valid maximum value

### DIFF
--- a/esp-hal/src/ledc/timer.rs
+++ b/esp-hal/src/ledc/timer.rs
@@ -260,7 +260,7 @@ where
             divisor = (1_000_000u64 << 8) / frequency as u64 / precision as u64;
         }
 
-        if !(256..LEDC_TIMER_DIV_NUM_MAX).contains(&divisor) {
+        if !(256..=LEDC_TIMER_DIV_NUM_MAX).contains(&divisor) {
             return Err(Error::Divisor);
         }
 


### PR DESCRIPTION
## Summary
- `LEDC_TIMER_DIV_NUM_MAX` is `0x3FFFF` (262143), the maximum value for the 18-bit register field
- The range `256..LEDC_TIMER_DIV_NUM_MAX` is exclusive of the upper bound, rejecting the valid value 262143
- Changed to `256..=LEDC_TIMER_DIV_NUM_MAX` to include it