### PR TITLE
Ensure breakpoint handler is inlined

### DIFF
--- a/esp-hal/src/exception_handler/mod.rs
+++ b/esp-hal/src/exception_handler/mod.rs
@@ -16,6 +16,7 @@ unsafe extern "C" fn __user_exception(
 }
 
 #[cfg(all(xtensa, stack_guard_monitoring))]
+#[inline(always)]
 pub(crate) fn breakpoint_interrupt(context: &TrapFrame) {
     let mut dbgcause: u32;
     unsafe {


### PR DESCRIPTION
Ever since d7e077a9c7779d14ddb93e9bb2edeae95afd3f64 the ESP32 had issues with running tests: A power-on reset hits a (semihosting) breakpoint without the debugger attached, which in turn triggers a double exception, likely due to a window overflow. This double exception wasn't properly handled before, but handling it with the fixed vector table _somehow_ breaks JTAG. This PR hopes to resolve this by inlining the breakpoint handler, so the double exception isn't triggered in our tests.

This is not an issue if a debugger is connected - in that case, the level 6 interrupt handler is not hit, instead the debug module takes control.

There are some unknowns here:
- Why does a double exception break JTAG? (which part of the handler breaks jtag?)
- Is it really a WindowOverflow exception that gets triggered?
- Why did a double exception handler, that only contained 0-bytes not trigger this issue?
- How could we actually panic in a high-level interrupt handler, since we're not supposed to use Rust in them?
- As this is an optimizer hint, when will it break again? 😅

# Changelog

## esp-hal

- Fixed: ESP32 should no longer break its debug interface when running embedded tests.