### PR TITLE
Unify chip filter expressions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -41,7 +41,7 @@ Tests and examples use `//% KEY: value` comments to control xtask builds (full d
 
 | Annotation | Purpose | Example |
 |------------|---------|---------|
-| `//% CHIP_FILTER:` | Boolean expression selecting chips; prefer a capability cfg flag over a chip list | `//% CHIP_FILTER: spi_slave_supports_dma && !esp32` |
+| `//% CHIP_FILTER:` | Boolean expression selecting chips; prefer a capability cfg flag over a chip list; key-value cfg symbols support `==` / `!=` with quoted strings | `//% CHIP_FILTER: riscv && interrupt_controller != "clic"` |
 | `//% FEATURES:` | Enable cargo features | `//% FEATURES: unstable embassy` |
 | `//% ENV:` | Set environment variables | `//% ENV: ESP_HAL_CONFIG_STACK_GUARD_OFFSET=4` |
 | `//% CARGO-CONFIG:` | Cargo `--config` passthrough | `//% CARGO-CONFIG: ...` |

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -14,21 +14,21 @@ exclude = [ "api-baseline", "MIGRATING-*", "CHANGELOG.md" ]
 [package.metadata.espressif]
 semver-checked = true
 doc-config = { features = ["unstable", "rt"], append = [
-    { if = 'chip_has("usb_otg_driver_supported")', features = ["__usb_otg"] },
-    { if = 'chip_has("bt_driver_supported")', features = ["__bluetooth"] },
+    { if = 'usb_otg_driver_supported', features = ["__usb_otg"] },
+    { if = 'bt_driver_supported', features = ["__bluetooth"] },
 ] }
 check-configs = [
     { features = [] },
     { features = ["rt"] },
     { features = ["unstable", "rt"] },
-    { features = ["unstable", "rt", "__usb_otg"],   if = 'chip_has("usb_otg_driver_supported")' },
-    { features = ["unstable", "rt", "__bluetooth"], if = 'chip_has("bt_driver_supported")' },
+    { features = ["unstable", "rt", "__usb_otg"],   if = 'usb_otg_driver_supported' },
+    { features = ["unstable", "rt", "__bluetooth"], if = 'bt_driver_supported' },
 ]
 # Prefer fewer, but more complex clippy rules. A clippy run should cover as much code as possible.
 clippy-configs = [
     { features = ["unstable", "rt"], append = [
-        { if = 'chip_has("usb_otg_driver_supported")', features = ["__usb_otg"] },
-        { if = 'chip_has("bt_driver_supported")', features = ["__bluetooth"] },
+        { if = 'usb_otg_driver_supported', features = ["__usb_otg"] },
+        { if = 'bt_driver_supported', features = ["__bluetooth"] },
     ] },
 ]
 

--- a/esp-lp-hal/Cargo.toml
+++ b/esp-lp-hal/Cargo.toml
@@ -18,7 +18,7 @@ rustdoc-args   = ["--cfg", "docsrs"]
 [package.metadata.espressif]
 targets_lp_core = true
 doc-config = { features = ["embedded-hal"], append = [
-    { features = ["embedded-io"], if = 'chip_has("lp_core")' },
+    { features = ["embedded-io"], if = 'lp_core' },
 ] }
 check-configs = [
     { features = [] },

--- a/esp-println/Cargo.toml
+++ b/esp-println/Cargo.toml
@@ -15,7 +15,7 @@ links         = "esp-println"
 doc-config = { features = ["auto", "defmt-espflash", "critical-section"] }
 check-configs = [
     { features = ["auto"] },
-    { features = ["jtag-serial"], if = 'chip_has("soc_has_usb_device")' },
+    { features = ["jtag-serial"], if = 'soc_has_usb_device' },
     { features = ["uart"] },
     { features = ["no-op"] },
     { features = ["auto", "log-04", "timestamp"] },

--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -13,36 +13,36 @@ license = "MIT OR Apache-2.0"
 [package.metadata.espressif]
 semver-checked = true
 doc-config = { features = ["esp-hal/unstable", "esp-hal/rt", "esp-alloc/global-allocator", "procmacros/__esp_idf_bootloader", "defmt"], append = [
-    { if = 'chip_has("wifi_driver_supported")', features = ["wifi", "wifi-eap", "esp-now", "sniffer"] },
-    { if = 'chip_has("wifi_driver_supported") && chip_has("wifi_csi_supported")', features = ["csi"] },
-    { if = 'chip_has("bt_driver_supported")', features = ["ble"] },
-    { if = 'chip_has("ieee802154_driver_supported")', features = ["ieee802154", "__docs_build"] },
-    { if = 'chip_has("wifi_driver_supported") && chip_has("bt_driver_supported")', features = ["coex"] },
-    { if = 'chip_has("wifi_driver_supported") || chip_has("bt_driver_supported") || chip_has("ieee802154_driver_supported")', features = ["unstable"] },
+    { if = 'wifi_driver_supported', features = ["wifi", "wifi-eap", "esp-now", "sniffer"] },
+    { if = 'wifi_driver_supported && wifi_csi_supported', features = ["csi"] },
+    { if = 'bt_driver_supported', features = ["ble"] },
+    { if = 'ieee802154_driver_supported', features = ["ieee802154", "__docs_build"] },
+    { if = 'wifi_driver_supported && bt_driver_supported', features = ["coex"] },
+    { if = 'wifi_driver_supported || bt_driver_supported || ieee802154_driver_supported', features = ["unstable"] },
 ] }
 # Semver guarantees cover only the stable API, so the `unstable` feature is left OFF: the
 # `instability_disable_unstable_docs` escape (set in `build_doc_json`) then drops all
 # `#[instability::unstable]` items from the baseline. `wifi` is the only radio feature that
 # does not pull in `unstable`.
 semver-config = { features = ["esp-hal/rt", "esp-alloc/global-allocator", "procmacros/__esp_idf_bootloader", "defmt"], append = [
-    { if = 'chip_has("wifi_driver_supported")', features = ["wifi"] },
+    { if = 'wifi_driver_supported', features = ["wifi"] },
 ] }
 check-configs = [
     { features = ["esp-hal/rt"] },
     { features = ["esp-hal/rt", "defmt"] },
-    { features = ["esp-hal/rt", "wifi"], if = 'chip_has("wifi_driver_supported")' },
+    { features = ["esp-hal/rt", "wifi"], if = 'wifi_driver_supported' },
     # feature(c_variadic) requires nightly compiler, but we can't configure the toolchain here. Only check xtensa chips, where the compiler has nightly features enabled.
-    { features = ["esp-hal/unstable", "esp-hal/rt", "wifi", "print-logs-from-driver", "unstable"], if = 'chip_has("wifi_driver_supported") && chip_has("xtensa")' },
-    { features = ["esp-hal/unstable", "esp-hal/rt", "unstable", "defmt", "wifi", "wifi-eap", "esp-now", "sniffer"], if = 'chip_has("wifi_driver_supported")' },
-    { features = ["esp-hal/unstable", "esp-hal/rt", "unstable", "ble"], if = 'chip_has("bt_driver_supported")' },
-    { features = ["esp-hal/unstable", "esp-hal/rt", "unstable", "ieee802154"], if = 'chip_has("ieee802154_driver_supported")' },
-    { features = ["esp-hal/unstable", "esp-hal/rt", "unstable", "defmt", "wifi", "wifi-eap", "esp-now", "sniffer", "ble", "coex"], if = 'chip_has("wifi_driver_supported") && chip_has("bt_driver_supported")' },
-    { features = ["esp-hal/unstable", "esp-hal/rt", "wifi-eap", "unstable"], if = 'chip_has("wifi_driver_supported")' },
+    { features = ["esp-hal/unstable", "esp-hal/rt", "wifi", "print-logs-from-driver", "unstable"], if = 'wifi_driver_supported && xtensa' },
+    { features = ["esp-hal/unstable", "esp-hal/rt", "unstable", "defmt", "wifi", "wifi-eap", "esp-now", "sniffer"], if = 'wifi_driver_supported' },
+    { features = ["esp-hal/unstable", "esp-hal/rt", "unstable", "ble"], if = 'bt_driver_supported' },
+    { features = ["esp-hal/unstable", "esp-hal/rt", "unstable", "ieee802154"], if = 'ieee802154_driver_supported' },
+    { features = ["esp-hal/unstable", "esp-hal/rt", "unstable", "defmt", "wifi", "wifi-eap", "esp-now", "sniffer", "ble", "coex"], if = 'wifi_driver_supported && bt_driver_supported' },
+    { features = ["esp-hal/unstable", "esp-hal/rt", "wifi-eap", "unstable"], if = 'wifi_driver_supported' },
 ]
 clippy-configs = [
     { features = ["esp-hal/rt"] },
-    { features = ["esp-hal/unstable", "esp-hal/rt", "wifi", "wifi-eap", "unstable"], if = 'chip_has("wifi_driver_supported")', append = [
-        { features = ["ble"], if = 'chip_has("bt_driver_supported")' },
+    { features = ["esp-hal/unstable", "esp-hal/rt", "wifi", "wifi-eap", "unstable"], if = 'wifi_driver_supported', append = [
+        { features = ["ble"], if = 'bt_driver_supported' },
     ] },
 ]
 

--- a/hil-test/README.md
+++ b/hil-test/README.md
@@ -141,8 +141,9 @@ sudo reboot
 3. Write the tests
 4. Document any necessary physical connections on boards connected to self-hosted runners
 5. Add a header in the test stating which targets support the given tests. The `//% CHIP_FILTER:`
-   line is a boolean expression evaluated per chip, where a symbol is either a chip name or a cfg
-   name (exactly as it appears in `#[cfg(...)]`). It supports `&&`, `||`, `!` and parentheses, so you
+   line is a boolean expression evaluated per chip, where a symbol is either a chip name, a boolean
+   cfg name (exactly as it appears in `#[cfg(...)]`), or a key-value cfg name that can be compared
+   with `==` / `!=` and a quoted string. It supports `&&`, `||`, `!` and parentheses, so you
    can do any of the following:
 ```rust
 //! Test Name
@@ -159,6 +160,9 @@ sudo reboot
 
 // Combine capabilities and group with parentheses:
 //% CHIP_FILTER: adc_driver_supported && (esp32c6 || esp32h2)
+
+// Filter by a key-value cfg symbol (when a boolean flag is not enough):
+//% CHIP_FILTER: riscv && interrupt_controller != "clic"
 ```
 If the test is supported by all the targets, you can omit the header. See [`xtask/README.md`](../xtask/README.md) for the full description of the metadata keys.
 

--- a/hil-test/src/bin/interrupt.rs
+++ b/hil-test/src/bin/interrupt.rs
@@ -2,7 +2,10 @@
 //!
 //! "Disabled" for now - see https://github.com/esp-rs/esp-hal/pull/1635#issuecomment-2137405251
 
-//% CHIP_FILTER: riscv
+// This test measures interrupt latency using CSRs, which only exist on the older RISC-V cores (C2,
+// C3, C6, H2), the newer CLIC-based cores (C5, C61, P4) don't have them, so accessing the CSRs
+// there traps. Exclude them.
+//% CHIP_FILTER: riscv && interrupt_controller != "clic"
 //% FEATURES: unstable
 
 #![no_std]

--- a/qa-test/README.md
+++ b/qa-test/README.md
@@ -4,7 +4,7 @@ This package contains a number of binary applications intended for manual/qualit
 
 Each device has its own unique set of peripherals, and as such not every test will run on every device. We recommend building and flashing the tests using the `xtask` method documented below, which will greatly simplify the process.
 
-To check if a device is compatible with a given test, check the metadata comments above the imports, which describe the supported devices following the `//% CHIP_FILTER:` designator. If this metadata is not present, then the test will work on any device supported by `esp-hal`.
+To check if a device is compatible with a given test, check the metadata comments above the imports, which describe the supported devices following the `//% CHIP_FILTER:` designator. The expression can use boolean cfg symbols, key-value cfg comparisons (e.g. `interrupt_controller != "clic"`), and chip names — see [`xtask/README.md`](../xtask/README.md) for details. If this metadata is not present, then the test will work on any device supported by `esp-hal`.
 
 As previously stated, we use the [cargo-xtask] pattern for automation. Commands invoking this tool must be run from the root of the repository.
 

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -98,8 +98,9 @@ capability flag does not exist:
 //% CHIP_FILTER: esp32c6 || esp32h2
 ```
 
-The expression is evaluated with [`somni`](https://crates.io/crates/somni-expr): `xtask` wraps each
-bare symbol into a `chip_has("symbol")` call and evaluates it per chip.
+The expression is evaluated with [`somni`](https://crates.io/crates/somni-expr). `xtask` turns each
+bare symbol into a boolean variable and evaluates it per chip. If a symbol does not exist, it
+causes an evaluation error.
 
 This key is a filter. If a named configuration contains an expression, the named line overwrites the
 unnamed line for that configuration. If multiple lines specify the same configuration, the latter one

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -77,7 +77,8 @@ The following metadata keys can be used:
 A boolean expression that selects which chips the test or example is built for. If the line is
 missing, the file is built for all known chips. A symbol in the expression is either a cfg name
 (exactly as it appears in `#[cfg(...)]`, e.g. `i2c_master_driver_supported` or
-`dma_can_access_psram`) or a chip name (e.g. `esp32`).
+`dma_can_access_psram`), a key-value cfg name (e.g. `interrupt_controller`), or a chip name
+(e.g. `esp32`).
 
 Prefer a capability cfg flag over an explicit chip list: it describes *why* a chip is supported and
 automatically picks up new chips that gain the capability. Only fall back to chip names when no cfg
@@ -98,9 +99,21 @@ capability flag does not exist:
 //% CHIP_FILTER: esp32c6 || esp32h2
 ```
 
+Some cfg symbols carry a string value rather than being simply present or absent (for example,
+`#[cfg(interrupt_controller = "clic")]`). These can be compared with `==` and `!=` using quoted
+string literals:
+
+```
+//% CHIP_FILTER: riscv && interrupt_controller != "clic"
+//% CHIP_FILTER: interrupt_controller == "plic"
+```
+
+Chips that do not define a key-value symbol are treated as having an empty string value.
+
 The expression is evaluated with [`somni`](https://crates.io/crates/somni-expr). `xtask` turns each
-bare symbol into a boolean variable and evaluates it per chip. If a symbol does not exist, it
-causes an evaluation error.
+boolean cfg symbol into a `true`/`false` variable and each key-value cfg symbol into a string
+variable, then evaluates the expression per chip. If a symbol does not exist, it causes an
+evaluation error.
 
 This key is a filter. If a named configuration contains an expression, the named line overwrites the
 unnamed line for that configuration. If multiple lines specify the same configuration, the latter one

--- a/xtask/src/firmware.rs
+++ b/xtask/src/firmware.rs
@@ -198,7 +198,8 @@ fn parse_meta_line(line: &str) -> anyhow::Result<MetaLine> {
 }
 
 /// Returns the chips selected by a `CHIP_FILTER` expression (a boolean expression over
-/// cfg symbols and chip names, e.g. `cfg_symbol && !esp32` or `esp32c6 || esp32h2`).
+/// cfg symbols, key-value cfg symbols, and chip names, e.g. `cfg_symbol && !esp32`,
+/// `esp32c6 || esp32h2`, or `interrupt_controller != "clic"`).
 fn parse_chips(expr: &str) -> anyhow::Result<Vec<Chip>> {
     let script_ctx = ScriptContext::new();
 

--- a/xtask/src/firmware.rs
+++ b/xtask/src/firmware.rs
@@ -6,11 +6,11 @@ use std::{
 
 use anyhow::{Context, Result, bail};
 use clap::ValueEnum;
-use esp_metadata::{Chip, Config};
+use esp_metadata::Chip;
 use serde::Deserialize;
 use strum::IntoEnumIterator as _;
 
-use crate::windows_safe_path;
+use crate::{ScriptContext, windows_safe_path};
 
 /// A single, configured example (or test).
 #[derive(Debug, Clone)]
@@ -200,45 +200,13 @@ fn parse_meta_line(line: &str) -> anyhow::Result<MetaLine> {
 /// Returns the chips selected by a `CHIP_FILTER` expression (a boolean expression over
 /// cfg symbols and chip names, e.g. `cfg_symbol && !esp32` or `esp32c6 || esp32h2`).
 fn parse_chips(expr: &str) -> anyhow::Result<Vec<Chip>> {
-    fn symbol_to_ident(s: &String) -> Option<String> {
-        s.chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.')
-            .then_some(s.replace(".", "_"))
-    }
-
-    let possible_symbols = Chip::list_of_possible_symbols()
-        .iter()
-        .filter_map(|(sym, values)| {
-            if values.is_none() {
-                symbol_to_ident(sym)
-            } else {
-                None
-            }
-        })
-        .collect::<Vec<_>>();
+    let script_ctx = ScriptContext::new();
 
     let mut chips = Vec::new();
     for chip in Chip::iter() {
-        let config = Config::for_chip(&chip);
-        let chip_symbols = config
-            .all()
-            .iter()
-            .filter_map(symbol_to_ident)
-            .collect::<Vec<_>>();
+        let mut ctx = script_ctx.for_chip(chip);
 
-        let mut ctx = somni_expr::Context::new();
-
-        // All known symbols are initially false
-        for sym in possible_symbols.iter() {
-            ctx.add_variable(sym.as_str(), false);
-        }
-
-        // All defined symbols for this chip are true
-        for sym in chip_symbols.iter() {
-            ctx.add_variable(sym.as_str(), true);
-        }
-
-        let selected = ctx.evaluate::<bool>(expr).map_err(|err| {
+        let selected = ctx.evaluate(expr).map_err(|err| {
             anyhow::anyhow!("{err:?}").context("Failed to evaluate chip expression")
         })?;
         if selected {

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -257,29 +257,15 @@ impl Package {
     }
 
     fn parse_conditional_features(table: &InlineTable, config: &Config) -> Option<Vec<String>> {
-        let mut eval_context = somni_expr::Context::new();
-        let possible_symbols = Chip::list_of_possible_symbols();
-        eval_context.add_function("chip_has", move |symbol: &str| {
-            assert!(
-                possible_symbols.contains_key(symbol),
-                "Unknown chip symbol: {symbol}",
-            );
-            config
-                .all()
-                .iter()
-                .any(|sym| sym.replace('.', "_") == symbol)
-        });
-        eval_context.add_variable("chip", config.name());
+        let script_ctx = ScriptContext::new();
+        let mut ctx = script_ctx.for_config(config);
 
         if let Some(condition) = table.get("if") {
             let Some(expr) = condition.as_str() else {
                 panic!("`if` condition must be a string.");
             };
 
-            if !eval_context
-                .evaluate::<bool>(expr)
-                .expect("Failed to evaluate expression")
-            {
+            if !ctx.evaluate(expr).expect("Failed to evaluate expression") {
                 return None;
             }
         }

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -1094,22 +1094,25 @@ pub fn find_packages(path: &Path) -> Result<Vec<PathBuf>> {
 
 struct ScriptContext {
     all_symbols: Vec<String>,
+    all_kv_symbols: Vec<String>,
 }
 
 struct ChipFilterEval<'a> {
     all_symbols: &'a [String],
+    all_kv_symbols: &'a [String],
     chip_symbols: Vec<String>,
+    chip_kv_values: Vec<(String, String)>,
 }
 
 impl ScriptContext {
-    fn symbol_to_ident(s: &String) -> Option<String> {
+    fn symbol_to_ident(s: &str) -> Option<String> {
         s.chars()
             .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.')
             .then_some(s.replace(".", "_"))
     }
 
     pub fn new() -> Self {
-        let possible_symbols = Chip::list_of_possible_symbols()
+        let all_symbols = Chip::list_of_possible_symbols()
             .iter()
             .filter_map(|(sym, values)| {
                 if values.is_none() {
@@ -1119,9 +1122,20 @@ impl ScriptContext {
                 }
             })
             .collect::<Vec<_>>();
+        let all_kv_symbols = Chip::list_of_possible_symbols()
+            .iter()
+            .filter_map(|(sym, values)| {
+                if values.is_some() {
+                    Self::symbol_to_ident(sym)
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
 
         Self {
-            all_symbols: possible_symbols,
+            all_symbols,
+            all_kv_symbols,
         }
     }
 
@@ -1133,12 +1147,28 @@ impl ScriptContext {
         let chip_symbols = config
             .all()
             .iter()
-            .filter_map(Self::symbol_to_ident)
+            .filter_map(|s| Self::symbol_to_ident(s))
+            .collect::<Vec<_>>();
+        let chip_kv_values = config
+            .all()
+            .iter()
+            .filter_map(|sym| {
+                if sym.contains('"') {
+                    let (k, v) = sym.split_once('=')?;
+                    let k = Self::symbol_to_ident(k.trim())?;
+                    let v = v.trim().trim_matches('"');
+                    Some((k.to_string(), v.to_string()))
+                } else {
+                    None
+                }
+            })
             .collect::<Vec<_>>();
 
         ChipFilterEval {
             all_symbols: &self.all_symbols,
+            all_kv_symbols: &self.all_kv_symbols,
             chip_symbols,
+            chip_kv_values,
         }
     }
 }
@@ -1151,10 +1181,17 @@ impl ChipFilterEval<'_> {
         for sym in self.all_symbols.iter() {
             ctx.add_variable(sym, false);
         }
+        for sym in self.all_kv_symbols.iter() {
+            // empty string is not a valid value, chips that don't define the symbol won't match
+            ctx.add_variable(sym, "");
+        }
 
         // All defined symbols for this chip are true
         for sym in self.chip_symbols.iter() {
             ctx.add_variable(sym, true);
+        }
+        for (k, v) in self.chip_kv_values.iter() {
+            ctx.add_variable(k, v.as_str());
         }
 
         match ctx.evaluate::<bool>(expr) {

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -1105,3 +1105,77 @@ pub fn find_packages(path: &Path) -> Result<Vec<PathBuf>> {
 
     Ok(packages)
 }
+
+struct ScriptContext {
+    all_symbols: Vec<String>,
+}
+
+struct ChipFilterEval<'a> {
+    all_symbols: &'a [String],
+    chip_symbols: Vec<String>,
+}
+
+impl ScriptContext {
+    fn symbol_to_ident(s: &String) -> Option<String> {
+        s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.')
+            .then_some(s.replace(".", "_"))
+    }
+
+    pub fn new() -> Self {
+        let possible_symbols = Chip::list_of_possible_symbols()
+            .iter()
+            .filter_map(|(sym, values)| {
+                if values.is_none() {
+                    Self::symbol_to_ident(sym)
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+
+        Self {
+            all_symbols: possible_symbols,
+        }
+    }
+
+    pub fn for_chip(&self, chip: Chip) -> ChipFilterEval<'_> {
+        self.for_config(&Config::for_chip(&chip))
+    }
+
+    pub fn for_config(&self, config: &Config) -> ChipFilterEval<'_> {
+        let chip_symbols = config
+            .all()
+            .iter()
+            .filter_map(Self::symbol_to_ident)
+            .collect::<Vec<_>>();
+
+        ChipFilterEval {
+            all_symbols: &self.all_symbols,
+            chip_symbols,
+        }
+    }
+}
+
+impl ChipFilterEval<'_> {
+    pub fn evaluate<'s>(&'s mut self, expr: &'s str) -> anyhow::Result<bool> {
+        let mut ctx = somni_expr::Context::new();
+
+        // All known symbols are initially false
+        for sym in self.all_symbols.iter() {
+            ctx.add_variable(sym, false);
+        }
+
+        // All defined symbols for this chip are true
+        for sym in self.chip_symbols.iter() {
+            ctx.add_variable(sym, true);
+        }
+
+        match ctx.evaluate::<bool>(expr) {
+            Ok(result) => Ok(result),
+            Err(err) => {
+                Err(anyhow::anyhow!("{err:?}").context("Failed to evaluate chip expression"))
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR reworks the crate-metadata filters to use the same mechanism as the example/test CHIP_FILTER. The end result is that we can replace `chip_has()` function calls with normal variables.

We also transform key-value symbols into string variables, so their value can be checked.