### PR TITLE
Split `release-pr` label into selectable release-check labels

### DIFF
--- a/.github/workflows/changelog-direct-edits.yml
+++ b/.github/workflows/changelog-direct-edits.yml
@@ -14,12 +14,11 @@ permissions:
 
 jobs:
   no-changelog-edits:
-    # Release PRs (labelled `release-pr`) and PRs where the author is taking
-    # full manual control of the changelog (`manual-changelog`) legitimately
-    # modify CHANGELOG.md — skip this check for them.
+    # PRs where the author is taking full manual control of the changelog
+    # (`manual-changelog`, applied to release PRs) legitimately modify
+    # CHANGELOG.md — skip this check for them.
     if: |
       !github.event.pull_request.draft &&
-      !contains(github.event.pull_request.labels.*.name, 'release-pr') &&
       !contains(github.event.pull_request.labels.*.name, 'manual-changelog')
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   setup:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'release-pr')) }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'release:docs')) }}
     # required for this step, as stdout is captured by `hal-xtask release tag-releases`
     env:
       RUST_LOG: off
@@ -78,7 +78,7 @@ jobs:
 
   build:
     needs: setup
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'release-pr')) }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'release:docs')) }}
     strategy:
       fail-fast: true
       matrix:
@@ -134,7 +134,7 @@ jobs:
   assemble:
     needs: [setup, build]
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'release-pr')) }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'release:docs')) }}
 
     steps:
       # Check out the sources, the xtask reads package versions from the Cargo.toml files
@@ -178,7 +178,7 @@ jobs:
           overwrite: true
   docsrs:
     runs-on: ubuntu-latest
-    if: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'release-pr')) }}
+    if: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'release:docs')) }}
     steps:
       - uses: dtolnay/rust-toolchain@v1
         with:

--- a/.github/workflows/pre-rel-check.yml
+++ b/.github/workflows/pre-rel-check.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   check:
     runs-on: macos-m1-self-hosted
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'release-pr')) }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && (contains(github.event.pull_request.labels.*.name, 'release:registry:compile-test') || contains(github.event.pull_request.labels.*.name, 'release:registry:ci'))) }}
 
     steps:
       - uses: actions/checkout@v6
@@ -57,36 +57,38 @@ jobs:
           cargo xrel-check update
           cargo xrel-check replace-path-deps
 
-      - name: try-build
+      # Build the compile-tests against the local registry. This is the cheap smoke
+      # test, so it runs first. Gated on `release:registry:compile-test` so it can be
+      # run independently of the heavier CI build.
+      - name: try-build [compile-tests]
+        if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'release:registry:compile-test') }}
+        shell: bash
+        run: |
+          cargo xtask build examples --toolchain esp --package=compile-tests all --chip=esp32
+          cargo xtask build examples --toolchain esp --package=compile-tests all --chip=esp32s2
+          cargo xtask build examples --toolchain esp --package=compile-tests all --chip=esp32s3
+          cargo xtask build examples --toolchain stable --package=compile-tests all --chip=esp32c2
+          cargo xtask build examples --toolchain stable --package=compile-tests all --chip=esp32c3
+          cargo xtask build examples --toolchain stable --package=compile-tests all --chip=esp32c5
+          cargo xtask build examples --toolchain stable --package=compile-tests all --chip=esp32c6
+          cargo xtask build examples --toolchain stable --package=compile-tests all --chip=esp32c61
+          cargo xtask build examples --toolchain stable --package=compile-tests all --chip=esp32p4
+          cargo xtask build examples --toolchain stable --package=compile-tests all --chip=esp32h2
+
+      # Build the examples/qa-test/tests against the local registry. Gated on
+      # `release:registry:ci` so a release can opt out of this heavy check.
+      - name: try-build [examples/qa-test/tests]
+        if: ${{ github.event_name == 'workflow_dispatch' || contains(github.event.pull_request.labels.*.name, 'release:registry:ci') }}
         shell: bash
         run: |
           # lints and docs are checked a couple of times already by other workflows
           cargo xcheck ci esp32 --toolchain esp --steps=lp-examples,examples,qa-test,tests
-          cargo xtask build examples --toolchain esp --package=compile-tests all --chip=esp32
-
           cargo xcheck ci esp32s2 --toolchain esp --steps=lp-examples,examples,qa-test,tests
-          cargo xtask build examples --toolchain esp --package=compile-tests all --chip=esp32s2
-
           cargo xcheck ci esp32s3 --toolchain esp --steps=lp-examples,examples,qa-test,tests
-          cargo xtask build examples --toolchain esp --package=compile-tests all --chip=esp32s3
-
           cargo xcheck ci esp32c2 --toolchain stable --steps=lp-examples,examples,qa-test,tests
-          cargo xtask build examples --toolchain stable --package=compile-tests all --chip=esp32c2
-
           cargo xcheck ci esp32c3 --toolchain stable --steps=lp-examples,examples,qa-test,tests
-          cargo xtask build examples --toolchain stable --package=compile-tests all --chip=esp32c3
-
           cargo xcheck ci esp32c5 --toolchain stable --steps=lp-examples,examples,qa-test,tests
-          cargo xtask build examples --toolchain stable --package=compile-tests all --chip=esp32c5
-
           cargo xcheck ci esp32c6 --toolchain stable --steps=lp-examples,examples,qa-test,tests
-          cargo xtask build examples --toolchain stable --package=compile-tests all --chip=esp32c6
-
           cargo xcheck ci esp32c61 --toolchain stable --steps=lp-examples,examples,qa-test,tests
-          cargo xtask build examples --toolchain stable --package=compile-tests all --chip=esp32c61
-
           cargo xcheck ci esp32p4 --toolchain stable --steps=lp-examples,examples,qa-test,tests
-          cargo xtask build examples --toolchain stable --package=compile-tests all --chip=esp32p4
-
           cargo xcheck ci esp32h2 --toolchain stable --steps=lp-examples,examples,qa-test,tests
-          cargo xtask build examples --toolchain stable --package=compile-tests all --chip=esp32h2

--- a/xtask/src/commands/release/execute_plan.rs
+++ b/xtask/src/commands/release/execute_plan.rs
@@ -377,7 +377,16 @@ fn commit_message(plan: &Plan) -> String {
 }
 
 const UPSTREAM_REPO: &str = "esp-rs/esp-hal";
-const PR_LABELS: &[&str] = &["release-pr", "skip-changelog"];
+// `manual-changelog` exempts the PR from the direct-CHANGELOG-edit check (the release
+// tooling writes the changelog wholesale). The `release:*` labels each gate an optional,
+// heavy CI workflow; all are applied by default so every check runs, and a maintainer can
+// remove individual ones to skip a check that isn't relevant to the packages being released.
+const PR_LABELS: &[&str] = &[
+    "manual-changelog",
+    "release:docs",
+    "release:registry:compile-test",
+    "release:registry:ci",
+];
 
 fn build_pr_body(plan: &Plan, release_plan_str: &str) -> String {
     let packages = format_package_list(plan);


### PR DESCRIPTION
Replaces the single `release-pr` label with granular, individually-selectable labels (`manual-changelog`, `release:docs`, `release:registry:compile-test`, `release:registry:ci`), all applied by default by `xtask execute-plan`.
A maintainer can now remove an individual label to skip a release-time CI check that is not relevant to the packages being released.
The `pre-rel-check` step is split in two so the cheap compile-test smoke test runs before the heavier examples/qa-test/tests build.