### PR TITLE
feat(ethernet): introduce MdioBus trait, make Phy generic over it

### DIFF
--- a/esp-hal/src/ethernet/mod.rs
+++ b/esp-hal/src/ethernet/mod.rs
@@ -680,8 +680,8 @@ impl<'d, Dm: DriverMode, P: Phy> Ethernet<'d, Dm, P> {
     /// Async callers are encouraged to pass the context to allow the PHY driver to wake them when
     /// the link state needs to be re-polled.
     pub fn poll_link(&mut self, cx: Option<&mut Context<'_>>) -> LinkState {
-        let mdio = MdioDriver::new(&EmacRegs);
-        self.phy.poll_link(&mdio, cx)
+        let mut mdio = MdioDriver::new(&EmacRegs);
+        self.phy.poll_link(&mut mdio, cx)
     }
 
     /// Returns the MAC address configured during construction.
@@ -796,8 +796,8 @@ fn init_common<'d, P: Phy, const RX: usize, const TX: usize>(
     EmacRegs.dma_soft_reset();
 
     // Init PHY (MDIO requires DMA/MAC clocks to be running after reset).
-    let mdio = MdioDriver::new(&EmacRegs);
-    phy.init(&mdio).map_err(Error::Phy)?;
+    let mut mdio = MdioDriver::new(&EmacRegs);
+    phy.init(&mut mdio).map_err(Error::Phy)?;
 
     // Build descriptor rings from the erased slice references.
     let tx = TDesRing::new(&mut storage.tx_descs, &mut storage.tx_bufs);

--- a/esp-hal/src/ethernet/phy/generic.rs
+++ b/esp-hal/src/ethernet/phy/generic.rs
@@ -43,7 +43,7 @@ impl GenericPhy {
     ///
     /// The scan is repeated up to 3 times to handle transient bus noise,
     /// matching the esp-idf `esp_eth_phy_802_3_detect_phy_addr` strategy.
-    fn discover<M: MdioBus>(mdio: &M) -> Option<u8> {
+    fn discover<M: MdioBus>(mdio: &mut M) -> Option<u8> {
         for _ in 0..3 {
             for addr in 0..32_u8 {
                 let id = mdio.read(addr, PHYIDR1);
@@ -63,7 +63,7 @@ impl Phy for GenericPhy {
             .expect("GenericPhy address not yet resolved — call init() first")
     }
 
-    fn init<M: MdioBus>(&mut self, mdio: &M) -> Result<(), PhyError> {
+    fn init<M: MdioBus>(&mut self, mdio: &mut M) -> Result<(), PhyError> {
         // Resolve address if auto-discovery was requested.
         if self.addr.is_none() {
             self.addr = Some(Self::discover(mdio).ok_or(PhyError::NotFound)?);
@@ -92,7 +92,7 @@ impl Phy for GenericPhy {
         Err(PhyError::Timeout)
     }
 
-    fn poll_link<M: MdioBus>(&mut self, mdio: &M, cx: Option<&mut Context<'_>>) -> LinkState {
+    fn poll_link<M: MdioBus>(&mut self, mdio: &mut M, cx: Option<&mut Context<'_>>) -> LinkState {
         const LINK_STATE_DOWN: LinkState = LinkState {
             up: false,
             speed: Speed::_100M,

--- a/esp-hal/src/ethernet/phy/generic.rs
+++ b/esp-hal/src/ethernet/phy/generic.rs
@@ -6,7 +6,7 @@ use core::task::Context;
 
 use crate::ethernet::{
     mac::{Duplex, LinkState, Speed},
-    phy::{ANAR, ANLPAR, BMCR, BMSR, MdioDriver, PHYIDR1, Phy, PhyError, an, bmcr, bmsr},
+    phy::{ANAR, ANLPAR, BMCR, BMSR, MdioBus, PHYIDR1, Phy, PhyError, an, bmcr, bmsr},
 };
 
 /// Maximum iterations to wait for the PHY reset bit to self-clear.
@@ -43,7 +43,7 @@ impl GenericPhy {
     ///
     /// The scan is repeated up to 3 times to handle transient bus noise,
     /// matching the esp-idf `esp_eth_phy_802_3_detect_phy_addr` strategy.
-    fn discover(mdio: &MdioDriver<'_>) -> Option<u8> {
+    fn discover<M: MdioBus>(mdio: &M) -> Option<u8> {
         for _ in 0..3 {
             for addr in 0..32_u8 {
                 let id = mdio.read(addr, PHYIDR1);
@@ -63,7 +63,7 @@ impl Phy for GenericPhy {
             .expect("GenericPhy address not yet resolved — call init() first")
     }
 
-    fn init(&mut self, mdio: &MdioDriver<'_>) -> Result<(), PhyError> {
+    fn init<M: MdioBus>(&mut self, mdio: &M) -> Result<(), PhyError> {
         // Resolve address if auto-discovery was requested.
         if self.addr.is_none() {
             self.addr = Some(Self::discover(mdio).ok_or(PhyError::NotFound)?);
@@ -92,7 +92,7 @@ impl Phy for GenericPhy {
         Err(PhyError::Timeout)
     }
 
-    fn poll_link(&mut self, mdio: &MdioDriver<'_>, cx: Option<&mut Context<'_>>) -> LinkState {
+    fn poll_link<M: MdioBus>(&mut self, mdio: &M, cx: Option<&mut Context<'_>>) -> LinkState {
         const LINK_STATE_DOWN: LinkState = LinkState {
             up: false,
             speed: Speed::_100M,

--- a/esp-hal/src/ethernet/phy/mod.rs
+++ b/esp-hal/src/ethernet/phy/mod.rs
@@ -63,10 +63,62 @@ pub mod an {
     pub const BASE_100_FULL: u16 = 1 << 8;
 }
 
+// ── MdioBus trait ───────────────────────────────────────────────────────────
+
+/// Generic MDIO bus interface used by [`Phy`] implementations.
+///
+/// PHY drivers are generic over this trait so they can live in external
+/// crates without depending on the concrete [`MdioDriver`] (whose
+/// constructor is sealed inside `esp-hal`). The trait mirrors IEEE 802.3
+/// Clause 22: PHY address 0-31, register address 0-31, 16-bit data.
+///
+/// # Error model
+///
+/// The trait surface is infallible (plain `u16`, no `Result`) because the
+/// Clause-22 protocol itself carries no application-level error response.
+/// Implementations choose how to behave when the bus stalls or the
+/// addressed device does not answer. The built-in [`MdioDriver`] busy-waits
+/// the EMAC's MDIO controller without a timeout — on a healthy bus a
+/// transaction completes in a few microseconds, and reads from a
+/// non-responsive PHY register typically return `0xFFFF` (Synopsys GMAC
+/// behavior, not part of the trait contract). Alternative implementations
+/// may take longer or return any other sentinel; PHY drivers must not rely
+/// on specific values or timing.
+///
+/// External implementations are useful for two cases:
+///
+/// 1. **Host-side mocks** for testing PHY drivers without a real MAC.
+/// 2. **Alternative MDIO controllers** (e.g. SPI-attached MDIO frontends or software bit-banged
+///    buses) feeding the same `Phy` driver code.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use esp_hal::ethernet::phy::MdioBus;
+///
+/// struct MockMdio;
+/// impl MdioBus for MockMdio {
+///     fn read(&self, _phy: u8, _reg: u8) -> u16 {
+///         0
+///     }
+///     fn write(&self, _phy: u8, _reg: u8, _val: u16) {}
+/// }
+/// ```
+pub trait MdioBus {
+    /// Read a 16-bit PHY register (Clause 22).
+    fn read(&self, phy_addr: u8, reg_addr: u8) -> u16;
+
+    /// Write a 16-bit PHY register (Clause 22).
+    fn write(&self, phy_addr: u8, reg_addr: u8, value: u16);
+}
+
 // ── MdioDriver ──────────────────────────────────────────────────────────────
 
 /// Thin wrapper that exposes Clause 22 MDIO read/write over the EMAC MAC's
 /// built-in MDIO controller.
+///
+/// Implements [`MdioBus`], so PHY drivers generic over `MdioBus` can run
+/// directly on top of this MAC without any adapter.
 pub struct MdioDriver<'a> {
     regs: &'a EmacRegs,
 }
@@ -87,6 +139,21 @@ impl<'a> MdioDriver<'a> {
     }
 }
 
+impl<'a> MdioBus for MdioDriver<'a> {
+    fn read(&self, phy_addr: u8, reg_addr: u8) -> u16 {
+        // Delegate to the inherent method — Rust's method resolution picks
+        // the inherent `read` over the trait `read` on `MdioDriver`, so this
+        // does not recurse. Keeping a single source of truth ensures any
+        // future changes to `MdioDriver::read` (timing barriers, instrumentation)
+        // automatically propagate to the trait impl.
+        MdioDriver::read(self, phy_addr, reg_addr)
+    }
+
+    fn write(&self, phy_addr: u8, reg_addr: u8, value: u16) {
+        MdioDriver::write(self, phy_addr, reg_addr, value);
+    }
+}
+
 // ── Phy trait ───────────────────────────────────────────────────────────────
 
 /// PHY error.
@@ -100,12 +167,16 @@ pub enum PhyError {
 }
 
 /// Trait implemented by all PHY drivers.
+///
+/// PHY drivers are generic over the [`MdioBus`] trait rather than tied to
+/// the concrete [`MdioDriver`], so impls can live in external crates and be
+/// tested with host-side mocks.
 pub trait Phy {
     /// One-time hardware initialization.
     ///
     /// Should reset the PHY, configure auto-negotiation, and wait until the
     /// hardware is ready to respond to further MDIO transactions.
-    fn init(&mut self, mdio: &MdioDriver<'_>) -> Result<(), PhyError>;
+    fn init<M: MdioBus>(&mut self, mdio: &M) -> Result<(), PhyError>;
 
     /// Polls the current link state.
     ///
@@ -113,7 +184,7 @@ pub trait Phy {
     /// complete and the link partner is detected. The context can be used
     /// to wake the caller when the link state should be re-polled, if the PHY chip
     /// supports interrupt-driven notifications.
-    fn poll_link(&mut self, mdio: &MdioDriver<'_>, _cx: Option<&mut Context<'_>>) -> LinkState;
+    fn poll_link<M: MdioBus>(&mut self, mdio: &M, _cx: Option<&mut Context<'_>>) -> LinkState;
 
     /// Returns the Clause 22 PHY address on the MDIO bus.
     fn address(&self) -> u8;

--- a/esp-hal/src/ethernet/phy/mod.rs
+++ b/esp-hal/src/ethernet/phy/mod.rs
@@ -138,11 +138,18 @@ impl<'a> MdioDriver<'a> {
 
     /// Reads one PHY register (Clause 22).
     pub fn read(&mut self, phy_addr: u8, reg: u8) -> u16 {
+        // Clause 22 frame fields are 5 bits — out-of-range values are silently
+        // truncated by the PAC writer (`FieldWriter<_, 5>`) and would hit a
+        // different PHY/register without any error. Catch this in debug builds.
+        debug_assert!(phy_addr < 32, "Clause 22 PHY address must be < 32");
+        debug_assert!(reg < 32, "Clause 22 register address must be < 32");
         self.regs.mdio_read(phy_addr, reg)
     }
 
     /// Writes one PHY register (Clause 22).
     pub fn write(&mut self, phy_addr: u8, reg: u8, data: u16) {
+        debug_assert!(phy_addr < 32, "Clause 22 PHY address must be < 32");
+        debug_assert!(reg < 32, "Clause 22 register address must be < 32");
         self.regs.mdio_write(phy_addr, reg, data)
     }
 }

--- a/esp-hal/src/ethernet/phy/mod.rs
+++ b/esp-hal/src/ethernet/phy/mod.rs
@@ -72,6 +72,14 @@ pub mod an {
 /// constructor is sealed inside `esp-hal`). The trait mirrors IEEE 802.3
 /// Clause 22: PHY address 0-31, register address 0-31, 16-bit data.
 ///
+/// # Mutability
+///
+/// Methods take `&mut self`. The MDIO bus is a strictly sequential
+/// hardware resource — the Synopsys GMAC's MII Address register has a
+/// BUSY bit that serialises one transaction at a time — and `&mut self`
+/// reflects that exclusivity in the type system, preventing API users
+/// from incorrectly assuming concurrent access is safe.
+///
 /// # Error model
 ///
 /// The trait surface is infallible (plain `u16`, no `Result`) because the
@@ -98,18 +106,18 @@ pub mod an {
 ///
 /// struct MockMdio;
 /// impl MdioBus for MockMdio {
-///     fn read(&self, _phy: u8, _reg: u8) -> u16 {
+///     fn read(&mut self, _phy: u8, _reg: u8) -> u16 {
 ///         0
 ///     }
-///     fn write(&self, _phy: u8, _reg: u8, _val: u16) {}
+///     fn write(&mut self, _phy: u8, _reg: u8, _val: u16) {}
 /// }
 /// ```
 pub trait MdioBus {
     /// Read a 16-bit PHY register (Clause 22).
-    fn read(&self, phy_addr: u8, reg_addr: u8) -> u16;
+    fn read(&mut self, phy_addr: u8, reg_addr: u8) -> u16;
 
     /// Write a 16-bit PHY register (Clause 22).
-    fn write(&self, phy_addr: u8, reg_addr: u8, value: u16);
+    fn write(&mut self, phy_addr: u8, reg_addr: u8, value: u16);
 }
 
 // ── MdioDriver ──────────────────────────────────────────────────────────────
@@ -129,18 +137,18 @@ impl<'a> MdioDriver<'a> {
     }
 
     /// Reads one PHY register (Clause 22).
-    pub fn read(&self, phy_addr: u8, reg: u8) -> u16 {
+    pub fn read(&mut self, phy_addr: u8, reg: u8) -> u16 {
         self.regs.mdio_read(phy_addr, reg)
     }
 
     /// Writes one PHY register (Clause 22).
-    pub fn write(&self, phy_addr: u8, reg: u8, data: u16) {
+    pub fn write(&mut self, phy_addr: u8, reg: u8, data: u16) {
         self.regs.mdio_write(phy_addr, reg, data)
     }
 }
 
 impl<'a> MdioBus for MdioDriver<'a> {
-    fn read(&self, phy_addr: u8, reg_addr: u8) -> u16 {
+    fn read(&mut self, phy_addr: u8, reg_addr: u8) -> u16 {
         // Delegate to the inherent method — Rust's method resolution picks
         // the inherent `read` over the trait `read` on `MdioDriver`, so this
         // does not recurse. Keeping a single source of truth ensures any
@@ -149,7 +157,7 @@ impl<'a> MdioBus for MdioDriver<'a> {
         MdioDriver::read(self, phy_addr, reg_addr)
     }
 
-    fn write(&self, phy_addr: u8, reg_addr: u8, value: u16) {
+    fn write(&mut self, phy_addr: u8, reg_addr: u8, value: u16) {
         MdioDriver::write(self, phy_addr, reg_addr, value);
     }
 }
@@ -176,7 +184,7 @@ pub trait Phy {
     ///
     /// Should reset the PHY, configure auto-negotiation, and wait until the
     /// hardware is ready to respond to further MDIO transactions.
-    fn init<M: MdioBus>(&mut self, mdio: &M) -> Result<(), PhyError>;
+    fn init<M: MdioBus>(&mut self, mdio: &mut M) -> Result<(), PhyError>;
 
     /// Polls the current link state.
     ///
@@ -184,7 +192,7 @@ pub trait Phy {
     /// complete and the link partner is detected. The context can be used
     /// to wake the caller when the link state should be re-polled, if the PHY chip
     /// supports interrupt-driven notifications.
-    fn poll_link<M: MdioBus>(&mut self, mdio: &M, _cx: Option<&mut Context<'_>>) -> LinkState;
+    fn poll_link<M: MdioBus>(&mut self, mdio: &mut M, _cx: Option<&mut Context<'_>>) -> LinkState;
 
     /// Returns the Clause 22 PHY address on the MDIO bus.
     fn address(&self) -> u8;

--- a/esp-hal/src/ethernet/phy/mod.rs
+++ b/esp-hal/src/ethernet/phy/mod.rs
@@ -114,11 +114,6 @@ impl<'a> MdioDriver<'a> {
 
 impl<'a> MdioBus for MdioDriver<'a> {
     fn read(&mut self, phy_addr: u8, reg_addr: u8) -> u16 {
-        // Delegate to the inherent method — Rust's method resolution picks
-        // the inherent `read` over the trait `read` on `MdioDriver`, so this
-        // does not recurse. Keeping a single source of truth ensures any
-        // future changes to `MdioDriver::read` (timing barriers, instrumentation)
-        // automatically propagate to the trait impl.
         MdioDriver::read(self, phy_addr, reg_addr)
     }
 
@@ -139,11 +134,7 @@ pub enum PhyError {
     NotFound,
 }
 
-/// Trait implemented by all PHY drivers.
-///
-/// PHY drivers are generic over the [`MdioBus`] trait rather than tied to
-/// the concrete [`MdioDriver`], so impls can live in external crates and be
-/// tested with host-side mocks.
+/// Ethernet PHY driver.
 pub trait Phy {
     /// One-time hardware initialization.
     ///

--- a/esp-hal/src/ethernet/phy/mod.rs
+++ b/esp-hal/src/ethernet/phy/mod.rs
@@ -65,58 +65,16 @@ pub mod an {
 
 // ── MdioBus trait ───────────────────────────────────────────────────────────
 
-/// Generic MDIO bus interface used by [`Phy`] implementations.
+/// Generic MDIO bus interface for Clause 22 PHY register access.
 ///
 /// PHY drivers are generic over this trait so they can live in external
-/// crates without depending on the concrete [`MdioDriver`] (whose
-/// constructor is sealed inside `esp-hal`). The trait mirrors IEEE 802.3
-/// Clause 22: PHY address 0-31, register address 0-31, 16-bit data.
-///
-/// # Mutability
-///
-/// Methods take `&mut self`. The MDIO bus is a strictly sequential
-/// hardware resource — the Synopsys GMAC's MII Address register has a
-/// BUSY bit that serialises one transaction at a time — and `&mut self`
-/// reflects that exclusivity in the type system, preventing API users
-/// from incorrectly assuming concurrent access is safe.
-///
-/// # Error model
-///
-/// The trait surface is infallible (plain `u16`, no `Result`) because the
-/// Clause-22 protocol itself carries no application-level error response.
-/// Implementations choose how to behave when the bus stalls or the
-/// addressed device does not answer. The built-in [`MdioDriver`] busy-waits
-/// the EMAC's MDIO controller without a timeout — on a healthy bus a
-/// transaction completes in a few microseconds, and reads from a
-/// non-responsive PHY register typically return `0xFFFF` (Synopsys GMAC
-/// behavior, not part of the trait contract). Alternative implementations
-/// may take longer or return any other sentinel; PHY drivers must not rely
-/// on specific values or timing.
-///
-/// External implementations are useful for two cases:
-///
-/// 1. **Host-side mocks** for testing PHY drivers without a real MAC.
-/// 2. **Alternative MDIO controllers** (e.g. SPI-attached MDIO frontends or software bit-banged
-///    buses) feeding the same `Phy` driver code.
-///
-/// # Example
-///
-/// ```rust,no_run
-/// use esp_hal::ethernet::phy::MdioBus;
-///
-/// struct MockMdio;
-/// impl MdioBus for MockMdio {
-///     fn read(&mut self, _phy: u8, _reg: u8) -> u16 {
-///         0
-///     }
-///     fn write(&mut self, _phy: u8, _reg: u8, _val: u16) {}
-/// }
-/// ```
+/// crates without depending on the concrete [`MdioDriver`]. PHY and
+/// register addresses are 5-bit Clause 22 fields (0-31).
 pub trait MdioBus {
-    /// Read a 16-bit PHY register (Clause 22).
+    /// Read a 16-bit PHY register.
     fn read(&mut self, phy_addr: u8, reg_addr: u8) -> u16;
 
-    /// Write a 16-bit PHY register (Clause 22).
+    /// Write a 16-bit PHY register.
     fn write(&mut self, phy_addr: u8, reg_addr: u8, value: u16);
 }
 

--- a/examples/async/embassy_ethernet/src/main.rs
+++ b/examples/async/embassy_ethernet/src/main.rs
@@ -105,11 +105,11 @@ impl Phy for ExamplePhy {
         self.phy.address()
     }
 
-    fn init<M: MdioBus>(&mut self, mdio: &M) -> Result<(), PhyError> {
+    fn init<M: MdioBus>(&mut self, mdio: &mut M) -> Result<(), PhyError> {
         self.phy.init(mdio)
     }
 
-    fn poll_link<M: MdioBus>(&mut self, mdio: &M, cx: Option<&mut Context<'_>>) -> LinkState {
+    fn poll_link<M: MdioBus>(&mut self, mdio: &mut M, cx: Option<&mut Context<'_>>) -> LinkState {
         if let Some(cx) = cx {
             if matches!(self.timer.poll_unpin(cx), Poll::Pending) {
                 return self.cached_link_state;

--- a/examples/async/embassy_ethernet/src/main.rs
+++ b/examples/async/embassy_ethernet/src/main.rs
@@ -48,7 +48,7 @@ use esp_hal::{
         RmiiPinBundle,
         clock::ExternalRefClock,
         mac::{Duplex, LinkState, Speed},
-        phy::{MdioDriver, Phy, PhyError, generic::GenericPhy},
+        phy::{MdioBus, Phy, PhyError, generic::GenericPhy},
     },
     gpio::{Level, Output, OutputConfig},
     interrupt::software::SoftwareInterruptControl,
@@ -105,11 +105,11 @@ impl Phy for ExamplePhy {
         self.phy.address()
     }
 
-    fn init(&mut self, mdio: &MdioDriver<'_>) -> Result<(), PhyError> {
+    fn init<M: MdioBus>(&mut self, mdio: &M) -> Result<(), PhyError> {
         self.phy.init(mdio)
     }
 
-    fn poll_link(&mut self, mdio: &MdioDriver<'_>, cx: Option<&mut Context<'_>>) -> LinkState {
+    fn poll_link<M: MdioBus>(&mut self, mdio: &M, cx: Option<&mut Context<'_>>) -> LinkState {
         if let Some(cx) = cx {
             if matches!(self.timer.poll_unpin(cx), Poll::Pending) {
                 return self.cached_link_state;


### PR DESCRIPTION
## Submission Checklist

- [x] My code follows the style guidelines of this project (`cargo xtask fmt-packages esp-hal examples --check` clean).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas (rustdoc on `MdioBus`, `Phy`, plus the `MdioDriver` trait-impl explaining why it delegates).
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings (`cargo xtask lint-packages --chips esp32 esp-hal` clean; `cargo +esp clippy --release --target xtensa-esp32-none-elf --features esp32` on `examples/async/embassy_ethernet` clean).
- [x] Any dependent changes have been merged.
- [ ] **HIL tests added** — N/A. No ethernet HIL tests exist yet; this PR doesn't change runtime behaviour, only the trait surface.
- [x] Examples updated — `examples/async/embassy_ethernet` uses the new generic signature.

## Why

`Phy` impls are locked to the concrete `MdioDriver`, whose constructor is `pub(super)`. External crates can't implement `Phy` against an arbitrary MDIO backend — no mocks for tests, no alternative MACs, no Clause-45 / MMD extension trait.

## What changes

- New `pub trait MdioBus { read, write }` mirroring the infallible Clause-22 surface.
- `impl MdioBus for MdioDriver<'_>` — the existing MAC keeps working without an adapter; the impl delegates to inherent methods so the two can't diverge.
- `Phy::init` and `Phy::poll_link` become generic over `M: MdioBus`. `GenericPhy` migrated in the same commit.
- `MdioDriver::new` stays `pub(super)` — external code can implement `Phy`, but still can't construct an MDIO bus over the EMAC directly.

Call sites in `Ethernet::poll_link` and `mod.rs` are unchanged — type inference picks up the existing `MdioDriver: MdioBus` impl. Diff ~70 ins / 5 del across 3 files.

New trait signatures:

```rust
fn init<M: MdioBus>(&mut self, mdio: &M) -> Result<(), PhyError>;
fn poll_link<M: MdioBus>(&mut self, mdio: &M, cx: Option<&mut Context<'_>>) -> LinkState;
```

## Object-safety note

`Phy` becomes non-object-safe as a side effect of the generic methods. Intentional:

- Embedded HALs pick the PHY at compile time via board config / features — no internal code holds a `dyn Phy`.
- Static dispatch keeps `poll_link`'s tight MDIO loop inline-friendly. `&dyn MdioBus` forces virtual dispatch on every register read (BMSR×2 + ANLPAR + extension probing per poll) and blocks LLVM from folding the constant phy/reg addresses.
- A trait-level type parameter (`trait Phy<M: MdioBus>`) is the other escape route but leaks `M` into every wrapper above the PHY (`EthernetDriver`, embassy-net adapter), which is worse than losing object-safety.

Downstream users needing dyn-erased selection can wrap a concrete `impl Phy` in a project-local trait.

## Future work this unblocks

- External PHY drivers on crates.io (10BASE-T1S / LAN867x, alternative LAN8720A variants, mock impls for unit testing).
- MMD / Clause-45 indirection as a blanket extension trait on `MdioBus` (separate PR).
- Alternative MAC backends (SPI-attached MDIO, software bit-banged buses) feeding the same `Phy` driver code.

## Testing

- `cargo xtask fmt-packages esp-hal examples --check` — clean.
- `cargo xtask lint-packages --chips esp32 esp-hal` — clean.
- `cargo +esp clippy --release --target xtensa-esp32-none-elf --features esp32` on `examples/async/embassy_ethernet` — clean.
- Built and flashed on ESP32 + LAN8720A — network works.

No runtime behaviour change — `MdioDriver` still delegates to `EmacRegs::mdio_{read,write}`; trait dispatch is fully monomorphised at call sites.

# Changelog

## esp-hal/Ethernet

- Added: Public MdioBus trait abstracting Clause-22 MDIO read/write, enabling external PHY drivers and host-side mocks.