### PR TITLE
Make UART RX errors configurable

### DIFF
--- a/esp-hal/src/uart/low_level/mod.rs
+++ b/esp-hal/src/uart/low_level/mod.rs
@@ -696,21 +696,30 @@ impl Info {
             .write(|w| unsafe { w.rxfifo_rd_byte().bits(byte) });
     }
 
-    pub(super) fn check_for_errors(
+    fn check_for_errors_and_reset_fifo(
         &self,
         reported_errors: EnumSet<RxErrorKind>,
-    ) -> Result<(), RxError> {
+    ) -> Result<bool, RxError> {
         let errors =
             RxEvent::FifoOvf | RxEvent::GlitchDetected | RxEvent::FrameError | RxEvent::ParityError;
         let events = self.rx_events().intersection(errors);
         let result = rx_event_check_for_error(events, reported_errors);
+        let fifo_overflowed = events.contains(RxEvent::FifoOvf);
         if !events.is_empty() {
             self.clear_rx_events(events);
-            if result == Err(RxError::FifoOverflowed) {
+            if fifo_overflowed {
                 self.rxfifo_reset();
             }
         }
-        result
+        result.map(|()| fifo_overflowed)
+    }
+
+    pub(super) fn check_for_errors(
+        &self,
+        reported_errors: EnumSet<RxErrorKind>,
+    ) -> Result<(), RxError> {
+        self.check_for_errors_and_reset_fifo(reported_errors)
+            .map(|_| ())
     }
 
     pub(super) fn check_rx_break_detected(&self) -> bool {
@@ -750,12 +759,17 @@ impl Info {
             return Ok(0);
         }
 
-        while self.rx_fifo_count() == 0 {
-            // Block until we received at least one byte
-            self.check_for_errors(reported_errors)?;
-        }
+        loop {
+            while self.rx_fifo_count() == 0 {
+                // Block until we received at least one byte
+                self.check_for_errors(reported_errors)?;
+            }
 
-        self.read_buffered(buf, reported_errors)
+            let read = self.read_buffered(buf, reported_errors)?;
+            if read > 0 {
+                break Ok(read);
+            }
+        }
     }
 
     pub(super) fn read_buffered(
@@ -766,7 +780,9 @@ impl Info {
         // Get the count first, to avoid accidentally reading a corrupted byte received
         // after the error check.
         let to_read = (self.rx_fifo_count() as usize).min(buf.len());
-        self.check_for_errors(reported_errors)?;
+        if self.check_for_errors_and_reset_fifo(reported_errors)? {
+            return Ok(0);
+        }
 
         for byte_into in buf[..to_read].iter_mut() {
             *byte_into = self.read_next_from_fifo();

--- a/esp-hal/src/uart/low_level/mod.rs
+++ b/esp-hal/src/uart/low_level/mod.rs
@@ -30,21 +30,32 @@ pub(super) enum RxEvent {
     BreakDetected,
 }
 
-pub(super) fn rx_event_check_for_error(events: EnumSet<RxEvent>) -> Result<(), RxError> {
+pub(super) fn rx_event_check_for_error(
+    events: EnumSet<RxEvent>,
+    reported_errors: EnumSet<RxErrorKind>,
+) -> Result<(), RxError> {
     for event in events {
-        match event {
-            RxEvent::FifoOvf => return Err(RxError::FifoOverflowed),
-            RxEvent::GlitchDetected => return Err(RxError::GlitchOccurred),
-            RxEvent::FrameError => return Err(RxError::FrameFormatViolated),
-            RxEvent::ParityError => return Err(RxError::ParityMismatch),
-            RxEvent::FifoFull
-            | RxEvent::CmdCharDetected
-            | RxEvent::FifoTout
-            | RxEvent::BreakDetected => continue,
+        if let Some(error) = rx_error_kind(event)
+            && reported_errors.contains(error)
+        {
+            return Err(error.into());
         }
     }
 
     Ok(())
+}
+
+fn rx_error_kind(event: RxEvent) -> Option<RxErrorKind> {
+    match event {
+        RxEvent::FifoOvf => Some(RxErrorKind::FifoOverflowed),
+        RxEvent::GlitchDetected => Some(RxErrorKind::GlitchOccurred),
+        RxEvent::FrameError => Some(RxErrorKind::FrameFormatViolated),
+        RxEvent::ParityError => Some(RxErrorKind::ParityMismatch),
+        RxEvent::FifoFull
+        | RxEvent::CmdCharDetected
+        | RxEvent::FifoTout
+        | RxEvent::BreakDetected => None,
+    }
 }
 
 /// A future that resolves when the passed interrupt is triggered,
@@ -527,6 +538,15 @@ impl Info {
         version::rx_timeout_enabled(self)
     }
 
+    pub(super) fn set_discard_erroneous_bytes(&self, discard: bool) {
+        // ERR_WR_MASK causes the hardware to discard bytes with UART errors
+        // instead of storing them in the RX FIFO.
+        self.regs()
+            .conf0()
+            .modify(|_, w| w.err_wr_mask().bit(discard));
+        self.sync_regs();
+    }
+
     pub(super) fn is_tx_idle(&self) -> bool {
         version::is_tx_idle(self)
     }
@@ -676,17 +696,17 @@ impl Info {
             .write(|w| unsafe { w.rxfifo_rd_byte().bits(byte) });
     }
 
-    pub(super) fn check_for_errors(&self) -> Result<(), RxError> {
-        let errors = RxEvent::FifoOvf
-            | RxEvent::FifoTout
-            | RxEvent::GlitchDetected
-            | RxEvent::FrameError
-            | RxEvent::ParityError;
+    pub(super) fn check_for_errors(
+        &self,
+        reported_errors: EnumSet<RxErrorKind>,
+    ) -> Result<(), RxError> {
+        let errors =
+            RxEvent::FifoOvf | RxEvent::GlitchDetected | RxEvent::FrameError | RxEvent::ParityError;
         let events = self.rx_events().intersection(errors);
-        let result = rx_event_check_for_error(events);
-        if result.is_err() {
-            self.clear_rx_events(errors);
-            if events.contains(RxEvent::FifoOvf) {
+        let result = rx_event_check_for_error(events, reported_errors);
+        if !events.is_empty() {
+            self.clear_rx_events(events);
+            if result == Err(RxError::FifoOverflowed) {
                 self.rxfifo_reset();
             }
         }
@@ -721,24 +741,32 @@ impl Info {
         Ok(to_write)
     }
 
-    pub(super) fn read(&self, buf: &mut [u8]) -> Result<usize, RxError> {
+    pub(super) fn read(
+        &self,
+        buf: &mut [u8],
+        reported_errors: EnumSet<RxErrorKind>,
+    ) -> Result<usize, RxError> {
         if buf.is_empty() {
             return Ok(0);
         }
 
         while self.rx_fifo_count() == 0 {
             // Block until we received at least one byte
-            self.check_for_errors()?;
+            self.check_for_errors(reported_errors)?;
         }
 
-        self.read_buffered(buf)
+        self.read_buffered(buf, reported_errors)
     }
 
-    pub(super) fn read_buffered(&self, buf: &mut [u8]) -> Result<usize, RxError> {
+    pub(super) fn read_buffered(
+        &self,
+        buf: &mut [u8],
+        reported_errors: EnumSet<RxErrorKind>,
+    ) -> Result<usize, RxError> {
         // Get the count first, to avoid accidentally reading a corrupted byte received
         // after the error check.
         let to_read = (self.rx_fifo_count() as usize).min(buf.len());
-        self.check_for_errors()?;
+        self.check_for_errors(reported_errors)?;
 
         for byte_into in buf[..to_read].iter_mut() {
             *byte_into = self.read_next_from_fifo();

--- a/esp-hal/src/uart/mod.rs
+++ b/esp-hal/src/uart/mod.rs
@@ -172,6 +172,7 @@ impl core::error::Error for RxError {}
 /// [`RxError`].
 #[derive(Debug, EnumSetType)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[instability::unstable]
 #[non_exhaustive]
 pub enum RxErrorKind {
     /// An RX FIFO overflow happened.
@@ -435,7 +436,7 @@ pub struct RxConfig {
     ///
     /// Error conditions not present in this set are cleared and ignored by
     /// UART read operations.
-    #[builder_lite(into)]
+    #[builder_lite(unstable, into)]
     reported_errors: EnumSet<RxErrorKind>,
     /// Whether received bytes with UART errors are discarded by the hardware.
     ///
@@ -444,6 +445,7 @@ pub struct RxConfig {
     /// `false` to keep those bytes in the RX FIFO. Use
     /// [`Self::with_reported_errors`] to control whether those error
     /// conditions make read operations fail.
+    #[builder_lite(unstable)]
     discard_erroneous_bytes: bool,
 }
 

--- a/esp-hal/src/uart/mod.rs
+++ b/esp-hal/src/uart/mod.rs
@@ -165,6 +165,36 @@ pub enum RxError {
 
 impl core::error::Error for RxError {}
 
+/// UART RX error conditions that can be reported by read operations.
+///
+/// This enum can be used with [`RxConfig::with_reported_errors`] to choose
+/// which hardware RX error conditions should make read operations return an
+/// [`RxError`].
+#[derive(Debug, EnumSetType)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub enum RxErrorKind {
+    /// An RX FIFO overflow happened.
+    FifoOverflowed,
+    /// A glitch was detected on the RX line.
+    GlitchOccurred,
+    /// A framing error was detected on the RX line.
+    FrameFormatViolated,
+    /// A parity error was detected on the RX line.
+    ParityMismatch,
+}
+
+impl From<RxErrorKind> for RxError {
+    fn from(value: RxErrorKind) -> Self {
+        match value {
+            RxErrorKind::FifoOverflowed => RxError::FifoOverflowed,
+            RxErrorKind::GlitchOccurred => RxError::GlitchOccurred,
+            RxErrorKind::FrameFormatViolated => RxError::FrameFormatViolated,
+            RxErrorKind::ParityMismatch => RxError::ParityMismatch,
+        }
+    }
+}
+
 impl core::fmt::Display for RxError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
@@ -401,6 +431,20 @@ pub struct RxConfig {
     fifo_full_threshold: u16,
     /// Optional timeout value for RX operations.
     timeout: Option<u8>,
+    /// RX error conditions that read operations should report.
+    ///
+    /// Error conditions not present in this set are cleared and ignored by
+    /// UART read operations.
+    #[builder_lite(into)]
+    reported_errors: EnumSet<RxErrorKind>,
+    /// Whether received bytes with UART errors are discarded by the hardware.
+    ///
+    /// When set to `true` (the default), bytes with UART errors (for example
+    /// parity or framing errors) are not stored in the RX FIFO. Set this to
+    /// `false` to keep those bytes in the RX FIFO. Use
+    /// [`Self::with_reported_errors`] to control whether those error
+    /// conditions make read operations fail.
+    discard_erroneous_bytes: bool,
 }
 
 impl Default for RxConfig {
@@ -410,6 +454,8 @@ impl Default for RxConfig {
             fifo_full_threshold: 120,
             // see <https://github.com/espressif/esp-idf/blob/8760e6d2a/components/esp_driver_uart/src/uart.c#L63>
             timeout: Some(10),
+            reported_errors: EnumSet::all(),
+            discard_erroneous_bytes: true,
         }
     }
 }
@@ -503,7 +549,9 @@ where
                 phantom: PhantomData,
                 guard: rx_guard,
                 peri_clock_guard: peri_clock_guard.clone(),
+                // Receiving data continuously, the peripheral can't let the system sleep.
                 _wake_lock: WakeLock::new(),
+                reported_errors: config.rx.reported_errors,
             },
             tx: UartTx {
                 uart: self.uart,
@@ -560,8 +608,9 @@ pub struct UartRx<'d, Dm: DriverMode> {
     phantom: PhantomData<Dm>,
     guard: PeripheralGuard,
     peri_clock_guard: UartClockGuard<'d>,
-    // Receiving data continuously, the peripheral can't let the system to sleep.
+    // Receiving data continuously, the peripheral can't let the system sleep.
     _wake_lock: WakeLock,
+    reported_errors: EnumSet<RxErrorKind>,
 }
 
 /// A configuration error.
@@ -1026,6 +1075,7 @@ impl<'d> UartRx<'d, Blocking> {
             guard: self.guard,
             peri_clock_guard: self.peri_clock_guard,
             _wake_lock: self._wake_lock,
+            reported_errors: self.reported_errors,
         }
     }
 }
@@ -1048,6 +1098,7 @@ impl<'d> UartRx<'d, Async> {
             guard: self.guard,
             peri_clock_guard: self.peri_clock_guard,
             _wake_lock: self._wake_lock,
+            reported_errors: self.reported_errors,
         }
     }
 
@@ -1056,6 +1107,7 @@ impl<'d> UartRx<'d, Async> {
         minimum: usize,
         max_threshold: usize,
         listen_for_timeout: bool,
+        reported_errors: EnumSet<RxErrorKind>,
     ) -> Result<(), RxError> {
         let current_threshold = self.uart.info().rx_fifo_full_threshold();
 
@@ -1095,7 +1147,7 @@ impl<'d> UartRx<'d, Async> {
 
             let events = UartRxFuture::new(self.uart.reborrow(), events).await;
 
-            let result = rx_event_check_for_error(events);
+            let result = rx_event_check_for_error(events, reported_errors);
             if let Err(error) = result {
                 if error == RxError::FifoOverflowed {
                     self.uart.info().rxfifo_reset();
@@ -1130,9 +1182,33 @@ impl<'d> UartRx<'d, Async> {
             return Ok(0);
         }
 
-        self.wait_for_buffered_data(1, buf.len(), true).await?;
+        self.wait_for_buffered_data(1, buf.len(), true, self.reported_errors)
+            .await?;
 
         self.read_buffered(buf)
+    }
+
+    /// Read data asynchronously with a custom set of reported RX errors.
+    ///
+    /// This is the same as [`Self::read_async`], but lets the caller choose
+    /// which RX error conditions should cause this specific read to return an
+    /// error. Error conditions not present in `reported_errors` are cleared and
+    /// ignored for this read.
+    #[instability::unstable]
+    pub async fn read_async_with_reported_errors(
+        &mut self,
+        buf: &mut [u8],
+        reported_errors: impl Into<EnumSet<RxErrorKind>>,
+    ) -> Result<usize, RxError> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
+        let reported_errors = reported_errors.into();
+        self.wait_for_buffered_data(1, buf.len(), true, reported_errors)
+            .await?;
+
+        self.uart.info().read_buffered(buf, reported_errors)
     }
 
     /// Fill buffer asynchronously.
@@ -1155,17 +1231,17 @@ impl<'d> UartRx<'d, Async> {
         }
 
         // Drain the buffer first, there's no point in waiting for data we've already received.
-        let read = self.uart.info().read_buffered(buf)?;
+        let read = self.read_buffered(buf)?;
         buf = &mut buf[read..];
 
         while !buf.is_empty() {
             // No point in listening for timeouts, as we're waiting for an exact amount of
             // data. On ESP32 and S2, the timeout interrupt can't be cleared unless the FIFO
             // is empty, so listening could cause an infinite loop here.
-            self.wait_for_buffered_data(buf.len(), buf.len(), false)
+            self.wait_for_buffered_data(buf.len(), buf.len(), false, self.reported_errors)
                 .await?;
 
-            let read = self.uart.info().read_buffered(buf)?;
+            let read = self.read_buffered(buf)?;
             buf = &mut buf[read..];
         }
 
@@ -1256,17 +1332,24 @@ where
         self.uart
             .info()
             .set_rx_timeout(config.rx.timeout, self.uart.info().current_symbol_length())?;
+        self.uart
+            .info()
+            .set_discard_erroneous_bytes(config.rx.discard_erroneous_bytes);
+        self.reported_errors = config.rx.reported_errors;
 
         self.uart.info().rxfifo_reset();
         Ok(())
     }
 
-    /// Reads and clears errors set by received data.
+    /// Reads and clears RX error conditions set by received data.
     ///
-    /// If a FIFO overflow is detected, the RX FIFO is reset.
+    /// Only errors enabled in [`RxConfig::with_reported_errors`] are returned;
+    /// disabled errors are cleared and ignored.
+    ///
+    /// If a reported FIFO overflow is detected, the RX FIFO is reset.
     #[instability::unstable]
     pub fn check_for_errors(&mut self) -> Result<(), RxError> {
-        self.uart.info().check_for_errors()
+        self.uart.info().check_for_errors(self.reported_errors)
     }
 
     /// Returns whether the UART buffer has data.
@@ -1291,15 +1374,15 @@ where
     ///
     /// ## Errors
     ///
-    /// This function returns an [`RxError`] if an error occurred since the last
-    /// call to [`Self::check_for_errors`], [`Self::read_buffered`], or this
-    /// function.
+    /// This function returns an [`RxError`] if a reported error occurred since
+    /// the last call to [`Self::check_for_errors`], [`Self::read_buffered`], or
+    /// this function.
     ///
     /// If the error occurred before this function was called, the contents of
     /// the FIFO are not modified.
     #[instability::unstable]
     pub fn read(&mut self, buf: &mut [u8]) -> Result<usize, RxError> {
-        self.uart.info().read(buf)
+        self.uart.info().read(buf, self.reported_errors)
     }
 
     /// Read already received bytes.
@@ -1313,15 +1396,15 @@ where
     ///
     /// ## Errors
     ///
-    /// This function returns an [`RxError`] if an error occurred since the last
-    /// call to [`Self::check_for_errors`], [`Self::read`], or this
+    /// This function returns an [`RxError`] if a reported error occurred since
+    /// the last call to [`Self::check_for_errors`], [`Self::read`], or this
     /// function.
     ///
     /// If the error occurred before this function was called, the contents of
     /// the FIFO are not modified.
     #[instability::unstable]
     pub fn read_buffered(&mut self, buf: &mut [u8]) -> Result<usize, RxError> {
-        self.uart.info().read_buffered(buf)
+        self.uart.info().read_buffered(buf, self.reported_errors)
     }
 
     /// Disables all RX-related interrupts for this UART instance.
@@ -1633,6 +1716,23 @@ impl<'d> Uart<'d, Async> {
         self.rx.read_async(buf).await
     }
 
+    /// Read data asynchronously with a custom set of reported RX errors.
+    ///
+    /// This is the same as [`Self::read_async`], but lets the caller choose
+    /// which RX error conditions should cause this specific read to return an
+    /// error. Error conditions not present in `reported_errors` are cleared and
+    /// ignored for this read.
+    #[instability::unstable]
+    pub async fn read_async_with_reported_errors(
+        &mut self,
+        buf: &mut [u8],
+        reported_errors: impl Into<EnumSet<RxErrorKind>>,
+    ) -> Result<usize, RxError> {
+        self.rx
+            .read_async_with_reported_errors(buf, reported_errors)
+            .await
+    }
+
     /// Fill buffer asynchronously.
     ///
     /// This function reads data from the UART receive buffer into the
@@ -1937,8 +2037,8 @@ where
     ///
     /// ## Errors
     ///
-    /// This function returns an [`RxError`] if an error occurred since the last
-    /// check for errors.
+    /// This function returns an [`RxError`] if a reported error occurred since
+    /// the last check for errors.
     ///
     /// If the error occurred before this function was called, the contents of
     /// the FIFO are not modified.
@@ -2055,7 +2155,10 @@ where
         (&mut self.rx, &mut self.tx)
     }
 
-    /// Reads and clears errors set by received data.
+    /// Reads and clears RX error conditions set by received data.
+    ///
+    /// Only errors enabled in [`RxConfig::with_reported_errors`] are returned;
+    /// disabled errors are cleared and ignored.
     #[instability::unstable]
     pub fn check_for_rx_errors(&mut self) -> Result<(), RxError> {
         self.rx.check_for_errors()
@@ -2072,8 +2175,8 @@ where
     ///
     /// ## Errors
     ///
-    /// This function returns an [`RxError`] if an error occurred since the last
-    /// check for errors.
+    /// This function returns an [`RxError`] if a reported error occurred since
+    /// the last check for errors.
     ///
     /// If the error occurred before this function was called, the contents of
     /// the FIFO are not modified.
@@ -2133,11 +2236,6 @@ where
         self.regs()
             .idle_conf()
             .modify(|_, w| unsafe { w.tx_idle_num().bits(0) });
-
-        // Setting err_wr_mask stops uart from storing data when data is wrong according
-        // to reference manual
-        self.regs().conf0().modify(|_, w| w.err_wr_mask().set_bit());
-        sync_regs(self.regs());
 
         crate::rom::ets_delay_us(15);
 

--- a/esp-hal/src/uart/mod.rs
+++ b/esp-hal/src/uart/mod.rs
@@ -1148,13 +1148,10 @@ impl<'d> UartRx<'d, Async> {
 
             let events = UartRxFuture::new(self.uart.reborrow(), events).await;
 
-            let result = rx_event_check_for_error(events, self.reported_errors);
             if events.contains(RxEvent::FifoOvf) {
                 self.uart.info().rxfifo_reset();
             }
-            if let Err(error) = result {
-                return Err(error);
-            }
+            rx_event_check_for_error(events, self.reported_errors)?;
         }
 
         Ok(())

--- a/esp-hal/src/uart/mod.rs
+++ b/esp-hal/src/uart/mod.rs
@@ -1107,7 +1107,6 @@ impl<'d> UartRx<'d, Async> {
         minimum: usize,
         max_threshold: usize,
         listen_for_timeout: bool,
-        reported_errors: EnumSet<RxErrorKind>,
     ) -> Result<(), RxError> {
         let current_threshold = self.uart.info().rx_fifo_full_threshold();
 
@@ -1147,7 +1146,7 @@ impl<'d> UartRx<'d, Async> {
 
             let events = UartRxFuture::new(self.uart.reborrow(), events).await;
 
-            let result = rx_event_check_for_error(events, reported_errors);
+            let result = rx_event_check_for_error(events, self.reported_errors);
             if let Err(error) = result {
                 if error == RxError::FifoOverflowed {
                     self.uart.info().rxfifo_reset();
@@ -1182,33 +1181,9 @@ impl<'d> UartRx<'d, Async> {
             return Ok(0);
         }
 
-        self.wait_for_buffered_data(1, buf.len(), true, self.reported_errors)
-            .await?;
+        self.wait_for_buffered_data(1, buf.len(), true).await?;
 
         self.read_buffered(buf)
-    }
-
-    /// Read data asynchronously with a custom set of reported RX errors.
-    ///
-    /// This is the same as [`Self::read_async`], but lets the caller choose
-    /// which RX error conditions should cause this specific read to return an
-    /// error. Error conditions not present in `reported_errors` are cleared and
-    /// ignored for this read.
-    #[instability::unstable]
-    pub async fn read_async_with_reported_errors(
-        &mut self,
-        buf: &mut [u8],
-        reported_errors: impl Into<EnumSet<RxErrorKind>>,
-    ) -> Result<usize, RxError> {
-        if buf.is_empty() {
-            return Ok(0);
-        }
-
-        let reported_errors = reported_errors.into();
-        self.wait_for_buffered_data(1, buf.len(), true, reported_errors)
-            .await?;
-
-        self.uart.info().read_buffered(buf, reported_errors)
     }
 
     /// Fill buffer asynchronously.
@@ -1238,7 +1213,7 @@ impl<'d> UartRx<'d, Async> {
             // No point in listening for timeouts, as we're waiting for an exact amount of
             // data. On ESP32 and S2, the timeout interrupt can't be cleared unless the FIFO
             // is empty, so listening could cause an infinite loop here.
-            self.wait_for_buffered_data(buf.len(), buf.len(), false, self.reported_errors)
+            self.wait_for_buffered_data(buf.len(), buf.len(), false)
                 .await?;
 
             let read = self.read_buffered(buf)?;
@@ -1714,23 +1689,6 @@ impl<'d> Uart<'d, Async> {
     /// ```
     pub async fn read_async(&mut self, buf: &mut [u8]) -> Result<usize, RxError> {
         self.rx.read_async(buf).await
-    }
-
-    /// Read data asynchronously with a custom set of reported RX errors.
-    ///
-    /// This is the same as [`Self::read_async`], but lets the caller choose
-    /// which RX error conditions should cause this specific read to return an
-    /// error. Error conditions not present in `reported_errors` are cleared and
-    /// ignored for this read.
-    #[instability::unstable]
-    pub async fn read_async_with_reported_errors(
-        &mut self,
-        buf: &mut [u8],
-        reported_errors: impl Into<EnumSet<RxErrorKind>>,
-    ) -> Result<usize, RxError> {
-        self.rx
-            .read_async_with_reported_errors(buf, reported_errors)
-            .await
     }
 
     /// Fill buffer asynchronously.

--- a/esp-hal/src/uart/mod.rs
+++ b/esp-hal/src/uart/mod.rs
@@ -1147,10 +1147,10 @@ impl<'d> UartRx<'d, Async> {
             let events = UartRxFuture::new(self.uart.reborrow(), events).await;
 
             let result = rx_event_check_for_error(events, self.reported_errors);
+            if events.contains(RxEvent::FifoOvf) {
+                self.uart.info().rxfifo_reset();
+            }
             if let Err(error) = result {
-                if error == RxError::FifoOverflowed {
-                    self.uart.info().rxfifo_reset();
-                }
                 return Err(error);
             }
         }
@@ -1321,7 +1321,7 @@ where
     /// Only errors enabled in [`RxConfig::with_reported_errors`] are returned;
     /// disabled errors are cleared and ignored.
     ///
-    /// If a reported FIFO overflow is detected, the RX FIFO is reset.
+    /// If a FIFO overflow is detected, the RX FIFO is reset.
     #[instability::unstable]
     pub fn check_for_errors(&mut self) -> Result<(), RxError> {
         self.uart.info().check_for_errors(self.reported_errors)

--- a/hil-test/src/bin/uart.rs
+++ b/hil-test/src/bin/uart.rs
@@ -558,7 +558,7 @@ mod async_tx_rx {
         Async,
         interrupt::software::SoftwareInterruptControl,
         timer::timg::TimerGroup,
-        uart::{self, RxConfig, RxError, UartRx, UartTx},
+        uart::{self, RxConfig, RxError, RxErrorKind, UartRx, UartTx},
     };
     use hil_test::{assert, assert_eq, assert_ne};
 
@@ -566,6 +566,14 @@ mod async_tx_rx {
         rx: UartRx<'static, Async>,
         tx: UartTx<'static, Async>,
     }
+
+    fn contains_subslice(haystack: &[u8], needle: &[u8]) -> bool {
+        needle.is_empty()
+            || haystack
+                .windows(needle.len())
+                .any(|window| window == needle)
+    }
+
     #[init]
     async fn init() -> Context {
         let peripherals = esp_hal::init(esp_hal::Config::default());
@@ -608,6 +616,77 @@ mod async_tx_rx {
             ctx.tx.send_break_async(&mut delay, 100).await;
         })
         .await;
+    }
+
+    #[test]
+    async fn read_async_can_ignore_break_related_errors(ctx: Context) {
+        let mut rx = ctx.rx;
+        let mut tx = ctx.tx;
+        let mut delay = Delay;
+        const PAYLOAD: &[u8] = &[0x55, 0x12, 0x34];
+
+        rx.apply_config(
+            &uart::Config::default().with_rx(
+                RxConfig::default()
+                    .with_discard_erroneous_bytes(false)
+                    .with_reported_errors(RxErrorKind::FifoOverflowed),
+            ),
+        )
+        .unwrap();
+
+        let read = async {
+            let mut received = [0u8; 16];
+            let mut received_len = 0;
+
+            while !contains_subslice(&received[..received_len], PAYLOAD) {
+                assert!(received_len < received.len());
+                let read = rx.read_async(&mut received[received_len..]).await.unwrap();
+                received_len += read;
+            }
+        };
+
+        let write = async {
+            tx.flush_async().await.unwrap();
+            tx.send_break_async(&mut delay, 100).await;
+            tx.write_async(PAYLOAD).await.unwrap();
+            tx.flush_async().await.unwrap();
+        };
+
+        join(read, write).await;
+    }
+
+    #[test]
+    async fn read_async_per_call_error_filter_ignores_break_related_errors(ctx: Context) {
+        let mut rx = ctx.rx;
+        let mut tx = ctx.tx;
+        let mut delay = Delay;
+        const PAYLOAD: &[u8] = &[0x55, 0x56, 0x57];
+
+        let read = async {
+            let mut received = [0u8; 16];
+            let mut received_len = 0;
+
+            while !contains_subslice(&received[..received_len], PAYLOAD) {
+                assert!(received_len < received.len());
+                let read = rx
+                    .read_async_with_reported_errors(
+                        &mut received[received_len..],
+                        RxErrorKind::FifoOverflowed,
+                    )
+                    .await
+                    .unwrap();
+                received_len += read;
+            }
+        };
+
+        let write = async {
+            tx.flush_async().await.unwrap();
+            tx.send_break_async(&mut delay, 100).await;
+            tx.write_async(PAYLOAD).await.unwrap();
+            tx.flush_async().await.unwrap();
+        };
+
+        join(read, write).await;
     }
 
     #[test]

--- a/hil-test/src/bin/uart.rs
+++ b/hil-test/src/bin/uart.rs
@@ -656,40 +656,6 @@ mod async_tx_rx {
     }
 
     #[test]
-    async fn read_async_per_call_error_filter_ignores_break_related_errors(ctx: Context) {
-        let mut rx = ctx.rx;
-        let mut tx = ctx.tx;
-        let mut delay = Delay;
-        const PAYLOAD: &[u8] = &[0x55, 0x56, 0x57];
-
-        let read = async {
-            let mut received = [0u8; 16];
-            let mut received_len = 0;
-
-            while !contains_subslice(&received[..received_len], PAYLOAD) {
-                assert!(received_len < received.len());
-                let read = rx
-                    .read_async_with_reported_errors(
-                        &mut received[received_len..],
-                        RxErrorKind::FifoOverflowed,
-                    )
-                    .await
-                    .unwrap();
-                received_len += read;
-            }
-        };
-
-        let write = async {
-            tx.flush_async().await.unwrap();
-            tx.send_break_async(&mut delay, 100).await;
-            tx.write_async(PAYLOAD).await.unwrap();
-            tx.flush_async().await.unwrap();
-        };
-
-        join(read, write).await;
-    }
-
-    #[test]
     async fn write_async_does_not_return_0(mut ctx: Context) {
         let bytes = [0; 200];
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [X] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` or `manual-changelog` label as appropriate.
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
 Fixes UART async reads aborting on break-related RX errors by making RX error reporting configurable. 

#### Testing
HIL test

---

# Changelog

## esp-hal

- Fixed: UART RX error reporting and erroneous-byte discarding are now configurable.