### PR TITLE
Clear crypto secrets

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -579,7 +579,7 @@ jobs:
             - `/hil <chip1> [<chip2> ...]` — run the full HIL tests **only** for the listed chips
             - `/test-size <example_name> [--package <pkg>] <chip1> [chip2 ...]` — run binary size analysis for the specified example on one or more chips. Example: `/test-size embassy_hello_world esp32c3 esp32c6` or `/test-size sleep_timer --package qa-test esp32c3`
             - You can optionally append `--test <name>[,<name>...]` to any `/hil` command to only run selected tests.
-            - You can optionally include `hil-test-radio` in the comment body of any `/hil` command to run radio HIL instead of the default `hil-test` package.           
+            - You can optionally include `hil-test-radio` in the comment body of any `/hil` command to run radio HIL instead of the default `hil-test` package.
             If you aren't a repository **member/owner**, you must be **trusted for this PR**.
             Maintainers can grant access with a `trusted-author` label or with:
             ```

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -22,6 +22,7 @@ check-configs = [
     { features = ["rt"] },
     { features = ["unstable", "rt"] },
     { features = ["unstable", "rt"], env = { ESP_HAL_CONFIG_PLACE_ANON_IN_RAM = "true", ESP_HAL_CONFIG_PLACE_RMT_DRIVER_IN_RAM = "true", ESP_HAL_CONFIG_PLACE_SPI_MASTER_DRIVER_IN_RAM = "true" } },
+    { features = ["unstable", "rt"], env = { ESP_HAL_CONFIG_CLEAR_CRYPTO_SECRETS = "false" } },
     { features = ["unstable", "rt", "__usb_otg"],   if = 'usb_otg_driver_supported' },
     { features = ["unstable", "rt", "__bluetooth"], if = 'bt_driver_supported' },
 ]

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -21,8 +21,7 @@ check-configs = [
     { features = [] },
     { features = ["rt"] },
     { features = ["unstable", "rt"] },
-    { features = ["unstable", "rt"], env = { ESP_HAL_CONFIG_PLACE_ANON_IN_RAM = "true", ESP_HAL_CONFIG_PLACE_RMT_DRIVER_IN_RAM = "true", ESP_HAL_CONFIG_PLACE_SPI_MASTER_DRIVER_IN_RAM = "true" } },
-    { features = ["unstable", "rt"], env = { ESP_HAL_CONFIG_CLEAR_CRYPTO_SECRETS = "false" } },
+    { features = ["unstable", "rt"], env = { ESP_HAL_CONFIG_PLACE_ANON_IN_RAM = "true", ESP_HAL_CONFIG_PLACE_RMT_DRIVER_IN_RAM = "true", ESP_HAL_CONFIG_PLACE_SPI_MASTER_DRIVER_IN_RAM = "true", ESP_HAL_CONFIG_CLEAR_CRYPTO_SECRETS = "false" } },
     { features = ["unstable", "rt", "__usb_otg"],   if = 'usb_otg_driver_supported' },
     { features = ["unstable", "rt", "__bluetooth"], if = 'bt_driver_supported' },
 ]

--- a/esp-hal/esp_config.yml
+++ b/esp-hal/esp_config.yml
@@ -199,5 +199,13 @@ options:
     default:
       - value: false
 
+  - name: clear-crypto-secrets
+    description: "Clear secret material (keys, exponents, intermediate results) from
+      the crypto accelerator registers after each operation. Disabling
+      this leaves secret material in the peripheral until a subsequent operation
+      overwrites it."
+    default:
+      - value: true
+
 checks:
   - "ESP_HAL_CONFIG_STACK_GUARD_OFFSET % 4 == 0"

--- a/esp-hal/esp_config.yml
+++ b/esp-hal/esp_config.yml
@@ -1,5 +1,9 @@
 crate: esp-hal
 
+# When adding an option whose non-default value changes the compiled code, set it via `env` in the
+# non-default `check-configs` entry in `Cargo.toml` of an appropriate crate (e.g.
+# `ESP_HAL_CONFIG_<NAME> = "false"`) so CI can check if the crate builds with non-default configurations.
+
 options:
   - name: place-spi-master-driver-in-ram
     description: Places the SPI master driver in RAM for better performance

--- a/esp-hal/src/aes/mod.rs
+++ b/esp-hal/src/aes/mod.rs
@@ -216,6 +216,12 @@ impl<'d> Aes<'d> {
         }
     }
 
+    /// Clears all key registers, no key material should be left in the peripheral.
+    #[cfg(clear_crypto_secrets)]
+    fn clear_key(&mut self) {
+        self.write_key(&[0; 32]);
+    }
+
     fn write_block(&mut self, block: &[u8]) {
         for (i, word) in read_words(block).enumerate() {
             cfg_if::cfg_if! {
@@ -256,6 +262,11 @@ impl<'d> Aes<'d> {
         self.start();
         while !(self.is_idle()) {}
         self.read_block(block);
+
+        // The `key` is dropped, but the hardware retains a copy in the key registers, clear them
+        // too.
+        #[cfg(clear_crypto_secrets)]
+        self.clear_key();
     }
 
     /// Encrypts the given buffer with the given key.
@@ -321,6 +332,9 @@ impl<'d> Aes<'d> {
                 }
             }
         }
+
+        #[cfg(clear_crypto_secrets)]
+        self.clear_key();
     }
 }
 

--- a/esp-hal/src/ecc.rs
+++ b/esp-hal/src/ecc.rs
@@ -118,6 +118,10 @@ from the bitlength of the prime fields of the curve."]
                     ) -> Result<EccResultHandle<'op, $op>, KeyLengthMismatch> {
                         curve.size_check([$($input),*])?;
 
+                        // Wipe any secrets left over from the previous operation before loading the new operands.
+                        #[cfg(clear_crypto_secrets)]
+                        self.info().clear_secrets();
+
                         paste::paste! {
                             $(
                                 self.info().write_mem(self.info().[<$input _mem>](), $input);
@@ -657,6 +661,29 @@ impl Info {
         self.read_mem(self.qz_mem(), qz);
     }
 
+    /// Clears all peripheral memory blocks
+    #[cfg(clear_crypto_secrets)]
+    fn clear_secrets(&self) {
+        self.zero_mem(self.k_mem());
+        self.zero_mem(self.px_mem());
+        self.zero_mem(self.py_mem());
+
+        #[cfg(ecc_separate_jacobian_point_memory)]
+        {
+            self.zero_mem(self.qx_mem());
+            self.zero_mem(self.qy_mem());
+            self.zero_mem(self.qz_mem());
+        }
+    }
+
+    #[cfg(clear_crypto_secrets)]
+    fn zero_mem(&self, mut word_ptr: *mut u32) {
+        for _ in 0..(MEM_BLOCK_SIZE / 4) {
+            unsafe { word_ptr.write_volatile(0) };
+            word_ptr = word_ptr.wrapping_add(1);
+        }
+    }
+
     fn is_busy(&self) -> bool {
         self.regs.mult_conf().read().start().bit_is_set()
     }
@@ -1134,6 +1161,9 @@ impl<'d> EccBackend<'d> {
 
         item.point_verification_result = driver.info().check_point_verification_result().is_ok();
 
+        #[cfg(clear_crypto_secrets)]
+        driver.info().clear_secrets();
+
         Poll::Ready(Status::Completed)
     }
 
@@ -1142,6 +1172,11 @@ impl<'d> EccBackend<'d> {
             unreachable!()
         };
         driver.reset();
+
+        // The operands may have already been written to the peripheral.
+        #[cfg(clear_crypto_secrets)]
+        driver.info().clear_secrets();
+
         item.cancelled = true;
     }
 

--- a/esp-hal/src/rsa/mod.rs
+++ b/esp-hal/src/rsa/mod.rs
@@ -263,6 +263,26 @@ impl<'d, Dm: DriverMode> Rsa<'d, Dm> {
         for (reg, op) in self.regs().z_mem_iter().zip(outbuf.iter_mut()) {
             *op = reg.read().bits();
         }
+
+        #[cfg(clear_crypto_secrets)]
+        self.clear_secrets();
+    }
+
+    /// Removes the operands and intermediate results from the peripheral.
+    #[cfg(clear_crypto_secrets)]
+    fn clear_secrets(&self) {
+        for reg in self.regs().x_mem_iter() {
+            reg.write(|w| unsafe { w.bits(0) });
+        }
+        for reg in self.regs().y_mem_iter() {
+            reg.write(|w| unsafe { w.bits(0) });
+        }
+        for reg in self.regs().z_mem_iter() {
+            reg.write(|w| unsafe { w.bits(0) });
+        }
+        for reg in self.regs().m_mem_iter() {
+            reg.write(|w| unsafe { w.bits(0) });
+        }
     }
 
     fn read_results(&mut self, outbuf: &mut [u32]) {


### PR DESCRIPTION
closes https://github.com/esp-rs/esp-hal/issues/3189

I'm wondering if config option is reasonable here 🤔 . I just thought about the cases when user might not want their crypto inter-values to be deleted, that's the only reason why that option has been introduced

SHA - nothing to do, keyless hash
HMAC - nothing to do, takes stuff from eFuse block

---

<!-- ============================================================
  Changelog and migration guide entries live here in the PR body.
  They will be collected automatically at release time.
  Delete any section that doesn't apply to your PR.
  ============================================================ -->

# Changelog

## esp-hal

- Added: `ESP_HAL_CONFIG_CLEAR_CRYPTO_SECRETS` option (enabled by default) that clears operands and intermediate values from crypto peripheral registers after each operation