### PR TITLE
fix(ledc): update_signal returns Error::Timer instead of Error::Channel

### DIFF
--- a/esp-hal/src/ledc/channel.rs
+++ b/esp-hal/src/ledc/channel.rs
@@ -605,7 +605,7 @@ where
 
             signal.connect_to(&self.output_pin);
         } else {
-            return Err(Error::Timer);
+            return Err(Error::Channel);
         }
 
         Ok(())


### PR DESCRIPTION
## Summary
- When `self.timer` is `None` (no timer associated with the channel), `update_signal()` returned `Error::Timer`
- The identical condition in `set_duty()` and `start_duty_fade()` correctly returns `Error::Channel`