### PR TITLE
P4: Fix interrupt status register count

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-CHANGELOG.md merge=union

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - C61: usb-serial-jtag and debug-assist (#5427)
 - C61: dedicated gpio (#5426)
 - Initial ESP32-P4 (chip revision v3.0+) support (#5400, #5523)
-- P4: Initial peripheral support for GPIO, UART, I2C, SPI, DMA, USB Serial/JTAG, eFuse, SYSTIMER (#5400, #5555)
+- P4: Initial peripheral support for GPIO, UART, I2C, SPI, DMA, USB Serial/JTAG, eFuse, SYSTIMER (#5400, #5555, #5559)
 - P4: Enable RNG, ECC (#5525)
 - P4: AP-HEX PSRAM driver stub with configurable HP L2MEM cache/RAM split via `ESP_HAL_CONFIG_L2_CACHE_SIZE` (#5400)
 - C5 and C61: I2S support (#5483)

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -111,7 +111,7 @@ esp32c61 = { version = "0.3", features = ["critical-section", "rt"], optional = 
 esp32h2 = { version = "0.19", features = ["critical-section", "rt"], optional = true }
 esp32s2 = { version = "0.31", features = ["critical-section", "rt"], optional = true }
 esp32s3 = { version = "0.35", features = ["critical-section", "rt"], optional = true }
-esp32p4 = { version = "0.2", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "ecce8f97b011945a0688aa25924dd2cafc165f4f" }
+esp32p4 = { version = "0.2", features = ["critical-section", "rt"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "f6f4ad1f804eebab59dbaf425684865781466e4c" }
 
 [target.'cfg(target_arch = "riscv32")'.dependencies]
 riscv            = { version = "0.15.0" }

--- a/esp-hal/src/interrupt/mod.rs
+++ b/esp-hal/src/interrupt/mod.rs
@@ -52,11 +52,8 @@ cfg_if::cfg_if! {
         use crate::peripherals::DPORT as INTERRUPT_CORE0;
         use crate::peripherals::DPORT as INTERRUPT_CORE1;
     } else {
-        // P4 reads these registers via raw MMIO, not through the PAC singletons,
-        // so the INTERRUPT_CORE0/1 imports aren't needed there.
-        #[cfg(not(esp32p4))]
         use crate::peripherals::INTERRUPT_CORE0;
-        #[cfg(esp32s3)]
+        #[cfg(multi_core)]
         use crate::peripherals::INTERRUPT_CORE1;
     }
 }
@@ -201,42 +198,29 @@ impl InterruptStatus {
         match Cpu::current() {
             Cpu::ProCpu => InterruptStatus {
                 status: core::array::from_fn(|idx| {
-                    // P4: Status registers at base + 0x200 (4 x 32-bit = 128 sources)
-                    //   INTERRUPT_CORE0_INTR_STATUS_REG_0_REG = base + 0x200
-                    //   INTERRUPT_CORE0_INTR_STATUS_REG_1_REG = base + 0x204
-                    //   INTERRUPT_CORE0_INTR_STATUS_REG_2_REG = base + 0x208
-                    //   INTERRUPT_CORE0_INTR_STATUS_REG_3_REG = base + 0x20c
                     #[cfg(esp32p4)]
-                    {
-                        let base = crate::soc::registers::INTERRUPT_MAP_BASE + 0x200;
-                        unsafe { ((base as *const u32).add(idx)).read_volatile() }
+                    if idx == 4 {
+                        // Discontiguous, cannot be part of the standard status array
+                        return INTERRUPT_CORE0::regs().core_0_intr_status4().read().bits();
                     }
-                    #[cfg(not(esp32p4))]
-                    {
-                        INTERRUPT_CORE0::regs()
-                            .core_0_intr_status(idx)
-                            .read()
-                            .bits()
-                    }
+                    INTERRUPT_CORE0::regs()
+                        .core_0_intr_status(idx)
+                        .read()
+                        .bits()
                 }),
             },
             #[cfg(multi_core)]
             Cpu::AppCpu => InterruptStatus {
                 status: core::array::from_fn(|idx| {
-                    // P4 Core1: base + 0x800 + 0x200
-                    //   INTERRUPT_CORE1 = INTERRUPT_CORE0 + 0x800
                     #[cfg(esp32p4)]
-                    {
-                        let base = crate::soc::registers::INTERRUPT_MAP_BASE_APP_CPU + 0x200;
-                        unsafe { ((base as *const u32).add(idx)).read_volatile() }
+                    if idx == 4 {
+                        // Discontiguous, cannot be part of the standard status array
+                        return INTERRUPT_CORE1::regs().core_1_intr_status4().read().bits();
                     }
-                    #[cfg(not(esp32p4))]
-                    {
-                        INTERRUPT_CORE1::regs()
-                            .core_1_intr_status(idx)
-                            .read()
-                            .bits()
-                    }
+                    INTERRUPT_CORE1::regs()
+                        .core_1_intr_status(idx)
+                        .read()
+                        .bits()
                 }),
             },
         }
@@ -378,23 +362,6 @@ pub fn disable(core: Cpu, interrupt: Interrupt) {
 }
 
 pub(super) fn map_raw(core: Cpu, interrupt: Interrupt, cpu_interrupt: u32) {
-    // P4: 120 individual INT_MAP registers at sequential 4-byte offsets from base.
-    // Each register has 6-bit field [5:0] for CPU interrupt line (0-63).
-    // Core0: base = 0x500D_6000, Core1: base = 0x500D_6800
-    //      LP_WDT_INT_MAP_REG at offset 0x4, etc.
-    #[cfg(esp32p4)]
-    {
-        let base = match core {
-            Cpu::ProCpu => crate::soc::registers::INTERRUPT_MAP_BASE,
-            #[cfg(multi_core)]
-            Cpu::AppCpu => crate::soc::registers::INTERRUPT_MAP_BASE_APP_CPU,
-        };
-        unsafe {
-            let reg = (base as *mut u32).add(interrupt as usize);
-            reg.write_volatile(cpu_interrupt);
-        }
-    }
-    #[cfg(not(esp32p4))]
     match core {
         Cpu::ProCpu => {
             INTERRUPT_CORE0::regs()
@@ -416,20 +383,6 @@ pub(crate) fn mapped_to(cpu: Cpu, interrupt: Interrupt) -> Option<CpuInterrupt> 
 }
 
 pub(crate) fn mapped_to_raw(cpu: Cpu, interrupt: u32) -> Option<CpuInterrupt> {
-    // P4: read INT_MAP register directly. 6-bit field [5:0] = CPU interrupt line.
-    #[cfg(esp32p4)]
-    let cpu_intr = {
-        let base = match cpu {
-            Cpu::ProCpu => crate::soc::registers::INTERRUPT_MAP_BASE,
-            #[cfg(multi_core)]
-            Cpu::AppCpu => crate::soc::registers::INTERRUPT_MAP_BASE_APP_CPU,
-        };
-        unsafe {
-            let reg = (base as *const u32).add(interrupt as usize);
-            reg.read_volatile() & 0x3F // 6-bit field
-        }
-    };
-    #[cfg(not(esp32p4))]
     let cpu_intr = match cpu {
         Cpu::ProCpu => INTERRUPT_CORE0::regs()
             .core_0_intr_map(interrupt as usize)

--- a/esp-hal/src/soc/esp32p4/mod.rs
+++ b/esp-hal/src/soc/esp32p4/mod.rs
@@ -10,12 +10,6 @@ pub(crate) mod regi2c;
 
 pub(crate) use esp32p4 as pac;
 
-pub(crate) mod registers {
-    pub const INTERRUPT_MAP_BASE: u32 = 0x500D_6000;
-    #[expect(dead_code)]
-    pub const INTERRUPT_MAP_BASE_APP_CPU: u32 = 0x500D_6800;
-}
-
 pub(crate) fn pre_init() {
     // TODO: Check if anything needs to be done here
 }

--- a/esp-metadata-generated/src/_build_script_utils.rs
+++ b/esp-metadata-generated/src/_build_script_utils.rs
@@ -4346,7 +4346,6 @@ impl Chip {
                     "soc_has_rsa",
                     "soc_has_ecc",
                     "soc_has_sw_interrupt",
-                    "very_large_intr_status",
                     "spi_octal",
                     "rom_crc_le",
                     "rom_crc_be",
@@ -4406,7 +4405,7 @@ impl Chip {
                     "i2c_master_max_bus_timeout=\"31\"",
                     "i2c_master_ll_intr_mask=\"262143\"",
                     "i2c_master_fifo_size=\"32\"",
-                    "interrupts_status_registers=\"3\"",
+                    "interrupts_status_registers=\"5\"",
                     "interrupt_controller=\"clic\"",
                     "lp_i2c_master_fifo_size=\"32\"",
                     "lp_uart_ram_size=\"32\"",
@@ -4507,7 +4506,6 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_rsa",
                     "cargo:rustc-cfg=soc_has_ecc",
                     "cargo:rustc-cfg=soc_has_sw_interrupt",
-                    "cargo:rustc-cfg=very_large_intr_status",
                     "cargo:rustc-cfg=spi_octal",
                     "cargo:rustc-cfg=rom_crc_le",
                     "cargo:rustc-cfg=rom_crc_be",
@@ -4567,7 +4565,7 @@ impl Chip {
                     "cargo:rustc-cfg=i2c_master_max_bus_timeout=\"31\"",
                     "cargo:rustc-cfg=i2c_master_ll_intr_mask=\"262143\"",
                     "cargo:rustc-cfg=i2c_master_fifo_size=\"32\"",
-                    "cargo:rustc-cfg=interrupts_status_registers=\"3\"",
+                    "cargo:rustc-cfg=interrupts_status_registers=\"5\"",
                     "cargo:rustc-cfg=interrupt_controller=\"clic\"",
                     "cargo:rustc-cfg=lp_i2c_master_fifo_size=\"32\"",
                     "cargo:rustc-cfg=lp_uart_ram_size=\"32\"",
@@ -6677,7 +6675,6 @@ pub fn emit_check_cfg_directives() {
     println!("cargo:rustc-check-cfg=cfg(soc_has_uart4)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_twai2)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_adc)");
-    println!("cargo:rustc-check-cfg=cfg(very_large_intr_status)");
     println!("cargo:rustc-check-cfg=cfg(spi_octal)");
     println!("cargo:rustc-check-cfg=cfg(uart_uart3)");
     println!("cargo:rustc-check-cfg=cfg(uart_uart4)");
@@ -6750,7 +6747,9 @@ pub fn emit_check_cfg_directives() {
     println!("cargo:rustc-check-cfg=cfg(i2s_default_clock_source, values(\"2\",\"1\"))");
     println!("cargo:rustc-check-cfg=cfg(i2s_mclk_divider_bit_width, values(\"6\",\"9\"))");
     println!("cargo:rustc-check-cfg=cfg(i2s_max_ws_width, values(\"128\",\"512\"))");
-    println!("cargo:rustc-check-cfg=cfg(interrupts_status_registers, values(\"3\",\"2\",\"4\"))");
+    println!(
+        "cargo:rustc-check-cfg=cfg(interrupts_status_registers, values(\"3\",\"2\",\"5\",\"4\"))"
+    );
     println!(
         "cargo:rustc-check-cfg=cfg(interrupt_controller, \
          values(\"xtensa\",\"riscv_basic\",\"clic\",\"plic\"))"

--- a/esp-metadata-generated/src/_generated_esp32p4.rs
+++ b/esp-metadata-generated/src/_generated_esp32p4.rs
@@ -209,10 +209,10 @@ macro_rules! property {
         false
     };
     ("interrupts.status_registers") => {
-        3
+        5
     };
     ("interrupts.status_registers", str) => {
-        stringify!(3)
+        stringify!(5)
     };
     ("interrupts.disabled_interrupt") => {
         0

--- a/esp-metadata/devices/esp32p4.toml
+++ b/esp-metadata/devices/esp32p4.toml
@@ -14,7 +14,6 @@ trm   = "https://www.espressif.com/sites/default/files/documentation/esp32-p4_te
 
 symbols = [
     # Additional peripherals defined by us (the developers):
-    "very_large_intr_status",
     "spi_octal",
 
     # ROM capabilities
@@ -35,11 +34,10 @@ symbols = [
 
 [device.interrupts]
 support_status = "partial"
-# ESP32-P4 uses CLIC with 48 interrupt lines (TRM v0.5, Ch 14)
-# "very_large_intr_status" uses 3 status registers (same as C5/C61)
-status_registers = 3
+status_registers = 5
 software_interrupt_count = 4
 software_interrupt_delay = 24
+# ESP32-P4 uses CLIC with 48 interrupt lines (TRM v0.5, Ch 14)
 controller = { Riscv = { flavour = "clic", interrupts = 48, priority_levels = 8 } }
 
 # TODO: align with newer TRM revisions after v0.5. The v0.5 TRM still has


### PR DESCRIPTION
Noticed while working on #5558 - missing the fourth (and fifth 🫠) status register can result in triggered, but unhandled interrupts causing an infinite loop.