### PR TITLE
Batched fixes

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -25,6 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - UART: disallow 0 as the RX FIFO full threshold (#5451)
 - UART: prevent returning 0 from `read_async` (#5451)
 - ESP32-S2, ESP32-S3: Fixed a bug where `UlpCore.run()` with `UlpCoreWakeupSource::HpCpu` fails to wake the ULP Core (#5410)
+- RMT: allow maximum pulse length on both phases in `PulseCode` (#5501)
+- LEDC: fix off-by-one error in clock divisor calculation (#5496)
+- UART: Wake on detecting a break condition (#5488)
+- Crypto/Copy DMA: fix issue where `in_dscr_empty` was ignored (#5491, #5493)
+- MCPWM: fix `set_timestamp_b` to actually set timestamp for channel B (#5487)
+- SPI DMA: correctly drop bus and buffer if the transfer object is dropped (#5492)
 
 ### Removed
 

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -2553,7 +2553,7 @@ where
     I: dma_private::DmaSupportTx,
 {
     fn drop(&mut self) {
-        self.instance.peripheral_wait_dma(true, false);
+        self.instance.peripheral_wait_dma(false, true);
     }
 }
 

--- a/esp-hal/src/dma/pdma/copy.rs
+++ b/esp-hal/src/dma/pdma/copy.rs
@@ -324,7 +324,7 @@ impl InterruptAccess<DmaRxInterrupt> for CopyDmaRxChannel<'_> {
         if int_ena.in_dscr_err().bit_is_set() {
             result |= DmaRxInterrupt::DescriptorError;
         }
-        if int_ena.in_dscr_err().bit_is_set() {
+        if int_ena.in_dscr_empty().bit_is_set() {
             result |= DmaRxInterrupt::DescriptorEmpty;
         }
         if int_ena.in_suc_eof().bit_is_set() {

--- a/esp-hal/src/dma/pdma/crypto.rs
+++ b/esp-hal/src/dma/pdma/crypto.rs
@@ -366,7 +366,7 @@ impl InterruptAccess<DmaRxInterrupt> for CryptoDmaRxChannel<'_> {
         if int_ena.in_dscr_err().bit_is_set() {
             result |= DmaRxInterrupt::DescriptorError;
         }
-        if int_ena.in_dscr_err().bit_is_set() {
+        if int_ena.in_dscr_empty().bit_is_set() {
             result |= DmaRxInterrupt::DescriptorEmpty;
         }
         if int_ena.in_suc_eof().bit_is_set() {

--- a/esp-hal/src/ledc/timer.rs
+++ b/esp-hal/src/ledc/timer.rs
@@ -260,7 +260,7 @@ where
             divisor = (1_000_000u64 << 8) / frequency as u64 / precision as u64;
         }
 
-        if !(256..LEDC_TIMER_DIV_NUM_MAX).contains(&divisor) {
+        if !(256..=LEDC_TIMER_DIV_NUM_MAX).contains(&divisor) {
             return Err(Error::Divisor);
         }
 

--- a/esp-hal/src/mcpwm/operator.rs
+++ b/esp-hal/src/mcpwm/operator.rs
@@ -540,7 +540,7 @@ impl<'d, PWM: PwmPeripheral, const OP: u8> LinkedPins<'d, PWM, OP> {
     /// The written value will take effect according to the set
     /// [`PwmUpdateMethod`].
     pub fn set_timestamp_b(&mut self, value: u16) {
-        self.pin_a.set_timestamp(value)
+        self.pin_b.set_timestamp(value)
     }
 
     /// Configure the deadtime generator

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -393,7 +393,7 @@ impl PulseCode {
         let (Ok(length1), Ok(length2)) = (length1.try_into(), length2.try_into()) else {
             return None;
         };
-        if length1 > Self::MAX_LEN || length2 >= Self::MAX_LEN {
+        if length1 > Self::MAX_LEN || length2 > Self::MAX_LEN {
             return None;
         }
 

--- a/esp-hal/src/spi/master/dma.rs
+++ b/esp-hal/src/spi/master/dma.rs
@@ -329,7 +329,7 @@ impl<'d> SpiDma<'d, Blocking> {
 }
 
 impl<'d> SpiDma<'d, Async> {
-    /// Converts the SPI driver into async mode.
+    /// Converts the SPI instance into blocking mode.
     #[instability::unstable]
     pub fn into_blocking(self) -> SpiDma<'d, Blocking> {
         self.spi.disable_peri_interrupt_on_all_cores();
@@ -1205,11 +1205,11 @@ where
         if !self.is_done() {
             self.spi_dma.cancel_transfer();
             self.spi_dma.wait_for_idle();
+        }
 
-            unsafe {
-                ManuallyDrop::drop(&mut self.spi_dma);
-                ManuallyDrop::drop(&mut self.dma_buf);
-            }
+        unsafe {
+            ManuallyDrop::drop(&mut self.spi_dma);
+            ManuallyDrop::drop(&mut self.dma_buf);
         }
     }
 }

--- a/esp-hal/src/uart/mod.rs
+++ b/esp-hal/src/uart/mod.rs
@@ -2690,7 +2690,8 @@ pub(super) fn intr_handler(uart: &Info, state: &State) {
         | interrupts.at_cmd_char_det().bit_is_set()
         | interrupts.glitch_det().bit_is_set()
         | interrupts.frm_err().bit_is_set()
-        | interrupts.parity_err().bit_is_set();
+        | interrupts.parity_err().bit_is_set()
+        | interrupts.brk_det().bit_is_set();
     let tx_wake = interrupts.tx_done().bit_is_set() | interrupts.txfifo_empty().bit_is_set();
 
     uart.regs()
@@ -3021,10 +3022,10 @@ pub struct State {
     /// Waker for the asynchronous TX operations.
     pub tx_waker: AtomicWaker,
 
-    /// Stores whether the TX half is configured for async operation.
+    /// Stores whether the RX half is configured for async operation.
     pub is_rx_async: AtomicBool,
 
-    /// Stores whether the RX half is configured for async operation.
+    /// Stores whether the TX half is configured for async operation.
     pub is_tx_async: AtomicBool,
 }
 


### PR DESCRIPTION
This PR batches up a number of recent, small pull requests into one.

<details>
<summary>Changelog</summary>

## esp-hal/RMT

- Fixed: allow maximum pulse length on both phases in `PulseCode`

## esp-hal/LEDC
- Fixed: off-by-one error in clock divisor calculation

## esp-hal/UART

- Fixed: Wake on detecting a break condition

## esp-hal/DMA

- Fixed: ESP32-S2: Crypto/Copy DMA no longer ignores `in_dscr_empty`

## esp-hal/MCPWM

- Fixed: `set_timestamp_b` now actually sets timestamp for channel B

## esp-hal/SPI DMA

- Fixed: correctly drop bus and buffer if the transfer object is dropped)

</details>