### PR TITLE
uart: Add option to borrow UART halves

### DIFF
--- a/esp-hal/src/uart/mod.rs
+++ b/esp-hal/src/uart/mod.rs
@@ -2014,6 +2014,38 @@ where
         (self.rx, self.tx)
     }
 
+    #[procmacros::doc_replace]
+    /// Split the UART into a borrowed transmitter and receiver
+    ///
+    /// This is particularly useful when having two futures correlating to
+    /// transmitting and receiving, and you want to go back to using the UART
+    /// as a whole later.
+    ///
+    /// ## Example
+    ///
+    /// ```rust, no_run
+    /// # {before_snippet}
+    /// use esp_hal::uart::{Config, Uart};
+    /// let mut uart = Uart::new(peripherals.UART0, Config::default())?
+    ///     .with_rx(peripherals.GPIO1)
+    ///     .with_tx(peripherals.GPIO2);
+    ///
+    /// loop {
+    ///     // The UART can be split into separate Transmit and Receive components:
+    ///     let (rx, tx) = uart.split_borrowed();
+    ///
+    ///     // Each component can be used individually to interact with the UART:
+    ///     tx.write(&[42u8])?;
+    ///     let mut byte = [0u8; 1];
+    ///     rx.read(&mut byte);
+    /// }
+    /// # {after_snippet}
+    /// ```
+    #[instability::unstable]
+    pub fn split_borrowed(&mut self) -> (&mut UartRx<'d, Dm>, &mut UartTx<'d, Dm>) {
+        (&mut self.rx, &mut self.tx)
+    }
+
     /// Reads and clears errors set by received data.
     #[instability::unstable]
     pub fn check_for_rx_errors(&mut self) -> Result<(), RxError> {

--- a/esp-hal/src/uart/mod.rs
+++ b/esp-hal/src/uart/mod.rs
@@ -2015,11 +2015,14 @@ where
     }
 
     #[procmacros::doc_replace]
-    /// Split the UART into a borrowed transmitter and receiver
+    /// Borrows the UART as separate transmitter and receiver halves.
     ///
-    /// This is particularly useful when having two futures correlating to
-    /// transmitting and receiving, and you want to go back to using the UART
-    /// as a whole later.
+    /// Unlike [`split`], this method does not consume the UART. The returned
+    /// transmitter and receiver are borrowed from the original UART, which can
+    /// be used again after those borrows end.
+    ///
+    /// This is particularly useful when running separate transmit and receive
+    /// futures concurrently.
     ///
     /// ## Example
     ///
@@ -2032,7 +2035,7 @@ where
     ///
     /// loop {
     ///     // The UART can be split into separate Transmit and Receive components:
-    ///     let (rx, tx) = uart.split_borrowed();
+    ///     let (rx, tx) = uart.split_mut();
     ///
     ///     // Each component can be used individually to interact with the UART:
     ///     tx.write(&[42u8])?;
@@ -2042,7 +2045,7 @@ where
     /// # {after_snippet}
     /// ```
     #[instability::unstable]
-    pub fn split_borrowed(&mut self) -> (&mut UartRx<'d, Dm>, &mut UartTx<'d, Dm>) {
+    pub fn split_mut(&mut self) -> (&mut UartRx<'d, Dm>, &mut UartTx<'d, Dm>) {
         (&mut self.rx, &mut self.tx)
     }
 

--- a/hil-test/src/bin/uart.rs
+++ b/hil-test/src/bin/uart.rs
@@ -375,7 +375,7 @@ mod tests {
     }
 
     #[test]
-    fn test_split_borrowed_send_receive_different_baudrates(ctx: Context) {
+    fn test_split_mut_send_receive_change_baud(ctx: Context) {
         let mut uart0 = ctx.uart0.with_tx(ctx.tx);
         let mut uart1 = ctx.uart1.with_rx(ctx.rx);
 
@@ -392,8 +392,8 @@ mod tests {
                 panic!("{:?}: Failed to apply UART 1 baudrate: {}", e, baudrate)
             });
 
-            let (_, tx) = uart0.split_borrowed();
-            let (rx, _) = uart1.split_borrowed();
+            let (_, tx) = uart0.split_mut();
+            let (rx, _) = uart1.split_mut();
 
             tx.flush().unwrap();
             tx.write(&bytes).unwrap();

--- a/hil-test/src/bin/uart.rs
+++ b/hil-test/src/bin/uart.rs
@@ -373,6 +373,36 @@ mod tests {
         rx.read(&mut buf).unwrap();
         assert_eq!(buf, [0xAA, 0xBB, 0xCC]);
     }
+
+    #[test]
+    fn test_split_borrowed_send_receive_different_baudrates(ctx: Context) {
+        let mut uart0 = ctx.uart0.with_tx(ctx.tx);
+        let mut uart1 = ctx.uart1.with_rx(ctx.rx);
+
+        let bytes = [0x42, 0x43, 0x44];
+        let mut buf = [0u8; 3];
+
+        for i in 1..=2 {
+            let baudrate = 9600 * i;
+            let uart_cfg = uart::Config::default().with_baudrate(baudrate);
+            uart0.apply_config(&uart_cfg).unwrap_or_else(|e| {
+                panic!("{:?}: Failed to apply UART 0 baudrate: {}", e, baudrate)
+            });
+            uart1.apply_config(&uart_cfg).unwrap_or_else(|e| {
+                panic!("{:?}: Failed to apply UART 1 baudrate: {}", e, baudrate)
+            });
+
+            let (_, tx) = uart0.split_borrowed();
+            let (rx, _) = uart1.split_borrowed();
+
+            tx.flush().unwrap();
+            tx.write(&bytes).unwrap();
+
+            embedded_io::Read::read_exact(rx, &mut buf).unwrap();
+
+            assert_eq!(buf, bytes);
+        }
+    }
 }
 
 #[embedded_test::tests(default_timeout = 3, executor = hil_test::Executor::new())]


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` or `manual-changelog` label as appropriate.
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
Prior to this, after splitting an Uart instance into its Rx and Tx components, there was no way to join these components back into the original Uart instance.
To solve that, a "split_mut" method was added to the uart driver. This new method returns mutable references to both halves, that can later be dropped allowing the whole uart driver to be used again.

#### Testing
Tested running code as on the example of the new method (on an ESP32-S3).

---

# Changelog

## esp-hal/UART

- Added: New `split_mut` method for borrowing the Uart Rx and Tx halves.

