### PR TITLE
CI(hil): Skip package instead of erroring when `--tests` filter doesn't match

### DIFF
--- a/.github/scripts/hil-parse.js
+++ b/.github/scripts/hil-parse.js
@@ -19,7 +19,7 @@ function parsePackage(body) {
   if (text.includes("hil-test")) {
     return "hil-test";
   }
-  return "all";
+  return "hil-test";
 }
 
 function parseTests(body) {

--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -579,7 +579,7 @@ jobs:
             - `/hil <chip1> [<chip2> ...]` — run the full HIL tests **only** for the listed chips
             - `/test-size <example_name> [--package <pkg>] <chip1> [chip2 ...]` — run binary size analysis for the specified example on one or more chips. Example: `/test-size embassy_hello_world esp32c3 esp32c6` or `/test-size sleep_timer --package qa-test esp32c3`
             - You can optionally append `--test <name>[,<name>...]` to any `/hil` command to only run selected tests.
-            - You can optionally include `hil-test` or `hil-test-radio` in the comment body of any `/hil` command to limit the run to that package (default: both are run).
+            - You can optionally include `hil-test-radio` in the comment body of any `/hil` command to run radio HIL instead of the default `hil-test` package.           
             If you aren't a repository **member/owner**, you must be **trusted for this PR**.
             Maintainers can grant access with a `trusted-author` label or with:
             ```

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -24,7 +24,7 @@ on:
         description: '"hil-test", "hil-test-radio", or "all"'
         required: false
         type: string
-        default: "all"
+        default: "hil-test"
       # Not used by the workflow_call path, but referenced in run-name; declared
       # here (with empty defaults) so that expression is well-defined for both
       # triggers.
@@ -60,7 +60,7 @@ on:
         default: ""
       package:
         description: '"hil-test", "hil-test-radio", or "all"'
-        default: "all"
+        default: "hil-test"
       distinct_id:
         description: "Correlation marker set by the dispatcher; do not set manually"
         required: false

--- a/documentation/HIL-GUIDE.md
+++ b/documentation/HIL-GUIDE.md
@@ -46,12 +46,17 @@ Examples:
 Runs **only chosen** HIL tests for selected chip(-s) or matrix.
 
 Examples:
+
 - `/hil quick --test rmt`
 - `/hil esp32 esp32c6 --tests rmt, i2c`
+- `/hil esp32c6 hil-test-radio`
+- `/hil esp32c6 hil-test-radio --tests wifi`
 
 Both `--test` and `--tests` will work.
 
-Please note that e.g. `/hil esp32s2 --test esp_radio::wifi_controller::tests::test_scan_doesnt_leak` will not work the same as running a specific test via `xtask`, because we use the `xtask` subcommand “run elfs” to run HIL tests in CI. Consequently, the command will be accepted by the bot, but the entire binary file will be run (in the case above, the entire `wifi_controller` test). 
+Please note that e.g. `/hil esp32s2 --test esp_radio::wifi_controller::tests::test_scan_doesnt_leak` will not work the same as running a specific test via `xtask`, because we use the `xtask` subcommand “run elfs” to run HIL tests in CI. Consequently, the command will be accepted by the bot, but the entire binary file will be run (in the case above, the entire `wifi_controller` test).
+
+By default, `/hil` commands run the `hil-test` package. Include `hil-test-radio` in the comment body to run the radio HIL package instead.
 
 ### `/test-size`
 


### PR DESCRIPTION
The `--tests` filters from the HIL workflow are applied to both `hil-test` and `hil-test-radio`. Since the packages have disjoint test sets, a test that is valid in one package can cause a "Test not found" error in the other.

This PR updates xtask so that missing test names are treated as skips for that package rather than fatal errors, allowing the same `--tests` filter to be used across multiple packages.

cc https://github.com/esp-rs/esp-hal/actions/runs/27205422326/job/80319846847#step:12:28 