### PR TITLE
pre-rel-check: run on macos-m1-self-hosted runner

### DIFF
--- a/.github/workflows/pre-rel-check.yml
+++ b/.github/workflows/pre-rel-check.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: macos-m1-self-hosted
     if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'release-pr')) }}
 
     steps:

--- a/.github/workflows/pre-rel-check.yml
+++ b/.github/workflows/pre-rel-check.yml
@@ -41,6 +41,12 @@ jobs:
           toolchain: nightly
           components: rust-src
 
+      - name: Setup cargo-batch
+        run: |
+          if ! command -v cargo-batch &> /dev/null; then
+              cargo install --git https://github.com/embassy-rs/cargo-batch cargo --bin cargo-batch --locked --force
+          fi
+
       - name: init-local-registry
         run: |
           # this example relies on a Cargo.lock file and won't compile after `cargo update` - for now lets remove it


### PR DESCRIPTION
Switch the pre-release check job from ubuntu-latest to the macos-m1-self-hosted runner.