### PR TITLE
Fix P4 PSRAM on v3.0

### DIFF
--- a/esp-hal/src/efuse/esp32p4/fields.rs
+++ b/esp-hal/src/efuse/esp32p4/fields.rs
@@ -505,7 +505,7 @@ pub const MAC1: EfuseField = EfuseField::new(1, 0, 32, 16);
 /// Minor chip version
 pub const WAFER_VERSION_MINOR: EfuseField = EfuseField::new(1, 2, 64, 4);
 /// Major chip version (lower 2 bits)
-pub const WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(1, 2, 87, 3);
+pub const WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(1, 2, 68, 2);
 /// Disables check of wafer version major
 pub const DISABLE_WAFER_VERSION_MAJOR: EfuseField = EfuseField::new(1, 2, 70, 1);
 /// Disables check of blk version major

--- a/esp-hal/src/psram/esp32p4.rs
+++ b/esp-hal/src/psram/esp32p4.rs
@@ -216,6 +216,7 @@ const AP_HEX_CS_SETUP_TIME: u32 = 4;
 const AP_HEX_CS_HOLD_TIME: u32 = 4;
 const AP_HEX_CS_HOLD_DELAY: u32 = 3;
 
+#[crate::ram]
 fn init_psram_inner(config: &mut PsramConfig) {
     // Resolve the speed parameter set from `ram_frequency`. The MPLL
     // override (`config.core_clock`) lets the caller bypass the default
@@ -233,6 +234,20 @@ fn init_psram_inner(config: &mut PsramConfig) {
     HP_SYS_CLKRST::regs()
         .soc_clk_ctrl0()
         .modify(|_, w| w.psram_sys_clk_en().set_bit());
+
+    HP_SYS_CLKRST::regs()
+        .hp_rst_en0()
+        .modify(|_, w| w.rst_en_dual_mspi_axi().set_bit());
+    HP_SYS_CLKRST::regs()
+        .hp_rst_en0()
+        .modify(|_, w| w.rst_en_dual_mspi_apb().set_bit());
+    HP_SYS_CLKRST::regs()
+        .hp_rst_en0()
+        .modify(|_, w| w.rst_en_dual_mspi_apb().clear_bit());
+    HP_SYS_CLKRST::regs()
+        .hp_rst_en0()
+        .modify(|_, w| w.rst_en_dual_mspi_axi().clear_bit());
+
     HP_SYS_CLKRST::regs()
         .peri_clk_ctrl00()
         .modify(|_, w| unsafe {
@@ -815,7 +830,7 @@ fn configure_mpll(freq_mhz: u32) {
         .ana_pll_ctrl0()
         .modify(|_, w| w.mspi_cal_stop().set_bit());
     // cal_end timeout (t == 0): surfaces later via `psram_detect_size` fallback.
-    let _ = t; // if need print this for debug
+    debug!("Calibration timeout left: {}us", t);
     crate::rom::ets_delay_us(10);
 }
 

--- a/esp-hal/src/psram/esp32p4.rs
+++ b/esp-hal/src/psram/esp32p4.rs
@@ -797,7 +797,7 @@ fn configure_mpll(freq_mhz: u32) {
     HP_SYS_CLKRST::regs()
         .ana_pll_ctrl0()
         .modify(|_, w| w.mspi_cal_stop().clear_bit());
-    let mut t = 1_000_000_u32;
+    let mut t = 1_000_u32;
     while !HP_SYS_CLKRST::regs()
         .ana_pll_ctrl0()
         .read()
@@ -806,9 +806,10 @@ fn configure_mpll(freq_mhz: u32) {
     {
         t = t.saturating_sub(1);
         if t == 0 {
+            warn!("PSRAM MPLL calibration timeout");
             break;
         }
-        core::hint::spin_loop();
+        crate::rom::ets_delay_us(1);
     }
     HP_SYS_CLKRST::regs()
         .ana_pll_ctrl0()

--- a/esp-hal/src/psram/esp32p4.rs
+++ b/esp-hal/src/psram/esp32p4.rs
@@ -827,11 +827,11 @@ fn configure_mpll(freq_mhz: u32) -> bool {
 
     let mut t = 1_000_u32;
     let mut success = true;
-    while !HP_SYS_CLKRST::regs()
+    while HP_SYS_CLKRST::regs()
         .ana_pll_ctrl0()
         .read()
         .mspi_cal_end()
-        .bit_is_set()
+        .bit_is_clear()
     {
         t = t.saturating_sub(1);
         if t == 0 {

--- a/esp-hal/src/psram/esp32p4.rs
+++ b/esp-hal/src/psram/esp32p4.rs
@@ -799,22 +799,22 @@ fn configure_mpll(freq_mhz: u32) -> bool {
         .lp_aonclkrst_hp_clk_ctrl()
         .modify(|_, w| w.lp_aonclkrst_hp_mpll_500m_clk_en().set_bit());
 
-    // div = freq_mhz/20 - 1, ref_div = 1 -> MPLL = XTAL(40) * (div+1) / (ref_div+1)
-    let ref_div: u8 = 1;
-    let div: u8 = (freq_mhz / 20).saturating_sub(1) as u8;
-    let div_val: u8 = (div << 3) | ref_div;
+    HP_SYS_CLKRST::regs()
+        .ana_pll_ctrl0()
+        .modify(|_, w| w.mspi_cal_stop().clear_bit());
 
-    let dhref = regi2c::I2C_MPLL_DHREF.read();
-    regi2c::I2C_MPLL_DHREF.write_reg(dhref | (3 << 4));
+    regi2c::I2C_MPLL_DHREF_DHREF.write_field(3);
 
     let rstb = regi2c::I2C_MPLL_IR_CAL_RSTB.read();
     regi2c::I2C_MPLL_IR_CAL_RSTB.write_reg(rstb & 0xDF);
     regi2c::I2C_MPLL_IR_CAL_RSTB.write_reg(rstb | (1 << 5));
+
+    // div = freq_mhz/20 - 1, ref_div = 1 -> MPLL = XTAL(40) * (div+1) / (ref_div+1)
+    let ref_div: u8 = 1;
+    let div: u8 = (freq_mhz / 20).saturating_sub(1) as u8;
+    let div_val: u8 = (div << 3) | ref_div;
     regi2c::I2C_MPLL_DIV_REG_ADDR.write_reg(div_val);
 
-    HP_SYS_CLKRST::regs()
-        .ana_pll_ctrl0()
-        .modify(|_, w| w.mspi_cal_stop().clear_bit());
     let mut t = 1_000_u32;
     let mut success = true;
     while !HP_SYS_CLKRST::regs()

--- a/esp-hal/src/psram/esp32p4.rs
+++ b/esp-hal/src/psram/esp32p4.rs
@@ -237,18 +237,7 @@ fn init_psram_inner(config: &mut PsramConfig) -> bool {
         .soc_clk_ctrl0()
         .modify(|_, w| w.psram_sys_clk_en().set_bit());
 
-    HP_SYS_CLKRST::regs()
-        .hp_rst_en0()
-        .modify(|_, w| w.rst_en_dual_mspi_axi().set_bit());
-    HP_SYS_CLKRST::regs()
-        .hp_rst_en0()
-        .modify(|_, w| w.rst_en_dual_mspi_apb().set_bit());
-    HP_SYS_CLKRST::regs()
-        .hp_rst_en0()
-        .modify(|_, w| w.rst_en_dual_mspi_apb().clear_bit());
-    HP_SYS_CLKRST::regs()
-        .hp_rst_en0()
-        .modify(|_, w| w.rst_en_dual_mspi_axi().clear_bit());
+    reset_psram_mspi();
 
     HP_SYS_CLKRST::regs()
         .peri_clk_ctrl00()
@@ -853,6 +842,21 @@ fn configure_mpll(freq_mhz: u32) -> bool {
     success
 }
 
+fn reset_psram_mspi() {
+    HP_SYS_CLKRST::regs()
+        .hp_rst_en0()
+        .modify(|_, w| w.rst_en_dual_mspi_axi().set_bit());
+    HP_SYS_CLKRST::regs()
+        .hp_rst_en0()
+        .modify(|_, w| w.rst_en_dual_mspi_apb().set_bit());
+    HP_SYS_CLKRST::regs()
+        .hp_rst_en0()
+        .modify(|_, w| w.rst_en_dual_mspi_apb().clear_bit());
+    HP_SYS_CLKRST::regs()
+        .hp_rst_en0()
+        .modify(|_, w| w.rst_en_dual_mspi_axi().clear_bit());
+}
+
 /// ESP32-P4 silicon revision 3.0 workaround.
 ///
 /// Port of IDF `esp_psram_p4_rev3_workaround` (`esp_psram.c`). Must be called
@@ -920,18 +924,7 @@ fn p4_rev3_psram_workaround() {
 
     // Pulse the PSRAM controller reset (AXI then APB), mirroring IDF's
     // `_psram_ctrlr_ll_reset_module_clock`.
-    HP_SYS_CLKRST::regs()
-        .hp_rst_en0()
-        .modify(|_, w| w.rst_en_dual_mspi_axi().set_bit());
-    HP_SYS_CLKRST::regs()
-        .hp_rst_en0()
-        .modify(|_, w| w.rst_en_dual_mspi_apb().set_bit());
-    HP_SYS_CLKRST::regs()
-        .hp_rst_en0()
-        .modify(|_, w| w.rst_en_dual_mspi_apb().clear_bit());
-    HP_SYS_CLKRST::regs()
-        .hp_rst_en0()
-        .modify(|_, w| w.rst_en_dual_mspi_axi().clear_bit());
+    reset_psram_mspi();
 
     // Re-enable bus-error responses.
     HP_SYS::regs()

--- a/esp-hal/src/psram/esp32p4.rs
+++ b/esp-hal/src/psram/esp32p4.rs
@@ -5,7 +5,8 @@
 
 use super::{EXTMEM_ORIGIN, PsramSize};
 use crate::{
-    peripherals::{HP_SYS_CLKRST, LP_AON_CLKRST, PMU},
+    efuse,
+    peripherals::{HP_SYS, HP_SYS_CLKRST, LP_AON_CLKRST, PMU},
     soc::regi2c,
 };
 
@@ -271,6 +272,15 @@ fn init_psram_inner(config: &mut PsramConfig) -> bool {
     }
 
     configure_psram_mspi(params, MSPI0_BASE); // basic AXI configuration here
+
+    // Silicon revision 3.0 (ECO5) requires two dummy PSRAM reads + a controller
+    // reset before the real MMU mapping is committed.  Port of IDF's
+    // `esp_psram_p4_rev3_workaround` in `esp_psram.c`.
+    if efuse::chip_revision() == efuse::ChipRevision::from_combined(300) {
+        debug!("Applying P4 v3.0 PSRAM workaround");
+        p4_rev3_psram_workaround();
+    }
+
     mmu_map_psram(MSPI0_BASE, config); // MMU mapping here
 
     true
@@ -841,6 +851,97 @@ fn configure_mpll(freq_mhz: u32) -> bool {
     }
 
     success
+}
+
+/// ESP32-P4 silicon revision 3.0 workaround.
+///
+/// Port of IDF `esp_psram_p4_rev3_workaround` (`esp_psram.c`). Must be called
+/// after `configure_psram_mspi` and before `mmu_map_psram`.
+///
+/// The silicon bug requires two dummy PSRAM reads followed by a controller
+/// reset before the real MMU mapping is committed.  The dummy reads must reach
+/// the PSRAM hardware (not just the L1 cache), so they are issued at
+/// `0x8800_0000` — an alias that shares the same MMU linear address
+/// (`addr & 0xFFF_FFFF`) as the cached PSRAM base `0x4800_0000` but bypasses
+/// the L1 cache.  Core error responses are suppressed for the duration because
+/// the address is outside the normally-mapped window; the reads are expected to
+/// produce garbage.  The controller reset clears all MSPI0 registers, so the
+/// registers configured by `configure_psram_mspi`, `set_bus_clock`,
+/// `enable_dll`, and `set_cs_timing` are backed up before the reset and
+/// restored afterwards.
+fn p4_rev3_psram_workaround() {
+    /// MSPI0 registers touched by `configure_psram_mspi`, `set_bus_clock`,
+    /// `enable_dll`, and `set_cs_timing` that must survive the controller reset.
+    const BACKUP_ADDRS: [u32; 11] = [
+        MSPI0_BASE + 0x3C,  // CACHE_FCTRL
+        MSPI0_BASE + 0x40,  // CACHE_SCTRL
+        MSPI0_BASE + 0x44,  // SRAM_CMD
+        MSPI0_BASE + 0x48,  // SRAM_DRD_CMD
+        MSPI0_BASE + 0x4C,  // SRAM_DWR_CMD
+        MSPI0_BASE + 0x50,  // SRAM_CLK  (set_bus_clock)
+        MSPI0_BASE + 0x70,  // MEM_CTRL1
+        MSPI0_BASE + 0xD8,  // SMEM_DDR
+        MSPI0_BASE + 0x180, // MEM_TIMING_CALI  (enable_dll)
+        MSPI0_BASE + 0x190, // SMEM_TIMING_CALI (enable_dll)
+        MSPI0_BASE + 0x1A0, // SMEM_AC  (set_cs_timing)
+    ];
+
+    // Snapshot the MSPI0 registers before the reset wipes them.
+    let mut backup = [0u32; 11];
+    for (i, &addr) in BACKUP_ADDRS.iter().enumerate() {
+        unsafe { backup[i] = mmio_read_32(addr) }
+    }
+
+    // Suppress CPU bus-error response so the dummy reads below don't trap.
+    HP_SYS::regs()
+        .core_err_resp_dis()
+        .write(|w| unsafe { w.bits(0x7) });
+
+    unsafe {
+        // Map physical PSRAM page 0 to MMU entry 0 so both 0x4800_0000 and
+        // its uncached alias 0x8800_0000 reach the PSRAM hardware.
+        const MMU_ITEM_INDEX: u32 = MSPI0_BASE + 0x380;
+        const MMU_ITEM_CONTENT: u32 = MSPI0_BASE + 0x37C;
+        const PSRAM_VALID: u32 = 1 << 11;
+        const ACCESS_PSRAM: u32 = 1 << 10;
+        mmio_write_32(MMU_ITEM_INDEX, 0);
+        mmio_write_32(
+            MMU_ITEM_CONTENT,
+            PSRAM_VALID | ACCESS_PSRAM, // phys page 0
+        );
+
+        // Two dummy reads at the uncached PSRAM alias; result is discarded.
+        // The reads are expected to fail (garbage data) but must hit the controller.
+        let _ = core::ptr::read_volatile(0x8800_0000u32 as *const u32);
+        let _ = core::ptr::read_volatile(0x8800_0080u32 as *const u32);
+
+        crate::rom::ets_delay_us(1);
+    }
+
+    // Pulse the PSRAM controller reset (AXI then APB), mirroring IDF's
+    // `_psram_ctrlr_ll_reset_module_clock`.
+    HP_SYS_CLKRST::regs()
+        .hp_rst_en0()
+        .modify(|_, w| w.rst_en_dual_mspi_axi().set_bit());
+    HP_SYS_CLKRST::regs()
+        .hp_rst_en0()
+        .modify(|_, w| w.rst_en_dual_mspi_apb().set_bit());
+    HP_SYS_CLKRST::regs()
+        .hp_rst_en0()
+        .modify(|_, w| w.rst_en_dual_mspi_apb().clear_bit());
+    HP_SYS_CLKRST::regs()
+        .hp_rst_en0()
+        .modify(|_, w| w.rst_en_dual_mspi_axi().clear_bit());
+
+    // Re-enable bus-error responses.
+    HP_SYS::regs()
+        .core_err_resp_dis()
+        .write(|w| unsafe { w.bits(0) });
+
+    // Restore the MSPI0 registers cleared by the reset.
+    for (i, &addr) in BACKUP_ADDRS.iter().enumerate() {
+        unsafe { mmio_write_32(addr, backup[i]) }
+    }
 }
 
 /// Configure PSRAM_MSPI0 (AXI cache) for HEX/DDR access at 0x4800_0000.

--- a/esp-hal/src/psram/esp32p4.rs
+++ b/esp-hal/src/psram/esp32p4.rs
@@ -138,8 +138,7 @@ pub struct PsramConfig {
 
 /// Initialize PSRAM.
 pub(crate) fn init_psram(config: &mut PsramConfig) -> bool {
-    init_psram_inner(config);
-    true
+    init_psram_inner(config)
 }
 
 pub(crate) fn map_psram(config: PsramConfig) -> core::ops::Range<usize> {
@@ -217,7 +216,7 @@ const AP_HEX_CS_HOLD_TIME: u32 = 4;
 const AP_HEX_CS_HOLD_DELAY: u32 = 3;
 
 #[crate::ram]
-fn init_psram_inner(config: &mut PsramConfig) {
+fn init_psram_inner(config: &mut PsramConfig) -> bool {
     // Resolve the speed parameter set from `ram_frequency`. The MPLL
     // override (`config.core_clock`) lets the caller bypass the default
     // pairing (e.g. force 400 MHz MPLL with `Mhz20` bus); `None`
@@ -227,8 +226,10 @@ fn init_psram_inner(config: &mut PsramConfig) {
         params.mpll_mhz = mpll as u32;
     }
 
-    psram_phy_ldo_init(); // PMU EXT_LDO regulator setup for the MSPI PHY analog block.
-    configure_mpll(params.mpll_mhz);
+    psram_phy_ldo_init();
+    if !configure_mpll(params.mpll_mhz) {
+        return false;
+    }
 
     // Module clock + clock source
     HP_SYS_CLKRST::regs()
@@ -271,6 +272,8 @@ fn init_psram_inner(config: &mut PsramConfig) {
 
     configure_psram_mspi(params, MSPI0_BASE); // basic AXI configuration here
     mmu_map_psram(MSPI0_BASE, config); // MMU mapping here
+
+    true
 }
 
 /// Set bus-clock divider for both PSRAM_MSPI0 (SRAM_CLK at 0x50) and
@@ -787,7 +790,7 @@ fn psram_phy_ldo_init() {
 }
 
 /// Configure MPLL to target frequency for PSRAM clock.
-fn configure_mpll(freq_mhz: u32) {
+fn configure_mpll(freq_mhz: u32) -> bool {
     // Power up the MPLL analog block.
     PMU::regs()
         .rf_pwc()
@@ -813,6 +816,7 @@ fn configure_mpll(freq_mhz: u32) {
         .ana_pll_ctrl0()
         .modify(|_, w| w.mspi_cal_stop().clear_bit());
     let mut t = 1_000_u32;
+    let mut success = true;
     while !HP_SYS_CLKRST::regs()
         .ana_pll_ctrl0()
         .read()
@@ -822,6 +826,7 @@ fn configure_mpll(freq_mhz: u32) {
         t = t.saturating_sub(1);
         if t == 0 {
             warn!("PSRAM MPLL calibration timeout");
+            success = false;
             break;
         }
         crate::rom::ets_delay_us(1);
@@ -829,9 +834,13 @@ fn configure_mpll(freq_mhz: u32) {
     HP_SYS_CLKRST::regs()
         .ana_pll_ctrl0()
         .modify(|_, w| w.mspi_cal_stop().set_bit());
-    // cal_end timeout (t == 0): surfaces later via `psram_detect_size` fallback.
-    debug!("Calibration timeout left: {}us", t);
-    crate::rom::ets_delay_us(10);
+
+    if success {
+        debug!("Calibration timeout left: {}us", t);
+        crate::rom::ets_delay_us(10);
+    }
+
+    success
 }
 
 /// Configure PSRAM_MSPI0 (AXI cache) for HEX/DDR access at 0x4800_0000.

--- a/esp-hal/src/soc/esp32p4/regi2c.rs
+++ b/esp-hal/src/soc/esp32p4/regi2c.rs
@@ -1,10 +1,12 @@
-use crate::rom::regi2c::{RegI2cMaster, RegI2cRegister, define_regi2c};
+use crate::rom::regi2c::{RawRegI2cField, RegI2cMaster, RegI2cRegister, define_regi2c};
 
 define_regi2c! {
     master: REGI2C_SDIO_PLL(0x62, 0) {}
     master: REGI2C_MSPI(0x63, 0) {
         reg: I2C_MPLL_DIV_REG_ADDR(2) {}
-        reg: I2C_MPLL_DHREF(3) {}
+        reg: I2C_MPLL_DHREF(3) {
+            field: I2C_MPLL_DHREF_DHREF(5..4)
+        }
         reg: I2C_MPLL_IR_CAL_RSTB(5) {}
     }
     master: REGI2C_SYS_PLL(0x66, 0) {

--- a/esp-hal/src/soc/esp32p4/regi2c.rs
+++ b/esp-hal/src/soc/esp32p4/regi2c.rs
@@ -3,11 +3,11 @@ use crate::rom::regi2c::{RawRegI2cField, RegI2cMaster, RegI2cRegister, define_re
 define_regi2c! {
     master: REGI2C_SDIO_PLL(0x62, 0) {}
     master: REGI2C_MSPI(0x63, 0) {
+        reg: I2C_MPLL_IR_CAL_RSTB(1) {}
         reg: I2C_MPLL_DIV_REG_ADDR(2) {}
         reg: I2C_MPLL_DHREF(3) {
             field: I2C_MPLL_DHREF_DHREF(5..4)
         }
-        reg: I2C_MPLL_IR_CAL_RSTB(5) {}
     }
     master: REGI2C_SYS_PLL(0x66, 0) {
         reg: I2C_SPLL_OC_REF_DIV(2) {}

--- a/esp-hal/src/soc/esp32p4/regi2c.rs
+++ b/esp-hal/src/soc/esp32p4/regi2c.rs
@@ -52,6 +52,12 @@ const LP_I2C_ANA_MST_ANA_CONF2_REG: u32 = LP_I2C_ANA_MST_BASE + 0x08;
 
 /// Select the I2C master for the given analog block.
 fn regi2c_enable_block(block: u8) {
+    // Enable I2C master clock
+    let lp_peri = unsafe { esp32p4::LP_PERI::steal() };
+    lp_peri
+        .clk_en()
+        .modify(|_, w| w.ck_en_lp_i2cmst().set_bit());
+
     // Clear both conf registers first
     unsafe {
         (LP_I2C_ANA_MST_ANA_CONF2_REG as *mut u32).write_volatile(0);

--- a/hil-test/src/bin/alloc_psram.rs
+++ b/hil-test/src/bin/alloc_psram.rs
@@ -8,7 +8,7 @@
 //% CHIPS(tlsf_with_storage): esp32 esp32s2 esp32c5 esp32c61 esp32s3
 //% ENV(llff): ESP_ALLOC_CONFIG_HEAP_ALGORITHM=LLFF
 //% ENV(tlsf): ESP_ALLOC_CONFIG_HEAP_ALGORITHM=TLSF
-//% FEATURES: unstable esp-alloc/nightly defmt
+//% FEATURES: unstable esp-alloc/nightly
 //% FEATURES(llff_with_storage): esp-storage
 
 #![no_std]

--- a/hil-test/src/bin/alloc_psram.rs
+++ b/hil-test/src/bin/alloc_psram.rs
@@ -8,7 +8,7 @@
 //% CHIPS(tlsf_with_storage): esp32 esp32s2 esp32c5 esp32c61 esp32s3
 //% ENV(llff): ESP_ALLOC_CONFIG_HEAP_ALGORITHM=LLFF
 //% ENV(tlsf): ESP_ALLOC_CONFIG_HEAP_ALGORITHM=TLSF
-//% FEATURES: unstable esp-alloc/nightly
+//% FEATURES: unstable esp-alloc/nightly defmt
 //% FEATURES(llff_with_storage): esp-storage
 
 #![no_std]


### PR DESCRIPTION
This PR aligns PSRAM code better with esp-idf, as well as makes a few tweaks. The end result is that the first run of the psram_alloc test now completes successfully.