### PR TITLE
Rework changelog workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ To help us review it efficiently, please ensure you've gone through the followin
 ### Submission Checklist 📝
 - [ ] I have updated existing examples or added new ones (if applicable).
 - [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
-- [ ] I have added changelog entries and/or migration guide notes in the sections below (if applicable).
+- [ ] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` label if not applicable.
 - [ ] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)
 
 #### Extra:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,8 +6,7 @@ To help us review it efficiently, please ensure you've gone through the followin
 ### Submission Checklist 📝
 - [ ] I have updated existing examples or added new ones (if applicable).
 - [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
-- [ ] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
-- [ ] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
+- [ ] I have added changelog entries and/or migration guide notes in the sections below (if applicable).
 - [ ] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)
 
 #### Extra:
@@ -20,3 +19,37 @@ Please provide a clear and concise description of your changes, including the mo
 
 #### Testing
 Describe how you tested your changes.
+
+---
+
+<!-- ============================================================
+  Changelog and migration guide entries live here in the PR body.
+  They will be collected automatically at release time.
+  Delete any section that doesn't apply to your PR.
+  ============================================================ -->
+
+# Changelog
+
+<!-- Add one or more ## <crate> or ## <crate>/<area> sections below.
+     Each entry must start with one of: Added, Changed, Fixed, Removed.
+
+## esp-hal
+
+- Added: Brief description of what was added.
+- Changed: Brief description of what changed.
+- Fixed: Brief description of what was fixed.
+- Removed: Brief description of what was removed.
+
+-->
+
+# Migration guide
+
+<!-- Add one or more ## <crate> or ## <crate>/<area> sections below.
+     Write free-form Markdown describing what users need to change.
+     Only needed when user code must be updated.
+
+## esp-hal
+
+`OldType` has been renamed to `NewType`. Update your code accordingly.
+
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ To help us review it efficiently, please ensure you've gone through the followin
 ### Submission Checklist 📝
 - [ ] I have updated existing examples or added new ones (if applicable).
 - [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
-- [ ] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` label if not applicable.
+- [ ] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` label if not applicable, or the `manual-changelog` label if I am directly editing `CHANGELOG.md`.
 - [ ] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)
 
 #### Extra:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,6 +32,9 @@ Describe how you tested your changes.
 
 <!-- Add one or more ## <crate> or ## <crate>/<area> sections below.
      Each entry must start with one of: Added, Changed, Fixed, Removed.
+     To explicitly declare that a crate needs no changelog entry, write:
+       - No changelog necessary.
+     as the sole item under that crate's heading.
 
 ## esp-hal
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -44,12 +44,14 @@ Describe how you tested your changes.
 
 # Migration guide
 
-<!-- Add one or more ## <crate> or ## <crate>/<area> sections below.
-     Write free-form Markdown describing what users need to change.
+<!-- Add one or more ## <crate>/<area> sections below (area is required).
+     Each breaking change needs a ### Title heading followed by the migration steps.
      Only needed when user code must be updated.
 
-## esp-hal
+## esp-hal/SPI
 
-`OldType` has been renamed to `NewType`. Update your code accordingly.
+### `OldType` has been renamed to `NewType`
+
+Replace all uses of `OldType` with `NewType`.
 
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ To help us review it efficiently, please ensure you've gone through the followin
 ### Submission Checklist 📝
 - [ ] I have updated existing examples or added new ones (if applicable).
 - [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
-- [ ] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` label if not applicable, or the `manual-changelog` label if I am directly editing `CHANGELOG.md`.
+- [ ] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` or `manual-changelog` label as appropriate.
 - [ ] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)
 
 #### Extra:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -3,7 +3,7 @@ name: Changelog check
 on:
   pull_request:
     # Run on labeled/unlabeled in addition to defaults to detect
-    # adding/removing the skip-changelog label.
+    # adding/removing the skip-changelog or manual-changelog labels.
     types: [opened, reopened, labeled, unlabeled, synchronize, ready_for_review]
 
 permissions:
@@ -36,12 +36,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   no-changelog-edits:
-    # Release PRs (labelled `release-pr`) legitimately modify CHANGELOG.md —
-    # skip this check for them.
+    # Release PRs (labelled `release-pr`) and PRs where the author is taking
+    # full manual control of the changelog (`manual-changelog`) legitimately
+    # modify CHANGELOG.md — skip this check for them.
     needs: get-labels
     if: |
       !github.event.pull_request.draft &&
-      !contains(needs.get-labels.outputs.labels, 'release-pr')
+      !contains(needs.get-labels.outputs.labels, 'release-pr') &&
+      !contains(needs.get-labels.outputs.labels, 'manual-changelog')
     runs-on: ubuntu-latest
     steps:
       - name: Check for direct CHANGELOG.md edits

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -2,205 +2,35 @@ name: Changelog check
 
 on:
   pull_request:
-    # We will not track changes for the following packages/directories.
-    paths-ignore:
-      - "/examples/"
-      - "/extras/"
-      - "/hil-tests/"
-      - "/resources/"
-      - "/xtask/"
     # Run on labeled/unlabeled in addition to defaults to detect
-    # adding/removing skip-changelog labels.
+    # adding/removing the skip-changelog label.
     types: [opened, reopened, labeled, unlabeled, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
 
 jobs:
   get-labels:
     uses: ./.github/workflows/get-labels.yml
+
   changelog:
     needs: get-labels
-    if: ${{ github.event_name != 'pull_request' ||
-      (!contains(needs.get-labels.outputs.labels, 'skip-ci-non-code-change') &&
-      !github.event.pull_request.draft) }} # don't bother checking the changelog for draft PRs
+    # Skip draft PRs and PRs that already carry the skip-changelog label —
+    # the label check inside xtask is authoritative, but skipping here avoids
+    # a full Rust compile when it isn't needed.
+    if: |
+      !github.event.pull_request.draft &&
+      !contains(needs.get-labels.outputs.labels, 'skip-changelog')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
 
-      - name: Check which package is modified
-        uses: dorny/paths-filter@v3
-        id: changes
-        with:
-          filters: |
-            esp-alloc:
-              - 'esp-alloc/**'
-            esp-backtrace:
-              - 'esp-backtrace/**'
-            esp-bootloader-esp-idf:
-              - 'esp-bootloader-esp-idf/**'
-            esp-config:
-              - 'esp-config/**'
-            esp-hal:
-              - 'esp-hal/**'
-            esp-hal-procmacros:
-              - 'esp-hal-procmacros/**'
-            esp-lp-hal:
-              - 'esp-lp-hal/**'
-            esp-phy:
-              - 'esp-phy/**'
-            esp-rtos:
-              - 'esp-rtos/**'
-            esp-println:
-              - 'esp-println/**'
-            esp-riscv-rt:
-              - 'esp-riscv-rt/**'
-            esp-storage:
-              - 'esp-storage/**'
-            esp-radio:
-              - 'esp-radio/**'
-            esp-radio-rtos-driver:
-              - 'esp-radio-rtos-driver/**'
-            esp-sync:
-              - 'esp-sync/**'
-            xtensa-lx:
-              - 'xtensa-lx/**'
-            xtensa-lx-rt:
-              - 'xtensa-lx-rt/**'
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
 
-      - name: Check that changelog updated (esp-alloc)
-        if: steps.changes.outputs.esp-alloc == 'true'
-        uses: dangoslen/changelog-enforcer@v3
-        with:
-          changeLogPath: esp-alloc/CHANGELOG.md
-          skipLabels: "skip-changelog"
-          missingUpdateErrorMessage: "Please add a changelog entry in the esp-alloc/CHANGELOG.md file."
-
-      - name: Check that changelog updated (esp-backtrace)
-        if: steps.changes.outputs.esp-backtrace == 'true'
-        uses: dangoslen/changelog-enforcer@v3
-        with:
-          changeLogPath: esp-backtrace/CHANGELOG.md
-          skipLabels: "skip-changelog"
-          missingUpdateErrorMessage: "Please add a changelog entry in the esp-backtrace/CHANGELOG.md file."
-
-      - name: Check that changelog updated (esp-bootloader-esp-idf)
-        if: steps.changes.outputs.esp-bootloader-esp-idf == 'true'
-        uses: dangoslen/changelog-enforcer@v3
-        with:
-          changeLogPath: esp-bootloader-esp-idf/CHANGELOG.md
-          skipLabels: "skip-changelog"
-          missingUpdateErrorMessage: "Please add a changelog entry in the esp-bootloader-esp-idf/CHANGELOG.md file."
-
-      - name: Check that changelog updated (esp-config)
-        if: steps.changes.outputs.esp-config == 'true'
-        uses: dangoslen/changelog-enforcer@v3
-        with:
-          changeLogPath: esp-config/CHANGELOG.md
-          skipLabels: "skip-changelog"
-          missingUpdateErrorMessage: "Please add a changelog entry in the esp-config/CHANGELOG.md file."
-
-      - name: Check that changelog updated (esp-hal)
-        if: steps.changes.outputs.esp-hal == 'true'
-        uses: dangoslen/changelog-enforcer@v3
-        with:
-          changeLogPath: esp-hal/CHANGELOG.md
-          skipLabels: "skip-changelog"
-          missingUpdateErrorMessage: "Please add a changelog entry in the esp-hal/CHANGELOG.md file."
-
-      - name: Check that changelog updated (esp-hal-procmacros)
-        if: steps.changes.outputs.esp-hal-procmacros == 'true'
-        uses: dangoslen/changelog-enforcer@v3
-        with:
-          changeLogPath: esp-hal-procmacros/CHANGELOG.md
-          skipLabels: "skip-changelog"
-          missingUpdateErrorMessage: "Please add a changelog entry in the esp-hal-procmacros/CHANGELOG.md file."
-
-      - name: Check that changelog updated (esp-lp-hal)
-        if: steps.changes.outputs.esp-lp-hal == 'true'
-        uses: dangoslen/changelog-enforcer@v3
-        with:
-          changeLogPath: esp-lp-hal/CHANGELOG.md
-          skipLabels: "skip-changelog"
-          missingUpdateErrorMessage: "Please add a changelog entry in the esp-lp-hal/CHANGELOG.md file."
-
-      - name: Check that changelog updated (esp-phy)
-        if: steps.changes.outputs.esp-phy == 'true'
-        uses: dangoslen/changelog-enforcer@v3
-        with:
-          changeLogPath: esp-phy/CHANGELOG.md
-          skipLabels: "skip-changelog"
-          missingUpdateErrorMessage: "Please add a changelog entry in the esp-phy/CHANGELOG.md file."
-
-      - name: Check that changelog updated (esp-rtos)
-        if: steps.changes.outputs.esp-rtos == 'true'
-        uses: dangoslen/changelog-enforcer@v3
-        with:
-          changeLogPath: esp-rtos/CHANGELOG.md
-          skipLabels: "skip-changelog"
-          missingUpdateErrorMessage: "Please add a changelog entry in the esp-rtos/CHANGELOG.md file."
-
-      - name: Check that changelog updated (esp-println)
-        if: steps.changes.outputs.esp-println == 'true'
-        uses: dangoslen/changelog-enforcer@v3
-        with:
-          changeLogPath: esp-println/CHANGELOG.md
-          skipLabels: "skip-changelog"
-          missingUpdateErrorMessage: "Please add a changelog entry in the esp-println/CHANGELOG.md file."
-
-      - name: Check that changelog updated (esp-riscv-rt)
-        if: steps.changes.outputs.esp-riscv-rt == 'true'
-        uses: dangoslen/changelog-enforcer@v3
-        with:
-          changeLogPath: esp-riscv-rt/CHANGELOG.md
-          skipLabels: "skip-changelog"
-          missingUpdateErrorMessage: "Please add a changelog entry in the esp-riscv-rt/CHANGELOG.md file."
-
-      - name: Check that changelog updated (esp-storage)
-        if: steps.changes.outputs.esp-storage == 'true'
-        uses: dangoslen/changelog-enforcer@v3
-        with:
-          changeLogPath: esp-storage/CHANGELOG.md
-          skipLabels: "skip-changelog"
-          missingUpdateErrorMessage: "Please add a changelog entry in the esp-storage/CHANGELOG.md file."
-
-      - name: Check that changelog updated (esp-radio)
-        if: steps.changes.outputs.esp-radio == 'true'
-        uses: dangoslen/changelog-enforcer@v3
-        with:
-          changeLogPath: esp-radio/CHANGELOG.md
-          skipLabels: "skip-changelog"
-          missingUpdateErrorMessage: "Please add a changelog entry in the esp-radio/CHANGELOG.md file."
-
-      - name: Check that changelog updated (esp-radio-rtos-driver)
-        if: steps.changes.outputs.esp-radio-rtos-driver == 'true'
-        uses: dangoslen/changelog-enforcer@v3
-        with:
-          changeLogPath: esp-radio-rtos-driver/CHANGELOG.md
-          skipLabels: "skip-changelog"
-          missingUpdateErrorMessage: "Please add a changelog entry in the esp-radio-rtos-driver/CHANGELOG.md file."
-
-      - name: Check that changelog updated (esp-sync)
-        if: steps.changes.outputs.esp-sync == 'true'
-        uses: dangoslen/changelog-enforcer@v3
-        with:
-          changeLogPath: esp-sync/CHANGELOG.md
-          skipLabels: "skip-changelog"
-          missingUpdateErrorMessage: "Please add a changelog entry in the esp-sync/CHANGELOG.md file."
-
-      - name: Check that changelog updated (xtensa-lx)
-        if: steps.changes.outputs.xtensa-lx == 'true'
-        uses: dangoslen/changelog-enforcer@v3
-        with:
-          changeLogPath: xtensa-lx/CHANGELOG.md
-          skipLabels: "skip-changelog"
-          missingUpdateErrorMessage: "Please add a changelog entry in the xtensa-lx/CHANGELOG.md file."
-
-      - name: Check that changelog updated (xtensa-lx-rt)
-        if: steps.changes.outputs.xtensa-lx-rt == 'true'
-        uses: dangoslen/changelog-enforcer@v3
-        with:
-          changeLogPath: xtensa-lx-rt/CHANGELOG.md
-          skipLabels: "skip-changelog"
-          missingUpdateErrorMessage: "Please add a changelog entry in the xtensa-lx-rt/CHANGELOG.md file."
-
-      - name: Changelog format check
-        run: cargo xtask check-changelog
+      - name: Check PR changelog
+        run: cargo xtask check-pr-changelog --pr ${{ github.event.pull_request.number }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -95,7 +95,9 @@ jobs:
           Run \`cargo xtask check-pr-changelog\` locally to validate the format before pushing.
           EOF
 
-          gh pr comment "$PR" --repo "$GITHUB_REPOSITORY" --edit-last --body-file /tmp/comment.md \
-            || gh pr comment "$PR" --repo "$GITHUB_REPOSITORY" --body-file /tmp/comment.md
+          # Update existing bot comment if present, otherwise create a new one.
+          gh pr comment "$PR" --repo "$GITHUB_REPOSITORY" --edit-last --body-file /tmp/comment.md 2>/dev/null \
+            || gh pr comment "$PR" --repo "$GITHUB_REPOSITORY" --body-file /tmp/comment.md \
+            || true
 
           exit 1

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -8,7 +8,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   get-labels:
@@ -34,3 +34,68 @@ jobs:
         run: cargo xtask check-pr-changelog --pr ${{ github.event.pull_request.number }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  no-changelog-edits:
+    # Release PRs (labelled `release-pr`) legitimately modify CHANGELOG.md —
+    # skip this check for them.
+    needs: get-labels
+    if: |
+      !github.event.pull_request.draft &&
+      !contains(needs.get-labels.outputs.labels, 'release-pr')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for direct CHANGELOG.md edits
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          changed=$(gh pr view "$PR" --repo "$GITHUB_REPOSITORY" --json files \
+            --jq '[.files[].path | select(endswith("/CHANGELOG.md") or . == "CHANGELOG.md")] | join("\n")')
+
+          if [ -z "$changed" ]; then
+            echo "No CHANGELOG.md files were edited — OK."
+            exit 0
+          fi
+
+          echo "The following CHANGELOG.md file(s) were edited directly:"
+          echo "$changed"
+
+          file_list=$(echo "$changed" | sed 's/^/- `/' | sed 's/$/`/')
+
+          cat > /tmp/comment.md <<EOF
+          <!-- xtask-changelog-edit-warning -->
+          ## :warning: Do not edit \`CHANGELOG.md\` manually
+
+          This PR modifies the following changelog file(s) directly:
+
+          ${file_list}
+
+          Changelog entries are no longer maintained by hand. Instead, add your entries to the **PR description** under the \`# Changelog\` section:
+
+          \`\`\`markdown
+          # Changelog
+
+          ## esp-hal
+
+          - Added: Short description of the change
+          - Fixed: Short description of the fix
+          \`\`\`
+
+          Migration guide entries go in the \`# Migration guide\` section:
+
+          \`\`\`markdown
+          # Migration guide
+
+          ## esp-hal
+
+          Explain what changed and how to migrate existing code.
+          \`\`\`
+
+          Please **revert** the changes to \`CHANGELOG.md\` and move your entries to the PR description instead.
+          Run \`cargo xtask check-pr-changelog\` locally to validate the format before pushing.
+          EOF
+
+          gh pr comment "$PR" --repo "$GITHUB_REPOSITORY" --edit-last --body-file /tmp/comment.md \
+            || gh pr comment "$PR" --repo "$GITHUB_REPOSITORY" --body-file /tmp/comment.md
+
+          exit 1

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -81,14 +81,16 @@ jobs:
           - Fixed: Short description of the fix
           \`\`\`
 
-          Migration guide entries go in the \`# Migration guide\` section:
+          Migration guide entries go in the \`# Migration guide\` section (area is required; each breaking change needs a \`### Title\` heading):
 
           \`\`\`markdown
           # Migration guide
 
-          ## esp-hal
+          ## esp-hal/SPI
 
-          Explain what changed and how to migrate existing code.
+          ### \`OldType\` has been renamed to \`NewType\`
+
+          Replace all uses of \`OldType\` with \`NewType\`.
           \`\`\`
 
           Please **revert** the changes to \`CHANGELOG.md\` and move your entries to the PR description instead.

--- a/documentation/CONTRIBUTING.md
+++ b/documentation/CONTRIBUTING.md
@@ -123,7 +123,7 @@ This will use `rustfmt` to ensure that all source code is formatted correctly pr
 *   [Link your PR] to any relevant issues it addresses.
 *   [Allow edits from maintainers] so the branch can be updated for a merge. Once you submit your PR, a Docs team member will review your proposal. We may ask questions or request additional information.
 *   If your change is user-visible, consider adding a brief changelog entry and/or migration guide note in the PR description using the structured sections provided by the template (see below). This is optional — if you skip it, a maintainer will either add the entries or apply the `skip-changelog` label on your behalf. Do **not** edit `CHANGELOG.md` files directly — those are updated automatically at release time.
-*   If your change requires user code to be updated, describe the required migration steps in the `# Migration guide` section of the PR description.
+*   If your change requires user code to be updated, add a `# Migration guide` section. Each breaking change needs a `## crate/area` heading and a `### Title` for the specific change, followed by the migration steps.
 *   We may ask for changes to be made before a PR can be merged, either using [suggested changes] or pull request comments. You can apply suggested changes directly through the UI. You can make any other changes in your fork, then commit them to your branch.
 *   As you update your PR and apply changes, mark each conversation as [resolved].
 *   Resolve merge conflicts if they arise, using resources like [this git tutorial] for help.
@@ -165,6 +165,8 @@ heading, group entries by crate (and optionally by feature area) using H2 headin
 # Migration guide
 
 ## esp-hal/SPI driver
+
+### `SpiDevice::transfer` signature changed
 
 `SpiDevice::transfer` now takes `&mut [u8]` instead of `(&[u8], &mut [u8])`.
 Update your call sites accordingly.

--- a/documentation/CONTRIBUTING.md
+++ b/documentation/CONTRIBUTING.md
@@ -122,8 +122,8 @@ This will use `rustfmt` to ensure that all source code is formatted correctly pr
 *   Fill the pull request template so that we can review your PR. This template helps reviewers understand your changes as well as the purpose of your pull request.
 *   [Link your PR] to any relevant issues it addresses.
 *   [Allow edits from maintainers] so the branch can be updated for a merge. Once you submit your PR, a Docs team member will review your proposal. We may ask questions or request additional information.
-*   Add changelog entries and/or migration guide notes directly in the PR description using the structured sections provided by the template (see below). Do **not** edit `CHANGELOG.md` files directly — those are updated automatically at release time from the PR descriptions.
-*   If your change requires user code to be changed, describe the required migration steps in the `# Migration guide` section of the PR description.
+*   If your change is user-visible, consider adding a brief changelog entry and/or migration guide note in the PR description using the structured sections provided by the template (see below). This is optional — if you skip it, a maintainer will either add the entries or apply the `skip-changelog` label on your behalf. Do **not** edit `CHANGELOG.md` files directly — those are updated automatically at release time.
+*   If your change requires user code to be updated, describe the required migration steps in the `# Migration guide` section of the PR description.
 *   We may ask for changes to be made before a PR can be merged, either using [suggested changes] or pull request comments. You can apply suggested changes directly through the UI. You can make any other changes in your fork, then commit them to your branch.
 *   As you update your PR and apply changes, mark each conversation as [resolved].
 *   Resolve merge conflicts if they arise, using resources like [this git tutorial] for help.
@@ -137,9 +137,13 @@ This will use `rustfmt` to ensure that all source code is formatted correctly pr
 
 ## Changelog and Migration Guide Entries
 
-Changelog information is collected from pull request descriptions rather than from
-manually edited `CHANGELOG.md` files. When you open a PR, use the template sections
-at the bottom of the description to record your changes.
+Changelog entries are **optional for contributors**. If you don't add them a
+maintainer will either write them or apply the `skip-changelog` label before the
+PR is merged.
+
+If you do want to document your change, add entries directly in the PR description
+using the structured sections in the template. Do **not** edit `CHANGELOG.md` —
+those files are updated automatically at release time from the PR descriptions.
 
 ### Format
 

--- a/documentation/CONTRIBUTING.md
+++ b/documentation/CONTRIBUTING.md
@@ -183,6 +183,27 @@ Each item in the `# Changelog` section must begin with one of:
 | `Fixed`   | Bug fixes                                          |
 | `Removed` | Removed API or feature                             |
 
+### Skipping the changelog for a specific crate
+
+If your PR touches a published crate but the change genuinely needs no
+user-visible entry (e.g. a documentation fix, an internal refactor, or a
+build-system tweak), you can exempt that crate by writing the special marker
+as the **sole** item in its `# Changelog` section:
+
+```markdown
+# Changelog
+
+## esp-metadata
+
+- No changelog necessary.
+```
+
+This tells CI that the omission is intentional.  The marker must be the only
+item in the section — combining it with real entries is an error.
+
+When the whole PR needs no changelog at all, a maintainer can apply the
+`skip-changelog` label instead.
+
 ### Validation
 
 You can validate your PR description locally before pushing:

--- a/documentation/CONTRIBUTING.md
+++ b/documentation/CONTRIBUTING.md
@@ -204,6 +204,23 @@ item in the section — combining it with real entries is an error.
 When the whole PR needs no changelog at all, a maintainer can apply the
 `skip-changelog` label instead.
 
+### Manually editing `CHANGELOG.md`
+
+In rare cases — such as backports, hotfixes, or curated release notes that
+cannot be expressed through the structured PR description format — a maintainer
+can apply the `manual-changelog` label to a PR.  This label:
+
+- Allows direct edits to `CHANGELOG.md` files (the automated "no direct
+  CHANGELOG.md edits" check is skipped).
+- Skips the per-package coverage check (the PR is not required to have
+  structured entries in the description).
+- Still validates any PR description entries that *are* present, as a
+  safety net against formatting accidents.
+
+Do **not** use `manual-changelog` for routine changes — the structured PR
+description format exists precisely to keep changelog maintenance consistent
+and automatable.
+
 ### Validation
 
 You can validate your PR description locally before pushing:

--- a/documentation/CONTRIBUTING.md
+++ b/documentation/CONTRIBUTING.md
@@ -122,11 +122,8 @@ This will use `rustfmt` to ensure that all source code is formatted correctly pr
 *   Fill the pull request template so that we can review your PR. This template helps reviewers understand your changes as well as the purpose of your pull request.
 *   [Link your PR] to any relevant issues it addresses.
 *   [Allow edits from maintainers] so the branch can be updated for a merge. Once you submit your PR, a Docs team member will review your proposal. We may ask questions or request additional information.
-*   Make sure you add an entry with your changes to the relevant crate's changelog.
-  * Place your entry in the appropriate section of the upcoming version
-  * Make sure you reference the right pull request at the end of the changelog entry. If you made a change in PR 1234, end your changelog entry with `(#1234)`.
-  * You can amend existing changelog entries, when appropriate. In this case, just append your PR number to that entry's, like `(#789, #1234)`.
-*   If your change requires user code to be changed, make sure you add your changes to the next version's migration guide.
+*   Add changelog entries and/or migration guide notes directly in the PR description using the structured sections provided by the template (see below). Do **not** edit `CHANGELOG.md` files directly — those are updated automatically at release time from the PR descriptions.
+*   If your change requires user code to be changed, describe the required migration steps in the `# Migration guide` section of the PR description.
 *   We may ask for changes to be made before a PR can be merged, either using [suggested changes] or pull request comments. You can apply suggested changes directly through the UI. You can make any other changes in your fork, then commit them to your branch.
 *   As you update your PR and apply changes, mark each conversation as [resolved].
 *   Resolve merge conflicts if they arise, using resources like [this git tutorial] for help.
@@ -137,6 +134,62 @@ This will use `rustfmt` to ensure that all source code is formatted correctly pr
 [resolved]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/commenting-on-a-pull-request#resolving-conversations
 [this git tutorial]: https://github.com/skills/resolve-merge-conflicts
 
+
+## Changelog and Migration Guide Entries
+
+Changelog information is collected from pull request descriptions rather than from
+manually edited `CHANGELOG.md` files. When you open a PR, use the template sections
+at the bottom of the description to record your changes.
+
+### Format
+
+Use `# Changelog` and `# Migration guide` as top-level headings (H1). Under each
+heading, group entries by crate (and optionally by feature area) using H2 headings:
+
+```markdown
+# Changelog
+
+## esp-hal
+
+- Added: Support for the Foo peripheral.
+- Fixed: A bug in the Bar driver that caused incorrect output.
+
+## esp-hal/SPI driver
+
+- Changed: `SpiDevice::transfer` now accepts a mutable slice.
+
+# Migration guide
+
+## esp-hal/SPI driver
+
+`SpiDevice::transfer` now takes `&mut [u8]` instead of `(&[u8], &mut [u8])`.
+Update your call sites accordingly.
+```
+
+### Entry kinds
+
+Each item in the `# Changelog` section must begin with one of:
+
+| Kind      | When to use                                        |
+| --------- | -------------------------------------------------- |
+| `Added`   | New public API, feature, or peripheral support     |
+| `Changed` | Behaviour or API change (non-breaking preferred)   |
+| `Fixed`   | Bug fixes                                          |
+| `Removed` | Removed API or feature                             |
+
+### Validation
+
+You can validate your PR description locally before pushing:
+
+```shell
+# Pipe the body directly:
+echo "# Changelog\n\n## esp-hal\n\n- Added: Something." | cargo xtask check-pr-changelog
+
+# Or validate an open PR by number (requires the `gh` CLI):
+cargo xtask check-pr-changelog --pr 1234
+```
+
+CI will also validate the format automatically on every PR.
 
 ## Your PR is Merged!
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -32,20 +32,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - RSA: the driver should no longer cause unhandled interrupts to fire (#5443)
-- ESP32: attenuation is now correctly set for ADC2 (#5463)
 - UART: disallow 0 as the RX FIFO full threshold (#5451)
 - UART: prevent returning 0 from `read_async` (#5451)
 - ESP32-S2, ESP32-S3: Fixed a bug where `UlpCore.run()` with `UlpCoreWakeupSource::HpCpu` fails to wake the ULP Core (#5410)
-- RMT: allow maximum pulse length on both phases in `PulseCode` (#5501)
-- LEDC: fix off-by-one error in clock divisor calculation (#5496)
-- UART: Wake on detecting a break condition (#5488)
-- Crypto/Copy DMA: fix issue where `in_dscr_empty` was ignored (#5491, #5493)
-- MCPWM: fix `set_timestamp_b` to actually set timestamp for channel B (#5487)
-- SPI DMA: correctly drop bus and buffer if the transfer object is dropped (#5492)
 
 ### Removed
 
-- ESP32: removed unsupported Hall-effect sensor API (#5463)
 - The `Clocks` struct has been removed (#5461)
 
 ## [v1.1.0] - 2026-04-24

--- a/xtask/src/changelog.rs
+++ b/xtask/src/changelog.rs
@@ -10,6 +10,23 @@ pub(crate) struct Changelog {
 }
 
 impl Changelog {
+    /// Create an empty changelog with a single empty `Unreleased` section.
+    pub fn empty() -> Self {
+        Self {
+            entries: vec![ChangelogForVersion {
+                version: "Unreleased".to_string(),
+                date: None,
+                tag: None,
+                groups: vec![
+                    ChangelogGroup::new("Added"),
+                    ChangelogGroup::new("Changed"),
+                    ChangelogGroup::new("Fixed"),
+                    ChangelogGroup::new("Removed"),
+                ],
+            }],
+        }
+    }
+
     /// Parse the changelog, normalizing it in the process.
     pub fn parse(changelog: &str) -> Result<Self> {
         let mut lines = changelog.lines().peekable();
@@ -43,6 +60,59 @@ impl Changelog {
         }
 
         Ok(this)
+    }
+
+    /// Add a new entry to the `Unreleased` section.
+    ///
+    /// `group` must be one of `"Added"`, `"Changed"`, `"Fixed"`, `"Removed"`.
+    /// If the `Unreleased` section does not yet exist it is created.
+    pub fn add_entry(&mut self, group: &str, text: &str, pr: u64) {
+        let unreleased = if let Some(e) = self.entries.iter_mut().find(|e| e.version == "Unreleased") {
+            e
+        } else {
+            self.entries.insert(0, ChangelogForVersion {
+                version: "Unreleased".to_string(),
+                date: None,
+                tag: None,
+                groups: vec![
+                    ChangelogGroup::new("Added"),
+                    ChangelogGroup::new("Changed"),
+                    ChangelogGroup::new("Fixed"),
+                    ChangelogGroup::new("Removed"),
+                ],
+            });
+            &mut self.entries[0]
+        };
+
+        let target_group = if let Some(g) = unreleased.groups.iter_mut().find(|g| g.name == group) {
+            g
+        } else {
+            let name = match group {
+                "Added" => "Added",
+                "Changed" => "Changed",
+                "Fixed" => "Fixed",
+                "Removed" => "Removed",
+                _ => return,
+            };
+            unreleased.groups.push(ChangelogGroup::new(name));
+            unreleased.groups.last_mut().unwrap()
+        };
+
+        target_group.lines.push(ChangelogLine {
+            indentation: 0,
+            line: text.to_string(),
+            prs: vec![pr as usize],
+        });
+    }
+
+    /// Return the `Unreleased` section formatted as it would appear in the
+    /// changelog, or `None` if there is no `Unreleased` section with content.
+    pub fn format_unreleased(&self) -> Option<String> {
+        let unreleased = self.entries.iter().find(|e| e.version == "Unreleased")?;
+        if unreleased.groups.iter().all(|g| g.lines.is_empty()) {
+            return None;
+        }
+        Some(unreleased.to_string())
     }
 
     /// Finalize the changelog for a new release.

--- a/xtask/src/changelog.rs
+++ b/xtask/src/changelog.rs
@@ -67,22 +67,26 @@ impl Changelog {
     /// `group` must be one of `"Added"`, `"Changed"`, `"Fixed"`, `"Removed"`.
     /// If the `Unreleased` section does not yet exist it is created.
     pub fn add_entry(&mut self, group: &str, text: &str, pr: u64) {
-        let unreleased = if let Some(e) = self.entries.iter_mut().find(|e| e.version == "Unreleased") {
-            e
-        } else {
-            self.entries.insert(0, ChangelogForVersion {
-                version: "Unreleased".to_string(),
-                date: None,
-                tag: None,
-                groups: vec![
-                    ChangelogGroup::new("Added"),
-                    ChangelogGroup::new("Changed"),
-                    ChangelogGroup::new("Fixed"),
-                    ChangelogGroup::new("Removed"),
-                ],
-            });
-            &mut self.entries[0]
-        };
+        let unreleased =
+            if let Some(e) = self.entries.iter_mut().find(|e| e.version == "Unreleased") {
+                e
+            } else {
+                self.entries.insert(
+                    0,
+                    ChangelogForVersion {
+                        version: "Unreleased".to_string(),
+                        date: None,
+                        tag: None,
+                        groups: vec![
+                            ChangelogGroup::new("Added"),
+                            ChangelogGroup::new("Changed"),
+                            ChangelogGroup::new("Fixed"),
+                            ChangelogGroup::new("Removed"),
+                        ],
+                    },
+                );
+                &mut self.entries[0]
+            };
 
         let target_group = if let Some(g) = unreleased.groups.iter_mut().find(|g| g.name == group) {
             g

--- a/xtask/src/commands/check_pr_changelog.rs
+++ b/xtask/src/commands/check_pr_changelog.rs
@@ -1,24 +1,26 @@
-use std::{io::Read as _, process::Command};
+use std::{collections::HashSet, io::Read as _, process::Command};
 
 use anyhow::{Context, Result, bail};
 use serde::Deserialize;
+use strum::IntoEnumIterator as _;
 
-use crate::pr_changelog::{PrChangelog, validate};
+use crate::{Package, pr_changelog::{PrChangelog, validate}};
 
 const SKIP_LABEL: &str = "skip-changelog";
 
 /// Check the changelog format of a PR description.
 ///
-/// When `--pr` is given the PR body and labels are fetched from GitHub. If no
-/// changelog entries are present and the `skip-changelog` label is not set the
-/// command fails.
+/// When `--pr` is given, the PR body, labels, and changed files are fetched
+/// from GitHub. For each package that was modified in the PR, a changelog entry
+/// must be present in the PR description — unless the `skip-changelog` label
+/// is set.
 ///
-/// When reading from stdin the label check is skipped (labels are unavailable).
+/// When reading from stdin only the format of the body is validated.
 pub fn check_pr_changelog(pr_number: Option<u64>) -> Result<()> {
     match pr_number {
         Some(pr) => {
             let info = fetch_pr_info(pr)?;
-            check_body_with_labels(pr, &info.body, &info.labels)
+            check_with_github_info(pr, &info)
         }
         None => {
             let mut body = String::new();
@@ -30,38 +32,62 @@ pub fn check_pr_changelog(pr_number: Option<u64>) -> Result<()> {
     }
 }
 
-/// Validate body format and — when no entries are found — require the
-/// `skip-changelog` label.
-fn check_body_with_labels(pr_number: u64, body: &str, labels: &[String]) -> Result<()> {
-    let errors = validate(body);
+fn check_with_github_info(pr_number: u64, info: &FetchedPrInfo) -> Result<()> {
+    // Validate format first.
+    let errors = validate(&info.body);
     if !errors.is_empty() {
         for error in &errors {
             log::error!("{error}");
         }
         bail!(
-            "{} format error(s) found in the PR #{pr_number} description.",
+            "{} format error(s) found in PR #{pr_number} description.",
             errors.len()
         );
     }
 
-    let has_entries = PrChangelog::parse(pr_number, body)?.is_some();
-    if !has_entries {
-        if labels.iter().any(|l| l == SKIP_LABEL) {
-            log::info!("PR #{pr_number}: no changelog entries, but `{SKIP_LABEL}` label is set — OK.");
-        } else {
-            bail!(
-                "PR #{pr_number} has no changelog entries and the `{SKIP_LABEL}` label is not set.\n\
-                 Add changelog entries to the PR description or apply the `{SKIP_LABEL}` label."
-            );
-        }
-    } else {
-        log::info!("PR #{pr_number}: changelog format is valid.");
+    // If the skip label is set, nothing else to check.
+    if info.labels.iter().any(|l| l == SKIP_LABEL) {
+        log::info!("PR #{pr_number}: `{SKIP_LABEL}` label is set — skipping changelog check.");
+        return Ok(());
     }
 
-    Ok(())
+    // Determine which published packages were touched.
+    let modified = modified_packages(&info.files);
+    if modified.is_empty() {
+        log::info!("PR #{pr_number}: no published packages modified — OK.");
+        return Ok(());
+    }
+
+    // Determine which crates have changelog entries in the PR body.
+    let covered: HashSet<String> = PrChangelog::parse(pr_number, &info.body)?
+        .map(|cl| {
+            cl.sections
+                .into_iter()
+                .map(|s| s.crate_name)
+                .collect::<HashSet<_>>()
+        })
+        .unwrap_or_default();
+
+    let missing: Vec<&str> = modified
+        .iter()
+        .filter(|pkg| !covered.contains(*pkg))
+        .map(|s| s.as_str())
+        .collect();
+
+    if missing.is_empty() {
+        log::info!("PR #{pr_number}: all modified packages have changelog entries — OK.");
+        Ok(())
+    } else {
+        bail!(
+            "PR #{pr_number} modifies the following package(s) without a changelog entry: {}.\n\
+             Add entries to the `# Changelog` section of the PR description, \
+             or apply the `{SKIP_LABEL}` label.",
+            missing.join(", ")
+        )
+    }
 }
 
-/// Validate body format only (no label check — used when reading from stdin).
+/// Validate body format only (used when reading from stdin).
 fn check_body_format_only(body: &str) -> Result<()> {
     let errors = validate(body);
     if errors.is_empty() {
@@ -78,10 +104,31 @@ fn check_body_format_only(body: &str) -> Result<()> {
     }
 }
 
+/// Return the set of published package directory names touched by `files`.
+///
+/// Only packages that are published (have a `CHANGELOG.md`) are considered.
+fn modified_packages(files: &[GhFile]) -> HashSet<String> {
+    let published: HashSet<String> = Package::iter()
+        .filter(|p| p.is_published())
+        .map(|p| p.to_string())
+        .collect();
+
+    files
+        .iter()
+        .filter_map(|f| f.path.split('/').next())
+        .filter(|dir| published.contains(*dir))
+        .map(|s| s.to_string())
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// GitHub API types
+
 #[derive(Debug, Deserialize)]
-struct PrInfo {
+struct GhPrInfo {
     body: String,
     labels: Vec<GhLabel>,
+    files: Vec<GhFile>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -89,18 +136,18 @@ struct GhLabel {
     name: String,
 }
 
-impl PrInfo {
-    fn labels(&self) -> Vec<String> {
-        self.labels.iter().map(|l| l.name.clone()).collect()
-    }
+#[derive(Debug, Deserialize)]
+struct GhFile {
+    path: String,
 }
 
 struct FetchedPrInfo {
     body: String,
     labels: Vec<String>,
+    files: Vec<GhFile>,
 }
 
-/// Use the `gh` CLI to fetch the body and labels of a pull request.
+/// Use the `gh` CLI to fetch the body, labels, and changed files of a PR.
 fn fetch_pr_info(pr_number: u64) -> Result<FetchedPrInfo> {
     let output = Command::new("gh")
         .args([
@@ -108,7 +155,7 @@ fn fetch_pr_info(pr_number: u64) -> Result<FetchedPrInfo> {
             "view",
             &pr_number.to_string(),
             "--json",
-            "body,labels",
+            "body,labels,files",
         ])
         .output()
         .context("Failed to invoke `gh`. Is the GitHub CLI installed and authenticated?")?;
@@ -120,11 +167,12 @@ fn fetch_pr_info(pr_number: u64) -> Result<FetchedPrInfo> {
         );
     }
 
-    let info: PrInfo = serde_json::from_slice(&output.stdout)
+    let info: GhPrInfo = serde_json::from_slice(&output.stdout)
         .context("Failed to parse `gh pr view` output")?;
 
     Ok(FetchedPrInfo {
-        labels: info.labels(),
         body: info.body,
+        labels: info.labels.into_iter().map(|l| l.name).collect(),
+        files: info.files,
     })
 }

--- a/xtask/src/commands/check_pr_changelog.rs
+++ b/xtask/src/commands/check_pr_changelog.rs
@@ -3,7 +3,10 @@ use std::{collections::HashSet, io::Read as _, path::Path, process::Command};
 use anyhow::{Context, Result, bail};
 use serde::Deserialize;
 
-use crate::{UPSTREAM_REPO, pr_changelog::{PrChangelog, PrSection, validate}};
+use crate::{
+    UPSTREAM_REPO,
+    pr_changelog::{PrChangelog, PrSection, validate},
+};
 
 const SKIP_LABEL: &str = "skip-changelog";
 

--- a/xtask/src/commands/check_pr_changelog.rs
+++ b/xtask/src/commands/check_pr_changelog.rs
@@ -3,7 +3,7 @@ use std::{collections::HashSet, io::Read as _, path::Path, process::Command};
 use anyhow::{Context, Result, bail};
 use serde::Deserialize;
 
-use crate::pr_changelog::{PrChangelog, validate};
+use crate::pr_changelog::{PrChangelog, PrSection, validate};
 
 const SKIP_LABEL: &str = "skip-changelog";
 
@@ -14,7 +14,8 @@ const SKIP_LABEL: &str = "skip-changelog";
 /// must be present in the PR description — unless the `skip-changelog` label
 /// is set.
 ///
-/// When reading from stdin only the format of the body is validated.
+/// When reading from stdin the body is parsed, its format and crate names are
+/// validated, but the per-package coverage check is skipped (no file list).
 pub fn check_pr_changelog(workspace: &Path, pr_number: Option<u64>) -> Result<()> {
     match pr_number {
         Some(pr) => {
@@ -26,23 +27,13 @@ pub fn check_pr_changelog(workspace: &Path, pr_number: Option<u64>) -> Result<()
             std::io::stdin()
                 .read_to_string(&mut body)
                 .context("Failed to read PR body from stdin")?;
-            check_body_format_only(workspace, &body)
+            check_body(workspace, &body)
         }
     }
 }
 
-fn check_with_github_info(workspace: &Path, pr_number: u64, info: &FetchedPrInfo) -> Result<()> {
-    // Validate format first.
-    let errors = validate(&info.body);
-    if !errors.is_empty() {
-        for error in &errors {
-            log::error!("{error}");
-        }
-        bail!(
-            "{} format error(s) found in PR #{pr_number} description.",
-            errors.len()
-        );
-    }
+fn check_with_github_info(workspace: &Path, pr_number: u64, info: &PrInfo) -> Result<()> {
+    fail_on_format_errors(pr_number, validate(&info.body))?;
 
     // If the skip label is set, nothing else to check.
     if info.labels.iter().any(|l| l == SKIP_LABEL) {
@@ -50,9 +41,8 @@ fn check_with_github_info(workspace: &Path, pr_number: u64, info: &FetchedPrInfo
         return Ok(());
     }
 
-    // Validate that all crate names referenced in the changelog exist and are published.
-    // This runs unconditionally so entries for unknown/unpublished packages always fail.
-    check_changelog_crate_names(workspace, pr_number, &info.body)?;
+    // Parse once; reuse for both crate-name validation and coverage check.
+    let sections = parse_and_validate_crates(workspace, &info.body)?;
 
     // Determine which published packages were touched.
     let modified = modified_packages(workspace, &info.files);
@@ -61,19 +51,10 @@ fn check_with_github_info(workspace: &Path, pr_number: u64, info: &FetchedPrInfo
         return Ok(());
     }
 
-    // Determine which crates have changelog entries in the PR body.
-    let covered: HashSet<String> = PrChangelog::parse(pr_number, &info.body)?
-        .map(|cl| {
-            cl.sections
-                .into_iter()
-                .map(|s| s.crate_name)
-                .collect::<HashSet<_>>()
-        })
-        .unwrap_or_default();
-
+    let covered: HashSet<&str> = sections.iter().map(|s| s.crate_name.as_str()).collect();
     let missing: Vec<&str> = modified
         .iter()
-        .filter(|pkg| !covered.contains(*pkg))
+        .filter(|pkg| !covered.contains(pkg.as_str()))
         .map(|s| s.as_str())
         .collect();
 
@@ -91,39 +72,40 @@ fn check_with_github_info(workspace: &Path, pr_number: u64, info: &FetchedPrInfo
 }
 
 /// Validate body format and crate names (used when reading from stdin).
-fn check_body_format_only(workspace: &Path, body: &str) -> Result<()> {
-    let errors = validate(body);
-    if !errors.is_empty() {
-        for error in &errors {
-            log::error!("{error}");
-        }
-        bail!(
-            "{} format error(s) found in the PR description.",
-            errors.len()
-        );
-    }
-    check_changelog_crate_names(workspace, 0, body)?;
+fn check_body(workspace: &Path, body: &str) -> Result<()> {
+    fail_on_format_errors(0, validate(body))?;
+    parse_and_validate_crates(workspace, body)?;
     log::info!("PR description changelog format is valid.");
     Ok(())
 }
 
-/// Verify that every crate name referenced in the changelog sections of `body`
-/// corresponds to a published package in the workspace.
-///
-/// Fails if any referenced crate:
-/// - has no `Cargo.toml` in the workspace (unknown package), or
-/// - has `publish = false` (not a published package).
-fn check_changelog_crate_names(workspace: &Path, pr_number: u64, body: &str) -> Result<()> {
-    let Some(cl) = PrChangelog::parse(pr_number, body)? else {
+/// Emit formatted errors and bail if `errors` is non-empty.
+fn fail_on_format_errors(pr_number: u64, errors: Vec<String>) -> Result<()> {
+    if errors.is_empty() {
         return Ok(());
-    };
+    }
+    for error in &errors {
+        log::error!("{error}");
+    }
+    if pr_number == 0 {
+        bail!("{} format error(s) found in the PR description.", errors.len());
+    } else {
+        bail!("{} format error(s) found in PR #{pr_number} description.", errors.len());
+    }
+}
+
+/// Parse `body` and verify every referenced crate is a published workspace package.
+///
+/// Returns the parsed sections so callers can reuse them without re-parsing.
+fn parse_and_validate_crates(workspace: &Path, body: &str) -> Result<Vec<PrSection>> {
+    let sections = PrChangelog::parse(0, body)?
+        .map(|cl| cl.sections)
+        .unwrap_or_default();
 
     let mut bad: Vec<String> = Vec::new();
-
-    for section in &cl.sections {
+    for section in &sections {
         let name = &section.crate_name;
         let cargo_toml = workspace.join(name).join("Cargo.toml");
-
         if !cargo_toml.exists() {
             bad.push(format!("`{name}` (no such package in the workspace)"));
         } else if !is_published(&cargo_toml) {
@@ -132,7 +114,7 @@ fn check_changelog_crate_names(workspace: &Path, pr_number: u64, body: &str) -> 
     }
 
     if bad.is_empty() {
-        Ok(())
+        Ok(sections)
     } else {
         bail!(
             "Changelog entries reference package(s) that are not published:\n  {}\n\
@@ -143,36 +125,28 @@ fn check_changelog_crate_names(workspace: &Path, pr_number: u64, body: &str) -> 
 }
 
 /// Return the set of published package directory names touched by `files`.
-///
-/// A package is considered published when its `Cargo.toml` does not contain
-/// `publish = false`. Packages without a `Cargo.toml` at the workspace root
-/// level are ignored.
 fn modified_packages(workspace: &Path, files: &[GhFile]) -> HashSet<String> {
-    let mut result = HashSet::new();
-
-    for dir in files
+    files
         .iter()
         .filter_map(|f| f.path.split('/').next())
         .collect::<HashSet<_>>()
-    {
-        let cargo_toml_path = workspace.join(dir).join("Cargo.toml");
-        if !cargo_toml_path.exists() {
-            continue;
-        }
-        if is_published(&cargo_toml_path) {
-            result.insert(dir.to_string());
-        } else {
-            log::debug!("Skipping '{dir}': publish = false");
-        }
-    }
-
-    result
+        .into_iter()
+        .filter(|dir| {
+            let p = workspace.join(dir).join("Cargo.toml");
+            if !p.exists() {
+                return false;
+            }
+            let published = is_published(&p);
+            if !published {
+                log::debug!("Skipping '{dir}': publish = false");
+            }
+            published
+        })
+        .map(|s| s.to_string())
+        .collect()
 }
 
-/// Returns `true` when the `Cargo.toml` at `path` does not opt out of publishing.
-///
-/// A package is considered unpublished when it has `publish = false` in its
-/// `[package]` table. Missing the key, or any parse error, defaults to `true`.
+/// Returns `true` when the `Cargo.toml` at `path` does not have `publish = false`.
 fn is_published(path: &Path) -> bool {
     let Ok(text) = std::fs::read_to_string(path) else {
         return true;
@@ -190,15 +164,21 @@ fn is_published(path: &Path) -> bool {
 // GitHub API types
 
 #[derive(Debug, Deserialize)]
-struct GhPrInfo {
+struct PrInfo {
     body: String,
-    labels: Vec<GhLabel>,
+    labels: Vec<Label>,
     files: Vec<GhFile>,
 }
 
 #[derive(Debug, Deserialize)]
-struct GhLabel {
+struct Label {
     name: String,
+}
+
+impl PartialEq<str> for Label {
+    fn eq(&self, other: &str) -> bool {
+        self.name == other
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -206,14 +186,8 @@ struct GhFile {
     path: String,
 }
 
-struct FetchedPrInfo {
-    body: String,
-    labels: Vec<String>,
-    files: Vec<GhFile>,
-}
-
 /// Use the `gh` CLI to fetch the body, labels, and changed files of a PR.
-fn fetch_pr_info(pr_number: u64) -> Result<FetchedPrInfo> {
+fn fetch_pr_info(pr_number: u64) -> Result<PrInfo> {
     let output = Command::new("gh")
         .args([
             "pr",
@@ -232,12 +206,5 @@ fn fetch_pr_info(pr_number: u64) -> Result<FetchedPrInfo> {
         );
     }
 
-    let info: GhPrInfo = serde_json::from_slice(&output.stdout)
-        .context("Failed to parse `gh pr view` output")?;
-
-    Ok(FetchedPrInfo {
-        body: info.body,
-        labels: info.labels.into_iter().map(|l| l.name).collect(),
-        files: info.files,
-    })
+    serde_json::from_slice(&output.stdout).context("Failed to parse `gh pr view` output")
 }

--- a/xtask/src/commands/check_pr_changelog.rs
+++ b/xtask/src/commands/check_pr_changelog.rs
@@ -1,26 +1,69 @@
 use std::{io::Read as _, process::Command};
 
 use anyhow::{Context, Result, bail};
+use serde::Deserialize;
 
-use crate::pr_changelog::validate;
+use crate::pr_changelog::{PrChangelog, validate};
+
+const SKIP_LABEL: &str = "skip-changelog";
 
 /// Check the changelog format of a PR description.
 ///
-/// The body is read from stdin, or fetched from GitHub when `--pr` is given.
+/// When `--pr` is given the PR body and labels are fetched from GitHub. If no
+/// changelog entries are present and the `skip-changelog` label is not set the
+/// command fails.
+///
+/// When reading from stdin the label check is skipped (labels are unavailable).
 pub fn check_pr_changelog(pr_number: Option<u64>) -> Result<()> {
-    let body = match pr_number {
-        Some(pr) => fetch_pr_body(pr)?,
-        None => {
-            let mut buf = String::new();
-            std::io::stdin()
-                .read_to_string(&mut buf)
-                .context("Failed to read PR body from stdin")?;
-            buf
+    match pr_number {
+        Some(pr) => {
+            let info = fetch_pr_info(pr)?;
+            check_body_with_labels(pr, &info.body, &info.labels)
         }
-    };
+        None => {
+            let mut body = String::new();
+            std::io::stdin()
+                .read_to_string(&mut body)
+                .context("Failed to read PR body from stdin")?;
+            check_body_format_only(&body)
+        }
+    }
+}
 
-    let errors = validate(&body);
+/// Validate body format and — when no entries are found — require the
+/// `skip-changelog` label.
+fn check_body_with_labels(pr_number: u64, body: &str, labels: &[String]) -> Result<()> {
+    let errors = validate(body);
+    if !errors.is_empty() {
+        for error in &errors {
+            log::error!("{error}");
+        }
+        bail!(
+            "{} format error(s) found in the PR #{pr_number} description.",
+            errors.len()
+        );
+    }
 
+    let has_entries = PrChangelog::parse(pr_number, body)?.is_some();
+    if !has_entries {
+        if labels.iter().any(|l| l == SKIP_LABEL) {
+            log::info!("PR #{pr_number}: no changelog entries, but `{SKIP_LABEL}` label is set — OK.");
+        } else {
+            bail!(
+                "PR #{pr_number} has no changelog entries and the `{SKIP_LABEL}` label is not set.\n\
+                 Add changelog entries to the PR description or apply the `{SKIP_LABEL}` label."
+            );
+        }
+    } else {
+        log::info!("PR #{pr_number}: changelog format is valid.");
+    }
+
+    Ok(())
+}
+
+/// Validate body format only (no label check — used when reading from stdin).
+fn check_body_format_only(body: &str) -> Result<()> {
+    let errors = validate(body);
     if errors.is_empty() {
         log::info!("PR description changelog format is valid.");
         Ok(())
@@ -29,16 +72,44 @@ pub fn check_pr_changelog(pr_number: Option<u64>) -> Result<()> {
             log::error!("{error}");
         }
         bail!(
-            "{} format error(s) found in the PR description changelog.",
+            "{} format error(s) found in the PR description.",
             errors.len()
         );
     }
 }
 
-/// Use the `gh` CLI to fetch the body of a pull request.
-fn fetch_pr_body(pr_number: u64) -> Result<String> {
+#[derive(Debug, Deserialize)]
+struct PrInfo {
+    body: String,
+    labels: Vec<GhLabel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhLabel {
+    name: String,
+}
+
+impl PrInfo {
+    fn labels(&self) -> Vec<String> {
+        self.labels.iter().map(|l| l.name.clone()).collect()
+    }
+}
+
+struct FetchedPrInfo {
+    body: String,
+    labels: Vec<String>,
+}
+
+/// Use the `gh` CLI to fetch the body and labels of a pull request.
+fn fetch_pr_info(pr_number: u64) -> Result<FetchedPrInfo> {
     let output = Command::new("gh")
-        .args(["pr", "view", &pr_number.to_string(), "--json", "body", "--jq", ".body"])
+        .args([
+            "pr",
+            "view",
+            &pr_number.to_string(),
+            "--json",
+            "body,labels",
+        ])
         .output()
         .context("Failed to invoke `gh`. Is the GitHub CLI installed and authenticated?")?;
 
@@ -49,5 +120,11 @@ fn fetch_pr_body(pr_number: u64) -> Result<String> {
         );
     }
 
-    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    let info: PrInfo = serde_json::from_slice(&output.stdout)
+        .context("Failed to parse `gh pr view` output")?;
+
+    Ok(FetchedPrInfo {
+        labels: info.labels(),
+        body: info.body,
+    })
 }

--- a/xtask/src/commands/check_pr_changelog.rs
+++ b/xtask/src/commands/check_pr_changelog.rs
@@ -56,12 +56,12 @@ fn check_with_github_info(workspace: &Path, pr_number: u64, info: &PrInfo) -> Re
         return Ok(());
     }
 
-    // A section counts as "covered" only when it contains at least one
-    // changelog list item. A migration-guide-only section does not satisfy
-    // the changelog requirement.
+    // A section counts as "covered" when it has at least one changelog list
+    // item, or when the author explicitly wrote `- No changelog necessary.`.
+    // A migration-guide-only section does not satisfy the changelog requirement.
     let covered: HashSet<&str> = sections
         .iter()
-        .filter(|s| !s.changelog.is_empty())
+        .filter(|s| !s.changelog.is_empty() || s.exempted)
         .map(|s| s.crate_name.as_str())
         .collect();
     let missing: Vec<&str> = modified
@@ -76,7 +76,8 @@ fn check_with_github_info(workspace: &Path, pr_number: u64, info: &PrInfo) -> Re
     } else {
         bail!(
             "PR #{pr_number} modifies the following package(s) without a changelog entry: {}.\n\
-             Add entries to the `# Changelog` section of the PR description, \
+             Add entries to the `# Changelog` section of the PR description, write \
+             `- No changelog necessary.` under the crate's heading to explicitly exempt it, \
              or ask a maintainer to apply the `{SKIP_LABEL}` label.",
             missing.join(", ")
         )

--- a/xtask/src/commands/check_pr_changelog.rs
+++ b/xtask/src/commands/check_pr_changelog.rs
@@ -26,7 +26,7 @@ pub fn check_pr_changelog(workspace: &Path, pr_number: Option<u64>) -> Result<()
             std::io::stdin()
                 .read_to_string(&mut body)
                 .context("Failed to read PR body from stdin")?;
-            check_body_format_only(&body)
+            check_body_format_only(workspace, &body)
         }
     }
 }
@@ -57,6 +57,9 @@ fn check_with_github_info(workspace: &Path, pr_number: u64, info: &FetchedPrInfo
         return Ok(());
     }
 
+    // Parse and validate crate names in the changelog entries.
+    check_changelog_crate_names(workspace, pr_number, &info.body)?;
+
     // Determine which crates have changelog entries in the PR body.
     let covered: HashSet<String> = PrChangelog::parse(pr_number, &info.body)?
         .map(|cl| {
@@ -86,13 +89,10 @@ fn check_with_github_info(workspace: &Path, pr_number: u64, info: &FetchedPrInfo
     }
 }
 
-/// Validate body format only (used when reading from stdin).
-fn check_body_format_only(body: &str) -> Result<()> {
+/// Validate body format and crate names (used when reading from stdin).
+fn check_body_format_only(workspace: &Path, body: &str) -> Result<()> {
     let errors = validate(body);
-    if errors.is_empty() {
-        log::info!("PR description changelog format is valid.");
-        Ok(())
-    } else {
+    if !errors.is_empty() {
         for error in &errors {
             log::error!("{error}");
         }
@@ -100,6 +100,44 @@ fn check_body_format_only(body: &str) -> Result<()> {
             "{} format error(s) found in the PR description.",
             errors.len()
         );
+    }
+    check_changelog_crate_names(workspace, 0, body)?;
+    log::info!("PR description changelog format is valid.");
+    Ok(())
+}
+
+/// Verify that every crate name referenced in the changelog sections of `body`
+/// corresponds to a published package in the workspace.
+///
+/// Fails if any referenced crate:
+/// - has no `Cargo.toml` in the workspace (unknown package), or
+/// - has `publish = false` (not a published package).
+fn check_changelog_crate_names(workspace: &Path, pr_number: u64, body: &str) -> Result<()> {
+    let Some(cl) = PrChangelog::parse(pr_number, body)? else {
+        return Ok(());
+    };
+
+    let mut bad: Vec<String> = Vec::new();
+
+    for section in &cl.sections {
+        let name = &section.crate_name;
+        let cargo_toml = workspace.join(name).join("Cargo.toml");
+
+        if !cargo_toml.exists() {
+            bad.push(format!("`{name}` (no such package in the workspace)"));
+        } else if !is_published(&cargo_toml) {
+            bad.push(format!("`{name}` (publish = false)"));
+        }
+    }
+
+    if bad.is_empty() {
+        Ok(())
+    } else {
+        bail!(
+            "Changelog entries reference package(s) that are not published:\n  {}\n\
+             Only published packages should have changelog entries.",
+            bad.join("\n  ")
+        )
     }
 }
 

--- a/xtask/src/commands/check_pr_changelog.rs
+++ b/xtask/src/commands/check_pr_changelog.rs
@@ -3,7 +3,7 @@ use std::{collections::HashSet, io::Read as _, path::Path, process::Command};
 use anyhow::{Context, Result, bail};
 use serde::Deserialize;
 
-use crate::pr_changelog::{PrChangelog, PrSection, validate};
+use crate::{UPSTREAM_REPO, pr_changelog::{PrChangelog, PrSection, validate}};
 
 const SKIP_LABEL: &str = "skip-changelog";
 
@@ -207,6 +207,8 @@ fn fetch_pr_info(pr_number: u64) -> Result<PrInfo> {
             "pr",
             "view",
             &pr_number.to_string(),
+            "--repo",
+            UPSTREAM_REPO,
             "--json",
             "body,labels,files",
         ])

--- a/xtask/src/commands/check_pr_changelog.rs
+++ b/xtask/src/commands/check_pr_changelog.rs
@@ -88,9 +88,15 @@ fn fail_on_format_errors(pr_number: u64, errors: Vec<String>) -> Result<()> {
         log::error!("{error}");
     }
     if pr_number == 0 {
-        bail!("{} format error(s) found in the PR description.", errors.len());
+        bail!(
+            "{} format error(s) found in the PR description.",
+            errors.len()
+        );
     } else {
-        bail!("{} format error(s) found in PR #{pr_number} description.", errors.len());
+        bail!(
+            "{} format error(s) found in PR #{pr_number} description.",
+            errors.len()
+        );
     }
 }
 

--- a/xtask/src/commands/check_pr_changelog.rs
+++ b/xtask/src/commands/check_pr_changelog.rs
@@ -50,15 +50,16 @@ fn check_with_github_info(workspace: &Path, pr_number: u64, info: &FetchedPrInfo
         return Ok(());
     }
 
+    // Validate that all crate names referenced in the changelog exist and are published.
+    // This runs unconditionally so entries for unknown/unpublished packages always fail.
+    check_changelog_crate_names(workspace, pr_number, &info.body)?;
+
     // Determine which published packages were touched.
     let modified = modified_packages(workspace, &info.files);
     if modified.is_empty() {
         log::info!("PR #{pr_number}: no published packages modified — OK.");
         return Ok(());
     }
-
-    // Parse and validate crate names in the changelog entries.
-    check_changelog_crate_names(workspace, pr_number, &info.body)?;
 
     // Determine which crates have changelog entries in the PR body.
     let covered: HashSet<String> = PrChangelog::parse(pr_number, &info.body)?

--- a/xtask/src/commands/check_pr_changelog.rs
+++ b/xtask/src/commands/check_pr_changelog.rs
@@ -20,8 +20,16 @@ const MANUAL_CHANGELOG_LABEL: &str = "manual-changelog";
 /// Changelog entries are optional — contributors are not required to add them.
 /// When entries are present their format is checked and the referenced crate
 /// names must be published workspace packages. If a published package was
-/// modified without any changelog entry, the check fails; a maintainer can
-/// apply the `skip-changelog` label to waive this requirement.
+/// modified without any changelog entry, the check fails.
+///
+/// Two labels affect the behaviour:
+///
+/// - `skip-changelog` — skips the entire check (format, crate names, coverage). Applied by a
+///   maintainer when the PR genuinely needs no changelog tracking.
+/// - `manual-changelog` — skips only the per-package coverage check. Format and crate-name
+///   validation still run so that any PR description entries that happen to be present are still
+///   well-formed.  Applied by a maintainer when the changelog is being updated by directly editing
+///   `CHANGELOG.md` (backports, hotfixes, curated release notes, etc.).
 ///
 /// When `--pr` is given, the PR body, labels, and changed files are fetched
 /// from GitHub. When reading from stdin the body format and crate names are

--- a/xtask/src/commands/check_pr_changelog.rs
+++ b/xtask/src/commands/check_pr_changelog.rs
@@ -90,8 +90,14 @@ fn fail_on_format_errors(pr_number: Option<u64>, errors: Vec<String>) -> Result<
         log::error!("{error}");
     }
     match pr_number {
-        Some(pr) => bail!("{} format error(s) found in PR #{pr} description.", errors.len()),
-        None => bail!("{} format error(s) found in the PR description.", errors.len()),
+        Some(pr) => bail!(
+            "{} format error(s) found in PR #{pr} description.",
+            errors.len()
+        ),
+        None => bail!(
+            "{} format error(s) found in the PR description.",
+            errors.len()
+        ),
     }
 }
 

--- a/xtask/src/commands/check_pr_changelog.rs
+++ b/xtask/src/commands/check_pr_changelog.rs
@@ -1,0 +1,53 @@
+use std::{io::Read as _, process::Command};
+
+use anyhow::{Context, Result, bail};
+
+use crate::pr_changelog::validate;
+
+/// Check the changelog format of a PR description.
+///
+/// The body is read from stdin, or fetched from GitHub when `--pr` is given.
+pub fn check_pr_changelog(pr_number: Option<u64>) -> Result<()> {
+    let body = match pr_number {
+        Some(pr) => fetch_pr_body(pr)?,
+        None => {
+            let mut buf = String::new();
+            std::io::stdin()
+                .read_to_string(&mut buf)
+                .context("Failed to read PR body from stdin")?;
+            buf
+        }
+    };
+
+    let errors = validate(&body);
+
+    if errors.is_empty() {
+        log::info!("PR description changelog format is valid.");
+        Ok(())
+    } else {
+        for error in &errors {
+            log::error!("{error}");
+        }
+        bail!(
+            "{} format error(s) found in the PR description changelog.",
+            errors.len()
+        );
+    }
+}
+
+/// Use the `gh` CLI to fetch the body of a pull request.
+fn fetch_pr_body(pr_number: u64) -> Result<String> {
+    let output = Command::new("gh")
+        .args(["pr", "view", &pr_number.to_string(), "--json", "body", "--jq", ".body"])
+        .output()
+        .context("Failed to invoke `gh`. Is the GitHub CLI installed and authenticated?")?;
+
+    if !output.status.success() {
+        bail!(
+            "`gh pr view` failed for PR #{pr_number}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}

--- a/xtask/src/commands/check_pr_changelog.rs
+++ b/xtask/src/commands/check_pr_changelog.rs
@@ -1,10 +1,9 @@
-use std::{collections::HashSet, io::Read as _, process::Command};
+use std::{collections::HashSet, io::Read as _, path::Path, process::Command};
 
 use anyhow::{Context, Result, bail};
 use serde::Deserialize;
-use strum::IntoEnumIterator as _;
 
-use crate::{Package, pr_changelog::{PrChangelog, validate}};
+use crate::pr_changelog::{PrChangelog, validate};
 
 const SKIP_LABEL: &str = "skip-changelog";
 
@@ -16,11 +15,11 @@ const SKIP_LABEL: &str = "skip-changelog";
 /// is set.
 ///
 /// When reading from stdin only the format of the body is validated.
-pub fn check_pr_changelog(pr_number: Option<u64>) -> Result<()> {
+pub fn check_pr_changelog(workspace: &Path, pr_number: Option<u64>) -> Result<()> {
     match pr_number {
         Some(pr) => {
             let info = fetch_pr_info(pr)?;
-            check_with_github_info(pr, &info)
+            check_with_github_info(workspace, pr, &info)
         }
         None => {
             let mut body = String::new();
@@ -32,7 +31,7 @@ pub fn check_pr_changelog(pr_number: Option<u64>) -> Result<()> {
     }
 }
 
-fn check_with_github_info(pr_number: u64, info: &FetchedPrInfo) -> Result<()> {
+fn check_with_github_info(workspace: &Path, pr_number: u64, info: &FetchedPrInfo) -> Result<()> {
     // Validate format first.
     let errors = validate(&info.body);
     if !errors.is_empty() {
@@ -52,7 +51,7 @@ fn check_with_github_info(pr_number: u64, info: &FetchedPrInfo) -> Result<()> {
     }
 
     // Determine which published packages were touched.
-    let modified = modified_packages(&info.files);
+    let modified = modified_packages(workspace, &info.files);
     if modified.is_empty() {
         log::info!("PR #{pr_number}: no published packages modified — OK.");
         return Ok(());
@@ -106,19 +105,46 @@ fn check_body_format_only(body: &str) -> Result<()> {
 
 /// Return the set of published package directory names touched by `files`.
 ///
-/// Only packages that are published (have a `CHANGELOG.md`) are considered.
-fn modified_packages(files: &[GhFile]) -> HashSet<String> {
-    let published: HashSet<String> = Package::iter()
-        .filter(|p| p.is_published())
-        .map(|p| p.to_string())
-        .collect();
+/// A package is considered published when its `Cargo.toml` does not contain
+/// `publish = false`. Packages without a `Cargo.toml` at the workspace root
+/// level are ignored.
+fn modified_packages(workspace: &Path, files: &[GhFile]) -> HashSet<String> {
+    let mut result = HashSet::new();
 
-    files
+    for dir in files
         .iter()
         .filter_map(|f| f.path.split('/').next())
-        .filter(|dir| published.contains(*dir))
-        .map(|s| s.to_string())
-        .collect()
+        .collect::<HashSet<_>>()
+    {
+        let cargo_toml_path = workspace.join(dir).join("Cargo.toml");
+        if !cargo_toml_path.exists() {
+            continue;
+        }
+        if is_published(&cargo_toml_path) {
+            result.insert(dir.to_string());
+        } else {
+            log::debug!("Skipping '{dir}': publish = false");
+        }
+    }
+
+    result
+}
+
+/// Returns `true` when the `Cargo.toml` at `path` does not opt out of publishing.
+///
+/// A package is considered unpublished when it has `publish = false` in its
+/// `[package]` table. Missing the key, or any parse error, defaults to `true`.
+fn is_published(path: &Path) -> bool {
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return true;
+    };
+    let Ok(doc) = text.parse::<toml_edit::DocumentMut>() else {
+        return true;
+    };
+    doc.get("package")
+        .and_then(|p| p.get("publish"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true)
 }
 
 // ---------------------------------------------------------------------------

--- a/xtask/src/commands/check_pr_changelog.rs
+++ b/xtask/src/commands/check_pr_changelog.rs
@@ -33,7 +33,7 @@ pub fn check_pr_changelog(workspace: &Path, pr_number: Option<u64>) -> Result<()
 }
 
 fn check_with_github_info(workspace: &Path, pr_number: u64, info: &PrInfo) -> Result<()> {
-    fail_on_format_errors(pr_number, validate(&info.body))?;
+    fail_on_format_errors(Some(pr_number), validate(&info.body))?;
 
     // If the skip label is set, nothing else to check.
     if info.labels.iter().any(|l| l == SKIP_LABEL) {
@@ -73,30 +73,23 @@ fn check_with_github_info(workspace: &Path, pr_number: u64, info: &PrInfo) -> Re
 
 /// Validate body format and crate names (used when reading from stdin).
 fn check_body(workspace: &Path, body: &str) -> Result<()> {
-    fail_on_format_errors(0, validate(body))?;
+    fail_on_format_errors(None, validate(body))?;
     parse_and_validate_crates(workspace, body)?;
     log::info!("PR description changelog format is valid.");
     Ok(())
 }
 
 /// Emit formatted errors and bail if `errors` is non-empty.
-fn fail_on_format_errors(pr_number: u64, errors: Vec<String>) -> Result<()> {
+fn fail_on_format_errors(pr_number: Option<u64>, errors: Vec<String>) -> Result<()> {
     if errors.is_empty() {
         return Ok(());
     }
     for error in &errors {
         log::error!("{error}");
     }
-    if pr_number == 0 {
-        bail!(
-            "{} format error(s) found in the PR description.",
-            errors.len()
-        );
-    } else {
-        bail!(
-            "{} format error(s) found in PR #{pr_number} description.",
-            errors.len()
-        );
+    match pr_number {
+        Some(pr) => bail!("{} format error(s) found in PR #{pr} description.", errors.len()),
+        None => bail!("{} format error(s) found in the PR description.", errors.len()),
     }
 }
 
@@ -135,7 +128,7 @@ fn modified_packages(workspace: &Path, files: &[GhFile]) -> HashSet<String> {
     files
         .iter()
         .filter_map(|f| f.path.split('/').next())
-        .collect::<HashSet<_>>()
+        .collect::<HashSet<_>>() // deduplicate: many files share the same top-level dir
         .into_iter()
         .filter(|dir| {
             let p = workspace.join(dir).join("Cargo.toml");

--- a/xtask/src/commands/check_pr_changelog.rs
+++ b/xtask/src/commands/check_pr_changelog.rs
@@ -7,14 +7,16 @@ use crate::pr_changelog::{PrChangelog, PrSection, validate};
 
 const SKIP_LABEL: &str = "skip-changelog";
 
-/// Check the changelog format of a PR description.
+/// Validate the changelog entries in a PR description.
+///
+/// Changelog entries are optional — contributors are not required to add them.
+/// When entries are present their format is checked and the referenced crate
+/// names must be published workspace packages. If a published package was
+/// modified without any changelog entry, the check fails; a maintainer can
+/// apply the `skip-changelog` label to waive this requirement.
 ///
 /// When `--pr` is given, the PR body, labels, and changed files are fetched
-/// from GitHub. For each package that was modified in the PR, a changelog entry
-/// must be present in the PR description — unless the `skip-changelog` label
-/// is set.
-///
-/// When reading from stdin the body is parsed, its format and crate names are
+/// from GitHub. When reading from stdin the body format and crate names are
 /// validated, but the per-package coverage check is skipped (no file list).
 pub fn check_pr_changelog(workspace: &Path, pr_number: Option<u64>) -> Result<()> {
     match pr_number {
@@ -65,7 +67,7 @@ fn check_with_github_info(workspace: &Path, pr_number: u64, info: &PrInfo) -> Re
         bail!(
             "PR #{pr_number} modifies the following package(s) without a changelog entry: {}.\n\
              Add entries to the `# Changelog` section of the PR description, \
-             or apply the `{SKIP_LABEL}` label.",
+             or ask a maintainer to apply the `{SKIP_LABEL}` label.",
             missing.join(", ")
         )
     }

--- a/xtask/src/commands/check_pr_changelog.rs
+++ b/xtask/src/commands/check_pr_changelog.rs
@@ -10,6 +10,11 @@ use crate::{
 
 const SKIP_LABEL: &str = "skip-changelog";
 
+/// When this label is present contributors may edit `CHANGELOG.md` directly
+/// and the per-package coverage check is skipped.  The PR-description format
+/// is still validated (a useful safety net if entries were added by accident).
+const MANUAL_CHANGELOG_LABEL: &str = "manual-changelog";
+
 /// Validate the changelog entries in a PR description.
 ///
 /// Changelog entries are optional — contributors are not required to add them.
@@ -48,6 +53,17 @@ fn check_with_github_info(workspace: &Path, pr_number: u64, info: &PrInfo) -> Re
 
     // Parse once; reuse for both crate-name validation and coverage check.
     let sections = parse_and_validate_crates(workspace, &info.body)?;
+
+    // If the manual-changelog label is set, direct CHANGELOG.md edits are
+    // permitted and the per-package coverage check is skipped.  Format
+    // validation above still runs.
+    if info.labels.iter().any(|l| l == MANUAL_CHANGELOG_LABEL) {
+        log::info!(
+            "PR #{pr_number}: `{MANUAL_CHANGELOG_LABEL}` label is set — \
+             skipping per-package coverage check."
+        );
+        return Ok(());
+    }
 
     // Determine which published packages were touched.
     let modified = modified_packages(workspace, &info.files);

--- a/xtask/src/commands/check_pr_changelog.rs
+++ b/xtask/src/commands/check_pr_changelog.rs
@@ -53,7 +53,14 @@ fn check_with_github_info(workspace: &Path, pr_number: u64, info: &PrInfo) -> Re
         return Ok(());
     }
 
-    let covered: HashSet<&str> = sections.iter().map(|s| s.crate_name.as_str()).collect();
+    // A section counts as "covered" only when it contains at least one
+    // changelog list item. A migration-guide-only section does not satisfy
+    // the changelog requirement.
+    let covered: HashSet<&str> = sections
+        .iter()
+        .filter(|s| !s.changelog.is_empty())
+        .map(|s| s.crate_name.as_str())
+        .collect();
     let missing: Vec<&str> = modified
         .iter()
         .filter(|pkg| !covered.contains(pkg.as_str()))

--- a/xtask/src/commands/mod.rs
+++ b/xtask/src/commands/mod.rs
@@ -6,13 +6,14 @@ use esp_metadata::Chip;
 use inquire::Select;
 use strum::IntoEnumIterator;
 
-pub use self::{build::*, check_changelog::*, release::*, run::*};
+pub use self::{build::*, check_changelog::*, check_pr_changelog::*, release::*, run::*};
 use crate::{
     Package,
     cargo::{CargoAction, CargoCommandBatcher},
 };
 mod build;
 mod check_changelog;
+mod check_pr_changelog;
 #[cfg(feature = "report")]
 pub mod generate_report;
 #[cfg(feature = "semver-checks")]

--- a/xtask/src/commands/release.rs
+++ b/xtask/src/commands/release.rs
@@ -3,6 +3,7 @@ use clap::Subcommand;
 #[cfg(feature = "release")]
 pub mod bump_msrv;
 pub mod bump_version;
+pub mod changelog_preview;
 #[cfg(feature = "release")]
 pub mod execute_plan;
 #[cfg(feature = "release")]
@@ -16,6 +17,7 @@ pub mod semver_check;
 pub mod tag_releases;
 
 pub use bump_version::*;
+pub use changelog_preview::*;
 #[cfg(feature = "release")]
 pub use execute_plan::*;
 #[cfg(feature = "release")]
@@ -60,6 +62,11 @@ pub enum Release {
     /// - Create new migration guides for packages that have a migration guide
     #[cfg(feature = "release")]
     PostRelease(PostReleaseArgs),
+    /// Preview the changelog that would result from PRs merged since a given ref.
+    ///
+    /// Fetches merged pull requests from GitHub and renders changelog/migration-guide
+    /// entries from their descriptions. Requires the `gh` CLI.
+    ChangelogPreview(ChangelogPreviewArgs),
     /// Bump the version of the specified package(s).
     ///
     /// This command will, for each specified package:

--- a/xtask/src/commands/release/changelog_preview.rs
+++ b/xtask/src/commands/release/changelog_preview.rs
@@ -4,10 +4,7 @@ use anyhow::{Context, Result, bail};
 use clap::Args;
 use serde::Deserialize;
 
-use crate::{
-    changelog::Changelog,
-    pr_changelog::PrChangelog,
-};
+use crate::{changelog::Changelog, pr_changelog::PrChangelog};
 
 const UPSTREAM_REPO: &str = "esp-rs/esp-hal";
 
@@ -38,7 +35,10 @@ pub fn changelog_preview(workspace: &Path, args: ChangelogPreviewArgs) -> Result
     let merged_after = ref_to_timestamp(workspace, &since)?;
     let prs = list_merged_prs(&merged_after, args.limit)?;
 
-    log::info!("Found {} merged PR(s). Parsing changelog entries…", prs.len());
+    log::info!(
+        "Found {} merged PR(s). Parsing changelog entries…",
+        prs.len()
+    );
 
     let mut pr_changelogs: Vec<PrChangelog> = Vec::new();
     let mut skipped = 0usize;
@@ -83,10 +83,11 @@ pub fn changelog_preview(workspace: &Path, args: ChangelogPreviewArgs) -> Result
             }
 
             if let Some(guide) = &section.migration_guide {
-                migrations
-                    .entry(crate_name.clone())
-                    .or_default()
-                    .push((section.area.clone(), pr_cl.pr_number, guide.clone()));
+                migrations.entry(crate_name.clone()).or_default().push((
+                    section.area.clone(),
+                    pr_cl.pr_number,
+                    guide.clone(),
+                ));
             }
         }
     }

--- a/xtask/src/commands/release/changelog_preview.rs
+++ b/xtask/src/commands/release/changelog_preview.rs
@@ -1,4 +1,8 @@
-use std::{collections::BTreeMap, path::Path, process::Command};
+use std::{
+    collections::{BTreeMap, btree_map::Entry},
+    path::Path,
+    process::Command,
+};
 
 use anyhow::{Context, Result, bail};
 use clap::Args;
@@ -139,9 +143,20 @@ pub(crate) fn collect_changelogs(
             let crate_name = &section.crate_name;
 
             for entry in &section.changelog {
-                let changelog = changelogs
-                    .entry(crate_name.clone())
-                    .or_insert_with(|| load_changelog(workspace, crate_name));
+                let changelog = match changelogs.entry(crate_name.clone()) {
+                    Entry::Occupied(e) => e.into_mut(),
+                    Entry::Vacant(e) => {
+                        match load_changelog(workspace, crate_name) {
+                            Ok(Some(cl)) => e.insert(cl),
+                            Ok(None) => e.insert(Changelog::empty()),
+                            Err(err) => {
+                                log::warn!("Skipping changelog entries for '{crate_name}': {err}");
+                                // Do not insert — prevents accidental overwrites.
+                                continue;
+                            }
+                        }
+                    }
+                };
 
                 let text = match &section.area {
                     Some(area) => format!("{area}: {}", entry.text),
@@ -205,21 +220,24 @@ pub fn changelog_preview(workspace: &Path, args: ChangelogPreviewArgs) -> Result
 
 /// Load and parse an existing `CHANGELOG.md` for the given crate name.
 ///
-/// If no changelog exists (e.g. the crate name is unknown or has no file),
-/// returns an empty `Changelog`.
-fn load_changelog(workspace: &Path, crate_name: &str) -> Changelog {
+/// Returns `Ok(None)` when no `CHANGELOG.md` exists for the crate (normal for
+/// new or changelog-free crates). Returns `Err` when the file exists but
+/// cannot be parsed — callers **must not** write a derived changelog back to
+/// disk in that case, to avoid accidentally overwriting good history with a
+/// partially-constructed file.
+fn load_changelog(workspace: &Path, crate_name: &str) -> Result<Option<Changelog>> {
     let path = workspace.join(crate_name).join("CHANGELOG.md");
-    let Ok(text) = std::fs::read_to_string(&path) else {
-        log::debug!("No CHANGELOG.md found for '{crate_name}' (checked {path:?})");
-        return Changelog::empty();
-    };
-    match Changelog::parse(&text) {
-        Ok(cl) => cl,
-        Err(e) => {
-            log::warn!("Failed to parse {}: {e}", path.display());
-            Changelog::empty()
+    let text = match std::fs::read_to_string(&path) {
+        Ok(t) => t,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            log::debug!("No CHANGELOG.md found for '{crate_name}' (checked {path:?})");
+            return Ok(None);
         }
-    }
+        Err(e) => return Err(e).context(format!("Failed to read {}", path.display())),
+    };
+    Changelog::parse(&text)
+        .map(Some)
+        .with_context(|| format!("Failed to parse {}", path.display()))
 }
 
 // ---------------------------------------------------------------------------

--- a/xtask/src/commands/release/changelog_preview.rs
+++ b/xtask/src/commands/release/changelog_preview.rs
@@ -130,12 +130,11 @@ pub fn changelog_preview(workspace: &Path, args: ChangelogPreviewArgs) -> Result
         println!("# Migration guide\n");
         for (crate_name, entries) in &migrations {
             println!("## {crate_name}\n");
-            for (area, pr, guide) in entries {
+            for (area, _pr, guide) in entries {
                 if let Some(area) = area {
                     println!("### {area}\n");
                 }
                 println!("{guide}\n");
-                println!("*(from PR #{pr})*\n");
             }
         }
     }

--- a/xtask/src/commands/release/changelog_preview.rs
+++ b/xtask/src/commands/release/changelog_preview.rs
@@ -2,9 +2,58 @@ use std::{collections::BTreeMap, path::Path, process::Command};
 
 use anyhow::{Context, Result, bail};
 use clap::Args;
+use jiff::Timestamp;
 use serde::Deserialize;
 
 use crate::{changelog::Changelog, pr_changelog::PrChangelog};
+
+// ---------------------------------------------------------------------------
+// Baseline helpers
+
+/// Coarse date + exact Unix timestamp derived from a git ref.
+struct Baseline {
+    /// `YYYY-MM-DD` used for the GitHub `merged:>=` search qualifier.
+    date: String,
+    /// Exact committer Unix timestamp — used for client-side filtering so
+    /// PRs merged on the same calendar day as the ref are not dropped.
+    unix: i64,
+}
+
+/// Derive a `Baseline` from `git_ref` by running `git log` once.
+fn ref_to_baseline(workspace: &Path, git_ref: &str) -> Result<Baseline> {
+    // Request both the short date and the Unix timestamp in one invocation.
+    let output = Command::new("git")
+        .args(["log", "-1", "--format=%cs%n%ct", git_ref])
+        .current_dir(workspace)
+        .output()
+        .context("Failed to run `git log`")?;
+
+    if !output.status.success() {
+        bail!(
+            "`git log` failed for ref '{git_ref}': {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let text = String::from_utf8_lossy(&output.stdout);
+    let mut lines = text.lines();
+
+    let date = lines
+        .next()
+        .filter(|s| !s.trim().is_empty())
+        .context("No date in `git log` output")?
+        .trim()
+        .to_string();
+
+    let unix = lines
+        .next()
+        .context("No Unix timestamp in `git log` output")?
+        .trim()
+        .parse::<i64>()
+        .context("Could not parse Unix timestamp from `git log`")?;
+
+    Ok(Baseline { date, unix })
+}
 
 const UPSTREAM_REPO: &str = "esp-rs/esp-hal";
 
@@ -40,8 +89,20 @@ pub(crate) fn collect_changelogs(
 ) -> Result<(BTreeMap<String, Changelog>, MigrationEntries)> {
     log::info!("Collecting PRs merged since `{since_ref}`…");
 
-    let merged_after = ref_to_timestamp(workspace, since_ref)?;
-    let prs = list_merged_prs(&merged_after, limit)?;
+    let baseline = ref_to_baseline(workspace, since_ref)?;
+    // Fetch with >= (inclusive date) to cast a wide enough net, then trim
+    // precisely client-side so PRs merged later on the same day as the
+    // baseline ref are not excluded.
+    let prs = list_merged_prs(&baseline.date, limit)?;
+    let prs: Vec<GhPr> = prs
+        .into_iter()
+        .filter(|pr| {
+            pr.merged_at
+                .parse::<Timestamp>()
+                .map(|t| t.as_second() > baseline.unix)
+                .unwrap_or(true) // keep if timestamp is unparseable
+        })
+        .collect();
 
     log::info!(
         "Found {} merged PR(s). Parsing changelog entries…",
@@ -169,31 +230,9 @@ struct GhPr {
     number: u64,
     #[serde(default)]
     body: String,
-}
-
-/// Return the date (`YYYY-MM-DD`) when `git_ref` was committed.
-///
-/// GitHub's search API accepts ISO 8601 dates; using the plain date avoids
-/// any timezone-offset parsing issues with the `merged:>DATE` qualifier.
-pub(crate) fn ref_to_timestamp(workspace: &Path, git_ref: &str) -> Result<String> {
-    let output = Command::new("git")
-        .args(["log", "-1", "--format=%cs", git_ref]) // %cs = short date YYYY-MM-DD
-        .current_dir(workspace)
-        .output()
-        .context("Failed to run `git log`")?;
-
-    if !output.status.success() {
-        bail!(
-            "`git log` failed for ref '{git_ref}': {}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
-
-    let ts = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if ts.is_empty() {
-        bail!("Could not determine timestamp for ref '{git_ref}'");
-    }
-    Ok(ts)
+    /// RFC 3339 merge timestamp from GitHub (e.g. `2024-01-15T10:30:00Z`).
+    #[serde(rename = "mergedAt", default)]
+    merged_at: String,
 }
 
 /// Return the most recent tag reachable from `HEAD`.
@@ -215,8 +254,12 @@ fn latest_tag(workspace: &Path) -> Result<String> {
 }
 
 /// Fetch merged PRs from GitHub using the `gh` CLI.
-fn list_merged_prs(merged_after: &str, limit: u32) -> Result<Vec<GhPr>> {
-    let search = format!("repo:{UPSTREAM_REPO} is:pr is:merged merged:>{merged_after}");
+///
+/// `since_date` is a `YYYY-MM-DD` string used with `merged:>=` (inclusive) as
+/// a coarse server-side filter. The caller is responsible for precise
+/// client-side filtering using the exact `mergedAt` timestamp.
+fn list_merged_prs(since_date: &str, limit: u32) -> Result<Vec<GhPr>> {
+    let search = format!("repo:{UPSTREAM_REPO} is:pr is:merged merged:>={since_date}");
 
     let output = Command::new("gh")
         .args([
@@ -231,7 +274,7 @@ fn list_merged_prs(merged_after: &str, limit: u32) -> Result<Vec<GhPr>> {
             "--limit",
             &limit.to_string(),
             "--json",
-            "number,body",
+            "number,body,mergedAt",
         ])
         .output()
         .context("`gh pr list` failed. Is the GitHub CLI installed and authenticated?")?;

--- a/xtask/src/commands/release/changelog_preview.rs
+++ b/xtask/src/commands/release/changelog_preview.rs
@@ -75,7 +75,11 @@ pub fn changelog_preview(workspace: &Path, args: ChangelogPreviewArgs) -> Result
                     .entry(crate_name.clone())
                     .or_insert_with(|| load_changelog(workspace, crate_name));
 
-                changelog.add_entry(entry.kind.as_str(), &entry.text, pr_cl.pr_number);
+                let text = match &section.area {
+                    Some(area) => format!("{area}: {}", entry.text),
+                    None => entry.text.clone(),
+                };
+                changelog.add_entry(entry.kind.as_str(), &text, pr_cl.pr_number);
             }
 
             if let Some(guide) = &section.migration_guide {

--- a/xtask/src/commands/release/changelog_preview.rs
+++ b/xtask/src/commands/release/changelog_preview.rs
@@ -1,0 +1,225 @@
+use std::{collections::BTreeMap, process::Command};
+
+use anyhow::{Context, Result, bail};
+use clap::Args;
+use serde::Deserialize;
+
+use crate::pr_changelog::{EntryKind, PrChangelog};
+
+const UPSTREAM_REPO: &str = "esp-rs/esp-hal";
+
+/// Arguments for the `release changelog-preview` subcommand.
+#[derive(Debug, Args)]
+pub struct ChangelogPreviewArgs {
+    /// Git ref (tag, branch, commit) to use as the baseline.
+    ///
+    /// Only PRs merged after this ref was created are included.
+    /// Defaults to the most recently published tag on the `main` branch.
+    #[arg(long)]
+    pub since: Option<String>,
+
+    /// Maximum number of PRs to fetch (newest first).
+    #[arg(long, default_value_t = 500)]
+    pub limit: u32,
+}
+
+/// Run the `release changelog-preview` subcommand.
+pub fn changelog_preview(args: ChangelogPreviewArgs) -> Result<()> {
+    let since = match args.since {
+        Some(r) => r,
+        None => latest_tag()?,
+    };
+
+    log::info!("Collecting PRs merged since `{since}`…");
+
+    let merged_after = ref_to_timestamp(&since)?;
+    let prs = list_merged_prs(&merged_after, args.limit)?;
+
+    log::info!("Found {} merged PR(s). Parsing changelog entries…", prs.len());
+
+    let mut changelogs: Vec<PrChangelog> = Vec::new();
+    let mut skipped = 0usize;
+
+    for pr in prs {
+        match PrChangelog::parse(pr.number, &pr.body) {
+            Ok(Some(cl)) => changelogs.push(cl),
+            Ok(None) => skipped += 1,
+            Err(e) => {
+                log::warn!("PR #{}: parse error — {e}", pr.number);
+                skipped += 1;
+            }
+        }
+    }
+
+    if skipped > 0 {
+        log::info!("{skipped} PR(s) had no changelog entries and were skipped.");
+    }
+
+    print_preview(&changelogs);
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Preview renderer
+
+/// Group and render all collected changelog entries.
+fn print_preview(changelogs: &[PrChangelog]) {
+    // crate → area (or "") → kind → Vec<(pr, text)>
+    let mut changelog_map: BTreeMap<String, BTreeMap<String, BTreeMap<EntryKind, Vec<(u64, String)>>>> =
+        BTreeMap::new();
+    // crate → area (or "") → Vec<(pr, text)>
+    let mut migration_map: BTreeMap<String, BTreeMap<String, Vec<(u64, String)>>> =
+        BTreeMap::new();
+
+    for cl in changelogs {
+        for section in &cl.sections {
+            let area_key = section.area.clone().unwrap_or_default();
+
+            for entry in &section.changelog {
+                changelog_map
+                    .entry(section.crate_name.clone())
+                    .or_default()
+                    .entry(area_key.clone())
+                    .or_default()
+                    .entry(entry.kind)
+                    .or_default()
+                    .push((cl.pr_number, entry.text.clone()));
+            }
+
+            if let Some(guide) = &section.migration_guide {
+                migration_map
+                    .entry(section.crate_name.clone())
+                    .or_default()
+                    .entry(area_key.clone())
+                    .or_default()
+                    .push((cl.pr_number, guide.clone()));
+            }
+        }
+    }
+
+    if changelog_map.is_empty() && migration_map.is_empty() {
+        println!("(No changelog entries found.)");
+        return;
+    }
+
+    // --- Changelog ---
+    if !changelog_map.is_empty() {
+        println!("# Changelog\n");
+        for (crate_name, areas) in &changelog_map {
+            for (area, kinds) in areas {
+                if area.is_empty() {
+                    println!("## {crate_name}\n");
+                } else {
+                    println!("## {crate_name}/{area}\n");
+                }
+                for kind in [EntryKind::Added, EntryKind::Changed, EntryKind::Fixed, EntryKind::Removed] {
+                    if let Some(entries) = kinds.get(&kind) {
+                        for (pr, text) in entries {
+                            println!("- {kind}: {text} (#{pr})");
+                        }
+                    }
+                }
+                println!();
+            }
+        }
+    }
+
+    // --- Migration guide ---
+    if !migration_map.is_empty() {
+        println!("# Migration guide\n");
+        for (crate_name, areas) in &migration_map {
+            for (area, entries) in areas {
+                if area.is_empty() {
+                    println!("## {crate_name}\n");
+                } else {
+                    println!("## {crate_name}/{area}\n");
+                }
+                for (pr, guide) in entries {
+                    println!("{guide}\n");
+                    println!("*(from PR #{pr})*\n");
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GitHub helpers
+
+#[derive(Debug, Deserialize)]
+struct GhPr {
+    number: u64,
+    #[serde(default)]
+    body: String,
+}
+
+/// Return the date-time string when `git_ref` was created (ISO 8601).
+fn ref_to_timestamp(git_ref: &str) -> Result<String> {
+    let output = Command::new("git")
+        .args(["log", "-1", "--format=%cI", git_ref])
+        .output()
+        .context("Failed to run `git log`")?;
+
+    if !output.status.success() {
+        bail!(
+            "`git log` failed for ref '{git_ref}': {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let ts = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if ts.is_empty() {
+        bail!("Could not determine timestamp for ref '{git_ref}'");
+    }
+    Ok(ts)
+}
+
+/// Return the most recent tag reachable from `HEAD`.
+fn latest_tag() -> Result<String> {
+    let output = Command::new("git")
+        .args(["describe", "--tags", "--abbrev=0"])
+        .output()
+        .context("Failed to run `git describe`")?;
+
+    if !output.status.success() {
+        bail!(
+            "`git describe` failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+/// Fetch merged PRs from GitHub using the `gh` CLI.
+fn list_merged_prs(merged_after: &str, limit: u32) -> Result<Vec<GhPr>> {
+    let search = format!("repo:{UPSTREAM_REPO} is:pr is:merged merged:>{merged_after}");
+
+    let output = Command::new("gh")
+        .args([
+            "pr",
+            "list",
+            "--repo",
+            UPSTREAM_REPO,
+            "--state",
+            "merged",
+            "--search",
+            &search,
+            "--limit",
+            &limit.to_string(),
+            "--json",
+            "number,body",
+        ])
+        .output()
+        .context("`gh pr list` failed. Is the GitHub CLI installed and authenticated?")?;
+
+    if !output.status.success() {
+        bail!(
+            "`gh pr list` failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    serde_json::from_slice(&output.stdout).context("Failed to parse `gh pr list` output")
+}

--- a/xtask/src/commands/release/changelog_preview.rs
+++ b/xtask/src/commands/release/changelog_preview.rs
@@ -1,10 +1,13 @@
-use std::{collections::BTreeMap, process::Command};
+use std::{collections::BTreeMap, path::Path, process::Command};
 
 use anyhow::{Context, Result, bail};
 use clap::Args;
 use serde::Deserialize;
 
-use crate::pr_changelog::{EntryKind, PrChangelog};
+use crate::{
+    changelog::Changelog,
+    pr_changelog::PrChangelog,
+};
 
 const UPSTREAM_REPO: &str = "esp-rs/esp-hal";
 
@@ -13,8 +16,8 @@ const UPSTREAM_REPO: &str = "esp-rs/esp-hal";
 pub struct ChangelogPreviewArgs {
     /// Git ref (tag, branch, commit) to use as the baseline.
     ///
-    /// Only PRs merged after this ref was created are included.
-    /// Defaults to the most recently published tag on the `main` branch.
+    /// Only PRs merged after this ref are included.
+    /// Defaults to the most recently reachable tag.
     #[arg(long)]
     pub since: Option<String>,
 
@@ -24,25 +27,25 @@ pub struct ChangelogPreviewArgs {
 }
 
 /// Run the `release changelog-preview` subcommand.
-pub fn changelog_preview(args: ChangelogPreviewArgs) -> Result<()> {
+pub fn changelog_preview(workspace: &Path, args: ChangelogPreviewArgs) -> Result<()> {
     let since = match args.since {
         Some(r) => r,
-        None => latest_tag()?,
+        None => latest_tag(workspace)?,
     };
 
     log::info!("Collecting PRs merged since `{since}`…");
 
-    let merged_after = ref_to_timestamp(&since)?;
+    let merged_after = ref_to_timestamp(workspace, &since)?;
     let prs = list_merged_prs(&merged_after, args.limit)?;
 
     log::info!("Found {} merged PR(s). Parsing changelog entries…", prs.len());
 
-    let mut changelogs: Vec<PrChangelog> = Vec::new();
+    let mut pr_changelogs: Vec<PrChangelog> = Vec::new();
     let mut skipped = 0usize;
 
     for pr in prs {
         match PrChangelog::parse(pr.number, &pr.body) {
-            Ok(Some(cl)) => changelogs.push(cl),
+            Ok(Some(cl)) => pr_changelogs.push(cl),
             Ok(None) => skipped += 1,
             Err(e) => {
                 log::warn!("PR #{}: parse error — {e}", pr.number);
@@ -55,97 +58,88 @@ pub fn changelog_preview(args: ChangelogPreviewArgs) -> Result<()> {
         log::info!("{skipped} PR(s) had no changelog entries and were skipped.");
     }
 
-    print_preview(&changelogs);
+    // Load each relevant crate's CHANGELOG.md, merge in the PR entries, and
+    // print only the Unreleased section.
+    //
+    // keyed by crate name (e.g. "esp-hal")
+    let mut changelogs: BTreeMap<String, Changelog> = BTreeMap::new();
+    // migration guide entries: crate → list of (area, pr, text)
+    let mut migrations: BTreeMap<String, Vec<(Option<String>, u64, String)>> = BTreeMap::new();
+
+    for pr_cl in &pr_changelogs {
+        for section in &pr_cl.sections {
+            let crate_name = &section.crate_name;
+
+            for entry in &section.changelog {
+                let changelog = changelogs
+                    .entry(crate_name.clone())
+                    .or_insert_with(|| load_changelog(workspace, crate_name));
+
+                changelog.add_entry(entry.kind.as_str(), &entry.text, pr_cl.pr_number);
+            }
+
+            if let Some(guide) = &section.migration_guide {
+                migrations
+                    .entry(crate_name.clone())
+                    .or_default()
+                    .push((section.area.clone(), pr_cl.pr_number, guide.clone()));
+            }
+        }
+    }
+
+    if changelogs.is_empty() && migrations.is_empty() {
+        println!("(No changelog entries found.)");
+        return Ok(());
+    }
+
+    // Print unreleased changelog sections
+    for (crate_name, changelog) in &changelogs {
+        if let Some(text) = changelog.format_unreleased() {
+            println!("<!-- {crate_name} -->");
+            println!("{text}");
+        }
+    }
+
+    // Print migration guide sections
+    if !migrations.is_empty() {
+        println!("---");
+        println!("# Migration guide\n");
+        for (crate_name, entries) in &migrations {
+            println!("## {crate_name}\n");
+            for (area, pr, guide) in entries {
+                if let Some(area) = area {
+                    println!("### {area}\n");
+                }
+                println!("{guide}\n");
+                println!("*(from PR #{pr})*\n");
+            }
+        }
+    }
 
     Ok(())
 }
 
-// ---------------------------------------------------------------------------
-// Preview renderer
-
-/// Group and render all collected changelog entries.
-fn print_preview(changelogs: &[PrChangelog]) {
-    // crate → area (or "") → kind → Vec<(pr, text)>
-    let mut changelog_map: BTreeMap<String, BTreeMap<String, BTreeMap<EntryKind, Vec<(u64, String)>>>> =
-        BTreeMap::new();
-    // crate → area (or "") → Vec<(pr, text)>
-    let mut migration_map: BTreeMap<String, BTreeMap<String, Vec<(u64, String)>>> =
-        BTreeMap::new();
-
-    for cl in changelogs {
-        for section in &cl.sections {
-            let area_key = section.area.clone().unwrap_or_default();
-
-            for entry in &section.changelog {
-                changelog_map
-                    .entry(section.crate_name.clone())
-                    .or_default()
-                    .entry(area_key.clone())
-                    .or_default()
-                    .entry(entry.kind)
-                    .or_default()
-                    .push((cl.pr_number, entry.text.clone()));
-            }
-
-            if let Some(guide) = &section.migration_guide {
-                migration_map
-                    .entry(section.crate_name.clone())
-                    .or_default()
-                    .entry(area_key.clone())
-                    .or_default()
-                    .push((cl.pr_number, guide.clone()));
-            }
-        }
-    }
-
-    if changelog_map.is_empty() && migration_map.is_empty() {
-        println!("(No changelog entries found.)");
-        return;
-    }
-
-    // --- Changelog ---
-    if !changelog_map.is_empty() {
-        println!("# Changelog\n");
-        for (crate_name, areas) in &changelog_map {
-            for (area, kinds) in areas {
-                if area.is_empty() {
-                    println!("## {crate_name}\n");
-                } else {
-                    println!("## {crate_name}/{area}\n");
-                }
-                for kind in [EntryKind::Added, EntryKind::Changed, EntryKind::Fixed, EntryKind::Removed] {
-                    if let Some(entries) = kinds.get(&kind) {
-                        for (pr, text) in entries {
-                            println!("- {kind}: {text} (#{pr})");
-                        }
-                    }
-                }
-                println!();
-            }
-        }
-    }
-
-    // --- Migration guide ---
-    if !migration_map.is_empty() {
-        println!("# Migration guide\n");
-        for (crate_name, areas) in &migration_map {
-            for (area, entries) in areas {
-                if area.is_empty() {
-                    println!("## {crate_name}\n");
-                } else {
-                    println!("## {crate_name}/{area}\n");
-                }
-                for (pr, guide) in entries {
-                    println!("{guide}\n");
-                    println!("*(from PR #{pr})*\n");
-                }
-            }
+/// Load and parse an existing `CHANGELOG.md` for the given crate name.
+///
+/// If no changelog exists (e.g. the crate name is unknown or has no file),
+/// returns an empty `Changelog`.
+fn load_changelog(workspace: &Path, crate_name: &str) -> Changelog {
+    let path = workspace.join(crate_name).join("CHANGELOG.md");
+    let Ok(text) = std::fs::read_to_string(&path) else {
+        log::debug!("No CHANGELOG.md found for '{crate_name}' (checked {path:?})");
+        return Changelog::empty();
+    };
+    match Changelog::parse(&text) {
+        Ok(cl) => cl,
+        Err(e) => {
+            log::warn!("Failed to parse {}: {e}", path.display());
+            Changelog::empty()
         }
     }
 }
 
 // ---------------------------------------------------------------------------
-// GitHub helpers
+// GitHub / git helpers
 
 #[derive(Debug, Deserialize)]
 struct GhPr {
@@ -154,10 +148,11 @@ struct GhPr {
     body: String,
 }
 
-/// Return the date-time string when `git_ref` was created (ISO 8601).
-fn ref_to_timestamp(git_ref: &str) -> Result<String> {
+/// Return the ISO 8601 timestamp when `git_ref` was committed.
+fn ref_to_timestamp(workspace: &Path, git_ref: &str) -> Result<String> {
     let output = Command::new("git")
         .args(["log", "-1", "--format=%cI", git_ref])
+        .current_dir(workspace)
         .output()
         .context("Failed to run `git log`")?;
 
@@ -176,9 +171,10 @@ fn ref_to_timestamp(git_ref: &str) -> Result<String> {
 }
 
 /// Return the most recent tag reachable from `HEAD`.
-fn latest_tag() -> Result<String> {
+fn latest_tag(workspace: &Path) -> Result<String> {
     let output = Command::new("git")
         .args(["describe", "--tags", "--abbrev=0"])
+        .current_dir(workspace)
         .output()
         .context("Failed to run `git describe`")?;
 

--- a/xtask/src/commands/release/changelog_preview.rs
+++ b/xtask/src/commands/release/changelog_preview.rs
@@ -23,17 +23,25 @@ pub struct ChangelogPreviewArgs {
     pub limit: u32,
 }
 
-/// Run the `release changelog-preview` subcommand.
-pub fn changelog_preview(workspace: &Path, args: ChangelogPreviewArgs) -> Result<()> {
-    let since = match args.since {
-        Some(r) => r,
-        None => latest_tag(workspace)?,
-    };
+/// Migration guide entries: `(area, pr_number, guide_text)`.
+pub(crate) type MigrationEntries = BTreeMap<String, Vec<(Option<String>, u64, String)>>;
 
-    log::info!("Collecting PRs merged since `{since}`…");
+/// Collect PR changelog entries merged since `since_ref` into per-crate changelogs.
+///
+/// Returns a pair of maps:
+/// - Merged changelog entries keyed by crate name.
+/// - Migration guide entries keyed by crate name.
+///
+/// Requires the `gh` CLI to be installed and authenticated.
+pub(crate) fn collect_changelogs(
+    workspace: &Path,
+    since_ref: &str,
+    limit: u32,
+) -> Result<(BTreeMap<String, Changelog>, MigrationEntries)> {
+    log::info!("Collecting PRs merged since `{since_ref}`…");
 
-    let merged_after = ref_to_timestamp(workspace, &since)?;
-    let prs = list_merged_prs(&merged_after, args.limit)?;
+    let merged_after = ref_to_timestamp(workspace, since_ref)?;
+    let prs = list_merged_prs(&merged_after, limit)?;
 
     log::info!(
         "Found {} merged PR(s). Parsing changelog entries…",
@@ -58,13 +66,12 @@ pub fn changelog_preview(workspace: &Path, args: ChangelogPreviewArgs) -> Result
         log::info!("{skipped} PR(s) had no changelog entries and were skipped.");
     }
 
-    // Load each relevant crate's CHANGELOG.md, merge in the PR entries, and
-    // print only the Unreleased section.
+    // Load each relevant crate's CHANGELOG.md, merge in the PR entries.
     //
     // keyed by crate name (e.g. "esp-hal")
     let mut changelogs: BTreeMap<String, Changelog> = BTreeMap::new();
     // migration guide entries: crate → list of (area, pr, text)
-    let mut migrations: BTreeMap<String, Vec<(Option<String>, u64, String)>> = BTreeMap::new();
+    let mut migrations: MigrationEntries = BTreeMap::new();
 
     for pr_cl in &pr_changelogs {
         for section in &pr_cl.sections {
@@ -91,6 +98,18 @@ pub fn changelog_preview(workspace: &Path, args: ChangelogPreviewArgs) -> Result
             }
         }
     }
+
+    Ok((changelogs, migrations))
+}
+
+/// Run the `release changelog-preview` subcommand.
+pub fn changelog_preview(workspace: &Path, args: ChangelogPreviewArgs) -> Result<()> {
+    let since = match args.since {
+        Some(r) => r,
+        None => latest_tag(workspace)?,
+    };
+
+    let (changelogs, migrations) = collect_changelogs(workspace, &since, args.limit)?;
 
     if changelogs.is_empty() && migrations.is_empty() {
         println!("(No changelog entries found.)");
@@ -157,7 +176,7 @@ struct GhPr {
 ///
 /// GitHub's search API accepts ISO 8601 dates; using the plain date avoids
 /// any timezone-offset parsing issues with the `merged:>DATE` qualifier.
-fn ref_to_timestamp(workspace: &Path, git_ref: &str) -> Result<String> {
+pub(crate) fn ref_to_timestamp(workspace: &Path, git_ref: &str) -> Result<String> {
     let output = Command::new("git")
         .args(["log", "-1", "--format=%cs", git_ref]) // %cs = short date YYYY-MM-DD
         .current_dir(workspace)

--- a/xtask/src/commands/release/changelog_preview.rs
+++ b/xtask/src/commands/release/changelog_preview.rs
@@ -55,7 +55,7 @@ fn ref_to_baseline(workspace: &Path, git_ref: &str) -> Result<Baseline> {
     Ok(Baseline { date, unix })
 }
 
-const UPSTREAM_REPO: &str = "esp-rs/esp-hal";
+use crate::UPSTREAM_REPO;
 
 /// Arguments for the `release changelog-preview` subcommand.
 #[derive(Debug, Args)]

--- a/xtask/src/commands/release/changelog_preview.rs
+++ b/xtask/src/commands/release/changelog_preview.rs
@@ -153,10 +153,13 @@ struct GhPr {
     body: String,
 }
 
-/// Return the ISO 8601 timestamp when `git_ref` was committed.
+/// Return the date (`YYYY-MM-DD`) when `git_ref` was committed.
+///
+/// GitHub's search API accepts ISO 8601 dates; using the plain date avoids
+/// any timezone-offset parsing issues with the `merged:>DATE` qualifier.
 fn ref_to_timestamp(workspace: &Path, git_ref: &str) -> Result<String> {
     let output = Command::new("git")
-        .args(["log", "-1", "--format=%cI", git_ref])
+        .args(["log", "-1", "--format=%cs", git_ref]) // %cs = short date YYYY-MM-DD
         .current_dir(workspace)
         .output()
         .context("Failed to run `git log`")?;

--- a/xtask/src/commands/release/plan.rs
+++ b/xtask/src/commands/release/plan.rs
@@ -12,7 +12,7 @@ use crate::{
     Package,
     Version,
     cargo::CargoToml,
-    commands::{VersionBump, checker::min_package_update, do_version_bump},
+    commands::{VersionBump, checker::min_package_update, do_version_bump, release::changelog_preview},
     git::{BackportInfo, current_branch, parse_backport_branch},
 };
 
@@ -365,6 +365,23 @@ pub fn plan(workspace: &Path, args: PlanArgs) -> Result<()> {
         file, then run the following command: `cargo xrelease execute-plan`",
     );
 
+    // Merge PR changelog entries directly into CHANGELOG.md / MIGRATING-*.md files.
+    let modified = generate_changelog_draft(workspace, &plan);
+    if modified.is_empty() {
+        println!();
+        println!(
+            "Note: No changelog entries were merged. Run \
+            `cargo xtask release changelog-preview` manually if needed."
+        );
+    } else {
+        println!();
+        println!("Merged changelog entries into the following files:");
+        for path in &modified {
+            println!("  {}", path.display());
+        }
+        println!("Please review and adjust these files before running `cargo xrelease execute-plan`.");
+    }
+
     Ok(())
 }
 
@@ -499,6 +516,141 @@ fn related_crates(workspace: &Path, package: Package) -> Vec<Package> {
     related_crates_cb(package, &|p| {
         CargoToml::new(workspace, p).unwrap().repo_dependencies()
     })
+}
+
+/// Merge PR changelog and migration guide entries from recently-merged PRs
+/// directly into each package's `CHANGELOG.md` and `MIGRATING-*.md` files.
+///
+/// Returns the paths of files that were modified. Returns an empty list if the
+/// `gh` CLI is unavailable, no entries were found, or any other non-fatal
+/// problem occurred.
+fn generate_changelog_draft(workspace: &Path, plan: &Plan) -> Vec<std::path::PathBuf> {
+    if plan.packages.is_empty() {
+        return vec![];
+    }
+
+    // Use the oldest last-release tag as the baseline so we don't miss entries
+    // for packages that were last released earlier than others.
+    let since_ref = plan
+        .packages
+        .iter()
+        .map(|pkg| pkg.package.tag(&pkg.current_version))
+        .min_by_key(|tag| tag_commit_timestamp(workspace, tag))
+        .expect("packages is non-empty");
+
+    // Map crate name → PackagePlan for quick lookup.
+    let pkg_by_crate: HashMap<String, &PackagePlan> = plan
+        .packages
+        .iter()
+        .map(|pkg| (pkg.package.to_string(), pkg))
+        .collect();
+
+    let (changelogs, migrations) =
+        match changelog_preview::collect_changelogs(workspace, &since_ref, 500) {
+            Ok(r) => r,
+            Err(e) => {
+                log::warn!(
+                    "Could not collect changelog entries (is `gh` installed and authenticated?): {e}"
+                );
+                return vec![];
+            }
+        };
+
+    let mut modified: Vec<std::path::PathBuf> = Vec::new();
+
+    // Merge changelog entries into each package's CHANGELOG.md.
+    for (crate_name, new_entries) in &changelogs {
+        let Some(_pkg) = pkg_by_crate.get(crate_name) else {
+            continue;
+        };
+        if new_entries.format_unreleased().is_none() {
+            continue;
+        }
+
+        let changelog_path = workspace.join(crate_name).join("CHANGELOG.md");
+        let changelog_path = crate::windows_safe_path(&changelog_path);
+
+        let written = match std::fs::write(&changelog_path, new_entries.to_string()) {
+            Ok(()) => true,
+            Err(e) => {
+                log::warn!("Could not write {}: {e}", changelog_path.display());
+                false
+            }
+        };
+        if written {
+            modified.push(changelog_path);
+        }
+    }
+
+    // Append migration guide entries to each package's active MIGRATING-*.md.
+    for (crate_name, entries) in &migrations {
+        let Some(pkg) = pkg_by_crate.get(crate_name) else {
+            continue;
+        };
+
+        // Patch releases don't have migration guides; skip them.
+        if pkg.bump.base == Some(Version::Patch) {
+            continue;
+        }
+
+        // The active migration guide is named after the current major.minor version
+        // (zeroed patch). It was created by `post_release` after the previous release.
+        let v = &pkg.current_version;
+        let migration_file = format!("MIGRATING-{}.{}.0.md", v.major, v.minor);
+        let migration_path = workspace.join(crate_name).join(&migration_file);
+        let migration_path = crate::windows_safe_path(&migration_path);
+
+        if !migration_path.exists() {
+            log::warn!(
+                "Migration guide {migration_file} not found for {crate_name}; skipping."
+            );
+            continue;
+        }
+
+        let mut content = match std::fs::read_to_string(&migration_path) {
+            Ok(c) => c,
+            Err(e) => {
+                log::warn!("Could not read {}: {e}", migration_path.display());
+                continue;
+            }
+        };
+
+        // Append each entry's guide text under its area heading.
+        let mut appended = false;
+        for (area, _pr, guide) in entries {
+            if !content.ends_with('\n') {
+                content.push('\n');
+            }
+            content.push('\n');
+            if let Some(area) = area {
+                content.push_str(&format!("## {area}\n\n"));
+            }
+            content.push_str(guide.trim_end());
+            content.push('\n');
+            appended = true;
+        }
+
+        if appended {
+            match std::fs::write(&migration_path, &content) {
+                Ok(()) => modified.push(migration_path),
+                Err(e) => log::warn!("Could not write {}: {e}", migration_path.display()),
+            }
+        }
+    }
+
+    modified
+}
+
+/// Return the UNIX commit timestamp for `tag`, or `0` if unknown.
+fn tag_commit_timestamp(workspace: &Path, tag: &str) -> i64 {
+    Command::new("git")
+        .args(["log", "-1", "--format=%ct", tag])
+        .current_dir(workspace)
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .and_then(|s| s.trim().parse::<i64>().ok())
+        .unwrap_or(0)
 }
 
 fn topological_sort(dep_graph: &HashMap<Package, Vec<Package>>) -> Vec<Package> {

--- a/xtask/src/commands/release/plan.rs
+++ b/xtask/src/commands/release/plan.rs
@@ -336,6 +336,13 @@ pub fn plan(workspace: &Path, args: PlanArgs) -> Result<()> {
 // Starting a pre-release cycle from a stable version without also setting
 // `base` is an error, as it would produce a version lower than the current
 // one.
+//
+// CHANGELOG REVIEW REQUIRED
+// Changelog entries from recently merged PRs have been collected and merged
+// into each package's CHANGELOG.md (Unreleased section) and MIGRATING-*.md
+// files. Please review and adjust those files before running execute-plan:
+//   - Add, remove, or reword entries as appropriate.
+//   - Ensure migration guide content is accurate and complete.
 "#,
     );
 

--- a/xtask/src/commands/release/plan.rs
+++ b/xtask/src/commands/release/plan.rs
@@ -12,7 +12,12 @@ use crate::{
     Package,
     Version,
     cargo::CargoToml,
-    commands::{VersionBump, checker::min_package_update, do_version_bump, release::changelog_preview},
+    commands::{
+        VersionBump,
+        checker::min_package_update,
+        do_version_bump,
+        release::changelog_preview,
+    },
     git::{BackportInfo, current_branch, parse_backport_branch},
 };
 
@@ -386,7 +391,9 @@ pub fn plan(workspace: &Path, args: PlanArgs) -> Result<()> {
         for path in &modified {
             println!("  {}", path.display());
         }
-        println!("Please review and adjust these files before running `cargo xrelease execute-plan`.");
+        println!(
+            "Please review and adjust these files before running `cargo xrelease execute-plan`."
+        );
     }
 
     Ok(())
@@ -552,16 +559,17 @@ fn generate_changelog_draft(workspace: &Path, plan: &Plan) -> Vec<std::path::Pat
         .map(|pkg| (pkg.package.to_string(), pkg))
         .collect();
 
-    let (changelogs, migrations) =
-        match changelog_preview::collect_changelogs(workspace, &since_ref, 500) {
-            Ok(r) => r,
-            Err(e) => {
-                log::warn!(
-                    "Could not collect changelog entries (is `gh` installed and authenticated?): {e}"
-                );
-                return vec![];
-            }
-        };
+    let (changelogs, migrations) = match changelog_preview::collect_changelogs(
+        workspace, &since_ref, 500,
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            log::warn!(
+                "Could not collect changelog entries (is `gh` installed and authenticated?): {e}"
+            );
+            return vec![];
+        }
+    };
 
     let mut modified: Vec<std::path::PathBuf> = Vec::new();
 
@@ -608,9 +616,7 @@ fn generate_changelog_draft(workspace: &Path, plan: &Plan) -> Vec<std::path::Pat
         let migration_path = crate::windows_safe_path(&migration_path);
 
         if !migration_path.exists() {
-            log::warn!(
-                "Migration guide {migration_file} not found for {crate_name}; skipping."
-            );
+            log::warn!("Migration guide {migration_file} not found for {crate_name}; skipping.");
             continue;
         }
 

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -27,6 +27,9 @@ pub mod firmware;
 pub mod git;
 pub mod pr_changelog;
 
+/// GitHub repository used for all `gh` CLI calls.
+pub const UPSTREAM_REPO: &str = "esp-rs/esp-hal";
+
 // ---------------------------------------------------------------------------
 // MCP tool registration
 

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -25,6 +25,7 @@ pub mod commands;
 pub mod documentation;
 pub mod firmware;
 pub mod git;
+pub mod pr_changelog;
 
 // ---------------------------------------------------------------------------
 // MCP tool registration

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -47,6 +47,10 @@ enum Cli {
     SemverCheck(SemverCheckArgs),
     /// Check the changelog for packages.
     CheckChangelog(CheckChangelogArgs),
+    /// Validate the changelog format of a PR description.
+    ///
+    /// Reads the body from stdin by default. Pass `--pr` to fetch from GitHub.
+    CheckPrChangelog(CheckPrChangelogArgs),
     /// Re-generate metadata and the chip support table in the esp-hal README.
     UpdateMetadata(UpdateMetadataArgs),
     /// Run host-tests in the workspace with `cargo test`
@@ -65,6 +69,15 @@ enum Cli {
     /// Start the MCP server (stdio transport, for use with Claude Code).
     #[cfg(feature = "mcp")]
     Mcp,
+}
+
+#[derive(Debug, Args)]
+struct CheckPrChangelogArgs {
+    /// GitHub pull-request number to fetch and validate.
+    ///
+    /// When omitted, the PR body is read from stdin.
+    #[arg(long)]
+    pr: Option<u64>,
 }
 
 #[derive(Debug, Args)]
@@ -154,6 +167,7 @@ fn main() -> Result<()> {
         Cli::LintPackages(args) => lint_packages(&workspace, args),
         Cli::SemverCheck(args) => semver_checks(&workspace, args),
         Cli::CheckChangelog(args) => check_changelog(&workspace, &args.packages, args.normalize),
+        Cli::CheckPrChangelog(args) => check_pr_changelog(args.pr),
         Cli::UpdateMetadata(args) => update_metadata(&workspace, args.check),
         Cli::HostTests(args) => host_tests(&workspace, args),
         Cli::CheckGlobalSymbols(args) => check_global_symbols(&args.chips),

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -145,7 +145,7 @@ fn main() -> Result<()> {
 
         // Release-related subcommands:
         Cli::Release(release) => match release {
-            Release::ChangelogPreview(args) => changelog_preview(args),
+            Release::ChangelogPreview(args) => changelog_preview(&workspace, args),
             Release::BumpVersion(args) => bump_version(&workspace, args),
             Release::TagReleases(args) => tag_releases(&workspace, args),
             Release::Publish(args) => publish(&workspace, args),

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -145,6 +145,7 @@ fn main() -> Result<()> {
 
         // Release-related subcommands:
         Cli::Release(release) => match release {
+            Release::ChangelogPreview(args) => changelog_preview(args),
             Release::BumpVersion(args) => bump_version(&workspace, args),
             Release::TagReleases(args) => tag_releases(&workspace, args),
             Release::Publish(args) => publish(&workspace, args),

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -168,7 +168,7 @@ fn main() -> Result<()> {
         Cli::LintPackages(args) => lint_packages(&workspace, args),
         Cli::SemverCheck(args) => semver_checks(&workspace, args),
         Cli::CheckChangelog(args) => check_changelog(&workspace, &args.packages, args.normalize),
-        Cli::CheckPrChangelog(args) => check_pr_changelog(args.pr),
+        Cli::CheckPrChangelog(args) => check_pr_changelog(&workspace, args.pr),
         Cli::UpdateMetadata(args) => update_metadata(&workspace, args.check),
         Cli::HostTests(args) => host_tests(&workspace, args),
         Cli::CheckGlobalSymbols(args) => check_global_symbols(&args.chips),

--- a/xtask/src/pr_changelog.rs
+++ b/xtask/src/pr_changelog.rs
@@ -181,7 +181,7 @@ fn parse_changelog_block(body: &str, sections: &mut Vec<PrSection>) -> Result<()
 
     let mut current: Option<(String, Option<String>)> = None;
 
-    for line in after.lines() {
+    for line in non_comment_lines(after) {
         if line.starts_with("# ") {
             break;
         } else if let Some(h2) = line.strip_prefix("## ") {
@@ -234,7 +234,7 @@ fn parse_migration_guide_block(body: &str, sections: &mut Vec<PrSection>) -> Res
     let mut current: Option<(String, Option<String>)> = None;
     let mut current_lines: Vec<&str> = Vec::new();
 
-    for line in after.lines() {
+    for line in non_comment_lines(after) {
         if line.starts_with("# ") {
             break;
         } else if let Some(h2) = line.strip_prefix("## ") {
@@ -268,6 +268,27 @@ fn flush_migration(
     }
 }
 
+/// Iterate over lines of `text`, skipping any that fall inside `<!-- ... -->` blocks.
+fn non_comment_lines(text: &str) -> impl Iterator<Item = &str> {
+    let mut in_comment = false;
+    text.lines().filter(move |line| {
+        if in_comment {
+            if line.contains("-->") {
+                in_comment = false;
+            }
+            return false;
+        }
+        if line.contains("<!--") {
+            // Single-line comment: <!-- foo --> — skip but don't enter comment mode.
+            if !line.contains("-->") {
+                in_comment = true;
+            }
+            return false;
+        }
+        true
+    })
+}
+
 /// Return the body text that follows a `# <title>` H1 heading (case-insensitive).
 ///
 /// Returns `None` if no matching heading is found.
@@ -299,7 +320,7 @@ pub fn validate(body: &str) -> Vec<String> {
 
     if let Some(after) = find_h1_section(body, "Changelog") {
         let mut in_section = false;
-        for line in after.lines() {
+        for line in non_comment_lines(after) {
             if line.starts_with("# ") {
                 break;
             } else if let Some(h2) = line.strip_prefix("## ") {
@@ -324,7 +345,7 @@ pub fn validate(body: &str) -> Vec<String> {
     }
 
     if let Some(after) = find_h1_section(body, "Migration guide") {
-        for line in after.lines() {
+        for line in non_comment_lines(after) {
             if line.starts_with("# ") {
                 break;
             } else if let Some(h2) = line.strip_prefix("## ") {
@@ -408,6 +429,51 @@ All transient byte-lattices should undergo recursive de-serialization.
     fn parse_no_sections() {
         let body = "This PR fixes a typo in the README.\n\nNo changelog entries needed.";
         assert!(PrChangelog::parse(1, body).unwrap().is_none());
+    }
+
+    /// The PR template ships with placeholder entries inside HTML comments.
+    /// Those must not be treated as real changelog entries.
+    #[test]
+    fn parse_template_placeholders_are_ignored() {
+        // Matches the structure of .github/PULL_REQUEST_TEMPLATE.md
+        let body = "\
+## Thank you for your contribution!
+
+# Changelog
+
+<!-- Add one or more ## <crate> or ## <crate>/<area> sections below.
+     Each entry must start with one of: Added, Changed, Fixed, Removed.
+
+## esp-hal
+
+- Added: Brief description of what was added.
+- Changed: Brief description of what changed.
+- Fixed: Brief description of what was fixed.
+- Removed: Brief description of what was removed.
+
+-->
+
+# Migration guide
+
+<!-- Add one or more ## <crate> or ## <crate>/<area> sections below.
+     Write free-form Markdown describing what users need to change.
+     Only needed when user code must be updated.
+
+## esp-hal
+
+`OldType` has been renamed to `NewType`. Update your code accordingly.
+
+-->
+";
+        assert!(
+            PrChangelog::parse(1, body).unwrap().is_none(),
+            "placeholder content inside HTML comments should not produce changelog entries"
+        );
+        let errors = validate(body);
+        assert!(
+            errors.is_empty(),
+            "placeholder body should pass validation: {errors:?}"
+        );
     }
 
     #[test]

--- a/xtask/src/pr_changelog.rs
+++ b/xtask/src/pr_changelog.rs
@@ -1,7 +1,9 @@
 //! Parser for changelog entries embedded in pull request descriptions.
 //!
 //! Pull requests may contain a `# Changelog` section and/or a `# Migration guide`
-//! section. This module extracts structured data from those sections.
+//! section. Changelog entries may also be placed inside
+//! `<details><summary>Changelog</summary>…</details>` (GitHub's collapsible region).
+//! This module extracts structured data from those sections.
 //!
 //! # Expected format
 //!
@@ -195,11 +197,27 @@ fn get_or_insert_section<'a>(
 }
 
 /// Parse the `# Changelog` block and populate `sections`.
+///
+/// Changelog entries may appear after a `# Changelog` heading and/or inside
+/// `<details><summary>Changelog</summary> … </details>` (GitHub PR folding).
 fn parse_changelog_block(body: &str, sections: &mut Vec<PrSection>) -> Result<()> {
-    let Some(after) = find_h1_section(body, "Changelog") else {
-        return Ok(());
-    };
+    let detail_parts = collect_changelog_details_parts(body);
+    let ranges: Vec<(usize, usize)> = detail_parts.iter().map(|p| p.span).collect();
 
+    if let Some(after) = find_h1_section_outside_ranges(body, "Changelog", &ranges) {
+        let cleaned = scrub_h1_changelog_tail(body, after, &ranges);
+        parse_changelog_subsection(&cleaned, sections)?;
+    }
+    for part in &detail_parts {
+        parse_changelog_subsection(part.markdown, sections)?;
+    }
+    Ok(())
+}
+
+/// Parse one contiguous changelog region (markdown after `# Changelog` and/or inside
+/// a Changelog `<details>` block).
+fn parse_changelog_subsection(text: &str, sections: &mut Vec<PrSection>) -> Result<()> {
+    let after = strip_optional_h1(text, "Changelog");
     let mut current: Option<(String, Option<String>)> = None;
 
     for line in non_comment_lines(after) {
@@ -353,6 +371,242 @@ fn find_h1_section<'a>(body: &'a str, title: &str) -> Option<&'a str> {
     None
 }
 
+/// Like [`find_h1_section`], but ignores `# <title>` headings whose first character falls inside one
+/// of the `[start, end)` byte ranges (e.g. `# Changelog` nested in a `<details>` block whose body
+/// is parsed separately).
+fn find_h1_section_outside_ranges<'a>(
+    body: &'a str,
+    title: &str,
+    ranges: &[(usize, usize)],
+) -> Option<&'a str> {
+    let needle = format!("# {title}");
+    let mut offset = 0usize;
+    for line in body.lines() {
+        let line_len = line.len();
+        if line.trim().eq_ignore_ascii_case(&needle) {
+            let excluded = ranges
+                .iter()
+                .any(|&(s, e)| offset >= s && offset < e);
+            if !excluded {
+                return Some(body[offset + line_len..].trim_start_matches('\n'));
+            }
+        }
+        offset += line_len + 1;
+    }
+    None
+}
+
+/// Remove `<details>…</details>` regions that hold a Changelog summary from `tail`, where `tail`
+/// must be a substring of `body` (see [`parse_changelog_block`]). Prevents folded regions from
+/// being parsed twice when a top-level `# Changelog` also wraps entries in `<details>`.
+fn scrub_h1_changelog_tail(body: &str, tail: &str, detail_spans: &[(usize, usize)]) -> String {
+    let base = (tail.as_ptr() as usize) - (body.as_ptr() as usize);
+    let tail_end = base + tail.len();
+    let mut rel_spans: Vec<(usize, usize)> = detail_spans
+        .iter()
+        .filter_map(|&(s, e)| {
+            let rs = s.max(base);
+            let re = e.min(tail_end);
+            (rs < re).then_some((rs - base, re - base))
+        })
+        .collect();
+    rel_spans.sort_by_key(|k| k.0);
+    if rel_spans.is_empty() {
+        return tail.to_string();
+    }
+    let mut out = String::with_capacity(tail.len());
+    let mut pos = 0usize;
+    for (s, e) in rel_spans {
+        out.push_str(&tail[pos..s]);
+        out.push('\n');
+        pos = e;
+    }
+    out.push_str(&tail[pos..]);
+    out
+}
+
+/// Returns the tail after `text`'s first line when that line is `# <title>` (case-insensitive),
+/// otherwise returns `text` unchanged.
+fn strip_optional_h1<'a>(text: &'a str, title: &str) -> &'a str {
+    let t = text.trim_start();
+    let needle = format!("# {title}");
+    let Some(first) = t.lines().next() else {
+        return t;
+    };
+    if first.trim().eq_ignore_ascii_case(&needle) {
+        let rest = &t[first.len()..];
+        return rest.trim_start_matches('\n').trim_start();
+    }
+    t
+}
+
+fn starts_with_ignore_case(haystack: &str, needle: &str) -> bool {
+    let h = haystack.as_bytes();
+    let n = needle.as_bytes();
+    h.len() >= n.len()
+        && h[..n.len()]
+            .iter()
+            .zip(n.iter())
+            .all(|(a, b)| a.eq_ignore_ascii_case(b))
+}
+
+/// Case-insensitive substring search (both strings must be ASCII-only for tags).
+fn find_case_insensitive(haystack: &str, needle: &str) -> Option<usize> {
+    if needle.is_empty() {
+        return Some(0);
+    }
+    let ned = needle.as_bytes();
+    haystack
+        .as_bytes()
+        .windows(ned.len())
+        .position(|w| w.iter().zip(ned.iter()).all(|(a, b)| a.eq_ignore_ascii_case(b)))
+}
+
+/// The slice must begin with `<details`; the next character after the word is `>` or whitespace.
+fn is_opening_details_tag(s: &str) -> bool {
+    if !starts_with_ignore_case(s, "<details") {
+        return false;
+    }
+    let rest = &s["<details".len()..];
+    rest.chars()
+        .next()
+        .is_some_and(|c| c == '>' || c.is_whitespace())
+}
+
+/// One `<details><summary>Changelog</summary> … </details>` region in a PR body.
+struct ChangelogDetailsPart<'a> {
+    /// Byte range `[start, end)` covering the full `<details>…</details>` in the original body.
+    span: (usize, usize),
+    markdown: &'a str,
+}
+
+/// Changelog bodies from `<details><summary>Changelog</summary> … </details>` blocks.
+fn collect_changelog_details_parts<'a>(body: &'a str) -> Vec<ChangelogDetailsPart<'a>> {
+    let mut out = Vec::new();
+    let mut pos = 0usize;
+    while pos < body.len() {
+        let rest = &body[pos..];
+        let Some(rel) = find_case_insensitive(rest, "<details") else {
+            break;
+        };
+        let open_at = pos + rel;
+        let from_open = &body[open_at..];
+        if !is_opening_details_tag(from_open) {
+            pos = open_at + 1;
+            continue;
+        }
+        let after_tag_word = &from_open["<details".len()..];
+        let Some(gt) = after_tag_word.find('>') else {
+            break;
+        };
+        let inner_start = open_at + "<details".len() + gt + 1;
+        let inner_region = &body[inner_start..];
+        let Some((inner_content, consumed)) = take_balanced_details_inner(inner_region) else {
+            break;
+        };
+        let block_end = inner_start + consumed;
+        if let Some(md) = body_after_changelog_summary(inner_content) {
+            out.push(ChangelogDetailsPart {
+                span: (open_at, block_end),
+                markdown: md,
+            });
+        }
+        pos = block_end;
+    }
+    out
+}
+
+/// `s` begins immediately after the opening `<details…>` `>`. Returns `(inner, total_bytes)`.
+fn take_balanced_details_inner(s: &str) -> Option<(&str, usize)> {
+    let mut i = 0usize;
+    let mut depth = 1i32;
+    while i < s.len() {
+        if is_opening_details_tag(&s[i..]) {
+            let after = &s[i + "<details".len()..];
+            let gt = after.find('>')?;
+            i += "<details".len() + gt + 1;
+            depth += 1;
+            continue;
+        }
+        if starts_with_ignore_case(&s[i..], "</details>") {
+            depth -= 1;
+            if depth == 0 {
+                return Some((&s[..i], i + "</details>".len()));
+            }
+            i += "</details>".len();
+            continue;
+        }
+        i += 1;
+    }
+    None
+}
+
+/// `details_inner` is the markup between `<details…>` and its matching `</details>`.
+fn body_after_changelog_summary(details_inner: &str) -> Option<&str> {
+    let s = details_inner.trim_start();
+    let summary_rel = find_case_insensitive(s, "<summary")?;
+    let after_summary_word = &s[summary_rel + "<summary".len()..];
+    let gt = after_summary_word.find('>')?;
+    let summary_value_and_rest = &after_summary_word[gt + 1..];
+    let close_rel = find_case_insensitive(summary_value_and_rest, "</summary>")?;
+    let title = summary_value_and_rest[..close_rel].trim();
+    if !title.eq_ignore_ascii_case("Changelog") {
+        return None;
+    }
+    let after = &summary_value_and_rest[close_rel + "</summary>".len()..];
+    Some(after.trim_start())
+}
+
+fn validate_changelog_subsection(after: &str, errors: &mut Vec<String>) {
+    let after = strip_optional_h1(after, "Changelog");
+    let mut in_section = false;
+    let mut section_exempted = false;
+    let mut section_has_entries = false;
+
+    for line in non_comment_lines(after) {
+        if line.starts_with("# ") {
+            break;
+        } else if let Some(h2) = line.strip_prefix("## ") {
+            section_exempted = false;
+            section_has_entries = false;
+            if parse_section_heading(h2).is_some() {
+                in_section = true;
+            } else {
+                in_section = false;
+                errors.push(format!(
+                    "Invalid section heading in `# Changelog`: `## {h2}`"
+                ));
+            }
+        } else if let Some(item) = line.strip_prefix("- ") {
+            if !in_section {
+                errors.push(format!(
+                    "List item found before any section heading: `- {item}`"
+                ));
+            } else if item.trim() == NO_CHANGELOG_MARKER {
+                if section_has_entries {
+                    errors.push(format!(
+                        "`- {NO_CHANGELOG_MARKER}` cannot appear alongside real changelog \
+                         entries in the same section; use one or the other"
+                    ));
+                }
+                section_exempted = true;
+            } else {
+                if section_exempted {
+                    errors.push(format!(
+                        "Changelog entry cannot appear alongside `- {NO_CHANGELOG_MARKER}` \
+                         in the same section; use one or the other"
+                    ));
+                }
+                if let Err(e) = parse_changelog_item(item) {
+                    errors.push(e.to_string());
+                } else {
+                    section_has_entries = true;
+                }
+            }
+        }
+    }
+}
+
 /// Validate a PR description body, returning human-readable error messages.
 ///
 /// Returns an empty `Vec` if the body is valid (or has no changelog sections at all).
@@ -361,55 +615,15 @@ pub fn validate(body: &str) -> Vec<String> {
 
     let mut errors = Vec::new();
 
-    if let Some(after) = find_h1_section(body, "Changelog") {
-        let mut in_section = false;
-        // Per-section state for detecting marker/entry mixing.
-        let mut section_exempted = false;
-        let mut section_has_entries = false;
+    let detail_parts = collect_changelog_details_parts(body);
+    let ranges: Vec<(usize, usize)> = detail_parts.iter().map(|p| p.span).collect();
 
-        for line in non_comment_lines(after) {
-            if line.starts_with("# ") {
-                break;
-            } else if let Some(h2) = line.strip_prefix("## ") {
-                // Entering a new section — reset per-section state.
-                section_exempted = false;
-                section_has_entries = false;
-                if parse_section_heading(h2).is_some() {
-                    in_section = true;
-                } else {
-                    in_section = false;
-                    errors.push(format!(
-                        "Invalid section heading in `# Changelog`: `## {h2}`"
-                    ));
-                }
-            } else if let Some(item) = line.strip_prefix("- ") {
-                if !in_section {
-                    errors.push(format!(
-                        "List item found before any section heading: `- {item}`"
-                    ));
-                } else if item.trim() == NO_CHANGELOG_MARKER {
-                    if section_has_entries {
-                        errors.push(format!(
-                            "`- {NO_CHANGELOG_MARKER}` cannot appear alongside real changelog \
-                             entries in the same section; use one or the other"
-                        ));
-                    }
-                    section_exempted = true;
-                } else {
-                    if section_exempted {
-                        errors.push(format!(
-                            "Changelog entry cannot appear alongside `- {NO_CHANGELOG_MARKER}` \
-                             in the same section; use one or the other"
-                        ));
-                    }
-                    if let Err(e) = parse_changelog_item(item) {
-                        errors.push(e.to_string());
-                    } else {
-                        section_has_entries = true;
-                    }
-                }
-            }
-        }
+    if let Some(after) = find_h1_section_outside_ranges(body, "Changelog", &ranges) {
+        let cleaned = scrub_h1_changelog_tail(body, after, &ranges);
+        validate_changelog_subsection(&cleaned, &mut errors);
+    }
+    for part in &detail_parts {
+        validate_changelog_subsection(part.markdown, &mut errors);
     }
 
     if let Some(after) = find_h1_section(body, "Migration guide") {
@@ -536,6 +750,76 @@ All transient byte-lattices should undergo recursive de-serialization.
     fn parse_no_sections() {
         let body = "This PR fixes a typo in the README.\n\nNo changelog entries needed.";
         assert!(PrChangelog::parse(1, body).unwrap().is_none());
+    }
+
+    #[test]
+    fn parse_changelog_inside_details_without_hash_heading() {
+        let body = "\
+<details>
+<summary>Changelog</summary>
+
+## esp-hal
+
+- Added: A change from a folded section.
+</details>";
+        let cl = PrChangelog::parse(1, body).unwrap().unwrap();
+        assert_eq!(cl.sections.len(), 1);
+        let hal = &cl.sections[0];
+        assert_eq!(hal.crate_name, "esp-hal");
+        assert_eq!(hal.changelog.len(), 1);
+        assert_eq!(hal.changelog[0].kind, EntryKind::Added);
+        let errors = validate(body);
+        assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+    }
+
+    #[test]
+    fn parse_changelog_details_with_optional_hash_heading_no_duplicate() {
+        let body = "\
+<details>
+<summary>Changelog</summary>
+
+# Changelog
+
+## esp-hal
+
+- Changed: Tweaked after an inner H1.
+</details>";
+        let cl = PrChangelog::parse(1, body).unwrap().unwrap();
+        assert_eq!(cl.sections.len(), 1);
+        assert_eq!(cl.sections[0].changelog.len(), 1);
+        assert_eq!(cl.sections[0].changelog[0].kind, EntryKind::Changed);
+    }
+
+    #[test]
+    fn parse_changelog_top_level_plus_details_merges() {
+        let body = "\
+# Changelog
+
+## esp-radio
+
+- Fixed: Top-level section.
+
+<details>
+<summary>Changelog</summary>
+
+## esp-hal
+
+- Added: From details only.
+</details>";
+        let cl = PrChangelog::parse(1, body).unwrap().unwrap();
+        assert_eq!(cl.sections.len(), 2);
+        assert!(
+            cl.sections
+                .iter()
+                .any(|s| s.crate_name == "esp-radio" && s.changelog.len() == 1)
+        );
+        assert!(
+            cl.sections
+                .iter()
+                .any(|s| s.crate_name == "esp-hal" && s.changelog.len() == 1)
+        );
+        let errors = validate(body);
+        assert!(errors.is_empty(), "unexpected errors: {errors:?}");
     }
 
     /// The PR template ships with placeholder entries inside HTML comments.

--- a/xtask/src/pr_changelog.rs
+++ b/xtask/src/pr_changelog.rs
@@ -1,0 +1,439 @@
+//! Parser for changelog entries embedded in pull request descriptions.
+//!
+//! Pull requests may contain a `# Changelog` section and/or a `# Migration guide`
+//! section. This module extracts structured data from those sections.
+//!
+//! # Expected format
+//!
+//! ```markdown
+//! # Changelog
+//!
+//! ## esp-hal
+//!
+//! - Added: Support for the foo peripheral.
+//! - Fixed: A bug in bar.
+//!
+//! ## esp-hal/RMT driver
+//!
+//! - Changed: The RMT API has been restructured.
+//!
+//! # Migration guide
+//!
+//! ## esp-hal/RMT driver
+//!
+//! Replace all uses of `Foo` with `Bar`.
+//! ```
+
+use std::fmt;
+
+use anyhow::{Result, bail};
+
+/// The kind of a changelog entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum EntryKind {
+    Added,
+    Changed,
+    Fixed,
+    Removed,
+}
+
+impl EntryKind {
+    fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "Added" => Some(Self::Added),
+            "Changed" => Some(Self::Changed),
+            "Fixed" => Some(Self::Fixed),
+            "Removed" => Some(Self::Removed),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Added => "Added",
+            Self::Changed => "Changed",
+            Self::Fixed => "Fixed",
+            Self::Removed => "Removed",
+        }
+    }
+}
+
+impl fmt::Display for EntryKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A single changelog entry extracted from a PR description.
+#[derive(Debug, Clone)]
+pub struct ChangelogEntry {
+    pub kind: EntryKind,
+    pub text: String,
+}
+
+/// A crate/area section extracted from a PR description.
+#[derive(Debug, Clone)]
+pub struct PrSection {
+    /// The crate name, e.g. `"esp-hal"`.
+    pub crate_name: String,
+    /// The optional area within the crate, e.g. `"RMT driver"`.
+    pub area: Option<String>,
+    /// Changelog entries (from `# Changelog`).
+    pub changelog: Vec<ChangelogEntry>,
+    /// Free-form migration guide text (from `# Migration guide`).
+    pub migration_guide: Option<String>,
+}
+
+impl PrSection {
+    fn new(crate_name: String, area: Option<String>) -> Self {
+        Self {
+            crate_name,
+            area,
+            changelog: Vec::new(),
+            migration_guide: None,
+        }
+    }
+
+    pub fn has_content(&self) -> bool {
+        !self.changelog.is_empty() || self.migration_guide.is_some()
+    }
+}
+
+/// All changelog/migration-guide information extracted from a single PR.
+#[derive(Debug, Clone)]
+pub struct PrChangelog {
+    pub pr_number: u64,
+    pub sections: Vec<PrSection>,
+}
+
+impl PrChangelog {
+    /// Parse the changelog entries from a PR description body.
+    ///
+    /// Returns `Ok(None)` if the body contains neither a `# Changelog` nor a
+    /// `# Migration guide` section.
+    pub fn parse(pr_number: u64, body: &str) -> Result<Option<Self>> {
+        let mut sections: Vec<PrSection> = Vec::new();
+
+        parse_changelog_block(body, &mut sections)?;
+        parse_migration_guide_block(body, &mut sections)?;
+
+        let sections: Vec<_> = sections.into_iter().filter(|s| s.has_content()).collect();
+
+        if sections.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(Self {
+                pr_number,
+                sections,
+            }))
+        }
+    }
+}
+
+/// Parse a `## <crate>[/<area>]` heading into `(crate_name, area)`.
+fn parse_section_heading(heading: &str) -> Option<(String, Option<String>)> {
+    let heading = heading.trim();
+    if heading.is_empty() {
+        return None;
+    }
+    if let Some((crate_name, area)) = heading.split_once('/') {
+        let area = area.trim();
+        if area.is_empty() {
+            None
+        } else {
+            Some((crate_name.trim().to_string(), Some(area.to_string())))
+        }
+    } else {
+        Some((heading.to_string(), None))
+    }
+}
+
+/// Find or create a `PrSection` for the given crate/area pair.
+fn get_or_insert_section<'a>(
+    sections: &'a mut Vec<PrSection>,
+    crate_name: &str,
+    area: Option<&str>,
+) -> &'a mut PrSection {
+    if let Some(pos) = sections
+        .iter()
+        .position(|s| s.crate_name == crate_name && s.area.as_deref() == area)
+    {
+        &mut sections[pos]
+    } else {
+        sections.push(PrSection::new(
+            crate_name.to_string(),
+            area.map(|s| s.to_string()),
+        ));
+        sections.last_mut().unwrap()
+    }
+}
+
+/// Parse the `# Changelog` block and populate `sections`.
+fn parse_changelog_block(body: &str, sections: &mut Vec<PrSection>) -> Result<()> {
+    let Some(after) = find_h1_section(body, "Changelog") else {
+        return Ok(());
+    };
+
+    let mut current: Option<(String, Option<String>)> = None;
+
+    for line in after.lines() {
+        if line.starts_with("# ") {
+            break;
+        } else if let Some(h2) = line.strip_prefix("## ") {
+            match parse_section_heading(h2) {
+                Some((crate_name, area)) => current = Some((crate_name, area)),
+                None => bail!("Invalid section heading in `# Changelog`: `## {h2}`"),
+            }
+        } else if let Some(item) = line.strip_prefix("- ") {
+            let Some((crate_name, area)) = &current else {
+                bail!("Changelog list item found before any section heading: `- {item}`");
+            };
+            let entry = parse_changelog_item(item)?;
+            get_or_insert_section(sections, crate_name, area.as_deref())
+                .changelog
+                .push(entry);
+        }
+    }
+
+    Ok(())
+}
+
+/// Parse a single list item `Kind: text` into a `ChangelogEntry`.
+fn parse_changelog_item(item: &str) -> Result<ChangelogEntry> {
+    let Some((kind_str, text)) = item.split_once(": ") else {
+        bail!(
+            "Changelog list item must start with 'Added: ', 'Changed: ', 'Fixed: ' or \
+             'Removed: '; got: `- {item}`"
+        );
+    };
+
+    let kind = EntryKind::from_str(kind_str.trim()).ok_or_else(|| {
+        anyhow::anyhow!(
+            "Unknown changelog entry kind `{kind_str}`. \
+             Expected one of: Added, Changed, Fixed, Removed"
+        )
+    })?;
+
+    Ok(ChangelogEntry {
+        kind,
+        text: text.trim().to_string(),
+    })
+}
+
+/// Parse the `# Migration guide` block and populate `sections`.
+fn parse_migration_guide_block(body: &str, sections: &mut Vec<PrSection>) -> Result<()> {
+    let Some(after) = find_h1_section(body, "Migration guide") else {
+        return Ok(());
+    };
+
+    let mut current: Option<(String, Option<String>)> = None;
+    let mut current_lines: Vec<&str> = Vec::new();
+
+    for line in after.lines() {
+        if line.starts_with("# ") {
+            break;
+        } else if let Some(h2) = line.strip_prefix("## ") {
+            flush_migration(sections, &current, &current_lines);
+            current_lines.clear();
+            match parse_section_heading(h2) {
+                Some((crate_name, area)) => current = Some((crate_name, area)),
+                None => bail!("Invalid section heading in `# Migration guide`: `## {h2}`"),
+            }
+        } else {
+            current_lines.push(line);
+        }
+    }
+
+    flush_migration(sections, &current, &current_lines);
+
+    Ok(())
+}
+
+fn flush_migration(
+    sections: &mut Vec<PrSection>,
+    current: &Option<(String, Option<String>)>,
+    lines: &[&str],
+) {
+    if let Some((crate_name, area)) = current {
+        let text = lines.join("\n").trim().to_string();
+        if !text.is_empty() {
+            get_or_insert_section(sections, crate_name, area.as_deref()).migration_guide =
+                Some(text);
+        }
+    }
+}
+
+/// Return the body text that follows a `# <title>` H1 heading (case-insensitive).
+///
+/// Returns `None` if no matching heading is found.
+fn find_h1_section<'a>(body: &'a str, title: &str) -> Option<&'a str> {
+    let needle = format!("# {title}");
+    let mut offset = 0usize;
+    for line in body.lines() {
+        let line_len = line.len();
+        if line.trim().eq_ignore_ascii_case(&needle) {
+            // Skip past the newline after this heading
+            let start = offset + line_len;
+            let rest = &body[start..];
+            return Some(rest.trim_start_matches('\n').trim_start_matches("\r\n"));
+        }
+        // +1 for the '\n'; handles both '\n' and '\r\n' bodies well enough
+        offset += line_len + 1;
+    }
+    None
+}
+
+/// Validate a PR description body, returning human-readable error messages.
+///
+/// Returns an empty `Vec` if the body is valid (or has no changelog sections at all).
+pub fn validate(body: &str) -> Vec<String> {
+    let mut errors = Vec::new();
+
+    if let Some(after) = find_h1_section(body, "Changelog") {
+        let mut in_section = false;
+        for line in after.lines() {
+            if line.starts_with("# ") {
+                break;
+            } else if let Some(h2) = line.strip_prefix("## ") {
+                if parse_section_heading(h2).is_some() {
+                    in_section = true;
+                } else {
+                    in_section = false;
+                    errors.push(format!(
+                        "Invalid section heading in `# Changelog`: `## {h2}`"
+                    ));
+                }
+            } else if let Some(item) = line.strip_prefix("- ") {
+                if !in_section {
+                    errors.push(format!(
+                        "List item found before any section heading: `- {item}`"
+                    ));
+                } else if let Err(e) = parse_changelog_item(item) {
+                    errors.push(e.to_string());
+                }
+            }
+        }
+    }
+
+    if let Some(after) = find_h1_section(body, "Migration guide") {
+        for line in after.lines() {
+            if line.starts_with("# ") {
+                break;
+            } else if let Some(h2) = line.strip_prefix("## ") {
+                if parse_section_heading(h2).is_none() {
+                    errors.push(format!(
+                        "Invalid section heading in `# Migration guide`: `## {h2}`"
+                    ));
+                }
+            }
+        }
+    }
+
+    errors
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const EXAMPLE_BODY: &str = "\
+This PR de-clutters the tantulum gluon autosequencers.
+
+# Changelog
+
+## esp-hal/Polymetric encabulator driver
+
+- Added: The distributed heap-matrix
+- Changed: The async flux-compiler overclocked its own dependency vortex again.
+- Removed: A polyphase micro-kernel
+
+## esp-radio
+
+- Changed: A runaway garbage collector vaporized the entire semantic token field.
+
+# Migration guide
+
+## esp-hal/LOL-area
+
+The entropy-driven commit pipeline must be re-aligned with a synthetic opcode vortex.
+All transient byte-lattices should undergo recursive de-serialization.
+";
+
+    #[test]
+    fn parse_full_example() {
+        let changelog = PrChangelog::parse(42, EXAMPLE_BODY).unwrap().unwrap();
+
+        assert_eq!(changelog.pr_number, 42);
+        assert_eq!(changelog.sections.len(), 3);
+
+        let hal = changelog
+            .sections
+            .iter()
+            .find(|s| {
+                s.crate_name == "esp-hal"
+                    && s.area.as_deref() == Some("Polymetric encabulator driver")
+            })
+            .unwrap();
+        assert_eq!(hal.changelog.len(), 3);
+        assert_eq!(hal.changelog[0].kind, EntryKind::Added);
+        assert_eq!(hal.changelog[1].kind, EntryKind::Changed);
+        assert_eq!(hal.changelog[2].kind, EntryKind::Removed);
+
+        let radio = changelog
+            .sections
+            .iter()
+            .find(|s| s.crate_name == "esp-radio" && s.area.is_none())
+            .unwrap();
+        assert_eq!(radio.changelog.len(), 1);
+        assert_eq!(radio.changelog[0].kind, EntryKind::Changed);
+
+        let migration = changelog
+            .sections
+            .iter()
+            .find(|s| s.crate_name == "esp-hal" && s.area.as_deref() == Some("LOL-area"))
+            .unwrap();
+        assert!(migration.migration_guide.is_some());
+        assert!(migration.changelog.is_empty());
+    }
+
+    #[test]
+    fn parse_no_sections() {
+        let body = "This PR fixes a typo in the README.\n\nNo changelog entries needed.";
+        assert!(PrChangelog::parse(1, body).unwrap().is_none());
+    }
+
+    #[test]
+    fn validate_bad_kind() {
+        let body = "# Changelog\n\n## esp-hal\n\n- Tweaked: something\n";
+        let errors = validate(body);
+        assert!(!errors.is_empty());
+        assert!(errors[0].contains("Unknown changelog entry kind"));
+    }
+
+    #[test]
+    fn validate_missing_separator() {
+        let body = "# Changelog\n\n## esp-hal\n\n- Just a description without kind\n";
+        let errors = validate(body);
+        assert!(!errors.is_empty());
+    }
+
+    #[test]
+    fn validate_clean() {
+        let errors = validate(EXAMPLE_BODY);
+        assert!(errors.is_empty(), "Unexpected errors: {errors:?}");
+    }
+
+    #[test]
+    fn section_heading_parsing() {
+        assert_eq!(
+            parse_section_heading("esp-hal"),
+            Some(("esp-hal".into(), None))
+        );
+        assert_eq!(
+            parse_section_heading("esp-hal/RMT driver"),
+            Some(("esp-hal".into(), Some("RMT driver".into())))
+        );
+        assert_eq!(parse_section_heading(""), None);
+        assert_eq!(parse_section_heading("esp-hal/"), None);
+    }
+}

--- a/xtask/src/pr_changelog.rs
+++ b/xtask/src/pr_changelog.rs
@@ -112,6 +112,11 @@ impl PrChangelog {
     /// Returns `Ok(None)` if the body contains neither a `# Changelog` nor a
     /// `# Migration guide` section.
     pub fn parse(pr_number: u64, body: &str) -> Result<Option<Self>> {
+        // Normalize line endings so the parser works regardless of whether the
+        // body came from GitHub (CRLF) or a local file (LF).
+        let body = body.replace("\r\n", "\n");
+        let body = body.as_str();
+
         let mut sections: Vec<PrSection> = Vec::new();
 
         parse_changelog_block(body, &mut sections)?;
@@ -287,6 +292,9 @@ fn find_h1_section<'a>(body: &'a str, title: &str) -> Option<&'a str> {
 ///
 /// Returns an empty `Vec` if the body is valid (or has no changelog sections at all).
 pub fn validate(body: &str) -> Vec<String> {
+    let body = body.replace("\r\n", "\n");
+    let body = body.as_str();
+
     let mut errors = Vec::new();
 
     if let Some(after) = find_h1_section(body, "Changelog") {

--- a/xtask/src/pr_changelog.rs
+++ b/xtask/src/pr_changelog.rs
@@ -34,6 +34,18 @@ use std::fmt;
 
 use anyhow::{Result, bail};
 
+/// Exact text of the per-crate changelog exemption marker.
+///
+/// A PR author can write `- No changelog necessary.` as the sole item under a
+/// `## <crate>` section in the `# Changelog` block to explicitly declare that
+/// the crate's changes do not need a public changelog entry.  The CI coverage
+/// check will then treat that crate as "covered", so the `skip-changelog` label
+/// is not required.
+///
+/// The marker must be the **only** item in its section; mixing it with real
+/// changelog entries is an error.
+pub const NO_CHANGELOG_MARKER: &str = "No changelog necessary.";
+
 /// The kind of a changelog entry.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum EntryKind {
@@ -88,6 +100,9 @@ pub struct PrSection {
     pub changelog: Vec<ChangelogEntry>,
     /// Free-form migration guide text (from `# Migration guide`).
     pub migration_guide: Option<String>,
+    /// Set when the author wrote `- No changelog necessary.` to explicitly
+    /// declare that this crate's changes need no public changelog entry.
+    pub exempted: bool,
 }
 
 impl PrSection {
@@ -97,11 +112,12 @@ impl PrSection {
             area,
             changelog: Vec::new(),
             migration_guide: None,
+            exempted: false,
         }
     }
 
     pub fn has_content(&self) -> bool {
-        !self.changelog.is_empty() || self.migration_guide.is_some()
+        self.exempted || !self.changelog.is_empty() || self.migration_guide.is_some()
     }
 }
 
@@ -198,10 +214,25 @@ fn parse_changelog_block(body: &str, sections: &mut Vec<PrSection>) -> Result<()
             let Some((crate_name, area)) = &current else {
                 bail!("Changelog list item found before any section heading: `- {item}`");
             };
-            let entry = parse_changelog_item(item)?;
-            get_or_insert_section(sections, crate_name, area.as_deref())
-                .changelog
-                .push(entry);
+            let section = get_or_insert_section(sections, crate_name, area.as_deref());
+            if item.trim() == NO_CHANGELOG_MARKER {
+                if !section.changelog.is_empty() {
+                    bail!(
+                        "`- {NO_CHANGELOG_MARKER}` in `## {crate_name}` cannot appear alongside \
+                         real changelog entries; use one or the other"
+                    );
+                }
+                section.exempted = true;
+            } else {
+                if section.exempted {
+                    bail!(
+                        "Changelog entry in `## {crate_name}` cannot appear alongside \
+                         `- {NO_CHANGELOG_MARKER}`; use one or the other"
+                    );
+                }
+                let entry = parse_changelog_item(item)?;
+                section.changelog.push(entry);
+            }
         }
     }
 
@@ -332,10 +363,17 @@ pub fn validate(body: &str) -> Vec<String> {
 
     if let Some(after) = find_h1_section(body, "Changelog") {
         let mut in_section = false;
+        // Per-section state for detecting marker/entry mixing.
+        let mut section_exempted = false;
+        let mut section_has_entries = false;
+
         for line in non_comment_lines(after) {
             if line.starts_with("# ") {
                 break;
             } else if let Some(h2) = line.strip_prefix("## ") {
+                // Entering a new section — reset per-section state.
+                section_exempted = false;
+                section_has_entries = false;
                 if parse_section_heading(h2).is_some() {
                     in_section = true;
                 } else {
@@ -349,8 +387,26 @@ pub fn validate(body: &str) -> Vec<String> {
                     errors.push(format!(
                         "List item found before any section heading: `- {item}`"
                     ));
-                } else if let Err(e) = parse_changelog_item(item) {
-                    errors.push(e.to_string());
+                } else if item.trim() == NO_CHANGELOG_MARKER {
+                    if section_has_entries {
+                        errors.push(format!(
+                            "`- {NO_CHANGELOG_MARKER}` cannot appear alongside real changelog \
+                             entries in the same section; use one or the other"
+                        ));
+                    }
+                    section_exempted = true;
+                } else {
+                    if section_exempted {
+                        errors.push(format!(
+                            "Changelog entry cannot appear alongside `- {NO_CHANGELOG_MARKER}` \
+                             in the same section; use one or the other"
+                        ));
+                    }
+                    if let Err(e) = parse_changelog_item(item) {
+                        errors.push(e.to_string());
+                    } else {
+                        section_has_entries = true;
+                    }
                 }
             }
         }
@@ -672,5 +728,87 @@ Do something else.
             errors.iter().any(|e| e.contains("Invalid section heading")),
             "unexpected errors: {errors:?}"
         );
+    }
+
+    // ---- NO_CHANGELOG_MARKER tests ----
+
+    #[test]
+    fn parse_exemption_marker() {
+        let body = "# Changelog\n\n## esp-metadata\n\n- No changelog necessary.\n";
+        let cl = PrChangelog::parse(1, body).unwrap().unwrap();
+        assert_eq!(cl.sections.len(), 1);
+        let section = &cl.sections[0];
+        assert_eq!(section.crate_name, "esp-metadata");
+        assert!(section.exempted, "section should be marked as exempted");
+        assert!(section.changelog.is_empty());
+    }
+
+    #[test]
+    fn validate_accepts_exemption_marker() {
+        let body = "# Changelog\n\n## esp-metadata\n\n- No changelog necessary.\n";
+        let errors = validate(body);
+        assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+    }
+
+    #[test]
+    fn parse_rejects_marker_mixed_with_entries_marker_first() {
+        let body =
+            "# Changelog\n\n## esp-hal\n\n- No changelog necessary.\n- Added: Something.\n";
+        assert!(PrChangelog::parse(1, body).is_err());
+    }
+
+    #[test]
+    fn parse_rejects_marker_mixed_with_entries_entry_first() {
+        let body =
+            "# Changelog\n\n## esp-hal\n\n- Added: Something.\n- No changelog necessary.\n";
+        assert!(PrChangelog::parse(1, body).is_err());
+    }
+
+    #[test]
+    fn validate_rejects_marker_mixed_with_entries() {
+        let body =
+            "# Changelog\n\n## esp-hal\n\n- Added: Something.\n- No changelog necessary.\n";
+        let errors = validate(body);
+        assert!(!errors.is_empty(), "expected error for mixed marker + entry");
+        assert!(
+            errors.iter().any(|e| e.contains("No changelog necessary")),
+            "unexpected errors: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn exempted_section_has_content() {
+        let mut section = PrSection::new("esp-metadata".into(), None);
+        assert!(!section.has_content());
+        section.exempted = true;
+        assert!(section.has_content());
+    }
+
+    /// Two crates in one PR: one exempted, one with a real entry.
+    #[test]
+    fn parse_mixed_exempted_and_real() {
+        let body = "\
+# Changelog
+
+## esp-hal
+
+- Added: The new thing.
+
+## esp-metadata
+
+- No changelog necessary.
+";
+        let cl = PrChangelog::parse(1, body).unwrap().unwrap();
+        assert_eq!(cl.sections.len(), 2);
+        let hal = cl.sections.iter().find(|s| s.crate_name == "esp-hal").unwrap();
+        assert!(!hal.exempted);
+        assert_eq!(hal.changelog.len(), 1);
+        let meta = cl
+            .sections
+            .iter()
+            .find(|s| s.crate_name == "esp-metadata")
+            .unwrap();
+        assert!(meta.exempted);
+        assert!(meta.changelog.is_empty());
     }
 }

--- a/xtask/src/pr_changelog.rs
+++ b/xtask/src/pr_changelog.rs
@@ -752,24 +752,24 @@ Do something else.
 
     #[test]
     fn parse_rejects_marker_mixed_with_entries_marker_first() {
-        let body =
-            "# Changelog\n\n## esp-hal\n\n- No changelog necessary.\n- Added: Something.\n";
+        let body = "# Changelog\n\n## esp-hal\n\n- No changelog necessary.\n- Added: Something.\n";
         assert!(PrChangelog::parse(1, body).is_err());
     }
 
     #[test]
     fn parse_rejects_marker_mixed_with_entries_entry_first() {
-        let body =
-            "# Changelog\n\n## esp-hal\n\n- Added: Something.\n- No changelog necessary.\n";
+        let body = "# Changelog\n\n## esp-hal\n\n- Added: Something.\n- No changelog necessary.\n";
         assert!(PrChangelog::parse(1, body).is_err());
     }
 
     #[test]
     fn validate_rejects_marker_mixed_with_entries() {
-        let body =
-            "# Changelog\n\n## esp-hal\n\n- Added: Something.\n- No changelog necessary.\n";
+        let body = "# Changelog\n\n## esp-hal\n\n- Added: Something.\n- No changelog necessary.\n";
         let errors = validate(body);
-        assert!(!errors.is_empty(), "expected error for mixed marker + entry");
+        assert!(
+            !errors.is_empty(),
+            "expected error for mixed marker + entry"
+        );
         assert!(
             errors.iter().any(|e| e.contains("No changelog necessary")),
             "unexpected errors: {errors:?}"
@@ -800,7 +800,11 @@ Do something else.
 ";
         let cl = PrChangelog::parse(1, body).unwrap().unwrap();
         assert_eq!(cl.sections.len(), 2);
-        let hal = cl.sections.iter().find(|s| s.crate_name == "esp-hal").unwrap();
+        let hal = cl
+            .sections
+            .iter()
+            .find(|s| s.crate_name == "esp-hal")
+            .unwrap();
         assert!(!hal.exempted);
         assert_eq!(hal.changelog.len(), 1);
         let meta = cl

--- a/xtask/src/pr_changelog.rs
+++ b/xtask/src/pr_changelog.rs
@@ -627,8 +627,7 @@ Some breaking change description.
 
     #[test]
     fn validate_rejects_migration_body_before_h3() {
-        let body =
-            "# Migration guide\n\n## esp-hal/SPI\n\nBody text before any H3.\n\n### Title\n\nMore.\n";
+        let body = "# Migration guide\n\n## esp-hal/SPI\n\nBody text before any H3.\n\n### Title\n\nMore.\n";
         let errors = validate(body);
         assert!(
             !errors.is_empty(),

--- a/xtask/src/pr_changelog.rs
+++ b/xtask/src/pr_changelog.rs
@@ -515,6 +515,30 @@ All transient byte-lattices should undergo recursive de-serialization.
         assert_eq!(parse_section_heading("  /  Some area"), None);
     }
 
+    /// A PR that only has a `# Migration guide` section for a crate must NOT be
+    /// treated as having a changelog entry for that crate.  The `changelog` field
+    /// of the resulting `PrSection` must be empty so that coverage checks
+    /// correctly identify the package as uncovered.
+    #[test]
+    fn migration_guide_only_section_has_empty_changelog() {
+        let body = "\
+# Migration guide
+
+## esp-hal
+
+Some breaking change description.
+";
+        let cl = PrChangelog::parse(1, body).unwrap().unwrap();
+        assert_eq!(cl.sections.len(), 1);
+        let section = &cl.sections[0];
+        assert_eq!(section.crate_name, "esp-hal");
+        assert!(
+            section.changelog.is_empty(),
+            "migration-guide-only section should have no changelog entries"
+        );
+        assert!(section.migration_guide.is_some());
+    }
+
     /// A heading like `## /Some area` must be rejected by the validator, not silently
     /// accepted with an empty crate name that would match the workspace root.
     #[test]

--- a/xtask/src/pr_changelog.rs
+++ b/xtask/src/pr_changelog.rs
@@ -112,10 +112,8 @@ impl PrChangelog {
     /// Returns `Ok(None)` if the body contains neither a `# Changelog` nor a
     /// `# Migration guide` section.
     pub fn parse(pr_number: u64, body: &str) -> Result<Option<Self>> {
-        // Normalize line endings so the parser works regardless of whether the
-        // body came from GitHub (CRLF) or a local file (LF).
-        let body = body.replace("\r\n", "\n");
-        let body = body.as_str();
+        // Normalize CRLF (GitHub) to LF so the parser doesn't need to handle both.
+        let body = &body.replace("\r\n", "\n");
 
         let mut sections: Vec<PrSection> = Vec::new();
 
@@ -291,6 +289,7 @@ fn non_comment_lines(text: &str) -> impl Iterator<Item = &str> {
 
 /// Return the body text that follows a `# <title>` H1 heading (case-insensitive).
 ///
+/// Assumes LF-only line endings (callers must normalize first).
 /// Returns `None` if no matching heading is found.
 fn find_h1_section<'a>(body: &'a str, title: &str) -> Option<&'a str> {
     let needle = format!("# {title}");
@@ -298,13 +297,9 @@ fn find_h1_section<'a>(body: &'a str, title: &str) -> Option<&'a str> {
     for line in body.lines() {
         let line_len = line.len();
         if line.trim().eq_ignore_ascii_case(&needle) {
-            // Skip past the newline after this heading
-            let start = offset + line_len;
-            let rest = &body[start..];
-            return Some(rest.trim_start_matches('\n').trim_start_matches("\r\n"));
+            return Some(body[offset + line_len..].trim_start_matches('\n'));
         }
-        // +1 for the '\n'; handles both '\n' and '\r\n' bodies well enough
-        offset += line_len + 1;
+        offset += line_len + 1; // +1 for '\n'
     }
     None
 }
@@ -313,8 +308,7 @@ fn find_h1_section<'a>(body: &'a str, title: &str) -> Option<&'a str> {
 ///
 /// Returns an empty `Vec` if the body is valid (or has no changelog sections at all).
 pub fn validate(body: &str) -> Vec<String> {
-    let body = body.replace("\r\n", "\n");
-    let body = body.as_str();
+    let body = &body.replace("\r\n", "\n");
 
     let mut errors = Vec::new();
 

--- a/xtask/src/pr_changelog.rs
+++ b/xtask/src/pr_changelog.rs
@@ -536,7 +536,8 @@ fn take_balanced_details_inner(s: &str) -> Option<(&str, usize)> {
             i += "</details>".len();
             continue;
         }
-        i += 1;
+        let adv = s[i..].chars().next()?.len_utf8();
+        i += adv;
     }
     None
 }
@@ -770,6 +771,21 @@ All transient byte-lattices should undergo recursive de-serialization.
         assert_eq!(hal.changelog[0].kind, EntryKind::Added);
         let errors = validate(body);
         assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+    }
+
+    #[test]
+    fn parse_changelog_details_with_unicode_in_body_does_not_panic() {
+        let body = "\
+<details>
+<summary>Changelog</summary>
+
+## esp-hal
+
+- Added: See “Peripheral support” table and link each ❌ in `esp-hal/README.md` to the tracking issue.
+</details>";
+        let cl = PrChangelog::parse(1, body).unwrap().unwrap();
+        assert_eq!(cl.sections.len(), 1);
+        assert_eq!(cl.sections[0].changelog.len(), 1);
     }
 
     #[test]

--- a/xtask/src/pr_changelog.rs
+++ b/xtask/src/pr_changelog.rs
@@ -261,8 +261,9 @@ fn parse_changelog_subsection(text: &str, sections: &mut Vec<PrSection>) -> Resu
 fn parse_changelog_item(item: &str) -> Result<ChangelogEntry> {
     let Some((kind_str, text)) = item.split_once(": ") else {
         bail!(
-            "Changelog list item must start with 'Added: ', 'Changed: ', 'Fixed: ' or \
-             'Removed: '; got: `- {item}`"
+            r#"Changelog list item must start with a category followed by a colon, or '- No changelog necessary.'; got: `- {item}`.
+
+Accepted categories: Added, Changed, Fixed, Removed"#
         );
     };
 
@@ -371,9 +372,9 @@ fn find_h1_section<'a>(body: &'a str, title: &str) -> Option<&'a str> {
     None
 }
 
-/// Like [`find_h1_section`], but ignores `# <title>` headings whose first character falls inside one
-/// of the `[start, end)` byte ranges (e.g. `# Changelog` nested in a `<details>` block whose body
-/// is parsed separately).
+/// Like [`find_h1_section`], but ignores `# <title>` headings whose first character falls inside
+/// one of the `[start, end)` byte ranges (e.g. `# Changelog` nested in a `<details>` block whose
+/// body is parsed separately).
 fn find_h1_section_outside_ranges<'a>(
     body: &'a str,
     title: &str,
@@ -384,9 +385,7 @@ fn find_h1_section_outside_ranges<'a>(
     for line in body.lines() {
         let line_len = line.len();
         if line.trim().eq_ignore_ascii_case(&needle) {
-            let excluded = ranges
-                .iter()
-                .any(|&(s, e)| offset >= s && offset < e);
+            let excluded = ranges.iter().any(|&(s, e)| offset >= s && offset < e);
             if !excluded {
                 return Some(body[offset + line_len..].trim_start_matches('\n'));
             }
@@ -456,10 +455,11 @@ fn find_case_insensitive(haystack: &str, needle: &str) -> Option<usize> {
         return Some(0);
     }
     let ned = needle.as_bytes();
-    haystack
-        .as_bytes()
-        .windows(ned.len())
-        .position(|w| w.iter().zip(ned.iter()).all(|(a, b)| a.eq_ignore_ascii_case(b)))
+    haystack.as_bytes().windows(ned.len()).position(|w| {
+        w.iter()
+            .zip(ned.iter())
+            .all(|(a, b)| a.eq_ignore_ascii_case(b))
+    })
 }
 
 /// The slice must begin with `<details`; the next character after the word is `>` or whitespace.

--- a/xtask/src/pr_changelog.rs
+++ b/xtask/src/pr_changelog.rs
@@ -21,8 +21,14 @@
 //!
 //! ## esp-hal/RMT driver
 //!
+//! ### `Foo` has been renamed to `Bar`
+//!
 //! Replace all uses of `Foo` with `Bar`.
 //! ```
+//!
+//! Migration guide sections **must** include an area (`## crate/area`) and each
+//! individual breaking change **must** be introduced by an H3 heading (`### Title`)
+//! before the body text.
 
 use std::fmt;
 
@@ -240,7 +246,13 @@ fn parse_migration_guide_block(body: &str, sections: &mut Vec<PrSection>) -> Res
             flush_migration(sections, &current, &current_lines);
             current_lines.clear();
             match parse_section_heading(h2) {
-                Some((crate_name, area)) => current = Some((crate_name, area)),
+                Some((crate_name, Some(area))) => {
+                    current = Some((crate_name, Some(area)));
+                }
+                Some((crate_name, None)) => bail!(
+                    "Migration guide section `## {crate_name}` must include an area \
+                     (e.g. `## {crate_name}/My area`)"
+                ),
                 None => bail!("Invalid section heading in `# Migration guide`: `## {h2}`"),
             }
         } else {
@@ -340,15 +352,52 @@ pub fn validate(body: &str) -> Vec<String> {
     }
 
     if let Some(after) = find_h1_section(body, "Migration guide") {
+        let mut in_section = false;
+        // True while inside a valid section but no `### title` has been seen yet.
+        let mut awaiting_h3 = false;
+
         for line in non_comment_lines(after) {
             if line.starts_with("# ") {
                 break;
             } else if let Some(h2) = line.strip_prefix("## ") {
-                if parse_section_heading(h2).is_none() {
-                    errors.push(format!(
-                        "Invalid section heading in `# Migration guide`: `## {h2}`"
-                    ));
+                in_section = false;
+                awaiting_h3 = false;
+                match parse_section_heading(h2) {
+                    Some((_, Some(_))) => {
+                        in_section = true;
+                        awaiting_h3 = true;
+                    }
+                    Some((crate_name, None)) => {
+                        errors.push(format!(
+                            "Migration guide section `## {crate_name}` must include an area \
+                             (e.g. `## {crate_name}/My area`)"
+                        ));
+                    }
+                    None => {
+                        errors.push(format!(
+                            "Invalid section heading in `# Migration guide`: `## {h2}`"
+                        ));
+                    }
                 }
+            } else if let Some(h3) = line.strip_prefix("### ") {
+                if !in_section {
+                    errors.push(format!(
+                        "`### {h3}` found before any `## crate/area` heading"
+                    ));
+                } else if h3.trim().is_empty() {
+                    errors.push(
+                        "Migration guide `### ` heading must have a non-empty title".to_string(),
+                    );
+                } else {
+                    awaiting_h3 = false;
+                }
+            } else if awaiting_h3 && !line.trim().is_empty() {
+                // Body text appearing before the first `###` in a section.
+                errors.push(format!(
+                    "Migration guide body text must be preceded by a `### Title` heading; \
+                     found: `{line}`"
+                ));
+                awaiting_h3 = false; // report only the first offending line per section
             }
         }
     }
@@ -378,6 +427,8 @@ This PR de-clutters the tantulum gluon autosequencers.
 # Migration guide
 
 ## esp-hal/LOL-area
+
+### The entropy pipeline must be reconfigured
 
 The entropy-driven commit pipeline must be re-aligned with a synthetic opcode vortex.
 All transient byte-lattices should undergo recursive de-serialization.
@@ -450,13 +501,15 @@ All transient byte-lattices should undergo recursive de-serialization.
 
 # Migration guide
 
-<!-- Add one or more ## <crate> or ## <crate>/<area> sections below.
-     Write free-form Markdown describing what users need to change.
+<!-- Add one or more ## <crate>/<area> sections below (area is required).
+     Each breaking change needs a ### Title heading followed by the migration steps.
      Only needed when user code must be updated.
 
-## esp-hal
+## esp-hal/SPI
 
-`OldType` has been renamed to `NewType`. Update your code accordingly.
+### `OldType` has been renamed to `NewType`
+
+Replace all uses of `OldType` with `NewType`.
 
 -->
 ";
@@ -524,7 +577,9 @@ All transient byte-lattices should undergo recursive de-serialization.
         let body = "\
 # Migration guide
 
-## esp-hal
+## esp-hal/SPI
+
+### The transfer API changed
 
 Some breaking change description.
 ";
@@ -532,11 +587,60 @@ Some breaking change description.
         assert_eq!(cl.sections.len(), 1);
         let section = &cl.sections[0];
         assert_eq!(section.crate_name, "esp-hal");
+        assert_eq!(section.area.as_deref(), Some("SPI"));
         assert!(
             section.changelog.is_empty(),
             "migration-guide-only section should have no changelog entries"
         );
         assert!(section.migration_guide.is_some());
+    }
+
+    #[test]
+    fn validate_rejects_migration_section_without_area() {
+        let body = "# Migration guide\n\n## esp-hal\n\n### Title\n\nContent.\n";
+        let errors = validate(body);
+        assert!(
+            !errors.is_empty(),
+            "expected error for migration section without area"
+        );
+        assert!(
+            errors.iter().any(|e| e.contains("must include an area")),
+            "unexpected errors: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_migration_body_before_h3() {
+        let body =
+            "# Migration guide\n\n## esp-hal/SPI\n\nBody text before any H3.\n\n### Title\n\nMore.\n";
+        let errors = validate(body);
+        assert!(
+            !errors.is_empty(),
+            "expected error for body text appearing before ### heading"
+        );
+        assert!(
+            errors.iter().any(|e| e.contains("### Title")),
+            "unexpected errors: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_valid_migration_guide() {
+        let body = "\
+# Migration guide
+
+## esp-hal/SPI
+
+### The foobulator has been encabulated
+
+Update your call sites from `foo()` to `bar()`.
+
+### Another breaking change
+
+Do something else.
+";
+        let errors = validate(body);
+        assert!(errors.is_empty(), "unexpected errors: {errors:?}");
     }
 
     /// A heading like `## /Some area` must be rejected by the validator, not silently

--- a/xtask/src/pr_changelog.rs
+++ b/xtask/src/pr_changelog.rs
@@ -224,9 +224,14 @@ fn parse_changelog_item(item: &str) -> Result<ChangelogEntry> {
         )
     })?;
 
+    let text = text.trim();
+    if text.is_empty() {
+        bail!("Changelog entry description must not be empty: `- {item}`");
+    }
+
     Ok(ChangelogEntry {
         kind,
-        text: text.trim().to_string(),
+        text: text.to_string(),
     })
 }
 
@@ -521,6 +526,17 @@ Replace all uses of `OldType` with `NewType`.
         assert!(
             errors.is_empty(),
             "placeholder body should pass validation: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_empty_description() {
+        let body = "# Changelog\n\n## esp-hal\n\n- Added: \n";
+        let errors = validate(body);
+        assert!(!errors.is_empty(), "expected error for empty description");
+        assert!(
+            errors.iter().any(|e| e.contains("must not be empty")),
+            "unexpected errors: {errors:?}"
         );
     }
 

--- a/xtask/src/pr_changelog.rs
+++ b/xtask/src/pr_changelog.rs
@@ -140,11 +140,12 @@ fn parse_section_heading(heading: &str) -> Option<(String, Option<String>)> {
         return None;
     }
     if let Some((crate_name, area)) = heading.split_once('/') {
+        let crate_name = crate_name.trim();
         let area = area.trim();
-        if area.is_empty() {
+        if crate_name.is_empty() || area.is_empty() {
             None
         } else {
-            Some((crate_name.trim().to_string(), Some(area.to_string())))
+            Some((crate_name.to_string(), Some(area.to_string())))
         }
     } else {
         Some((heading.to_string(), None))
@@ -501,7 +502,32 @@ All transient byte-lattices should undergo recursive de-serialization.
             parse_section_heading("esp-hal/RMT driver"),
             Some(("esp-hal".into(), Some("RMT driver".into())))
         );
+        assert_eq!(
+            parse_section_heading(" esp-hal / RMT driver"),
+            Some(("esp-hal".into(), Some("RMT driver".into())))
+        );
+        // Empty heading
         assert_eq!(parse_section_heading(""), None);
+        // Missing area after slash
         assert_eq!(parse_section_heading("esp-hal/"), None);
+        // Missing crate name before slash — must not produce an empty crate_name
+        assert_eq!(parse_section_heading("/Some area"), None);
+        assert_eq!(parse_section_heading("  /  Some area"), None);
+    }
+
+    /// A heading like `## /Some area` must be rejected by the validator, not silently
+    /// accepted with an empty crate name that would match the workspace root.
+    #[test]
+    fn validate_rejects_empty_crate_name() {
+        let body = "# Changelog\n\n## /Some area\n\n- Added: something\n";
+        let errors = validate(body);
+        assert!(
+            !errors.is_empty(),
+            "expected a validation error for `## /Some area` but got none"
+        );
+        assert!(
+            errors.iter().any(|e| e.contains("Invalid section heading")),
+            "unexpected errors: {errors:?}"
+        );
     }
 }


### PR DESCRIPTION
Closes #4784

Implements the new changelog tracking scheme from #4784. Contributors embed changelog and migration guide entries in their PR descriptions using a structured Markdown format; tooling collects them automatically at release time.

- **`cargo xtask check-pr-changelog`**: validates PR description format and checks that modified published packages have entries; integrated into CI, replacing the old `changelog-enforcer`
- **`cargo xtask release changelog-preview`**: renders a draft changelog from merged PRs at any time
- **`cargo xtask release plan`**: now merges PR changelog entries directly into `CHANGELOG.md` (Unreleased section) and `MIGRATING-*.md` before prompting the release manager to review
- **CI edit guard**: new `no-changelog-edits` job detects direct `CHANGELOG.md` edits and posts a guidance comment
- Updated `CONTRIBUTING.md` and the PR template to document the new format


I've added changelog entries to https://github.com/esp-rs/esp-hal/pull/5514, https://github.com/esp-rs/esp-hal/pull/5498 and https://github.com/esp-rs/esp-hal/pull/5463. The result can be previewed using `cargo xtask release changelog-preview`. The relevant entries have been removed from the changelog to avoid duplicating them.

~The changelog workflows are kind of intended to fail on this PR - they are optional, this PR cleans up duplicate entries, and so it both affects a crate and doesn't actually adds changelog entries to esp-hal.~

Current output:

```
<!-- esp-hal -->
## [Unreleased]

### Added

- C5 and C61: Enable RTC timekeeping (#5449)
- C61: usb-serial-jtag and debug-assist (#5427)
- C61: dedicated gpio (#5426)

### Changed

- The clock frequency accessor functions no longer need to lock the clock tree (#5461)
- SPI: `SpiDmaBus` has been merged into `SpiDma`. `with_buffers` now returns `SpiDma` directly, and the buffer-taking transfer methods have been renamed to `read_buffer`, `write_buffer`, `transfer_buffers`, `half_duplex_read_buffer` and `half_duplex_write_buffer` to avoid conflicts with the `SpiBus` trait methods. (#5272)

### Fixed

- RSA: the driver should no longer cause unhandled interrupts to fire (#5443)
- ESP32: attenuation is now correctly set for ADC2 (#5463)
- UART: disallow 0 as the RX FIFO full threshold (#5451)
- UART: prevent returning 0 from `read_async` (#5451)
- ESP32-S2, ESP32-S3: Fixed a bug where `UlpCore.run()` with `UlpCoreWakeupSource::HpCpu` fails to wake the ULP Core (#5410)
- RMT: allow maximum pulse length on both phases in `PulseCode` (#5514)
- LEDC: off-by-one error in clock divisor calculation (#5514)
- UART: Wake on detecting a break condition (#5514)
- DMA: ESP32-S2: Crypto/Copy DMA no longer ignores `in_dscr_empty` (#5514)
- MCPWM: `set_timestamp_b` now actually sets timestamp for channel B (#5514)
- SPI DMA: correctly drop bus and buffer if the transfer object is dropped) (#5514)
- ADC: Corrected a typo that accidentally configured the incorrect ADC instance (#5463)

### Removed

- ESP32: removed unsupported Hall-effect sensor API (#5463)
- The `Clocks` struct has been removed (#5461)
- ADC: ESP32: removed non-functional Hall-sensor code (#5463)


<!-- esp-radio -->
## [Unreleased]

### Added


### Changed


### Fixed

- Fixed a crash when using advanced BLE scanning on certain chips (C6,H2,C5,C61) (#5458)
- Correctly use BTBB_REG_RST (#5498)

### Removed

```

## Changes compared to #4784 and the original RFC:

1. Migration guide requires an area** (`## crate/area` mandatory, `## crate` rejected).
   Both RFCs treat area as optional everywhere. This change should make the final migration guide better structured.

2. **Migration guide entries require `### Title` before body text.**
   Neither RFC mentions H3 titles. The free-form-text-after-`##`-heading model in the RFCs is no longer valid. This change should make the final migration guide better structured.

3. **`check-pr-changelog` fails for modified published packages with no entries.**
   RFC #4618 and #4784 both state contributors are *not required* to add entries. The CI check nevertheless fails, relying on the `skip-changelog` label as an escape hatch. The intent is to reduce friction with contributors, but the original wording was imprecise - contributors are not required to document changes, but documenting changes is still required (by us).

4. The ability to exempt specific packages from under the changelog reqirements.
   `No changelog necessary.` can be used for packages that contain invisible changes (i.e. usage related, or typos).

5. `manual-changelog` label can be used to allow manual edits to the changelog. Also disables package coverage check, assumes the contributor knows what needs to be changelogged.