### PR TITLE
feat(GPIO): Wake from light sleep while waiting for event (#5543)

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - C5 and C61: I2S support (#5483)
 - UART: `send_break_async` (#5536)
 - `handle_gpio_interrupt` and `wake_pin()` for user-defined GPIO ISRs (#5531)
+- GPIO: `Input::wait_for_with_options()` allows waking from light sleep while waiting for event (#5551)
 
 ### Changed
 

--- a/esp-hal/src/gpio/asynch.rs
+++ b/esp-hal/src/gpio/asynch.rs
@@ -3,7 +3,7 @@ use core::{
     task::{Context, Poll},
 };
 
-use crate::gpio::{Event, Flex, GpioBank, Input, InputPin};
+use crate::gpio::{Event, Flex, GpioBank, Input, InputPin, WaitForOptions, WakeConfigError};
 
 impl Flex<'_> {
     /// Wait until the pin experiences a particular [`Event`].
@@ -17,6 +17,41 @@ impl Flex<'_> {
     #[inline]
     #[instability::unstable]
     pub async fn wait_for(&mut self, event: Event) {
+        unwrap!(
+            self.wait_for_with_options(event, WaitForOptions::default())
+                .await
+        );
+    }
+
+    /// Wait until the pin experiences a particular [`Event`], with
+    /// configurable options.
+    ///
+    /// The GPIO driver will disable listening for the event once it occurs,
+    /// or if the `Future` is dropped - which also means this method is **not**
+    /// cancellation-safe, it will always wait for a future event.
+    ///
+    /// Note that calling this function will overwrite previous
+    /// [`listen`][Self::listen] and [`wakeup_enable`][Self::wakeup_enable]
+    /// operations for this pin.
+    ///
+    /// When `options.wake_enable` is `true`, the pin will also wake the
+    /// CPU from light sleep when the event occurs. Only level-triggered
+    /// events ([`Event::LowLevel`] and [`Event::HighLevel`]) support wake-up;
+    /// edge-triggered events will return an error.
+    ///
+    /// # Error
+    ///
+    /// Returns an error if [`WaitForOptions`] specifies `wake_enable: true`
+    /// and the event is an edge trigger ([`Event::RisingEdge`],
+    /// [`Event::FallingEdge`], or [`Event::AnyEdge`]), as edge-triggered
+    /// wake-up is not supported.
+    #[inline]
+    #[instability::unstable]
+    pub async fn wait_for_with_options(
+        &mut self,
+        event: Event,
+        options: WaitForOptions,
+    ) -> Result<(), WakeConfigError> {
         // Make sure this pin is not being processed by an interrupt handler. We need to
         // always take a critical section even if the pin is not listening, because the
         // interrupt handler may be running on another core and the interrupt handler
@@ -24,6 +59,17 @@ impl Flex<'_> {
         // regardless of the pin actually listening or not.
         if self.is_listening() || self.is_interrupt_set() {
             self.unlisten_and_clear();
+        }
+
+        // Validate wake config upfront to avoid partial setup (async bit set but
+        // interrupt not configured).
+        if options.wake_enable {
+            match event {
+                Event::AnyEdge | Event::RisingEdge | Event::FallingEdge => {
+                    return Err(WakeConfigError::EdgeTriggeringNotSupported);
+                }
+                _ => {}
+            }
         }
 
         // At this point the pin is no longer listening, and not being processed, so we
@@ -40,9 +86,11 @@ impl Flex<'_> {
 
         // Start listening for the event. We only need to do this once, as disabling
         // the interrupt will signal the future to complete.
-        self.listen(event);
+        self.pin
+            .listen_with_options(event, true, false, options.wake_enable)?;
 
-        PinFuture { pin: self }.await
+        PinFuture { pin: self }.await;
+        Ok(())
     }
 
     /// Wait until the pin is high.
@@ -120,6 +168,52 @@ impl Input<'_> {
     #[instability::unstable]
     pub async fn wait_for(&mut self, event: Event) {
         self.pin.wait_for(event).await
+    }
+
+    #[procmacros::doc_replace]
+    /// Wait until the pin experiences a particular [`Event`], with
+    /// configurable options.
+    ///
+    /// ## Example
+    ///
+    /// ```rust, no_run
+    /// # {before_snippet}
+    /// use esp_hal::gpio::{Event, Input, InputConfig, WaitForOptions};
+    /// let mut input_pin = Input::new(peripherals.GPIO4, InputConfig::default());
+    ///
+    /// input_pin
+    ///     .wait_for_with_options(
+    ///         Event::HighLevel,
+    ///         WaitForOptions::default().with_wake_enable(true),
+    ///     )
+    ///     .await
+    ///     .unwrap();
+    /// # {after_snippet}
+    /// ```
+    ///
+    /// ## Cancellation
+    ///
+    /// This function is not cancellation-safe.
+    ///
+    /// - Calling this function will overwrite previous [`listen`][Self::listen] and
+    ///   [`wakeup_enable`][Self::wakeup_enable] operations for this pin, making it side-effectful.
+    /// - Dropping the [`Future`] returned by this function will cancel the wait operation. If the
+    ///   event occurs after the future is dropped, a consequent wait operation will ignore the
+    ///   event.
+    ///
+    /// # Error
+    ///
+    /// Returns an error if [`WaitForOptions`] specifies `wake_enable: true`
+    /// and the event is an edge trigger, as edge-triggered wake-up is not
+    /// supported.
+    #[inline]
+    #[instability::unstable]
+    pub async fn wait_for_with_options(
+        &mut self,
+        event: Event,
+        options: WaitForOptions,
+    ) -> Result<(), WakeConfigError> {
+        self.pin.wait_for_with_options(event, options).await
     }
 
     #[procmacros::doc_replace]

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -270,15 +270,10 @@ impl core::error::Error for WakeConfigError {}
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, procmacros::BuilderLite)]
 #[non_exhaustive]
+#[instability::unstable]
 pub struct WaitForOptions {
     /// Enable waking from light sleep on the configured event.
     wake_enable: bool,
-}
-
-impl Default for WaitForOptions {
-    fn default() -> Self {
-        Self { wake_enable: false }
-    }
 }
 
 /// Pull setting for a GPIO.

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -265,6 +265,22 @@ impl Display for WakeConfigError {
 
 impl core::error::Error for WakeConfigError {}
 
+/// Options for [`Input::wait_for_with_options`] and
+/// [`Flex::wait_for_with_options`].
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, procmacros::BuilderLite)]
+#[non_exhaustive]
+pub struct WaitForOptions {
+    /// Enable waking from light sleep on the configured event.
+    wake_enable: bool,
+}
+
+impl Default for WaitForOptions {
+    fn default() -> Self {
+        Self { wake_enable: false }
+    }
+}
+
 /// Pull setting for a GPIO.
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] My changes were added to the [`CHANGELOG.md`](https://github.com/esp-rs/esp-hal/blob/main/esp-hal/CHANGELOG.md) in the **_proper_** section.
- [x] I have added necessary changes to user code to the latest [Migration Guide](https://github.com/esp-rs/esp-hal/blob/main/esp-hal).
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Added `esp_hal::gpio::Input::wait_for_with_options()` and `esp_hal::gpio::Flex::wait_for_with_options()` to allow waking up from light sleep while waiting for an event.

#### Testing
Manual testing in project.