### PR TITLE
fix(esp-bootloader-esp-idf): allow FlashRegion::erase up to partition end

### DIFF
--- a/esp-bootloader-esp-idf/src/partitions.rs
+++ b/esp-bootloader-esp-idf/src/partitions.rs
@@ -681,7 +681,7 @@ where
             return Err(Error::OutOfBounds);
         }
 
-        if !self.range().contains(&address_to) {
+        if address_to > self.range().end || address_to < address_from {
             return Err(Error::OutOfBounds);
         }
 


### PR DESCRIPTION
### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` or `manual-changelog` label as appropriate.
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

`FlashRegion::erase(from, to)` rejects `to == partition_end` with `Error::OutOfBounds`, even though that is the natural and correct value for "erase the whole slot." `embedded_storage::nor_flash::NorFlash::erase` documents its `to` parameter as the **exclusive** end of the range, so erasing an N-byte partition aligned to its start needs to pass `to = N` — which today fails.

**Root cause.** The two `address_to` bounds checks both use `Range::contains`, which has half-open `[start, end)` semantics and rejects exactly `address_to == range.end`. The sibling `write`/`read` impls in the same file use the `in_range` helper, which does the upper bound the right way (`address + len <= range.end`); `erase` is the odd one out.

**Fix.** Replace the half-open check with an inclusive upper-bound comparison, and add a defensive `to < from` guard the original code happened not to have.