### PR TITLE
Don't try to calibrate XTAL32K

### DIFF
--- a/esp-hal/src/clock/mod.rs
+++ b/esp-hal/src/clock/mod.rs
@@ -148,6 +148,14 @@ impl RtcClock {
     #[cfg(soc_has_clock_node_timg_calibration_clock)]
     pub(crate) fn calibrate(cal_clk: TimgCalibrationClockConfig, slowclk_cycles: u32) -> u32 {
         ClockTree::with(|clocks| {
+            #[cfg(not(esp32c2))]
+            if cal_clk == TimgCalibrationClockConfig::Xtal32kClk {
+                debug!("Assuming Xtal32k has precisely 32.768kHz instead of calibrating");
+                let freq_hz: u64 = 32_768;
+                let period_64 = (1_000_000u64 << RtcClock::CAL_FRACT) / freq_hz;
+                return period_64 as u32;
+            }
+
             let xtal_freq = Rate::from_hz(clocks::xtal_clk_frequency());
 
             let (xtal_cycles, _) = RtcClock::measure_rtc_clock(


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` or `manual-changelog` label as appropriate.
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
The whole point of using an external 32.768 kHz crystal is to have a more accurate slow clock source. This is why esp-idf does not perform any calibration in this case: https://github.com/espressif/esp-idf/blob/bc6616854ea6303c538b97de66b7aaf290f8f1b0/components/esp_hw_support/sleep_modes.c#L804

Resolves #5462

#### Testing
Tested on ESP32-C6. Clock drift is significantly reduced compared to the measurements originally reported in #5462.

---

<!-- ============================================================
  Changelog and migration guide entries live here in the PR body.
  They will be collected automatically at release time.
  Delete any section that doesn't apply to your PR.
  ============================================================ -->

# Changelog



## esp-hal

- Changed: Skip slow clock calibration for XTAL32K clock source, assume 32.768 kHz instead
