### PR TITLE
fix(radio): modem reset mask uses duplicate BTBB_RST instead of BTBB_REG_RST

### DIFF
--- a/esp-radio/src/common_adapter.rs
+++ b/esp-radio/src/common_adapter.rs
@@ -351,7 +351,7 @@ pub(crate) fn enable_wifi_power_domain() {
                 | FE_RST
                 | WIFIMAC_RST
                 | if cfg!(soc_has_bt) {
-                    BTBB_RST | BTMAC_RST | RW_BTMAC_RST | RW_BTMAC_REG_RST | BTBB_RST
+                    BTBB_RST | BTMAC_RST | RW_BTMAC_RST | RW_BTMAC_REG_RST | BTBB_REG_RST
                 } else {
                     0
                 };


### PR DESCRIPTION
## Summary
- `BTBB_RST` (bit 3) appeared twice in the `MODEM_RESET_FIELD_WHEN_PU` mask
- `BTBB_REG_RST` (bit 13) was defined on line 348 but never used
- Since `A | A == A`, the duplicate was a no-op but the Bluetooth Baseband Registers were never pulsed-reset during modem power-up

# Changelog

## esp-radio

- Fixed: Correctly use BTBB_REG_RST 