### PR TITLE
Fix esp-rtos crashing on P4

### DIFF
--- a/esp-hal/src/system.rs
+++ b/esp-hal/src/system.rs
@@ -258,11 +258,14 @@ impl Cpu {
         // in the case of Xtensa.
         match raw_core() {
             0 => Cpu::ProCpu,
+
             #[cfg(all(multi_core, riscv))]
             1 => Cpu::AppCpu,
+
             #[cfg(all(multi_core, xtensa))]
             0x2000 => Cpu::AppCpu,
-            _ => unreachable!(),
+
+            other => unreachable!("unknown core id: {}", other),
         }
     }
 

--- a/esp-rtos/src/scheduler.rs
+++ b/esp-rtos/src/scheduler.rs
@@ -46,9 +46,6 @@ pub(crate) struct SchedulerState {
     /// A list of tasks ready to run
     pub(crate) run_queue: RunQueue,
 
-    /// Pointer to the task that is scheduled for deletion.
-    pub(crate) to_delete: TaskList<TaskDeleteListElement>,
-
     pub(crate) time_driver: Option<TimeDriver>,
 
     pub(crate) per_cpu: [CpuState; Cpu::COUNT],
@@ -65,6 +62,9 @@ pub(crate) struct CpuState {
     #[cfg(multi_core)]
     current_task: *mut Task,
 
+    /// Pointer to the task that is scheduled for deletion.
+    pub(crate) to_delete: TaskList<TaskDeleteListElement>,
+
     // This context will be filled out by the first context switch.
     // We allocate the main task statically, because there is always a main task. If deleted, we
     // simply don't deallocate this.
@@ -76,6 +76,7 @@ impl CpuState {
         Self {
             initialized: false,
             idle_context: CpuContext::new(),
+            to_delete: TaskList::new(),
 
             #[cfg(multi_core)]
             current_task: core::ptr::null_mut(),
@@ -118,7 +119,6 @@ impl SchedulerState {
         Self {
             all_tasks: TaskList::new(),
             run_queue: RunQueue::new(),
-            to_delete: TaskList::new(),
 
             time_driver: None,
 
@@ -138,12 +138,6 @@ impl SchedulerState {
     pub(crate) fn set_current_task(&mut self, cpu: Cpu, task: Option<TaskPtr>) {
         self.per_cpu[cpu as usize].current_task =
             task.map(|task| task.as_ptr()).unwrap_or_default();
-    }
-
-    #[inline]
-    #[cfg(multi_core)]
-    pub(crate) fn try_get_current_task(&self, cpu: Cpu) -> Option<TaskPtr> {
-        NonNull::new(self.per_cpu[cpu as usize].current_task)
     }
 
     pub(crate) fn setup(&mut self, time_driver: TimeDriver, idle_hook: IdleFn) {
@@ -202,21 +196,9 @@ impl SchedulerState {
 
     #[cold]
     #[inline(never)]
-    fn delete_marked_tasks(&mut self) {
-        let mut to_delete = core::mem::take(&mut self.to_delete);
-
-        while let Some(task_ptr) = to_delete.pop() {
+    fn delete_marked_tasks(&mut self, cpu: Cpu) {
+        while let Some(task_ptr) = self.per_cpu[cpu as usize].to_delete.pop() {
             assert!(task_ptr.state() == TaskState::Deleted);
-
-            #[cfg(multi_core)]
-            if Cpu::other()
-                .filter_map(|cpu| self.try_get_current_task(cpu))
-                .any(|task| task == task_ptr)
-            {
-                // We can't delete a task that is currently running on another CPU.
-                self.to_delete.push(task_ptr);
-                continue;
-            }
 
             trace!("delete_marked_tasks {:?}", task_ptr);
             self.delete_task(task_ptr);
@@ -227,12 +209,12 @@ impl SchedulerState {
         #[cfg(feature = "rtos-trace")]
         rtos_trace::trace::marker_begin(TraceEvents::RunSchedule as u32);
 
-        if !self.to_delete.is_empty() {
-            self.delete_marked_tasks();
-        }
-
         let cpu = Cpu::current();
         let current_cpu = cpu as usize;
+
+        if !self.per_cpu[cpu as usize].to_delete.is_empty() {
+            self.delete_marked_tasks(cpu);
+        }
 
         let current_sp: u32;
         cfg_if::cfg_if! {
@@ -369,7 +351,9 @@ impl SchedulerState {
 
         if is_current {
             if task_to_delete.state() != TaskState::Deleted {
-                self.to_delete.push(task_to_delete);
+                self.per_cpu[Cpu::current() as usize]
+                    .to_delete
+                    .push(task_to_delete);
                 task_to_delete.set_state(TaskState::Deleted);
             }
 

--- a/esp-rtos/src/task/riscv.rs
+++ b/esp-rtos/src/task/riscv.rs
@@ -204,8 +204,11 @@ unsafe extern "C" fn swint_handler_trampoline() {
         # Save registers
         addi sp, sp, -16 # allocate 16 bytes for saving regs (RISC-V requires 16-byte alignment)
 
-        # Store the thread pointer on the stack. We'll use it to check what needs to be restored
+        # Store the thread pointer on the stack. We'll use it to check what needs to be restored.
         sw tp, 0*4(sp)
+        # Also save ra: jalr below clobbers it, and we must restore it on the idle-stays-idle
+        # path where tp==0 means there is no CpuContext to reload it from.
+        sw ra, 1*4(sp)
 
         # Skip storing context for the idle context or deleted tasks (no thread pointer)
         beqz tp, 1f # Skip to calling the interrupt handler
@@ -233,8 +236,10 @@ unsafe extern "C" fn swint_handler_trampoline() {
         la t0, {scheduler_interrupt_handler}
         jalr ra, t0, 0
 
-        # Load old thread pointer and free up stack. This way we store/reload the unmodified stack pointer.
+        # Load old thread pointer and return address, and free up stack.
+        # This way we store/reload the unmodified stack pointer.
         lw t0, 0*4(sp)
+        lw ra, 1*4(sp)
         addi sp, sp, 16
 
         # If the thread pointer has not changed, just restore caller-saved registers
@@ -286,6 +291,10 @@ unsafe extern "C" fn swint_handler_trampoline() {
         csrw mepc, t1
 
 3:
+        # When tp==0 the idle task is (re-)entering: its caller-saved registers were never
+        # written to a CpuContext, so there is nothing to reload.
+        beqz tp, 4f
+
         lw ra, 0*4(tp)
         lw t0, 1*4(tp)
         lw t1, 2*4(tp)
@@ -306,6 +315,7 @@ unsafe extern "C" fn swint_handler_trampoline() {
         # Restore TP last. For the idle hook, this should write 0, which prevents saving its state.
         lw tp, 29*4(tp)
 
+4:
         mret
         .cfi_endproc
         ",


### PR DESCRIPTION
This PR makes two changes to esp-rtos:

- Changes the task deletion queue into per-core separate queues. This prevents deallocating a thread that is still not fully switched out.
- Updates the software interrupt handler to skip trying to reload context when tp == 0

# Changelog

## esp-hal

- No changelog necessary.

## esp-rtos

- Fixed: fixed a potential crash on RISC-V devices
