### PR TITLE
Keep XTAL32K powered during ESP32-C6 deep sleep

### DIFF
--- a/esp-hal/src/rtc_cntl/sleep/esp32c6.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c6.rs
@@ -15,7 +15,7 @@ use crate::{
             WakeupLevel,
         },
     },
-    soc::clocks::{ClockTree, TimgCalibrationClockConfig},
+    soc::clocks::{self, ClockTree, LpSlowClkConfig, TimgCalibrationClockConfig},
 };
 
 impl WakeSource for TimerWakeupSource {
@@ -887,7 +887,13 @@ impl RtcSleepConfig {
             self.pd_flags.set_pd_xtal(true);
             self.pd_flags.set_pd_hp_aon(true);
             self.pd_flags.set_pd_lp_periph(true);
-            self.pd_flags.set_pd_xtal32k(true);
+            let lp_slow_uses_xtal32k = ClockTree::with(|clocks| {
+                matches!(
+                    clocks::lp_slow_clk_config(clocks),
+                    Some(LpSlowClkConfig::Xtal32k)
+                )
+            });
+            self.pd_flags.set_pd_xtal32k(!lp_slow_uses_xtal32k);
             self.pd_flags.set_pd_rc32k(true);
             self.pd_flags.set_pd_rc_fast(true);
         }

--- a/esp-hal/src/rtc_cntl/sleep/esp32h2.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32h2.rs
@@ -9,7 +9,14 @@ use crate::{
         rtc::{HpSysCntlReg, HpSysPower, LpSysPower},
         sleep::{Ext1WakeupSource, TimerWakeupSource, WakeSource, WakeTriggers, WakeupLevel},
     },
-    soc::clocks::{ClockTree, CpuClkConfig, HpRootClkConfig, TimgCalibrationClockConfig},
+    soc::clocks::{
+        self,
+        ClockTree,
+        CpuClkConfig,
+        HpRootClkConfig,
+        LpSlowClkConfig,
+        TimgCalibrationClockConfig,
+    },
 };
 
 impl WakeSource for TimerWakeupSource {
@@ -685,7 +692,13 @@ impl RtcSleepConfig {
             self.pd_flags.set_pd_cpu(true);
             self.pd_flags.set_pd_xtal(true);
             self.pd_flags.set_pd_rc_fast(true);
-            self.pd_flags.set_pd_xtal32k(true);
+            let lp_slow_uses_xtal32k = ClockTree::with(|clocks| {
+                matches!(
+                    clocks::lp_slow_clk_config(clocks),
+                    Some(LpSlowClkConfig::Xtal32k)
+                )
+            });
+            self.pd_flags.set_pd_xtal32k(!lp_slow_uses_xtal32k);
         } else if self.need_pd_top {
             self.pd_flags.set_pd_top(false);
         }


### PR DESCRIPTION
Fixes #5672

# Changelog

## esp-hal/Sleep

- Fixed: ESP32-C6, H2: esp-hal no longer powers down the XTAL32K clock source when in use