### PR TITLE
esp-radio: `rst_zbmac` reset on C5, C61 and C6 when enabling wifi power domain

### DIFF
--- a/esp-radio/src/common_adapter.rs
+++ b/esp-radio/src/common_adapter.rs
@@ -381,15 +381,15 @@ pub(crate) fn enable_wifi_power_domain() {
                 w.rst_btbb_apb().set_bit();
                 w.rst_btmac().set_bit();
                 w.rst_btmac_apb().set_bit();
+                w.rst_zbmac().set_bit();
                 cfg_select! {
-                    any(esp32c5, esp32c6, esp32c61) => {
+                    not(esp32h2) => {
                         w.rst_wifibb().set_bit();
-                        w.rst_wifimac().set_bit()
+                        w.rst_wifimac().set_bit();
                     }
-                    esp32h2 => {
-                        w.rst_zbmac().set_bit()
-                    }
+                    _ => {}
                 }
+                w
             });
             regs!(MODEM_SYSCON).modem_rst_conf().modify(|_, w| {
                 w.rst_fe().clear_bit();
@@ -397,15 +397,15 @@ pub(crate) fn enable_wifi_power_domain() {
                 w.rst_btbb_apb().clear_bit();
                 w.rst_btmac().clear_bit();
                 w.rst_btmac_apb().clear_bit();
+                w.rst_zbmac().clear_bit();
                 cfg_select! {
-                    any(esp32c5, esp32c6, esp32c61) => {
+                    not(esp32h2) => {
                         w.rst_wifibb().clear_bit();
-                        w.rst_wifimac().clear_bit()
+                        w.rst_wifimac().clear_bit();
                     }
-                    esp32h2 => {
-                        w.rst_zbmac().clear_bit()
-                    }
+                    _ => {}
                 }
+                w
             });
         }
         // ESP32-C2 has no separate modem power domain (RTC_CNTL lacks

--- a/esp-radio/src/common_adapter.rs
+++ b/esp-radio/src/common_adapter.rs
@@ -374,16 +374,17 @@ pub(crate) fn enable_wifi_power_domain() {
     // but leaves the modem power domain untouched, so without this the radio
     // would inherit whatever state the previously-used radio left.
     cfg_select! {
-        any(esp32c5, esp32c6, esp32c61, esp32h2) => {
+        not(wifi_mac_version = "1") => {
             regs!(MODEM_SYSCON).modem_rst_conf().modify(|_, w| {
                 w.rst_fe().set_bit();
                 w.rst_btbb().set_bit();
                 w.rst_btbb_apb().set_bit();
                 w.rst_btmac().set_bit();
                 w.rst_btmac_apb().set_bit();
+                #[cfg(soc_has_ieee802154)]
                 w.rst_zbmac().set_bit();
                 cfg_select! {
-                    not(esp32h2) => {
+                    soc_has_wifi => {
                         w.rst_wifibb().set_bit();
                         w.rst_wifimac().set_bit();
                     }
@@ -397,9 +398,10 @@ pub(crate) fn enable_wifi_power_domain() {
                 w.rst_btbb_apb().clear_bit();
                 w.rst_btmac().clear_bit();
                 w.rst_btmac_apb().clear_bit();
+                #[cfg(soc_has_ieee802154)]
                 w.rst_zbmac().clear_bit();
                 cfg_select! {
-                    not(esp32h2) => {
+                    soc_has_wifi => {
                         w.rst_wifibb().clear_bit();
                         w.rst_wifimac().clear_bit();
                     }


### PR DESCRIPTION
cc https://github.com/esp-rs/esp-hal/pull/5700#discussion_r3388083412