### PR TITLE
Pre beta fixups

### DIFF
--- a/esp-radio/src/lib.rs
+++ b/esp-radio/src/lib.rs
@@ -6,27 +6,31 @@
 //!
 //! This documentation is built for the
 #![doc = concat!("**", chip_pretty!(), "**")]
-//! . Please ensure you are reading the correct [documentation](https://docs.espressif.com/projects/rust/esp-radio/latest/) for your target
+//! . Please ensure you are reading the correct [documentation] for your target
 //! device.
 //!
-//! ## Usage
+//! ## Overview
 //!
-//! ### Importing
+//! esp-radio provides Wi-Fi, Bluetooth Low Energy (BLE), ESP-NOW and IEEE
+//! 802.15.4 drivers for Espressif microcontrollers. It builds on top of
+//! [esp-hal] and the vendor binary blobs to provide wireless connectivity in a
+//! `no_std` environment.
 //!
-//! Enabling the `unstable` feature on `esp-radio` requires you to also enable
-//! the `unstable` feature on `esp-hal` in the final binary crate.
-//!
-//! Ensure that the right features are enabled for your chip. See [Examples](https://github.com/esp-rs/esp-hal/tree/main/examples#examples) for more examples.
-//!
-//! You will also need a dynamic memory allocator, and a preemptive task scheduler in your
-//! application. For the dynamic allocator, we recommend using `esp-alloc`. For the task scheduler,
-//! the simplest option that is supported by us is `esp-rtos`, but you may use Ariel
-//! OS or other operating systems as well.
+//! Wi-Fi and BLE require a dynamic memory allocator and a preemptive task
+//! scheduler at runtime. We recommend [`esp-alloc`] and [`esp-rtos`] for this,
+//! though any allocator or RTOS (such as Ariel OS) that implements the required
+//! interfaces will work.
 #![cfg_attr(
     feature = "ieee802154",
-    doc = "<div class=\"warning\"><b>Hint:</b> The scheduler is not required for the 802.15.4.</div>"
+    doc = "<div class=\"warning\"><b>Hint:</b> The scheduler is not required for IEEE 802.15.4.</div>"
 )]
-#![doc = ""]
+//! Drivers that don't currently have a stable API are marked as `unstable` in
+//! the documentation. Enabling the `unstable` feature on `esp-radio` requires
+//! you to also enable the `unstable` feature on `esp-hal` in the final binary
+//! crate.
+//!
+//! ### Quick start
+//!
 //! ```rust, no_run
 #![doc = esp_hal::before_snippet!()]
 //! use esp_hal::interrupt::software::SoftwareInterruptControl;
@@ -72,26 +76,43 @@ if let Ok(controller) = BleConnector::new(peripherals.BT, Default::default()) {}
 #![doc = concat!(r#"features = [""#, chip!(), r#""]"#)]
 //! ```
 //! 
-//! ### Optimization Level
+//! ## Examples
 //!
-//! It is necessary to build with optimization level 2 or 3 since otherwise, it
-//! might not even be able to connect or advertise.
+//! We have a number of [examples] in the esp-hal repository. We use
+//! an [xtask] to automate the building, running, and testing of code and
+//! examples within esp-hal.
 //!
-//! To make it work also for your debug builds add this to your `Cargo.toml`
+//! Invoke the following command in the root of the esp-hal repository to get
+//! started:
+//! ```bash
+//! cargo xtask help
+//! ```
+//! 
+//! We have a [book] that explains the full esp-hal ecosystem
+//! and how to get started, and a [training] that covers some common
+//! scenarios with examples.
+//!
+//! ## Optimization level
+//!
+//! The radio blobs require optimization level 2 or 3 to function correctly.
+//! Without it, Wi-Fi may fail to connect and BLE may fail to advertise.
+//!
+//! To apply this only to esp-radio in debug builds, add to your `Cargo.toml`:
 //! ```toml
 //! [profile.dev.package.esp-radio]
 //! opt-level = 3
 //! ```
-//! ## Globally disable logging
+//! 
+//! ## Disabling logging
 //!
-//! `esp-radio` contains a lot of trace-level logging statements.
-//! For maximum performance you might want to disable logging via
-//! a feature flag of the `log` crate. See [documentation](https://docs.rs/log/0.4.19/log/#compile-time-filters).
-//! You should set it to `release_max_level_off`.
+//! `esp-radio` contains trace-level logging statements that may impact
+//! performance. To disable them, use the `log` crate's compile-time
+//! [filters](https://docs.rs/log/latest/log/#compile-time-filters) and set
+//! `release_max_level_off`.
 #![cfg_attr(
     multi_core,
     doc = concat!(
-        "### Running on the Second Core",
+        "## Running on the second core",
         "\n\n",
         "BLE and Wi-Fi can also be run on the second core.",
         "\n\n",
@@ -122,6 +143,14 @@ if let Ok(controller) = BleConnector::new(peripherals.BT, Default::default()) {}
 //! for this crate:
 #![doc = ""]
 #![doc = include_str!(concat!(env!("OUT_DIR"), "/esp_radio_config_table.md"))]
+//! [documentation]: https://docs.espressif.com/projects/rust/esp-radio/latest/
+//! [esp-hal]: https://docs.espressif.com/projects/rust/esp-hal/latest/
+//! [`esp-alloc`]: https://docs.espressif.com/projects/rust/esp-alloc/latest/
+//! [`esp-rtos`]: https://docs.espressif.com/projects/rust/esp-rtos/latest/
+//! [examples]: https://github.com/esp-rs/esp-hal/tree/main/examples
+//! [xtask]: https://github.com/matklad/cargo-xtask
+//! [book]: https://docs.espressif.com/projects/rust/book/
+//! [training]: https://docs.espressif.com/projects/rust/no_std-training/
 #![doc(html_logo_url = "https://docs.espressif.com/projects/rust/esp-rs-grey-bg.svg")]
 #![no_std]
 #![cfg_attr(xtensa, feature(asm_experimental_arch))]

--- a/esp-radio/src/lib.rs
+++ b/esp-radio/src/lib.rs
@@ -46,7 +46,7 @@
     wifi_driver_supported,
     doc = r#"
 
-if let Ok(controller) = esp_radio::wifi::new(
+if let Ok(controller) = esp_radio::wifi::WifiController::new(
     peripherals.WIFI,
     Default::default(),
 ) {}

--- a/esp-radio/src/lib.rs
+++ b/esp-radio/src/lib.rs
@@ -109,6 +109,15 @@ if let Ok(controller) = BleConnector::new(peripherals.BT, Default::default()) {}
 //! performance. To disable them, use the `log` crate's compile-time
 //! [filters](https://docs.rs/log/latest/log/#compile-time-filters) and set
 //! `release_max_level_off`.
+//!
+//! [documentation]: https://docs.espressif.com/projects/rust/esp-radio/latest/
+//! [esp-hal]: https://docs.espressif.com/projects/rust/esp-hal/latest/
+//! [`esp-alloc`]: https://docs.espressif.com/projects/rust/esp-alloc/latest/
+//! [`esp-rtos`]: https://docs.espressif.com/projects/rust/esp-rtos/latest/
+//! [examples]: https://github.com/esp-rs/esp-hal/tree/main/examples
+//! [xtask]: https://github.com/matklad/cargo-xtask
+//! [book]: https://docs.espressif.com/projects/rust/book/
+//! [training]: https://docs.espressif.com/projects/rust/no_std-training/
 #![cfg_attr(
     multi_core,
     doc = concat!(
@@ -143,14 +152,6 @@ if let Ok(controller) = BleConnector::new(peripherals.BT, Default::default()) {}
 //! for this crate:
 #![doc = ""]
 #![doc = include_str!(concat!(env!("OUT_DIR"), "/esp_radio_config_table.md"))]
-//! [documentation]: https://docs.espressif.com/projects/rust/esp-radio/latest/
-//! [esp-hal]: https://docs.espressif.com/projects/rust/esp-hal/latest/
-//! [`esp-alloc`]: https://docs.espressif.com/projects/rust/esp-alloc/latest/
-//! [`esp-rtos`]: https://docs.espressif.com/projects/rust/esp-rtos/latest/
-//! [examples]: https://github.com/esp-rs/esp-hal/tree/main/examples
-//! [xtask]: https://github.com/matklad/cargo-xtask
-//! [book]: https://docs.espressif.com/projects/rust/book/
-//! [training]: https://docs.espressif.com/projects/rust/no_std-training/
 #![doc(html_logo_url = "https://docs.espressif.com/projects/rust/esp-rs-grey-bg.svg")]
 #![no_std]
 #![cfg_attr(xtensa, feature(asm_experimental_arch))]

--- a/esp-radio/src/wifi/ap.rs
+++ b/esp-radio/src/wifi/ap.rs
@@ -155,7 +155,7 @@ impl defmt::Format for AccessPointConfig {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
-pub struct AccessPointStationConnectedInfo {
+pub struct ConnectedInfo {
     /// The MAC address.
     pub mac: [u8; 6],
     /// The Association ID (AID) of the connected station.
@@ -168,7 +168,7 @@ pub struct AccessPointStationConnectedInfo {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
-pub struct AccessPointStationDisconnectedInfo {
+pub struct DisconnectedInfo {
     /// The MAC address.
     pub mac: [u8; 6],
     /// The Association ID (AID) of the connected station.
@@ -179,14 +179,14 @@ pub struct AccessPointStationDisconnectedInfo {
     pub reason: DisconnectReason,
 }
 
-/// Either the [AccessPointStationConnectedInfo] or [AccessPointStationDisconnectedInfo].
+/// Either the [ConnectedInfo] or [DisconnectedInfo].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum AccessPointStationEventInfo {
+pub enum EventInfo {
     /// Information about a station connected to the access point.
-    Connected(AccessPointStationConnectedInfo),
+    Connected(ConnectedInfo),
     /// Information about a station disconnected from the access point.
-    Disconnected(AccessPointStationDisconnectedInfo),
+    Disconnected(DisconnectedInfo),
 }
 
 #[allow(non_upper_case_globals)]

--- a/esp-radio/src/wifi/ap.rs
+++ b/esp-radio/src/wifi/ap.rs
@@ -7,7 +7,7 @@ use procmacros::BuilderLite;
 
 #[cfg(feature = "unstable")]
 use super::CountryInfo;
-use super::{AuthenticationMethod, Protocols, SecondaryChannel, Ssid};
+use super::{AuthenticationMethod, DisconnectReason, Protocols, SecondaryChannel, Ssid};
 use crate::{WifiError, sys::include::wifi_ap_record_t};
 
 /// Information about a detected Wi-Fi access point.
@@ -149,6 +149,44 @@ impl defmt::Format for AccessPointConfig {
             self.beacon_timeout
         );
     }
+}
+
+/// Information about a station connected to the access point.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub struct AccessPointStationConnectedInfo {
+    /// The MAC address.
+    pub mac: [u8; 6],
+    /// The Association ID (AID) of the connected station.
+    pub aid: u16,
+    /// If this is a mesh child.
+    pub is_mesh_child: bool,
+}
+
+/// Information about a station disconnected from the access point.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub struct AccessPointStationDisconnectedInfo {
+    /// The MAC address.
+    pub mac: [u8; 6],
+    /// The Association ID (AID) of the connected station.
+    pub aid: u16,
+    /// If this is a mesh child.
+    pub is_mesh_child: bool,
+    /// The disconnect reason.
+    pub reason: DisconnectReason,
+}
+
+/// Either the [AccessPointStationConnectedInfo] or [AccessPointStationDisconnectedInfo].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum AccessPointStationEventInfo {
+    /// Information about a station connected to the access point.
+    Connected(AccessPointStationConnectedInfo),
+    /// Information about a station disconnected from the access point.
+    Disconnected(AccessPointStationDisconnectedInfo),
 }
 
 #[allow(non_upper_case_globals)]

--- a/esp-radio/src/wifi/ap.rs
+++ b/esp-radio/src/wifi/ap.rs
@@ -53,8 +53,10 @@ pub struct AccessPointConfig {
     #[builder_lite(reference)]
     pub(crate) password: String,
     /// The maximum number of connections allowed on the access point.
+    #[builder_lite(unstable)]
     pub(crate) max_connections: u16,
     /// Dtim period of the access point (Range: 1 ~ 10).
+    #[builder_lite(unstable)]
     pub(crate) dtim_period: u8,
     /// Time to force deauth the station if the Soft-AccessPoint doesn't receive any data.
     #[builder_lite(unstable)]

--- a/esp-radio/src/wifi/event.rs
+++ b/esp-radio/src/wifi/event.rs
@@ -1289,7 +1289,8 @@ pub fn enable_wifi_events(events: EnumSet<WifiEvent>) {
 /// - [WifiEvent::AccessPointStationDisconnected]
 /// - [WifiEvent::ScanDone]
 ///
-/// [crate::wifi::new] always enables these events, even if they were disabled beforehand.
+/// [crate::wifi::WifiController::new] always enables these events, even if they were disabled
+/// beforehand.
 #[instability::unstable]
 pub fn disable_wifi_events(events: EnumSet<WifiEvent>) {
     WIFI_EVENT_ENABLE_MASK.with(|mask| *mask &= !events);

--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -65,17 +65,10 @@ use self::sniffer::Sniffer;
 #[cfg(feature = "wifi-eap")]
 use self::sta::eap::EapStationConfig;
 use self::{
-    ap::{
-        AccessPointConfig,
-        AccessPointInfo,
-        AccessPointStationConnectedInfo,
-        AccessPointStationDisconnectedInfo,
-        AccessPointStationEventInfo,
-        convert_ap_info,
-    },
+    ap::{AccessPointConfig, AccessPointInfo, convert_ap_info},
     private::PacketBuffer,
     scan::{FreeApListOnDrop, ScanConfig, ScanResults, ScanTypeConfig},
-    sta::{ConnectedStationInfo, DisconnectedStationInfo, StationConfig},
+    sta::StationConfig,
     state::*,
 };
 use crate::{
@@ -879,7 +872,7 @@ static DATA_QUEUE_RX_STA: NonReentrantMutex<PacketQueue> =
 #[non_exhaustive]
 pub enum WifiError {
     /// The device disconnected from the network or failed to connect to it.
-    Disconnected(DisconnectedStationInfo),
+    Disconnected(sta::DisconnectedInfo),
 
     /// Unsupported operation or mode.
     Unsupported,
@@ -2924,7 +2917,7 @@ ignored."
     ///     }
     /// }
     /// # {after_snippet}
-    pub async fn connect_async(&mut self) -> Result<ConnectedStationInfo, WifiError> {
+    pub async fn connect_async(&mut self) -> Result<sta::ConnectedInfo, WifiError> {
         let mut subscriber = EVENT_CHANNEL
             .subscriber()
             .expect("Unable to subscribe to events - consider increasing the internal event channel subscriber count");
@@ -2953,7 +2946,7 @@ ignored."
                 channel,
                 authmode,
                 aid,
-            } => Ok(ConnectedStationInfo {
+            } => Ok(sta::ConnectedInfo {
                 ssid,
                 bssid,
                 channel,
@@ -2965,7 +2958,7 @@ ignored."
                 bssid,
                 reason,
                 rssi,
-            } => Err(WifiError::Disconnected(DisconnectedStationInfo {
+            } => Err(WifiError::Disconnected(sta::DisconnectedInfo {
                 ssid,
                 bssid,
                 reason: DisconnectReason::from_raw(reason),
@@ -2997,7 +2990,7 @@ ignored."
     ///     }
     /// }
     /// # {after_snippet}
-    pub async fn disconnect_async(&mut self) -> Result<DisconnectedStationInfo, WifiError> {
+    pub async fn disconnect_async(&mut self) -> Result<sta::DisconnectedInfo, WifiError> {
         // If not connected it would wait forever for a `StationDisconnected` event that will never
         // happen. Return early instead of hanging.
         if !self.is_connected() {
@@ -3020,7 +3013,7 @@ ignored."
                 rssi,
             } = event
             {
-                break Ok(DisconnectedStationInfo {
+                break Ok(sta::DisconnectedInfo {
                     ssid,
                     bssid,
                     reason: DisconnectReason::from_raw(reason),
@@ -3031,7 +3024,7 @@ ignored."
     }
 
     /// Wait until the station gets disconnected from the AP.
-    pub async fn wait_for_disconnect_async(&self) -> Result<DisconnectedStationInfo, WifiError> {
+    pub async fn wait_for_disconnect_async(&self) -> Result<sta::DisconnectedInfo, WifiError> {
         // If not connected it would wait forever for a `StationDisconnected` event that will never
         // happen. Return early instead of hanging.
         if !self.is_connected() {
@@ -3052,7 +3045,7 @@ ignored."
                 rssi,
             } = event
             {
-                break Ok(DisconnectedStationInfo {
+                break Ok(sta::DisconnectedInfo {
                     ssid,
                     bssid,
                     reason: DisconnectReason::from_raw(reason),
@@ -3065,7 +3058,7 @@ ignored."
     /// Wait for connected / disconnected events.
     pub async fn wait_for_access_point_connected_event_async(
         &self,
-    ) -> Result<AccessPointStationEventInfo, WifiError> {
+    ) -> Result<ap::EventInfo, WifiError> {
         let mut subscriber = EVENT_CHANNEL
             .subscriber()
             .expect("Unable to subscribe to events - consider increasing the internal event channel subscriber count");
@@ -3079,13 +3072,11 @@ ignored."
                     aid,
                     is_mesh_child,
                 } => {
-                    break Ok(AccessPointStationEventInfo::Connected(
-                        AccessPointStationConnectedInfo {
-                            mac,
-                            aid,
-                            is_mesh_child,
-                        },
-                    ));
+                    break Ok(ap::EventInfo::Connected(ap::ConnectedInfo {
+                        mac,
+                        aid,
+                        is_mesh_child,
+                    }));
                 }
                 event::EventInfo::AccessPointStationDisconnected {
                     mac,
@@ -3093,14 +3084,12 @@ ignored."
                     is_mesh_child,
                     reason,
                 } => {
-                    break Ok(AccessPointStationEventInfo::Disconnected(
-                        AccessPointStationDisconnectedInfo {
-                            mac,
-                            aid: aid as u16,
-                            is_mesh_child,
-                            reason: DisconnectReason::from_raw(reason),
-                        },
-                    ));
+                    break Ok(ap::EventInfo::Disconnected(ap::DisconnectedInfo {
+                        mac,
+                        aid: aid as u16,
+                        is_mesh_child,
+                        reason: DisconnectReason::from_raw(reason),
+                    }));
                 }
                 _ => (),
             }

--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -1317,7 +1317,7 @@ pub(super) fn release(bit: u8) {
 /// Each interface mode (station, access point) is a singleton — only one
 /// instance of each can exist at a time. Create interfaces via
 /// [`Interface::station()`] or [`Interface::access_point()`] before or after
-/// calling [`new()`]. Dropping the interface releases the singleton so it can
+/// calling [`WifiController::new()`]. Dropping the interface releases the singleton so it can
 /// be created again.
 #[derive(Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -1379,7 +1379,7 @@ impl Interface {
     ///
     /// ```rust,no_run
     /// # {before_snippet}
-    /// let _controller = esp_radio::wifi::new(peripherals.WIFI, Default::default())?;
+    /// let _controller = esp_radio::wifi::WifiController::new(peripherals.WIFI, Default::default())?;
     ///
     /// let station = esp_radio::wifi::Interface::station();
     /// let mac = station.mac_address();
@@ -2241,115 +2241,7 @@ impl ControllerConfig {
     }
 }
 
-#[procmacros::doc_replace]
-/// Create a Wi-Fi controller. The default initial configuration is
-/// [Config::Station(StationConfig::default())].
-///
-/// Dropping the controller will deinitialize / stop Wi-Fi.
-///
-/// Create [`Interface`]s separately via [`Interface::station()`] /
-/// [`Interface::access_point()`]. ESP-NOW and sniffer instances are
-/// available through the controller's [`WifiController::esp_now()`] and
-/// [`WifiController::sniffer()`] methods.
-///
-/// Make sure to **not** call this function while interrupts are disabled, or IEEE 802.15.4 is
-/// currently in use.
-///
-/// ## Example
-///
-/// ```rust,no_run
-/// # {before_snippet}
-/// let controller = esp_radio::wifi::new(peripherals.WIFI, Default::default())?;
-/// let sta = esp_radio::wifi::Interface::station();
-/// # {after_snippet}
-/// ```
-pub fn new<'d>(
-    device: crate::hal::peripherals::WIFI<'d>,
-    config: ControllerConfig,
-) -> Result<WifiController<'d>, WifiError> {
-    let _guard = RadioRefGuard::new();
-
-    config.validate();
-
-    event::enable_wifi_events(
-        WifiEvent::StationStart
-            | WifiEvent::StationStop
-            | WifiEvent::StationConnected
-            | WifiEvent::StationDisconnected
-            | WifiEvent::AccessPointStart
-            | WifiEvent::AccessPointStop
-            | WifiEvent::AccessPointStationConnected
-            | WifiEvent::AccessPointStationDisconnected
-            | WifiEvent::ScanDone,
-    );
-
-    unsafe {
-        internal::G_CONFIG = wifi_init_config_t {
-            osi_funcs: (&raw const internal::__ESP_RADIO_G_WIFI_OSI_FUNCS).cast_mut(),
-
-            wpa_crypto_funcs: g_wifi_default_wpa_crypto_funcs,
-            static_rx_buf_num: config.static_rx_buf_num as _,
-            dynamic_rx_buf_num: config.dynamic_rx_buf_num as _,
-            tx_buf_type: crate::sys::include::CONFIG_ESP_WIFI_TX_BUFFER_TYPE as i32,
-            static_tx_buf_num: config.static_tx_buf_num as _,
-            dynamic_tx_buf_num: config.dynamic_tx_buf_num as _,
-            rx_mgmt_buf_type: crate::sys::include::CONFIG_ESP_WIFI_DYNAMIC_RX_MGMT_BUF as i32,
-            rx_mgmt_buf_num: crate::sys::include::CONFIG_ESP_WIFI_RX_MGMT_BUF_NUM_DEF as i32,
-            cache_tx_buf_num: crate::sys::include::WIFI_CACHE_TX_BUFFER_NUM as i32,
-            csi_enable: cfg!(feature = "csi") as i32,
-            ampdu_rx_enable: config.ampdu_rx_enable as _,
-            ampdu_tx_enable: config.ampdu_tx_enable as _,
-            amsdu_tx_enable: config.amsdu_tx_enable as _,
-            nvs_enable: 0,
-            nano_enable: 0,
-            rx_ba_win: config.rx_ba_win as _,
-            wifi_task_core_id: Cpu::current() as _,
-            beacon_max_len: crate::sys::include::WIFI_SOFTAP_BEACON_MAX_LEN as i32,
-            mgmt_sbuf_num: crate::sys::include::WIFI_MGMT_SBUF_NUM as i32,
-            feature_caps: internal::__ESP_RADIO_G_WIFI_FEATURE_CAPS,
-            sta_disconnected_pm: false,
-            espnow_max_encrypt_num: crate::sys::include::CONFIG_ESP_WIFI_ESPNOW_MAX_ENCRYPT_NUM
-                as i32,
-
-            tx_hetb_queue_num: 3,
-            dump_hesigb_enable: false,
-
-            magic: WIFI_INIT_CONFIG_MAGIC as i32,
-        };
-    }
-
-    DATA_QUEUE_RX_AP.with(|queue| queue.change_capacity(config.rx_queue_size))?;
-    DATA_QUEUE_RX_STA.with(|queue| queue.change_capacity(config.rx_queue_size))?;
-
-    TX_QUEUE_SIZE.store(config.tx_queue_size, Ordering::Relaxed);
-
-    crate::wifi::wifi_init(device)?;
-
-    // At some point the "High-speed ADC" entropy source became available.
-    #[cfg(all(rng_trng_supported, feature = "unstable"))]
-    unsafe {
-        esp_hal::rng::TrngSource::increase_entropy_source_counter()
-    };
-
-    // Only create WifiController after we've enabled TRNG - otherwise returning an error from this
-    // function will cause panic because WifiController::drop tries to disable the TRNG.
-    let mut controller = WifiController {
-        _guard,
-        _phantom: Default::default(),
-    };
-
-    controller.set_country_info(&config.country_info)?;
-    // Set a sane default power saving mode. The blob default is not the best for bandwidth.
-    controller.set_power_saving(PowerSaveMode::default())?;
-
-    controller.set_config(&config.initial_config)?;
-
-    Ok(controller)
-}
-
 /// Wi-Fi controller.
-///
-/// Calling [new] starts the controller.
 ///
 /// When the controller is dropped, the Wi-Fi driver is
 /// deinitialized and Wi-Fi is stopped.
@@ -2375,6 +2267,115 @@ impl Drop for WifiController<'_> {
                 esp_hal::Internal::conjure()
             });
         })
+    }
+}
+
+impl<'d> WifiController<'d> {
+    #[procmacros::doc_replace]
+    /// Create a Wi-Fi controller. The default initial configuration is
+    /// [`Config::Station`]`(`[`StationConfig::default()`]`)`.
+    ///
+    /// Dropping the controller will deinitialize / stop Wi-Fi.
+    ///
+    /// Create [`Interface`]s separately via [`Interface::station()`] /
+    /// [`Interface::access_point()`]. ESP-NOW and sniffer instances are
+    /// available through the controller's [`WifiController::esp_now()`] and
+    /// [`WifiController::sniffer()`] methods.
+    ///
+    /// Make sure to **not** call this function while interrupts are disabled, or IEEE 802.15.4 is
+    /// currently in use.
+    ///
+    /// ## Example
+    ///
+    /// ```rust,no_run
+    /// # {before_snippet}
+    /// let controller = esp_radio::wifi::WifiController::new(peripherals.WIFI, Default::default())?;
+    /// let sta = esp_radio::wifi::Interface::station();
+    /// # {after_snippet}
+    /// ```
+    pub fn new(
+        device: crate::hal::peripherals::WIFI<'d>,
+        config: ControllerConfig,
+    ) -> Result<Self, WifiError> {
+        let _guard = RadioRefGuard::new();
+
+        config.validate();
+
+        event::enable_wifi_events(
+            WifiEvent::StationStart
+                | WifiEvent::StationStop
+                | WifiEvent::StationConnected
+                | WifiEvent::StationDisconnected
+                | WifiEvent::AccessPointStart
+                | WifiEvent::AccessPointStop
+                | WifiEvent::AccessPointStationConnected
+                | WifiEvent::AccessPointStationDisconnected
+                | WifiEvent::ScanDone,
+        );
+
+        unsafe {
+            internal::G_CONFIG = wifi_init_config_t {
+                osi_funcs: (&raw const internal::__ESP_RADIO_G_WIFI_OSI_FUNCS).cast_mut(),
+
+                wpa_crypto_funcs: g_wifi_default_wpa_crypto_funcs,
+                static_rx_buf_num: config.static_rx_buf_num as _,
+                dynamic_rx_buf_num: config.dynamic_rx_buf_num as _,
+                tx_buf_type: crate::sys::include::CONFIG_ESP_WIFI_TX_BUFFER_TYPE as i32,
+                static_tx_buf_num: config.static_tx_buf_num as _,
+                dynamic_tx_buf_num: config.dynamic_tx_buf_num as _,
+                rx_mgmt_buf_type: crate::sys::include::CONFIG_ESP_WIFI_DYNAMIC_RX_MGMT_BUF as i32,
+                rx_mgmt_buf_num: crate::sys::include::CONFIG_ESP_WIFI_RX_MGMT_BUF_NUM_DEF as i32,
+                cache_tx_buf_num: crate::sys::include::WIFI_CACHE_TX_BUFFER_NUM as i32,
+                csi_enable: cfg!(feature = "csi") as i32,
+                ampdu_rx_enable: config.ampdu_rx_enable as _,
+                ampdu_tx_enable: config.ampdu_tx_enable as _,
+                amsdu_tx_enable: config.amsdu_tx_enable as _,
+                nvs_enable: 0,
+                nano_enable: 0,
+                rx_ba_win: config.rx_ba_win as _,
+                wifi_task_core_id: Cpu::current() as _,
+                beacon_max_len: crate::sys::include::WIFI_SOFTAP_BEACON_MAX_LEN as i32,
+                mgmt_sbuf_num: crate::sys::include::WIFI_MGMT_SBUF_NUM as i32,
+                feature_caps: internal::__ESP_RADIO_G_WIFI_FEATURE_CAPS,
+                sta_disconnected_pm: false,
+                espnow_max_encrypt_num: crate::sys::include::CONFIG_ESP_WIFI_ESPNOW_MAX_ENCRYPT_NUM
+                    as i32,
+
+                tx_hetb_queue_num: 3,
+                dump_hesigb_enable: false,
+
+                magic: WIFI_INIT_CONFIG_MAGIC as i32,
+            };
+        }
+
+        DATA_QUEUE_RX_AP.with(|queue| queue.change_capacity(config.rx_queue_size))?;
+        DATA_QUEUE_RX_STA.with(|queue| queue.change_capacity(config.rx_queue_size))?;
+
+        TX_QUEUE_SIZE.store(config.tx_queue_size, Ordering::Relaxed);
+
+        crate::wifi::wifi_init(device)?;
+
+        // At some point the "High-speed ADC" entropy source became available.
+        #[cfg(all(rng_trng_supported, feature = "unstable"))]
+        unsafe {
+            esp_hal::rng::TrngSource::increase_entropy_source_counter()
+        };
+
+        // Only create WifiController after we've enabled TRNG - otherwise returning an
+        // error from this function will cause panic because WifiController::drop tries
+        // to disable the TRNG.
+        let mut controller = WifiController {
+            _guard,
+            _phantom: Default::default(),
+        };
+
+        controller.set_country_info(&config.country_info)?;
+        // Set a sane default power saving mode. The blob default is not the best for bandwidth.
+        controller.set_power_saving(PowerSaveMode::default())?;
+
+        controller.set_config(&config.initial_config)?;
+
+        Ok(controller)
     }
 }
 
@@ -2435,7 +2436,8 @@ impl WifiController<'_> {
     /// let controller_config = ControllerConfig::default().with_initial_config(Config::AccessPoint(
     ///     AccessPointConfig::default().with_ssid("esp-radio"),
     /// ));
-    /// let mut wifi_controller = esp_radio::wifi::new(peripherals.WIFI, controller_config)?;
+    /// let mut wifi_controller =
+    ///     esp_radio::wifi::WifiController::new(peripherals.WIFI, controller_config)?;
     ///
     /// wifi_controller.set_protocols(Protocols::default());
     /// # {after_snippet}
@@ -2474,7 +2476,8 @@ impl WifiController<'_> {
     /// ```rust,no_run
     /// # {before_snippet}
     /// # use esp_radio::wifi::PowerSaveMode;
-    /// let mut controller = esp_radio::wifi::new(peripherals.WIFI, Default::default())?;
+    /// let mut controller =
+    ///     esp_radio::wifi::WifiController::new(peripherals.WIFI, Default::default())?;
     /// controller.set_power_saving(PowerSaveMode::Maximum)?;
     /// # {after_snippet}
     /// ```
@@ -2505,7 +2508,7 @@ impl WifiController<'_> {
     ///
     /// ```rust,no_run
     /// # {before_snippet}
-    /// # let controller = esp_radio::wifi::new(peripherals.WIFI, Default::default())?;
+    /// # let controller = esp_radio::wifi::WifiController::new(peripherals.WIFI, Default::default())?;
     /// // Assume the station has already been started and connected
     /// match controller.rssi() {
     ///     Ok(rssi) => {
@@ -2546,7 +2549,7 @@ impl WifiController<'_> {
     ///
     /// ```rust,no_run
     /// # {before_snippet}
-    /// # let controller = esp_radio::wifi::new(peripherals.WIFI, Default::default())?;
+    /// # let controller = esp_radio::wifi::WifiController::new(peripherals.WIFI, Default::default())?;
     /// // Assume the station has already been started and connected
     /// match controller.ap_info() {
     ///     Ok(info) => {
@@ -2595,7 +2598,7 @@ impl WifiController<'_> {
     /// # {before_snippet}
     /// # use esp_radio::wifi::{Config, sta::StationConfig};
     /// # let mut controller =
-    /// #    esp_radio::wifi::new(peripherals.WIFI, Default::default())?;
+    /// #    esp_radio::wifi::WifiController::new(peripherals.WIFI, Default::default())?;
     /// let station_config = Config::Station(
     ///     StationConfig::default()
     ///         .with_ssid("SSID")
@@ -2823,7 +2826,7 @@ ignored."
     /// ```rust,no_run
     /// # {before_snippet}
     /// # use esp_radio::wifi::WifiError;
-    /// # let controller = esp_radio::wifi::new(peripherals.WIFI, Default::default())?;
+    /// # let controller = esp_radio::wifi::WifiController::new(peripherals.WIFI, Default::default())?;
     /// if controller.is_connected() {
     ///     println!("Station is connected");
     /// } else {
@@ -2853,7 +2856,7 @@ ignored."
     /// ```rust,no_run
     /// # {before_snippet}
     /// # use esp_radio::wifi::{WifiController, scan::ScanConfig};
-    /// # let mut controller = esp_radio::wifi::new(peripherals.WIFI, Default::default())?;
+    /// # let mut controller = esp_radio::wifi::WifiController::new(peripherals.WIFI, Default::default())?;
     /// // Create a scan configuration (e.g., scan up to 10 APs)
     /// let scan_config = ScanConfig::default().with_max(10);
     /// let result = controller.scan_async(&scan_config).await.unwrap();
@@ -2910,7 +2913,7 @@ ignored."
     /// # use esp_radio::wifi::{Config, sta::StationConfig};
     ///
     /// # let mut controller =
-    /// #   esp_radio::wifi::new(peripherals.WIFI, Default::default())?;
+    /// #   esp_radio::wifi::WifiController::new(peripherals.WIFI, Default::default())?;
     ///
     /// match controller.connect_async().await {
     ///     Ok(_) => {
@@ -2984,7 +2987,7 @@ ignored."
     /// # use esp_radio::wifi::{Config, sta::StationConfig};
     ///
     /// # let mut controller =
-    /// #    esp_radio::wifi::new(peripherals.WIFI, Default::default())?;
+    /// #    esp_radio::wifi::WifiController::new(peripherals.WIFI, Default::default())?;
     /// match controller.disconnect_async().await {
     ///     Ok(info) => {
     ///         println!("Station disconnected successfully. {info:?}");

--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -65,10 +65,17 @@ use self::sniffer::Sniffer;
 #[cfg(feature = "wifi-eap")]
 use self::sta::eap::EapStationConfig;
 use self::{
-    ap::{AccessPointConfig, AccessPointInfo, convert_ap_info},
+    ap::{
+        AccessPointConfig,
+        AccessPointInfo,
+        AccessPointStationConnectedInfo,
+        AccessPointStationDisconnectedInfo,
+        AccessPointStationEventInfo,
+        convert_ap_info,
+    },
     private::PacketBuffer,
     scan::{FreeApListOnDrop, ScanConfig, ScanResults, ScanTypeConfig},
-    sta::StationConfig,
+    sta::{ConnectedStationInfo, DisconnectedStationInfo, StationConfig},
     state::*,
 };
 use crate::{
@@ -797,77 +804,6 @@ impl From<&[u8]> for Ssid {
     fn from(ssid: &[u8]) -> Self {
         Self::from_raw(ssid, ssid.len() as u8)
     }
-}
-
-/// Information about a connected station.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[non_exhaustive]
-pub struct ConnectedStationInfo {
-    /// The SSID of the connected station.
-    pub ssid: Ssid,
-    /// The BSSID of the connected station.
-    pub bssid: [u8; 6],
-    /// The channel of the connected station.
-    pub channel: u8,
-    /// The authmode of the connected station.
-    pub authmode: AuthenticationMethod,
-    /// The Association ID (AID) of the connected station.
-    pub aid: u16,
-}
-
-/// Information about a disconnected station.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[non_exhaustive]
-pub struct DisconnectedStationInfo {
-    /// The SSID of the disconnected station.
-    pub ssid: Ssid,
-    /// The BSSID of the disconnected station.
-    pub bssid: [u8; 6],
-    /// The disconnect reason.
-    // should we introduce an enum?
-    pub reason: DisconnectReason,
-    /// The RSSI.
-    pub rssi: i8,
-}
-
-/// Information about a station connected to the access point.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[non_exhaustive]
-pub struct AccessPointStationConnectedInfo {
-    /// The MAC address.
-    pub mac: [u8; 6],
-    /// The Association ID (AID) of the connected station.
-    pub aid: u16,
-    /// If this is a mesh child.
-    pub is_mesh_child: bool,
-}
-
-/// Information about a station disconnected from the access point.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[non_exhaustive]
-pub struct AccessPointStationDisconnectedInfo {
-    /// The MAC address.
-    pub mac: [u8; 6],
-    /// The Association ID (AID) of the connected station.
-    pub aid: u16,
-    /// If this is a mesh child.
-    pub is_mesh_child: bool,
-    /// The disconnect reason.
-    pub reason: DisconnectReason,
-}
-
-/// Either the [AccessPointStationConnectedInfo] or [AccessPointStationDisconnectedInfo].
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub enum AccessPointStationEventInfo {
-    /// Information about a station connected to the access point.
-    Connected(AccessPointStationConnectedInfo),
-    /// Information about a station disconnected from the access point.
-    Disconnected(AccessPointStationDisconnectedInfo),
 }
 
 static TX_QUEUE_SIZE: AtomicUsize = AtomicUsize::new(0);

--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -37,14 +37,6 @@
 //!
 //! Please note that the configuration keys are usually named slightly different and not all
 //! configuration keys apply.
-//!
-//! By default the power-saving mode is [PowerSaveMode::None]
-//! and `ESP_PHY_CONFIG_PHY_ENABLE_USB` is enabled by default.
-//!
-//! In addition pay attention to these configuration keys:
-//! - `ESP_RADIO_CONFIG_RX_QUEUE_SIZE`
-//! - `ESP_RADIO_CONFIG_TX_QUEUE_SIZE`
-//! - `ESP_RADIO_CONFIG_MAX_BURST_SIZE`
 
 use alloc::{borrow::ToOwned, collections::vec_deque::VecDeque, str, vec::Vec};
 use core::{

--- a/esp-radio/src/wifi/sta/mod.rs
+++ b/esp-radio/src/wifi/sta/mod.rs
@@ -161,7 +161,7 @@ impl defmt::Format for StationConfig {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
-pub struct ConnectedStationInfo {
+pub struct ConnectedInfo {
     /// The SSID of the connected station.
     pub ssid: Ssid,
     /// The BSSID of the connected station.
@@ -178,7 +178,7 @@ pub struct ConnectedStationInfo {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
-pub struct DisconnectedStationInfo {
+pub struct DisconnectedInfo {
     /// The SSID of the disconnected station.
     pub ssid: Ssid,
     /// The BSSID of the disconnected station.

--- a/esp-radio/src/wifi/sta/mod.rs
+++ b/esp-radio/src/wifi/sta/mod.rs
@@ -5,7 +5,7 @@ use core::fmt;
 
 use procmacros::BuilderLite;
 
-use super::{AuthenticationMethod, Protocols, Ssid};
+use super::{AuthenticationMethod, DisconnectReason, Protocols, Ssid};
 use crate::WifiError;
 
 unstable_module!(
@@ -155,4 +155,36 @@ impl defmt::Format for StationConfig {
             self.scan_method
         )
     }
+}
+
+/// Information about a connected station.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub struct ConnectedStationInfo {
+    /// The SSID of the connected station.
+    pub ssid: Ssid,
+    /// The BSSID of the connected station.
+    pub bssid: [u8; 6],
+    /// The channel of the connected station.
+    pub channel: u8,
+    /// The authmode of the connected station.
+    pub authmode: AuthenticationMethod,
+    /// The Association ID (AID) of the connected station.
+    pub aid: u16,
+}
+
+/// Information about a disconnected station.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub struct DisconnectedStationInfo {
+    /// The SSID of the disconnected station.
+    pub ssid: Ssid,
+    /// The BSSID of the disconnected station.
+    pub bssid: [u8; 6],
+    /// The disconnect reason.
+    pub reason: DisconnectReason,
+    /// The RSSI.
+    pub rssi: i8,
 }

--- a/esp-radio/src/wifi/sta/mod.rs
+++ b/esp-radio/src/wifi/sta/mod.rs
@@ -157,31 +157,31 @@ impl defmt::Format for StationConfig {
     }
 }
 
-/// Information about a connected station.
+/// Information about the access point the station connected to.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub struct ConnectedInfo {
-    /// The SSID of the connected station.
+    /// The SSID of the access point.
     pub ssid: Ssid,
-    /// The BSSID of the connected station.
+    /// The BSSID of the access point.
     pub bssid: [u8; 6],
-    /// The channel of the connected station.
+    /// The channel of the access point.
     pub channel: u8,
-    /// The authmode of the connected station.
+    /// The authentication method used.
     pub authmode: AuthenticationMethod,
-    /// The Association ID (AID) of the connected station.
+    /// The Association ID (AID) assigned by the access point.
     pub aid: u16,
 }
 
-/// Information about a disconnected station.
+/// Information about the access point the station disconnected from.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub struct DisconnectedInfo {
-    /// The SSID of the disconnected station.
+    /// The SSID of the access point.
     pub ssid: Ssid,
-    /// The BSSID of the disconnected station.
+    /// The BSSID of the access point.
     pub bssid: [u8; 6],
     /// The disconnect reason.
     pub reason: DisconnectReason,

--- a/examples/esp-now/embassy_esp_now/src/main.rs
+++ b/examples/esp-now/embassy_esp_now/src/main.rs
@@ -33,7 +33,7 @@ async fn main(_spawner: Spawner) -> ! {
     esp_rtos::start(timg0.timer0, sw_int.software_interrupt0);
 
     let wifi = peripherals.WIFI;
-    let controller = esp_radio::wifi::new(wifi, Default::default()).unwrap();
+    let controller = esp_radio::wifi::WifiController::new(wifi, Default::default()).unwrap();
 
     let mut esp_now = controller.esp_now();
     esp_now.set_channel(11).unwrap();

--- a/examples/esp-now/embassy_esp_now_duplex/src/main.rs
+++ b/examples/esp-now/embassy_esp_now_duplex/src/main.rs
@@ -52,7 +52,7 @@ async fn main(spawner: Spawner) -> ! {
     let wifi = peripherals.WIFI;
     let controller = mk_static!(
         esp_radio::wifi::WifiController<'static>,
-        esp_radio::wifi::new(wifi, Default::default()).unwrap()
+        esp_radio::wifi::WifiController::new(wifi, Default::default()).unwrap()
     );
 
     let esp_now = controller.esp_now();

--- a/examples/wifi/80211_tx/src/main.rs
+++ b/examples/wifi/80211_tx/src/main.rs
@@ -50,7 +50,8 @@ async fn main(_spawner: embassy_executor::Spawner) -> ! {
 
     // The sniffer borrows the controller, so we only need the controller here —
     // no station/AP `Interface` is required for raw 802.11 transmit.
-    let controller = esp_radio::wifi::new(peripherals.WIFI, Default::default()).unwrap();
+    let controller =
+        esp_radio::wifi::WifiController::new(peripherals.WIFI, Default::default()).unwrap();
 
     let mut sniffer = controller.sniffer();
 

--- a/examples/wifi/embassy_access_point/src/main.rs
+++ b/examples/wifi/embassy_access_point/src/main.rs
@@ -67,7 +67,7 @@ async fn main(spawner: Spawner) -> ! {
 
     println!("Starting wifi");
     let device = esp_radio::wifi::Interface::access_point();
-    let controller = esp_radio::wifi::new(
+    let controller = esp_radio::wifi::WifiController::new(
         peripherals.WIFI,
         ControllerConfig::default().with_initial_config(access_point_config),
     )

--- a/examples/wifi/embassy_access_point/src/main.rs
+++ b/examples/wifi/embassy_access_point/src/main.rs
@@ -234,21 +234,11 @@ async fn connection(controller: WifiController<'static>) {
             .wait_for_access_point_connected_event_async()
             .await;
         match ev {
-            Ok(esp_radio::wifi::ap::AccessPointStationEventInfo::Connected(
-                access_point_station_connected_info,
-            )) => {
-                println!(
-                    "Station connected: {:?}",
-                    access_point_station_connected_info
-                );
+            Ok(esp_radio::wifi::ap::EventInfo::Connected(info)) => {
+                println!("Station connected: {:?}", info);
             }
-            Ok(esp_radio::wifi::ap::AccessPointStationEventInfo::Disconnected(
-                access_point_station_disconnected_info,
-            )) => {
-                println!(
-                    "Station disconnected: {:?}",
-                    access_point_station_disconnected_info
-                );
+            Ok(esp_radio::wifi::ap::EventInfo::Disconnected(info)) => {
+                println!("Station disconnected: {:?}", info);
             }
             _ => (),
         }

--- a/examples/wifi/embassy_access_point/src/main.rs
+++ b/examples/wifi/embassy_access_point/src/main.rs
@@ -234,7 +234,7 @@ async fn connection(controller: WifiController<'static>) {
             .wait_for_access_point_connected_event_async()
             .await;
         match ev {
-            Ok(esp_radio::wifi::AccessPointStationEventInfo::Connected(
+            Ok(esp_radio::wifi::ap::AccessPointStationEventInfo::Connected(
                 access_point_station_connected_info,
             )) => {
                 println!(
@@ -242,7 +242,7 @@ async fn connection(controller: WifiController<'static>) {
                     access_point_station_connected_info
                 );
             }
-            Ok(esp_radio::wifi::AccessPointStationEventInfo::Disconnected(
+            Ok(esp_radio::wifi::ap::AccessPointStationEventInfo::Disconnected(
                 access_point_station_disconnected_info,
             )) => {
                 println!(

--- a/examples/wifi/embassy_access_point_with_sta/src/main.rs
+++ b/examples/wifi/embassy_access_point_with_sta/src/main.rs
@@ -346,21 +346,11 @@ async fn connection(mut controller: WifiController<'static>) {
                         Either::Second(event) => {
                             if let Ok(event) = event {
                                 match event {
-                                    esp_radio::wifi::ap::AccessPointStationEventInfo::Connected(
-                                        access_point_station_connected_info,
-                                    ) => {
-                                        println!(
-                                            "Station connected: {:?}",
-                                            access_point_station_connected_info
-                                        );
+                                    esp_radio::wifi::ap::EventInfo::Connected(info) => {
+                                        println!("Station connected: {:?}", info);
                                     }
-                                    esp_radio::wifi::ap::AccessPointStationEventInfo::Disconnected(
-                                        access_point_station_disconnected_info,
-                                    ) => {
-                                        println!(
-                                            "Station disconnected: {:?}",
-                                            access_point_station_disconnected_info
-                                        );
+                                    esp_radio::wifi::ap::EventInfo::Disconnected(info) => {
+                                        println!("Station disconnected: {:?}", info);
                                     }
                                 }
                             }

--- a/examples/wifi/embassy_access_point_with_sta/src/main.rs
+++ b/examples/wifi/embassy_access_point_with_sta/src/main.rs
@@ -97,7 +97,7 @@ async fn main(spawner: Spawner) -> ! {
     println!("Starting wifi");
     let wifi_ap_device = esp_radio::wifi::Interface::access_point();
     let wifi_sta_device = esp_radio::wifi::Interface::station();
-    let controller = esp_radio::wifi::new(
+    let controller = esp_radio::wifi::WifiController::new(
         peripherals.WIFI,
         ControllerConfig::default().with_initial_config(access_point_station_config),
     )

--- a/examples/wifi/embassy_access_point_with_sta/src/main.rs
+++ b/examples/wifi/embassy_access_point_with_sta/src/main.rs
@@ -346,7 +346,7 @@ async fn connection(mut controller: WifiController<'static>) {
                         Either::Second(event) => {
                             if let Ok(event) = event {
                                 match event {
-                                    esp_radio::wifi::AccessPointStationEventInfo::Connected(
+                                    esp_radio::wifi::ap::AccessPointStationEventInfo::Connected(
                                         access_point_station_connected_info,
                                     ) => {
                                         println!(
@@ -354,7 +354,7 @@ async fn connection(mut controller: WifiController<'static>) {
                                             access_point_station_connected_info
                                         );
                                     }
-                                    esp_radio::wifi::AccessPointStationEventInfo::Disconnected(
+                                    esp_radio::wifi::ap::AccessPointStationEventInfo::Disconnected(
                                         access_point_station_disconnected_info,
                                     ) => {
                                         println!(

--- a/examples/wifi/embassy_coex/src/main.rs
+++ b/examples/wifi/embassy_coex/src/main.rs
@@ -115,7 +115,7 @@ async fn main(spawner: Spawner) -> ! {
 
     println!("Starting wifi");
     let wifi_interface = esp_radio::wifi::Interface::station();
-    let mut controller = esp_radio::wifi::new(
+    let mut controller = esp_radio::wifi::WifiController::new(
         peripherals.WIFI,
         ControllerConfig::default().with_initial_config(station_config),
     )

--- a/examples/wifi/embassy_dhcp/src/main.rs
+++ b/examples/wifi/embassy_dhcp/src/main.rs
@@ -98,7 +98,7 @@ async fn main(spawner: Spawner) -> ! {
 
     println!("Starting wifi");
     let wifi_interface = esp_radio::wifi::Interface::station();
-    let mut controller = esp_radio::wifi::new(
+    let mut controller = esp_radio::wifi::WifiController::new(
         peripherals.WIFI,
         ControllerConfig::default().with_initial_config(station_config),
     )

--- a/examples/wifi/embassy_sntp/src/main.rs
+++ b/examples/wifi/embassy_sntp/src/main.rs
@@ -103,7 +103,7 @@ async fn main(spawner: Spawner) -> ! {
 
     println!("Starting wifi");
     let wifi_interface = esp_radio::wifi::Interface::station();
-    let mut controller = esp_radio::wifi::new(
+    let mut controller = esp_radio::wifi::WifiController::new(
         peripherals.WIFI,
         ControllerConfig::default().with_initial_config(station_config),
     )

--- a/examples/wifi/sniffer/src/main.rs
+++ b/examples/wifi/sniffer/src/main.rs
@@ -41,7 +41,8 @@ async fn main(_spawner: embassy_executor::Spawner) -> ! {
 
     // The sniffer borrows the controller, so we only need the controller here —
     // no station/AP `Interface` is required for promiscuous capture.
-    let controller = esp_radio::wifi::new(peripherals.WIFI, Default::default()).unwrap();
+    let controller =
+        esp_radio::wifi::WifiController::new(peripherals.WIFI, Default::default()).unwrap();
 
     let mut sniffer = controller.sniffer();
     sniffer.set_promiscuous_mode(true).unwrap();

--- a/hil-test/src/bin/esp_radio/init_tests.rs
+++ b/hil-test/src/bin/esp_radio/init_tests.rs
@@ -28,7 +28,7 @@ mod init_tests {
         signal: &'static Signal<CriticalSectionRawMutex, Option<WifiError>>,
         wifi_peripheral: WIFI<'static>,
     ) {
-        match esp_radio::wifi::new(wifi_peripheral, Default::default()) {
+        match esp_radio::wifi::WifiController::new(wifi_peripheral, Default::default()) {
             Ok(_) => signal.signal(None),
             Err(err) => signal.signal(Some(err)),
         }
@@ -50,7 +50,7 @@ mod init_tests {
     #[cfg(soc_has_wifi)]
     fn test_init_fails_without_scheduler(p: Peripherals) {
         // esp-rtos must be initialized before esp-radio.
-        let _ = esp_radio::wifi::new(p.WIFI, Default::default());
+        let _ = esp_radio::wifi::WifiController::new(p.WIFI, Default::default());
     }
 
     #[test]
@@ -61,7 +61,9 @@ mod init_tests {
         let sw_ints = SoftwareInterruptControl::new(p.SW_INTERRUPT);
         esp_rtos::start(timg0.timer0, sw_ints.software_interrupt0);
 
-        let _ = critical_section::with(|_| esp_radio::wifi::new(p.WIFI, Default::default()));
+        let _ = critical_section::with(|_| {
+            esp_radio::wifi::WifiController::new(p.WIFI, Default::default())
+        });
     }
 
     #[test]
@@ -72,7 +74,7 @@ mod init_tests {
         let sw_ints = SoftwareInterruptControl::new(p.SW_INTERRUPT);
         esp_rtos::start(timg0.timer0, sw_ints.software_interrupt0);
 
-        let _ = interrupt_free(|| esp_radio::wifi::new(p.WIFI, Default::default()));
+        let _ = interrupt_free(|| esp_radio::wifi::WifiController::new(p.WIFI, Default::default()));
     }
 
     #[test]
@@ -105,11 +107,13 @@ mod init_tests {
         esp_rtos::start(timg0.timer0, sw_ints.software_interrupt0);
 
         // Initialize, then de-initialize wifi
-        let wifi = esp_radio::wifi::new(p.WIFI.reborrow(), Default::default()).unwrap();
+        let wifi =
+            esp_radio::wifi::WifiController::new(p.WIFI.reborrow(), Default::default()).unwrap();
         drop(wifi);
 
         // Now, can we do it again?
-        let _wifi = esp_radio::wifi::new(p.WIFI.reborrow(), Default::default()).unwrap();
+        let _wifi =
+            esp_radio::wifi::WifiController::new(p.WIFI.reborrow(), Default::default()).unwrap();
     }
 
     #[test]
@@ -122,7 +126,8 @@ mod init_tests {
 
         // Initialize BLE and WiFi then drop BLE
         let connector = BleConnector::new(p.BT.reborrow(), Default::default()).unwrap();
-        let wifi = esp_radio::wifi::new(p.WIFI.reborrow(), Default::default()).unwrap();
+        let wifi =
+            esp_radio::wifi::WifiController::new(p.WIFI.reborrow(), Default::default()).unwrap();
         drop(connector);
 
         // Re-initialize BLE and drop WiFi and BLE
@@ -140,14 +145,16 @@ mod init_tests {
         esp_rtos::start(timg0.timer0, sw_ints.software_interrupt0);
 
         // Initialize WiFi and BLE then drop BLE and WiFi
-        let wifi = esp_radio::wifi::new(p.WIFI.reborrow(), Default::default()).unwrap();
+        let wifi =
+            esp_radio::wifi::WifiController::new(p.WIFI.reborrow(), Default::default()).unwrap();
         let connector = BleConnector::new(p.BT.reborrow(), Default::default()).unwrap();
 
         drop(connector);
         drop(wifi);
 
         // Re-initialize WiFi and BLE then drop WiFi
-        let wifi = esp_radio::wifi::new(p.WIFI.reborrow(), Default::default()).unwrap();
+        let wifi =
+            esp_radio::wifi::WifiController::new(p.WIFI.reborrow(), Default::default()).unwrap();
         let _connector = BleConnector::new(p.BT.reborrow(), Default::default()).unwrap();
 
         drop(wifi);

--- a/hil-test/src/bin/esp_radio/wifi_controller.rs
+++ b/hil-test/src/bin/esp_radio/wifi_controller.rs
@@ -26,7 +26,7 @@ mod tests {
 
         let _source = esp_hal::rng::TrngSource::new(p.RNG, p.ADC1);
 
-        let _controller = esp_radio::wifi::new(p.WIFI, Default::default()).unwrap();
+        let _controller = esp_radio::wifi::WifiController::new(p.WIFI, Default::default()).unwrap();
     }
 
     // If this turns out to be too flaky or time-consuming,
@@ -38,7 +38,8 @@ mod tests {
         let sw_ints = SoftwareInterruptControl::new(p.SW_INTERRUPT);
         esp_rtos::start(timg0.timer0, sw_ints.software_interrupt0);
 
-        let mut controller = esp_radio::wifi::new(p.WIFI, Default::default()).unwrap();
+        let mut controller =
+            esp_radio::wifi::WifiController::new(p.WIFI, Default::default()).unwrap();
 
         // scanning all channels takes a (too) long time - even more for dual-band capable targets
         let scan_config = ScanConfig::default().with_max(1).with_channel(13);

--- a/qa-test/src/bin/embassy_scan_after_sleep.rs
+++ b/qa-test/src/bin/embassy_scan_after_sleep.rs
@@ -50,7 +50,8 @@ async fn main(_spawner: Spawner) {
     esp_println::println!("Done sleeping");
 
     // WiFi
-    let mut controller = esp_radio::wifi::new(peripherals.WIFI, Default::default()).unwrap();
+    let mut controller =
+        esp_radio::wifi::WifiController::new(peripherals.WIFI, Default::default()).unwrap();
 
     let res = controller
         .scan_async(&esp_radio::wifi::scan::ScanConfig::default())

--- a/qa-test/src/bin/embassy_wifi_bench.rs
+++ b/qa-test/src/bin/embassy_wifi_bench.rs
@@ -86,7 +86,7 @@ async fn main(spawner: Spawner) -> ! {
 
     println!("Starting wifi");
     let wifi_interface = esp_radio::wifi::Interface::station();
-    let mut controller = esp_radio::wifi::new(
+    let mut controller = esp_radio::wifi::WifiController::new(
         peripherals.WIFI,
         ControllerConfig::default().with_initial_config(station_config),
     )

--- a/qa-test/src/bin/embassy_wifi_csi.rs
+++ b/qa-test/src/bin/embassy_wifi_csi.rs
@@ -67,7 +67,7 @@ async fn main(spawner: Spawner) -> ! {
 
     println!("Starting wifi");
     let wifi_interface = esp_radio::wifi::Interface::station();
-    let mut controller = esp_radio::wifi::new(
+    let mut controller = esp_radio::wifi::WifiController::new(
         peripherals.WIFI,
         ControllerConfig::default().with_initial_config(station_config),
     )

--- a/qa-test/src/bin/embassy_wifi_drop.rs
+++ b/qa-test/src/bin/embassy_wifi_drop.rs
@@ -46,7 +46,7 @@ async fn main(_spawner: Spawner) {
         );
 
         let mut wifi_interface = esp_radio::wifi::Interface::station();
-        let mut controller = esp_radio::wifi::new(
+        let mut controller = esp_radio::wifi::WifiController::new(
             wifi.reborrow(),
             ControllerConfig::default().with_initial_config(station_config),
         )
@@ -82,7 +82,7 @@ async fn main(_spawner: Spawner) {
         );
 
         let mut wifi_interface = esp_radio::wifi::Interface::station();
-        let mut controller = esp_radio::wifi::new(
+        let mut controller = esp_radio::wifi::WifiController::new(
             wifi.reborrow(),
             ControllerConfig::default().with_initial_config(station_config),
         )

--- a/qa-test/src/bin/embassy_wifi_i2s.rs
+++ b/qa-test/src/bin/embassy_wifi_i2s.rs
@@ -208,7 +208,7 @@ async fn main(spawner: Spawner) {
 
     println!("Starting wifi");
     let wifi_interface = esp_radio::wifi::Interface::station();
-    let controller = esp_radio::wifi::new(
+    let controller = esp_radio::wifi::WifiController::new(
         peripherals.WIFI,
         ControllerConfig::default().with_initial_config(station_config),
     )

--- a/qa-test/src/bin/embassy_wifi_stress.rs
+++ b/qa-test/src/bin/embassy_wifi_stress.rs
@@ -61,7 +61,8 @@ async fn main(_spawner: Spawner) {
 
         println!("Wifi stack setup (STA)");
         let mut controller =
-            esp_radio::wifi::new(peripherals.WIFI.reborrow(), Default::default()).unwrap();
+            esp_radio::wifi::WifiController::new(peripherals.WIFI.reborrow(), Default::default())
+                .unwrap();
 
         {
             println!("Connecting to WiFi SSID: {}", SSID);

--- a/qa-test/src/bin/wifi_survives_ble_drop.rs
+++ b/qa-test/src/bin/wifi_survives_ble_drop.rs
@@ -85,7 +85,7 @@ async fn main(spawner: Spawner) -> ! {
 
     println!("Starting wifi");
     let wifi_interface = esp_radio::wifi::Interface::station();
-    let mut controller = esp_radio::wifi::new(
+    let mut controller = esp_radio::wifi::WifiController::new(
         peripherals.WIFI,
         ControllerConfig::default().with_initial_config(station_config),
     )

--- a/qa-test/src/bin/wifi_syslog.rs
+++ b/qa-test/src/bin/wifi_syslog.rs
@@ -46,7 +46,7 @@ async fn main(_spawner: Spawner) {
 
     println!("Creating wifi controller with print-logs-from-driver enabled");
 
-    let mut controller = esp_radio::wifi::new(
+    let mut controller = esp_radio::wifi::WifiController::new(
         peripherals.WIFI,
         ControllerConfig::default().with_initial_config(station_config),
     )


### PR DESCRIPTION
Please review commit by commit.

# Changelog

## esp-radio

- Changed: `esp_radio::wifi::new()` is now `esp_radio::wifi::WifiController::new()`.
- Changed: `ConnectedStationInfo` renamed to `sta::ConnectedInfo` and moved to the `sta` module.
- Changed: `DisconnectedStationInfo` renamed to `sta::DisconnectedInfo` and moved to the `sta` module.
- Changed: `AccessPointStationConnectedInfo` renamed to `ap::ConnectedInfo` and moved to the `ap` module.
- Changed: `AccessPointStationDisconnectedInfo` renamed to `ap::DisconnectedInfo` and moved to the `ap` module.
- Changed: `AccessPointStationEventInfo` renamed to `ap::EventInfo` and moved to the `ap` module.
- Changed: `AccessPointConfig::max_connections` and `AccessPointConfig::dtim_period` setters are now gated behind the `unstable` feature.

# Migration guide

## esp-radio/Wi-Fi

### `wifi::new()` replaced with `WifiController::new()`

The free function `esp_radio::wifi::new()` has been replaced by `esp_radio::wifi::WifiController::new()`.

```rust
// Before
let controller = esp_radio::wifi::new(peripherals.WIFI, Default::default())?;

// After
let controller = esp_radio::wifi::WifiController::new(peripherals.WIFI, Default::default())?;
```

### Station info types moved to `sta` module and renamed

The following types have been moved from `esp_radio::wifi` into `esp_radio::wifi::sta` and renamed:

| Before | After |
|--------|-------|
| `ConnectedStationInfo` | `sta::ConnectedInfo` |
| `DisconnectedStationInfo` | `sta::DisconnectedInfo` |

### Access point info types moved to `ap` module and renamed

The following types have been moved from `esp_radio::wifi` into `esp_radio::wifi::ap` and renamed:

| Before | After |
|--------|-------|
| `AccessPointStationConnectedInfo` | `ap::ConnectedInfo` |
| `AccessPointStationDisconnectedInfo` | `ap::DisconnectedInfo` |
| `AccessPointStationEventInfo` | `ap::EventInfo` |

### `max_connections` and `dtim_period` setters are now unstable

`AccessPointConfig::with_max_connections()` and `AccessPointConfig::with_dtim_period()` now require the `unstable` feature. If you use these setters, enable the `unstable` feature on `esp-radio`.

