### PR TITLE
P4: fix exception messages

### DIFF
--- a/esp-hal/src/exception_handler/mod.rs
+++ b/esp-hal/src/exception_handler/mod.rs
@@ -50,14 +50,19 @@ unsafe extern "C" fn ExceptionHandler(context: &TrapFrame) -> ! {
     let code = riscv::register::mcause::read().code();
     let mtval = riscv::register::mtval::read();
 
+    #[cfg(esp32p4)]
+    let code = code & 0x3F;
+
     unsafe extern "C" {
         static mut __stack_chk_guard: u32;
     }
 
+    let core = crate::system::Cpu::current();
+
     if code == 14 {
         panic!(
-            "Stack overflow detected at 0x{:x}, possibly called by 0x{:x}",
-            mepc, context.ra
+            "[{:?}] Stack overflow detected at 0x{:x}, possibly called by 0x{:x}",
+            core, mepc, context.ra
         );
     }
 
@@ -67,30 +72,30 @@ unsafe extern "C" fn ExceptionHandler(context: &TrapFrame) -> ! {
 
         if mtval == guard_addr {
             panic!(
-                "Detected a write to the main stack's guard value at 0x{:x}, possibly called by 0x{:x}",
-                mepc, context.ra
+                "[{:?}] Detected a write to the main stack's guard value at 0x{:x}, possibly called by 0x{:x}",
+                core, mepc, context.ra
             )
         } else {
             if unsafe { crate::debugger::watchpoint_hit(1) } {
                 panic!(
-                    "Detected a write to the trap/rwtext segment at 0x{:x}, possibly called by 0x{:x}",
-                    mepc, context.ra
+                    "[{:?}] Detected a write to the trap/rwtext segment at 0x{:x}, possibly called by 0x{:x}",
+                    core, mepc, context.ra
                 );
             } else if unsafe { crate::debugger::watchpoint_hit(0) } {
                 panic!(
-                    "Detected a write to a stack guard value at 0x{:x}, possibly called by 0x{:x}",
-                    mepc, context.ra
+                    "[{:?}] Detected a write to a stack guard value at 0x{:x}, possibly called by 0x{:x}",
+                    core, mepc, context.ra
                 );
             } else {
                 panic!(
-                    "Breakpoint exception at 0x{:08x}, mtval=0x{:08x}\n{:?}",
-                    mepc, mtval, context
+                    "[{:?}] Breakpoint exception at 0x{:08x}, mtval=0x{:08x}\n{:?}",
+                    core, mepc, mtval, context
                 );
             }
         }
     }
 
-    let code = match code {
+    let code_str = match code {
         0 => "Instruction address misaligned",
         1 => "Instruction access fault",
         2 => "Illegal instruction",
@@ -107,11 +112,13 @@ unsafe extern "C" fn ExceptionHandler(context: &TrapFrame) -> ! {
         13 => "Load page fault",
         14 => "Reserved",
         15 => "Store/AMO page fault",
+        #[cfg(esp32p4)]
+        0x1f => "Illegal PIE instruction",
         _ => "UNKNOWN",
     };
 
     panic!(
-        "Exception '{}' mepc=0x{:08x}, mtval=0x{:08x}\n{:?}",
-        code, mepc, mtval, context
+        "[{:?}] Exception '{} ({:x})' mepc=0x{:08x}, mtval=0x{:08x}\n{:?}",
+        core, code_str, code, mepc, mtval, context
     );
 }


### PR DESCRIPTION
Before:

```
[ERROR] panicked at 'Exception 'UNKNOWN' mepc=0x4ff403a6, mtval=0x00000000
TrapFrame { ra: 4377862, t0: 4377862, t1: 252645135, t2: 16843009, t3: 0, t4: 4294967295, t5: 0, t6: 1, a0: 15, a1: 256, a2: 0, a3: 4294967295, a4: 0, a5: 4294967295, a6: 4294967295, a7: 4294967295 }' (esp_hal src/exception_handler/mod.rs:113)
[ERROR] panicked at 'Exception 'UNKNOWN' mepc=0x4000e6c4, mtval=0x00000000
TrapFrame { ra: 1073799862, t0: 255, t1: 1073827784, t2: 16843009, t3: 0, t4: 4294967295, t5: 0, t6: 1, a0: 1, a1: 1341412352, a2: 1341412352, a3: 8, a4: 1341412400, a5: 1341532822, a6: 15, a7: 1341406896 }' (esp_hal src/exception_handler/mod.rs:113)
```

After:

```
[ERROR] panicked at '[AppCpu] Exception 'Load access fault (5)' mepc=0x4ff403a6, mtval=0x00000000
TrapFrame { ra: 3221234688, t0: 3221234688, t1: 1073848868, t2: 16843009, t3: 0, t4: 4294967295, t5: 0, t6: 1, a0: 15, a1: 256, a2: 0, a3: 65516, a4: 4294967276, a5: 0, a6: 4096000000, a7: 0 }' (esp_hal src/exception_handler/mod.rs:113)
[ERROR] panicked at 'Breakpoint exception at 0x4000e6c4, mtval=0x00000000
TrapFrame { ra: 1073799862, t0: 255, t1: 1073827784, t2: 16843009, t3: 0, t4: 4294967295, t5: 0, t6: 1, a0: 1, a1: 1341412352, a2: 1341412352, a3: 8, a4: 1341412400, a5: 1341532822, a6: 15, a7: 1341406896 }' (esp_hal src/exception_handler/mod.rs:85)
```

This PR adds the current core to the exception message, the raw mcause value to help debugging UNKNOWN, and correctly masks off the lower bits for P4, where the rest of the bits have meaning:

<img width="757" height="165" alt="image" src="https://github.com/user-attachments/assets/57f06f0e-984a-4614-b7e4-883e712ce78c" />

# Changelog

## esp-hal/Exceptions

- Changed: The exception messages now include which core has the exception, and what the raw code value is.
