### PR TITLE
fix(radio): remove duplicate CONFIG_ESP_WIFI_DYNAMIC_RX_BUFFER_NUM assertion

### DIFF
--- a/esp-radio/src/lib.rs
+++ b/esp-radio/src/lib.rs
@@ -241,7 +241,6 @@ const _: () = {
             core::assert!(sys::include::CONFIG_ESP_WIFI_STATIC_RX_BUFFER_NUM == 10);
             core::assert!(sys::include::CONFIG_ESP_WIFI_DYNAMIC_RX_BUFFER_NUM == 32);
             core::assert!(sys::include::WIFI_STATIC_TX_BUFFER_NUM == 0);
-            core::assert!(sys::include::CONFIG_ESP_WIFI_DYNAMIC_RX_BUFFER_NUM == 32);
             core::assert!(sys::include::CONFIG_ESP_WIFI_AMPDU_RX_ENABLED == 1);
             core::assert!(sys::include::CONFIG_ESP_WIFI_AMPDU_TX_ENABLED == 1);
             core::assert!(sys::include::WIFI_AMSDU_TX_ENABLED == 0);


### PR DESCRIPTION
## Summary
- Line 244 was an exact duplicate of line 242, both asserting `CONFIG_ESP_WIFI_DYNAMIC_RX_BUFFER_NUM == 32`
- Removed the duplicate line