### PR TITLE
ci: update xtensa toolchain to 1.96.0.0

### DIFF
--- a/.github/actions/build-tests/action.yml
+++ b/.github/actions/build-tests/action.yml
@@ -57,7 +57,7 @@ runs:
       with:
         buildtargets: ${{ inputs.soc }}
         default: true
-        version: 1.95.0.0
+        version: 1.96.0.0
 
     - name: Check if chip is supported by this ref's xtask
       id: chip

--- a/.github/workflows/api-baseline-check.yml
+++ b/.github/workflows/api-baseline-check.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: esp-rs/xtensa-toolchain@v1.6
         if: env.SKIP_CI != 'true'
         with:
-          version: 1.95.0.0
+          version: 1.96.0.0
 
       # Install the Rust stable toolchain for RISC-V devices:
       - uses: dtolnay/rust-toolchain@v1

--- a/.github/workflows/api-baseline-generation.yml
+++ b/.github/workflows/api-baseline-generation.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Install xtensa toolchain
         uses: esp-rs/xtensa-toolchain@v1.6
         with:
-          version: 1.95.0.0
+          version: 1.96.0.0
 
       - name: Check if baseline generation is needed
         id: check-generation

--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           buildtargets: ${{ matrix.soc }}
           default: true
-          version: 1.95.0.0
+          version: 1.96.0.0
 
       - name: Install Binutils and Hub
         run: |

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -78,7 +78,7 @@ jobs:
       # Install the Rust toolchain for Xtensa devices:
       - uses: esp-rs/xtensa-toolchain@v1.6
         with:
-          version: 1.95.0.0
+          version: 1.96.0.0
 
       - name: Lint esp-hal on Xtensa chip
         run: cargo xtask lint-packages --chips ${{ matrix.device }} --toolchain esp
@@ -92,7 +92,7 @@ jobs:
         # Install the Rust toolchain for Xtensa devices:
       - uses: esp-rs/xtensa-toolchain@v1.6
         with:
-          version: 1.95.0.0
+          version: 1.96.0.0
 
       # Check all chips at once only for esp-hal
       - name: Run check-global-symbols

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       - uses: esp-rs/xtensa-toolchain@v1.6
         if: env.SKIP_CI != 'true' && matrix.group == 'xtensa'
         with:
-          version: 1.95.0.0
+          version: 1.96.0.0
 
       # Install the Rust stable toolchain for RISC-V devices:
       - uses: dtolnay/rust-toolchain@v1

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -89,7 +89,7 @@ jobs:
       - uses: esp-rs/xtensa-toolchain@v1.6
         with:
           default: true
-          version: 1.95.0.0
+          version: 1.96.0.0
 
       # xtensa-toolchain installs rustup and a basic toolchain, but doesn't install rust-src
       - name: rust-src

--- a/.github/workflows/pre-rel-check.yml
+++ b/.github/workflows/pre-rel-check.yml
@@ -25,7 +25,7 @@ jobs:
       # Install the Rust toolchain for Xtensa devices:
       - uses: esp-rs/xtensa-toolchain@v1.6
         with:
-          version: 1.95.0.0
+          version: 1.96.0.0
 
       # Install the Rust stable toolchain for RISC-V devices:
       - uses: dtolnay/rust-toolchain@v1


### PR DESCRIPTION

- Update from 1.95.0.0 to 1.96.0.0 across all CI workflows and actions