### PR TITLE
Allow specifying env vars in Cargo.toml config lists

### DIFF
--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -21,6 +21,7 @@ check-configs = [
     { features = [] },
     { features = ["rt"] },
     { features = ["unstable", "rt"] },
+    { features = ["unstable", "rt"], env = { ESP_HAL_CONFIG_PLACE_ANON_IN_RAM = "true", ESP_HAL_CONFIG_PLACE_RMT_DRIVER_IN_RAM = "true", ESP_HAL_CONFIG_PLACE_SPI_MASTER_DRIVER_IN_RAM = "true" } },
     { features = ["unstable", "rt", "__usb_otg"],   if = 'usb_otg_driver_supported' },
     { features = ["unstable", "rt", "__bluetooth"], if = 'bt_driver_supported' },
 ]

--- a/esp-metadata/devices/esp32c3.toml
+++ b/esp-metadata/devices/esp32c3.toml
@@ -415,7 +415,7 @@ output_signals = [
     { name = "GPIO_SD2",         id = 57 },
     { name = "GPIO_SD3",         id = 58 },
     { name = "I2SO_SD1",         id = 59 },
-    { name = "FSPICLK"    ,      id = 63 },
+    { name = "FSPICLK",          id = 63 },
     { name = "FSPIQ",            id = 64 },
     { name = "FSPID",            id = 65 },
     { name = "FSPIHD",           id = 66 },

--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -24,9 +24,12 @@ doc-config = { features = ["esp-hal/unstable", "esp-hal/rt", "esp-alloc/global-a
 # `instability_disable_unstable_docs` escape (set in `build_doc_json`) then drops all
 # `#[instability::unstable]` items from the baseline. `wifi` is the only radio feature that
 # does not pull in `unstable`.
-semver-config = { features = ["esp-hal/rt", "esp-alloc/global-allocator", "procmacros/__esp_idf_bootloader", "defmt"], append = [
-    { if = 'wifi_driver_supported', features = ["wifi"] },
-] }
+semver-config = {
+    features = ["esp-hal/rt", "esp-alloc/global-allocator", "procmacros/__esp_idf_bootloader", "defmt"],
+    append = [
+        { if = 'wifi_driver_supported', features = ["wifi"] },
+    ],
+}
 check-configs = [
     { features = ["esp-hal/rt"] },
     { features = ["esp-hal/rt", "defmt"] },

--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -24,15 +24,13 @@ doc-config = { features = ["esp-hal/unstable", "esp-hal/rt", "esp-alloc/global-a
 # `instability_disable_unstable_docs` escape (set in `build_doc_json`) then drops all
 # `#[instability::unstable]` items from the baseline. `wifi` is the only radio feature that
 # does not pull in `unstable`.
-semver-config = {
-    features = ["esp-hal/rt", "esp-alloc/global-allocator", "procmacros/__esp_idf_bootloader", "defmt"],
-    append = [
-        { if = 'wifi_driver_supported', features = ["wifi"] },
-    ],
-}
+semver-config = { features = ["esp-hal/rt", "esp-alloc/global-allocator", "procmacros/__esp_idf_bootloader", "defmt"], append = [
+    { if = 'wifi_driver_supported', features = ["wifi"] },
+] }
 check-configs = [
     { features = ["esp-hal/rt"] },
     { features = ["esp-hal/rt", "defmt"] },
+    { features = ["esp-hal/rt", "defmt"], env = { ESP_RADIO_CONFIG_DUMP_PACKETS = "true" } },
     { features = ["esp-hal/rt", "wifi"], if = 'wifi_driver_supported' },
     # feature(c_variadic) requires nightly compiler, but we can't configure the toolchain here. Only check xtensa chips, where the compiler has nightly features enabled.
     { features = ["esp-hal/unstable", "esp-hal/rt", "wifi", "print-logs-from-driver", "unstable"], if = 'wifi_driver_supported && xtensa' },

--- a/esp-rom-sys/Cargo.toml
+++ b/esp-rom-sys/Cargo.toml
@@ -16,7 +16,7 @@ links         = "esp_rom_sys"
 forever-unstable = true
 check-configs = [{ features = [] }]
 clippy-configs = [{ features = [] }]
-semver-config = { features = ["__internal_rom_symbols"]}
+semver-config = { features = ["__internal_rom_symbols"] }
 
 [package.metadata.docs.rs]
 default-target = "riscv32imac-unknown-none-elf"

--- a/esp-rtos/Cargo.toml
+++ b/esp-rtos/Cargo.toml
@@ -18,6 +18,9 @@ check-configs = [
     { features = ["esp-hal/unstable", "esp-radio"] },
     { features = ["esp-hal/unstable", "esp-radio", "embassy"] },
     { features = ["esp-hal/unstable", "esp-alloc", "embassy"] },
+    { features = ["esp-hal/unstable", "esp-radio", "embassy"], env = { ESP_RTOS_CONFIG_STACK_POINTER_RANGE_CHECK = "false" } },
+    { features = ["esp-hal/unstable", "esp-radio", "embassy"], env = { ESP_RTOS_CONFIG_SW_TASK_OVERFLOW_DETECTION = "true", ESP_RTOS_CONFIG_HW_TASK_OVERFLOW_DETECTION = "false" } },
+    { features = ["esp-hal/unstable", "esp-radio", "embassy"], env = { ESP_RTOS_CONFIG_SW_TASK_OVERFLOW_DETECTION = "true", ESP_RTOS_CONFIG_HW_TASK_OVERFLOW_DETECTION = "true" } },
 ]
 clippy-configs = [
     { features = ["esp-hal/unstable", "esp-alloc", "defmt", "esp-radio", "embassy"] },

--- a/esp-storage/Cargo.toml
+++ b/esp-storage/Cargo.toml
@@ -14,7 +14,7 @@ license       = "MIT OR Apache-2.0"
 check-configs = [
     { features = [] },
     { features = ["critical-section"] },
-    { features = ["bytewise-read"]},
+    { features = ["bytewise-read"] },
     { features = ["critical-section", "bytewise-read"] },
 ]
 clippy-configs = [{ features = ["critical-section", "bytewise-read"] }]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -29,7 +29,7 @@ serde_json     = "1.0.70"
 somni-expr     = { version = "0.2.0" }
 strum          = { version = "0.27.1", features = ["derive"] }
 syn            = { version = "2", default-features = false, features = ["full", "parsing"] }
-toml_edit      = { version = "0.22.22", features = ["serde"] }
+toml_edit      = { version = "0.25", features = ["serde"] }
 walkdir        = "2.5.0"
 zip            = "6.0.0"
 

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -62,7 +62,7 @@ single backport package, and forces Patch bumps. No `--allow-non-main` needed.
 
 Published crates can list CI check, clippy, documentation, and semver cases under
 `[package.metadata.espressif]` in their `Cargo.toml`. Each case is one inline table; `features`
-is required, `env` is optional:
+and `env` are both optional:
 
 ```toml
 [package.metadata.espressif]

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -58,11 +58,11 @@ The standard `plan` → `execute-plan` → `publish-plan` → `post-release` flo
 works from a backport branch — the tooling auto-detects it, scopes to the
 single backport package, and forces Patch bumps. No `--allow-non-main` needed.
 
-## Package `check-configs` / `clippy-configs` / `semver-config` metadata
+## Package metadata: `check-configs`, `clippy-configs`, `doc-config`, `semver-config`
 
-Published crates can list CI check, clippy, and semver cases under
-`[package.metadata.espressif]` in their `Cargo.toml`. Each case is one inline table with
-**required** `features` and `env` keys:
+Published crates can list CI check, clippy, documentation, and semver cases under
+`[package.metadata.espressif]` in their `Cargo.toml`. Each case is one inline table; `features`
+is required, `env` is optional:
 
 ```toml
 [package.metadata.espressif]
@@ -72,7 +72,7 @@ check-configs = [
         features = ["unstable", "rt"],
         env = {
             ESP_HAL_EMBASSY_CONFIG_TIMER_QUEUE = "generic"
-        }
+        },
     },
     { features = ["unstable", "rt"], append = [
         { if = 'usb_otg_driver_supported', features = ["__usb_otg"] },
@@ -81,9 +81,14 @@ check-configs = [
 clippy-configs = [
     { features = ["unstable", "rt"] },
 ]
+doc-config = {
+    features = ["unstable", "rt"],
+    append = [
+        { if = 'usb_otg_driver_supported', features = ["__usb_otg"] },
+    ],
+}
 semver-config = {
     features = ["unstable", "rt"],
-    env = {},
     append = [
         { if = 'wifi_driver_supported', features = ["wifi"] },
     ],
@@ -91,21 +96,22 @@ semver-config = {
 ```
 
 - `features` — cargo features to enable for that case (same as before).
-- `env` — inline table of environment variables passed to the cargo invocation.
-  Mainly used for `esp-config` options (`ESP_*` variables). Use an empty table when no
-  overrides are needed.
+- `env` — optional inline table of environment variables passed to the cargo invocation.
+  Mainly used for `esp-config` options (`ESP_*` variables). Omit when no overrides are needed.
 - `if` — optional somni expression; the whole case is skipped when the condition is false.
 - `append` — optional list of partial inline tables. Matching rows add more `features` and/or
   `env` entries. Append rows may specify only `features` or only `env`.
 
-`check-configs` and `clippy-configs` are arrays of cases. `semver-config` is a single inline
-table (one API surface per chip for semver baselines).
+`check-configs` and `clippy-configs` are arrays of cases. `doc-config` and `semver-config` are
+single inline tables.
 
 `cargo xtask check-packages` reads `check-configs`; `cargo xtask lint-packages` reads
-`clippy-configs`; semver checks read `semver-config`. If `check-configs` is absent, a single
+`clippy-configs`; documentation builds read `doc-config`; semver checks read `semver-config`. If `check-configs` is absent, a single
 default case with no features and no env overrides is used. `CI`, `DEFMT_LOG`, and `ESP_LOG`
-(check only) are always set by xtask and override duplicate keys from metadata. Semver checks
-always set `RUSTDOCFLAGS` and override duplicate keys from `semver-config`.
+(check only) are always set by xtask and override duplicate keys from metadata. Documentation
+builds and doc-tests always set `RUSTDOCFLAGS` (and `ESP_HAL_DOCTEST` for doc-tests) and override
+duplicate keys from `doc-config`. Semver checks always set `RUSTDOCFLAGS` and override duplicate
+keys from `semver-config`.
 
 ## Test/example metadata use
 

--- a/xtask/README.md
+++ b/xtask/README.md
@@ -58,6 +58,55 @@ The standard `plan` → `execute-plan` → `publish-plan` → `post-release` flo
 works from a backport branch — the tooling auto-detects it, scopes to the
 single backport package, and forces Patch bumps. No `--allow-non-main` needed.
 
+## Package `check-configs` / `clippy-configs` / `semver-config` metadata
+
+Published crates can list CI check, clippy, and semver cases under
+`[package.metadata.espressif]` in their `Cargo.toml`. Each case is one inline table with
+**required** `features` and `env` keys:
+
+```toml
+[package.metadata.espressif]
+check-configs = [
+    { features = [] },
+    {
+        features = ["unstable", "rt"],
+        env = {
+            ESP_HAL_EMBASSY_CONFIG_TIMER_QUEUE = "generic"
+        }
+    },
+    { features = ["unstable", "rt"], append = [
+        { if = 'usb_otg_driver_supported', features = ["__usb_otg"] },
+    ] },
+]
+clippy-configs = [
+    { features = ["unstable", "rt"] },
+]
+semver-config = {
+    features = ["unstable", "rt"],
+    env = {},
+    append = [
+        { if = 'wifi_driver_supported', features = ["wifi"] },
+    ],
+}
+```
+
+- `features` — cargo features to enable for that case (same as before).
+- `env` — inline table of environment variables passed to the cargo invocation.
+  Mainly used for `esp-config` options (`ESP_*` variables). Use an empty table when no
+  overrides are needed.
+- `if` — optional somni expression; the whole case is skipped when the condition is false.
+- `append` — optional list of partial inline tables. Matching rows add more `features` and/or
+  `env` entries. Append rows may specify only `features` or only `env`.
+
+`check-configs` and `clippy-configs` are arrays of cases. `semver-config` is a single inline
+table (one API surface per chip for semver baselines).
+
+`cargo xtask check-packages` reads `check-configs`; `cargo xtask lint-packages` reads
+`clippy-configs`; semver checks read `semver-config`. If `check-configs` is absent, a single
+default case with no features and no env overrides is used. `CI`, `DEFMT_LOG`, and `ESP_LOG`
+(check only) are always set by xtask and override duplicate keys from metadata. Semver checks
+always set `RUSTDOCFLAGS` and override duplicate keys from `semver-config`.
+
 ## Test/example metadata use
 
 Each test and example can specify metadata. This metadata is read, interpreted and used by the

--- a/xtask/src/commands/run.rs
+++ b/xtask/src/commands/run.rs
@@ -91,7 +91,7 @@ pub fn run_doc_tests_for_package(workspace: &Path, package: Package, chip: Chip)
     }
 
     // Packages that have doc features are documented. We run doc-tests for these, and only these.
-    let Some(mut features) = package.doc_feature_rules(&esp_metadata::Config::for_chip(&chip))
+    let Some(mut doc_config) = package.doc_config_rules(&esp_metadata::Config::for_chip(&chip))
     else {
         log::info!("Skipping undocumented package {package}.");
         return Ok(true);
@@ -101,8 +101,9 @@ pub fn run_doc_tests_for_package(workspace: &Path, package: Package, chip: Chip)
     let package_path = crate::windows_safe_path(&workspace.join(&package_name));
 
     if package.has_chip_features() {
-        features.push(chip.to_string());
+        doc_config.features.push(chip.to_string());
     }
+    let features = &doc_config.features;
 
     // Determine the appropriate build target, and cargo features for the given
     // package and chip:
@@ -115,25 +116,27 @@ pub fn run_doc_tests_for_package(workspace: &Path, package: Package, chip: Chip)
     let toolchain = if chip.is_xtensa() { "esp" } else { "nightly" };
 
     // Build up an array of command-line arguments to pass to `cargo`:
-    let builder = CargoArgsBuilder::default()
+    let mut builder = CargoArgsBuilder::default()
         .toolchain(toolchain)
         .subcommand("test")
         .arg("--doc")
         .arg("-Zbuild-std=core,alloc,panic_abort")
         .target(target)
-        .features(&features)
+        .features(features)
         .arg("--release");
 
-    let args = builder.build();
-    log::debug!("{args:#?}");
+    for (key, value) in &doc_config.env {
+        builder.add_env_var(key, value);
+    }
+    builder.add_env_var("RUSTDOCFLAGS", "--cfg docsrs --cfg not_really_docsrs");
+    builder.add_env_var("ESP_HAL_DOCTEST", "1");
 
-    let envs = vec![
-        ("RUSTDOCFLAGS", "--cfg docsrs --cfg not_really_docsrs"),
-        ("ESP_HAL_DOCTEST", "1"),
-    ];
+    let command = crate::cargo::CargoCommandBatcher::build_one_for_cargo(&builder);
+    log::debug!("{command:#?}");
 
-    // Execute `cargo doc` from the package root:
-    let success = crate::cargo::run_with_env(&args, &package_path, envs, false).is_ok();
+    let success =
+        crate::cargo::run_with_env(&command.command, &package_path, command.env_vars, false)
+            .is_ok();
     Ok(success)
 }
 

--- a/xtask/src/documentation.rs
+++ b/xtask/src/documentation.rs
@@ -11,7 +11,12 @@ use minijinja::Value;
 use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 
-use crate::{Chip, Package, cargo::CargoArgsBuilder, windows_safe_path};
+use crate::{
+    Chip,
+    Package,
+    cargo::{CargoArgsBuilder, CargoCommandBatcher},
+    windows_safe_path,
+};
 
 // ----------------------------------------------------------------------------
 // Build Documentation
@@ -279,14 +284,14 @@ fn cargo_doc_without_pre_processing(
     };
 
     let mut features = vec![];
-    let doc_features = if let Some(chip) = &chip {
+    let doc_config = if let Some(chip) = &chip {
         features.push(chip.to_string());
-        package.doc_feature_rules(Config::for_chip(chip))
+        package.doc_config_rules(Config::for_chip(chip))
     } else {
-        package.doc_feature_rules(&Config::empty())
+        package.doc_config_rules(&Config::empty())
     };
-    if let Some(doc_features) = doc_features {
-        features.extend(doc_features);
+    if let Some(doc_config) = &doc_config {
+        features.extend(doc_config.features.clone());
     }
 
     // Build up an array of command-line arguments to pass to `cargo`:
@@ -308,10 +313,7 @@ fn cargo_doc_without_pre_processing(
         builder.add_arg("-Zbuild-std=alloc,core");
     }
 
-    let args = builder.build();
-    log::debug!("{args:#?}");
-
-    let rustdocflags = vec![
+    let rustdocflags = [
         "--cfg docsrs",
         "--cfg not_really_docsrs",
         // Activating this would redirect *all* rand_core version to 0.10.0, which is wrong.
@@ -320,17 +322,24 @@ fn cargo_doc_without_pre_processing(
         // support multiple versions of the same crate. We could redirect everything to 0.10.0,
         // which isn't ideal.
         // "--extern-html-root-url rand_core-09=https://docs.rs/rand_core/0.9.5/",
-    ];
+    ]
+    .join(" ");
 
-    let rustdocflags = rustdocflags.join(" ");
-    let mut envs = vec![("RUSTDOCFLAGS", rustdocflags.as_str())];
+    if let Some(doc_config) = &doc_config {
+        for (key, value) in &doc_config.env {
+            builder.add_env_var(key, value);
+        }
+    }
+    builder.add_env_var("RUSTDOCFLAGS", &rustdocflags);
     // Special case: `esp-storage` requires the optimization level to be 2 or 3:
     if package == Package::EspStorage {
-        envs.push(("CARGO_PROFILE_DEBUG_OPT_LEVEL", "3"));
+        builder.add_env_var("CARGO_PROFILE_DEBUG_OPT_LEVEL", "3");
     }
 
-    // Execute `cargo doc` from the package root:
-    crate::cargo::run_with_env(&args, &package_path, envs, false)?;
+    let command = CargoCommandBatcher::build_one_for_cargo(&builder);
+    log::debug!("{command:#?}");
+    crate::cargo::run_with_env(&command.command, &package_path, command.env_vars, false)
+        .with_context(|| format!("Failed to run `cargo doc` for {}", package_name))?;
 
     // Build up the path at which the built documentation can be found:
     let mut docs_path = if let Ok(target_path) = std::env::var("CARGO_TARGET_DIR") {

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -56,6 +56,13 @@ inventory::collect!(McpToolRegistration);
 #[cfg(feature = "semver-checks")]
 pub mod semver_check;
 
+/// One `check-configs` or `clippy-configs` case from `[package.metadata.espressif]`.
+#[derive(Debug, Clone, Default)]
+pub struct CheckConfig {
+    pub features: Vec<String>,
+    pub env: HashMap<String, String>,
+}
+
 #[derive(
     Debug,
     Clone,
@@ -256,6 +263,38 @@ impl Package {
         }
     }
 
+    fn parse_required_features(table: &InlineTable) -> Vec<String> {
+        let mut features = Vec::new();
+        if let Some(config_features) = table.get("features") {
+            let Value::Array(config_features) = config_features else {
+                panic!("features must be an array.");
+            };
+
+            for feature in config_features {
+                let feature = feature.as_str().expect("features must be strings.");
+                features.push(feature.to_owned());
+            }
+        }
+
+        features
+    }
+
+    fn parse_env_table(table: &InlineTable) -> HashMap<String, String> {
+        let mut env = HashMap::new();
+        if let Some(env_value) = table.get("env") {
+            let Value::InlineTable(env_table) = env_value else {
+                panic!("env must be an inline table.");
+            };
+
+            for (key, value) in env_table.iter() {
+                let value = value.as_str().expect("env values must be strings.");
+                env.insert(key.to_string(), value.to_owned());
+            }
+        }
+
+        env
+    }
+
     fn parse_conditional_features(table: &InlineTable, config: &Config) -> Option<Vec<String>> {
         let script_ctx = ScriptContext::new();
         let mut ctx = script_ctx.for_config(config);
@@ -270,20 +309,84 @@ impl Package {
             }
         }
 
-        let Some(config_features) = table.get("features") else {
-            panic!("Missing features array.");
-        };
-        let Value::Array(config_features) = config_features else {
-            panic!("features must be an array.");
-        };
+        Some(Self::parse_required_features(table))
+    }
 
-        let mut features = Vec::new();
-        for feature in config_features {
-            let feature = feature.as_str().expect("features must be strings.");
-            features.push(feature.to_owned());
+    fn parse_conditional_append(
+        table: &InlineTable,
+        config: &Config,
+    ) -> Option<(Option<Vec<String>>, Option<HashMap<String, String>>)> {
+        let script_ctx = ScriptContext::new();
+        let mut ctx = script_ctx.for_config(config);
+
+        if let Some(condition) = table.get("if") {
+            let Some(expr) = condition.as_str() else {
+                panic!("`if` condition must be a string.");
+            };
+
+            if !ctx.evaluate(expr).expect("Failed to evaluate expression") {
+                return None;
+            }
         }
 
-        Some(features)
+        let features = if table.contains_key("features") {
+            Some(Self::parse_required_features(table))
+        } else {
+            None
+        };
+
+        let env = if table.contains_key("env") {
+            Some(Self::parse_env_table(table))
+        } else {
+            None
+        };
+
+        if features.is_none() && env.is_none() {
+            panic!("append items must specify at least one of `features` or `env`.");
+        }
+
+        Some((features, env))
+    }
+
+    fn parse_config_set(table: &InlineTable, config: &Config) -> Option<CheckConfig> {
+        let script_ctx = ScriptContext::new();
+        let mut ctx = script_ctx.for_config(config);
+
+        if let Some(condition) = table.get("if") {
+            let Some(expr) = condition.as_str() else {
+                panic!("`if` condition must be a string.");
+            };
+
+            if !ctx.evaluate(expr).expect("Failed to evaluate expression") {
+                return None;
+            }
+        }
+
+        let mut features = Self::parse_required_features(table);
+        let mut env = Self::parse_env_table(table);
+
+        if let Some(conditionals) = table.get("append") {
+            let Value::Array(conditionals) = conditionals else {
+                panic!("append must be an array.");
+            };
+            for cond in conditionals {
+                let Value::InlineTable(cond_table) = cond else {
+                    panic!("append items must be inline tables.");
+                };
+                if let Some((append_features, append_env)) =
+                    Self::parse_conditional_append(cond_table, config)
+                {
+                    if let Some(append_features) = append_features {
+                        features.extend(append_features);
+                    }
+                    if let Some(append_env) = append_env {
+                        env.extend(append_env);
+                    }
+                }
+            }
+        }
+
+        Some(CheckConfig { features, env })
     }
 
     fn parse_feature_set(table: &InlineTable, config: &Config) -> Option<Vec<String>> {
@@ -374,42 +477,90 @@ impl Package {
         features
     }
 
-    /// Given a device config, return the features which should be enabled for
-    /// semver checking of this package.
     #[cfg(feature = "semver-checks")]
-    pub fn semver_feature_rules(&self, config: &Config) -> Vec<String> {
-        let feature_sets = self
-            .feature_rules_from_metadata(config, "semver-config", false)
-            .unwrap_or_default();
+    fn single_config_rule_from_metadata(
+        &self,
+        config: &Config,
+        metadata_key: &str,
+    ) -> Option<CheckConfig> {
+        let toml = self.toml();
 
-        let features: Vec<String> = feature_sets.into_iter().flatten().collect();
+        if let Some(metadata) = toml.espressif_metadata()
+            && let Some(config_meta) = metadata.get(metadata_key)
+        {
+            let Item::Value(Value::InlineTable(table)) = config_meta else {
+                panic!("'{}' must be an inline table.", metadata_key);
+            };
 
-        log::debug!("Semver features for package '{}': {:?}", self, features);
-        features
-    }
-
-    /// Additional feature rules to test subsets of features for a package.
-    pub fn check_feature_rules(&self, config: &Config) -> Vec<Vec<String>> {
-        let mut cases = self
-            .feature_rules_from_metadata(config, "check-configs", true)
-            .unwrap_or_default();
-
-        // Add the default "no features" case if nothing was specified
-        if cases.is_empty() {
-            cases.push(vec![]);
+            return Self::parse_config_set(table, config);
         }
 
-        log::debug!("Check features for package '{}': {:?}", self, cases);
+        None
+    }
+
+    /// Configuration for semver checking of this package.
+    #[cfg(feature = "semver-checks")]
+    pub fn semver_config_rules(&self, config: &Config) -> CheckConfig {
+        let config = self
+            .single_config_rule_from_metadata(config, "semver-config")
+            .unwrap_or_default();
+
+        log::debug!("Semver config for package '{}': {:?}", self, config);
+        config
+    }
+
+    fn config_rules_from_metadata(
+        &self,
+        config: &Config,
+        metadata_key: &str,
+    ) -> Option<Vec<CheckConfig>> {
+        let toml = self.toml();
+        let mut cases = Vec::new();
+
+        if let Some(metadata) = toml.espressif_metadata()
+            && let Some(config_meta) = metadata.get(metadata_key)
+        {
+            let Item::Value(Value::Array(tables)) = config_meta else {
+                panic!(
+                    "'{}' must be an array of tables. {:?}",
+                    metadata_key, config_meta
+                );
+            };
+
+            for table in tables {
+                let Value::InlineTable(table) = table else {
+                    panic!("'{}' items must be inline tables.", metadata_key);
+                };
+                if let Some(case) = Self::parse_config_set(table, config) {
+                    cases.push(case);
+                }
+            }
+        }
+
+        if cases.is_empty() { None } else { Some(cases) }
+    }
+
+    /// Check configurations to compile for this package in CI.
+    pub fn check_config_rules(&self, config: &Config) -> Vec<CheckConfig> {
+        let mut cases = self
+            .config_rules_from_metadata(config, "check-configs")
+            .unwrap_or_default();
+
+        if cases.is_empty() {
+            cases.push(CheckConfig::default());
+        }
+
+        log::debug!("Check configs for package '{}': {:?}", self, cases);
         cases
     }
 
-    /// Additional feature rules to test subsets of features for a package.
-    pub fn lint_feature_rules(&self, config: &Config) -> Vec<Vec<String>> {
+    /// Clippy configurations to run for this package in CI.
+    pub fn lint_config_rules(&self, config: &Config) -> Vec<CheckConfig> {
         let cases = self
-            .feature_rules_from_metadata(config, "clippy-configs", true)
+            .config_rules_from_metadata(config, "clippy-configs")
             .unwrap_or_default();
 
-        log::debug!("Check features for package '{}': {:?}", self, cases);
+        log::debug!("Clippy configs for package '{}': {:?}", self, cases);
         cases
     }
 

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -295,23 +295,6 @@ impl Package {
         env
     }
 
-    fn parse_conditional_features(table: &InlineTable, config: &Config) -> Option<Vec<String>> {
-        let script_ctx = ScriptContext::new();
-        let mut ctx = script_ctx.for_config(config);
-
-        if let Some(condition) = table.get("if") {
-            let Some(expr) = condition.as_str() else {
-                panic!("`if` condition must be a string.");
-            };
-
-            if !ctx.evaluate(expr).expect("Failed to evaluate expression") {
-                return None;
-            }
-        }
-
-        Some(Self::parse_required_features(table))
-    }
-
     fn parse_conditional_append(
         table: &InlineTable,
         config: &Config,
@@ -389,95 +372,6 @@ impl Package {
         Some(CheckConfig { features, env })
     }
 
-    fn parse_feature_set(table: &InlineTable, config: &Config) -> Option<Vec<String>> {
-        // Base features. If their condition is not met, the whole item is ignored.
-        let mut features = Self::parse_conditional_features(table, config)?;
-
-        if let Some(conditionals) = table.get("append") {
-            // Optional features. If their conditions are met, they are appended to the base
-            // features.
-            let Value::Array(conditionals) = conditionals else {
-                panic!("append must be an array.");
-            };
-            for cond in conditionals {
-                let Value::InlineTable(cond_table) = cond else {
-                    panic!("append items must be inline tables.");
-                };
-                if let Some(cond_features) = Self::parse_conditional_features(cond_table, config) {
-                    features.extend(cond_features);
-                }
-            }
-        };
-
-        Some(features)
-    }
-
-    /// Common function to get feature rules from metadata.
-    fn feature_rules_from_metadata(
-        &self,
-        config: &Config,
-        metadata_key: &str,
-        is_array: bool,
-    ) -> Option<Vec<Vec<String>>> {
-        let toml = self.toml();
-        let mut cases = Vec::new();
-
-        if let Some(metadata) = toml.espressif_metadata()
-            && let Some(config_meta) = metadata.get(metadata_key)
-        {
-            if is_array {
-                let Item::Value(Value::Array(tables)) = config_meta else {
-                    panic!(
-                        "'{}' must be an array of tables. {:?}",
-                        metadata_key, config_meta
-                    );
-                };
-
-                for table in tables {
-                    let Value::InlineTable(table) = table else {
-                        panic!("'{}' items must be inline tables.", metadata_key);
-                    };
-                    if let Some(features) = Self::parse_feature_set(table, config) {
-                        cases.push(features);
-                    }
-                }
-            } else {
-                let Item::Value(Value::InlineTable(table)) = config_meta else {
-                    panic!("'{}' must be an inline table.", metadata_key);
-                };
-
-                if let Some(features) = Self::parse_feature_set(table, config) {
-                    cases.push(features);
-                }
-            }
-        }
-
-        if cases.is_empty() { None } else { Some(cases) }
-    }
-
-    /// Given a device config, return the features which should be enabled for
-    /// this package.
-    ///
-    /// Features are read from Cargo.toml metadata, from the `doc-config` table. Currently only
-    /// one feature set is supported. If the `doc-config` table is not found, this function returns
-    /// `None`. This differs from specifying an empty set of features, which returns `Some(empty
-    /// vector)`.
-    // TODO: perhaps we should use the docs.rs metadata for doc features for packages that have no
-    // chip-specific features.
-    pub fn doc_feature_rules(&self, config: &Config) -> Option<Vec<String>> {
-        if *self == Self::Examples {
-            return None;
-        }
-
-        let features = self
-            .feature_rules_from_metadata(config, "doc-config", false)
-            .and_then(|mut vec_of_vecs| vec_of_vecs.pop());
-
-        log::debug!("Doc features for package '{}': {:?}", self, features);
-        features
-    }
-
-    #[cfg(feature = "semver-checks")]
     fn single_config_rule_from_metadata(
         &self,
         config: &Config,
@@ -496,6 +390,23 @@ impl Package {
         }
 
         None
+    }
+
+    /// Documentation build configuration for this package.
+    ///
+    /// If the `doc-config` table is not found, this function returns `None`. This differs from
+    /// specifying an empty set of features, which returns `Some` with empty `features` and `env`.
+    // TODO: perhaps we should use the docs.rs metadata for doc features for packages that have no
+    // chip-specific features.
+    pub fn doc_config_rules(&self, config: &Config) -> Option<CheckConfig> {
+        if *self == Self::Examples {
+            return None;
+        }
+
+        let config = self.single_config_rule_from_metadata(config, "doc-config");
+
+        log::debug!("Doc config for package '{}': {:?}", self, config);
+        config
     }
 
     /// Configuration for semver checking of this package.

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -402,7 +402,9 @@ fn lint_package(
     let path = workspace.join(package.to_string());
     let features = &check_config.features;
 
-    let mut builder = CargoArgsBuilder::default().subcommand("clippy");
+    let mut builder = CargoArgsBuilder::default()
+        .subcommand("clippy")
+        .manifest_path(path.join("Cargo.toml"));
 
     if !package.build_on_host(features) {
         if chip.is_xtensa() {
@@ -440,8 +442,7 @@ fn lint_package(
     builder.add_env_var("DEFMT_LOG", "trace");
 
     let command = CargoCommandBatcher::build_one_for_cargo(&builder);
-    command
-        .run(false)
+    xtask::cargo::run_with_env(&command.command, &path, command.env_vars, false)
         .with_context(|| format!("Failed to run `cargo clippy` in {}", path.display()))?;
 
     Ok(())

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -260,9 +260,9 @@ fn check_packages(workspace: &Path, args: CheckPackagesArgs) -> Result<()> {
                 continue;
             }
 
-            for mut features in package.check_feature_rules(device) {
+            for mut check_config in package.check_config_rules(device) {
                 if package.has_chip_features() {
-                    features.push(device.name())
+                    check_config.features.push(device.name());
                 }
 
                 commands.push(build_check_package_command(
@@ -270,7 +270,7 @@ fn check_packages(workspace: &Path, args: CheckPackagesArgs) -> Result<()> {
                     *package,
                     chip,
                     &["--no-default-features"],
-                    &features,
+                    &check_config,
                     args.toolchain.as_deref(),
                 )?);
             }
@@ -293,17 +293,19 @@ fn build_check_package_command(
     package: Package,
     chip: &Chip,
     args: &[&str],
-    features: &[String],
+    check_config: &xtask::CheckConfig,
     mut toolchain: Option<&str>,
 ) -> Result<CargoArgsBuilder> {
     log::info!(
-        "Linting package: {} ({}, features: {:?})",
+        "Checking package: {} ({}, features: {:?}, env: {:?})",
         package,
         chip,
-        features
+        check_config.features,
+        check_config.env
     );
 
     let path = workspace.join(package.to_string());
+    let features = &check_config.features;
 
     let mut builder = CargoArgsBuilder::default()
         .subcommand("check")
@@ -330,6 +332,9 @@ fn build_check_package_command(
         builder = builder.arg(format!("--features={}", features.join(",")));
     }
 
+    for (key, value) in &check_config.env {
+        builder.add_env_var(key, value);
+    }
     // TODO: these should come from the outside
     builder.add_env_var("CI", "1");
     builder.add_env_var("DEFMT_LOG", "trace");
@@ -356,9 +361,9 @@ fn lint_packages(workspace: &Path, args: LintPackagesArgs) -> Result<()> {
                 continue;
             }
 
-            for mut features in package.lint_feature_rules(device) {
+            for mut check_config in package.lint_config_rules(device) {
                 if package.has_chip_features() {
-                    features.push(device.name())
+                    check_config.features.push(device.name());
                 }
 
                 lint_package(
@@ -366,7 +371,7 @@ fn lint_packages(workspace: &Path, args: LintPackagesArgs) -> Result<()> {
                     *package,
                     chip,
                     &["--no-default-features"],
-                    &features,
+                    &check_config,
                     args.fix,
                     args.toolchain.as_deref(),
                 )?;
@@ -382,18 +387,20 @@ fn lint_package(
     package: Package,
     chip: &Chip,
     args: &[&str],
-    features: &[String],
+    check_config: &xtask::CheckConfig,
     fix: bool,
     mut toolchain: Option<&str>,
 ) -> Result<()> {
     log::info!(
-        "Linting package: {} ({}, features: {:?})",
+        "Linting package: {} ({}, features: {:?}, env: {:?})",
         package,
         chip,
-        features
+        check_config.features,
+        check_config.env
     );
 
     let path = workspace.join(package.to_string());
+    let features = &check_config.features;
 
     let mut builder = CargoArgsBuilder::default().subcommand("clippy");
 
@@ -420,26 +427,22 @@ fn lint_package(
         builder = builder.arg(format!("--features={}", features.join(",")));
     }
 
-    let builder = if fix {
+    let mut builder = if fix {
         builder.arg("--fix").arg("--lib").arg("--allow-dirty")
     } else {
         builder.arg("--").arg("-D").arg("warnings").arg("--no-deps")
     };
 
-    let cargo_args = builder.build();
+    for (key, value) in &check_config.env {
+        builder.add_env_var(key, value);
+    }
+    builder.add_env_var("CI", "1");
+    builder.add_env_var("DEFMT_LOG", "trace");
 
-    xtask::cargo::run_with_env(
-        &cargo_args,
-        &path,
-        [("CI", "1"), ("DEFMT_LOG", "trace")],
-        false,
-    )
-    .with_context(|| {
-        format!(
-            "Failed to run `cargo run` with {args:?} `CI, `1`, `DEFMT_LOG`, and `trace` envs in {}",
-            path.display()
-        )
-    })?;
+    let command = CargoCommandBatcher::build_one_for_cargo(&builder);
+    command
+        .run(false)
+        .with_context(|| format!("Failed to run `cargo clippy` in {}", path.display()))?;
 
     Ok(())
 }

--- a/xtask/src/semver_check.rs
+++ b/xtask/src/semver_check.rs
@@ -119,6 +119,7 @@ pub(crate) fn build_doc_json(
     let mut cargo_builder = CargoArgsBuilder::default()
         .toolchain("esp")
         .subcommand("rustdoc")
+        .manifest_path(package_path.join("Cargo.toml"))
         .features(&features)
         .target(chip.target())
         .arg("-Zunstable-options")
@@ -139,8 +140,8 @@ pub(crate) fn build_doc_json(
 
     let command = CargoCommandBatcher::build_one_for_cargo(&cargo_builder);
     log::debug!("{command:#?}");
-    command
-        .run(false)
-        .with_context(|| format!("Failed to run `cargo rustdoc` with {command:?}",))?;
+    let cargo_command = command.command.clone();
+    crate::cargo::run_with_env(&command.command, package_path, command.env_vars, false)
+        .with_context(|| format!("Failed to run `cargo rustdoc` with {cargo_command:?}",))?;
     Ok(current_path)
 }

--- a/xtask/src/semver_check.rs
+++ b/xtask/src/semver_check.rs
@@ -8,7 +8,11 @@ use anyhow::{Context, Error};
 use cargo_semver_checks::{Check, GlobalConfig, ReleaseType, Rustdoc};
 use esp_metadata::{Chip, Config};
 
-use crate::{Package, cargo::CargoArgsBuilder, commands::checker::download_baselines};
+use crate::{
+    Package,
+    cargo::{CargoArgsBuilder, CargoCommandBatcher},
+    commands::checker::download_baselines,
+};
 
 /// Return the minimum required bump for the next release.
 /// Even if nothing changed this will be [ReleaseType::Patch]
@@ -100,23 +104,19 @@ pub(crate) fn build_doc_json(
 
     let chip_config = Config::for_chip(chip);
 
-    let semver_feature = package.semver_feature_rules(&chip_config);
-    features.extend(semver_feature);
+    let semver_config = package.semver_config_rules(&chip_config);
+    features.extend(semver_config.features.clone());
 
     log::info!(
-        "Building doc json for {} with features: {:?}",
+        "Building doc json for {} with features: {:?}, env: {:?}",
         package,
-        features
+        features,
+        semver_config.env
     );
-
-    let envs = vec![(
-        "RUSTDOCFLAGS",
-        "--cfg docsrs --cfg not_really_docsrs --cfg semver_checks",
-    )];
 
     // always use `esp` toolchain so we don't have to deal with potentially
     // different versions of the doc-json
-    let cargo_builder = CargoArgsBuilder::default()
+    let mut cargo_builder = CargoArgsBuilder::default()
         .toolchain("esp")
         .subcommand("rustdoc")
         .features(&features)
@@ -128,9 +128,19 @@ pub(crate) fn build_doc_json(
         .arg("--output-format=json")
         .arg("-Zbuild-std=alloc,core")
         .arg("--config=host.rustflags=[\"--cfg=instability_disable_unstable_docs\"]");
-    let cargo_args = cargo_builder.build();
-    log::debug!("{cargo_args:#?}");
-    crate::cargo::run_with_env(&cargo_args, package_path, envs, false)
-        .with_context(|| format!("Failed to run `cargo rustdoc` with {cargo_args:?}",))?;
+
+    for (key, value) in &semver_config.env {
+        cargo_builder.add_env_var(key, value);
+    }
+    cargo_builder.add_env_var(
+        "RUSTDOCFLAGS",
+        "--cfg docsrs --cfg not_really_docsrs --cfg semver_checks",
+    );
+
+    let command = CargoCommandBatcher::build_one_for_cargo(&cargo_builder);
+    log::debug!("{command:#?}");
+    command
+        .run(false)
+        .with_context(|| format!("Failed to run `cargo rustdoc` with {command:?}",))?;
     Ok(current_path)
 }


### PR DESCRIPTION
Closes #5587

cargo-batch is blocking us using TOML 1.1 still