### PR TITLE
fix(alloc): realloc_with_caps reads 4 bytes past end of old user data

### DIFF
--- a/esp-alloc/src/malloc.rs
+++ b/esp-alloc/src/malloc.rs
@@ -106,7 +106,7 @@ unsafe fn realloc_with_caps(
         let p = malloc_with_caps(new_size, caps);
         if !p.is_null() && !ptr.is_null() {
             let len = usize::min(
-                (ptr as *const u32).sub(1).read_volatile() as usize,
+                (ptr as *const u32).sub(1).read_volatile() as usize - 4,
                 new_size,
             );
             memcpy(p, ptr, len);


### PR DESCRIPTION
## Summary
- `malloc_with_caps` stores `total_size = user_size + 4` in the header
- In `realloc_with_caps`, when `new_size >= total_size`, `len` becomes `total_size` and `memcpy` copies `user_size + 4` bytes from `ptr`, but only `user_size` bytes of valid user data exist — a 4-byte buffer over-read
- Fixed by subtracting 4 from the header value to get the actual user data size