### PR TITLE
Enable GPIO tests, update to PAC that merges SPIs

### DIFF
--- a/esp-metadata-generated/src/_generated_esp32p4.rs
+++ b/esp-metadata-generated/src/_generated_esp32p4.rs
@@ -3475,11 +3475,11 @@ macro_rules! for_each_peripheral {
         bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
         (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "SPI2 peripheral singleton"] SPI2 <= SPI2(SPI2 : { bind_peri_interrupt,
-        enable_peri_interrupt, disable_peri_interrupt }) (unstable)));
+        enable_peri_interrupt, disable_peri_interrupt })));
         _for_each_inner_peripheral!((@ peri_type #[doc = "SPI3 peripheral singleton"]
-        SPI3 <= SPI2(SPI3 : { bind_peri_interrupt, enable_peri_interrupt,
-        disable_peri_interrupt }) (unstable))); _for_each_inner_peripheral!((@ peri_type
-        #[doc = "I2C0 peripheral singleton"] I2C0 <= I2C0(I2C0 : { bind_peri_interrupt,
+        SPI3 <= SPI3(SPI3 : { bind_peri_interrupt, enable_peri_interrupt,
+        disable_peri_interrupt }))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "I2C0 peripheral singleton"] I2C0 <= I2C0(I2C0 : { bind_peri_interrupt,
         enable_peri_interrupt, disable_peri_interrupt }) (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc = "I2C1 peripheral singleton"]
         I2C1 <= I2C1(I2C1 : { bind_peri_interrupt, enable_peri_interrupt,
@@ -3590,8 +3590,7 @@ macro_rules! for_each_peripheral {
         _for_each_inner_peripheral!((UART2(unstable)));
         _for_each_inner_peripheral!((UART3(unstable)));
         _for_each_inner_peripheral!((UART4(unstable)));
-        _for_each_inner_peripheral!((SPI2(unstable)));
-        _for_each_inner_peripheral!((SPI3(unstable)));
+        _for_each_inner_peripheral!((SPI2)); _for_each_inner_peripheral!((SPI3));
         _for_each_inner_peripheral!((I2C0(unstable)));
         _for_each_inner_peripheral!((I2C1(unstable)));
         _for_each_inner_peripheral!((TWAI0(unstable)));
@@ -3775,10 +3774,10 @@ macro_rules! for_each_peripheral {
         = "UART4 peripheral singleton"] UART4 <= UART4(UART4 : { bind_peri_interrupt,
         enable_peri_interrupt, disable_peri_interrupt }) (unstable)), (@ peri_type #[doc
         = "SPI2 peripheral singleton"] SPI2 <= SPI2(SPI2 : { bind_peri_interrupt,
-        enable_peri_interrupt, disable_peri_interrupt }) (unstable)), (@ peri_type #[doc
-        = "SPI3 peripheral singleton"] SPI3 <= SPI2(SPI3 : { bind_peri_interrupt,
-        enable_peri_interrupt, disable_peri_interrupt }) (unstable)), (@ peri_type #[doc
-        = "I2C0 peripheral singleton"] I2C0 <= I2C0(I2C0 : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt })), (@ peri_type #[doc =
+        "SPI3 peripheral singleton"] SPI3 <= SPI3(SPI3 : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt })), (@ peri_type #[doc =
+        "I2C0 peripheral singleton"] I2C0 <= I2C0(I2C0 : { bind_peri_interrupt,
         enable_peri_interrupt, disable_peri_interrupt }) (unstable)), (@ peri_type #[doc
         = "I2C1 peripheral singleton"] I2C1 <= I2C1(I2C1 : { bind_peri_interrupt,
         enable_peri_interrupt, disable_peri_interrupt }) (unstable)), (@ peri_type #[doc
@@ -3837,16 +3836,16 @@ macro_rules! for_each_peripheral {
         (LP_AON(unstable)), (LP_AON_CLKRST(unstable)), (LP_SYS(unstable)),
         (LP_WDT(unstable)), (LPWR(unstable)), (PMU(unstable)), (SYSTIMER(unstable)),
         (TIMG0(unstable)), (TIMG1(unstable)), (UART0(unstable)), (UART1(unstable)),
-        (UART2(unstable)), (UART3(unstable)), (UART4(unstable)), (SPI2(unstable)),
-        (SPI3(unstable)), (I2C0(unstable)), (I2C1(unstable)), (TWAI0(unstable)),
-        (TWAI1(unstable)), (TWAI2(unstable)), (PSRAM(unstable)), (DMA(unstable)),
-        (DMA_CH0(unstable)), (DMA_CH1(unstable)), (DMA_CH2(unstable)),
-        (USB_DEVICE(unstable)), (SDHOST(unstable)), (LEDC(unstable)), (MCPWM0(unstable)),
-        (MCPWM1(unstable)), (PCNT(unstable)), (RMT(unstable)), (ADC(unstable)),
-        (AES(unstable)), (SHA(unstable)), (RSA(unstable)), (ECC(unstable)),
-        (USB_FS(unstable)), (USB_HS(unstable)), (SW_INTERRUPT(unstable)),
-        (CPU_CTRL(unstable)))); _for_each_inner_peripheral!((dma_eligible(SPI2, Spi2, 1),
-        (SPI3, Spi3, 2), (AES, Aes, 4), (SHA, Sha, 5)));
+        (UART2(unstable)), (UART3(unstable)), (UART4(unstable)), (SPI2), (SPI3),
+        (I2C0(unstable)), (I2C1(unstable)), (TWAI0(unstable)), (TWAI1(unstable)),
+        (TWAI2(unstable)), (PSRAM(unstable)), (DMA(unstable)), (DMA_CH0(unstable)),
+        (DMA_CH1(unstable)), (DMA_CH2(unstable)), (USB_DEVICE(unstable)),
+        (SDHOST(unstable)), (LEDC(unstable)), (MCPWM0(unstable)), (MCPWM1(unstable)),
+        (PCNT(unstable)), (RMT(unstable)), (ADC(unstable)), (AES(unstable)),
+        (SHA(unstable)), (RSA(unstable)), (ECC(unstable)), (USB_FS(unstable)),
+        (USB_HS(unstable)), (SW_INTERRUPT(unstable)), (CPU_CTRL(unstable))));
+        _for_each_inner_peripheral!((dma_eligible(SPI2, Spi2, 1), (SPI3, Spi3, 2), (AES,
+        Aes, 4), (SHA, Sha, 5)));
     };
 }
 /// This macro can be used to generate code for each `GPIOn` instance.

--- a/esp-metadata/devices/esp32p4.toml
+++ b/esp-metadata/devices/esp32p4.toml
@@ -269,12 +269,8 @@ peripherals = [
     { name = "UART2", interrupts = { peri = "UART2" }, clock_group = "UART" },
     { name = "UART3", interrupts = { peri = "UART3" }, clock_group = "UART" },
     { name = "UART4", interrupts = { peri = "UART4" }, clock_group = "UART" },
-    { name = "SPI2", interrupts = { peri = "SPI2" }, dma_peripheral = 1 },
-    # SPI3 has the same RegisterBlock layout as SPI2 but the PAC exposes it as
-    # a distinct type. Map to SPI2 so the SPI master driver can reuse its
-    # register accessors directly. Verified field-compatible against the
-    # upstream esp32p4 PAC at the time of this port.
-    { name = "SPI3", pac = "SPI2", interrupts = { peri = "SPI3" }, dma_peripheral = 2 },
+    { name = "SPI2", interrupts = { peri = "SPI2" }, dma_peripheral = 1, stable = true },
+    { name = "SPI3", interrupts = { peri = "SPI3" }, dma_peripheral = 2, stable = true },
     { name = "I2C0", interrupts = { peri = "I2C0" } },
     { name = "I2C1", interrupts = { peri = "I2C1" } },
     { name = "TWAI0", interrupts = { peri = "TWAI0" } },

--- a/hil-test/README.md
+++ b/hil-test/README.md
@@ -84,7 +84,7 @@ Our self-hosted runners have the following setup:
 - ESP32-P4 (`esp32p4`):
   - Devkit: `ESP32-P4 EV Board 1.5.2` connected via USB-Serial-JTAG (`USB` port).
     - `GPIO2` and `GPIO3` are I2C pins.
-    - `GPIO7` and `GPIO8` are connected.
+    - `GPIO5` and `GPIO6` are connected.
   - RPi: Raspbian 12 configured with the following [setup]
 - ESP32-S2 (`esp32s2-jtag`):
   - Devkit: `ESP32-S2-Saola-1` connected via UART (`UART` port).

--- a/hil-test/src/bin/gpio.rs
+++ b/hil-test/src/bin/gpio.rs
@@ -1,6 +1,6 @@
 //! GPIO Test
 
-//% CHIPS: esp32 esp32c2 esp32c3 esp32c5 esp32c6 esp32c61 esp32h2 esp32s2 esp32s3
+//% CHIPS: esp32 esp32c2 esp32c3 esp32c5 esp32c6 esp32c61 esp32h2 esp32p4 esp32s2 esp32s3
 //% FEATURES(unstable): unstable embassy
 //% FEATURES(stable):
 

--- a/hil-test/src/bin/gpio_custom_handler.rs
+++ b/hil-test/src/bin/gpio_custom_handler.rs
@@ -9,7 +9,7 @@
 //! let user-defined raw `GPIO()` handlers re-enable the async API
 //! (regression coverage for esp-rs/esp-hal#2659).
 
-//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32s2 esp32s3
+//% CHIPS: esp32 esp32c2 esp32c3 esp32c6 esp32h2 esp32p4 esp32s2 esp32s3
 //% FEATURES: unstable embassy
 
 #![no_std]

--- a/hil-test/src/lib.rs
+++ b/hil-test/src/lib.rs
@@ -94,7 +94,7 @@ macro_rules! common_test_pins {
             } else if #[cfg(esp32)] {
                 ($peripherals.GPIO2, $peripherals.GPIO4)
             } else if #[cfg(esp32p4)] {
-                ($peripherals.GPIO7, $peripherals.GPIO8)
+                ($peripherals.GPIO5, $peripherals.GPIO6)
             } else { // esp32c6, esp32c61, esp32h2, esp32c2, esp32c3
                 ($peripherals.GPIO2, $peripherals.GPIO3)
             }


### PR DESCRIPTION
Some GPIO tests are failing because the devkit has strong enough pullups on GPIO7/8 to interfere.

[PAC PR](https://github.com/esp-rs/esp-pacs/pull/442)

# Changelog

## esp-hal

- No changelog necessary.

## esp-metadata

- No changelog necessary.