### PR TITLE
Mark unsupported peripherals as such

### DIFF
--- a/esp-hal/README.md
+++ b/esp-hal/README.md
@@ -98,8 +98,8 @@ For help getting started with this HAL, please refer to [The Rust on ESP Book] a
 | RNG                       | ⚒️   | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️       | ⚒️      | ⚒️      | ⚒️      | ⚒️      |
 | RSA                       | ⚒️   |          | ⚒️      | ⚒️      | ⚒️      |           | ⚒️      | ❌       | ⚒️      | ⚒️      |
 | RTC Timekeeping           | ⚒️   | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️       | ⚒️      | ❌       | ⚒️      | ⚒️      |
-| SDIO host                 | ⚒️   |          |          |          |          |           |          | ❌       |          | ⚒️      |
-| SDIO slave                | ⚒️   |          |          | [❌][5169] [^1] | ⚒️      | [❌][5417] [^1] |          | ❌       |          |          |
+| SDIO host                 | ❌    |          |          |          |          |           |          | ❌       |          | ❌       |
+| SDIO slave                | ❌    |          |          | [❌][5169] [^1] | ❌       | [❌][5417] [^1] |          | ❌       |          |          |
 | SHA                       | ⚒️   | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️       | ⚒️      | ❌       | ⚒️      | ⚒️      |
 | Light/deep sleep          | ⚒️   | ⚒️      | ⚒️      | [❌][5165] [^1] | ⚒️      | [❌][5424] [^1] | ⚒️      | ❌       | ⚒️      | ⚒️      |
 | SPI master                | ✔️   | ✔️      | ✔️      | ✔️      | ✔️      | ✔️       | ✔️      | ⚒️      | ✔️      | ✔️      |
@@ -111,7 +111,7 @@ For help getting started with this HAL, please refer to [The Rust on ESP Book] a
 | TWAI / CAN / CANFD        | ⚒️   |          | ⚒️      | [❌][5163] [^1] | ⚒️      |           | ⚒️      | ❌       | ⚒️      | ⚒️      |
 | UART                      | ✔️   | ✔️      | ✔️      | ✔️      | ✔️      | ✔️       | ✔️      | ⚒️      | ✔️      | ✔️      |
 | UHCI                      | ❌    |          | ⚒️      | ⚒️      | ⚒️      |           | ⚒️      | ❌       | ❌       | ⚒️      |
-| ULP (FSM)                 | ⚒️   |          |          |          |          |           |          |          | ⚒️      | ⚒️      |
+| ULP (FSM)                 | ❌    |          |          |          |          |           |          |          | ❌       | ❌       |
 | ULP (RISC-V)              |       |          |          | [❌][5160] [^1] | ⚒️      |           |          | ❌       | ⚒️      | ⚒️      |
 | USB OTG FS                |       |          |          |          |          |           |          | ⚒️      | ⚒️      | ⚒️      |
 | USB Serial/JTAG           |       |          | ⚒️      | ⚒️      | ⚒️      | ⚒️       | ⚒️      | ⚒️      |          | ⚒️      |

--- a/esp-metadata-generated/src/_build_script_utils.rs
+++ b/esp-metadata-generated/src/_build_script_utils.rs
@@ -293,8 +293,6 @@ impl Chip {
                     "rng_driver_supported",
                     "rsa_driver_supported",
                     "lp_timer_driver_supported",
-                    "sd_host_driver_supported",
-                    "sd_slave_driver_supported",
                     "sha_driver_supported",
                     "sleep_driver_supported",
                     "soc_driver_supported",
@@ -305,7 +303,6 @@ impl Chip {
                     "touch_driver_supported",
                     "twai_driver_supported",
                     "uart_driver_supported",
-                    "ulp_fsm_driver_supported",
                     "wifi_driver_supported",
                     "adc_adc1",
                     "adc_adc2",
@@ -507,8 +504,6 @@ impl Chip {
                     "cargo:rustc-cfg=rng_driver_supported",
                     "cargo:rustc-cfg=rsa_driver_supported",
                     "cargo:rustc-cfg=lp_timer_driver_supported",
-                    "cargo:rustc-cfg=sd_host_driver_supported",
-                    "cargo:rustc-cfg=sd_slave_driver_supported",
                     "cargo:rustc-cfg=sha_driver_supported",
                     "cargo:rustc-cfg=sleep_driver_supported",
                     "cargo:rustc-cfg=soc_driver_supported",
@@ -519,7 +514,6 @@ impl Chip {
                     "cargo:rustc-cfg=touch_driver_supported",
                     "cargo:rustc-cfg=twai_driver_supported",
                     "cargo:rustc-cfg=uart_driver_supported",
-                    "cargo:rustc-cfg=ulp_fsm_driver_supported",
                     "cargo:rustc-cfg=wifi_driver_supported",
                     "cargo:rustc-cfg=adc_adc1",
                     "cargo:rustc-cfg=adc_adc2",
@@ -2555,7 +2549,6 @@ impl Chip {
                     "rng_driver_supported",
                     "rsa_driver_supported",
                     "lp_timer_driver_supported",
-                    "sd_slave_driver_supported",
                     "sha_driver_supported",
                     "sleep_driver_supported",
                     "soc_driver_supported",
@@ -2841,7 +2834,6 @@ impl Chip {
                     "cargo:rustc-cfg=rng_driver_supported",
                     "cargo:rustc-cfg=rsa_driver_supported",
                     "cargo:rustc-cfg=lp_timer_driver_supported",
-                    "cargo:rustc-cfg=sd_slave_driver_supported",
                     "cargo:rustc-cfg=sha_driver_supported",
                     "cargo:rustc-cfg=sleep_driver_supported",
                     "cargo:rustc-cfg=soc_driver_supported",
@@ -5006,7 +4998,6 @@ impl Chip {
                     "timergroup_driver_supported",
                     "twai_driver_supported",
                     "uart_driver_supported",
-                    "ulp_fsm_driver_supported",
                     "ulp_riscv_driver_supported",
                     "usb_otg_driver_supported",
                     "wifi_driver_supported",
@@ -5233,7 +5224,6 @@ impl Chip {
                     "cargo:rustc-cfg=timergroup_driver_supported",
                     "cargo:rustc-cfg=twai_driver_supported",
                     "cargo:rustc-cfg=uart_driver_supported",
-                    "cargo:rustc-cfg=ulp_fsm_driver_supported",
                     "cargo:rustc-cfg=ulp_riscv_driver_supported",
                     "cargo:rustc-cfg=usb_otg_driver_supported",
                     "cargo:rustc-cfg=wifi_driver_supported",
@@ -5660,7 +5650,6 @@ impl Chip {
                     "rng_driver_supported",
                     "rsa_driver_supported",
                     "lp_timer_driver_supported",
-                    "sd_host_driver_supported",
                     "sha_driver_supported",
                     "sleep_driver_supported",
                     "soc_driver_supported",
@@ -5672,7 +5661,6 @@ impl Chip {
                     "twai_driver_supported",
                     "uart_driver_supported",
                     "uhci_driver_supported",
-                    "ulp_fsm_driver_supported",
                     "ulp_riscv_driver_supported",
                     "usb_otg_driver_supported",
                     "usb_serial_jtag_driver_supported",
@@ -5921,7 +5909,6 @@ impl Chip {
                     "cargo:rustc-cfg=rng_driver_supported",
                     "cargo:rustc-cfg=rsa_driver_supported",
                     "cargo:rustc-cfg=lp_timer_driver_supported",
-                    "cargo:rustc-cfg=sd_host_driver_supported",
                     "cargo:rustc-cfg=sha_driver_supported",
                     "cargo:rustc-cfg=sleep_driver_supported",
                     "cargo:rustc-cfg=soc_driver_supported",
@@ -5933,7 +5920,6 @@ impl Chip {
                     "cargo:rustc-cfg=twai_driver_supported",
                     "cargo:rustc-cfg=uart_driver_supported",
                     "cargo:rustc-cfg=uhci_driver_supported",
-                    "cargo:rustc-cfg=ulp_fsm_driver_supported",
                     "cargo:rustc-cfg=ulp_riscv_driver_supported",
                     "cargo:rustc-cfg=usb_otg_driver_supported",
                     "cargo:rustc-cfg=usb_serial_jtag_driver_supported",
@@ -6426,8 +6412,6 @@ pub fn emit_check_cfg_directives() {
     println!("cargo:rustc-check-cfg=cfg(rng_driver_supported)");
     println!("cargo:rustc-check-cfg=cfg(rsa_driver_supported)");
     println!("cargo:rustc-check-cfg=cfg(lp_timer_driver_supported)");
-    println!("cargo:rustc-check-cfg=cfg(sd_host_driver_supported)");
-    println!("cargo:rustc-check-cfg=cfg(sd_slave_driver_supported)");
     println!("cargo:rustc-check-cfg=cfg(sha_driver_supported)");
     println!("cargo:rustc-check-cfg=cfg(sleep_driver_supported)");
     println!("cargo:rustc-check-cfg=cfg(soc_driver_supported)");
@@ -6438,7 +6422,6 @@ pub fn emit_check_cfg_directives() {
     println!("cargo:rustc-check-cfg=cfg(touch_driver_supported)");
     println!("cargo:rustc-check-cfg=cfg(twai_driver_supported)");
     println!("cargo:rustc-check-cfg=cfg(uart_driver_supported)");
-    println!("cargo:rustc-check-cfg=cfg(ulp_fsm_driver_supported)");
     println!("cargo:rustc-check-cfg=cfg(wifi_driver_supported)");
     println!("cargo:rustc-check-cfg=cfg(adc_adc1)");
     println!("cargo:rustc-check-cfg=cfg(adc_adc2)");

--- a/esp-metadata/devices/esp32.toml
+++ b/esp-metadata/devices/esp32.toml
@@ -896,7 +896,9 @@ max_ws_width = 128
 [device.mcpwm]
 [device.pcnt]
 [device.sd_host]
+support_status = "not_supported"
 [device.sd_slave]
+support_status = "not_supported"
 [device.touch]
 [device.twai]
 
@@ -908,6 +910,7 @@ extmem_origin = 0x3F800000
 [device.lp_timer]
 
 [device.ulp_fsm]
+support_status = "not_supported"
 
 ## Radio
 [device.wifi]

--- a/esp-metadata/devices/esp32c6.toml
+++ b/esp-metadata/devices/esp32c6.toml
@@ -765,6 +765,7 @@ clock_configured_by_pcr = true
 
 [device.pcnt]
 [device.sd_slave]
+support_status = "not_supported"
 [device.twai]
 [device.usb_serial_jtag]
 

--- a/esp-metadata/devices/esp32s2.toml
+++ b/esp-metadata/devices/esp32s2.toml
@@ -699,6 +699,7 @@ extmem_origin = 0x3f500000
 [device.systimer]
 [device.temp_sensor]
 [device.ulp_fsm]
+support_status = "not_supported"
 [device.ulp_riscv]
 [device.lp_timer]
 

--- a/esp-metadata/devices/esp32s3.toml
+++ b/esp-metadata/devices/esp32s3.toml
@@ -879,6 +879,7 @@ max_ws_width = 128
 [device.mcpwm]
 [device.pcnt]
 [device.sd_host]
+support_status = "not_supported"
 [device.twai]
 [device.usb_otg]
 fifo_depth_words = 256
@@ -894,6 +895,7 @@ octal_spi = true
 [device.systimer]
 [device.temp_sensor]
 [device.ulp_fsm]
+support_status = "not_supported"
 [device.ulp_riscv]
 [device.lp_timer]
 


### PR DESCRIPTION
# Changelog

## esp-hal

- Fixed: Corrected support status of SDMMC, SDIO and ULP_FSM
