### PR TITLE
xtask: move changelog harvesting from plan phase to execute phase

### DIFF
--- a/xtask/src/commands/release/execute_plan.rs
+++ b/xtask/src/commands/release/execute_plan.rs
@@ -134,6 +134,24 @@ pub fn execute_plan(workspace: &Path, args: ApplyPlanArgs) -> Result<()> {
         }
     }
 
+    // Merge PR changelog entries into CHANGELOG.md / MIGRATING-*.md files.
+    if args.no_dry_run {
+        let modified = crate::commands::release::plan::generate_changelog_draft(workspace, &plan);
+        if modified.is_empty() {
+            println!(
+                "Note: No changelog entries were merged. Run \
+                `cargo xtask release changelog-preview` manually if needed."
+            );
+        } else {
+            println!("Merged changelog entries into the following files:");
+            for path in &modified {
+                println!("  {}", path.display());
+            }
+        }
+    } else {
+        println!("Dry run: would merge PR changelog entries into CHANGELOG.md / MIGRATING-*.md");
+    }
+
     // Update release plan file
     let plan_source = serde_json::to_string_pretty(&plan).with_context(|| {
         format!(

--- a/xtask/src/commands/release/plan.rs
+++ b/xtask/src/commands/release/plan.rs
@@ -342,12 +342,11 @@ pub fn plan(workspace: &Path, args: PlanArgs) -> Result<()> {
 // `base` is an error, as it would produce a version lower than the current
 // one.
 //
-// CHANGELOG REVIEW REQUIRED
-// Changelog entries from recently merged PRs have been collected and merged
-// into each package's CHANGELOG.md (Unreleased section) and MIGRATING-*.md
-// files. Please review and adjust those files before running execute-plan:
-//   - Add, remove, or reword entries as appropriate.
-//   - Ensure migration guide content is accurate and complete.
+// CHANGELOG NOTE
+// When you run `cargo xrelease execute-plan`, changelog entries from recently
+// merged PRs will be collected and merged into each package's CHANGELOG.md
+// (Unreleased section) and MIGRATING-*.md files. You can preview them with:
+//   cargo xtask release changelog-preview
 "#,
     );
 
@@ -376,25 +375,6 @@ pub fn plan(workspace: &Path, args: PlanArgs) -> Result<()> {
         "To apply the release plan, you'll need to remove the heading comment, save the \
         file, then run the following command: `cargo xrelease execute-plan`",
     );
-
-    // Merge PR changelog entries directly into CHANGELOG.md / MIGRATING-*.md files.
-    let modified = generate_changelog_draft(workspace, &plan);
-    if modified.is_empty() {
-        println!();
-        println!(
-            "Note: No changelog entries were merged. Run \
-            `cargo xtask release changelog-preview` manually if needed."
-        );
-    } else {
-        println!();
-        println!("Merged changelog entries into the following files:");
-        for path in &modified {
-            println!("  {}", path.display());
-        }
-        println!(
-            "Please review and adjust these files before running `cargo xrelease execute-plan`."
-        );
-    }
 
     Ok(())
 }
@@ -538,7 +518,7 @@ fn related_crates(workspace: &Path, package: Package) -> Vec<Package> {
 /// Returns the paths of files that were modified. Returns an empty list if the
 /// `gh` CLI is unavailable, no entries were found, or any other non-fatal
 /// problem occurred.
-fn generate_changelog_draft(workspace: &Path, plan: &Plan) -> Vec<std::path::PathBuf> {
+pub(super) fn generate_changelog_draft(workspace: &Path, plan: &Plan) -> Vec<std::path::PathBuf> {
     if plan.packages.is_empty() {
         return vec![];
     }


### PR DESCRIPTION
The `generate_changelog_draft` call was running during `cargo xrelease plan`, which meant the CHANGELOG.md / MIGRATING-*.md modifications happened before the user had even finalized the release plan. Move the harvesting into `execute_plan` so the entries are collected and written at execution time and included in the release commit.
