### PR TITLE
Add UART break detection status APIs

### DIFF
--- a/esp-hal/src/uart/low_level/mod.rs
+++ b/esp-hal/src/uart/low_level/mod.rs
@@ -697,6 +697,14 @@ impl Info {
         result
     }
 
+    pub(super) fn is_rx_break_detected(&self) -> bool {
+        self.rx_events().contains(RxEvent::BreakDetected)
+    }
+
+    pub(super) fn clear_rx_break_detected(&self) {
+        self.clear_rx_events(RxEvent::BreakDetected);
+    }
+
     pub(super) fn rx_fifo_count(&self) -> u16 {
         version::rx_fifo_count(self)
     }

--- a/esp-hal/src/uart/low_level/mod.rs
+++ b/esp-hal/src/uart/low_level/mod.rs
@@ -697,12 +697,12 @@ impl Info {
         result
     }
 
-    pub(super) fn is_rx_break_detected(&self) -> bool {
-        self.rx_events().contains(RxEvent::BreakDetected)
-    }
-
-    pub(super) fn clear_rx_break_detected(&self) {
-        self.clear_rx_events(RxEvent::BreakDetected);
+    pub(super) fn check_rx_break_detected(&self) -> bool {
+        let detected = self.rx_events().contains(RxEvent::BreakDetected);
+        if detected {
+            self.clear_rx_events(RxEvent::BreakDetected);
+        }
+        detected
     }
 
     pub(super) fn rx_fifo_count(&self) -> u16 {

--- a/esp-hal/src/uart/low_level/mod.rs
+++ b/esp-hal/src/uart/low_level/mod.rs
@@ -698,11 +698,11 @@ impl Info {
     }
 
     pub(super) fn check_rx_break_detected(&self) -> bool {
-        let detected = self.rx_events().contains(RxEvent::BreakDetected);
-        if detected {
-            self.clear_rx_events(RxEvent::BreakDetected);
-        }
-        detected
+        self.rx_events().contains(RxEvent::BreakDetected)
+    }
+
+    pub(super) fn clear_rx_break_detected(&self) {
+        self.clear_rx_events(RxEvent::BreakDetected);
     }
 
     pub(super) fn rx_fifo_count(&self) -> u16 {

--- a/esp-hal/src/uart/mod.rs
+++ b/esp-hal/src/uart/mod.rs
@@ -980,6 +980,8 @@ impl<'d> UartRx<'d, Blocking> {
         while !self.is_break_detected() {
             // wait
         }
+
+        self.clear_break_detected();
     }
 
     /// Waits for a break condition to be detected with a timeout.
@@ -1001,6 +1003,7 @@ impl<'d> UartRx<'d, Blocking> {
             }
         }
 
+        self.clear_break_detected();
         true
     }
 
@@ -1219,11 +1222,18 @@ where
 
     /// Returns whether a break condition has been detected.
     ///
-    /// If a break has been detected, the break-detection status is cleared before
-    /// this method returns.
+    /// The returned status is sticky and remains set until
+    /// [`Self::clear_break_detected`] is called, or until one of the
+    /// `wait_for_break` methods observes and clears it.
     #[instability::unstable]
-    pub fn is_break_detected(&mut self) -> bool {
+    pub fn is_break_detected(&self) -> bool {
         self.uart.info().check_rx_break_detected()
+    }
+
+    /// Clears the break-detection status.
+    #[instability::unstable]
+    pub fn clear_break_detected(&mut self) {
+        self.uart.info().clear_rx_break_detected();
     }
 
     /// Change the configuration.
@@ -1892,11 +1902,18 @@ where
 
     /// Returns whether a break condition has been detected.
     ///
-    /// If a break has been detected, the break-detection status is cleared before
-    /// this method returns.
+    /// The returned status is sticky and remains set until
+    /// [`Self::clear_break_detected`] is called, or until one of the
+    /// `wait_for_break` methods observes and clears it.
     #[instability::unstable]
-    pub fn is_break_detected(&mut self) -> bool {
+    pub fn is_break_detected(&self) -> bool {
         self.rx.is_break_detected()
+    }
+
+    /// Clears the break-detection status.
+    #[instability::unstable]
+    pub fn clear_break_detected(&mut self) {
+        self.rx.clear_break_detected();
     }
 
     #[procmacros::doc_replace]

--- a/esp-hal/src/uart/mod.rs
+++ b/esp-hal/src/uart/mod.rs
@@ -972,45 +972,38 @@ impl<'d> UartRx<'d, Blocking> {
 
     /// Waits for a break condition to be detected.
     ///
-    /// This is a blocking function that will continuously check for a break condition.
-    /// After detection, the break interrupt flag is automatically cleared.
+    /// This function polls the break-detection interrupt status and returns once
+    /// the receiver has detected a break condition. After detection, the break
+    /// status is automatically cleared.
     #[instability::unstable]
     pub fn wait_for_break(&mut self) {
-        self.enable_break_detection();
-
-        while !self.regs().int_raw().read().brk_det().bit_is_set() {
+        while !self.is_break_detected() {
             // wait
         }
 
-        self.regs()
-            .int_clr()
-            .write(|w| w.brk_det().clear_bit_by_one());
+        self.clear_break_detected();
     }
 
     /// Waits for a break condition to be detected with a timeout.
     ///
-    /// This is a blocking function that will check for a break condition up to
-    /// the specified timeout. Returns `true` if a break was detected, `false` if
-    /// the timeout elapsed. After successful detection, the break interrupt flag
-    /// is automatically cleared.
+    /// This function polls the break-detection interrupt status until a break is
+    /// detected or the specified timeout expires. Returns `true` if a break was
+    /// detected, `false` if the timeout elapsed. After successful detection, the
+    /// break status is automatically cleared.
     ///
     /// ## Arguments
     /// * `timeout` - Maximum time to wait for a break condition
     #[instability::unstable]
     pub fn wait_for_break_with_timeout(&mut self, timeout: crate::time::Duration) -> bool {
-        self.enable_break_detection();
-
         let start = crate::time::Instant::now();
 
-        while !self.regs().int_raw().read().brk_det().bit_is_set() {
+        while !self.is_break_detected() {
             if crate::time::Instant::now() - start >= timeout {
                 return false;
             }
         }
 
-        self.regs()
-            .int_clr()
-            .write(|w| w.brk_det().clear_bit_by_one());
+        self.clear_break_detected();
         true
     }
 
@@ -1181,9 +1174,6 @@ impl<'d> UartRx<'d, Async> {
     #[instability::unstable]
     pub async fn wait_for_break_async(&mut self) {
         UartRxFuture::new(self.uart.reborrow(), RxEvent::BreakDetected).await;
-        self.regs()
-            .int_clr()
-            .write(|w| w.brk_det().clear_bit_by_one());
     }
 }
 
@@ -1230,20 +1220,20 @@ where
         self
     }
 
-    /// Enable break detection.
+    /// Returns whether a break condition has been detected.
     ///
-    /// This must be called before any breaks are expected to be received.
-    /// Break detection is enabled automatically by [`Self::wait_for_break`]
-    /// and [`Self::wait_for_break_with_timeout`], but calling this method
-    /// explicitly ensures that breaks occurring before the first wait call
-    /// will be reliably detected.
+    /// The returned status is sticky and remains set until
+    /// [`Self::clear_break_detected`] is called, or until one of the
+    /// `wait_for_break` methods observes and clears it.
     #[instability::unstable]
-    pub fn enable_break_detection(&mut self) {
-        self.uart
-            .info()
-            .enable_listen_rx(RxEvent::BreakDetected.into(), true);
+    pub fn is_break_detected(&self) -> bool {
+        self.uart.info().is_rx_break_detected()
+    }
 
-        sync_regs(self.regs());
+    /// Clears the break-detection status.
+    #[instability::unstable]
+    pub fn clear_break_detected(&mut self) {
+        self.uart.info().clear_rx_break_detected();
     }
 
     /// Change the configuration.
@@ -1685,7 +1675,7 @@ impl<'d> Uart<'d, Async> {
 #[non_exhaustive]
 #[instability::unstable]
 pub enum UartInterrupt {
-    /// Indicates that the received has detected the configured
+    /// Indicates that the receiver has detected the configured
     /// [`Uart::set_at_cmd`] byte.
     AtCmd,
 
@@ -1908,6 +1898,22 @@ where
     /// ```
     pub fn read_ready(&self) -> bool {
         self.rx.read_ready()
+    }
+
+    /// Returns whether a break condition has been detected.
+    ///
+    /// The returned status is sticky and remains set until
+    /// [`Self::clear_break_detected`] is called, or until one of the
+    /// `wait_for_break` methods observes and clears it.
+    #[instability::unstable]
+    pub fn is_break_detected(&self) -> bool {
+        self.rx.is_break_detected()
+    }
+
+    /// Clears the break-detection status.
+    #[instability::unstable]
+    pub fn clear_break_detected(&mut self) {
+        self.rx.clear_break_detected();
     }
 
     #[procmacros::doc_replace]

--- a/esp-hal/src/uart/mod.rs
+++ b/esp-hal/src/uart/mod.rs
@@ -980,8 +980,6 @@ impl<'d> UartRx<'d, Blocking> {
         while !self.is_break_detected() {
             // wait
         }
-
-        self.clear_break_detected();
     }
 
     /// Waits for a break condition to be detected with a timeout.
@@ -1003,7 +1001,6 @@ impl<'d> UartRx<'d, Blocking> {
             }
         }
 
-        self.clear_break_detected();
         true
     }
 
@@ -1222,18 +1219,11 @@ where
 
     /// Returns whether a break condition has been detected.
     ///
-    /// The returned status is sticky and remains set until
-    /// [`Self::clear_break_detected`] is called, or until one of the
-    /// `wait_for_break` methods observes and clears it.
+    /// If a break has been detected, the break-detection status is cleared before
+    /// this method returns.
     #[instability::unstable]
-    pub fn is_break_detected(&self) -> bool {
-        self.uart.info().is_rx_break_detected()
-    }
-
-    /// Clears the break-detection status.
-    #[instability::unstable]
-    pub fn clear_break_detected(&mut self) {
-        self.uart.info().clear_rx_break_detected();
+    pub fn is_break_detected(&mut self) -> bool {
+        self.uart.info().check_rx_break_detected()
     }
 
     /// Change the configuration.
@@ -1902,18 +1892,11 @@ where
 
     /// Returns whether a break condition has been detected.
     ///
-    /// The returned status is sticky and remains set until
-    /// [`Self::clear_break_detected`] is called, or until one of the
-    /// `wait_for_break` methods observes and clears it.
+    /// If a break has been detected, the break-detection status is cleared before
+    /// this method returns.
     #[instability::unstable]
-    pub fn is_break_detected(&self) -> bool {
+    pub fn is_break_detected(&mut self) -> bool {
         self.rx.is_break_detected()
-    }
-
-    /// Clears the break-detection status.
-    #[instability::unstable]
-    pub fn clear_break_detected(&mut self) {
-        self.rx.clear_break_detected();
     }
 
     #[procmacros::doc_replace]

--- a/hil-test/src/bin/uart.rs
+++ b/hil-test/src/bin/uart.rs
@@ -526,7 +526,7 @@ mod async_tx_rx {
         join::join,
         select::{Either, select},
     };
-    use embassy_time::{Duration, Timer};
+    use embassy_time::{Delay, Duration, Timer};
     use embedded_io_async::Write;
     use esp_hal::{
         Async,
@@ -576,8 +576,10 @@ mod async_tx_rx {
 
     #[test]
     async fn test_break_detection(mut ctx: Context) {
+        let mut delay = Delay;
+
         join(ctx.rx.wait_for_break_async(), async {
-            ctx.tx.send_break(100);
+            ctx.tx.send_break_async(&mut delay, 100).await;
         })
         .await;
     }

--- a/hil-test/src/bin/uart.rs
+++ b/hil-test/src/bin/uart.rs
@@ -260,7 +260,6 @@ mod tests {
         let mut tx = ctx.uart0.split().1.with_tx(ctx.tx);
         let mut rx = ctx.uart1.split().0.with_rx(ctx.rx);
 
-        rx.enable_break_detection();
         tx.send_break(100);
         assert!(rx.wait_for_break_with_timeout(Duration::from_secs(1)));
     }
@@ -277,7 +276,6 @@ mod tests {
         let mut tx = ctx.uart0.split().1.with_tx(ctx.tx);
         let mut rx = ctx.uart1.split().0.with_rx(ctx.rx);
 
-        rx.enable_break_detection();
         for _ in 0..3 {
             tx.send_break(100);
             assert!(rx.wait_for_break_with_timeout(Duration::from_secs(1)));
@@ -288,8 +286,6 @@ mod tests {
     fn test_break_detection_interleaved(ctx: Context) {
         let mut tx = ctx.uart0.split().1.with_tx(ctx.tx);
         let mut rx = ctx.uart1.split().0.with_rx(ctx.rx);
-
-        rx.enable_break_detection();
 
         // Test 1: Send break, expect detection
         tx.send_break(100);
@@ -314,8 +310,6 @@ mod tests {
     fn test_break_detection_with_data(ctx: Context) {
         let mut tx = ctx.uart0.split().1.with_tx(ctx.tx);
         let mut rx = ctx.uart1.split().0.with_rx(ctx.rx);
-
-        rx.enable_break_detection();
 
         // Test 1: Send break, expect detection
         tx.send_break(100);
@@ -354,8 +348,6 @@ mod tests {
     fn test_break_detection_preserves_data(ctx: Context) {
         let mut tx = ctx.uart0.split().1.with_tx(ctx.tx);
         let mut rx = ctx.uart1.split().0.with_rx(ctx.rx);
-
-        rx.enable_break_detection();
 
         // Send data, flush to ensure transmission, then send break
         tx.write(&[0x01, 0x02, 0x03, 0x04]).unwrap();
@@ -580,6 +572,14 @@ mod async_tx_rx {
         let _ = ctx.rx.read_async(&mut read).await;
 
         assert_eq!(read, byte);
+    }
+
+    #[test]
+    async fn test_break_detection(mut ctx: Context) {
+        join(ctx.rx.wait_for_break_async(), async {
+            ctx.tx.send_break(100);
+        })
+        .await;
     }
 
     #[test]


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` or `manual-changelog` label as appropriate.
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
 Add UART RX break-detection status/clear APIs and fix break waiting to poll status without enabling interrupts.  

#### Testing
HIL

---

<!-- ============================================================
  Changelog and migration guide entries live here in the PR body.
  They will be collected automatically at release time.
  Delete any section that doesn't apply to your PR.
  ============================================================ -->

# Changelog

## esp-hal/UART

- Added: `Uart::is_break_detected`, `UartRx::is_break_detected`, `Uart::clear_break_detected`, and  `UartRx::clear_break_detected` for RX break detection.
- Fixed: `wait_for_break` no longer enables the RX break interrupt while polling.
