### PR TITLE
gpio: expose `handle_gpio_interrupt` and `wake_pin` for user-defined GPIO ISRs

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - P4: Initial peripheral support for GPIO, UART, I2C, SPI, DMA, USB Serial/JTAG, eFuse, SYSTIMER (#5400)
 - P4: AP-HEX PSRAM driver stub with configurable HP L2MEM cache/RAM split via `ESP_HAL_CONFIG_L2_CACHE_SIZE` (#5400)
 - C5 and C61: I2S support (#5483)
+- `handle_gpio_interrupt` and `wake_pin()` for user-defined GPIO ISRs (#5531)
 
 ### Changed
 

--- a/esp-hal/src/gpio/interrupt.rs
+++ b/esp-hal/src/gpio/interrupt.rs
@@ -50,9 +50,6 @@
 //! would be slightly more complicated to prevent the user from breaking things.
 //! (If the user were to clear the interrupt status, we would need to re-enable
 //! it, for PinFuture to detect the completion).
-//!
-//! TODO: currently, direct-binding a GPIO interrupt handler will completely
-//! break the async API. We will need to expose a way to handle async events.
 
 use portable_atomic::{AtomicPtr, Ordering};
 use strum::EnumCount;
@@ -203,16 +200,55 @@ pub(super) extern "C" fn user_gpio_interrupt_handler() {
         // interrupt handler.
         USER_INTERRUPT_HANDLER.call();
 
-        // Handle the async interrupts
-        for (bank, intrs) in banks {
-            // Get the mask of active async pins and clear the relevant bits to signal
-            // completion. This way the user may clear the interrupt status
-            // without worrying about the async bit being cleared.
-            let async_pins = bank.async_operations().load(Ordering::Relaxed);
+        process_async_banks(banks);
+    });
+}
 
-            // Wake up the tasks
-            handle_async_pins(bank, async_pins, intrs);
+/// Internal entry point for [`crate::gpio::handle_gpio_interrupt`].
+///
+/// Kept here (rather than at the public callsite) because this module owns
+/// the GPIO ISR critical section and the per-bank dispatch routine, both of
+/// which are private to this module.
+///
+/// # Safety
+///
+/// Must be called from a GPIO interrupt context.
+#[ram]
+pub(super) unsafe fn handle_gpio_interrupt_impl() {
+    GPIO_LOCK.lock(|| {
+        let banks = interrupt_status();
+        process_async_banks(banks);
+    });
+}
+
+#[inline]
+pub(super) fn process_async_banks(banks: [(GpioBank, u32); GpioBank::COUNT]) {
+    for (bank, intrs) in banks {
+        let async_pins = bank.async_operations().load(Ordering::Relaxed);
+
+        handle_async_pins(bank, async_pins, intrs);
+    }
+}
+
+/// Internal entry point for [`crate::gpio::wake_pin`].
+///
+/// # Safety
+///
+/// Must be called from a GPIO interrupt context.
+#[ram]
+pub(super) unsafe fn wake_pin_impl(pin: u8) {
+    GPIO_LOCK.lock(|| {
+        let any = unsafe { AnyPin::steal(pin) };
+        let bank = any.bank();
+        let mask = any.mask();
+
+        // Only act if this pin is registered as an async waiter.
+        let async_pins = bank.async_operations().load(Ordering::Relaxed);
+        if async_pins & mask == 0 {
+            return;
         }
+
+        handle_async_pins(bank, mask, mask);
     });
 }
 

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -690,6 +690,33 @@ impl crate::interrupt::InterruptConfigurable for Io<'_> {
     }
 }
 
+/// Drive the GPIO async API from a user-installed raw GPIO interrupt handler.
+///
+/// This is the entry point that lets users who bypass esp-hal's GPIO ISR
+/// dispatch (typically by defining their own `#[unsafe(no_mangle)]
+/// unsafe extern "C" fn GPIO()`, or by registering their own handler via
+/// [`crate::interrupt::bind_handler`]) keep the GPIO async API working.
+///
+/// # Safety
+///
+/// Must be called from a GPIO interrupt context.
+#[instability::unstable]
+pub unsafe fn handle_gpio_interrupt() {
+    unsafe { interrupt::handle_gpio_interrupt_impl() }
+}
+
+/// Complete any in-flight async wait on a single GPIO pin.
+///
+/// Per-pin counterpart of [`handle_gpio_interrupt`].
+///
+/// # Safety
+///
+/// Must be called from a GPIO interrupt context.
+#[instability::unstable]
+pub unsafe fn wake_pin(pin: u8) {
+    unsafe { interrupt::wake_pin_impl(pin) }
+}
+
 for_each_analog_function! {
     (($_ch:ident, ADCn_CHm, $_n:literal, $_m:literal), $gpio:ident) => {
         #[instability::unstable]

--- a/hil-test/src/bin/gpio_custom_handler.rs
+++ b/hil-test/src/bin/gpio_custom_handler.rs
@@ -4,6 +4,10 @@
 //! GPIO interrupt handlers. We also check that binding a custom interrupt
 //! handler explicitly overwrites the handler set by the user, as well as the
 //! async API works for user handlers automatically.
+//!
+//! It also covers the `handle_gpio_interrupt`/`wake_pin` escape hatches that
+//! let user-defined raw `GPIO()` handlers re-enable the async API
+//! (regression coverage for esp-rs/esp-hal#2659).
 
 //% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
 //% FEATURES: unstable embassy
@@ -30,26 +34,60 @@ use esp_hal::{
         Pull,
     },
     handler,
-    interrupt::{Priority, software::SoftwareInterruptControl},
+    interrupt::{InterruptHandler, Priority, bind_handler, software::SoftwareInterruptControl},
+    peripherals::Interrupt,
     timer::timg::TimerGroup,
 };
 use esp_rtos::embassy::InterruptExecutor;
 use hil_test::mk_static;
-use portable_atomic::{AtomicUsize, Ordering};
+use portable_atomic::{AtomicU8, AtomicUsize, Ordering};
+
+// Selects what the user-defined `GPIO()` handler does. Set by each test
+// before triggering any pin events, read inside the ISR.
+#[repr(u8)]
+#[derive(Clone, Copy)]
+enum HandlerMode {
+    // Original behavior: clear the pin's listen state by hand. Used by the
+    // negative test that documents the pre-fix bug.
+    UnlistenOnly    = 0,
+    // Call `handle_gpio_interrupt()` to drive the whole async pass.
+    HandleAll       = 1,
+    // Call `wake_pin(SENSE_PIN_NR)` for the pin recorded by the test.
+    WakeSpecificPin = 2,
+}
+
+static HANDLER_MODE: AtomicU8 = AtomicU8::new(HandlerMode::UnlistenOnly as u8);
+static SENSE_PIN_NR: AtomicU8 = AtomicU8::new(u8::MAX);
+static HANDLER_INVOCATIONS: AtomicUsize = AtomicUsize::new(0);
+
+extern "C" fn gpio_isr() {
+    HANDLER_INVOCATIONS.fetch_add(1, Ordering::Relaxed);
+
+    match HANDLER_MODE.load(Ordering::Relaxed) {
+        x if x == HandlerMode::HandleAll as u8 => {
+            unsafe { esp_hal::gpio::handle_gpio_interrupt() };
+        }
+        x if x == HandlerMode::WakeSpecificPin as u8 => {
+            let pin = SENSE_PIN_NR.load(Ordering::Relaxed);
+            if pin != u8::MAX {
+                unsafe { esp_hal::gpio::wake_pin(pin) };
+            }
+        }
+        _ => {
+            // UnlistenOnly: prevents binding the default handler, but we need
+            // to clear the GPIO interrupts by hand and we deliberately do
+            // *not* wake any async future.
+            let peripherals = unsafe { esp_hal::peripherals::Peripherals::steal() };
+            let (gpio1, _) = hil_test::common_test_pins!(peripherals);
+            let mut gpio1 = Flex::new(gpio1);
+            gpio1.unlisten();
+        }
+    }
+}
 
 #[unsafe(no_mangle)]
 unsafe extern "C" fn GPIO() {
-    // Prevents binding the default handler, but we need to clear the GPIO
-    // interrupts by hand.
-    let peripherals = unsafe { esp_hal::peripherals::Peripherals::steal() };
-
-    let (gpio1, _) = hil_test::common_test_pins!(peripherals);
-
-    // Using flex will reinitialize the pin, but it's okay here since we access an
-    // Input.
-    let mut gpio1 = Flex::new(gpio1);
-
-    gpio1.unlisten();
+    gpio_isr();
 }
 
 #[handler]
@@ -107,6 +145,14 @@ async fn sense_pin(gpio: AnyPin<'static>, done: &'static Signal<CriticalSectionR
 #[embedded_test::tests(executor = hil_test::Executor::new(), default_timeout = 3)]
 mod tests {
     use super::*;
+
+    // Restore the GPIO vector entry to point at the user-defined handler.
+    fn rebind_user_gpio_handler() {
+        bind_handler(
+            Interrupt::GPIO,
+            InterruptHandler::new(gpio_isr, Priority::Priority1),
+        );
+    }
 
     #[test]
     async fn default_handler_does_not_run_because_gpio_is_defined() {
@@ -172,5 +218,58 @@ mod tests {
         interrupt_spawner.spawn(drive_pin(gpio2.degrade()).unwrap());
 
         done.wait().await;
+    }
+
+    // Regression test for esp-rs/esp-hal#2659: a user-defined raw `GPIO()`
+    // handler that calls `handle_gpio_interrupt()` keeps the async API
+    // fully functional, even though esp-hal's own dispatch shim never gets
+    // to bind itself.
+    #[test]
+    async fn user_gpio_handler_can_drive_async_api_via_handle_gpio_interrupt() {
+        rebind_user_gpio_handler();
+        HANDLER_MODE.store(HandlerMode::HandleAll as u8, Ordering::Relaxed);
+
+        let peripherals = esp_hal::init(esp_hal::Config::default());
+
+        let (gpio1, gpio2) = hil_test::common_test_pins!(peripherals);
+
+        let sw_int = SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
+        let timg0 = TimerGroup::new(peripherals.TIMG0);
+        esp_rtos::start(timg0.timer0, sw_int.software_interrupt0);
+
+        let counter = drive_pins(gpio1, gpio2).await;
+
+        assert!(
+            HANDLER_INVOCATIONS.load(Ordering::Relaxed) > 0,
+            "user-defined GPIO() handler was never invoked"
+        );
+        assert_eq!(counter, 5);
+    }
+
+    // Companion test for the per-pin escape hatch: the user handler calls
+    // `wake_pin(n)` for exactly the pin being awaited.
+    #[test]
+    async fn user_gpio_handler_can_drive_async_api_via_wake_pin() {
+        rebind_user_gpio_handler();
+
+        let peripherals = esp_hal::init(esp_hal::Config::default());
+
+        let (gpio1, gpio2) = hil_test::common_test_pins!(peripherals);
+
+        // Record the awaited pin's number for the ISR before any event can fire.
+        SENSE_PIN_NR.store(gpio1.number(), Ordering::Relaxed);
+        HANDLER_MODE.store(HandlerMode::WakeSpecificPin as u8, Ordering::Relaxed);
+
+        let sw_int = SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
+        let timg0 = TimerGroup::new(peripherals.TIMG0);
+        esp_rtos::start(timg0.timer0, sw_int.software_interrupt0);
+
+        let counter = drive_pins(gpio1, gpio2).await;
+
+        assert!(
+            HANDLER_INVOCATIONS.load(Ordering::Relaxed) > 0,
+            "user-defined GPIO() handler was never invoked"
+        );
+        assert_eq!(counter, 5);
     }
 }


### PR DESCRIPTION
Users who own the GPIO vector themselves (`#[unsafe(no_mangle)] unsafe extern "C" fn GPIO()` or a direct `bind_handler`) bypass esp-hal's dispatch and break the GPIO async API - `wait_for_* futures` never complete - this PR fixes that.

closes https://github.com/esp-rs/esp-hal/issues/2659