### PR TITLE
Fix compile error and nightly CI

### DIFF
--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -73,7 +73,7 @@ procmacros               = { version = "0.22.0", package = "esp-hal-procmacros",
 # They are needed when using the `unstable` feature.
 digest                   = { version = "0.10.7", default-features = false, features = ["core-api"], optional = true }
 embassy-usb-driver       = { version = "0.2", optional = true }
-embassy-usb-synopsys-otg = { version = "0.3", optional = true, features = ["host"] }
+embassy-usb-synopsys-otg = { version = "0.3.3", optional = true, features = ["host"] }
 embedded-can             = { version = "0.4.1", optional = true }
 esp-synopsys-usb-otg     = { version = "0.4.2", optional = true }
 nb                       = { version = "1.1", optional = true }

--- a/examples/wifi/embassy_coex/Cargo.toml
+++ b/examples/wifi/embassy_coex/Cargo.toml
@@ -13,7 +13,7 @@ embassy-net = { version = "0.8.0", features = [
     "tcp",
     "dns",
 ] }
-embassy-time = "0.5.0"
+embassy-time = "0.5.1"
 embassy-sync = "0.7" # TODO: update once trouble supports 0.8
 esp-alloc = { path = "../../../esp-alloc" }
 esp-backtrace = { path = "../../../esp-backtrace", features = [
@@ -89,6 +89,10 @@ esp32s3 = [
     "esp-rtos/esp32s3",
     "esp-radio/esp32s3",
 ]
+
+[profile.dev]
+# To fix  rust-lld: error: section '.text' will not fit in region 'IROM': overflowed by 1588 bytes
+opt-level = 2
 
 [profile.release]
 debug            = true


### PR DESCRIPTION
We got some version mismatch errors (at least locally 🤔 ), first one:
```rust
error: failed to select a version for `embassy-usb-synopsys-otg`.
    ... required by package `esp-hal v1.1.0 (/Users/jurajsadel/esp-rs/esp-hal-main/esp-hal)`
    ... which satisfies path dependency `esp-hal` (locked to 1.1.0) of package `embassy-coex v0.0.0 (/Users/jurajsadel/esp-rs/esp-hal-main/examples/wifi/embassy_coex)`
versions that meet the requirements `^0.3` (locked to 0.3.1) are: 0.3.1

package `esp-hal` depends on `embassy-usb-synopsys-otg` with feature `host` but `embassy-usb-synopsys-otg` does not have that feature.
help: there is a feature `log` with a similar name
```
and then
```rust
error: failed to select a version for `embassy-time`.
    ... required by package `embassy-usb-synopsys-otg v0.3.3`
    ... which satisfies dependency `embassy-usb-synopsys-otg = "^0.3.3"` of package `esp-hal v1.1.0 (/Users/jurajsadel/esp-rs/esp-hal-main/esp-hal)`
    ... which satisfies path dependency `esp-hal` (locked to 1.1.0) of package `embassy-coex v0.0.0 (/Users/jurajsadel/esp-rs/esp-hal-main/examples/wifi/embassy_coex)`
versions that meet the requirements `^0.5.1` are: 0.5.1

all possible versions conflict with previously selected packages

  previously selected package `embassy-time v0.5.0`
    ... which satisfies dependency `embassy-time = "^0.5.0"` (locked to 0.5.0) of package `embassy-coex v0.0.0 (/Users/jurajsadel/esp-rs/esp-hal-main/examples/wifi/embassy_coex)`
```

closes https://github.com/esp-rs/esp-hal/issues/5565