### PR TITLE
Release esp-radio: 0.18.0 → 1.0.0-beta.0

### DIFF
--- a/esp-radio/CHANGELOG.md
+++ b/esp-radio/CHANGELOG.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `AccessPointStationDisconnectedInfo` renamed to `ap::DisconnectedInfo` and moved to the `ap` module. (#5605)
 - `AccessPointStationEventInfo` renamed to `ap::EventInfo` and moved to the `ap` module. (#5605)
 - `AccessPointConfig::max_connections` and `AccessPointConfig::dtim_period` setters are now gated behind the `unstable` feature. (#5605)
-- `wifi::new()` now returns `WifiController` instead of `(WifiController, Interfaces)`. (#5480)
+- `WifiController::new()` now returns `WifiController` instead of `(WifiController, Interfaces)`. (#5480)
 - `Interface` no longer has a lifetime parameter and is no longer `Clone`/`Copy` (singleton semantics). (#5480)
 
 ### Fixed

--- a/esp-radio/CHANGELOG.md
+++ b/esp-radio/CHANGELOG.md
@@ -15,11 +15,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed a crash when using advanced BLE scanning on certain chips (C6,H2,C5,C61) (#5458)
-- Fixed minor issues (#5490, #5495, #5499)
 
 ### Removed
 
+
+## [v1.0.0-beta.0] - 2026-06-03
+
+### Added
+
+- `Interface::station()`, `Interface::try_station()`, `Interface::access_point()`, and `Interface::try_access_point()` singleton constructors. (#5480)
+- `WifiController::esp_now()` and `WifiController::sniffer()` methods to create ESP-NOW and sniffer instances tied to the controller's lifetime. (#5480)
+- `Drop` impl for `Sniffer` that disables promiscuous mode and unregisters the callback. (#5480)
+
+### Changed
+
+- `esp_radio::wifi::new()` is now `esp_radio::wifi::WifiController::new()`. (#5605)
+- `ConnectedStationInfo` renamed to `sta::ConnectedInfo` and moved to the `sta` module. (#5605)
+- `DisconnectedStationInfo` renamed to `sta::DisconnectedInfo` and moved to the `sta` module. (#5605)
+- `AccessPointStationConnectedInfo` renamed to `ap::ConnectedInfo` and moved to the `ap` module. (#5605)
+- `AccessPointStationDisconnectedInfo` renamed to `ap::DisconnectedInfo` and moved to the `ap` module. (#5605)
+- `AccessPointStationEventInfo` renamed to `ap::EventInfo` and moved to the `ap` module. (#5605)
+- `AccessPointConfig::max_connections` and `AccessPointConfig::dtim_period` setters are now gated behind the `unstable` feature. (#5605)
+- `wifi::new()` now returns `WifiController` instead of `(WifiController, Interfaces)`. (#5480)
+- `Interface` no longer has a lifetime parameter and is no longer `Clone`/`Copy` (singleton semantics). (#5480)
+
+### Fixed
+
+- Fixed a crash when using advanced BLE scanning on certain chips (C6,H2,C5,C61) (#5458)
+- Fixed minor issues (#5490, #5495, #5499)
+- Read the 802.15.4 AR (ack-request) bit and frame-version from the correct FCF octet. They were read one octet too high, misclassifying ack-required frames and breaking ACK handling for fragmented frames. (#5650)
+- Correctly use BTBB_REG_RST (#5498)
+
+### Removed
+
+- The `Interfaces` struct; interfaces and sub-peripherals are now created independently. (#5480)
 
 ## [v0.18.0] - 2026-04-16
 
@@ -451,4 +480,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v0.16.0]: https://github.com/esp-rs/esp-hal/compare/esp-wifi-v0.15.0...esp-radio-v0.16.0
 [v0.17.0]: https://github.com/esp-rs/esp-hal/compare/esp-radio-v0.16.0...esp-radio-v0.17.0
 [v0.18.0]: https://github.com/esp-rs/esp-hal/compare/esp-radio-v0.17.0...esp-radio-v0.18.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-radio-v0.18.0...HEAD
+[v1.0.0-beta.0]: https://github.com/esp-rs/esp-hal/compare/esp-radio-v0.18.0...esp-radio-v1.0.0-beta.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-radio-v1.0.0-beta.0...HEAD

--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "esp-radio"
-version = "0.18.0"
+version = "1.0.0-beta.0"
 edition = "2024"
 rust-version  = "1.95.0"
 description = "A WiFi, Bluetooth and ESP-NOW driver for use with Espressif chips and bare-metal Rust"

--- a/esp-radio/MIGRATING-0.18.0.md
+++ b/esp-radio/MIGRATING-0.18.0.md
@@ -37,14 +37,12 @@ The following types have been moved from `esp_radio::wifi` into `esp_radio::wifi
 
 `AccessPointConfig::with_max_connections()` and `AccessPointConfig::with_dtim_period()` now require the `unstable` feature. If you use these setters, enable the `unstable` feature on `esp-radio`.
 
-## Wi-Fi
+### `WifiController::new()` no longer returns `Interfaces`
 
-### `wifi::new()` no longer returns `Interfaces`
-
-`wifi::new()` now returns just a `WifiController` instead of `(WifiController, Interfaces)`.
+`WifiController::new()` now returns just a `WifiController` instead of `(WifiController, Interfaces)`.
 
 `Interface` is now a lifetime-free singleton — create it via `Interface::station()` or
-`Interface::access_point()` before or after calling `wifi::new()`. ESP-NOW and Sniffer
+`Interface::access_point()` before or after calling `WifiController::new()`. ESP-NOW and Sniffer
 instances are obtained from the controller.
 
 ```rust
@@ -54,7 +52,7 @@ let wifi_interface = interfaces.station;
 
 // After
 let wifi_interface = esp_radio::wifi::Interface::station();
-let mut controller = esp_radio::wifi::new(peripherals.WIFI, config)?;
+let mut controller = esp_radio::wifi::WifiController::new(peripherals.WIFI, config)?;
 ```
 
 For ESP-NOW and Sniffer, use the controller methods. The returned instances borrow the
@@ -67,7 +65,7 @@ let mut sniffer = interfaces.sniffer;
 let esp_now = interfaces.esp_now;
 
 // After
-let controller = esp_radio::wifi::new(peripherals.WIFI, config)?;
+let controller = esp_radio::wifi::WifiController::new(peripherals.WIFI, config)?;
 let mut sniffer = controller.sniffer();
 let esp_now = controller.esp_now();
 ```

--- a/esp-radio/MIGRATING-0.18.0.md
+++ b/esp-radio/MIGRATING-0.18.0.md
@@ -1,1 +1,77 @@
 # Migration Guide from 0.18.0 to {{currentVersion}}
+
+## Wi-Fi
+
+### `wifi::new()` replaced with `WifiController::new()`
+
+The free function `esp_radio::wifi::new()` has been replaced by `esp_radio::wifi::WifiController::new()`.
+
+```rust
+// Before
+let controller = esp_radio::wifi::new(peripherals.WIFI, Default::default())?;
+
+// After
+let controller = esp_radio::wifi::WifiController::new(peripherals.WIFI, Default::default())?;
+```
+
+### Station info types moved to `sta` module and renamed
+
+The following types have been moved from `esp_radio::wifi` into `esp_radio::wifi::sta` and renamed:
+
+| Before | After |
+|--------|-------|
+| `ConnectedStationInfo` | `sta::ConnectedInfo` |
+| `DisconnectedStationInfo` | `sta::DisconnectedInfo` |
+
+### Access point info types moved to `ap` module and renamed
+
+The following types have been moved from `esp_radio::wifi` into `esp_radio::wifi::ap` and renamed:
+
+| Before | After |
+|--------|-------|
+| `AccessPointStationConnectedInfo` | `ap::ConnectedInfo` |
+| `AccessPointStationDisconnectedInfo` | `ap::DisconnectedInfo` |
+| `AccessPointStationEventInfo` | `ap::EventInfo` |
+
+### `max_connections` and `dtim_period` setters are now unstable
+
+`AccessPointConfig::with_max_connections()` and `AccessPointConfig::with_dtim_period()` now require the `unstable` feature. If you use these setters, enable the `unstable` feature on `esp-radio`.
+
+## Wi-Fi
+
+### `wifi::new()` no longer returns `Interfaces`
+
+`wifi::new()` now returns just a `WifiController` instead of `(WifiController, Interfaces)`.
+
+`Interface` is now a lifetime-free singleton — create it via `Interface::station()` or
+`Interface::access_point()` before or after calling `wifi::new()`. ESP-NOW and Sniffer
+instances are obtained from the controller.
+
+```rust
+// Before
+let (mut controller, interfaces) = esp_radio::wifi::new(peripherals.WIFI, config)?;
+let wifi_interface = interfaces.station;
+
+// After
+let wifi_interface = esp_radio::wifi::Interface::station();
+let mut controller = esp_radio::wifi::new(peripherals.WIFI, config)?;
+```
+
+For ESP-NOW and Sniffer, use the controller methods. The returned instances borrow the
+controller, so the controller must outlive them:
+
+```rust
+// Before
+let (_controller, interfaces) = esp_radio::wifi::new(peripherals.WIFI, config)?;
+let mut sniffer = interfaces.sniffer;
+let esp_now = interfaces.esp_now;
+
+// After
+let controller = esp_radio::wifi::new(peripherals.WIFI, config)?;
+let mut sniffer = controller.sniffer();
+let esp_now = controller.esp_now();
+```
+
+`Interface` is no longer `Clone` or `Copy`. Each mode (station / access point) is a
+singleton — only one instance can exist at a time. Dropping it releases the slot so it
+can be created again.


### PR DESCRIPTION
This pull request prepares the following packages for release:

- esp-radio: 0.18.0 → 1.0.0-beta.0

<details>

<summary>Release plan (click to expand)</summary>

```jsonc
{
  "base": "main",
  "slug": "00dyfe",
  "packages": [
    {
      "package": "esp-radio",
      "semver_checked": false,
      "current_version": "0.18.0",
      "new_version": "1.0.0-beta.0",
      "tag_name": "esp-radio-v1.0.0-beta.0",
      "bump": {
        "base": "Major",
        "pre": "beta"
      }
    }
  ]
}
```

</details>

Please review the changes and merge them into the `main` branch.

After merging, please make sure you have this release plan in the repo root,
then run the following command on the `main` branch to tag and publish the packages:

```
cargo xrelease publish-plan --no-dry-run
```
