### PR TITLE
clarify that migration guide headings require an area

### DIFF
--- a/documentation/CONTRIBUTING.md
+++ b/documentation/CONTRIBUTING.md
@@ -148,7 +148,9 @@ those files are updated automatically at release time from the PR descriptions.
 ### Format
 
 Use `# Changelog` and `# Migration guide` as top-level headings (H1). Under each
-heading, group entries by crate (and optionally by feature area) using H2 headings:
+heading, group entries by crate (and optionally by feature area) using H2 headings.
+**Note:** Migration guide H2 headings _must_ include an area (e.g.
+`## esp-hal/SPI driver`), while changelog H2 headings may use just the crate name.
 
 ```markdown
 # Changelog

--- a/documentation/CONTRIBUTING.md
+++ b/documentation/CONTRIBUTING.md
@@ -148,9 +148,9 @@ those files are updated automatically at release time from the PR descriptions.
 ### Format
 
 Use `# Changelog` and `# Migration guide` as top-level headings (H1). Under each
-heading, group entries by crate (and optionally by feature area) using H2 headings.
-**Note:** Migration guide H2 headings _must_ include an area (e.g.
-`## esp-hal/SPI driver`), while changelog H2 headings may use just the crate name.
+heading, group entries using H2 headings. Changelog H2 headings may use just the
+crate name (e.g. `## esp-hal`), while migration guide H2 headings _must_ include
+an area (e.g. `## esp-hal/SPI driver`).
 
 ```markdown
 # Changelog


### PR DESCRIPTION
## Summary

- The contributing docs say grouping by area is "optional", but CI rejects migration guide headings without one. Added a note clarifying the distinction.