### PR TITLE
Fix C2 ECC

### DIFF
--- a/esp-hal/src/ecc.rs
+++ b/esp-hal/src/ecc.rs
@@ -118,10 +118,6 @@ from the bitlength of the prime fields of the curve."]
                     ) -> Result<EccResultHandle<'op, $op>, KeyLengthMismatch> {
                         curve.size_check([$($input),*])?;
 
-                        // Wipe any secrets left over from the previous operation before loading the new operands.
-                        #[cfg(clear_crypto_secrets)]
-                        self.info().clear_secrets();
-
                         paste::paste! {
                             $(
                                 self.info().write_mem(self.info().[<$input _mem>](), $input);


### PR DESCRIPTION
Writing ECC memory has side effects, we can't just do it before every operation. It also doesn't make sense to clear something that we'll immediately overwrite.