### PR TITLE
Rework esp-config conditional expressions

### DIFF
--- a/esp-backtrace/esp_config.yml
+++ b/esp-backtrace/esp_config.yml
@@ -18,4 +18,4 @@ options:
             - "8K"
             - "16K"
             - "32K"
-    active: 'chip == "esp32c2" || chip == "esp32c3" || chip == "esp32c6" || chip == "esp32h2"'
+    active: "esp32c2 || esp32c3 || esp32c6 || esp32h2"

--- a/esp-config/README.md
+++ b/esp-config/README.md
@@ -97,13 +97,13 @@ checks:
 The expression supports these custom functions:
 |Function|Description|
 |---|---|
-|feature(String)|`true` if the given chip feature is present|
 |cargo_feature(String)|`true` if the given Cargo feature is active|
 |ignore_feature_gates|Usually `false` but tooling will set this to `true` to hint that the expression is evaluated by e.g. a TUI|
 
 `ignore_feature_gates` is useful to enable otherwise disabled functionality - e.g. to offer all possible options regardless of any active / non-active features.
 
-The `chip` variable is populated with the name of the targeted chip (if the crate is using chip specific features).
+All `esp-metadata-generated` symbols are available for use as variables. Simple symbols are available as booleans, `key = "value"` pairs are available as strings.
+If a symbol is not defined for a particular chip, it will be substituted as `false` or an empty string.
 
 The conditions for `default` and `constraints` are evaluated in order and the first match is taken no matter if there is more.
 This way you could have a catch-all condition as the last item by just specifying `true`.

--- a/esp-config/README.md
+++ b/esp-config/README.md
@@ -71,9 +71,9 @@ options:
 - name: esp_idf_version
   description: ESP-IDF version used in the application descriptor. Currently it's not checked by the bootloader.
   default:
-    - if: 'chip == "esp32c6"'
+    - if: 'esp32c6'
       value: '"esp32c6"'
-    - if: 'chip == "esp32"'
+    - if: 'esp32'
       value: '"other"'
   active: true
 
@@ -86,7 +86,7 @@ options:
     - if: true
       value: 32768
   stability: Unstable
-  active: 'chip == "esp32c6"'
+  active: 'esp32c6'
 
 checks:
   - 'ESP_BOOTLOADER_ESP_IDF_CONFIG_PARTITION_TABLE_OFFSET >= 32768'

--- a/esp-config/src/generate/mod.rs
+++ b/esp-config/src/generate/mod.rs
@@ -201,10 +201,32 @@ pub fn evaluate_yaml_config(
     let config: Config = serde_yaml::from_str(yaml).map_err(|err| Error::Parse(err.to_string()))?;
     let mut options = Vec::new();
     let mut eval_ctx = somni_expr::Context::new();
-    if let Some(chip) = chip {
-        eval_ctx.add_variable("chip", chip.name());
+
+    for c in esp_metadata_generated::Chip::iter() {
+        if chip != Some(c) {
+            eval_ctx.add_variable(c.name(), false);
+            for symbol in c.all_symbols() {
+                if let Some((key, _value)) = symbol.split_once('=') {
+                    eval_ctx.add_variable(key.trim(), "");
+                } else {
+                    eval_ctx.add_variable(symbol, false);
+                }
+            }
+        } else {
+            eval_ctx.add_variable(c.name(), true);
+            for symbol in c.all_symbols() {
+                if let Some((key, value)) = symbol.split_once('=') {
+                    let value = value.trim().trim_matches('"');
+                    eval_ctx.add_variable(key.trim(), value);
+                } else {
+                    eval_ctx.add_variable(symbol, true);
+                }
+            }
+        }
+    }
+
+    if chip.is_some() {
         eval_ctx.add_variable("ignore_feature_gates", ignore_feature_gates);
-        eval_ctx.add_function("feature", move |feature: &str| chip.contains(feature));
         eval_ctx.add_function("cargo_feature", |feature: &str| {
             features.contains(&feature.to_uppercase().replace("-", "_"))
         });
@@ -968,9 +990,9 @@ options:
 - name: esp_idf_version
   description: ESP-IDF version used in the application descriptor. Currently it's not checked by the bootloader.
   default:
-    - if: 'chip == "esp32c6"'
+    - if: 'esp32c6'
       value: '"esp32c6"'
-    - if: 'chip == "esp32"'
+    - if: 'esp32'
       value: '"other"'
   active: true
 
@@ -983,7 +1005,7 @@ options:
     - if: true
       value: 32768
   stability: Unstable
-  active: 'chip == "esp32c6"'
+  active: 'esp32c6'
 "#;
 
         let (cfg, options) = evaluate_yaml_config(
@@ -1048,9 +1070,9 @@ options:
 - name: esp_idf_version
   description: ESP-IDF version used in the application descriptor. Currently it's not checked by the bootloader.
   default:
-    - if: 'chip == "esp32c6"'
+    - if: 'esp32c6'
       value: '"esp32c6"'
-    - if: 'chip == "esp32"'
+    - if: 'esp32'
       value: '"other"'
     - value: '"default"'
   active: true
@@ -1093,7 +1115,7 @@ options:
   default:
     - value: 100
   constraints:
-    - if: 'chip == "esp32c6"'
+    - if: 'esp32c6'
       type:
         validator: integer_in_range
         value:

--- a/esp-hal/esp_config.yml
+++ b/esp-hal/esp_config.yml
@@ -37,7 +37,7 @@ options:
       data buffer is empty."
     default:
       - value: true
-    active: 'chip == "esp32"'
+    active: "esp32"
 
   - name: stack-guard-offset
     description: The stack guard variable will be placed this many bytes from the stack's end. Needs to be a multiple of 4.
@@ -61,7 +61,7 @@ options:
     description: Use a data watchpoint to check that the vector table was not unintentionally overwritten.
     default:
       - value: false
-    active: 'chip == "esp32c2" || chip == "esp32c3" || chip == "esp32c6" || chip == "esp32h2"'
+    active: "esp32c2 || esp32c3 || esp32c6 || esp32h2"
 
   - name: stack-guard-monitoring-with-debugger-connected
     description: Enable the stack guard also with a debugger connected. Also applies to `write-vec-table-monitoring`.
@@ -79,10 +79,10 @@ options:
     description: Instruction cache size to be set on application startup.
     default:
       - value: '"8KB"'
-        if: 'chip == "esp32s2"'
+        if: "esp32s2"
       - value: '"32KB"'
     constraints:
-      - if: 'chip == "esp32s2"'
+      - if: "esp32s2"
         type:
           validator: enumeration
           value:
@@ -93,7 +93,7 @@ options:
           value:
             - "16KB"
             - "32KB"
-    active: 'chip == "esp32s2" || chip == "esp32s3"'
+    active: "esp32s2 || esp32s3"
 
   - name: instruction-cache-line-size
     description: Instruction cache line size to be set on application startup.
@@ -105,7 +105,7 @@ options:
           value:
             - "16B"
             - "32B"
-    active: 'chip == "esp32s2" || chip == "esp32s3"'
+    active: "esp32s2 || esp32s3"
 
   - name: icache-associated-ways
     description: Instruction cache associated ways to be set on application startup.
@@ -117,16 +117,16 @@ options:
           value:
             - "4"
             - "8"
-    active: 'chip == "esp32s3"'
+    active: "esp32s3"
 
   - name: data-cache-size
     description: Data cache size to be set on application startup.
     default:
       - value: '"8KB"'
-        if: 'chip == "esp32s2"'
+        if: "esp32s2"
       - value: '"32KB"'
     constraints:
-      - if: 'chip == "esp32s2"'
+      - if: "esp32s2"
         type:
           validator: enumeration
           value:
@@ -139,14 +139,14 @@ options:
             - "16KB"
             - "32KB"
             - "64KB"
-    active: 'chip == "esp32s2" || chip == "esp32s3"'
+    active: "esp32s2 || esp32s3"
 
   - name: data-cache-line-size
     description: Data cache line size to be set on application startup.
     default:
       - value: '"32B"'
     constraints:
-      - if: 'chip == "esp32s2"'
+      - if: "esp32s2"
         type:
           validator: enumeration
           value:
@@ -158,7 +158,7 @@ options:
             - "16B"
             - "32B"
             - "64B"
-    active: 'chip == "esp32s2" || chip == "esp32s3"'
+    active: "esp32s2 || esp32s3"
 
   - name: dcache-associated-ways
     description: Data cache associated ways to be set on application startup.
@@ -170,7 +170,7 @@ options:
           value:
             - "4"
             - "8"
-    active: 'chip == "esp32s3"'
+    active: "esp32s3"
 
   - name: l2-cache-size
     description: "ESP32-P4 L2 cache size. Must match the 2nd-stage bootloader's
@@ -186,7 +186,7 @@ options:
             - "128KB"
             - "256KB"
             - "512KB"
-    active: 'chip == "esp32p4"'
+    active: "esp32p4"
 
   - name: min-chip-revision
     description: "The minimum chip revision required for the application to run, in format: major * 100 + minor."


### PR DESCRIPTION
# Changelog

## esp-config

- Changed: In `if` conditions, `chip` and `feature()` have been removed. Instead, chip symbols are used to generate boolean and string variables. For example, `chip == "esp32"` became `esp32`, and `feature("soc_has_foobar")` has become `soc_has_foobar`.

## esp-backtrace

- No changelog necessary.

## esp-hal

- No changelog necessary.