### PR TITLE
ci: correlate dispatched runs with a unique marker

### DIFF
--- a/.github/scripts/hil-find-run.js
+++ b/.github/scripts/hil-find-run.js
@@ -1,44 +1,71 @@
-async function findHilRun({
+// Correlating a workflow we just dispatched with its actual run.
+//
+// GitHub's `workflow_dispatch` REST API returns 204 No Content with **no run
+// id**, so the dispatcher cannot learn which run it created from the API
+// response. Matching on the run *title* alone is ambiguous: a previous dispatch
+// for the same PR/chips produces an identical title, so an hour-old run can be
+// returned as if it were the one we just triggered.
+//
+// To make the correlation exact, the dispatcher passes a unique `distinct_id`
+// input, and the dispatched workflow embeds it into its `run-name` via the
+// marker below. We then poll for the (single) run whose title contains that
+// marker.
+function dispatchMarker(distinctId) {
+  const id = String(distinctId ?? '').trim();
+  if (!id) {
+    // An empty id would produce `[dispatch-id: ]`, which correlates nothing.
+    // Fail loudly so a misconfigured dispatcher is obvious rather than silently
+    // never matching.
+    throw new Error('dispatchMarker: a non-empty distinctId is required');
+  }
+  return `[dispatch-id: ${id}]`;
+}
+
+// Poll the workflow's recent dispatch runs until one carries our marker.
+async function findDispatchedRun({
   github,
   context,
-  pr,
-  selector,
-  tests = '',
-  attempts = 10,
+  workflowId,
+  distinctId,
+  attempts = 20,
   delayMs = 3000,
 }) {
   const { owner, repo } = context.repo;
-  const tests_trimmed = String(tests || '').trim();
-
-  const expectedTitle = tests_trimmed
-    ? `HIL for PR #${pr} (${selector}; tests: ${tests_trimmed})`
-    : `HIL for PR #${pr} (${selector})`;
-
+  const marker = dispatchMarker(distinctId);
   const delay = (ms) => new Promise((r) => setTimeout(r, ms));
-  let run = null;
 
-  // Poll multiple times; keep the *last* matching run we see
   for (let attempt = 1; attempt <= attempts; attempt++) {
     const { data } = await github.rest.actions.listWorkflowRuns({
       owner,
       repo,
-      workflow_id: 'hil.yml',
+      workflow_id: workflowId,
       event: 'workflow_dispatch',
       per_page: 50,
     });
 
-    if (data.workflow_runs && data.workflow_runs.length > 0) {
-      const candidate = data.workflow_runs.find(r =>
-        (r.display_title && r.display_title.trim() === expectedTitle) ||
-        (r.name && r.name.trim() === expectedTitle)
-      );
-      // Keep the *last* matching run we see across all attempts
-      if (candidate) {
-        run = candidate;
-      }
-    }
-    await delay(delayMs);
+    const run = (data.workflow_runs || []).find(
+      (r) =>
+        (r.display_title && r.display_title.includes(marker)) ||
+        (r.name && r.name.includes(marker))
+    );
+
+    if (run) return run;
+
+    // The run we just dispatched may not be visible yet; wait and retry.
+    // Don't sleep after the final check.
+    if (attempt < attempts) await delay(delayMs);
   }
+
+  return null;
+}
+
+async function findHilRun({ github, context, pr, selector, distinctId }) {
+  const run = await findDispatchedRun({
+    github,
+    context,
+    workflowId: 'hil.yml',
+    distinctId,
+  });
 
   const isMatrix = selector === 'quick' || selector === 'full';
 
@@ -55,4 +82,4 @@ async function findHilRun({
   return { runId: run?.id ? String(run.id) : '', body };
 }
 
-module.exports = { findHilRun };
+module.exports = { findHilRun, findDispatchedRun, dispatchMarker };

--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -1,6 +1,10 @@
 name: Binary Size Analysis
 
-run-name: Binary size for PR
+run-name: >-
+  ${{ format('Binary size for PR #{0}{1}',
+      inputs.pr_number,
+      inputs.distinct_id != '' && format(' [dispatch-id: {0}]', inputs.distinct_id) || ''
+  ) }}
 
 on:
   workflow_dispatch:
@@ -24,6 +28,11 @@ on:
         type: string
       comment_id:
         description: "Comment ID to update with binary size results"
+        required: false
+        default: ""
+        type: string
+      distinct_id:
+        description: "Correlation marker set by the dispatcher; do not set manually"
         required: false
         default: ""
         type: string

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -13,6 +13,12 @@ permissions:
   pull-requests: write
   contents: read
 
+# Unique marker correlating a dispatched run with this dispatcher invocation.
+# The dispatch step and its matching find-run step MUST use the same value, so
+# define it once here rather than repeating the expression at every call site.
+env:
+  DISTINCT_ID: ${{ github.run_id }}-${{ github.run_attempt }}
+
 jobs:
   # ---------------------------------------------------------------------------
   # LABEL: TRUSTED AUTHOR
@@ -269,7 +275,8 @@ jobs:
               "pr_number": "${{ github.event.issue.number }}",
               "chips": "esp32c6 esp32s3",
               "tests": "${{ steps.parse-tests.outputs.tests }}",
-              "package": "${{ steps.parse-tests.outputs.package }}"
+              "package": "${{ steps.parse-tests.outputs.package }}",
+              "distinct_id": "${{ env.DISTINCT_ID }}"
             }
 
       - name: Find HIL run URL (quick)
@@ -284,7 +291,7 @@ jobs:
               context,
               pr: context.payload.issue.number,
               selector: 'quick',
-              tests: '${{ steps.parse-tests.outputs.tests }}',
+              distinctId: '${{ env.DISTINCT_ID }}',
             });
 
             core.setOutput('run_id', runId);
@@ -359,7 +366,8 @@ jobs:
               "pr_number": "${{ github.event.issue.number }}",
               "chips": "esp32 esp32s2 esp32s3 esp32c2 esp32c3 esp32c5 esp32c6 esp32c61 esp32h2 esp32p4",
               "tests": "${{ steps.parse-tests.outputs.tests }}",
-              "package": "${{ steps.parse-tests.outputs.package }}"
+              "package": "${{ steps.parse-tests.outputs.package }}",
+              "distinct_id": "${{ env.DISTINCT_ID }}"
             }
 
       - name: Find HIL run URL (full)
@@ -374,7 +382,7 @@ jobs:
               context,
               pr: context.payload.issue.number,
               selector: 'full',
-              tests: '${{ steps.parse-tests.outputs.tests }}',
+              distinctId: '${{ env.DISTINCT_ID }}',
             });
 
             core.setOutput('run_id', runId);
@@ -475,7 +483,8 @@ jobs:
               "pr_number": "${{ github.event.issue.number }}",
               "chips": "${{ steps.parse.outputs.chips }}",
               "tests": "${{ steps.parse-tests.outputs.tests }}",
-              "package": "${{ steps.parse-tests.outputs.package }}"
+              "package": "${{ steps.parse-tests.outputs.package }}",
+              "distinct_id": "${{ env.DISTINCT_ID }}"
             }
 
       - name: Find HIL run URL (per-chip)
@@ -491,7 +500,7 @@ jobs:
               context,
               pr: context.payload.issue.number,
               selector: '${{ steps.parse.outputs.chips }}',
-              tests: '${{ steps.parse-tests.outputs.tests }}',
+              distinctId: '${{ env.DISTINCT_ID }}',
             });
 
             core.setOutput('run_id', runId);
@@ -588,6 +597,10 @@ jobs:
       startsWith(github.event.comment.body, '/test-size')
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4 # for `require`
+        with:
+          fetch-depth: 1
+
       - name: Extract parameters from comment
         id: extract
         run: |
@@ -665,12 +678,27 @@ jobs:
             Results will be posted as a comment when ready.
 
       - name: Dispatch Binary Size Analysis
-        id: dispatch
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: binary-size.yml
           ref: ${{ github.event.repository.default_branch }}
-          inputs: '{"pr_number":"${{ github.event.issue.number }}","comment_id":"${{ steps.comment.outputs.comment-id }}","example_name":"${{ steps.extract.outputs.example_name }}","package":"${{ steps.extract.outputs.package }}","chips":"${{ steps.extract.outputs.chips_escaped }}"}'
+          inputs: '{"pr_number":"${{ github.event.issue.number }}","comment_id":"${{ steps.comment.outputs.comment-id }}","example_name":"${{ steps.extract.outputs.example_name }}","package":"${{ steps.extract.outputs.package }}","chips":"${{ steps.extract.outputs.chips_escaped }}","distinct_id":"${{ env.DISTINCT_ID }}"}'
+
+      - name: Find binary size run URL
+        id: find-run
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { findDispatchedRun } = require('./.github/scripts/hil-find-run.js');
+
+            const run = await findDispatchedRun({
+              github,
+              context,
+              workflowId: 'binary-size.yml',
+              distinctId: '${{ env.DISTINCT_ID }}',
+            });
+
+            core.setOutput('url', run?.html_url || '');
 
       - name: Add run URL to comment
         uses: peter-evans/create-or-update-comment@v4
@@ -680,5 +708,5 @@ jobs:
             Triggered **binary size analysis** for #${{ github.event.issue.number }}
             (example: `${{ steps.extract.outputs.example_name }}`, chips: `${{ steps.extract.outputs.chips }}`).
 
-            Run: ${{ steps.dispatch.outputs.runUrlHtml }}
+            Run: ${{ steps.find-run.outputs.url != '' && steps.find-run.outputs.url || 'could not be determined yet; check the Binary Size Analysis workflow runs manually.' }}
           edit-mode: replace

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -1,22 +1,12 @@
 name: HIL
 
-run-name: >
-  ${{ inputs.pr_number != '' &&
-      format(
-        'HIL for PR #{0} ({1}{2}{3})',
-        inputs.pr_number,
-        inputs.chips,
-        inputs.tests != '' && format('; tests: {0}', inputs.tests) || '',
-        inputs.package != '' && inputs.package != 'all' && format('; package: {0}', inputs.package) || ''
-      ) ||
-
-      format(
-        'HIL ({0}{1}{2})',
-        inputs.chips,
-        inputs.tests != '' && format('; tests: {0}', inputs.tests) || '',
-        inputs.package != '' && inputs.package != 'all' && format('; package: {0}', inputs.package) || ''
-      )
-  }}
+run-name: >-
+  ${{ format('{0}{1}',
+      inputs.pr_number != '' &&
+        format('HIL for PR #{0} ({1}{2}{3})', inputs.pr_number, inputs.chips, inputs.tests != '' && format('; tests: {0}', inputs.tests) || '', inputs.package != '' && inputs.package != 'all' && format('; package: {0}', inputs.package) || '') ||
+        format('HIL ({0}{1}{2})', inputs.chips, inputs.tests != '' && format('; tests: {0}', inputs.tests) || '', inputs.package != '' && inputs.package != 'all' && format('; package: {0}', inputs.package) || ''),
+      inputs.distinct_id != '' && format(' [dispatch-id: {0}]', inputs.distinct_id) || ''
+  ) }}
 
 on:
   workflow_call:
@@ -35,6 +25,17 @@ on:
         required: false
         type: string
         default: "all"
+      # Not used by the workflow_call path, but referenced in run-name; declared
+      # here (with empty defaults) so that expression is well-defined for both
+      # triggers.
+      pr_number:
+        required: false
+        type: string
+        default: ""
+      distinct_id:
+        required: false
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       repository:
@@ -60,6 +61,10 @@ on:
       package:
         description: '"hil-test", "hil-test-radio", or "all"'
         default: "all"
+      distinct_id:
+        description: "Correlation marker set by the dispatcher; do not set manually"
+        required: false
+        default: ""
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Dispatched HIL/binary-size runs were matched to their dispatch by run title, which is ambiguous (a stale run with the same title could match) and never matched at all for `/hil quick` and `/hil full`. This passes a unique dispatch-id into each dispatched run, embeds it in the run-name, and matches on that marker instead.