### PR TITLE
fix: duplicated words in esp-hal peripherals doc and rmt hil-test comments

### DIFF
--- a/esp-hal/src/peripherals/mod.rs
+++ b/esp-hal/src/peripherals/mod.rs
@@ -4,7 +4,7 @@
 //! and re-exports them to allow users to access and use them in their
 //! applications.
 //!
-//! Should be noted that that the module also re-exports the [Interrupt] enum
+//! Should be noted that the module also re-exports the [Interrupt] enum
 //! from the PAC, allowing users to handle interrupts associated with these
 //! peripherals.
 

--- a/hil-test/src/bin/rmt.rs
+++ b/hil-test/src/bin/rmt.rs
@@ -354,7 +354,7 @@ fn do_rmt_loopback_inner(
         core::mem::drop(rx_transaction);
         core::mem::drop(tx_transaction);
 
-        // The test should fail here when the the delay above is increased, e.g. to 100ms.
+        // The test should fail here when the delay above is increased, e.g. to 100ms.
         assert!(!rx_done);
         assert!(!tx_done);
     } else {
@@ -414,7 +414,7 @@ async fn do_rmt_loopback_async_inner(
         let rx_poll = poll_once(rx_fut);
         let tx_poll = poll_once(tx_fut);
 
-        // The test should fail here when the the delay above is increased, e.g. to 100ms.
+        // The test should fail here when the delay above is increased, e.g. to 100ms.
         assert!(rx_poll.is_pending());
         assert!(tx_poll.is_pending());
     } else {


### PR DESCRIPTION
Three one-line typo fixes for duplicated words in comments:
- `esp-hal/src/peripherals/mod.rs` — "Should be noted that that the module also re-exports" → "Should be noted that the module also re-exports"
- `hil-test/src/bin/rmt.rs` line ~357 — "The test should fail here when the the delay above" → "...when the delay above"
- `hil-test/src/bin/rmt.rs` line ~417 — same fix on the duplicate comment

<details>
<summary>Changelog</summary>

## esp-hal

- No changelog necessary.

</details>