### PR TITLE
Expose RMT clock frequency

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- RMT: expose the configured counter clock frequency from `Rmt::frequency` and update the clock tree when configuring the source clock (#5532)
 - C5 and C61: Enable RTC timekeeping (#5449)
 - C61: usb-serial-jtag and debug-assist (#5427)
 - C61: dedicated gpio (#5426)

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- RMT: expose the configured counter clock frequency from `Rmt::frequency` and update the clock tree when configuring the source clock (#5532)
 - C5 and C61: Enable RTC timekeeping (#5449)
 - C61: usb-serial-jtag and debug-assist (#5427)
 - C61: dedicated gpio (#5426)

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -1134,7 +1134,7 @@ impl RmtClockGuard {
         #[cfg(soc_has_clock_node_rmt_sclk)]
         clocks::ClockTree::with(|clocks| {
             if clocks::RmtInstance::Rmt.sclk_config(clocks).is_none() {
-                clocks::RmtInstance::Rmt.configure_sclk(clocks, ClockSource::default().into());
+                clocks::RmtInstance::Rmt.configure_sclk(clocks, ClockSource::default());
             }
 
             clocks::RmtInstance::Rmt.request_sclk(clocks);
@@ -2231,84 +2231,7 @@ impl DynChannelAccess<Rx> {
     }
 }
 
-for_each_rmt_clock_source!(
-    (all $(($name:ident, $bits:literal)),+) => {
-        #[derive(Clone, Copy, Debug)]
-        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-        #[repr(u8)]
-        enum ClockSource {
-            $(
-                #[allow(unused)]
-                $name = $bits,
-            )+
-        }
-    };
-
-    (is_boolean) => {
-        impl ClockSource {
-            fn bit(self) -> bool {
-                match (self as u8) {
-                    0 => false,
-                    1 => true,
-                    _ => unreachable!("should be removed by the compiler!"),
-                }
-            }
-        }
-    };
-
-    (default ($name:ident)) => {
-        impl ClockSource {
-            fn default() -> Self {
-                Self::$name
-            }
-
-            fn bits(self) -> u8 {
-                self as u8
-            }
-
-            fn freq(self) -> crate::time::Rate {
-                match self {
-                    #[cfg(rmt_supports_apb_clock)]
-                    ClockSource::Apb => Rate::from_hz(clocks::apb_clk_frequency()),
-
-                    #[cfg(rmt_supports_rcfast_clock)]
-                    ClockSource::RcFast => Rate::from_hz(clocks::rc_fast_clk_frequency()),
-
-                    #[cfg(rmt_supports_xtal_clock)]
-                    ClockSource::Xtal => Rate::from_hz(clocks::xtal_clk_frequency()),
-
-                    #[cfg(rmt_supports_pll80mhz_clock)]
-                    ClockSource::Pll80MHz => Rate::from_mhz(80),
-
-                    #[cfg(rmt_supports_reftick_clock)]
-                    ClockSource::RefTick => todo!(),
-                }
-            }
-        }
-    };
-);
-
-#[cfg(soc_has_clock_node_rmt_sclk)]
-impl From<ClockSource> for clocks::RmtSclkConfig {
-    fn from(value: ClockSource) -> Self {
-        match value {
-            #[cfg(rmt_supports_apb_clock)]
-            ClockSource::Apb => Self::ApbClk,
-
-            #[cfg(rmt_supports_rcfast_clock)]
-            ClockSource::RcFast => Self::RcFastClk,
-
-            #[cfg(rmt_supports_xtal_clock)]
-            ClockSource::Xtal => Self::XtalClk,
-
-            #[cfg(rmt_supports_pll80mhz_clock)]
-            ClockSource::Pll80MHz => Self::PllF80m,
-
-            #[cfg(rmt_supports_reftick_clock)]
-            ClockSource::RefTick => unreachable!(),
-        }
-    }
-}
+type ClockSource = clocks::RmtSclkConfig;
 
 // Obtain maximum value for a register field from the PAC's register spec.
 macro_rules! max_from_register_spec {
@@ -2331,8 +2254,6 @@ mod chip_specific {
     use enumset::EnumSet;
     #[cfg(place_rmt_driver_in_ram)]
     use procmacros::ram;
-    #[cfg(soc_has_clock_node_rmt_sclk)]
-    use crate::soc::clocks;
 
     use super::{
         ChannelIndex,
@@ -2349,13 +2270,15 @@ mod chip_specific {
         Tx,
         WAKER,
     };
-    use crate::{peripherals::RMT, time::Rate};
+    use crate::{peripherals::RMT, soc::clocks, time::Rate};
 
     pub(super) fn validate_clock(
         source: ClockSource,
         frequency: Rate,
     ) -> Result<(u8, Rate), ConfigError> {
-        let src_clock = source.freq();
+        let src_clock = clocks::ClockTree::with(|clocks| {
+            Rate::from_hz(clocks::RmtInstance::Rmt.sclk_config_frequency(clocks, source))
+        });
 
         if frequency > src_clock {
             return Err(ConfigError::UnreachableTargetFrequency);
@@ -2373,19 +2296,12 @@ mod chip_specific {
     }
 
     pub(super) fn configure_clock(source: ClockSource, div: u8) {
-        #[cfg(soc_has_clock_node_rmt_sclk)]
         clocks::ClockTree::with(|clocks| {
-            clocks::RmtInstance::Rmt.configure_sclk(clocks, source.into());
+            clocks::RmtInstance::Rmt.configure_sclk(clocks, source);
         });
 
         #[cfg(not(soc_has_pcr))]
         RMT::regs().sys_conf().modify(|_, w| unsafe {
-            #[cfg(not(soc_has_clock_node_rmt_sclk))]
-            {
-                w.clk_en().clear_bit();
-                w.sclk_sel().bits(source.bits());
-            }
-
             w.sclk_div_num().bits(div);
             w.sclk_div_a().bits(0);
             w.sclk_div_b().bits(0);
@@ -2397,21 +2313,9 @@ mod chip_specific {
             use crate::peripherals::PCR;
 
             PCR::regs().rmt_sclk_conf().modify(|_, w| unsafe {
-                #[cfg(not(soc_has_clock_node_rmt_sclk))]
-                cfg_if::cfg_if!(
-                    if #[cfg(any(esp32c5, esp32c6))] {
-                        w.sclk_sel().bits(source.bits());
-                    } else {
-                        w.sclk_sel().bit(source.bit());
-                    }
-                );
-
                 w.sclk_div_num().bits(div);
                 w.sclk_div_a().bits(0);
                 w.sclk_div_b().bits(0);
-                #[cfg(not(soc_has_clock_node_rmt_sclk))]
-                w.sclk_en().set_bit();
-
                 w
             });
 
@@ -2897,19 +2801,22 @@ mod chip_specific {
         Event,
         Level,
         MemSize,
-        NUM_CHANNELS,
         RMT_LOCK,
         Rx,
         Tx,
         WAKER,
     };
-    use crate::{peripherals::RMT, time::Rate};
+    use crate::{peripherals::RMT, soc::clocks, time::Rate};
 
     pub(super) fn validate_clock(
         source: ClockSource,
         frequency: Rate,
     ) -> Result<(u8, Rate), ConfigError> {
-        if frequency != source.freq() {
+        let source_frequency = clocks::ClockTree::with(|clocks| {
+            Rate::from_hz(clocks::RmtInstance::Rmt.sclk_config_frequency(clocks, source))
+        });
+
+        if frequency != source_frequency {
             return Err(ConfigError::UnreachableTargetFrequency);
         }
 
@@ -2919,15 +2826,11 @@ mod chip_specific {
     pub(super) fn configure_clock(source: ClockSource, _div: u8) {
         let rmt = RMT::regs();
 
-        for ch_num in 0..NUM_CHANNELS {
-            rmt.chconf1(ch_num)
-                .modify(|_, w| w.ref_always_on().bit(source.bit()));
-        }
+        clocks::ClockTree::with(|clocks| {
+            clocks::RmtInstance::Rmt.configure_sclk(clocks, source);
+        });
 
         rmt.apb_conf().modify(|_, w| w.apb_fifo_mask().set_bit());
-
-        #[cfg(not(esp32))]
-        rmt.apb_conf().modify(|_, w| w.clk_en().set_bit());
     }
 
     #[crate::handler]

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -735,6 +735,7 @@ for_each_rmt_channel!(
                 Dm: crate::DriverMode,
             {
                 peripheral: RMT<'rmt>,
+                frequency: Rate,
                 $(
                     #[doc = concat!("RMT Channel ", $num)]
                     pub [<channel $num>]: ChannelCreator<'rmt, Dm, $num>,
@@ -746,14 +747,25 @@ for_each_rmt_channel!(
             where
                 Dm: crate::DriverMode,
             {
-                fn create(peripheral: RMT<'rmt>) -> Self {
+                fn create(peripheral: RMT<'rmt>, frequency: Rate) -> Self {
                     Self {
                         peripheral,
+                        frequency,
                         $(
                             [<channel $num>]: ChannelCreator::conjure(),
                         )+
                         _mode: PhantomData,
                     }
+                }
+
+                /// Returns the configured RMT counter clock frequency.
+                ///
+                /// This is the actual frequency after the global RMT clock divider has been
+                /// configured. Pulse code lengths are expressed in cycles of
+                /// this clock divided by the channel divider configured with
+                /// [`TxChannelConfig::with_clk_divider`] or [`RxChannelConfig::with_clk_divider`].
+                pub fn frequency(&self) -> Rate {
+                    self.frequency
                 }
             }
 
@@ -764,6 +776,7 @@ for_each_rmt_channel!(
 
                     Rmt {
                         peripheral: self.peripheral,
+                        frequency: self.frequency,
                         $(
                             [<channel $num>]: unsafe { self.[<channel $num>].into_async() },
                         )+
@@ -901,7 +914,12 @@ impl ChannelIndex {
 }
 
 impl<'rmt> Rmt<'rmt, Blocking> {
-    /// Create a new RMT instance
+    /// Create a new RMT instance.
+    ///
+    /// The `frequency` parameter configures the global RMT counter clock. Use
+    /// [`Rmt::frequency`] to retrieve the actual configured frequency when
+    /// converting real-time pulse durations to [`PulseCode`] lengths; this is
+    /// not necessarily the APB clock frequency.
     ///
     /// ## Errors
     ///
@@ -909,11 +927,11 @@ impl<'rmt> Rmt<'rmt, Blocking> {
     /// - [`ConfigError::UnreachableTargetFrequency`].
     pub fn new(peripheral: RMT<'rmt>, frequency: Rate) -> Result<Self, ConfigError> {
         let clk_src = ClockSource::default();
-        let div = self::chip_specific::validate_clock(clk_src, frequency)?;
+        let (div, counter_frequency) = self::chip_specific::validate_clock(clk_src, frequency)?;
 
         // Only create the peripheral guards after validate_clock() to avoid that this function
         // contains lots of code to drop them again on error.
-        let this = Rmt::create(peripheral);
+        let this = Rmt::create(peripheral, counter_frequency);
 
         self::chip_specific::configure_clock(clk_src, div);
         Ok(this)
@@ -2313,6 +2331,8 @@ mod chip_specific {
     use enumset::EnumSet;
     #[cfg(place_rmt_driver_in_ram)]
     use procmacros::ram;
+    #[cfg(soc_has_clock_node_rmt_sclk)]
+    use crate::soc::clocks;
 
     use super::{
         ChannelIndex,
@@ -2331,7 +2351,10 @@ mod chip_specific {
     };
     use crate::{peripherals::RMT, time::Rate};
 
-    pub(super) fn validate_clock(source: ClockSource, frequency: Rate) -> Result<u8, ConfigError> {
+    pub(super) fn validate_clock(
+        source: ClockSource,
+        frequency: Rate,
+    ) -> Result<(u8, Rate), ConfigError> {
         let src_clock = source.freq();
 
         if frequency > src_clock {
@@ -2343,12 +2366,17 @@ mod chip_specific {
             .checked_div(frequency.as_hz())
             .ok_or(ConfigError::UnreachableTargetFrequency)?;
 
-        u8::try_from(div - 1).map_err(|_| ConfigError::UnreachableTargetFrequency)
+        let div = u8::try_from(div - 1).map_err(|_| ConfigError::UnreachableTargetFrequency)?;
+        let actual_frequency = src_clock / (u32::from(div) + 1);
+
+        Ok((div, actual_frequency))
     }
 
     pub(super) fn configure_clock(source: ClockSource, div: u8) {
         #[cfg(soc_has_clock_node_rmt_sclk)]
-        let _ = source;
+        clocks::ClockTree::with(|clocks| {
+            clocks::RmtInstance::Rmt.configure_sclk(clocks, source.into());
+        });
 
         #[cfg(not(soc_has_pcr))]
         RMT::regs().sys_conf().modify(|_, w| unsafe {
@@ -2877,12 +2905,15 @@ mod chip_specific {
     };
     use crate::{peripherals::RMT, time::Rate};
 
-    pub(super) fn validate_clock(source: ClockSource, frequency: Rate) -> Result<u8, ConfigError> {
+    pub(super) fn validate_clock(
+        source: ClockSource,
+        frequency: Rate,
+    ) -> Result<(u8, Rate), ConfigError> {
         if frequency != source.freq() {
             return Err(ConfigError::UnreachableTargetFrequency);
         }
 
-        Ok(1)
+        Ok((1, frequency))
     }
 
     pub(super) fn configure_clock(source: ClockSource, _div: u8) {

--- a/esp-hal/src/soc/esp32/clocks.rs
+++ b/esp-hal/src/soc/esp32/clocks.rs
@@ -20,7 +20,7 @@ use esp_rom_sys::rom::{ets_delay_us, ets_update_cpu_frequency_rom};
 use crate::{
     clock::RtcClock,
     efuse::VOL_LEVEL_HP_INV,
-    peripherals::{APB_CTRL, LPWR, RTC_IO, SYSTEM, TIMG0, UART0, UART1, UART2},
+    peripherals::{APB_CTRL, LPWR, RMT, RTC_IO, SYSTEM, TIMG0, UART0, UART1, UART2},
     rtc_cntl::Rtc,
     soc::regi2c,
     time::Rate,
@@ -747,6 +747,27 @@ impl McpwmInstance {
         _new_config: McpwmFunctionClockConfig,
     ) {
         // Nothing to do.
+    }
+}
+
+impl RmtInstance {
+    // RMT_SCLK
+
+    fn enable_sclk_impl(self, _clocks: &mut ClockTree, _en: bool) {
+        // Nothing to do.
+    }
+
+    fn configure_sclk_impl(
+        self,
+        _clocks: &mut ClockTree,
+        _old_config: Option<RmtSclkConfig>,
+        new_config: RmtSclkConfig,
+    ) {
+        for ch_num in 0..8 {
+            RMT::regs()
+                .chconf1(ch_num)
+                .modify(|_, w| w.ref_always_on().bit(new_config == RmtSclkConfig::ApbClk));
+        }
     }
 }
 

--- a/esp-hal/src/soc/esp32s2/clocks.rs
+++ b/esp-hal/src/soc/esp32s2/clocks.rs
@@ -18,7 +18,7 @@
 use esp_rom_sys::rom::{ets_delay_us, ets_update_cpu_frequency_rom};
 
 use crate::{
-    peripherals::{I2C_ANA_MST, LPWR, SYSCON, SYSTEM, TIMG0, TIMG1, UART0, UART1},
+    peripherals::{I2C_ANA_MST, LPWR, RMT, SYSCON, SYSTEM, TIMG0, TIMG1, UART0, UART1},
     soc::regi2c,
     time::Rate,
 };
@@ -678,6 +678,27 @@ impl TimgInstance {
             w.use_xtal()
                 .bit(new_config == TimgFunctionClockConfig::XtalClk)
         });
+    }
+}
+
+impl RmtInstance {
+    // RMT_SCLK
+
+    fn enable_sclk_impl(self, _clocks: &mut ClockTree, en: bool) {
+        RMT::regs().apb_conf().modify(|_, w| w.clk_en().bit(en));
+    }
+
+    fn configure_sclk_impl(
+        self,
+        _clocks: &mut ClockTree,
+        _old_config: Option<RmtSclkConfig>,
+        new_config: RmtSclkConfig,
+    ) {
+        for ch_num in 0..4 {
+            RMT::regs()
+                .chconf1(ch_num)
+                .modify(|_, w| w.ref_always_on().bit(new_config == RmtSclkConfig::ApbClk));
+        }
     }
 }
 

--- a/esp-metadata-generated/src/_build_script_utils.rs
+++ b/esp-metadata-generated/src/_build_script_utils.rs
@@ -353,8 +353,6 @@ impl Chip {
                     "rmt_ram_start=\"1073047552\"",
                     "rmt_channel_ram_size=\"64\"",
                     "rmt_has_per_channel_clock",
-                    "rmt_supports_reftick_clock",
-                    "rmt_supports_apb_clock",
                     "rng_apb_cycle_wait_num=\"16\"",
                     "rng_trng_supported",
                     "rsa_size_increment=\"512\"",
@@ -394,6 +392,7 @@ impl Chip {
                     "soc_has_clock_node_uart_function_clock",
                     "soc_has_clock_node_uart_mem_clock",
                     "soc_has_clock_node_uart_baud_rate_generator",
+                    "soc_has_clock_node_rmt_sclk",
                     "has_dram_region",
                     "has_dram2_uninit_region",
                     "spi_master_supports_dma",
@@ -562,8 +561,6 @@ impl Chip {
                     "cargo:rustc-cfg=rmt_ram_start=\"1073047552\"",
                     "cargo:rustc-cfg=rmt_channel_ram_size=\"64\"",
                     "cargo:rustc-cfg=rmt_has_per_channel_clock",
-                    "cargo:rustc-cfg=rmt_supports_reftick_clock",
-                    "cargo:rustc-cfg=rmt_supports_apb_clock",
                     "cargo:rustc-cfg=rng_apb_cycle_wait_num=\"16\"",
                     "cargo:rustc-cfg=rng_trng_supported",
                     "cargo:rustc-cfg=rsa_size_increment=\"512\"",
@@ -603,6 +600,7 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_clock_node_uart_function_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_uart_mem_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_uart_baud_rate_generator",
+                    "cargo:rustc-cfg=soc_has_clock_node_rmt_sclk",
                     "cargo:rustc-cfg=has_dram_region",
                     "cargo:rustc-cfg=has_dram2_uninit_region",
                     "cargo:rustc-cfg=spi_master_supports_dma",
@@ -1363,10 +1361,6 @@ impl Chip {
                     "rmt_has_tx_sync",
                     "rmt_has_rx_wrap",
                     "rmt_has_rx_demodulation",
-                    "rmt_supports_none_clock",
-                    "rmt_supports_apb_clock",
-                    "rmt_supports_rcfast_clock",
-                    "rmt_supports_xtal_clock",
                     "rng_apb_cycle_wait_num=\"16\"",
                     "rng_trng_supported",
                     "rsa_size_increment=\"32\"",
@@ -1577,10 +1571,6 @@ impl Chip {
                     "cargo:rustc-cfg=rmt_has_tx_sync",
                     "cargo:rustc-cfg=rmt_has_rx_wrap",
                     "cargo:rustc-cfg=rmt_has_rx_demodulation",
-                    "cargo:rustc-cfg=rmt_supports_none_clock",
-                    "cargo:rustc-cfg=rmt_supports_apb_clock",
-                    "cargo:rustc-cfg=rmt_supports_rcfast_clock",
-                    "cargo:rustc-cfg=rmt_supports_xtal_clock",
                     "cargo:rustc-cfg=rng_apb_cycle_wait_num=\"16\"",
                     "cargo:rustc-cfg=rng_trng_supported",
                     "cargo:rustc-cfg=rsa_size_increment=\"32\"",
@@ -1944,9 +1934,6 @@ impl Chip {
                     "rmt_has_tx_sync",
                     "rmt_has_rx_wrap",
                     "rmt_has_rx_demodulation",
-                    "rmt_supports_xtal_clock",
-                    "rmt_supports_rcfast_clock",
-                    "rmt_supports_pll80mhz_clock",
                     "rng_apb_cycle_wait_num=\"16\"",
                     "rsa_size_increment=\"32\"",
                     "rsa_memory_size_bytes=\"384\"",
@@ -2205,9 +2192,6 @@ impl Chip {
                     "cargo:rustc-cfg=rmt_has_tx_sync",
                     "cargo:rustc-cfg=rmt_has_rx_wrap",
                     "cargo:rustc-cfg=rmt_has_rx_demodulation",
-                    "cargo:rustc-cfg=rmt_supports_xtal_clock",
-                    "cargo:rustc-cfg=rmt_supports_rcfast_clock",
-                    "cargo:rustc-cfg=rmt_supports_pll80mhz_clock",
                     "cargo:rustc-cfg=rng_apb_cycle_wait_num=\"16\"",
                     "cargo:rustc-cfg=rsa_size_increment=\"32\"",
                     "cargo:rustc-cfg=rsa_memory_size_bytes=\"384\"",
@@ -2621,10 +2605,6 @@ impl Chip {
                     "rmt_has_tx_sync",
                     "rmt_has_rx_wrap",
                     "rmt_has_rx_demodulation",
-                    "rmt_supports_none_clock",
-                    "rmt_supports_pll80mhz_clock",
-                    "rmt_supports_rcfast_clock",
-                    "rmt_supports_xtal_clock",
                     "rng_apb_cycle_wait_num=\"16\"",
                     "rng_trng_supported",
                     "rsa_size_increment=\"32\"",
@@ -2907,10 +2887,6 @@ impl Chip {
                     "cargo:rustc-cfg=rmt_has_tx_sync",
                     "cargo:rustc-cfg=rmt_has_rx_wrap",
                     "cargo:rustc-cfg=rmt_has_rx_demodulation",
-                    "cargo:rustc-cfg=rmt_supports_none_clock",
-                    "cargo:rustc-cfg=rmt_supports_pll80mhz_clock",
-                    "cargo:rustc-cfg=rmt_supports_rcfast_clock",
-                    "cargo:rustc-cfg=rmt_supports_xtal_clock",
                     "cargo:rustc-cfg=rng_apb_cycle_wait_num=\"16\"",
                     "cargo:rustc-cfg=rng_trng_supported",
                     "cargo:rustc-cfg=rsa_size_increment=\"32\"",
@@ -3861,8 +3837,6 @@ impl Chip {
                     "rmt_has_tx_sync",
                     "rmt_has_rx_wrap",
                     "rmt_has_rx_demodulation",
-                    "rmt_supports_xtal_clock",
-                    "rmt_supports_rcfast_clock",
                     "rng_apb_cycle_wait_num=\"16\"",
                     "rng_trng_supported",
                     "rsa_size_increment=\"32\"",
@@ -4111,8 +4085,6 @@ impl Chip {
                     "cargo:rustc-cfg=rmt_has_tx_sync",
                     "cargo:rustc-cfg=rmt_has_rx_wrap",
                     "cargo:rustc-cfg=rmt_has_rx_demodulation",
-                    "cargo:rustc-cfg=rmt_supports_xtal_clock",
-                    "cargo:rustc-cfg=rmt_supports_rcfast_clock",
                     "cargo:rustc-cfg=rng_apb_cycle_wait_num=\"16\"",
                     "cargo:rustc-cfg=rng_trng_supported",
                     "cargo:rustc-cfg=rsa_size_increment=\"32\"",
@@ -4980,8 +4952,6 @@ impl Chip {
                     "rmt_has_tx_sync",
                     "rmt_has_rx_demodulation",
                     "rmt_has_per_channel_clock",
-                    "rmt_supports_reftick_clock",
-                    "rmt_supports_apb_clock",
                     "rng_apb_cycle_wait_num=\"16\"",
                     "rng_trng_supported",
                     "rsa_size_increment=\"32\"",
@@ -5018,6 +4988,7 @@ impl Chip {
                     "soc_has_clock_node_uart_function_clock",
                     "soc_has_clock_node_uart_baud_rate_generator",
                     "soc_has_clock_node_uart_mem_clock",
+                    "soc_has_clock_node_rmt_sclk",
                     "has_dram_region",
                     "has_dram2_uninit_region",
                     "spi_master_supports_dma",
@@ -5203,8 +5174,6 @@ impl Chip {
                     "cargo:rustc-cfg=rmt_has_tx_sync",
                     "cargo:rustc-cfg=rmt_has_rx_demodulation",
                     "cargo:rustc-cfg=rmt_has_per_channel_clock",
-                    "cargo:rustc-cfg=rmt_supports_reftick_clock",
-                    "cargo:rustc-cfg=rmt_supports_apb_clock",
                     "cargo:rustc-cfg=rng_apb_cycle_wait_num=\"16\"",
                     "cargo:rustc-cfg=rng_trng_supported",
                     "cargo:rustc-cfg=rsa_size_increment=\"32\"",
@@ -5241,6 +5210,7 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_clock_node_uart_function_clock",
                     "cargo:rustc-cfg=soc_has_clock_node_uart_baud_rate_generator",
                     "cargo:rustc-cfg=soc_has_clock_node_uart_mem_clock",
+                    "cargo:rustc-cfg=soc_has_clock_node_rmt_sclk",
                     "cargo:rustc-cfg=has_dram_region",
                     "cargo:rustc-cfg=has_dram2_uninit_region",
                     "cargo:rustc-cfg=spi_master_supports_dma",
@@ -5651,10 +5621,6 @@ impl Chip {
                     "rmt_has_rx_wrap",
                     "rmt_has_rx_demodulation",
                     "rmt_has_dma",
-                    "rmt_supports_none_clock",
-                    "rmt_supports_apb_clock",
-                    "rmt_supports_rcfast_clock",
-                    "rmt_supports_xtal_clock",
                     "rng_apb_cycle_wait_num=\"16\"",
                     "rng_trng_supported",
                     "rsa_size_increment=\"32\"",
@@ -5911,10 +5877,6 @@ impl Chip {
                     "cargo:rustc-cfg=rmt_has_rx_wrap",
                     "cargo:rustc-cfg=rmt_has_rx_demodulation",
                     "cargo:rustc-cfg=rmt_has_dma",
-                    "cargo:rustc-cfg=rmt_supports_none_clock",
-                    "cargo:rustc-cfg=rmt_supports_apb_clock",
-                    "cargo:rustc-cfg=rmt_supports_rcfast_clock",
-                    "cargo:rustc-cfg=rmt_supports_xtal_clock",
                     "cargo:rustc-cfg=rng_apb_cycle_wait_num=\"16\"",
                     "cargo:rustc-cfg=rng_trng_supported",
                     "cargo:rustc-cfg=rsa_size_increment=\"32\"",
@@ -6360,8 +6322,6 @@ pub fn emit_check_cfg_directives() {
     println!("cargo:rustc-check-cfg=cfg(i2s_max_ws_width_is_set)");
     println!("cargo:rustc-check-cfg=cfg(phy_combo_module)");
     println!("cargo:rustc-check-cfg=cfg(rmt_has_per_channel_clock)");
-    println!("cargo:rustc-check-cfg=cfg(rmt_supports_reftick_clock)");
-    println!("cargo:rustc-check-cfg=cfg(rmt_supports_apb_clock)");
     println!("cargo:rustc-check-cfg=cfg(rng_trng_supported)");
     println!("cargo:rustc-check-cfg=cfg(sleep_light_sleep)");
     println!("cargo:rustc-check-cfg=cfg(sleep_deep_sleep)");
@@ -6397,6 +6357,7 @@ pub fn emit_check_cfg_directives() {
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_uart_function_clock)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_uart_mem_clock)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_uart_baud_rate_generator)");
+    println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_rmt_sclk)");
     println!("cargo:rustc-check-cfg=cfg(has_dram_region)");
     println!("cargo:rustc-check-cfg=cfg(has_dram2_uninit_region)");
     println!("cargo:rustc-check-cfg=cfg(spi_master_supports_dma)");
@@ -6492,12 +6453,8 @@ pub fn emit_check_cfg_directives() {
     println!("cargo:rustc-check-cfg=cfg(rmt_has_tx_sync)");
     println!("cargo:rustc-check-cfg=cfg(rmt_has_rx_wrap)");
     println!("cargo:rustc-check-cfg=cfg(rmt_has_rx_demodulation)");
-    println!("cargo:rustc-check-cfg=cfg(rmt_supports_none_clock)");
-    println!("cargo:rustc-check-cfg=cfg(rmt_supports_rcfast_clock)");
-    println!("cargo:rustc-check-cfg=cfg(rmt_supports_xtal_clock)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_cpu_pll_div_out)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_pll_160m)");
-    println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_rmt_sclk)");
     println!("cargo:rustc-check-cfg=cfg(esp32c5)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_cache)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_clint)");
@@ -6554,7 +6511,6 @@ pub fn emit_check_cfg_directives() {
     println!("cargo:rustc-check-cfg=cfg(i2c_master_has_reliable_fsm_reset)");
     println!("cargo:rustc-check-cfg=cfg(i2s_clock_configured_by_pcr)");
     println!("cargo:rustc-check-cfg=cfg(rmt_has_tx_loop_auto_stop)");
-    println!("cargo:rustc-check-cfg=cfg(rmt_supports_pll80mhz_clock)");
     println!("cargo:rustc-check-cfg=cfg(soc_cpu_has_branch_predictor)");
     println!("cargo:rustc-check-cfg=cfg(soc_cpu_csr_prv_mode_is_set)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_pll_f12m)");

--- a/esp-metadata-generated/src/_generated_esp32.rs
+++ b/esp-metadata-generated/src/_generated_esp32.rs
@@ -472,19 +472,6 @@ macro_rules! for_each_rmt_channel {
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
-macro_rules! for_each_rmt_clock_source {
-    ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner_rmt_clock_source { $(($pattern) => $code;)* ($other
-        : tt) => {} } _for_each_inner_rmt_clock_source!((RefTick, 0));
-        _for_each_inner_rmt_clock_source!((Apb, 1));
-        _for_each_inner_rmt_clock_source!((Apb));
-        _for_each_inner_rmt_clock_source!((all(RefTick, 0), (Apb, 1)));
-        _for_each_inner_rmt_clock_source!((default(Apb)));
-        _for_each_inner_rmt_clock_source!((is_boolean));
-    };
-}
-#[macro_export]
-#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rsa_exponentiation {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_rsa_exponentiation { $(($pattern) => $code;)*
@@ -834,6 +821,22 @@ macro_rules! for_each_sha_algorithm {
 ///         todo!()
 ///     }
 /// }
+/// impl RmtInstance {
+///     // RMT_SCLK
+///
+///     fn enable_sclk_impl(self, _clocks: &mut ClockTree, _en: bool) {
+///         todo!()
+///     }
+///
+///     fn configure_sclk_impl(
+///         self,
+///         _clocks: &mut ClockTree,
+///         _old_config: Option<RmtSclkConfig>,
+///         _new_config: RmtSclkConfig,
+///     ) {
+///         todo!()
+///     }
+/// }
 /// impl UartInstance {
 ///     // UART_FUNCTION_CLOCK
 ///
@@ -888,6 +891,11 @@ macro_rules! define_clock_tree_types {
         pub enum McpwmInstance {
             Mcpwm0 = 0,
             Mcpwm1 = 1,
+        }
+        #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+        pub enum RmtInstance {
+            Rmt = 0,
         }
         #[derive(Clone, Copy, PartialEq, Eq, Debug)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -1214,6 +1222,16 @@ macro_rules! define_clock_tree_types {
             /// Selects `PLL_F160M_CLK`.
             PllF160m,
         }
+        /// The list of clock signals that the `RMT_SCLK` multiplexer can output.
+        #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+        pub enum RmtSclkConfig {
+            /// Selects `REF_TICK`.
+            RefTick,
+            #[default]
+            /// Selects `APB_CLK`.
+            ApbClk,
+        }
         #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum UartFunctionClockSclk {
@@ -1314,6 +1332,7 @@ macro_rules! define_clock_tree_types {
             rtc_fast_clk: Option<RtcFastClkConfig>,
             timg_calibration_clock: Option<TimgCalibrationClockConfig>,
             mcpwm_function_clock: [Option<McpwmFunctionClockConfig>; 2],
+            rmt_sclk: [Option<RmtSclkConfig>; 1],
             uart_function_clock: [Option<UartFunctionClockConfig>; 3],
             uart_mem_clock: [Option<UartMemClockConfig>; 3],
             uart_baud_rate_generator: [Option<UartBaudRateGeneratorConfig>; 3],
@@ -1330,6 +1349,7 @@ macro_rules! define_clock_tree_types {
             uart_mem_clk_refcount: u32,
             timg_calibration_clock_refcount: u32,
             mcpwm_function_clock_refcount: [u32; 2],
+            rmt_sclk_refcount: [u32; 1],
             uart_function_clock_refcount: [u32; 3],
             uart_mem_clock_refcount: [u32; 3],
             uart_baud_rate_generator_refcount: [u32; 3],
@@ -1415,6 +1435,10 @@ macro_rules! define_clock_tree_types {
             pub fn mcpwm1_function_clock(&self) -> Option<McpwmFunctionClockConfig> {
                 self.mcpwm_function_clock[McpwmInstance::Mcpwm1 as usize]
             }
+            /// Returns the current configuration of the RMT_SCLK clock tree node
+            pub fn rmt_sclk(&self) -> Option<RmtSclkConfig> {
+                self.rmt_sclk[RmtInstance::Rmt as usize]
+            }
             /// Returns the current configuration of the UART0_FUNCTION_CLOCK clock tree node
             pub fn uart0_function_clock(&self) -> Option<UartFunctionClockConfig> {
                 self.uart_function_clock[UartInstance::Uart0 as usize]
@@ -1472,6 +1496,7 @@ macro_rules! define_clock_tree_types {
                 rtc_fast_clk: None,
                 timg_calibration_clock: None,
                 mcpwm_function_clock: [None; 2],
+                rmt_sclk: [None; 1],
                 uart_function_clock: [None; 3],
                 uart_mem_clock: [None; 3],
                 uart_baud_rate_generator: [None; 3],
@@ -1488,6 +1513,7 @@ macro_rules! define_clock_tree_types {
                 uart_mem_clk_refcount: 0,
                 timg_calibration_clock_refcount: 0,
                 mcpwm_function_clock_refcount: [0; 2],
+                rmt_sclk_refcount: [0; 1],
                 uart_function_clock_refcount: [0; 3],
                 uart_mem_clock_refcount: [0; 3],
                 uart_baud_rate_generator_refcount: [0; 3],
@@ -1530,6 +1556,8 @@ macro_rules! define_clock_tree_types {
             ::core::sync::atomic::AtomicU32::new(0);
         static REF_TICK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
             ::core::sync::atomic::AtomicU32::new(0);
+        static RMT_SCLK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 1] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 1];
         static UART_FUNCTION_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 3] =
             [const { ::core::sync::atomic::AtomicU32::new(0) }; 3];
         static UART_BAUD_RATE_GENERATOR_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 3] =
@@ -2487,6 +2515,66 @@ macro_rules! define_clock_tree_types {
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
         }
+        impl RmtInstance {
+            pub fn configure_sclk(self, clocks: &mut ClockTree, new_selector: RmtSclkConfig) {
+                let old_selector = clocks.rmt_sclk[self as usize].replace(new_selector);
+                refresh_rmt_sclk_downstream(clocks, self);
+                if clocks.rmt_sclk_refcount[self as usize] > 0 {
+                    match new_selector {
+                        RmtSclkConfig::RefTick => request_ref_tick(clocks),
+                        RmtSclkConfig::ApbClk => request_apb_clk(clocks),
+                    }
+                    self.configure_sclk_impl(clocks, old_selector, new_selector);
+                    if let Some(old_selector) = old_selector {
+                        match old_selector {
+                            RmtSclkConfig::RefTick => release_ref_tick(clocks),
+                            RmtSclkConfig::ApbClk => release_apb_clk(clocks),
+                        }
+                    }
+                } else {
+                    self.configure_sclk_impl(clocks, old_selector, new_selector);
+                }
+            }
+            pub fn sclk_config(self, clocks: &mut ClockTree) -> Option<RmtSclkConfig> {
+                clocks.rmt_sclk[self as usize]
+            }
+            pub fn request_sclk(self, clocks: &mut ClockTree) {
+                trace!("Requesting {:?}::SCLK", self);
+                if increment_reference_count(&mut clocks.rmt_sclk_refcount[self as usize]) {
+                    trace!("Enabling {:?}::SCLK", self);
+                    match unwrap!(clocks.rmt_sclk[self as usize]) {
+                        RmtSclkConfig::RefTick => request_ref_tick(clocks),
+                        RmtSclkConfig::ApbClk => request_apb_clk(clocks),
+                    }
+                    self.enable_sclk_impl(clocks, true);
+                }
+            }
+            pub fn release_sclk(self, clocks: &mut ClockTree) {
+                trace!("Releasing {:?}::SCLK", self);
+                if decrement_reference_count(&mut clocks.rmt_sclk_refcount[self as usize]) {
+                    trace!("Disabling {:?}::SCLK", self);
+                    self.enable_sclk_impl(clocks, false);
+                    match unwrap!(clocks.rmt_sclk[self as usize]) {
+                        RmtSclkConfig::RefTick => release_ref_tick(clocks),
+                        RmtSclkConfig::ApbClk => release_apb_clk(clocks),
+                    }
+                }
+            }
+            #[allow(unused_variables)]
+            pub fn sclk_config_frequency(
+                self,
+                clocks: &mut ClockTree,
+                config: RmtSclkConfig,
+            ) -> u32 {
+                match config {
+                    RmtSclkConfig::RefTick => ref_tick_frequency(),
+                    RmtSclkConfig::ApbClk => apb_clk_frequency(),
+                }
+            }
+            pub fn sclk_frequency(self) -> u32 {
+                RMT_SCLK_FREQ_CACHE[self as usize].load(::core::sync::atomic::Ordering::Acquire)
+            }
+        }
         impl UartInstance {
             pub fn configure_function_clock(
                 self,
@@ -2853,6 +2941,9 @@ macro_rules! define_clock_tree_types {
             refresh_ref_tick_fosc_downstream(clocks);
             refresh_ref_tick_apll_downstream(clocks);
             refresh_ref_tick_pll_downstream(clocks);
+            for child_instance in [RmtInstance::Rmt] {
+                refresh_rmt_sclk_downstream(clocks, child_instance);
+            }
             for child_instance in [
                 UartInstance::Uart0,
                 UartInstance::Uart1,
@@ -2904,12 +2995,23 @@ macro_rules! define_clock_tree_types {
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            for child_instance in [RmtInstance::Rmt] {
+                refresh_rmt_sclk_downstream(clocks, child_instance);
+            }
             for child_instance in [
                 UartInstance::Uart0,
                 UartInstance::Uart1,
                 UartInstance::Uart2,
             ] {
                 refresh_uart_function_clock_downstream(clocks, child_instance);
+            }
+        }
+        fn refresh_rmt_sclk_downstream(clocks: &mut ClockTree, instance: RmtInstance) {
+            if let Some(config) = clocks.rmt_sclk[instance as usize] {
+                RMT_SCLK_FREQ_CACHE[instance as usize].store(
+                    instance.sclk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
         }
         fn refresh_uart_function_clock_downstream(clocks: &mut ClockTree, instance: UartInstance) {

--- a/esp-metadata-generated/src/_generated_esp32c3.rs
+++ b/esp-metadata-generated/src/_generated_esp32c3.rs
@@ -626,19 +626,6 @@ macro_rules! for_each_rmt_channel {
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
-macro_rules! for_each_rmt_clock_source {
-    ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner_rmt_clock_source { $(($pattern) => $code;)* ($other
-        : tt) => {} } _for_each_inner_rmt_clock_source!((Apb, 1));
-        _for_each_inner_rmt_clock_source!((RcFast, 2));
-        _for_each_inner_rmt_clock_source!((Xtal, 3));
-        _for_each_inner_rmt_clock_source!((Apb));
-        _for_each_inner_rmt_clock_source!((all(Apb, 1), (RcFast, 2), (Xtal, 3)));
-        _for_each_inner_rmt_clock_source!((default(Apb)));
-    };
-}
-#[macro_export]
-#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rsa_exponentiation {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_rsa_exponentiation { $(($pattern) => $code;)*

--- a/esp-metadata-generated/src/_generated_esp32c5.rs
+++ b/esp-metadata-generated/src/_generated_esp32c5.rs
@@ -761,19 +761,6 @@ macro_rules! for_each_rmt_channel {
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
-macro_rules! for_each_rmt_clock_source {
-    ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner_rmt_clock_source { $(($pattern) => $code;)* ($other
-        : tt) => {} } _for_each_inner_rmt_clock_source!((Xtal, 0));
-        _for_each_inner_rmt_clock_source!((RcFast, 1));
-        _for_each_inner_rmt_clock_source!((Pll80MHz, 2));
-        _for_each_inner_rmt_clock_source!((Pll80MHz));
-        _for_each_inner_rmt_clock_source!((all(Xtal, 0), (RcFast, 1), (Pll80MHz, 2)));
-        _for_each_inner_rmt_clock_source!((default(Pll80MHz)));
-    };
-}
-#[macro_export]
-#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rsa_exponentiation {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_rsa_exponentiation { $(($pattern) => $code;)*

--- a/esp-metadata-generated/src/_generated_esp32c6.rs
+++ b/esp-metadata-generated/src/_generated_esp32c6.rs
@@ -698,19 +698,6 @@ macro_rules! for_each_rmt_channel {
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
-macro_rules! for_each_rmt_clock_source {
-    ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner_rmt_clock_source { $(($pattern) => $code;)* ($other
-        : tt) => {} } _for_each_inner_rmt_clock_source!((Pll80MHz, 1));
-        _for_each_inner_rmt_clock_source!((RcFast, 2));
-        _for_each_inner_rmt_clock_source!((Xtal, 3));
-        _for_each_inner_rmt_clock_source!((Pll80MHz));
-        _for_each_inner_rmt_clock_source!((all(Pll80MHz, 1), (RcFast, 2), (Xtal, 3)));
-        _for_each_inner_rmt_clock_source!((default(Pll80MHz)));
-    };
-}
-#[macro_export]
-#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rsa_exponentiation {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_rsa_exponentiation { $(($pattern) => $code;)*

--- a/esp-metadata-generated/src/_generated_esp32h2.rs
+++ b/esp-metadata-generated/src/_generated_esp32h2.rs
@@ -678,19 +678,6 @@ macro_rules! for_each_rmt_channel {
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
-macro_rules! for_each_rmt_clock_source {
-    ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner_rmt_clock_source { $(($pattern) => $code;)* ($other
-        : tt) => {} } _for_each_inner_rmt_clock_source!((Xtal, 0));
-        _for_each_inner_rmt_clock_source!((RcFast, 1));
-        _for_each_inner_rmt_clock_source!((Xtal));
-        _for_each_inner_rmt_clock_source!((all(Xtal, 0), (RcFast, 1)));
-        _for_each_inner_rmt_clock_source!((default(Xtal)));
-        _for_each_inner_rmt_clock_source!((is_boolean));
-    };
-}
-#[macro_export]
-#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rsa_exponentiation {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_rsa_exponentiation { $(($pattern) => $code;)*

--- a/esp-metadata-generated/src/_generated_esp32s2.rs
+++ b/esp-metadata-generated/src/_generated_esp32s2.rs
@@ -489,19 +489,6 @@ macro_rules! for_each_rmt_channel {
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
-macro_rules! for_each_rmt_clock_source {
-    ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner_rmt_clock_source { $(($pattern) => $code;)* ($other
-        : tt) => {} } _for_each_inner_rmt_clock_source!((RefTick, 0));
-        _for_each_inner_rmt_clock_source!((Apb, 1));
-        _for_each_inner_rmt_clock_source!((Apb));
-        _for_each_inner_rmt_clock_source!((all(RefTick, 0), (Apb, 1)));
-        _for_each_inner_rmt_clock_source!((default(Apb)));
-        _for_each_inner_rmt_clock_source!((is_boolean));
-    };
-}
-#[macro_export]
-#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rsa_exponentiation {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_rsa_exponentiation { $(($pattern) => $code;)*
@@ -1006,6 +993,22 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
+/// impl RmtInstance {
+///     // RMT_SCLK
+///
+///     fn enable_sclk_impl(self, _clocks: &mut ClockTree, _en: bool) {
+///         todo!()
+///     }
+///
+///     fn configure_sclk_impl(
+///         self,
+///         _clocks: &mut ClockTree,
+///         _old_config: Option<RmtSclkConfig>,
+///         _new_config: RmtSclkConfig,
+///     ) {
+///         todo!()
+///     }
+/// }
 /// impl TimgInstance {
 ///     // TIMG_FUNCTION_CLOCK
 ///
@@ -1071,6 +1074,11 @@ macro_rules! for_each_sha_algorithm {
 /// ```
 macro_rules! define_clock_tree_types {
     () => {
+        #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+        pub enum RmtInstance {
+            Rmt = 0,
+        }
         #[derive(Clone, Copy, PartialEq, Eq, Debug)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum TimgInstance {
@@ -1346,6 +1354,16 @@ macro_rules! define_clock_tree_types {
             /// Selects `XTAL32K_CLK`.
             Xtal32kClk,
         }
+        /// The list of clock signals that the `RMT_SCLK` multiplexer can output.
+        #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+        pub enum RmtSclkConfig {
+            /// Selects `REF_TICK`.
+            RefTick,
+            #[default]
+            /// Selects `APB_CLK`.
+            ApbClk,
+        }
         /// The list of clock signals that the `TIMG0_FUNCTION_CLOCK` multiplexer can output.
         #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -1453,6 +1471,7 @@ macro_rules! define_clock_tree_types {
             rtc_slow_clk: Option<RtcSlowClkConfig>,
             rtc_fast_clk: Option<RtcFastClkConfig>,
             timg_calibration_clock: Option<TimgCalibrationClockConfig>,
+            rmt_sclk: [Option<RmtSclkConfig>; 1],
             timg_function_clock: [Option<TimgFunctionClockConfig>; 2],
             uart_function_clock: [Option<UartFunctionClockConfig>; 2],
             uart_baud_rate_generator: [Option<UartBaudRateGeneratorConfig>; 2],
@@ -1466,6 +1485,7 @@ macro_rules! define_clock_tree_types {
             rtc_fast_clk_refcount: u32,
             uart_mem_clk_refcount: u32,
             timg_calibration_clock_refcount: u32,
+            rmt_sclk_refcount: [u32; 1],
             timg_function_clock_refcount: [u32; 2],
             uart_function_clock_refcount: [u32; 2],
             uart_baud_rate_generator_refcount: [u32; 2],
@@ -1536,6 +1556,10 @@ macro_rules! define_clock_tree_types {
             pub fn timg_calibration_clock(&self) -> Option<TimgCalibrationClockConfig> {
                 self.timg_calibration_clock
             }
+            /// Returns the current configuration of the RMT_SCLK clock tree node
+            pub fn rmt_sclk(&self) -> Option<RmtSclkConfig> {
+                self.rmt_sclk[RmtInstance::Rmt as usize]
+            }
             /// Returns the current configuration of the TIMG0_FUNCTION_CLOCK clock tree node
             pub fn timg0_function_clock(&self) -> Option<TimgFunctionClockConfig> {
                 self.timg_function_clock[TimgInstance::Timg0 as usize]
@@ -1586,6 +1610,7 @@ macro_rules! define_clock_tree_types {
                 rtc_slow_clk: None,
                 rtc_fast_clk: None,
                 timg_calibration_clock: None,
+                rmt_sclk: [None; 1],
                 timg_function_clock: [None; 2],
                 uart_function_clock: [None; 2],
                 uart_baud_rate_generator: [None; 2],
@@ -1599,6 +1624,7 @@ macro_rules! define_clock_tree_types {
                 rtc_fast_clk_refcount: 0,
                 uart_mem_clk_refcount: 0,
                 timg_calibration_clock_refcount: 0,
+                rmt_sclk_refcount: [0; 1],
                 timg_function_clock_refcount: [0; 2],
                 uart_function_clock_refcount: [0; 2],
                 uart_baud_rate_generator_refcount: [0; 2],
@@ -1636,6 +1662,8 @@ macro_rules! define_clock_tree_types {
             ::core::sync::atomic::AtomicU32::new(0);
         static REF_TICK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
             ::core::sync::atomic::AtomicU32::new(0);
+        static RMT_SCLK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 1] =
+            [const { ::core::sync::atomic::AtomicU32::new(0) }; 1];
         static TIMG_FUNCTION_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 2] =
             [const { ::core::sync::atomic::AtomicU32::new(0) }; 2];
         static UART_FUNCTION_CLOCK_FREQ_CACHE: [::core::sync::atomic::AtomicU32; 2] =
@@ -2444,6 +2472,66 @@ macro_rules! define_clock_tree_types {
         pub fn timg_calibration_clock_frequency() -> u32 {
             TIMG_CALIBRATION_CLOCK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        impl RmtInstance {
+            pub fn configure_sclk(self, clocks: &mut ClockTree, new_selector: RmtSclkConfig) {
+                let old_selector = clocks.rmt_sclk[self as usize].replace(new_selector);
+                refresh_rmt_sclk_downstream(clocks, self);
+                if clocks.rmt_sclk_refcount[self as usize] > 0 {
+                    match new_selector {
+                        RmtSclkConfig::RefTick => request_ref_tick(clocks),
+                        RmtSclkConfig::ApbClk => request_apb_clk(clocks),
+                    }
+                    self.configure_sclk_impl(clocks, old_selector, new_selector);
+                    if let Some(old_selector) = old_selector {
+                        match old_selector {
+                            RmtSclkConfig::RefTick => release_ref_tick(clocks),
+                            RmtSclkConfig::ApbClk => release_apb_clk(clocks),
+                        }
+                    }
+                } else {
+                    self.configure_sclk_impl(clocks, old_selector, new_selector);
+                }
+            }
+            pub fn sclk_config(self, clocks: &mut ClockTree) -> Option<RmtSclkConfig> {
+                clocks.rmt_sclk[self as usize]
+            }
+            pub fn request_sclk(self, clocks: &mut ClockTree) {
+                trace!("Requesting {:?}::SCLK", self);
+                if increment_reference_count(&mut clocks.rmt_sclk_refcount[self as usize]) {
+                    trace!("Enabling {:?}::SCLK", self);
+                    match unwrap!(clocks.rmt_sclk[self as usize]) {
+                        RmtSclkConfig::RefTick => request_ref_tick(clocks),
+                        RmtSclkConfig::ApbClk => request_apb_clk(clocks),
+                    }
+                    self.enable_sclk_impl(clocks, true);
+                }
+            }
+            pub fn release_sclk(self, clocks: &mut ClockTree) {
+                trace!("Releasing {:?}::SCLK", self);
+                if decrement_reference_count(&mut clocks.rmt_sclk_refcount[self as usize]) {
+                    trace!("Disabling {:?}::SCLK", self);
+                    self.enable_sclk_impl(clocks, false);
+                    match unwrap!(clocks.rmt_sclk[self as usize]) {
+                        RmtSclkConfig::RefTick => release_ref_tick(clocks),
+                        RmtSclkConfig::ApbClk => release_apb_clk(clocks),
+                    }
+                }
+            }
+            #[allow(unused_variables)]
+            pub fn sclk_config_frequency(
+                self,
+                clocks: &mut ClockTree,
+                config: RmtSclkConfig,
+            ) -> u32 {
+                match config {
+                    RmtSclkConfig::RefTick => ref_tick_frequency(),
+                    RmtSclkConfig::ApbClk => apb_clk_frequency(),
+                }
+            }
+            pub fn sclk_frequency(self) -> u32 {
+                RMT_SCLK_FREQ_CACHE[self as usize].load(::core::sync::atomic::Ordering::Acquire)
+            }
+        }
         impl TimgInstance {
             pub fn configure_function_clock(
                 self,
@@ -2883,6 +2971,9 @@ macro_rules! define_clock_tree_types {
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            for child_instance in [RmtInstance::Rmt] {
+                refresh_rmt_sclk_downstream(clocks, child_instance);
+            }
             for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
                 refresh_timg_function_clock_downstream(clocks, child_instance);
             }
@@ -2897,8 +2988,19 @@ macro_rules! define_clock_tree_types {
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
+            for child_instance in [RmtInstance::Rmt] {
+                refresh_rmt_sclk_downstream(clocks, child_instance);
+            }
             for child_instance in [UartInstance::Uart0, UartInstance::Uart1] {
                 refresh_uart_function_clock_downstream(clocks, child_instance);
+            }
+        }
+        fn refresh_rmt_sclk_downstream(clocks: &mut ClockTree, instance: RmtInstance) {
+            if let Some(config) = clocks.rmt_sclk[instance as usize] {
+                RMT_SCLK_FREQ_CACHE[instance as usize].store(
+                    instance.sclk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
             }
         }
         fn refresh_timg_function_clock_downstream(clocks: &mut ClockTree, instance: TimgInstance) {

--- a/esp-metadata-generated/src/_generated_esp32s3.rs
+++ b/esp-metadata-generated/src/_generated_esp32s3.rs
@@ -520,19 +520,6 @@ macro_rules! for_each_rmt_channel {
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
-macro_rules! for_each_rmt_clock_source {
-    ($($pattern:tt => $code:tt;)*) => {
-        macro_rules! _for_each_inner_rmt_clock_source { $(($pattern) => $code;)* ($other
-        : tt) => {} } _for_each_inner_rmt_clock_source!((Apb, 1));
-        _for_each_inner_rmt_clock_source!((RcFast, 2));
-        _for_each_inner_rmt_clock_source!((Xtal, 3));
-        _for_each_inner_rmt_clock_source!((Apb));
-        _for_each_inner_rmt_clock_source!((all(Apb, 1), (RcFast, 2), (Xtal, 3)));
-        _for_each_inner_rmt_clock_source!((default(Apb)));
-    };
-}
-#[macro_export]
-#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rsa_exponentiation {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_rsa_exponentiation { $(($pattern) => $code;)*

--- a/esp-metadata/devices/esp32.toml
+++ b/esp-metadata/devices/esp32.toml
@@ -63,7 +63,7 @@ peripherals = [
     { name = "MCPWM1", clock_group = "MCPWM" },
     { name = "NRX" },
     { name = "PCNT" },
-    { name = "RMT" },
+    { name = "RMT", clock_group = "RMT" },
     { name = "RNG" },
     { name = "RSA", interrupts = { peri = "RSA" } },
     { name = "LPWR", pac = "RTC_CNTL" },
@@ -256,6 +256,12 @@ clocks = { system_clocks = { clock_tree = [
         ] } },
         { name = "MEM_CLOCK", type = "generic", output = "UART_MEM_CLK" },
         { name = "BAUD_RATE_GENERATOR", type = "generic", output = "(FUNCTION_CLOCK * 16) / (integral * 16 + fractional)", params = { fractional = "0..16", integral = "0..0x100000" } },
+    ] },
+    { group = "RMT", clocks = [
+        { name = "SCLK", type = "mux", variants = [
+            { name = "REF_TICK", outputs = "REF_TICK" },
+            { name = "APB_CLK",  outputs = "APB_CLK", default = true },
+        ] },
     ] },
 ] }, peripheral_clocks = { templates = [
     # templates
@@ -810,9 +816,6 @@ ram_start = 0x3ff56800
 channel_ram_size = 64
 channels = ["RxTx", "RxTx", "RxTx", "RxTx", "RxTx", "RxTx", "RxTx", "RxTx"]
 has_per_channel_clock = true
-clock_sources.supported = [ "RefTick", "Apb" ]
-# Power-on value is RefTick!
-clock_sources.default = "Apb"
 
 [device.rsa]
 support_status = "partial"

--- a/esp-metadata/devices/esp32c3.toml
+++ b/esp-metadata/devices/esp32c3.toml
@@ -471,8 +471,6 @@ has_tx_carrier_data_only = true
 has_tx_sync = true
 has_rx_wrap = true
 has_rx_demodulation = true
-clock_sources.supported = [ "None", "Apb", "RcFast", "Xtal" ]
-clock_sources.default = "Apb"
 
 [device.rsa]
 support_status = "partial"

--- a/esp-metadata/devices/esp32c5.toml
+++ b/esp-metadata/devices/esp32c5.toml
@@ -592,8 +592,6 @@ has_tx_carrier_data_only = true
 has_tx_sync = true
 has_rx_wrap = true
 has_rx_demodulation = true
-clock_sources.supported = ["Xtal", "RcFast", "Pll80MHz"]
-clock_sources.default = "Pll80MHz"
 
 [device.spi_master]
 support_status = "supported"

--- a/esp-metadata/devices/esp32c6.toml
+++ b/esp-metadata/devices/esp32c6.toml
@@ -677,8 +677,6 @@ has_tx_carrier_data_only = true
 has_tx_sync = true
 has_rx_wrap = true
 has_rx_demodulation = true
-clock_sources.supported = [ "None", "Pll80MHz", "RcFast", "Xtal" ]
-clock_sources.default = "Pll80MHz"
 
 [device.rsa]
 support_status = "partial"

--- a/esp-metadata/devices/esp32h2.toml
+++ b/esp-metadata/devices/esp32h2.toml
@@ -575,9 +575,6 @@ has_tx_carrier_data_only = true
 has_tx_sync = true
 has_rx_wrap = true
 has_rx_demodulation = true
-clock_sources.supported = ["Xtal", "RcFast" ]
-# Power-on value is RcFast!
-clock_sources.default = "Xtal"
 
 [device.rsa]
 support_status = "partial"

--- a/esp-metadata/devices/esp32s2.toml
+++ b/esp-metadata/devices/esp32s2.toml
@@ -61,7 +61,7 @@ peripherals = [
     { name = "NRX" },
     { name = "PCNT" },
     { name = "PMS" },
-    { name = "RMT" },
+    { name = "RMT", clock_group = "RMT" },
     { name = "RNG" },
     { name = "RSA", interrupts = { peri = "RSA" } },
     { name = "LPWR", pac = "RTC_CNTL" },
@@ -196,6 +196,12 @@ clocks = { system_clocks = { clock_tree = [
         ] } },
         { name = "BAUD_RATE_GENERATOR", type = "generic", output = "(FUNCTION_CLOCK * 16) / (integral * 16 + fractional)", params = { fractional = "0..16", integral = "0..0x100000" } },
         { name = "MEM_CLOCK", type = "generic", output = "UART_MEM_CLK" },
+    ] },
+    { group = "RMT", clocks = [
+        { name = "SCLK", type = "mux", variants = [
+            { name = "REF_TICK", outputs = "REF_TICK" },
+            { name = "APB_CLK",  outputs = "APB_CLK", default = true },
+        ] },
     ] },
 ] }, peripheral_clocks = { templates = [
     # templates
@@ -594,9 +600,6 @@ has_tx_carrier_data_only = true
 has_tx_sync = true
 has_rx_demodulation = true
 has_per_channel_clock = true
-clock_sources.supported = [ "RefTick", "Apb" ]
-# Power-on value is :RefTick
-clock_sources.default = "Apb"
 
 [device.rsa]
 support_status = "partial"

--- a/esp-metadata/devices/esp32s3.toml
+++ b/esp-metadata/devices/esp32s3.toml
@@ -792,8 +792,6 @@ has_tx_sync = true
 has_rx_wrap = true
 has_rx_demodulation = true
 has_dma = true
-clock_sources.supported = [ "None", "Apb", "RcFast", "Xtal" ]
-clock_sources.default = "Apb"
 
 [device.rsa]
 support_status = "partial"

--- a/esp-metadata/src/cfg.rs
+++ b/esp-metadata/src/cfg.rs
@@ -579,7 +579,6 @@ driver_configs![
             has_dma: bool,
             #[serde(default)]
             has_per_channel_clock: bool,
-            clock_sources: RmtClockSourcesConfig,
         }
     },
     RngProperties {

--- a/esp-metadata/src/cfg/rmt.rs
+++ b/esp-metadata/src/cfg/rmt.rs
@@ -1,5 +1,5 @@
 use proc_macro2::TokenStream;
-use quote::{format_ident, quote};
+use quote::quote;
 
 use crate::{cfg::GenericProperty, generate_for_each_macro, number};
 
@@ -91,54 +91,5 @@ impl GenericProperty for RmtChannelConfig {
             /// - `rx`: `(2, 0)`
             #for_each
         })
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
-pub(crate) struct RmtClockSourcesConfig {
-    supported: Vec<String>,
-    default: String,
-}
-
-impl GenericProperty for RmtClockSourcesConfig {
-    fn cfgs(&self) -> Option<Vec<String>> {
-        let mut cfgs = Vec::new();
-
-        for value in &self.supported {
-            cfgs.push(format!("rmt_supports_{}_clock", value.to_lowercase()));
-        }
-
-        Some(cfgs)
-    }
-
-    fn macros(&self) -> Option<TokenStream> {
-        let clock_sources = self
-            .supported
-            .iter()
-            .enumerate()
-            .filter(|(_, name)| *name != "None")
-            .map(|(bits, name)| {
-                let src_name = format_ident!("{}", name);
-                let bits = number(bits);
-                quote! {
-                    #src_name, #bits
-                }
-            })
-            .collect::<Vec<_>>();
-
-        let default = format_ident!("{}", self.default);
-        let default_clock_source = [quote!( #default )];
-
-        let branches: &[(&str, &[TokenStream])] = if self.supported.len() <= 2 {
-            &[
-                ("all", &clock_sources),
-                ("default", &default_clock_source),
-                ("is_boolean", &[]),
-            ]
-        } else {
-            &[("all", &clock_sources), ("default", &default_clock_source)]
-        };
-
-        Some(generate_for_each_macro("rmt_clock_source", branches))
     }
 }

--- a/hil-test/src/bin/rmt.rs
+++ b/hil-test/src/bin/rmt.rs
@@ -535,7 +535,10 @@ mod tests {
         assert_eq!(rmt.frequency(), FREQ);
 
         #[cfg(soc_has_clock_node_rmt_sclk)]
-        assert_eq!(esp_hal::clock::ll::RmtInstance::Rmt.sclk_frequency(), FREQ.as_hz());
+        assert_eq!(
+            esp_hal::clock::ll::RmtInstance::Rmt.sclk_frequency(),
+            FREQ.as_hz()
+        );
     }
 
     #[test]
@@ -551,9 +554,8 @@ mod tests {
         assert_eq!(apb_frequency.as_hz(), 40_000_000);
         assert_eq!(rmt.frequency().as_hz(), 80_000_000);
 
-        let ticks_for_400ns = |frequency: Rate| {
-            ((400_u64 * u64::from(frequency.as_hz())) / 1_000_000_000) as u16
-        };
+        let ticks_for_400ns =
+            |frequency: Rate| ((400_u64 * u64::from(frequency.as_hz())) / 1_000_000_000) as u16;
         assert_eq!(ticks_for_400ns(apb_frequency), 16);
         assert_eq!(ticks_for_400ns(rmt.frequency()), 32);
     }

--- a/hil-test/src/bin/rmt.rs
+++ b/hil-test/src/bin/rmt.rs
@@ -530,6 +530,35 @@ mod tests {
     }
 
     #[test]
+    fn rmt_frequency_accessor_reports_configured_rate(mut ctx: Context) {
+        let rmt = Rmt::new(ctx.rmt.reborrow(), FREQ).unwrap();
+        assert_eq!(rmt.frequency(), FREQ);
+
+        #[cfg(soc_has_clock_node_rmt_sclk)]
+        assert_eq!(esp_hal::clock::ll::RmtInstance::Rmt.sclk_frequency(), FREQ.as_hz());
+    }
+
+    #[test]
+    #[cfg(esp32c6)]
+    fn rmt_frequency_is_not_apb_on_default_esp32c6(mut ctx: Context) {
+        // Reproducer for #5532: with the default ESP32-C6 clock configuration, APB runs at
+        // 40 MHz, while the RMT driver configures the RMT counter clock to 80 MHz. Code that
+        // derives pulse lengths from APB will therefore generate pulses that are too short.
+        let rmt = Rmt::new(ctx.rmt.reborrow(), FREQ).unwrap();
+
+        let apb_frequency = Rate::from_hz(esp_hal::clock::ll::apb_clk_frequency());
+
+        assert_eq!(apb_frequency.as_hz(), 40_000_000);
+        assert_eq!(rmt.frequency().as_hz(), 80_000_000);
+
+        let ticks_for_400ns = |frequency: Rate| {
+            ((400_u64 * u64::from(frequency.as_hz())) / 1_000_000_000) as u16
+        };
+        assert_eq!(ticks_for_400ns(apb_frequency), 16);
+        assert_eq!(ticks_for_400ns(rmt.frequency()), 32);
+    }
+
+    #[test]
     fn rmt_loopback_simple(mut ctx: Context) {
         // Fit both tx and rx data into a single memory block
         let conf = LoopbackConfig::default();


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` or `manual-changelog` label as appropriate.
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
- Adds `Rmt::frequency()`.                                           
- Stores the actual configured RMT counter frequency returned from `validate_clock()`.                                                      
- Adds a C6-specific HIL test 
                                           
#### Testing
HIL

---

# Changelog

## esp-hal/RMT

- Added: expose the configured counter clock frequency from `Rmt::frequency` and update the clock tree when configuring the source clock

## esp-metadata

- No changelog necessary.