### PR TITLE
Correct the 802.15.4 AR-bit and frame-version FCF offsets

### DIFF
--- a/esp-radio/src/ieee802154/frame.rs
+++ b/esp-radio/src/ieee802154/frame.rs
@@ -6,9 +6,14 @@ pub(crate) const FRAME_SIZE: usize = 129;
 pub(crate) const FRAME_VERSION_1: u8 = 0x10; // IEEE 802.15.4 - 2006 & 2011
 pub(crate) const FRAME_VERSION_2: u8 = 0x20; // IEEE 802.15.4 - 2015
 
-const FRAME_AR_OFFSET: usize = 1;
+// These offsets index the length-stripped PSDU that every caller passes in:
+// frames are built from a pointer one byte past the PHY length byte (`.add(1)`)
+// and the RX path reads `RX_BUFFER[1..]`, so byte 0 is the first FCF octet. The
+// IEEE 802.15.4 FCF carries the AR (ack-request) bit in FCF octet 0 and the
+// frame-version field in FCF octet 1.
+const FRAME_AR_OFFSET: usize = 0;
 const FRAME_AR_BIT: u8 = 0x20;
-const FRAME_VERSION_OFFSET: usize = 2;
+const FRAME_VERSION_OFFSET: usize = 1;
 const FRAME_VERSION_MASK: u8 = 0x30;
 
 /// IEEE 802.15.4 MAC frame


### PR DESCRIPTION
Fixes #5649.

#### Description

`frame_is_ack_required` / `frame_get_version` index the length-stripped PSDU that all callers pass (byte 0 = FCF octet 0), but `FRAME_AR_OFFSET` / `FRAME_VERSION_OFFSET` were 1 and 2, reading the AR bit and frame-version one octet too high. Ack-required frames get misclassified as no-ACK, so TX reports false success and never retransmits — breaking fragmented Thread/802.15.4 datagrams. Set the offsets to 0 and 1.

Full root-cause analysis and evidence in #5649.

#### Testing

Two firmwares differing only in these two offsets on an ESP32-C6 (Thread/Matter). With the fix: the SRP host registers first try, the Thread interface is stable, the node is operational. Without it: repeated `SRP callback error: code=28` (RESPONSE_TIMEOUT), Thread netif flap loop, RLOC16 churn, never stabilizes. A deterministic check of `frame_is_ack_required` over the FCF space confirms the current offset reads AR from the wrong octet (128/256 vs 256/256 correct).

# Changelog

## esp-radio

- Fixed: Read the 802.15.4 AR (ack-request) bit and frame-version from the correct FCF octet. They were read one octet too high, misclassifying ack-required frames and breaking ACK handling for fragmented frames.
