### PR TITLE
Refactor crypto tests

### DIFF
--- a/hil-test/src/bin/crypto/aes.rs
+++ b/hil-test/src/bin/crypto/aes.rs
@@ -452,79 +452,28 @@ mod tests {
 mod work_queue_tests {
     use super::*;
 
-    #[test]
-    fn test_aes_work_queue_cpu() {
-        let p = esp_hal::init(Config::default().with_cpu_clock(CpuClock::max()));
+    struct Context {
+        aes: AesBackend<'static>,
+    }
 
-        let mut aes = AesBackend::new(p.AES);
-        let _backend = aes.start();
+    #[init]
+    fn init() -> Context {
+        let p = esp_hal::init(Config::default().with_cpu_clock(CpuClock::max()));
+        Context {
+            aes: AesBackend::new(p.AES),
+        }
+    }
+
+    #[test]
+    fn test_aes_work_queue_cpu(mut ctx: Context) {
+        let _backend = ctx.aes.start();
 
         let mut buffer = [0; PLAINTEXT_BUF_SIZE];
         run_cipher_tests(&mut buffer);
     }
 
     #[test]
-    #[cfg(aes_dma)]
-    fn test_aes_dma_work_queue() {
-        use allocator_api2::vec::Vec;
-
-        let p = esp_hal::init(Config::default().with_cpu_clock(CpuClock::max()));
-
-        esp_alloc::heap_allocator!(size: 32 * 1024);
-
-        cfg_if::cfg_if! {
-            if #[cfg(esp32s2)] {
-                let mut aes = AesDmaBackend::new(p.AES, p.DMA_CRYPTO);
-            } else {
-                let mut aes = AesDmaBackend::new(p.AES, p.DMA_CH0);
-            }
-        }
-        let _backend = aes.start();
-
-        const MAX_SHIFT: usize = 15;
-
-        let mut internal_memory =
-            Vec::with_capacity_in(PLAINTEXT_BUF_SIZE + MAX_SHIFT, esp_alloc::InternalMemory);
-        internal_memory.resize(PLAINTEXT_BUF_SIZE + MAX_SHIFT, 0);
-
-        // Different alignments in internal memory
-        run_unaligned_dma_tests::<MAX_SHIFT>(&mut internal_memory);
-    }
-
-    #[test]
-    #[cfg(all(aes_dma, soc_has_psram))]
-    fn test_aes_dma_work_queue_psram() {
-        use allocator_api2::vec::Vec;
-
-        let p = esp_hal::init(Config::default().with_cpu_clock(CpuClock::max()));
-        esp_alloc::psram_allocator!(p.PSRAM, esp_hal::psram);
-
-        cfg_if::cfg_if! {
-            if #[cfg(esp32s2)] {
-                let mut aes = AesDmaBackend::new(p.AES, p.DMA_CRYPTO);
-            } else {
-                let mut aes = AesDmaBackend::new(p.AES, p.DMA_CH0);
-            }
-        }
-        let _backend = aes.start();
-
-        let mut plaintext = [0; PLAINTEXT_BUF_SIZE];
-        fill_with_plaintext(&mut plaintext);
-
-        const MAX_SHIFT: usize = 15;
-
-        let mut external_memory =
-            Vec::with_capacity_in(PLAINTEXT_BUF_SIZE + MAX_SHIFT, esp_alloc::ExternalMemory);
-        external_memory.resize(PLAINTEXT_BUF_SIZE + MAX_SHIFT, 0);
-
-        // Different alignments in external memory
-        run_unaligned_dma_tests::<MAX_SHIFT>(&mut external_memory);
-    }
-
-    #[test]
-    fn test_aes_work_queue_work_posted_before_queue_started() {
-        let p = esp_hal::init(Config::default().with_cpu_clock(CpuClock::max()));
-
+    fn test_aes_work_queue_work_posted_before_queue_started(mut ctx: Context) {
         let mut output = [0; PLAINTEXT_BUF_SIZE];
 
         let mut plaintext = [0; PLAINTEXT_BUF_SIZE];
@@ -533,8 +482,7 @@ mod work_queue_tests {
         let mut ecb_encrypt = AesContext::new(Ecb, Operation::Encrypt, KEY_128);
         let handle = ecb_encrypt.process(&plaintext, &mut output).unwrap();
 
-        let mut aes = AesBackend::new(p.AES);
-        let _backend = aes.start();
+        let _backend = ctx.aes.start();
 
         handle.wait_blocking();
 
@@ -542,7 +490,7 @@ mod work_queue_tests {
     }
 
     #[test]
-    async fn test_aes_work_queue_work_posted_before_queue_started_async() {
+    async fn test_aes_work_queue_work_posted_before_queue_started_async(mut ctx: Context) {
         #[embassy_executor::task]
         async fn aes_task(signal: &'static Signal<CriticalSectionRawMutex, ()>) {
             let mut output = [0; PLAINTEXT_BUF_SIZE];
@@ -564,8 +512,6 @@ mod work_queue_tests {
             signal.signal(());
         }
 
-        let p = esp_hal::init(Config::default().with_cpu_clock(CpuClock::max()));
-
         let signal = mk_static!(Signal<CriticalSectionRawMutex, ()>, Signal::new());
 
         // Start task before we'd start the AES operation
@@ -574,24 +520,20 @@ mod work_queue_tests {
 
         signal.wait().await;
 
-        let mut aes = AesBackend::new(p.AES);
-        let _backend = aes.start();
+        let _backend = ctx.aes.start();
 
         signal.wait().await;
     }
 
     #[test]
-    fn test_aes_work_queue_in_place() {
-        let p = esp_hal::init(Config::default().with_cpu_clock(CpuClock::max()));
-
+    fn test_aes_work_queue_in_place(mut ctx: Context) {
         let mut buffer = [0; PLAINTEXT_BUF_SIZE];
         fill_with_plaintext(&mut buffer);
 
         let mut ecb_encrypt = AesContext::new(Ecb, Operation::Encrypt, KEY_128);
         let handle = ecb_encrypt.process_in_place(&mut buffer).unwrap();
 
-        let mut aes = AesBackend::new(p.AES);
-        let _backend = aes.start();
+        let _backend = ctx.aes.start();
 
         handle.wait_blocking();
 
@@ -599,15 +541,13 @@ mod work_queue_tests {
     }
 
     #[test]
-    fn test_aes_cancelling_work() {
+    fn test_aes_cancelling_work(mut ctx: Context) {
         // In this test, we post two work items, and cancel the first one before starting the
         // backend. We will assert that, when the second item has finished correctly, the first did
         // not modify its output buffer.
         // Note that this result is not guaranteed. The cancellation can come later than the work
         // item has finished processing. We can only reliably test it because we start the backend
         // after cancelling the operation.
-        let p = esp_hal::init(Config::default().with_cpu_clock(CpuClock::max()));
-
         let mut buffer1 = [0; PLAINTEXT_BUF_SIZE];
         fill_with_plaintext(&mut buffer1);
         let mut ecb_encrypt = AesContext::new(Ecb, Operation::Encrypt, KEY_128);
@@ -625,8 +565,7 @@ mod work_queue_tests {
 
         core::mem::drop(handle1);
 
-        let mut aes = AesBackend::new(p.AES);
-        let _backend = aes.start();
+        let _backend = ctx.aes.start();
 
         handle3.wait_blocking();
         handle2.wait_blocking();
@@ -634,5 +573,68 @@ mod work_queue_tests {
         hil_test::assert_eq!(&buffer1[..PLAINTEXT.len()], PLAINTEXT);
         hil_test::assert_eq!(buffer2, CIPHERTEXT_ECB_256);
         hil_test::assert_eq!(buffer3, CIPHERTEXT_ECB_128);
+    }
+}
+
+#[cfg(aes_dma)]
+#[embedded_test::tests(default_timeout = 10)]
+mod work_queue_dma_tests {
+    use allocator_api2::vec::Vec;
+
+    use super::*;
+
+    struct Context {
+        aes: AesDmaBackend<'static>,
+    }
+
+    #[init]
+    fn init() -> Context {
+        let p = esp_hal::init(Config::default().with_cpu_clock(CpuClock::max()));
+
+        esp_alloc::heap_allocator!(size: 32 * 1024);
+
+        #[cfg(soc_has_psram)]
+        esp_alloc::psram_allocator!(p.PSRAM, esp_hal::psram);
+
+        cfg_if::cfg_if! {
+            if #[cfg(esp32s2)] {
+                let dma = p.DMA_CRYPTO;
+            } else {
+                let dma = p.DMA_CH0;
+            }
+        }
+
+        Context {
+            aes: AesDmaBackend::new(p.AES, dma),
+        }
+    }
+
+    #[test]
+    fn test_aes_dma_work_queue(mut ctx: Context) {
+        let _backend = ctx.aes.start();
+
+        const MAX_SHIFT: usize = 15;
+
+        let mut internal_memory =
+            Vec::with_capacity_in(PLAINTEXT_BUF_SIZE + MAX_SHIFT, esp_alloc::InternalMemory);
+        internal_memory.resize(PLAINTEXT_BUF_SIZE + MAX_SHIFT, 0);
+
+        // Different alignments in internal memory
+        run_unaligned_dma_tests::<MAX_SHIFT>(&mut internal_memory);
+    }
+
+    #[test]
+    #[cfg(soc_has_psram)]
+    fn test_aes_dma_work_queue_psram(mut ctx: Context) {
+        let _backend = ctx.aes.start();
+
+        const MAX_SHIFT: usize = 15;
+
+        let mut external_memory =
+            Vec::with_capacity_in(PLAINTEXT_BUF_SIZE + MAX_SHIFT, esp_alloc::ExternalMemory);
+        external_memory.resize(PLAINTEXT_BUF_SIZE + MAX_SHIFT, 0);
+
+        // Different alignments in external memory
+        run_unaligned_dma_tests::<MAX_SHIFT>(&mut external_memory);
     }
 }

--- a/hil-test/src/bin/crypto/aes.rs
+++ b/hil-test/src/bin/crypto/aes.rs
@@ -446,6 +446,11 @@ mod tests {
             CIPHERTEXT_ECB_256[0..16].try_into().unwrap(),
         );
     }
+}
+
+#[embedded_test::tests(default_timeout = 10, executor = hil_test::Executor::new())]
+mod work_queue_tests {
+    use super::*;
 
     #[test]
     fn test_aes_work_queue_cpu() {

--- a/hil-test/src/bin/crypto/sha.rs
+++ b/hil-test/src/bin/crypto/sha.rs
@@ -38,11 +38,7 @@ fn hash_sha<S: ShaAlgorithm>(sha: &mut Sha<'static>, mut input: &[u8], output: &
     block!(digest.finish(output)).unwrap();
 }
 
-fn hash_digest<'a, S: ShaAlgorithm>(
-    sha: &'a mut Sha<'static>,
-    input: &[u8],
-    output: &mut [u8],
-) {
+fn hash_digest<'a, S: ShaAlgorithm>(sha: &'a mut Sha<'static>, input: &[u8], output: &mut [u8]) {
     let mut hasher = ShaDigest::<S, _>::new(sha);
     Update::update(&mut hasher, input);
     output.copy_from_slice(&digest::FixedOutput::finalize_fixed(hasher));

--- a/hil-test/src/bin/crypto/sha.rs
+++ b/hil-test/src/bin/crypto/sha.rs
@@ -1,156 +1,158 @@
+use digest::{Digest, Update};
+#[cfg(rng_trng_supported)]
+use esp_hal::rng::TrngSource;
+#[cfg(not(esp32))]
+use esp_hal::sha::Sha224;
+#[cfg(any(esp32, esp32s2, esp32s3))]
+use esp_hal::sha::{Sha384, Sha512};
+#[cfg(any(esp32s2, esp32s3))]
+use esp_hal::sha::{Sha512_224, Sha512_256};
+use esp_hal::{
+    clock::CpuClock,
+    rng::Rng,
+    sha::{Sha, Sha1, Sha256, ShaAlgorithm, ShaBackend, ShaDigest},
+};
+use nb::block;
+
+const SOURCE_DATA: &[u8] = &[b'a'; 258];
+
+#[track_caller]
+fn assert_sw_hash<D: Digest>(algo: &str, input: &[u8], expected_output: &[u8]) {
+    let mut hasher = D::new();
+    hasher.update(input);
+    let soft_result = hasher.finalize();
+
+    hil_test::assert_eq!(
+        expected_output,
+        &soft_result[..],
+        "Output mismatch with {}",
+        algo
+    );
+}
+
+fn hash_sha<S: ShaAlgorithm>(sha: &mut Sha<'static>, mut input: &[u8], output: &mut [u8]) {
+    let mut digest = sha.start::<S>();
+    while !input.is_empty() {
+        input = block!(digest.update(input)).unwrap();
+    }
+    block!(digest.finish(output)).unwrap();
+}
+
+fn hash_digest<'a, S: ShaAlgorithm>(
+    sha: &'a mut Sha<'static>,
+    input: &[u8],
+    output: &mut [u8],
+) {
+    let mut hasher = ShaDigest::<S, _>::new(sha);
+    Update::update(&mut hasher, input);
+    output.copy_from_slice(&digest::FixedOutput::finalize_fixed(hasher));
+}
+
+/// A simple test using the Sha trait. This will compare the result with a
+/// software implementation.
+#[track_caller]
+fn assert_sha<S: ShaAlgorithm, const N: usize>(sha: &mut Sha<'static>, input: &[u8]) {
+    let mut output = [0u8; N];
+    hash_sha::<S>(sha, input, &mut output);
+
+    // Compare against Software result.
+    match N {
+        20 => assert_sw_hash::<sha1::Sha1>("SHA-1", input, &output),
+        28 => assert_sw_hash::<sha2::Sha224>("SHA-224", input, &output),
+        32 => assert_sw_hash::<sha2::Sha256>("SHA-256", input, &output),
+        48 => assert_sw_hash::<sha2::Sha384>("SHA-384", input, &output),
+        64 => assert_sw_hash::<sha2::Sha512>("SHA-512", input, &output),
+        _ => unreachable!(),
+    }
+}
+
+/// A simple test using the Digest trait. This will compare the result with a
+/// software implementation.
+#[track_caller]
+fn assert_digest<'a, S: ShaAlgorithm, const N: usize>(sha: &'a mut Sha<'static>, input: &[u8]) {
+    let mut output = [0u8; N];
+    hash_digest::<S>(sha, input, &mut output);
+
+    // Compare against Software result.
+    match N {
+        20 => assert_sw_hash::<sha1::Sha1>("SHA-1", input, &output),
+        28 => assert_sw_hash::<sha2::Sha224>("SHA-224", input, &output),
+        32 => assert_sw_hash::<sha2::Sha256>("SHA-256", input, &output),
+        48 => assert_sw_hash::<sha2::Sha384>("SHA-384", input, &output),
+        64 => assert_sw_hash::<sha2::Sha512>("SHA-512", input, &output),
+        _ => unreachable!(),
+    }
+}
+
+#[allow(unused_mut)]
+fn with_random_data(
+    mut f: impl FnMut(
+        (&[u8], &mut [u8]),
+        (&[u8], &mut [u8]),
+        (&[u8], &mut [u8]),
+        (&[u8], &mut [u8]),
+        (&[u8], &mut [u8]),
+    ),
+) {
+    // Make sure this is not a multiple of the block size
+    const BUFFER_LEN: usize = 264;
+
+    let mut sha1_random = [0u8; BUFFER_LEN];
+    let mut sha224_random = [0u8; BUFFER_LEN];
+    let mut sha256_random = [0u8; BUFFER_LEN];
+    let mut sha384_random = [0u8; BUFFER_LEN];
+    let mut sha512_random = [0u8; BUFFER_LEN];
+
+    let rng = Rng::new();
+
+    // Fill source data with random data
+    rng.read(&mut sha1_random);
+    #[cfg(not(esp32))]
+    rng.read(&mut sha224_random);
+    rng.read(&mut sha256_random);
+    #[cfg(any(esp32, esp32s2, esp32s3))]
+    rng.read(&mut sha384_random);
+    #[cfg(any(esp32, esp32s2, esp32s3))]
+    rng.read(&mut sha512_random);
+
+    for size in [1, 64, 128, 256, BUFFER_LEN] {
+        let mut sha1_output = [0u8; 20];
+        let mut sha224_output = [0u8; 28];
+        let mut sha256_output = [0u8; 32];
+        let mut sha384_output = [0u8; 48];
+        let mut sha512_output = [0u8; 64];
+        f(
+            (&sha1_random[..size], &mut sha1_output[..]),
+            (&sha224_random[..size], &mut sha224_output[..]),
+            (&sha256_random[..size], &mut sha256_output[..]),
+            (&sha384_random[..size], &mut sha384_output[..]),
+            (&sha512_random[..size], &mut sha512_output[..]),
+        );
+
+        // Calculate software result to compare against
+        assert_sw_hash::<sha1::Sha1>("SHA-1", &sha1_random[..size], &sha1_output);
+
+        #[cfg(not(esp32))]
+        assert_sw_hash::<sha2::Sha224>("SHA-224", &sha224_random[..size], &sha224_output);
+
+        assert_sw_hash::<sha2::Sha256>("SHA-256", &sha256_random[..size], &sha256_output);
+
+        #[cfg(any(esp32, esp32s2, esp32s3))]
+        assert_sw_hash::<sha2::Sha384>("SHA-384", &sha384_random[..size], &sha384_output);
+
+        #[cfg(any(esp32, esp32s2, esp32s3))]
+        assert_sw_hash::<sha2::Sha512>("SHA-512", &sha512_random[..size], &sha512_output);
+    }
+}
+
 #[embedded_test::tests(default_timeout = 6)]
 mod tests {
-    use digest::{Digest, Update};
-    #[cfg(rng_trng_supported)]
-    use esp_hal::rng::TrngSource;
-    #[cfg(not(esp32))]
-    use esp_hal::sha::Sha224;
-    #[cfg(any(esp32, esp32s2, esp32s3))]
-    use esp_hal::sha::{Sha384, Sha512};
-    #[cfg(any(esp32s2, esp32s3))]
-    use esp_hal::sha::{Sha512_224, Sha512_256};
-    use esp_hal::{
-        clock::CpuClock,
-        rng::Rng,
-        sha::{Sha, Sha1, Sha256, ShaAlgorithm, ShaBackend, ShaDigest},
-    };
-    use nb::block;
-
-    const SOURCE_DATA: &[u8] = &[b'a'; 258];
+    use super::*;
 
     pub struct Context {
         #[cfg(rng_trng_supported)]
         _rng_source: TrngSource<'static>,
         sha: Sha<'static>,
-    }
-
-    #[track_caller]
-    fn assert_sw_hash<D: Digest>(algo: &str, input: &[u8], expected_output: &[u8]) {
-        let mut hasher = D::new();
-        hasher.update(input);
-        let soft_result = hasher.finalize();
-
-        hil_test::assert_eq!(
-            expected_output,
-            &soft_result[..],
-            "Output mismatch with {}",
-            algo
-        );
-    }
-
-    fn hash_sha<S: ShaAlgorithm>(sha: &mut Sha<'static>, mut input: &[u8], output: &mut [u8]) {
-        let mut digest = sha.start::<S>();
-        while !input.is_empty() {
-            input = block!(digest.update(input)).unwrap();
-        }
-        block!(digest.finish(output)).unwrap();
-    }
-
-    fn hash_digest<'a, S: ShaAlgorithm>(
-        sha: &'a mut Sha<'static>,
-        input: &[u8],
-        output: &mut [u8],
-    ) {
-        let mut hasher = ShaDigest::<S, _>::new(sha);
-        Update::update(&mut hasher, input);
-        output.copy_from_slice(&digest::FixedOutput::finalize_fixed(hasher));
-    }
-
-    /// A simple test using the Sha trait. This will compare the result with a
-    /// software implementation.
-    #[track_caller]
-    fn assert_sha<S: ShaAlgorithm, const N: usize>(sha: &mut Sha<'static>, input: &[u8]) {
-        let mut output = [0u8; N];
-        hash_sha::<S>(sha, input, &mut output);
-
-        // Compare against Software result.
-        match N {
-            20 => assert_sw_hash::<sha1::Sha1>("SHA-1", input, &output),
-            28 => assert_sw_hash::<sha2::Sha224>("SHA-224", input, &output),
-            32 => assert_sw_hash::<sha2::Sha256>("SHA-256", input, &output),
-            48 => assert_sw_hash::<sha2::Sha384>("SHA-384", input, &output),
-            64 => assert_sw_hash::<sha2::Sha512>("SHA-512", input, &output),
-            _ => unreachable!(),
-        }
-    }
-
-    /// A simple test using the Digest trait. This will compare the result with a
-    /// software implementation.
-    #[track_caller]
-    fn assert_digest<'a, S: ShaAlgorithm, const N: usize>(sha: &'a mut Sha<'static>, input: &[u8]) {
-        let mut output = [0u8; N];
-        hash_digest::<S>(sha, input, &mut output);
-
-        // Compare against Software result.
-        match N {
-            20 => assert_sw_hash::<sha1::Sha1>("SHA-1", input, &output),
-            28 => assert_sw_hash::<sha2::Sha224>("SHA-224", input, &output),
-            32 => assert_sw_hash::<sha2::Sha256>("SHA-256", input, &output),
-            48 => assert_sw_hash::<sha2::Sha384>("SHA-384", input, &output),
-            64 => assert_sw_hash::<sha2::Sha512>("SHA-512", input, &output),
-            _ => unreachable!(),
-        }
-    }
-
-    #[allow(unused_mut)]
-    fn with_random_data(
-        mut f: impl FnMut(
-            (&[u8], &mut [u8]),
-            (&[u8], &mut [u8]),
-            (&[u8], &mut [u8]),
-            (&[u8], &mut [u8]),
-            (&[u8], &mut [u8]),
-        ),
-    ) {
-        // Make sure this is not a multiple of the block size
-        const BUFFER_LEN: usize = 264;
-
-        let mut sha1_random = [0u8; BUFFER_LEN];
-        let mut sha224_random = [0u8; BUFFER_LEN];
-        let mut sha256_random = [0u8; BUFFER_LEN];
-        let mut sha384_random = [0u8; BUFFER_LEN];
-        let mut sha512_random = [0u8; BUFFER_LEN];
-
-        let rng = Rng::new();
-
-        // Fill source data with random data
-        rng.read(&mut sha1_random);
-        #[cfg(not(esp32))]
-        rng.read(&mut sha224_random);
-        rng.read(&mut sha256_random);
-        #[cfg(any(esp32, esp32s2, esp32s3))]
-        rng.read(&mut sha384_random);
-        #[cfg(any(esp32, esp32s2, esp32s3))]
-        rng.read(&mut sha512_random);
-
-        for size in [1, 64, 128, 256, BUFFER_LEN] {
-            let mut sha1_output = [0u8; 20];
-            let mut sha224_output = [0u8; 28];
-            let mut sha256_output = [0u8; 32];
-            let mut sha384_output = [0u8; 48];
-            let mut sha512_output = [0u8; 64];
-            f(
-                (&sha1_random[..size], &mut sha1_output[..]),
-                (&sha224_random[..size], &mut sha224_output[..]),
-                (&sha256_random[..size], &mut sha256_output[..]),
-                (&sha384_random[..size], &mut sha384_output[..]),
-                (&sha512_random[..size], &mut sha512_output[..]),
-            );
-
-            // Calculate software result to compare against
-            assert_sw_hash::<sha1::Sha1>("SHA-1", &sha1_random[..size], &sha1_output);
-
-            #[cfg(not(esp32))]
-            assert_sw_hash::<sha2::Sha224>("SHA-224", &sha224_random[..size], &sha224_output);
-
-            assert_sw_hash::<sha2::Sha256>("SHA-256", &sha256_random[..size], &sha256_output);
-
-            #[cfg(any(esp32, esp32s2, esp32s3))]
-            assert_sw_hash::<sha2::Sha384>("SHA-384", &sha384_random[..size], &sha384_output);
-
-            #[cfg(any(esp32, esp32s2, esp32s3))]
-            assert_sw_hash::<sha2::Sha512>("SHA-512", &sha512_random[..size], &sha512_output);
-        }
     }
 
     #[init]
@@ -352,12 +354,51 @@ mod tests {
         });
     }
 
+    /// Test the owned code path (start_owned) to ensure it works with BorrowMut
+    #[test]
+    fn test_sha_owned(ctx: Context) {
+        let mut sha_digest = ctx.sha.start_owned::<Sha256>();
+
+        let mut remaining = SOURCE_DATA;
+        while !remaining.is_empty() {
+            remaining = block!(sha_digest.update(remaining)).unwrap();
+        }
+
+        let mut output = [0u8; 32];
+        block!(sha_digest.finish(&mut output)).unwrap();
+
+        // Verify against software implementation
+        assert_sw_hash::<sha2::Sha256>("SHA-256", SOURCE_DATA, &output);
+    }
+}
+
+#[embedded_test::tests(default_timeout = 6)]
+mod work_queue_tests {
+    use super::*;
+
+    struct Context {
+        sha: ShaBackend<'static>,
+        #[cfg(rng_trng_supported)]
+        _rng_source: TrngSource<'static>,
+    }
+
+    #[init]
+    fn init() -> Context {
+        let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
+        let peripherals = esp_hal::init(config);
+
+        Context {
+            sha: ShaBackend::new(peripherals.SHA),
+            #[cfg(rng_trng_supported)]
+            _rng_source: TrngSource::new(peripherals.RNG, peripherals.ADC1),
+        }
+    }
+
     /// Calling finalize repeatedly will first return the result of the first hashing operation,
     /// then return result for hashing 0 bytes.
     #[test]
-    fn test_repeated_finalize_is_empty_hash(_ctx: Context) {
-        let mut sha_backend = ShaBackend::new(unsafe { esp_hal::peripherals::SHA::steal() });
-        let _sha_driver = sha_backend.start();
+    fn test_repeated_finalize_is_empty_hash(mut ctx: Context) {
+        let _sha_driver = ctx.sha.start();
 
         let mut sha1 = esp_hal::sha::Sha1Context::new();
         let sha1 = &mut sha1; // Trick to not pick Digest methods erroneously
@@ -380,11 +421,10 @@ mod tests {
 
     #[test]
     #[cfg(not(esp32))]
-    fn test_clone_separates_state(_ctx: Context) {
+    fn test_clone_separates_state(mut ctx: Context) {
         use esp_hal::sha::Sha1Context;
 
-        let mut sha_backend = ShaBackend::new(unsafe { esp_hal::peripherals::SHA::steal() });
-        let _sha_driver = sha_backend.start();
+        let _sha_driver = ctx.sha.start();
 
         let mut sha1 = Sha1Context::new();
 
@@ -405,9 +445,8 @@ mod tests {
     /// A rolling test that loops between hasher for every step to test
     /// interleaving. This specifically tests the SHA backend implementation
     #[test]
-    fn test_for_digest_rolling_context(_ctx: Context) {
-        let mut sha_backend = ShaBackend::new(unsafe { esp_hal::peripherals::SHA::steal() });
-        let _sha_driver = sha_backend.start();
+    fn test_for_digest_rolling_context(mut ctx: Context) {
+        let _sha_driver = ctx.sha.start();
 
         #[allow(unused)]
         with_random_data(|sha1_p, sha224_p, sha256_p, sha384_p, sha512_p| {
@@ -461,12 +500,8 @@ mod tests {
     /// A rolling test that loops between hasher for every step to test
     /// interleaving. This specifically tests the SHA backend implementation
     #[test]
-    fn test_for_digest_rolling_context_interleaved(_ctx: Context) {
-        // Drop the Sha driver so that the backend can release resources when it needs to.
-        core::mem::drop(_ctx.sha);
-
-        let mut sha_backend = ShaBackend::new(unsafe { esp_hal::peripherals::SHA::steal() });
-        let _sha_driver = sha_backend.start();
+    fn test_for_digest_rolling_context_interleaved(mut ctx: Context) {
+        let _sha_driver = ctx.sha.start();
 
         let mut sha1 = esp_hal::sha::Sha1Context::new();
 
@@ -523,22 +558,5 @@ mod tests {
                     .wait_blocking();
             }
         });
-    }
-
-    /// Test the owned code path (start_owned) to ensure it works with BorrowMut
-    #[test]
-    fn test_sha_owned(ctx: Context) {
-        let mut sha_digest = ctx.sha.start_owned::<Sha256>();
-
-        let mut remaining = SOURCE_DATA;
-        while !remaining.is_empty() {
-            remaining = block!(sha_digest.update(remaining)).unwrap();
-        }
-
-        let mut output = [0u8; 32];
-        block!(sha_digest.finish(&mut output)).unwrap();
-
-        // Verify against software implementation
-        assert_sw_hash::<sha2::Sha256>("SHA-256", SOURCE_DATA, &output);
     }
 }


### PR DESCRIPTION
Splits classic/work-queue tests into separate modules, so that we can properly initialize the drivers instead of the unsafe hackery we've had before - and without the accidental refcount retention issues we've had with the previous solution.