### PR TITLE
fix: Missing import when building with SPI driver in RAM

### DIFF
--- a/esp-hal/src/spi/master/dma.rs
+++ b/esp-hal/src/spi/master/dma.rs
@@ -11,6 +11,8 @@ use core::{
 #[cfg(feature = "unstable")]
 use embedded_hal::spi::{ErrorType, SpiBus};
 use enumset::EnumSet;
+#[cfg(place_spi_master_driver_in_ram)]
+use procmacros::ram;
 
 use super::*;
 use crate::{


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` or `manual-changelog` label as appropriate.
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Somewhere between the last release (1.1.0) and the current main (50f4e5844ee4f1a8576b59ddebe7cb119aa57aef) an issue was introduced to the SPI DMA implementation. The sram attribute wasn't being imported when ESP_HAL_CONFIG_PLACE_SPI_MASTER_DRIVER_IN_RAM is enabled. As such, esp-hal would fail to compile.

#### Testing
Tested by building the SPI example with `ESP_HAL_CONFIG_PLACE_SPI_MASTER_DRIVER_IN_RAM = "true"`, as well as running the ESP32-S3 hil tests.

---

<!-- ============================================================
  Changelog and migration guide entries live here in the PR body.
  They will be collected automatically at release time.
  Delete any section that doesn't apply to your PR.
  ============================================================ -->

# Changelog

## esp-hal

- Fixed: Add missing import when building SPI with `ESP_HAL_CONFIG_PLACE_SPI_MASTER_DRIVER_IN_RAM = "true"`


