### PR TITLE
Fail CI if half of the HIL runs failed

### DIFF
--- a/.github/scripts/hil-gate.js
+++ b/.github/scripts/hil-gate.js
@@ -19,7 +19,11 @@ function classifyMatrixJob(job) {
   if (conclusion === "success") {
     return { kind: "passed" };
   }
-  if (conclusion === "failure" || conclusion === "cancelled") {
+  if (
+    conclusion === "failure" ||
+    conclusion === "cancelled" ||
+    conclusion === null
+  ) {
     return { kind: "failed" };
   }
 

--- a/.github/scripts/hil-gate.js
+++ b/.github/scripts/hil-gate.js
@@ -1,0 +1,110 @@
+const RUN_TESTS_STEP = "Run Tests";
+
+function isHilRunMatrixJob(name) {
+  // Matches "hil-run (…)" but not "hil-run-radio (…)".
+  return /^hil-run \(/i.test(String(name || ""));
+}
+
+function classifyMatrixJob(job) {
+  const steps = job.steps || [];
+  const runTests = steps.find((s) => s.name === RUN_TESTS_STEP);
+  if (!runTests) {
+    return { error: `job "${job.name}" is missing "${RUN_TESTS_STEP}" step` };
+  }
+
+  const conclusion = runTests.conclusion;
+  if (conclusion === "skipped") {
+    return { kind: "skipped" };
+  }
+  if (conclusion === "success") {
+    return { kind: "passed" };
+  }
+  if (conclusion === "failure" || conclusion === "cancelled") {
+    return { kind: "failed" };
+  }
+
+  return {
+    error: `job "${job.name}" has unexpected "${RUN_TESTS_STEP}" conclusion: ${conclusion}`,
+  };
+}
+
+function evaluateHilRunResults(classifications) {
+  const executed = classifications.filter(
+    (c) => c.kind === "passed" || c.kind === "failed",
+  );
+  const failures = classifications.filter((c) => c.kind === "failed");
+
+  if (executed.length === 0) {
+    return { pass: true, executed: 0, failures: 0 };
+  }
+
+  const pass = failures.length * 2 < executed.length;
+  return { pass, executed: executed.length, failures: failures.length };
+}
+
+async function listWorkflowRunJobs(github, context) {
+  const { owner, repo } = context.repo;
+  const run_id = context.runId;
+  const jobs = [];
+  let page = 1;
+
+  while (true) {
+    const { data } = await github.rest.actions.listJobsForWorkflowRun({
+      owner,
+      repo,
+      run_id,
+      per_page: 100,
+      page,
+    });
+
+    jobs.push(...(data.jobs || []));
+    if (jobs.length >= data.total_count) {
+      break;
+    }
+    page += 1;
+  }
+
+  return jobs;
+}
+
+async function evaluateHilGate({ github, context, core }) {
+  const jobs = await listWorkflowRunJobs(github, context);
+  const matrixJobs = jobs.filter((job) => isHilRunMatrixJob(job.name));
+
+  if (matrixJobs.length === 0) {
+    core.setFailed("HIL gate failed: could not find hil-run matrix jobs");
+    return;
+  }
+
+  const classifications = [];
+  for (const job of matrixJobs) {
+    const result = classifyMatrixJob(job);
+    if (result.error) {
+      core.setFailed(`HIL gate failed: ${result.error}`);
+      return;
+    }
+    classifications.push(result);
+  }
+
+  const verdict = evaluateHilRunResults(classifications);
+  if (verdict.pass) {
+    if (verdict.executed > 0) {
+      core.info(
+        `HIL gate passed (${verdict.failures}/${verdict.executed} executed runners failed)`,
+      );
+    } else {
+      core.info("HIL gate passed (no hil-run matrix legs executed tests)");
+    }
+    return;
+  }
+
+  core.setFailed("HIL gate failed: ≥50% of executed runners failed");
+}
+
+module.exports = {
+  RUN_TESTS_STEP,
+  isHilRunMatrixJob,
+  classifyMatrixJob,
+  evaluateHilRunResults,
+  evaluateHilGate,
+};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -630,7 +630,7 @@ jobs:
       needs.hil-run.result != 'skipped'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,7 +421,7 @@ jobs:
     secrets: inherit
 
   # --------------------------------------------------------------------------
-  # HIL — build gates CI, device runs do not.
+  # HIL — hil-build gates compilation; hil-gate gates device runs (≥50% rule).
 
   hil-build:
     needs: calculate
@@ -530,7 +530,7 @@ jobs:
           path: target/tests/
           if-no-files-found: ignore
 
-  # Device runs — not gated by ci-result.
+  # Device runs — aggregated by hil-gate (see below).
   hil-run:
     needs: hil-build
     runs-on:
@@ -573,7 +573,7 @@ jobs:
           rm -f xtask || true
 
   # Radio HIL device runs — wifi/BT capable chips on dedicated radio runners.
-  # Not gated by ci-result for the same reason hil-run is excluded.
+  # Not gated by hil-gate or ci-result.
   hil-run-radio:
     needs: hil-build
     runs-on:
@@ -619,6 +619,28 @@ jobs:
           rm -rf tests/ || true
           rm -f xtask || true
 
+  # Merge gate for hil-run matrix legs.  Blocks when ≥50% of legs that actually
+  # ran tests failed or were cancelled.  Skipped legs (no ELFs for that chip)
+  # are excluded.  hil-run-radio is not part of this gate.
+  hil-gate:
+    needs: [hil-build, hil-run]
+    if: >
+      always() &&
+      needs.hil-build.result == 'success' &&
+      needs.hil-run.result != 'skipped'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Evaluate hil-run results
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { evaluateHilGate } = require('./.github/scripts/hil-gate.js');
+            await evaluateHilGate({ github, context, core });
+
   # --------------------------------------------------------------------------
   # Gate job for branch protection
   #
@@ -626,9 +648,8 @@ jobs:
   # Skipped jobs (due to calculate outputs) are treated as success.
   # Failed or cancelled jobs cause this gate to fail.
   #
-  # NOTE: hil-run and hil-run-radio are intentionally excluded — device tests
-  # should not block the merge queue.  hil-build IS included so we gate on
-  # test compilation.
+  # hil-build gates test compilation.  hil-gate gates device runs when ≥50% of
+  # executed hil-run matrix legs fail.  hil-run-radio is informational only.
   ci-result:
     if: always()
     needs:
@@ -640,6 +661,7 @@ jobs:
       - changelog
       - semver-check
       - hil-build
+      - hil-gate
     runs-on: ubuntu-latest
     steps:
       - name: Check CI results

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -28,7 +28,7 @@ jobs:
       github.event.label.name == 'trusted-author'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -90,7 +90,7 @@ jobs:
       startsWith(github.event.comment.body, '/trust ')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -145,7 +145,7 @@ jobs:
       startsWith(github.event.comment.body, '/revoke ')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -248,7 +248,7 @@ jobs:
       run_id: ${{ steps.find-run.outputs.run_id }}
       comment_id: ${{ steps.comment.outputs.comment-id }}
     steps:
-      - uses: actions/checkout@v4 # for `require`
+      - uses: actions/checkout@v6 # for `require`
         with:
           fetch-depth: 1
 
@@ -309,7 +309,7 @@ jobs:
     if: needs.hil-quick.outputs.run_id != '' && needs.hil-quick.outputs.comment_id != ''
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4 # for `require`
+      - uses: actions/checkout@v6 # for `require`
         with:
           fetch-depth: 1
 
@@ -339,7 +339,7 @@ jobs:
       run_id: ${{ steps.find-run.outputs.run_id }}
       comment_id: ${{ steps.comment.outputs.comment-id }}
     steps:
-      - uses: actions/checkout@v4 # for `require`
+      - uses: actions/checkout@v6 # for `require`
         with:
           fetch-depth: 1
 
@@ -400,7 +400,7 @@ jobs:
     if: needs.hil-full.outputs.run_id != '' && needs.hil-full.outputs.comment_id != ''
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4 # for `require`
+      - uses: actions/checkout@v6 # for `require`
         with:
           fetch-depth: 1
 
@@ -434,7 +434,7 @@ jobs:
       run_id: ${{ steps.find-run.outputs.run_id }}
       comment_id: ${{ steps.comment.outputs.comment-id }}
     steps:
-      - uses: actions/checkout@v4 # for `require`
+      - uses: actions/checkout@v6 # for `require`
         with:
           fetch-depth: 1
 
@@ -519,7 +519,7 @@ jobs:
     if: needs.hil-chips.outputs.run_id != '' && needs.hil-chips.outputs.comment_id != ''
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4 # for `require`
+      - uses: actions/checkout@v6 # for `require`
         with:
           fetch-depth: 1
 
@@ -597,7 +597,7 @@ jobs:
       startsWith(github.event.comment.body, '/test-size')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4 # for `require`
+      - uses: actions/checkout@v6 # for `require`
         with:
           fetch-depth: 1
 


### PR DESCRIPTION
Partially verified locally by running this command:

```
node -e "
const g = require('./.github/scripts/hil-gate.js');

// job name filter
console.log('hil-run:', g.isHilRunMatrixJob('hil-run (esp32)'));
console.log('radio:', g.isHilRunMatrixJob('hil-run-radio (esp32c6)'));

// threshold math
const fiveOfTen = Array.from({length:10}, (_,i) => ({kind: i<5 ? 'failed' : 'passed'}));
const fourOfTen = Array.from({length:10}, (_,i) => ({kind: i<4 ? 'failed' : 'passed'}));
console.log('5/10 blocks:', !g.evaluateHilRunResults(fiveOfTen).pass);
console.log('4/10 passes:', g.evaluateHilRunResults(fourOfTen).pass);
console.log('0 executed passes:', g.evaluateHilRunResults([{kind:'skipped'}]).pass);
"
```