### PR TITLE
Remove unnecessary defaults

### DIFF
--- a/examples/async/embassy_usb_serial/src/main.rs
+++ b/examples/async/embassy_usb_serial/src/main.rs
@@ -62,7 +62,6 @@ async fn main(_spawner: Spawner) {
     config.serial_number = Some("12345678");
 
     // Required for windows compatibility.
-    // https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.9.1/kconfig/CONFIG_CDC_ACM_IAD.html#help
     config.device_class = 0xEF;
     config.device_sub_class = 0x02;
     config.device_protocol = 0x01;

--- a/examples/async/embassy_usb_serial/src/main.rs
+++ b/examples/async/embassy_usb_serial/src/main.rs
@@ -61,12 +61,6 @@ async fn main(_spawner: Spawner) {
     config.product = Some("USB-serial example");
     config.serial_number = Some("12345678");
 
-    // Required for windows compatibility.
-    config.device_class = 0xEF;
-    config.device_sub_class = 0x02;
-    config.device_protocol = 0x01;
-    config.composite_with_iads = true;
-
     // Create embassy-usb DeviceBuilder using the driver and config.
     // It needs some buffers for building the descriptors.
     let mut config_descriptor = [0; 256];

--- a/examples/async/embassy_usb_serial_hs/src/main.rs
+++ b/examples/async/embassy_usb_serial_hs/src/main.rs
@@ -54,7 +54,6 @@ async fn main(_spawner: Spawner) {
     config.serial_number = Some("12345678");
 
     // Required for windows compatibility.
-    // https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.9.1/kconfig/CONFIG_CDC_ACM_IAD.html#help
     config.device_class = 0xEF;
     config.device_sub_class = 0x02;
     config.device_protocol = 0x01;

--- a/examples/async/embassy_usb_serial_hs/src/main.rs
+++ b/examples/async/embassy_usb_serial_hs/src/main.rs
@@ -53,12 +53,6 @@ async fn main(_spawner: Spawner) {
     config.product = Some("USB-serial example");
     config.serial_number = Some("12345678");
 
-    // Required for windows compatibility.
-    config.device_class = 0xEF;
-    config.device_sub_class = 0x02;
-    config.device_protocol = 0x01;
-    config.composite_with_iads = true;
-
     // Create embassy-usb DeviceBuilder using the driver and config.
     // It needs some buffers for building the descriptors.
     let mut config_descriptor = [0; 256];


### PR DESCRIPTION
- The link checker has some issues with the link
- embassy-usb documentation documents what these values should be by default
- The compatibility issue Nordic documents relates to Windows 7, which is no longer supported