### PR TITLE
Return blocking timer from OneShotTimer::into_blocking()

### DIFF
--- a/esp-hal/src/timer/mod.rs
+++ b/esp-hal/src/timer/mod.rs
@@ -163,11 +163,11 @@ impl<'d> OneShotTimer<'d, Blocking> {
     }
 }
 
-impl OneShotTimer<'_, Async> {
+impl<'d> OneShotTimer<'d, Async> {
     /// Converts the driver to [`Blocking`] mode.
-    pub fn into_blocking(self) -> Self {
+    pub fn into_blocking(self) -> OneShotTimer<'d, Blocking> {
         crate::interrupt::disable(Cpu::current(), self.inner.peripheral_interrupt());
-        Self {
+        OneShotTimer {
             inner: self.inner,
             _ph: PhantomData,
         }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
  -  I did not see any usage in examples
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` or `manual-changelog` label as appropriate.
  -  asked above
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

Return a blocking `OneShotTimer` from `OneShotTimer::into_blocking()`.

#### Description

`OneShotTimer::into_blocking()` is designed to convert a `OneShotTimer<Async>` into a `OneShotTimer<Blocking>`. It mistakenly returns `Self`, which is a `OneShotTimer<Async>`. This has the effect of converting a `OneShotTimer<Async>` back into a `OneShotTimer<Async>`.

#### Testing

Tested with local changes but not yet in CI or example apps. 

---

<!-- ============================================================
  Changelog and migration guide entries live here in the PR body.
  They will be collected automatically at release time.
  Delete any section that doesn't apply to your PR.
  ============================================================ -->

# Changelog

## esp-hal/timer

- Fixed: `OneShotTimer::into_blocking()` now returns `OneShotTimer<'d, Blocking>`

<!-- Add one or more ## <crate> or ## <crate>/<area> sections below.
     Each entry must start with one of: Added, Changed, Fixed, Removed.
     To explicitly declare that a crate needs no changelog entry, write:
       - No changelog necessary.
     as the sole item under that crate's heading.

## esp-hal

- Added: Brief description of what was added.
- Changed: Brief description of what changed.
- Fixed: Brief description of what was fixed.
- Removed: Brief description of what was removed.

-->

# Migration guide

<!-- Add one or more ## <crate>/<area> sections below (area is required).
     Each breaking change needs a ### Title heading followed by the migration steps.
     Only needed when user code must be updated.

## esp-hal/SPI

### `OldType` has been renamed to `NewType`

Replace all uses of `OldType` with `NewType`.

-->
