### PR TITLE
Fix SPI clock setup issues & cleanup

### DIFF
--- a/esp-hal/src/clock/mod.rs
+++ b/esp-hal/src/clock/mod.rs
@@ -205,6 +205,10 @@ pub(crate) fn init(cpu_clock_config: ClockConfig) {
         clocks::request_pll_clk(clocks);
         #[cfg(soc_has_clock_node_pll_f96m_clk)]
         clocks::request_pll_f96m_clk(clocks);
+        #[cfg(soc_has_clock_node_pll_f120m)]
+        clocks::request_pll_f120m(clocks);
+        #[cfg(soc_has_clock_node_pll_f160m)]
+        clocks::request_pll_f160m(clocks);
         #[cfg(soc_has_clock_node_pll_f240m)]
         clocks::request_pll_f240m(clocks);
         #[cfg(soc_has_clock_node_rc_fast_div_clk)]

--- a/esp-hal/src/soc/esp32c2/clocks.rs
+++ b/esp-hal/src/soc/esp32c2/clocks.rs
@@ -765,13 +765,7 @@ impl I2cInstance {
 impl SpiInstance {
     // SPI_FUNCTION_CLOCK
 
-    fn enable_function_clock_impl(self, _clocks: &mut ClockTree, en: bool) {
-        let _ = self;
-        SPI2::regs().clk_gate().modify(|_, w| {
-            w.clk_en().bit(en);
-            w.mst_clk_active().bit(en)
-        });
-    }
+    fn enable_function_clock_impl(self, _clocks: &mut ClockTree, _en: bool) {}
 
     fn configure_function_clock_impl(
         self,

--- a/esp-hal/src/soc/esp32c3/clocks.rs
+++ b/esp-hal/src/soc/esp32c3/clocks.rs
@@ -758,12 +758,7 @@ impl I2cInstance {
 impl SpiInstance {
     // SPI_FUNCTION_CLOCK
 
-    fn enable_function_clock_impl(self, _clocks: &mut ClockTree, en: bool) {
-        SPI2::regs().clk_gate().modify(|_, w| {
-            w.clk_en().bit(en);
-            w.mst_clk_active().bit(en)
-        });
-    }
+    fn enable_function_clock_impl(self, _clocks: &mut ClockTree, _en: bool) {}
 
     fn configure_function_clock_impl(
         self,

--- a/esp-hal/src/soc/esp32s3/clocks.rs
+++ b/esp-hal/src/soc/esp32s3/clocks.rs
@@ -971,16 +971,7 @@ impl I2cInstance {
 impl SpiInstance {
     // SPI_FUNCTION_CLOCK
 
-    fn enable_function_clock_impl(self, _clocks: &mut ClockTree, en: bool) {
-        let regs = match self {
-            SpiInstance::Spi2 => SPI2::regs(),
-            SpiInstance::Spi3 => SPI3::regs(),
-        };
-        regs.clk_gate().modify(|_, w| {
-            w.clk_en().bit(en);
-            w.mst_clk_active().bit(en)
-        });
-    }
+    fn enable_function_clock_impl(self, _clocks: &mut ClockTree, _en: bool) {}
 
     fn configure_function_clock_impl(
         self,

--- a/esp-hal/src/spi/master/low_level/mod.rs
+++ b/esp-hal/src/spi/master/low_level/mod.rs
@@ -201,6 +201,14 @@ impl Driver {
 
     /// Initialize for full-duplex 1 bit mode
     pub(super) fn init(&self) {
+        version::enable_peripheral_clock(self);
+        crate::soc::clocks::ClockTree::with(|clocks| {
+            self.info.clock_instance.configure_function_clock(
+                clocks,
+                crate::soc::clocks::SpiFunctionClockConfig::default(),
+            );
+            self.info.clock_instance.request_function_clock(clocks);
+        });
         self.regs().user().modify(|_, w| {
             w.usr_miso_highpart().clear_bit();
             w.usr_mosi_highpart().clear_bit();
@@ -211,14 +219,6 @@ impl Driver {
             w.usr_dummy_idle().set_bit();
             w.usr_addr().clear_bit();
             w.usr_command().clear_bit()
-        });
-
-        crate::soc::clocks::ClockTree::with(|clocks| {
-            self.info.clock_instance.configure_function_clock(
-                clocks,
-                crate::soc::clocks::SpiFunctionClockConfig::default(),
-            );
-            self.info.clock_instance.request_function_clock(clocks);
         });
 
         version::init(self);
@@ -261,10 +261,7 @@ impl Driver {
                 .clock_instance
                 .configure_function_clock(clocks, config.clock_source);
 
-            // TODO: release should return whether the clock was released
-            self.info.clock_instance.release_function_clock(clocks);
             self.regs().clock().write(|w| unsafe { w.bits(raw) });
-            self.info.clock_instance.request_function_clock(clocks);
         });
 
         self.set_bit_order(config.read_bit_order, config.write_bit_order);
@@ -619,20 +616,6 @@ impl Driver {
             w.usr_addr().bit(!address.is_none());
             w.usr_command().bit(!cmd.is_none())
         });
-
-        // FIXME why is clock config even here?
-        #[cfg(spi_master_version = "3")]
-        reg_block.clk_gate().modify(|_, w| {
-            w.clk_en().set_bit();
-            w.mst_clk_active().set_bit();
-            w.mst_clk_sel().set_bit()
-        });
-
-        #[cfg(soc_has_pcr)]
-        // use default clock source
-        crate::peripherals::PCR::regs()
-            .spi2_clkm_conf()
-            .modify(|_, w| unsafe { w.spi2_clkm_sel().bits(1) });
 
         version::setup_half_duplex(self);
 

--- a/esp-hal/src/spi/master/low_level/v1.rs
+++ b/esp-hal/src/spi/master/low_level/v1.rs
@@ -14,6 +14,8 @@ pub(super) fn abort_transfer(driver: &Driver) {
     driver.regs().slave().toggle(|w, en| w.mode().bit(en));
 }
 
+pub(super) fn enable_peripheral_clock(_driver: &Driver) {}
+
 pub(super) fn init(driver: &Driver) {
     driver.regs().ctrl().modify(|_, w| w.wp().clear_bit());
 }

--- a/esp-hal/src/spi/master/low_level/v2.rs
+++ b/esp-hal/src/spi/master/low_level/v2.rs
@@ -10,6 +10,11 @@ pub(super) fn abort_transfer(driver: &Driver) {
     driver.configure_datalen(1, 1);
 }
 
+pub(super) fn enable_peripheral_clock(_driver: &Driver) {
+    // The PAC places a clock gate register to the same address that would be SPI_W17_REG.
+    // I don't believe it.
+}
+
 pub(super) fn init(driver: &Driver) {
     driver.regs().ctrl().modify(|_, w| {
         w.q_pol().clear_bit();

--- a/esp-hal/src/spi/master/low_level/v3.rs
+++ b/esp-hal/src/spi/master/low_level/v3.rs
@@ -10,6 +10,13 @@ pub(super) fn abort_transfer(driver: &Driver) {
     driver.configure_datalen(1, 1);
 }
 
+pub(super) fn enable_peripheral_clock(driver: &Driver) {
+    driver.regs().clk_gate().modify(|_, w| {
+        w.clk_en().set_bit();
+        w.mst_clk_active().set_bit()
+    });
+}
+
 pub(super) fn init(driver: &Driver) {
     driver.regs().ctrl().modify(|_, w| {
         w.q_pol().clear_bit();

--- a/esp-hal/src/spi/slave.rs
+++ b/esp-hal/src/spi/slave.rs
@@ -679,6 +679,11 @@ impl Info {
 
     /// Initialize for full-duplex 1 bit mode
     fn init(&self) {
+        #[cfg(soc_has_pcr)]
+        crate::peripherals::PCR::regs()
+            .spi2_clkm_conf()
+            .modify(|_, w| w.spi2_clkm_en().set_bit());
+
         self.regs().clock().write(|w| unsafe { w.bits(0) });
         self.regs().user().write(|w| unsafe { w.bits(0) });
         self.regs().ctrl().write(|w| unsafe { w.bits(0) });

--- a/esp-metadata-generated/src/_generated_esp32c6.rs
+++ b/esp-metadata-generated/src/_generated_esp32c6.rs
@@ -2084,9 +2084,9 @@ macro_rules! define_clock_tree_types {
         #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum SpiFunctionClockConfig {
-            #[default]
             /// Selects `PLL_F80M`.
             PllF80m,
+            #[default]
             /// Selects `XTAL_CLK`.
             Xtal,
             /// Selects `RC_FAST_CLK`.

--- a/esp-metadata/devices/esp32c6.toml
+++ b/esp-metadata/devices/esp32c6.toml
@@ -254,8 +254,8 @@ clocks = { system_clocks = { clock_tree = [
     ] },
     { group = "SPI", clocks = [
         { name = "FUNCTION_CLOCK", type = "mux", variants = [
-            { name = "PLL_F80M", outputs = "PLL_F80M", default = true },
-            { name = "XTAL",     outputs = "XTAL_CLK" },
+            { name = "PLL_F80M", outputs = "PLL_F80M" },
+            { name = "XTAL",     outputs = "XTAL_CLK", default = true },
             { name = "RC_FAST",  outputs = "RC_FAST_CLK" },
         ] },
     ] },

--- a/hil-test/src/bin/spi_full_duplex.rs
+++ b/hil-test/src/bin/spi_full_duplex.rs
@@ -1228,7 +1228,15 @@ mod tests {
 
             let actual = f_mst / ((n + 1) * (pre + 1));
 
-            assert_eq!(actual, expectation);
+            assert_eq!(
+                actual,
+                expectation,
+                "source: {}, input: {}, n={}, pre={}",
+                f_mst,
+                input,
+                n + 1,
+                pre + 1
+            );
         }
     }
 }

--- a/hil-test/src/bin/spi_full_duplex.rs
+++ b/hil-test/src/bin/spi_full_duplex.rs
@@ -1207,15 +1207,19 @@ mod tests {
     #[test]
     #[cfg(feature = "unstable")] // Needed for register access
     fn test_clock_calculation_accuracy(mut ctx: Context) {
-        let lowest = if cfg!(esp32h2) { 78048 } else { 78125 };
-
-        let f_mst = esp_hal::clock::ll::SpiInstance::Spi2.function_clock_frequency();
-        let inputs = [lowest, 100_000, 1_000_000, f_mst];
-        let expected_outputs = [lowest, 100_000, 1_000_000, f_mst];
-
-        for (input, expectation) in inputs.into_iter().zip(expected_outputs.into_iter()) {
+        #[track_caller]
+        fn assert_frequency_roundtrips(
+            ctx: &mut Context,
+            source: SpiFunctionClockConfig,
+            input: u32,
+        ) {
+            let f_mst = SpiInstance::function_clock_source_frequency(source);
             ctx.spi
-                .apply_config(&Config::default().with_frequency(Rate::from_hz(input)))
+                .apply_config(
+                    &Config::default()
+                        .with_frequency(Rate::from_hz(input))
+                        .with_clock_source(source),
+                )
                 .unwrap();
 
             // Read back effective SCLK
@@ -1223,20 +1227,51 @@ mod tests {
 
             let clock = spi2.register_block().clock().read();
 
-            let n = clock.clkcnt_n().bits() as u32;
-            let pre = clock.clkdiv_pre().bits() as u32;
+            let n = clock.clkcnt_n().bits() as u32 + 1;
+            let pre = clock.clkdiv_pre().bits() as u32 + 1;
 
-            let actual = f_mst / ((n + 1) * (pre + 1));
+            let actual = f_mst / (n * pre);
 
             assert_eq!(
-                actual,
-                expectation,
-                "source: {}, input: {}, n={}, pre={}",
-                f_mst,
-                input,
-                n + 1,
-                pre + 1
+                actual, input,
+                "source: {:?} ({}), n={}, pre={}",
+                source, f_mst, n, pre
             );
         }
+
+        fn check_typical_values(ctx: &mut Context, source: SpiFunctionClockConfig) {
+            let f_min = SpiInstance::function_clock_source_frequency(source) / 1024;
+            assert_frequency_roundtrips(ctx, source, f_min);
+            assert_frequency_roundtrips(
+                ctx,
+                source,
+                SpiInstance::function_clock_source_frequency(source),
+            );
+
+            if f_min < 100_000 {
+                assert_frequency_roundtrips(ctx, source, 100_000);
+            }
+            assert_frequency_roundtrips(ctx, source, 1_000_000);
+            assert_frequency_roundtrips(ctx, source, 2_000_000);
+        }
+
+        use esp_hal::clock::ll::{SpiFunctionClockConfig, SpiInstance};
+
+        #[cfg(any(esp32, esp32s2, esp32s3))]
+        check_typical_values(&mut ctx, SpiFunctionClockConfig::Apb);
+        #[cfg(not(any(esp32, esp32s2)))]
+        check_typical_values(&mut ctx, SpiFunctionClockConfig::Xtal);
+        #[cfg(esp32c2)]
+        check_typical_values(&mut ctx, SpiFunctionClockConfig::Pll40m);
+        #[cfg(esp32h2)]
+        check_typical_values(&mut ctx, SpiFunctionClockConfig::PllF48m);
+        #[cfg(esp32c3)]
+        check_typical_values(&mut ctx, SpiFunctionClockConfig::Pll80m);
+        #[cfg(esp32c6)]
+        check_typical_values(&mut ctx, SpiFunctionClockConfig::PllF80m);
+        #[cfg(esp32c5)]
+        check_typical_values(&mut ctx, SpiFunctionClockConfig::PllF120m);
+        #[cfg(any(esp32c5, esp32c61))]
+        check_typical_values(&mut ctx, SpiFunctionClockConfig::PllF160m);
     }
 }


### PR DESCRIPTION
This PR enabled SPI function clocks before writing registers, which seems to be necessary for some reason... `test_clock_calculation_accuracy` has been updated to not assume a specific clock source (although how useful it is, is questionable). C6 SPI clock now also defaults to XTAL.

# Changelog

## esp-hal

- No changelog necessary.