### PR TITLE
I2S `stop` transfer

### DIFF
--- a/esp-hal/src/i2s/master.rs
+++ b/esp-hal/src/i2s/master.rs
@@ -242,10 +242,8 @@ where
     }
 
     /// Waits for the transfer to finish and returns the peripheral and buffer.
-    pub fn wait(mut self) -> (Result<(), DmaError>, I2sTx<'d, Dm>, Buf::Final) {
+    pub fn wait(self) -> (Result<(), DmaError>, I2sTx<'d, Dm>, Buf::Final) {
         while !self.is_done() {}
-        self.completed = true;
-
         self.stop()
     }
 
@@ -293,16 +291,7 @@ where
             self.completed = true;
         }
 
-        self.i2s_tx.tx_channel.stop_transfer();
-        self.i2s_tx.i2s.tx_stop();
-
-        let (i2s_tx, buf) = self.release();
-
-        if i2s_tx.tx_channel.has_error() {
-            (Err(DmaError::DescriptorError), i2s_tx, Buf::from_view(buf))
-        } else {
-            (Ok(()), i2s_tx, Buf::from_view(buf))
-        }
+        self.stop()
     }
 
     /// Waits for the transfer to finish.
@@ -437,16 +426,7 @@ where
             self.completed = true;
         }
 
-        self.i2s_rx.i2s.rx_stop();
-        self.i2s_rx.rx_channel.stop_transfer();
-
-        let (i2s_rx, buf) = self.release();
-
-        if i2s_rx.rx_channel.has_error() {
-            (Err(DmaError::DescriptorError), i2s_rx, Buf::from_view(buf))
-        } else {
-            (Ok(()), i2s_rx, Buf::from_view(buf))
-        }
+        self.stop()
     }
 
     /// Waits for the transfer to finish and returns the peripheral and buffer.

--- a/esp-hal/src/i2s/master.rs
+++ b/esp-hal/src/i2s/master.rs
@@ -244,21 +244,23 @@ where
     /// Waits for the transfer to finish and returns the peripheral and buffer.
     pub fn wait(self) -> (Result<(), DmaError>, I2sTx<'d, Dm>, Buf::Final) {
         while !self.is_done() {}
-        self.stop()
+        let (i2s_tx, buf) = self.stop();
+
+        if i2s_tx.tx_channel.has_error() {
+            (Err(DmaError::DescriptorError), i2s_tx, buf)
+        } else {
+            (Ok(()), i2s_tx, buf)
+        }
     }
 
     /// Immediately stop the transfer and return the peripheral and buffer.
-    pub fn stop(mut self) -> (Result<(), DmaError>, I2sTx<'d, Dm>, Buf::Final) {
+    pub fn stop(mut self) -> (I2sTx<'d, Dm>, Buf::Final) {
         self.i2s_tx.tx_channel.stop_transfer();
         self.i2s_tx.i2s.tx_stop();
 
         let (i2s_tx, buf) = self.release();
 
-        if i2s_tx.tx_channel.has_error() {
-            (Err(DmaError::DescriptorError), i2s_tx, Buf::from_view(buf))
-        } else {
-            (Ok(()), i2s_tx, Buf::from_view(buf))
-        }
+        (i2s_tx, Buf::from_view(buf))
     }
 
     fn release(mut self) -> (I2sTx<'d, Dm>, Buf::View) {
@@ -291,7 +293,13 @@ where
             self.completed = true;
         }
 
-        self.stop()
+        let (i2s_tx, buf) = self.stop();
+
+        if i2s_tx.tx_channel.has_error() {
+            (Err(DmaError::DescriptorError), i2s_tx, buf)
+        } else {
+            (Ok(()), i2s_tx, buf)
+        }
     }
 
     /// Waits for the transfer to finish.
@@ -372,21 +380,22 @@ where
     pub fn wait(self) -> (Result<(), DmaError>, I2sRx<'d, Dm>, Buf::Final) {
         while !self.is_done() {}
 
-        self.stop()
+        let (i2s_rx, buf) = self.stop();
+
+        if i2s_rx.rx_channel.has_error() {
+            (Err(DmaError::DescriptorError), i2s_rx, buf)
+        } else {
+            (Ok(()), i2s_rx, buf)
+        }
     }
 
     /// Immediately stop the transfer and return the peripheral and buffer.
-    pub fn stop(mut self) -> (Result<(), DmaError>, I2sRx<'d, Dm>, Buf::Final) {
+    pub fn stop(mut self) -> (I2sRx<'d, Dm>, Buf::Final) {
         self.i2s_rx.i2s.rx_stop();
         self.i2s_rx.rx_channel.stop_transfer();
 
         let (i2s_rx, buf) = self.release();
-
-        if i2s_rx.rx_channel.has_error() {
-            (Err(DmaError::DescriptorError), i2s_rx, Buf::from_view(buf))
-        } else {
-            (Ok(()), i2s_rx, Buf::from_view(buf))
-        }
+        (i2s_rx, Buf::from_view(buf))
     }
 
     fn release(mut self) -> (I2sRx<'d, Dm>, Buf::View) {
@@ -426,7 +435,13 @@ where
             self.completed = true;
         }
 
-        self.stop()
+        let (i2s_rx, buf) = self.stop();
+
+        if i2s_rx.rx_channel.has_error() {
+            (Err(DmaError::DescriptorError), i2s_rx, buf)
+        } else {
+            (Ok(()), i2s_rx, buf)
+        }
     }
 
     /// Waits for the transfer to finish and returns the peripheral and buffer.

--- a/esp-hal/src/i2s/master.rs
+++ b/esp-hal/src/i2s/master.rs
@@ -246,6 +246,11 @@ where
         while !self.is_done() {}
         self.completed = true;
 
+        self.stop()
+    }
+
+    /// Immediately stop the transfer and return the peripheral and buffer.
+    pub fn stop(mut self) -> (Result<(), DmaError>, I2sTx<'d, Dm>, Buf::Final) {
         self.i2s_tx.tx_channel.stop_transfer();
         self.i2s_tx.i2s.tx_stop();
 
@@ -375,9 +380,14 @@ where
     }
 
     /// Waits for the transfer to finish and returns the peripheral and buffer.
-    pub fn wait(mut self) -> (Result<(), DmaError>, I2sRx<'d, Dm>, Buf::Final) {
+    pub fn wait(self) -> (Result<(), DmaError>, I2sRx<'d, Dm>, Buf::Final) {
         while !self.is_done() {}
 
+        self.stop()
+    }
+
+    /// Immediately stop the transfer and return the peripheral and buffer.
+    pub fn stop(mut self) -> (Result<(), DmaError>, I2sRx<'d, Dm>, Buf::Final) {
         self.i2s_rx.i2s.rx_stop();
         self.i2s_rx.rx_channel.stop_transfer();
 

--- a/hil-test/src/bin/i2s.rs
+++ b/hil-test/src/bin/i2s.rs
@@ -213,6 +213,7 @@ mod tests {
         .unwrap();
 
         let (din, dout) = unsafe { ctx.dout.split() };
+        let mut counter = super::EdgeCounter::new(din.clone());
 
         let i2s_tx = i2s
             .i2s_tx
@@ -312,6 +313,15 @@ mod tests {
                 break;
             }
         }
+
+        // test that stop works for streaming transfers
+        let _ = tx_transfer.stop();
+        let _ = rx_transfer.stop();
+
+        // check that at least TX actually stopped emitting pulses
+        counter.clear();
+        esp_hal::delay::Delay::new().delay_millis(20);
+        counter.check(0);
     }
 
     #[test]


### PR DESCRIPTION
Closes #3285 

# Changelog

## esp-hal

- Added: Added `stop` method to `I2sTxDmaTransfer` and `I2sRxDmaTransfer` to immediately abort transfers and return peripheral/buffers.

