### PR TITLE
Enable embassy-serial example on C5 and C61

### DIFF
--- a/examples/async/embassy_serial/Cargo.toml
+++ b/examples/async/embassy_serial/Cargo.toml
@@ -38,11 +38,23 @@ esp32c3 = [
     "esp-rtos/esp32c3",
     "esp-hal/esp32c3",
 ]
+esp32c5 = [
+    "esp-backtrace/esp32c5",
+    "esp-bootloader-esp-idf/esp32c5",
+    "esp-rtos/esp32c5",
+    "esp-hal/esp32c5",
+]
 esp32c6 = [
     "esp-backtrace/esp32c6",
     "esp-bootloader-esp-idf/esp32c6",
     "esp-rtos/esp32c6",
     "esp-hal/esp32c6",
+]
+esp32c61 = [
+    "esp-backtrace/esp32c61",
+    "esp-bootloader-esp-idf/esp32c61",
+    "esp-rtos/esp32c61",
+    "esp-hal/esp32c61",
 ]
 esp32h2 = [
     "esp-backtrace/esp32h2",


### PR DESCRIPTION
We had warnings because the chip features were handled in code, but not actually defined in Cargo.toml.