### PR TITLE
C5/C61 missing examples

### DIFF
--- a/examples/async/embassy_serial/src/main.rs
+++ b/examples/async/embassy_serial/src/main.rs
@@ -81,8 +81,12 @@ async fn main(spawner: Spawner) {
             let (tx_pin, rx_pin) = (peripherals.GPIO20, peripherals.GPIO19);
         } else if #[cfg(feature = "esp32c3")] {
             let (tx_pin, rx_pin) = (peripherals.GPIO21, peripherals.GPIO20);
+        } else if #[cfg(feature = "esp32c5")] {
+            let (tx_pin, rx_pin) = (peripherals.GPIO11, peripherals.GPIO12);
         } else if #[cfg(feature = "esp32c6")] {
             let (tx_pin, rx_pin) = (peripherals.GPIO16, peripherals.GPIO17);
+        } else if #[cfg(feature = "esp32c61")] {
+            let (tx_pin, rx_pin) = (peripherals.GPIO11, peripherals.GPIO10);
         } else if #[cfg(feature = "esp32h2")] {
             let (tx_pin, rx_pin) = (peripherals.GPIO24, peripherals.GPIO23);
         } else if #[cfg(any(feature = "esp32s2", feature = "esp32s3"))] {

--- a/examples/async/embassy_spi/Cargo.toml
+++ b/examples/async/embassy_spi/Cargo.toml
@@ -37,11 +37,23 @@ esp32c3 = [
     "esp-rtos/esp32c3",
     "esp-hal/esp32c3",
 ]
+esp32c5 = [
+    "esp-backtrace/esp32c5",
+    "esp-bootloader-esp-idf/esp32c5",
+    "esp-rtos/esp32c5",
+    "esp-hal/esp32c5",
+]
 esp32c6 = [
     "esp-backtrace/esp32c6",
     "esp-bootloader-esp-idf/esp32c6",
     "esp-rtos/esp32c6",
     "esp-hal/esp32c6",
+]
+esp32c61 = [
+    "esp-backtrace/esp32c61",
+    "esp-bootloader-esp-idf/esp32c61",
+    "esp-rtos/esp32c61",
+    "esp-hal/esp32c61",
 ]
 esp32h2 = [
     "esp-backtrace/esp32h2",

--- a/examples/interrupt/gpio/Cargo.toml
+++ b/examples/interrupt/gpio/Cargo.toml
@@ -37,6 +37,11 @@ esp32c6 = [
     "esp-bootloader-esp-idf/esp32c6",
     "esp-hal/esp32c6",
 ]
+esp32c61 = [
+    "esp-backtrace/esp32c61",
+    "esp-bootloader-esp-idf/esp32c61",
+    "esp-hal/esp32c61",
+]
 esp32h2 = [
     "esp-backtrace/esp32h2",
     "esp-bootloader-esp-idf/esp32h2",

--- a/examples/ota/update/Cargo.toml
+++ b/examples/ota/update/Cargo.toml
@@ -47,6 +47,12 @@ esp32c6 = [
     "esp-hal/esp32c6",
     "esp-storage/esp32c6",
 ]
+esp32c61 = [
+    "esp-backtrace/esp32c61",
+    "esp-bootloader-esp-idf/esp32c61",
+    "esp-hal/esp32c61",
+    "esp-storage/esp32c61",
+]
 esp32h2 = [
     "esp-backtrace/esp32h2",
     "esp-bootloader-esp-idf/esp32h2",

--- a/examples/peripheral/dma/mem2mem/Cargo.toml
+++ b/examples/peripheral/dma/mem2mem/Cargo.toml
@@ -26,10 +26,20 @@ esp32c3 = [
     "esp-bootloader-esp-idf/esp32c3",
     "esp-hal/esp32c3",
 ]
+esp32c5 = [
+    "esp-backtrace/esp32c5",
+    "esp-bootloader-esp-idf/esp32c5",
+    "esp-hal/esp32c5",
+]
 esp32c6 = [
     "esp-backtrace/esp32c6",
     "esp-bootloader-esp-idf/esp32c6",
     "esp-hal/esp32c6",
+]
+esp32c61 = [
+    "esp-backtrace/esp32c61",
+    "esp-bootloader-esp-idf/esp32c61",
+    "esp-hal/esp32c61",
 ]
 esp32h2 = [
     "esp-backtrace/esp32h2",

--- a/examples/peripheral/spi/loopback/Cargo.toml
+++ b/examples/peripheral/spi/loopback/Cargo.toml
@@ -25,10 +25,20 @@ esp32c3 = [
     "esp-bootloader-esp-idf/esp32c3",
     "esp-hal/esp32c3",
 ]
+esp32c5 = [
+    "esp-backtrace/esp32c5",
+    "esp-bootloader-esp-idf/esp32c5",
+    "esp-hal/esp32c5",
+]
 esp32c6 = [
     "esp-backtrace/esp32c6",
     "esp-bootloader-esp-idf/esp32c6",
     "esp-hal/esp32c6",
+]
+esp32c61 = [
+    "esp-backtrace/esp32c61",
+    "esp-bootloader-esp-idf/esp32c61",
+    "esp-hal/esp32c61",
 ]
 esp32h2 = [
     "esp-backtrace/esp32h2",


### PR DESCRIPTION
I haven't tested C61 (I don't have working board). 

I noticed `spi_loopback` always read `[ff, ff, ff, ff]` (at least on C3, C5, C6) - esp32, s2, s3 and h2 work fine