### PR TITLE
fix(wifi): password length validation allows 64 bytes with no room for null terminator

### DIFF
--- a/esp-radio/src/wifi/ap.rs
+++ b/esp-radio/src/wifi/ap.rs
@@ -73,7 +73,7 @@ impl AccessPointConfig {
             return Err(WifiError::InvalidArguments);
         }
 
-        if self.password.len() > 64 {
+        if self.password.len() >= 64 {
             return Err(WifiError::InvalidArguments);
         }
 

--- a/esp-radio/src/wifi/sta/mod.rs
+++ b/esp-radio/src/wifi/sta/mod.rs
@@ -81,7 +81,7 @@ impl StationConfig {
             return Err(WifiError::InvalidArguments);
         }
 
-        if self.password.len() > 64 {
+        if self.password.len() >= 64 {
             return Err(WifiError::InvalidArguments);
         }
 


### PR DESCRIPTION
## Summary
- The password is copied into a `[u8; 64]` C array (zero-initialized) via `copy_from_slice`
- When `password.len() == 64`, all 64 bytes are overwritten, leaving no room for a null terminator that the C firmware expects when reading the string
- WPA passwords are at most 63 characters; the 64-byte array holds 63 chars + null
- Changed `> 64` to `>= 64` in both `AccessPointConfig` and `StationConfig` validation