### PR TITLE
fix(mcpwm): cfg1() SAFETY comment incorrectly references CFG0

### DIFF
--- a/esp-hal/src/mcpwm/timer.rs
+++ b/esp-hal/src/mcpwm/timer.rs
@@ -104,7 +104,7 @@ impl<const TIM: u8, PWM: PwmPeripheral> Timer<TIM, PWM> {
 
     fn cfg1(&mut self) -> &pac::mcpwm0::timer::CFG1 {
         // SAFETY:
-        // We only grant access to our CFG0 register with the lifetime of &mut self
+        // We only grant access to our CFG1 register with the lifetime of &mut self
         unsafe { Self::tmr() }.cfg1()
     }
 


### PR DESCRIPTION
## Summary
- The safety comment in `cfg1()` was copy-pasted from `cfg0()` and still referenced "CFG0 register" instead of "CFG1 register"