### PR TITLE
Simplify macros, ensure DRAM buffers are aligned on P4

### DIFF
--- a/esp-hal/src/aes/mod.rs
+++ b/esp-hal/src/aes/mod.rs
@@ -382,6 +382,7 @@ pub mod dma {
             DmaError,
             DmaRxBuffer,
             DmaTxBuffer,
+            InternalMemoryCachelineAligned,
             NoBuffer,
             prepare_for_rx,
             prepare_for_tx,
@@ -760,8 +761,7 @@ pub mod dma {
 
         #[cfg(dma_can_access_psram)]
         unaligned_data_buffers: [Option<ManualWritebackBuffer>; 2],
-        input_descriptors: [DmaDescriptor; 1],
-        output_descriptors: [DmaDescriptor; OUT_DESCR_COUNT],
+        descriptors: InternalMemoryCachelineAligned<[DmaDescriptor; OUT_DESCR_COUNT + 1]>,
     }
 
     // The DMA descriptors prevent auto-implementing Sync and Send, but they can be treated as Send
@@ -801,8 +801,9 @@ pub mod dma {
 
                 #[cfg(dma_can_access_psram)]
                 unaligned_data_buffers: [const { None }; 2],
-                input_descriptors: [DmaDescriptor::EMPTY; 1],
-                output_descriptors: [DmaDescriptor::EMPTY; OUT_DESCR_COUNT],
+                descriptors: InternalMemoryCachelineAligned::new(
+                    [DmaDescriptor::EMPTY; OUT_DESCR_COUNT + 1],
+                ),
             }
         }
 
@@ -987,11 +988,12 @@ pub mod dma {
             work_item: &mut AesOperation,
         ) -> Result<(), AesDma<'d>> {
             let input_len = work_item.buffers.input.len();
+            let (input_dscr, output_dscr) = self.descriptors.get_mut().split_at_mut(1);
             let (input_buffer, data_len) = unsafe {
                 // This unwrap is infallible as AES-DMA devices don't have TX DMA alignment
                 // requirements.
                 unwrap!(prepare_for_tx(
-                    &mut self.input_descriptors,
+                    input_dscr,
                     work_item.buffers.input,
                     BLOCK_SIZE,
                 ))
@@ -1005,7 +1007,7 @@ pub mod dma {
 
             let (output_buffer, rx_data_len) = unsafe {
                 prepare_for_rx(
-                    &mut self.output_descriptors,
+                    output_dscr,
                     #[cfg(dma_can_access_psram)]
                     &mut self.unaligned_data_buffers,
                     // Truncate data based on how much the TX buffer can read.

--- a/esp-hal/src/dma/buffers/mod.rs
+++ b/esp-hal/src/dma/buffers/mod.rs
@@ -8,7 +8,10 @@ use core::{
 use super::*;
 use crate::soc::is_slice_in_dram;
 #[cfg(dma_can_access_psram)]
-use crate::soc::{is_slice_in_psram, is_valid_psram_address, is_valid_ram_address};
+use crate::{
+    dma::InternalMemoryBuffer,
+    soc::{is_slice_in_psram, is_valid_psram_address, is_valid_ram_address},
+};
 
 pub(crate) mod scoped;
 pub(crate) use scoped::*;
@@ -2134,8 +2137,8 @@ const BUF_LEN: usize = 16 + 2 * (MIN_LAST_DMA_LEN - 1); // 2x makes aligning sho
 /// the CPU back to PSRAM.
 #[cfg(dma_can_access_psram)]
 pub(crate) struct ManualWritebackBuffer {
+    buffer: InternalMemoryBuffer<BUF_LEN>,
     dst_address: NonNull<u8>,
-    buffer: [u8; BUF_LEN],
     n_bytes: u8,
 }
 
@@ -2144,8 +2147,8 @@ impl ManualWritebackBuffer {
     pub fn new(ptr: NonNull<[u8]>) -> Self {
         assert!(ptr.len() <= BUF_LEN);
         Self {
+            buffer: InternalMemoryBuffer::new(),
             dst_address: ptr.cast(),
-            buffer: [0; BUF_LEN],
             n_bytes: ptr.len() as u8,
         }
     }
@@ -2156,15 +2159,15 @@ impl ManualWritebackBuffer {
             // Invalidate the cache lines covering the alignment buffer so the CPU
             // reads the fresh DMA data rather than the stale zeros from new().
             #[cfg(soc_internal_memory_cached)]
-            crate::soc::cache_invalidate_addr(self.buffer.as_ptr() as u32, BUF_LEN as u32);
+            crate::soc::cache_invalidate_addr(self.buffer_ptr() as u32, BUF_LEN as u32);
 
             self.dst_address
                 .as_ptr()
-                .copy_from(self.buffer.as_ptr(), self.n_bytes as usize);
+                .copy_from(self.buffer_ptr().cast_const(), self.n_bytes as usize);
         }
     }
 
     pub fn buffer_ptr(&self) -> *mut u8 {
-        self.buffer.as_ptr().cast_mut()
+        self.buffer.get() as *const [u8] as *mut u8
     }
 }

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -629,13 +629,17 @@ macro_rules! dma_circular_descriptors_chunk_size {
 
 // ESP32-P4 internal memory is cached, enforce alignment to avoid memory
 // corruption. Technically only needed for IN buffers and descriptor lists.
-#[cfg_attr(esp32p4, repr(C, align(64)))] // dcache cache line
+#[cfg_attr(soc_internal_memory_cached, repr(C, align(64)))] // dcache cache line
 #[doc(hidden)]
 pub struct InternalMemoryCachelineAligned<T>(T);
 
 impl<T> InternalMemoryCachelineAligned<T> {
     pub const fn new(init: T) -> Self {
         Self(init)
+    }
+
+    pub const fn get(&self) -> &T {
+        &self.0
     }
 
     pub const fn get_mut(&mut self) -> &mut T {
@@ -646,13 +650,17 @@ impl<T> InternalMemoryCachelineAligned<T> {
 // ESP32 requires word alignment for DMA buffers.
 // ESP32-S2 technically supports byte-aligned DMA buffers, but the
 // transfer ends up writing out of bounds.
-#[cfg_attr(not(esp32p4), repr(C, align(4)))]
+#[cfg_attr(not(soc_internal_memory_cached), repr(C, align(4)))]
 #[doc(hidden)]
 pub struct InternalMemoryBuffer<const N: usize>(InternalMemoryCachelineAligned<[u8; N]>);
 
 impl<const N: usize> InternalMemoryBuffer<N> {
     pub const fn new() -> Self {
         Self(InternalMemoryCachelineAligned::new([0u8; N]))
+    }
+
+    pub const fn get(&self) -> &[u8] {
+        self.0.get()
     }
 
     pub const fn get_mut(&mut self) -> &mut [u8] {

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -536,30 +536,6 @@ macro_rules! dma_circular_descriptors {
     };
 }
 
-/// Declares a DMA buffer with a specific size, aligned to 4 bytes
-#[doc(hidden)]
-#[macro_export]
-macro_rules! declare_aligned_dma_buffer {
-    ($name:ident, $size:expr) => {
-        // ESP32 requires word alignment for DMA buffers.
-        // ESP32-S2 technically supports byte-aligned DMA buffers, but the
-        // transfer ends up writing out of bounds.
-        // if the buffer's length is 2 or 3 (mod 4).
-        static mut $name: [u32; ($size as usize).div_ceil(4)] = [0; ($size as usize).div_ceil(4)];
-    };
-}
-
-/// Turns the potentially oversized static `u32`` array reference into a
-/// correctly sized `u8` one
-#[doc(hidden)]
-#[macro_export]
-macro_rules! as_mut_byte_array {
-    ($name:expr, $size:expr) => {
-        unsafe { &mut *($name.as_mut_ptr() as *mut [u8; $size]) }
-    };
-}
-pub use as_mut_byte_array; // TODO: can be removed as soon as DMA is stabilized
-
 #[procmacros::doc_replace]
 /// Convenience macro to create DMA buffers and descriptors with specific chunk
 /// size.
@@ -651,6 +627,39 @@ macro_rules! dma_circular_descriptors_chunk_size {
     };
 }
 
+// ESP32-P4 internal memory is cached, enforce alignment to avoid memory
+// corruption. Technically only needed for IN buffers and descriptor lists.
+#[cfg_attr(esp32p4, repr(C, align(64)))] // dcache cache line
+#[doc(hidden)]
+pub struct InternalMemoryCachelineAligned<T>(T);
+
+impl<T> InternalMemoryCachelineAligned<T> {
+    pub const fn new(init: T) -> Self {
+        Self(init)
+    }
+
+    pub const fn get_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}
+
+// ESP32 requires word alignment for DMA buffers.
+// ESP32-S2 technically supports byte-aligned DMA buffers, but the
+// transfer ends up writing out of bounds.
+#[cfg_attr(not(esp32p4), repr(C, align(4)))]
+#[doc(hidden)]
+pub struct InternalMemoryBuffer<const N: usize>(InternalMemoryCachelineAligned<[u8; N]>);
+
+impl<const N: usize> InternalMemoryBuffer<N> {
+    pub const fn new() -> Self {
+        Self(InternalMemoryCachelineAligned::new([0u8; N]))
+    }
+
+    pub const fn get_mut(&mut self) -> &mut [u8] {
+        self.0.get_mut()
+    }
+}
+
 #[doc(hidden)]
 #[macro_export]
 macro_rules! dma_buffers_impl {
@@ -661,11 +670,16 @@ macro_rules! dma_buffers_impl {
     }};
 
     ($size:expr, $chunk_size:expr, is_circular = $circular:tt) => {{
-        $crate::declare_aligned_dma_buffer!(BUFFER, $size);
-
         unsafe {
             (
-                $crate::dma::as_mut_byte_array!(BUFFER, $size),
+                {
+                    #[allow(unused_braces)]
+                    static mut BUFFER: $crate::dma::InternalMemoryBuffer<{ $size }> =
+                        $crate::dma::InternalMemoryBuffer::new();
+                    // SAFETY: The ConstStaticCell in the descriptor part ensures there will only
+                    // be a single mutable reference to this buffer.
+                    unsafe { BUFFER.get_mut() }
+                },
                 $crate::dma_descriptors_impl!($size, $chunk_size, is_circular = $circular),
             )
         }
@@ -690,16 +704,21 @@ macro_rules! dma_descriptors_impl {
     }};
 
     ($size:expr, $chunk_size:expr, is_circular = $circular:tt) => {{
+        use $crate::{
+            __macro_implementation::static_cell::ConstStaticCell,
+            dma::{DmaDescriptor, InternalMemoryCachelineAligned},
+        };
+
         const COUNT: usize =
             $crate::dma_descriptor_count!($size, $chunk_size, is_circular = $circular);
 
-        static DESCRIPTORS: $crate::__macro_implementation::static_cell::ConstStaticCell<
-            [$crate::dma::DmaDescriptor; COUNT],
-        > = $crate::__macro_implementation::static_cell::ConstStaticCell::new(
-            [$crate::dma::DmaDescriptor::EMPTY; COUNT],
-        );
+        static DESCRIPTORS: ConstStaticCell<
+            InternalMemoryCachelineAligned<[DmaDescriptor; COUNT]>,
+        > = ConstStaticCell::new(InternalMemoryCachelineAligned::new(
+            [DmaDescriptor::EMPTY; COUNT],
+        ));
 
-        DESCRIPTORS.take()
+        DESCRIPTORS.take().get_mut()
     }};
 }
 

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -654,6 +654,12 @@ impl<T> InternalMemoryCachelineAligned<T> {
 #[doc(hidden)]
 pub struct InternalMemoryBuffer<const N: usize>(InternalMemoryCachelineAligned<[u8; N]>);
 
+impl<const N: usize> Default for InternalMemoryBuffer<N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<const N: usize> InternalMemoryBuffer<N> {
     pub const fn new() -> Self {
         Self(InternalMemoryCachelineAligned::new([0u8; N]))

--- a/esp-hal/src/spi/master/dma.rs
+++ b/esp-hal/src/spi/master/dma.rs
@@ -694,6 +694,7 @@ impl<'a> MaybeCopyTxBuf<'a> {
     }
 }
 
+#[allow(clippy::large_enum_variant)]
 enum MaybeCopyRxBuf<'a> {
     Copy(&'a mut ScopedDmaRxBuf<'static>),
     Direct {

--- a/esp-hal/src/spi/master/dma.rs
+++ b/esp-hal/src/spi/master/dma.rs
@@ -285,12 +285,14 @@ impl<'d> SpiDma<'d, Blocking> {
             _ => &mut []
         };
 
+        #[allow(static_mut_refs)]
         let rx_buffer = unwrap!(DmaRxBuf::new(
-            core::slice::from_mut(unsafe { &mut RX_DESCRIPTORS.get_mut()[id] }),
+            core::slice::from_mut(unsafe { &mut (RX_DESCRIPTORS.get_mut()[id]) }),
             &mut []
         ));
+        #[allow(static_mut_refs)]
         let tx_buffer = unwrap!(DmaTxBuf::new(
-            core::slice::from_mut(unsafe { &mut TX_DESCRIPTORS.get_mut()[id] }),
+            core::slice::from_mut(unsafe { &mut (TX_DESCRIPTORS.get_mut()[id]) }),
             tx_buffer
         ));
 

--- a/esp-hal/src/spi/master/dma.rs
+++ b/esp-hal/src/spi/master/dma.rs
@@ -26,6 +26,7 @@ use crate::{
         DmaRxBuffer,
         DmaTxBuf,
         DmaTxBuffer,
+        InternalMemoryCachelineAligned,
         NoBuffer,
         ScopedDmaRxBuf,
         ScopedDmaTxBuf,
@@ -270,22 +271,28 @@ impl<'d> SpiDma<'d, Blocking> {
         state.tx_transfer_in_progress.set(false);
         state.rx_transfer_in_progress.set(false);
 
-        static mut TX_DESCRIPTORS: [[DmaDescriptor; 1]; SPI_NUM] =
-            [[DmaDescriptor::EMPTY]; SPI_NUM];
-        static mut RX_DESCRIPTORS: [[DmaDescriptor; 1]; SPI_NUM] =
-            [[DmaDescriptor::EMPTY]; SPI_NUM];
+        static mut TX_DESCRIPTORS: InternalMemoryCachelineAligned<[DmaDescriptor; SPI_NUM]> =
+            InternalMemoryCachelineAligned::new([DmaDescriptor::EMPTY; SPI_NUM]);
+        static mut RX_DESCRIPTORS: InternalMemoryCachelineAligned<[DmaDescriptor; SPI_NUM]> =
+            InternalMemoryCachelineAligned::new([DmaDescriptor::EMPTY; SPI_NUM]);
 
-        let rx_buffer = unwrap!(DmaRxBuf::new(unsafe { &mut RX_DESCRIPTORS[id] }, &mut []));
+        let tx_buffer = cfg_select! {
+            all(spi_master_version = "1", spi_address_workaround) => {{
+                use crate::dma::InternalMemoryBuffer;
+                static mut BUFFERS: [InternalMemoryBuffer<4>; SPI_NUM] = [const { InternalMemoryBuffer::new() }; SPI_NUM];
+                unsafe { BUFFERS[id].get_mut() }
+            }}
+            _ => &mut []
+        };
 
-        cfg_if::cfg_if! {
-            if #[cfg(all(spi_master_version = "1", spi_address_workaround))] {
-                static mut BUFFERS: [[u32; 1]; SPI_NUM] = [[0]; SPI_NUM];
-                let buffer = crate::dma::as_mut_byte_array!(BUFFERS[id], 4);
-                let tx_buffer = unwrap!(DmaTxBuf::new(unsafe { &mut TX_DESCRIPTORS[id] }, buffer));
-            } else {
-                let tx_buffer = unwrap!(DmaTxBuf::new(unsafe { &mut TX_DESCRIPTORS[id] }, &mut []));
-            }
-        }
+        let rx_buffer = unwrap!(DmaRxBuf::new(
+            core::slice::from_mut(unsafe { &mut RX_DESCRIPTORS.get_mut()[id] }),
+            &mut []
+        ));
+        let tx_buffer = unwrap!(DmaTxBuf::new(
+            core::slice::from_mut(unsafe { &mut TX_DESCRIPTORS.get_mut()[id] }),
+            tx_buffer
+        ));
 
         // The buffers must be set up when creating the driver.
         unsafe { (&mut *state.tx_buffer.get()).write(tx_buffer.into_scoped()) };


### PR DESCRIPTION
On P4, we must align IN buffers to the DRAM cache line (64 bytes). Because internal memory is cached, if the DMA fills a buffer, we need to invalidate the cache line to allow the CPU to read up-to-date data. This invalidation can delete valid dirty data if other variables are allowed to be placed into the same cache line as an IN buffer, causing memory corruption.

OUT buffers aren't necessary to align this way, but we can optimize those later.

Only hidden macros were removed and the PR has no observable effect on released chips, so:

# Changelog

## esp-hal

- No changelog necessary.