### PR TITLE
DMA metadata and codegen refactor, first pass

### DIFF
--- a/esp-hal/src/dma/gdma/ahb_v1.rs
+++ b/esp-hal/src/dma/gdma/ahb_v1.rs
@@ -4,25 +4,25 @@ use crate::RegisterToggle;
 impl AnyGdmaTxChannel<'_> {
     #[inline(always)]
     pub(super) fn ch(&self) -> &pac::dma::ch::CH {
-        DMA::regs().ch(self.channel as usize)
+        DMA::regs().ch(self.info.channel as usize)
     }
 
     #[cfg(any(esp32c2, esp32c3))]
     #[inline(always)]
     pub(super) fn int(&self) -> &pac::dma::int_ch::INT_CH {
-        DMA::regs().int_ch(self.channel as usize)
+        DMA::regs().int_ch(self.info.channel as usize)
     }
 
     #[inline(always)]
     #[cfg(any(esp32c6, esp32h2))]
     pub(super) fn int(&self) -> &pac::dma::out_int_ch::OUT_INT_CH {
-        DMA::regs().out_int_ch(self.channel as usize)
+        DMA::regs().out_int_ch(self.info.channel as usize)
     }
 
     #[cfg(esp32s3)]
     #[inline(always)]
     pub(super) fn int(&self) -> &pac::dma::ch::out_int::OUT_INT {
-        DMA::regs().ch(self.channel as usize).out_int()
+        DMA::regs().ch(self.info.channel as usize).out_int()
     }
 }
 
@@ -124,35 +124,11 @@ impl TxRegisterAccess for AnyGdmaTxChannel<'_> {
     }
 
     fn async_handler(&self) -> Option<InterruptHandler> {
-        match self.channel {
-            #[cfg(soc_has_dma_ch0)]
-            0 => DMA_CH0::handler_out(),
-            #[cfg(soc_has_dma_ch1)]
-            1 => DMA_CH1::handler_out(),
-            #[cfg(soc_has_dma_ch2)]
-            2 => DMA_CH2::handler_out(),
-            #[cfg(soc_has_dma_ch3)]
-            3 => DMA_CH3::handler_out(),
-            #[cfg(soc_has_dma_ch4)]
-            4 => DMA_CH4::handler_out(),
-            _ => unreachable!(),
-        }
+        self.info.handler_out
     }
 
     fn peripheral_interrupt(&self) -> Option<Interrupt> {
-        match self.channel {
-            #[cfg(soc_has_dma_ch0)]
-            0 => DMA_CH0::isr_out(),
-            #[cfg(soc_has_dma_ch1)]
-            1 => DMA_CH1::isr_out(),
-            #[cfg(soc_has_dma_ch2)]
-            2 => DMA_CH2::isr_out(),
-            #[cfg(soc_has_dma_ch3)]
-            3 => DMA_CH3::isr_out(),
-            #[cfg(soc_has_dma_ch4)]
-            4 => DMA_CH4::isr_out(),
-            _ => unreachable!(),
-        }
+        self.info.isr_out
     }
 }
 
@@ -226,13 +202,13 @@ impl InterruptAccess<DmaTxInterrupt> for AnyGdmaTxChannel<'_> {
     }
 
     fn waker(&self) -> &'static AtomicWaker {
-        &TX_WAKERS[self.channel as usize]
+        &self.state.tx_waker
     }
 
     fn is_async(&self) -> bool {
         cfg_if::cfg_if! {
             if #[cfg(any(esp32c2, esp32c3))] {
-                TX_IS_ASYNC[self.channel as usize].load(portable_atomic::Ordering::Acquire)
+                self.state.tx_is_async.load(portable_atomic::Ordering::Acquire)
             } else {
                 true
             }
@@ -242,7 +218,7 @@ impl InterruptAccess<DmaTxInterrupt> for AnyGdmaTxChannel<'_> {
     fn set_async(&self, _is_async: bool) {
         cfg_if::cfg_if! {
             if #[cfg(any(esp32c2, esp32c3))] {
-                TX_IS_ASYNC[self.channel as usize].store(_is_async, portable_atomic::Ordering::Release);
+                self.state.tx_is_async.store(_is_async, portable_atomic::Ordering::Release);
             }
         }
     }
@@ -251,25 +227,25 @@ impl InterruptAccess<DmaTxInterrupt> for AnyGdmaTxChannel<'_> {
 impl AnyGdmaRxChannel<'_> {
     #[inline(always)]
     fn ch(&self) -> &pac::dma::ch::CH {
-        DMA::regs().ch(self.channel as usize)
+        DMA::regs().ch(self.info.channel as usize)
     }
 
     #[cfg(any(esp32c2, esp32c3))]
     #[inline(always)]
     fn int(&self) -> &pac::dma::int_ch::INT_CH {
-        DMA::regs().int_ch(self.channel as usize)
+        DMA::regs().int_ch(self.info.channel as usize)
     }
 
     #[inline(always)]
     #[cfg(any(esp32c6, esp32h2))]
     fn int(&self) -> &pac::dma::in_int_ch::IN_INT_CH {
-        DMA::regs().in_int_ch(self.channel as usize)
+        DMA::regs().in_int_ch(self.info.channel as usize)
     }
 
     #[cfg(esp32s3)]
     #[inline(always)]
     fn int(&self) -> &pac::dma::ch::in_int::IN_INT {
-        DMA::regs().ch(self.channel as usize).in_int()
+        DMA::regs().ch(self.info.channel as usize).in_int()
     }
 }
 
@@ -351,35 +327,11 @@ impl RxRegisterAccess for AnyGdmaRxChannel<'_> {
     }
 
     fn async_handler(&self) -> Option<InterruptHandler> {
-        match self.channel {
-            #[cfg(soc_has_dma_ch0)]
-            0 => DMA_CH0::handler_in(),
-            #[cfg(soc_has_dma_ch1)]
-            1 => DMA_CH1::handler_in(),
-            #[cfg(soc_has_dma_ch2)]
-            2 => DMA_CH2::handler_in(),
-            #[cfg(soc_has_dma_ch3)]
-            3 => DMA_CH3::handler_in(),
-            #[cfg(soc_has_dma_ch4)]
-            4 => DMA_CH4::handler_in(),
-            _ => unreachable!(),
-        }
+        self.info.handler_in
     }
 
     fn peripheral_interrupt(&self) -> Option<Interrupt> {
-        match self.channel {
-            #[cfg(soc_has_dma_ch0)]
-            0 => DMA_CH0::isr_in(),
-            #[cfg(soc_has_dma_ch1)]
-            1 => DMA_CH1::isr_in(),
-            #[cfg(soc_has_dma_ch2)]
-            2 => DMA_CH2::isr_in(),
-            #[cfg(soc_has_dma_ch3)]
-            3 => DMA_CH3::isr_in(),
-            #[cfg(soc_has_dma_ch4)]
-            4 => DMA_CH4::isr_in(),
-            _ => unreachable!(),
-        }
+        self.info.isr_in
     }
 }
 
@@ -461,13 +413,13 @@ impl InterruptAccess<DmaRxInterrupt> for AnyGdmaRxChannel<'_> {
     }
 
     fn waker(&self) -> &'static AtomicWaker {
-        &RX_WAKERS[self.channel as usize]
+        &self.state.rx_waker
     }
 
     fn is_async(&self) -> bool {
         cfg_if::cfg_if! {
             if #[cfg(any(esp32c2, esp32c3))] {
-                RX_IS_ASYNC[self.channel as usize].load(portable_atomic::Ordering::Acquire)
+                self.state.rx_is_async.load(portable_atomic::Ordering::Acquire)
             } else {
                 true
             }
@@ -477,7 +429,7 @@ impl InterruptAccess<DmaRxInterrupt> for AnyGdmaRxChannel<'_> {
     fn set_async(&self, _is_async: bool) {
         cfg_if::cfg_if! {
             if #[cfg(any(esp32c2, esp32c3))] {
-                RX_IS_ASYNC[self.channel as usize].store(_is_async, portable_atomic::Ordering::Release);
+                self.state.rx_is_async.store(_is_async, portable_atomic::Ordering::Release);
             }
         }
     }

--- a/esp-hal/src/dma/gdma/ahb_v2.rs
+++ b/esp-hal/src/dma/gdma/ahb_v2.rs
@@ -16,12 +16,12 @@ cfg_if::cfg_if! {
 impl AnyGdmaTxChannel<'_> {
     #[inline(always)]
     pub(super) fn ch(&self) -> &gdma_pac::ch::CH {
-        DMA::regs().ch(self.channel as usize)
+        DMA::regs().ch(self.info.channel as usize)
     }
 
     #[inline(always)]
     pub(super) fn int(&self) -> &gdma_pac::out_int_ch::OUT_INT_CH {
-        DMA::regs().out_int_ch(self.channel as usize)
+        DMA::regs().out_int_ch(self.info.channel as usize)
     }
 }
 
@@ -57,7 +57,7 @@ impl RegisterAccess for AnyGdmaTxChannel<'_> {
     fn set_link_addr(&self, address: u32) {
         trace!("Setting out-link address to 0x{:08X}", address);
         DMA::regs()
-            .out_link_addr_ch(self.channel as usize)
+            .out_link_addr_ch(self.info.channel as usize)
             .write(|w| unsafe { w.outlink_addr().bits(address) });
     }
 
@@ -115,35 +115,11 @@ impl TxRegisterAccess for AnyGdmaTxChannel<'_> {
     }
 
     fn async_handler(&self) -> Option<InterruptHandler> {
-        match self.channel {
-            #[cfg(soc_has_dma_ch0)]
-            0 => DMA_CH0::handler_out(),
-            #[cfg(soc_has_dma_ch1)]
-            1 => DMA_CH1::handler_out(),
-            #[cfg(soc_has_dma_ch2)]
-            2 => DMA_CH2::handler_out(),
-            #[cfg(soc_has_dma_ch3)]
-            3 => DMA_CH3::handler_out(),
-            #[cfg(soc_has_dma_ch4)]
-            4 => DMA_CH4::handler_out(),
-            _ => unreachable!(),
-        }
+        self.info.handler_out
     }
 
     fn peripheral_interrupt(&self) -> Option<Interrupt> {
-        match self.channel {
-            #[cfg(soc_has_dma_ch0)]
-            0 => DMA_CH0::isr_out(),
-            #[cfg(soc_has_dma_ch1)]
-            1 => DMA_CH1::isr_out(),
-            #[cfg(soc_has_dma_ch2)]
-            2 => DMA_CH2::isr_out(),
-            #[cfg(soc_has_dma_ch3)]
-            3 => DMA_CH3::isr_out(),
-            #[cfg(soc_has_dma_ch4)]
-            4 => DMA_CH4::isr_out(),
-            _ => unreachable!(),
-        }
+        self.info.isr_out
     }
 }
 
@@ -217,7 +193,7 @@ impl InterruptAccess<DmaTxInterrupt> for AnyGdmaTxChannel<'_> {
     }
 
     fn waker(&self) -> &'static AtomicWaker {
-        &TX_WAKERS[self.channel as usize]
+        &self.state.tx_waker
     }
 
     fn is_async(&self) -> bool {
@@ -230,12 +206,12 @@ impl InterruptAccess<DmaTxInterrupt> for AnyGdmaTxChannel<'_> {
 impl AnyGdmaRxChannel<'_> {
     #[inline(always)]
     fn ch(&self) -> &gdma_pac::ch::CH {
-        DMA::regs().ch(self.channel as usize)
+        DMA::regs().ch(self.info.channel as usize)
     }
 
     #[inline(always)]
     fn int(&self) -> &gdma_pac::in_int_ch::IN_INT_CH {
-        DMA::regs().in_int_ch(self.channel as usize)
+        DMA::regs().in_int_ch(self.info.channel as usize)
     }
 }
 
@@ -271,7 +247,7 @@ impl RegisterAccess for AnyGdmaRxChannel<'_> {
     fn set_link_addr(&self, address: u32) {
         trace!("Setting in-link address to 0x{:08X}", address);
         DMA::regs()
-            .in_link_addr_ch(self.channel as usize)
+            .in_link_addr_ch(self.info.channel as usize)
             .write(|w| unsafe { w.inlink_addr().bits(address) });
     }
 
@@ -311,35 +287,11 @@ impl RxRegisterAccess for AnyGdmaRxChannel<'_> {
     }
 
     fn async_handler(&self) -> Option<InterruptHandler> {
-        match self.channel {
-            #[cfg(soc_has_dma_ch0)]
-            0 => DMA_CH0::handler_in(),
-            #[cfg(soc_has_dma_ch1)]
-            1 => DMA_CH1::handler_in(),
-            #[cfg(soc_has_dma_ch2)]
-            2 => DMA_CH2::handler_in(),
-            #[cfg(soc_has_dma_ch3)]
-            3 => DMA_CH3::handler_in(),
-            #[cfg(soc_has_dma_ch4)]
-            4 => DMA_CH4::handler_in(),
-            _ => unreachable!(),
-        }
+        self.info.handler_in
     }
 
     fn peripheral_interrupt(&self) -> Option<Interrupt> {
-        match self.channel {
-            #[cfg(soc_has_dma_ch0)]
-            0 => DMA_CH0::isr_in(),
-            #[cfg(soc_has_dma_ch1)]
-            1 => DMA_CH1::isr_in(),
-            #[cfg(soc_has_dma_ch2)]
-            2 => DMA_CH2::isr_in(),
-            #[cfg(soc_has_dma_ch3)]
-            3 => DMA_CH3::isr_in(),
-            #[cfg(soc_has_dma_ch4)]
-            4 => DMA_CH4::isr_in(),
-            _ => unreachable!(),
-        }
+        self.info.isr_in
     }
 }
 
@@ -421,7 +373,7 @@ impl InterruptAccess<DmaRxInterrupt> for AnyGdmaRxChannel<'_> {
     }
 
     fn waker(&self) -> &'static AtomicWaker {
-        &RX_WAKERS[self.channel as usize]
+        &self.state.rx_waker
     }
 
     fn is_async(&self) -> bool {

--- a/esp-hal/src/dma/gdma/mod.rs
+++ b/esp-hal/src/dma/gdma/mod.rs
@@ -11,6 +11,7 @@
 use core::marker::PhantomData;
 
 use crate::{
+    asynch::AtomicWaker,
     dma::*,
     handler,
     interrupt::Priority,
@@ -21,19 +22,62 @@ use crate::{
 #[cfg_attr(dma_gdma_version = "2", path = "ahb_v2.rs")]
 mod implementation;
 
+/// Mutable per-channel runtime state (wakers and async-mode flags).
+pub(crate) struct ChannelState {
+    /// Async waker for the TX (out) half of this channel.
+    pub(crate) tx_waker: AtomicWaker,
+    /// Async waker for the RX (in) half of this channel.
+    pub(crate) rx_waker: AtomicWaker,
+    /// Whether the TX half is currently in async mode (shared-interrupt chips only).
+    #[cfg(not(dma_separate_in_out_interrupts))]
+    pub(crate) tx_is_async: portable_atomic::AtomicBool,
+    /// Whether the RX half is currently in async mode (shared-interrupt chips only).
+    #[cfg(not(dma_separate_in_out_interrupts))]
+    pub(crate) rx_is_async: portable_atomic::AtomicBool,
+}
+
+/// Immutable per-channel metadata owned by each `DMA_CH*` singleton.
+pub(crate) struct ChannelInfo {
+    /// Hardware channel index used to select the register bank.
+    pub(crate) channel: u8,
+    /// Interrupt handler for the RX (in) direction.
+    pub(crate) handler_in: Option<InterruptHandler>,
+    /// Interrupt handler for the TX (out) direction.
+    pub(crate) handler_out: Option<InterruptHandler>,
+    /// Peripheral interrupt for the RX (in) direction.
+    pub(crate) isr_in: Option<Interrupt>,
+    /// Peripheral interrupt for the TX (out) direction.
+    pub(crate) isr_out: Option<Interrupt>,
+}
+
 /// An arbitrary GDMA channel
-#[derive(Debug)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AnyGdmaChannel<'d> {
-    channel: u8,
+    info: &'static ChannelInfo,
+    state: &'static ChannelState,
     _lifetime: PhantomData<&'d mut ()>,
+}
+
+impl core::fmt::Debug for AnyGdmaChannel<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AnyGdmaChannel")
+            .field("channel", &self.info.channel)
+            .finish()
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for AnyGdmaChannel<'_> {
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(fmt, "AnyGdmaChannel {{ channel: {} }}", self.info.channel)
+    }
 }
 
 impl AnyGdmaChannel<'_> {
     #[cfg_attr(any(esp32c2, esp32c61), expect(unused))]
     pub(crate) unsafe fn clone_unchecked(&self) -> Self {
         Self {
-            channel: self.channel,
+            info: self.info,
+            state: self.state,
             _lifetime: PhantomData,
         }
     }
@@ -47,11 +91,13 @@ impl<'d> DmaChannel for AnyGdmaChannel<'d> {
     unsafe fn split_internal(self, _: crate::private::Internal) -> (Self::Rx, Self::Tx) {
         (
             AnyGdmaRxChannel {
-                channel: self.channel,
+                info: self.info,
+                state: self.state,
                 _lifetime: PhantomData,
             },
             AnyGdmaTxChannel {
-                channel: self.channel,
+                info: self.info,
+                state: self.state,
                 _lifetime: PhantomData,
             },
         )
@@ -59,11 +105,25 @@ impl<'d> DmaChannel for AnyGdmaChannel<'d> {
 }
 
 /// An arbitrary GDMA RX channel
-#[derive(Debug)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AnyGdmaRxChannel<'d> {
-    channel: u8,
+    info: &'static ChannelInfo,
+    state: &'static ChannelState,
     _lifetime: PhantomData<&'d mut ()>,
+}
+
+impl core::fmt::Debug for AnyGdmaRxChannel<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AnyGdmaRxChannel")
+            .field("channel", &self.info.channel)
+            .finish()
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for AnyGdmaRxChannel<'_> {
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(fmt, "AnyGdmaRxChannel {{ channel: {} }}", self.info.channel)
+    }
 }
 
 impl<'d> DmaChannelConvert<AnyGdmaRxChannel<'d>> for AnyGdmaRxChannel<'d> {
@@ -73,29 +133,30 @@ impl<'d> DmaChannelConvert<AnyGdmaRxChannel<'d>> for AnyGdmaRxChannel<'d> {
 }
 
 /// An arbitrary GDMA TX channel
-#[derive(Debug)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AnyGdmaTxChannel<'d> {
-    channel: u8,
+    info: &'static ChannelInfo,
+    state: &'static ChannelState,
     _lifetime: PhantomData<&'d mut ()>,
+}
+
+impl core::fmt::Debug for AnyGdmaTxChannel<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AnyGdmaTxChannel")
+            .field("channel", &self.info.channel)
+            .finish()
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for AnyGdmaTxChannel<'_> {
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(fmt, "AnyGdmaTxChannel {{ channel: {} }}", self.info.channel)
+    }
 }
 
 impl<'d> DmaChannelConvert<AnyGdmaTxChannel<'d>> for AnyGdmaTxChannel<'d> {
     fn degrade(self) -> AnyGdmaTxChannel<'d> {
         self
-    }
-}
-
-use crate::asynch::AtomicWaker;
-
-static TX_WAKERS: [AtomicWaker; CHANNEL_COUNT] = [const { AtomicWaker::new() }; CHANNEL_COUNT];
-static RX_WAKERS: [AtomicWaker; CHANNEL_COUNT] = [const { AtomicWaker::new() }; CHANNEL_COUNT];
-
-cfg_if::cfg_if! {
-    if #[cfg(any(esp32c2, esp32c3))] {
-        use portable_atomic::AtomicBool;
-        static TX_IS_ASYNC: [AtomicBool; CHANNEL_COUNT] = [const { AtomicBool::new(false) }; CHANNEL_COUNT];
-        static RX_IS_ASYNC: [AtomicBool; CHANNEL_COUNT] = [const { AtomicBool::new(false) }; CHANNEL_COUNT];
     }
 }
 
@@ -113,55 +174,85 @@ impl<CH: DmaChannel, Dm: DriverMode> Channel<Dm, CH> {
 }
 
 macro_rules! impl_channel {
-    ($num:literal, $interrupt_in:ident $(, $interrupt_out:ident)? ) => {
+    // Single shared interrupt: one handler drives both the in and out paths.
+    ($num:literal, $interrupt_in:ident) => {
         paste::paste! {
             use $crate::peripherals::[<DMA_CH $num>];
             impl [<DMA_CH $num>]<'_> {
-                fn handler_in() -> Option<InterruptHandler> {
-                    $crate::if_set! {
-                        $({
-                            // $interrupt_out is present, meaning we have split handlers
-                            #[handler(priority = Priority::max())]
-                            fn interrupt_handler_in() {
-                                $crate::ignore!($interrupt_out);
-                                super::asynch::handle_in_interrupt::<[< DMA_CH $num >]<'static>>();
-                            }
-                            Some(interrupt_handler_in)
-                        })?,
-                        {
-                            #[handler(priority = Priority::max())]
-                            fn interrupt_handler() {
-                                super::asynch::handle_in_interrupt::<[< DMA_CH $num >]<'static>>();
-                                super::asynch::handle_out_interrupt::<[< DMA_CH $num >]<'static>>();
-                            }
-                            Some(interrupt_handler)
-                        }
+                pub(super) fn info() -> &'static ChannelInfo {
+                    #[handler(priority = Priority::max())]
+                    fn interrupt_handler() {
+                        asynch::handle_in_interrupt::<[<DMA_CH $num>]<'static>>();
+                        asynch::handle_out_interrupt::<[<DMA_CH $num>]<'static>>();
                     }
+                    static INFO: ChannelInfo = ChannelInfo {
+                        channel: $num,
+                        handler_in: Some(interrupt_handler),
+                        handler_out: None,
+                        isr_in: Some(Interrupt::$interrupt_in),
+                        isr_out: None,
+                    };
+                    &INFO
                 }
 
-                fn isr_in() -> Option<Interrupt> {
-                    Some(Interrupt::$interrupt_in)
-                }
-
-                fn handler_out() -> Option<InterruptHandler> {
-                    $crate::if_set! {
-                        $({
-                            #[handler(priority = Priority::max())]
-                            fn interrupt_handler_out() {
-                                $crate::ignore!($interrupt_out);
-                                super::asynch::handle_out_interrupt::<[< DMA_CH $num >]<'static>>();
-                            }
-                            Some(interrupt_handler_out)
-                        })?,
-                        None
-                    }
-                }
-
-                fn isr_out() -> Option<Interrupt> {
-                    $crate::if_set! { $(Some(Interrupt::$interrupt_out))?, None }
+                pub(super) fn state() -> &'static ChannelState {
+                    static STATE: ChannelState = ChannelState {
+                        tx_waker: AtomicWaker::new(),
+                        rx_waker: AtomicWaker::new(),
+                        tx_is_async: portable_atomic::AtomicBool::new(false),
+                        rx_is_async: portable_atomic::AtomicBool::new(false),
+                    };
+                    &STATE
                 }
             }
+        }
+        impl_channel_common!($num);
+    };
 
+    // Split interrupts: separate handlers for the in and out paths.
+    ($num:literal, $interrupt_in:ident, $interrupt_out:ident) => {
+        paste::paste! {
+            use $crate::peripherals::[<DMA_CH $num>];
+            impl [<DMA_CH $num>]<'_> {
+                pub(super) fn info() -> &'static ChannelInfo {
+                    #[handler(priority = Priority::max())]
+                    fn interrupt_handler_in() {
+                        asynch::handle_in_interrupt::<[<DMA_CH $num>]<'static>>();
+                    }
+
+                    #[handler(priority = Priority::max())]
+                    fn interrupt_handler_out() {
+                        asynch::handle_out_interrupt::<[<DMA_CH $num>]<'static>>();
+                    }
+
+                    static INFO: ChannelInfo = ChannelInfo {
+                        channel: $num,
+                        handler_in: Some(interrupt_handler_in),
+                        handler_out: Some(interrupt_handler_out),
+                        isr_in: Some(Interrupt::$interrupt_in),
+                        isr_out: Some(Interrupt::$interrupt_out),
+                    };
+                    &INFO
+                }
+
+                pub(super) fn state() -> &'static ChannelState {
+                    static STATE: ChannelState = ChannelState {
+                        tx_waker: AtomicWaker::new(),
+                        rx_waker: AtomicWaker::new(),
+                    };
+                    &STATE
+                }
+            }
+        }
+        impl_channel_common!($num);
+    };
+}
+
+/// Generates the `state()` accessor and all trait impls that are identical
+/// regardless of whether the channel uses split or shared interrupts.
+macro_rules! impl_channel_common {
+    ($num:literal) => {
+        paste::paste! {
             impl<'d> DmaChannel for [<DMA_CH $num>]<'d> {
                 type Rx = AnyGdmaRxChannel<'d>;
                 type Tx = AnyGdmaTxChannel<'d>;
@@ -169,11 +260,13 @@ macro_rules! impl_channel {
                 unsafe fn split_internal(self, _: $crate::private::Internal) -> (Self::Rx, Self::Tx) {
                     (
                         AnyGdmaRxChannel {
-                            channel: $num,
+                            info: Self::info(),
+                            state: Self::state(),
                             _lifetime: core::marker::PhantomData,
                         },
                         AnyGdmaTxChannel {
-                            channel: $num,
+                            info: Self::info(),
+                            state: Self::state(),
                             _lifetime: core::marker::PhantomData,
                         },
                     )
@@ -183,7 +276,8 @@ macro_rules! impl_channel {
             impl<'d> DmaChannelConvert<AnyGdmaChannel<'d>> for [<DMA_CH $num>]<'d> {
                 fn degrade(self) -> AnyGdmaChannel<'d> {
                     AnyGdmaChannel {
-                        channel: $num,
+                        info: Self::info(),
+                        state: Self::state(),
                         _lifetime: core::marker::PhantomData,
                     }
                 }
@@ -192,7 +286,8 @@ macro_rules! impl_channel {
             impl<'d> DmaChannelConvert<AnyGdmaRxChannel<'d>> for [<DMA_CH $num>]<'d> {
                 fn degrade(self) -> AnyGdmaRxChannel<'d> {
                     AnyGdmaRxChannel {
-                        channel: $num,
+                        info: Self::info(),
+                        state: Self::state(),
                         _lifetime: core::marker::PhantomData,
                     }
                 }
@@ -201,7 +296,8 @@ macro_rules! impl_channel {
             impl<'d> DmaChannelConvert<AnyGdmaTxChannel<'d>> for [<DMA_CH $num>]<'d> {
                 fn degrade(self) -> AnyGdmaTxChannel<'d> {
                     AnyGdmaTxChannel {
-                        channel: $num,
+                        info: Self::info(),
+                        state: Self::state(),
                         _lifetime: core::marker::PhantomData,
                     }
                 }
@@ -210,14 +306,16 @@ macro_rules! impl_channel {
             impl DmaChannelExt for [<DMA_CH $num>]<'_> {
                 fn rx_interrupts() -> impl InterruptAccess<DmaRxInterrupt> {
                     AnyGdmaRxChannel {
-                        channel: $num,
+                        info: Self::info(),
+                        state: Self::state(),
                         _lifetime: core::marker::PhantomData,
                     }
                 }
 
                 fn tx_interrupts() -> impl InterruptAccess<DmaTxInterrupt> {
                     AnyGdmaTxChannel {
-                        channel: $num,
+                        info: Self::info(),
+                        state: Self::state(),
                         _lifetime: core::marker::PhantomData,
                     }
                 }
@@ -225,12 +323,6 @@ macro_rules! impl_channel {
         }
     };
 }
-
-const CHANNEL_COUNT: usize = cfg!(soc_has_dma_ch0) as usize
-    + cfg!(soc_has_dma_ch1) as usize
-    + cfg!(soc_has_dma_ch2) as usize
-    + cfg!(soc_has_dma_ch3) as usize
-    + cfg!(soc_has_dma_ch4) as usize;
 
 cfg_if::cfg_if! {
     // ESP32-P4: AHB_DMA interrupt names are AHB_PDMA_IN_CHn / AHB_PDMA_OUT_CHn

--- a/esp-hal/src/dma/gdma/mod.rs
+++ b/esp-hal/src/dma/gdma/mod.rs
@@ -67,7 +67,7 @@ impl core::fmt::Debug for AnyGdmaChannel<'_> {
 
 #[cfg(feature = "defmt")]
 impl defmt::Format for AnyGdmaChannel<'_> {
-    fn format(&self, fmt: defmt::Formatter) {
+    fn format(&self, fmt: defmt::Formatter<'_>) {
         defmt::write!(fmt, "AnyGdmaChannel {{ channel: {} }}", self.info.channel)
     }
 }
@@ -121,7 +121,7 @@ impl core::fmt::Debug for AnyGdmaRxChannel<'_> {
 
 #[cfg(feature = "defmt")]
 impl defmt::Format for AnyGdmaRxChannel<'_> {
-    fn format(&self, fmt: defmt::Formatter) {
+    fn format(&self, fmt: defmt::Formatter<'_>) {
         defmt::write!(fmt, "AnyGdmaRxChannel {{ channel: {} }}", self.info.channel)
     }
 }
@@ -149,7 +149,7 @@ impl core::fmt::Debug for AnyGdmaTxChannel<'_> {
 
 #[cfg(feature = "defmt")]
 impl defmt::Format for AnyGdmaTxChannel<'_> {
-    fn format(&self, fmt: defmt::Formatter) {
+    fn format(&self, fmt: defmt::Formatter<'_>) {
         defmt::write!(fmt, "AnyGdmaTxChannel {{ channel: {} }}", self.info.channel)
     }
 }
@@ -175,187 +175,156 @@ impl<CH: DmaChannel, Dm: DriverMode> Channel<Dm, CH> {
 
 macro_rules! impl_channel {
     // Single shared interrupt: one handler drives both the in and out paths.
-    ($num:literal, $interrupt_in:ident) => {
-        paste::paste! {
-            use $crate::peripherals::[<DMA_CH $num>];
-            impl [<DMA_CH $num>]<'_> {
-                pub(super) fn info() -> &'static ChannelInfo {
-                    #[handler(priority = Priority::max())]
-                    fn interrupt_handler() {
-                        asynch::handle_in_interrupt::<[<DMA_CH $num>]<'static>>();
-                        asynch::handle_out_interrupt::<[<DMA_CH $num>]<'static>>();
-                    }
-                    static INFO: ChannelInfo = ChannelInfo {
-                        channel: $num,
-                        handler_in: Some(interrupt_handler),
-                        handler_out: None,
-                        isr_in: Some(Interrupt::$interrupt_in),
-                        isr_out: None,
-                    };
-                    &INFO
+    ($ch:ident, $num:literal, $interrupt_in:ident) => {
+        use $crate::peripherals::$ch;
+        impl $ch<'_> {
+            pub(super) fn info() -> &'static ChannelInfo {
+                #[handler(priority = Priority::max())]
+                fn interrupt_handler() {
+                    asynch::handle_in_interrupt::<$ch<'static>>();
+                    asynch::handle_out_interrupt::<$ch<'static>>();
                 }
+                static INFO: ChannelInfo = ChannelInfo {
+                    channel: $num,
+                    handler_in: Some(interrupt_handler),
+                    handler_out: None,
+                    isr_in: Some(Interrupt::$interrupt_in),
+                    isr_out: None,
+                };
+                &INFO
+            }
 
-                pub(super) fn state() -> &'static ChannelState {
-                    static STATE: ChannelState = ChannelState {
-                        tx_waker: AtomicWaker::new(),
-                        rx_waker: AtomicWaker::new(),
-                        tx_is_async: portable_atomic::AtomicBool::new(false),
-                        rx_is_async: portable_atomic::AtomicBool::new(false),
-                    };
-                    &STATE
-                }
+            pub(super) fn state() -> &'static ChannelState {
+                static STATE: ChannelState = ChannelState {
+                    tx_waker: AtomicWaker::new(),
+                    rx_waker: AtomicWaker::new(),
+                    tx_is_async: portable_atomic::AtomicBool::new(false),
+                    rx_is_async: portable_atomic::AtomicBool::new(false),
+                };
+                &STATE
             }
         }
-        impl_channel_common!($num);
+        impl_channel_common!($ch, $num);
     };
 
     // Split interrupts: separate handlers for the in and out paths.
-    ($num:literal, $interrupt_in:ident, $interrupt_out:ident) => {
-        paste::paste! {
-            use $crate::peripherals::[<DMA_CH $num>];
-            impl [<DMA_CH $num>]<'_> {
-                pub(super) fn info() -> &'static ChannelInfo {
-                    #[handler(priority = Priority::max())]
-                    fn interrupt_handler_in() {
-                        asynch::handle_in_interrupt::<[<DMA_CH $num>]<'static>>();
-                    }
-
-                    #[handler(priority = Priority::max())]
-                    fn interrupt_handler_out() {
-                        asynch::handle_out_interrupt::<[<DMA_CH $num>]<'static>>();
-                    }
-
-                    static INFO: ChannelInfo = ChannelInfo {
-                        channel: $num,
-                        handler_in: Some(interrupt_handler_in),
-                        handler_out: Some(interrupt_handler_out),
-                        isr_in: Some(Interrupt::$interrupt_in),
-                        isr_out: Some(Interrupt::$interrupt_out),
-                    };
-                    &INFO
+    ($ch:ident, $num:literal, $interrupt_in:ident, $interrupt_out:ident) => {
+        use $crate::peripherals::$ch;
+        impl $ch<'_> {
+            pub(super) fn info() -> &'static ChannelInfo {
+                #[handler(priority = Priority::max())]
+                fn interrupt_handler_in() {
+                    asynch::handle_in_interrupt::<$ch<'static>>();
                 }
 
-                pub(super) fn state() -> &'static ChannelState {
-                    static STATE: ChannelState = ChannelState {
-                        tx_waker: AtomicWaker::new(),
-                        rx_waker: AtomicWaker::new(),
-                    };
-                    &STATE
+                #[handler(priority = Priority::max())]
+                fn interrupt_handler_out() {
+                    asynch::handle_out_interrupt::<$ch<'static>>();
                 }
+
+                static INFO: ChannelInfo = ChannelInfo {
+                    channel: $num,
+                    handler_in: Some(interrupt_handler_in),
+                    handler_out: Some(interrupt_handler_out),
+                    isr_in: Some(Interrupt::$interrupt_in),
+                    isr_out: Some(Interrupt::$interrupt_out),
+                };
+                &INFO
+            }
+
+            pub(super) fn state() -> &'static ChannelState {
+                static STATE: ChannelState = ChannelState {
+                    tx_waker: AtomicWaker::new(),
+                    rx_waker: AtomicWaker::new(),
+                };
+                &STATE
             }
         }
-        impl_channel_common!($num);
+        impl_channel_common!($ch, $num);
     };
 }
 
 /// Generates the `state()` accessor and all trait impls that are identical
 /// regardless of whether the channel uses split or shared interrupts.
 macro_rules! impl_channel_common {
-    ($num:literal) => {
-        paste::paste! {
-            impl<'d> DmaChannel for [<DMA_CH $num>]<'d> {
-                type Rx = AnyGdmaRxChannel<'d>;
-                type Tx = AnyGdmaTxChannel<'d>;
+    ($ch:ident, $num:literal) => {
+        impl<'d> DmaChannel for $ch<'d> {
+            type Rx = AnyGdmaRxChannel<'d>;
+            type Tx = AnyGdmaTxChannel<'d>;
 
-                unsafe fn split_internal(self, _: $crate::private::Internal) -> (Self::Rx, Self::Tx) {
-                    (
-                        AnyGdmaRxChannel {
-                            info: Self::info(),
-                            state: Self::state(),
-                            _lifetime: core::marker::PhantomData,
-                        },
-                        AnyGdmaTxChannel {
-                            info: Self::info(),
-                            state: Self::state(),
-                            _lifetime: core::marker::PhantomData,
-                        },
-                    )
-                }
-            }
-
-            impl<'d> DmaChannelConvert<AnyGdmaChannel<'d>> for [<DMA_CH $num>]<'d> {
-                fn degrade(self) -> AnyGdmaChannel<'d> {
-                    AnyGdmaChannel {
-                        info: Self::info(),
-                        state: Self::state(),
-                        _lifetime: core::marker::PhantomData,
-                    }
-                }
-            }
-
-            impl<'d> DmaChannelConvert<AnyGdmaRxChannel<'d>> for [<DMA_CH $num>]<'d> {
-                fn degrade(self) -> AnyGdmaRxChannel<'d> {
+            unsafe fn split_internal(self, _: $crate::private::Internal) -> (Self::Rx, Self::Tx) {
+                (
                     AnyGdmaRxChannel {
                         info: Self::info(),
                         state: Self::state(),
                         _lifetime: core::marker::PhantomData,
-                    }
-                }
-            }
-
-            impl<'d> DmaChannelConvert<AnyGdmaTxChannel<'d>> for [<DMA_CH $num>]<'d> {
-                fn degrade(self) -> AnyGdmaTxChannel<'d> {
+                    },
                     AnyGdmaTxChannel {
                         info: Self::info(),
                         state: Self::state(),
                         _lifetime: core::marker::PhantomData,
-                    }
+                    },
+                )
+            }
+        }
+
+        impl<'d> DmaChannelConvert<AnyGdmaChannel<'d>> for $ch<'d> {
+            fn degrade(self) -> AnyGdmaChannel<'d> {
+                AnyGdmaChannel {
+                    info: Self::info(),
+                    state: Self::state(),
+                    _lifetime: core::marker::PhantomData,
+                }
+            }
+        }
+
+        impl<'d> DmaChannelConvert<AnyGdmaRxChannel<'d>> for $ch<'d> {
+            fn degrade(self) -> AnyGdmaRxChannel<'d> {
+                AnyGdmaRxChannel {
+                    info: Self::info(),
+                    state: Self::state(),
+                    _lifetime: core::marker::PhantomData,
+                }
+            }
+        }
+
+        impl<'d> DmaChannelConvert<AnyGdmaTxChannel<'d>> for $ch<'d> {
+            fn degrade(self) -> AnyGdmaTxChannel<'d> {
+                AnyGdmaTxChannel {
+                    info: Self::info(),
+                    state: Self::state(),
+                    _lifetime: core::marker::PhantomData,
+                }
+            }
+        }
+
+        impl DmaChannelExt for $ch<'_> {
+            fn rx_interrupts() -> impl InterruptAccess<DmaRxInterrupt> {
+                AnyGdmaRxChannel {
+                    info: Self::info(),
+                    state: Self::state(),
+                    _lifetime: core::marker::PhantomData,
                 }
             }
 
-            impl DmaChannelExt for [<DMA_CH $num>]<'_> {
-                fn rx_interrupts() -> impl InterruptAccess<DmaRxInterrupt> {
-                    AnyGdmaRxChannel {
-                        info: Self::info(),
-                        state: Self::state(),
-                        _lifetime: core::marker::PhantomData,
-                    }
-                }
-
-                fn tx_interrupts() -> impl InterruptAccess<DmaTxInterrupt> {
-                    AnyGdmaTxChannel {
-                        info: Self::info(),
-                        state: Self::state(),
-                        _lifetime: core::marker::PhantomData,
-                    }
+            fn tx_interrupts() -> impl InterruptAccess<DmaTxInterrupt> {
+                AnyGdmaTxChannel {
+                    info: Self::info(),
+                    state: Self::state(),
+                    _lifetime: core::marker::PhantomData,
                 }
             }
         }
     };
 }
 
-cfg_if::cfg_if! {
-    // ESP32-P4: AHB_DMA interrupt names are AHB_PDMA_IN_CHn / AHB_PDMA_OUT_CHn
-    if #[cfg(esp32p4)] {
-        #[cfg(soc_has_dma_ch0)]
-        impl_channel!(0, AHB_PDMA_IN_CH0, AHB_PDMA_OUT_CH0);
-        #[cfg(soc_has_dma_ch1)]
-        impl_channel!(1, AHB_PDMA_IN_CH1, AHB_PDMA_OUT_CH1);
-        #[cfg(soc_has_dma_ch2)]
-        impl_channel!(2, AHB_PDMA_IN_CH2, AHB_PDMA_OUT_CH2);
-    } else if #[cfg(dma_separate_in_out_interrupts)] {
-        #[cfg(soc_has_dma_ch0)]
-        impl_channel!(0, DMA_IN_CH0, DMA_OUT_CH0);
-        #[cfg(soc_has_dma_ch1)]
-        impl_channel!(1, DMA_IN_CH1, DMA_OUT_CH1);
-        #[cfg(soc_has_dma_ch2)]
-        impl_channel!(2, DMA_IN_CH2, DMA_OUT_CH2);
-        #[cfg(soc_has_dma_ch3)]
-        impl_channel!(3, DMA_IN_CH3, DMA_OUT_CH3);
-        #[cfg(soc_has_dma_ch4)]
-        impl_channel!(4, DMA_IN_CH4, DMA_OUT_CH4);
-    } else {
-        #[cfg(soc_has_dma_ch0)]
-        impl_channel!(0, DMA_CH0);
-        #[cfg(soc_has_dma_ch1)]
-        impl_channel!(1, DMA_CH1);
-        #[cfg(soc_has_dma_ch2)]
-        impl_channel!(2, DMA_CH2);
-        #[cfg(soc_has_dma_ch3)]
-        impl_channel!(3, DMA_CH3);
-        #[cfg(soc_has_dma_ch4)]
-        impl_channel!(4, DMA_CH4);
-    }
+for_each_dma_channel! {
+    ($ch:ident, $num:literal, interrupt = $interrupt:ident) => {
+        impl_channel!($ch, $num, $interrupt);
+    };
+    ($ch:ident, $num:literal, interrupt_in = $interrupt_in:ident, interrupt_out = $interrupt_out:ident) => {
+        impl_channel!($ch, $num, $interrupt_in, $interrupt_out);
+    };
 }
 
 for_each_peripheral! {

--- a/esp-metadata-generated/src/_build_script_utils.rs
+++ b/esp-metadata-generated/src/_build_script_utils.rs
@@ -249,10 +249,6 @@ impl Chip {
                     "soc_has_uhci0",
                     "soc_has_uhci1",
                     "soc_has_wifi",
-                    "soc_has_dma_spi2",
-                    "soc_has_dma_spi3",
-                    "soc_has_dma_i2s0",
-                    "soc_has_dma_i2s1",
                     "soc_has_adc1",
                     "soc_has_adc2",
                     "soc_has_bt",
@@ -325,6 +321,10 @@ impl Chip {
                     "aes_endianness_configurable",
                     "bt_controller=\"btdm\"",
                     "dma_kind=\"pdma\"",
+                    "soc_has_dma_spi2",
+                    "soc_has_dma_spi3",
+                    "soc_has_dma_i2s0",
+                    "soc_has_dma_i2s1",
                     "gpio_has_bank_1",
                     "gpio_gpio_function=\"2\"",
                     "gpio_constant_0_input=\"48\"",
@@ -463,10 +463,6 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_uhci0",
                     "cargo:rustc-cfg=soc_has_uhci1",
                     "cargo:rustc-cfg=soc_has_wifi",
-                    "cargo:rustc-cfg=soc_has_dma_spi2",
-                    "cargo:rustc-cfg=soc_has_dma_spi3",
-                    "cargo:rustc-cfg=soc_has_dma_i2s0",
-                    "cargo:rustc-cfg=soc_has_dma_i2s1",
                     "cargo:rustc-cfg=soc_has_adc1",
                     "cargo:rustc-cfg=soc_has_adc2",
                     "cargo:rustc-cfg=soc_has_bt",
@@ -539,6 +535,10 @@ impl Chip {
                     "cargo:rustc-cfg=aes_endianness_configurable",
                     "cargo:rustc-cfg=bt_controller=\"btdm\"",
                     "cargo:rustc-cfg=dma_kind=\"pdma\"",
+                    "cargo:rustc-cfg=soc_has_dma_spi2",
+                    "cargo:rustc-cfg=soc_has_dma_spi3",
+                    "cargo:rustc-cfg=soc_has_dma_i2s0",
+                    "cargo:rustc-cfg=soc_has_dma_i2s1",
                     "cargo:rustc-cfg=gpio_has_bank_1",
                     "cargo:rustc-cfg=gpio_gpio_function=\"2\"",
                     "cargo:rustc-cfg=gpio_constant_0_input=\"48\"",
@@ -4952,11 +4952,6 @@ impl Chip {
                     "soc_has_usb_wrap",
                     "soc_has_xts_aes",
                     "soc_has_wifi",
-                    "soc_has_dma_spi2",
-                    "soc_has_dma_spi3",
-                    "soc_has_dma_i2s0",
-                    "soc_has_dma_crypto",
-                    "soc_has_dma_copy",
                     "soc_has_adc1",
                     "soc_has_adc2",
                     "soc_has_dac1",
@@ -5039,6 +5034,11 @@ impl Chip {
                     "dma_supports_mem2mem",
                     "dma_can_access_psram",
                     "dma_ext_mem_configurable_block_size",
+                    "soc_has_dma_spi2",
+                    "soc_has_dma_spi3",
+                    "soc_has_dma_i2s0",
+                    "soc_has_dma_crypto",
+                    "soc_has_dma_copy",
                     "gpio_has_bank_1",
                     "gpio_gpio_function=\"1\"",
                     "gpio_constant_0_input=\"60\"",
@@ -5179,11 +5179,6 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_usb_wrap",
                     "cargo:rustc-cfg=soc_has_xts_aes",
                     "cargo:rustc-cfg=soc_has_wifi",
-                    "cargo:rustc-cfg=soc_has_dma_spi2",
-                    "cargo:rustc-cfg=soc_has_dma_spi3",
-                    "cargo:rustc-cfg=soc_has_dma_i2s0",
-                    "cargo:rustc-cfg=soc_has_dma_crypto",
-                    "cargo:rustc-cfg=soc_has_dma_copy",
                     "cargo:rustc-cfg=soc_has_adc1",
                     "cargo:rustc-cfg=soc_has_adc2",
                     "cargo:rustc-cfg=soc_has_dac1",
@@ -5266,6 +5261,11 @@ impl Chip {
                     "cargo:rustc-cfg=dma_supports_mem2mem",
                     "cargo:rustc-cfg=dma_can_access_psram",
                     "cargo:rustc-cfg=dma_ext_mem_configurable_block_size",
+                    "cargo:rustc-cfg=soc_has_dma_spi2",
+                    "cargo:rustc-cfg=soc_has_dma_spi3",
+                    "cargo:rustc-cfg=soc_has_dma_i2s0",
+                    "cargo:rustc-cfg=soc_has_dma_crypto",
+                    "cargo:rustc-cfg=soc_has_dma_copy",
                     "cargo:rustc-cfg=gpio_has_bank_1",
                     "cargo:rustc-cfg=gpio_gpio_function=\"1\"",
                     "cargo:rustc-cfg=gpio_constant_0_input=\"60\"",
@@ -6382,10 +6382,6 @@ pub fn emit_check_cfg_directives() {
     println!("cargo:rustc-check-cfg=cfg(soc_has_uhci0)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_uhci1)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_wifi)");
-    println!("cargo:rustc-check-cfg=cfg(soc_has_dma_spi2)");
-    println!("cargo:rustc-check-cfg=cfg(soc_has_dma_spi3)");
-    println!("cargo:rustc-check-cfg=cfg(soc_has_dma_i2s0)");
-    println!("cargo:rustc-check-cfg=cfg(soc_has_dma_i2s1)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_adc1)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_adc2)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_bt)");
@@ -6456,6 +6452,10 @@ pub fn emit_check_cfg_directives() {
     println!("cargo:rustc-check-cfg=cfg(uart_uart1)");
     println!("cargo:rustc-check-cfg=cfg(uart_uart2)");
     println!("cargo:rustc-check-cfg=cfg(aes_endianness_configurable)");
+    println!("cargo:rustc-check-cfg=cfg(soc_has_dma_spi2)");
+    println!("cargo:rustc-check-cfg=cfg(soc_has_dma_spi3)");
+    println!("cargo:rustc-check-cfg=cfg(soc_has_dma_i2s0)");
+    println!("cargo:rustc-check-cfg=cfg(soc_has_dma_i2s1)");
     println!("cargo:rustc-check-cfg=cfg(gpio_has_bank_1)");
     println!("cargo:rustc-check-cfg=cfg(gpio_remap_iomux_pin_registers)");
     println!("cargo:rustc-check-cfg=cfg(i2c_master_separate_filter_config_registers)");
@@ -6747,14 +6747,14 @@ pub fn emit_check_cfg_directives() {
     println!("cargo:rustc-check-cfg=cfg(soc_has_dedicated_gpio)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_pms)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_syscon)");
-    println!("cargo:rustc-check-cfg=cfg(soc_has_dma_crypto)");
-    println!("cargo:rustc-check-cfg=cfg(soc_has_dma_copy)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_ulp_riscv_core)");
     println!("cargo:rustc-check-cfg=cfg(ulp_riscv_core)");
     println!("cargo:rustc-check-cfg=cfg(riscv_coproc_supported)");
     println!("cargo:rustc-check-cfg=cfg(aes_dma_mode_gcm)");
     println!("cargo:rustc-check-cfg=cfg(dedicated_gpio_needs_initialization)");
     println!("cargo:rustc-check-cfg=cfg(dma_ext_mem_configurable_block_size)");
+    println!("cargo:rustc-check-cfg=cfg(soc_has_dma_crypto)");
+    println!("cargo:rustc-check-cfg=cfg(soc_has_dma_copy)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_ref_tick_ck8m)");
     println!("cargo:rustc-check-cfg=cfg(spi_master_has_octal)");
     println!("cargo:rustc-check-cfg=cfg(esp32s3)");

--- a/esp-metadata-generated/src/_build_script_utils.rs
+++ b/esp-metadata-generated/src/_build_script_utils.rs
@@ -818,7 +818,6 @@ impl Chip {
                     "soc_has_uart0",
                     "soc_has_uart1",
                     "soc_has_xts_aes",
-                    "soc_has_dma_ch0",
                     "soc_has_adc1",
                     "soc_has_bt",
                     "soc_has_flash",
@@ -873,6 +872,7 @@ impl Chip {
                     "dma_max_priority_is_set",
                     "dma_gdma_version=\"1\"",
                     "dma_gdma_version_is_set",
+                    "soc_has_dma_ch0",
                     "ecc_zero_extend_writes",
                     "ecc_has_finite_field_division",
                     "ecc_has_curve_p192",
@@ -982,7 +982,6 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_uart0",
                     "cargo:rustc-cfg=soc_has_uart1",
                     "cargo:rustc-cfg=soc_has_xts_aes",
-                    "cargo:rustc-cfg=soc_has_dma_ch0",
                     "cargo:rustc-cfg=soc_has_adc1",
                     "cargo:rustc-cfg=soc_has_bt",
                     "cargo:rustc-cfg=soc_has_flash",
@@ -1037,6 +1036,7 @@ impl Chip {
                     "cargo:rustc-cfg=dma_max_priority_is_set",
                     "cargo:rustc-cfg=dma_gdma_version=\"1\"",
                     "cargo:rustc-cfg=dma_gdma_version_is_set",
+                    "cargo:rustc-cfg=soc_has_dma_ch0",
                     "cargo:rustc-cfg=ecc_zero_extend_writes",
                     "cargo:rustc-cfg=ecc_has_finite_field_division",
                     "cargo:rustc-cfg=ecc_has_curve_p192",
@@ -1264,9 +1264,6 @@ impl Chip {
                     "soc_has_uhci0",
                     "soc_has_usb_device",
                     "soc_has_xts_aes",
-                    "soc_has_dma_ch0",
-                    "soc_has_dma_ch1",
-                    "soc_has_dma_ch2",
                     "soc_has_adc1",
                     "soc_has_adc2",
                     "soc_has_bt",
@@ -1341,6 +1338,9 @@ impl Chip {
                     "dma_max_priority_is_set",
                     "dma_gdma_version=\"1\"",
                     "dma_gdma_version_is_set",
+                    "soc_has_dma_ch0",
+                    "soc_has_dma_ch1",
+                    "soc_has_dma_ch2",
                     "gpio_gpio_function=\"1\"",
                     "gpio_constant_0_input=\"31\"",
                     "gpio_constant_1_input=\"30\"",
@@ -1479,9 +1479,6 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_uhci0",
                     "cargo:rustc-cfg=soc_has_usb_device",
                     "cargo:rustc-cfg=soc_has_xts_aes",
-                    "cargo:rustc-cfg=soc_has_dma_ch0",
-                    "cargo:rustc-cfg=soc_has_dma_ch1",
-                    "cargo:rustc-cfg=soc_has_dma_ch2",
                     "cargo:rustc-cfg=soc_has_adc1",
                     "cargo:rustc-cfg=soc_has_adc2",
                     "cargo:rustc-cfg=soc_has_bt",
@@ -1556,6 +1553,9 @@ impl Chip {
                     "cargo:rustc-cfg=dma_max_priority_is_set",
                     "cargo:rustc-cfg=dma_gdma_version=\"1\"",
                     "cargo:rustc-cfg=dma_gdma_version_is_set",
+                    "cargo:rustc-cfg=soc_has_dma_ch0",
+                    "cargo:rustc-cfg=soc_has_dma_ch1",
+                    "cargo:rustc-cfg=soc_has_dma_ch2",
                     "cargo:rustc-cfg=gpio_gpio_function=\"1\"",
                     "cargo:rustc-cfg=gpio_constant_0_input=\"31\"",
                     "cargo:rustc-cfg=gpio_constant_1_input=\"30\"",
@@ -1828,9 +1828,6 @@ impl Chip {
                     "soc_has_uart1",
                     "soc_has_uhci0",
                     "soc_has_usb_device",
-                    "soc_has_dma_ch0",
-                    "soc_has_dma_ch1",
-                    "soc_has_dma_ch2",
                     "soc_has_adc1",
                     "soc_has_bt",
                     "soc_has_flash",
@@ -1910,6 +1907,9 @@ impl Chip {
                     "dma_max_priority_is_set",
                     "dma_gdma_version=\"2\"",
                     "dma_gdma_version_is_set",
+                    "soc_has_dma_ch0",
+                    "soc_has_dma_ch1",
+                    "soc_has_dma_ch2",
                     "ecc_separate_jacobian_point_memory",
                     "ecc_has_memory_clock_gate",
                     "ecc_supports_enhanced_security",
@@ -2091,9 +2091,6 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_uart1",
                     "cargo:rustc-cfg=soc_has_uhci0",
                     "cargo:rustc-cfg=soc_has_usb_device",
-                    "cargo:rustc-cfg=soc_has_dma_ch0",
-                    "cargo:rustc-cfg=soc_has_dma_ch1",
-                    "cargo:rustc-cfg=soc_has_dma_ch2",
                     "cargo:rustc-cfg=soc_has_adc1",
                     "cargo:rustc-cfg=soc_has_bt",
                     "cargo:rustc-cfg=soc_has_flash",
@@ -2173,6 +2170,9 @@ impl Chip {
                     "cargo:rustc-cfg=dma_max_priority_is_set",
                     "cargo:rustc-cfg=dma_gdma_version=\"2\"",
                     "cargo:rustc-cfg=dma_gdma_version_is_set",
+                    "cargo:rustc-cfg=soc_has_dma_ch0",
+                    "cargo:rustc-cfg=soc_has_dma_ch1",
+                    "cargo:rustc-cfg=soc_has_dma_ch2",
                     "cargo:rustc-cfg=ecc_separate_jacobian_point_memory",
                     "cargo:rustc-cfg=ecc_has_memory_clock_gate",
                     "cargo:rustc-cfg=ecc_supports_enhanced_security",
@@ -2497,9 +2497,6 @@ impl Chip {
                     "soc_has_uart1",
                     "soc_has_uhci0",
                     "soc_has_usb_device",
-                    "soc_has_dma_ch0",
-                    "soc_has_dma_ch1",
-                    "soc_has_dma_ch2",
                     "soc_has_adc1",
                     "soc_has_bt",
                     "soc_has_flash",
@@ -2596,6 +2593,9 @@ impl Chip {
                     "dma_max_priority_is_set",
                     "dma_gdma_version=\"1\"",
                     "dma_gdma_version_is_set",
+                    "soc_has_dma_ch0",
+                    "soc_has_dma_ch1",
+                    "soc_has_dma_ch2",
                     "ecc_zero_extend_writes",
                     "ecc_has_memory_clock_gate",
                     "ecc_has_curve_p192",
@@ -2783,9 +2783,6 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_uart1",
                     "cargo:rustc-cfg=soc_has_uhci0",
                     "cargo:rustc-cfg=soc_has_usb_device",
-                    "cargo:rustc-cfg=soc_has_dma_ch0",
-                    "cargo:rustc-cfg=soc_has_dma_ch1",
-                    "cargo:rustc-cfg=soc_has_dma_ch2",
                     "cargo:rustc-cfg=soc_has_adc1",
                     "cargo:rustc-cfg=soc_has_bt",
                     "cargo:rustc-cfg=soc_has_flash",
@@ -2882,6 +2879,9 @@ impl Chip {
                     "cargo:rustc-cfg=dma_max_priority_is_set",
                     "cargo:rustc-cfg=dma_gdma_version=\"1\"",
                     "cargo:rustc-cfg=dma_gdma_version_is_set",
+                    "cargo:rustc-cfg=soc_has_dma_ch0",
+                    "cargo:rustc-cfg=soc_has_dma_ch1",
+                    "cargo:rustc-cfg=soc_has_dma_ch2",
                     "cargo:rustc-cfg=ecc_zero_extend_writes",
                     "cargo:rustc-cfg=ecc_has_memory_clock_gate",
                     "cargo:rustc-cfg=ecc_has_curve_p192",
@@ -3194,8 +3194,6 @@ impl Chip {
                     "soc_has_uart0",
                     "soc_has_uart1",
                     "soc_has_usb_device",
-                    "soc_has_dma_ch0",
-                    "soc_has_dma_ch1",
                     "soc_has_bt",
                     "soc_has_flash",
                     "soc_has_gpio_dedicated",
@@ -3259,6 +3257,8 @@ impl Chip {
                     "dma_max_priority_is_set",
                     "dma_gdma_version=\"2\"",
                     "dma_gdma_version_is_set",
+                    "soc_has_dma_ch0",
+                    "soc_has_dma_ch1",
                     "ecc_zero_extend_writes",
                     "ecc_separate_jacobian_point_memory",
                     "ecc_has_memory_clock_gate",
@@ -3400,8 +3400,6 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_uart0",
                     "cargo:rustc-cfg=soc_has_uart1",
                     "cargo:rustc-cfg=soc_has_usb_device",
-                    "cargo:rustc-cfg=soc_has_dma_ch0",
-                    "cargo:rustc-cfg=soc_has_dma_ch1",
                     "cargo:rustc-cfg=soc_has_bt",
                     "cargo:rustc-cfg=soc_has_flash",
                     "cargo:rustc-cfg=soc_has_gpio_dedicated",
@@ -3465,6 +3463,8 @@ impl Chip {
                     "cargo:rustc-cfg=dma_max_priority_is_set",
                     "cargo:rustc-cfg=dma_gdma_version=\"2\"",
                     "cargo:rustc-cfg=dma_gdma_version_is_set",
+                    "cargo:rustc-cfg=soc_has_dma_ch0",
+                    "cargo:rustc-cfg=soc_has_dma_ch1",
                     "cargo:rustc-cfg=ecc_zero_extend_writes",
                     "cargo:rustc-cfg=ecc_separate_jacobian_point_memory",
                     "cargo:rustc-cfg=ecc_has_memory_clock_gate",
@@ -3760,9 +3760,6 @@ impl Chip {
                     "soc_has_uart1",
                     "soc_has_uhci0",
                     "soc_has_usb_device",
-                    "soc_has_dma_ch0",
-                    "soc_has_dma_ch1",
-                    "soc_has_dma_ch2",
                     "soc_has_adc1",
                     "soc_has_bt",
                     "soc_has_flash",
@@ -3845,6 +3842,9 @@ impl Chip {
                     "dma_max_priority_is_set",
                     "dma_gdma_version=\"1\"",
                     "dma_gdma_version_is_set",
+                    "soc_has_dma_ch0",
+                    "soc_has_dma_ch1",
+                    "soc_has_dma_ch2",
                     "ecc_zero_extend_writes",
                     "ecc_separate_jacobian_point_memory",
                     "ecc_has_memory_clock_gate",
@@ -4012,9 +4012,6 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_uart1",
                     "cargo:rustc-cfg=soc_has_uhci0",
                     "cargo:rustc-cfg=soc_has_usb_device",
-                    "cargo:rustc-cfg=soc_has_dma_ch0",
-                    "cargo:rustc-cfg=soc_has_dma_ch1",
-                    "cargo:rustc-cfg=soc_has_dma_ch2",
                     "cargo:rustc-cfg=soc_has_adc1",
                     "cargo:rustc-cfg=soc_has_bt",
                     "cargo:rustc-cfg=soc_has_flash",
@@ -4097,6 +4094,9 @@ impl Chip {
                     "cargo:rustc-cfg=dma_max_priority_is_set",
                     "cargo:rustc-cfg=dma_gdma_version=\"1\"",
                     "cargo:rustc-cfg=dma_gdma_version_is_set",
+                    "cargo:rustc-cfg=soc_has_dma_ch0",
+                    "cargo:rustc-cfg=soc_has_dma_ch1",
+                    "cargo:rustc-cfg=soc_has_dma_ch2",
                     "cargo:rustc-cfg=ecc_zero_extend_writes",
                     "cargo:rustc-cfg=ecc_separate_jacobian_point_memory",
                     "cargo:rustc-cfg=ecc_has_memory_clock_gate",
@@ -4344,9 +4344,6 @@ impl Chip {
                     "soc_has_twai2",
                     "soc_has_psram",
                     "soc_has_dma",
-                    "soc_has_dma_ch0",
-                    "soc_has_dma_ch1",
-                    "soc_has_dma_ch2",
                     "soc_has_eth",
                     "soc_has_emac_dma",
                     "soc_has_emac_mac",
@@ -4406,6 +4403,9 @@ impl Chip {
                     "dma_max_priority_is_set",
                     "dma_gdma_version=\"2\"",
                     "dma_gdma_version_is_set",
+                    "soc_has_dma_ch0",
+                    "soc_has_dma_ch1",
+                    "soc_has_dma_ch2",
                     "ecc_separate_jacobian_point_memory",
                     "ecc_has_memory_clock_gate",
                     "ecc_supports_enhanced_security",
@@ -4521,9 +4521,6 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_twai2",
                     "cargo:rustc-cfg=soc_has_psram",
                     "cargo:rustc-cfg=soc_has_dma",
-                    "cargo:rustc-cfg=soc_has_dma_ch0",
-                    "cargo:rustc-cfg=soc_has_dma_ch1",
-                    "cargo:rustc-cfg=soc_has_dma_ch2",
                     "cargo:rustc-cfg=soc_has_eth",
                     "cargo:rustc-cfg=soc_has_emac_dma",
                     "cargo:rustc-cfg=soc_has_emac_mac",
@@ -4583,6 +4580,9 @@ impl Chip {
                     "cargo:rustc-cfg=dma_max_priority_is_set",
                     "cargo:rustc-cfg=dma_gdma_version=\"2\"",
                     "cargo:rustc-cfg=dma_gdma_version_is_set",
+                    "cargo:rustc-cfg=soc_has_dma_ch0",
+                    "cargo:rustc-cfg=soc_has_dma_ch1",
+                    "cargo:rustc-cfg=soc_has_dma_ch2",
                     "cargo:rustc-cfg=ecc_separate_jacobian_point_memory",
                     "cargo:rustc-cfg=ecc_has_memory_clock_gate",
                     "cargo:rustc-cfg=ecc_supports_enhanced_security",
@@ -5608,11 +5608,6 @@ impl Chip {
                     "soc_has_usb_wrap",
                     "soc_has_wcl",
                     "soc_has_xts_aes",
-                    "soc_has_dma_ch0",
-                    "soc_has_dma_ch1",
-                    "soc_has_dma_ch2",
-                    "soc_has_dma_ch3",
-                    "soc_has_dma_ch4",
                     "soc_has_adc1",
                     "soc_has_adc2",
                     "soc_has_bt",
@@ -5710,6 +5705,11 @@ impl Chip {
                     "dma_max_priority_is_set",
                     "dma_gdma_version=\"1\"",
                     "dma_gdma_version_is_set",
+                    "soc_has_dma_ch0",
+                    "soc_has_dma_ch1",
+                    "soc_has_dma_ch2",
+                    "soc_has_dma_ch3",
+                    "soc_has_dma_ch4",
                     "gpio_has_bank_1",
                     "gpio_gpio_function=\"1\"",
                     "gpio_constant_0_input=\"60\"",
@@ -5869,11 +5869,6 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_usb_wrap",
                     "cargo:rustc-cfg=soc_has_wcl",
                     "cargo:rustc-cfg=soc_has_xts_aes",
-                    "cargo:rustc-cfg=soc_has_dma_ch0",
-                    "cargo:rustc-cfg=soc_has_dma_ch1",
-                    "cargo:rustc-cfg=soc_has_dma_ch2",
-                    "cargo:rustc-cfg=soc_has_dma_ch3",
-                    "cargo:rustc-cfg=soc_has_dma_ch4",
                     "cargo:rustc-cfg=soc_has_adc1",
                     "cargo:rustc-cfg=soc_has_adc2",
                     "cargo:rustc-cfg=soc_has_bt",
@@ -5971,6 +5966,11 @@ impl Chip {
                     "cargo:rustc-cfg=dma_max_priority_is_set",
                     "cargo:rustc-cfg=dma_gdma_version=\"1\"",
                     "cargo:rustc-cfg=dma_gdma_version_is_set",
+                    "cargo:rustc-cfg=soc_has_dma_ch0",
+                    "cargo:rustc-cfg=soc_has_dma_ch1",
+                    "cargo:rustc-cfg=soc_has_dma_ch2",
+                    "cargo:rustc-cfg=soc_has_dma_ch3",
+                    "cargo:rustc-cfg=soc_has_dma_ch4",
                     "cargo:rustc-cfg=gpio_has_bank_1",
                     "cargo:rustc-cfg=gpio_gpio_function=\"1\"",
                     "cargo:rustc-cfg=gpio_constant_0_input=\"60\"",
@@ -6524,7 +6524,6 @@ pub fn emit_check_cfg_directives() {
     println!("cargo:rustc-check-cfg=cfg(soc_has_sensitive)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_systimer)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_xts_aes)");
-    println!("cargo:rustc-check-cfg=cfg(soc_has_dma_ch0)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_gpio_dedicated)");
     println!("cargo:rustc-check-cfg=cfg(swd)");
     println!("cargo:rustc-check-cfg=cfg(rom_md5_mbedtls)");
@@ -6540,6 +6539,7 @@ pub fn emit_check_cfg_directives() {
     println!("cargo:rustc-check-cfg=cfg(dma_supports_mem2mem)");
     println!("cargo:rustc-check-cfg=cfg(dma_max_priority_is_set)");
     println!("cargo:rustc-check-cfg=cfg(dma_gdma_version_is_set)");
+    println!("cargo:rustc-check-cfg=cfg(soc_has_dma_ch0)");
     println!("cargo:rustc-check-cfg=cfg(ecc_zero_extend_writes)");
     println!("cargo:rustc-check-cfg=cfg(ecc_has_finite_field_division)");
     println!("cargo:rustc-check-cfg=cfg(ecc_has_curve_p192)");
@@ -6577,8 +6577,6 @@ pub fn emit_check_cfg_directives() {
     println!("cargo:rustc-check-cfg=cfg(soc_has_fe2)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_hmac)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_usb_device)");
-    println!("cargo:rustc-check-cfg=cfg(soc_has_dma_ch1)");
-    println!("cargo:rustc-check-cfg=cfg(soc_has_dma_ch2)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_tsens)");
     println!("cargo:rustc-check-cfg=cfg(hmac_driver_supported)");
     println!("cargo:rustc-check-cfg=cfg(uhci_driver_supported)");
@@ -6592,6 +6590,8 @@ pub fn emit_check_cfg_directives() {
     println!("cargo:rustc-check-cfg=cfg(aes_dma_mode_cfb128)");
     println!("cargo:rustc-check-cfg=cfg(aes_has_split_text_registers)");
     println!("cargo:rustc-check-cfg=cfg(assist_debug_has_region_monitor)");
+    println!("cargo:rustc-check-cfg=cfg(soc_has_dma_ch1)");
+    println!("cargo:rustc-check-cfg=cfg(soc_has_dma_ch2)");
     println!("cargo:rustc-check-cfg=cfg(phy_backed_up_digital_register_count_is_set)");
     println!("cargo:rustc-check-cfg=cfg(rmt_has_tx_immediate_stop)");
     println!("cargo:rustc-check-cfg=cfg(rmt_has_tx_loop_count)");
@@ -6762,9 +6762,9 @@ pub fn emit_check_cfg_directives() {
     println!("cargo:rustc-check-cfg=cfg(soc_has_peri_backup)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_rtc_cntl)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_wcl)");
+    println!("cargo:rustc-check-cfg=cfg(camera_driver_supported)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_dma_ch3)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_dma_ch4)");
-    println!("cargo:rustc-check-cfg=cfg(camera_driver_supported)");
     println!("cargo:rustc-check-cfg=cfg(psram_octal_spi)");
     println!("cargo:rustc-check-cfg=cfg(rmt_has_dma)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_clock_node_pll_d2)");

--- a/esp-metadata-generated/src/_generated_esp32.rs
+++ b/esp-metadata-generated/src/_generated_esp32.rs
@@ -441,6 +441,20 @@ macro_rules! for_each_aes_key_length {
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_dma_channel {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner_dma_channel { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_dma_channel!((DMA_SPI2, 0, interrupt = SPI2_DMA));
+        _for_each_inner_dma_channel!((DMA_SPI3, 1, interrupt = SPI3_DMA));
+        _for_each_inner_dma_channel!((DMA_I2S0, 0, interrupt = I2S0));
+        _for_each_inner_dma_channel!((DMA_I2S1, 1, interrupt = I2S1));
+        _for_each_inner_dma_channel!((shared(DMA_SPI2, 0, interrupt = SPI2_DMA),
+        (DMA_SPI3, 1, interrupt = SPI3_DMA), (DMA_I2S0, 0, interrupt = I2S0), (DMA_I2S1,
+        1, interrupt = I2S1))); _for_each_inner_dma_channel!((split));
+    };
+}
+#[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_sw_interrupt {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_sw_interrupt { $(($pattern) => $code;)* ($other :
@@ -3760,11 +3774,15 @@ macro_rules! for_each_peripheral {
         #[doc = "<ul>"] #[doc = "<li>This pin can only be used as an input.</li>"] #[doc
         = "</ul>"] #[doc = "</section>"] GPIO39 <= virtual()));
         _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_SPI2 peripheral singleton"]
-        DMA_SPI2 <= SPI2() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
-        "DMA_SPI3 peripheral singleton"] DMA_SPI3 <= SPI3() (unstable)));
+        DMA_SPI2 <= SPI2(SPI2_DMA : { bind_dma_interrupt, enable_dma_interrupt,
+        disable_dma_interrupt }) (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "DMA_SPI3 peripheral singleton"] DMA_SPI3 <= SPI3(SPI3_DMA : {
+        bind_dma_interrupt, enable_dma_interrupt, disable_dma_interrupt }) (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_I2S0 peripheral singleton"]
-        DMA_I2S0 <= I2S0() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
-        "DMA_I2S1 peripheral singleton"] DMA_I2S1 <= I2S1() (unstable)));
+        DMA_I2S0 <= I2S0(I2S0 : { bind_dma_interrupt, enable_dma_interrupt,
+        disable_dma_interrupt }) (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "DMA_I2S1 peripheral singleton"] DMA_I2S1 <= I2S1(I2S1 : {
+        bind_dma_interrupt, enable_dma_interrupt, disable_dma_interrupt }) (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc = "AES peripheral singleton"] AES
         <= AES() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "APB_CTRL peripheral singleton"] APB_CTRL <= APB_CTRL() (unstable)));
@@ -4108,17 +4126,21 @@ macro_rules! for_each_peripheral {
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc = "<li>This pin can only be used as an input.</li>"] #[doc
         = "</ul>"] #[doc = "</section>"] GPIO39 <= virtual()), (@ peri_type #[doc =
-        "DMA_SPI2 peripheral singleton"] DMA_SPI2 <= SPI2() (unstable)), (@ peri_type
-        #[doc = "DMA_SPI3 peripheral singleton"] DMA_SPI3 <= SPI3() (unstable)), (@
-        peri_type #[doc = "DMA_I2S0 peripheral singleton"] DMA_I2S0 <= I2S0()
-        (unstable)), (@ peri_type #[doc = "DMA_I2S1 peripheral singleton"] DMA_I2S1 <=
-        I2S1() (unstable)), (@ peri_type #[doc = "AES peripheral singleton"] AES <= AES()
-        (unstable)), (@ peri_type #[doc = "APB_CTRL peripheral singleton"] APB_CTRL <=
-        APB_CTRL() (unstable)), (@ peri_type #[doc = "BB peripheral singleton"] BB <=
-        BB() (unstable)), (@ peri_type #[doc = "DPORT peripheral singleton"] DPORT <=
-        DPORT() (unstable)), (@ peri_type #[doc = "SYSTEM peripheral singleton"] SYSTEM
-        <= DPORT() (unstable)), (@ peri_type #[doc = "EFUSE peripheral singleton"] EFUSE
-        <= EFUSE() (unstable)), (@ peri_type #[doc = "ETH peripheral singleton"] ETH <=
+        "DMA_SPI2 peripheral singleton"] DMA_SPI2 <= SPI2(SPI2_DMA : {
+        bind_dma_interrupt, enable_dma_interrupt, disable_dma_interrupt }) (unstable)),
+        (@ peri_type #[doc = "DMA_SPI3 peripheral singleton"] DMA_SPI3 <= SPI3(SPI3_DMA :
+        { bind_dma_interrupt, enable_dma_interrupt, disable_dma_interrupt }) (unstable)),
+        (@ peri_type #[doc = "DMA_I2S0 peripheral singleton"] DMA_I2S0 <= I2S0(I2S0 : {
+        bind_dma_interrupt, enable_dma_interrupt, disable_dma_interrupt }) (unstable)),
+        (@ peri_type #[doc = "DMA_I2S1 peripheral singleton"] DMA_I2S1 <= I2S1(I2S1 : {
+        bind_dma_interrupt, enable_dma_interrupt, disable_dma_interrupt }) (unstable)),
+        (@ peri_type #[doc = "AES peripheral singleton"] AES <= AES() (unstable)), (@
+        peri_type #[doc = "APB_CTRL peripheral singleton"] APB_CTRL <= APB_CTRL()
+        (unstable)), (@ peri_type #[doc = "BB peripheral singleton"] BB <= BB()
+        (unstable)), (@ peri_type #[doc = "DPORT peripheral singleton"] DPORT <= DPORT()
+        (unstable)), (@ peri_type #[doc = "SYSTEM peripheral singleton"] SYSTEM <=
+        DPORT() (unstable)), (@ peri_type #[doc = "EFUSE peripheral singleton"] EFUSE <=
+        EFUSE() (unstable)), (@ peri_type #[doc = "ETH peripheral singleton"] ETH <=
         virtual() (unstable)), (@ peri_type #[doc = "EMAC_DMA peripheral singleton"]
         EMAC_DMA <= EMAC_DMA() (unstable)), (@ peri_type #[doc =
         "EMAC_EXT peripheral singleton"] EMAC_EXT <= EMAC_EXT() (unstable)), (@ peri_type

--- a/esp-metadata-generated/src/_generated_esp32.rs
+++ b/esp-metadata-generated/src/_generated_esp32.rs
@@ -3759,6 +3759,12 @@ macro_rules! for_each_peripheral {
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc = "<li>This pin can only be used as an input.</li>"] #[doc
         = "</ul>"] #[doc = "</section>"] GPIO39 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_SPI2 peripheral singleton"]
+        DMA_SPI2 <= SPI2() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "DMA_SPI3 peripheral singleton"] DMA_SPI3 <= SPI3() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_I2S0 peripheral singleton"]
+        DMA_I2S0 <= I2S0() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "DMA_I2S1 peripheral singleton"] DMA_I2S1 <= I2S1() (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc = "AES peripheral singleton"] AES
         <= AES() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "APB_CTRL peripheral singleton"] APB_CTRL <= APB_CTRL() (unstable)));
@@ -3847,12 +3853,6 @@ macro_rules! for_each_peripheral {
         _for_each_inner_peripheral!((@ peri_type #[doc = "WIFI peripheral singleton"]
         WIFI <= WIFI(WIFI_MAC : { bind_mac_interrupt, enable_mac_interrupt,
         disable_mac_interrupt }))); _for_each_inner_peripheral!((@ peri_type #[doc =
-        "DMA_SPI2 peripheral singleton"] DMA_SPI2 <= SPI2() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_SPI3 peripheral singleton"]
-        DMA_SPI3 <= SPI3() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
-        "DMA_I2S0 peripheral singleton"] DMA_I2S0 <= I2S0() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_I2S1 peripheral singleton"]
-        DMA_I2S1 <= I2S1() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "ADC1 peripheral singleton"] ADC1 <= virtual() (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc = "ADC2 peripheral singleton"]
         ADC2 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
@@ -3888,6 +3888,10 @@ macro_rules! for_each_peripheral {
         _for_each_inner_peripheral!((GPIO34)); _for_each_inner_peripheral!((GPIO35));
         _for_each_inner_peripheral!((GPIO36)); _for_each_inner_peripheral!((GPIO37));
         _for_each_inner_peripheral!((GPIO38)); _for_each_inner_peripheral!((GPIO39));
+        _for_each_inner_peripheral!((DMA_SPI2(unstable)));
+        _for_each_inner_peripheral!((DMA_SPI3(unstable)));
+        _for_each_inner_peripheral!((DMA_I2S0(unstable)));
+        _for_each_inner_peripheral!((DMA_I2S1(unstable)));
         _for_each_inner_peripheral!((AES(unstable)));
         _for_each_inner_peripheral!((APB_CTRL(unstable)));
         _for_each_inner_peripheral!((BB(unstable)));
@@ -3930,10 +3934,6 @@ macro_rules! for_each_peripheral {
         _for_each_inner_peripheral!((UHCI0(unstable)));
         _for_each_inner_peripheral!((UHCI1(unstable)));
         _for_each_inner_peripheral!((WIFI));
-        _for_each_inner_peripheral!((DMA_SPI2(unstable)));
-        _for_each_inner_peripheral!((DMA_SPI3(unstable)));
-        _for_each_inner_peripheral!((DMA_I2S0(unstable)));
-        _for_each_inner_peripheral!((DMA_I2S1(unstable)));
         _for_each_inner_peripheral!((ADC1(unstable)));
         _for_each_inner_peripheral!((ADC2(unstable)));
         _for_each_inner_peripheral!((BT(unstable)));
@@ -4108,18 +4108,23 @@ macro_rules! for_each_peripheral {
         "This pin may be available with certain limitations. Check your hardware to make sure whether you can use it."]
         #[doc = "<ul>"] #[doc = "<li>This pin can only be used as an input.</li>"] #[doc
         = "</ul>"] #[doc = "</section>"] GPIO39 <= virtual()), (@ peri_type #[doc =
-        "AES peripheral singleton"] AES <= AES() (unstable)), (@ peri_type #[doc =
-        "APB_CTRL peripheral singleton"] APB_CTRL <= APB_CTRL() (unstable)), (@ peri_type
-        #[doc = "BB peripheral singleton"] BB <= BB() (unstable)), (@ peri_type #[doc =
-        "DPORT peripheral singleton"] DPORT <= DPORT() (unstable)), (@ peri_type #[doc =
-        "SYSTEM peripheral singleton"] SYSTEM <= DPORT() (unstable)), (@ peri_type #[doc
-        = "EFUSE peripheral singleton"] EFUSE <= EFUSE() (unstable)), (@ peri_type #[doc
-        = "ETH peripheral singleton"] ETH <= virtual() (unstable)), (@ peri_type #[doc =
-        "EMAC_DMA peripheral singleton"] EMAC_DMA <= EMAC_DMA() (unstable)), (@ peri_type
-        #[doc = "EMAC_EXT peripheral singleton"] EMAC_EXT <= EMAC_EXT() (unstable)), (@
-        peri_type #[doc = "EMAC_MAC peripheral singleton"] EMAC_MAC <= EMAC_MAC()
-        (unstable)), (@ peri_type #[doc = "FLASH_ENCRYPTION peripheral singleton"]
-        FLASH_ENCRYPTION <= FLASH_ENCRYPTION() (unstable)), (@ peri_type #[doc =
+        "DMA_SPI2 peripheral singleton"] DMA_SPI2 <= SPI2() (unstable)), (@ peri_type
+        #[doc = "DMA_SPI3 peripheral singleton"] DMA_SPI3 <= SPI3() (unstable)), (@
+        peri_type #[doc = "DMA_I2S0 peripheral singleton"] DMA_I2S0 <= I2S0()
+        (unstable)), (@ peri_type #[doc = "DMA_I2S1 peripheral singleton"] DMA_I2S1 <=
+        I2S1() (unstable)), (@ peri_type #[doc = "AES peripheral singleton"] AES <= AES()
+        (unstable)), (@ peri_type #[doc = "APB_CTRL peripheral singleton"] APB_CTRL <=
+        APB_CTRL() (unstable)), (@ peri_type #[doc = "BB peripheral singleton"] BB <=
+        BB() (unstable)), (@ peri_type #[doc = "DPORT peripheral singleton"] DPORT <=
+        DPORT() (unstable)), (@ peri_type #[doc = "SYSTEM peripheral singleton"] SYSTEM
+        <= DPORT() (unstable)), (@ peri_type #[doc = "EFUSE peripheral singleton"] EFUSE
+        <= EFUSE() (unstable)), (@ peri_type #[doc = "ETH peripheral singleton"] ETH <=
+        virtual() (unstable)), (@ peri_type #[doc = "EMAC_DMA peripheral singleton"]
+        EMAC_DMA <= EMAC_DMA() (unstable)), (@ peri_type #[doc =
+        "EMAC_EXT peripheral singleton"] EMAC_EXT <= EMAC_EXT() (unstable)), (@ peri_type
+        #[doc = "EMAC_MAC peripheral singleton"] EMAC_MAC <= EMAC_MAC() (unstable)), (@
+        peri_type #[doc = "FLASH_ENCRYPTION peripheral singleton"] FLASH_ENCRYPTION <=
+        FLASH_ENCRYPTION() (unstable)), (@ peri_type #[doc =
         "FRC_TIMER peripheral singleton"] FRC_TIMER <= FRC_TIMER() (unstable)), (@
         peri_type #[doc = "GPIO peripheral singleton"] GPIO <= GPIO() (unstable)), (@
         peri_type #[doc = "GPIO_SD peripheral singleton"] GPIO_SD <= GPIO_SD()
@@ -4172,30 +4177,27 @@ macro_rules! for_each_peripheral {
         peri_type #[doc = "UHCI1 peripheral singleton"] UHCI1 <= UHCI1() (unstable)), (@
         peri_type #[doc = "WIFI peripheral singleton"] WIFI <= WIFI(WIFI_MAC : {
         bind_mac_interrupt, enable_mac_interrupt, disable_mac_interrupt })), (@ peri_type
-        #[doc = "DMA_SPI2 peripheral singleton"] DMA_SPI2 <= SPI2() (unstable)), (@
-        peri_type #[doc = "DMA_SPI3 peripheral singleton"] DMA_SPI3 <= SPI3()
-        (unstable)), (@ peri_type #[doc = "DMA_I2S0 peripheral singleton"] DMA_I2S0 <=
-        I2S0() (unstable)), (@ peri_type #[doc = "DMA_I2S1 peripheral singleton"]
-        DMA_I2S1 <= I2S1() (unstable)), (@ peri_type #[doc = "ADC1 peripheral singleton"]
-        ADC1 <= virtual() (unstable)), (@ peri_type #[doc = "ADC2 peripheral singleton"]
-        ADC2 <= virtual() (unstable)), (@ peri_type #[doc = "BT peripheral singleton"] BT
-        <= virtual(BT_BB : { bind_bb_interrupt, enable_bb_interrupt, disable_bb_interrupt
-        }, RWBLE : { bind_rwble_interrupt, enable_rwble_interrupt,
-        disable_rwble_interrupt }, RWBT : { bind_rwbt_interrupt, enable_rwbt_interrupt,
-        disable_rwbt_interrupt }) (unstable)), (@ peri_type #[doc =
-        "CPU_CTRL peripheral singleton"] CPU_CTRL <= virtual() (unstable)), (@ peri_type
-        #[doc = "DAC1 peripheral singleton"] DAC1 <= virtual() (unstable)), (@ peri_type
-        #[doc = "DAC2 peripheral singleton"] DAC2 <= virtual() (unstable)), (@ peri_type
-        #[doc = "FLASH peripheral singleton"] FLASH <= virtual() (unstable)), (@
-        peri_type #[doc = "PSRAM peripheral singleton"] PSRAM <= virtual() (unstable)),
-        (@ peri_type #[doc = "SW_INTERRUPT peripheral singleton"] SW_INTERRUPT <=
-        virtual() (unstable)), (@ peri_type #[doc = "TOUCH peripheral singleton"] TOUCH
-        <= virtual() (unstable)))); _for_each_inner_peripheral!((singletons(GPIO0),
-        (GPIO1), (GPIO2), (GPIO3), (GPIO4), (GPIO5), (GPIO6), (GPIO7), (GPIO8), (GPIO9),
-        (GPIO10), (GPIO11), (GPIO12), (GPIO13), (GPIO14), (GPIO15), (GPIO16), (GPIO17),
-        (GPIO18), (GPIO19), (GPIO20), (GPIO21), (GPIO22), (GPIO23), (GPIO25), (GPIO26),
-        (GPIO27), (GPIO32), (GPIO33), (GPIO34), (GPIO35), (GPIO36), (GPIO37), (GPIO38),
-        (GPIO39), (AES(unstable)), (APB_CTRL(unstable)), (BB(unstable)),
+        #[doc = "ADC1 peripheral singleton"] ADC1 <= virtual() (unstable)), (@ peri_type
+        #[doc = "ADC2 peripheral singleton"] ADC2 <= virtual() (unstable)), (@ peri_type
+        #[doc = "BT peripheral singleton"] BT <= virtual(BT_BB : { bind_bb_interrupt,
+        enable_bb_interrupt, disable_bb_interrupt }, RWBLE : { bind_rwble_interrupt,
+        enable_rwble_interrupt, disable_rwble_interrupt }, RWBT : { bind_rwbt_interrupt,
+        enable_rwbt_interrupt, disable_rwbt_interrupt }) (unstable)), (@ peri_type #[doc
+        = "CPU_CTRL peripheral singleton"] CPU_CTRL <= virtual() (unstable)), (@
+        peri_type #[doc = "DAC1 peripheral singleton"] DAC1 <= virtual() (unstable)), (@
+        peri_type #[doc = "DAC2 peripheral singleton"] DAC2 <= virtual() (unstable)), (@
+        peri_type #[doc = "FLASH peripheral singleton"] FLASH <= virtual() (unstable)),
+        (@ peri_type #[doc = "PSRAM peripheral singleton"] PSRAM <= virtual()
+        (unstable)), (@ peri_type #[doc = "SW_INTERRUPT peripheral singleton"]
+        SW_INTERRUPT <= virtual() (unstable)), (@ peri_type #[doc =
+        "TOUCH peripheral singleton"] TOUCH <= virtual() (unstable))));
+        _for_each_inner_peripheral!((singletons(GPIO0), (GPIO1), (GPIO2), (GPIO3),
+        (GPIO4), (GPIO5), (GPIO6), (GPIO7), (GPIO8), (GPIO9), (GPIO10), (GPIO11),
+        (GPIO12), (GPIO13), (GPIO14), (GPIO15), (GPIO16), (GPIO17), (GPIO18), (GPIO19),
+        (GPIO20), (GPIO21), (GPIO22), (GPIO23), (GPIO25), (GPIO26), (GPIO27), (GPIO32),
+        (GPIO33), (GPIO34), (GPIO35), (GPIO36), (GPIO37), (GPIO38), (GPIO39),
+        (DMA_SPI2(unstable)), (DMA_SPI3(unstable)), (DMA_I2S0(unstable)),
+        (DMA_I2S1(unstable)), (AES(unstable)), (APB_CTRL(unstable)), (BB(unstable)),
         (DPORT(unstable)), (SYSTEM(unstable)), (ETH(unstable)),
         (FLASH_ENCRYPTION(unstable)), (FRC_TIMER(unstable)), (GPIO(unstable)),
         (GPIO_SD(unstable)), (HINF(unstable)), (I2C0), (I2C1), (I2S0(unstable)),
@@ -4205,13 +4207,12 @@ macro_rules! for_each_peripheral {
         (RTC_IO(unstable)), (SDHOST(unstable)), (SENS(unstable)), (SHA(unstable)),
         (SLC(unstable)), (SLCHOST(unstable)), (SPI0(unstable)), (SPI1(unstable)), (SPI2),
         (SPI3), (TIMG0(unstable)), (TIMG1(unstable)), (TWAI0(unstable)), (UART0),
-        (UART1), (UART2), (UHCI0(unstable)), (UHCI1(unstable)), (WIFI),
-        (DMA_SPI2(unstable)), (DMA_SPI3(unstable)), (DMA_I2S0(unstable)),
-        (DMA_I2S1(unstable)), (ADC1(unstable)), (ADC2(unstable)), (BT(unstable)),
-        (CPU_CTRL(unstable)), (DAC1(unstable)), (DAC2(unstable)), (FLASH(unstable)),
-        (PSRAM(unstable)), (SW_INTERRUPT(unstable)), (TOUCH(unstable))));
-        _for_each_inner_peripheral!((dma_eligible(I2S0, I2s0, 0), (I2S1, I2s1, 1), (SPI2,
-        Spi2, 2), (SPI3, Spi3, 3), (UHCI0, Uhci0, 4), (UHCI1, Uhci1, 5)));
+        (UART1), (UART2), (UHCI0(unstable)), (UHCI1(unstable)), (WIFI), (ADC1(unstable)),
+        (ADC2(unstable)), (BT(unstable)), (CPU_CTRL(unstable)), (DAC1(unstable)),
+        (DAC2(unstable)), (FLASH(unstable)), (PSRAM(unstable)), (SW_INTERRUPT(unstable)),
+        (TOUCH(unstable)))); _for_each_inner_peripheral!((dma_eligible(I2S0, I2s0, 0),
+        (I2S1, I2s1, 1), (SPI2, Spi2, 2), (SPI3, Spi3, 3), (UHCI0, Uhci0, 4), (UHCI1,
+        Uhci1, 5)));
     };
 }
 /// This macro can be used to generate code for each `GPIOn` instance.

--- a/esp-metadata-generated/src/_generated_esp32c2.rs
+++ b/esp-metadata-generated/src/_generated_esp32c2.rs
@@ -375,6 +375,16 @@ macro_rules! for_each_dedicated_gpio {
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_dma_channel {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner_dma_channel { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_dma_channel!((DMA_CH0, 0, interrupt = DMA_CH0));
+        _for_each_inner_dma_channel!((shared(DMA_CH0, 0, interrupt = DMA_CH0)));
+        _for_each_inner_dma_channel!((split));
+    };
+}
+#[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_ecc_working_mode {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_ecc_working_mode { $(($pattern) => $code;)* ($other
@@ -3217,8 +3227,9 @@ macro_rules! for_each_peripheral {
         "<li>By default, this pin is used by the UART programming interface.</li>"] #[doc
         = "</ul>"] #[doc = "</section>"] GPIO20 <= virtual()));
         _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH0 peripheral singleton"]
-        DMA_CH0 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
-        = "APB_CTRL peripheral singleton"] APB_CTRL <= APB_CTRL() (unstable)));
+        DMA_CH0 <= virtual(DMA_CH0 : { bind_dma_interrupt, enable_dma_interrupt,
+        disable_dma_interrupt }) (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "APB_CTRL peripheral singleton"] APB_CTRL <= APB_CTRL() (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc =
         "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC() (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc = "BB peripheral singleton"] BB <=
@@ -3421,11 +3432,12 @@ macro_rules! for_each_peripheral {
         #[doc = "<ul>"] #[doc =
         "<li>By default, this pin is used by the UART programming interface.</li>"] #[doc
         = "</ul>"] #[doc = "</section>"] GPIO20 <= virtual()), (@ peri_type #[doc =
-        "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual() (unstable)), (@ peri_type
-        #[doc = "APB_CTRL peripheral singleton"] APB_CTRL <= APB_CTRL() (unstable)), (@
-        peri_type #[doc = "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC()
-        (unstable)), (@ peri_type #[doc = "BB peripheral singleton"] BB <= BB()
-        (unstable)), (@ peri_type #[doc = "ASSIST_DEBUG peripheral singleton"]
+        "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual(DMA_CH0 : {
+        bind_dma_interrupt, enable_dma_interrupt, disable_dma_interrupt }) (unstable)),
+        (@ peri_type #[doc = "APB_CTRL peripheral singleton"] APB_CTRL <= APB_CTRL()
+        (unstable)), (@ peri_type #[doc = "APB_SARADC peripheral singleton"] APB_SARADC
+        <= APB_SARADC() (unstable)), (@ peri_type #[doc = "BB peripheral singleton"] BB
+        <= BB() (unstable)), (@ peri_type #[doc = "ASSIST_DEBUG peripheral singleton"]
         ASSIST_DEBUG <= ASSIST_DEBUG() (unstable)), (@ peri_type #[doc =
         "DMA peripheral singleton"] DMA <= DMA() (unstable)), (@ peri_type #[doc =
         "ECC peripheral singleton"] ECC <= ECC() (unstable)), (@ peri_type #[doc =

--- a/esp-metadata-generated/src/_generated_esp32c2.rs
+++ b/esp-metadata-generated/src/_generated_esp32c2.rs
@@ -3216,12 +3216,13 @@ macro_rules! for_each_peripheral {
         #[doc = "<ul>"] #[doc =
         "<li>By default, this pin is used by the UART programming interface.</li>"] #[doc
         = "</ul>"] #[doc = "</section>"] GPIO20 <= virtual()));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "APB_CTRL peripheral singleton"]
-        APB_CTRL <= APB_CTRL() (unstable))); _for_each_inner_peripheral!((@ peri_type
-        #[doc = "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC()
-        (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
-        "BB peripheral singleton"] BB <= BB() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH0 peripheral singleton"]
+        DMA_CH0 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "APB_CTRL peripheral singleton"] APB_CTRL <= APB_CTRL() (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc =
+        "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "BB peripheral singleton"] BB <=
+        BB() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "ASSIST_DEBUG peripheral singleton"] ASSIST_DEBUG <= ASSIST_DEBUG() (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc = "DMA peripheral singleton"] DMA
         <= DMA() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
@@ -3265,13 +3266,11 @@ macro_rules! for_each_peripheral {
         UART1 <= UART1(UART1 : { bind_peri_interrupt, enable_peri_interrupt,
         disable_peri_interrupt }))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "XTS_AES peripheral singleton"] XTS_AES <= XTS_AES() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH0 peripheral singleton"]
-        DMA_CH0 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
-        = "ADC1 peripheral singleton"] ADC1 <= virtual() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "BT peripheral singleton"] BT <=
-        virtual(LP_TIMER : { bind_lp_timer_interrupt, enable_lp_timer_interrupt,
-        disable_lp_timer_interrupt }, BT_MAC : { bind_mac_interrupt,
-        enable_mac_interrupt, disable_mac_interrupt }) (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "ADC1 peripheral singleton"]
+        ADC1 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "BT peripheral singleton"] BT <= virtual(LP_TIMER : { bind_lp_timer_interrupt,
+        enable_lp_timer_interrupt, disable_lp_timer_interrupt }, BT_MAC : {
+        bind_mac_interrupt, enable_mac_interrupt, disable_mac_interrupt }) (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc = "FLASH peripheral singleton"]
         FLASH <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "GPIO_DEDICATED peripheral singleton"] GPIO_DEDICATED <= virtual() (unstable)));
@@ -3291,6 +3290,7 @@ macro_rules! for_each_peripheral {
         _for_each_inner_peripheral!((GPIO15)); _for_each_inner_peripheral!((GPIO16));
         _for_each_inner_peripheral!((GPIO17)); _for_each_inner_peripheral!((GPIO18));
         _for_each_inner_peripheral!((GPIO19)); _for_each_inner_peripheral!((GPIO20));
+        _for_each_inner_peripheral!((DMA_CH0(unstable)));
         _for_each_inner_peripheral!((APB_CTRL(unstable)));
         _for_each_inner_peripheral!((APB_SARADC(unstable)));
         _for_each_inner_peripheral!((BB(unstable)));
@@ -3317,7 +3317,6 @@ macro_rules! for_each_peripheral {
         _for_each_inner_peripheral!((TIMG0(unstable)));
         _for_each_inner_peripheral!((UART0)); _for_each_inner_peripheral!((UART1));
         _for_each_inner_peripheral!((XTS_AES(unstable)));
-        _for_each_inner_peripheral!((DMA_CH0(unstable)));
         _for_each_inner_peripheral!((ADC1(unstable)));
         _for_each_inner_peripheral!((BT(unstable)));
         _for_each_inner_peripheral!((FLASH(unstable)));
@@ -3422,8 +3421,9 @@ macro_rules! for_each_peripheral {
         #[doc = "<ul>"] #[doc =
         "<li>By default, this pin is used by the UART programming interface.</li>"] #[doc
         = "</ul>"] #[doc = "</section>"] GPIO20 <= virtual()), (@ peri_type #[doc =
-        "APB_CTRL peripheral singleton"] APB_CTRL <= APB_CTRL() (unstable)), (@ peri_type
-        #[doc = "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC()
+        "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual() (unstable)), (@ peri_type
+        #[doc = "APB_CTRL peripheral singleton"] APB_CTRL <= APB_CTRL() (unstable)), (@
+        peri_type #[doc = "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC()
         (unstable)), (@ peri_type #[doc = "BB peripheral singleton"] BB <= BB()
         (unstable)), (@ peri_type #[doc = "ASSIST_DEBUG peripheral singleton"]
         ASSIST_DEBUG <= ASSIST_DEBUG() (unstable)), (@ peri_type #[doc =
@@ -3458,32 +3458,31 @@ macro_rules! for_each_peripheral {
         UART1 <= UART1(UART1 : { bind_peri_interrupt, enable_peri_interrupt,
         disable_peri_interrupt })), (@ peri_type #[doc = "XTS_AES peripheral singleton"]
         XTS_AES <= XTS_AES() (unstable)), (@ peri_type #[doc =
-        "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual() (unstable)), (@ peri_type
-        #[doc = "ADC1 peripheral singleton"] ADC1 <= virtual() (unstable)), (@ peri_type
-        #[doc = "BT peripheral singleton"] BT <= virtual(LP_TIMER : {
-        bind_lp_timer_interrupt, enable_lp_timer_interrupt, disable_lp_timer_interrupt },
-        BT_MAC : { bind_mac_interrupt, enable_mac_interrupt, disable_mac_interrupt })
-        (unstable)), (@ peri_type #[doc = "FLASH peripheral singleton"] FLASH <=
-        virtual() (unstable)), (@ peri_type #[doc =
-        "GPIO_DEDICATED peripheral singleton"] GPIO_DEDICATED <= virtual() (unstable)),
-        (@ peri_type #[doc = "SW_INTERRUPT peripheral singleton"] SW_INTERRUPT <=
-        virtual() (unstable)), (@ peri_type #[doc = "WIFI peripheral singleton"] WIFI <=
-        virtual(WIFI_MAC : { bind_mac_interrupt, enable_mac_interrupt,
-        disable_mac_interrupt }, WIFI_PWR : { bind_pwr_interrupt, enable_pwr_interrupt,
-        disable_pwr_interrupt })))); _for_each_inner_peripheral!((singletons(GPIO0),
-        (GPIO1), (GPIO2), (GPIO3), (GPIO4), (GPIO5), (GPIO6), (GPIO7), (GPIO8), (GPIO9),
-        (GPIO10), (GPIO11), (GPIO12), (GPIO13), (GPIO14), (GPIO15), (GPIO16), (GPIO17),
-        (GPIO18), (GPIO19), (GPIO20), (APB_CTRL(unstable)), (APB_SARADC(unstable)),
+        "ADC1 peripheral singleton"] ADC1 <= virtual() (unstable)), (@ peri_type #[doc =
+        "BT peripheral singleton"] BT <= virtual(LP_TIMER : { bind_lp_timer_interrupt,
+        enable_lp_timer_interrupt, disable_lp_timer_interrupt }, BT_MAC : {
+        bind_mac_interrupt, enable_mac_interrupt, disable_mac_interrupt }) (unstable)),
+        (@ peri_type #[doc = "FLASH peripheral singleton"] FLASH <= virtual()
+        (unstable)), (@ peri_type #[doc = "GPIO_DEDICATED peripheral singleton"]
+        GPIO_DEDICATED <= virtual() (unstable)), (@ peri_type #[doc =
+        "SW_INTERRUPT peripheral singleton"] SW_INTERRUPT <= virtual() (unstable)), (@
+        peri_type #[doc = "WIFI peripheral singleton"] WIFI <= virtual(WIFI_MAC : {
+        bind_mac_interrupt, enable_mac_interrupt, disable_mac_interrupt }, WIFI_PWR : {
+        bind_pwr_interrupt, enable_pwr_interrupt, disable_pwr_interrupt }))));
+        _for_each_inner_peripheral!((singletons(GPIO0), (GPIO1), (GPIO2), (GPIO3),
+        (GPIO4), (GPIO5), (GPIO6), (GPIO7), (GPIO8), (GPIO9), (GPIO10), (GPIO11),
+        (GPIO12), (GPIO13), (GPIO14), (GPIO15), (GPIO16), (GPIO17), (GPIO18), (GPIO19),
+        (GPIO20), (DMA_CH0(unstable)), (APB_CTRL(unstable)), (APB_SARADC(unstable)),
         (BB(unstable)), (ASSIST_DEBUG(unstable)), (DMA(unstable)), (ECC(unstable)),
         (EXTMEM(unstable)), (GPIO(unstable)), (I2C_ANA_MST(unstable)), (I2C0),
         (INTERRUPT_CORE0(unstable)), (IO_MUX(unstable)), (LEDC(unstable)),
         (RNG(unstable)), (LPWR(unstable)), (MODEM_CLKRST(unstable)),
         (SENSITIVE(unstable)), (SHA(unstable)), (SPI0(unstable)), (SPI1(unstable)),
         (SPI2), (SYSTEM(unstable)), (SYSTIMER(unstable)), (TIMG0(unstable)), (UART0),
-        (UART1), (XTS_AES(unstable)), (DMA_CH0(unstable)), (ADC1(unstable)),
-        (BT(unstable)), (FLASH(unstable)), (GPIO_DEDICATED(unstable)),
-        (SW_INTERRUPT(unstable)), (WIFI)));
-        _for_each_inner_peripheral!((dma_eligible(SPI2, Spi2, 0), (SHA, Sha, 7)));
+        (UART1), (XTS_AES(unstable)), (ADC1(unstable)), (BT(unstable)),
+        (FLASH(unstable)), (GPIO_DEDICATED(unstable)), (SW_INTERRUPT(unstable)),
+        (WIFI))); _for_each_inner_peripheral!((dma_eligible(SPI2, Spi2, 0), (SHA, Sha,
+        7)));
     };
 }
 /// This macro can be used to generate code for each `GPIOn` instance.

--- a/esp-metadata-generated/src/_generated_esp32c3.rs
+++ b/esp-metadata-generated/src/_generated_esp32c3.rs
@@ -3647,13 +3647,17 @@ macro_rules! for_each_peripheral {
         #[doc = "<ul>"] #[doc =
         "<li>By default, this pin is used by the UART programming interface.</li>"] #[doc
         = "</ul>"] #[doc = "</section>"] GPIO21 <= virtual()));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "AES peripheral singleton"] AES
-        <= AES(AES : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt
-        }) (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
-        "APB_CTRL peripheral singleton"] APB_CTRL <= APB_CTRL() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc =
-        "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH0 peripheral singleton"]
+        DMA_CH0 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH2 peripheral singleton"]
+        DMA_CH2 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "AES peripheral singleton"] AES <= AES(AES : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt }) (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "APB_CTRL peripheral singleton"]
+        APB_CTRL <= APB_CTRL() (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC()
+        (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "ASSIST_DEBUG peripheral singleton"] ASSIST_DEBUG <= ASSIST_DEBUG() (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc = "BB peripheral singleton"] BB <=
         BB() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
@@ -3720,20 +3724,16 @@ macro_rules! for_each_peripheral {
         bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
         (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "XTS_AES peripheral singleton"] XTS_AES <= XTS_AES() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH0 peripheral singleton"]
-        DMA_CH0 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
-        = "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH2 peripheral singleton"]
-        DMA_CH2 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
-        = "ADC1 peripheral singleton"] ADC1 <= virtual() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "ADC2 peripheral singleton"]
-        ADC2 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
-        "BT peripheral singleton"] BT <= virtual(BT_BB : { bind_bb_interrupt,
-        enable_bb_interrupt, disable_bb_interrupt }, RWBLE : { bind_rwble_interrupt,
-        enable_rwble_interrupt, disable_rwble_interrupt }, RWBT : { bind_rwbt_interrupt,
-        enable_rwbt_interrupt, disable_rwbt_interrupt }) (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "FLASH peripheral singleton"]
-        FLASH <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "ADC1 peripheral singleton"]
+        ADC1 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "ADC2 peripheral singleton"] ADC2 <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "BT peripheral singleton"] BT <=
+        virtual(BT_BB : { bind_bb_interrupt, enable_bb_interrupt, disable_bb_interrupt },
+        RWBLE : { bind_rwble_interrupt, enable_rwble_interrupt, disable_rwble_interrupt
+        }, RWBT : { bind_rwbt_interrupt, enable_rwbt_interrupt, disable_rwbt_interrupt })
+        (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "FLASH peripheral singleton"] FLASH <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
         "GPIO_DEDICATED peripheral singleton"] GPIO_DEDICATED <= virtual() (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc =
         "SW_INTERRUPT peripheral singleton"] SW_INTERRUPT <= virtual() (unstable)));
@@ -3753,6 +3753,9 @@ macro_rules! for_each_peripheral {
         _for_each_inner_peripheral!((GPIO16)); _for_each_inner_peripheral!((GPIO17));
         _for_each_inner_peripheral!((GPIO18)); _for_each_inner_peripheral!((GPIO19));
         _for_each_inner_peripheral!((GPIO20)); _for_each_inner_peripheral!((GPIO21));
+        _for_each_inner_peripheral!((DMA_CH0(unstable)));
+        _for_each_inner_peripheral!((DMA_CH1(unstable)));
+        _for_each_inner_peripheral!((DMA_CH2(unstable)));
         _for_each_inner_peripheral!((AES(unstable)));
         _for_each_inner_peripheral!((APB_CTRL(unstable)));
         _for_each_inner_peripheral!((APB_SARADC(unstable)));
@@ -3791,9 +3794,6 @@ macro_rules! for_each_peripheral {
         _for_each_inner_peripheral!((UHCI0(unstable)));
         _for_each_inner_peripheral!((USB_DEVICE(unstable)));
         _for_each_inner_peripheral!((XTS_AES(unstable)));
-        _for_each_inner_peripheral!((DMA_CH0(unstable)));
-        _for_each_inner_peripheral!((DMA_CH1(unstable)));
-        _for_each_inner_peripheral!((DMA_CH2(unstable)));
         _for_each_inner_peripheral!((ADC1(unstable)));
         _for_each_inner_peripheral!((ADC2(unstable)));
         _for_each_inner_peripheral!((BT(unstable)));
@@ -3919,20 +3919,23 @@ macro_rules! for_each_peripheral {
         #[doc = "<ul>"] #[doc =
         "<li>By default, this pin is used by the UART programming interface.</li>"] #[doc
         = "</ul>"] #[doc = "</section>"] GPIO21 <= virtual()), (@ peri_type #[doc =
-        "AES peripheral singleton"] AES <= AES(AES : { bind_peri_interrupt,
-        enable_peri_interrupt, disable_peri_interrupt }) (unstable)), (@ peri_type #[doc
-        = "APB_CTRL peripheral singleton"] APB_CTRL <= APB_CTRL() (unstable)), (@
-        peri_type #[doc = "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC()
-        (unstable)), (@ peri_type #[doc = "ASSIST_DEBUG peripheral singleton"]
-        ASSIST_DEBUG <= ASSIST_DEBUG() (unstable)), (@ peri_type #[doc =
-        "BB peripheral singleton"] BB <= BB() (unstable)), (@ peri_type #[doc =
-        "DMA peripheral singleton"] DMA <= DMA() (unstable)), (@ peri_type #[doc =
-        "DS peripheral singleton"] DS <= DS() (unstable)), (@ peri_type #[doc =
-        "EFUSE peripheral singleton"] EFUSE <= EFUSE() (unstable)), (@ peri_type #[doc =
-        "EXTMEM peripheral singleton"] EXTMEM <= EXTMEM() (unstable)), (@ peri_type #[doc
-        = "FE peripheral singleton"] FE <= FE() (unstable)), (@ peri_type #[doc =
-        "FE2 peripheral singleton"] FE2 <= FE2() (unstable)), (@ peri_type #[doc =
-        "GPIO peripheral singleton"] GPIO <= GPIO() (unstable)), (@ peri_type #[doc =
+        "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual() (unstable)), (@ peri_type
+        #[doc = "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual() (unstable)), (@
+        peri_type #[doc = "DMA_CH2 peripheral singleton"] DMA_CH2 <= virtual()
+        (unstable)), (@ peri_type #[doc = "AES peripheral singleton"] AES <= AES(AES : {
+        bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
+        (unstable)), (@ peri_type #[doc = "APB_CTRL peripheral singleton"] APB_CTRL <=
+        APB_CTRL() (unstable)), (@ peri_type #[doc = "APB_SARADC peripheral singleton"]
+        APB_SARADC <= APB_SARADC() (unstable)), (@ peri_type #[doc =
+        "ASSIST_DEBUG peripheral singleton"] ASSIST_DEBUG <= ASSIST_DEBUG() (unstable)),
+        (@ peri_type #[doc = "BB peripheral singleton"] BB <= BB() (unstable)), (@
+        peri_type #[doc = "DMA peripheral singleton"] DMA <= DMA() (unstable)), (@
+        peri_type #[doc = "DS peripheral singleton"] DS <= DS() (unstable)), (@ peri_type
+        #[doc = "EFUSE peripheral singleton"] EFUSE <= EFUSE() (unstable)), (@ peri_type
+        #[doc = "EXTMEM peripheral singleton"] EXTMEM <= EXTMEM() (unstable)), (@
+        peri_type #[doc = "FE peripheral singleton"] FE <= FE() (unstable)), (@ peri_type
+        #[doc = "FE2 peripheral singleton"] FE2 <= FE2() (unstable)), (@ peri_type #[doc
+        = "GPIO peripheral singleton"] GPIO <= GPIO() (unstable)), (@ peri_type #[doc =
         "GPIO_SD peripheral singleton"] GPIO_SD <= GPIO_SD() (unstable)), (@ peri_type
         #[doc = "HMAC peripheral singleton"] HMAC <= HMAC() (unstable)), (@ peri_type
         #[doc = "I2C_ANA_MST peripheral singleton"] I2C_ANA_MST <= I2C_ANA_MST()
@@ -3971,16 +3974,12 @@ macro_rules! for_each_peripheral {
         "USB_DEVICE peripheral singleton"] USB_DEVICE <= USB_DEVICE(USB_DEVICE : {
         bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
         (unstable)), (@ peri_type #[doc = "XTS_AES peripheral singleton"] XTS_AES <=
-        XTS_AES() (unstable)), (@ peri_type #[doc = "DMA_CH0 peripheral singleton"]
-        DMA_CH0 <= virtual() (unstable)), (@ peri_type #[doc =
-        "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual() (unstable)), (@ peri_type
-        #[doc = "DMA_CH2 peripheral singleton"] DMA_CH2 <= virtual() (unstable)), (@
-        peri_type #[doc = "ADC1 peripheral singleton"] ADC1 <= virtual() (unstable)), (@
-        peri_type #[doc = "ADC2 peripheral singleton"] ADC2 <= virtual() (unstable)), (@
-        peri_type #[doc = "BT peripheral singleton"] BT <= virtual(BT_BB : {
-        bind_bb_interrupt, enable_bb_interrupt, disable_bb_interrupt }, RWBLE : {
-        bind_rwble_interrupt, enable_rwble_interrupt, disable_rwble_interrupt }, RWBT : {
-        bind_rwbt_interrupt, enable_rwbt_interrupt, disable_rwbt_interrupt })
+        XTS_AES() (unstable)), (@ peri_type #[doc = "ADC1 peripheral singleton"] ADC1 <=
+        virtual() (unstable)), (@ peri_type #[doc = "ADC2 peripheral singleton"] ADC2 <=
+        virtual() (unstable)), (@ peri_type #[doc = "BT peripheral singleton"] BT <=
+        virtual(BT_BB : { bind_bb_interrupt, enable_bb_interrupt, disable_bb_interrupt },
+        RWBLE : { bind_rwble_interrupt, enable_rwble_interrupt, disable_rwble_interrupt
+        }, RWBT : { bind_rwbt_interrupt, enable_rwbt_interrupt, disable_rwbt_interrupt })
         (unstable)), (@ peri_type #[doc = "FLASH peripheral singleton"] FLASH <=
         virtual() (unstable)), (@ peri_type #[doc =
         "GPIO_DEDICATED peripheral singleton"] GPIO_DEDICATED <= virtual() (unstable)),
@@ -3992,7 +3991,8 @@ macro_rules! for_each_peripheral {
         disable_pwr_interrupt })))); _for_each_inner_peripheral!((singletons(GPIO0),
         (GPIO1), (GPIO2), (GPIO3), (GPIO4), (GPIO5), (GPIO6), (GPIO7), (GPIO8), (GPIO9),
         (GPIO10), (GPIO11), (GPIO12), (GPIO13), (GPIO14), (GPIO15), (GPIO16), (GPIO17),
-        (GPIO18), (GPIO19), (GPIO20), (GPIO21), (AES(unstable)), (APB_CTRL(unstable)),
+        (GPIO18), (GPIO19), (GPIO20), (GPIO21), (DMA_CH0(unstable)), (DMA_CH1(unstable)),
+        (DMA_CH2(unstable)), (AES(unstable)), (APB_CTRL(unstable)),
         (APB_SARADC(unstable)), (ASSIST_DEBUG(unstable)), (BB(unstable)),
         (DMA(unstable)), (DS(unstable)), (EXTMEM(unstable)), (FE(unstable)),
         (FE2(unstable)), (GPIO(unstable)), (GPIO_SD(unstable)), (HMAC(unstable)),
@@ -4002,11 +4002,11 @@ macro_rules! for_each_peripheral {
         (SHA(unstable)), (SPI0(unstable)), (SPI1(unstable)), (SPI2), (SYSTEM(unstable)),
         (SYSTIMER(unstable)), (TIMG0(unstable)), (TIMG1(unstable)), (TWAI0(unstable)),
         (UART0), (UART1), (UHCI0(unstable)), (USB_DEVICE(unstable)), (XTS_AES(unstable)),
-        (DMA_CH0(unstable)), (DMA_CH1(unstable)), (DMA_CH2(unstable)), (ADC1(unstable)),
-        (ADC2(unstable)), (BT(unstable)), (FLASH(unstable)), (GPIO_DEDICATED(unstable)),
-        (SW_INTERRUPT(unstable)), (TSENS(unstable)), (WIFI)));
-        _for_each_inner_peripheral!((dma_eligible(SPI2, Spi2, 0), (UHCI0, Uhci0, 2),
-        (I2S0, I2s0, 3), (AES, Aes, 6), (SHA, Sha, 7), (APB_SARADC, ApbSaradc, 8)));
+        (ADC1(unstable)), (ADC2(unstable)), (BT(unstable)), (FLASH(unstable)),
+        (GPIO_DEDICATED(unstable)), (SW_INTERRUPT(unstable)), (TSENS(unstable)),
+        (WIFI))); _for_each_inner_peripheral!((dma_eligible(SPI2, Spi2, 0), (UHCI0,
+        Uhci0, 2), (I2S0, I2s0, 3), (AES, Aes, 6), (SHA, Sha, 7), (APB_SARADC, ApbSaradc,
+        8)));
     };
 }
 /// This macro can be used to generate code for each `GPIOn` instance.

--- a/esp-metadata-generated/src/_generated_esp32c3.rs
+++ b/esp-metadata-generated/src/_generated_esp32c3.rs
@@ -474,6 +474,19 @@ macro_rules! for_each_dedicated_gpio {
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_dma_channel {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner_dma_channel { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_dma_channel!((DMA_CH0, 0, interrupt = DMA_CH0));
+        _for_each_inner_dma_channel!((DMA_CH1, 1, interrupt = DMA_CH1));
+        _for_each_inner_dma_channel!((DMA_CH2, 2, interrupt = DMA_CH2));
+        _for_each_inner_dma_channel!((shared(DMA_CH0, 0, interrupt = DMA_CH0), (DMA_CH1,
+        1, interrupt = DMA_CH1), (DMA_CH2, 2, interrupt = DMA_CH2)));
+        _for_each_inner_dma_channel!((split));
+    };
+}
+#[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_interrupt {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_interrupt { $(($pattern) => $code;)* ($other : tt)
@@ -3648,11 +3661,14 @@ macro_rules! for_each_peripheral {
         "<li>By default, this pin is used by the UART programming interface.</li>"] #[doc
         = "</ul>"] #[doc = "</section>"] GPIO21 <= virtual()));
         _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH0 peripheral singleton"]
-        DMA_CH0 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
-        = "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual() (unstable)));
+        DMA_CH0 <= virtual(DMA_CH0 : { bind_dma_interrupt, enable_dma_interrupt,
+        disable_dma_interrupt }) (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual(DMA_CH1 : {
+        bind_dma_interrupt, enable_dma_interrupt, disable_dma_interrupt }) (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH2 peripheral singleton"]
-        DMA_CH2 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
-        = "AES peripheral singleton"] AES <= AES(AES : { bind_peri_interrupt,
+        DMA_CH2 <= virtual(DMA_CH2 : { bind_dma_interrupt, enable_dma_interrupt,
+        disable_dma_interrupt }) (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "AES peripheral singleton"] AES <= AES(AES : { bind_peri_interrupt,
         enable_peri_interrupt, disable_peri_interrupt }) (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc = "APB_CTRL peripheral singleton"]
         APB_CTRL <= APB_CTRL() (unstable))); _for_each_inner_peripheral!((@ peri_type
@@ -3919,10 +3935,13 @@ macro_rules! for_each_peripheral {
         #[doc = "<ul>"] #[doc =
         "<li>By default, this pin is used by the UART programming interface.</li>"] #[doc
         = "</ul>"] #[doc = "</section>"] GPIO21 <= virtual()), (@ peri_type #[doc =
-        "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual() (unstable)), (@ peri_type
-        #[doc = "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual() (unstable)), (@
-        peri_type #[doc = "DMA_CH2 peripheral singleton"] DMA_CH2 <= virtual()
-        (unstable)), (@ peri_type #[doc = "AES peripheral singleton"] AES <= AES(AES : {
+        "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual(DMA_CH0 : {
+        bind_dma_interrupt, enable_dma_interrupt, disable_dma_interrupt }) (unstable)),
+        (@ peri_type #[doc = "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual(DMA_CH1 :
+        { bind_dma_interrupt, enable_dma_interrupt, disable_dma_interrupt }) (unstable)),
+        (@ peri_type #[doc = "DMA_CH2 peripheral singleton"] DMA_CH2 <= virtual(DMA_CH2 :
+        { bind_dma_interrupt, enable_dma_interrupt, disable_dma_interrupt }) (unstable)),
+        (@ peri_type #[doc = "AES peripheral singleton"] AES <= AES(AES : {
         bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
         (unstable)), (@ peri_type #[doc = "APB_CTRL peripheral singleton"] APB_CTRL <=
         APB_CTRL() (unstable)), (@ peri_type #[doc = "APB_SARADC peripheral singleton"]

--- a/esp-metadata-generated/src/_generated_esp32c5.rs
+++ b/esp-metadata-generated/src/_generated_esp32c5.rs
@@ -3826,9 +3826,14 @@ macro_rules! for_each_peripheral {
         #[doc = "<ul>"] #[doc =
         "<li>This pin is a strapping pin, it determines how the chip boots.</li>"] #[doc
         = "</ul>"] #[doc = "</section>"] GPIO28 <= virtual()));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "AES peripheral singleton"] AES
-        <= AES(AES : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt
-        }) (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH0 peripheral singleton"]
+        DMA_CH0 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH2 peripheral singleton"]
+        DMA_CH2 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "AES peripheral singleton"] AES <= AES(AES : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt }) (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
         "ASSIST_DEBUG peripheral singleton"] ASSIST_DEBUG <= ASSIST_DEBUG() (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc =
         "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC() (unstable)));
@@ -3940,15 +3945,11 @@ macro_rules! for_each_peripheral {
         "USB_DEVICE peripheral singleton"] USB_DEVICE <= USB_DEVICE(USB_DEVICE : {
         bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
         (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
-        "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH1 peripheral singleton"]
-        DMA_CH1 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
-        = "DMA_CH2 peripheral singleton"] DMA_CH2 <= virtual() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "ADC1 peripheral singleton"]
-        ADC1 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
-        "BT peripheral singleton"] BT <= virtual(LP_TIMER : { bind_lp_timer_interrupt,
-        enable_lp_timer_interrupt, disable_lp_timer_interrupt }, BT_MAC : {
-        bind_mac_interrupt, enable_mac_interrupt, disable_mac_interrupt }) (unstable)));
+        "ADC1 peripheral singleton"] ADC1 <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "BT peripheral singleton"] BT <=
+        virtual(LP_TIMER : { bind_lp_timer_interrupt, enable_lp_timer_interrupt,
+        disable_lp_timer_interrupt }, BT_MAC : { bind_mac_interrupt,
+        enable_mac_interrupt, disable_mac_interrupt }) (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc = "FLASH peripheral singleton"]
         FLASH <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "GPIO_DEDICATED peripheral singleton"] GPIO_DEDICATED <= virtual() (unstable)));
@@ -3989,6 +3990,9 @@ macro_rules! for_each_peripheral {
         _for_each_inner_peripheral!((GPIO23)); _for_each_inner_peripheral!((GPIO24));
         _for_each_inner_peripheral!((GPIO25)); _for_each_inner_peripheral!((GPIO26));
         _for_each_inner_peripheral!((GPIO27)); _for_each_inner_peripheral!((GPIO28));
+        _for_each_inner_peripheral!((DMA_CH0(unstable)));
+        _for_each_inner_peripheral!((DMA_CH1(unstable)));
+        _for_each_inner_peripheral!((DMA_CH2(unstable)));
         _for_each_inner_peripheral!((AES(unstable)));
         _for_each_inner_peripheral!((ASSIST_DEBUG(unstable)));
         _for_each_inner_peripheral!((APB_SARADC(unstable)));
@@ -4051,9 +4055,6 @@ macro_rules! for_each_peripheral {
         _for_each_inner_peripheral!((UART0)); _for_each_inner_peripheral!((UART1));
         _for_each_inner_peripheral!((UHCI0(unstable)));
         _for_each_inner_peripheral!((USB_DEVICE(unstable)));
-        _for_each_inner_peripheral!((DMA_CH0(unstable)));
-        _for_each_inner_peripheral!((DMA_CH1(unstable)));
-        _for_each_inner_peripheral!((DMA_CH2(unstable)));
         _for_each_inner_peripheral!((ADC1(unstable)));
         _for_each_inner_peripheral!((BT(unstable)));
         _for_each_inner_peripheral!((FLASH(unstable)));
@@ -4230,31 +4231,35 @@ macro_rules! for_each_peripheral {
         #[doc = "<ul>"] #[doc =
         "<li>This pin is a strapping pin, it determines how the chip boots.</li>"] #[doc
         = "</ul>"] #[doc = "</section>"] GPIO28 <= virtual()), (@ peri_type #[doc =
-        "AES peripheral singleton"] AES <= AES(AES : { bind_peri_interrupt,
-        enable_peri_interrupt, disable_peri_interrupt }) (unstable)), (@ peri_type #[doc
-        = "ASSIST_DEBUG peripheral singleton"] ASSIST_DEBUG <= ASSIST_DEBUG()
-        (unstable)), (@ peri_type #[doc = "APB_SARADC peripheral singleton"] APB_SARADC
-        <= APB_SARADC() (unstable)), (@ peri_type #[doc = "CACHE peripheral singleton"]
-        CACHE <= CACHE() (unstable)), (@ peri_type #[doc = "CLINT peripheral singleton"]
-        CLINT <= CLINT() (unstable)), (@ peri_type #[doc = "DMA peripheral singleton"]
-        DMA <= DMA() (unstable)), (@ peri_type #[doc = "DS peripheral singleton"] DS <=
-        DS() (unstable)), (@ peri_type #[doc = "ECC peripheral singleton"] ECC <= ECC()
-        (unstable)), (@ peri_type #[doc = "ECDSA peripheral singleton"] ECDSA <= ECDSA()
-        (unstable)), (@ peri_type #[doc = "EFUSE peripheral singleton"] EFUSE <= EFUSE()
-        (unstable)), (@ peri_type #[doc = "ETM peripheral singleton"] ETM <= SOC_ETM()
-        (unstable)), (@ peri_type #[doc = "GPIO peripheral singleton"] GPIO <= GPIO()
-        (unstable)), (@ peri_type #[doc = "GPIO_SD peripheral singleton"] GPIO_SD <=
-        GPIO_EXT() (unstable)), (@ peri_type #[doc = "HMAC peripheral singleton"] HMAC <=
-        HMAC() (unstable)), (@ peri_type #[doc = "HP_APM peripheral singleton"] HP_APM <=
-        HP_APM() (unstable)), (@ peri_type #[doc = "HP_SYS peripheral singleton"] HP_SYS
-        <= HP_SYS() (unstable)), (@ peri_type #[doc = "HUK peripheral singleton"] HUK <=
-        HUK() (unstable)), (@ peri_type #[doc = "I2C_ANA_MST peripheral singleton"]
-        I2C_ANA_MST <= I2C_ANA_MST() (unstable)), (@ peri_type #[doc =
-        "I2C0 peripheral singleton"] I2C0 <= I2C0(I2C_EXT0 : { bind_peri_interrupt,
-        enable_peri_interrupt, disable_peri_interrupt })), (@ peri_type #[doc =
-        "I2S0 peripheral singleton"] I2S0 <= I2S0(I2S0 : { bind_peri_interrupt,
-        enable_peri_interrupt, disable_peri_interrupt }) (unstable)), (@ peri_type #[doc
-        = "IEEE802154 peripheral singleton"] IEEE802154 <= IEEE802154(ZB_MAC : {
+        "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual() (unstable)), (@ peri_type
+        #[doc = "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual() (unstable)), (@
+        peri_type #[doc = "DMA_CH2 peripheral singleton"] DMA_CH2 <= virtual()
+        (unstable)), (@ peri_type #[doc = "AES peripheral singleton"] AES <= AES(AES : {
+        bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
+        (unstable)), (@ peri_type #[doc = "ASSIST_DEBUG peripheral singleton"]
+        ASSIST_DEBUG <= ASSIST_DEBUG() (unstable)), (@ peri_type #[doc =
+        "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC() (unstable)), (@
+        peri_type #[doc = "CACHE peripheral singleton"] CACHE <= CACHE() (unstable)), (@
+        peri_type #[doc = "CLINT peripheral singleton"] CLINT <= CLINT() (unstable)), (@
+        peri_type #[doc = "DMA peripheral singleton"] DMA <= DMA() (unstable)), (@
+        peri_type #[doc = "DS peripheral singleton"] DS <= DS() (unstable)), (@ peri_type
+        #[doc = "ECC peripheral singleton"] ECC <= ECC() (unstable)), (@ peri_type #[doc
+        = "ECDSA peripheral singleton"] ECDSA <= ECDSA() (unstable)), (@ peri_type #[doc
+        = "EFUSE peripheral singleton"] EFUSE <= EFUSE() (unstable)), (@ peri_type #[doc
+        = "ETM peripheral singleton"] ETM <= SOC_ETM() (unstable)), (@ peri_type #[doc =
+        "GPIO peripheral singleton"] GPIO <= GPIO() (unstable)), (@ peri_type #[doc =
+        "GPIO_SD peripheral singleton"] GPIO_SD <= GPIO_EXT() (unstable)), (@ peri_type
+        #[doc = "HMAC peripheral singleton"] HMAC <= HMAC() (unstable)), (@ peri_type
+        #[doc = "HP_APM peripheral singleton"] HP_APM <= HP_APM() (unstable)), (@
+        peri_type #[doc = "HP_SYS peripheral singleton"] HP_SYS <= HP_SYS() (unstable)),
+        (@ peri_type #[doc = "HUK peripheral singleton"] HUK <= HUK() (unstable)), (@
+        peri_type #[doc = "I2C_ANA_MST peripheral singleton"] I2C_ANA_MST <=
+        I2C_ANA_MST() (unstable)), (@ peri_type #[doc = "I2C0 peripheral singleton"] I2C0
+        <= I2C0(I2C_EXT0 : { bind_peri_interrupt, enable_peri_interrupt,
+        disable_peri_interrupt })), (@ peri_type #[doc = "I2S0 peripheral singleton"]
+        I2S0 <= I2S0(I2S0 : { bind_peri_interrupt, enable_peri_interrupt,
+        disable_peri_interrupt }) (unstable)), (@ peri_type #[doc =
+        "IEEE802154 peripheral singleton"] IEEE802154 <= IEEE802154(ZB_MAC : {
         bind_mac_interrupt, enable_mac_interrupt, disable_mac_interrupt }) (unstable)),
         (@ peri_type #[doc = "INTERRUPT_CORE0 peripheral singleton"] INTERRUPT_CORE0 <=
         INTERRUPT_CORE0() (unstable)), (@ peri_type #[doc =
@@ -4314,17 +4319,13 @@ macro_rules! for_each_peripheral {
         UHCI0 <= UHCI0() (unstable)), (@ peri_type #[doc =
         "USB_DEVICE peripheral singleton"] USB_DEVICE <= USB_DEVICE(USB_DEVICE : {
         bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
-        (unstable)), (@ peri_type #[doc = "DMA_CH0 peripheral singleton"] DMA_CH0 <=
-        virtual() (unstable)), (@ peri_type #[doc = "DMA_CH1 peripheral singleton"]
-        DMA_CH1 <= virtual() (unstable)), (@ peri_type #[doc =
-        "DMA_CH2 peripheral singleton"] DMA_CH2 <= virtual() (unstable)), (@ peri_type
-        #[doc = "ADC1 peripheral singleton"] ADC1 <= virtual() (unstable)), (@ peri_type
-        #[doc = "BT peripheral singleton"] BT <= virtual(LP_TIMER : {
-        bind_lp_timer_interrupt, enable_lp_timer_interrupt, disable_lp_timer_interrupt },
-        BT_MAC : { bind_mac_interrupt, enable_mac_interrupt, disable_mac_interrupt })
-        (unstable)), (@ peri_type #[doc = "FLASH peripheral singleton"] FLASH <=
-        virtual() (unstable)), (@ peri_type #[doc =
-        "GPIO_DEDICATED peripheral singleton"] GPIO_DEDICATED <= virtual() (unstable)),
+        (unstable)), (@ peri_type #[doc = "ADC1 peripheral singleton"] ADC1 <= virtual()
+        (unstable)), (@ peri_type #[doc = "BT peripheral singleton"] BT <=
+        virtual(LP_TIMER : { bind_lp_timer_interrupt, enable_lp_timer_interrupt,
+        disable_lp_timer_interrupt }, BT_MAC : { bind_mac_interrupt,
+        enable_mac_interrupt, disable_mac_interrupt }) (unstable)), (@ peri_type #[doc =
+        "FLASH peripheral singleton"] FLASH <= virtual() (unstable)), (@ peri_type #[doc
+        = "GPIO_DEDICATED peripheral singleton"] GPIO_DEDICATED <= virtual() (unstable)),
         (@ peri_type #[doc = "LP_CORE peripheral singleton"] LP_CORE <= virtual()
         (unstable)), (@ peri_type #[doc = "SW_INTERRUPT peripheral singleton"]
         SW_INTERRUPT <= virtual() (unstable)), (@ peri_type #[doc =
@@ -4347,7 +4348,8 @@ macro_rules! for_each_peripheral {
         (GPIO1), (GPIO2), (GPIO3), (GPIO4), (GPIO5), (GPIO6), (GPIO7), (GPIO8), (GPIO9),
         (GPIO10), (GPIO11), (GPIO12), (GPIO13), (GPIO14), (GPIO15), (GPIO16), (GPIO17),
         (GPIO18), (GPIO19), (GPIO20), (GPIO21), (GPIO22), (GPIO23), (GPIO24), (GPIO25),
-        (GPIO26), (GPIO27), (GPIO28), (AES(unstable)), (ASSIST_DEBUG(unstable)),
+        (GPIO26), (GPIO27), (GPIO28), (DMA_CH0(unstable)), (DMA_CH1(unstable)),
+        (DMA_CH2(unstable)), (AES(unstable)), (ASSIST_DEBUG(unstable)),
         (APB_SARADC(unstable)), (CACHE(unstable)), (CLINT(unstable)), (DMA(unstable)),
         (DS(unstable)), (ECC(unstable)), (ECDSA(unstable)), (ETM(unstable)),
         (GPIO(unstable)), (GPIO_SD(unstable)), (HMAC(unstable)), (HP_APM(unstable)),
@@ -4364,8 +4366,7 @@ macro_rules! for_each_peripheral {
         (RSA(unstable)), (SHA(unstable)), (SLC(unstable)), (SPI0(unstable)),
         (SPI1(unstable)), (SPI2), (SYSTEM(unstable)), (SYSTIMER(unstable)),
         (TEE(unstable)), (TIMG0(unstable)), (TIMG1(unstable)), (UART0), (UART1),
-        (UHCI0(unstable)), (USB_DEVICE(unstable)), (DMA_CH0(unstable)),
-        (DMA_CH1(unstable)), (DMA_CH2(unstable)), (ADC1(unstable)), (BT(unstable)),
+        (UHCI0(unstable)), (USB_DEVICE(unstable)), (ADC1(unstable)), (BT(unstable)),
         (FLASH(unstable)), (GPIO_DEDICATED(unstable)), (LP_CORE(unstable)),
         (SW_INTERRUPT(unstable)), (WIFI), (MEM2MEM0(unstable)), (MEM2MEM1(unstable)),
         (MEM2MEM2(unstable)), (MEM2MEM3(unstable)), (MEM2MEM4(unstable)),

--- a/esp-metadata-generated/src/_generated_esp32c5.rs
+++ b/esp-metadata-generated/src/_generated_esp32c5.rs
@@ -519,6 +519,22 @@ macro_rules! for_each_dedicated_gpio {
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_dma_channel {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner_dma_channel { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_dma_channel!((DMA_CH0, 0, interrupt_in = DMA_IN_CH0,
+        interrupt_out = DMA_OUT_CH0)); _for_each_inner_dma_channel!((DMA_CH1, 1,
+        interrupt_in = DMA_IN_CH1, interrupt_out = DMA_OUT_CH1));
+        _for_each_inner_dma_channel!((DMA_CH2, 2, interrupt_in = DMA_IN_CH2,
+        interrupt_out = DMA_OUT_CH2)); _for_each_inner_dma_channel!((shared));
+        _for_each_inner_dma_channel!((split(DMA_CH0, 0, interrupt_in = DMA_IN_CH0,
+        interrupt_out = DMA_OUT_CH0), (DMA_CH1, 1, interrupt_in = DMA_IN_CH1,
+        interrupt_out = DMA_OUT_CH1), (DMA_CH2, 2, interrupt_in = DMA_IN_CH2,
+        interrupt_out = DMA_OUT_CH2)));
+    };
+}
+#[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_ecc_working_mode {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_ecc_working_mode { $(($pattern) => $code;)* ($other
@@ -3827,13 +3843,20 @@ macro_rules! for_each_peripheral {
         "<li>This pin is a strapping pin, it determines how the chip boots.</li>"] #[doc
         = "</ul>"] #[doc = "</section>"] GPIO28 <= virtual()));
         _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH0 peripheral singleton"]
-        DMA_CH0 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
-        = "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual() (unstable)));
+        DMA_CH0 <= virtual(DMA_IN_CH0 : { bind_dma_in_interrupt, enable_dma_in_interrupt,
+        disable_dma_in_interrupt }, DMA_OUT_CH0 : { bind_dma_out_interrupt,
+        enable_dma_out_interrupt, disable_dma_out_interrupt }) (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH1 peripheral singleton"]
+        DMA_CH1 <= virtual(DMA_IN_CH1 : { bind_dma_in_interrupt, enable_dma_in_interrupt,
+        disable_dma_in_interrupt }, DMA_OUT_CH1 : { bind_dma_out_interrupt,
+        enable_dma_out_interrupt, disable_dma_out_interrupt }) (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH2 peripheral singleton"]
-        DMA_CH2 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
-        = "AES peripheral singleton"] AES <= AES(AES : { bind_peri_interrupt,
-        enable_peri_interrupt, disable_peri_interrupt }) (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc =
+        DMA_CH2 <= virtual(DMA_IN_CH2 : { bind_dma_in_interrupt, enable_dma_in_interrupt,
+        disable_dma_in_interrupt }, DMA_OUT_CH2 : { bind_dma_out_interrupt,
+        enable_dma_out_interrupt, disable_dma_out_interrupt }) (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "AES peripheral singleton"] AES
+        <= AES(AES : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt
+        }) (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "ASSIST_DEBUG peripheral singleton"] ASSIST_DEBUG <= ASSIST_DEBUG() (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc =
         "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC() (unstable)));
@@ -4231,35 +4254,43 @@ macro_rules! for_each_peripheral {
         #[doc = "<ul>"] #[doc =
         "<li>This pin is a strapping pin, it determines how the chip boots.</li>"] #[doc
         = "</ul>"] #[doc = "</section>"] GPIO28 <= virtual()), (@ peri_type #[doc =
-        "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual() (unstable)), (@ peri_type
-        #[doc = "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual() (unstable)), (@
-        peri_type #[doc = "DMA_CH2 peripheral singleton"] DMA_CH2 <= virtual()
-        (unstable)), (@ peri_type #[doc = "AES peripheral singleton"] AES <= AES(AES : {
-        bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
-        (unstable)), (@ peri_type #[doc = "ASSIST_DEBUG peripheral singleton"]
-        ASSIST_DEBUG <= ASSIST_DEBUG() (unstable)), (@ peri_type #[doc =
-        "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC() (unstable)), (@
-        peri_type #[doc = "CACHE peripheral singleton"] CACHE <= CACHE() (unstable)), (@
-        peri_type #[doc = "CLINT peripheral singleton"] CLINT <= CLINT() (unstable)), (@
-        peri_type #[doc = "DMA peripheral singleton"] DMA <= DMA() (unstable)), (@
-        peri_type #[doc = "DS peripheral singleton"] DS <= DS() (unstable)), (@ peri_type
-        #[doc = "ECC peripheral singleton"] ECC <= ECC() (unstable)), (@ peri_type #[doc
-        = "ECDSA peripheral singleton"] ECDSA <= ECDSA() (unstable)), (@ peri_type #[doc
-        = "EFUSE peripheral singleton"] EFUSE <= EFUSE() (unstable)), (@ peri_type #[doc
-        = "ETM peripheral singleton"] ETM <= SOC_ETM() (unstable)), (@ peri_type #[doc =
-        "GPIO peripheral singleton"] GPIO <= GPIO() (unstable)), (@ peri_type #[doc =
-        "GPIO_SD peripheral singleton"] GPIO_SD <= GPIO_EXT() (unstable)), (@ peri_type
-        #[doc = "HMAC peripheral singleton"] HMAC <= HMAC() (unstable)), (@ peri_type
-        #[doc = "HP_APM peripheral singleton"] HP_APM <= HP_APM() (unstable)), (@
-        peri_type #[doc = "HP_SYS peripheral singleton"] HP_SYS <= HP_SYS() (unstable)),
-        (@ peri_type #[doc = "HUK peripheral singleton"] HUK <= HUK() (unstable)), (@
-        peri_type #[doc = "I2C_ANA_MST peripheral singleton"] I2C_ANA_MST <=
-        I2C_ANA_MST() (unstable)), (@ peri_type #[doc = "I2C0 peripheral singleton"] I2C0
-        <= I2C0(I2C_EXT0 : { bind_peri_interrupt, enable_peri_interrupt,
-        disable_peri_interrupt })), (@ peri_type #[doc = "I2S0 peripheral singleton"]
-        I2S0 <= I2S0(I2S0 : { bind_peri_interrupt, enable_peri_interrupt,
-        disable_peri_interrupt }) (unstable)), (@ peri_type #[doc =
-        "IEEE802154 peripheral singleton"] IEEE802154 <= IEEE802154(ZB_MAC : {
+        "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual(DMA_IN_CH0 : {
+        bind_dma_in_interrupt, enable_dma_in_interrupt, disable_dma_in_interrupt },
+        DMA_OUT_CH0 : { bind_dma_out_interrupt, enable_dma_out_interrupt,
+        disable_dma_out_interrupt }) (unstable)), (@ peri_type #[doc =
+        "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual(DMA_IN_CH1 : {
+        bind_dma_in_interrupt, enable_dma_in_interrupt, disable_dma_in_interrupt },
+        DMA_OUT_CH1 : { bind_dma_out_interrupt, enable_dma_out_interrupt,
+        disable_dma_out_interrupt }) (unstable)), (@ peri_type #[doc =
+        "DMA_CH2 peripheral singleton"] DMA_CH2 <= virtual(DMA_IN_CH2 : {
+        bind_dma_in_interrupt, enable_dma_in_interrupt, disable_dma_in_interrupt },
+        DMA_OUT_CH2 : { bind_dma_out_interrupt, enable_dma_out_interrupt,
+        disable_dma_out_interrupt }) (unstable)), (@ peri_type #[doc =
+        "AES peripheral singleton"] AES <= AES(AES : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt }) (unstable)), (@ peri_type #[doc
+        = "ASSIST_DEBUG peripheral singleton"] ASSIST_DEBUG <= ASSIST_DEBUG()
+        (unstable)), (@ peri_type #[doc = "APB_SARADC peripheral singleton"] APB_SARADC
+        <= APB_SARADC() (unstable)), (@ peri_type #[doc = "CACHE peripheral singleton"]
+        CACHE <= CACHE() (unstable)), (@ peri_type #[doc = "CLINT peripheral singleton"]
+        CLINT <= CLINT() (unstable)), (@ peri_type #[doc = "DMA peripheral singleton"]
+        DMA <= DMA() (unstable)), (@ peri_type #[doc = "DS peripheral singleton"] DS <=
+        DS() (unstable)), (@ peri_type #[doc = "ECC peripheral singleton"] ECC <= ECC()
+        (unstable)), (@ peri_type #[doc = "ECDSA peripheral singleton"] ECDSA <= ECDSA()
+        (unstable)), (@ peri_type #[doc = "EFUSE peripheral singleton"] EFUSE <= EFUSE()
+        (unstable)), (@ peri_type #[doc = "ETM peripheral singleton"] ETM <= SOC_ETM()
+        (unstable)), (@ peri_type #[doc = "GPIO peripheral singleton"] GPIO <= GPIO()
+        (unstable)), (@ peri_type #[doc = "GPIO_SD peripheral singleton"] GPIO_SD <=
+        GPIO_EXT() (unstable)), (@ peri_type #[doc = "HMAC peripheral singleton"] HMAC <=
+        HMAC() (unstable)), (@ peri_type #[doc = "HP_APM peripheral singleton"] HP_APM <=
+        HP_APM() (unstable)), (@ peri_type #[doc = "HP_SYS peripheral singleton"] HP_SYS
+        <= HP_SYS() (unstable)), (@ peri_type #[doc = "HUK peripheral singleton"] HUK <=
+        HUK() (unstable)), (@ peri_type #[doc = "I2C_ANA_MST peripheral singleton"]
+        I2C_ANA_MST <= I2C_ANA_MST() (unstable)), (@ peri_type #[doc =
+        "I2C0 peripheral singleton"] I2C0 <= I2C0(I2C_EXT0 : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt })), (@ peri_type #[doc =
+        "I2S0 peripheral singleton"] I2S0 <= I2S0(I2S0 : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt }) (unstable)), (@ peri_type #[doc
+        = "IEEE802154 peripheral singleton"] IEEE802154 <= IEEE802154(ZB_MAC : {
         bind_mac_interrupt, enable_mac_interrupt, disable_mac_interrupt }) (unstable)),
         (@ peri_type #[doc = "INTERRUPT_CORE0 peripheral singleton"] INTERRUPT_CORE0 <=
         INTERRUPT_CORE0() (unstable)), (@ peri_type #[doc =

--- a/esp-metadata-generated/src/_generated_esp32c6.rs
+++ b/esp-metadata-generated/src/_generated_esp32c6.rs
@@ -510,6 +510,22 @@ macro_rules! for_each_dedicated_gpio {
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_dma_channel {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner_dma_channel { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_dma_channel!((DMA_CH0, 0, interrupt_in = DMA_IN_CH0,
+        interrupt_out = DMA_OUT_CH0)); _for_each_inner_dma_channel!((DMA_CH1, 1,
+        interrupt_in = DMA_IN_CH1, interrupt_out = DMA_OUT_CH1));
+        _for_each_inner_dma_channel!((DMA_CH2, 2, interrupt_in = DMA_IN_CH2,
+        interrupt_out = DMA_OUT_CH2)); _for_each_inner_dma_channel!((shared));
+        _for_each_inner_dma_channel!((split(DMA_CH0, 0, interrupt_in = DMA_IN_CH0,
+        interrupt_out = DMA_OUT_CH0), (DMA_CH1, 1, interrupt_in = DMA_IN_CH1,
+        interrupt_out = DMA_OUT_CH1), (DMA_CH2, 2, interrupt_in = DMA_IN_CH2,
+        interrupt_out = DMA_OUT_CH2)));
+    };
+}
+#[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_ecc_working_mode {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_ecc_working_mode { $(($pattern) => $code;)* ($other
@@ -4643,13 +4659,20 @@ macro_rules! for_each_peripheral {
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
         "</ul>"] #[doc = "</section>"] GPIO30 <= virtual()));
         _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH0 peripheral singleton"]
-        DMA_CH0 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
-        = "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual() (unstable)));
+        DMA_CH0 <= virtual(DMA_IN_CH0 : { bind_dma_in_interrupt, enable_dma_in_interrupt,
+        disable_dma_in_interrupt }, DMA_OUT_CH0 : { bind_dma_out_interrupt,
+        enable_dma_out_interrupt, disable_dma_out_interrupt }) (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH1 peripheral singleton"]
+        DMA_CH1 <= virtual(DMA_IN_CH1 : { bind_dma_in_interrupt, enable_dma_in_interrupt,
+        disable_dma_in_interrupt }, DMA_OUT_CH1 : { bind_dma_out_interrupt,
+        enable_dma_out_interrupt, disable_dma_out_interrupt }) (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH2 peripheral singleton"]
-        DMA_CH2 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
-        = "AES peripheral singleton"] AES <= AES(AES : { bind_peri_interrupt,
-        enable_peri_interrupt, disable_peri_interrupt }) (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc =
+        DMA_CH2 <= virtual(DMA_IN_CH2 : { bind_dma_in_interrupt, enable_dma_in_interrupt,
+        disable_dma_in_interrupt }, DMA_OUT_CH2 : { bind_dma_out_interrupt,
+        enable_dma_out_interrupt, disable_dma_out_interrupt }) (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "AES peripheral singleton"] AES
+        <= AES(AES : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt
+        }) (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC() (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc =
         "ASSIST_DEBUG peripheral singleton"] ASSIST_DEBUG <= ASSIST_DEBUG() (unstable)));
@@ -5044,18 +5067,26 @@ macro_rules! for_each_peripheral {
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
         "</ul>"] #[doc = "</section>"] GPIO30 <= virtual()), (@ peri_type #[doc =
-        "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual() (unstable)), (@ peri_type
-        #[doc = "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual() (unstable)), (@
-        peri_type #[doc = "DMA_CH2 peripheral singleton"] DMA_CH2 <= virtual()
-        (unstable)), (@ peri_type #[doc = "AES peripheral singleton"] AES <= AES(AES : {
-        bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
-        (unstable)), (@ peri_type #[doc = "APB_SARADC peripheral singleton"] APB_SARADC
-        <= APB_SARADC() (unstable)), (@ peri_type #[doc =
-        "ASSIST_DEBUG peripheral singleton"] ASSIST_DEBUG <= ASSIST_DEBUG() (unstable)),
-        (@ peri_type #[doc = "ATOMIC peripheral singleton"] ATOMIC <= ATOMIC()
-        (unstable)), (@ peri_type #[doc = "DMA peripheral singleton"] DMA <= DMA()
-        (unstable)), (@ peri_type #[doc = "DS peripheral singleton"] DS <= DS()
-        (unstable)), (@ peri_type #[doc = "ECC peripheral singleton"] ECC <= ECC()
+        "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual(DMA_IN_CH0 : {
+        bind_dma_in_interrupt, enable_dma_in_interrupt, disable_dma_in_interrupt },
+        DMA_OUT_CH0 : { bind_dma_out_interrupt, enable_dma_out_interrupt,
+        disable_dma_out_interrupt }) (unstable)), (@ peri_type #[doc =
+        "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual(DMA_IN_CH1 : {
+        bind_dma_in_interrupt, enable_dma_in_interrupt, disable_dma_in_interrupt },
+        DMA_OUT_CH1 : { bind_dma_out_interrupt, enable_dma_out_interrupt,
+        disable_dma_out_interrupt }) (unstable)), (@ peri_type #[doc =
+        "DMA_CH2 peripheral singleton"] DMA_CH2 <= virtual(DMA_IN_CH2 : {
+        bind_dma_in_interrupt, enable_dma_in_interrupt, disable_dma_in_interrupt },
+        DMA_OUT_CH2 : { bind_dma_out_interrupt, enable_dma_out_interrupt,
+        disable_dma_out_interrupt }) (unstable)), (@ peri_type #[doc =
+        "AES peripheral singleton"] AES <= AES(AES : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt }) (unstable)), (@ peri_type #[doc
+        = "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC() (unstable)), (@
+        peri_type #[doc = "ASSIST_DEBUG peripheral singleton"] ASSIST_DEBUG <=
+        ASSIST_DEBUG() (unstable)), (@ peri_type #[doc = "ATOMIC peripheral singleton"]
+        ATOMIC <= ATOMIC() (unstable)), (@ peri_type #[doc = "DMA peripheral singleton"]
+        DMA <= DMA() (unstable)), (@ peri_type #[doc = "DS peripheral singleton"] DS <=
+        DS() (unstable)), (@ peri_type #[doc = "ECC peripheral singleton"] ECC <= ECC()
         (unstable)), (@ peri_type #[doc = "EFUSE peripheral singleton"] EFUSE <= EFUSE()
         (unstable)), (@ peri_type #[doc = "EXTMEM peripheral singleton"] EXTMEM <=
         EXTMEM() (unstable)), (@ peri_type #[doc = "GPIO peripheral singleton"] GPIO <=

--- a/esp-metadata-generated/src/_generated_esp32c6.rs
+++ b/esp-metadata-generated/src/_generated_esp32c6.rs
@@ -4642,9 +4642,14 @@ macro_rules! for_each_peripheral {
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
         "</ul>"] #[doc = "</section>"] GPIO30 <= virtual()));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "AES peripheral singleton"] AES
-        <= AES(AES : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt
-        }) (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH0 peripheral singleton"]
+        DMA_CH0 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH2 peripheral singleton"]
+        DMA_CH2 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "AES peripheral singleton"] AES <= AES(AES : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt }) (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
         "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC() (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc =
         "ASSIST_DEBUG peripheral singleton"] ASSIST_DEBUG <= ASSIST_DEBUG() (unstable)));
@@ -4763,15 +4768,11 @@ macro_rules! for_each_peripheral {
         "USB_DEVICE peripheral singleton"] USB_DEVICE <= USB_DEVICE(USB_DEVICE : {
         bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
         (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
-        "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH1 peripheral singleton"]
-        DMA_CH1 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
-        = "DMA_CH2 peripheral singleton"] DMA_CH2 <= virtual() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "ADC1 peripheral singleton"]
-        ADC1 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
-        "BT peripheral singleton"] BT <= virtual(LP_TIMER : { bind_lp_timer_interrupt,
-        enable_lp_timer_interrupt, disable_lp_timer_interrupt }, BT_MAC : {
-        bind_mac_interrupt, enable_mac_interrupt, disable_mac_interrupt }) (unstable)));
+        "ADC1 peripheral singleton"] ADC1 <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "BT peripheral singleton"] BT <=
+        virtual(LP_TIMER : { bind_lp_timer_interrupt, enable_lp_timer_interrupt,
+        disable_lp_timer_interrupt }, BT_MAC : { bind_mac_interrupt,
+        enable_mac_interrupt, disable_mac_interrupt }) (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc = "FLASH peripheral singleton"]
         FLASH <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "GPIO_DEDICATED peripheral singleton"] GPIO_DEDICATED <= virtual() (unstable)));
@@ -4815,6 +4816,9 @@ macro_rules! for_each_peripheral {
         _for_each_inner_peripheral!((GPIO25)); _for_each_inner_peripheral!((GPIO26));
         _for_each_inner_peripheral!((GPIO27)); _for_each_inner_peripheral!((GPIO28));
         _for_each_inner_peripheral!((GPIO29)); _for_each_inner_peripheral!((GPIO30));
+        _for_each_inner_peripheral!((DMA_CH0(unstable)));
+        _for_each_inner_peripheral!((DMA_CH1(unstable)));
+        _for_each_inner_peripheral!((DMA_CH2(unstable)));
         _for_each_inner_peripheral!((AES(unstable)));
         _for_each_inner_peripheral!((APB_SARADC(unstable)));
         _for_each_inner_peripheral!((ASSIST_DEBUG(unstable)));
@@ -4882,9 +4886,6 @@ macro_rules! for_each_peripheral {
         _for_each_inner_peripheral!((UART0)); _for_each_inner_peripheral!((UART1));
         _for_each_inner_peripheral!((UHCI0(unstable)));
         _for_each_inner_peripheral!((USB_DEVICE(unstable)));
-        _for_each_inner_peripheral!((DMA_CH0(unstable)));
-        _for_each_inner_peripheral!((DMA_CH1(unstable)));
-        _for_each_inner_peripheral!((DMA_CH2(unstable)));
         _for_each_inner_peripheral!((ADC1(unstable)));
         _for_each_inner_peripheral!((BT(unstable)));
         _for_each_inner_peripheral!((FLASH(unstable)));
@@ -5043,14 +5044,18 @@ macro_rules! for_each_peripheral {
         #[doc = "<ul>"] #[doc =
         "<li>This pin may be reserved for interfacing with SPI flash.</li>"] #[doc =
         "</ul>"] #[doc = "</section>"] GPIO30 <= virtual()), (@ peri_type #[doc =
-        "AES peripheral singleton"] AES <= AES(AES : { bind_peri_interrupt,
-        enable_peri_interrupt, disable_peri_interrupt }) (unstable)), (@ peri_type #[doc
-        = "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC() (unstable)), (@
-        peri_type #[doc = "ASSIST_DEBUG peripheral singleton"] ASSIST_DEBUG <=
-        ASSIST_DEBUG() (unstable)), (@ peri_type #[doc = "ATOMIC peripheral singleton"]
-        ATOMIC <= ATOMIC() (unstable)), (@ peri_type #[doc = "DMA peripheral singleton"]
-        DMA <= DMA() (unstable)), (@ peri_type #[doc = "DS peripheral singleton"] DS <=
-        DS() (unstable)), (@ peri_type #[doc = "ECC peripheral singleton"] ECC <= ECC()
+        "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual() (unstable)), (@ peri_type
+        #[doc = "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual() (unstable)), (@
+        peri_type #[doc = "DMA_CH2 peripheral singleton"] DMA_CH2 <= virtual()
+        (unstable)), (@ peri_type #[doc = "AES peripheral singleton"] AES <= AES(AES : {
+        bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
+        (unstable)), (@ peri_type #[doc = "APB_SARADC peripheral singleton"] APB_SARADC
+        <= APB_SARADC() (unstable)), (@ peri_type #[doc =
+        "ASSIST_DEBUG peripheral singleton"] ASSIST_DEBUG <= ASSIST_DEBUG() (unstable)),
+        (@ peri_type #[doc = "ATOMIC peripheral singleton"] ATOMIC <= ATOMIC()
+        (unstable)), (@ peri_type #[doc = "DMA peripheral singleton"] DMA <= DMA()
+        (unstable)), (@ peri_type #[doc = "DS peripheral singleton"] DS <= DS()
+        (unstable)), (@ peri_type #[doc = "ECC peripheral singleton"] ECC <= ECC()
         (unstable)), (@ peri_type #[doc = "EFUSE peripheral singleton"] EFUSE <= EFUSE()
         (unstable)), (@ peri_type #[doc = "EXTMEM peripheral singleton"] EXTMEM <=
         EXTMEM() (unstable)), (@ peri_type #[doc = "GPIO peripheral singleton"] GPIO <=
@@ -5130,17 +5135,13 @@ macro_rules! for_each_peripheral {
         UHCI0 <= UHCI0() (unstable)), (@ peri_type #[doc =
         "USB_DEVICE peripheral singleton"] USB_DEVICE <= USB_DEVICE(USB_DEVICE : {
         bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
-        (unstable)), (@ peri_type #[doc = "DMA_CH0 peripheral singleton"] DMA_CH0 <=
-        virtual() (unstable)), (@ peri_type #[doc = "DMA_CH1 peripheral singleton"]
-        DMA_CH1 <= virtual() (unstable)), (@ peri_type #[doc =
-        "DMA_CH2 peripheral singleton"] DMA_CH2 <= virtual() (unstable)), (@ peri_type
-        #[doc = "ADC1 peripheral singleton"] ADC1 <= virtual() (unstable)), (@ peri_type
-        #[doc = "BT peripheral singleton"] BT <= virtual(LP_TIMER : {
-        bind_lp_timer_interrupt, enable_lp_timer_interrupt, disable_lp_timer_interrupt },
-        BT_MAC : { bind_mac_interrupt, enable_mac_interrupt, disable_mac_interrupt })
-        (unstable)), (@ peri_type #[doc = "FLASH peripheral singleton"] FLASH <=
-        virtual() (unstable)), (@ peri_type #[doc =
-        "GPIO_DEDICATED peripheral singleton"] GPIO_DEDICATED <= virtual() (unstable)),
+        (unstable)), (@ peri_type #[doc = "ADC1 peripheral singleton"] ADC1 <= virtual()
+        (unstable)), (@ peri_type #[doc = "BT peripheral singleton"] BT <=
+        virtual(LP_TIMER : { bind_lp_timer_interrupt, enable_lp_timer_interrupt,
+        disable_lp_timer_interrupt }, BT_MAC : { bind_mac_interrupt,
+        enable_mac_interrupt, disable_mac_interrupt }) (unstable)), (@ peri_type #[doc =
+        "FLASH peripheral singleton"] FLASH <= virtual() (unstable)), (@ peri_type #[doc
+        = "GPIO_DEDICATED peripheral singleton"] GPIO_DEDICATED <= virtual() (unstable)),
         (@ peri_type #[doc = "LP_CORE peripheral singleton"] LP_CORE <= virtual()
         (unstable)), (@ peri_type #[doc = "SW_INTERRUPT peripheral singleton"]
         SW_INTERRUPT <= virtual() (unstable)), (@ peri_type #[doc =
@@ -5165,7 +5166,8 @@ macro_rules! for_each_peripheral {
         (GPIO2), (GPIO3), (GPIO4), (GPIO5), (GPIO6), (GPIO7), (GPIO8), (GPIO9), (GPIO10),
         (GPIO11), (GPIO12), (GPIO13), (GPIO14), (GPIO15), (GPIO16), (GPIO17), (GPIO18),
         (GPIO19), (GPIO20), (GPIO21), (GPIO22), (GPIO23), (GPIO24), (GPIO25), (GPIO26),
-        (GPIO27), (GPIO28), (GPIO29), (GPIO30), (AES(unstable)), (APB_SARADC(unstable)),
+        (GPIO27), (GPIO28), (GPIO29), (GPIO30), (DMA_CH0(unstable)), (DMA_CH1(unstable)),
+        (DMA_CH2(unstable)), (AES(unstable)), (APB_SARADC(unstable)),
         (ASSIST_DEBUG(unstable)), (ATOMIC(unstable)), (DMA(unstable)), (DS(unstable)),
         (ECC(unstable)), (EXTMEM(unstable)), (GPIO(unstable)), (GPIO_SD(unstable)),
         (HINF(unstable)), (HMAC(unstable)), (HP_APM(unstable)), (HP_SYS(unstable)),
@@ -5183,8 +5185,7 @@ macro_rules! for_each_peripheral {
         (ETM(unstable)), (SPI0(unstable)), (SPI1(unstable)), (SPI2), (SYSTEM(unstable)),
         (SYSTIMER(unstable)), (TEE(unstable)), (TIMG0(unstable)), (TIMG1(unstable)),
         (TRACE0(unstable)), (TWAI0(unstable)), (TWAI1(unstable)), (UART0), (UART1),
-        (UHCI0(unstable)), (USB_DEVICE(unstable)), (DMA_CH0(unstable)),
-        (DMA_CH1(unstable)), (DMA_CH2(unstable)), (ADC1(unstable)), (BT(unstable)),
+        (UHCI0(unstable)), (USB_DEVICE(unstable)), (ADC1(unstable)), (BT(unstable)),
         (FLASH(unstable)), (GPIO_DEDICATED(unstable)), (LP_CORE(unstable)),
         (SW_INTERRUPT(unstable)), (TSENS(unstable)), (WIFI), (MEM2MEM0(unstable)),
         (MEM2MEM1(unstable)), (MEM2MEM2(unstable)), (MEM2MEM3(unstable)),

--- a/esp-metadata-generated/src/_generated_esp32c61.rs
+++ b/esp-metadata-generated/src/_generated_esp32c61.rs
@@ -2836,6 +2836,9 @@ macro_rules! for_each_peripheral {
         _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO28 peripheral singleton"]
         GPIO28 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
         "GPIO29 peripheral singleton"] GPIO29 <= virtual()));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH0 peripheral singleton"]
+        DMA_CH0 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual() (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc =
         "ASSIST_DEBUG peripheral singleton"] ASSIST_DEBUG <= ASSIST_DEBUG() (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc = "CLINT peripheral singleton"]
@@ -2920,10 +2923,7 @@ macro_rules! for_each_peripheral {
         "USB_DEVICE peripheral singleton"] USB_DEVICE <= USB_DEVICE(USB_DEVICE : {
         bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
         (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
-        "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH1 peripheral singleton"]
-        DMA_CH1 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
-        = "BT peripheral singleton"] BT <= virtual(LP_TIMER : { bind_lp_timer_interrupt,
+        "BT peripheral singleton"] BT <= virtual(LP_TIMER : { bind_lp_timer_interrupt,
         enable_lp_timer_interrupt, disable_lp_timer_interrupt }, BT_MAC : {
         bind_mac_interrupt, enable_mac_interrupt, disable_mac_interrupt }) (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc = "FLASH peripheral singleton"]
@@ -2972,6 +2972,8 @@ macro_rules! for_each_peripheral {
         _for_each_inner_peripheral!((GPIO25)); _for_each_inner_peripheral!((GPIO26));
         _for_each_inner_peripheral!((GPIO27)); _for_each_inner_peripheral!((GPIO28));
         _for_each_inner_peripheral!((GPIO29));
+        _for_each_inner_peripheral!((DMA_CH0(unstable)));
+        _for_each_inner_peripheral!((DMA_CH1(unstable)));
         _for_each_inner_peripheral!((ASSIST_DEBUG(unstable)));
         _for_each_inner_peripheral!((CLINT(unstable)));
         _for_each_inner_peripheral!((CACHE(unstable)));
@@ -3019,8 +3021,6 @@ macro_rules! for_each_peripheral {
         _for_each_inner_peripheral!((TIMG1(unstable)));
         _for_each_inner_peripheral!((UART0)); _for_each_inner_peripheral!((UART1));
         _for_each_inner_peripheral!((USB_DEVICE(unstable)));
-        _for_each_inner_peripheral!((DMA_CH0(unstable)));
-        _for_each_inner_peripheral!((DMA_CH1(unstable)));
         _for_each_inner_peripheral!((BT(unstable)));
         _for_each_inner_peripheral!((FLASH(unstable)));
         _for_each_inner_peripheral!((GPIO_DEDICATED(unstable)));
@@ -3191,48 +3191,51 @@ macro_rules! for_each_peripheral {
         "GPIO27 peripheral singleton"] GPIO27 <= virtual()), (@ peri_type #[doc =
         "GPIO28 peripheral singleton"] GPIO28 <= virtual()), (@ peri_type #[doc =
         "GPIO29 peripheral singleton"] GPIO29 <= virtual()), (@ peri_type #[doc =
-        "ASSIST_DEBUG peripheral singleton"] ASSIST_DEBUG <= ASSIST_DEBUG() (unstable)),
-        (@ peri_type #[doc = "CLINT peripheral singleton"] CLINT <= CLINT() (unstable)),
-        (@ peri_type #[doc = "CACHE peripheral singleton"] CACHE <= CACHE() (unstable)),
-        (@ peri_type #[doc = "DMA peripheral singleton"] DMA <= DMA() (unstable)), (@
-        peri_type #[doc = "ECC peripheral singleton"] ECC <= ECC() (unstable)), (@
-        peri_type #[doc = "ECDSA peripheral singleton"] ECDSA <= ECDSA() (unstable)), (@
-        peri_type #[doc = "EFUSE peripheral singleton"] EFUSE <= EFUSE() (unstable)), (@
-        peri_type #[doc = "ETM peripheral singleton"] ETM <= SOC_ETM() (unstable)), (@
-        peri_type #[doc = "GPIO peripheral singleton"] GPIO <= GPIO() (unstable)), (@
-        peri_type #[doc = "GPIO_SD peripheral singleton"] GPIO_SD <= GPIO_EXT()
-        (unstable)), (@ peri_type #[doc = "HP_APM peripheral singleton"] HP_APM <=
-        HP_APM() (unstable)), (@ peri_type #[doc = "HP_SYS peripheral singleton"] HP_SYS
-        <= HP_SYS() (unstable)), (@ peri_type #[doc = "I2C_ANA_MST peripheral singleton"]
-        I2C_ANA_MST <= I2C_ANA_MST() (unstable)), (@ peri_type #[doc =
-        "I2C0 peripheral singleton"] I2C0 <= I2C0(I2C_EXT0 : { bind_peri_interrupt,
-        enable_peri_interrupt, disable_peri_interrupt })), (@ peri_type #[doc =
-        "I2S0 peripheral singleton"] I2S0 <= I2S0(I2S0 : { bind_peri_interrupt,
-        enable_peri_interrupt, disable_peri_interrupt }) (unstable)), (@ peri_type #[doc
-        = "INTERRUPT_CORE0 peripheral singleton"] INTERRUPT_CORE0 <= INTERRUPT_CORE0()
-        (unstable)), (@ peri_type #[doc = "INTPRI peripheral singleton"] INTPRI <=
-        INTPRI() (unstable)), (@ peri_type #[doc = "IO_MUX peripheral singleton"] IO_MUX
-        <= IO_MUX() (unstable)), (@ peri_type #[doc = "LP_ANA peripheral singleton"]
-        LP_ANA <= LP_ANA() (unstable)), (@ peri_type #[doc =
-        "LP_AON peripheral singleton"] LP_AON <= LP_AON() (unstable)), (@ peri_type #[doc
-        = "LP_APM peripheral singleton"] LP_APM <= LP_APM() (unstable)), (@ peri_type
-        #[doc = "LP_CLKRST peripheral singleton"] LP_CLKRST <= LP_CLKRST() (unstable)),
-        (@ peri_type #[doc = "LPWR peripheral singleton"] LPWR <= LP_CLKRST()
-        (unstable)), (@ peri_type #[doc = "LP_IO_MUX peripheral singleton"] LP_IO_MUX <=
-        LP_IO_MUX() (unstable)), (@ peri_type #[doc = "LP_PERI peripheral singleton"]
-        LP_PERI <= LPPERI() (unstable)), (@ peri_type #[doc =
-        "LP_TEE peripheral singleton"] LP_TEE <= LP_TEE() (unstable)), (@ peri_type #[doc
-        = "LP_TIMER peripheral singleton"] LP_TIMER <= LP_TIMER() (unstable)), (@
-        peri_type #[doc = "LP_WDT peripheral singleton"] LP_WDT <= LP_WDT() (unstable)),
-        (@ peri_type #[doc = "MEM_MONITOR peripheral singleton"] MEM_MONITOR <=
-        MEM_MONITOR() (unstable)), (@ peri_type #[doc =
-        "MODEM_LPCON peripheral singleton"] MODEM_LPCON <= MODEM_LPCON() (unstable)), (@
-        peri_type #[doc = "MODEM_SYSCON peripheral singleton"] MODEM_SYSCON <=
-        MODEM_SYSCON() (unstable)), (@ peri_type #[doc = "PAU peripheral singleton"] PAU
-        <= PAU() (unstable)), (@ peri_type #[doc = "PCR peripheral singleton"] PCR <=
-        PCR() (unstable)), (@ peri_type #[doc = "PMU peripheral singleton"] PMU <= PMU()
-        (unstable)), (@ peri_type #[doc = "RNG peripheral singleton"] RNG <= RNG()
-        (unstable)), (@ peri_type #[doc = "SHA peripheral singleton"] SHA <= SHA(SHA : {
+        "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual() (unstable)), (@ peri_type
+        #[doc = "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual() (unstable)), (@
+        peri_type #[doc = "ASSIST_DEBUG peripheral singleton"] ASSIST_DEBUG <=
+        ASSIST_DEBUG() (unstable)), (@ peri_type #[doc = "CLINT peripheral singleton"]
+        CLINT <= CLINT() (unstable)), (@ peri_type #[doc = "CACHE peripheral singleton"]
+        CACHE <= CACHE() (unstable)), (@ peri_type #[doc = "DMA peripheral singleton"]
+        DMA <= DMA() (unstable)), (@ peri_type #[doc = "ECC peripheral singleton"] ECC <=
+        ECC() (unstable)), (@ peri_type #[doc = "ECDSA peripheral singleton"] ECDSA <=
+        ECDSA() (unstable)), (@ peri_type #[doc = "EFUSE peripheral singleton"] EFUSE <=
+        EFUSE() (unstable)), (@ peri_type #[doc = "ETM peripheral singleton"] ETM <=
+        SOC_ETM() (unstable)), (@ peri_type #[doc = "GPIO peripheral singleton"] GPIO <=
+        GPIO() (unstable)), (@ peri_type #[doc = "GPIO_SD peripheral singleton"] GPIO_SD
+        <= GPIO_EXT() (unstable)), (@ peri_type #[doc = "HP_APM peripheral singleton"]
+        HP_APM <= HP_APM() (unstable)), (@ peri_type #[doc =
+        "HP_SYS peripheral singleton"] HP_SYS <= HP_SYS() (unstable)), (@ peri_type #[doc
+        = "I2C_ANA_MST peripheral singleton"] I2C_ANA_MST <= I2C_ANA_MST() (unstable)),
+        (@ peri_type #[doc = "I2C0 peripheral singleton"] I2C0 <= I2C0(I2C_EXT0 : {
+        bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })), (@
+        peri_type #[doc = "I2S0 peripheral singleton"] I2S0 <= I2S0(I2S0 : {
+        bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
+        (unstable)), (@ peri_type #[doc = "INTERRUPT_CORE0 peripheral singleton"]
+        INTERRUPT_CORE0 <= INTERRUPT_CORE0() (unstable)), (@ peri_type #[doc =
+        "INTPRI peripheral singleton"] INTPRI <= INTPRI() (unstable)), (@ peri_type #[doc
+        = "IO_MUX peripheral singleton"] IO_MUX <= IO_MUX() (unstable)), (@ peri_type
+        #[doc = "LP_ANA peripheral singleton"] LP_ANA <= LP_ANA() (unstable)), (@
+        peri_type #[doc = "LP_AON peripheral singleton"] LP_AON <= LP_AON() (unstable)),
+        (@ peri_type #[doc = "LP_APM peripheral singleton"] LP_APM <= LP_APM()
+        (unstable)), (@ peri_type #[doc = "LP_CLKRST peripheral singleton"] LP_CLKRST <=
+        LP_CLKRST() (unstable)), (@ peri_type #[doc = "LPWR peripheral singleton"] LPWR
+        <= LP_CLKRST() (unstable)), (@ peri_type #[doc =
+        "LP_IO_MUX peripheral singleton"] LP_IO_MUX <= LP_IO_MUX() (unstable)), (@
+        peri_type #[doc = "LP_PERI peripheral singleton"] LP_PERI <= LPPERI()
+        (unstable)), (@ peri_type #[doc = "LP_TEE peripheral singleton"] LP_TEE <=
+        LP_TEE() (unstable)), (@ peri_type #[doc = "LP_TIMER peripheral singleton"]
+        LP_TIMER <= LP_TIMER() (unstable)), (@ peri_type #[doc =
+        "LP_WDT peripheral singleton"] LP_WDT <= LP_WDT() (unstable)), (@ peri_type #[doc
+        = "MEM_MONITOR peripheral singleton"] MEM_MONITOR <= MEM_MONITOR() (unstable)),
+        (@ peri_type #[doc = "MODEM_LPCON peripheral singleton"] MODEM_LPCON <=
+        MODEM_LPCON() (unstable)), (@ peri_type #[doc =
+        "MODEM_SYSCON peripheral singleton"] MODEM_SYSCON <= MODEM_SYSCON() (unstable)),
+        (@ peri_type #[doc = "PAU peripheral singleton"] PAU <= PAU() (unstable)), (@
+        peri_type #[doc = "PCR peripheral singleton"] PCR <= PCR() (unstable)), (@
+        peri_type #[doc = "PMU peripheral singleton"] PMU <= PMU() (unstable)), (@
+        peri_type #[doc = "RNG peripheral singleton"] RNG <= RNG() (unstable)), (@
+        peri_type #[doc = "SHA peripheral singleton"] SHA <= SHA(SHA : {
         bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
         (unstable)), (@ peri_type #[doc = "SLC peripheral singleton"] SLC <= SLC()
         (unstable)), (@ peri_type #[doc = "SPI0 peripheral singleton"] SPI0 <= SPI0()
@@ -3251,10 +3254,8 @@ macro_rules! for_each_peripheral {
         disable_peri_interrupt })), (@ peri_type #[doc =
         "USB_DEVICE peripheral singleton"] USB_DEVICE <= USB_DEVICE(USB_DEVICE : {
         bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
-        (unstable)), (@ peri_type #[doc = "DMA_CH0 peripheral singleton"] DMA_CH0 <=
-        virtual() (unstable)), (@ peri_type #[doc = "DMA_CH1 peripheral singleton"]
-        DMA_CH1 <= virtual() (unstable)), (@ peri_type #[doc = "BT peripheral singleton"]
-        BT <= virtual(LP_TIMER : { bind_lp_timer_interrupt, enable_lp_timer_interrupt,
+        (unstable)), (@ peri_type #[doc = "BT peripheral singleton"] BT <=
+        virtual(LP_TIMER : { bind_lp_timer_interrupt, enable_lp_timer_interrupt,
         disable_lp_timer_interrupt }, BT_MAC : { bind_mac_interrupt,
         enable_mac_interrupt, disable_mac_interrupt }) (unstable)), (@ peri_type #[doc =
         "FLASH peripheral singleton"] FLASH <= virtual() (unstable)), (@ peri_type #[doc
@@ -3285,32 +3286,31 @@ macro_rules! for_each_peripheral {
         (GPIO2), (GPIO3), (GPIO4), (GPIO5), (GPIO6), (GPIO7), (GPIO8), (GPIO9), (GPIO10),
         (GPIO11), (GPIO12), (GPIO13), (GPIO14), (GPIO15), (GPIO16), (GPIO17), (GPIO18),
         (GPIO19), (GPIO20), (GPIO21), (GPIO22), (GPIO23), (GPIO24), (GPIO25), (GPIO26),
-        (GPIO27), (GPIO28), (GPIO29), (ASSIST_DEBUG(unstable)), (CLINT(unstable)),
-        (CACHE(unstable)), (DMA(unstable)), (ECC(unstable)), (ECDSA(unstable)),
-        (EFUSE(unstable)), (ETM(unstable)), (GPIO(unstable)), (GPIO_SD(unstable)),
-        (HP_APM(unstable)), (HP_SYS(unstable)), (I2C_ANA_MST(unstable)), (I2C0),
-        (I2S0(unstable)), (INTERRUPT_CORE0(unstable)), (INTPRI(unstable)),
-        (IO_MUX(unstable)), (LP_ANA(unstable)), (LP_AON(unstable)), (LP_APM(unstable)),
-        (LP_CLKRST(unstable)), (LPWR(unstable)), (LP_IO_MUX(unstable)),
-        (LP_PERI(unstable)), (LP_TEE(unstable)), (LP_TIMER(unstable)),
-        (LP_WDT(unstable)), (MEM_MONITOR(unstable)), (MODEM_LPCON(unstable)),
-        (MODEM_SYSCON(unstable)), (PAU(unstable)), (PCR(unstable)), (PMU(unstable)),
-        (RNG(unstable)), (SHA(unstable)), (SLC(unstable)), (SPI0(unstable)),
-        (SPI1(unstable)), (SPI2), (SYSTEM(unstable)), (SYSTIMER(unstable)),
-        (TEE(unstable)), (TIMG0(unstable)), (TIMG1(unstable)), (UART0), (UART1),
-        (USB_DEVICE(unstable)), (DMA_CH0(unstable)), (DMA_CH1(unstable)), (BT(unstable)),
-        (FLASH(unstable)), (GPIO_DEDICATED(unstable)), (LP_CORE(unstable)),
-        (SW_INTERRUPT(unstable)), (WIFI), (MEM2MEM0(unstable)), (MEM2MEM1(unstable)),
-        (MEM2MEM2(unstable)), (MEM2MEM3(unstable)), (MEM2MEM4(unstable)),
-        (MEM2MEM5(unstable)), (MEM2MEM6(unstable)), (MEM2MEM7(unstable)),
-        (MEM2MEM8(unstable)), (MEM2MEM9(unstable)), (MEM2MEM10(unstable)),
-        (MEM2MEM11(unstable)), (PSRAM(unstable))));
-        _for_each_inner_peripheral!((dma_eligible(MEM2MEM0, Mem2mem0, 0), (SPI2, Spi2,
-        1), (MEM2MEM1, Mem2mem1, 2), (I2S0, I2s0, 3), (MEM2MEM2, Mem2mem2, 4), (MEM2MEM3,
-        Mem2mem3, 5), (MEM2MEM4, Mem2mem4, 6), (SHA, Sha, 7), (MEM2MEM5, Mem2mem5, 9),
-        (MEM2MEM6, Mem2mem6, 10), (MEM2MEM7, Mem2mem7, 11), (MEM2MEM8, Mem2mem8, 12),
-        (MEM2MEM9, Mem2mem9, 13), (MEM2MEM10, Mem2mem10, 14), (MEM2MEM11, Mem2mem11,
-        15)));
+        (GPIO27), (GPIO28), (GPIO29), (DMA_CH0(unstable)), (DMA_CH1(unstable)),
+        (ASSIST_DEBUG(unstable)), (CLINT(unstable)), (CACHE(unstable)), (DMA(unstable)),
+        (ECC(unstable)), (ECDSA(unstable)), (EFUSE(unstable)), (ETM(unstable)),
+        (GPIO(unstable)), (GPIO_SD(unstable)), (HP_APM(unstable)), (HP_SYS(unstable)),
+        (I2C_ANA_MST(unstable)), (I2C0), (I2S0(unstable)), (INTERRUPT_CORE0(unstable)),
+        (INTPRI(unstable)), (IO_MUX(unstable)), (LP_ANA(unstable)), (LP_AON(unstable)),
+        (LP_APM(unstable)), (LP_CLKRST(unstable)), (LPWR(unstable)),
+        (LP_IO_MUX(unstable)), (LP_PERI(unstable)), (LP_TEE(unstable)),
+        (LP_TIMER(unstable)), (LP_WDT(unstable)), (MEM_MONITOR(unstable)),
+        (MODEM_LPCON(unstable)), (MODEM_SYSCON(unstable)), (PAU(unstable)),
+        (PCR(unstable)), (PMU(unstable)), (RNG(unstable)), (SHA(unstable)),
+        (SLC(unstable)), (SPI0(unstable)), (SPI1(unstable)), (SPI2), (SYSTEM(unstable)),
+        (SYSTIMER(unstable)), (TEE(unstable)), (TIMG0(unstable)), (TIMG1(unstable)),
+        (UART0), (UART1), (USB_DEVICE(unstable)), (BT(unstable)), (FLASH(unstable)),
+        (GPIO_DEDICATED(unstable)), (LP_CORE(unstable)), (SW_INTERRUPT(unstable)),
+        (WIFI), (MEM2MEM0(unstable)), (MEM2MEM1(unstable)), (MEM2MEM2(unstable)),
+        (MEM2MEM3(unstable)), (MEM2MEM4(unstable)), (MEM2MEM5(unstable)),
+        (MEM2MEM6(unstable)), (MEM2MEM7(unstable)), (MEM2MEM8(unstable)),
+        (MEM2MEM9(unstable)), (MEM2MEM10(unstable)), (MEM2MEM11(unstable)),
+        (PSRAM(unstable)))); _for_each_inner_peripheral!((dma_eligible(MEM2MEM0,
+        Mem2mem0, 0), (SPI2, Spi2, 1), (MEM2MEM1, Mem2mem1, 2), (I2S0, I2s0, 3),
+        (MEM2MEM2, Mem2mem2, 4), (MEM2MEM3, Mem2mem3, 5), (MEM2MEM4, Mem2mem4, 6), (SHA,
+        Sha, 7), (MEM2MEM5, Mem2mem5, 9), (MEM2MEM6, Mem2mem6, 10), (MEM2MEM7, Mem2mem7,
+        11), (MEM2MEM8, Mem2mem8, 12), (MEM2MEM9, Mem2mem9, 13), (MEM2MEM10, Mem2mem10,
+        14), (MEM2MEM11, Mem2mem11, 15)));
     };
 }
 /// This macro can be used to generate code for each `GPIOn` instance.

--- a/esp-metadata-generated/src/_generated_esp32c61.rs
+++ b/esp-metadata-generated/src/_generated_esp32c61.rs
@@ -414,6 +414,20 @@ macro_rules! for_each_dedicated_gpio {
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_dma_channel {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner_dma_channel { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_dma_channel!((DMA_CH0, 0, interrupt_in = DMA_IN_CH0,
+        interrupt_out = DMA_OUT_CH0)); _for_each_inner_dma_channel!((DMA_CH1, 1,
+        interrupt_in = DMA_IN_CH1, interrupt_out = DMA_OUT_CH1));
+        _for_each_inner_dma_channel!((shared));
+        _for_each_inner_dma_channel!((split(DMA_CH0, 0, interrupt_in = DMA_IN_CH0,
+        interrupt_out = DMA_OUT_CH0), (DMA_CH1, 1, interrupt_in = DMA_IN_CH1,
+        interrupt_out = DMA_OUT_CH1)));
+    };
+}
+#[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_ecc_working_mode {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_ecc_working_mode { $(($pattern) => $code;)* ($other
@@ -2837,8 +2851,13 @@ macro_rules! for_each_peripheral {
         GPIO28 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
         "GPIO29 peripheral singleton"] GPIO29 <= virtual()));
         _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH0 peripheral singleton"]
-        DMA_CH0 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
-        = "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual() (unstable)));
+        DMA_CH0 <= virtual(DMA_IN_CH0 : { bind_dma_in_interrupt, enable_dma_in_interrupt,
+        disable_dma_in_interrupt }, DMA_OUT_CH0 : { bind_dma_out_interrupt,
+        enable_dma_out_interrupt, disable_dma_out_interrupt }) (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH1 peripheral singleton"]
+        DMA_CH1 <= virtual(DMA_IN_CH1 : { bind_dma_in_interrupt, enable_dma_in_interrupt,
+        disable_dma_in_interrupt }, DMA_OUT_CH1 : { bind_dma_out_interrupt,
+        enable_dma_out_interrupt, disable_dma_out_interrupt }) (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc =
         "ASSIST_DEBUG peripheral singleton"] ASSIST_DEBUG <= ASSIST_DEBUG() (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc = "CLINT peripheral singleton"]
@@ -3191,51 +3210,56 @@ macro_rules! for_each_peripheral {
         "GPIO27 peripheral singleton"] GPIO27 <= virtual()), (@ peri_type #[doc =
         "GPIO28 peripheral singleton"] GPIO28 <= virtual()), (@ peri_type #[doc =
         "GPIO29 peripheral singleton"] GPIO29 <= virtual()), (@ peri_type #[doc =
-        "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual() (unstable)), (@ peri_type
-        #[doc = "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual() (unstable)), (@
-        peri_type #[doc = "ASSIST_DEBUG peripheral singleton"] ASSIST_DEBUG <=
-        ASSIST_DEBUG() (unstable)), (@ peri_type #[doc = "CLINT peripheral singleton"]
-        CLINT <= CLINT() (unstable)), (@ peri_type #[doc = "CACHE peripheral singleton"]
-        CACHE <= CACHE() (unstable)), (@ peri_type #[doc = "DMA peripheral singleton"]
-        DMA <= DMA() (unstable)), (@ peri_type #[doc = "ECC peripheral singleton"] ECC <=
-        ECC() (unstable)), (@ peri_type #[doc = "ECDSA peripheral singleton"] ECDSA <=
-        ECDSA() (unstable)), (@ peri_type #[doc = "EFUSE peripheral singleton"] EFUSE <=
-        EFUSE() (unstable)), (@ peri_type #[doc = "ETM peripheral singleton"] ETM <=
-        SOC_ETM() (unstable)), (@ peri_type #[doc = "GPIO peripheral singleton"] GPIO <=
-        GPIO() (unstable)), (@ peri_type #[doc = "GPIO_SD peripheral singleton"] GPIO_SD
-        <= GPIO_EXT() (unstable)), (@ peri_type #[doc = "HP_APM peripheral singleton"]
-        HP_APM <= HP_APM() (unstable)), (@ peri_type #[doc =
-        "HP_SYS peripheral singleton"] HP_SYS <= HP_SYS() (unstable)), (@ peri_type #[doc
-        = "I2C_ANA_MST peripheral singleton"] I2C_ANA_MST <= I2C_ANA_MST() (unstable)),
-        (@ peri_type #[doc = "I2C0 peripheral singleton"] I2C0 <= I2C0(I2C_EXT0 : {
-        bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })), (@
-        peri_type #[doc = "I2S0 peripheral singleton"] I2S0 <= I2S0(I2S0 : {
-        bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
-        (unstable)), (@ peri_type #[doc = "INTERRUPT_CORE0 peripheral singleton"]
-        INTERRUPT_CORE0 <= INTERRUPT_CORE0() (unstable)), (@ peri_type #[doc =
-        "INTPRI peripheral singleton"] INTPRI <= INTPRI() (unstable)), (@ peri_type #[doc
-        = "IO_MUX peripheral singleton"] IO_MUX <= IO_MUX() (unstable)), (@ peri_type
-        #[doc = "LP_ANA peripheral singleton"] LP_ANA <= LP_ANA() (unstable)), (@
-        peri_type #[doc = "LP_AON peripheral singleton"] LP_AON <= LP_AON() (unstable)),
-        (@ peri_type #[doc = "LP_APM peripheral singleton"] LP_APM <= LP_APM()
-        (unstable)), (@ peri_type #[doc = "LP_CLKRST peripheral singleton"] LP_CLKRST <=
-        LP_CLKRST() (unstable)), (@ peri_type #[doc = "LPWR peripheral singleton"] LPWR
-        <= LP_CLKRST() (unstable)), (@ peri_type #[doc =
-        "LP_IO_MUX peripheral singleton"] LP_IO_MUX <= LP_IO_MUX() (unstable)), (@
-        peri_type #[doc = "LP_PERI peripheral singleton"] LP_PERI <= LPPERI()
-        (unstable)), (@ peri_type #[doc = "LP_TEE peripheral singleton"] LP_TEE <=
-        LP_TEE() (unstable)), (@ peri_type #[doc = "LP_TIMER peripheral singleton"]
-        LP_TIMER <= LP_TIMER() (unstable)), (@ peri_type #[doc =
-        "LP_WDT peripheral singleton"] LP_WDT <= LP_WDT() (unstable)), (@ peri_type #[doc
-        = "MEM_MONITOR peripheral singleton"] MEM_MONITOR <= MEM_MONITOR() (unstable)),
-        (@ peri_type #[doc = "MODEM_LPCON peripheral singleton"] MODEM_LPCON <=
-        MODEM_LPCON() (unstable)), (@ peri_type #[doc =
-        "MODEM_SYSCON peripheral singleton"] MODEM_SYSCON <= MODEM_SYSCON() (unstable)),
-        (@ peri_type #[doc = "PAU peripheral singleton"] PAU <= PAU() (unstable)), (@
-        peri_type #[doc = "PCR peripheral singleton"] PCR <= PCR() (unstable)), (@
-        peri_type #[doc = "PMU peripheral singleton"] PMU <= PMU() (unstable)), (@
-        peri_type #[doc = "RNG peripheral singleton"] RNG <= RNG() (unstable)), (@
-        peri_type #[doc = "SHA peripheral singleton"] SHA <= SHA(SHA : {
+        "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual(DMA_IN_CH0 : {
+        bind_dma_in_interrupt, enable_dma_in_interrupt, disable_dma_in_interrupt },
+        DMA_OUT_CH0 : { bind_dma_out_interrupt, enable_dma_out_interrupt,
+        disable_dma_out_interrupt }) (unstable)), (@ peri_type #[doc =
+        "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual(DMA_IN_CH1 : {
+        bind_dma_in_interrupt, enable_dma_in_interrupt, disable_dma_in_interrupt },
+        DMA_OUT_CH1 : { bind_dma_out_interrupt, enable_dma_out_interrupt,
+        disable_dma_out_interrupt }) (unstable)), (@ peri_type #[doc =
+        "ASSIST_DEBUG peripheral singleton"] ASSIST_DEBUG <= ASSIST_DEBUG() (unstable)),
+        (@ peri_type #[doc = "CLINT peripheral singleton"] CLINT <= CLINT() (unstable)),
+        (@ peri_type #[doc = "CACHE peripheral singleton"] CACHE <= CACHE() (unstable)),
+        (@ peri_type #[doc = "DMA peripheral singleton"] DMA <= DMA() (unstable)), (@
+        peri_type #[doc = "ECC peripheral singleton"] ECC <= ECC() (unstable)), (@
+        peri_type #[doc = "ECDSA peripheral singleton"] ECDSA <= ECDSA() (unstable)), (@
+        peri_type #[doc = "EFUSE peripheral singleton"] EFUSE <= EFUSE() (unstable)), (@
+        peri_type #[doc = "ETM peripheral singleton"] ETM <= SOC_ETM() (unstable)), (@
+        peri_type #[doc = "GPIO peripheral singleton"] GPIO <= GPIO() (unstable)), (@
+        peri_type #[doc = "GPIO_SD peripheral singleton"] GPIO_SD <= GPIO_EXT()
+        (unstable)), (@ peri_type #[doc = "HP_APM peripheral singleton"] HP_APM <=
+        HP_APM() (unstable)), (@ peri_type #[doc = "HP_SYS peripheral singleton"] HP_SYS
+        <= HP_SYS() (unstable)), (@ peri_type #[doc = "I2C_ANA_MST peripheral singleton"]
+        I2C_ANA_MST <= I2C_ANA_MST() (unstable)), (@ peri_type #[doc =
+        "I2C0 peripheral singleton"] I2C0 <= I2C0(I2C_EXT0 : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt })), (@ peri_type #[doc =
+        "I2S0 peripheral singleton"] I2S0 <= I2S0(I2S0 : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt }) (unstable)), (@ peri_type #[doc
+        = "INTERRUPT_CORE0 peripheral singleton"] INTERRUPT_CORE0 <= INTERRUPT_CORE0()
+        (unstable)), (@ peri_type #[doc = "INTPRI peripheral singleton"] INTPRI <=
+        INTPRI() (unstable)), (@ peri_type #[doc = "IO_MUX peripheral singleton"] IO_MUX
+        <= IO_MUX() (unstable)), (@ peri_type #[doc = "LP_ANA peripheral singleton"]
+        LP_ANA <= LP_ANA() (unstable)), (@ peri_type #[doc =
+        "LP_AON peripheral singleton"] LP_AON <= LP_AON() (unstable)), (@ peri_type #[doc
+        = "LP_APM peripheral singleton"] LP_APM <= LP_APM() (unstable)), (@ peri_type
+        #[doc = "LP_CLKRST peripheral singleton"] LP_CLKRST <= LP_CLKRST() (unstable)),
+        (@ peri_type #[doc = "LPWR peripheral singleton"] LPWR <= LP_CLKRST()
+        (unstable)), (@ peri_type #[doc = "LP_IO_MUX peripheral singleton"] LP_IO_MUX <=
+        LP_IO_MUX() (unstable)), (@ peri_type #[doc = "LP_PERI peripheral singleton"]
+        LP_PERI <= LPPERI() (unstable)), (@ peri_type #[doc =
+        "LP_TEE peripheral singleton"] LP_TEE <= LP_TEE() (unstable)), (@ peri_type #[doc
+        = "LP_TIMER peripheral singleton"] LP_TIMER <= LP_TIMER() (unstable)), (@
+        peri_type #[doc = "LP_WDT peripheral singleton"] LP_WDT <= LP_WDT() (unstable)),
+        (@ peri_type #[doc = "MEM_MONITOR peripheral singleton"] MEM_MONITOR <=
+        MEM_MONITOR() (unstable)), (@ peri_type #[doc =
+        "MODEM_LPCON peripheral singleton"] MODEM_LPCON <= MODEM_LPCON() (unstable)), (@
+        peri_type #[doc = "MODEM_SYSCON peripheral singleton"] MODEM_SYSCON <=
+        MODEM_SYSCON() (unstable)), (@ peri_type #[doc = "PAU peripheral singleton"] PAU
+        <= PAU() (unstable)), (@ peri_type #[doc = "PCR peripheral singleton"] PCR <=
+        PCR() (unstable)), (@ peri_type #[doc = "PMU peripheral singleton"] PMU <= PMU()
+        (unstable)), (@ peri_type #[doc = "RNG peripheral singleton"] RNG <= RNG()
+        (unstable)), (@ peri_type #[doc = "SHA peripheral singleton"] SHA <= SHA(SHA : {
         bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
         (unstable)), (@ peri_type #[doc = "SLC peripheral singleton"] SLC <= SLC()
         (unstable)), (@ peri_type #[doc = "SPI0 peripheral singleton"] SPI0 <= SPI0()

--- a/esp-metadata-generated/src/_generated_esp32h2.rs
+++ b/esp-metadata-generated/src/_generated_esp32h2.rs
@@ -492,6 +492,22 @@ macro_rules! for_each_dedicated_gpio {
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_dma_channel {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner_dma_channel { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_dma_channel!((DMA_CH0, 0, interrupt_in = DMA_IN_CH0,
+        interrupt_out = DMA_OUT_CH0)); _for_each_inner_dma_channel!((DMA_CH1, 1,
+        interrupt_in = DMA_IN_CH1, interrupt_out = DMA_OUT_CH1));
+        _for_each_inner_dma_channel!((DMA_CH2, 2, interrupt_in = DMA_IN_CH2,
+        interrupt_out = DMA_OUT_CH2)); _for_each_inner_dma_channel!((shared));
+        _for_each_inner_dma_channel!((split(DMA_CH0, 0, interrupt_in = DMA_IN_CH0,
+        interrupt_out = DMA_OUT_CH0), (DMA_CH1, 1, interrupt_in = DMA_IN_CH1,
+        interrupt_out = DMA_OUT_CH1), (DMA_CH2, 2, interrupt_in = DMA_IN_CH2,
+        interrupt_out = DMA_OUT_CH2)));
+    };
+}
+#[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_ecc_working_mode {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_ecc_working_mode { $(($pattern) => $code;)* ($other
@@ -3594,14 +3610,21 @@ macro_rules! for_each_peripheral {
         #[doc = "<ul>"] #[doc =
         "<li>These pins may be used to debug the chip using USB.</li>"] #[doc = "</ul>"]
         #[doc = "</section>"] GPIO27 <= virtual())); _for_each_inner_peripheral!((@
-        peri_type #[doc = "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual()
+        peri_type #[doc = "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual(DMA_IN_CH0 :
+        { bind_dma_in_interrupt, enable_dma_in_interrupt, disable_dma_in_interrupt },
+        DMA_OUT_CH0 : { bind_dma_out_interrupt, enable_dma_out_interrupt,
+        disable_dma_out_interrupt }) (unstable))); _for_each_inner_peripheral!((@
+        peri_type #[doc = "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual(DMA_IN_CH1 :
+        { bind_dma_in_interrupt, enable_dma_in_interrupt, disable_dma_in_interrupt },
+        DMA_OUT_CH1 : { bind_dma_out_interrupt, enable_dma_out_interrupt,
+        disable_dma_out_interrupt }) (unstable))); _for_each_inner_peripheral!((@
+        peri_type #[doc = "DMA_CH2 peripheral singleton"] DMA_CH2 <= virtual(DMA_IN_CH2 :
+        { bind_dma_in_interrupt, enable_dma_in_interrupt, disable_dma_in_interrupt },
+        DMA_OUT_CH2 : { bind_dma_out_interrupt, enable_dma_out_interrupt,
+        disable_dma_out_interrupt }) (unstable))); _for_each_inner_peripheral!((@
+        peri_type #[doc = "AES peripheral singleton"] AES <= AES(AES : {
+        bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
         (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
-        "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH2 peripheral singleton"]
-        DMA_CH2 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
-        = "AES peripheral singleton"] AES <= AES(AES : { bind_peri_interrupt,
-        enable_peri_interrupt, disable_peri_interrupt }) (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc =
         "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC() (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc =
         "ASSIST_DEBUG peripheral singleton"] ASSIST_DEBUG <= ASSIST_DEBUG() (unstable)));
@@ -3917,32 +3940,40 @@ macro_rules! for_each_peripheral {
         #[doc = "<ul>"] #[doc =
         "<li>These pins may be used to debug the chip using USB.</li>"] #[doc = "</ul>"]
         #[doc = "</section>"] GPIO27 <= virtual()), (@ peri_type #[doc =
-        "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual() (unstable)), (@ peri_type
-        #[doc = "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual() (unstable)), (@
-        peri_type #[doc = "DMA_CH2 peripheral singleton"] DMA_CH2 <= virtual()
-        (unstable)), (@ peri_type #[doc = "AES peripheral singleton"] AES <= AES(AES : {
-        bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
-        (unstable)), (@ peri_type #[doc = "APB_SARADC peripheral singleton"] APB_SARADC
-        <= APB_SARADC() (unstable)), (@ peri_type #[doc =
-        "ASSIST_DEBUG peripheral singleton"] ASSIST_DEBUG <= ASSIST_DEBUG() (unstable)),
-        (@ peri_type #[doc = "DMA peripheral singleton"] DMA <= DMA() (unstable)), (@
-        peri_type #[doc = "DS peripheral singleton"] DS <= DS() (unstable)), (@ peri_type
-        #[doc = "ECC peripheral singleton"] ECC <= ECC() (unstable)), (@ peri_type #[doc
-        = "EFUSE peripheral singleton"] EFUSE <= EFUSE() (unstable)), (@ peri_type #[doc
-        = "GPIO peripheral singleton"] GPIO <= GPIO() (unstable)), (@ peri_type #[doc =
-        "GPIO_SD peripheral singleton"] GPIO_SD <= GPIO_SD() (unstable)), (@ peri_type
-        #[doc = "HMAC peripheral singleton"] HMAC <= HMAC() (unstable)), (@ peri_type
-        #[doc = "HP_APM peripheral singleton"] HP_APM <= HP_APM() (unstable)), (@
-        peri_type #[doc = "HP_SYS peripheral singleton"] HP_SYS <= HP_SYS() (unstable)),
-        (@ peri_type #[doc = "I2C_ANA_MST peripheral singleton"] I2C_ANA_MST <=
-        I2C_ANA_MST() (unstable)), (@ peri_type #[doc = "I2C0 peripheral singleton"] I2C0
-        <= I2C0(I2C_EXT0 : { bind_peri_interrupt, enable_peri_interrupt,
-        disable_peri_interrupt })), (@ peri_type #[doc = "I2C1 peripheral singleton"]
-        I2C1 <= I2C1(I2C_EXT1 : { bind_peri_interrupt, enable_peri_interrupt,
-        disable_peri_interrupt })), (@ peri_type #[doc = "I2S0 peripheral singleton"]
-        I2S0 <= I2S0(I2S0 : { bind_peri_interrupt, enable_peri_interrupt,
-        disable_peri_interrupt }) (unstable)), (@ peri_type #[doc =
-        "IEEE802154 peripheral singleton"] IEEE802154 <= IEEE802154(ZB_MAC : {
+        "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual(DMA_IN_CH0 : {
+        bind_dma_in_interrupt, enable_dma_in_interrupt, disable_dma_in_interrupt },
+        DMA_OUT_CH0 : { bind_dma_out_interrupt, enable_dma_out_interrupt,
+        disable_dma_out_interrupt }) (unstable)), (@ peri_type #[doc =
+        "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual(DMA_IN_CH1 : {
+        bind_dma_in_interrupt, enable_dma_in_interrupt, disable_dma_in_interrupt },
+        DMA_OUT_CH1 : { bind_dma_out_interrupt, enable_dma_out_interrupt,
+        disable_dma_out_interrupt }) (unstable)), (@ peri_type #[doc =
+        "DMA_CH2 peripheral singleton"] DMA_CH2 <= virtual(DMA_IN_CH2 : {
+        bind_dma_in_interrupt, enable_dma_in_interrupt, disable_dma_in_interrupt },
+        DMA_OUT_CH2 : { bind_dma_out_interrupt, enable_dma_out_interrupt,
+        disable_dma_out_interrupt }) (unstable)), (@ peri_type #[doc =
+        "AES peripheral singleton"] AES <= AES(AES : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt }) (unstable)), (@ peri_type #[doc
+        = "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC() (unstable)), (@
+        peri_type #[doc = "ASSIST_DEBUG peripheral singleton"] ASSIST_DEBUG <=
+        ASSIST_DEBUG() (unstable)), (@ peri_type #[doc = "DMA peripheral singleton"] DMA
+        <= DMA() (unstable)), (@ peri_type #[doc = "DS peripheral singleton"] DS <= DS()
+        (unstable)), (@ peri_type #[doc = "ECC peripheral singleton"] ECC <= ECC()
+        (unstable)), (@ peri_type #[doc = "EFUSE peripheral singleton"] EFUSE <= EFUSE()
+        (unstable)), (@ peri_type #[doc = "GPIO peripheral singleton"] GPIO <= GPIO()
+        (unstable)), (@ peri_type #[doc = "GPIO_SD peripheral singleton"] GPIO_SD <=
+        GPIO_SD() (unstable)), (@ peri_type #[doc = "HMAC peripheral singleton"] HMAC <=
+        HMAC() (unstable)), (@ peri_type #[doc = "HP_APM peripheral singleton"] HP_APM <=
+        HP_APM() (unstable)), (@ peri_type #[doc = "HP_SYS peripheral singleton"] HP_SYS
+        <= HP_SYS() (unstable)), (@ peri_type #[doc = "I2C_ANA_MST peripheral singleton"]
+        I2C_ANA_MST <= I2C_ANA_MST() (unstable)), (@ peri_type #[doc =
+        "I2C0 peripheral singleton"] I2C0 <= I2C0(I2C_EXT0 : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt })), (@ peri_type #[doc =
+        "I2C1 peripheral singleton"] I2C1 <= I2C1(I2C_EXT1 : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt })), (@ peri_type #[doc =
+        "I2S0 peripheral singleton"] I2S0 <= I2S0(I2S0 : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt }) (unstable)), (@ peri_type #[doc
+        = "IEEE802154 peripheral singleton"] IEEE802154 <= IEEE802154(ZB_MAC : {
         bind_mac_interrupt, enable_mac_interrupt, disable_mac_interrupt }) (unstable)),
         (@ peri_type #[doc = "INTERRUPT_CORE0 peripheral singleton"] INTERRUPT_CORE0 <=
         INTERRUPT_CORE0() (unstable)), (@ peri_type #[doc =

--- a/esp-metadata-generated/src/_generated_esp32h2.rs
+++ b/esp-metadata-generated/src/_generated_esp32h2.rs
@@ -3594,9 +3594,14 @@ macro_rules! for_each_peripheral {
         #[doc = "<ul>"] #[doc =
         "<li>These pins may be used to debug the chip using USB.</li>"] #[doc = "</ul>"]
         #[doc = "</section>"] GPIO27 <= virtual())); _for_each_inner_peripheral!((@
-        peri_type #[doc = "AES peripheral singleton"] AES <= AES(AES : {
-        bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
+        peri_type #[doc = "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual()
         (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH2 peripheral singleton"]
+        DMA_CH2 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "AES peripheral singleton"] AES <= AES(AES : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt }) (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
         "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC() (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc =
         "ASSIST_DEBUG peripheral singleton"] ASSIST_DEBUG <= ASSIST_DEBUG() (unstable)));
@@ -3702,18 +3707,13 @@ macro_rules! for_each_peripheral {
         "USB_DEVICE peripheral singleton"] USB_DEVICE <= USB_DEVICE(USB_DEVICE : {
         bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
         (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
-        "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH1 peripheral singleton"]
-        DMA_CH1 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
-        = "DMA_CH2 peripheral singleton"] DMA_CH2 <= virtual() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "ADC1 peripheral singleton"]
-        ADC1 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
-        "BT peripheral singleton"] BT <= virtual(LP_BLE_TIMER : {
-        bind_lp_timer_interrupt, enable_lp_timer_interrupt, disable_lp_timer_interrupt },
-        BT_MAC : { bind_mac_interrupt, enable_mac_interrupt, disable_mac_interrupt })
-        (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
-        "FLASH peripheral singleton"] FLASH <= virtual() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "ADC1 peripheral singleton"] ADC1 <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "BT peripheral singleton"] BT <=
+        virtual(LP_BLE_TIMER : { bind_lp_timer_interrupt, enable_lp_timer_interrupt,
+        disable_lp_timer_interrupt }, BT_MAC : { bind_mac_interrupt,
+        enable_mac_interrupt, disable_mac_interrupt }) (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "FLASH peripheral singleton"]
+        FLASH <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "GPIO_DEDICATED peripheral singleton"] GPIO_DEDICATED <= virtual() (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc =
         "SW_INTERRUPT peripheral singleton"] SW_INTERRUPT <= virtual() (unstable)));
@@ -3741,6 +3741,9 @@ macro_rules! for_each_peripheral {
         _for_each_inner_peripheral!((GPIO22)); _for_each_inner_peripheral!((GPIO23));
         _for_each_inner_peripheral!((GPIO24)); _for_each_inner_peripheral!((GPIO25));
         _for_each_inner_peripheral!((GPIO26)); _for_each_inner_peripheral!((GPIO27));
+        _for_each_inner_peripheral!((DMA_CH0(unstable)));
+        _for_each_inner_peripheral!((DMA_CH1(unstable)));
+        _for_each_inner_peripheral!((DMA_CH2(unstable)));
         _for_each_inner_peripheral!((AES(unstable)));
         _for_each_inner_peripheral!((APB_SARADC(unstable)));
         _for_each_inner_peripheral!((ASSIST_DEBUG(unstable)));
@@ -3798,9 +3801,6 @@ macro_rules! for_each_peripheral {
         _for_each_inner_peripheral!((UART0)); _for_each_inner_peripheral!((UART1));
         _for_each_inner_peripheral!((UHCI0(unstable)));
         _for_each_inner_peripheral!((USB_DEVICE(unstable)));
-        _for_each_inner_peripheral!((DMA_CH0(unstable)));
-        _for_each_inner_peripheral!((DMA_CH1(unstable)));
-        _for_each_inner_peripheral!((DMA_CH2(unstable)));
         _for_each_inner_peripheral!((ADC1(unstable)));
         _for_each_inner_peripheral!((BT(unstable)));
         _for_each_inner_peripheral!((FLASH(unstable)));
@@ -3917,28 +3917,32 @@ macro_rules! for_each_peripheral {
         #[doc = "<ul>"] #[doc =
         "<li>These pins may be used to debug the chip using USB.</li>"] #[doc = "</ul>"]
         #[doc = "</section>"] GPIO27 <= virtual()), (@ peri_type #[doc =
-        "AES peripheral singleton"] AES <= AES(AES : { bind_peri_interrupt,
-        enable_peri_interrupt, disable_peri_interrupt }) (unstable)), (@ peri_type #[doc
-        = "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC() (unstable)), (@
-        peri_type #[doc = "ASSIST_DEBUG peripheral singleton"] ASSIST_DEBUG <=
-        ASSIST_DEBUG() (unstable)), (@ peri_type #[doc = "DMA peripheral singleton"] DMA
-        <= DMA() (unstable)), (@ peri_type #[doc = "DS peripheral singleton"] DS <= DS()
-        (unstable)), (@ peri_type #[doc = "ECC peripheral singleton"] ECC <= ECC()
-        (unstable)), (@ peri_type #[doc = "EFUSE peripheral singleton"] EFUSE <= EFUSE()
-        (unstable)), (@ peri_type #[doc = "GPIO peripheral singleton"] GPIO <= GPIO()
-        (unstable)), (@ peri_type #[doc = "GPIO_SD peripheral singleton"] GPIO_SD <=
-        GPIO_SD() (unstable)), (@ peri_type #[doc = "HMAC peripheral singleton"] HMAC <=
-        HMAC() (unstable)), (@ peri_type #[doc = "HP_APM peripheral singleton"] HP_APM <=
-        HP_APM() (unstable)), (@ peri_type #[doc = "HP_SYS peripheral singleton"] HP_SYS
-        <= HP_SYS() (unstable)), (@ peri_type #[doc = "I2C_ANA_MST peripheral singleton"]
-        I2C_ANA_MST <= I2C_ANA_MST() (unstable)), (@ peri_type #[doc =
-        "I2C0 peripheral singleton"] I2C0 <= I2C0(I2C_EXT0 : { bind_peri_interrupt,
-        enable_peri_interrupt, disable_peri_interrupt })), (@ peri_type #[doc =
-        "I2C1 peripheral singleton"] I2C1 <= I2C1(I2C_EXT1 : { bind_peri_interrupt,
-        enable_peri_interrupt, disable_peri_interrupt })), (@ peri_type #[doc =
-        "I2S0 peripheral singleton"] I2S0 <= I2S0(I2S0 : { bind_peri_interrupt,
-        enable_peri_interrupt, disable_peri_interrupt }) (unstable)), (@ peri_type #[doc
-        = "IEEE802154 peripheral singleton"] IEEE802154 <= IEEE802154(ZB_MAC : {
+        "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual() (unstable)), (@ peri_type
+        #[doc = "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual() (unstable)), (@
+        peri_type #[doc = "DMA_CH2 peripheral singleton"] DMA_CH2 <= virtual()
+        (unstable)), (@ peri_type #[doc = "AES peripheral singleton"] AES <= AES(AES : {
+        bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
+        (unstable)), (@ peri_type #[doc = "APB_SARADC peripheral singleton"] APB_SARADC
+        <= APB_SARADC() (unstable)), (@ peri_type #[doc =
+        "ASSIST_DEBUG peripheral singleton"] ASSIST_DEBUG <= ASSIST_DEBUG() (unstable)),
+        (@ peri_type #[doc = "DMA peripheral singleton"] DMA <= DMA() (unstable)), (@
+        peri_type #[doc = "DS peripheral singleton"] DS <= DS() (unstable)), (@ peri_type
+        #[doc = "ECC peripheral singleton"] ECC <= ECC() (unstable)), (@ peri_type #[doc
+        = "EFUSE peripheral singleton"] EFUSE <= EFUSE() (unstable)), (@ peri_type #[doc
+        = "GPIO peripheral singleton"] GPIO <= GPIO() (unstable)), (@ peri_type #[doc =
+        "GPIO_SD peripheral singleton"] GPIO_SD <= GPIO_SD() (unstable)), (@ peri_type
+        #[doc = "HMAC peripheral singleton"] HMAC <= HMAC() (unstable)), (@ peri_type
+        #[doc = "HP_APM peripheral singleton"] HP_APM <= HP_APM() (unstable)), (@
+        peri_type #[doc = "HP_SYS peripheral singleton"] HP_SYS <= HP_SYS() (unstable)),
+        (@ peri_type #[doc = "I2C_ANA_MST peripheral singleton"] I2C_ANA_MST <=
+        I2C_ANA_MST() (unstable)), (@ peri_type #[doc = "I2C0 peripheral singleton"] I2C0
+        <= I2C0(I2C_EXT0 : { bind_peri_interrupt, enable_peri_interrupt,
+        disable_peri_interrupt })), (@ peri_type #[doc = "I2C1 peripheral singleton"]
+        I2C1 <= I2C1(I2C_EXT1 : { bind_peri_interrupt, enable_peri_interrupt,
+        disable_peri_interrupt })), (@ peri_type #[doc = "I2S0 peripheral singleton"]
+        I2S0 <= I2S0(I2S0 : { bind_peri_interrupt, enable_peri_interrupt,
+        disable_peri_interrupt }) (unstable)), (@ peri_type #[doc =
+        "IEEE802154 peripheral singleton"] IEEE802154 <= IEEE802154(ZB_MAC : {
         bind_mac_interrupt, enable_mac_interrupt, disable_mac_interrupt }) (unstable)),
         (@ peri_type #[doc = "INTERRUPT_CORE0 peripheral singleton"] INTERRUPT_CORE0 <=
         INTERRUPT_CORE0() (unstable)), (@ peri_type #[doc =
@@ -3997,16 +4001,13 @@ macro_rules! for_each_peripheral {
         peri_type #[doc = "USB_DEVICE peripheral singleton"] USB_DEVICE <=
         USB_DEVICE(USB_DEVICE : { bind_peri_interrupt, enable_peri_interrupt,
         disable_peri_interrupt }) (unstable)), (@ peri_type #[doc =
-        "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual() (unstable)), (@ peri_type
-        #[doc = "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual() (unstable)), (@
-        peri_type #[doc = "DMA_CH2 peripheral singleton"] DMA_CH2 <= virtual()
-        (unstable)), (@ peri_type #[doc = "ADC1 peripheral singleton"] ADC1 <= virtual()
-        (unstable)), (@ peri_type #[doc = "BT peripheral singleton"] BT <=
-        virtual(LP_BLE_TIMER : { bind_lp_timer_interrupt, enable_lp_timer_interrupt,
-        disable_lp_timer_interrupt }, BT_MAC : { bind_mac_interrupt,
-        enable_mac_interrupt, disable_mac_interrupt }) (unstable)), (@ peri_type #[doc =
-        "FLASH peripheral singleton"] FLASH <= virtual() (unstable)), (@ peri_type #[doc
-        = "GPIO_DEDICATED peripheral singleton"] GPIO_DEDICATED <= virtual() (unstable)),
+        "ADC1 peripheral singleton"] ADC1 <= virtual() (unstable)), (@ peri_type #[doc =
+        "BT peripheral singleton"] BT <= virtual(LP_BLE_TIMER : {
+        bind_lp_timer_interrupt, enable_lp_timer_interrupt, disable_lp_timer_interrupt },
+        BT_MAC : { bind_mac_interrupt, enable_mac_interrupt, disable_mac_interrupt })
+        (unstable)), (@ peri_type #[doc = "FLASH peripheral singleton"] FLASH <=
+        virtual() (unstable)), (@ peri_type #[doc =
+        "GPIO_DEDICATED peripheral singleton"] GPIO_DEDICATED <= virtual() (unstable)),
         (@ peri_type #[doc = "SW_INTERRUPT peripheral singleton"] SW_INTERRUPT <=
         virtual() (unstable)), (@ peri_type #[doc = "MEM2MEM0 peripheral singleton"]
         MEM2MEM0 <= virtual() (unstable)), (@ peri_type #[doc =
@@ -4022,7 +4023,8 @@ macro_rules! for_each_peripheral {
         (unstable)))); _for_each_inner_peripheral!((singletons(GPIO0), (GPIO1), (GPIO2),
         (GPIO3), (GPIO4), (GPIO5), (GPIO6), (GPIO7), (GPIO8), (GPIO9), (GPIO10),
         (GPIO11), (GPIO12), (GPIO13), (GPIO14), (GPIO22), (GPIO23), (GPIO24), (GPIO25),
-        (GPIO26), (GPIO27), (AES(unstable)), (APB_SARADC(unstable)),
+        (GPIO26), (GPIO27), (DMA_CH0(unstable)), (DMA_CH1(unstable)),
+        (DMA_CH2(unstable)), (AES(unstable)), (APB_SARADC(unstable)),
         (ASSIST_DEBUG(unstable)), (DMA(unstable)), (DS(unstable)), (ECC(unstable)),
         (GPIO(unstable)), (GPIO_SD(unstable)), (HMAC(unstable)), (HP_APM(unstable)),
         (HP_SYS(unstable)), (I2C_ANA_MST(unstable)), (I2C0), (I2C1), (I2S0(unstable)),
@@ -4038,8 +4040,7 @@ macro_rules! for_each_peripheral {
         (SPI1(unstable)), (SPI2), (SYSTEM(unstable)), (SYSTIMER(unstable)),
         (TEE(unstable)), (TIMG0(unstable)), (TIMG1(unstable)), (TRACE0(unstable)),
         (TWAI0(unstable)), (UART0), (UART1), (UHCI0(unstable)), (USB_DEVICE(unstable)),
-        (DMA_CH0(unstable)), (DMA_CH1(unstable)), (DMA_CH2(unstable)), (ADC1(unstable)),
-        (BT(unstable)), (FLASH(unstable)), (GPIO_DEDICATED(unstable)),
+        (ADC1(unstable)), (BT(unstable)), (FLASH(unstable)), (GPIO_DEDICATED(unstable)),
         (SW_INTERRUPT(unstable)), (MEM2MEM0(unstable)), (MEM2MEM1(unstable)),
         (MEM2MEM2(unstable)), (MEM2MEM3(unstable)), (MEM2MEM4(unstable)),
         (MEM2MEM5(unstable)), (MEM2MEM6(unstable)), (MEM2MEM7(unstable)),

--- a/esp-metadata-generated/src/_generated_esp32p4.rs
+++ b/esp-metadata-generated/src/_generated_esp32p4.rs
@@ -403,6 +403,22 @@ macro_rules! for_each_aes_key_length {
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_dma_channel {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner_dma_channel { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_dma_channel!((DMA_CH0, 0, interrupt_in = AHB_PDMA_IN_CH0,
+        interrupt_out = AHB_PDMA_OUT_CH0)); _for_each_inner_dma_channel!((DMA_CH1, 1,
+        interrupt_in = AHB_PDMA_IN_CH1, interrupt_out = AHB_PDMA_OUT_CH1));
+        _for_each_inner_dma_channel!((DMA_CH2, 2, interrupt_in = AHB_PDMA_IN_CH2,
+        interrupt_out = AHB_PDMA_OUT_CH2)); _for_each_inner_dma_channel!((shared));
+        _for_each_inner_dma_channel!((split(DMA_CH0, 0, interrupt_in = AHB_PDMA_IN_CH0,
+        interrupt_out = AHB_PDMA_OUT_CH0), (DMA_CH1, 1, interrupt_in = AHB_PDMA_IN_CH1,
+        interrupt_out = AHB_PDMA_OUT_CH1), (DMA_CH2, 2, interrupt_in = AHB_PDMA_IN_CH2,
+        interrupt_out = AHB_PDMA_OUT_CH2)));
+    };
+}
+#[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_ecc_working_mode {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_ecc_working_mode { $(($pattern) => $code;)* ($other
@@ -3614,16 +3630,25 @@ macro_rules! for_each_peripheral {
         GPIO53 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
         "GPIO54 peripheral singleton"] GPIO54 <= virtual()));
         _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH0 peripheral singleton"]
-        DMA_CH0 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
-        = "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH2 peripheral singleton"]
-        DMA_CH2 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
-        = "EFUSE peripheral singleton"] EFUSE <= EFUSE() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO peripheral singleton"]
-        GPIO <= GPIO() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
-        "SYSTEM peripheral singleton"] SYSTEM <= HP_SYS() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "HP_SYS peripheral singleton"]
-        HP_SYS <= HP_SYS() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        DMA_CH0 <= virtual(AHB_PDMA_IN_CH0 : { bind_dma_in_interrupt,
+        enable_dma_in_interrupt, disable_dma_in_interrupt }, AHB_PDMA_OUT_CH0 : {
+        bind_dma_out_interrupt, enable_dma_out_interrupt, disable_dma_out_interrupt })
+        (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual(AHB_PDMA_IN_CH1 : {
+        bind_dma_in_interrupt, enable_dma_in_interrupt, disable_dma_in_interrupt },
+        AHB_PDMA_OUT_CH1 : { bind_dma_out_interrupt, enable_dma_out_interrupt,
+        disable_dma_out_interrupt }) (unstable))); _for_each_inner_peripheral!((@
+        peri_type #[doc = "DMA_CH2 peripheral singleton"] DMA_CH2 <=
+        virtual(AHB_PDMA_IN_CH2 : { bind_dma_in_interrupt, enable_dma_in_interrupt,
+        disable_dma_in_interrupt }, AHB_PDMA_OUT_CH2 : { bind_dma_out_interrupt,
+        enable_dma_out_interrupt, disable_dma_out_interrupt }) (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "EFUSE peripheral singleton"]
+        EFUSE <= EFUSE() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "GPIO peripheral singleton"] GPIO <= GPIO() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "SYSTEM peripheral singleton"]
+        SYSTEM <= HP_SYS() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "HP_SYS peripheral singleton"] HP_SYS <= HP_SYS() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
         "HP_SYS_CLKRST peripheral singleton"] HP_SYS_CLKRST <= HP_SYS_CLKRST()
         (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "RNG peripheral singleton"] RNG <= LP_SYS() (unstable)));
@@ -3932,15 +3957,23 @@ macro_rules! for_each_peripheral {
         "GPIO52 peripheral singleton"] GPIO52 <= virtual()), (@ peri_type #[doc =
         "GPIO53 peripheral singleton"] GPIO53 <= virtual()), (@ peri_type #[doc =
         "GPIO54 peripheral singleton"] GPIO54 <= virtual()), (@ peri_type #[doc =
-        "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual() (unstable)), (@ peri_type
-        #[doc = "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual() (unstable)), (@
-        peri_type #[doc = "DMA_CH2 peripheral singleton"] DMA_CH2 <= virtual()
-        (unstable)), (@ peri_type #[doc = "EFUSE peripheral singleton"] EFUSE <= EFUSE()
-        (unstable)), (@ peri_type #[doc = "GPIO peripheral singleton"] GPIO <= GPIO()
-        (unstable)), (@ peri_type #[doc = "SYSTEM peripheral singleton"] SYSTEM <=
-        HP_SYS() (unstable)), (@ peri_type #[doc = "HP_SYS peripheral singleton"] HP_SYS
-        <= HP_SYS() (unstable)), (@ peri_type #[doc =
-        "HP_SYS_CLKRST peripheral singleton"] HP_SYS_CLKRST <= HP_SYS_CLKRST()
+        "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual(AHB_PDMA_IN_CH0 : {
+        bind_dma_in_interrupt, enable_dma_in_interrupt, disable_dma_in_interrupt },
+        AHB_PDMA_OUT_CH0 : { bind_dma_out_interrupt, enable_dma_out_interrupt,
+        disable_dma_out_interrupt }) (unstable)), (@ peri_type #[doc =
+        "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual(AHB_PDMA_IN_CH1 : {
+        bind_dma_in_interrupt, enable_dma_in_interrupt, disable_dma_in_interrupt },
+        AHB_PDMA_OUT_CH1 : { bind_dma_out_interrupt, enable_dma_out_interrupt,
+        disable_dma_out_interrupt }) (unstable)), (@ peri_type #[doc =
+        "DMA_CH2 peripheral singleton"] DMA_CH2 <= virtual(AHB_PDMA_IN_CH2 : {
+        bind_dma_in_interrupt, enable_dma_in_interrupt, disable_dma_in_interrupt },
+        AHB_PDMA_OUT_CH2 : { bind_dma_out_interrupt, enable_dma_out_interrupt,
+        disable_dma_out_interrupt }) (unstable)), (@ peri_type #[doc =
+        "EFUSE peripheral singleton"] EFUSE <= EFUSE() (unstable)), (@ peri_type #[doc =
+        "GPIO peripheral singleton"] GPIO <= GPIO() (unstable)), (@ peri_type #[doc =
+        "SYSTEM peripheral singleton"] SYSTEM <= HP_SYS() (unstable)), (@ peri_type #[doc
+        = "HP_SYS peripheral singleton"] HP_SYS <= HP_SYS() (unstable)), (@ peri_type
+        #[doc = "HP_SYS_CLKRST peripheral singleton"] HP_SYS_CLKRST <= HP_SYS_CLKRST()
         (unstable)), (@ peri_type #[doc = "RNG peripheral singleton"] RNG <= LP_SYS()
         (unstable)), (@ peri_type #[doc = "INTERRUPT_CORE0 peripheral singleton"]
         INTERRUPT_CORE0 <= INTERRUPT_CORE0() (unstable)), (@ peri_type #[doc =

--- a/esp-metadata-generated/src/_generated_esp32p4.rs
+++ b/esp-metadata-generated/src/_generated_esp32p4.rs
@@ -3613,13 +3613,17 @@ macro_rules! for_each_peripheral {
         _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO53 peripheral singleton"]
         GPIO53 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
         "GPIO54 peripheral singleton"] GPIO54 <= virtual()));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "EFUSE peripheral singleton"]
-        EFUSE <= EFUSE() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
-        "GPIO peripheral singleton"] GPIO <= GPIO() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "SYSTEM peripheral singleton"]
-        SYSTEM <= HP_SYS() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
-        "HP_SYS peripheral singleton"] HP_SYS <= HP_SYS() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH0 peripheral singleton"]
+        DMA_CH0 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH2 peripheral singleton"]
+        DMA_CH2 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "EFUSE peripheral singleton"] EFUSE <= EFUSE() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO peripheral singleton"]
+        GPIO <= GPIO() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "SYSTEM peripheral singleton"] SYSTEM <= HP_SYS() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "HP_SYS peripheral singleton"]
+        HP_SYS <= HP_SYS() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "HP_SYS_CLKRST peripheral singleton"] HP_SYS_CLKRST <= HP_SYS_CLKRST()
         (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "RNG peripheral singleton"] RNG <= LP_SYS() (unstable)));
@@ -3682,17 +3686,13 @@ macro_rules! for_each_peripheral {
         #[doc = "PSRAM peripheral singleton"] PSRAM <= virtual() (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc = "DMA peripheral singleton"] DMA
         <= AHB_DMA() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
-        "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH1 peripheral singleton"]
-        DMA_CH1 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
-        = "DMA_CH2 peripheral singleton"] DMA_CH2 <= virtual() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "ETH peripheral singleton"] ETH
-        <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
-        "EMAC_DMA peripheral singleton"] EMAC_DMA <= EMAC_DMA() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "EMAC_MAC peripheral singleton"]
-        EMAC_MAC <= EMAC_MAC() (unstable))); _for_each_inner_peripheral!((@ peri_type
-        #[doc = "USB_DEVICE peripheral singleton"] USB_DEVICE <= USB_DEVICE(USB_DEVICE :
-        { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
+        "ETH peripheral singleton"] ETH <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "EMAC_DMA peripheral singleton"]
+        EMAC_DMA <= EMAC_DMA() (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "EMAC_MAC peripheral singleton"] EMAC_MAC <= EMAC_MAC() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "USB_DEVICE peripheral singleton"] USB_DEVICE <= USB_DEVICE(USB_DEVICE : {
+        bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
         (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "SDHOST peripheral singleton"] SDHOST <= SDHOST() (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc = "LEDC peripheral singleton"]
@@ -3757,6 +3757,9 @@ macro_rules! for_each_peripheral {
         _for_each_inner_peripheral!((GPIO49)); _for_each_inner_peripheral!((GPIO50));
         _for_each_inner_peripheral!((GPIO51)); _for_each_inner_peripheral!((GPIO52));
         _for_each_inner_peripheral!((GPIO53)); _for_each_inner_peripheral!((GPIO54));
+        _for_each_inner_peripheral!((DMA_CH0(unstable)));
+        _for_each_inner_peripheral!((DMA_CH1(unstable)));
+        _for_each_inner_peripheral!((DMA_CH2(unstable)));
         _for_each_inner_peripheral!((GPIO(unstable)));
         _for_each_inner_peripheral!((SYSTEM(unstable)));
         _for_each_inner_peripheral!((HP_SYS(unstable)));
@@ -3789,9 +3792,6 @@ macro_rules! for_each_peripheral {
         _for_each_inner_peripheral!((TWAI2(unstable)));
         _for_each_inner_peripheral!((PSRAM(unstable)));
         _for_each_inner_peripheral!((DMA(unstable)));
-        _for_each_inner_peripheral!((DMA_CH0(unstable)));
-        _for_each_inner_peripheral!((DMA_CH1(unstable)));
-        _for_each_inner_peripheral!((DMA_CH2(unstable)));
         _for_each_inner_peripheral!((ETH(unstable)));
         _for_each_inner_peripheral!((USB_DEVICE(unstable)));
         _for_each_inner_peripheral!((SDHOST(unstable)));
@@ -3932,11 +3932,15 @@ macro_rules! for_each_peripheral {
         "GPIO52 peripheral singleton"] GPIO52 <= virtual()), (@ peri_type #[doc =
         "GPIO53 peripheral singleton"] GPIO53 <= virtual()), (@ peri_type #[doc =
         "GPIO54 peripheral singleton"] GPIO54 <= virtual()), (@ peri_type #[doc =
-        "EFUSE peripheral singleton"] EFUSE <= EFUSE() (unstable)), (@ peri_type #[doc =
-        "GPIO peripheral singleton"] GPIO <= GPIO() (unstable)), (@ peri_type #[doc =
-        "SYSTEM peripheral singleton"] SYSTEM <= HP_SYS() (unstable)), (@ peri_type #[doc
-        = "HP_SYS peripheral singleton"] HP_SYS <= HP_SYS() (unstable)), (@ peri_type
-        #[doc = "HP_SYS_CLKRST peripheral singleton"] HP_SYS_CLKRST <= HP_SYS_CLKRST()
+        "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual() (unstable)), (@ peri_type
+        #[doc = "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual() (unstable)), (@
+        peri_type #[doc = "DMA_CH2 peripheral singleton"] DMA_CH2 <= virtual()
+        (unstable)), (@ peri_type #[doc = "EFUSE peripheral singleton"] EFUSE <= EFUSE()
+        (unstable)), (@ peri_type #[doc = "GPIO peripheral singleton"] GPIO <= GPIO()
+        (unstable)), (@ peri_type #[doc = "SYSTEM peripheral singleton"] SYSTEM <=
+        HP_SYS() (unstable)), (@ peri_type #[doc = "HP_SYS peripheral singleton"] HP_SYS
+        <= HP_SYS() (unstable)), (@ peri_type #[doc =
+        "HP_SYS_CLKRST peripheral singleton"] HP_SYS_CLKRST <= HP_SYS_CLKRST()
         (unstable)), (@ peri_type #[doc = "RNG peripheral singleton"] RNG <= LP_SYS()
         (unstable)), (@ peri_type #[doc = "INTERRUPT_CORE0 peripheral singleton"]
         INTERRUPT_CORE0 <= INTERRUPT_CORE0() (unstable)), (@ peri_type #[doc =
@@ -3981,22 +3985,18 @@ macro_rules! for_each_peripheral {
         enable_peri_interrupt, disable_peri_interrupt }) (unstable)), (@ peri_type #[doc
         = "PSRAM peripheral singleton"] PSRAM <= virtual() (unstable)), (@ peri_type
         #[doc = "DMA peripheral singleton"] DMA <= AHB_DMA() (unstable)), (@ peri_type
-        #[doc = "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual() (unstable)), (@
-        peri_type #[doc = "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual()
-        (unstable)), (@ peri_type #[doc = "DMA_CH2 peripheral singleton"] DMA_CH2 <=
-        virtual() (unstable)), (@ peri_type #[doc = "ETH peripheral singleton"] ETH <=
-        virtual() (unstable)), (@ peri_type #[doc = "EMAC_DMA peripheral singleton"]
-        EMAC_DMA <= EMAC_DMA() (unstable)), (@ peri_type #[doc =
-        "EMAC_MAC peripheral singleton"] EMAC_MAC <= EMAC_MAC() (unstable)), (@ peri_type
-        #[doc = "USB_DEVICE peripheral singleton"] USB_DEVICE <= USB_DEVICE(USB_DEVICE :
-        { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
-        (unstable)), (@ peri_type #[doc = "SDHOST peripheral singleton"] SDHOST <=
-        SDHOST() (unstable)), (@ peri_type #[doc = "LEDC peripheral singleton"] LEDC <=
-        LEDC(LEDC : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt
-        }) (unstable)), (@ peri_type #[doc = "MCPWM0 peripheral singleton"] MCPWM0 <=
-        MCPWM0(PWM0 : { bind_peri_interrupt, enable_peri_interrupt,
+        #[doc = "ETH peripheral singleton"] ETH <= virtual() (unstable)), (@ peri_type
+        #[doc = "EMAC_DMA peripheral singleton"] EMAC_DMA <= EMAC_DMA() (unstable)), (@
+        peri_type #[doc = "EMAC_MAC peripheral singleton"] EMAC_MAC <= EMAC_MAC()
+        (unstable)), (@ peri_type #[doc = "USB_DEVICE peripheral singleton"] USB_DEVICE
+        <= USB_DEVICE(USB_DEVICE : { bind_peri_interrupt, enable_peri_interrupt,
         disable_peri_interrupt }) (unstable)), (@ peri_type #[doc =
-        "MCPWM1 peripheral singleton"] MCPWM1 <= MCPWM1(PWM1 : { bind_peri_interrupt,
+        "SDHOST peripheral singleton"] SDHOST <= SDHOST() (unstable)), (@ peri_type #[doc
+        = "LEDC peripheral singleton"] LEDC <= LEDC(LEDC : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt }) (unstable)), (@ peri_type #[doc
+        = "MCPWM0 peripheral singleton"] MCPWM0 <= MCPWM0(PWM0 : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt }) (unstable)), (@ peri_type #[doc
+        = "MCPWM1 peripheral singleton"] MCPWM1 <= MCPWM1(PWM1 : { bind_peri_interrupt,
         enable_peri_interrupt, disable_peri_interrupt }) (unstable)), (@ peri_type #[doc
         = "PCNT peripheral singleton"] PCNT <= PCNT(PCNT : { bind_peri_interrupt,
         enable_peri_interrupt, disable_peri_interrupt }) (unstable)), (@ peri_type #[doc
@@ -4025,23 +4025,23 @@ macro_rules! for_each_peripheral {
         (GPIO27), (GPIO28), (GPIO29), (GPIO30), (GPIO31), (GPIO32), (GPIO33), (GPIO34),
         (GPIO35), (GPIO36), (GPIO37), (GPIO38), (GPIO39), (GPIO40), (GPIO41), (GPIO42),
         (GPIO43), (GPIO44), (GPIO45), (GPIO46), (GPIO47), (GPIO48), (GPIO49), (GPIO50),
-        (GPIO51), (GPIO52), (GPIO53), (GPIO54), (GPIO(unstable)), (SYSTEM(unstable)),
-        (HP_SYS(unstable)), (HP_SYS_CLKRST(unstable)), (RNG(unstable)),
-        (INTERRUPT_CORE0(unstable)), (INTERRUPT_CORE1(unstable)),
-        (LP_I2C_ANA_MST(unstable)), (CLIC(unstable)), (IO_MUX(unstable)),
-        (LP_AON(unstable)), (LP_AON_CLKRST(unstable)), (LP_SYS(unstable)),
-        (LP_WDT(unstable)), (LPWR(unstable)), (PMU(unstable)), (SYSTIMER(unstable)),
-        (TIMG0(unstable)), (TIMG1(unstable)), (UART0(unstable)), (UART1(unstable)),
-        (UART2(unstable)), (UART3(unstable)), (UART4(unstable)), (SPI2), (SPI3),
-        (I2C0(unstable)), (I2C1(unstable)), (TWAI0(unstable)), (TWAI1(unstable)),
-        (TWAI2(unstable)), (PSRAM(unstable)), (DMA(unstable)), (DMA_CH0(unstable)),
-        (DMA_CH1(unstable)), (DMA_CH2(unstable)), (ETH(unstable)),
-        (USB_DEVICE(unstable)), (SDHOST(unstable)), (LEDC(unstable)), (MCPWM0(unstable)),
-        (MCPWM1(unstable)), (PCNT(unstable)), (RMT(unstable)), (ADC(unstable)),
-        (AES(unstable)), (SHA(unstable)), (RSA(unstable)), (ECC(unstable)),
-        (USB_FS(unstable)), (USB_HS(unstable)), (SW_INTERRUPT(unstable)),
-        (CPU_CTRL(unstable)))); _for_each_inner_peripheral!((dma_eligible(SPI2, Spi2, 1),
-        (SPI3, Spi3, 2), (AES, Aes, 4), (SHA, Sha, 5)));
+        (GPIO51), (GPIO52), (GPIO53), (GPIO54), (DMA_CH0(unstable)), (DMA_CH1(unstable)),
+        (DMA_CH2(unstable)), (GPIO(unstable)), (SYSTEM(unstable)), (HP_SYS(unstable)),
+        (HP_SYS_CLKRST(unstable)), (RNG(unstable)), (INTERRUPT_CORE0(unstable)),
+        (INTERRUPT_CORE1(unstable)), (LP_I2C_ANA_MST(unstable)), (CLIC(unstable)),
+        (IO_MUX(unstable)), (LP_AON(unstable)), (LP_AON_CLKRST(unstable)),
+        (LP_SYS(unstable)), (LP_WDT(unstable)), (LPWR(unstable)), (PMU(unstable)),
+        (SYSTIMER(unstable)), (TIMG0(unstable)), (TIMG1(unstable)), (UART0(unstable)),
+        (UART1(unstable)), (UART2(unstable)), (UART3(unstable)), (UART4(unstable)),
+        (SPI2), (SPI3), (I2C0(unstable)), (I2C1(unstable)), (TWAI0(unstable)),
+        (TWAI1(unstable)), (TWAI2(unstable)), (PSRAM(unstable)), (DMA(unstable)),
+        (ETH(unstable)), (USB_DEVICE(unstable)), (SDHOST(unstable)), (LEDC(unstable)),
+        (MCPWM0(unstable)), (MCPWM1(unstable)), (PCNT(unstable)), (RMT(unstable)),
+        (ADC(unstable)), (AES(unstable)), (SHA(unstable)), (RSA(unstable)),
+        (ECC(unstable)), (USB_FS(unstable)), (USB_HS(unstable)),
+        (SW_INTERRUPT(unstable)), (CPU_CTRL(unstable))));
+        _for_each_inner_peripheral!((dma_eligible(SPI2, Spi2, 1), (SPI3, Spi3, 2), (AES,
+        Aes, 4), (SHA, Sha, 5)));
     };
 }
 /// This macro can be used to generate code for each `GPIOn` instance.

--- a/esp-metadata-generated/src/_generated_esp32s2.rs
+++ b/esp-metadata-generated/src/_generated_esp32s2.rs
@@ -3858,9 +3858,17 @@ macro_rules! for_each_peripheral {
         #[doc = "<ul>"] #[doc =
         "<li>This pin is a strapping pin, it determines how the chip boots.</li>"] #[doc
         = "</ul>"] #[doc = "</section>"] GPIO46 <= virtual()));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "AES peripheral singleton"] AES
-        <= AES(AES : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt
-        }) (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_SPI2 peripheral singleton"]
+        DMA_SPI2 <= SPI2() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "DMA_SPI3 peripheral singleton"] DMA_SPI3 <= SPI3() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_I2S0 peripheral singleton"]
+        DMA_I2S0 <= I2S0() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "DMA_CRYPTO peripheral singleton"] DMA_CRYPTO <= CRYPTO_DMA() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_COPY peripheral singleton"]
+        DMA_COPY <= COPY_DMA() (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "AES peripheral singleton"] AES <= AES(AES : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt }) (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
         "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC() (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc =
         "DEDICATED_GPIO peripheral singleton"] DEDICATED_GPIO <= DEDICATED_GPIO()
@@ -3944,15 +3952,7 @@ macro_rules! for_each_peripheral {
         WIFI <= WIFI(WIFI_MAC : { bind_mac_interrupt, enable_mac_interrupt,
         disable_mac_interrupt }, WIFI_PWR : { bind_pwr_interrupt, enable_pwr_interrupt,
         disable_pwr_interrupt }))); _for_each_inner_peripheral!((@ peri_type #[doc =
-        "DMA_SPI2 peripheral singleton"] DMA_SPI2 <= SPI2() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_SPI3 peripheral singleton"]
-        DMA_SPI3 <= SPI3() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
-        "DMA_I2S0 peripheral singleton"] DMA_I2S0 <= I2S0() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc =
-        "DMA_CRYPTO peripheral singleton"] DMA_CRYPTO <= CRYPTO_DMA() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_COPY peripheral singleton"]
-        DMA_COPY <= COPY_DMA() (unstable))); _for_each_inner_peripheral!((@ peri_type
-        #[doc = "ADC1 peripheral singleton"] ADC1 <= virtual() (unstable)));
+        "ADC1 peripheral singleton"] ADC1 <= virtual() (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc = "ADC2 peripheral singleton"]
         ADC2 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "DAC1 peripheral singleton"] DAC1 <= virtual() (unstable)));
@@ -3988,6 +3988,11 @@ macro_rules! for_each_peripheral {
         _for_each_inner_peripheral!((GPIO42)); _for_each_inner_peripheral!((GPIO43));
         _for_each_inner_peripheral!((GPIO44)); _for_each_inner_peripheral!((GPIO45));
         _for_each_inner_peripheral!((GPIO46));
+        _for_each_inner_peripheral!((DMA_SPI2(unstable)));
+        _for_each_inner_peripheral!((DMA_SPI3(unstable)));
+        _for_each_inner_peripheral!((DMA_I2S0(unstable)));
+        _for_each_inner_peripheral!((DMA_CRYPTO(unstable)));
+        _for_each_inner_peripheral!((DMA_COPY(unstable)));
         _for_each_inner_peripheral!((AES(unstable)));
         _for_each_inner_peripheral!((APB_SARADC(unstable)));
         _for_each_inner_peripheral!((DEDICATED_GPIO(unstable)));
@@ -4029,11 +4034,6 @@ macro_rules! for_each_peripheral {
         _for_each_inner_peripheral!((USB_FS(unstable)));
         _for_each_inner_peripheral!((XTS_AES(unstable)));
         _for_each_inner_peripheral!((WIFI));
-        _for_each_inner_peripheral!((DMA_SPI2(unstable)));
-        _for_each_inner_peripheral!((DMA_SPI3(unstable)));
-        _for_each_inner_peripheral!((DMA_I2S0(unstable)));
-        _for_each_inner_peripheral!((DMA_CRYPTO(unstable)));
-        _for_each_inner_peripheral!((DMA_COPY(unstable)));
         _for_each_inner_peripheral!((ADC1(unstable)));
         _for_each_inner_peripheral!((ADC2(unstable)));
         _for_each_inner_peripheral!((DAC1(unstable)));
@@ -4206,7 +4206,13 @@ macro_rules! for_each_peripheral {
         #[doc = "<ul>"] #[doc =
         "<li>This pin is a strapping pin, it determines how the chip boots.</li>"] #[doc
         = "</ul>"] #[doc = "</section>"] GPIO46 <= virtual()), (@ peri_type #[doc =
-        "AES peripheral singleton"] AES <= AES(AES : { bind_peri_interrupt,
+        "DMA_SPI2 peripheral singleton"] DMA_SPI2 <= SPI2() (unstable)), (@ peri_type
+        #[doc = "DMA_SPI3 peripheral singleton"] DMA_SPI3 <= SPI3() (unstable)), (@
+        peri_type #[doc = "DMA_I2S0 peripheral singleton"] DMA_I2S0 <= I2S0()
+        (unstable)), (@ peri_type #[doc = "DMA_CRYPTO peripheral singleton"] DMA_CRYPTO
+        <= CRYPTO_DMA() (unstable)), (@ peri_type #[doc =
+        "DMA_COPY peripheral singleton"] DMA_COPY <= COPY_DMA() (unstable)), (@ peri_type
+        #[doc = "AES peripheral singleton"] AES <= AES(AES : { bind_peri_interrupt,
         enable_peri_interrupt, disable_peri_interrupt }) (unstable)), (@ peri_type #[doc
         = "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC() (unstable)), (@
         peri_type #[doc = "DEDICATED_GPIO peripheral singleton"] DEDICATED_GPIO <=
@@ -4269,12 +4275,6 @@ macro_rules! for_each_peripheral {
         peri_type #[doc = "WIFI peripheral singleton"] WIFI <= WIFI(WIFI_MAC : {
         bind_mac_interrupt, enable_mac_interrupt, disable_mac_interrupt }, WIFI_PWR : {
         bind_pwr_interrupt, enable_pwr_interrupt, disable_pwr_interrupt })), (@ peri_type
-        #[doc = "DMA_SPI2 peripheral singleton"] DMA_SPI2 <= SPI2() (unstable)), (@
-        peri_type #[doc = "DMA_SPI3 peripheral singleton"] DMA_SPI3 <= SPI3()
-        (unstable)), (@ peri_type #[doc = "DMA_I2S0 peripheral singleton"] DMA_I2S0 <=
-        I2S0() (unstable)), (@ peri_type #[doc = "DMA_CRYPTO peripheral singleton"]
-        DMA_CRYPTO <= CRYPTO_DMA() (unstable)), (@ peri_type #[doc =
-        "DMA_COPY peripheral singleton"] DMA_COPY <= COPY_DMA() (unstable)), (@ peri_type
         #[doc = "ADC1 peripheral singleton"] ADC1 <= virtual() (unstable)), (@ peri_type
         #[doc = "ADC2 peripheral singleton"] ADC2 <= virtual() (unstable)), (@ peri_type
         #[doc = "DAC1 peripheral singleton"] DAC1 <= virtual() (unstable)), (@ peri_type
@@ -4291,23 +4291,24 @@ macro_rules! for_each_peripheral {
         (GPIO19), (GPIO20), (GPIO21), (GPIO26), (GPIO27), (GPIO28), (GPIO29), (GPIO30),
         (GPIO31), (GPIO32), (GPIO33), (GPIO34), (GPIO35), (GPIO36), (GPIO37), (GPIO38),
         (GPIO39), (GPIO40), (GPIO41), (GPIO42), (GPIO43), (GPIO44), (GPIO45), (GPIO46),
-        (AES(unstable)), (APB_SARADC(unstable)), (DEDICATED_GPIO(unstable)),
-        (DS(unstable)), (EXTMEM(unstable)), (FE(unstable)), (FE2(unstable)),
-        (GPIO(unstable)), (GPIO_SD(unstable)), (HMAC(unstable)), (I2C_ANA_MST(unstable)),
-        (I2C0), (I2C1), (I2S0(unstable)), (INTERRUPT_CORE0(unstable)),
-        (IO_MUX(unstable)), (LEDC(unstable)), (NRX(unstable)), (PCNT(unstable)),
-        (PMS(unstable)), (RMT(unstable)), (RNG(unstable)), (RSA(unstable)),
-        (LPWR(unstable)), (RTC_I2C(unstable)), (RTC_IO(unstable)), (SENS(unstable)),
-        (SHA(unstable)), (SPI0(unstable)), (SPI1(unstable)), (SPI2), (SPI3),
-        (SYSCON(unstable)), (SYSTEM(unstable)), (SYSTIMER(unstable)), (TIMG0(unstable)),
-        (TIMG1(unstable)), (TWAI0(unstable)), (UART0), (UART1), (UHCI0(unstable)),
-        (USB_FS(unstable)), (XTS_AES(unstable)), (WIFI), (DMA_SPI2(unstable)),
-        (DMA_SPI3(unstable)), (DMA_I2S0(unstable)), (DMA_CRYPTO(unstable)),
-        (DMA_COPY(unstable)), (ADC1(unstable)), (ADC2(unstable)), (DAC1(unstable)),
-        (DAC2(unstable)), (FLASH(unstable)), (GPIO_DEDICATED(unstable)),
-        (PSRAM(unstable)), (SW_INTERRUPT(unstable)), (ULP_RISCV_CORE(unstable))));
-        _for_each_inner_peripheral!((dma_eligible(I2S0, I2s0, 0), (SPI2, Spi2, 1), (SPI3,
-        Spi3, 2), (UHCI0, Uhci0, 3), (AES, Aes, 4), (SHA, Sha, 5)));
+        (DMA_SPI2(unstable)), (DMA_SPI3(unstable)), (DMA_I2S0(unstable)),
+        (DMA_CRYPTO(unstable)), (DMA_COPY(unstable)), (AES(unstable)),
+        (APB_SARADC(unstable)), (DEDICATED_GPIO(unstable)), (DS(unstable)),
+        (EXTMEM(unstable)), (FE(unstable)), (FE2(unstable)), (GPIO(unstable)),
+        (GPIO_SD(unstable)), (HMAC(unstable)), (I2C_ANA_MST(unstable)), (I2C0), (I2C1),
+        (I2S0(unstable)), (INTERRUPT_CORE0(unstable)), (IO_MUX(unstable)),
+        (LEDC(unstable)), (NRX(unstable)), (PCNT(unstable)), (PMS(unstable)),
+        (RMT(unstable)), (RNG(unstable)), (RSA(unstable)), (LPWR(unstable)),
+        (RTC_I2C(unstable)), (RTC_IO(unstable)), (SENS(unstable)), (SHA(unstable)),
+        (SPI0(unstable)), (SPI1(unstable)), (SPI2), (SPI3), (SYSCON(unstable)),
+        (SYSTEM(unstable)), (SYSTIMER(unstable)), (TIMG0(unstable)), (TIMG1(unstable)),
+        (TWAI0(unstable)), (UART0), (UART1), (UHCI0(unstable)), (USB_FS(unstable)),
+        (XTS_AES(unstable)), (WIFI), (ADC1(unstable)), (ADC2(unstable)),
+        (DAC1(unstable)), (DAC2(unstable)), (FLASH(unstable)),
+        (GPIO_DEDICATED(unstable)), (PSRAM(unstable)), (SW_INTERRUPT(unstable)),
+        (ULP_RISCV_CORE(unstable)))); _for_each_inner_peripheral!((dma_eligible(I2S0,
+        I2s0, 0), (SPI2, Spi2, 1), (SPI3, Spi3, 2), (UHCI0, Uhci0, 3), (AES, Aes, 4),
+        (SHA, Sha, 5)));
     };
 }
 /// This macro can be used to generate code for each `GPIOn` instance.

--- a/esp-metadata-generated/src/_generated_esp32s2.rs
+++ b/esp-metadata-generated/src/_generated_esp32s2.rs
@@ -468,6 +468,22 @@ macro_rules! for_each_dedicated_gpio {
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_dma_channel {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner_dma_channel { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_dma_channel!((DMA_SPI2, 0, interrupt = SPI2_DMA));
+        _for_each_inner_dma_channel!((DMA_SPI3, 1, interrupt = SPI3_DMA));
+        _for_each_inner_dma_channel!((DMA_I2S0, 0, interrupt = I2S0));
+        _for_each_inner_dma_channel!((DMA_CRYPTO, 0, interrupt = CRYPTO_DMA));
+        _for_each_inner_dma_channel!((DMA_COPY, 0, interrupt = DMA_COPY));
+        _for_each_inner_dma_channel!((shared(DMA_SPI2, 0, interrupt = SPI2_DMA),
+        (DMA_SPI3, 1, interrupt = SPI3_DMA), (DMA_I2S0, 0, interrupt = I2S0),
+        (DMA_CRYPTO, 0, interrupt = CRYPTO_DMA), (DMA_COPY, 0, interrupt = DMA_COPY)));
+        _for_each_inner_dma_channel!((split));
+    };
+}
+#[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_sw_interrupt {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_sw_interrupt { $(($pattern) => $code;)* ($other :
@@ -3859,16 +3875,21 @@ macro_rules! for_each_peripheral {
         "<li>This pin is a strapping pin, it determines how the chip boots.</li>"] #[doc
         = "</ul>"] #[doc = "</section>"] GPIO46 <= virtual()));
         _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_SPI2 peripheral singleton"]
-        DMA_SPI2 <= SPI2() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
-        "DMA_SPI3 peripheral singleton"] DMA_SPI3 <= SPI3() (unstable)));
+        DMA_SPI2 <= SPI2(SPI2_DMA : { bind_dma_interrupt, enable_dma_interrupt,
+        disable_dma_interrupt }) (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "DMA_SPI3 peripheral singleton"] DMA_SPI3 <= SPI3(SPI3_DMA : {
+        bind_dma_interrupt, enable_dma_interrupt, disable_dma_interrupt }) (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_I2S0 peripheral singleton"]
-        DMA_I2S0 <= I2S0() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
-        "DMA_CRYPTO peripheral singleton"] DMA_CRYPTO <= CRYPTO_DMA() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_COPY peripheral singleton"]
-        DMA_COPY <= COPY_DMA() (unstable))); _for_each_inner_peripheral!((@ peri_type
-        #[doc = "AES peripheral singleton"] AES <= AES(AES : { bind_peri_interrupt,
-        enable_peri_interrupt, disable_peri_interrupt }) (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc =
+        DMA_I2S0 <= I2S0(I2S0 : { bind_dma_interrupt, enable_dma_interrupt,
+        disable_dma_interrupt }) (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "DMA_CRYPTO peripheral singleton"] DMA_CRYPTO <= CRYPTO_DMA(CRYPTO_DMA :
+        { bind_dma_interrupt, enable_dma_interrupt, disable_dma_interrupt })
+        (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "DMA_COPY peripheral singleton"] DMA_COPY <= COPY_DMA(DMA_COPY : {
+        bind_dma_interrupt, enable_dma_interrupt, disable_dma_interrupt }) (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "AES peripheral singleton"] AES
+        <= AES(AES : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt
+        }) (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC() (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc =
         "DEDICATED_GPIO peripheral singleton"] DEDICATED_GPIO <= DEDICATED_GPIO()
@@ -4206,21 +4227,27 @@ macro_rules! for_each_peripheral {
         #[doc = "<ul>"] #[doc =
         "<li>This pin is a strapping pin, it determines how the chip boots.</li>"] #[doc
         = "</ul>"] #[doc = "</section>"] GPIO46 <= virtual()), (@ peri_type #[doc =
-        "DMA_SPI2 peripheral singleton"] DMA_SPI2 <= SPI2() (unstable)), (@ peri_type
-        #[doc = "DMA_SPI3 peripheral singleton"] DMA_SPI3 <= SPI3() (unstable)), (@
-        peri_type #[doc = "DMA_I2S0 peripheral singleton"] DMA_I2S0 <= I2S0()
-        (unstable)), (@ peri_type #[doc = "DMA_CRYPTO peripheral singleton"] DMA_CRYPTO
-        <= CRYPTO_DMA() (unstable)), (@ peri_type #[doc =
-        "DMA_COPY peripheral singleton"] DMA_COPY <= COPY_DMA() (unstable)), (@ peri_type
-        #[doc = "AES peripheral singleton"] AES <= AES(AES : { bind_peri_interrupt,
-        enable_peri_interrupt, disable_peri_interrupt }) (unstable)), (@ peri_type #[doc
-        = "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC() (unstable)), (@
-        peri_type #[doc = "DEDICATED_GPIO peripheral singleton"] DEDICATED_GPIO <=
-        DEDICATED_GPIO() (unstable)), (@ peri_type #[doc = "DS peripheral singleton"] DS
-        <= DS() (unstable)), (@ peri_type #[doc = "EFUSE peripheral singleton"] EFUSE <=
-        EFUSE() (unstable)), (@ peri_type #[doc = "EXTMEM peripheral singleton"] EXTMEM
-        <= EXTMEM() (unstable)), (@ peri_type #[doc = "FE peripheral singleton"] FE <=
-        FE() (unstable)), (@ peri_type #[doc = "FE2 peripheral singleton"] FE2 <= FE2()
+        "DMA_SPI2 peripheral singleton"] DMA_SPI2 <= SPI2(SPI2_DMA : {
+        bind_dma_interrupt, enable_dma_interrupt, disable_dma_interrupt }) (unstable)),
+        (@ peri_type #[doc = "DMA_SPI3 peripheral singleton"] DMA_SPI3 <= SPI3(SPI3_DMA :
+        { bind_dma_interrupt, enable_dma_interrupt, disable_dma_interrupt }) (unstable)),
+        (@ peri_type #[doc = "DMA_I2S0 peripheral singleton"] DMA_I2S0 <= I2S0(I2S0 : {
+        bind_dma_interrupt, enable_dma_interrupt, disable_dma_interrupt }) (unstable)),
+        (@ peri_type #[doc = "DMA_CRYPTO peripheral singleton"] DMA_CRYPTO <=
+        CRYPTO_DMA(CRYPTO_DMA : { bind_dma_interrupt, enable_dma_interrupt,
+        disable_dma_interrupt }) (unstable)), (@ peri_type #[doc =
+        "DMA_COPY peripheral singleton"] DMA_COPY <= COPY_DMA(DMA_COPY : {
+        bind_dma_interrupt, enable_dma_interrupt, disable_dma_interrupt }) (unstable)),
+        (@ peri_type #[doc = "AES peripheral singleton"] AES <= AES(AES : {
+        bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt })
+        (unstable)), (@ peri_type #[doc = "APB_SARADC peripheral singleton"] APB_SARADC
+        <= APB_SARADC() (unstable)), (@ peri_type #[doc =
+        "DEDICATED_GPIO peripheral singleton"] DEDICATED_GPIO <= DEDICATED_GPIO()
+        (unstable)), (@ peri_type #[doc = "DS peripheral singleton"] DS <= DS()
+        (unstable)), (@ peri_type #[doc = "EFUSE peripheral singleton"] EFUSE <= EFUSE()
+        (unstable)), (@ peri_type #[doc = "EXTMEM peripheral singleton"] EXTMEM <=
+        EXTMEM() (unstable)), (@ peri_type #[doc = "FE peripheral singleton"] FE <= FE()
+        (unstable)), (@ peri_type #[doc = "FE2 peripheral singleton"] FE2 <= FE2()
         (unstable)), (@ peri_type #[doc = "GPIO peripheral singleton"] GPIO <= GPIO()
         (unstable)), (@ peri_type #[doc = "GPIO_SD peripheral singleton"] GPIO_SD <=
         GPIO_SD() (unstable)), (@ peri_type #[doc = "HMAC peripheral singleton"] HMAC <=

--- a/esp-metadata-generated/src/_generated_esp32s3.rs
+++ b/esp-metadata-generated/src/_generated_esp32s3.rs
@@ -497,6 +497,27 @@ macro_rules! for_each_dedicated_gpio {
 }
 #[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_dma_channel {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner_dma_channel { $(($pattern) => $code;)* ($other : tt)
+        => {} } _for_each_inner_dma_channel!((DMA_CH0, 0, interrupt_in = DMA_IN_CH0,
+        interrupt_out = DMA_OUT_CH0)); _for_each_inner_dma_channel!((DMA_CH1, 1,
+        interrupt_in = DMA_IN_CH1, interrupt_out = DMA_OUT_CH1));
+        _for_each_inner_dma_channel!((DMA_CH2, 2, interrupt_in = DMA_IN_CH2,
+        interrupt_out = DMA_OUT_CH2)); _for_each_inner_dma_channel!((DMA_CH3, 3,
+        interrupt_in = DMA_IN_CH3, interrupt_out = DMA_OUT_CH3));
+        _for_each_inner_dma_channel!((DMA_CH4, 4, interrupt_in = DMA_IN_CH4,
+        interrupt_out = DMA_OUT_CH4)); _for_each_inner_dma_channel!((shared));
+        _for_each_inner_dma_channel!((split(DMA_CH0, 0, interrupt_in = DMA_IN_CH0,
+        interrupt_out = DMA_OUT_CH0), (DMA_CH1, 1, interrupt_in = DMA_IN_CH1,
+        interrupt_out = DMA_OUT_CH1), (DMA_CH2, 2, interrupt_in = DMA_IN_CH2,
+        interrupt_out = DMA_OUT_CH2), (DMA_CH3, 3, interrupt_in = DMA_IN_CH3,
+        interrupt_out = DMA_OUT_CH3), (DMA_CH4, 4, interrupt_in = DMA_IN_CH4,
+        interrupt_out = DMA_OUT_CH4)));
+    };
+}
+#[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_sw_interrupt {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_sw_interrupt { $(($pattern) => $code;)* ($other :
@@ -3910,19 +3931,32 @@ macro_rules! for_each_peripheral {
         GPIO47 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
         "GPIO48 peripheral singleton"] GPIO48 <= virtual()));
         _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH0 peripheral singleton"]
-        DMA_CH0 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
-        = "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual() (unstable)));
+        DMA_CH0 <= virtual(DMA_IN_CH0 : { bind_dma_in_interrupt, enable_dma_in_interrupt,
+        disable_dma_in_interrupt }, DMA_OUT_CH0 : { bind_dma_out_interrupt,
+        enable_dma_out_interrupt, disable_dma_out_interrupt }) (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH1 peripheral singleton"]
+        DMA_CH1 <= virtual(DMA_IN_CH1 : { bind_dma_in_interrupt, enable_dma_in_interrupt,
+        disable_dma_in_interrupt }, DMA_OUT_CH1 : { bind_dma_out_interrupt,
+        enable_dma_out_interrupt, disable_dma_out_interrupt }) (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH2 peripheral singleton"]
-        DMA_CH2 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
-        = "DMA_CH3 peripheral singleton"] DMA_CH3 <= virtual() (unstable)));
+        DMA_CH2 <= virtual(DMA_IN_CH2 : { bind_dma_in_interrupt, enable_dma_in_interrupt,
+        disable_dma_in_interrupt }, DMA_OUT_CH2 : { bind_dma_out_interrupt,
+        enable_dma_out_interrupt, disable_dma_out_interrupt }) (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH3 peripheral singleton"]
+        DMA_CH3 <= virtual(DMA_IN_CH3 : { bind_dma_in_interrupt, enable_dma_in_interrupt,
+        disable_dma_in_interrupt }, DMA_OUT_CH3 : { bind_dma_out_interrupt,
+        enable_dma_out_interrupt, disable_dma_out_interrupt }) (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH4 peripheral singleton"]
-        DMA_CH4 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
-        = "AES peripheral singleton"] AES <= AES(AES : { bind_peri_interrupt,
-        enable_peri_interrupt, disable_peri_interrupt }) (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "APB_CTRL peripheral singleton"]
-        APB_CTRL <= APB_CTRL() (unstable))); _for_each_inner_peripheral!((@ peri_type
-        #[doc = "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC()
-        (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        DMA_CH4 <= virtual(DMA_IN_CH4 : { bind_dma_in_interrupt, enable_dma_in_interrupt,
+        disable_dma_in_interrupt }, DMA_OUT_CH4 : { bind_dma_out_interrupt,
+        enable_dma_out_interrupt, disable_dma_out_interrupt }) (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "AES peripheral singleton"] AES
+        <= AES(AES : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt
+        }) (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "APB_CTRL peripheral singleton"] APB_CTRL <= APB_CTRL() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
+        "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc =
         "ASSIST_DEBUG peripheral singleton"] ASSIST_DEBUG <= ASSIST_DEBUG() (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc = "DMA peripheral singleton"] DMA
         <= DMA() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
@@ -4302,12 +4336,26 @@ macro_rules! for_each_peripheral {
         = "</ul>"] #[doc = "</section>"] GPIO46 <= virtual()), (@ peri_type #[doc =
         "GPIO47 peripheral singleton"] GPIO47 <= virtual()), (@ peri_type #[doc =
         "GPIO48 peripheral singleton"] GPIO48 <= virtual()), (@ peri_type #[doc =
-        "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual() (unstable)), (@ peri_type
-        #[doc = "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual() (unstable)), (@
-        peri_type #[doc = "DMA_CH2 peripheral singleton"] DMA_CH2 <= virtual()
-        (unstable)), (@ peri_type #[doc = "DMA_CH3 peripheral singleton"] DMA_CH3 <=
-        virtual() (unstable)), (@ peri_type #[doc = "DMA_CH4 peripheral singleton"]
-        DMA_CH4 <= virtual() (unstable)), (@ peri_type #[doc =
+        "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual(DMA_IN_CH0 : {
+        bind_dma_in_interrupt, enable_dma_in_interrupt, disable_dma_in_interrupt },
+        DMA_OUT_CH0 : { bind_dma_out_interrupt, enable_dma_out_interrupt,
+        disable_dma_out_interrupt }) (unstable)), (@ peri_type #[doc =
+        "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual(DMA_IN_CH1 : {
+        bind_dma_in_interrupt, enable_dma_in_interrupt, disable_dma_in_interrupt },
+        DMA_OUT_CH1 : { bind_dma_out_interrupt, enable_dma_out_interrupt,
+        disable_dma_out_interrupt }) (unstable)), (@ peri_type #[doc =
+        "DMA_CH2 peripheral singleton"] DMA_CH2 <= virtual(DMA_IN_CH2 : {
+        bind_dma_in_interrupt, enable_dma_in_interrupt, disable_dma_in_interrupt },
+        DMA_OUT_CH2 : { bind_dma_out_interrupt, enable_dma_out_interrupt,
+        disable_dma_out_interrupt }) (unstable)), (@ peri_type #[doc =
+        "DMA_CH3 peripheral singleton"] DMA_CH3 <= virtual(DMA_IN_CH3 : {
+        bind_dma_in_interrupt, enable_dma_in_interrupt, disable_dma_in_interrupt },
+        DMA_OUT_CH3 : { bind_dma_out_interrupt, enable_dma_out_interrupt,
+        disable_dma_out_interrupt }) (unstable)), (@ peri_type #[doc =
+        "DMA_CH4 peripheral singleton"] DMA_CH4 <= virtual(DMA_IN_CH4 : {
+        bind_dma_in_interrupt, enable_dma_in_interrupt, disable_dma_in_interrupt },
+        DMA_OUT_CH4 : { bind_dma_out_interrupt, enable_dma_out_interrupt,
+        disable_dma_out_interrupt }) (unstable)), (@ peri_type #[doc =
         "AES peripheral singleton"] AES <= AES(AES : { bind_peri_interrupt,
         enable_peri_interrupt, disable_peri_interrupt }) (unstable)), (@ peri_type #[doc
         = "APB_CTRL peripheral singleton"] APB_CTRL <= APB_CTRL() (unstable)), (@

--- a/esp-metadata-generated/src/_generated_esp32s3.rs
+++ b/esp-metadata-generated/src/_generated_esp32s3.rs
@@ -3909,13 +3909,20 @@ macro_rules! for_each_peripheral {
         _for_each_inner_peripheral!((@ peri_type #[doc = "GPIO47 peripheral singleton"]
         GPIO47 <= virtual())); _for_each_inner_peripheral!((@ peri_type #[doc =
         "GPIO48 peripheral singleton"] GPIO48 <= virtual()));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "AES peripheral singleton"] AES
-        <= AES(AES : { bind_peri_interrupt, enable_peri_interrupt, disable_peri_interrupt
-        }) (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
-        "APB_CTRL peripheral singleton"] APB_CTRL <= APB_CTRL() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc =
-        "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH0 peripheral singleton"]
+        DMA_CH0 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH2 peripheral singleton"]
+        DMA_CH2 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "DMA_CH3 peripheral singleton"] DMA_CH3 <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH4 peripheral singleton"]
+        DMA_CH4 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
+        = "AES peripheral singleton"] AES <= AES(AES : { bind_peri_interrupt,
+        enable_peri_interrupt, disable_peri_interrupt }) (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "APB_CTRL peripheral singleton"]
+        APB_CTRL <= APB_CTRL() (unstable))); _for_each_inner_peripheral!((@ peri_type
+        #[doc = "APB_SARADC peripheral singleton"] APB_SARADC <= APB_SARADC()
+        (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "ASSIST_DEBUG peripheral singleton"] ASSIST_DEBUG <= ASSIST_DEBUG() (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc = "DMA peripheral singleton"] DMA
         <= DMA() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
@@ -4008,24 +4015,16 @@ macro_rules! for_each_peripheral {
         _for_each_inner_peripheral!((@ peri_type #[doc = "WCL peripheral singleton"] WCL
         <= WCL() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "XTS_AES peripheral singleton"] XTS_AES <= XTS_AES() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH0 peripheral singleton"]
-        DMA_CH0 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
-        = "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH2 peripheral singleton"]
-        DMA_CH2 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
-        = "DMA_CH3 peripheral singleton"] DMA_CH3 <= virtual() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "DMA_CH4 peripheral singleton"]
-        DMA_CH4 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc
-        = "ADC1 peripheral singleton"] ADC1 <= virtual() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "ADC2 peripheral singleton"]
-        ADC2 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
-        "BT peripheral singleton"] BT <= virtual(BT_BB : { bind_bb_interrupt,
-        enable_bb_interrupt, disable_bb_interrupt }, RWBLE : { bind_rwble_interrupt,
-        enable_rwble_interrupt, disable_rwble_interrupt }) (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc = "CPU_CTRL peripheral singleton"]
-        CPU_CTRL <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type
-        #[doc = "FLASH peripheral singleton"] FLASH <= virtual() (unstable)));
-        _for_each_inner_peripheral!((@ peri_type #[doc =
+        _for_each_inner_peripheral!((@ peri_type #[doc = "ADC1 peripheral singleton"]
+        ADC1 <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "ADC2 peripheral singleton"] ADC2 <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "BT peripheral singleton"] BT <=
+        virtual(BT_BB : { bind_bb_interrupt, enable_bb_interrupt, disable_bb_interrupt },
+        RWBLE : { bind_rwble_interrupt, enable_rwble_interrupt, disable_rwble_interrupt
+        }) (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
+        "CPU_CTRL peripheral singleton"] CPU_CTRL <= virtual() (unstable)));
+        _for_each_inner_peripheral!((@ peri_type #[doc = "FLASH peripheral singleton"]
+        FLASH <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
         "GPIO_DEDICATED peripheral singleton"] GPIO_DEDICATED <= virtual() (unstable)));
         _for_each_inner_peripheral!((@ peri_type #[doc = "PSRAM peripheral singleton"]
         PSRAM <= virtual() (unstable))); _for_each_inner_peripheral!((@ peri_type #[doc =
@@ -4058,6 +4057,11 @@ macro_rules! for_each_peripheral {
         _for_each_inner_peripheral!((GPIO43)); _for_each_inner_peripheral!((GPIO44));
         _for_each_inner_peripheral!((GPIO45)); _for_each_inner_peripheral!((GPIO46));
         _for_each_inner_peripheral!((GPIO47)); _for_each_inner_peripheral!((GPIO48));
+        _for_each_inner_peripheral!((DMA_CH0(unstable)));
+        _for_each_inner_peripheral!((DMA_CH1(unstable)));
+        _for_each_inner_peripheral!((DMA_CH2(unstable)));
+        _for_each_inner_peripheral!((DMA_CH3(unstable)));
+        _for_each_inner_peripheral!((DMA_CH4(unstable)));
         _for_each_inner_peripheral!((AES(unstable)));
         _for_each_inner_peripheral!((APB_CTRL(unstable)));
         _for_each_inner_peripheral!((APB_SARADC(unstable)));
@@ -4107,11 +4111,6 @@ macro_rules! for_each_peripheral {
         _for_each_inner_peripheral!((USB_DEVICE(unstable)));
         _for_each_inner_peripheral!((WCL(unstable)));
         _for_each_inner_peripheral!((XTS_AES(unstable)));
-        _for_each_inner_peripheral!((DMA_CH0(unstable)));
-        _for_each_inner_peripheral!((DMA_CH1(unstable)));
-        _for_each_inner_peripheral!((DMA_CH2(unstable)));
-        _for_each_inner_peripheral!((DMA_CH3(unstable)));
-        _for_each_inner_peripheral!((DMA_CH4(unstable)));
         _for_each_inner_peripheral!((ADC1(unstable)));
         _for_each_inner_peripheral!((ADC2(unstable)));
         _for_each_inner_peripheral!((BT(unstable)));
@@ -4303,6 +4302,12 @@ macro_rules! for_each_peripheral {
         = "</ul>"] #[doc = "</section>"] GPIO46 <= virtual()), (@ peri_type #[doc =
         "GPIO47 peripheral singleton"] GPIO47 <= virtual()), (@ peri_type #[doc =
         "GPIO48 peripheral singleton"] GPIO48 <= virtual()), (@ peri_type #[doc =
+        "DMA_CH0 peripheral singleton"] DMA_CH0 <= virtual() (unstable)), (@ peri_type
+        #[doc = "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual() (unstable)), (@
+        peri_type #[doc = "DMA_CH2 peripheral singleton"] DMA_CH2 <= virtual()
+        (unstable)), (@ peri_type #[doc = "DMA_CH3 peripheral singleton"] DMA_CH3 <=
+        virtual() (unstable)), (@ peri_type #[doc = "DMA_CH4 peripheral singleton"]
+        DMA_CH4 <= virtual() (unstable)), (@ peri_type #[doc =
         "AES peripheral singleton"] AES <= AES(AES : { bind_peri_interrupt,
         enable_peri_interrupt, disable_peri_interrupt }) (unstable)), (@ peri_type #[doc
         = "APB_CTRL peripheral singleton"] APB_CTRL <= APB_CTRL() (unstable)), (@
@@ -4376,15 +4381,9 @@ macro_rules! for_each_peripheral {
         (unstable)), (@ peri_type #[doc = "USB_WRAP peripheral singleton"] USB_WRAP <=
         USB_WRAP() (unstable)), (@ peri_type #[doc = "WCL peripheral singleton"] WCL <=
         WCL() (unstable)), (@ peri_type #[doc = "XTS_AES peripheral singleton"] XTS_AES
-        <= XTS_AES() (unstable)), (@ peri_type #[doc = "DMA_CH0 peripheral singleton"]
-        DMA_CH0 <= virtual() (unstable)), (@ peri_type #[doc =
-        "DMA_CH1 peripheral singleton"] DMA_CH1 <= virtual() (unstable)), (@ peri_type
-        #[doc = "DMA_CH2 peripheral singleton"] DMA_CH2 <= virtual() (unstable)), (@
-        peri_type #[doc = "DMA_CH3 peripheral singleton"] DMA_CH3 <= virtual()
-        (unstable)), (@ peri_type #[doc = "DMA_CH4 peripheral singleton"] DMA_CH4 <=
-        virtual() (unstable)), (@ peri_type #[doc = "ADC1 peripheral singleton"] ADC1 <=
-        virtual() (unstable)), (@ peri_type #[doc = "ADC2 peripheral singleton"] ADC2 <=
-        virtual() (unstable)), (@ peri_type #[doc = "BT peripheral singleton"] BT <=
+        <= XTS_AES() (unstable)), (@ peri_type #[doc = "ADC1 peripheral singleton"] ADC1
+        <= virtual() (unstable)), (@ peri_type #[doc = "ADC2 peripheral singleton"] ADC2
+        <= virtual() (unstable)), (@ peri_type #[doc = "BT peripheral singleton"] BT <=
         virtual(BT_BB : { bind_bb_interrupt, enable_bb_interrupt, disable_bb_interrupt },
         RWBLE : { bind_rwble_interrupt, enable_rwble_interrupt, disable_rwble_interrupt
         }) (unstable)), (@ peri_type #[doc = "CPU_CTRL peripheral singleton"] CPU_CTRL <=
@@ -4404,22 +4403,22 @@ macro_rules! for_each_peripheral {
         (GPIO20), (GPIO21), (GPIO26), (GPIO27), (GPIO28), (GPIO29), (GPIO30), (GPIO31),
         (GPIO32), (GPIO33), (GPIO34), (GPIO35), (GPIO36), (GPIO37), (GPIO38), (GPIO39),
         (GPIO40), (GPIO41), (GPIO42), (GPIO43), (GPIO44), (GPIO45), (GPIO46), (GPIO47),
-        (GPIO48), (AES(unstable)), (APB_CTRL(unstable)), (APB_SARADC(unstable)),
-        (ASSIST_DEBUG(unstable)), (DMA(unstable)), (DS(unstable)), (EXTMEM(unstable)),
-        (GPIO(unstable)), (GPIO_SD(unstable)), (HMAC(unstable)), (I2C_ANA_MST(unstable)),
-        (I2C0), (I2C1), (I2S0(unstable)), (I2S1(unstable)), (INTERRUPT_CORE0(unstable)),
-        (INTERRUPT_CORE1(unstable)), (IO_MUX(unstable)), (LCD_CAM(unstable)),
-        (LEDC(unstable)), (LPWR(unstable)), (MCPWM0(unstable)), (MCPWM1(unstable)),
-        (PCNT(unstable)), (PERI_BACKUP(unstable)), (RMT(unstable)), (RNG(unstable)),
-        (RSA(unstable)), (RTC_CNTL(unstable)), (RTC_I2C(unstable)), (RTC_IO(unstable)),
+        (GPIO48), (DMA_CH0(unstable)), (DMA_CH1(unstable)), (DMA_CH2(unstable)),
+        (DMA_CH3(unstable)), (DMA_CH4(unstable)), (AES(unstable)), (APB_CTRL(unstable)),
+        (APB_SARADC(unstable)), (ASSIST_DEBUG(unstable)), (DMA(unstable)),
+        (DS(unstable)), (EXTMEM(unstable)), (GPIO(unstable)), (GPIO_SD(unstable)),
+        (HMAC(unstable)), (I2C_ANA_MST(unstable)), (I2C0), (I2C1), (I2S0(unstable)),
+        (I2S1(unstable)), (INTERRUPT_CORE0(unstable)), (INTERRUPT_CORE1(unstable)),
+        (IO_MUX(unstable)), (LCD_CAM(unstable)), (LEDC(unstable)), (LPWR(unstable)),
+        (MCPWM0(unstable)), (MCPWM1(unstable)), (PCNT(unstable)),
+        (PERI_BACKUP(unstable)), (RMT(unstable)), (RNG(unstable)), (RSA(unstable)),
+        (RTC_CNTL(unstable)), (RTC_I2C(unstable)), (RTC_IO(unstable)),
         (SDHOST(unstable)), (SENS(unstable)), (SENSITIVE(unstable)), (SHA(unstable)),
         (SPI0(unstable)), (SPI1(unstable)), (SPI2), (SPI3), (SYSTEM(unstable)),
         (SYSTIMER(unstable)), (TIMG0(unstable)), (TIMG1(unstable)), (TWAI0(unstable)),
         (UART0), (UART1), (UART2), (UHCI0(unstable)), (USB_FS(unstable)),
-        (USB_DEVICE(unstable)), (WCL(unstable)), (XTS_AES(unstable)),
-        (DMA_CH0(unstable)), (DMA_CH1(unstable)), (DMA_CH2(unstable)),
-        (DMA_CH3(unstable)), (DMA_CH4(unstable)), (ADC1(unstable)), (ADC2(unstable)),
-        (BT(unstable)), (CPU_CTRL(unstable)), (FLASH(unstable)),
+        (USB_DEVICE(unstable)), (WCL(unstable)), (XTS_AES(unstable)), (ADC1(unstable)),
+        (ADC2(unstable)), (BT(unstable)), (CPU_CTRL(unstable)), (FLASH(unstable)),
         (GPIO_DEDICATED(unstable)), (PSRAM(unstable)), (SW_INTERRUPT(unstable)),
         (ULP_RISCV_CORE(unstable)), (WIFI)));
         _for_each_inner_peripheral!((dma_eligible(SPI2, Spi2, 0), (SPI3, Spi3, 1),

--- a/esp-metadata/devices/esp32.toml
+++ b/esp-metadata/devices/esp32.toml
@@ -77,8 +77,8 @@ peripherals = [
     { name = "SLCHOST" },
     { name = "SPI0" },
     { name = "SPI1" },
-    { name = "SPI2", interrupts = { peri = "SPI2", dma = "SPI2_DMA" }, dma_peripheral = 2, stable = true },
-    { name = "SPI3", interrupts = { peri = "SPI3", dma = "SPI3_DMA" }, dma_peripheral = 3, stable = true },
+    { name = "SPI2", interrupts = { peri = "SPI2", dma = "SPI2_DMA"  }, dma_peripheral = 2, stable = true },
+    { name = "SPI3", interrupts = { peri = "SPI3", dma = "SPI3_DMA"  }, dma_peripheral = 3, stable = true },
     { name = "TIMG0" },
     { name = "TIMG1" },
     { name = "TWAI0" },
@@ -338,12 +338,12 @@ kind = "pdma"
 supports_mem2mem = false
 engines = [
     { name = "SPI_DMA", channels = [
-        { name = "DMA_SPI2", pac = "SPI2" },
-        { name = "DMA_SPI3", pac = "SPI3" },
+        { name = "DMA_SPI2", pac = "SPI2", interrupt = "SPI2_DMA" },
+        { name = "DMA_SPI3", pac = "SPI3", interrupt = "SPI3_DMA" },
     ] },
     { name = "I2S_DMA", channels = [
-        { name = "DMA_I2S0", pac = "I2S0" },
-        { name = "DMA_I2S1", pac = "I2S1" },
+        { name = "DMA_I2S0", pac = "I2S0", interrupt = "I2S0" },
+        { name = "DMA_I2S1", pac = "I2S1", interrupt = "I2S1" },
     ] },
 ]
 

--- a/esp-metadata/devices/esp32.toml
+++ b/esp-metadata/devices/esp32.toml
@@ -89,11 +89,6 @@ peripherals = [
     { name = "UHCI1", dma_peripheral = 5 },
     { name = "WIFI", interrupts = { mac = "WIFI_MAC" }, stable = true },
 
-    { name = "DMA_SPI2", pac = "SPI2" },
-    { name = "DMA_SPI3", pac = "SPI3" },
-    { name = "DMA_I2S0", pac = "I2S0" },
-    { name = "DMA_I2S1", pac = "I2S1" },
-
     { name = "ADC1", virtual = true },
     { name = "ADC2", virtual = true },
     { name = "BT", virtual = true, interrupts = { rwbt = "RWBT", rwble = "RWBLE", bb = "BT_BB" } },
@@ -341,6 +336,16 @@ instances = [
 support_status = "partial"
 kind = "pdma"
 supports_mem2mem = false
+engines = [
+    { name = "SPI_DMA", channels = [
+        { name = "DMA_SPI2", pac = "SPI2" },
+        { name = "DMA_SPI3", pac = "SPI3" },
+    ] },
+    { name = "I2S_DMA", channels = [
+        { name = "DMA_I2S0", pac = "I2S0" },
+        { name = "DMA_I2S1", pac = "I2S1" },
+    ] },
+]
 
 [device.gpio]
 support_status = "supported"

--- a/esp-metadata/devices/esp32c2.toml
+++ b/esp-metadata/devices/esp32c2.toml
@@ -226,7 +226,7 @@ supports_mem2mem = true
 max_priority = 9
 engines = [
     { name = "AHB_GDMA", channels = [
-        { name = "DMA_CH0", mem2mem = true },
+        { name = "DMA_CH0", mem2mem = true, interrupt = "DMA_CH0" },
     ] },
 ]
 

--- a/esp-metadata/devices/esp32c2.toml
+++ b/esp-metadata/devices/esp32c2.toml
@@ -68,8 +68,6 @@ peripherals = [
     { name = "UART1", interrupts = { peri = "UART1" }, stable = true, clock_group = "UART" },
     { name = "XTS_AES" },
 
-    { name = "DMA_CH0", virtual = true },
-
     { name = "ADC1", virtual = true },
     { name = "BT", virtual = true, interrupts = { mac = "BT_MAC", lp_timer = "LP_TIMER" } },
     { name = "FLASH", virtual = true },
@@ -226,6 +224,9 @@ kind = "gdma"
 gdma_version = 1
 supports_mem2mem = true
 max_priority = 9
+channels = [
+    { name = "DMA_CH0", mem2mem = true },
+]
 
 [device.ecc]
 support_status = "partial"

--- a/esp-metadata/devices/esp32c2.toml
+++ b/esp-metadata/devices/esp32c2.toml
@@ -224,8 +224,10 @@ kind = "gdma"
 gdma_version = 1
 supports_mem2mem = true
 max_priority = 9
-channels = [
-    { name = "DMA_CH0", mem2mem = true },
+engines = [
+    { name = "AHB_GDMA", channels = [
+        { name = "DMA_CH0", mem2mem = true },
+    ] },
 ]
 
 [device.ecc]

--- a/esp-metadata/devices/esp32c3.toml
+++ b/esp-metadata/devices/esp32c3.toml
@@ -263,10 +263,12 @@ kind = "gdma"
 gdma_version = 1
 supports_mem2mem = true
 max_priority = 9
-channels = [
-    { name = "DMA_CH0", mem2mem = true },
-    { name = "DMA_CH1", mem2mem = true },
-    { name = "DMA_CH2", mem2mem = true },
+engines = [
+    { name = "AHB_GDMA", channels = [
+        { name = "DMA_CH0", mem2mem = true },
+        { name = "DMA_CH1", mem2mem = true },
+        { name = "DMA_CH2", mem2mem = true },
+    ] },
 ]
 
 [device.gpio]

--- a/esp-metadata/devices/esp32c3.toml
+++ b/esp-metadata/devices/esp32c3.toml
@@ -80,10 +80,6 @@ peripherals = [
     { name = "USB_DEVICE", interrupts = { peri = "USB_DEVICE" } },
     { name = "XTS_AES" },
 
-    { name = "DMA_CH0", virtual = true },
-    { name = "DMA_CH1", virtual = true },
-    { name = "DMA_CH2", virtual = true },
-
     { name = "ADC1", virtual = true },
     { name = "ADC2", virtual = true },
     { name = "BT", virtual = true, interrupts = { rwbt = "RWBT", rwble = "RWBLE", bb = "BT_BB" } },
@@ -267,6 +263,11 @@ kind = "gdma"
 gdma_version = 1
 supports_mem2mem = true
 max_priority = 9
+channels = [
+    { name = "DMA_CH0", mem2mem = true },
+    { name = "DMA_CH1", mem2mem = true },
+    { name = "DMA_CH2", mem2mem = true },
+]
 
 [device.gpio]
 support_status = "supported"

--- a/esp-metadata/devices/esp32c3.toml
+++ b/esp-metadata/devices/esp32c3.toml
@@ -265,9 +265,9 @@ supports_mem2mem = true
 max_priority = 9
 engines = [
     { name = "AHB_GDMA", channels = [
-        { name = "DMA_CH0", mem2mem = true },
-        { name = "DMA_CH1", mem2mem = true },
-        { name = "DMA_CH2", mem2mem = true },
+        { name = "DMA_CH0", mem2mem = true, interrupt = "DMA_CH0" },
+        { name = "DMA_CH1", mem2mem = true, interrupt = "DMA_CH1" },
+        { name = "DMA_CH2", mem2mem = true, interrupt = "DMA_CH2" },
     ] },
 ]
 

--- a/esp-metadata/devices/esp32c5.toml
+++ b/esp-metadata/devices/esp32c5.toml
@@ -118,10 +118,6 @@ peripherals = [
     { name = "UHCI0", dma_peripheral = 2 },
     { name = "USB_DEVICE", interrupts = { peri = "USB_DEVICE" } },
 
-    { name = "DMA_CH0", virtual = true },
-    { name = "DMA_CH1", virtual = true },
-    { name = "DMA_CH2", virtual = true },
-
     { name = "ADC1", virtual = true },
 
     { name = "BT", virtual = true, interrupts = { mac = "BT_MAC", lp_timer = "LP_TIMER" } },
@@ -307,6 +303,11 @@ max_priority = 5
 can_access_psram = true
 # TODO: DMA can access flash
 # TODO: weight-based arbitration
+channels = [
+    { name = "DMA_CH0", mem2mem = true },
+    { name = "DMA_CH1", mem2mem = true },
+    { name = "DMA_CH2", mem2mem = true },
+]
 
 [device.ecc]
 support_status = "partial"

--- a/esp-metadata/devices/esp32c5.toml
+++ b/esp-metadata/devices/esp32c5.toml
@@ -305,9 +305,9 @@ can_access_psram = true
 # TODO: weight-based arbitration
 engines = [
     { name = "AHB_GDMA", channels = [
-        { name = "DMA_CH0", mem2mem = true },
-        { name = "DMA_CH1", mem2mem = true },
-        { name = "DMA_CH2", mem2mem = true },
+        { name = "DMA_CH0", mem2mem = true, interrupt_in = "DMA_IN_CH0", interrupt_out = "DMA_OUT_CH0" },
+        { name = "DMA_CH1", mem2mem = true, interrupt_in = "DMA_IN_CH1", interrupt_out = "DMA_OUT_CH1" },
+        { name = "DMA_CH2", mem2mem = true, interrupt_in = "DMA_IN_CH2", interrupt_out = "DMA_OUT_CH2" },
     ] },
 ]
 

--- a/esp-metadata/devices/esp32c5.toml
+++ b/esp-metadata/devices/esp32c5.toml
@@ -303,10 +303,12 @@ max_priority = 5
 can_access_psram = true
 # TODO: DMA can access flash
 # TODO: weight-based arbitration
-channels = [
-    { name = "DMA_CH0", mem2mem = true },
-    { name = "DMA_CH1", mem2mem = true },
-    { name = "DMA_CH2", mem2mem = true },
+engines = [
+    { name = "AHB_GDMA", channels = [
+        { name = "DMA_CH0", mem2mem = true },
+        { name = "DMA_CH1", mem2mem = true },
+        { name = "DMA_CH2", mem2mem = true },
+    ] },
 ]
 
 [device.ecc]

--- a/esp-metadata/devices/esp32c6.toml
+++ b/esp-metadata/devices/esp32c6.toml
@@ -113,10 +113,6 @@ peripherals = [
     { name = "UHCI0", dma_peripheral = 2 },
     { name = "USB_DEVICE", interrupts = { peri = "USB_DEVICE" } },
 
-    { name = "DMA_CH0", virtual = true },
-    { name = "DMA_CH1", virtual = true },
-    { name = "DMA_CH2", virtual = true },
-
     { name = "ADC1", virtual = true },
     { name = "BT", virtual = true, interrupts = { mac = "BT_MAC", lp_timer = "LP_TIMER" } },
     { name = "FLASH", virtual = true },
@@ -341,6 +337,11 @@ gdma_version = 1
 separate_in_out_interrupts = true
 supports_mem2mem = true
 max_priority = 9
+channels = [
+    { name = "DMA_CH0", mem2mem = true },
+    { name = "DMA_CH1", mem2mem = true },
+    { name = "DMA_CH2", mem2mem = true },
+]
 
 [device.ecc]
 support_status = "partial"

--- a/esp-metadata/devices/esp32c6.toml
+++ b/esp-metadata/devices/esp32c6.toml
@@ -339,9 +339,9 @@ supports_mem2mem = true
 max_priority = 9
 engines = [
     { name = "AHB_GDMA", channels = [
-        { name = "DMA_CH0", mem2mem = true },
-        { name = "DMA_CH1", mem2mem = true },
-        { name = "DMA_CH2", mem2mem = true },
+        { name = "DMA_CH0", mem2mem = true, interrupt_in = "DMA_IN_CH0", interrupt_out = "DMA_OUT_CH0" },
+        { name = "DMA_CH1", mem2mem = true, interrupt_in = "DMA_IN_CH1", interrupt_out = "DMA_OUT_CH1" },
+        { name = "DMA_CH2", mem2mem = true, interrupt_in = "DMA_IN_CH2", interrupt_out = "DMA_OUT_CH2" },
     ] },
 ]
 

--- a/esp-metadata/devices/esp32c6.toml
+++ b/esp-metadata/devices/esp32c6.toml
@@ -337,10 +337,12 @@ gdma_version = 1
 separate_in_out_interrupts = true
 supports_mem2mem = true
 max_priority = 9
-channels = [
-    { name = "DMA_CH0", mem2mem = true },
-    { name = "DMA_CH1", mem2mem = true },
-    { name = "DMA_CH2", mem2mem = true },
+engines = [
+    { name = "AHB_GDMA", channels = [
+        { name = "DMA_CH0", mem2mem = true },
+        { name = "DMA_CH1", mem2mem = true },
+        { name = "DMA_CH2", mem2mem = true },
+    ] },
 ]
 
 [device.ecc]

--- a/esp-metadata/devices/esp32c61.toml
+++ b/esp-metadata/devices/esp32c61.toml
@@ -378,8 +378,8 @@ max_priority = 5
 # TODO: weight-based arbitration
 engines = [
     { name = "AHB_GDMA", channels = [
-        { name = "DMA_CH0", mem2mem = true },
-        { name = "DMA_CH1", mem2mem = true },
+        { name = "DMA_CH0", mem2mem = true, interrupt_in = "DMA_IN_CH0", interrupt_out = "DMA_OUT_CH0" },
+        { name = "DMA_CH1", mem2mem = true, interrupt_in = "DMA_IN_CH1", interrupt_out = "DMA_OUT_CH1" },
     ] },
 ]
 

--- a/esp-metadata/devices/esp32c61.toml
+++ b/esp-metadata/devices/esp32c61.toml
@@ -93,9 +93,6 @@ peripherals = [
     { name = "UART1", interrupts = { peri = "UART1" }, stable = true, clock_group = "UART" },
     { name = "USB_DEVICE", interrupts = { peri = "USB_DEVICE" } },
 
-    { name = "DMA_CH0", virtual = true },
-    { name = "DMA_CH1", virtual = true },
-
     { name = "BT", virtual = true, interrupts = { mac = "BT_MAC", lp_timer = "LP_TIMER" } },
     { name = "FLASH", virtual = true },
     { name = "GPIO_DEDICATED", virtual = true },
@@ -379,6 +376,10 @@ supports_mem2mem = true
 max_priority = 5
 # TODO: DMA can access flash
 # TODO: weight-based arbitration
+channels = [
+    { name = "DMA_CH0", mem2mem = true },
+    { name = "DMA_CH1", mem2mem = true },
+]
 
 [device.ecc]
 support_status = "partial"

--- a/esp-metadata/devices/esp32c61.toml
+++ b/esp-metadata/devices/esp32c61.toml
@@ -376,9 +376,11 @@ supports_mem2mem = true
 max_priority = 5
 # TODO: DMA can access flash
 # TODO: weight-based arbitration
-channels = [
-    { name = "DMA_CH0", mem2mem = true },
-    { name = "DMA_CH1", mem2mem = true },
+engines = [
+    { name = "AHB_GDMA", channels = [
+        { name = "DMA_CH0", mem2mem = true },
+        { name = "DMA_CH1", mem2mem = true },
+    ] },
 ]
 
 [device.ecc]

--- a/esp-metadata/devices/esp32h2.toml
+++ b/esp-metadata/devices/esp32h2.toml
@@ -95,10 +95,6 @@ peripherals = [
     { name = "UHCI0", dma_peripheral = 2 },
     { name = "USB_DEVICE", interrupts = { peri = "USB_DEVICE" } },
 
-    { name = "DMA_CH0", virtual = true },
-    { name = "DMA_CH1", virtual = true },
-    { name = "DMA_CH2", virtual = true },
-
     { name = "ADC1", virtual = true },
     { name = "BT", virtual = true, interrupts = { mac = "BT_MAC", lp_timer = "LP_BLE_TIMER" } },
     { name = "FLASH", virtual = true },
@@ -294,6 +290,11 @@ gdma_version = 1
 separate_in_out_interrupts = true
 supports_mem2mem = true
 max_priority = 5
+channels = [
+    { name = "DMA_CH0", mem2mem = true },
+    { name = "DMA_CH1", mem2mem = true },
+    { name = "DMA_CH2", mem2mem = true },
+]
 
 [device.ecc]
 support_status = "partial"

--- a/esp-metadata/devices/esp32h2.toml
+++ b/esp-metadata/devices/esp32h2.toml
@@ -290,10 +290,12 @@ gdma_version = 1
 separate_in_out_interrupts = true
 supports_mem2mem = true
 max_priority = 5
-channels = [
-    { name = "DMA_CH0", mem2mem = true },
-    { name = "DMA_CH1", mem2mem = true },
-    { name = "DMA_CH2", mem2mem = true },
+engines = [
+    { name = "AHB_GDMA", channels = [
+        { name = "DMA_CH0", mem2mem = true },
+        { name = "DMA_CH1", mem2mem = true },
+        { name = "DMA_CH2", mem2mem = true },
+    ] },
 ]
 
 [device.ecc]

--- a/esp-metadata/devices/esp32h2.toml
+++ b/esp-metadata/devices/esp32h2.toml
@@ -292,9 +292,9 @@ supports_mem2mem = true
 max_priority = 5
 engines = [
     { name = "AHB_GDMA", channels = [
-        { name = "DMA_CH0", mem2mem = true },
-        { name = "DMA_CH1", mem2mem = true },
-        { name = "DMA_CH2", mem2mem = true },
+        { name = "DMA_CH0", mem2mem = true, interrupt_in = "DMA_IN_CH0", interrupt_out = "DMA_OUT_CH0" },
+        { name = "DMA_CH1", mem2mem = true, interrupt_in = "DMA_IN_CH1", interrupt_out = "DMA_OUT_CH1" },
+        { name = "DMA_CH2", mem2mem = true, interrupt_in = "DMA_IN_CH2", interrupt_out = "DMA_OUT_CH2" },
     ] },
 ]
 

--- a/esp-metadata/devices/esp32p4.toml
+++ b/esp-metadata/devices/esp32p4.toml
@@ -285,9 +285,6 @@ peripherals = [
     # DMA: P4 has three DMA blocks; see [device.dma] below for the table.
     # esp-hal's `Dma` singleton needs the GDMA v2 layout, so map it to AHB_DMA.
     { name = "DMA", pac = "AHB_DMA" },
-    { name = "DMA_CH0", virtual = true },
-    { name = "DMA_CH1", virtual = true },
-    { name = "DMA_CH2", virtual = true },
 
     { name = "ETH", virtual = true },
     { name = "EMAC_DMA", hidden = true },
@@ -382,6 +379,11 @@ kind = "gdma"
 gdma_version = 2
 separate_in_out_interrupts = true
 max_priority = 5
+channels = [
+    { name = "DMA_CH0", mem2mem = false },
+    { name = "DMA_CH1", mem2mem = false },
+    { name = "DMA_CH2", mem2mem = false },
+]
 
 # TODO: Check later with PAC and TRM both
 [device.twai]

--- a/esp-metadata/devices/esp32p4.toml
+++ b/esp-metadata/devices/esp32p4.toml
@@ -381,9 +381,9 @@ separate_in_out_interrupts = true
 max_priority = 5
 engines = [
     { name = "AHB_GDMA", channels = [
-        { name = "DMA_CH0" },
-        { name = "DMA_CH1", mem2mem = false },
-        { name = "DMA_CH2", mem2mem = false },
+        { name = "DMA_CH0", interrupt_in = "AHB_PDMA_IN_CH0", interrupt_out = "AHB_PDMA_OUT_CH0" },
+        { name = "DMA_CH1", mem2mem = false, interrupt_in = "AHB_PDMA_IN_CH1", interrupt_out = "AHB_PDMA_OUT_CH1" },
+        { name = "DMA_CH2", mem2mem = false, interrupt_in = "AHB_PDMA_IN_CH2", interrupt_out = "AHB_PDMA_OUT_CH2" },
     ] },
 ]
 

--- a/esp-metadata/devices/esp32p4.toml
+++ b/esp-metadata/devices/esp32p4.toml
@@ -379,10 +379,12 @@ kind = "gdma"
 gdma_version = 2
 separate_in_out_interrupts = true
 max_priority = 5
-channels = [
-    { name = "DMA_CH0", mem2mem = false },
-    { name = "DMA_CH1", mem2mem = false },
-    { name = "DMA_CH2", mem2mem = false },
+engines = [
+    { name = "AHB_GDMA", channels = [
+        { name = "DMA_CH0" },
+        { name = "DMA_CH1", mem2mem = false },
+        { name = "DMA_CH2", mem2mem = false },
+    ] },
 ]
 
 # TODO: Check later with PAC and TRM both

--- a/esp-metadata/devices/esp32s2.toml
+++ b/esp-metadata/devices/esp32s2.toml
@@ -71,8 +71,8 @@ peripherals = [
     { name = "SHA", interrupts = { peri = "SHA" }, dma_peripheral = 5 },
     { name = "SPI0" },
     { name = "SPI1" },
-    { name = "SPI2", interrupts = { peri = "SPI2", dma = "SPI2_DMA" }, dma_peripheral = 1, stable = true },
-    { name = "SPI3", interrupts = { peri = "SPI3", dma = "SPI3_DMA" }, dma_peripheral = 2, stable = true },
+    { name = "SPI2", interrupts = { peri = "SPI2", dma = "SPI2_DMA"  }, dma_peripheral = 1, stable = true },
+    { name = "SPI3", interrupts = { peri = "SPI3", dma = "SPI3_DMA"  }, dma_peripheral = 2, stable = true },
     { name = "SYSCON" },
     { name = "SYSTEM" },
     { name = "SYSTIMER" },
@@ -288,12 +288,12 @@ can_access_psram = true
 ext_mem_configurable_block_size = true
 engines = [
     { name = "SPI_DMA", channels = [
-        { name = "DMA_SPI2", pac = "SPI2" },
-        { name = "DMA_SPI3", pac = "SPI3" },
+        { name = "DMA_SPI2", pac = "SPI2", interrupt = "SPI2_DMA" },
+        { name = "DMA_SPI3", pac = "SPI3", interrupt = "SPI3_DMA" },
     ] },
-    { name = "I2S_DMA",    channels = [{ name = "DMA_I2S0",   pac = "I2S0"       }] },
-    { name = "CRYPTO_DMA", channels = [{ name = "DMA_CRYPTO", pac = "CRYPTO_DMA" }] },
-    { name = "COPY_DMA",   channels = [{ name = "DMA_COPY",   pac = "COPY_DMA", mem2mem = true }] },
+    { name = "I2S_DMA",    channels = [{ name = "DMA_I2S0",   pac = "I2S0",       interrupt = "I2S0"       }] },
+    { name = "CRYPTO_DMA", channels = [{ name = "DMA_CRYPTO", pac = "CRYPTO_DMA", interrupt = "CRYPTO_DMA" }] },
+    { name = "COPY_DMA",   channels = [{ name = "DMA_COPY",   pac = "COPY_DMA", mem2mem = true, interrupt = "DMA_COPY" }] },
 ]
 
 [device.gpio]

--- a/esp-metadata/devices/esp32s2.toml
+++ b/esp-metadata/devices/esp32s2.toml
@@ -87,12 +87,6 @@ peripherals = [
     { name = "XTS_AES" },
     { name = "WIFI", interrupts = { mac = "WIFI_MAC", pwr = "WIFI_PWR" }, stable = true },
 
-    { name = "DMA_SPI2", pac = "SPI2" },
-    { name = "DMA_SPI3", pac = "SPI3" },
-    { name = "DMA_I2S0", pac = "I2S0" },
-    { name = "DMA_CRYPTO", pac = "CRYPTO_DMA" },
-    { name = "DMA_COPY", pac = "COPY_DMA" },
-
     { name = "ADC1", virtual = true },
     { name = "ADC2", virtual = true },
     { name = "DAC1", virtual = true },
@@ -292,6 +286,15 @@ kind = "pdma"
 supports_mem2mem = true
 can_access_psram = true
 ext_mem_configurable_block_size = true
+engines = [
+    { name = "SPI_DMA", channels = [
+        { name = "DMA_SPI2", pac = "SPI2" },
+        { name = "DMA_SPI3", pac = "SPI3" },
+    ] },
+    { name = "I2S_DMA",    channels = [{ name = "DMA_I2S0",   pac = "I2S0"       }] },
+    { name = "CRYPTO_DMA", channels = [{ name = "DMA_CRYPTO", pac = "CRYPTO_DMA" }] },
+    { name = "COPY_DMA",   channels = [{ name = "DMA_COPY",   pac = "COPY_DMA", mem2mem = true }] },
+]
 
 [device.gpio]
 support_status = "supported"

--- a/esp-metadata/devices/esp32s3.toml
+++ b/esp-metadata/devices/esp32s3.toml
@@ -301,11 +301,11 @@ can_access_psram = true
 ext_mem_configurable_block_size = true
 engines = [
     { name = "GDMA", channels = [
-        { name = "DMA_CH0", mem2mem = true },
-        { name = "DMA_CH1", mem2mem = true },
-        { name = "DMA_CH2", mem2mem = true },
-        { name = "DMA_CH3", mem2mem = true },
-        { name = "DMA_CH4", mem2mem = true },
+        { name = "DMA_CH0", mem2mem = true, interrupt_in = "DMA_IN_CH0", interrupt_out = "DMA_OUT_CH0" },
+        { name = "DMA_CH1", mem2mem = true, interrupt_in = "DMA_IN_CH1", interrupt_out = "DMA_OUT_CH1" },
+        { name = "DMA_CH2", mem2mem = true, interrupt_in = "DMA_IN_CH2", interrupt_out = "DMA_OUT_CH2" },
+        { name = "DMA_CH3", mem2mem = true, interrupt_in = "DMA_IN_CH3", interrupt_out = "DMA_OUT_CH3" },
+        { name = "DMA_CH4", mem2mem = true, interrupt_in = "DMA_IN_CH4", interrupt_out = "DMA_OUT_CH4" },
     ] },
 ]
 

--- a/esp-metadata/devices/esp32s3.toml
+++ b/esp-metadata/devices/esp32s3.toml
@@ -99,12 +99,6 @@ peripherals = [
     { name = "WCL" },
     { name = "XTS_AES" },
 
-    { name = "DMA_CH0", virtual = true },
-    { name = "DMA_CH1", virtual = true },
-    { name = "DMA_CH2", virtual = true },
-    { name = "DMA_CH3", virtual = true },
-    { name = "DMA_CH4", virtual = true },
-
     { name = "ADC1", virtual = true },
     { name = "ADC2", virtual = true },
     { name = "BT", virtual = true, interrupts = { rwble = "RWBLE", bb = "BT_BB" } },
@@ -305,6 +299,13 @@ supports_mem2mem = true
 max_priority = 9
 can_access_psram = true
 ext_mem_configurable_block_size = true
+channels = [
+    { name = "DMA_CH0", mem2mem = true },
+    { name = "DMA_CH1", mem2mem = true },
+    { name = "DMA_CH2", mem2mem = true },
+    { name = "DMA_CH3", mem2mem = true },
+    { name = "DMA_CH4", mem2mem = true },
+]
 
 [device.gpio]
 support_status = "supported"

--- a/esp-metadata/devices/esp32s3.toml
+++ b/esp-metadata/devices/esp32s3.toml
@@ -299,12 +299,14 @@ supports_mem2mem = true
 max_priority = 9
 can_access_psram = true
 ext_mem_configurable_block_size = true
-channels = [
-    { name = "DMA_CH0", mem2mem = true },
-    { name = "DMA_CH1", mem2mem = true },
-    { name = "DMA_CH2", mem2mem = true },
-    { name = "DMA_CH3", mem2mem = true },
-    { name = "DMA_CH4", mem2mem = true },
+engines = [
+    { name = "GDMA", channels = [
+        { name = "DMA_CH0", mem2mem = true },
+        { name = "DMA_CH1", mem2mem = true },
+        { name = "DMA_CH2", mem2mem = true },
+        { name = "DMA_CH3", mem2mem = true },
+        { name = "DMA_CH4", mem2mem = true },
+    ] },
 ]
 
 [device.gpio]

--- a/esp-metadata/src/cfg.rs
+++ b/esp-metadata/src/cfg.rs
@@ -1,4 +1,5 @@
 pub(crate) mod aes;
+pub(crate) mod dma;
 pub(crate) mod ecc;
 pub(crate) mod gpio;
 pub(crate) mod i2c_master;
@@ -13,6 +14,7 @@ pub(crate) mod timergroup;
 pub(crate) mod uart;
 
 pub(crate) use aes::*;
+pub(crate) use dma::*;
 pub(crate) use ecc::*;
 pub(crate) use gpio::*;
 pub(crate) use i2c_master::*;
@@ -351,6 +353,8 @@ driver_configs![
             max_priority: Option<u32>,
             #[serde(default)]
             gdma_version: Option<u32>,
+            #[serde(default)]
+            channels: DmaChannels,
         }
     },
     DsProperties {

--- a/esp-metadata/src/cfg.rs
+++ b/esp-metadata/src/cfg.rs
@@ -354,7 +354,7 @@ driver_configs![
             #[serde(default)]
             gdma_version: Option<u32>,
             #[serde(default)]
-            channels: DmaChannels,
+            engines: DmaEngines,
         }
     },
     DsProperties {

--- a/esp-metadata/src/cfg/dma.rs
+++ b/esp-metadata/src/cfg/dma.rs
@@ -1,25 +1,42 @@
 use super::GenericProperty;
 
-/// A single GDMA channel definition.
+/// A single DMA channel definition.
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct DmaChannelDef {
     /// The name of the peripheral singleton for this channel.
     pub name: String,
     /// Whether this channel supports memory-to-memory transfers.
     #[serde(default)]
+    #[expect(unused)]
     pub mem2mem: bool,
+    /// PAC peripheral type backing this channel's register block.
+    /// When absent the singleton is virtual (GDMA channels).
+    /// When present the singleton maps to the given PAC type (PDMA channels).
+    #[serde(default)]
+    pub pac: Option<String>,
 }
 
-/// The list of GDMA channels for a DMA engine.
+/// A single DMA engine with its channels.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct DmaEngineDef {
+    /// The name of the engine (e.g. `"GDMA"`, `"SPI2"`, `"I2S0"`).
+    #[expect(unused)]
+    pub name: String,
+    /// The channels belonging to this engine.
+    pub channels: Vec<DmaChannelDef>,
+}
+
+/// All DMA engines on a device.
 #[derive(Debug, Default, Clone, serde::Deserialize)]
 #[serde(transparent)]
-pub struct DmaChannels(pub Vec<DmaChannelDef>);
+pub struct DmaEngines(pub Vec<DmaEngineDef>);
 
-impl GenericProperty for DmaChannels {
+impl GenericProperty for DmaEngines {
     fn cfgs(&self) -> Option<Vec<String>> {
         let cfgs = self
             .0
             .iter()
+            .flat_map(|e| e.channels.iter())
             .map(|ch| format!("soc_has_{}", ch.name.to_lowercase()))
             .collect();
         Some(cfgs)

--- a/esp-metadata/src/cfg/dma.rs
+++ b/esp-metadata/src/cfg/dma.rs
@@ -1,4 +1,6 @@
-use super::GenericProperty;
+use quote::quote;
+
+use crate::{cfg::GenericProperty, generate_for_each_macro, number};
 
 /// A single DMA channel definition.
 #[derive(Debug, Clone, serde::Deserialize)]
@@ -14,6 +16,15 @@ pub struct DmaChannelDef {
     /// When present the singleton maps to the given PAC type (PDMA channels).
     #[serde(default)]
     pub pac: Option<String>,
+    /// Shared interrupt name (set when the channel has one interrupt for both directions).
+    #[serde(default)]
+    pub interrupt: Option<String>,
+    /// RX/IN direction interrupt name (set when the channel has separate in/out interrupts).
+    #[serde(default)]
+    pub interrupt_in: Option<String>,
+    /// TX/OUT direction interrupt name (set when the channel has separate in/out interrupts).
+    #[serde(default)]
+    pub interrupt_out: Option<String>,
 }
 
 /// A single DMA engine with its channels.
@@ -40,5 +51,54 @@ impl GenericProperty for DmaEngines {
             .map(|ch| format!("soc_has_{}", ch.name.to_lowercase()))
             .collect();
         Some(cfgs)
+    }
+
+    fn macros(&self) -> Option<proc_macro2::TokenStream> {
+        let mut shared = vec![];
+        let mut split = vec![];
+
+        for engine in self.0.iter() {
+            for (idx, channel) in engine.channels.iter().enumerate() {
+                let idx = number(idx);
+                match (
+                    &channel.interrupt,
+                    &channel.interrupt_in,
+                    &channel.interrupt_out,
+                ) {
+                    (Some(interrupt), None, None) => {
+                        let ch = quote::format_ident!("{}", channel.name);
+                        let interrupt = quote::format_ident!("{}", interrupt);
+                        shared.push(quote! { #ch, #idx, interrupt = #interrupt });
+                    }
+                    (None, Some(interrupt_in), Some(interrupt_out)) => {
+                        let ch = quote::format_ident!("{}", channel.name);
+                        let interrupt_in = quote::format_ident!("{}", interrupt_in);
+                        let interrupt_out = quote::format_ident!("{}", interrupt_out);
+                        split.push(
+                            quote! { #ch, #idx, interrupt_in = #interrupt_in, interrupt_out = #interrupt_out },
+                        );
+                    }
+                    (None, None, None) => {
+                        // No interrupt info – skip
+                    }
+                    _ => {
+                        panic!(
+                            "DMA channel '{}': set either `interrupt` (shared) or both \
+                             `interrupt_in` and `interrupt_out` (split), not a mix",
+                            channel.name
+                        );
+                    }
+                }
+            }
+        }
+
+        if shared.is_empty() && split.is_empty() {
+            return None;
+        }
+
+        Some(generate_for_each_macro(
+            "dma_channel",
+            &[("shared", &shared), ("split", &split)],
+        ))
     }
 }

--- a/esp-metadata/src/cfg/dma.rs
+++ b/esp-metadata/src/cfg/dma.rs
@@ -1,0 +1,27 @@
+use super::GenericProperty;
+
+/// A single GDMA channel definition.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct DmaChannelDef {
+    /// The name of the peripheral singleton for this channel.
+    pub name: String,
+    /// Whether this channel supports memory-to-memory transfers.
+    #[serde(default)]
+    pub mem2mem: bool,
+}
+
+/// The list of GDMA channels for a DMA engine.
+#[derive(Debug, Default, Clone, serde::Deserialize)]
+#[serde(transparent)]
+pub struct DmaChannels(pub Vec<DmaChannelDef>);
+
+impl GenericProperty for DmaChannels {
+    fn cfgs(&self) -> Option<Vec<String>> {
+        let cfgs = self
+            .0
+            .iter()
+            .map(|ch| format!("soc_has_{}", ch.name.to_lowercase()))
+            .collect();
+        Some(cfgs)
+    }
+}

--- a/esp-metadata/src/lib.rs
+++ b/esp-metadata/src/lib.rs
@@ -693,8 +693,29 @@ This pin may be available with certain limitations. Check your hardware to make 
                         Some(pac_name) => format_ident!("{}", pac_name),
                         None => format_ident!("virtual"),
                     };
+                    let interrupts: Vec<TokenStream> = match (
+                        &channel.interrupt,
+                        &channel.interrupt_in,
+                        &channel.interrupt_out,
+                    ) {
+                        (Some(interrupt), None, None) => {
+                            let interrupt = format_ident!("{}", interrupt);
+                            vec![quote! {
+                                #interrupt: { bind_dma_interrupt, enable_dma_interrupt, disable_dma_interrupt }
+                            }]
+                        }
+                        (None, Some(interrupt_in), Some(interrupt_out)) => {
+                            let interrupt_in = format_ident!("{}", interrupt_in);
+                            let interrupt_out = format_ident!("{}", interrupt_out);
+                            vec![
+                                quote! { #interrupt_in: { bind_dma_in_interrupt, enable_dma_in_interrupt, disable_dma_in_interrupt } },
+                                quote! { #interrupt_out: { bind_dma_out_interrupt, enable_dma_out_interrupt, disable_dma_out_interrupt } },
+                            ]
+                        }
+                        _ => vec![],
+                    };
                     let tokens = quote! {
-                        #[doc = #singleton_doc] #ch_name <= #pac ()
+                        #[doc = #singleton_doc] #ch_name <= #pac ( #(#interrupts),* )
                     };
                     all_peripherals.push(quote! { @peri_type #tokens (unstable) });
                     singleton_peripherals.push(quote! { #ch_name (unstable) });

--- a/esp-metadata/src/lib.rs
+++ b/esp-metadata/src/lib.rs
@@ -685,14 +685,20 @@ This pin may be available with certain limitations. Check your hardware to make 
         }
 
         if let Some(dma) = self.device.peri_config.dma.as_ref() {
-            for channel in dma.channels.0.iter() {
-                let ch_name = format_ident!("{}", channel.name);
-                let singleton_doc = format!("{} peripheral singleton", channel.name);
-                let tokens = quote! {
-                    #[doc = #singleton_doc] #ch_name <= virtual ()
-                };
-                all_peripherals.push(quote! { @peri_type #tokens (unstable) });
-                singleton_peripherals.push(quote! { #ch_name (unstable) });
+            for engine in dma.engines.0.iter() {
+                for channel in engine.channels.iter() {
+                    let ch_name = format_ident!("{}", channel.name);
+                    let singleton_doc = format!("{} peripheral singleton", channel.name);
+                    let pac = match &channel.pac {
+                        Some(pac_name) => format_ident!("{}", pac_name),
+                        None => format_ident!("virtual"),
+                    };
+                    let tokens = quote! {
+                        #[doc = #singleton_doc] #ch_name <= #pac ()
+                    };
+                    all_peripherals.push(quote! { @peri_type #tokens (unstable) });
+                    singleton_peripherals.push(quote! { #ch_name (unstable) });
+                }
             }
         }
 

--- a/esp-metadata/src/lib.rs
+++ b/esp-metadata/src/lib.rs
@@ -684,6 +684,18 @@ This pin may be available with certain limitations. Check your hardware to make 
             }
         }
 
+        if let Some(dma) = self.device.peri_config.dma.as_ref() {
+            for channel in dma.channels.0.iter() {
+                let ch_name = format_ident!("{}", channel.name);
+                let singleton_doc = format!("{} peripheral singleton", channel.name);
+                let tokens = quote! {
+                    #[doc = #singleton_doc] #ch_name <= virtual ()
+                };
+                all_peripherals.push(quote! { @peri_type #tokens (unstable) });
+                singleton_peripherals.push(quote! { #ch_name (unstable) });
+            }
+        }
+
         for peri in self.peripherals().iter() {
             let hal = format_ident!("{}", peri.name);
             let pac = if peri.is_virtual {


### PR DESCRIPTION
This PR defines the concept of a DMA engine in metadata. An engine can have a number of channels, channels can have a number of properties. DMA channel singletons are generated from this metadata and are no longer listed as (virtual or derived-from-peripheral) peripherals.

PDMA has not been updated in any meaningful way just yet. The end goal is to remove the special differentiation we have between these concepts - P4 has elements of both, and so we need to unify as much as we can before tackling that problem.
