### PR TITLE
fix(timer): ETM Tasks trait doc comments are shifted by one method

### DIFF
--- a/esp-hal/src/timer/timg.rs
+++ b/esp-hal/src/timer/timg.rs
@@ -897,13 +897,13 @@ pub mod etm {
         /// ETM task to start the counter
         fn cnt_start(&self) -> Task;
 
-        /// ETM task to start the alarm
+        /// ETM task to stop the counter
         fn cnt_stop(&self) -> Task;
 
-        /// ETM task to stop the counter
+        /// ETM task to reload the counter
         fn cnt_reload(&self) -> Task;
 
-        /// ETM task to reload the counter
+        /// ETM task to capture the counter
         fn cnt_cap(&self) -> Task;
 
         /// ETM task to load the counter with the value stored when the last


### PR DESCRIPTION
## Summary
- `cnt_stop` doc said "start the alarm"
- `cnt_reload` doc said "stop the counter"
- `cnt_cap` doc said "reload the counter"
- Fixed to match the actual method names