### PR TITLE
Set an actual `tx_power` default value, document related connection failures

### DIFF
--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -44,8 +44,8 @@
 //!
 //! If WiFi connections fail, especially on boards with a small or low-quality antenna or when the
 //! device is placed inside an enclosure, the TX power may need to be increased. The default
-//! maximum TX power is 20 (5dBm) on the 0.25dBm scale used by [`WifiController::set_max_tx_power`].
-//! Try increasing it if connections are unreliable.
+//! maximum TX power is 20 (5dBm) on the 0.25dBm scale used by `WifiController::set_max_tx_power`
+//! (requires the `unstable` feature). Try increasing it if connections are unreliable.
 
 use alloc::{borrow::ToOwned, collections::vec_deque::VecDeque, str, vec::Vec};
 use core::{

--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -42,10 +42,11 @@
 //!
 //! ### Connection failures on boards with a weak antenna or in a poor RF environment
 //!
-//! If WiFi connections fail, especially on boards with a small or low-quality antenna or when the
-//! device is placed inside an enclosure, the TX power may need to be increased. The default
-//! maximum TX power is 20 (5dBm) on the 0.25dBm scale used by `WifiController::set_max_tx_power`
-//! (requires the `unstable` feature). Try increasing it if connections are unreliable.
+//! The default maximum TX power is 20 (5dBm) on the 0.25dBm scale. The optimal value is
+//! board-dependent: if connections are unreliable, try adjusting it via
+//! `WifiController::set_max_tx_power` (requires the `unstable` feature) using a value in the
+//! range [8, 84]. Note that values above roughly 65 (~16dBm) have been reported to cause
+//! authentication failures on some hardware, so setting it to the maximum is not always better.
 
 use alloc::{borrow::ToOwned, collections::vec_deque::VecDeque, str, vec::Vec};
 use core::{
@@ -2090,9 +2091,10 @@ impl CountryInfo {
             // TODO: these may be valid defaults, but they should be configurable.
             schan: 1,
             nchan: 13,
-            // 20 on the 0.25dBm scale (5dBm). Can be overridden via
-            // WifiController::set_max_tx_power. See https://github.com/esp-rs/esp-hal/issues/5631#issuecomment-4634839995
-            max_tx_power: 20,
+            // This field is output-only: esp_wifi_set_country ignores it. The actual TX power
+            // is controlled exclusively via esp_wifi_set_max_tx_power after WiFi start.
+            // See: https://github.com/espressif/esp-idf/blob/20f5e18/components/esp_wifi/include/esp_wifi_types.h#L46
+            max_tx_power: 0,
             policy: wifi_country_policy_t_WIFI_COUNTRY_POLICY_MANUAL,
 
             #[cfg(wifi_has_5g)]
@@ -2394,6 +2396,9 @@ impl<'d> WifiController<'d> {
         controller.set_power_saving(PowerSaveMode::default())?;
 
         controller.set_config(&config.initial_config)?;
+
+        // Set a default TX power
+        esp_wifi_result!(unsafe { esp_wifi_set_max_tx_power(20) })?;
 
         Ok(controller)
     }
@@ -2813,10 +2818,9 @@ ignored."
     /// Set maximum transmitting power after WiFi start.
     ///
     /// Power unit is 0.25dBm, range is [8, 84] corresponding to 2dBm - 20dBm. The default is
-    /// 20 (5dBm). If WiFi connections are unreliable or you are experiencing problems connecting to
-    /// the AP, especially on boards with a weak or low-quality antenna, try increasing this
-    /// value. See the [module-level troubleshooting section](self#troubleshooting) for more
-    /// details.
+    /// 20 (5dBm). Values above roughly 65 (~16dBm) have been reported to cause authentication
+    /// failures on some hardware. See the
+    /// [module-level troubleshooting section](self#troubleshooting) for details.
     #[instability::unstable]
     pub fn set_max_tx_power(&mut self, power: i8) -> Result<(), WifiError> {
         esp_wifi_result!(unsafe { esp_wifi_set_max_tx_power(power) })

--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -37,6 +37,15 @@
 //!
 //! Please note that the configuration keys are usually named slightly different and not all
 //! configuration keys apply.
+//!
+//! ## Troubleshooting
+//!
+//! ### Connection failures on boards with a weak antenna or in a poor RF environment
+//!
+//! If WiFi connections fail, especially on boards with a small or low-quality antenna or when the
+//! device is placed inside an enclosure, the TX power may need to be increased. The default
+//! maximum TX power is 20 (5dBm) on the 0.25dBm scale used by [`WifiController::set_max_tx_power`].
+//! Try increasing it if connections are unreliable.
 
 use alloc::{borrow::ToOwned, collections::vec_deque::VecDeque, str, vec::Vec};
 use core::{
@@ -2081,6 +2090,8 @@ impl CountryInfo {
             // TODO: these may be valid defaults, but they should be configurable.
             schan: 1,
             nchan: 13,
+            // 20 on the 0.25dBm scale (5dBm). Can be overridden via
+            // WifiController::set_max_tx_power. See https://github.com/esp-rs/esp-hal/issues/5631#issuecomment-4634839995
             max_tx_power: 20,
             policy: wifi_country_policy_t_WIFI_COUNTRY_POLICY_MANUAL,
 
@@ -2801,7 +2812,11 @@ ignored."
 
     /// Set maximum transmitting power after WiFi start.
     ///
-    /// Power unit is 0.25dBm, range is [8, 84] corresponding to 2dBm - 20dBm.
+    /// Power unit is 0.25dBm, range is [8, 84] corresponding to 2dBm - 20dBm. The default is
+    /// 20 (5dBm). If WiFi connections are unreliable or you are experiencing problems connecting to
+    /// the AP, especially on boards with a weak or low-quality antenna, try increasing this
+    /// value. See the [module-level troubleshooting section](self#troubleshooting) for more
+    /// details.
     #[instability::unstable]
     pub fn set_max_tx_power(&mut self, power: i8) -> Result<(), WifiError> {
         esp_wifi_result!(unsafe { esp_wifi_set_max_tx_power(power) })


### PR DESCRIPTION
closes https://github.com/esp-rs/esp-hal/issues/5631

The issue in the original ticket turned out to be hardware-specific: it may occur on boards with poor antennas or in RF-noisy environments. It can be resolved by increasing `max_tx_power`, this is what's being documented in this PR