### PR TITLE
HIL: Add basic BLE test

### DIFF
--- a/hil-test-radio/Cargo.toml
+++ b/hil-test-radio/Cargo.toml
@@ -19,11 +19,25 @@ harness           = false
 required-features = ["esp-alloc"]
 path              = "src/bin/support/wifi_ap_support.rs"
 
+[[bin]]
+name              = "ble"
+harness           = false
+required-features = ["esp-alloc"]
+path              = "src/bin/tests/ble.rs"
+
+[[bin]]
+name              = "ble_peripheral_support"
+harness           = false
+required-features = ["esp-alloc"]
+path              = "src/bin/support/ble_peripheral_support.rs"
+
 [dependencies]
 cfg-if             = "1"
 defmt              = "1.0.1"
 defmt-rtt          = { version = "1.0.0", optional = true }
 embassy-executor   = { version = "0.10.0", default-features = false }
+embassy-futures    = "0.1"
+embassy-sync       = "0.7"
 embassy-time       = "0.5.0"
 embedded-io        = "0.7.1"
 embedded-io-async  = "0.7.0"
@@ -50,6 +64,14 @@ reqwless = { version = "0.14.0", default-features = false }
 edge-dhcp = "0.7.0"
 edge-nal = "0.6.0"
 edge-nal-embassy = "0.8.1"
+trouble-host = { version = "0.6.0", default-features = false, features = [
+    "central",
+    "default-packet-pool-mtu-255",
+    "derive",
+    "gatt",
+    "peripheral",
+    "scan",
+] }
 
 [build-dependencies]
 esp-metadata-generated = { path = "../esp-metadata-generated", features = ["build-script"] }

--- a/hil-test-radio/src/bin/support/ble_peripheral_support.rs
+++ b/hil-test-radio/src/bin/support/ble_peripheral_support.rs
@@ -1,0 +1,168 @@
+//% CHIP_FILTER(has_wifi_ble): esp32c6
+//% SUPPORT-FIRMWARE: true
+//% FEATURES: unstable esp-alloc embassy
+//% FEATURES(has_wifi_ble): esp-radio/ble esp-radio esp-radio-unstable
+//% FEATURES(has_wifi_ble): esp-radio/defmt defmt
+//% ENV: ESP_HAL_CONFIG_STACK_GUARD_OFFSET=4
+
+#![no_std]
+#![no_main]
+
+use embassy_executor::Spawner;
+use embassy_futures::join::join;
+use embassy_time::{Duration, Timer};
+use esp_hal::{
+    clock::CpuClock,
+    interrupt::software::SoftwareInterruptControl,
+    timer::timg::TimerGroup,
+};
+use esp_radio::ble::controller::BleConnector;
+use hil_test as _;
+use semihosting as _;
+use trouble_host::prelude::*;
+
+extern crate alloc;
+
+const PERIPHERAL_ADDRESS: [u8; 6] = [0xff, 0x48, 0x49, 0x4c, 0x42, 0xff];
+const DEVICE_NAME: &str = "HIL BAS";
+const INITIAL_BATTERY_LEVEL: u8 = 12;
+
+#[gatt_server]
+struct Server {
+    battery_service: BatteryService,
+}
+
+#[gatt_service(uuid = service::BATTERY)]
+struct BatteryService {
+    #[descriptor(uuid = descriptors::VALID_RANGE, read, value = [0, 100])]
+    #[descriptor(uuid = descriptors::MEASUREMENT_DESCRIPTION, read, value = "Battery Level")]
+    #[characteristic(uuid = characteristic::BATTERY_LEVEL, read, value = INITIAL_BATTERY_LEVEL)]
+    level: u8,
+}
+
+fn init_heap() {
+    cfg_if::cfg_if! {
+        if #[cfg(any(esp32, esp32s2, esp32s3, esp32c3, esp32c2, esp32c6))] {
+            use esp_hal::ram;
+            esp_alloc::heap_allocator!(#[ram(reclaimed)] size: 64 * 1024);
+            esp_alloc::heap_allocator!(size: 36 * 1024);
+        } else if #[cfg(any(esp32c5, esp32h2))] {
+            esp_alloc::heap_allocator!(size: 72 * 1024);
+        }
+    }
+}
+
+#[esp_hal::main]
+async fn main(_spawner: Spawner) {
+    init_heap();
+
+    let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
+    let p = esp_hal::init(config);
+
+    let timg0 = TimerGroup::new(p.TIMG0);
+    let sw_ints = SoftwareInterruptControl::new(p.SW_INTERRUPT);
+    esp_rtos::start(timg0.timer0, sw_ints.software_interrupt0);
+
+    let connector = BleConnector::new(p.BT, Default::default()).unwrap();
+    let controller: ExternalController<_, 1> = ExternalController::new(connector);
+
+    run_peripheral(controller).await;
+}
+
+async fn run_peripheral<C>(controller: C)
+where
+    C: Controller,
+{
+    let address = Address::random(PERIPHERAL_ADDRESS);
+    defmt::info!("[BLE-SUPPORT] address configured");
+
+    let mut resources: HostResources<DefaultPacketPool, 1, 2> = HostResources::new();
+    let stack = trouble_host::new(controller, &mut resources).set_random_address(address);
+    let Host {
+        mut peripheral,
+        runner,
+        ..
+    } = stack.build();
+    let server = Server::new_with_config(GapConfig::Peripheral(PeripheralConfig {
+        name: DEVICE_NAME,
+        appearance: &appearance::power_device::GENERIC_POWER_DEVICE,
+    }))
+    .unwrap();
+
+    let _ = join(ble_task(runner), async {
+        loop {
+            match advertise(&mut peripheral, &server).await {
+                Ok(conn) => {
+                    defmt::info!("[BLE-SUPPORT] connected");
+                    gatt_events_task(&server, &conn).await;
+                    defmt::info!("[BLE-SUPPORT] disconnected");
+                }
+                Err(_) => Timer::after(Duration::from_millis(100)).await,
+            }
+        }
+    })
+    .await;
+}
+
+async fn ble_task<C: Controller, P: PacketPool>(mut runner: Runner<'_, C, P>) {
+    loop {
+        if runner.run().await.is_err() {
+            defmt::warn!("[BLE-SUPPORT] runner stopped");
+            Timer::after(Duration::from_millis(100)).await;
+        }
+    }
+}
+
+async fn advertise<'values, 'server, C>(
+    peripheral: &mut Peripheral<'values, C, DefaultPacketPool>,
+    server: &'server Server<'values>,
+) -> Result<GattConnection<'values, 'server, DefaultPacketPool>, BleHostError<C::Error>>
+where
+    C: Controller,
+{
+    let mut adv_data = [0; 31];
+    let len = AdStructure::encode_slice(
+        &[
+            AdStructure::Flags(LE_GENERAL_DISCOVERABLE | BR_EDR_NOT_SUPPORTED),
+            AdStructure::ServiceUuids16(&[[0x0f, 0x18]]),
+            AdStructure::CompleteLocalName(DEVICE_NAME.as_bytes()),
+        ],
+        &mut adv_data,
+    )?;
+
+    let advertiser = peripheral
+        .advertise(
+            &Default::default(),
+            Advertisement::ConnectableScannableUndirected {
+                adv_data: &adv_data[..len],
+                scan_data: &[],
+            },
+        )
+        .await?;
+
+    defmt::info!("[BLE-SUPPORT] advertising");
+    Ok(advertiser.accept().await?.with_attribute_server(server)?)
+}
+
+async fn gatt_events_task<P: PacketPool>(server: &Server<'_>, conn: &GattConnection<'_, '_, P>) {
+    let level = server.battery_service.level;
+
+    loop {
+        match conn.next().await {
+            GattConnectionEvent::Disconnected { .. } => break,
+            GattConnectionEvent::Gatt { event } => {
+                if let GattEvent::Read(event) = &event
+                    && event.handle() == level.handle
+                {
+                    defmt::info!("[BLE-SUPPORT] battery level read");
+                }
+
+                match event.accept() {
+                    Ok(reply) => reply.send().await,
+                    Err(_) => defmt::warn!("[BLE-SUPPORT] failed to accept GATT event"),
+                }
+            }
+            _ => {}
+        }
+    }
+}

--- a/hil-test-radio/src/bin/tests/ble.rs
+++ b/hil-test-radio/src/bin/tests/ble.rs
@@ -1,0 +1,161 @@
+//! BLE HIL tests.
+//!
+//! The support firmware is a BLE peripheral; this test binary acts as the
+//! central device and validates that scanning and connection establishment work
+//! against real peer hardware.
+
+//% CHIP_FILTER(has_wifi_ble): esp32c6
+//% HARNESS-FIRMWARE(has_wifi_ble): ble_peripheral_support
+
+//% FEATURES: unstable esp-alloc embassy
+//% FEATURES(has_wifi_ble): esp-radio/ble esp-radio esp-radio-unstable
+//% FEATURES(has_wifi_ble): esp-radio/defmt defmt
+
+//% ENV: ESP_HAL_CONFIG_STACK_GUARD_OFFSET=4
+
+#![no_std]
+#![no_main]
+
+use hil_test as _;
+
+extern crate alloc;
+
+const PERIPHERAL_ADDRESS: [u8; 6] = [0xff, 0x48, 0x49, 0x4c, 0x42, 0xff];
+const BATTERY_SERVICE_UUID: u16 = 0x180f;
+const BATTERY_LEVEL_UUID: u16 = 0x2a19;
+
+fn init_heap() {
+    cfg_if::cfg_if! {
+        if #[cfg(any(esp32, esp32s2, esp32s3, esp32c3, esp32c2, esp32c6))] {
+            use esp_hal::ram;
+            esp_alloc::heap_allocator!(#[ram(reclaimed)] size: 64 * 1024);
+            esp_alloc::heap_allocator!(size: 36 * 1024);
+        } else if #[cfg(any(esp32c5, esp32h2))] {
+            esp_alloc::heap_allocator!(size: 72 * 1024);
+        }
+    }
+}
+
+#[embedded_test::tests(default_timeout = 30, executor = esp_rtos::embassy::Executor::new())]
+mod tests {
+    use embassy_futures::select::select;
+    use embassy_time::{Duration, Timer, with_timeout};
+    use esp_hal::{
+        clock::CpuClock,
+        interrupt::software::SoftwareInterruptControl,
+        peripherals::Peripherals,
+        timer::timg::TimerGroup,
+    };
+    use esp_radio::ble::controller::BleConnector;
+    use trouble_host::prelude::*;
+
+    #[init]
+    fn init() -> Peripherals {
+        crate::init_heap();
+
+        let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
+        esp_hal::init(config)
+    }
+
+    #[test]
+    async fn ble_central_connects_to_peripheral(p: Peripherals) {
+        defmt::info!("[BLE-CENTRAL] starting BLE central connect test");
+
+        let timg0 = TimerGroup::new(p.TIMG0);
+        let sw_ints = SoftwareInterruptControl::new(p.SW_INTERRUPT);
+        esp_rtos::start(timg0.timer0, sw_ints.software_interrupt0);
+
+        let connector = BleConnector::new(p.BT, Default::default()).unwrap();
+        let controller: ExternalController<_, 1> = ExternalController::new(connector);
+
+        let address = Address::random(crate::PERIPHERAL_ADDRESS);
+        let mut resources: HostResources<DefaultPacketPool, 1, 2> = HostResources::new();
+        let stack = trouble_host::new(controller, &mut resources)
+            .set_random_address(Address::random([0xff, 0x48, 0x49, 0x4c, 0x43, 0xff]));
+
+        let Host {
+            mut central,
+            runner,
+            ..
+        } = stack.build();
+
+        let _ = select(ble_task(runner), async {
+            let accept_list = [(address.kind, &address.addr)];
+            let connect_config = ConnectConfig {
+                scan_config: ScanConfig {
+                    filter_accept_list: &accept_list,
+                    active: true,
+                    phys: PhySet::M1,
+                    interval: Duration::from_millis(100),
+                    window: Duration::from_millis(100),
+                    timeout: Duration::from_secs(10),
+                },
+                connect_params: RequestedConnParams::default(),
+            };
+
+            let conn = with_timeout(Duration::from_secs(15), central.connect(&connect_config))
+                .await
+                .expect("BLE connect timed out")
+                .expect("BLE connect failed");
+
+            assert_eq!(conn.peer_address(), address.addr);
+            assert!(conn.is_connected());
+
+            defmt::info!("[BLE-CENTRAL] connected to support peripheral");
+            let client = GattClient::<_, DefaultPacketPool, 4>::new(&stack, &conn)
+                .await
+                .expect("GATT client setup failed");
+
+            let _ = select(client.task(), async {
+                let services = client
+                    .services_by_uuid(&Uuid::new_short(crate::BATTERY_SERVICE_UUID))
+                    .await
+                    .expect("Battery service discovery failed");
+                let service = services.first().expect("Battery service not found");
+                let level = client
+                    .characteristic_by_uuid::<u8>(
+                        service,
+                        &Uuid::new_short(crate::BATTERY_LEVEL_UUID),
+                    )
+                    .await
+                    .expect("Battery Level characteristic not found");
+
+                let mut initial_level = [0];
+                let len = client
+                    .read_characteristic(&level, &mut initial_level)
+                    .await
+                    .expect("Battery Level read failed");
+
+                assert_eq!(len, initial_level.len());
+                assert!(initial_level[0] <= 100);
+                defmt::info!("[BLE-CENTRAL] battery level read PASS");
+
+                let mut second_level = [0];
+                let len = client
+                    .read_characteristic(&level, &mut second_level)
+                    .await
+                    .expect("Second Battery Level read failed");
+
+                assert_eq!(len, second_level.len());
+                assert!(second_level[0] <= 100);
+                assert_eq!(second_level, initial_level);
+                defmt::info!("[BLE-CENTRAL] repeated battery level read PASS");
+            })
+            .await;
+
+            Timer::after(Duration::from_millis(250)).await;
+        })
+        .await;
+
+        defmt::info!("[BLE-CENTRAL] TEST_DONE: PASS");
+    }
+
+    async fn ble_task<C: Controller, P: PacketPool>(mut runner: Runner<'_, C, P>) {
+        loop {
+            if runner.run().await.is_err() {
+                defmt::warn!("[BLE-CENTRAL] runner stopped");
+                Timer::after(Duration::from_millis(100)).await;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This (not always but it's not that hard to reproduce with a few tries) crashes with:
```rust
running 1 test
test tests::ble_central_connects_to_peripheral ... [INFO ] [BLE-CENTRAL] starting BLE central connect test (ble bin/tests/ble.rs:62)
[INFO ] [BLE-CENTRAL] connected to support peripheral (ble bin/tests/ble.rs:103)
[HARNESS] [ERROR] panicked at '[ProCpu] Exception 'Load access fault (5)' mepc=0x408051ae, mtval=0x86ad6412
[HARNESS] TrapFrame { ra: 1107562376, t0: 1073941962, t1: 1082155620, t2: 1082610420, t3: 4294967292, t4: 296, t5: 1082614980, t6: 1082614684, a0: 2259510286, a1: 2, a2: 1082585020, a3: 7, a4: 2, a5: 1082606032, a6: 1048576, a7: 8 }' (esp_hal src/exception_handler/mod.rs:120)
panicked at /Users/jurajsadel/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/defmt-1.1.0/src/lib.rs:385:5:
explicit panic
[ERROR] panicked at '[ProCpu] Exception 'Load access fault (5)' mepc=0x408051ae, mtval=0xf7e4d75b
TrapFrame { ra: 1107572748, t0: 0, t1: 1107590132, t2: 0, t3: 0, t4: 134218496, t5: 365765, t6: 365455, a0: 4158969687, a1: 1, a2: 4, a3: 1107357828, a4: 1082591180, a5: 1082606032, a6: 1048576, a7: 23 }' (esp_hal src/exception_handler/mod.rs:120)
panicked at [HARNESS] Firmware exited with: Application exit (Unknown exit code 101)
/Users/jurajsadel/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/defmt-1.1.0/src/lib.rs:385:5:
explicit panicERROR probe_rs_debug::debug_info: Other("Stack pointer is too low to unwind")
[HARNESS] Core 0
[HARNESS]     Frame 0: syscall_readonly : ERROR : Stack pointer is too low to unwind @ 0x42025954 inline
[HARNESS]        /Users/jurajsadel/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/semihosting-0.1.25/src/sys/arm_compat/syscall/riscv.rs:47:9
[HARNESS]     Frame 1: sys_exit_extended @ 0x0000000042025934 inline
[HARNESS]        /Users/jurajsadel/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/semihosting-0.1.25/src/sys/arm_compat/mod.rs:287:9
[HARNESS]     Frame 2: exit @ 0x0000000042025934 inline
[HARNESS]        /Users/jurajsadel/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/semihosting-0.1.25/src/sys/arm_compat/mod.rs:257:9
[HARNESS]     Frame 3: exit @ 0x0000000042025934 inline
[HARNESS]        /Users/jurajsadel/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/semihosting-0.1.25/src/process.rs:73:5
[HARNESS]     Frame 4: _panic @ 0x0000000042025934
[HARNESS]        /Users/jurajsadel/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/semihosting-0.1.25/src/panicking.rs:53:5
[HARNESS]     Frame 5: panic_fmt @ 0x42038d7a
[HARNESS]        /Users/jurajsadel/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/panicking.rs:80:14
[HARNESS]     Frame 6: panic @ 0x42038d4c
[HARNESS]        /Users/jurajsadel/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/panicking.rs:150:5
[HARNESS]     Frame 7: default_panic @ 0x42036c62
[HARNESS]        /Users/jurajsadel/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/defmt-1.1.0/src/lib.rs:385:5
[HARNESS]     Frame 8: panic @ 0x420304fe inline
[HARNESS]        /Users/jurajsadel/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/defmt-1.1.0/src/export/mod.rs:133:14
[HARNESS]     Frame 9: ExceptionHandler @ 0x00000000420304f8
[HARNESS]        /Users/jurajsadel/esp-rs/esp-hal/esp-hal/src/exception_handler/mod.rs:0
[HARNESS]     Frame 10: start_trap_rust_hal @ 0x408001c4
[HARNESS]        /Users/jurajsadel/esp-rs/esp-hal/esp-hal/src/interrupt/riscv.rs:570:13
[HARNESS]     Frame 11: Trap9 @ 0x4080054e> @ 0x000000004080054e
[HARNESS] 
[HARNESS]     Frame 12: Trap9 @ 0x4080054e> @ 0x000000004080054e
[HARNESS] 
[HARNESS]     Frame 13: Trap9 @ 0x4080054e> @ 0x000000004080054e
[HARNESS] 
Error: Application exit

ERROR probe_rs_debug::debug_info: Other("Stack pointer is too low to unwind")
Core 0
    Frame 0: syscall_readonly : ERROR : Stack pointer is too low to unwind @ 0x42028f54 inline
       /Users/jurajsadel/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/semihosting-0.1.25/src/sys/arm_compat/syscall/riscv.rs:47:9
    Frame 1: sys_exit_extended @ 0x0000000042028f34 inline
       /Users/jurajsadel/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/semihosting-0.1.25/src/sys/arm_compat/mod.rs:287:9
    Frame 2: exit @ 0x0000000042028f34 inline
       /Users/jurajsadel/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/semihosting-0.1.25/src/sys/arm_compat/mod.rs:257:9
    Frame 3: exit @ 0x0000000042028f34 inline
       /Users/jurajsadel/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/semihosting-0.1.25/src/process.rs:73:5
    Frame 4: _panic @ 0x0000000042028f34
       /Users/jurajsadel/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/semihosting-0.1.25/src/panicking.rs:53:5
    Frame 5: panic_fmt @ 0x42036fac
       /Users/jurajsadel/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/panicking.rs:80:14
    Frame 6: panic @ 0x42036f7e
       /Users/jurajsadel/.rustup/toolchains/nightly-aarch64-apple-darwin/lib/rustlib/src/rust/library/core/src/panicking.rs:150:5
    Frame 7: default_panic @ 0x42035110
       /Users/jurajsadel/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/defmt-1.1.0/src/lib.rs:385:5
    Frame 8: panic @ 0x4202ea6c inline
       /Users/jurajsadel/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/defmt-1.1.0/src/export/mod.rs:133:14
    Frame 9: ExceptionHandler @ 0x000000004202ea66
       /Users/jurajsadel/esp-rs/esp-hal/esp-hal/src/exception_handler/mod.rs:0
    Frame 10: start_trap_rust_hal @ 0x408001c4
       /Users/jurajsadel/esp-rs/esp-hal/esp-hal/src/interrupt/riscv.rs:570:13
    Frame 11: Trap9 @ 0x4080054e> @ 0x000000004080054e

    Frame 12: Trap9 @ 0x4080054e> @ 0x000000004080054e

    Frame 13: Trap9 @ 0x4080054e> @ 0x000000004080054e
```
    
Maybe related to #4004 ? Opening as a draft as it need to be investigated more (I really spend lots of time on this but no luck 🥺 )