### PR TITLE
fix(i2c): RTC I2C read() doc says 'Writes bytes' instead of 'Reads bytes'

### DIFF
--- a/esp-hal/src/i2c/rtc.rs
+++ b/esp-hal/src/i2c/rtc.rs
@@ -292,7 +292,7 @@ impl<'d> I2c<'d> {
     }
 
     #[procmacros::doc_replace]
-    /// Reads bytes from slave with given `address` and `register`.
+    /// Writes bytes to slave with given `address` and `register`.
     ///
     /// ## Example
     ///

--- a/esp-hal/src/i2c/rtc.rs
+++ b/esp-hal/src/i2c/rtc.rs
@@ -292,7 +292,7 @@ impl<'d> I2c<'d> {
     }
 
     #[procmacros::doc_replace]
-    /// Writes bytes to slave with given `address` and `register`.
+    /// Reads bytes from slave with given `address` and `register`.
     ///
     /// ## Example
     ///
@@ -393,7 +393,7 @@ impl<'d> I2c<'d> {
     }
 
     #[procmacros::doc_replace]
-    /// Writes bytes to slave with given `address` and `register`.
+    /// Reads bytes from slave with given `address` and `register`.
     ///
     /// ## Example
     ///


### PR DESCRIPTION
## Summary
- Copy-paste error — the `read()` method documentation described writing instead of reading