### PR TITLE
Add more I2S tests, fixes to make them pass on ESP32

### DIFF
--- a/esp-hal/src/i2s/master.rs
+++ b/esp-hal/src/i2s/master.rs
@@ -1843,6 +1843,7 @@ mod private {
             // `test_i2s_write_one_shot_twice_*` tests ... it will fail on the second
             // write without this delay, but pass with it. So there you go. (on ESP32 at
             // least)
+            #[cfg(esp32)]
             unsafe {
                 core::arch::asm!(
                     ".rept 40

--- a/esp-hal/src/i2s/master.rs
+++ b/esp-hal/src/i2s/master.rs
@@ -1741,6 +1741,8 @@ mod private {
                 w.tx_short_sync().bit(config.ws_width == WsWidth::Bit)
             });
 
+            self.regs().conf1().modify(|_, w| w.tx_stop_en().set_bit());
+
             #[cfg(not(esp32))]
             self.regs().conf().modify(|_, w| {
                 // Channel configurations other than Stereo should use same data from DMA
@@ -1829,9 +1831,29 @@ mod private {
         }
 
         fn reset_tx(&self) {
-            self.regs().conf().toggle(|w, bit| {
-                w.tx_reset().bit(bit);
-                w.tx_fifo_reset().bit(bit)
+            self.regs().conf().modify(|_, w| {
+                w.tx_reset().bit(true);
+                w.tx_fifo_reset().bit(true)
+            });
+
+            // looks sus? yes - it does
+            // just toggling the reset bits should be enough but you can verify this
+            // by making this function `#[crate::ram]` (just to make sure cache misses don't make
+            // things look good), commenting this out and run the
+            // `test_i2s_write_one_shot_twice_*` tests ... it will fail on the second
+            // write without this delay, but pass with it. So there you go. (on ESP32 at
+            // least)
+            unsafe {
+                core::arch::asm!(
+                    ".rept 40
+                    nop
+                    .endr"
+                );
+            }
+
+            self.regs().conf().modify(|_, w| {
+                w.tx_reset().bit(false);
+                w.tx_fifo_reset().bit(false)
             });
 
             #[cfg(esp32s2)]

--- a/esp-hal/src/i2s/master.rs
+++ b/esp-hal/src/i2s/master.rs
@@ -117,11 +117,12 @@ use core::mem::ManuallyDrop;
 use enumset::{EnumSet, EnumSetType, enum_set};
 use private::*;
 
+#[cfg(i2s_version = "1")]
+use crate::RegisterToggle;
 use crate::{
     Async,
     Blocking,
     DriverMode,
-    RegisterToggle,
     dma::{
         Channel,
         ChannelRx,
@@ -2289,18 +2290,21 @@ mod private {
         }
 
         fn update(&self) {
-            self.regs()
-                .tx_conf()
-                .toggle(|w, bit| w.tx_update().bit(!bit));
-            self.regs()
-                .rx_conf()
-                .toggle(|w, bit| w.rx_update().bit(!bit));
+            self.regs().tx_conf().modify(|_, w| w.tx_update().bit(true));
+
+            self.regs().rx_conf().modify(|_, w| w.rx_update().bit(true));
+
+            while self.regs().tx_conf().read().tx_update().bit_is_set()
+                || self.regs().rx_conf().read().rx_update().bit_is_set()
+            {
+                // wait
+            }
         }
 
         fn reset_tx(&self) {
-            self.regs().tx_conf().toggle(|w, bit| {
-                w.tx_reset().bit(bit);
-                w.tx_fifo_reset().bit(bit)
+            self.regs().tx_conf().modify(|_, w| {
+                w.tx_reset().set_bit();
+                w.tx_fifo_reset().set_bit()
             });
 
             self.regs().int_clr().write(|w| {
@@ -2338,9 +2342,9 @@ mod private {
                 .rx_conf()
                 .modify(|_, w| w.rx_start().clear_bit());
 
-            self.regs().rx_conf().toggle(|w, bit| {
-                w.rx_reset().bit(bit);
-                w.rx_fifo_reset().bit(bit)
+            self.regs().rx_conf().modify(|_, w| {
+                w.rx_reset().set_bit();
+                w.rx_fifo_reset().set_bit()
             });
 
             self.regs().int_clr().write(|w| {

--- a/esp-hal/src/i2s/master.rs
+++ b/esp-hal/src/i2s/master.rs
@@ -1832,26 +1832,10 @@ mod private {
         }
 
         fn reset_tx(&self) {
-            self.regs().conf().modify(|_, w| {
-                w.tx_reset().bit(true);
-                w.tx_fifo_reset().bit(true)
-            });
-
-            // looks sus? yes - it does
-            // just toggling the reset bits should be enough but you can verify this
-            // by making this function `#[crate::ram]` (just to make sure cache misses don't make
-            // things look good), commenting this out and run the
-            // `test_i2s_write_one_shot_twice_*` tests ... it will fail on the second
-            // write without this delay, but pass with it. So there you go. (on ESP32 at
-            // least)
-            #[cfg(esp32)]
-            unsafe {
-                core::arch::asm!(
-                    ".rept 40
-                    nop
-                    .endr"
-                );
-            }
+            self.regs().conf().modify(|_, w| w.tx_reset().bit(true));
+            self.regs()
+                .conf()
+                .modify(|_, w| w.tx_fifo_reset().bit(true));
 
             self.regs().conf().modify(|_, w| {
                 w.tx_reset().bit(false);
@@ -1861,7 +1845,11 @@ mod private {
             #[cfg(esp32s2)]
             while self.regs().conf().read().tx_reset_st().bit_is_set() {}
 
-            self.regs().lc_conf().toggle(|w, bit| w.out_rst().bit(bit));
+            #[cfg(esp32)]
+            while self.regs().state().read().tx_fifo_reset_back().bit_is_set() {}
+
+            self.regs().lc_conf().modify(|_, w| w.out_rst().bit(true));
+            self.regs().lc_conf().modify(|_, w| w.out_rst().bit(false));
 
             self.regs().int_clr().write(|w| {
                 w.out_done().clear_bit_by_one();
@@ -1871,6 +1859,10 @@ mod private {
 
         fn tx_start(&self) {
             self.regs().conf().modify(|_, w| w.tx_start().set_bit());
+
+            while self.regs().state().read().tx_idle().bit_is_set() {
+                // wait
+            }
         }
 
         fn tx_stop(&self) {

--- a/hil-test/src/bin/i2s.rs
+++ b/hil-test/src/bin/i2s.rs
@@ -447,11 +447,11 @@ mod tests {
         }
     }
 
-    // We don't actually check the output but just make sure the write completes.
-    // On supported chips we could use PCNT to verify at least the expected clock edges or similar.
+    // On chips supporting PCNT we check the number of written bytes, otherwise just make sure the
+    // write completes.
     #[test]
     fn test_i2s_write_one_shot(ctx: Context) {
-        let buffer = hil_test::mk_static!([u8; 8000], [0u8; 8000]);
+        let buffer = hil_test::mk_static!([u8; 8000], [1u8; 8000]);
         let descr = hil_test::mk_static!([DmaDescriptor; 4], [DmaDescriptor::EMPTY; 4]);
         let tx_buffer = DmaTxBuf::new(descr, buffer).unwrap();
 
@@ -465,23 +465,28 @@ mod tests {
         )
         .unwrap();
 
+        let (other, dout) = unsafe { ctx.dout.split() };
+        let counter = super::EdgeCounter::new(other);
+
         let i2s_tx = i2s
             .i2s_tx
             .with_bclk(NoPin)
             .with_ws(NoPin)
-            .with_dout(ctx.dout)
+            .with_dout(dout)
             .build();
 
         let tx_transfer = i2s_tx.write(tx_buffer).unwrap();
+        esp_hal::delay::Delay::new().delay_millis(500);
         let (res, _, _done_tx) = tx_transfer.wait();
         assert!(res.is_ok(), "I2S read transfer failed: {:?}", res.err());
+        counter.check(8000);
     }
 
-    // We don't actually check the output but just make sure the write completes.
-    // On supported chips we could use PCNT to verify at least the expected clock edges or similar.
+    // On chips supporting PCNT we check the number of written bytes, otherwise just make sure the
+    // write completes.
     #[test]
     async fn test_i2s_write_one_shot_async(ctx: Context) {
-        let buffer = hil_test::mk_static!([u8; 8000], [0u8; 8000]);
+        let buffer = hil_test::mk_static!([u8; 8000], [1u8; 8000]);
         let descr = hil_test::mk_static!([DmaDescriptor; 4], [DmaDescriptor::EMPTY; 4]);
         let tx_buffer = DmaTxBuf::new(descr, buffer).unwrap();
 
@@ -496,11 +501,14 @@ mod tests {
         .unwrap()
         .into_async();
 
+        let (other, dout) = unsafe { ctx.dout.split() };
+        let counter = super::EdgeCounter::new(other);
+
         let i2s_tx = i2s
             .i2s_tx
             .with_bclk(NoPin)
             .with_ws(NoPin)
-            .with_dout(ctx.dout)
+            .with_dout(dout)
             .build();
 
         let mut tx_transfer = i2s_tx.write(tx_buffer).unwrap();
@@ -508,6 +516,90 @@ mod tests {
         assert_eq!(tx_transfer.is_done(), true);
         let (res, _, _done_tx) = tx_transfer.wait_async().await;
         assert!(res.is_ok(), "I2S read transfer failed: {:?}", res.err());
+        counter.check(8000);
+    }
+
+    // On chips supporting PCNT we check the number of written bytes, otherwise just make sure the
+    // write completes.
+    #[test]
+    async fn test_i2s_write_one_shot_twice(ctx: Context) {
+        let buffer = hil_test::mk_static!([u8; 4], [1u8; 4]);
+        let descr = hil_test::mk_static!([DmaDescriptor; 4], [DmaDescriptor::EMPTY; 4]);
+        let tx_buffer = DmaTxBuf::new(descr, buffer).unwrap();
+
+        let i2s = I2s::new(
+            ctx.i2s,
+            ctx.dma_channel,
+            Config::new_tdm_philips()
+                .with_sample_rate(Rate::from_hz(16000))
+                .with_data_format(DataFormat::Data16Channel16)
+                .with_channels(Channels::STEREO),
+        )
+        .unwrap();
+
+        let (other, dout) = unsafe { ctx.dout.split() };
+        let counter = super::EdgeCounter::new(other);
+
+        let i2s_tx = i2s
+            .i2s_tx
+            .with_bclk(NoPin)
+            .with_ws(NoPin)
+            .with_dout(dout)
+            .build();
+
+        let tx_transfer = i2s_tx.write(tx_buffer).unwrap();
+        let (res, i2s_tx, tx_buffer) = tx_transfer.wait();
+        assert!(res.is_ok(), "I2S read transfer failed: {:?}", res.err());
+        counter.check(4);
+
+        let tx_transfer = i2s_tx.write(tx_buffer).unwrap();
+        let (res, _i2s_tx, _tx_buffer) = tx_transfer.wait();
+        assert!(res.is_ok(), "I2S read transfer failed: {:?}", res.err());
+        counter.check(8);
+    }
+
+    // On chips supporting PCNT we check the number of written bytes, otherwise just make sure the
+    // write completes.
+    #[test]
+    async fn test_i2s_write_one_shot_twice_async(ctx: Context) {
+        let buffer = hil_test::mk_static!([u8; 4], [1u8; 4]);
+        let descr = hil_test::mk_static!([DmaDescriptor; 4], [DmaDescriptor::EMPTY; 4]);
+        let tx_buffer = DmaTxBuf::new(descr, buffer).unwrap();
+
+        let i2s = I2s::new(
+            ctx.i2s,
+            ctx.dma_channel,
+            Config::new_tdm_philips()
+                .with_sample_rate(Rate::from_hz(16000))
+                .with_data_format(DataFormat::Data16Channel16)
+                .with_channels(Channels::STEREO),
+        )
+        .unwrap()
+        .into_async();
+
+        let (other, dout) = unsafe { ctx.dout.split() };
+        let counter = super::EdgeCounter::new(other);
+
+        let i2s_tx = i2s
+            .i2s_tx
+            .with_bclk(NoPin)
+            .with_ws(NoPin)
+            .with_dout(dout)
+            .build();
+
+        let mut tx_transfer = i2s_tx.write(tx_buffer).unwrap();
+        tx_transfer.wait_for_done_async().await.unwrap();
+        assert_eq!(tx_transfer.is_done(), true);
+        let (res, i2s_tx, tx_buffer) = tx_transfer.wait_async().await;
+        assert!(res.is_ok(), "I2S read transfer failed: {:?}", res.err());
+        counter.check(4);
+
+        let mut tx_transfer = i2s_tx.write(tx_buffer).unwrap();
+        tx_transfer.wait_for_done_async().await.unwrap();
+        assert_eq!(tx_transfer.is_done(), true);
+        let (res, _i2s_tx, _tx_buffer) = tx_transfer.wait_async().await;
+        assert!(res.is_ok(), "I2S read transfer failed: {:?}", res.err());
+        counter.check(8);
     }
 }
 
@@ -567,4 +659,49 @@ mod parallel_tests {
             .unwrap();
         xfer.wait_for_done().await.unwrap();
     }
+}
+
+struct EdgeCounter<'a> {
+    #[cfg(pcnt_driver_supported)]
+    unit: esp_hal::pcnt::unit::Unit<'a, 0>,
+
+    phantom: core::marker::PhantomData<&'a ()>,
+}
+
+#[cfg(pcnt_driver_supported)]
+impl<'a> EdgeCounter<'a> {
+    fn new<'i>(input: impl esp_hal::gpio::interconnect::PeripheralInput<'i>) -> Self {
+        let pcnt = esp_hal::pcnt::Pcnt::new(unsafe { esp_hal::peripherals::PCNT::steal() });
+        let unit = pcnt.unit0;
+        unit.channel0.set_edge_signal(input);
+        unit.channel0.set_input_mode(
+            esp_hal::pcnt::channel::EdgeMode::Hold,
+            esp_hal::pcnt::channel::EdgeMode::Increment,
+        );
+
+        Self {
+            unit,
+            phantom: Default::default(),
+        }
+    }
+
+    fn count(&self) -> i32 {
+        self.unit.counter.get() as i32
+    }
+
+    fn check(&self, expected: i32) {
+        let count = self.count();
+        assert_eq!(count, expected, "Edge count does not match expected value");
+    }
+}
+
+#[cfg(not(pcnt_driver_supported))]
+impl<'a> EdgeCounter<'a> {
+    fn new<'i>(_input: impl esp_hal::gpio::interconnect::PeripheralInput<'i>) -> Self {
+        Self {
+            phantom: Default::default(),
+        }
+    }
+
+    fn check(&self, _expected: i32) {}
 }

--- a/hil-test/src/bin/i2s.rs
+++ b/hil-test/src/bin/i2s.rs
@@ -358,10 +358,10 @@ mod tests {
     }
 
     #[test]
-    fn test_i2s_read_one_shot(ctx: Context) {
+    fn test_i2s_read_one_shot_multiple(ctx: Context) {
         let buffer = hil_test::mk_static!([u8; 8000], [0u8; 8000]);
         let descr = hil_test::mk_static!([DmaDescriptor; 4], [DmaDescriptor::EMPTY; 4]);
-        let rx_buffer = DmaRxBuf::new(descr, buffer).unwrap();
+        let mut rx_buffer = DmaRxBuf::new(descr, buffer).unwrap();
 
         let i2s = I2s::new(
             ctx.i2s,
@@ -377,38 +377,43 @@ mod tests {
         // check was received correctly
         let (din, ws) = unsafe { ctx.dout.split() };
 
-        let i2s_rx = i2s
+        let mut i2s_rx = i2s
             .i2s_rx
             .with_bclk(NoPin)
             .with_ws(ws)
             .with_din(din)
             .build();
 
-        let rx_transfer = i2s_rx.read(rx_buffer).unwrap();
-        let (res, _, done_rx) = rx_transfer.wait();
-        assert!(res.is_ok(), "I2S read transfer failed: {:?}", res.err());
+        for _ in 0..10 {
+            let rx_transfer = i2s_rx.read(rx_buffer).unwrap();
+            let (res, i2s_rx_back, done_rx) = rx_transfer.wait();
+            assert!(res.is_ok(), "I2S read transfer failed: {:?}", res.err());
 
-        assert!(done_rx.number_of_received_bytes() != 0);
+            assert!(done_rx.number_of_received_bytes() != 0);
 
-        let mut tmp = [0u8; 8000];
-        let read = done_rx.read_received_data(&mut tmp);
+            let mut tmp = [0u8; 8000];
+            let read = done_rx.read_received_data(&mut tmp);
 
-        // I2S RX might not fill each buffer for every descriptor - so the read byte count might be
-        // less than the buffer size, but it should never be zero if the transfer completed
-        // successfully.
-        assert!(read != 0);
+            // I2S RX might not fill each buffer for every descriptor - so the read byte count might
+            // be less than the buffer size, but it should never be zero if the transfer
+            // completed successfully.
+            assert!(read != 0);
 
-        let l = read - read % 4;
-        for chunk in tmp[..l].chunks(4) {
-            assert_eq!(chunk, [1, 0, 254, 255]);
+            let l = read - read % 4;
+            for chunk in tmp[..l].chunks(4) {
+                assert_eq!(chunk, [1, 0, 254, 255]);
+            }
+
+            i2s_rx = i2s_rx_back;
+            rx_buffer = done_rx;
         }
     }
 
     #[test]
-    async fn test_i2s_read_one_shot_async(ctx: Context) {
+    async fn test_i2s_read_one_shot_multiple_async(ctx: Context) {
         let buffer = hil_test::mk_static!([u8; 8000], [0u8; 8000]);
         let descr = hil_test::mk_static!([DmaDescriptor; 4], [DmaDescriptor::EMPTY; 4]);
-        let rx_buffer = DmaRxBuf::new(descr, buffer).unwrap();
+        let mut rx_buffer = DmaRxBuf::new(descr, buffer).unwrap();
 
         let i2s = I2s::new(
             ctx.i2s,
@@ -425,32 +430,37 @@ mod tests {
         // check was received correctly
         let (din, ws) = unsafe { ctx.dout.split() };
 
-        let i2s_rx = i2s
+        let mut i2s_rx = i2s
             .i2s_rx
             .with_bclk(NoPin)
             .with_ws(ws)
             .with_din(din)
             .build();
 
-        let mut rx_transfer = i2s_rx.read(rx_buffer).unwrap();
-        rx_transfer.wait_for_done_async().await.unwrap();
-        assert_eq!(rx_transfer.is_done(), true);
-        let (res, _, done_rx) = rx_transfer.wait_async().await;
-        assert!(res.is_ok(), "I2S read transfer failed: {:?}", res.err());
+        for _ in 0..10 {
+            let mut rx_transfer = i2s_rx.read(rx_buffer).unwrap();
+            rx_transfer.wait_for_done_async().await.unwrap();
+            assert_eq!(rx_transfer.is_done(), true);
+            let (res, i2s_rx_back, done_rx) = rx_transfer.wait_async().await;
+            assert!(res.is_ok(), "I2S read transfer failed: {:?}", res.err());
 
-        assert!(done_rx.number_of_received_bytes() != 0);
+            assert!(done_rx.number_of_received_bytes() != 0);
 
-        let mut tmp = [0u8; 8000];
-        let read = done_rx.read_received_data(&mut tmp);
+            let mut tmp = [0u8; 8000];
+            let read = done_rx.read_received_data(&mut tmp);
 
-        // I2S RX might not fill each buffer for every descriptor - so the read byte count might be
-        // less than the buffer size, but it should never be zero if the transfer completed
-        // successfully.
-        assert!(read != 0);
+            // I2S RX might not fill each buffer for every descriptor - so the read byte count might
+            // be less than the buffer size, but it should never be zero if the transfer
+            // completed successfully.
+            assert!(read != 0);
 
-        let l = read - read % 4;
-        for chunk in tmp[..l].chunks(4) {
-            assert_eq!(chunk, [1, 0, 254, 255]);
+            let l = read - read % 4;
+            for chunk in tmp[..l].chunks(4) {
+                assert_eq!(chunk, [1, 0, 254, 255]);
+            }
+
+            i2s_rx = i2s_rx_back;
+            rx_buffer = done_rx;
         }
     }
 
@@ -488,7 +498,7 @@ mod tests {
         let tx_transfer = i2s_tx.write(tx_buffer).unwrap();
         esp_hal::delay::Delay::new().delay_millis(500);
         let (res, _, _done_tx) = tx_transfer.wait();
-        assert!(res.is_ok(), "I2S read transfer failed: {:?}", res.err());
+        assert!(res.is_ok(), "I2S write transfer failed: {:?}", res.err());
         counter.check(8000);
     }
 
@@ -528,7 +538,7 @@ mod tests {
         tx_transfer.wait_for_done_async().await.unwrap();
         assert_eq!(tx_transfer.is_done(), true);
         let (res, _, _done_tx) = tx_transfer.wait_async().await;
-        assert!(res.is_ok(), "I2S read transfer failed: {:?}", res.err());
+        assert!(res.is_ok(), "I2S write transfer failed: {:?}", res.err());
         counter.check(8000);
     }
 
@@ -567,7 +577,7 @@ mod tests {
         for _ in 0..10 {
             let tx_transfer = i2s_tx.write(tx_buffer).unwrap();
             let (res, i2s_tx_back, tx_buffer_back) = tx_transfer.wait();
-            assert!(res.is_ok(), "I2S read transfer failed: {:?}", res.err());
+            assert!(res.is_ok(), "I2S write transfer failed: {:?}", res.err());
             counter.check(compare);
             compare += 4;
 
@@ -614,7 +624,7 @@ mod tests {
             tx_transfer.wait_for_done_async().await.unwrap();
             assert_eq!(tx_transfer.is_done(), true);
             let (res, i2s_tx_back, tx_buffer_back) = tx_transfer.wait_async().await;
-            assert!(res.is_ok(), "I2S read transfer failed: {:?}", res.err());
+            assert!(res.is_ok(), "I2S write transfer failed: {:?}", res.err());
             counter.check(compare);
             compare += 4;
             tx_buffer = tx_buffer_back;

--- a/hil-test/src/bin/i2s.rs
+++ b/hil-test/src/bin/i2s.rs
@@ -528,10 +528,10 @@ mod tests {
     // On chips supporting PCNT we check the number of written bytes, otherwise just make sure the
     // write completes.
     #[test]
-    async fn test_i2s_write_one_shot_twice(ctx: Context) {
+    async fn test_i2s_write_one_shot_multiple(ctx: Context) {
         let buffer = hil_test::mk_static!([u8; 4], [1u8; 4]);
         let descr = hil_test::mk_static!([DmaDescriptor; 4], [DmaDescriptor::EMPTY; 4]);
-        let tx_buffer = DmaTxBuf::new(descr, buffer).unwrap();
+        let mut tx_buffer = DmaTxBuf::new(descr, buffer).unwrap();
 
         let i2s = I2s::new(
             ctx.i2s,
@@ -546,7 +546,7 @@ mod tests {
         let (other, dout) = unsafe { ctx.dout.split() };
         let mut counter = super::EdgeCounter::new(other);
 
-        let i2s_tx = i2s
+        let mut i2s_tx = i2s
             .i2s_tx
             .with_bclk(NoPin)
             .with_ws(NoPin)
@@ -556,24 +556,26 @@ mod tests {
         counter.clear();
         counter.check(0);
 
-        let tx_transfer = i2s_tx.write(tx_buffer).unwrap();
-        let (res, i2s_tx, tx_buffer) = tx_transfer.wait();
-        assert!(res.is_ok(), "I2S read transfer failed: {:?}", res.err());
-        counter.check(4);
+        let mut compare = 4;
+        for _ in 0..10 {
+            let tx_transfer = i2s_tx.write(tx_buffer).unwrap();
+            let (res, i2s_tx_back, tx_buffer_back) = tx_transfer.wait();
+            assert!(res.is_ok(), "I2S read transfer failed: {:?}", res.err());
+            counter.check(compare);
+            compare += 4;
 
-        let tx_transfer = i2s_tx.write(tx_buffer).unwrap();
-        let (res, _i2s_tx, _tx_buffer) = tx_transfer.wait();
-        assert!(res.is_ok(), "I2S read transfer failed: {:?}", res.err());
-        counter.check(8);
+            tx_buffer = tx_buffer_back;
+            i2s_tx = i2s_tx_back;
+        }
     }
 
     // On chips supporting PCNT we check the number of written bytes, otherwise just make sure the
     // write completes.
     #[test]
-    async fn test_i2s_write_one_shot_twice_async(ctx: Context) {
+    async fn test_i2s_write_one_shot_multiple_async(ctx: Context) {
         let buffer = hil_test::mk_static!([u8; 4], [1u8; 4]);
         let descr = hil_test::mk_static!([DmaDescriptor; 4], [DmaDescriptor::EMPTY; 4]);
-        let tx_buffer = DmaTxBuf::new(descr, buffer).unwrap();
+        let mut tx_buffer = DmaTxBuf::new(descr, buffer).unwrap();
 
         let i2s = I2s::new(
             ctx.i2s,
@@ -589,7 +591,7 @@ mod tests {
         let (other, dout) = unsafe { ctx.dout.split() };
         let mut counter = super::EdgeCounter::new(other);
 
-        let i2s_tx = i2s
+        let mut i2s_tx = i2s
             .i2s_tx
             .with_bclk(NoPin)
             .with_ws(NoPin)
@@ -599,19 +601,18 @@ mod tests {
         counter.clear();
         counter.check(0);
 
-        let mut tx_transfer = i2s_tx.write(tx_buffer).unwrap();
-        tx_transfer.wait_for_done_async().await.unwrap();
-        assert_eq!(tx_transfer.is_done(), true);
-        let (res, i2s_tx, tx_buffer) = tx_transfer.wait_async().await;
-        assert!(res.is_ok(), "I2S read transfer failed: {:?}", res.err());
-        counter.check(4);
-
-        let mut tx_transfer = i2s_tx.write(tx_buffer).unwrap();
-        tx_transfer.wait_for_done_async().await.unwrap();
-        assert_eq!(tx_transfer.is_done(), true);
-        let (res, _i2s_tx, _tx_buffer) = tx_transfer.wait_async().await;
-        assert!(res.is_ok(), "I2S read transfer failed: {:?}", res.err());
-        counter.check(8);
+        let mut compare = 4;
+        for _ in 0..10 {
+            let mut tx_transfer = i2s_tx.write(tx_buffer).unwrap();
+            tx_transfer.wait_for_done_async().await.unwrap();
+            assert_eq!(tx_transfer.is_done(), true);
+            let (res, i2s_tx_back, tx_buffer_back) = tx_transfer.wait_async().await;
+            assert!(res.is_ok(), "I2S read transfer failed: {:?}", res.err());
+            counter.check(compare);
+            compare += 4;
+            tx_buffer = tx_buffer_back;
+            i2s_tx = i2s_tx_back;
+        }
     }
 }
 

--- a/hil-test/src/bin/i2s.rs
+++ b/hil-test/src/bin/i2s.rs
@@ -110,7 +110,14 @@ mod tests {
             }
         }
 
+        #[cfg(not(esp32c5))]
         let (_, dout) = hil_test::common_test_pins!(peripherals);
+
+        // there are some random pulses counted on ESP32-C5 in our HIL setup
+        // with the common test pin, so just use a fixed GPIO pin which is not used for anything
+        // else in this test on that chip in the hope it will fix it
+        #[cfg(esp32c5)]
+        let dout = peripherals.GPIO6;
 
         Context {
             dout: dout.degrade(),

--- a/hil-test/src/bin/i2s.rs
+++ b/hil-test/src/bin/i2s.rs
@@ -466,7 +466,7 @@ mod tests {
         .unwrap();
 
         let (other, dout) = unsafe { ctx.dout.split() };
-        let counter = super::EdgeCounter::new(other);
+        let mut counter = super::EdgeCounter::new(other);
 
         let i2s_tx = i2s
             .i2s_tx
@@ -474,6 +474,9 @@ mod tests {
             .with_ws(NoPin)
             .with_dout(dout)
             .build();
+
+        counter.clear();
+        counter.check(0);
 
         let tx_transfer = i2s_tx.write(tx_buffer).unwrap();
         esp_hal::delay::Delay::new().delay_millis(500);
@@ -502,7 +505,7 @@ mod tests {
         .into_async();
 
         let (other, dout) = unsafe { ctx.dout.split() };
-        let counter = super::EdgeCounter::new(other);
+        let mut counter = super::EdgeCounter::new(other);
 
         let i2s_tx = i2s
             .i2s_tx
@@ -510,6 +513,9 @@ mod tests {
             .with_ws(NoPin)
             .with_dout(dout)
             .build();
+
+        counter.clear();
+        counter.check(0);
 
         let mut tx_transfer = i2s_tx.write(tx_buffer).unwrap();
         tx_transfer.wait_for_done_async().await.unwrap();
@@ -538,7 +544,7 @@ mod tests {
         .unwrap();
 
         let (other, dout) = unsafe { ctx.dout.split() };
-        let counter = super::EdgeCounter::new(other);
+        let mut counter = super::EdgeCounter::new(other);
 
         let i2s_tx = i2s
             .i2s_tx
@@ -546,6 +552,9 @@ mod tests {
             .with_ws(NoPin)
             .with_dout(dout)
             .build();
+
+        counter.clear();
+        counter.check(0);
 
         let tx_transfer = i2s_tx.write(tx_buffer).unwrap();
         let (res, i2s_tx, tx_buffer) = tx_transfer.wait();
@@ -578,7 +587,7 @@ mod tests {
         .into_async();
 
         let (other, dout) = unsafe { ctx.dout.split() };
-        let counter = super::EdgeCounter::new(other);
+        let mut counter = super::EdgeCounter::new(other);
 
         let i2s_tx = i2s
             .i2s_tx
@@ -586,6 +595,9 @@ mod tests {
             .with_ws(NoPin)
             .with_dout(dout)
             .build();
+
+        counter.clear();
+        counter.check(0);
 
         let mut tx_transfer = i2s_tx.write(tx_buffer).unwrap();
         tx_transfer.wait_for_done_async().await.unwrap();
@@ -678,11 +690,16 @@ impl<'a> EdgeCounter<'a> {
             esp_hal::pcnt::channel::EdgeMode::Hold,
             esp_hal::pcnt::channel::EdgeMode::Increment,
         );
+        unit.clear();
 
         Self {
             unit,
             phantom: Default::default(),
         }
+    }
+
+    fn clear(&mut self) {
+        self.unit.clear();
     }
 
     fn count(&self) -> i32 {
@@ -701,6 +718,10 @@ impl<'a> EdgeCounter<'a> {
         Self {
             phantom: Default::default(),
         }
+    }
+
+    fn clear(&mut self) {
+        // NOOP
     }
 
     fn check(&self, _expected: i32) {}


### PR DESCRIPTION
This adds more tests (and verifications for existing tests) - and make them actually pass on ESP32

# Changelog

## esp-hal

- Fixed: ESP32/ESP32-S2 I2S TX not stopping once the DMA buffer is exhausted
- Fixed: ESP32 sub-sequent TX transactions might not transfer anything
