### PR TITLE
Read back pending interrupts to ensure SW int is raised

### DIFF
--- a/esp-hal/src/interrupt/mod.rs
+++ b/esp-hal/src/interrupt/mod.rs
@@ -192,37 +192,54 @@ pub struct InterruptStatus {
 }
 
 impl InterruptStatus {
+    /// Get status of a particular peripheral interrupt
+    #[instability::unstable]
+    #[inline]
+    pub fn is_pending(interrupt: Interrupt) -> bool {
+        let word = (interrupt as usize) / 32;
+        let bit = (interrupt as usize) % 32;
+        let mut status_word = 0;
+        for cpu in Cpu::all() {
+            status_word |= Self::interrupt_status_word(cpu, word);
+        }
+        (status_word & (1 << bit)) != 0
+    }
+
+    #[inline]
+    fn interrupt_status_word(cpu: Cpu, word: usize) -> u32 {
+        match cpu {
+            Cpu::ProCpu => {
+                #[cfg(esp32p4)]
+                if word == 4 {
+                    // Discontiguous, cannot be part of the standard status array
+                    return INTERRUPT_CORE0::regs().core_0_intr_status4().read().bits();
+                }
+                INTERRUPT_CORE0::regs()
+                    .core_0_intr_status(word)
+                    .read()
+                    .bits()
+            }
+            #[cfg(multi_core)]
+            Cpu::AppCpu => {
+                #[cfg(esp32p4)]
+                if word == 4 {
+                    // Discontiguous, cannot be part of the standard status array
+                    return INTERRUPT_CORE1::regs().core_1_intr_status4().read().bits();
+                }
+                INTERRUPT_CORE1::regs()
+                    .core_1_intr_status(word)
+                    .read()
+                    .bits()
+            }
+        }
+    }
+
     /// Get status of peripheral interrupts
     #[instability::unstable]
     pub fn current() -> InterruptStatus {
-        match Cpu::current() {
-            Cpu::ProCpu => InterruptStatus {
-                status: core::array::from_fn(|idx| {
-                    #[cfg(esp32p4)]
-                    if idx == 4 {
-                        // Discontiguous, cannot be part of the standard status array
-                        return INTERRUPT_CORE0::regs().core_0_intr_status4().read().bits();
-                    }
-                    INTERRUPT_CORE0::regs()
-                        .core_0_intr_status(idx)
-                        .read()
-                        .bits()
-                }),
-            },
-            #[cfg(multi_core)]
-            Cpu::AppCpu => InterruptStatus {
-                status: core::array::from_fn(|idx| {
-                    #[cfg(esp32p4)]
-                    if idx == 4 {
-                        // Discontiguous, cannot be part of the standard status array
-                        return INTERRUPT_CORE1::regs().core_1_intr_status4().read().bits();
-                    }
-                    INTERRUPT_CORE1::regs()
-                        .core_1_intr_status(idx)
-                        .read()
-                        .bits()
-                }),
-            },
+        let cpu = Cpu::current();
+        InterruptStatus {
+            status: core::array::from_fn(|word| Self::interrupt_status_word(cpu, word)),
         }
     }
 

--- a/esp-hal/src/interrupt/riscv.rs
+++ b/esp-hal/src/interrupt/riscv.rs
@@ -18,6 +18,8 @@ pub use esp_riscv_rt::TrapFrame;
 #[cfg_attr(interrupt_controller = "clic", path = "riscv/clic.rs")]
 mod cpu_int;
 
+pub(crate) use riscv::interrupt::free;
+
 use crate::{
     interrupt::{PriorityError, RunLevel},
     peripherals::Interrupt,

--- a/esp-hal/src/interrupt/software.rs
+++ b/esp-hal/src/interrupt/software.rs
@@ -109,25 +109,26 @@ impl<const NUM: u8> SoftwareInterrupt<'_, NUM> {
     /// Trigger this software-interrupt
     #[crate::ram]
     pub fn raise(&self) {
-        crate::interrupt::free(|| {
-            let regs = cfg_select! {
-                soc_has_intpri => crate::peripherals::INTPRI::regs(),
-                _ => crate::peripherals::SYSTEM::regs(),
-            };
-            let reg = regs.cpu_intr_from_cpu(NUM as usize);
-            reg.write(|w| w.cpu_intr().set_bit());
+        let regs = cfg_select! {
+            soc_has_intpri => crate::peripherals::INTPRI::regs(),
+            _ => crate::peripherals::SYSTEM::regs(),
+        };
+        let reg = regs.cpu_intr_from_cpu(NUM as usize);
 
-            cfg_select! {
-                xtensa => {
-                    // Read back to ensure the write is completed.
-                    _ = reg.read();
-                },
-                _ => {
+        cfg_select! {
+            xtensa => {
+                reg.write(|w| w.cpu_intr().set_bit());
+                // Read back to ensure the write is completed.
+                _ = reg.read();
+            },
+            _ => {
+                crate::interrupt::free(|| {
+                    reg.write(|w| w.cpu_intr().set_bit());
                     // Wait for the interrupt to actually take effect.
                     while !self.is_pending() {}
-                },
+                });
             }
-        });
+        }
     }
 
     #[cfg(riscv)]

--- a/esp-hal/src/interrupt/software.rs
+++ b/esp-hal/src/interrupt/software.rs
@@ -107,30 +107,41 @@ impl<const NUM: u8> SoftwareInterrupt<'_, NUM> {
     }
 
     /// Trigger this software-interrupt
+    #[crate::ram]
     pub fn raise(&self) {
-        cfg_if::cfg_if! {
-            if #[cfg(soc_has_intpri)] {
-                let regs = crate::peripherals::INTPRI::regs();
-            } else {
-                let regs = crate::peripherals::SYSTEM::regs();
-            }
-        }
-        let reg;
+        crate::interrupt::free(|| {
+            let regs = cfg_select! {
+                soc_has_intpri => crate::peripherals::INTPRI::regs(),
+                _ => crate::peripherals::SYSTEM::regs(),
+            };
+            let reg = regs.cpu_intr_from_cpu(NUM as usize);
+            reg.write(|w| w.cpu_intr().set_bit());
 
+            cfg_select! {
+                xtensa => {
+                    // Read back to ensure the write is completed.
+                    _ = reg.read();
+                },
+                _ => {
+                    // Wait for the interrupt to actually take effect.
+                    while !self.is_pending() {}
+                },
+            }
+        });
+    }
+
+    #[cfg(riscv)]
+    fn is_pending(&self) -> bool {
+        let interrupt;
         for_each_sw_interrupt! {
-            (all $( ($n:literal, $i:ident, $f:ident) ),*) => {
-                reg = match NUM {
-                    $($n => regs.cpu_intr_from_cpu($n),)*
+            (all $( ($n:literal, $interrupt_name:ident, $f:ident) ),*) => {
+                interrupt = match NUM {
+                    $($n => Interrupt::$interrupt_name,)*
                     _ => unreachable!(),
                 };
             };
         }
-
-        reg.write(|w| w.cpu_intr().set_bit());
-        _ = reg.read(); // Read back to ensure the write is completed.
-
-        // Insert enough delay to ensure the interrupt is fired before returning.
-        sw_interrupt_delay!();
+        crate::interrupt::InterruptStatus::is_pending(interrupt)
     }
 
     /// Resets this software-interrupt

--- a/esp-hal/src/interrupt/xtensa.rs
+++ b/esp-hal/src/interrupt/xtensa.rs
@@ -1,6 +1,5 @@
 //! Interrupt handling
 
-#[cfg(esp32)]
 pub(crate) use xtensa_lx::interrupt::free;
 
 use crate::{

--- a/esp-hal/src/interrupt/xtensa.rs
+++ b/esp-hal/src/interrupt/xtensa.rs
@@ -1,5 +1,6 @@
 //! Interrupt handling
 
+#[cfg(esp32)]
 pub(crate) use xtensa_lx::interrupt::free;
 
 use crate::{

--- a/esp-metadata-generated/src/_generated_esp32.rs
+++ b/esp-metadata-generated/src/_generated_esp32.rs
@@ -536,12 +536,6 @@ macro_rules! for_each_sw_interrupt {
         FROM_CPU_INTR2, software_interrupt2), (3, FROM_CPU_INTR3, software_interrupt3)));
     };
 }
-#[macro_export]
-macro_rules! sw_interrupt_delay {
-    () => {
-        unsafe {}
-    };
-}
 /// This macro can be used to generate code for each channel of the RMT peripheral.
 ///
 /// For an explanation on the general syntax, as well as usage of individual/repeated

--- a/esp-metadata-generated/src/_generated_esp32c2.rs
+++ b/esp-metadata-generated/src/_generated_esp32c2.rs
@@ -616,18 +616,6 @@ macro_rules! for_each_sw_interrupt {
     };
 }
 #[macro_export]
-macro_rules! sw_interrupt_delay {
-    () => {
-        unsafe {
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-        }
-    };
-}
-#[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_sha_algorithm {
     ($($pattern:tt => $code:tt;)*) => {

--- a/esp-metadata-generated/src/_generated_esp32c3.rs
+++ b/esp-metadata-generated/src/_generated_esp32c3.rs
@@ -753,18 +753,6 @@ macro_rules! for_each_sw_interrupt {
         FROM_CPU_INTR2, software_interrupt2), (3, FROM_CPU_INTR3, software_interrupt3)));
     };
 }
-#[macro_export]
-macro_rules! sw_interrupt_delay {
-    () => {
-        unsafe {
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-        }
-    };
-}
 /// This macro can be used to generate code for each channel of the RMT peripheral.
 ///
 /// For an explanation on the general syntax, as well as usage of individual/repeated

--- a/esp-metadata-generated/src/_generated_esp32c5.rs
+++ b/esp-metadata-generated/src/_generated_esp32c5.rs
@@ -877,37 +877,6 @@ macro_rules! for_each_sw_interrupt {
         FROM_CPU_INTR2, software_interrupt2), (3, FROM_CPU_INTR3, software_interrupt3)));
     };
 }
-#[macro_export]
-macro_rules! sw_interrupt_delay {
-    () => {
-        unsafe {
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-        }
-    };
-}
 /// This macro can be used to generate code for each channel of the RMT peripheral.
 ///
 /// For an explanation on the general syntax, as well as usage of individual/repeated

--- a/esp-metadata-generated/src/_generated_esp32c6.rs
+++ b/esp-metadata-generated/src/_generated_esp32c6.rs
@@ -832,27 +832,6 @@ macro_rules! for_each_sw_interrupt {
         FROM_CPU_INTR2, software_interrupt2), (3, FROM_CPU_INTR3, software_interrupt3)));
     };
 }
-#[macro_export]
-macro_rules! sw_interrupt_delay {
-    () => {
-        unsafe {
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-        }
-    };
-}
 /// This macro can be used to generate code for each channel of the RMT peripheral.
 ///
 /// For an explanation on the general syntax, as well as usage of individual/repeated

--- a/esp-metadata-generated/src/_generated_esp32c61.rs
+++ b/esp-metadata-generated/src/_generated_esp32c61.rs
@@ -679,37 +679,6 @@ macro_rules! for_each_sw_interrupt {
     };
 }
 #[macro_export]
-macro_rules! sw_interrupt_delay {
-    () => {
-        unsafe {
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-        }
-    };
-}
-#[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_sha_algorithm {
     ($($pattern:tt => $code:tt;)*) => {

--- a/esp-metadata-generated/src/_generated_esp32h2.rs
+++ b/esp-metadata-generated/src/_generated_esp32h2.rs
@@ -821,18 +821,6 @@ macro_rules! for_each_sw_interrupt {
         FROM_CPU_INTR2, software_interrupt2), (3, FROM_CPU_INTR3, software_interrupt3)));
     };
 }
-#[macro_export]
-macro_rules! sw_interrupt_delay {
-    () => {
-        unsafe {
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-        }
-    };
-}
 /// This macro can be used to generate code for each channel of the RMT peripheral.
 ///
 /// For an explanation on the general syntax, as well as usage of individual/repeated

--- a/esp-metadata-generated/src/_generated_esp32p4.rs
+++ b/esp-metadata-generated/src/_generated_esp32p4.rs
@@ -776,37 +776,6 @@ macro_rules! for_each_sw_interrupt {
     };
 }
 #[macro_export]
-macro_rules! sw_interrupt_delay {
-    () => {
-        unsafe {
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-            ::core::arch::asm!("nop");
-        }
-    };
-}
-#[macro_export]
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! for_each_rsa_exponentiation {
     ($($pattern:tt => $code:tt;)*) => {

--- a/esp-metadata-generated/src/_generated_esp32s2.rs
+++ b/esp-metadata-generated/src/_generated_esp32s2.rs
@@ -601,12 +601,6 @@ macro_rules! for_each_sw_interrupt {
         FROM_CPU_INTR2, software_interrupt2), (3, FROM_CPU_INTR3, software_interrupt3)));
     };
 }
-#[macro_export]
-macro_rules! sw_interrupt_delay {
-    () => {
-        unsafe {}
-    };
-}
 /// This macro can be used to generate code for each channel of the RMT peripheral.
 ///
 /// For an explanation on the general syntax, as well as usage of individual/repeated

--- a/esp-metadata-generated/src/_generated_esp32s3.rs
+++ b/esp-metadata-generated/src/_generated_esp32s3.rs
@@ -742,12 +742,6 @@ macro_rules! for_each_sw_interrupt {
         FROM_CPU_INTR2, software_interrupt2), (3, FROM_CPU_INTR3, software_interrupt3)));
     };
 }
-#[macro_export]
-macro_rules! sw_interrupt_delay {
-    () => {
-        unsafe {}
-    };
-}
 /// This macro can be used to generate code for each channel of the RMT peripheral.
 ///
 /// For an explanation on the general syntax, as well as usage of individual/repeated

--- a/esp-metadata/devices/esp32/soc.toml
+++ b/esp-metadata/devices/esp32/soc.toml
@@ -625,7 +625,6 @@ support_status = { status = "not_supported", issue = 1909 }
 support_status = "partial"
 status_registers = 3
 software_interrupt_count = 4
-software_interrupt_delay = 0
 controller = "Xtensa"
 
 [device.rmt]

--- a/esp-metadata/devices/esp32c2/soc.toml
+++ b/esp-metadata/devices/esp32c2/soc.toml
@@ -286,7 +286,6 @@ bus_timeout_is_exponential = true
 support_status = "partial"
 status_registers = 2
 software_interrupt_count = 4
-software_interrupt_delay = 5
 controller = { Riscv = { flavour = "basic", interrupts = 32, priority_levels = 15 } }
 
 [device.sha]

--- a/esp-metadata/devices/esp32c3/soc.toml
+++ b/esp-metadata/devices/esp32c3/soc.toml
@@ -335,7 +335,6 @@ instances = [
 support_status = "partial"
 status_registers = 2
 software_interrupt_count = 4
-software_interrupt_delay = 5
 controller = { Riscv = { flavour = "basic", interrupts = 32, priority_levels = 15 } }
 
 [device.rmt]

--- a/esp-metadata/devices/esp32c5/soc.toml
+++ b/esp-metadata/devices/esp32c5/soc.toml
@@ -447,7 +447,6 @@ algo = { sha1 = 0, sha224 = 1, sha256 = 2 }
 support_status = "partial"
 status_registers = 3
 software_interrupt_count = 4
-software_interrupt_delay = 24 # CPU speed dependent
 controller = { Riscv = { flavour = "clic", interrupts = 48, priority_levels = 8 } }
 
 [device.rmt]

--- a/esp-metadata/devices/esp32c6/soc.toml
+++ b/esp-metadata/devices/esp32c6/soc.toml
@@ -499,7 +499,6 @@ instances = [
 support_status = "partial"
 status_registers = 3
 software_interrupt_count = 4
-software_interrupt_delay = 14 # CPU-speed sensitive - what's clocked from where?
 controller = { Riscv = { flavour = "plic", interrupts = 32, priority_levels = 15 } }
 
 [device.rmt]

--- a/esp-metadata/devices/esp32c61/soc.toml
+++ b/esp-metadata/devices/esp32c61/soc.toml
@@ -111,7 +111,6 @@ support_status = { status = "not_supported", issue = 5422 }
 support_status = "partial"
 status_registers = 3
 software_interrupt_count = 4
-software_interrupt_delay = 24 # CPU speed dependent
 controller = { Riscv = { flavour = "clic", interrupts = 32, priority_levels = 8 } }
 
 [device.timergroup]

--- a/esp-metadata/devices/esp32h2/soc.toml
+++ b/esp-metadata/devices/esp32h2/soc.toml
@@ -420,7 +420,6 @@ support_status = { status = "not_supported", issue = 1909 }
 support_status = "partial"
 status_registers = 2
 software_interrupt_count = 4
-software_interrupt_delay = 5
 controller = { Riscv = { flavour = "plic", interrupts = 32, priority_levels = 15 } }
 
 [device.rmt]

--- a/esp-metadata/devices/esp32p4/soc.toml
+++ b/esp-metadata/devices/esp32p4/soc.toml
@@ -36,7 +36,6 @@ symbols = [
 support_status = "partial"
 status_registers = 5
 software_interrupt_count = 4
-software_interrupt_delay = 24
 # ESP32-P4 uses CLIC with 48 interrupt lines (TRM v0.5, Ch 14)
 controller = { Riscv = { flavour = "clic", interrupts = 48, priority_levels = 8 } }
 

--- a/esp-metadata/devices/esp32s2/soc.toml
+++ b/esp-metadata/devices/esp32s2/soc.toml
@@ -469,7 +469,6 @@ support_status = { status = "not_supported", issue = 1909 }
 support_status = "partial"
 status_registers = 3
 software_interrupt_count = 4
-software_interrupt_delay = 0
 controller = "Xtensa"
 
 [device.rmt]

--- a/esp-metadata/devices/esp32s3/soc.toml
+++ b/esp-metadata/devices/esp32s3/soc.toml
@@ -642,7 +642,6 @@ support_status = { status = "not_supported", issue = 1909 }
 support_status = "partial"
 status_registers = 4
 software_interrupt_count = 4
-software_interrupt_delay = 0
 controller = "Xtensa"
 
 [device.rmt]

--- a/esp-metadata/src/cfg/interrupt.rs
+++ b/esp-metadata/src/cfg/interrupt.rs
@@ -8,18 +8,11 @@ use crate::{cfg::GenericProperty, generate_for_each_macro, number};
 pub struct SoftwareInterruptProperties {
     #[serde(rename = "software_interrupt_count")]
     count: u32,
-    #[serde(rename = "software_interrupt_delay")]
-    delay: u32,
 }
 
-/// Generates `for_each_sw_interrupt!` which can be used to implement SoftwareInterruptControl, and
-/// `sw_interrupt_delay` which repeats `nop` enough times to ensure the interrupt is fired before
-/// returning.
+/// Generates `for_each_sw_interrupt!` which can be used to implement SoftwareInterruptControl.
 impl GenericProperty for SoftwareInterruptProperties {
     fn macros(&self) -> Option<TokenStream> {
-        let nops =
-            std::iter::repeat(quote! { ::core::arch::asm!("nop"); }).take(self.delay as usize);
-
         let channels = (0..self.count)
             .map(|i| {
                 let idx = number(i);
@@ -34,14 +27,6 @@ impl GenericProperty for SoftwareInterruptProperties {
         Some(quote! {
             #for_each_sw_interrupt
 
-            #[macro_export]
-            macro_rules! sw_interrupt_delay {
-                () => {
-                    unsafe {
-                        #(#nops)*
-                    }
-                };
-            }
         })
     }
 }

--- a/hil-test/src/bin/misc_non_drivers.rs
+++ b/hil-test/src/bin/misc_non_drivers.rs
@@ -27,7 +27,6 @@
 #[path = "misc_non_drivers/clock_monitor.rs"]
 mod clock_monitor;
 
-#[cfg(not(esp32c61))]
 #[path = "misc_non_drivers/critical_section.rs"]
 mod critical_section;
 
@@ -47,11 +46,9 @@ mod dma_buffers;
 #[cfg(all(dma_driver_supported, dma_supports_mem2mem))]
 mod dma_mem2mem;
 
-#[cfg(not(esp32c61))]
 #[path = "misc_non_drivers/init.rs"]
 mod init;
 
-#[cfg(not(esp32c61))]
 #[path = "misc_non_drivers/simple.rs"]
 mod simple;
 

--- a/hil-test/src/bin/radio_basic.rs
+++ b/hil-test/src/bin/radio_basic.rs
@@ -1,9 +1,8 @@
-// TODO: validate ESP32-C61 radio, then drop the `!esp32c61` exclusions.
 //% CHIP_FILTER(no_wifi):      bt_driver_supported && !wifi_driver_supported
 //% CHIP_FILTER(no_ble):       wifi_driver_supported && !bt_driver_supported
 //% CHIP_FILTER(no_radio):     !wifi_driver_supported && !bt_driver_supported
-//% CHIP_FILTER(has_wifi_ble): wifi_driver_supported && bt_driver_supported && !esp32c61
-//% CHIP_FILTER(stable_wifi):  wifi_driver_supported && !esp32c61
+//% CHIP_FILTER(has_wifi_ble): wifi_driver_supported && bt_driver_supported
+//% CHIP_FILTER(stable_wifi):  wifi_driver_supported
 
 //% FEATURES: unstable esp-alloc embassy
 //% FEATURES(no_radio): rtos-radio-driver

--- a/hil-test/src/bin/radio_basic.rs
+++ b/hil-test/src/bin/radio_basic.rs
@@ -27,15 +27,14 @@ extern crate alloc;
 
 fn init_heap() {
     cfg_select! {
-        any(esp32, esp32s2, esp32s3, esp32c3, esp32c2, esp32c5, esp32c6, esp32c61, esp32p4) => {
+        esp32h2 => {
+            esp_alloc::heap_allocator!(size: 72 * 1024);
+        }
+        _ => {
             use esp_hal::ram;
             esp_alloc::heap_allocator!(#[ram(reclaimed)] size: 64 * 1024);
             esp_alloc::heap_allocator!(size: 48 * 1024);
         }
-        esp32h2 => {
-            esp_alloc::heap_allocator!(size: 72 * 1024);
-        }
-        _ => {}
     }
 }
 


### PR DESCRIPTION
This PR replaces the previous naive nop chain with actually checking if the interrupt is pending.

# Changelog

## esp-hal

- No changelog necessary.