### PR TITLE
Enable mem2mem on DMA_CRYPTO

### DIFF
--- a/esp-hal/src/dma/engine/crypto.rs
+++ b/esp-hal/src/dma/engine/crypto.rs
@@ -364,9 +364,7 @@ impl RegisterAccess for CryptoDmaRxChannel<'_> {
 impl RxRegisterAccess for CryptoDmaRxChannel<'_> {
     #[cfg(dma_supports_mem2mem)]
     fn set_mem2mem_mode(&self, en: bool) {
-        if en {
-            unimplemented!("Crypto DMA mem2mem mode is not supported on this chip");
-        }
+        self.regs().conf().modify(|_, w| w.mem_trans_en().bit(en));
     }
 
     fn peripheral_interrupt(&self) -> Option<Interrupt> {

--- a/esp-hal/src/dma/engine/i2s.rs
+++ b/esp-hal/src/dma/engine/i2s.rs
@@ -333,9 +333,9 @@ impl RegisterAccess for I2sDmaRxChannel<'_> {
 impl RxRegisterAccess for I2sDmaRxChannel<'_> {
     #[cfg(dma_supports_mem2mem)]
     fn set_mem2mem_mode(&self, en: bool) {
-        if en {
-            unimplemented!("I2S DMA mem2mem mode is not supported on this chip");
-        }
+        self.regs()
+            .lc_conf()
+            .modify(|_, w| w.mem_trans_en().bit(en));
     }
 
     fn peripheral_interrupt(&self) -> Option<Interrupt> {

--- a/esp-hal/src/dma/engine/spi.rs
+++ b/esp-hal/src/dma/engine/spi.rs
@@ -354,9 +354,9 @@ impl RegisterAccess for SpiDmaRxChannel<'_> {
 impl RxRegisterAccess for SpiDmaRxChannel<'_> {
     #[cfg(dma_supports_mem2mem)]
     fn set_mem2mem_mode(&self, en: bool) {
-        if en {
-            unimplemented!("SPI DMA mem2mem mode is not supported on this chip");
-        }
+        self.regs()
+            .dma_conf()
+            .modify(|_, w| w.mem_trans_en().bit(en));
     }
 
     fn peripheral_interrupt(&self) -> Option<Interrupt> {

--- a/esp-metadata-generated/src/_generated_esp32s2.rs
+++ b/esp-metadata-generated/src/_generated_esp32s2.rs
@@ -543,12 +543,16 @@ macro_rules! for_each_dma_channel_peri_pair {
 macro_rules! for_each_mem2mem_channel {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_mem2mem_channel { $(($pattern) => $code;)* ($other :
-        tt) => {} } _for_each_inner_mem2mem_channel!(("COPY_DMA", CopyDma,
-        CopyDmaChannel, DMA_COPY, 0)); _for_each_inner_mem2mem_channel!(("COPY_DMA",
-        CopyDma, CopyDmaChannel)); _for_each_inner_mem2mem_channel!((channels("COPY_DMA",
-        CopyDma, CopyDmaChannel, DMA_COPY, 0)));
-        _for_each_inner_mem2mem_channel!((erased));
-        _for_each_inner_mem2mem_channel!((engines("COPY_DMA", CopyDma, CopyDmaChannel)));
+        tt) => {} } _for_each_inner_mem2mem_channel!(("CRYPTO_DMA", CryptoDma,
+        CryptoDmaChannel, DMA_CRYPTO, 0)); _for_each_inner_mem2mem_channel!(("COPY_DMA",
+        CopyDma, CopyDmaChannel, DMA_COPY, 0));
+        _for_each_inner_mem2mem_channel!(("CRYPTO_DMA", CryptoDma, CryptoDmaChannel));
+        _for_each_inner_mem2mem_channel!(("COPY_DMA", CopyDma, CopyDmaChannel));
+        _for_each_inner_mem2mem_channel!((channels("CRYPTO_DMA", CryptoDma,
+        CryptoDmaChannel, DMA_CRYPTO, 0), ("COPY_DMA", CopyDma, CopyDmaChannel, DMA_COPY,
+        0))); _for_each_inner_mem2mem_channel!((erased));
+        _for_each_inner_mem2mem_channel!((engines("CRYPTO_DMA", CryptoDma,
+        CryptoDmaChannel), ("COPY_DMA", CopyDma, CopyDmaChannel)));
     };
 }
 #[macro_export]

--- a/esp-metadata/devices/esp32s2.toml
+++ b/esp-metadata/devices/esp32s2.toml
@@ -310,7 +310,9 @@ engines = [
     { name = "CRYPTO_DMA", drivers = ["aes", "sha"], peripheral_instances = [
         { name = "AES", dma_id = 0 },
         { name = "SHA", dma_id = 1 },
-    ], channels = [{ name = "DMA_CRYPTO", pac = "CRYPTO_DMA", interrupt = "CRYPTO_DMA", compatible_with = ["AES", "SHA"] }] },
+    ], channels = [
+        { name = "DMA_CRYPTO", pac = "CRYPTO_DMA", interrupt = "CRYPTO_DMA", compatible_with = ["AES", "SHA"], mem2mem = true, mem2mem_id = 0 }
+    ] },
     { name = "COPY_DMA", channels = [
         { name = "DMA_COPY", pac = "COPY_DMA", interrupt = "DMA_COPY", mem2mem = true, mem2mem_id = 0 },
     ] },

--- a/esp-metadata/src/cfg/dma.rs
+++ b/esp-metadata/src/cfg/dma.rs
@@ -199,10 +199,14 @@ impl GenericProperty for DmaEngines {
                     );
                     mem2mem_channels
                         .push(quote! { #engine_name, #variant, #any_channel, #ch, #mem2mem_id });
-                    mem2mem_erased_by_engine
-                        .entry(engine_name)
-                        .or_default()
-                        .push((idx.clone(), mem2mem_id));
+                    // CRYPTO_DMA and COPY_DMA alias their any-channel type to the singleton
+                    // peripheral type; an erased impl would conflict with the singleton impl.
+                    if !matches!(engine_name, "CRYPTO_DMA" | "COPY_DMA") {
+                        mem2mem_erased_by_engine
+                            .entry(engine_name)
+                            .or_default()
+                            .push((idx.clone(), mem2mem_id));
+                    }
                     if mem2mem_engine_seen.insert(engine_name) {
                         mem2mem_engines.push(quote! { #engine_name, #variant, #any_channel });
                     }
@@ -284,7 +288,6 @@ impl GenericProperty for DmaEngines {
 
         let mem2mem_erased = mem2mem_erased_by_engine
             .iter()
-            .filter(|(engine_name, _)| **engine_name != "COPY_DMA")
             .map(|(engine_name, arms)| {
                 let variant = format_ident!(
                     "{}",

--- a/examples/peripheral/dma/extmem2mem/src/main.rs
+++ b/examples/peripheral/dma/extmem2mem/src/main.rs
@@ -1,7 +1,6 @@
 //! Uses DMA to copy psram to internal memory.
 
-//% CHIP_FILTER: dma_can_access_psram && dma_supports_mem2mem && !esp32s2
-// FIXME: ESP32-S2 CopyDMA is not an EDMA - CryptoDMA or SpiDMA should work, maybe?
+//% CHIP_FILTER: dma_can_access_psram && dma_supports_mem2mem
 
 #![no_std]
 #![no_main]
@@ -60,6 +59,7 @@ fn main() -> ! {
     let (rx_descriptors, tx_descriptors) = dma_descriptors_chunk_size!(DATA_SIZE, CHUNK_SIZE);
 
     let mem2mem = cfg_select! {
+        feature = "esp32s2" => Mem2Mem::new(peripherals.DMA_CRYPTO),
         feature = "esp32s3" => Mem2Mem::new(peripherals.DMA_CH0, peripherals.SPI2),
         feature = "esp32p4" => Mem2Mem::new(peripherals.DMA_AXI_CH0),
         _ => Mem2Mem::new(peripherals.DMA_CH0),
@@ -70,7 +70,11 @@ fn main() -> ! {
             rx_descriptors,
             tx_descriptors,
             BurstConfig {
-                external_memory: ExternalBurstConfig::Size64,
+                external_memory: if cfg!(feature = "esp32s2") {
+                    ExternalBurstConfig::Size32
+                } else {
+                    ExternalBurstConfig::Size64
+                },
                 internal_memory: Default::default(),
             },
         )


### PR DESCRIPTION
# Changelog

## esp-hal/DMA

- Added: ESP32-S2: DMA_CRYPTO can now be used to drive memory-to-memory transfers. Supports transfers to/from PSRAM.
