### PR TITLE
Revert accidental macro change in compile-tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ api-baseline/
 
 .mcp.json
 .cursor/
+
+# Ignore compile tests
+compile-tests/

--- a/compile-tests/ble_1-0/src/main.rs
+++ b/compile-tests/ble_1-0/src/main.rs
@@ -20,7 +20,7 @@ use trouble_host::prelude::*;
 
 esp_bootloader_esp_idf::esp_app_desc!();
 
-#[esp_hal::main]
+#[esp_rtos::main]
 async fn main(_s: Spawner) {
     esp_println::logger::init_logger_from_env();
     let peripherals = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));

--- a/compile-tests/ble_1-1/src/main.rs
+++ b/compile-tests/ble_1-1/src/main.rs
@@ -19,7 +19,7 @@ use trouble_host::prelude::*;
 
 esp_bootloader_esp_idf::esp_app_desc!();
 
-#[esp_hal::main]
+#[esp_rtos::main]
 async fn main(_s: Spawner) {
     esp_println::logger::init_logger_from_env();
     let peripherals = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));

--- a/compile-tests/wifi_1-0/src/main.rs
+++ b/compile-tests/wifi_1-0/src/main.rs
@@ -44,7 +44,7 @@ macro_rules! mk_static {
 const SSID: &str = "SSID";
 const PASSWORD: &str = "PASSWORD";
 
-#[esp_hal::main]
+#[esp_rtos::main]
 async fn main(spawner: Spawner) -> ! {
     esp_println::logger::init_logger_from_env();
     let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());

--- a/compile-tests/wifi_1-1/src/main.rs
+++ b/compile-tests/wifi_1-1/src/main.rs
@@ -43,7 +43,7 @@ macro_rules! mk_static {
 const SSID: &str = "SSID";
 const PASSWORD: &str = "PASSWORD";
 
-#[esp_hal::main]
+#[esp_rtos::main]
 async fn main(spawner: Spawner) -> ! {
     esp_println::logger::init_logger_from_env();
     let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());


### PR DESCRIPTION
Reverts the `#[esp_hal::main]` change that an unrelated find-and-replace swept into `compile-tests`; these tests pin specific usage and shouldn't change incidentally. Also adds `compile-tests/` to `.gitignore` so gitignore-aware search/replace tools skip the folder going forward.