### PR TITLE
Release esp-hal: 1.1.0 → 1.1.1

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -15,6 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+
+### Removed
+
+
+## [v1.1.1] - 2026-05-07
+
+### Fixed
+
 - RSA: the driver should no longer cause unhandled interrupts to fire (#5443)
 - ESP32: attenuation is now correctly set for ADC2 (#5463)
 - UART: disallow 0 as the RX FIFO full threshold (#5451)
@@ -1628,4 +1636,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v1.0.0]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.0.0-rc.1...esp-hal-v1.0.0
 [v1.1.0-rc.0]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.0.0...esp-hal-v1.1.0-rc.0
 [v1.1.0]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.1.0-rc.0...esp-hal-v1.1.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.1.0...HEAD
+[v1.1.1]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.1.0...esp-hal-v1.1.1
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.1.1...HEAD

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-hal"
-version       = "1.1.0"
+version       = "1.1.1"
 edition       = "2024"
 rust-version  = "1.88.0"
 description   = "Bare-metal HAL for Espressif devices"


### PR DESCRIPTION
⚠️ This pull request was branched off from `esp-hal-1.1.x`. ⚠️

This pull request prepares the following packages for release:

- esp-hal: 1.1.0 → 1.1.1

<details>

<summary>Release plan (click to expand)</summary>

```jsonc
{
  "base": "esp-hal-1.1.x",
  "slug": "v4vwtp",
  "backport": {
    "package": "esp-hal",
    "major": 1,
    "minor": 1
  },
  "packages": [
    {
      "package": "esp-hal",
      "semver_checked": true,
      "current_version": "1.1.0",
      "new_version": "1.1.1",
      "tag_name": "esp-hal-v1.1.1",
      "bump": {
        "base": "Patch",
        "pre": null
      }
    }
  ]
}
```

</details>

Please review the changes and merge them into the `esp-hal-1.1.x` branch.

After merging, please make sure you have this release plan in the repo root,
then run the following command on the `esp-hal-1.1.x` branch to tag and publish the packages:

```
cargo xrelease publish-plan --no-dry-run
```
