### PR TITLE
fix(rmt): PulseCode::try_new rejects the valid maximum value for length2

### DIFF
--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -393,7 +393,7 @@ impl PulseCode {
         let (Ok(length1), Ok(length2)) = (length1.try_into(), length2.try_into()) else {
             return None;
         };
-        if length1 > Self::MAX_LEN || length2 >= Self::MAX_LEN {
+        if length1 > Self::MAX_LEN || length2 > Self::MAX_LEN {
             return None;
         }
 


### PR DESCRIPTION
## Summary
- `try_new()` used `>=` for `length2` but `>` for `length1`, rejecting the valid max value `0x7FFF` (32767) for `length2`
- The const `new()` uses `>` for both, which is correct