### PR TITLE
Reset modem subsystems on radio init

### DIFF
--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -90,15 +90,15 @@ esp-wifi-sys-esp32h2 = { version = "0.2.0", optional = true }
 esp-wifi-sys-esp32s2 = { version = "0.2.0", optional = true }
 esp-wifi-sys-esp32s3 = { version = "0.2.0", optional = true }
 
-esp32   = { version = "0.40", features = ["critical-section"], optional = true }
+esp32   = { version = "0.40", features = ["critical-section"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "9504df468a04b67b960dc5cc7430788efa257207" }
 esp32c2 = { version = "0.29", features = ["critical-section"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "9504df468a04b67b960dc5cc7430788efa257207" }
-esp32c3 = { version = "0.32", features = ["critical-section"], optional = true }
-esp32c5 = { version = "0.2",  features = ["critical-section"], optional = true }
-esp32c6 = { version = "0.23", features = ["critical-section"], optional = true }
-esp32c61 = { version = "0.3", features = ["critical-section"], optional = true }
-esp32h2 = { version = "0.19", features = ["critical-section"], optional = true }
-esp32s2 = { version = "0.31", features = ["critical-section"], optional = true }
-esp32s3 = { version = "0.35", features = ["critical-section"], optional = true }
+esp32c3 = { version = "0.32", features = ["critical-section"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "9504df468a04b67b960dc5cc7430788efa257207" }
+esp32c5 = { version = "0.2",  features = ["critical-section"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "9504df468a04b67b960dc5cc7430788efa257207" }
+esp32c6 = { version = "0.23", features = ["critical-section"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "9504df468a04b67b960dc5cc7430788efa257207" }
+esp32c61 = { version = "0.3", features = ["critical-section"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "9504df468a04b67b960dc5cc7430788efa257207" }
+esp32h2 = { version = "0.19", features = ["critical-section"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "9504df468a04b67b960dc5cc7430788efa257207" }
+esp32s2 = { version = "0.31", features = ["critical-section"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "9504df468a04b67b960dc5cc7430788efa257207" }
+esp32s3 = { version = "0.35", features = ["critical-section"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "9504df468a04b67b960dc5cc7430788efa257207" }
 
 # Optional dependencies enabling ecosystem features
 embedded-io-06 = { package = "embedded-io", version = "0.6", default-features = false, optional = true }

--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -91,7 +91,7 @@ esp-wifi-sys-esp32s2 = { version = "0.2.0", optional = true }
 esp-wifi-sys-esp32s3 = { version = "0.2.0", optional = true }
 
 esp32   = { version = "0.40", features = ["critical-section"], optional = true }
-esp32c2 = { version = "0.29", features = ["critical-section"], optional = true }
+esp32c2 = { version = "0.29", features = ["critical-section"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "9504df468a04b67b960dc5cc7430788efa257207" }
 esp32c3 = { version = "0.32", features = ["critical-section"], optional = true }
 esp32c5 = { version = "0.2",  features = ["critical-section"], optional = true }
 esp32c6 = { version = "0.23", features = ["critical-section"], optional = true }

--- a/esp-radio/src/common_adapter.rs
+++ b/esp-radio/src/common_adapter.rs
@@ -422,18 +422,18 @@ pub(crate) fn enable_wifi_power_domain() {
     // subsystems in their previous state.
     #[cfg(esp32c2)]
     {
-        const WIFIBB_RST: u32 = 1 << 0;
-        const FE_RST: u32 = 1 << 1;
-        const WIFIMAC_RST: u32 = 1 << 2;
-        const BLE_RPA_RST: u32 = 1 << 27;
-        const MODEM_RESET: u32 = WIFIBB_RST | FE_RST | WIFIMAC_RST | BLE_RPA_RST;
-
-        regs!(APB_CTRL)
-            .wifi_rst_en()
-            .modify(|r, w| unsafe { w.bits(r.bits() | MODEM_RESET) });
-        regs!(APB_CTRL)
-            .wifi_rst_en()
-            .modify(|r, w| unsafe { w.bits(r.bits() & !MODEM_RESET) });
+        regs!(APB_CTRL).wifi_rst_en().modify(|_, w| {
+            w.wifibb_rst().set_bit();
+            w.fe_rst().set_bit();
+            w.mac_rst().set_bit();
+            w.ble_rpa_rst().set_bit()
+        });
+        regs!(APB_CTRL).wifi_rst_en().modify(|_, w| {
+            w.wifibb_rst().clear_bit();
+            w.fe_rst().clear_bit();
+            w.mac_rst().clear_bit();
+            w.ble_rpa_rst().clear_bit()
+        });
     }
 }
 

--- a/esp-radio/src/common_adapter.rs
+++ b/esp-radio/src/common_adapter.rs
@@ -373,67 +373,59 @@ pub(crate) fn enable_wifi_power_domain() {
     // baseband and MAC). On PMU-based chips a system reset restarts the digital core
     // but leaves the modem power domain untouched, so without this the radio
     // would inherit whatever state the previously-used radio left.
-    #[cfg(any(esp32c5, esp32c6, esp32c61))]
-    {
-        regs!(MODEM_SYSCON).modem_rst_conf().modify(|_, w| {
-            w.rst_fe().set_bit();
-            w.rst_btbb().set_bit();
-            w.rst_btbb_apb().set_bit();
-            w.rst_btmac().set_bit();
-            w.rst_btmac_apb().set_bit();
-            w.rst_wifibb().set_bit();
-            w.rst_wifimac().set_bit()
-        });
-        regs!(MODEM_SYSCON).modem_rst_conf().modify(|_, w| {
-            w.rst_fe().clear_bit();
-            w.rst_btbb().clear_bit();
-            w.rst_btbb_apb().clear_bit();
-            w.rst_btmac().clear_bit();
-            w.rst_btmac_apb().clear_bit();
-            w.rst_wifibb().clear_bit();
-            w.rst_wifimac().clear_bit()
-        });
-    }
-
-    // ESP32-H2 has no Wi-Fi baseband/MAC; reset the BT + RF frontend (and the
-    // 802.15.4 MAC) modem subsystems instead.
-    #[cfg(esp32h2)]
-    {
-        regs!(MODEM_SYSCON).modem_rst_conf().modify(|_, w| {
-            w.rst_fe().set_bit();
-            w.rst_btbb().set_bit();
-            w.rst_btbb_apb().set_bit();
-            w.rst_btmac().set_bit();
-            w.rst_btmac_apb().set_bit();
-            w.rst_zbmac().set_bit()
-        });
-        regs!(MODEM_SYSCON).modem_rst_conf().modify(|_, w| {
-            w.rst_fe().clear_bit();
-            w.rst_btbb().clear_bit();
-            w.rst_btbb_apb().clear_bit();
-            w.rst_btmac().clear_bit();
-            w.rst_btmac_apb().clear_bit();
-            w.rst_zbmac().clear_bit()
-        });
-    }
-
-    // ESP32-C2 has no separate modem power domain (RTC_CNTL lacks
-    // wifi_force_pd/iso), but a system reset still leaves the shared modem
-    // subsystems in their previous state.
-    #[cfg(esp32c2)]
-    {
-        regs!(APB_CTRL).wifi_rst_en().modify(|_, w| {
-            w.wifibb_rst().set_bit();
-            w.fe_rst().set_bit();
-            w.mac_rst().set_bit();
-            w.ble_rpa_rst().set_bit()
-        });
-        regs!(APB_CTRL).wifi_rst_en().modify(|_, w| {
-            w.wifibb_rst().clear_bit();
-            w.fe_rst().clear_bit();
-            w.mac_rst().clear_bit();
-            w.ble_rpa_rst().clear_bit()
-        });
+    cfg_select! {
+        any(esp32c5, esp32c6, esp32c61, esp32h2) => {
+            regs!(MODEM_SYSCON).modem_rst_conf().modify(|_, w| {
+                w.rst_fe().set_bit();
+                w.rst_btbb().set_bit();
+                w.rst_btbb_apb().set_bit();
+                w.rst_btmac().set_bit();
+                w.rst_btmac_apb().set_bit();
+                cfg_select! {
+                    any(esp32c5, esp32c6, esp32c61) => {
+                        w.rst_wifibb().set_bit();
+                        w.rst_wifimac().set_bit()
+                    }
+                    esp32h2 => {
+                        w.rst_zbmac().set_bit()
+                    }
+                }
+            });
+            regs!(MODEM_SYSCON).modem_rst_conf().modify(|_, w| {
+                w.rst_fe().clear_bit();
+                w.rst_btbb().clear_bit();
+                w.rst_btbb_apb().clear_bit();
+                w.rst_btmac().clear_bit();
+                w.rst_btmac_apb().clear_bit();
+                cfg_select! {
+                    any(esp32c5, esp32c6, esp32c61) => {
+                        w.rst_wifibb().clear_bit();
+                        w.rst_wifimac().clear_bit()
+                    }
+                    esp32h2 => {
+                        w.rst_zbmac().clear_bit()
+                    }
+                }
+            });
+        }
+        // ESP32-C2 has no separate modem power domain (RTC_CNTL lacks
+        // wifi_force_pd/iso), but a system reset still leaves the shared modem
+        // subsystems in their previous state.
+        esp32c2 => {
+            regs!(APB_CTRL).wifi_rst_en().modify(|_, w| {
+                w.wifibb_rst().set_bit();
+                w.fe_rst().set_bit();
+                w.mac_rst().set_bit();
+                w.ble_rpa_rst().set_bit()
+            });
+            regs!(APB_CTRL).wifi_rst_en().modify(|_, w| {
+                w.wifibb_rst().clear_bit();
+                w.fe_rst().clear_bit();
+                w.mac_rst().clear_bit();
+                w.ble_rpa_rst().clear_bit()
+            });
+        }
+        _ => {}
     }
 }
 

--- a/esp-radio/src/common_adapter.rs
+++ b/esp-radio/src/common_adapter.rs
@@ -368,6 +368,73 @@ pub(crate) fn enable_wifi_power_domain() {
             .dig_iso()
             .modify(|_, w| w.wifi_force_iso().clear_bit());
     }
+
+    // Pulse a reset over the shared modem subsystems (RF frontend, BT/Wi-Fi
+    // baseband and MAC). On PMU-based chips a system reset restarts the digital core
+    // but leaves the modem power domain untouched, so without this the radio
+    // would inherit whatever state the previously-used radio left.
+    #[cfg(any(esp32c5, esp32c6, esp32c61))]
+    {
+        regs!(MODEM_SYSCON).modem_rst_conf().modify(|_, w| {
+            w.rst_fe().set_bit();
+            w.rst_btbb().set_bit();
+            w.rst_btbb_apb().set_bit();
+            w.rst_btmac().set_bit();
+            w.rst_btmac_apb().set_bit();
+            w.rst_wifibb().set_bit();
+            w.rst_wifimac().set_bit()
+        });
+        regs!(MODEM_SYSCON).modem_rst_conf().modify(|_, w| {
+            w.rst_fe().clear_bit();
+            w.rst_btbb().clear_bit();
+            w.rst_btbb_apb().clear_bit();
+            w.rst_btmac().clear_bit();
+            w.rst_btmac_apb().clear_bit();
+            w.rst_wifibb().clear_bit();
+            w.rst_wifimac().clear_bit()
+        });
+    }
+
+    // ESP32-H2 has no Wi-Fi baseband/MAC; reset the BT + RF frontend (and the
+    // 802.15.4 MAC) modem subsystems instead.
+    #[cfg(esp32h2)]
+    {
+        regs!(MODEM_SYSCON).modem_rst_conf().modify(|_, w| {
+            w.rst_fe().set_bit();
+            w.rst_btbb().set_bit();
+            w.rst_btbb_apb().set_bit();
+            w.rst_btmac().set_bit();
+            w.rst_btmac_apb().set_bit();
+            w.rst_zbmac().set_bit()
+        });
+        regs!(MODEM_SYSCON).modem_rst_conf().modify(|_, w| {
+            w.rst_fe().clear_bit();
+            w.rst_btbb().clear_bit();
+            w.rst_btbb_apb().clear_bit();
+            w.rst_btmac().clear_bit();
+            w.rst_btmac_apb().clear_bit();
+            w.rst_zbmac().clear_bit()
+        });
+    }
+
+    // ESP32-C2 has no separate modem power domain (RTC_CNTL lacks
+    // wifi_force_pd/iso), but a system reset still leaves the shared modem
+    // subsystems in their previous state.
+    #[cfg(esp32c2)]
+    {
+        const WIFIBB_RST: u32 = 1 << 0;
+        const FE_RST: u32 = 1 << 1;
+        const WIFIMAC_RST: u32 = 1 << 2;
+        const BLE_RPA_RST: u32 = 1 << 27;
+        const MODEM_RESET: u32 = WIFIBB_RST | FE_RST | WIFIMAC_RST | BLE_RPA_RST;
+
+        regs!(APB_CTRL)
+            .wifi_rst_en()
+            .modify(|r, w| unsafe { w.bits(r.bits() | MODEM_RESET) });
+        regs!(APB_CTRL)
+            .wifi_rst_en()
+            .modify(|r, w| unsafe { w.bits(r.bits() & !MODEM_RESET) });
+    }
 }
 
 /// **************************************************************************

--- a/qa-test/Cargo.toml
+++ b/qa-test/Cargo.toml
@@ -10,7 +10,7 @@ embassy-executor = "0.10.0"
 embassy-time = "0.5.0"
 embassy-futures = "0.1"
 embassy-net = { version = "0.9.0", features = [ "tcp", "udp", "dhcpv4", "medium-ethernet"] }
-embassy-sync = "0.8.0"
+embassy-sync = "0.7.0" # TODO: update to 0.8 once trouble supports it
 embedded-graphics = "0.8.1"
 embedded-hal-async = "1.0.0"
 embedded-io-async = "0.7.0"

--- a/qa-test/src/bin/wifi_ble_modem_handoff.rs
+++ b/qa-test/src/bin/wifi_ble_modem_handoff.rs
@@ -1,0 +1,297 @@
+//! Alternating Wi-Fi / BLE radio stress test
+//!
+//! https://github.com/esp-rs/esp-hal/pull/5670
+//% FEATURES: esp-radio esp-radio/wifi esp-radio/ble esp-radio/unstable esp-hal/unstable
+//% CHIPS: esp32 esp32c3 esp32c5 esp32c6 esp32s3
+
+#![no_std]
+#![no_main]
+#![allow(static_mut_refs)]
+
+use embassy_executor::Spawner;
+use embassy_futures::{join::join, select::select};
+use embassy_time::{Duration, Timer};
+use esp_alloc as _;
+use esp_backtrace as _;
+use esp_hal::{
+    clock::CpuClock,
+    interrupt::software::SoftwareInterruptControl,
+    ram,
+    rng::Rng,
+    system::software_reset,
+    timer::timg::TimerGroup,
+};
+use esp_radio::{
+    ble::controller::BleConnector,
+    wifi::{Config, ControllerConfig, WifiController, ap::AccessPointConfig},
+};
+use log::{info, warn};
+use trouble_host::prelude::*;
+
+esp_bootloader_esp_idf::esp_app_desc!();
+
+/// Iteration counter, retained across software resets via persistent RTC RAM.
+/// Zeroed once on the initial (power-on) boot, then preserved thereafter.
+#[ram(unstable(rtc_fast, persistent))]
+static mut ITERATION: u32 = 0;
+
+const AP_SSID: &str = "esp-handoff";
+
+/// Max number of connections.
+const CONNECTIONS_MAX: usize = 1;
+/// Max number of L2CAP channels.
+const L2CAP_CHANNELS_MAX: usize = 2; // Signal + att
+
+// GATT Server definition
+#[gatt_server]
+struct Server {
+    battery_service: BatteryService,
+}
+
+/// Battery service
+#[gatt_service(uuid = service::BATTERY)]
+struct BatteryService {
+    /// Battery Level
+    #[descriptor(uuid = descriptors::VALID_RANGE, read, value = [0, 100])]
+    #[descriptor(uuid = descriptors::MEASUREMENT_DESCRIPTION, name = "hello", read, value = "Battery Level", type = &'static str)]
+    #[characteristic(uuid = characteristic::BATTERY_LEVEL, read, notify, value = 10)]
+    level: u8,
+    #[characteristic(uuid = "408813df-5dd4-1f87-ec11-cdb001100000", write, read, notify)]
+    status: bool,
+}
+
+fn init_heap() {
+    #[cfg(feature = "esp32")]
+    {
+        esp_alloc::heap_allocator!(#[ram(reclaimed)] size: 96 * 1024);
+        esp_alloc::heap_allocator!(size: 24 * 1024);
+    }
+    #[cfg(not(feature = "esp32"))]
+    {
+        esp_alloc::heap_allocator!(#[ram(reclaimed)] size: 64 * 1024);
+        esp_alloc::heap_allocator!(size: 64 * 1024);
+    }
+}
+
+#[esp_hal::main]
+async fn main(_s: Spawner) -> ! {
+    esp_println::logger::init_logger_from_env();
+
+    let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
+    let peripherals = esp_hal::init(config);
+
+    init_heap();
+
+    let timg0 = TimerGroup::new(peripherals.TIMG0);
+    let sw_int = SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
+    esp_rtos::start(timg0.timer0, sw_int.software_interrupt0);
+
+    // Read the iteration left behind by the previous boot, then bump it so the
+    // next boot (after our software reset) runs the other radio.
+    let iteration = unsafe { ITERATION };
+    unsafe { ITERATION = iteration.wrapping_add(1) };
+
+    let wifi_phase = iteration % 2 == 0;
+
+    // Pseudo-random active window: 3000..=8000 ms (long enough for a central to
+    // find us and connect during the BLE phase).
+    let rng = Rng::new();
+    let active_ms = 3000 + (rng.random() % 5000);
+
+    info!(
+        "iteration {iteration}: {} phase, active for {active_ms} ms",
+        if wifi_phase { "WIFI" } else { "BLE" }
+    );
+
+    if wifi_phase {
+        run_wifi(peripherals.WIFI, active_ms).await;
+    } else {
+        let connector = BleConnector::new(peripherals.BT, Default::default()).unwrap();
+        let controller: ExternalController<_, 1> = ExternalController::new(connector);
+        run_ble_peripheral(controller, active_ms).await;
+    }
+
+    info!("iteration {iteration} done, software reset");
+    // Give the logger a moment to flush before we reset.
+    Timer::after(Duration::from_millis(50)).await;
+
+    software_reset();
+}
+
+/// Bring up a Wi-Fi SoftAP and keep it beaconing for `active_ms`.
+async fn run_wifi(wifi: esp_hal::peripherals::WIFI<'static>, active_ms: u32) {
+    let ap_config = Config::AccessPoint(AccessPointConfig::default().with_ssid(AP_SSID));
+
+    // Creating the controller in AP mode calls `esp_wifi_start()`, so the radio
+    // starts beaconing immediately.
+    let controller = WifiController::new(
+        wifi,
+        ControllerConfig::default().with_initial_config(ap_config),
+    )
+    .unwrap();
+
+    info!("[WIFI] SoftAP '{AP_SSID}' started, beaconing for {active_ms} ms");
+    Timer::after(Duration::from_millis(active_ms as u64)).await;
+
+    // Tear the radio down before the reset so we exercise the deinit path too.
+    core::mem::drop(controller);
+    info!("[WIFI] controller dropped");
+}
+
+/// Run the BLE battery-service peripheral for `active_ms`, then return so the
+/// caller can software-reset. Mirrors the `bas_peripheral` example, but bounded
+/// by the active window instead of looping forever.
+async fn run_ble_peripheral<C>(controller: C, active_ms: u32)
+where
+    C: Controller,
+{
+    // Using a fixed "random" address can be useful for testing. In real scenarios, one would
+    // use e.g. the MAC 6 byte array as the address (how to get that varies by the platform).
+    let address: Address = Address::random([0xff, 0x8f, 0x1a, 0x05, 0xe4, 0xff]);
+    info!("[BLE] our address = {:?}", address);
+
+    let mut resources: HostResources<DefaultPacketPool, CONNECTIONS_MAX, L2CAP_CHANNELS_MAX> =
+        HostResources::new();
+    let stack = trouble_host::new(controller, &mut resources).set_random_address(address);
+    let Host {
+        mut peripheral,
+        runner,
+        ..
+    } = stack.build();
+
+    info!("[BLE] starting advertising and GATT service");
+    let server = Server::new_with_config(GapConfig::Peripheral(PeripheralConfig {
+        name: "TrouBLE",
+        appearance: &appearance::power_device::GENERIC_POWER_DEVICE,
+    }))
+    .unwrap();
+
+    let app = async {
+        loop {
+            match advertise("Trouble Example", &mut peripheral, &server).await {
+                Ok(conn) => {
+                    // set up tasks when the connection is established to a central, so they don't
+                    // run when no one is connected.
+                    let a = gatt_events_task(&server, &conn);
+                    let b = custom_task(&server, &conn, &stack);
+                    // run until any task ends (usually because the connection has been closed),
+                    // then return to advertising state.
+                    select(a, b).await;
+                }
+                Err(e) => {
+                    warn!("[BLE][adv] error: {:?}", e);
+                    Timer::after(Duration::from_millis(100)).await;
+                }
+            }
+        }
+    };
+
+    // Bound the whole BLE phase by the active window so we always get back to
+    // the software reset and alternate with Wi-Fi.
+    let window = Timer::after(Duration::from_millis(active_ms as u64));
+    select(window, join(ble_task(runner), app)).await;
+    info!("[BLE] active window elapsed");
+}
+
+/// This is a background task that is required to run forever alongside any other BLE tasks.
+async fn ble_task<C: Controller, P: PacketPool>(mut runner: Runner<'_, C, P>) {
+    loop {
+        if let Err(e) = runner.run().await {
+            warn!("[BLE][ble_task] error: {:?}", e);
+            Timer::after(Duration::from_millis(100)).await;
+        }
+    }
+}
+
+/// Stream Events until the connection closes.
+async fn gatt_events_task<P: PacketPool>(
+    server: &Server<'_>,
+    conn: &GattConnection<'_, '_, P>,
+) -> Result<(), Error> {
+    let level = server.battery_service.level;
+    let reason = loop {
+        match conn.next().await {
+            GattConnectionEvent::Disconnected { reason } => break reason,
+            GattConnectionEvent::Gatt { event } => {
+                match &event {
+                    GattEvent::Read(event) => {
+                        if event.handle() == level.handle {
+                            let value = server.get(&level);
+                            info!("[BLE][gatt] read level characteristic: {:?}", value);
+                        }
+                    }
+                    GattEvent::Write(event) => {
+                        if event.handle() == level.handle {
+                            info!("[BLE][gatt] write level characteristic: {:?}", event.data());
+                        }
+                    }
+                    _ => {}
+                };
+                // This step is also performed at drop(), but writing it explicitly is necessary
+                // in order to ensure reply is sent.
+                match event.accept() {
+                    Ok(reply) => reply.send().await,
+                    Err(e) => warn!("[BLE][gatt] error sending response: {:?}", e),
+                };
+            }
+            _ => {} // ignore other Gatt Connection Events
+        }
+    };
+    info!("[BLE][gatt] disconnected: {:?}", reason);
+    Ok(())
+}
+
+/// Create an advertiser to use to connect to a BLE Central, and wait for it to connect.
+async fn advertise<'values, 'server, C: Controller>(
+    name: &'values str,
+    peripheral: &mut Peripheral<'values, C, DefaultPacketPool>,
+    server: &'server Server<'values>,
+) -> Result<GattConnection<'values, 'server, DefaultPacketPool>, BleHostError<C::Error>> {
+    let mut advertiser_data = [0; 31];
+    let len = AdStructure::encode_slice(
+        &[
+            AdStructure::Flags(LE_GENERAL_DISCOVERABLE | BR_EDR_NOT_SUPPORTED),
+            AdStructure::ServiceUuids16(&[[0x0f, 0x18]]),
+            AdStructure::CompleteLocalName(name.as_bytes()),
+        ],
+        &mut advertiser_data[..],
+    )?;
+    let advertiser = peripheral
+        .advertise(
+            &Default::default(),
+            Advertisement::ConnectableScannableUndirected {
+                adv_data: &advertiser_data[..len],
+                scan_data: &[],
+            },
+        )
+        .await?;
+    info!("[BLE][adv] advertising");
+    let conn = advertiser.accept().await?.with_attribute_server(server)?;
+    info!("[BLE][adv] connection established");
+    Ok(conn)
+}
+
+/// Notify the connected central of a counter value and read RSSI every 2 seconds.
+async fn custom_task<C: Controller, P: PacketPool>(
+    server: &Server<'_>,
+    conn: &GattConnection<'_, '_, P>,
+    stack: &Stack<'_, C, P>,
+) {
+    let mut tick: u8 = 0;
+    let level = server.battery_service.level;
+    loop {
+        tick = tick.wrapping_add(1);
+        info!("[BLE][custom_task] notifying connection of tick {}", tick);
+        if level.notify(conn, &tick).await.is_err() {
+            info!("[BLE][custom_task] error notifying connection");
+            break;
+        };
+        if let Ok(rssi) = conn.raw().rssi(stack).await {
+            info!("[BLE][custom_task] RSSI: {:?}", rssi);
+        } else {
+            info!("[BLE][custom_task] error getting RSSI");
+            break;
+        };
+        Timer::after_secs(2).await;
+    }
+}

--- a/qa-test/src/bin/wifi_ble_modem_handoff.rs
+++ b/qa-test/src/bin/wifi_ble_modem_handoff.rs
@@ -1,8 +1,11 @@
 //! Alternating Wi-Fi / BLE radio stress test
 //!
 //! https://github.com/esp-rs/esp-hal/pull/5670
+//!
+//! The easiest way to reproduce the crash is to press Ctrl+R during the Wi-Fi phase.
+//! In the next iteration, when it enters the BLE phase, it should crash immediately.
 //% FEATURES: esp-radio esp-radio/wifi esp-radio/ble esp-radio/unstable esp-hal/unstable
-//% CHIPS: esp32 esp32c3 esp32c5 esp32c6 esp32s3
+//% CHIP_FILTER: wifi_driver_supported && bt_driver_supported && !esp32c2 && !esp32c61
 
 #![no_std]
 #![no_main]
@@ -30,10 +33,38 @@ use trouble_host::prelude::*;
 
 esp_bootloader_esp_idf::esp_app_desc!();
 
-/// Iteration counter, retained across software resets via persistent RTC RAM.
-/// Zeroed once on the initial (power-on) boot, then preserved thereafter.
+/// Iteration counter, retained across software resets.
+///
+/// Most chips keep it in persistent RTC fast RAM: zeroed once on the initial
+/// (power-on) boot, then preserved thereafter. The ESP32-C2 has no RTC fast RAM,
+/// so it stashes the counter in an otherwise-unused RTC_CNTL scratch register
+/// (`STORE6`), which likewise survives a software reset and is cleared only on
+/// power-on reset.
+#[cfg(not(feature = "esp32c2"))]
 #[ram(unstable(rtc_fast, persistent))]
 static mut ITERATION: u32 = 0;
+
+#[cfg(not(feature = "esp32c2"))]
+fn load_iteration() -> u32 {
+    unsafe { ITERATION }
+}
+
+#[cfg(not(feature = "esp32c2"))]
+fn store_iteration(value: u32) {
+    unsafe { ITERATION = value };
+}
+
+#[cfg(feature = "esp32c2")]
+fn load_iteration() -> u32 {
+    esp_hal::peripherals::LPWR::regs().store6().read().bits()
+}
+
+#[cfg(feature = "esp32c2")]
+fn store_iteration(value: u32) {
+    esp_hal::peripherals::LPWR::regs()
+        .store6()
+        .write(|w| unsafe { w.bits(value) });
+}
 
 const AP_SSID: &str = "esp-handoff";
 
@@ -88,8 +119,8 @@ async fn main(_s: Spawner) -> ! {
 
     // Read the iteration left behind by the previous boot, then bump it so the
     // next boot (after our software reset) runs the other radio.
-    let iteration = unsafe { ITERATION };
-    unsafe { ITERATION = iteration.wrapping_add(1) };
+    let iteration = load_iteration();
+    store_iteration(iteration.wrapping_add(1));
 
     let wifi_phase = iteration % 2 == 0;
 

--- a/qa-test/src/bin/wifi_ble_modem_handoff.rs
+++ b/qa-test/src/bin/wifi_ble_modem_handoff.rs
@@ -5,7 +5,7 @@
 //! The easiest way to reproduce the crash is to press Ctrl+R during the Wi-Fi phase.
 //! In the next iteration, when it enters the BLE phase, it should crash immediately.
 //% FEATURES: esp-radio esp-radio/wifi esp-radio/ble esp-radio/unstable esp-hal/unstable
-//% CHIP_FILTER: wifi_driver_supported && bt_driver_supported && !esp32c2 && !esp32c61
+//% CHIP_FILTER: wifi_driver_supported && bt_driver_supported
 
 #![no_std]
 #![no_main]
@@ -36,34 +36,40 @@ esp_bootloader_esp_idf::esp_app_desc!();
 /// Iteration counter, retained across software resets.
 ///
 /// Most chips keep it in persistent RTC fast RAM: zeroed once on the initial
-/// (power-on) boot, then preserved thereafter. The ESP32-C2 has no RTC fast RAM,
-/// so it stashes the counter in an otherwise-unused RTC_CNTL scratch register
-/// (`STORE6`), which likewise survives a software reset and is cleared only on
+/// (power-on) boot, then preserved thereafter. The ESP32-C2 and ESP32-C61 have
+/// no persistent RTC fast RAM, so they stash the counter in an otherwise-unused
+/// always-on scratch register (`STORE6`) - on C2 in `RTC_CNTL`, on C61 in
+/// `LP_AON` - which likewise survives a software reset and is cleared only on
 /// power-on reset.
-#[cfg(not(feature = "esp32c2"))]
+#[cfg(not(any(feature = "esp32c2", feature = "esp32c61")))]
 #[ram(unstable(rtc_fast, persistent))]
 static mut ITERATION: u32 = 0;
 
-#[cfg(not(feature = "esp32c2"))]
 fn load_iteration() -> u32 {
-    unsafe { ITERATION }
+    cfg_select! {
+        feature = "esp32c2" => {
+            esp_hal::peripherals::LPWR::regs().store6().read().bits()
+        },
+        feature = "esp32c61" => {
+            esp_hal::peripherals::LP_AON::regs().store6().read().bits()
+        },
+        _ => unsafe { ITERATION },
+    }
 }
-
-#[cfg(not(feature = "esp32c2"))]
 fn store_iteration(value: u32) {
-    unsafe { ITERATION = value };
-}
-
-#[cfg(feature = "esp32c2")]
-fn load_iteration() -> u32 {
-    esp_hal::peripherals::LPWR::regs().store6().read().bits()
-}
-
-#[cfg(feature = "esp32c2")]
-fn store_iteration(value: u32) {
-    esp_hal::peripherals::LPWR::regs()
-        .store6()
-        .write(|w| unsafe { w.bits(value) });
+    cfg_select! {
+        feature = "esp32c2" => {
+            esp_hal::peripherals::LPWR::regs()
+                .store6()
+                .write(|w| unsafe { w.bits(value) });
+        },
+        feature = "esp32c61" => {
+            esp_hal::peripherals::LP_AON::regs()
+                .store6()
+                .write(|w| unsafe { w.bits(value) });
+        },
+        _ => unsafe { ITERATION = value },
+    }
 }
 
 const AP_SSID: &str = "esp-handoff";
@@ -92,15 +98,15 @@ struct BatteryService {
 }
 
 fn init_heap() {
-    #[cfg(feature = "esp32")]
-    {
-        esp_alloc::heap_allocator!(#[ram(reclaimed)] size: 96 * 1024);
-        esp_alloc::heap_allocator!(size: 24 * 1024);
-    }
-    #[cfg(not(feature = "esp32"))]
-    {
-        esp_alloc::heap_allocator!(#[ram(reclaimed)] size: 64 * 1024);
-        esp_alloc::heap_allocator!(size: 64 * 1024);
+    cfg_select! {
+        feature = "esp32" => {
+            esp_alloc::heap_allocator!(#[ram(reclaimed)] size: 96 * 1024);
+            esp_alloc::heap_allocator!(size: 24 * 1024);
+        },
+        _ => {
+            esp_alloc::heap_allocator!(#[ram(reclaimed)] size: 64 * 1024);
+            esp_alloc::heap_allocator!(size: 64 * 1024);
+        },
     }
 }
 


### PR DESCRIPTION
On PMU chips, a system reset (**JTAG**) leaves the modem domain intact, so the radio inherits stale RF/baseband state and trips controller asserts (e.g. `r_ble_lll_mmgmt_block_copy`).

This PR resets modem subsystems in `enable_wifi_power_domain()` (C2/C5/C6/C61/H2) so the radio doesn't inherit stale RF/baseband state across system resets, which tripped controller asserts. 

Should at least fix crashes described in https://github.com/esp-rs/esp-hal/pull/5670. 
~~I'm not 100% sure this resolves #4004.~~
closes #4004 

Do we want to add this to changelog? 