### PR TITLE
Ensure DMA macros cannot be used unsoundly

### DIFF
--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -51,6 +51,7 @@ embedded-hal-async       = "1.0.0"
 enumset                  = "1.1"
 paste                    = "1.0.15"
 portable-atomic          = { version = "1.11", default-features = false }
+static_cell              = "2"
 
 esp-rom-sys              = { version = "~0.1", path = "../esp-rom-sys" }
 

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -693,10 +693,13 @@ macro_rules! dma_descriptors_impl {
         const COUNT: usize =
             $crate::dma_descriptor_count!($size, $chunk_size, is_circular = $circular);
 
-        static mut DESCRIPTORS: [$crate::dma::DmaDescriptor; COUNT] =
-            [$crate::dma::DmaDescriptor::EMPTY; COUNT];
+        static DESCRIPTORS: $crate::__macro_implementation::static_cell::ConstStaticCell<
+            [$crate::dma::DmaDescriptor; COUNT],
+        > = $crate::__macro_implementation::static_cell::ConstStaticCell::new(
+            [$crate::dma::DmaDescriptor::EMPTY; COUNT],
+        );
 
-        unsafe { &mut DESCRIPTORS }
+        DESCRIPTORS.take()
     }};
 }
 

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -611,6 +611,7 @@ pub mod __macro_implementation {
     #[cfg(feature = "rt")]
     #[cfg(riscv)]
     pub use esp_riscv_rt::entry as __entry;
+    pub use static_cell;
     #[cfg(feature = "rt")]
     #[cfg(xtensa)]
     pub use xtensa_lx_rt::entry as __entry;

--- a/hil-test/src/bin/misc_non_drivers/dma_buffers.rs
+++ b/hil-test/src/bin/misc_non_drivers/dma_buffers.rs
@@ -82,6 +82,12 @@ mod tests {
         f(buf.into_view());
     }
 
+    #[init]
+    fn init() {
+        // Ensures that watchdogs are disabled
+        let _ = esp_hal::init(Default::default());
+    }
+
     #[test]
     fn test_dma_rx_stream_buf_new() {
         let buf = dma_rx_stream_buffer!(BUFFER_SIZE, CHUNK_SIZE);

--- a/hil-test/src/bin/misc_non_drivers/dma_macros.rs
+++ b/hil-test/src/bin/misc_non_drivers/dma_macros.rs
@@ -18,6 +18,12 @@ mod tests {
     #[allow(unused_imports)]
     use defmt::*;
 
+    #[init]
+    fn init() {
+        // Ensures that watchdogs are disabled
+        let _ = esp_hal::init(Default::default());
+    }
+
     #[test]
     fn test_dma_descriptors_same_size() {
         use esp_hal::dma::CHUNK_SIZE;
@@ -208,5 +214,16 @@ mod tests {
         check(esp_hal::dma_tx_buffer!(TX_SIZE + 1), TX_SIZE + 1);
         check(esp_hal::dma_tx_buffer!(TX_SIZE + 2), TX_SIZE + 2);
         check(esp_hal::dma_tx_buffer!(TX_SIZE + 3), TX_SIZE + 3);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_dma_macro_can_only_be_called_once() {
+        fn alloc_buffer() -> esp_hal::dma::DmaTxBuf {
+            esp_hal::dma_tx_buffer!(5).unwrap()
+        }
+
+        alloc_buffer();
+        alloc_buffer();
     }
 }


### PR DESCRIPTION
Fixes #2993


# Changelog

## esp-hal/DMA

- Fixed: Fixed an issue that allowed invoking `dma_*` macros unsoundly