### PR TITLE
fix(gpio): OutputSignal::is_gpio_matrix_forced doc says 'input signal'

### DIFF
--- a/esp-hal/src/gpio/interconnect.rs
+++ b/esp-hal/src/gpio/interconnect.rs
@@ -838,7 +838,7 @@ impl<'d> OutputSignal<'d> {
         self
     }
 
-    /// Returns `true` if the input signal must be routed through the GPIO
+    /// Returns `true` if the output signal must be routed through the GPIO
     /// matrix.
     pub fn is_gpio_matrix_forced(&self) -> bool {
         self.flags.contains(OutputFlags::ForceGpioMatrix)


### PR DESCRIPTION
## Summary
- The method is on `OutputSignal` but the doc said "if the input signal must be routed through the GPIO matrix"