### PR TITLE
Enable semver checking for esp-radio

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,9 +91,11 @@ jobs:
           BUILD=true; DOCS=true; MSRV=true; HOST=true; EXTRAS=true
           HIL=true; CHANGELOG=true; SEMVER=true
 
+          # `skip-ci-non-code-change` only skips building/testing; API checks (semver) still run.
+          # Use the dedicated `skip-semver-checks` label to skip semver checks.
           if echo "$LABELS" | grep -qw 'skip-ci-non-code-change'; then
             BUILD=false; DOCS=false; MSRV=false; HOST=false; EXTRAS=false
-            HIL=false; SEMVER=false
+            HIL=false
           fi
           if echo "$LABELS" | grep -qw 'skip-semver-checks'; then SEMVER=false; fi
           if echo "$LABELS" | grep -qw 'skip-changelog'; then CHANGELOG=false; fi

--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/esp-rs/esp-hal"
 license = "MIT OR Apache-2.0"
 
 [package.metadata.espressif]
+semver-checked = true
 doc-config = { features = ["esp-hal/unstable", "esp-hal/rt", "esp-alloc/global-allocator", "procmacros/__esp_idf_bootloader", "defmt"], append = [
     { if = 'chip_has("wifi_driver_supported")', features = ["wifi", "wifi-eap", "esp-now", "sniffer"] },
     { if = 'chip_has("wifi_driver_supported") && chip_has("wifi_csi_supported")', features = ["csi"] },
@@ -18,6 +19,9 @@ doc-config = { features = ["esp-hal/unstable", "esp-hal/rt", "esp-alloc/global-a
     { if = 'chip_has("ieee802154_driver_supported")', features = ["ieee802154", "__docs_build"] },
     { if = 'chip_has("wifi_driver_supported") && chip_has("bt_driver_supported")', features = ["coex"] },
     { if = 'chip_has("wifi_driver_supported") || chip_has("bt_driver_supported") || chip_has("ieee802154_driver_supported")', features = ["unstable"] },
+] }
+semver-config = { features = ["esp-hal/rt"], append = [
+    { if = 'chip_has("wifi_driver_supported")', features = ["wifi"] },
 ] }
 check-configs = [
     { features = ["esp-hal/rt"] },

--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -20,8 +20,15 @@ doc-config = { features = ["esp-hal/unstable", "esp-hal/rt", "esp-alloc/global-a
     { if = 'chip_has("wifi_driver_supported") && chip_has("bt_driver_supported")', features = ["coex"] },
     { if = 'chip_has("wifi_driver_supported") || chip_has("bt_driver_supported") || chip_has("ieee802154_driver_supported")', features = ["unstable"] },
 ] }
-semver-config = { features = ["esp-hal/rt"], append = [
-    { if = 'chip_has("wifi_driver_supported")', features = ["wifi"] },
+# Mirrors `doc-config`: the semver baseline is built with `cargo rustdoc`, which needs the same
+# feature set so feature-gated intra-doc links (e.g. `WifiController::esp_now`) resolve.
+semver-config = { features = ["esp-hal/unstable", "esp-hal/rt", "esp-alloc/global-allocator", "procmacros/__esp_idf_bootloader", "defmt"], append = [
+    { if = 'chip_has("wifi_driver_supported")', features = ["wifi", "wifi-eap", "esp-now", "sniffer"] },
+    { if = 'chip_has("wifi_driver_supported") && chip_has("wifi_csi_supported")', features = ["csi"] },
+    { if = 'chip_has("bt_driver_supported")', features = ["ble"] },
+    { if = 'chip_has("ieee802154_driver_supported")', features = ["ieee802154", "__docs_build"] },
+    { if = 'chip_has("wifi_driver_supported") && chip_has("bt_driver_supported")', features = ["coex"] },
+    { if = 'chip_has("wifi_driver_supported") || chip_has("bt_driver_supported") || chip_has("ieee802154_driver_supported")', features = ["unstable"] },
 ] }
 check-configs = [
     { features = ["esp-hal/rt"] },

--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -20,15 +20,12 @@ doc-config = { features = ["esp-hal/unstable", "esp-hal/rt", "esp-alloc/global-a
     { if = 'chip_has("wifi_driver_supported") && chip_has("bt_driver_supported")', features = ["coex"] },
     { if = 'chip_has("wifi_driver_supported") || chip_has("bt_driver_supported") || chip_has("ieee802154_driver_supported")', features = ["unstable"] },
 ] }
-# Mirrors `doc-config`: the semver baseline is built with `cargo rustdoc`, which needs the same
-# feature set so feature-gated intra-doc links (e.g. `WifiController::esp_now`) resolve.
-semver-config = { features = ["esp-hal/unstable", "esp-hal/rt", "esp-alloc/global-allocator", "procmacros/__esp_idf_bootloader", "defmt"], append = [
-    { if = 'chip_has("wifi_driver_supported")', features = ["wifi", "wifi-eap", "esp-now", "sniffer"] },
-    { if = 'chip_has("wifi_driver_supported") && chip_has("wifi_csi_supported")', features = ["csi"] },
-    { if = 'chip_has("bt_driver_supported")', features = ["ble"] },
-    { if = 'chip_has("ieee802154_driver_supported")', features = ["ieee802154", "__docs_build"] },
-    { if = 'chip_has("wifi_driver_supported") && chip_has("bt_driver_supported")', features = ["coex"] },
-    { if = 'chip_has("wifi_driver_supported") || chip_has("bt_driver_supported") || chip_has("ieee802154_driver_supported")', features = ["unstable"] },
+# Semver guarantees cover only the stable API, so the `unstable` feature is left OFF: the
+# `instability_disable_unstable_docs` escape (set in `build_doc_json`) then drops all
+# `#[instability::unstable]` items from the baseline. `wifi` is the only radio feature that
+# does not pull in `unstable`.
+semver-config = { features = ["esp-hal/rt", "esp-alloc/global-allocator", "procmacros/__esp_idf_bootloader", "defmt"], append = [
+    { if = 'chip_has("wifi_driver_supported")', features = ["wifi"] },
 ] }
 check-configs = [
     { features = ["esp-hal/rt"] },

--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -2264,7 +2264,16 @@ impl Drop for WifiController<'_> {
 }
 
 impl<'d> WifiController<'d> {
-    #[procmacros::doc_replace]
+    #[procmacros::doc_replace(
+        "esp_now" => {
+            cfg(all(feature = "esp-now", feature = "unstable")) => "An ESP-NOW instance is available through the controller's [`WifiController::esp_now()`] method.",
+            _ => "",
+        },
+        "sniffer" => {
+            cfg(all(feature = "sniffer", feature = "unstable")) => "A sniffer instance is available through the controller's [`WifiController::sniffer()`] method.",
+            _ => "",
+        },
+    )]
     /// Create a Wi-Fi controller. The default initial configuration is
     /// [`Config::Station`]`(`[`StationConfig::default()`]`)`.
     ///
@@ -2272,10 +2281,9 @@ impl<'d> WifiController<'d> {
     ///
     /// Create [`Interface`]s separately via [`Interface::station()`] /
     /// [`Interface::access_point()`].
-    #[cfg_attr(
-        feature = "unstable",
-        doc = "ESP-NOW and sniffer instances are available through the controller's [`WifiController::esp_now()`] and [`WifiController::sniffer()`] methods."
-    )]
+    /// # {esp_now}
+    /// # {sniffer}
+    ///
     /// Make sure to **not** call this function while interrupts are disabled, or IEEE 802.15.4 is
     /// currently in use.
     ///

--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -2276,7 +2276,6 @@ impl<'d> WifiController<'d> {
         feature = "unstable",
         doc = "ESP-NOW and sniffer instances are available through the controller's [`WifiController::esp_now()`] and [`WifiController::sniffer()`] methods."
     )]
-    ///
     /// Make sure to **not** call this function while interrupts are disabled, or IEEE 802.15.4 is
     /// currently in use.
     ///

--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -2271,9 +2271,11 @@ impl<'d> WifiController<'d> {
     /// Dropping the controller will deinitialize / stop Wi-Fi.
     ///
     /// Create [`Interface`]s separately via [`Interface::station()`] /
-    /// [`Interface::access_point()`]. ESP-NOW and sniffer instances are
-    /// available through the controller's [`WifiController::esp_now()`] and
-    /// [`WifiController::sniffer()`] methods.
+    /// [`Interface::access_point()`].
+    #[cfg_attr(
+        feature = "unstable",
+        doc = "ESP-NOW and sniffer instances are available through the controller's [`WifiController::esp_now()`] and [`WifiController::sniffer()`] methods."
+    )]
     ///
     /// Make sure to **not** call this function while interrupts are disabled, or IEEE 802.15.4 is
     /// currently in use.

--- a/xtask/src/commands/release/semver_check.rs
+++ b/xtask/src/commands/release/semver_check.rs
@@ -90,6 +90,10 @@ pub mod checker {
             log::info!("Generating API baseline for {package}");
 
             for chip in &chips {
+                if !package.supports_chip(*chip) {
+                    log::info!("Skipping unsupported chip {chip} for {package}");
+                    continue;
+                }
                 log::info!("Chip = {}", chip.to_string());
                 let package_name = package.to_string();
                 let package_path = crate::windows_safe_path(&workspace.join(&package_name));
@@ -149,6 +153,9 @@ pub mod checker {
 
         let mut highest_result = ReleaseType::Patch;
         for chip in chips {
+            if !package.supports_chip(*chip) {
+                continue;
+            }
             let result = minimum_update(workspace, package, *chip)?;
 
             if result == ReleaseType::Major {

--- a/xtask/src/commands/release/semver_check.rs
+++ b/xtask/src/commands/release/semver_check.rs
@@ -22,7 +22,7 @@ pub struct SemverCheckArgs {
     pub command: SemverCheckCmd,
 
     /// Package(s) to target.
-    #[arg(long, value_enum, value_delimiter = ',', default_values_t = vec![Package::EspHal, Package::EspRomSys])]
+    #[arg(long, value_enum, value_delimiter = ',', default_values_t = vec![Package::EspHal, Package::EspRomSys, Package::EspRadio])]
     pub packages: Vec<Package>,
 
     /// Default packages that are not supposed to run, used in CI.


### PR DESCRIPTION
Now that esp-radio 1.0 beta is out, this marks it `semver-checked` and adds it to the default semver-check package set, with a `semver-config` (`esp-hal/rt` + chip-conditional `wifi`) so the doc-JSON builds. A baseline artifact must be generated (dispatch `api-baseline-generation.yml` with `package_name=esp-radio`) before CI's download+check will pass.