### PR TITLE
feat(esp32p4): support pre-v3.0 silicon (non-standard CLIC + 360 MHz CPLL)

### DIFF
--- a/esp-hal/build.rs
+++ b/esp-hal/build.rs
@@ -57,6 +57,23 @@ fn main() -> Result<(), Box<dyn Error>> {
         .expect("Failed to read esp_config.yml for esp-hal");
     let cfg = generate_config_from_yaml_definition(&cfg_yaml, true, true, Some(chip)).unwrap();
 
+    // Pre-v3.0 ESP32-P4 silicon uses a non-standard CLIC (memory-mapped interrupt
+    // threshold, no `mintthresh` CSR, `mintstatus` at 0x346). Derive a cfg from the
+    // configured minimum chip revision so the relevant paths are selected at compile time
+    // — runtime detection can't be used here, as the wrong CSR access traps and the chip
+    // revision isn't known until after init.
+    println!("cargo:rustc-check-cfg=cfg(esp32p4_rev_lt_v3)");
+    if chip.name() == "esp32p4" {
+        let min_rev = cfg
+            .iter()
+            .find(|(k, _)| k.to_ascii_lowercase().ends_with("min_chip_revision"))
+            .map(|(_, v)| v.as_integer())
+            .unwrap_or(0);
+        if min_rev < 300 {
+            println!("cargo:rustc-cfg=esp32p4_rev_lt_v3");
+        }
+    }
+
     // RISC-V and Xtensa devices each require some special handling and processing
     // of linker scripts:
 

--- a/esp-hal/esp_config.yml
+++ b/esp-hal/esp_config.yml
@@ -185,8 +185,14 @@ options:
     active: 'chip == "esp32p4"'
 
   - name: min-chip-revision
-    description: "The minimum chip revision required for the application to run, in format: major * 100 + minor."
+    description: "The minimum chip revision required for the application to run, in format:
+      major * 100 + minor. On ESP32-P4 this also selects the CLIC variant: revisions below
+      v3.0 (< 300) use the non-standard CLIC (memory-mapped interrupt threshold, mintstatus
+      at 0x346); v3.0+ uses the standard CLIC. Defaults to 300 (v3.0) on ESP32-P4 — set it
+      to your silicon revision (e.g. 100 for v1.0, 103 for v1.3) on older parts."
     default:
+      - value: 300
+        if: 'chip == "esp32p4"'
       - value: 0
 
   - name: use_rwdata_ld_hook

--- a/esp-hal/src/clock/mod.rs
+++ b/esp-hal/src/clock/mod.rs
@@ -104,7 +104,7 @@ impl CpuClock {
             } else if #[cfg(esp32h2)] {
                 Self::_96MHz
             } else if #[cfg(esp32p4)] {
-                Self::_400MHz
+                Self::MAX
             } else {
                 Self::_240MHz
             }

--- a/esp-hal/src/interrupt/riscv.rs
+++ b/esp-hal/src/interrupt/riscv.rs
@@ -593,6 +593,17 @@ pub(crate) mod rt {
 
         cfg_if::cfg_if! {
             if #[cfg(interrupt_controller = "clic")] {
+                // On the pre-v3 ESP32-P4 non-standard CLIC, `mintstatus.mil` (CSR 0x346) does
+                // not match the slot's `ctl` level encoding, so `current_runlevel()` is
+                // unreliable; since `should_handle()` requires `cpu_interrupt.level() ==
+                // runlevel`, a wrong runlevel drops the interrupt and a level-triggered source
+                // is never cleared (interrupt storm). Dispatch off the serviced interrupt's own
+                // ctl-derived level instead — this matches how IDF's CLIC handler dispatches,
+                // off the cause (`mcause & VECTORS_MCAUSE_REASON_MASK`) rather than `mintstatus`
+                // (ESP-IDF components/riscv/vectors.S `_interrupt_handler`).
+                #[cfg(esp32p4_rev_lt_v3)]
+                let prio = cpu_intr.level() as u8;
+                #[cfg(not(esp32p4_rev_lt_v3))]
                 let prio = cpu_int::current_runlevel();
                 let mcause = riscv::register::mcause::read();
             } else {

--- a/esp-hal/src/interrupt/riscv/clic.rs
+++ b/esp-hal/src/interrupt/riscv/clic.rs
@@ -68,7 +68,7 @@ pub(super) fn change_current_runlevel(level: RunLevel) -> u8 {
 
     // All machine mode pending interrupts with levels less than or equal
     // to the effective threshold level are not allowed to preempt the execution.
-    unsafe { mintthresh::write(prio_to_bits(level) as usize) };
+    unsafe { intthresh::write(prio_to_bits(level) as usize) };
 
     current_runlevel
 }
@@ -79,11 +79,11 @@ pub(crate) fn mil() -> usize {
 }
 
 pub(super) fn current_runlevel() -> u8 {
-    let mintthresh = mintthresh::read();
+    let thresh = intthresh::read();
 
     let mil = mil();
 
-    let level = mil.max(mintthresh);
+    let level = mil.max(thresh);
 
     bits_to_prio(level)
 }
@@ -105,9 +105,40 @@ fn bits_to_prio(bits: usize) -> u8 {
     }
 }
 
-mod mintthresh {
+/// Interrupt-level threshold (the level below which interrupts are masked).
+///
+/// Standard CLIC (incl. ESP32-P4 v3.0+) uses the `mintthresh` CSR (0x347). Pre-v3
+/// ESP32-P4's non-standard CLIC has no such CSR (0x347 traps illegal-instruction);
+/// the threshold is the memory-mapped `CLIC_INT_THRESH_REG`, upper 8 bits. Selected by
+/// the `esp32p4-rev-lt-v3` esp-config option (mirrors IDF
+/// `CONFIG_ESP32P4_SELECTS_REV_LESS_V3`); the memory-mapped path mirrors IDF
+/// `rv_utils_{get,restore}_interrupt_threshold` under `!INTTHRESH_STANDARD`.
+#[cfg(not(esp32p4_rev_lt_v3))]
+mod intthresh {
     riscv::read_csr_as_usize!(0x347);
     riscv::write_csr_as_usize!(0x347);
+}
+
+#[cfg(esp32p4_rev_lt_v3)]
+mod intthresh {
+    // CLIC_INT_THRESH_REG = DR_REG_CLIC_BASE (0x2080_0000) + 0x8, threshold in the top
+    // byte (CLIC_CPU_INT_THRESH_S = 24). The CLIC region is CPU-local, so this fixed
+    // address always targets the current core.
+    const CLIC_INT_THRESH_REG: *mut u32 = 0x2080_0008 as *mut u32;
+    const THRESH_SHIFT: u32 = 24;
+
+    #[inline]
+    pub fn read() -> usize {
+        let v = unsafe { CLIC_INT_THRESH_REG.read_volatile() };
+        ((v >> THRESH_SHIFT) & 0xff) as usize
+    }
+
+    #[inline]
+    pub unsafe fn write(val: usize) {
+        unsafe { CLIC_INT_THRESH_REG.write_volatile(((val as u32) & 0xff) << THRESH_SHIFT) };
+        // Read back so the write lands before the caller re-enables mstatus.mie (per IDF).
+        let _ = unsafe { CLIC_INT_THRESH_REG.read_volatile() };
+    }
 }
 
 mod mintstatus {
@@ -117,9 +148,19 @@ mod mintstatus {
                 ::core::assert!($($tt)*)
             };
         }
+    // Standard CLIC places `mintstatus` at 0xFB1; pre-v3 ESP32-P4's non-standard CLIC
+    // at 0x346. (On the non-standard CLIC the 0x346 `mil` reads inconsistently with the
+    // slot ctl encoding, so `handle_interrupts` does not rely on it — see riscv.rs.)
+    #[cfg(not(esp32p4_rev_lt_v3))]
     riscv::read_only_csr! {
         /// `mintstatus` register
         Mintstatus: 0xfb1,
+        mask: usize::MAX,
+    }
+    #[cfg(esp32p4_rev_lt_v3)]
+    riscv::read_only_csr! {
+        /// `mintstatus` register (non-standard ESP32-P4 CLIC address)
+        Mintstatus: 0x346,
         mask: usize::MAX,
     }
     riscv::read_only_csr_field! {

--- a/esp-hal/src/rtc_cntl/rtc/esp32p4.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32p4.rs
@@ -160,17 +160,21 @@ pub(crate) fn init() {
         w.force_dcdc_switch_pd().bit(false)
     });
 
-    // 7. Enable CPLL (400 MHz) and SPLL (480 MHz)
-    cpll_configure(400);
+    // 7. Enable CPLL and SPLL (480 MHz). Pre-v3.0 silicon is qualified for a 360 MHz maximum CPU
+    //    clock (CPLL 360 MHz); v3.0+ raises this to 400 MHz. ESP-IDF makes the same split via
+    //    `CONFIG_ESP32P4_SELECTS_REV_LESS_V3`:
+    //    https://github.com/espressif/esp-idf/blob/de7baafb265625d66fd0af4ed4761a9c5b200bde/components/esp_hw_support/port/esp32p4/rtc_clk.c#L320
+    cpll_configure(if cfg!(esp32p4_rev_lt_v3) { 360 } else { 400 });
     spll_configure(480);
 
-    // 8. Set CPU divider to 1 (400 MHz CPU), MEM divider 2, APB divider 2
+    // 8. Set CPU divider to 1 (max CPU clock: 360 MHz pre-v3.0, 400 MHz v3.0+), MEM divider 2, APB
+    //    divider 2
     // Set CPU divider: cpu_clk_div_num = divider - 1 = 0
     // Ref: HP_SYS_CLKRST.root_clk_ctrl0.reg_cpu_clk_div_num
     HP_SYS_CLKRST::regs()
         .root_clk_ctrl0()
         .modify(|_, w| unsafe {
-            w.cpu_clk_div_num().bits(0); // CPU: /1 = 400 MHz
+            w.cpu_clk_div_num().bits(0); // CPU: /1 (= CPLL: 360 MHz pre-v3.0, 400 MHz v3.0+)
             w.cpu_clk_div_numerator().bits(0);
             w.cpu_clk_div_denominator().bits(0)
         });
@@ -196,7 +200,6 @@ pub(crate) fn init() {
 
 /// Configure CPLL for the given frequency (360 or 400 MHz).
 ///
-/// eco5 (v3.x) uses different I2C register values than eco4 (v1.x).
 /// Ref: TRM v0.5 Ch 12 -- CPLL configuration
 fn cpll_configure(freq_mhz: u32) {
     // 1. Enable CPLL power PMU.imm_hp_ck_power: tie_high_xpd_pll, tie_high_xpd_pll_i2c Note: PAC
@@ -212,12 +215,15 @@ fn cpll_configure(freq_mhz: u32) {
     // Note: this field may not exist in eco4 PAC; use direct bit write if needed
     // For now, the PLL is enabled via xpd_pll above.
 
-    // 2. Configure CPLL via I2C analog registers
-    // eco5 values (v3.x): div7_0 = 10 (400MHz), 9 (360MHz) with 40MHz XTAL
+    // 2. Configure CPLL via I2C analog registers (40 MHz XTAL).
+    // `div7_0` encoding is revision-dependent: pre-production v0.x samples use 6/5,
+    // all shipped silicon (v1.0+) uses 10/9 -- bits 2 and 3 are swapped between the two.
+    // Only v1.0+ is supported here. Ref: ESP-IDF `clk_ll_cpll_set_config`:
+    // https://github.com/espressif/esp-idf/blob/de7baafb265625d66fd0af4ed4761a9c5b200bde/components/esp_hal_clock/esp32p4/include/hal/clk_tree_ll.h#L375
     let div7_0: u8 = match freq_mhz {
-        400 => 10, // eco5: 400 MHz
-        360 => 9,  // eco5: 360 MHz
-        _ => 10,   // default to 400 MHz
+        400 => 10, // 400 MHz (v3.0+)
+        360 => 9,  // 360 MHz (pre-v3.0)
+        _ => 10,
     };
 
     // OC_REF_DIV + DCHGP: (oc_enb_fcal << 7) | (dchgp << 4) | div_ref = 0x50

--- a/esp-hal/src/soc/esp32p4/clocks.rs
+++ b/esp-hal/src/soc/esp32p4/clocks.rs
@@ -1,6 +1,6 @@
-//! Clock tree for ESP32-P4X (chip revision v3.x / eco5).
+//! Clock tree for ESP32-P4.
 //!
-//! CPLL: 400 MHz (eco5 default), 360 MHz (conservative)
+//! CPLL: 400 MHz on v3.0+ silicon, 360 MHz on pre-v3.0 (`esp32p4_rev_lt_v3`)
 //! SPLL: 480 MHz (peripheral clocks)
 //! MPLL: 400 MHz (PSRAM, media)
 //! XTAL: 40 MHz
@@ -27,56 +27,82 @@ use crate::{
 define_clock_tree_types!();
 
 /// CPU clock frequency presets for ESP32-P4.
+///
+/// The CPU runs off the CPLL, which tops out at 360 MHz on pre-v3.0 silicon and 400 MHz on
+/// v3.0+ (see [`super`] clock tree). The three presets are CPLL/1, CPLL/2 and CPLL/4, so the
+/// available frequencies track the CPLL base accordingly.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub enum CpuClock {
-    /// 400 MHz CPU clock (eco5 / v3.x maximum)
-    /// CPLL -> CPU_ROOT -> CPU/1, APB divider /4 = 100MHz
+    /// 400 MHz CPU clock (CPLL/1; v3.0+ maximum).
+    #[cfg(not(esp32p4_rev_lt_v3))]
     _400MHz = 400,
+    /// 360 MHz CPU clock (CPLL/1; pre-v3.0 maximum).
+    #[cfg(esp32p4_rev_lt_v3)]
+    _360MHz = 360,
 
-    /// 200 MHz CPU clock (low power)
-    /// CPLL -> CPU_ROOT -> CPU/2, APB /2 = 100MHz
+    /// 200 MHz CPU clock (CPLL/2).
+    #[cfg(not(esp32p4_rev_lt_v3))]
     _200MHz = 200,
+    /// 180 MHz CPU clock (CPLL/2).
+    #[cfg(esp32p4_rev_lt_v3)]
+    _180MHz = 180,
 
-    /// 100 MHz CPU clock (ultra low power)
-    /// CPLL -> CPU_ROOT -> CPU/4, APB /1 = 100MHz
+    /// 100 MHz CPU clock (CPLL/4), default.
+    #[cfg(not(esp32p4_rev_lt_v3))]
     #[default]
     _100MHz = 100,
+    /// 90 MHz CPU clock (CPLL/4), default.
+    #[cfg(esp32p4_rev_lt_v3)]
+    #[default]
+    _90MHz  = 90,
 }
 
 impl CpuClock {
-    // Preset: 400 MHz CPU, 100 MHz APB
-    const PRESET_400: ClockConfig = ClockConfig {
+    // Highest preset (CPLL/1): 400 MHz on v3.0+, 360 MHz on pre-v3.0.
+    pub(crate) const MAX: Self = {
+        cfg_if::cfg_if! {
+            if #[cfg(esp32p4_rev_lt_v3)] { Self::_360MHz } else { Self::_400MHz }
+        }
+    };
+
+    // Dividers are identical for the 360 and 400 MHz CPLL: the constraint is MEM_CLK <= 200,
+    // APB_CLK <= 100 MHz, satisfied by the same divider tree in both cases (cf. ESP-IDF
+    // `rtc_clk_cpu_freq_to_cpll_mhz`):
+    // https://github.com/espressif/esp-idf/blob/de7baafb265625d66fd0af4ed4761a9c5b200bde/components/esp_hw_support/port/esp32p4/rtc_clk.c#L224
+
+    // CPLL/1 (max CPU), MEM CPLL/2, APB CPLL/4.
+    const PRESET_DIV1: ClockConfig = ClockConfig {
         cpu_root_clk: Some(CpuRootClkConfig::Cpll),
-        cpu_clk: Some(CpuClkConfig::new(0)), // /1 = 400 MHz
-        mem_clk: Some(MemClkConfig::new(1)), // /2 = 200 MHz
-        sys_clk: Some(SysClkConfig::new(0)), // /1 = 200 MHz
-        apb_clk: Some(ApbClkConfig::new(1)), // /2 = 100 MHz
+        cpu_clk: Some(CpuClkConfig::new(0)), // /1
+        mem_clk: Some(MemClkConfig::new(1)), // /2
+        sys_clk: Some(SysClkConfig::new(0)), // /1
+        apb_clk: Some(ApbClkConfig::new(1)), // /2
         lp_fast_clk: Some(LpFastClkConfig::RcFast),
         lp_slow_clk: Some(LpSlowClkConfig::RcSlow),
         timg_calibration_clock: None,
     };
 
-    // TODO: 360 MHz preset
-
-    const PRESET_200: ClockConfig = ClockConfig {
+    // CPLL/2 (CPU), APB CPLL/4.
+    const PRESET_DIV2: ClockConfig = ClockConfig {
         cpu_root_clk: Some(CpuRootClkConfig::Cpll),
-        cpu_clk: Some(CpuClkConfig::new(1)), // /2 = 200 MHz
-        mem_clk: Some(MemClkConfig::new(0)), // /1 = 200 MHz
-        sys_clk: Some(SysClkConfig::new(0)), // /1 = 200 MHz
-        apb_clk: Some(ApbClkConfig::new(1)), // /2 = 100 MHz
+        cpu_clk: Some(CpuClkConfig::new(1)), // /2
+        mem_clk: Some(MemClkConfig::new(0)), // /1
+        sys_clk: Some(SysClkConfig::new(0)), // /1
+        apb_clk: Some(ApbClkConfig::new(1)), // /2
         lp_fast_clk: Some(LpFastClkConfig::RcFast),
         lp_slow_clk: Some(LpSlowClkConfig::RcSlow),
         timg_calibration_clock: None,
     };
 
-    const PRESET_100: ClockConfig = ClockConfig {
+    // CPLL/4 (CPU), all downstream /1.
+    const PRESET_DIV4: ClockConfig = ClockConfig {
         cpu_root_clk: Some(CpuRootClkConfig::Cpll),
-        cpu_clk: Some(CpuClkConfig::new(3)), // /4 = 100 MHz
-        mem_clk: Some(MemClkConfig::new(0)), // /1 = 100 MHz
-        sys_clk: Some(SysClkConfig::new(0)), // /1 = 100 MHz
-        apb_clk: Some(ApbClkConfig::new(0)), // /1 = 100 MHz
+        cpu_clk: Some(CpuClkConfig::new(3)), // /4
+        mem_clk: Some(MemClkConfig::new(0)), // /1
+        sys_clk: Some(SysClkConfig::new(0)), // /1
+        apb_clk: Some(ApbClkConfig::new(0)), // /1
         lp_fast_clk: Some(LpFastClkConfig::RcFast),
         lp_slow_clk: Some(LpSlowClkConfig::RcSlow),
         timg_calibration_clock: None,
@@ -86,9 +112,18 @@ impl CpuClock {
 impl From<CpuClock> for ClockConfig {
     fn from(value: CpuClock) -> ClockConfig {
         match value {
-            CpuClock::_400MHz => CpuClock::PRESET_400,
-            CpuClock::_200MHz => CpuClock::PRESET_200,
-            CpuClock::_100MHz => CpuClock::PRESET_100,
+            #[cfg(not(esp32p4_rev_lt_v3))]
+            CpuClock::_400MHz => CpuClock::PRESET_DIV1,
+            #[cfg(esp32p4_rev_lt_v3)]
+            CpuClock::_360MHz => CpuClock::PRESET_DIV1,
+            #[cfg(not(esp32p4_rev_lt_v3))]
+            CpuClock::_200MHz => CpuClock::PRESET_DIV2,
+            #[cfg(esp32p4_rev_lt_v3)]
+            CpuClock::_180MHz => CpuClock::PRESET_DIV2,
+            #[cfg(not(esp32p4_rev_lt_v3))]
+            CpuClock::_100MHz => CpuClock::PRESET_DIV4,
+            #[cfg(esp32p4_rev_lt_v3)]
+            CpuClock::_90MHz => CpuClock::PRESET_DIV4,
         }
     }
 }
@@ -102,9 +137,18 @@ impl Default for ClockConfig {
 impl ClockConfig {
     pub(crate) fn try_get_preset(self) -> Option<CpuClock> {
         match self {
-            v if v == CpuClock::PRESET_400 => Some(CpuClock::_400MHz),
-            v if v == CpuClock::PRESET_200 => Some(CpuClock::_200MHz),
-            v if v == CpuClock::PRESET_100 => Some(CpuClock::_100MHz),
+            #[cfg(not(esp32p4_rev_lt_v3))]
+            v if v == CpuClock::PRESET_DIV1 => Some(CpuClock::_400MHz),
+            #[cfg(esp32p4_rev_lt_v3)]
+            v if v == CpuClock::PRESET_DIV1 => Some(CpuClock::_360MHz),
+            #[cfg(not(esp32p4_rev_lt_v3))]
+            v if v == CpuClock::PRESET_DIV2 => Some(CpuClock::_200MHz),
+            #[cfg(esp32p4_rev_lt_v3)]
+            v if v == CpuClock::PRESET_DIV2 => Some(CpuClock::_180MHz),
+            #[cfg(not(esp32p4_rev_lt_v3))]
+            v if v == CpuClock::PRESET_DIV4 => Some(CpuClock::_100MHz),
+            #[cfg(esp32p4_rev_lt_v3)]
+            v if v == CpuClock::PRESET_DIV4 => Some(CpuClock::_90MHz),
             _ => None,
         }
     }

--- a/esp-metadata-generated/src/_generated_esp32p4.rs
+++ b/esp-metadata-generated/src/_generated_esp32p4.rs
@@ -2065,7 +2065,16 @@ macro_rules! define_clock_tree_types {
             }
         }
         pub fn cpll_clk_frequency() -> u32 {
-            400000000
+            {
+                #[cfg(esp32p4_rev_lt_v3)]
+                {
+                    360000000
+                }
+                #[cfg(not(any(esp32p4_rev_lt_v3)))]
+                {
+                    400000000
+                }
+            }
         }
         pub fn cpll_clk_source_frequency() -> u32 {
             xtal_clk_frequency()

--- a/esp-metadata/devices/esp32p4.toml
+++ b/esp-metadata/devices/esp32p4.toml
@@ -56,12 +56,13 @@ cpu_has_csr_pc = false
 rc_fast_clk_default = 20_000_000
 internal_memory_cached = true
 
-# Clock tree for ESP32-P4 (eco5 / chip revision v3.x)
+# Clock tree for ESP32-P4. CPLL tops out at 360 MHz on pre-v3.0 silicon and 400 MHz on v3.0+.
 # 3 PLLs: CPLL (CPU, 360/400MHz), SPLL (480MHz, peripherals), MPLL (400MHz, PSRAM/media)
 clocks = { system_clocks = { clock_tree = [
     # High-speed clock sources
     { name = "XTAL_CLK",    type = "source",  output = "40_000_000", always_on = true },
-    { name = "CPLL_CLK",    type = "derived", from = "XTAL_CLK", output = "400_000_000" }, # eco5 default 400MHz
+    # CPLL: 400 MHz on v3.0+ silicon, 360 MHz on pre-v3.0 (`esp32p4_rev_lt_v3`); see rtc_cntl
+    { name = "CPLL_CLK",    type = "derived", from = "XTAL_CLK", output = "400_000_000", output-overrides = { esp32p4_rev_lt_v3 = "360_000_000" } },
     { name = "SPLL_CLK",    type = "derived", from = "XTAL_CLK", output = "480_000_000" }, # System PLL
     { name = "MPLL_CLK",    type = "derived", from = "XTAL_CLK", output = "500_000_000" }, # Media PLL
     { name = "RC_FAST_CLK", type = "source",                     output = "20_000_000" },

--- a/esp-metadata/src/cfg/soc/clock_tree/source.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/source.rs
@@ -72,6 +72,13 @@ pub struct Source {
     values: Option<ValuesExpression>,
 
     output: OutputExpression,
+
+    /// Per-`cfg` overrides for `output`. Each key is a `cfg` predicate; when it is active the
+    /// corresponding expression replaces `output`. Used for sources whose fixed frequency
+    /// depends on a build-time selection, e.g. the ESP32-P4 CPLL runs at 360 MHz on pre-v3.0
+    /// silicon (`esp32p4_rev_lt_v3`) and 400 MHz otherwise. The overrides must be constant.
+    #[serde(default, rename = "output-overrides")]
+    output_overrides: std::collections::BTreeMap<String, OutputExpression>,
 }
 
 impl ClockTreeNodeType for Source {
@@ -130,8 +137,36 @@ impl ClockTreeNodeType for Source {
     ) -> TokenStream {
         if self.values.is_some() {
             quote! { config.value() }
-        } else {
+        } else if self.output_overrides.is_empty() {
             self.output.0.to_rust(HashMap::new(), instance, tree)
+        } else {
+            // Emit one `#[cfg]`-gated arm per override plus a default arm for the remaining
+            // case. Exactly one survives cfg evaluation and becomes the block's tail
+            // expression. `cfg` predicates are taken verbatim from the override keys.
+            let predicates: Vec<TokenStream> = self
+                .output_overrides
+                .keys()
+                .map(|cfg| {
+                    cfg.parse()
+                        .expect("invalid cfg predicate in output-overrides")
+                })
+                .collect();
+            let arms = self
+                .output_overrides
+                .values()
+                .zip(&predicates)
+                .map(|(expr, pred)| {
+                    let value = expr.0.to_rust(HashMap::new(), instance, tree);
+                    quote! { #[cfg(#pred)] { #value } }
+                });
+            let default = self.output.0.to_rust(HashMap::new(), instance, tree);
+            quote! {
+                {
+                    #(#arms)*
+                    #[cfg(not(any(#(#predicates),*)))]
+                    { #default }
+                }
+            }
         }
     }
 

--- a/esp-metadata/src/lib.rs
+++ b/esp-metadata/src/lib.rs
@@ -123,7 +123,7 @@ pub enum Chip {
     Esp32c61,
     /// ESP32-H2
     Esp32h2,
-    /// ESP32-P4 (chip revision v3.x / eco5 only)
+    /// ESP32-P4 (defaults to chip revision v3.0+; pre-v3.0 via `min-chip-revision`)
     Esp32p4,
     /// ESP32-S2
     Esp32s2,

--- a/esp-sync/Cargo.toml
+++ b/esp-sync/Cargo.toml
@@ -38,6 +38,7 @@ xtensa-lx        = { version = "0.13.0", path = "../xtensa-lx" }
 
 [build-dependencies]
 esp-metadata-generated = { version = "0.4.0", path = "../esp-metadata-generated", features = ["build-script"] }
+esp-config = { version = "0.7.0", path = "../esp-config", features = ["build"] }
 
 [features]
 #! ### Chip Support Feature Flags

--- a/esp-sync/build.rs
+++ b/esp-sync/build.rs
@@ -1,9 +1,31 @@
 use std::error::Error;
 
+use esp_config::generate_config_from_yaml_definition;
+
 fn main() -> Result<(), Box<dyn Error>> {
     // Define all necessary configuration symbols for the configured device:
     let chip = esp_metadata_generated::Chip::from_cargo_feature()?;
     chip.define_cfgs();
+
+    // Derive `esp32p4_rev_lt_v3` from the configured minimum chip revision: pre-v3.0
+    // ESP32-P4 lacks the `mintthresh` CSR the Zcmp critical-section workaround writes
+    // (0x347 traps). Compile-time, since the workaround runs in hot/early paths.
+    println!("cargo:rerun-if-changed=./esp_config.yml");
+    let cfg_yaml = std::fs::read_to_string("./esp_config.yml")
+        .expect("Failed to read esp_config.yml for esp-sync");
+    let cfg = generate_config_from_yaml_definition(&cfg_yaml, true, true, Some(chip)).unwrap();
+
+    println!("cargo:rustc-check-cfg=cfg(esp32p4_rev_lt_v3)");
+    if chip.name() == "esp32p4" {
+        let min_rev = cfg
+            .iter()
+            .find(|(k, _)| k.to_ascii_lowercase().ends_with("min_chip_revision"))
+            .map(|(_, v)| v.as_integer())
+            .unwrap_or(0);
+        if min_rev < 300 {
+            println!("cargo:rustc-cfg=esp32p4_rev_lt_v3");
+        }
+    }
 
     Ok(())
 }

--- a/esp-sync/esp_config.yml
+++ b/esp-sync/esp_config.yml
@@ -1,0 +1,15 @@
+crate: esp-sync
+
+options:
+  - name: min-chip-revision
+    description: "The minimum chip revision the application targets, in format:
+      major * 100 + minor. On ESP32-P4, revisions below v3.0 (< 300) lack the `mintthresh`
+      CSR (writing 0x347 traps illegal-instruction), so the Zcmp critical-section workaround
+      is disabled there. Defaults to 300 (v3.0) on ESP32-P4 — set it to your silicon
+      revision (e.g. 100 for v1.0) on older parts. Keep in sync with the esp-hal option of
+      the same name. Mirrors ESP-IDF `CONFIG_ESP32P4_SELECTS_REV_LESS_V3`."
+    default:
+      - value: 300
+        if: 'chip == "esp32p4"'
+      - value: 0
+    active: 'chip == "esp32p4"'

--- a/esp-sync/src/raw.rs
+++ b/esp-sync/src/raw.rs
@@ -35,7 +35,7 @@ impl RawLock for SingleCoreInterruptLock {
     #[inline]
     unsafe fn enter(&self) -> RestoreState {
         cfg_if::cfg_if! {
-            if #[cfg(esp32p4)] { // TODO: any with zcmp
+            if #[cfg(all(esp32p4, not(esp32p4_rev_lt_v3)))] { // TODO: any with zcmp
                 // ESP32-P4 (v3.2/ECO7 etc.) Zcmp hardware bug workaround (IDF-14279 / DIG-661):
                 // Clearing mstatus.mie alone does not fully mask CLIC interrupts -- an
                 // interrupt can still fire mid-instruction on cm.push (and possibly on
@@ -43,6 +43,10 @@ impl RawLock for SingleCoreInterruptLock {
                 // while mie is cleared, then restore the previous mintthresh on exit.
                 // Ref: esp-idf commit c27c33a83 "fix(riscv): implement a workaround for
                 // Zcmp hardware bug".
+                //
+                // Disabled on pre-v3.0 ESP32-P4 (`esp32p4-rev-lt-v3`): those revisions have no
+                // `mintthresh` CSR — writing 0x347 traps illegal-instruction. Mirrors IDF
+                // `CONFIG_ESP32P4_SELECTS_REV_LESS_V3`.
                 let old_mintthresh: u32;
                 unsafe {
                     core::arch::asm!(
@@ -86,7 +90,7 @@ impl RawLock for SingleCoreInterruptLock {
         let token = token.inner();
 
         cfg_if::cfg_if! {
-            if #[cfg(esp32p4)] {
+            if #[cfg(all(esp32p4, not(esp32p4_rev_lt_v3)))] {
                 if (token & 0b1000) != 0 {
                     unsafe {
                         riscv::interrupt::enable();


### PR DESCRIPTION
### Submission Checklist 📝

- [x] I have updated existing examples or added new ones (if applicable). _(No example changes; behavior is gated and defaults are unchanged.)_
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] I have added changelog entries and/or migration guide notes in the sections below.
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

### Pull Request Details 📖

#### Description

The HAL's ESP32-P4 support currently targets v3.0+ (eco5) silicon only. This PR adds
support for **pre-v3.0** parts (v0.0/v1.0/v1.3 — e.g. the Waveshare ESP32-P4-NANO and
other v1.x boards in the field), which differ in several hardware blocks. ESP-IDF gates
these on `CONFIG_ESP32P4_SELECTS_REV_LESS_V3` (revision < v3.0); this PR mirrors that
boundary with a build-time `esp32p4_rev_lt_v3` cfg **derived from the existing
`ESP_HAL_CONFIG_MIN_CHIP_REVISION`** (and `ESP_SYNC_CONFIG_MIN_CHIP_REVISION`), defaulting
to 300 (v3.0) on ESP32-P4 so existing v3.0+ behavior is unchanged.

The two blocks handled here:

**1. Non-standard CLIC (interrupt controller).** Pre-v3.0 silicon has a non-standard CLIC:
- **No `mintthresh` CSR** — writing `0x347` traps illegal-instruction (the first thing that
  breaks: every critical section / `println!` hits it). The interrupt threshold is the
  memory-mapped `CLIC_INT_THRESH_REG` (`0x2080_0008`, upper 8 bits).
- **`mintstatus` is at CSR `0x346`** (not `0xFB1`).
- `mintstatus.mil` does not match the slot `ctl` level encoding, so CLIC dispatch uses the
  serviced interrupt's own ctl-derived level rather than `current_runlevel()` — matching how
  ESP-IDF dispatches off `mcause` in `components/riscv/vectors.S` (`_interrupt_handler`).
  Without this, level-triggered sources (e.g. the systimer alarm) storm and starve the executor.
- In esp-sync, the `Zcmp` critical-section workaround writes `mintthresh`; it is gated off
  pre-v3.0 (and is unnecessary for the `riscv32imafc` target, which emits no Zcmp anyway).

**2. CPLL maximum frequency (360 vs 400 MHz).** The HAL drives the CPLL to 400 MHz and offers
400/200/100 MHz `CpuClock` presets on all P4. Pre-v3.0 silicon is only qualified to **360 MHz**;
IDF gates this identically (`soc/esp32p4/Kconfig.cpu`: the 360 MHz CPU option `depends on
ESP32P4_SELECTS_REV_LESS_V3`; `esp_hw_support/port/esp32p4/rtc_clk.c` runs CPLL=360 with a
90/180/360 grid pre-v3.0 and CPLL=400 with 100/200/400 on v3.0+). On a 400 MHz CPLL you cannot
divide down to 360, so 360 is genuinely pre-v3.0-only. Gated on `esp32p4_rev_lt_v3`:
- `rtc_cntl` configures the CPLL to 360 MHz (the `div7_0` I2C encoding 9/10 is the v1.0+ value
  per IDF `clk_ll_cpll_set_config` and is unchanged; only pre-production v0.x samples differ
  and are not supported).
- `CpuClock` presets become 360/180/90 MHz and `CpuClock::max()` follows. The divider presets
  (CPLL/1, /2, /4) are shared between both CPLL frequencies.
- **esp-metadata**: the generated `cpll_clk_frequency()` (which feeds every derived frequency —
  APB, baud, etc.) is made revision-conditional via a new, generic **`output-overrides`** map on
  clock-tree sources (a `cfg` predicate → frequency expression). The generated clock code expands
  inside `define_clock_tree_types!` in the esp-hal crate, where the cfg resolves, so no extra
  crate plumbing is needed. (Reusable for other per-revision clock values, e.g. the MPLL/PSRAM
  200-vs-250 MHz split.)

#### Testing

Verified on **v1.0 (ECO2) hardware** (Waveshare ESP32-P4-NANO), built with
`ESP_HAL_CONFIG_MIN_CHIP_REVISION=100`:
- Full embassy async runtime now boots and runs: executor, tasks, `println` over
  USB-Serial/JTAG, and interrupt-driven `embassy_time::Timer` (steady 1 Hz). Previously the
  first `println!` trapped illegal-instruction on the `mintthresh` CSR.
- CPU clock measured via the `mcycle` counter against the XTAL-driven SYSTIMER reads **360 MHz**
  at `CpuClock::max()` (was 400 before the fix); `esp_hal::clock::cpu_clock()` agrees; the
  default `CpuClock` runs the CPU at 90 MHz (CPLL/4).
- Both gate directions verified: by disassembly (min-rev 100 ⇒ no `csr 0x347`, memory-mapped
  threshold, 360 MHz CPLL; min-rev 300 ⇒ `csr 0x347`, 400 MHz CPLL), and `lint-packages esp-hal
  esp-sync --chips esp32p4` is clean with `MIN_CHIP_REVISION` = both 100 and 300.
- `cargo xtask update-metadata` is idempotent (only `_generated_esp32p4.rs` changes); build is
  warning-free. v3.0+ behavior is unchanged (default min-chip-revision 300).

#### Notes for maintainers — two design questions

**1. `CpuClock` variants vary by `MIN_CHIP_REVISION` vs the "config shouldn't alter public API"
guideline.** Pre-v3.0's qualified frequencies genuinely differ (90/180/360 vs 100/200/400), so
to keep the variant names truthful they're gated on `esp32p4_rev_lt_v3`, which means the public
`CpuClock` enum changes with the `MIN_CHIP_REVISION` esp-config value. That's in tension with the
guideline that config options shouldn't alter the public API — but the alternatives each have
downsides: always exposing all six variants and validating at init trades against "prefer
compile-time checks over runtime" and lets users pick an unachievable frequency; reusing the
v3.0 names (`_400MHz`) on pre-v3.0 would be untruthful (they'd deliver 360). I went with the
compile-time-truthful option; happy to switch to always-expose-and-validate if you'd prefer the
API be config-invariant.

**2. CI coverage of the pre-v3.0 paths.** The pre-v3.0 code is gated on `esp32p4_rev_lt_v3` (from
`MIN_CHIP_REVISION` < 300). CI builds
ESP32-P4 at the default revision (300), so it only exercises the v3.0+ side today; the pre-v3.0
branches aren't built/linted and could bit-rot. The existing `check-configs`/`clippy-configs`
combos are feature-based and can't express an esp-config *value* like `MIN_CHIP_REVISION`. Since
IDF gates many ESP32-P4 blocks on this same boundary (CLIC, efuse, sleep/PMU, RTC clock, USB PHY,
bootloader, …), esp-hal will likely accrue more pre-v3.0 code, so a general mechanism seems
worthwhile — e.g. allowing a config combo to set esp-config env values. I'm happy to do that as a
focused follow-up, but wanted your input on the preferred approach before adding CI/infra surface
here.

---

# Changelog

## esp-hal

- Added: ESP32-P4 support for pre-v3.0 silicon (revisions below v3.0), selected via
  `ESP_HAL_CONFIG_MIN_CHIP_REVISION`: the non-standard CLIC (memory-mapped interrupt threshold,
  `mintstatus` at CSR 0x346, dispatch off the serviced interrupt's level) and the 360 MHz CPLL
  maximum (`CpuClock` presets become 360/180/90 MHz).

## esp-sync

- Added: ESP32-P4 support for pre-v3.0 silicon, selected via `ESP_SYNC_CONFIG_MIN_CHIP_REVISION`:
  the `Zcmp` critical-section workaround (which writes the `mintthresh` CSR, absent before v3.0)
  is gated off.

## esp-metadata

- Added: clock-tree sources accept an `output-overrides` map (cfg predicate → frequency
  expression) so a source's fixed frequency can depend on a build-time selection (used for the
  ESP32-P4 360/400 MHz CPLL).
