### PR TITLE
Clock tree: Add `_source_frequency` functions

### DIFF
--- a/esp-hal/src/i2c/master/low_level/v3.rs
+++ b/esp-hal/src/i2c/master/low_level/v3.rs
@@ -1,5 +1,5 @@
 use super::{Config, ConfigError, Driver, RegisterBlock, configure_clock};
-use crate::soc::clocks::{ClockTree, I2cFunctionClockConfig};
+use crate::soc::clocks::{ClockTree, I2cFunctionClockConfig, I2cInstance};
 
 /// Sets the frequency of the I2C interface by calculating and applying the
 /// associated timings - corresponds to i2c_ll_cal_bus_clk and
@@ -10,10 +10,9 @@ pub(super) fn set_frequency(driver: &Driver<'_>, clock_config: &Config) -> Resul
     let sclk = clock_config.clock_source;
     let clock = driver.info.clock_instance;
 
-    ClockTree::with(|clocks| {
-        let source_clk =
-            clock.function_clock_config_frequency(clocks, I2cFunctionClockConfig::new(sclk, 0));
+    let source_clk = I2cInstance::function_clock_source_frequency(sclk);
 
+    ClockTree::with(|clocks| {
         let clkm_div: u32 = source_clk / (bus_freq * 1024) + 1;
 
         clock.configure_function_clock(clocks, I2cFunctionClockConfig::new(sclk, clkm_div - 1));

--- a/esp-hal/src/rmt.rs
+++ b/esp-hal/src/rmt.rs
@@ -2276,9 +2276,7 @@ mod chip_specific {
         source: ClockSource,
         frequency: Rate,
     ) -> Result<(u8, Rate), ConfigError> {
-        let src_clock = clocks::ClockTree::with(|clocks| {
-            Rate::from_hz(clocks::RmtInstance::Rmt.sclk_config_frequency(clocks, source))
-        });
+        let src_clock = Rate::from_hz(clocks::RmtInstance::sclk_source_frequency(source));
 
         if frequency > src_clock {
             return Err(ConfigError::UnreachableTargetFrequency);
@@ -2812,9 +2810,7 @@ mod chip_specific {
         source: ClockSource,
         frequency: Rate,
     ) -> Result<(u8, Rate), ConfigError> {
-        let source_frequency = clocks::ClockTree::with(|clocks| {
-            Rate::from_hz(clocks::RmtInstance::Rmt.sclk_config_frequency(clocks, source))
-        });
+        let source_frequency = Rate::from_hz(clocks::RmtInstance::sclk_source_frequency(source));
 
         if frequency != source_frequency {
             return Err(ConfigError::UnreachableTargetFrequency);

--- a/esp-hal/src/spi/master/mod.rs
+++ b/esp-hal/src/spi/master/mod.rs
@@ -505,15 +505,9 @@ impl Config {
     }
 
     fn clock_source_freq_hz(&self) -> Rate {
-        let freq = crate::soc::clocks::ClockTree::with(|clocks| {
-            // The specific instance (Spi2) does not matter here,
-            // because we query a source clock frequency.
-            // TODO: should config_frequency should not take `self` in general?
-            crate::soc::clocks::SpiInstance::Spi2
-                .function_clock_config_frequency(clocks, self.clock_source)
-        });
-
-        Rate::from_hz(freq)
+        Rate::from_hz(
+            crate::soc::clocks::SpiInstance::function_clock_source_frequency(self.clock_source),
+        )
     }
 
     fn recalculate(&self) -> Result<u32, ConfigError> {

--- a/esp-hal/src/uart/low_level/mod.rs
+++ b/esp-hal/src/uart/low_level/mod.rs
@@ -539,8 +539,7 @@ impl Info {
         ClockTree::with(|clocks| {
             let clock = self.clock_instance;
 
-            let clk =
-                clocks::UartInstance::function_clock_source_frequency(config.clock_source);
+            let clk = clocks::UartInstance::function_clock_source_frequency(config.clock_source);
 
             // The UART baud rate clock divider is, depending on the device, either a
             // 20.4 bit, or a 12.4 bit divider.

--- a/esp-hal/src/uart/low_level/mod.rs
+++ b/esp-hal/src/uart/low_level/mod.rs
@@ -539,12 +539,8 @@ impl Info {
         ClockTree::with(|clocks| {
             let clock = self.clock_instance;
 
-            let source_config = ClockConfig::new(
-                config.clock_source,
-                #[cfg(any(uart_has_sclk_divider, soc_has_pcr, esp32p4))]
-                0,
-            );
-            let clk = clock.function_clock_config_frequency(clocks, source_config);
+            let clk =
+                clocks::UartInstance::function_clock_source_frequency(config.clock_source);
 
             // The UART baud rate clock divider is, depending on the device, either a
             // 20.4 bit, or a 12.4 bit divider.

--- a/esp-metadata-generated/src/_generated_esp32.rs
+++ b/esp-metadata-generated/src/_generated_esp32.rs
@@ -1371,6 +1371,14 @@ macro_rules! define_clock_tree_types {
             /// Selects `RC_FAST_CLK`.
             Rc,
         }
+        /// The list of clock signals that the `UART_MEM_CLK` multiplexer can output.
+        #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+        pub enum UartMemClkConfig {
+            #[default]
+            /// Selects `XTAL_CLK`.
+            Xtal,
+        }
         /// The list of clock signals that the `TIMG_CALIBRATION_CLOCK` multiplexer can output.
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -1844,6 +1852,9 @@ macro_rules! define_clock_tree_types {
         pub fn pll_clk_frequency() -> u32 {
             PLL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn pll_clk_source_frequency() -> u32 {
+            xtal_clk_frequency()
+        }
         pub fn configure_apll_clk(clocks: &mut ClockTree, config: ApllClkConfig) {
             let old_config = clocks.apll_clk.replace(config);
             refresh_apll_clk_downstream(clocks);
@@ -1870,6 +1881,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn apll_clk_frequency() -> u32 {
             APLL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn apll_clk_source_frequency() -> u32 {
+            pll_clk_frequency()
         }
         pub fn request_rc_fast_clk(clocks: &mut ClockTree) {
             trace!("Requesting RC_FAST_CLK");
@@ -1906,6 +1920,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn pll_f160m_clk_frequency() -> u32 {
             160000000
+        }
+        pub fn pll_f160m_clk_source_frequency() -> u32 {
+            pll_clk_frequency()
         }
         pub fn configure_cpu_pll_div_in(clocks: &mut ClockTree, new_selector: CpuPllDivInConfig) {
             let old_selector = clocks.cpu_pll_div_in.replace(new_selector);
@@ -1956,6 +1973,12 @@ macro_rules! define_clock_tree_types {
         pub fn cpu_pll_div_in_frequency() -> u32 {
             CPU_PLL_DIV_IN_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn cpu_pll_div_in_source_frequency(source: CpuPllDivInConfig) -> u32 {
+            match source {
+                CpuPllDivInConfig::Pll => pll_clk_frequency(),
+                CpuPllDivInConfig::Apll => apll_clk_frequency(),
+            }
+        }
         pub fn configure_cpu_pll_div(clocks: &mut ClockTree, config: CpuPllDivConfig) {
             if clocks.pll_clk.is_some() {
                 assert!(!((pll_clk_frequency() == 480000000) && (config.divisor() == 4)));
@@ -1988,6 +2011,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn cpu_pll_div_frequency() -> u32 {
             CPU_PLL_DIV_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn cpu_pll_div_source_frequency() -> u32 {
+            cpu_pll_div_in_frequency()
         }
         pub fn configure_syscon_pre_div_in(
             clocks: &mut ClockTree,
@@ -2041,6 +2067,12 @@ macro_rules! define_clock_tree_types {
         pub fn syscon_pre_div_in_frequency() -> u32 {
             SYSCON_PRE_DIV_IN_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn syscon_pre_div_in_source_frequency(source: SysconPreDivInConfig) -> u32 {
+            match source {
+                SysconPreDivInConfig::Xtal => xtal_clk_frequency(),
+                SysconPreDivInConfig::RcFast => rc_fast_clk_frequency(),
+            }
+        }
         pub fn configure_syscon_pre_div(clocks: &mut ClockTree, config: SysconPreDivConfig) {
             let old_config = clocks.syscon_pre_div.replace(config);
             refresh_syscon_pre_div_downstream(clocks);
@@ -2070,6 +2102,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn syscon_pre_div_frequency() -> u32 {
             SYSCON_PRE_DIV_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn syscon_pre_div_source_frequency() -> u32 {
+            syscon_pre_div_in_frequency()
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, new_selector: ApbClkConfig) {
             let old_selector = clocks.apb_clk.replace(new_selector);
@@ -2129,6 +2164,13 @@ macro_rules! define_clock_tree_types {
         }
         pub fn apb_clk_frequency() -> u32 {
             APB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn apb_clk_source_frequency(source: ApbClkConfig) -> u32 {
+            match source {
+                ApbClkConfig::Pll80m => apb_clk_80m_frequency(),
+                ApbClkConfig::CpuDiv2 => apb_clk_cpu_div2_frequency(),
+                ApbClkConfig::Cpu => cpu_clk_frequency(),
+            }
         }
         pub fn configure_ref_tick(clocks: &mut ClockTree, new_selector: RefTickConfig) {
             let old_selector = clocks.ref_tick.replace(new_selector);
@@ -2194,6 +2236,14 @@ macro_rules! define_clock_tree_types {
         pub fn ref_tick_frequency() -> u32 {
             REF_TICK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn ref_tick_source_frequency(source: RefTickConfig) -> u32 {
+            match source {
+                RefTickConfig::Pll => ref_tick_pll_frequency(),
+                RefTickConfig::Apll => ref_tick_apll_frequency(),
+                RefTickConfig::Xtal => ref_tick_xtal_frequency(),
+                RefTickConfig::Fosc => ref_tick_fosc_frequency(),
+            }
+        }
         pub fn configure_ref_tick_xtal(clocks: &mut ClockTree, config: RefTickXtalConfig) {
             let old_config = clocks.ref_tick_xtal.replace(config);
             refresh_ref_tick_xtal_downstream(clocks);
@@ -2223,6 +2273,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn ref_tick_xtal_frequency() -> u32 {
             REF_TICK_XTAL_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn ref_tick_xtal_source_frequency() -> u32 {
+            apb_clk_frequency()
         }
         pub fn configure_ref_tick_fosc(clocks: &mut ClockTree, config: RefTickFoscConfig) {
             let old_config = clocks.ref_tick_fosc.replace(config);
@@ -2254,6 +2307,9 @@ macro_rules! define_clock_tree_types {
         pub fn ref_tick_fosc_frequency() -> u32 {
             REF_TICK_FOSC_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn ref_tick_fosc_source_frequency() -> u32 {
+            apb_clk_frequency()
+        }
         pub fn configure_ref_tick_apll(clocks: &mut ClockTree, config: RefTickApllConfig) {
             let old_config = clocks.ref_tick_apll.replace(config);
             refresh_ref_tick_apll_downstream(clocks);
@@ -2284,6 +2340,9 @@ macro_rules! define_clock_tree_types {
         pub fn ref_tick_apll_frequency() -> u32 {
             REF_TICK_APLL_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn ref_tick_apll_source_frequency() -> u32 {
+            apb_clk_frequency()
+        }
         pub fn configure_ref_tick_pll(clocks: &mut ClockTree, config: RefTickPllConfig) {
             let old_config = clocks.ref_tick_pll.replace(config);
             refresh_ref_tick_pll_downstream(clocks);
@@ -2313,6 +2372,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn ref_tick_pll_frequency() -> u32 {
             REF_TICK_PLL_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn ref_tick_pll_source_frequency() -> u32 {
+            apb_clk_frequency()
         }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, new_selector: CpuClkConfig) {
             let old_selector = clocks.cpu_clk.replace(new_selector);
@@ -2398,6 +2460,9 @@ macro_rules! define_clock_tree_types {
         pub fn apb_clk_cpu_div2_frequency() -> u32 {
             (cpu_clk_frequency() / 2)
         }
+        pub fn apb_clk_cpu_div2_source_frequency() -> u32 {
+            cpu_clk_frequency()
+        }
         pub fn request_apb_clk_80m(clocks: &mut ClockTree) {
             trace!("Requesting APB_CLK_80M");
             trace!("Enabling APB_CLK_80M");
@@ -2412,6 +2477,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn apb_clk_80m_frequency() -> u32 {
             80000000
+        }
+        pub fn apb_clk_80m_source_frequency() -> u32 {
+            cpu_clk_frequency()
         }
         pub fn request_xtal32k_clk(clocks: &mut ClockTree) {
             trace!("Requesting XTAL32K_CLK");
@@ -2466,6 +2534,9 @@ macro_rules! define_clock_tree_types {
         pub fn rc_fast_div_clk_frequency() -> u32 {
             (rc_fast_clk_frequency() / 256)
         }
+        pub fn rc_fast_div_clk_source_frequency() -> u32 {
+            rc_fast_clk_frequency()
+        }
         pub fn request_xtal_div_clk(clocks: &mut ClockTree) {
             trace!("Requesting XTAL_DIV_CLK");
             trace!("Enabling XTAL_DIV_CLK");
@@ -2480,6 +2551,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn xtal_div_clk_frequency() -> u32 {
             (xtal_clk_frequency() / 4)
+        }
+        pub fn xtal_div_clk_source_frequency() -> u32 {
+            xtal_clk_frequency()
         }
         pub fn configure_rtc_slow_clk(clocks: &mut ClockTree, new_selector: RtcSlowClkConfig) {
             let old_selector = clocks.rtc_slow_clk.replace(new_selector);
@@ -2543,6 +2617,13 @@ macro_rules! define_clock_tree_types {
         pub fn rtc_slow_clk_frequency() -> u32 {
             RTC_SLOW_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn rtc_slow_clk_source_frequency(source: RtcSlowClkConfig) -> u32 {
+            match source {
+                RtcSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
+                RtcSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
+                RtcSlowClkConfig::RcFast => rc_fast_div_clk_frequency(),
+            }
+        }
         pub fn configure_rtc_fast_clk(clocks: &mut ClockTree, new_selector: RtcFastClkConfig) {
             let old_selector = clocks.rtc_fast_clk.replace(new_selector);
             refresh_rtc_fast_clk_downstream(clocks);
@@ -2600,6 +2681,12 @@ macro_rules! define_clock_tree_types {
         pub fn rtc_fast_clk_frequency() -> u32 {
             RTC_FAST_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn rtc_fast_clk_source_frequency(source: RtcFastClkConfig) -> u32 {
+            match source {
+                RtcFastClkConfig::Xtal => xtal_div_clk_frequency(),
+                RtcFastClkConfig::Rc => rc_fast_clk_frequency(),
+            }
+        }
         pub fn request_uart_mem_clk(clocks: &mut ClockTree) {
             trace!("Requesting UART_MEM_CLK");
             if increment_reference_count(&mut clocks.uart_mem_clk_refcount) {
@@ -2618,6 +2705,11 @@ macro_rules! define_clock_tree_types {
         }
         pub fn uart_mem_clk_frequency() -> u32 {
             xtal_clk_frequency()
+        }
+        pub fn uart_mem_clk_source_frequency(source: UartMemClkConfig) -> u32 {
+            match source {
+                UartMemClkConfig::Xtal => xtal_clk_frequency(),
+            }
         }
         pub fn configure_timg_calibration_clock(
             clocks: &mut ClockTree,
@@ -2686,6 +2778,13 @@ macro_rules! define_clock_tree_types {
         pub fn timg_calibration_clock_frequency() -> u32 {
             TIMG_CALIBRATION_CLOCK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn timg_calibration_clock_source_frequency(source: TimgCalibrationClockConfig) -> u32 {
+            match source {
+                TimgCalibrationClockConfig::RcSlowClk => rc_slow_clk_frequency(),
+                TimgCalibrationClockConfig::RcFastDivClk => rc_fast_div_clk_frequency(),
+                TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
+            }
+        }
         impl I2cInstance {
             pub fn configure_function_clock(
                 self,
@@ -2707,7 +2806,9 @@ macro_rules! define_clock_tree_types {
                 if increment_reference_count(&mut clocks.i2c_function_clock_refcount[self as usize])
                 {
                     trace!("Enabling {:?}::FUNCTION_CLOCK", self);
-                    request_apb_clk(clocks);
+                    match unwrap!(clocks.i2c_function_clock[self as usize]).sclk {
+                        I2cFunctionClockSclk::Apb => request_apb_clk(clocks),
+                    }
                     self.enable_function_clock_impl(clocks, true);
                 }
             }
@@ -2717,20 +2818,28 @@ macro_rules! define_clock_tree_types {
                 {
                     trace!("Disabling {:?}::FUNCTION_CLOCK", self);
                     self.enable_function_clock_impl(clocks, false);
-                    release_apb_clk(clocks);
+                    match unwrap!(clocks.i2c_function_clock[self as usize]).sclk {
+                        I2cFunctionClockSclk::Apb => release_apb_clk(clocks),
+                    }
                 }
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: I2cFunctionClockConfig,
             ) -> u32 {
-                apb_clk_frequency()
+                match config.sclk {
+                    I2cFunctionClockSclk::Apb => apb_clk_frequency(),
+                }
             }
             pub fn function_clock_frequency(self) -> u32 {
                 I2C_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(sclk: I2cFunctionClockSclk) -> u32 {
+                match sclk {
+                    I2cFunctionClockSclk::Apb => apb_clk_frequency(),
+                }
             }
         }
         impl McpwmInstance {
@@ -2779,7 +2888,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: McpwmFunctionClockConfig,
             ) -> u32 {
@@ -2788,6 +2896,11 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 MCPWM_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(source: McpwmFunctionClockConfig) -> u32 {
+                match source {
+                    McpwmFunctionClockConfig::PllF160m => pll_f160m_clk_frequency(),
+                }
             }
         }
         impl RmtInstance {
@@ -2836,11 +2949,7 @@ macro_rules! define_clock_tree_types {
                 }
             }
             #[allow(unused_variables)]
-            pub fn sclk_config_frequency(
-                self,
-                clocks: &mut ClockTree,
-                config: RmtSclkConfig,
-            ) -> u32 {
+            pub fn sclk_config_frequency(clocks: &mut ClockTree, config: RmtSclkConfig) -> u32 {
                 match config {
                     RmtSclkConfig::RefTick => ref_tick_frequency(),
                     RmtSclkConfig::ApbClk => apb_clk_frequency(),
@@ -2848,6 +2957,12 @@ macro_rules! define_clock_tree_types {
             }
             pub fn sclk_frequency(self) -> u32 {
                 RMT_SCLK_FREQ_CACHE[self as usize].load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn sclk_source_frequency(source: RmtSclkConfig) -> u32 {
+                match source {
+                    RmtSclkConfig::RefTick => ref_tick_frequency(),
+                    RmtSclkConfig::ApbClk => apb_clk_frequency(),
+                }
             }
         }
         impl SpiInstance {
@@ -2894,7 +3009,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: SpiFunctionClockConfig,
             ) -> u32 {
@@ -2903,6 +3017,11 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 SPI_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(source: SpiFunctionClockConfig) -> u32 {
+                match source {
+                    SpiFunctionClockConfig::Apb => apb_clk_frequency(),
+                }
             }
         }
         impl UartInstance {
@@ -2963,7 +3082,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: UartFunctionClockConfig,
             ) -> u32 {
@@ -2975,6 +3093,12 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 UART_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(sclk: UartFunctionClockSclk) -> u32 {
+                match sclk {
+                    UartFunctionClockSclk::Apb => apb_clk_frequency(),
+                    UartFunctionClockSclk::RefTick => ref_tick_frequency(),
+                }
             }
             pub fn configure_mem_clock(self, clocks: &mut ClockTree, config: UartMemClockConfig) {
                 let old_config = clocks.uart_mem_clock[self as usize].replace(config);
@@ -3002,7 +3126,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn mem_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: UartMemClockConfig,
             ) -> u32 {
@@ -3011,6 +3134,9 @@ macro_rules! define_clock_tree_types {
             pub fn mem_clock_frequency(self) -> u32 {
                 UART_MEM_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn mem_clock_source_frequency() -> u32 {
+                uart_mem_clk_frequency()
             }
             pub fn configure_baud_rate_generator(
                 self,
@@ -3247,7 +3373,7 @@ macro_rules! define_clock_tree_types {
         ) {
             if let Some(config) = clocks.mcpwm_function_clock[instance as usize] {
                 MCPWM_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    McpwmInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3255,7 +3381,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_uart_mem_clock_downstream(clocks: &mut ClockTree, instance: UartInstance) {
             if let Some(config) = clocks.uart_mem_clock[instance as usize] {
                 UART_MEM_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.mem_clock_config_frequency(clocks, config),
+                    UartInstance::mem_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3327,7 +3453,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_i2c_function_clock_downstream(clocks: &mut ClockTree, instance: I2cInstance) {
             if let Some(config) = clocks.i2c_function_clock[instance as usize] {
                 I2C_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    I2cInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3335,7 +3461,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_spi_function_clock_downstream(clocks: &mut ClockTree, instance: SpiInstance) {
             if let Some(config) = clocks.spi_function_clock[instance as usize] {
                 SPI_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    SpiInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3361,7 +3487,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_rmt_sclk_downstream(clocks: &mut ClockTree, instance: RmtInstance) {
             if let Some(config) = clocks.rmt_sclk[instance as usize] {
                 RMT_SCLK_FREQ_CACHE[instance as usize].store(
-                    instance.sclk_config_frequency(clocks, config),
+                    RmtInstance::sclk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3369,7 +3495,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_uart_function_clock_downstream(clocks: &mut ClockTree, instance: UartInstance) {
             if let Some(config) = clocks.uart_function_clock[instance as usize] {
                 UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    UartInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }

--- a/esp-metadata-generated/src/_generated_esp32c2.rs
+++ b/esp-metadata-generated/src/_generated_esp32c2.rs
@@ -1219,6 +1219,14 @@ macro_rules! define_clock_tree_types {
             /// Selects `RTC_SLOW_CLK`.
             RtcSlow,
         }
+        /// The list of clock signals that the `UART_MEM_CLK` multiplexer can output.
+        #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+        pub enum UartMemClkConfig {
+            #[default]
+            /// Selects `XTAL_CLK`.
+            Xtal,
+        }
         /// The list of clock signals that the `TIMG_CALIBRATION_CLOCK` multiplexer can output.
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -1649,6 +1657,9 @@ macro_rules! define_clock_tree_types {
         pub fn pll_clk_frequency() -> u32 {
             480000000
         }
+        pub fn pll_clk_source_frequency() -> u32 {
+            xtal_clk_frequency()
+        }
         pub fn request_rc_fast_clk(clocks: &mut ClockTree) {
             trace!("Requesting RC_FAST_CLK");
             if increment_reference_count(&mut clocks.rc_fast_clk_refcount) {
@@ -1719,6 +1730,9 @@ macro_rules! define_clock_tree_types {
         pub fn rc_fast_div_clk_frequency() -> u32 {
             (rc_fast_clk_frequency() / 256)
         }
+        pub fn rc_fast_div_clk_source_frequency() -> u32 {
+            rc_fast_clk_frequency()
+        }
         pub fn configure_system_pre_div_in(
             clocks: &mut ClockTree,
             new_selector: SystemPreDivInConfig,
@@ -1771,6 +1785,12 @@ macro_rules! define_clock_tree_types {
         pub fn system_pre_div_in_frequency() -> u32 {
             SYSTEM_PRE_DIV_IN_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn system_pre_div_in_source_frequency(source: SystemPreDivInConfig) -> u32 {
+            match source {
+                SystemPreDivInConfig::Xtal => xtal_clk_frequency(),
+                SystemPreDivInConfig::RcFast => rc_fast_clk_frequency(),
+            }
+        }
         pub fn configure_system_pre_div(clocks: &mut ClockTree, config: SystemPreDivConfig) {
             let old_config = clocks.system_pre_div.replace(config);
             refresh_system_pre_div_downstream(clocks);
@@ -1801,6 +1821,9 @@ macro_rules! define_clock_tree_types {
         pub fn system_pre_div_frequency() -> u32 {
             SYSTEM_PRE_DIV_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn system_pre_div_source_frequency() -> u32 {
+            system_pre_div_in_frequency()
+        }
         pub fn configure_cpu_pll_div(clocks: &mut ClockTree, config: CpuPllDivConfig) {
             let old_config = clocks.cpu_pll_div.replace(config);
             refresh_cpu_pll_div_downstream(clocks);
@@ -1830,6 +1853,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn cpu_pll_div_frequency() -> u32 {
             CPU_PLL_DIV_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn cpu_pll_div_source_frequency() -> u32 {
+            pll_clk_frequency()
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, new_selector: ApbClkConfig) {
             let old_selector = clocks.apb_clk.replace(new_selector);
@@ -1885,6 +1911,12 @@ macro_rules! define_clock_tree_types {
         pub fn apb_clk_frequency() -> u32 {
             APB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn apb_clk_source_frequency(source: ApbClkConfig) -> u32 {
+            match source {
+                ApbClkConfig::Pll40m => pll_40m_frequency(),
+                ApbClkConfig::Cpu => cpu_clk_frequency(),
+            }
+        }
         pub fn configure_crypto_clk(clocks: &mut ClockTree, new_selector: CryptoClkConfig) {
             let old_selector = clocks.crypto_clk.replace(new_selector);
             refresh_crypto_clk_downstream(clocks);
@@ -1939,6 +1971,12 @@ macro_rules! define_clock_tree_types {
         pub fn crypto_clk_frequency() -> u32 {
             CRYPTO_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn crypto_clk_source_frequency(source: CryptoClkConfig) -> u32 {
+            match source {
+                CryptoClkConfig::Pll80m => pll_80m_frequency(),
+                CryptoClkConfig::Cpu => cpu_clk_frequency(),
+            }
+        }
         pub fn configure_mspi_clk(clocks: &mut ClockTree, new_selector: MspiClkConfig) {
             let old_selector = clocks.mspi_clk.replace(new_selector);
             refresh_mspi_clk_downstream(clocks);
@@ -1992,6 +2030,12 @@ macro_rules! define_clock_tree_types {
         }
         pub fn mspi_clk_frequency() -> u32 {
             MSPI_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn mspi_clk_source_frequency(source: MspiClkConfig) -> u32 {
+            match source {
+                MspiClkConfig::CpuDiv2 => cpu_div2_frequency(),
+                MspiClkConfig::Cpu => cpu_clk_frequency(),
+            }
         }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, new_selector: CpuClkConfig) {
             let old_selector = clocks.cpu_clk.replace(new_selector);
@@ -2064,6 +2108,9 @@ macro_rules! define_clock_tree_types {
         pub fn pll_40m_frequency() -> u32 {
             40000000
         }
+        pub fn pll_40m_source_frequency() -> u32 {
+            cpu_clk_frequency()
+        }
         pub fn request_pll_60m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_60M");
             if increment_reference_count(&mut clocks.pll_60m_refcount) {
@@ -2083,6 +2130,9 @@ macro_rules! define_clock_tree_types {
         pub fn pll_60m_frequency() -> u32 {
             60000000
         }
+        pub fn pll_60m_source_frequency() -> u32 {
+            cpu_clk_frequency()
+        }
         pub fn request_pll_80m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_80M");
             trace!("Enabling PLL_80M");
@@ -2098,6 +2148,9 @@ macro_rules! define_clock_tree_types {
         pub fn pll_80m_frequency() -> u32 {
             80000000
         }
+        pub fn pll_80m_source_frequency() -> u32 {
+            cpu_clk_frequency()
+        }
         pub fn request_cpu_div2(clocks: &mut ClockTree) {
             trace!("Requesting CPU_DIV2");
             trace!("Enabling CPU_DIV2");
@@ -2112,6 +2165,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn cpu_div2_frequency() -> u32 {
             (cpu_clk_frequency() / 2)
+        }
+        pub fn cpu_div2_source_frequency() -> u32 {
+            cpu_clk_frequency()
         }
         pub fn configure_rc_fast_clk_div_n(clocks: &mut ClockTree, config: RcFastClkDivNConfig) {
             let old_config = clocks.rc_fast_clk_div_n.replace(config);
@@ -2143,6 +2199,9 @@ macro_rules! define_clock_tree_types {
         pub fn rc_fast_clk_div_n_frequency() -> u32 {
             RC_FAST_CLK_DIV_N_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn rc_fast_clk_div_n_source_frequency() -> u32 {
+            rc_fast_clk_frequency()
+        }
         pub fn request_xtal_div_clk(clocks: &mut ClockTree) {
             trace!("Requesting XTAL_DIV_CLK");
             trace!("Enabling XTAL_DIV_CLK");
@@ -2157,6 +2216,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn xtal_div_clk_frequency() -> u32 {
             (xtal_clk_frequency() / 2)
+        }
+        pub fn xtal_div_clk_source_frequency() -> u32 {
+            xtal_clk_frequency()
         }
         pub fn configure_rtc_slow_clk(clocks: &mut ClockTree, new_selector: RtcSlowClkConfig) {
             let old_selector = clocks.rtc_slow_clk.replace(new_selector);
@@ -2211,6 +2273,13 @@ macro_rules! define_clock_tree_types {
         }
         pub fn rtc_slow_clk_frequency() -> u32 {
             RTC_SLOW_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn rtc_slow_clk_source_frequency(source: RtcSlowClkConfig) -> u32 {
+            match source {
+                RtcSlowClkConfig::OscSlow => osc_slow_clk_frequency(),
+                RtcSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
+                RtcSlowClkConfig::RcFast => rc_fast_div_clk_frequency(),
+            }
         }
         pub fn configure_rtc_fast_clk(clocks: &mut ClockTree, new_selector: RtcFastClkConfig) {
             let old_selector = clocks.rtc_fast_clk.replace(new_selector);
@@ -2268,6 +2337,12 @@ macro_rules! define_clock_tree_types {
         }
         pub fn rtc_fast_clk_frequency() -> u32 {
             RTC_FAST_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn rtc_fast_clk_source_frequency(source: RtcFastClkConfig) -> u32 {
+            match source {
+                RtcFastClkConfig::Xtal => xtal_div_clk_frequency(),
+                RtcFastClkConfig::Rc => rc_fast_clk_div_n_frequency(),
+            }
         }
         pub fn configure_low_power_clk(clocks: &mut ClockTree, new_selector: LowPowerClkConfig) {
             let old_selector = clocks.low_power_clk.replace(new_selector);
@@ -2336,6 +2411,14 @@ macro_rules! define_clock_tree_types {
         pub fn low_power_clk_frequency() -> u32 {
             LOW_POWER_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn low_power_clk_source_frequency(source: LowPowerClkConfig) -> u32 {
+            match source {
+                LowPowerClkConfig::Xtal => xtal_clk_frequency(),
+                LowPowerClkConfig::RcFast => rc_fast_clk_frequency(),
+                LowPowerClkConfig::OscSlow => osc_slow_clk_frequency(),
+                LowPowerClkConfig::RtcSlow => rtc_slow_clk_frequency(),
+            }
+        }
         pub fn request_uart_mem_clk(clocks: &mut ClockTree) {
             trace!("Requesting UART_MEM_CLK");
             if increment_reference_count(&mut clocks.uart_mem_clk_refcount) {
@@ -2354,6 +2437,11 @@ macro_rules! define_clock_tree_types {
         }
         pub fn uart_mem_clk_frequency() -> u32 {
             xtal_clk_frequency()
+        }
+        pub fn uart_mem_clk_source_frequency(source: UartMemClkConfig) -> u32 {
+            match source {
+                UartMemClkConfig::Xtal => xtal_clk_frequency(),
+            }
         }
         pub fn configure_timg_calibration_clock(
             clocks: &mut ClockTree,
@@ -2422,6 +2510,13 @@ macro_rules! define_clock_tree_types {
         pub fn timg_calibration_clock_frequency() -> u32 {
             TIMG_CALIBRATION_CLOCK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn timg_calibration_clock_source_frequency(source: TimgCalibrationClockConfig) -> u32 {
+            match source {
+                TimgCalibrationClockConfig::RcSlowClk => rc_slow_clk_frequency(),
+                TimgCalibrationClockConfig::RcFastDivClk => rc_fast_div_clk_frequency(),
+                TimgCalibrationClockConfig::Osc32kClk => osc_slow_clk_frequency(),
+            }
+        }
         impl I2cInstance {
             pub fn configure_function_clock(
                 self,
@@ -2478,7 +2573,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: I2cFunctionClockConfig,
             ) -> u32 {
@@ -2490,6 +2584,12 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 I2C_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(sclk: I2cFunctionClockSclk) -> u32 {
+                match sclk {
+                    I2cFunctionClockSclk::Xtal => xtal_clk_frequency(),
+                    I2cFunctionClockSclk::RcFast => rc_fast_clk_frequency(),
+                }
             }
         }
         impl SpiInstance {
@@ -2548,7 +2648,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: SpiFunctionClockConfig,
             ) -> u32 {
@@ -2560,6 +2659,12 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 SPI_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(source: SpiFunctionClockConfig) -> u32 {
+                match source {
+                    SpiFunctionClockConfig::Xtal => xtal_clk_frequency(),
+                    SpiFunctionClockConfig::Pll40m => pll_40m_frequency(),
+                }
             }
         }
         impl TimgInstance {
@@ -2620,7 +2725,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: TimgFunctionClockConfig,
             ) -> u32 {
@@ -2632,6 +2736,12 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 TIMG_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(source: TimgFunctionClockConfig) -> u32 {
+                match source {
+                    TimgFunctionClockConfig::XtalClk => xtal_clk_frequency(),
+                    TimgFunctionClockConfig::Pll40m => pll_40m_frequency(),
+                }
             }
             pub fn configure_wdt_clock(
                 self,
@@ -2683,7 +2793,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn wdt_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: TimgWdtClockConfig,
             ) -> u32 {
@@ -2695,6 +2804,12 @@ macro_rules! define_clock_tree_types {
             pub fn wdt_clock_frequency(self) -> u32 {
                 TIMG_WDT_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn wdt_clock_source_frequency(source: TimgWdtClockConfig) -> u32 {
+                match source {
+                    TimgWdtClockConfig::Pll40m => pll_40m_frequency(),
+                    TimgWdtClockConfig::XtalClk => xtal_clk_frequency(),
+                }
             }
         }
         impl UartInstance {
@@ -2759,7 +2874,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: UartFunctionClockConfig,
             ) -> u32 {
@@ -2772,6 +2886,13 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 UART_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(sclk: UartFunctionClockSclk) -> u32 {
+                match sclk {
+                    UartFunctionClockSclk::PllF40m => pll_40m_frequency(),
+                    UartFunctionClockSclk::RcFast => rc_fast_clk_frequency(),
+                    UartFunctionClockSclk::Xtal => xtal_clk_frequency(),
+                }
             }
             pub fn configure_mem_clock(self, clocks: &mut ClockTree, config: UartMemClockConfig) {
                 let old_config = clocks.uart_mem_clock[self as usize].replace(config);
@@ -2799,7 +2920,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn mem_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: UartMemClockConfig,
             ) -> u32 {
@@ -2808,6 +2928,9 @@ macro_rules! define_clock_tree_types {
             pub fn mem_clock_frequency(self) -> u32 {
                 UART_MEM_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn mem_clock_source_frequency() -> u32 {
+                uart_mem_clk_frequency()
             }
             pub fn configure_baud_rate_generator(
                 self,
@@ -3048,7 +3171,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_i2c_function_clock_downstream(clocks: &mut ClockTree, instance: I2cInstance) {
             if let Some(config) = clocks.i2c_function_clock[instance as usize] {
                 I2C_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    I2cInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3056,7 +3179,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_spi_function_clock_downstream(clocks: &mut ClockTree, instance: SpiInstance) {
             if let Some(config) = clocks.spi_function_clock[instance as usize] {
                 SPI_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    SpiInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3064,7 +3187,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_timg_function_clock_downstream(clocks: &mut ClockTree, instance: TimgInstance) {
             if let Some(config) = clocks.timg_function_clock[instance as usize] {
                 TIMG_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    TimgInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3072,7 +3195,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_timg_wdt_clock_downstream(clocks: &mut ClockTree, instance: TimgInstance) {
             if let Some(config) = clocks.timg_wdt_clock[instance as usize] {
                 TIMG_WDT_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.wdt_clock_config_frequency(clocks, config),
+                    TimgInstance::wdt_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3080,7 +3203,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_uart_function_clock_downstream(clocks: &mut ClockTree, instance: UartInstance) {
             if let Some(config) = clocks.uart_function_clock[instance as usize] {
                 UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    UartInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3089,7 +3212,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_uart_mem_clock_downstream(clocks: &mut ClockTree, instance: UartInstance) {
             if let Some(config) = clocks.uart_mem_clock[instance as usize] {
                 UART_MEM_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.mem_clock_config_frequency(clocks, config),
+                    UartInstance::mem_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }

--- a/esp-metadata-generated/src/_generated_esp32c3.rs
+++ b/esp-metadata-generated/src/_generated_esp32c3.rs
@@ -1556,6 +1556,14 @@ macro_rules! define_clock_tree_types {
             /// Selects `RTC_SLOW_CLK`.
             RtcSlow,
         }
+        /// The list of clock signals that the `UART_MEM_CLK` multiplexer can output.
+        #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+        pub enum UartMemClkConfig {
+            #[default]
+            /// Selects `XTAL_CLK`.
+            Xtal,
+        }
         /// The list of clock signals that the `TIMG_CALIBRATION_CLOCK` multiplexer can output.
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -2024,6 +2032,9 @@ macro_rules! define_clock_tree_types {
         pub fn pll_clk_frequency() -> u32 {
             PLL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn pll_clk_source_frequency() -> u32 {
+            xtal_clk_frequency()
+        }
         pub fn request_rc_fast_clk(clocks: &mut ClockTree) {
             trace!("Requesting RC_FAST_CLK");
             if increment_reference_count(&mut clocks.rc_fast_clk_refcount) {
@@ -2094,6 +2105,9 @@ macro_rules! define_clock_tree_types {
         pub fn rc_fast_div_clk_frequency() -> u32 {
             (rc_fast_clk_frequency() / 256)
         }
+        pub fn rc_fast_div_clk_source_frequency() -> u32 {
+            rc_fast_clk_frequency()
+        }
         pub fn configure_system_pre_div_in(
             clocks: &mut ClockTree,
             new_selector: SystemPreDivInConfig,
@@ -2146,6 +2160,12 @@ macro_rules! define_clock_tree_types {
         pub fn system_pre_div_in_frequency() -> u32 {
             SYSTEM_PRE_DIV_IN_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn system_pre_div_in_source_frequency(source: SystemPreDivInConfig) -> u32 {
+            match source {
+                SystemPreDivInConfig::Xtal => xtal_clk_frequency(),
+                SystemPreDivInConfig::RcFast => rc_fast_clk_frequency(),
+            }
+        }
         pub fn configure_system_pre_div(clocks: &mut ClockTree, config: SystemPreDivConfig) {
             let old_config = clocks.system_pre_div.replace(config);
             refresh_system_pre_div_downstream(clocks);
@@ -2176,6 +2196,9 @@ macro_rules! define_clock_tree_types {
         pub fn system_pre_div_frequency() -> u32 {
             SYSTEM_PRE_DIV_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn system_pre_div_source_frequency() -> u32 {
+            system_pre_div_in_frequency()
+        }
         pub fn configure_cpu_pll_div_out(clocks: &mut ClockTree, config: CpuPllDivOutConfig) {
             let old_config = clocks.cpu_pll_div_out.replace(config);
             refresh_cpu_pll_div_out_downstream(clocks);
@@ -2205,6 +2228,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn cpu_pll_div_out_frequency() -> u32 {
             CPU_PLL_DIV_OUT_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn cpu_pll_div_out_source_frequency() -> u32 {
+            pll_clk_frequency()
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, new_selector: ApbClkConfig) {
             let old_selector = clocks.apb_clk.replace(new_selector);
@@ -2260,6 +2286,12 @@ macro_rules! define_clock_tree_types {
         pub fn apb_clk_frequency() -> u32 {
             APB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn apb_clk_source_frequency(source: ApbClkConfig) -> u32 {
+            match source {
+                ApbClkConfig::Pll80m => pll_80m_frequency(),
+                ApbClkConfig::Cpu => cpu_clk_frequency(),
+            }
+        }
         pub fn configure_crypto_clk(clocks: &mut ClockTree, new_selector: CryptoClkConfig) {
             let old_selector = clocks.crypto_clk.replace(new_selector);
             refresh_crypto_clk_downstream(clocks);
@@ -2313,6 +2345,12 @@ macro_rules! define_clock_tree_types {
         }
         pub fn crypto_clk_frequency() -> u32 {
             CRYPTO_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn crypto_clk_source_frequency(source: CryptoClkConfig) -> u32 {
+            match source {
+                CryptoClkConfig::Pll160m => pll_160m_frequency(),
+                CryptoClkConfig::Cpu => cpu_clk_frequency(),
+            }
         }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, new_selector: CpuClkConfig) {
             let old_selector = clocks.cpu_clk.replace(new_selector);
@@ -2382,6 +2420,9 @@ macro_rules! define_clock_tree_types {
         pub fn pll_80m_frequency() -> u32 {
             80000000
         }
+        pub fn pll_80m_source_frequency() -> u32 {
+            cpu_clk_frequency()
+        }
         pub fn request_pll_160m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_160M");
             trace!("Enabling PLL_160M");
@@ -2396,6 +2437,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn pll_160m_frequency() -> u32 {
             160000000
+        }
+        pub fn pll_160m_source_frequency() -> u32 {
+            cpu_clk_frequency()
         }
         pub fn configure_rc_fast_clk_div_n(clocks: &mut ClockTree, config: RcFastClkDivNConfig) {
             let old_config = clocks.rc_fast_clk_div_n.replace(config);
@@ -2427,6 +2471,9 @@ macro_rules! define_clock_tree_types {
         pub fn rc_fast_clk_div_n_frequency() -> u32 {
             RC_FAST_CLK_DIV_N_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn rc_fast_clk_div_n_source_frequency() -> u32 {
+            rc_fast_clk_frequency()
+        }
         pub fn request_xtal_div_clk(clocks: &mut ClockTree) {
             trace!("Requesting XTAL_DIV_CLK");
             trace!("Enabling XTAL_DIV_CLK");
@@ -2441,6 +2488,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn xtal_div_clk_frequency() -> u32 {
             (xtal_clk_frequency() / 2)
+        }
+        pub fn xtal_div_clk_source_frequency() -> u32 {
+            xtal_clk_frequency()
         }
         pub fn configure_rtc_slow_clk(clocks: &mut ClockTree, new_selector: RtcSlowClkConfig) {
             let old_selector = clocks.rtc_slow_clk.replace(new_selector);
@@ -2495,6 +2545,13 @@ macro_rules! define_clock_tree_types {
         }
         pub fn rtc_slow_clk_frequency() -> u32 {
             RTC_SLOW_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn rtc_slow_clk_source_frequency(source: RtcSlowClkConfig) -> u32 {
+            match source {
+                RtcSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
+                RtcSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
+                RtcSlowClkConfig::RcFast => rc_fast_div_clk_frequency(),
+            }
         }
         pub fn configure_rtc_fast_clk(clocks: &mut ClockTree, new_selector: RtcFastClkConfig) {
             let old_selector = clocks.rtc_fast_clk.replace(new_selector);
@@ -2552,6 +2609,12 @@ macro_rules! define_clock_tree_types {
         }
         pub fn rtc_fast_clk_frequency() -> u32 {
             RTC_FAST_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn rtc_fast_clk_source_frequency(source: RtcFastClkConfig) -> u32 {
+            match source {
+                RtcFastClkConfig::Xtal => xtal_div_clk_frequency(),
+                RtcFastClkConfig::Rc => rc_fast_clk_div_n_frequency(),
+            }
         }
         pub fn configure_low_power_clk(clocks: &mut ClockTree, new_selector: LowPowerClkConfig) {
             let old_selector = clocks.low_power_clk.replace(new_selector);
@@ -2620,6 +2683,14 @@ macro_rules! define_clock_tree_types {
         pub fn low_power_clk_frequency() -> u32 {
             LOW_POWER_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn low_power_clk_source_frequency(source: LowPowerClkConfig) -> u32 {
+            match source {
+                LowPowerClkConfig::Xtal => xtal_clk_frequency(),
+                LowPowerClkConfig::RcFast => rc_fast_clk_frequency(),
+                LowPowerClkConfig::Xtal32k => xtal32k_clk_frequency(),
+                LowPowerClkConfig::RtcSlow => rtc_slow_clk_frequency(),
+            }
+        }
         pub fn request_uart_mem_clk(clocks: &mut ClockTree) {
             trace!("Requesting UART_MEM_CLK");
             if increment_reference_count(&mut clocks.uart_mem_clk_refcount) {
@@ -2638,6 +2709,11 @@ macro_rules! define_clock_tree_types {
         }
         pub fn uart_mem_clk_frequency() -> u32 {
             xtal_clk_frequency()
+        }
+        pub fn uart_mem_clk_source_frequency(source: UartMemClkConfig) -> u32 {
+            match source {
+                UartMemClkConfig::Xtal => xtal_clk_frequency(),
+            }
         }
         pub fn configure_timg_calibration_clock(
             clocks: &mut ClockTree,
@@ -2706,6 +2782,13 @@ macro_rules! define_clock_tree_types {
         pub fn timg_calibration_clock_frequency() -> u32 {
             TIMG_CALIBRATION_CLOCK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn timg_calibration_clock_source_frequency(source: TimgCalibrationClockConfig) -> u32 {
+            match source {
+                TimgCalibrationClockConfig::RcSlowClk => rc_slow_clk_frequency(),
+                TimgCalibrationClockConfig::RcFastDivClk => rc_fast_div_clk_frequency(),
+                TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
+            }
+        }
         impl I2cInstance {
             pub fn configure_function_clock(
                 self,
@@ -2762,7 +2845,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: I2cFunctionClockConfig,
             ) -> u32 {
@@ -2774,6 +2856,12 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 I2C_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(sclk: I2cFunctionClockSclk) -> u32 {
+                match sclk {
+                    I2cFunctionClockSclk::Xtal => xtal_clk_frequency(),
+                    I2cFunctionClockSclk::RcFast => rc_fast_clk_frequency(),
+                }
             }
         }
         impl RmtInstance {
@@ -2826,11 +2914,7 @@ macro_rules! define_clock_tree_types {
                 }
             }
             #[allow(unused_variables)]
-            pub fn sclk_config_frequency(
-                self,
-                clocks: &mut ClockTree,
-                config: RmtSclkConfig,
-            ) -> u32 {
+            pub fn sclk_config_frequency(clocks: &mut ClockTree, config: RmtSclkConfig) -> u32 {
                 match config {
                     RmtSclkConfig::ApbClk => apb_clk_frequency(),
                     RmtSclkConfig::RcFastClk => rc_fast_clk_frequency(),
@@ -2839,6 +2923,13 @@ macro_rules! define_clock_tree_types {
             }
             pub fn sclk_frequency(self) -> u32 {
                 RMT_SCLK_FREQ_CACHE[self as usize].load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn sclk_source_frequency(source: RmtSclkConfig) -> u32 {
+                match source {
+                    RmtSclkConfig::ApbClk => apb_clk_frequency(),
+                    RmtSclkConfig::RcFastClk => rc_fast_clk_frequency(),
+                    RmtSclkConfig::XtalClk => xtal_clk_frequency(),
+                }
             }
         }
         impl SpiInstance {
@@ -2897,7 +2988,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: SpiFunctionClockConfig,
             ) -> u32 {
@@ -2909,6 +2999,12 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 SPI_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(source: SpiFunctionClockConfig) -> u32 {
+                match source {
+                    SpiFunctionClockConfig::Xtal => xtal_clk_frequency(),
+                    SpiFunctionClockConfig::Pll80m => pll_80m_frequency(),
+                }
             }
         }
         impl TimgInstance {
@@ -2969,7 +3065,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: TimgFunctionClockConfig,
             ) -> u32 {
@@ -2981,6 +3076,12 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 TIMG_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(source: TimgFunctionClockConfig) -> u32 {
+                match source {
+                    TimgFunctionClockConfig::XtalClk => xtal_clk_frequency(),
+                    TimgFunctionClockConfig::ApbClk => apb_clk_frequency(),
+                }
             }
             pub fn configure_wdt_clock(
                 self,
@@ -3032,7 +3133,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn wdt_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: TimgWdtClockConfig,
             ) -> u32 {
@@ -3044,6 +3144,12 @@ macro_rules! define_clock_tree_types {
             pub fn wdt_clock_frequency(self) -> u32 {
                 TIMG_WDT_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn wdt_clock_source_frequency(source: TimgWdtClockConfig) -> u32 {
+                match source {
+                    TimgWdtClockConfig::ApbClk => apb_clk_frequency(),
+                    TimgWdtClockConfig::XtalClk => xtal_clk_frequency(),
+                }
             }
         }
         impl UartInstance {
@@ -3108,7 +3214,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: UartFunctionClockConfig,
             ) -> u32 {
@@ -3121,6 +3226,13 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 UART_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(sclk: UartFunctionClockSclk) -> u32 {
+                match sclk {
+                    UartFunctionClockSclk::Apb => apb_clk_frequency(),
+                    UartFunctionClockSclk::RcFast => rc_fast_clk_frequency(),
+                    UartFunctionClockSclk::Xtal => xtal_clk_frequency(),
+                }
             }
             pub fn configure_mem_clock(self, clocks: &mut ClockTree, config: UartMemClockConfig) {
                 let old_config = clocks.uart_mem_clock[self as usize].replace(config);
@@ -3148,7 +3260,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn mem_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: UartMemClockConfig,
             ) -> u32 {
@@ -3157,6 +3268,9 @@ macro_rules! define_clock_tree_types {
             pub fn mem_clock_frequency(self) -> u32 {
                 UART_MEM_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn mem_clock_source_frequency() -> u32 {
+                uart_mem_clk_frequency()
             }
             pub fn configure_baud_rate_generator(
                 self,
@@ -3406,7 +3520,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_i2c_function_clock_downstream(clocks: &mut ClockTree, instance: I2cInstance) {
             if let Some(config) = clocks.i2c_function_clock[instance as usize] {
                 I2C_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    I2cInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3414,7 +3528,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_spi_function_clock_downstream(clocks: &mut ClockTree, instance: SpiInstance) {
             if let Some(config) = clocks.spi_function_clock[instance as usize] {
                 SPI_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    SpiInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3422,7 +3536,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_uart_mem_clock_downstream(clocks: &mut ClockTree, instance: UartInstance) {
             if let Some(config) = clocks.uart_mem_clock[instance as usize] {
                 UART_MEM_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.mem_clock_config_frequency(clocks, config),
+                    UartInstance::mem_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3456,7 +3570,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_rmt_sclk_downstream(clocks: &mut ClockTree, instance: RmtInstance) {
             if let Some(config) = clocks.rmt_sclk[instance as usize] {
                 RMT_SCLK_FREQ_CACHE[instance as usize].store(
-                    instance.sclk_config_frequency(clocks, config),
+                    RmtInstance::sclk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3464,7 +3578,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_timg_function_clock_downstream(clocks: &mut ClockTree, instance: TimgInstance) {
             if let Some(config) = clocks.timg_function_clock[instance as usize] {
                 TIMG_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    TimgInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3472,7 +3586,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_timg_wdt_clock_downstream(clocks: &mut ClockTree, instance: TimgInstance) {
             if let Some(config) = clocks.timg_wdt_clock[instance as usize] {
                 TIMG_WDT_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.wdt_clock_config_frequency(clocks, config),
+                    TimgInstance::wdt_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3480,7 +3594,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_uart_function_clock_downstream(clocks: &mut ClockTree, instance: UartInstance) {
             if let Some(config) = clocks.uart_function_clock[instance as usize] {
                 UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    UartInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }

--- a/esp-metadata-generated/src/_generated_esp32c5.rs
+++ b/esp-metadata-generated/src/_generated_esp32c5.rs
@@ -2155,6 +2155,9 @@ macro_rules! define_clock_tree_types {
         pub fn pll_clk_frequency() -> u32 {
             480000000
         }
+        pub fn pll_clk_source_frequency() -> u32 {
+            xtal_clk_frequency()
+        }
         pub fn request_rc_fast_clk(clocks: &mut ClockTree) {
             trace!("Requesting RC_FAST_CLK");
             if increment_reference_count(&mut clocks.rc_fast_clk_refcount) {
@@ -2242,6 +2245,9 @@ macro_rules! define_clock_tree_types {
         pub fn pll_f12m_frequency() -> u32 {
             (pll_clk_frequency() / 40)
         }
+        pub fn pll_f12m_source_frequency() -> u32 {
+            pll_clk_frequency()
+        }
         pub fn request_pll_f20m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F20M");
             if increment_reference_count(&mut clocks.pll_f20m_refcount) {
@@ -2260,6 +2266,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn pll_f20m_frequency() -> u32 {
             (pll_clk_frequency() / 24)
+        }
+        pub fn pll_f20m_source_frequency() -> u32 {
+            pll_clk_frequency()
         }
         pub fn request_pll_f40m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F40M");
@@ -2280,6 +2289,9 @@ macro_rules! define_clock_tree_types {
         pub fn pll_f40m_frequency() -> u32 {
             (pll_clk_frequency() / 12)
         }
+        pub fn pll_f40m_source_frequency() -> u32 {
+            pll_clk_frequency()
+        }
         pub fn request_pll_f48m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F48M");
             if increment_reference_count(&mut clocks.pll_f48m_refcount) {
@@ -2298,6 +2310,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn pll_f48m_frequency() -> u32 {
             (pll_clk_frequency() / 10)
+        }
+        pub fn pll_f48m_source_frequency() -> u32 {
+            pll_clk_frequency()
         }
         pub fn request_pll_f60m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F60M");
@@ -2318,6 +2333,9 @@ macro_rules! define_clock_tree_types {
         pub fn pll_f60m_frequency() -> u32 {
             (pll_clk_frequency() / 8)
         }
+        pub fn pll_f60m_source_frequency() -> u32 {
+            pll_clk_frequency()
+        }
         pub fn request_pll_f80m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F80M");
             if increment_reference_count(&mut clocks.pll_f80m_refcount) {
@@ -2337,6 +2355,9 @@ macro_rules! define_clock_tree_types {
         pub fn pll_f80m_frequency() -> u32 {
             (pll_clk_frequency() / 6)
         }
+        pub fn pll_f80m_source_frequency() -> u32 {
+            pll_clk_frequency()
+        }
         pub fn request_pll_f120m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F120M");
             trace!("Enabling PLL_F120M");
@@ -2351,6 +2372,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn pll_f120m_frequency() -> u32 {
             (pll_clk_frequency() / 4)
+        }
+        pub fn pll_f120m_source_frequency() -> u32 {
+            pll_clk_frequency()
         }
         pub fn request_pll_f160m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F160M");
@@ -2371,6 +2395,9 @@ macro_rules! define_clock_tree_types {
         pub fn pll_f160m_frequency() -> u32 {
             (pll_clk_frequency() / 3)
         }
+        pub fn pll_f160m_source_frequency() -> u32 {
+            pll_clk_frequency()
+        }
         pub fn request_pll_f240m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F240M");
             if increment_reference_count(&mut clocks.pll_f240m_refcount) {
@@ -2389,6 +2416,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn pll_f240m_frequency() -> u32 {
             (pll_clk_frequency() / 2)
+        }
+        pub fn pll_f240m_source_frequency() -> u32 {
+            pll_clk_frequency()
         }
         pub fn configure_hp_root_clk(clocks: &mut ClockTree, new_selector: HpRootClkConfig) {
             let old_selector = clocks.hp_root_clk.replace(new_selector);
@@ -2457,6 +2487,14 @@ macro_rules! define_clock_tree_types {
         pub fn hp_root_clk_frequency() -> u32 {
             HP_ROOT_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn hp_root_clk_source_frequency(source: HpRootClkConfig) -> u32 {
+            match source {
+                HpRootClkConfig::Xtal => xtal_clk_frequency(),
+                HpRootClkConfig::RcFast => rc_fast_clk_frequency(),
+                HpRootClkConfig::PllF160m => pll_f160m_frequency(),
+                HpRootClkConfig::PllF240m => pll_f240m_frequency(),
+            }
+        }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, config: CpuClkConfig) {
             let old_config = clocks.cpu_clk.replace(config);
             refresh_cpu_clk_downstream(clocks);
@@ -2488,6 +2526,9 @@ macro_rules! define_clock_tree_types {
         pub fn cpu_clk_frequency() -> u32 {
             CPU_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn cpu_clk_source_frequency() -> u32 {
+            hp_root_clk_frequency()
+        }
         pub fn configure_ahb_clk(clocks: &mut ClockTree, config: AhbClkConfig) {
             let old_config = clocks.ahb_clk.replace(config);
             refresh_ahb_clk_downstream(clocks);
@@ -2514,6 +2555,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn ahb_clk_frequency() -> u32 {
             AHB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn ahb_clk_source_frequency() -> u32 {
+            hp_root_clk_frequency()
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, config: ApbClkConfig) {
             let old_config = clocks.apb_clk.replace(config);
@@ -2546,6 +2590,9 @@ macro_rules! define_clock_tree_types {
         pub fn apb_clk_frequency() -> u32 {
             APB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn apb_clk_source_frequency() -> u32 {
+            ahb_clk_frequency()
+        }
         pub fn request_xtal_d2_clk(clocks: &mut ClockTree) {
             trace!("Requesting XTAL_D2_CLK");
             trace!("Enabling XTAL_D2_CLK");
@@ -2560,6 +2607,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn xtal_d2_clk_frequency() -> u32 {
             (xtal_clk_frequency() / 2)
+        }
+        pub fn xtal_d2_clk_source_frequency() -> u32 {
+            xtal_clk_frequency()
         }
         pub fn configure_lp_fast_clk(clocks: &mut ClockTree, new_selector: LpFastClkConfig) {
             let old_selector = clocks.lp_fast_clk.replace(new_selector);
@@ -2623,6 +2673,13 @@ macro_rules! define_clock_tree_types {
         pub fn lp_fast_clk_frequency() -> u32 {
             LP_FAST_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn lp_fast_clk_source_frequency(source: LpFastClkConfig) -> u32 {
+            match source {
+                LpFastClkConfig::RcFast => rc_fast_clk_frequency(),
+                LpFastClkConfig::XtalD2 => xtal_d2_clk_frequency(),
+                LpFastClkConfig::Xtal => xtal_clk_frequency(),
+            }
+        }
         pub fn configure_lp_slow_clk(clocks: &mut ClockTree, new_selector: LpSlowClkConfig) {
             let old_selector = clocks.lp_slow_clk.replace(new_selector);
             refresh_lp_slow_clk_downstream(clocks);
@@ -2685,6 +2742,13 @@ macro_rules! define_clock_tree_types {
         pub fn lp_slow_clk_frequency() -> u32 {
             LP_SLOW_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn lp_slow_clk_source_frequency(source: LpSlowClkConfig) -> u32 {
+            match source {
+                LpSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
+                LpSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
+                LpSlowClkConfig::OscSlow => osc_slow_clk_frequency(),
+            }
+        }
         pub fn configure_crypto_clk(clocks: &mut ClockTree, new_selector: CryptoClkConfig) {
             let old_selector = clocks.crypto_clk.replace(new_selector);
             refresh_crypto_clk_downstream(clocks);
@@ -2743,6 +2807,13 @@ macro_rules! define_clock_tree_types {
         }
         pub fn crypto_clk_frequency() -> u32 {
             CRYPTO_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn crypto_clk_source_frequency(source: CryptoClkConfig) -> u32 {
+            match source {
+                CryptoClkConfig::Xtal => xtal_clk_frequency(),
+                CryptoClkConfig::Fosc => rc_fast_clk_frequency(),
+                CryptoClkConfig::PllF480m => pll_clk_frequency(),
+            }
         }
         pub fn configure_timg_calibration_clock(
             clocks: &mut ClockTree,
@@ -2816,6 +2887,14 @@ macro_rules! define_clock_tree_types {
         pub fn timg_calibration_clock_frequency() -> u32 {
             TIMG_CALIBRATION_CLOCK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn timg_calibration_clock_source_frequency(source: TimgCalibrationClockConfig) -> u32 {
+            match source {
+                TimgCalibrationClockConfig::OscSlowClk => osc_slow_clk_frequency(),
+                TimgCalibrationClockConfig::RcSlowClk => rc_slow_clk_frequency(),
+                TimgCalibrationClockConfig::RcFastDivClk => rc_fast_clk_frequency(),
+                TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
+            }
+        }
         impl I2cInstance {
             pub fn configure_function_clock(
                 self,
@@ -2872,7 +2951,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: I2cFunctionClockConfig,
             ) -> u32 {
@@ -2884,6 +2962,12 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 I2C_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(sclk: I2cFunctionClockSclk) -> u32 {
+                match sclk {
+                    I2cFunctionClockSclk::Xtal => xtal_clk_frequency(),
+                    I2cFunctionClockSclk::RcFast => rc_fast_clk_frequency(),
+                }
             }
         }
         impl ParlIoInstance {
@@ -2941,7 +3025,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn rx_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: ParlIoRxClockConfig,
             ) -> u32 {
@@ -2954,6 +3037,13 @@ macro_rules! define_clock_tree_types {
             pub fn rx_clock_frequency(self) -> u32 {
                 PARL_IO_RX_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn rx_clock_source_frequency(source: ParlIoRxClockConfig) -> u32 {
+                match source {
+                    ParlIoRxClockConfig::XtalClk => xtal_clk_frequency(),
+                    ParlIoRxClockConfig::RcFastClk => rc_fast_clk_frequency(),
+                    ParlIoRxClockConfig::PllF240m => pll_f240m_frequency(),
+                }
             }
             pub fn configure_tx_clock(
                 self,
@@ -3009,7 +3099,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn tx_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: ParlIoTxClockConfig,
             ) -> u32 {
@@ -3022,6 +3111,13 @@ macro_rules! define_clock_tree_types {
             pub fn tx_clock_frequency(self) -> u32 {
                 PARL_IO_TX_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn tx_clock_source_frequency(source: ParlIoTxClockConfig) -> u32 {
+                match source {
+                    ParlIoTxClockConfig::XtalClk => xtal_clk_frequency(),
+                    ParlIoTxClockConfig::RcFastClk => rc_fast_clk_frequency(),
+                    ParlIoTxClockConfig::PllF240m => pll_f240m_frequency(),
+                }
             }
         }
         impl RmtInstance {
@@ -3074,11 +3170,7 @@ macro_rules! define_clock_tree_types {
                 }
             }
             #[allow(unused_variables)]
-            pub fn sclk_config_frequency(
-                self,
-                clocks: &mut ClockTree,
-                config: RmtSclkConfig,
-            ) -> u32 {
+            pub fn sclk_config_frequency(clocks: &mut ClockTree, config: RmtSclkConfig) -> u32 {
                 match config {
                     RmtSclkConfig::XtalClk => xtal_clk_frequency(),
                     RmtSclkConfig::RcFastClk => rc_fast_clk_frequency(),
@@ -3087,6 +3179,13 @@ macro_rules! define_clock_tree_types {
             }
             pub fn sclk_frequency(self) -> u32 {
                 RMT_SCLK_FREQ_CACHE[self as usize].load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn sclk_source_frequency(source: RmtSclkConfig) -> u32 {
+                match source {
+                    RmtSclkConfig::XtalClk => xtal_clk_frequency(),
+                    RmtSclkConfig::RcFastClk => rc_fast_clk_frequency(),
+                    RmtSclkConfig::PllF80m => pll_f80m_frequency(),
+                }
             }
         }
         impl SpiInstance {
@@ -3153,7 +3252,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: SpiFunctionClockConfig,
             ) -> u32 {
@@ -3167,6 +3265,14 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 SPI_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(source: SpiFunctionClockConfig) -> u32 {
+                match source {
+                    SpiFunctionClockConfig::Xtal => xtal_clk_frequency(),
+                    SpiFunctionClockConfig::PllF160m => pll_f160m_frequency(),
+                    SpiFunctionClockConfig::PllF120m => pll_f120m_frequency(),
+                    SpiFunctionClockConfig::RcFast => rc_fast_clk_frequency(),
+                }
             }
         }
         impl TimgInstance {
@@ -3231,7 +3337,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: TimgFunctionClockConfig,
             ) -> u32 {
@@ -3244,6 +3349,13 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 TIMG_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(source: TimgFunctionClockConfig) -> u32 {
+                match source {
+                    TimgFunctionClockConfig::XtalClk => xtal_clk_frequency(),
+                    TimgFunctionClockConfig::RcFastClk => rc_fast_clk_frequency(),
+                    TimgFunctionClockConfig::PllF80m => pll_f80m_frequency(),
+                }
             }
             pub fn configure_wdt_clock(
                 self,
@@ -3299,7 +3411,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn wdt_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: TimgWdtClockConfig,
             ) -> u32 {
@@ -3312,6 +3423,13 @@ macro_rules! define_clock_tree_types {
             pub fn wdt_clock_frequency(self) -> u32 {
                 TIMG_WDT_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn wdt_clock_source_frequency(source: TimgWdtClockConfig) -> u32 {
+                match source {
+                    TimgWdtClockConfig::XtalClk => xtal_clk_frequency(),
+                    TimgWdtClockConfig::PllF80m => pll_f80m_frequency(),
+                    TimgWdtClockConfig::RcFastClk => rc_fast_clk_frequency(),
+                }
             }
         }
         impl UartInstance {
@@ -3376,7 +3494,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: UartFunctionClockConfig,
             ) -> u32 {
@@ -3389,6 +3506,13 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 UART_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(sclk: UartFunctionClockSclk) -> u32 {
+                match sclk {
+                    UartFunctionClockSclk::Xtal => xtal_clk_frequency(),
+                    UartFunctionClockSclk::PllF80m => pll_f80m_frequency(),
+                    UartFunctionClockSclk::RcFast => rc_fast_clk_frequency(),
+                }
             }
             pub fn configure_baud_rate_generator(
                 self,
@@ -3611,7 +3735,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_i2c_function_clock_downstream(clocks: &mut ClockTree, instance: I2cInstance) {
             if let Some(config) = clocks.i2c_function_clock[instance as usize] {
                 I2C_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    I2cInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3619,7 +3743,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_parl_io_rx_clock_downstream(clocks: &mut ClockTree, instance: ParlIoInstance) {
             if let Some(config) = clocks.parl_io_rx_clock[instance as usize] {
                 PARL_IO_RX_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.rx_clock_config_frequency(clocks, config),
+                    ParlIoInstance::rx_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3627,7 +3751,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_parl_io_tx_clock_downstream(clocks: &mut ClockTree, instance: ParlIoInstance) {
             if let Some(config) = clocks.parl_io_tx_clock[instance as usize] {
                 PARL_IO_TX_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.tx_clock_config_frequency(clocks, config),
+                    ParlIoInstance::tx_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3635,7 +3759,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_rmt_sclk_downstream(clocks: &mut ClockTree, instance: RmtInstance) {
             if let Some(config) = clocks.rmt_sclk[instance as usize] {
                 RMT_SCLK_FREQ_CACHE[instance as usize].store(
-                    instance.sclk_config_frequency(clocks, config),
+                    RmtInstance::sclk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3643,7 +3767,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_spi_function_clock_downstream(clocks: &mut ClockTree, instance: SpiInstance) {
             if let Some(config) = clocks.spi_function_clock[instance as usize] {
                 SPI_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    SpiInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3651,7 +3775,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_timg_function_clock_downstream(clocks: &mut ClockTree, instance: TimgInstance) {
             if let Some(config) = clocks.timg_function_clock[instance as usize] {
                 TIMG_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    TimgInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3659,7 +3783,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_timg_wdt_clock_downstream(clocks: &mut ClockTree, instance: TimgInstance) {
             if let Some(config) = clocks.timg_wdt_clock[instance as usize] {
                 TIMG_WDT_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.wdt_clock_config_frequency(clocks, config),
+                    TimgInstance::wdt_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3667,7 +3791,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_uart_function_clock_downstream(clocks: &mut ClockTree, instance: UartInstance) {
             if let Some(config) = clocks.uart_function_clock[instance as usize] {
                 UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    UartInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }

--- a/esp-metadata-generated/src/_generated_esp32c6.rs
+++ b/esp-metadata-generated/src/_generated_esp32c6.rs
@@ -2522,6 +2522,9 @@ macro_rules! define_clock_tree_types {
         pub fn pll_clk_frequency() -> u32 {
             480000000
         }
+        pub fn pll_clk_source_frequency() -> u32 {
+            xtal_clk_frequency()
+        }
         pub fn request_rc_fast_clk(clocks: &mut ClockTree) {
             trace!("Requesting RC_FAST_CLK");
             if increment_reference_count(&mut clocks.rc_fast_clk_refcount) {
@@ -2616,6 +2619,9 @@ macro_rules! define_clock_tree_types {
         pub fn hp_root_clk_frequency() -> u32 {
             HP_ROOT_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn hp_root_clk_source_frequency() -> u32 {
+            soc_root_clk_frequency()
+        }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, new_selector: CpuClkConfig) {
             let old_selector = clocks.cpu_clk.replace(new_selector);
             refresh_cpu_clk_downstream(clocks);
@@ -2646,6 +2652,12 @@ macro_rules! define_clock_tree_types {
         pub fn cpu_clk_frequency() -> u32 {
             CPU_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn cpu_clk_source_frequency(source: CpuClkConfig) -> u32 {
+            match source {
+                CpuClkConfig::Hs => cpu_hs_div_frequency(),
+                CpuClkConfig::Ls => cpu_ls_div_frequency(),
+            }
+        }
         pub fn configure_ahb_clk(clocks: &mut ClockTree, new_selector: AhbClkConfig) {
             let old_selector = clocks.ahb_clk.replace(new_selector);
             refresh_ahb_clk_downstream(clocks);
@@ -2675,6 +2687,12 @@ macro_rules! define_clock_tree_types {
         }
         pub fn ahb_clk_frequency() -> u32 {
             AHB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn ahb_clk_source_frequency(source: AhbClkConfig) -> u32 {
+            match source {
+                AhbClkConfig::Hs => ahb_hs_div_frequency(),
+                AhbClkConfig::Ls => ahb_ls_div_frequency(),
+            }
         }
         pub fn configure_mspi_fast_clk(clocks: &mut ClockTree, new_selector: MspiFastClkConfig) {
             let old_selector = clocks.mspi_fast_clk.replace(new_selector);
@@ -2732,6 +2750,12 @@ macro_rules! define_clock_tree_types {
         }
         pub fn mspi_fast_clk_frequency() -> u32 {
             MSPI_FAST_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn mspi_fast_clk_source_frequency(source: MspiFastClkConfig) -> u32 {
+            match source {
+                MspiFastClkConfig::Hs => mspi_fast_hs_clk_frequency(),
+                MspiFastClkConfig::Ls => mspi_fast_ls_clk_frequency(),
+            }
         }
         pub fn configure_soc_root_clk(clocks: &mut ClockTree, new_selector: SocRootClkConfig) {
             let old_selector = clocks.soc_root_clk.replace(new_selector);
@@ -2837,6 +2861,9 @@ macro_rules! define_clock_tree_types {
         pub fn cpu_hs_div_frequency() -> u32 {
             CPU_HS_DIV_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn cpu_hs_div_source_frequency() -> u32 {
+            hp_root_clk_frequency()
+        }
         pub fn configure_cpu_ls_div(clocks: &mut ClockTree, config: CpuLsDivConfig) {
             let old_config = clocks.cpu_ls_div.replace(config);
             refresh_cpu_ls_div_downstream(clocks);
@@ -2863,6 +2890,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn cpu_ls_div_frequency() -> u32 {
             CPU_LS_DIV_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn cpu_ls_div_source_frequency() -> u32 {
+            hp_root_clk_frequency()
         }
         pub fn configure_ahb_hs_div(clocks: &mut ClockTree, config: AhbHsDivConfig) {
             let old_config = clocks.ahb_hs_div.replace(config);
@@ -2891,6 +2921,9 @@ macro_rules! define_clock_tree_types {
         pub fn ahb_hs_div_frequency() -> u32 {
             AHB_HS_DIV_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn ahb_hs_div_source_frequency() -> u32 {
+            hp_root_clk_frequency()
+        }
         pub fn configure_ahb_ls_div(clocks: &mut ClockTree, config: AhbLsDivConfig) {
             let old_config = clocks.ahb_ls_div.replace(config);
             refresh_ahb_ls_div_downstream(clocks);
@@ -2917,6 +2950,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn ahb_ls_div_frequency() -> u32 {
             AHB_LS_DIV_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn ahb_ls_div_source_frequency() -> u32 {
+            hp_root_clk_frequency()
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, config: ApbClkConfig) {
             let old_config = clocks.apb_clk.replace(config);
@@ -2949,6 +2985,9 @@ macro_rules! define_clock_tree_types {
         pub fn apb_clk_frequency() -> u32 {
             APB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn apb_clk_source_frequency() -> u32 {
+            ahb_clk_frequency()
+        }
         pub fn configure_mspi_fast_hs_clk(clocks: &mut ClockTree, config: MspiFastHsClkConfig) {
             let old_config = clocks.mspi_fast_hs_clk.replace(config);
             refresh_mspi_fast_hs_clk_downstream(clocks);
@@ -2978,6 +3017,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn mspi_fast_hs_clk_frequency() -> u32 {
             MSPI_FAST_HS_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn mspi_fast_hs_clk_source_frequency() -> u32 {
+            hp_root_clk_frequency()
         }
         pub fn configure_mspi_fast_ls_clk(clocks: &mut ClockTree, config: MspiFastLsClkConfig) {
             let old_config = clocks.mspi_fast_ls_clk.replace(config);
@@ -3009,6 +3051,9 @@ macro_rules! define_clock_tree_types {
         pub fn mspi_fast_ls_clk_frequency() -> u32 {
             MSPI_FAST_LS_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn mspi_fast_ls_clk_source_frequency() -> u32 {
+            hp_root_clk_frequency()
+        }
         pub fn request_pll_f48m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F48M");
             if increment_reference_count(&mut clocks.pll_f48m_refcount) {
@@ -3027,6 +3072,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn pll_f48m_frequency() -> u32 {
             48000000
+        }
+        pub fn pll_f48m_source_frequency() -> u32 {
+            pll_clk_frequency()
         }
         pub fn request_pll_f80m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F80M");
@@ -3047,6 +3095,9 @@ macro_rules! define_clock_tree_types {
         pub fn pll_f80m_frequency() -> u32 {
             80000000
         }
+        pub fn pll_f80m_source_frequency() -> u32 {
+            pll_clk_frequency()
+        }
         pub fn request_pll_f160m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F160M");
             trace!("Enabling PLL_F160M");
@@ -3061,6 +3112,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn pll_f160m_frequency() -> u32 {
             160000000
+        }
+        pub fn pll_f160m_source_frequency() -> u32 {
+            pll_clk_frequency()
         }
         pub fn request_pll_f240m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F240M");
@@ -3080,6 +3134,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn pll_f240m_frequency() -> u32 {
             240000000
+        }
+        pub fn pll_f240m_source_frequency() -> u32 {
+            pll_clk_frequency()
         }
         pub fn configure_ledc_sclk(clocks: &mut ClockTree, new_selector: LedcSclkConfig) {
             let old_selector = clocks.ledc_sclk.replace(new_selector);
@@ -3140,6 +3197,13 @@ macro_rules! define_clock_tree_types {
         pub fn ledc_sclk_frequency() -> u32 {
             LEDC_SCLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn ledc_sclk_source_frequency(source: LedcSclkConfig) -> u32 {
+            match source {
+                LedcSclkConfig::PllF80m => pll_f80m_frequency(),
+                LedcSclkConfig::RcFastClk => rc_fast_clk_frequency(),
+                LedcSclkConfig::XtalClk => xtal_clk_frequency(),
+            }
+        }
         pub fn request_xtal_d2_clk(clocks: &mut ClockTree) {
             trace!("Requesting XTAL_D2_CLK");
             trace!("Enabling XTAL_D2_CLK");
@@ -3154,6 +3218,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn xtal_d2_clk_frequency() -> u32 {
             (xtal_clk_frequency() / 2)
+        }
+        pub fn xtal_d2_clk_source_frequency() -> u32 {
+            xtal_clk_frequency()
         }
         pub fn configure_lp_fast_clk(clocks: &mut ClockTree, new_selector: LpFastClkConfig) {
             let old_selector = clocks.lp_fast_clk.replace(new_selector);
@@ -3212,6 +3279,12 @@ macro_rules! define_clock_tree_types {
         pub fn lp_fast_clk_frequency() -> u32 {
             LP_FAST_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn lp_fast_clk_source_frequency(source: LpFastClkConfig) -> u32 {
+            match source {
+                LpFastClkConfig::RcFastClk => rc_fast_clk_frequency(),
+                LpFastClkConfig::XtalD2Clk => xtal_d2_clk_frequency(),
+            }
+        }
         pub fn configure_lp_slow_clk(clocks: &mut ClockTree, new_selector: LpSlowClkConfig) {
             let old_selector = clocks.lp_slow_clk.replace(new_selector);
             refresh_lp_slow_clk_downstream(clocks);
@@ -3265,6 +3338,13 @@ macro_rules! define_clock_tree_types {
         }
         pub fn lp_slow_clk_frequency() -> u32 {
             LP_SLOW_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn lp_slow_clk_source_frequency(source: LpSlowClkConfig) -> u32 {
+            match source {
+                LpSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
+                LpSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
+                LpSlowClkConfig::OscSlow => osc_slow_clk_frequency(),
+            }
         }
         pub fn configure_timg_calibration_clock(
             clocks: &mut ClockTree,
@@ -3333,6 +3413,13 @@ macro_rules! define_clock_tree_types {
         pub fn timg_calibration_clock_frequency() -> u32 {
             TIMG_CALIBRATION_CLOCK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn timg_calibration_clock_source_frequency(source: TimgCalibrationClockConfig) -> u32 {
+            match source {
+                TimgCalibrationClockConfig::RcSlowClk => lp_slow_clk_frequency(),
+                TimgCalibrationClockConfig::RcFastDivClk => rc_fast_clk_frequency(),
+                TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
+            }
+        }
         impl I2cInstance {
             pub fn configure_function_clock(
                 self,
@@ -3389,7 +3476,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: I2cFunctionClockConfig,
             ) -> u32 {
@@ -3401,6 +3487,12 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 I2C_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(sclk: I2cFunctionClockSclk) -> u32 {
+                match sclk {
+                    I2cFunctionClockSclk::Xtal => xtal_clk_frequency(),
+                    I2cFunctionClockSclk::RcFast => rc_fast_clk_frequency(),
+                }
             }
         }
         impl McpwmInstance {
@@ -3465,7 +3557,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: McpwmFunctionClockConfig,
             ) -> u32 {
@@ -3478,6 +3569,13 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 MCPWM_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(source: McpwmFunctionClockConfig) -> u32 {
+                match source {
+                    McpwmFunctionClockConfig::PllF160m => pll_f160m_frequency(),
+                    McpwmFunctionClockConfig::RcFastClk => rc_fast_clk_frequency(),
+                    McpwmFunctionClockConfig::XtalClk => xtal_clk_frequency(),
+                }
             }
         }
         impl ParlIoInstance {
@@ -3535,7 +3633,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn rx_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: ParlIoRxClockConfig,
             ) -> u32 {
@@ -3548,6 +3645,13 @@ macro_rules! define_clock_tree_types {
             pub fn rx_clock_frequency(self) -> u32 {
                 PARL_IO_RX_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn rx_clock_source_frequency(source: ParlIoRxClockConfig) -> u32 {
+                match source {
+                    ParlIoRxClockConfig::XtalClk => xtal_clk_frequency(),
+                    ParlIoRxClockConfig::RcFastClk => rc_fast_clk_frequency(),
+                    ParlIoRxClockConfig::PllF240m => pll_f240m_frequency(),
+                }
             }
             pub fn configure_tx_clock(
                 self,
@@ -3603,7 +3707,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn tx_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: ParlIoTxClockConfig,
             ) -> u32 {
@@ -3616,6 +3719,13 @@ macro_rules! define_clock_tree_types {
             pub fn tx_clock_frequency(self) -> u32 {
                 PARL_IO_TX_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn tx_clock_source_frequency(source: ParlIoTxClockConfig) -> u32 {
+                match source {
+                    ParlIoTxClockConfig::XtalClk => xtal_clk_frequency(),
+                    ParlIoTxClockConfig::RcFastClk => rc_fast_clk_frequency(),
+                    ParlIoTxClockConfig::PllF240m => pll_f240m_frequency(),
+                }
             }
         }
         impl RmtInstance {
@@ -3668,11 +3778,7 @@ macro_rules! define_clock_tree_types {
                 }
             }
             #[allow(unused_variables)]
-            pub fn sclk_config_frequency(
-                self,
-                clocks: &mut ClockTree,
-                config: RmtSclkConfig,
-            ) -> u32 {
+            pub fn sclk_config_frequency(clocks: &mut ClockTree, config: RmtSclkConfig) -> u32 {
                 match config {
                     RmtSclkConfig::PllF80m => pll_f80m_frequency(),
                     RmtSclkConfig::RcFastClk => rc_fast_clk_frequency(),
@@ -3681,6 +3787,13 @@ macro_rules! define_clock_tree_types {
             }
             pub fn sclk_frequency(self) -> u32 {
                 RMT_SCLK_FREQ_CACHE[self as usize].load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn sclk_source_frequency(source: RmtSclkConfig) -> u32 {
+                match source {
+                    RmtSclkConfig::PllF80m => pll_f80m_frequency(),
+                    RmtSclkConfig::RcFastClk => rc_fast_clk_frequency(),
+                    RmtSclkConfig::XtalClk => xtal_clk_frequency(),
+                }
             }
         }
         impl SpiInstance {
@@ -3743,7 +3856,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: SpiFunctionClockConfig,
             ) -> u32 {
@@ -3756,6 +3868,13 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 SPI_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(source: SpiFunctionClockConfig) -> u32 {
+                match source {
+                    SpiFunctionClockConfig::PllF80m => pll_f80m_frequency(),
+                    SpiFunctionClockConfig::Xtal => xtal_clk_frequency(),
+                    SpiFunctionClockConfig::RcFast => rc_fast_clk_frequency(),
+                }
             }
         }
         impl TimgInstance {
@@ -3820,7 +3939,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: TimgFunctionClockConfig,
             ) -> u32 {
@@ -3833,6 +3951,13 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 TIMG_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(source: TimgFunctionClockConfig) -> u32 {
+                match source {
+                    TimgFunctionClockConfig::XtalClk => xtal_clk_frequency(),
+                    TimgFunctionClockConfig::RcFastClk => rc_fast_clk_frequency(),
+                    TimgFunctionClockConfig::PllF80m => pll_f80m_frequency(),
+                }
             }
             pub fn configure_wdt_clock(
                 self,
@@ -3888,7 +4013,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn wdt_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: TimgWdtClockConfig,
             ) -> u32 {
@@ -3901,6 +4025,13 @@ macro_rules! define_clock_tree_types {
             pub fn wdt_clock_frequency(self) -> u32 {
                 TIMG_WDT_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn wdt_clock_source_frequency(source: TimgWdtClockConfig) -> u32 {
+                match source {
+                    TimgWdtClockConfig::XtalClk => xtal_clk_frequency(),
+                    TimgWdtClockConfig::PllF80m => pll_f80m_frequency(),
+                    TimgWdtClockConfig::RcFastClk => rc_fast_clk_frequency(),
+                }
             }
         }
         impl UartInstance {
@@ -3965,7 +4096,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: UartFunctionClockConfig,
             ) -> u32 {
@@ -3978,6 +4108,13 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 UART_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(sclk: UartFunctionClockSclk) -> u32 {
+                match sclk {
+                    UartFunctionClockSclk::PllF80m => pll_f80m_frequency(),
+                    UartFunctionClockSclk::RcFast => rc_fast_clk_frequency(),
+                    UartFunctionClockSclk::Xtal => xtal_clk_frequency(),
+                }
             }
             pub fn configure_baud_rate_generator(
                 self,
@@ -4198,7 +4335,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_i2c_function_clock_downstream(clocks: &mut ClockTree, instance: I2cInstance) {
             if let Some(config) = clocks.i2c_function_clock[instance as usize] {
                 I2C_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    I2cInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -4209,7 +4346,7 @@ macro_rules! define_clock_tree_types {
         ) {
             if let Some(config) = clocks.mcpwm_function_clock[instance as usize] {
                 MCPWM_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    McpwmInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -4217,7 +4354,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_parl_io_rx_clock_downstream(clocks: &mut ClockTree, instance: ParlIoInstance) {
             if let Some(config) = clocks.parl_io_rx_clock[instance as usize] {
                 PARL_IO_RX_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.rx_clock_config_frequency(clocks, config),
+                    ParlIoInstance::rx_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -4225,7 +4362,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_parl_io_tx_clock_downstream(clocks: &mut ClockTree, instance: ParlIoInstance) {
             if let Some(config) = clocks.parl_io_tx_clock[instance as usize] {
                 PARL_IO_TX_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.tx_clock_config_frequency(clocks, config),
+                    ParlIoInstance::tx_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -4233,7 +4370,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_rmt_sclk_downstream(clocks: &mut ClockTree, instance: RmtInstance) {
             if let Some(config) = clocks.rmt_sclk[instance as usize] {
                 RMT_SCLK_FREQ_CACHE[instance as usize].store(
-                    instance.sclk_config_frequency(clocks, config),
+                    RmtInstance::sclk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -4241,7 +4378,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_spi_function_clock_downstream(clocks: &mut ClockTree, instance: SpiInstance) {
             if let Some(config) = clocks.spi_function_clock[instance as usize] {
                 SPI_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    SpiInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -4249,7 +4386,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_timg_function_clock_downstream(clocks: &mut ClockTree, instance: TimgInstance) {
             if let Some(config) = clocks.timg_function_clock[instance as usize] {
                 TIMG_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    TimgInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -4257,7 +4394,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_timg_wdt_clock_downstream(clocks: &mut ClockTree, instance: TimgInstance) {
             if let Some(config) = clocks.timg_wdt_clock[instance as usize] {
                 TIMG_WDT_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.wdt_clock_config_frequency(clocks, config),
+                    TimgInstance::wdt_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -4265,7 +4402,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_uart_function_clock_downstream(clocks: &mut ClockTree, instance: UartInstance) {
             if let Some(config) = clocks.uart_function_clock[instance as usize] {
                 UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    UartInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }

--- a/esp-metadata-generated/src/_generated_esp32c61.rs
+++ b/esp-metadata-generated/src/_generated_esp32c61.rs
@@ -1585,6 +1585,9 @@ macro_rules! define_clock_tree_types {
         pub fn pll_clk_frequency() -> u32 {
             480000000
         }
+        pub fn pll_clk_source_frequency() -> u32 {
+            xtal_clk_frequency()
+        }
         pub fn request_xtal32k_clk(clocks: &mut ClockTree) {
             trace!("Requesting XTAL32K_CLK");
             if increment_reference_count(&mut clocks.xtal32k_clk_refcount) {
@@ -1655,6 +1658,9 @@ macro_rules! define_clock_tree_types {
         pub fn pll_f20m_frequency() -> u32 {
             (pll_clk_frequency() / 24)
         }
+        pub fn pll_f20m_source_frequency() -> u32 {
+            pll_clk_frequency()
+        }
         pub fn request_pll_f40m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F40M");
             if increment_reference_count(&mut clocks.pll_f40m_refcount) {
@@ -1673,6 +1679,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn pll_f40m_frequency() -> u32 {
             (pll_clk_frequency() / 12)
+        }
+        pub fn pll_f40m_source_frequency() -> u32 {
+            pll_clk_frequency()
         }
         pub fn request_pll_f48m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F48M");
@@ -1693,6 +1702,9 @@ macro_rules! define_clock_tree_types {
         pub fn pll_f48m_frequency() -> u32 {
             (pll_clk_frequency() / 10)
         }
+        pub fn pll_f48m_source_frequency() -> u32 {
+            pll_clk_frequency()
+        }
         pub fn request_pll_f60m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F60M");
             if increment_reference_count(&mut clocks.pll_f60m_refcount) {
@@ -1711,6 +1723,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn pll_f60m_frequency() -> u32 {
             (pll_clk_frequency() / 8)
+        }
+        pub fn pll_f60m_source_frequency() -> u32 {
+            pll_clk_frequency()
         }
         pub fn request_pll_f80m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F80M");
@@ -1731,6 +1746,9 @@ macro_rules! define_clock_tree_types {
         pub fn pll_f80m_frequency() -> u32 {
             (pll_clk_frequency() / 6)
         }
+        pub fn pll_f80m_source_frequency() -> u32 {
+            pll_clk_frequency()
+        }
         pub fn request_pll_f120m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F120M");
             if increment_reference_count(&mut clocks.pll_f120m_refcount) {
@@ -1750,6 +1768,9 @@ macro_rules! define_clock_tree_types {
         pub fn pll_f120m_frequency() -> u32 {
             (pll_clk_frequency() / 4)
         }
+        pub fn pll_f120m_source_frequency() -> u32 {
+            pll_clk_frequency()
+        }
         pub fn request_pll_f160m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F160M");
             if increment_reference_count(&mut clocks.pll_f160m_refcount) {
@@ -1768,6 +1789,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn pll_f160m_frequency() -> u32 {
             (pll_clk_frequency() / 3)
+        }
+        pub fn pll_f160m_source_frequency() -> u32 {
+            pll_clk_frequency()
         }
         pub fn configure_hp_root_clk(clocks: &mut ClockTree, new_selector: HpRootClkConfig) {
             let old_selector = clocks.hp_root_clk.replace(new_selector);
@@ -1831,6 +1855,13 @@ macro_rules! define_clock_tree_types {
         pub fn hp_root_clk_frequency() -> u32 {
             HP_ROOT_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn hp_root_clk_source_frequency(source: HpRootClkConfig) -> u32 {
+            match source {
+                HpRootClkConfig::Xtal => xtal_clk_frequency(),
+                HpRootClkConfig::RcFast => rc_fast_clk_frequency(),
+                HpRootClkConfig::PllF160m => pll_f160m_frequency(),
+            }
+        }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, config: CpuClkConfig) {
             let old_config = clocks.cpu_clk.replace(config);
             refresh_cpu_clk_downstream(clocks);
@@ -1862,6 +1893,9 @@ macro_rules! define_clock_tree_types {
         pub fn cpu_clk_frequency() -> u32 {
             CPU_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn cpu_clk_source_frequency() -> u32 {
+            hp_root_clk_frequency()
+        }
         pub fn configure_ahb_clk(clocks: &mut ClockTree, config: AhbClkConfig) {
             let old_config = clocks.ahb_clk.replace(config);
             refresh_ahb_clk_downstream(clocks);
@@ -1888,6 +1922,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn ahb_clk_frequency() -> u32 {
             AHB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn ahb_clk_source_frequency() -> u32 {
+            hp_root_clk_frequency()
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, config: ApbClkConfig) {
             let old_config = clocks.apb_clk.replace(config);
@@ -1920,6 +1957,9 @@ macro_rules! define_clock_tree_types {
         pub fn apb_clk_frequency() -> u32 {
             APB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn apb_clk_source_frequency() -> u32 {
+            ahb_clk_frequency()
+        }
         pub fn request_xtal_d2_clk(clocks: &mut ClockTree) {
             trace!("Requesting XTAL_D2_CLK");
             trace!("Enabling XTAL_D2_CLK");
@@ -1934,6 +1974,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn xtal_d2_clk_frequency() -> u32 {
             (xtal_clk_frequency() / 2)
+        }
+        pub fn xtal_d2_clk_source_frequency() -> u32 {
+            xtal_clk_frequency()
         }
         pub fn configure_lp_fast_clk(clocks: &mut ClockTree, new_selector: LpFastClkConfig) {
             let old_selector = clocks.lp_fast_clk.replace(new_selector);
@@ -1997,6 +2040,13 @@ macro_rules! define_clock_tree_types {
         pub fn lp_fast_clk_frequency() -> u32 {
             LP_FAST_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn lp_fast_clk_source_frequency(source: LpFastClkConfig) -> u32 {
+            match source {
+                LpFastClkConfig::RcFast => rc_fast_clk_frequency(),
+                LpFastClkConfig::XtalD2 => xtal_d2_clk_frequency(),
+                LpFastClkConfig::Xtal => xtal_clk_frequency(),
+            }
+        }
         pub fn configure_lp_slow_clk(clocks: &mut ClockTree, new_selector: LpSlowClkConfig) {
             let old_selector = clocks.lp_slow_clk.replace(new_selector);
             refresh_lp_slow_clk_downstream(clocks);
@@ -2058,6 +2108,13 @@ macro_rules! define_clock_tree_types {
         }
         pub fn lp_slow_clk_frequency() -> u32 {
             LP_SLOW_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn lp_slow_clk_source_frequency(source: LpSlowClkConfig) -> u32 {
+            match source {
+                LpSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
+                LpSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
+                LpSlowClkConfig::OscSlow => osc_slow_clk_frequency(),
+            }
         }
         pub fn configure_timg_calibration_clock(
             clocks: &mut ClockTree,
@@ -2131,6 +2188,14 @@ macro_rules! define_clock_tree_types {
         pub fn timg_calibration_clock_frequency() -> u32 {
             TIMG_CALIBRATION_CLOCK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn timg_calibration_clock_source_frequency(source: TimgCalibrationClockConfig) -> u32 {
+            match source {
+                TimgCalibrationClockConfig::OscSlowClk => osc_slow_clk_frequency(),
+                TimgCalibrationClockConfig::RcSlowClk => rc_slow_clk_frequency(),
+                TimgCalibrationClockConfig::RcFastDivClk => rc_fast_clk_frequency(),
+                TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
+            }
+        }
         impl I2cInstance {
             pub fn configure_function_clock(
                 self,
@@ -2187,7 +2252,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: I2cFunctionClockConfig,
             ) -> u32 {
@@ -2199,6 +2263,12 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 I2C_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(sclk: I2cFunctionClockSclk) -> u32 {
+                match sclk {
+                    I2cFunctionClockSclk::Xtal => xtal_clk_frequency(),
+                    I2cFunctionClockSclk::RcFast => rc_fast_clk_frequency(),
+                }
             }
         }
         impl SpiInstance {
@@ -2261,7 +2331,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: SpiFunctionClockConfig,
             ) -> u32 {
@@ -2274,6 +2343,13 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 SPI_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(source: SpiFunctionClockConfig) -> u32 {
+                match source {
+                    SpiFunctionClockConfig::Xtal => xtal_clk_frequency(),
+                    SpiFunctionClockConfig::PllF160m => pll_f160m_frequency(),
+                    SpiFunctionClockConfig::RcFast => rc_fast_clk_frequency(),
+                }
             }
         }
         impl TimgInstance {
@@ -2338,7 +2414,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: TimgFunctionClockConfig,
             ) -> u32 {
@@ -2351,6 +2426,13 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 TIMG_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(source: TimgFunctionClockConfig) -> u32 {
+                match source {
+                    TimgFunctionClockConfig::XtalClk => xtal_clk_frequency(),
+                    TimgFunctionClockConfig::RcFastClk => rc_fast_clk_frequency(),
+                    TimgFunctionClockConfig::PllF80m => pll_f80m_frequency(),
+                }
             }
             pub fn configure_wdt_clock(
                 self,
@@ -2406,7 +2488,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn wdt_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: TimgWdtClockConfig,
             ) -> u32 {
@@ -2419,6 +2500,13 @@ macro_rules! define_clock_tree_types {
             pub fn wdt_clock_frequency(self) -> u32 {
                 TIMG_WDT_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn wdt_clock_source_frequency(source: TimgWdtClockConfig) -> u32 {
+                match source {
+                    TimgWdtClockConfig::XtalClk => xtal_clk_frequency(),
+                    TimgWdtClockConfig::RcFastClk => rc_fast_clk_frequency(),
+                    TimgWdtClockConfig::PllF80m => pll_f80m_frequency(),
+                }
             }
         }
         impl UartInstance {
@@ -2483,7 +2571,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: UartFunctionClockConfig,
             ) -> u32 {
@@ -2496,6 +2583,13 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 UART_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(sclk: UartFunctionClockSclk) -> u32 {
+                match sclk {
+                    UartFunctionClockSclk::Xtal => xtal_clk_frequency(),
+                    UartFunctionClockSclk::PllF80m => pll_f80m_frequency(),
+                    UartFunctionClockSclk::RcFast => rc_fast_clk_frequency(),
+                }
             }
             pub fn configure_baud_rate_generator(
                 self,
@@ -2697,7 +2791,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_i2c_function_clock_downstream(clocks: &mut ClockTree, instance: I2cInstance) {
             if let Some(config) = clocks.i2c_function_clock[instance as usize] {
                 I2C_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    I2cInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -2705,7 +2799,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_spi_function_clock_downstream(clocks: &mut ClockTree, instance: SpiInstance) {
             if let Some(config) = clocks.spi_function_clock[instance as usize] {
                 SPI_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    SpiInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -2713,7 +2807,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_timg_function_clock_downstream(clocks: &mut ClockTree, instance: TimgInstance) {
             if let Some(config) = clocks.timg_function_clock[instance as usize] {
                 TIMG_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    TimgInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -2721,7 +2815,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_timg_wdt_clock_downstream(clocks: &mut ClockTree, instance: TimgInstance) {
             if let Some(config) = clocks.timg_wdt_clock[instance as usize] {
                 TIMG_WDT_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.wdt_clock_config_frequency(clocks, config),
+                    TimgInstance::wdt_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -2729,7 +2823,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_uart_function_clock_downstream(clocks: &mut ClockTree, instance: UartInstance) {
             if let Some(config) = clocks.uart_function_clock[instance as usize] {
                 UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    UartInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }

--- a/esp-metadata-generated/src/_generated_esp32h2.rs
+++ b/esp-metadata-generated/src/_generated_esp32h2.rs
@@ -2018,6 +2018,9 @@ macro_rules! define_clock_tree_types {
         pub fn pll_f96m_clk_frequency() -> u32 {
             96000000
         }
+        pub fn pll_f96m_clk_source_frequency() -> u32 {
+            xtal_clk_frequency()
+        }
         pub fn request_pll_f64m_clk(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F64M_CLK");
             trace!("Enabling PLL_F64M_CLK");
@@ -2032,6 +2035,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn pll_f64m_clk_frequency() -> u32 {
             ((pll_f96m_clk_frequency() * 2) / 3)
+        }
+        pub fn pll_f64m_clk_source_frequency() -> u32 {
+            pll_f96m_clk_frequency()
         }
         pub fn request_pll_f48m_clk(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F48M_CLK");
@@ -2051,6 +2057,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn pll_f48m_clk_frequency() -> u32 {
             (pll_f96m_clk_frequency() / 2)
+        }
+        pub fn pll_f48m_clk_source_frequency() -> u32 {
+            pll_f96m_clk_frequency()
         }
         pub fn request_rc_fast_clk(clocks: &mut ClockTree) {
             trace!("Requesting RC_FAST_CLK");
@@ -2127,6 +2136,9 @@ macro_rules! define_clock_tree_types {
         pub fn pll_lp_clk_frequency() -> u32 {
             8000000
         }
+        pub fn pll_lp_clk_source_frequency() -> u32 {
+            xtal32k_clk_frequency()
+        }
         pub fn configure_hp_root_clk(clocks: &mut ClockTree, new_selector: HpRootClkConfig) {
             let old_selector = clocks.hp_root_clk.replace(new_selector);
             refresh_hp_root_clk_downstream(clocks);
@@ -2194,6 +2206,14 @@ macro_rules! define_clock_tree_types {
         pub fn hp_root_clk_frequency() -> u32 {
             HP_ROOT_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn hp_root_clk_source_frequency(source: HpRootClkConfig) -> u32 {
+            match source {
+                HpRootClkConfig::Pll96 => pll_f96m_clk_frequency(),
+                HpRootClkConfig::Pll64 => pll_f64m_clk_frequency(),
+                HpRootClkConfig::Xtal => xtal_clk_frequency(),
+                HpRootClkConfig::RcFast => rc_fast_clk_frequency(),
+            }
+        }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, config: CpuClkConfig) {
             let old_config = clocks.cpu_clk.replace(config);
             refresh_cpu_clk_downstream(clocks);
@@ -2211,6 +2231,9 @@ macro_rules! define_clock_tree_types {
         pub fn cpu_clk_frequency() -> u32 {
             CPU_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn cpu_clk_source_frequency() -> u32 {
+            hp_root_clk_frequency()
+        }
         pub fn configure_ahb_clk(clocks: &mut ClockTree, config: AhbClkConfig) {
             let old_config = clocks.ahb_clk.replace(config);
             refresh_ahb_clk_downstream(clocks);
@@ -2227,6 +2250,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn ahb_clk_frequency() -> u32 {
             AHB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn ahb_clk_source_frequency() -> u32 {
+            hp_root_clk_frequency()
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, config: ApbClkConfig) {
             let old_config = clocks.apb_clk.replace(config);
@@ -2259,6 +2285,9 @@ macro_rules! define_clock_tree_types {
         pub fn apb_clk_frequency() -> u32 {
             APB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn apb_clk_source_frequency() -> u32 {
+            ahb_clk_frequency()
+        }
         pub fn request_xtal_d2_clk(clocks: &mut ClockTree) {
             trace!("Requesting XTAL_D2_CLK");
             trace!("Enabling XTAL_D2_CLK");
@@ -2273,6 +2302,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn xtal_d2_clk_frequency() -> u32 {
             (xtal_clk_frequency() / 2)
+        }
+        pub fn xtal_d2_clk_source_frequency() -> u32 {
+            xtal_clk_frequency()
         }
         pub fn configure_lp_fast_clk(clocks: &mut ClockTree, new_selector: LpFastClkConfig) {
             let old_selector = clocks.lp_fast_clk.replace(new_selector);
@@ -2336,6 +2368,13 @@ macro_rules! define_clock_tree_types {
         pub fn lp_fast_clk_frequency() -> u32 {
             LP_FAST_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn lp_fast_clk_source_frequency(source: LpFastClkConfig) -> u32 {
+            match source {
+                LpFastClkConfig::RcFastClk => rc_fast_clk_frequency(),
+                LpFastClkConfig::PllLpClk => pll_lp_clk_frequency(),
+                LpFastClkConfig::XtalD2Clk => xtal_d2_clk_frequency(),
+            }
+        }
         pub fn configure_lp_slow_clk(clocks: &mut ClockTree, new_selector: LpSlowClkConfig) {
             let old_selector = clocks.lp_slow_clk.replace(new_selector);
             refresh_lp_slow_clk_downstream(clocks);
@@ -2389,6 +2428,13 @@ macro_rules! define_clock_tree_types {
         }
         pub fn lp_slow_clk_frequency() -> u32 {
             LP_SLOW_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn lp_slow_clk_source_frequency(source: LpSlowClkConfig) -> u32 {
+            match source {
+                LpSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
+                LpSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
+                LpSlowClkConfig::OscSlow => osc_slow_clk_frequency(),
+            }
         }
         pub fn configure_timg_calibration_clock(
             clocks: &mut ClockTree,
@@ -2457,6 +2503,13 @@ macro_rules! define_clock_tree_types {
         pub fn timg_calibration_clock_frequency() -> u32 {
             TIMG_CALIBRATION_CLOCK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn timg_calibration_clock_source_frequency(source: TimgCalibrationClockConfig) -> u32 {
+            match source {
+                TimgCalibrationClockConfig::RcSlowClk => lp_slow_clk_frequency(),
+                TimgCalibrationClockConfig::RcFastDivClk => rc_fast_clk_frequency(),
+                TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
+            }
+        }
         impl I2cInstance {
             pub fn configure_function_clock(
                 self,
@@ -2513,7 +2566,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: I2cFunctionClockConfig,
             ) -> u32 {
@@ -2525,6 +2577,12 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 I2C_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(sclk: I2cFunctionClockSclk) -> u32 {
+                match sclk {
+                    I2cFunctionClockSclk::Xtal => xtal_clk_frequency(),
+                    I2cFunctionClockSclk::RcFast => rc_fast_clk_frequency(),
+                }
             }
         }
         impl McpwmInstance {
@@ -2589,7 +2647,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: McpwmFunctionClockConfig,
             ) -> u32 {
@@ -2602,6 +2659,13 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 MCPWM_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(source: McpwmFunctionClockConfig) -> u32 {
+                match source {
+                    McpwmFunctionClockConfig::PllF96m => pll_f96m_clk_frequency(),
+                    McpwmFunctionClockConfig::RcFastClk => rc_fast_clk_frequency(),
+                    McpwmFunctionClockConfig::XtalClk => xtal_clk_frequency(),
+                }
             }
         }
         impl ParlIoInstance {
@@ -2659,7 +2723,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn rx_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: ParlIoRxClockConfig,
             ) -> u32 {
@@ -2672,6 +2735,13 @@ macro_rules! define_clock_tree_types {
             pub fn rx_clock_frequency(self) -> u32 {
                 PARL_IO_RX_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn rx_clock_source_frequency(source: ParlIoRxClockConfig) -> u32 {
+                match source {
+                    ParlIoRxClockConfig::XtalClk => xtal_clk_frequency(),
+                    ParlIoRxClockConfig::RcFastClk => rc_fast_clk_frequency(),
+                    ParlIoRxClockConfig::PllF96m => pll_f96m_clk_frequency(),
+                }
             }
             pub fn configure_tx_clock(
                 self,
@@ -2727,7 +2797,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn tx_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: ParlIoTxClockConfig,
             ) -> u32 {
@@ -2740,6 +2809,13 @@ macro_rules! define_clock_tree_types {
             pub fn tx_clock_frequency(self) -> u32 {
                 PARL_IO_TX_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn tx_clock_source_frequency(source: ParlIoTxClockConfig) -> u32 {
+                match source {
+                    ParlIoTxClockConfig::XtalClk => xtal_clk_frequency(),
+                    ParlIoTxClockConfig::RcFastClk => rc_fast_clk_frequency(),
+                    ParlIoTxClockConfig::PllF96m => pll_f96m_clk_frequency(),
+                }
             }
         }
         impl RmtInstance {
@@ -2788,11 +2864,7 @@ macro_rules! define_clock_tree_types {
                 }
             }
             #[allow(unused_variables)]
-            pub fn sclk_config_frequency(
-                self,
-                clocks: &mut ClockTree,
-                config: RmtSclkConfig,
-            ) -> u32 {
+            pub fn sclk_config_frequency(clocks: &mut ClockTree, config: RmtSclkConfig) -> u32 {
                 match config {
                     RmtSclkConfig::XtalClk => xtal_clk_frequency(),
                     RmtSclkConfig::RcFastClk => rc_fast_clk_frequency(),
@@ -2800,6 +2872,12 @@ macro_rules! define_clock_tree_types {
             }
             pub fn sclk_frequency(self) -> u32 {
                 RMT_SCLK_FREQ_CACHE[self as usize].load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn sclk_source_frequency(source: RmtSclkConfig) -> u32 {
+                match source {
+                    RmtSclkConfig::XtalClk => xtal_clk_frequency(),
+                    RmtSclkConfig::RcFastClk => rc_fast_clk_frequency(),
+                }
             }
         }
         impl SpiInstance {
@@ -2862,7 +2940,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: SpiFunctionClockConfig,
             ) -> u32 {
@@ -2875,6 +2952,13 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 SPI_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(source: SpiFunctionClockConfig) -> u32 {
+                match source {
+                    SpiFunctionClockConfig::Xtal => xtal_clk_frequency(),
+                    SpiFunctionClockConfig::PllF48m => pll_f48m_clk_frequency(),
+                    SpiFunctionClockConfig::RcFast => rc_fast_clk_frequency(),
+                }
             }
         }
         impl TimgInstance {
@@ -2939,7 +3023,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: TimgFunctionClockConfig,
             ) -> u32 {
@@ -2952,6 +3035,13 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 TIMG_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(source: TimgFunctionClockConfig) -> u32 {
+                match source {
+                    TimgFunctionClockConfig::XtalClk => xtal_clk_frequency(),
+                    TimgFunctionClockConfig::RcFastClk => rc_fast_clk_frequency(),
+                    TimgFunctionClockConfig::PllF48m => pll_f48m_clk_frequency(),
+                }
             }
             pub fn configure_wdt_clock(
                 self,
@@ -3007,7 +3097,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn wdt_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: TimgWdtClockConfig,
             ) -> u32 {
@@ -3020,6 +3109,13 @@ macro_rules! define_clock_tree_types {
             pub fn wdt_clock_frequency(self) -> u32 {
                 TIMG_WDT_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn wdt_clock_source_frequency(source: TimgWdtClockConfig) -> u32 {
+                match source {
+                    TimgWdtClockConfig::XtalClk => xtal_clk_frequency(),
+                    TimgWdtClockConfig::RcFastClk => rc_fast_clk_frequency(),
+                    TimgWdtClockConfig::PllF48m => pll_f48m_clk_frequency(),
+                }
             }
         }
         impl UartInstance {
@@ -3084,7 +3180,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: UartFunctionClockConfig,
             ) -> u32 {
@@ -3097,6 +3192,13 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 UART_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(sclk: UartFunctionClockSclk) -> u32 {
+                match sclk {
+                    UartFunctionClockSclk::PllF48m => pll_f48m_clk_frequency(),
+                    UartFunctionClockSclk::RcFast => rc_fast_clk_frequency(),
+                    UartFunctionClockSclk::Xtal => xtal_clk_frequency(),
+                }
             }
             pub fn configure_baud_rate_generator(
                 self,
@@ -3309,7 +3411,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_i2c_function_clock_downstream(clocks: &mut ClockTree, instance: I2cInstance) {
             if let Some(config) = clocks.i2c_function_clock[instance as usize] {
                 I2C_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    I2cInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3320,7 +3422,7 @@ macro_rules! define_clock_tree_types {
         ) {
             if let Some(config) = clocks.mcpwm_function_clock[instance as usize] {
                 MCPWM_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    McpwmInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3328,7 +3430,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_parl_io_rx_clock_downstream(clocks: &mut ClockTree, instance: ParlIoInstance) {
             if let Some(config) = clocks.parl_io_rx_clock[instance as usize] {
                 PARL_IO_RX_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.rx_clock_config_frequency(clocks, config),
+                    ParlIoInstance::rx_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3336,7 +3438,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_parl_io_tx_clock_downstream(clocks: &mut ClockTree, instance: ParlIoInstance) {
             if let Some(config) = clocks.parl_io_tx_clock[instance as usize] {
                 PARL_IO_TX_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.tx_clock_config_frequency(clocks, config),
+                    ParlIoInstance::tx_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3344,7 +3446,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_rmt_sclk_downstream(clocks: &mut ClockTree, instance: RmtInstance) {
             if let Some(config) = clocks.rmt_sclk[instance as usize] {
                 RMT_SCLK_FREQ_CACHE[instance as usize].store(
-                    instance.sclk_config_frequency(clocks, config),
+                    RmtInstance::sclk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3352,7 +3454,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_spi_function_clock_downstream(clocks: &mut ClockTree, instance: SpiInstance) {
             if let Some(config) = clocks.spi_function_clock[instance as usize] {
                 SPI_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    SpiInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3360,7 +3462,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_timg_function_clock_downstream(clocks: &mut ClockTree, instance: TimgInstance) {
             if let Some(config) = clocks.timg_function_clock[instance as usize] {
                 TIMG_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    TimgInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3368,7 +3470,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_timg_wdt_clock_downstream(clocks: &mut ClockTree, instance: TimgInstance) {
             if let Some(config) = clocks.timg_wdt_clock[instance as usize] {
                 TIMG_WDT_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.wdt_clock_config_frequency(clocks, config),
+                    TimgInstance::wdt_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3376,7 +3478,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_uart_function_clock_downstream(clocks: &mut ClockTree, instance: UartInstance) {
             if let Some(config) = clocks.uart_function_clock[instance as usize] {
                 UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    UartInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }

--- a/esp-metadata-generated/src/_generated_esp32p4.rs
+++ b/esp-metadata-generated/src/_generated_esp32p4.rs
@@ -1871,6 +1871,9 @@ macro_rules! define_clock_tree_types {
         pub fn cpll_clk_frequency() -> u32 {
             400000000
         }
+        pub fn cpll_clk_source_frequency() -> u32 {
+            xtal_clk_frequency()
+        }
         pub fn request_spll_clk(clocks: &mut ClockTree) {
             trace!("Requesting SPLL_CLK");
             if increment_reference_count(&mut clocks.spll_clk_refcount) {
@@ -1890,6 +1893,9 @@ macro_rules! define_clock_tree_types {
         pub fn spll_clk_frequency() -> u32 {
             480000000
         }
+        pub fn spll_clk_source_frequency() -> u32 {
+            xtal_clk_frequency()
+        }
         pub fn request_mpll_clk(clocks: &mut ClockTree) {
             trace!("Requesting MPLL_CLK");
             if increment_reference_count(&mut clocks.mpll_clk_refcount) {
@@ -1908,6 +1914,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn mpll_clk_frequency() -> u32 {
             500000000
+        }
+        pub fn mpll_clk_source_frequency() -> u32 {
+            xtal_clk_frequency()
         }
         pub fn request_rc_fast_clk(clocks: &mut ClockTree) {
             trace!("Requesting RC_FAST_CLK");
@@ -2005,6 +2014,9 @@ macro_rules! define_clock_tree_types {
         pub fn pll_f20m_frequency() -> u32 {
             (spll_clk_frequency() / 24)
         }
+        pub fn pll_f20m_source_frequency() -> u32 {
+            spll_clk_frequency()
+        }
         pub fn request_pll_f80m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F80M");
             if increment_reference_count(&mut clocks.pll_f80m_refcount) {
@@ -2023,6 +2035,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn pll_f80m_frequency() -> u32 {
             (spll_clk_frequency() / 6)
+        }
+        pub fn pll_f80m_source_frequency() -> u32 {
+            spll_clk_frequency()
         }
         pub fn request_pll_f120m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F120M");
@@ -2043,6 +2058,9 @@ macro_rules! define_clock_tree_types {
         pub fn pll_f120m_frequency() -> u32 {
             (spll_clk_frequency() / 4)
         }
+        pub fn pll_f120m_source_frequency() -> u32 {
+            spll_clk_frequency()
+        }
         pub fn request_pll_f160m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F160M");
             if increment_reference_count(&mut clocks.pll_f160m_refcount) {
@@ -2061,6 +2079,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn pll_f160m_frequency() -> u32 {
             (spll_clk_frequency() / 3)
+        }
+        pub fn pll_f160m_source_frequency() -> u32 {
+            spll_clk_frequency()
         }
         pub fn request_pll_f240m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F240M");
@@ -2081,6 +2102,9 @@ macro_rules! define_clock_tree_types {
         pub fn pll_f240m_frequency() -> u32 {
             (spll_clk_frequency() / 2)
         }
+        pub fn pll_f240m_source_frequency() -> u32 {
+            spll_clk_frequency()
+        }
         pub fn request_pll_f25m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F25M");
             if increment_reference_count(&mut clocks.pll_f25m_refcount) {
@@ -2099,6 +2123,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn pll_f25m_frequency() -> u32 {
             (mpll_clk_frequency() / 20)
+        }
+        pub fn pll_f25m_source_frequency() -> u32 {
+            mpll_clk_frequency()
         }
         pub fn request_pll_f50m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_F50M");
@@ -2119,6 +2146,9 @@ macro_rules! define_clock_tree_types {
         pub fn pll_f50m_frequency() -> u32 {
             (mpll_clk_frequency() / 10)
         }
+        pub fn pll_f50m_source_frequency() -> u32 {
+            mpll_clk_frequency()
+        }
         pub fn request_xtal_d2_clk(clocks: &mut ClockTree) {
             trace!("Requesting XTAL_D2_CLK");
             trace!("Enabling XTAL_D2_CLK");
@@ -2133,6 +2163,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn xtal_d2_clk_frequency() -> u32 {
             (xtal_clk_frequency() / 2)
+        }
+        pub fn xtal_d2_clk_source_frequency() -> u32 {
+            xtal_clk_frequency()
         }
         pub fn configure_cpu_root_clk(clocks: &mut ClockTree, new_selector: CpuRootClkConfig) {
             let old_selector = clocks.cpu_root_clk.replace(new_selector);
@@ -2188,6 +2221,13 @@ macro_rules! define_clock_tree_types {
         pub fn cpu_root_clk_frequency() -> u32 {
             CPU_ROOT_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn cpu_root_clk_source_frequency(source: CpuRootClkConfig) -> u32 {
+            match source {
+                CpuRootClkConfig::Xtal => xtal_clk_frequency(),
+                CpuRootClkConfig::Cpll => cpll_clk_frequency(),
+                CpuRootClkConfig::RcFast => rc_fast_clk_frequency(),
+            }
+        }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, config: CpuClkConfig) {
             let old_config = clocks.cpu_clk.replace(config);
             refresh_cpu_clk_downstream(clocks);
@@ -2214,6 +2254,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn cpu_clk_frequency() -> u32 {
             CPU_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn cpu_clk_source_frequency() -> u32 {
+            cpu_root_clk_frequency()
         }
         pub fn configure_mem_clk(clocks: &mut ClockTree, config: MemClkConfig) {
             let old_config = clocks.mem_clk.replace(config);
@@ -2242,6 +2285,9 @@ macro_rules! define_clock_tree_types {
         pub fn mem_clk_frequency() -> u32 {
             MEM_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn mem_clk_source_frequency() -> u32 {
+            cpu_clk_frequency()
+        }
         pub fn configure_sys_clk(clocks: &mut ClockTree, config: SysClkConfig) {
             let old_config = clocks.sys_clk.replace(config);
             refresh_sys_clk_downstream(clocks);
@@ -2268,6 +2314,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn sys_clk_frequency() -> u32 {
             SYS_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn sys_clk_source_frequency() -> u32 {
+            mem_clk_frequency()
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, config: ApbClkConfig) {
             let old_config = clocks.apb_clk.replace(config);
@@ -2299,6 +2348,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn apb_clk_frequency() -> u32 {
             APB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn apb_clk_source_frequency() -> u32 {
+            sys_clk_frequency()
         }
         pub fn configure_lp_fast_clk(clocks: &mut ClockTree, new_selector: LpFastClkConfig) {
             let old_selector = clocks.lp_fast_clk.replace(new_selector);
@@ -2357,6 +2409,12 @@ macro_rules! define_clock_tree_types {
         pub fn lp_fast_clk_frequency() -> u32 {
             LP_FAST_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn lp_fast_clk_source_frequency(source: LpFastClkConfig) -> u32 {
+            match source {
+                LpFastClkConfig::RcFast => rc_fast_clk_frequency(),
+                LpFastClkConfig::XtalD2 => xtal_d2_clk_frequency(),
+            }
+        }
         pub fn configure_lp_slow_clk(clocks: &mut ClockTree, new_selector: LpSlowClkConfig) {
             let old_selector = clocks.lp_slow_clk.replace(new_selector);
             refresh_lp_slow_clk_downstream(clocks);
@@ -2410,6 +2468,13 @@ macro_rules! define_clock_tree_types {
         }
         pub fn lp_slow_clk_frequency() -> u32 {
             LP_SLOW_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn lp_slow_clk_source_frequency(source: LpSlowClkConfig) -> u32 {
+            match source {
+                LpSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
+                LpSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
+                LpSlowClkConfig::OscSlow => osc_slow_clk_frequency(),
+            }
         }
         pub fn configure_timg_calibration_clock(
             clocks: &mut ClockTree,
@@ -2493,6 +2558,16 @@ macro_rules! define_clock_tree_types {
         pub fn timg_calibration_clock_frequency() -> u32 {
             TIMG_CALIBRATION_CLOCK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn timg_calibration_clock_source_frequency(source: TimgCalibrationClockConfig) -> u32 {
+            match source {
+                TimgCalibrationClockConfig::MpllClk => mpll_clk_frequency(),
+                TimgCalibrationClockConfig::SpllClk => spll_clk_frequency(),
+                TimgCalibrationClockConfig::CpllClk => cpll_clk_frequency(),
+                TimgCalibrationClockConfig::RcFastClk => rc_fast_clk_frequency(),
+                TimgCalibrationClockConfig::RcSlowClk => lp_slow_clk_frequency(),
+                TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
+            }
+        }
         impl TimgInstance {
             pub fn configure_function_clock(
                 self,
@@ -2555,7 +2630,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: TimgFunctionClockConfig,
             ) -> u32 {
@@ -2568,6 +2642,13 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 TIMG_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(source: TimgFunctionClockConfig) -> u32 {
+                match source {
+                    TimgFunctionClockConfig::XtalClk => xtal_clk_frequency(),
+                    TimgFunctionClockConfig::RcFastClk => rc_fast_clk_frequency(),
+                    TimgFunctionClockConfig::PllF80m => pll_f80m_frequency(),
+                }
             }
             pub fn configure_wdt_clock(
                 self,
@@ -2623,7 +2704,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn wdt_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: TimgWdtClockConfig,
             ) -> u32 {
@@ -2636,6 +2716,13 @@ macro_rules! define_clock_tree_types {
             pub fn wdt_clock_frequency(self) -> u32 {
                 TIMG_WDT_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn wdt_clock_source_frequency(source: TimgWdtClockConfig) -> u32 {
+                match source {
+                    TimgWdtClockConfig::XtalClk => xtal_clk_frequency(),
+                    TimgWdtClockConfig::PllF80m => pll_f80m_frequency(),
+                    TimgWdtClockConfig::RcFastClk => rc_fast_clk_frequency(),
+                }
             }
         }
         impl UartInstance {
@@ -2700,7 +2787,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: UartFunctionClockConfig,
             ) -> u32 {
@@ -2713,6 +2799,13 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 UART_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(sclk: UartFunctionClockSclk) -> u32 {
+                match sclk {
+                    UartFunctionClockSclk::Xtal => xtal_clk_frequency(),
+                    UartFunctionClockSclk::PllF80m => pll_f80m_frequency(),
+                    UartFunctionClockSclk::RcFast => rc_fast_clk_frequency(),
+                }
             }
             pub fn configure_baud_rate_generator(
                 self,
@@ -2823,7 +2916,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: SpiFunctionClockConfig,
             ) -> u32 {
@@ -2836,6 +2928,13 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 SPI_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(source: SpiFunctionClockConfig) -> u32 {
+                match source {
+                    SpiFunctionClockConfig::Xtal => xtal_clk_frequency(),
+                    SpiFunctionClockConfig::RcFast => rc_fast_clk_frequency(),
+                    SpiFunctionClockConfig::Spll => spll_clk_frequency(),
+                }
             }
         }
         impl I2cInstance {
@@ -2894,7 +2993,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: I2cFunctionClockConfig,
             ) -> u32 {
@@ -2906,6 +3004,12 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 I2C_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(sclk: I2cFunctionClockSclk) -> u32 {
+                match sclk {
+                    I2cFunctionClockSclk::Xtal => xtal_clk_frequency(),
+                    I2cFunctionClockSclk::RcFast => rc_fast_clk_frequency(),
+                }
             }
         }
         /// Clock tree configuration.
@@ -3046,7 +3150,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_timg_function_clock_downstream(clocks: &mut ClockTree, instance: TimgInstance) {
             if let Some(config) = clocks.timg_function_clock[instance as usize] {
                 TIMG_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    TimgInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3054,7 +3158,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_timg_wdt_clock_downstream(clocks: &mut ClockTree, instance: TimgInstance) {
             if let Some(config) = clocks.timg_wdt_clock[instance as usize] {
                 TIMG_WDT_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.wdt_clock_config_frequency(clocks, config),
+                    TimgInstance::wdt_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3062,7 +3166,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_uart_function_clock_downstream(clocks: &mut ClockTree, instance: UartInstance) {
             if let Some(config) = clocks.uart_function_clock[instance as usize] {
                 UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    UartInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3082,7 +3186,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_spi_function_clock_downstream(clocks: &mut ClockTree, instance: SpiInstance) {
             if let Some(config) = clocks.spi_function_clock[instance as usize] {
                 SPI_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    SpiInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3090,7 +3194,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_i2c_function_clock_downstream(clocks: &mut ClockTree, instance: I2cInstance) {
             if let Some(config) = clocks.i2c_function_clock[instance as usize] {
                 I2C_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    I2cInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }

--- a/esp-metadata-generated/src/_generated_esp32s2.rs
+++ b/esp-metadata-generated/src/_generated_esp32s2.rs
@@ -1548,6 +1548,14 @@ macro_rules! define_clock_tree_types {
             /// Selects `RC_FAST_CLK`.
             Rc,
         }
+        /// The list of clock signals that the `UART_MEM_CLK` multiplexer can output.
+        #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+        pub enum UartMemClkConfig {
+            #[default]
+            /// Selects `XTAL_CLK`.
+            Xtal,
+        }
         /// The list of clock signals that the `TIMG_CALIBRATION_CLOCK` multiplexer can output.
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -1985,6 +1993,9 @@ macro_rules! define_clock_tree_types {
         pub fn pll_clk_frequency() -> u32 {
             PLL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn pll_clk_source_frequency() -> u32 {
+            xtal_clk_frequency()
+        }
         pub fn configure_apll_clk(clocks: &mut ClockTree, config: ApllClkConfig) {
             let old_config = clocks.apll_clk.replace(config);
             refresh_apll_clk_downstream(clocks);
@@ -2011,6 +2022,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn apll_clk_frequency() -> u32 {
             APLL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn apll_clk_source_frequency() -> u32 {
+            pll_clk_frequency()
         }
         pub fn request_rc_fast_clk(clocks: &mut ClockTree) {
             trace!("Requesting RC_FAST_CLK");
@@ -2078,6 +2092,12 @@ macro_rules! define_clock_tree_types {
         pub fn cpu_pll_div_in_frequency() -> u32 {
             CPU_PLL_DIV_IN_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn cpu_pll_div_in_source_frequency(source: CpuPllDivInConfig) -> u32 {
+            match source {
+                CpuPllDivInConfig::Pll => pll_clk_frequency(),
+                CpuPllDivInConfig::Apll => apll_clk_frequency(),
+            }
+        }
         pub fn configure_cpu_pll_div(clocks: &mut ClockTree, config: CpuPllDivConfig) {
             let old_config = clocks.cpu_pll_div.replace(config);
             refresh_cpu_pll_div_downstream(clocks);
@@ -2107,6 +2127,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn cpu_pll_div_frequency() -> u32 {
             CPU_PLL_DIV_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn cpu_pll_div_source_frequency() -> u32 {
+            cpu_pll_div_in_frequency()
         }
         pub fn configure_system_pre_div_in(
             clocks: &mut ClockTree,
@@ -2160,6 +2183,12 @@ macro_rules! define_clock_tree_types {
         pub fn system_pre_div_in_frequency() -> u32 {
             SYSTEM_PRE_DIV_IN_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn system_pre_div_in_source_frequency(source: SystemPreDivInConfig) -> u32 {
+            match source {
+                SystemPreDivInConfig::Xtal => xtal_clk_frequency(),
+                SystemPreDivInConfig::RcFast => rc_fast_clk_frequency(),
+            }
+        }
         pub fn configure_system_pre_div(clocks: &mut ClockTree, config: SystemPreDivConfig) {
             let old_config = clocks.system_pre_div.replace(config);
             refresh_system_pre_div_downstream(clocks);
@@ -2189,6 +2218,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn system_pre_div_frequency() -> u32 {
             SYSTEM_PRE_DIV_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn system_pre_div_source_frequency() -> u32 {
+            system_pre_div_in_frequency()
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, new_selector: ApbClkConfig) {
             let old_selector = clocks.apb_clk.replace(new_selector);
@@ -2254,6 +2286,14 @@ macro_rules! define_clock_tree_types {
         pub fn apb_clk_frequency() -> u32 {
             APB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn apb_clk_source_frequency(source: ApbClkConfig) -> u32 {
+            match source {
+                ApbClkConfig::Pll => apb_clk_80m_frequency(),
+                ApbClkConfig::Apll => apb_clk_cpu_div2_frequency(),
+                ApbClkConfig::Xtal => cpu_clk_frequency(),
+                ApbClkConfig::RcFast => cpu_clk_frequency(),
+            }
+        }
         pub fn configure_ref_tick(clocks: &mut ClockTree, new_selector: RefTickConfig) {
             let old_selector = clocks.ref_tick.replace(new_selector);
             refresh_ref_tick_downstream(clocks);
@@ -2318,6 +2358,14 @@ macro_rules! define_clock_tree_types {
         pub fn ref_tick_frequency() -> u32 {
             REF_TICK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn ref_tick_source_frequency(source: RefTickConfig) -> u32 {
+            match source {
+                RefTickConfig::Pll => ref_tick_xtal_frequency(),
+                RefTickConfig::Apll => ref_tick_xtal_frequency(),
+                RefTickConfig::Xtal => ref_tick_xtal_frequency(),
+                RefTickConfig::RcFast => ref_tick_ck8m_frequency(),
+            }
+        }
         pub fn configure_ref_tick_xtal(clocks: &mut ClockTree, config: RefTickXtalConfig) {
             let old_config = clocks.ref_tick_xtal.replace(config);
             refresh_ref_tick_xtal_downstream(clocks);
@@ -2348,6 +2396,9 @@ macro_rules! define_clock_tree_types {
         pub fn ref_tick_xtal_frequency() -> u32 {
             REF_TICK_XTAL_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn ref_tick_xtal_source_frequency() -> u32 {
+            xtal_clk_frequency()
+        }
         pub fn configure_ref_tick_ck8m(clocks: &mut ClockTree, config: RefTickCk8mConfig) {
             let old_config = clocks.ref_tick_ck8m.replace(config);
             refresh_ref_tick_ck8m_downstream(clocks);
@@ -2377,6 +2428,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn ref_tick_ck8m_frequency() -> u32 {
             REF_TICK_CK8M_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn ref_tick_ck8m_source_frequency() -> u32 {
+            rc_fast_clk_frequency()
         }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, new_selector: CpuClkConfig) {
             let old_selector = clocks.cpu_clk.replace(new_selector);
@@ -2463,6 +2517,9 @@ macro_rules! define_clock_tree_types {
         pub fn apb_clk_cpu_div2_frequency() -> u32 {
             (cpu_clk_frequency() / 2)
         }
+        pub fn apb_clk_cpu_div2_source_frequency() -> u32 {
+            cpu_clk_frequency()
+        }
         pub fn request_apb_clk_80m(clocks: &mut ClockTree) {
             trace!("Requesting APB_CLK_80M");
             trace!("Enabling APB_CLK_80M");
@@ -2477,6 +2534,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn apb_clk_80m_frequency() -> u32 {
             80000000
+        }
+        pub fn apb_clk_80m_source_frequency() -> u32 {
+            cpu_clk_frequency()
         }
         pub fn request_xtal32k_clk(clocks: &mut ClockTree) {
             trace!("Requesting XTAL32K_CLK");
@@ -2527,6 +2587,9 @@ macro_rules! define_clock_tree_types {
         pub fn rc_fast_div_clk_frequency() -> u32 {
             (rc_fast_clk_frequency() / 256)
         }
+        pub fn rc_fast_div_clk_source_frequency() -> u32 {
+            rc_fast_clk_frequency()
+        }
         pub fn request_xtal_div_clk(clocks: &mut ClockTree) {
             trace!("Requesting XTAL_DIV_CLK");
             trace!("Enabling XTAL_DIV_CLK");
@@ -2541,6 +2604,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn xtal_div_clk_frequency() -> u32 {
             (xtal_clk_frequency() / 4)
+        }
+        pub fn xtal_div_clk_source_frequency() -> u32 {
+            xtal_clk_frequency()
         }
         pub fn configure_rtc_slow_clk(clocks: &mut ClockTree, new_selector: RtcSlowClkConfig) {
             let old_selector = clocks.rtc_slow_clk.replace(new_selector);
@@ -2595,6 +2661,13 @@ macro_rules! define_clock_tree_types {
         }
         pub fn rtc_slow_clk_frequency() -> u32 {
             RTC_SLOW_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn rtc_slow_clk_source_frequency(source: RtcSlowClkConfig) -> u32 {
+            match source {
+                RtcSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
+                RtcSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
+                RtcSlowClkConfig::RcFast => rc_fast_div_clk_frequency(),
+            }
         }
         pub fn configure_rtc_fast_clk(clocks: &mut ClockTree, new_selector: RtcFastClkConfig) {
             let old_selector = clocks.rtc_fast_clk.replace(new_selector);
@@ -2653,6 +2726,12 @@ macro_rules! define_clock_tree_types {
         pub fn rtc_fast_clk_frequency() -> u32 {
             RTC_FAST_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn rtc_fast_clk_source_frequency(source: RtcFastClkConfig) -> u32 {
+            match source {
+                RtcFastClkConfig::Xtal => xtal_div_clk_frequency(),
+                RtcFastClkConfig::Rc => rc_fast_clk_frequency(),
+            }
+        }
         pub fn request_uart_mem_clk(clocks: &mut ClockTree) {
             trace!("Requesting UART_MEM_CLK");
             if increment_reference_count(&mut clocks.uart_mem_clk_refcount) {
@@ -2671,6 +2750,11 @@ macro_rules! define_clock_tree_types {
         }
         pub fn uart_mem_clk_frequency() -> u32 {
             xtal_clk_frequency()
+        }
+        pub fn uart_mem_clk_source_frequency(source: UartMemClkConfig) -> u32 {
+            match source {
+                UartMemClkConfig::Xtal => xtal_clk_frequency(),
+            }
         }
         pub fn configure_timg_calibration_clock(
             clocks: &mut ClockTree,
@@ -2739,6 +2823,13 @@ macro_rules! define_clock_tree_types {
         pub fn timg_calibration_clock_frequency() -> u32 {
             TIMG_CALIBRATION_CLOCK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn timg_calibration_clock_source_frequency(source: TimgCalibrationClockConfig) -> u32 {
+            match source {
+                TimgCalibrationClockConfig::RtcClk => rtc_slow_clk_frequency(),
+                TimgCalibrationClockConfig::RcFastDivClk => rc_fast_div_clk_frequency(),
+                TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
+            }
+        }
         impl I2cInstance {
             pub fn configure_function_clock(
                 self,
@@ -2795,7 +2886,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: I2cFunctionClockConfig,
             ) -> u32 {
@@ -2807,6 +2897,12 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 I2C_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(sclk: I2cFunctionClockSclk) -> u32 {
+                match sclk {
+                    I2cFunctionClockSclk::Apb => apb_clk_frequency(),
+                    I2cFunctionClockSclk::RefTick => ref_tick_frequency(),
+                }
             }
         }
         impl RmtInstance {
@@ -2855,11 +2951,7 @@ macro_rules! define_clock_tree_types {
                 }
             }
             #[allow(unused_variables)]
-            pub fn sclk_config_frequency(
-                self,
-                clocks: &mut ClockTree,
-                config: RmtSclkConfig,
-            ) -> u32 {
+            pub fn sclk_config_frequency(clocks: &mut ClockTree, config: RmtSclkConfig) -> u32 {
                 match config {
                     RmtSclkConfig::RefTick => ref_tick_frequency(),
                     RmtSclkConfig::ApbClk => apb_clk_frequency(),
@@ -2867,6 +2959,12 @@ macro_rules! define_clock_tree_types {
             }
             pub fn sclk_frequency(self) -> u32 {
                 RMT_SCLK_FREQ_CACHE[self as usize].load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn sclk_source_frequency(source: RmtSclkConfig) -> u32 {
+                match source {
+                    RmtSclkConfig::RefTick => ref_tick_frequency(),
+                    RmtSclkConfig::ApbClk => apb_clk_frequency(),
+                }
             }
         }
         impl SpiInstance {
@@ -2913,7 +3011,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: SpiFunctionClockConfig,
             ) -> u32 {
@@ -2922,6 +3019,11 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 SPI_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(source: SpiFunctionClockConfig) -> u32 {
+                match source {
+                    SpiFunctionClockConfig::Apb => apb_clk_frequency(),
+                }
             }
         }
         impl TimgInstance {
@@ -2982,7 +3084,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: TimgFunctionClockConfig,
             ) -> u32 {
@@ -2994,6 +3095,12 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 TIMG_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(source: TimgFunctionClockConfig) -> u32 {
+                match source {
+                    TimgFunctionClockConfig::XtalClk => xtal_clk_frequency(),
+                    TimgFunctionClockConfig::ApbClk => apb_clk_frequency(),
+                }
             }
         }
         impl UartInstance {
@@ -3054,7 +3161,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: UartFunctionClockConfig,
             ) -> u32 {
@@ -3066,6 +3172,12 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 UART_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(sclk: UartFunctionClockSclk) -> u32 {
+                match sclk {
+                    UartFunctionClockSclk::Apb => apb_clk_frequency(),
+                    UartFunctionClockSclk::RefTick => ref_tick_frequency(),
+                }
             }
             pub fn configure_baud_rate_generator(
                 self,
@@ -3141,7 +3253,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn mem_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: UartMemClockConfig,
             ) -> u32 {
@@ -3150,6 +3261,9 @@ macro_rules! define_clock_tree_types {
             pub fn mem_clock_frequency(self) -> u32 {
                 UART_MEM_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn mem_clock_source_frequency() -> u32 {
+                uart_mem_clk_frequency()
             }
         }
         /// Clock tree configuration.
@@ -3351,7 +3465,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_uart_mem_clock_downstream(clocks: &mut ClockTree, instance: UartInstance) {
             if let Some(config) = clocks.uart_mem_clock[instance as usize] {
                 UART_MEM_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.mem_clock_config_frequency(clocks, config),
+                    UartInstance::mem_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3399,7 +3513,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_i2c_function_clock_downstream(clocks: &mut ClockTree, instance: I2cInstance) {
             if let Some(config) = clocks.i2c_function_clock[instance as usize] {
                 I2C_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    I2cInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3407,7 +3521,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_rmt_sclk_downstream(clocks: &mut ClockTree, instance: RmtInstance) {
             if let Some(config) = clocks.rmt_sclk[instance as usize] {
                 RMT_SCLK_FREQ_CACHE[instance as usize].store(
-                    instance.sclk_config_frequency(clocks, config),
+                    RmtInstance::sclk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3415,7 +3529,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_spi_function_clock_downstream(clocks: &mut ClockTree, instance: SpiInstance) {
             if let Some(config) = clocks.spi_function_clock[instance as usize] {
                 SPI_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    SpiInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3423,7 +3537,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_timg_function_clock_downstream(clocks: &mut ClockTree, instance: TimgInstance) {
             if let Some(config) = clocks.timg_function_clock[instance as usize] {
                 TIMG_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    TimgInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3431,7 +3545,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_uart_function_clock_downstream(clocks: &mut ClockTree, instance: UartInstance) {
             if let Some(config) = clocks.uart_function_clock[instance as usize] {
                 UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    UartInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }

--- a/esp-metadata-generated/src/_generated_esp32s3.rs
+++ b/esp-metadata-generated/src/_generated_esp32s3.rs
@@ -1624,6 +1624,14 @@ macro_rules! define_clock_tree_types {
             /// Selects `RTC_SLOW_CLK`.
             RtcSlow,
         }
+        /// The list of clock signals that the `UART_MEM_CLK` multiplexer can output.
+        #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+        pub enum UartMemClkConfig {
+            #[default]
+            /// Selects `XTAL_CLK`.
+            Xtal,
+        }
         /// The list of clock signals that the `TIMG_CALIBRATION_CLOCK` multiplexer can output.
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -2121,6 +2129,9 @@ macro_rules! define_clock_tree_types {
         pub fn pll_clk_frequency() -> u32 {
             PLL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn pll_clk_source_frequency() -> u32 {
+            xtal_clk_frequency()
+        }
         pub fn request_rc_fast_clk(clocks: &mut ClockTree) {
             trace!("Requesting RC_FAST_CLK");
             if increment_reference_count(&mut clocks.rc_fast_clk_refcount) {
@@ -2191,6 +2202,9 @@ macro_rules! define_clock_tree_types {
         pub fn rc_fast_div_clk_frequency() -> u32 {
             (rc_fast_clk_frequency() / 256)
         }
+        pub fn rc_fast_div_clk_source_frequency() -> u32 {
+            rc_fast_clk_frequency()
+        }
         pub fn configure_system_pre_div_in(
             clocks: &mut ClockTree,
             new_selector: SystemPreDivInConfig,
@@ -2243,6 +2257,12 @@ macro_rules! define_clock_tree_types {
         pub fn system_pre_div_in_frequency() -> u32 {
             SYSTEM_PRE_DIV_IN_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn system_pre_div_in_source_frequency(source: SystemPreDivInConfig) -> u32 {
+            match source {
+                SystemPreDivInConfig::Xtal => xtal_clk_frequency(),
+                SystemPreDivInConfig::RcFast => rc_fast_clk_frequency(),
+            }
+        }
         pub fn configure_system_pre_div(clocks: &mut ClockTree, config: SystemPreDivConfig) {
             let old_config = clocks.system_pre_div.replace(config);
             refresh_system_pre_div_downstream(clocks);
@@ -2272,6 +2292,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn system_pre_div_frequency() -> u32 {
             SYSTEM_PRE_DIV_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn system_pre_div_source_frequency() -> u32 {
+            system_pre_div_in_frequency()
         }
         pub fn configure_cpu_pll_div_out(clocks: &mut ClockTree, config: CpuPllDivOutConfig) {
             if clocks.pll_clk.is_some() {
@@ -2305,6 +2328,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn cpu_pll_div_out_frequency() -> u32 {
             CPU_PLL_DIV_OUT_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn cpu_pll_div_out_source_frequency() -> u32 {
+            pll_clk_frequency()
         }
         pub fn configure_apb_clk(clocks: &mut ClockTree, new_selector: ApbClkConfig) {
             let old_selector = clocks.apb_clk.replace(new_selector);
@@ -2359,6 +2385,12 @@ macro_rules! define_clock_tree_types {
         }
         pub fn apb_clk_frequency() -> u32 {
             APB_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn apb_clk_source_frequency(source: ApbClkConfig) -> u32 {
+            match source {
+                ApbClkConfig::Pll => apb_80m_frequency(),
+                ApbClkConfig::Cpu => cpu_clk_frequency(),
+            }
         }
         pub fn configure_crypto_pwm_clk(clocks: &mut ClockTree, new_selector: CryptoPwmClkConfig) {
             let old_selector = clocks.crypto_pwm_clk.replace(new_selector);
@@ -2416,6 +2448,12 @@ macro_rules! define_clock_tree_types {
         }
         pub fn crypto_pwm_clk_frequency() -> u32 {
             CRYPTO_PWM_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn crypto_pwm_clk_source_frequency(source: CryptoPwmClkConfig) -> u32 {
+            match source {
+                CryptoPwmClkConfig::Pll => pll_160m_frequency(),
+                CryptoPwmClkConfig::Cpu => cpu_clk_frequency(),
+            }
         }
         pub fn configure_cpu_clk(clocks: &mut ClockTree, new_selector: CpuClkConfig) {
             let old_selector = clocks.cpu_clk.replace(new_selector);
@@ -2485,6 +2523,9 @@ macro_rules! define_clock_tree_types {
         pub fn pll_d2_frequency() -> u32 {
             (pll_clk_frequency() / 2)
         }
+        pub fn pll_d2_source_frequency() -> u32 {
+            pll_clk_frequency()
+        }
         pub fn request_pll_160m(clocks: &mut ClockTree) {
             trace!("Requesting PLL_160M");
             trace!("Enabling PLL_160M");
@@ -2500,6 +2541,9 @@ macro_rules! define_clock_tree_types {
         pub fn pll_160m_frequency() -> u32 {
             160000000
         }
+        pub fn pll_160m_source_frequency() -> u32 {
+            cpu_clk_frequency()
+        }
         pub fn request_apb_80m(clocks: &mut ClockTree) {
             trace!("Requesting APB_80M");
             trace!("Enabling APB_80M");
@@ -2514,6 +2558,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn apb_80m_frequency() -> u32 {
             80000000
+        }
+        pub fn apb_80m_source_frequency() -> u32 {
+            cpu_clk_frequency()
         }
         pub fn configure_rc_fast_clk_div_n(clocks: &mut ClockTree, config: RcFastClkDivNConfig) {
             let old_config = clocks.rc_fast_clk_div_n.replace(config);
@@ -2545,6 +2592,9 @@ macro_rules! define_clock_tree_types {
         pub fn rc_fast_clk_div_n_frequency() -> u32 {
             RC_FAST_CLK_DIV_N_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn rc_fast_clk_div_n_source_frequency() -> u32 {
+            rc_fast_clk_frequency()
+        }
         pub fn request_xtal_div_clk(clocks: &mut ClockTree) {
             trace!("Requesting XTAL_DIV_CLK");
             trace!("Enabling XTAL_DIV_CLK");
@@ -2559,6 +2609,9 @@ macro_rules! define_clock_tree_types {
         }
         pub fn xtal_div_clk_frequency() -> u32 {
             (xtal_clk_frequency() / 2)
+        }
+        pub fn xtal_div_clk_source_frequency() -> u32 {
+            xtal_clk_frequency()
         }
         pub fn configure_rtc_slow_clk(clocks: &mut ClockTree, new_selector: RtcSlowClkConfig) {
             let old_selector = clocks.rtc_slow_clk.replace(new_selector);
@@ -2613,6 +2666,13 @@ macro_rules! define_clock_tree_types {
         }
         pub fn rtc_slow_clk_frequency() -> u32 {
             RTC_SLOW_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn rtc_slow_clk_source_frequency(source: RtcSlowClkConfig) -> u32 {
+            match source {
+                RtcSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
+                RtcSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
+                RtcSlowClkConfig::RcFast => rc_fast_div_clk_frequency(),
+            }
         }
         pub fn configure_rtc_fast_clk(clocks: &mut ClockTree, new_selector: RtcFastClkConfig) {
             let old_selector = clocks.rtc_fast_clk.replace(new_selector);
@@ -2670,6 +2730,12 @@ macro_rules! define_clock_tree_types {
         }
         pub fn rtc_fast_clk_frequency() -> u32 {
             RTC_FAST_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
+        }
+        pub fn rtc_fast_clk_source_frequency(source: RtcFastClkConfig) -> u32 {
+            match source {
+                RtcFastClkConfig::Xtal => xtal_div_clk_frequency(),
+                RtcFastClkConfig::Rc => rc_fast_clk_div_n_frequency(),
+            }
         }
         pub fn configure_low_power_clk(clocks: &mut ClockTree, new_selector: LowPowerClkConfig) {
             let old_selector = clocks.low_power_clk.replace(new_selector);
@@ -2738,6 +2804,14 @@ macro_rules! define_clock_tree_types {
         pub fn low_power_clk_frequency() -> u32 {
             LOW_POWER_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn low_power_clk_source_frequency(source: LowPowerClkConfig) -> u32 {
+            match source {
+                LowPowerClkConfig::Xtal => xtal_clk_frequency(),
+                LowPowerClkConfig::RcFast => rc_fast_clk_frequency(),
+                LowPowerClkConfig::Xtal32k => xtal32k_clk_frequency(),
+                LowPowerClkConfig::RtcSlow => rtc_slow_clk_frequency(),
+            }
+        }
         pub fn request_uart_mem_clk(clocks: &mut ClockTree) {
             trace!("Requesting UART_MEM_CLK");
             if increment_reference_count(&mut clocks.uart_mem_clk_refcount) {
@@ -2756,6 +2830,11 @@ macro_rules! define_clock_tree_types {
         }
         pub fn uart_mem_clk_frequency() -> u32 {
             xtal_clk_frequency()
+        }
+        pub fn uart_mem_clk_source_frequency(source: UartMemClkConfig) -> u32 {
+            match source {
+                UartMemClkConfig::Xtal => xtal_clk_frequency(),
+            }
         }
         pub fn configure_timg_calibration_clock(
             clocks: &mut ClockTree,
@@ -2824,6 +2903,13 @@ macro_rules! define_clock_tree_types {
         pub fn timg_calibration_clock_frequency() -> u32 {
             TIMG_CALIBRATION_CLOCK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
+        pub fn timg_calibration_clock_source_frequency(source: TimgCalibrationClockConfig) -> u32 {
+            match source {
+                TimgCalibrationClockConfig::RcSlowClk => rc_slow_clk_frequency(),
+                TimgCalibrationClockConfig::RcFastDivClk => rc_fast_div_clk_frequency(),
+                TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
+            }
+        }
         impl I2cInstance {
             pub fn configure_function_clock(
                 self,
@@ -2880,7 +2966,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: I2cFunctionClockConfig,
             ) -> u32 {
@@ -2892,6 +2977,12 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 I2C_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(sclk: I2cFunctionClockSclk) -> u32 {
+                match sclk {
+                    I2cFunctionClockSclk::Xtal => xtal_clk_frequency(),
+                    I2cFunctionClockSclk::RcFast => rc_fast_clk_frequency(),
+                }
             }
         }
         impl McpwmInstance {
@@ -2940,7 +3031,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: McpwmFunctionClockConfig,
             ) -> u32 {
@@ -2949,6 +3039,11 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 MCPWM_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(source: McpwmFunctionClockConfig) -> u32 {
+                match source {
+                    McpwmFunctionClockConfig::CryptoPwmClk => crypto_pwm_clk_frequency(),
+                }
             }
         }
         impl RmtInstance {
@@ -3001,11 +3096,7 @@ macro_rules! define_clock_tree_types {
                 }
             }
             #[allow(unused_variables)]
-            pub fn sclk_config_frequency(
-                self,
-                clocks: &mut ClockTree,
-                config: RmtSclkConfig,
-            ) -> u32 {
+            pub fn sclk_config_frequency(clocks: &mut ClockTree, config: RmtSclkConfig) -> u32 {
                 match config {
                     RmtSclkConfig::ApbClk => apb_clk_frequency(),
                     RmtSclkConfig::RcFastClk => rc_fast_clk_frequency(),
@@ -3014,6 +3105,13 @@ macro_rules! define_clock_tree_types {
             }
             pub fn sclk_frequency(self) -> u32 {
                 RMT_SCLK_FREQ_CACHE[self as usize].load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn sclk_source_frequency(source: RmtSclkConfig) -> u32 {
+                match source {
+                    RmtSclkConfig::ApbClk => apb_clk_frequency(),
+                    RmtSclkConfig::RcFastClk => rc_fast_clk_frequency(),
+                    RmtSclkConfig::XtalClk => xtal_clk_frequency(),
+                }
             }
         }
         impl SpiInstance {
@@ -3072,7 +3170,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: SpiFunctionClockConfig,
             ) -> u32 {
@@ -3084,6 +3181,12 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 SPI_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(source: SpiFunctionClockConfig) -> u32 {
+                match source {
+                    SpiFunctionClockConfig::Xtal => xtal_clk_frequency(),
+                    SpiFunctionClockConfig::Apb => apb_clk_frequency(),
+                }
             }
         }
         impl TimgInstance {
@@ -3144,7 +3247,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: TimgFunctionClockConfig,
             ) -> u32 {
@@ -3156,6 +3258,12 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 TIMG_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(source: TimgFunctionClockConfig) -> u32 {
+                match source {
+                    TimgFunctionClockConfig::XtalClk => xtal_clk_frequency(),
+                    TimgFunctionClockConfig::ApbClk => apb_clk_frequency(),
+                }
             }
         }
         impl UartInstance {
@@ -3220,7 +3328,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn function_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: UartFunctionClockConfig,
             ) -> u32 {
@@ -3233,6 +3340,13 @@ macro_rules! define_clock_tree_types {
             pub fn function_clock_frequency(self) -> u32 {
                 UART_FUNCTION_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn function_clock_source_frequency(sclk: UartFunctionClockSclk) -> u32 {
+                match sclk {
+                    UartFunctionClockSclk::Apb => apb_clk_frequency(),
+                    UartFunctionClockSclk::RcFast => rc_fast_clk_frequency(),
+                    UartFunctionClockSclk::Xtal => xtal_clk_frequency(),
+                }
             }
             pub fn configure_baud_rate_generator(
                 self,
@@ -3308,7 +3422,6 @@ macro_rules! define_clock_tree_types {
             }
             #[allow(unused_variables)]
             pub fn mem_clock_config_frequency(
-                self,
                 clocks: &mut ClockTree,
                 config: UartMemClockConfig,
             ) -> u32 {
@@ -3317,6 +3430,9 @@ macro_rules! define_clock_tree_types {
             pub fn mem_clock_frequency(self) -> u32 {
                 UART_MEM_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
+            }
+            pub fn mem_clock_source_frequency() -> u32 {
+                uart_mem_clk_frequency()
             }
         }
         /// Clock tree configuration.
@@ -3518,7 +3634,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_i2c_function_clock_downstream(clocks: &mut ClockTree, instance: I2cInstance) {
             if let Some(config) = clocks.i2c_function_clock[instance as usize] {
                 I2C_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    I2cInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3526,7 +3642,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_uart_mem_clock_downstream(clocks: &mut ClockTree, instance: UartInstance) {
             if let Some(config) = clocks.uart_mem_clock[instance as usize] {
                 UART_MEM_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.mem_clock_config_frequency(clocks, config),
+                    UartInstance::mem_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3572,7 +3688,7 @@ macro_rules! define_clock_tree_types {
         ) {
             if let Some(config) = clocks.mcpwm_function_clock[instance as usize] {
                 MCPWM_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    McpwmInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3580,7 +3696,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_rmt_sclk_downstream(clocks: &mut ClockTree, instance: RmtInstance) {
             if let Some(config) = clocks.rmt_sclk[instance as usize] {
                 RMT_SCLK_FREQ_CACHE[instance as usize].store(
-                    instance.sclk_config_frequency(clocks, config),
+                    RmtInstance::sclk_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3588,7 +3704,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_spi_function_clock_downstream(clocks: &mut ClockTree, instance: SpiInstance) {
             if let Some(config) = clocks.spi_function_clock[instance as usize] {
                 SPI_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    SpiInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3596,7 +3712,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_timg_function_clock_downstream(clocks: &mut ClockTree, instance: TimgInstance) {
             if let Some(config) = clocks.timg_function_clock[instance as usize] {
                 TIMG_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    TimgInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }
@@ -3604,7 +3720,7 @@ macro_rules! define_clock_tree_types {
         fn refresh_uart_function_clock_downstream(clocks: &mut ClockTree, instance: UartInstance) {
             if let Some(config) = clocks.uart_function_clock[instance as usize] {
                 UART_FUNCTION_CLOCK_FREQ_CACHE[instance as usize].store(
-                    instance.function_clock_config_frequency(clocks, config),
+                    UartInstance::function_clock_config_frequency(clocks, config),
                     ::core::sync::atomic::Ordering::Release,
                 );
             }

--- a/esp-metadata/src/cfg/soc.rs
+++ b/esp-metadata/src/cfg/soc.rs
@@ -22,6 +22,7 @@ use crate::{
         DependencyGraph,
         Function,
         ManagementProperties,
+        SourceFrequencySignature,
         ValidationContext,
     },
     number,
@@ -198,8 +199,58 @@ impl ClockTreeNodeInstance {
         self.node.config_documentation(self)
     }
 
-    fn node_frequency_impl(&self, tree: &ProcessedClockData) -> TokenStream {
-        self.node.node_frequency_impl(self, tree)
+    fn node_frequency_impl(
+        &self,
+        tree: &ProcessedClockData,
+        frequency_receiver: &[TokenStream],
+    ) -> TokenStream {
+        self.node
+            .node_frequency_impl(self, tree, frequency_receiver)
+    }
+
+    fn config_frequency_needs_instance(&self, tree: &ProcessedClockData) -> bool {
+        self.node.config_frequency_needs_instance(self, tree)
+    }
+
+    fn emits_config_type(&self, tree: &ProcessedClockData) -> bool {
+        self.is_configurable()
+            || matches!(
+                self.node_source_frequency_signature(tree),
+                SourceFrequencySignature::Selector { .. }
+            )
+    }
+
+    fn frequency_call_with_receiver(&self, frequency_receiver: &[TokenStream]) -> TokenStream {
+        let frequency_fn = self.frequency_function_name();
+        let receiver = if self.properties.receiver.is_some() && !frequency_receiver.is_empty() {
+            frequency_receiver
+        } else {
+            self.properties.receiver()
+        };
+        quote! { #(#receiver.)*#frequency_fn() }
+    }
+
+    fn node_source_frequency_signature(
+        &self,
+        tree: &ProcessedClockData,
+    ) -> SourceFrequencySignature {
+        self.node.node_source_frequency_impl(self, tree)
+    }
+
+    fn frequency_call(&self) -> TokenStream {
+        let frequency_fn = self.frequency_function_name();
+        let receiver = self.properties.receiver();
+        quote! { #(#receiver.)*#frequency_fn() }
+    }
+
+    /// Returns a frequency query expression when the node does not require an instance
+    /// receiver. Per-instance cached frequencies cannot be queried without `self`.
+    fn try_frequency_call(&self) -> Option<TokenStream> {
+        if self.properties.receiver.is_some() {
+            None
+        } else {
+            Some(self.frequency_call())
+        }
     }
 
     fn always_on(&self) -> bool {
@@ -289,6 +340,10 @@ impl ClockTreeNodeInstance {
         self.suffix_function("config_frequency")
     }
 
+    fn source_frequency_function_name(&self) -> Ident {
+        self.suffix_function("source_frequency")
+    }
+
     fn config_apply_function_name(&self) -> Ident {
         self.prefix_function("configure")
     }
@@ -357,10 +412,39 @@ impl ClockTreeNodeInstance {
             .as_ref()
             .map(|_| self.config_apply_impl_function())
             .unwrap_or_default();
-        let frequency_function_impl = self.node_frequency_impl(tree);
+        let needs_instance = self.config_frequency_needs_instance(tree);
+        let config_frequency_receiver = if needs_instance {
+            vec![quote! { self }]
+        } else {
+            vec![]
+        };
+        let frequency_function_impl =
+            self.node_frequency_impl(tree, config_frequency_receiver.as_slice());
         let frequency_function_name = self.frequency_function_name();
         let config_frequency_function_name = self.config_frequency_function_name();
+        let source_frequency_function_name = self.source_frequency_function_name();
         let receiver = self.properties.receiver();
+        let source_frequency_impl = match self.node_source_frequency_signature(tree) {
+            SourceFrequencySignature::Skip => quote! {},
+            SourceFrequencySignature::Parameterless(body) => {
+                quote! {
+                    pub fn #source_frequency_function_name() -> u32 {
+                        #body
+                    }
+                }
+            }
+            SourceFrequencySignature::Selector {
+                param_type,
+                param_name,
+                body,
+            } => {
+                quote! {
+                    pub fn #source_frequency_function_name(#param_name: #param_type) -> u32 {
+                        #body
+                    }
+                }
+            }
+        };
 
         let log_msg = |msg: &str| {
             if receiver.is_empty() {
@@ -471,6 +555,11 @@ impl ClockTreeNodeInstance {
                 implementation: quote! { #current_config_fn },
             },
 
+            source_frequency: Function {
+                _name: source_frequency_function_name.to_string(),
+                implementation: source_frequency_impl,
+            },
+
             frequency: Function {
                 _name: frequency_function_name.to_string(),
                 implementation: if self.is_configurable() {
@@ -480,11 +569,18 @@ impl ClockTreeNodeInstance {
                     } else {
                         quote! { #cache_name.load(::core::sync::atomic::Ordering::Acquire) }
                     };
+                    let config_fn_self = needs_instance.then_some(quote! { self }).into_iter();
+
                     quote! {
                         #[allow(unused_variables)]
-                        pub fn #config_frequency_function_name(#(#receiver,)* clocks: &mut ClockTree, config: #ty_name) -> u32 {
+                        pub fn #config_frequency_function_name(
+                            #(#config_fn_self,)*
+                            clocks: &mut ClockTree,
+                            config: #ty_name,
+                        ) -> u32 {
                             #frequency_function_impl
                         }
+
                         pub fn #frequency_function_name(#(#receiver)*) -> u32 {
                             #cache_load
                         }
@@ -606,7 +702,7 @@ impl SystemClocks {
                 clock_item.node.name()
             ));
             if is_first_instance {
-                if clock_item.is_configurable() {
+                if clock_item.emits_config_type(tree) {
                     clock_tree_node_defs.push(clock_item.config_type());
                 }
 
@@ -801,18 +897,29 @@ impl SystemClocks {
                 let instances = tree.group_instances.get(&node.group_template).unwrap();
                 let instance_count = number(instances.len());
                 let field_name = node.properties.field_name();
+                let instance_type = format_ident!(
+                    "{}Instance",
+                    node.group_template
+                        .from_case(Case::Constant)
+                        .to_case(Case::Pascal)
+                );
 
                 freq_cache_statics.push(quote! {
                     static #cache_name: [::core::sync::atomic::AtomicU32; #instance_count] =
                         [const { ::core::sync::atomic::AtomicU32::new(0) }; #instance_count];
                 });
                 // Refresh stmt for template nodes uses an `instance` variable (passed by caller).
+                let config_freq_call = if node.config_frequency_needs_instance(tree) {
+                    quote! { instance.#config_freq_fn(clocks, config) }
+                } else {
+                    quote! { #instance_type::#config_freq_fn(clocks, config) }
+                };
                 refresh_stmt_by_key.insert(
                     template_key.clone(),
                     quote! {
                         if let Some(config) = clocks.#field_name[instance as usize] {
                             #cache_name[instance as usize].store(
-                                instance.#config_freq_fn(clocks, config),
+                                #config_freq_call,
                                 ::core::sync::atomic::Ordering::Release,
                             );
                         }

--- a/esp-metadata/src/cfg/soc/clock_tree.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree.rs
@@ -72,6 +72,16 @@ pub(crate) struct Function {
     pub implementation: TokenStream,
 }
 
+pub(crate) enum SourceFrequencySignature {
+    Skip,
+    Parameterless(TokenStream),
+    Selector {
+        param_type: TokenStream,
+        param_name: Ident,
+        body: TokenStream,
+    },
+}
+
 pub(crate) struct ClockNodeFunctions {
     pub impl_type: Option<Ident>,
 
@@ -81,6 +91,7 @@ pub(crate) struct ClockNodeFunctions {
     pub current_config: Function,
 
     pub frequency: Function,
+    pub source_frequency: Function,
     pub hal_functions: Vec<TokenStream>,
 }
 
@@ -91,6 +102,7 @@ impl ClockNodeFunctions {
         let apply_impl = &self.apply_config.implementation;
         let current_config_impl = &self.current_config.implementation;
         let frequency_impl = &self.frequency.implementation;
+        let source_frequency_impl = &self.source_frequency.implementation;
 
         quote! {
             #apply_impl
@@ -98,6 +110,7 @@ impl ClockNodeFunctions {
             #request_impl
             #release_impl
             #frequency_impl
+            #source_frequency_impl
         }
     }
 }
@@ -345,7 +358,31 @@ pub(crate) trait ClockTreeNodeType: Any {
         &self,
         instance: &ClockTreeNodeInstance,
         tree: &ProcessedClockData,
+        frequency_receiver: &[TokenStream],
     ) -> TokenStream;
+
+    /// Returns true when `config_frequency` must take an `instance` parameter because its
+    /// frequency formula reads a per-instance upstream node's cached frequency.
+    fn config_frequency_needs_instance(
+        &self,
+        _instance: &ClockTreeNodeInstance,
+        _tree: &ProcessedClockData,
+    ) -> bool {
+        false
+    }
+
+    fn has_configures(&self) -> bool {
+        false
+    }
+
+    fn node_source_frequency_impl(
+        &self,
+        instance: &ClockTreeNodeInstance,
+        tree: &ProcessedClockData,
+    ) -> SourceFrequencySignature {
+        let _ = (instance, tree);
+        SourceFrequencySignature::Skip
+    }
 
     /// Returns the documentation for the clock configuration, which will be placed on the
     /// `ClockConfig` field.

--- a/esp-metadata/src/cfg/soc/clock_tree/generic.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/generic.rs
@@ -449,7 +449,9 @@ impl ClockTreeNodeType for Generic {
     fn has_configures(&self) -> bool {
         self.params.values().any(|param| {
             if let NodeParameter::Source(variants) = param {
-                variants.iter().any(|variant| !variant.configures.is_empty())
+                variants
+                    .iter()
+                    .any(|variant| !variant.configures.is_empty())
             } else {
                 false
             }

--- a/esp-metadata/src/cfg/soc/clock_tree/generic.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/generic.rs
@@ -22,6 +22,7 @@ use crate::{
             ConfiguresExpression,
             Expression,
             RejectExpression,
+            SourceFrequencySignature,
             ValidationContext,
             ValuesExpression,
             expr_compiler::ExprCompiler,
@@ -445,10 +446,78 @@ impl ClockTreeNodeType for Generic {
         }
     }
 
+    fn has_configures(&self) -> bool {
+        self.params.values().any(|param| {
+            if let NodeParameter::Source(variants) = param {
+                variants.iter().any(|variant| !variant.configures.is_empty())
+            } else {
+                false
+            }
+        })
+    }
+
+    fn node_source_frequency_impl(
+        &self,
+        instance: &ClockTreeNodeInstance,
+        tree: &ProcessedClockData,
+    ) -> SourceFrequencySignature {
+        if self.has_configures() {
+            return SourceFrequencySignature::Skip;
+        }
+
+        let source_param_name = self.clock_source_parameter();
+        match self.upstream_clocks() {
+            ClockSource::Fixed(input) => {
+                let source_node = instance.resolve_node(tree, input);
+                let Some(body) = source_node.try_frequency_call() else {
+                    return SourceFrequencySignature::Skip;
+                };
+                SourceFrequencySignature::Parameterless(body)
+            }
+            ClockSource::Mux(inputs) => {
+                let ty_name = self.param_type_name(instance, source_param_name);
+                let param_name = format_ident!("{source_param_name}");
+
+                let mut variants = Vec::with_capacity(inputs.len());
+                let mut variant_frequencies = Vec::with_capacity(inputs.len());
+                for variant in inputs {
+                    let name = variant.config_enum_variant_name();
+                    let source_node = instance.resolve_node(tree, &variant.outputs);
+                    let Some(frequency) = source_node.try_frequency_call() else {
+                        return SourceFrequencySignature::Skip;
+                    };
+                    variants.push(quote! { #ty_name::#name });
+                    variant_frequencies.push(frequency);
+                }
+
+                SourceFrequencySignature::Selector {
+                    param_type: quote! { #ty_name },
+                    param_name: param_name.clone(),
+                    body: quote! {
+                        match #param_name {
+                            #(#variants => #variant_frequencies,)*
+                        }
+                    },
+                }
+            }
+        }
+    }
+
+    fn config_frequency_needs_instance(
+        &self,
+        instance: &ClockTreeNodeInstance,
+        tree: &ProcessedClockData,
+    ) -> bool {
+        self.upstream_source_nodes(instance, tree)
+            .into_iter()
+            .any(|node| node.properties.receiver.is_some())
+    }
+
     fn node_frequency_impl(
         &self,
         instance: &ClockTreeNodeInstance,
         tree: &ProcessedClockData,
+        frequency_receiver: &[TokenStream],
     ) -> TokenStream {
         let mut variables = HashMap::new();
 
@@ -457,15 +526,7 @@ impl ClockTreeNodeType for Generic {
         let source_frequency_tokens = match self.upstream_clocks() {
             ClockSource::Fixed(input) => {
                 let source_node = instance.resolve_node(tree, &input);
-                let source_receiver = source_node.properties.receiver();
-                let freq_fn = source_node.frequency_function_name();
-                quote! { #(#source_receiver.)* #freq_fn() }
-            }
-            ClockSource::Mux(input) if input.len() == 1 => {
-                let source_node = instance.resolve_node(tree, &input[0].outputs);
-                let source_receiver = source_node.properties.receiver();
-                let freq_fn = source_node.frequency_function_name();
-                quote! { #(#source_receiver.)* #freq_fn() }
+                source_node.frequency_call_with_receiver(frequency_receiver)
             }
             ClockSource::Mux(inputs) => {
                 let ty_name = self.param_type_name(instance, source_param_name);
@@ -476,12 +537,10 @@ impl ClockTreeNodeType for Generic {
                     .map(|variant| {
                         let name = variant.config_enum_variant_name();
                         let source_node = instance.resolve_node(tree, &variant.outputs);
-                        let frequency_fn = source_node.frequency_function_name();
-                        let source_receiver = source_node.properties.receiver();
 
                         (
                             quote! { #ty_name::#name },
-                            quote! { #(#source_receiver.)* #frequency_fn() },
+                            source_node.frequency_call_with_receiver(frequency_receiver),
                         )
                     })
                     .unzip::<_, _, Vec<_>, Vec<_>>();
@@ -688,6 +747,20 @@ impl ClockSource<'_> {
 }
 
 impl Generic {
+    fn upstream_source_nodes<'a>(
+        &'a self,
+        instance: &'a ClockTreeNodeInstance,
+        tree: &'a ProcessedClockData,
+    ) -> Vec<&'a ClockTreeNodeInstance> {
+        match self.upstream_clocks() {
+            ClockSource::Fixed(input) => vec![instance.resolve_node(tree, &input)],
+            ClockSource::Mux(inputs) => inputs
+                .iter()
+                .map(|variant| instance.resolve_node(tree, &variant.outputs))
+                .collect(),
+        }
+    }
+
     fn upstream_clocks(&self) -> ClockSource<'_> {
         let input_name = self.clock_source_parameter();
 
@@ -720,9 +793,7 @@ impl Generic {
     ) -> TokenStream {
         let single_source = match self.upstream_clocks() {
             ClockSource::Fixed(name) => name,
-            ClockSource::Mux(mux) if mux.len() == 1 => &mux.first().unwrap().outputs,
             ClockSource::Mux(mux_inputs) => {
-                // Multiple options, generate a match expression
                 let param = self.clock_source_parameter();
                 let ty_name = self.param_type_name(instance, param);
                 let request_upstream_branches = mux_inputs.iter().map(|variant| {

--- a/esp-metadata/src/cfg/soc/clock_tree/mux.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/mux.rs
@@ -9,7 +9,12 @@ use somni_parser::ast;
 
 use crate::cfg::{
     ClockTreeNodeInstance,
-    clock_tree::{ClockTreeNodeType, ConfiguresExpression, ValidationContext},
+    clock_tree::{
+        ClockTreeNodeType,
+        ConfiguresExpression,
+        SourceFrequencySignature,
+        ValidationContext,
+    },
     soc::ProcessedClockData,
 };
 
@@ -136,10 +141,48 @@ impl ClockTreeNodeType for Multiplexer {
         self.impl_config_apply_function(instance, tree)
     }
 
+    fn has_configures(&self) -> bool {
+        self.variants.iter().any(|variant| !variant.configures.is_empty())
+    }
+
+    fn node_source_frequency_impl(
+        &self,
+        instance: &ClockTreeNodeInstance,
+        tree: &ProcessedClockData,
+    ) -> SourceFrequencySignature {
+        if self.has_configures() {
+            return SourceFrequencySignature::Skip;
+        }
+
+        let ty_name = instance.config_type_name();
+        let mut variant_frequencies = Vec::with_capacity(self.variants.len());
+        let mut variants = Vec::with_capacity(self.variants.len());
+        for variant in &self.variants {
+            let name = variant.config_enum_variant_name();
+            let upstream_node = instance.resolve_node(tree, &variant.outputs);
+            let Some(frequency) = upstream_node.try_frequency_call() else {
+                return SourceFrequencySignature::Skip;
+            };
+            variants.push(quote! { #ty_name::#name });
+            variant_frequencies.push(frequency);
+        }
+
+        SourceFrequencySignature::Selector {
+            param_type: quote! { #ty_name },
+            param_name: format_ident!("source"),
+            body: quote! {
+                match source {
+                    #(#variants => #variant_frequencies,)*
+                }
+            },
+        }
+    }
+
     fn node_frequency_impl(
         &self,
         instance: &ClockTreeNodeInstance,
         tree: &ProcessedClockData,
+        _frequency_receiver: &[TokenStream],
     ) -> TokenStream {
         let ty_name = instance.config_type_name();
         let variants = self

--- a/esp-metadata/src/cfg/soc/clock_tree/mux.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/mux.rs
@@ -142,7 +142,9 @@ impl ClockTreeNodeType for Multiplexer {
     }
 
     fn has_configures(&self) -> bool {
-        self.variants.iter().any(|variant| !variant.configures.is_empty())
+        self.variants
+            .iter()
+            .any(|variant| !variant.configures.is_empty())
     }
 
     fn node_source_frequency_impl(

--- a/esp-metadata/src/cfg/soc/clock_tree/source.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/source.rs
@@ -42,6 +42,7 @@ use crate::{
             ClockTreeNodeType,
             Expression,
             RejectExpression,
+            SourceFrequencySignature,
             ValidationContext,
             ValuesExpression,
             human_readable_frequency,
@@ -125,6 +126,7 @@ impl ClockTreeNodeType for Source {
         &self,
         instance: &ClockTreeNodeInstance,
         tree: &ProcessedClockData,
+        _frequency_receiver: &[TokenStream],
     ) -> TokenStream {
         if self.values.is_some() {
             quote! { config.value() }
@@ -345,8 +347,22 @@ impl ClockTreeNodeType for DerivedClockSource {
         &self,
         instance: &ClockTreeNodeInstance,
         tree: &ProcessedClockData,
+        frequency_receiver: &[TokenStream],
     ) -> TokenStream {
-        self.source_options.node_frequency_impl(instance, tree)
+        self.source_options
+            .node_frequency_impl(instance, tree, frequency_receiver)
+    }
+
+    fn node_source_frequency_impl(
+        &self,
+        instance: &ClockTreeNodeInstance,
+        tree: &ProcessedClockData,
+    ) -> SourceFrequencySignature {
+        let upstream_node = instance.resolve_node(tree, &self.from);
+        let Some(body) = upstream_node.try_frequency_call() else {
+            return SourceFrequencySignature::Skip;
+        };
+        SourceFrequencySignature::Parameterless(body)
     }
 
     fn config_type(&self, instance: &ClockTreeNodeInstance) -> TokenStream {


### PR DESCRIPTION
This PR allows simplifying a clock configuration. We generate a new function to directly query source clocks, instead of needing to produce a valid, but dummy configuration. The PR also resolves a TODO by removing `self` from query functions that don't need the actual instance.