### PR TITLE
Prefer inherent functions for esp-storage / esp-bootloader-esp-idf 

### DIFF
--- a/esp-bootloader-esp-idf/Cargo.toml
+++ b/esp-bootloader-esp-idf/Cargo.toml
@@ -36,7 +36,8 @@ esp-config = { version = "0.7.0", path = "../esp-config" }
 esp-hal-procmacros = { version = "0.22.0", path = "../esp-hal-procmacros", features = ["__esp_idf_bootloader"] }
 esp-metadata-generated = { version = "0.4.0", path = "../esp-metadata-generated" }
 esp-rom-sys = { version = "~0.1", path = "../esp-rom-sys", optional = true }
-embedded-storage = "0.3.1"
+embedded-storage = { version = "0.3.1", optional = true }
+esp-storage = { path = "../esp-storage", default-features = false }
 log-04 = { package = "log", version = "0.4", optional = true }
 strum = { version = "0.27", default-features = false, features = ["derive"] }
 
@@ -65,31 +66,34 @@ log-04 = ["dep:log-04"]
 defmt = ["dep:defmt"]
 
 # Replace ROM functions with pure Rust implementations, needed for tests.
-std = ["dep:crc", "dep:md-5"]
+std = ["dep:crc", "dep:md-5", "esp-storage/emulation"]
+
+## Implement traits from `embedded-storage` for [`FlashRegion`].
+embedded-storage = ["dep:embedded-storage", "esp-storage/embedded-storage"]
 
 #! ### Chip selection
 #! One of the following features must be enabled to select the target chip:
 
 ##
-esp32c2   = ["esp-rom-sys/esp32c2", "esp-metadata-generated/esp32c2", "esp-hal/esp32c2"]
+esp32c2   = ["esp-rom-sys/esp32c2", "esp-metadata-generated/esp32c2", "esp-hal/esp32c2", "esp-storage/esp32c2"]
 ##
-esp32c3   = ["esp-rom-sys/esp32c3", "esp-metadata-generated/esp32c3", "esp-hal/esp32c3"]
+esp32c3   = ["esp-rom-sys/esp32c3", "esp-metadata-generated/esp32c3", "esp-hal/esp32c3", "esp-storage/esp32c3"]
 ##
-esp32c5   = ["esp-rom-sys/esp32c5", "esp-metadata-generated/esp32c5", "esp-hal/esp32c5"]
+esp32c5   = ["esp-rom-sys/esp32c5", "esp-metadata-generated/esp32c5", "esp-hal/esp32c5", "esp-storage/esp32c5"]
 ##
-esp32c6   = ["esp-rom-sys/esp32c6", "esp-metadata-generated/esp32c6", "esp-hal/esp32c6"]
+esp32c6   = ["esp-rom-sys/esp32c6", "esp-metadata-generated/esp32c6", "esp-hal/esp32c6", "esp-storage/esp32c6"]
 ##
-esp32c61   = ["esp-rom-sys/esp32c61", "esp-metadata-generated/esp32c61", "esp-hal/esp32c61"]
+esp32c61   = ["esp-rom-sys/esp32c61", "esp-metadata-generated/esp32c61", "esp-hal/esp32c61", "esp-storage/esp32c61"]
 ##
-esp32h2   = ["esp-rom-sys/esp32h2", "esp-metadata-generated/esp32h2", "esp-hal/esp32h2"]
+esp32h2   = ["esp-rom-sys/esp32h2", "esp-metadata-generated/esp32h2", "esp-hal/esp32h2", "esp-storage/esp32h2"]
 ##
 esp32p4   = ["esp-rom-sys/esp32p4", "esp-metadata-generated/esp32p4", "esp-hal/esp32p4"]
 ##
-esp32     = ["esp-rom-sys/esp32", "esp-metadata-generated/esp32", "esp-hal/esp32"]
+esp32     = ["esp-rom-sys/esp32", "esp-metadata-generated/esp32", "esp-hal/esp32", "esp-storage/esp32"]
 ##
-esp32s2   = ["esp-rom-sys/esp32s2", "esp-metadata-generated/esp32s2", "esp-hal/esp32s2"]
+esp32s2   = ["esp-rom-sys/esp32s2", "esp-metadata-generated/esp32s2", "esp-hal/esp32s2", "esp-storage/esp32s2"]
 ##
-esp32s3   = ["esp-rom-sys/esp32s3", "esp-metadata-generated/esp32s3", "esp-hal/esp32s3"]
+esp32s3   = ["esp-rom-sys/esp32s3", "esp-metadata-generated/esp32s3", "esp-hal/esp32s3", "esp-storage/esp32s3"]
 
 # "md-5" is hidden behind `std` feature and `cargo machete` incorrectly marks it as unused.
 [package.metadata.cargo-machete]

--- a/esp-bootloader-esp-idf/Cargo.toml
+++ b/esp-bootloader-esp-idf/Cargo.toml
@@ -37,7 +37,7 @@ esp-hal-procmacros = { version = "0.22.0", path = "../esp-hal-procmacros", featu
 esp-metadata-generated = { version = "0.4.0", path = "../esp-metadata-generated" }
 esp-rom-sys = { version = "~0.1", path = "../esp-rom-sys", optional = true }
 embedded-storage = { version = "0.3.1", optional = true }
-esp-storage = { path = "../esp-storage", default-features = false }
+esp-storage = { path = "../esp-storage", default-features = false, optional = true }
 log-04 = { package = "log", version = "0.4", optional = true }
 strum = { version = "0.27", default-features = false, features = ["derive"] }
 

--- a/esp-bootloader-esp-idf/src/lib.rs
+++ b/esp-bootloader-esp-idf/src/lib.rs
@@ -101,9 +101,11 @@
 // MUST be the first module
 mod fmt;
 
-#[cfg(not(feature = "std"))]
+// temporary fix - no esp-storage support for P4 yet
+#[cfg(not(any(feature = "std", feature = "esp32p4")))]
 mod rom;
-#[cfg(not(feature = "std"))]
+// temporary fix - no esp-storage support for P4 yet
+#[cfg(not(any(feature = "std", feature = "esp32p4")))]
 pub(crate) use rom as crypto;
 
 #[cfg(feature = "std")]

--- a/esp-bootloader-esp-idf/src/lib.rs
+++ b/esp-bootloader-esp-idf/src/lib.rs
@@ -113,10 +113,16 @@ pub use crypto::Crc32 as Crc32ForTesting;
 #[cfg(feature = "std")]
 pub(crate) use non_rom as crypto;
 
+// temporary fix - no esp-storage support for P4 yet
+#[cfg(not(feature = "esp32p4"))]
 pub mod partitions;
 
+// temporary fix - no esp-storage support for P4 yet
+#[cfg(not(feature = "esp32p4"))]
 pub mod ota;
 
+// temporary fix - no esp-storage support for P4 yet
+#[cfg(not(feature = "esp32p4"))]
 pub mod ota_updater;
 
 // We run tests on the host which happens to be MacOS machines and mach-o

--- a/esp-bootloader-esp-idf/src/lib.rs
+++ b/esp-bootloader-esp-idf/src/lib.rs
@@ -110,7 +110,7 @@ pub(crate) use rom as crypto;
 
 #[cfg(feature = "std")]
 mod non_rom;
-#[cfg(embedded_test)]
+#[cfg(all(embedded_test, not(feature = "esp32p4")))]
 pub use crypto::Crc32 as Crc32ForTesting;
 #[cfg(feature = "std")]
 pub(crate) use non_rom as crypto;

--- a/esp-bootloader-esp-idf/src/ota.rs
+++ b/esp-bootloader-esp-idf/src/ota.rs
@@ -24,8 +24,6 @@
 //! - read the current slot, change the current slot
 //!
 //! For more details see <https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/system/ota.html>
-use embedded_storage::{ReadStorage, Storage};
-
 use crate::partitions::{
     AppPartitionSubType,
     DataPartitionSubType,
@@ -145,18 +143,12 @@ impl OtaSelectEntry {
 /// If you are looking for a more high-level way to do this, see [crate::ota_updater::OtaUpdater]
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct Ota<'a, F>
-where
-    F: embedded_storage::Storage,
-{
-    flash: FlashRegion<'a, F>,
+pub struct Ota<'a, 'd> {
+    flash: FlashRegion<'a, 'd>,
     ota_partition_count: usize,
 }
 
-impl<'a, F> Ota<'a, F>
-where
-    F: embedded_storage::Storage,
-{
+impl<'a, 'd> Ota<'a, 'd> {
     /// Create a [Ota] instance from the given [FlashRegion] and the count of OTA app partitions
     /// (not including "firmware" and "test" partitions)
     ///
@@ -165,7 +157,10 @@ where
     /// doesn't represent a Data/Ota partition or the size is unexpected.
     ///
     /// [Error::InvalidArgument] if the `ota_partition_count` exceeds the maximum or if it's 0.
-    pub fn new(flash: FlashRegion<'a, F>, ota_partition_count: usize) -> Result<Ota<'a, F>, Error> {
+    pub fn new(
+        flash: FlashRegion<'a, 'd>,
+        ota_partition_count: usize,
+    ) -> Result<Ota<'a, 'd>, Error> {
         if ota_partition_count == 0 || ota_partition_count > 16 {
             return Err(Error::InvalidArgument);
         }
@@ -355,32 +350,10 @@ where
 
 #[cfg(test)]
 mod tests {
+    use esp_storage::{Flash, FlashStorage};
+
     use super::*;
     use crate::partitions::PartitionEntry;
-
-    struct MockFlash {
-        data: [u8; 0x2000],
-    }
-
-    impl embedded_storage::Storage for MockFlash {
-        fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error> {
-            self.data[offset as usize..][..bytes.len()].copy_from_slice(bytes);
-            Ok(())
-        }
-    }
-
-    impl embedded_storage::ReadStorage for MockFlash {
-        type Error = crate::partitions::Error;
-        fn read(&mut self, offset: u32, buffer: &mut [u8]) -> Result<(), Self::Error> {
-            let l = buffer.len();
-            buffer[..l].copy_from_slice(&self.data[offset as usize..][..l]);
-            Ok(())
-        }
-
-        fn capacity(&self) -> usize {
-            unimplemented!()
-        }
-    }
 
     const PARTITION_RAW: [u8; 32] = [
         0xaa, 0x50, // MAGIC
@@ -417,22 +390,34 @@ mod tests {
         255, 255, 255, 255, 1, 0, 0, 0, 17, 80, 74, 237,
     ];
 
+    fn ota_region<'a>(
+        flash: &'a mut FlashStorage<'static>,
+        binary: &'a mut [u8; 32],
+    ) -> FlashRegion<'a, 'static> {
+        FlashRegion {
+            raw: PartitionEntry { binary },
+            flash,
+        }
+    }
+
+    fn init_ota_flash(flash: &mut FlashStorage<'static>) {
+        flash.erase(0, 0x2000).unwrap();
+    }
+
+    fn read_slot(flash: &mut FlashStorage<'static>, offset: u32) -> [u8; 0x20] {
+        let mut buf = [0u8; 0x20];
+        flash.read(offset, &mut buf).unwrap();
+        buf
+    }
+
     #[test]
     fn test_initial_state_and_next_slot() {
         let mut binary = PARTITION_RAW;
 
-        let mock_entry = PartitionEntry {
-            binary: &mut binary,
-        };
+        let mut flash = FlashStorage::new(Flash::new());
+        init_ota_flash(&mut flash);
 
-        let mut mock_flash = MockFlash {
-            data: [0xff; 0x2000],
-        };
-
-        let mock_region = FlashRegion {
-            raw: mock_entry,
-            flash: &mut mock_flash,
-        };
+        let mock_region = ota_region(&mut flash, &mut binary);
 
         let mut sut = Ota::new(mock_region, 2).unwrap();
         assert_eq!(
@@ -460,29 +445,20 @@ mod tests {
         );
         assert_eq!(sut.current_ota_state(), Ok(OtaImageState::Undefined));
 
-        assert_eq!(SLOT_COUNT_1_UNDEFINED, &mock_flash.data[0x0000..][..0x20],);
-        assert_eq!(SLOT_INITIAL, &mock_flash.data[0x1000..][..0x20],);
+        assert_eq!(&read_slot(&mut flash, 0x0000)[..], SLOT_COUNT_1_UNDEFINED);
+        assert_eq!(&read_slot(&mut flash, 0x1000)[..], SLOT_INITIAL);
     }
 
     #[test]
     fn test_slot0_valid_next_slot() {
         let mut binary = PARTITION_RAW;
 
-        let mock_entry = PartitionEntry {
-            binary: &mut binary,
-        };
+        let mut flash = FlashStorage::new(Flash::new());
+        init_ota_flash(&mut flash);
+        flash.write(0x0000, SLOT_COUNT_1_VALID).unwrap();
+        flash.write(0x1000, SLOT_INITIAL).unwrap();
 
-        let mut mock_flash = MockFlash {
-            data: [0xff; 0x2000],
-        };
-
-        mock_flash.data[0x0000..][..0x20].copy_from_slice(SLOT_COUNT_1_VALID);
-        mock_flash.data[0x1000..][..0x20].copy_from_slice(SLOT_INITIAL);
-
-        let mock_region = FlashRegion {
-            raw: mock_entry,
-            flash: &mut mock_flash,
-        };
+        let mock_region = ota_region(&mut flash, &mut binary);
 
         let mut sut = Ota::new(mock_region, 2).unwrap();
         assert_eq!(
@@ -500,29 +476,20 @@ mod tests {
         );
         assert_eq!(sut.current_ota_state(), Ok(OtaImageState::New));
 
-        assert_eq!(SLOT_COUNT_1_VALID, &mock_flash.data[0x0000..][..0x20],);
-        assert_eq!(SLOT_COUNT_2_NEW, &mock_flash.data[0x1000..][..0x20],);
+        assert_eq!(&read_slot(&mut flash, 0x0000)[..], SLOT_COUNT_1_VALID);
+        assert_eq!(&read_slot(&mut flash, 0x1000)[..], SLOT_COUNT_2_NEW);
     }
 
     #[test]
     fn test_slot1_new_next_slot() {
         let mut binary = PARTITION_RAW;
 
-        let mock_entry = PartitionEntry {
-            binary: &mut binary,
-        };
+        let mut flash = FlashStorage::new(Flash::new());
+        init_ota_flash(&mut flash);
+        flash.write(0x0000, SLOT_COUNT_1_VALID).unwrap();
+        flash.write(0x1000, SLOT_COUNT_2_NEW).unwrap();
 
-        let mut mock_flash = MockFlash {
-            data: [0xff; 0x2000],
-        };
-
-        mock_flash.data[0x0000..][..0x20].copy_from_slice(SLOT_COUNT_1_VALID);
-        mock_flash.data[0x1000..][..0x20].copy_from_slice(SLOT_COUNT_2_NEW);
-
-        let mock_region = FlashRegion {
-            raw: mock_entry,
-            flash: &mut mock_flash,
-        };
+        let mock_region = ota_region(&mut flash, &mut binary);
 
         let mut sut = Ota::new(mock_region, 2).unwrap();
         assert_eq!(
@@ -541,26 +508,18 @@ mod tests {
         );
         assert_eq!(sut.current_ota_state(), Ok(OtaImageState::PendingVerify));
 
-        assert_eq!(SLOT_COUNT_3_PENDING, &mock_flash.data[0x0000..][..0x20],);
-        assert_eq!(SLOT_COUNT_2_NEW, &mock_flash.data[0x1000..][..0x20],);
+        assert_eq!(&read_slot(&mut flash, 0x0000)[..], SLOT_COUNT_3_PENDING);
+        assert_eq!(&read_slot(&mut flash, 0x1000)[..], SLOT_COUNT_2_NEW);
     }
 
     #[test]
     fn test_multi_updates() {
         let mut binary = PARTITION_RAW;
 
-        let mock_entry = PartitionEntry {
-            binary: &mut binary,
-        };
+        let mut flash = FlashStorage::new(Flash::new());
+        init_ota_flash(&mut flash);
 
-        let mut mock_flash = MockFlash {
-            data: [0xff; 0x2000],
-        };
-
-        let mock_region = FlashRegion {
-            raw: mock_entry,
-            flash: &mut mock_flash,
-        };
+        let mock_region = ota_region(&mut flash, &mut binary);
 
         let mut sut = Ota::new(mock_region, 2).unwrap();
         assert_eq!(
@@ -615,18 +574,10 @@ mod tests {
     fn test_multi_updates_4_apps() {
         let mut binary = PARTITION_RAW;
 
-        let mock_entry = PartitionEntry {
-            binary: &mut binary,
-        };
+        let mut flash = FlashStorage::new(Flash::new());
+        init_ota_flash(&mut flash);
 
-        let mut mock_flash = MockFlash {
-            data: [0xff; 0x2000],
-        };
-
-        let mock_region = FlashRegion {
-            raw: mock_entry,
-            flash: &mut mock_flash,
-        };
+        let mock_region = ota_region(&mut flash, &mut binary);
 
         let mut sut = Ota::new(mock_region, 4).unwrap();
         assert_eq!(
@@ -700,18 +651,10 @@ mod tests {
     fn test_multi_updates_skip_parts() {
         let mut binary = PARTITION_RAW;
 
-        let mock_entry = PartitionEntry {
-            binary: &mut binary,
-        };
+        let mut flash = FlashStorage::new(Flash::new());
+        init_ota_flash(&mut flash);
 
-        let mut mock_flash = MockFlash {
-            data: [0xff; 0x2000],
-        };
-
-        let mock_region = FlashRegion {
-            raw: mock_entry,
-            flash: &mut mock_flash,
-        };
+        let mock_region = ota_region(&mut flash, &mut binary);
 
         let mut sut = Ota::new(mock_region, 16).unwrap();
         assert_eq!(

--- a/esp-bootloader-esp-idf/src/ota_updater.rs
+++ b/esp-bootloader-esp-idf/src/ota_updater.rs
@@ -10,25 +10,19 @@ use crate::{
 /// If you need lower level access see [crate::ota::Ota]
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct OtaUpdater<'a, F>
-where
-    F: embedded_storage::Storage,
-{
-    flash: &'a mut F,
+pub struct OtaUpdater<'a, 'd> {
+    flash: &'a mut esp_storage::FlashStorage<'d>,
     pt: PartitionTable<'a>,
     ota_count: usize,
 }
 
-impl<'a, F> OtaUpdater<'a, F>
-where
-    F: embedded_storage::Storage,
-{
+impl<'a, 'd> OtaUpdater<'a, 'd> {
     /// Create a new instance of [OtaUpdater].
     ///
     /// # Errors
     /// [Error::Invalid] if no OTA data partition or less than two OTA app partition were found.
     pub fn new(
-        flash: &'a mut F,
+        flash: &'a mut esp_storage::FlashStorage<'d>,
         buffer: &'a mut [u8; crate::partitions::PARTITION_TABLE_MAX_LEN],
     ) -> Result<Self, Error> {
         let pt = crate::partitions::read_partition_table(flash, buffer)?;
@@ -71,14 +65,14 @@ where
     ///
     /// # Errors
     /// [Error::Invalid] if no OTA data partition was found.
-    pub fn ota_data(&mut self) -> Result<crate::ota::Ota<'_, F>, Error> {
+    pub fn ota_data(&mut self) -> Result<crate::ota::Ota<'_, 'd>, Error> {
         let ota_part = self
             .pt
             .find_partition(crate::partitions::PartitionType::Data(
                 crate::partitions::DataPartitionSubType::Ota,
             ))?;
         if let Some(ota_part) = ota_part {
-            let ota_part = ota_part.as_embedded_storage(self.flash);
+            let ota_part = ota_part.as_flash_region(self.flash);
             let ota = crate::ota::Ota::new(ota_part, self.ota_count)?;
             Ok(ota)
         } else {
@@ -144,14 +138,14 @@ where
 
     /// Returns a [FlashRegion] along with the [AppPartitionSubType] for the
     /// partition which would be selected by [Self::activate_next_partition].
-    pub fn next_partition(&mut self) -> Result<(FlashRegion<'_, F>, AppPartitionSubType), Error> {
+    pub fn next_partition(&mut self) -> Result<(FlashRegion<'_, 'd>, AppPartitionSubType), Error> {
         let next_slot = self.next_ota_part()?;
 
         let flash_region = self
             .pt
             .find_partition(crate::partitions::PartitionType::App(next_slot))?
             .ok_or(Error::Invalid)?
-            .as_embedded_storage(self.flash);
+            .as_flash_region(self.flash);
 
         Ok((flash_region, next_slot))
     }

--- a/esp-bootloader-esp-idf/src/partitions.rs
+++ b/esp-bootloader-esp-idf/src/partitions.rs
@@ -105,13 +105,21 @@ impl<'a> PartitionEntry<'a> {
     }
 
     /// Provides a "view" into the partition allowing to read/write the
-    /// partition contents by using the given [embedded_storage::Storage] and/or
-    /// [embedded_storage::ReadStorage] implementation.
-    pub fn as_embedded_storage<F>(self, flash: &'a mut F) -> FlashRegion<'a, F>
-    where
-        F: embedded_storage::ReadStorage,
-    {
+    /// partition contents using the given [`esp_storage::FlashStorage`].
+    pub fn as_flash_region<'d>(
+        self,
+        flash: &'a mut esp_storage::FlashStorage<'d>,
+    ) -> FlashRegion<'a, 'd> {
         FlashRegion { raw: self, flash }
+    }
+
+    /// Alias for [`Self::as_flash_region`].
+    #[deprecated(note = "renamed to `as_flash_region`")]
+    pub fn as_embedded_storage<'d>(
+        self,
+        flash: &'a mut esp_storage::FlashStorage<'d>,
+    ) -> FlashRegion<'a, 'd> {
+        self.as_flash_region(flash)
     }
 }
 
@@ -536,10 +544,10 @@ impl TryFrom<u8> for PartitionTablePartitionSubType {
 
 /// Read the partition table.
 ///
-/// Pass an implementation of [embedded_storage::Storage] which can read from
-/// the whole flash and provide storage to read the partition table into.
-pub fn read_partition_table<'a>(
-    flash: &mut impl embedded_storage::Storage,
+/// Pass a [`esp_storage::FlashStorage`] which can read from the whole flash
+/// and provide storage to read the partition table into.
+pub fn read_partition_table<'a, 'd>(
+    flash: &mut esp_storage::FlashStorage<'d>,
     storage: &'a mut [u8],
 ) -> Result<PartitionTable<'a>, Error> {
     flash
@@ -555,12 +563,12 @@ pub fn read_partition_table<'a>(
 /// the partition offset.
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-pub struct FlashRegion<'a, F> {
+pub struct FlashRegion<'a, 'd> {
     pub(crate) raw: PartitionEntry<'a>,
-    pub(crate) flash: &'a mut F,
+    pub(crate) flash: &'a mut esp_storage::FlashStorage<'d>,
 }
 
-impl<F> FlashRegion<'_, F> {
+impl FlashRegion<'_, '_> {
     /// Returns the size of the partition in bytes.
     pub fn partition_size(&self) -> usize {
         self.raw.len() as _
@@ -573,21 +581,9 @@ impl<F> FlashRegion<'_, F> {
     fn in_range(&self, start: u32, len: usize) -> bool {
         self.range().contains(&start) && (start + len as u32 <= self.range().end)
     }
-}
 
-impl<F> embedded_storage::Region for FlashRegion<'_, F> {
-    fn contains(&self, address: u32) -> bool {
-        self.range().contains(&address)
-    }
-}
-
-impl<F> embedded_storage::ReadStorage for FlashRegion<'_, F>
-where
-    F: embedded_storage::ReadStorage,
-{
-    type Error = Error;
-
-    fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error> {
+    /// Read bytes from the partition.
+    pub fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Error> {
         let address = offset + self.raw.offset();
 
         if !self.in_range(address, bytes.len()) {
@@ -599,16 +595,8 @@ where
             .map_err(|_e| Error::StorageError)
     }
 
-    fn capacity(&self) -> usize {
-        self.partition_size()
-    }
-}
-
-impl<F> embedded_storage::Storage for FlashRegion<'_, F>
-where
-    F: embedded_storage::Storage,
-{
-    fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error> {
+    /// Write bytes to the partition.
+    pub fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Error> {
         let address = offset + self.raw.offset();
 
         if self.raw.is_read_only() {
@@ -623,53 +611,16 @@ where
             .write(address, bytes)
             .map_err(|_e| Error::StorageError)
     }
-}
 
-impl embedded_storage::nor_flash::NorFlashError for Error {
-    fn kind(&self) -> embedded_storage::nor_flash::NorFlashErrorKind {
-        match self {
-            Error::OutOfBounds => embedded_storage::nor_flash::NorFlashErrorKind::OutOfBounds,
-            _ => embedded_storage::nor_flash::NorFlashErrorKind::Other,
-        }
-    }
-}
-
-impl<F> embedded_storage::nor_flash::ErrorType for FlashRegion<'_, F> {
-    type Error = Error;
-}
-
-impl<F> embedded_storage::nor_flash::ReadNorFlash for FlashRegion<'_, F>
-where
-    F: embedded_storage::nor_flash::ReadNorFlash,
-{
-    const READ_SIZE: usize = F::READ_SIZE;
-
-    fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error> {
-        let address = offset + self.raw.offset();
-
-        if !self.in_range(address, bytes.len()) {
-            return Err(Error::OutOfBounds);
-        }
-
-        self.flash
-            .read(address, bytes)
-            .map_err(|_e| Error::StorageError)
-    }
-
-    fn capacity(&self) -> usize {
+    /// Returns the size of the partition in bytes.
+    pub fn capacity(&self) -> usize {
         self.partition_size()
     }
-}
 
-impl<F> embedded_storage::nor_flash::NorFlash for FlashRegion<'_, F>
-where
-    F: embedded_storage::nor_flash::NorFlash,
-{
-    const WRITE_SIZE: usize = F::WRITE_SIZE;
-
-    const ERASE_SIZE: usize = F::ERASE_SIZE;
-
-    fn erase(&mut self, from: u32, to: u32) -> Result<(), Self::Error> {
+    /// Erase flash in the partition from `from` up to but not including `to`.
+    ///
+    /// Addresses are relative to the partition start.
+    pub fn erase(&mut self, from: u32, to: u32) -> Result<(), Error> {
         let address_from = from + self.raw.offset();
         let address_to = to + self.raw.offset();
 
@@ -689,27 +640,109 @@ where
             .erase(address_from, address_to)
             .map_err(|_e| Error::StorageError)
     }
-
-    fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error> {
-        let address = offset + self.raw.offset();
-
-        if self.raw.is_read_only() {
-            return Err(Error::WriteProtected);
-        }
-
-        if !self.in_range(address, bytes.len()) {
-            return Err(Error::OutOfBounds);
-        }
-
-        self.flash
-            .write(address, bytes)
-            .map_err(|_e| Error::StorageError)
-    }
 }
 
-impl<F> embedded_storage::nor_flash::MultiwriteNorFlash for FlashRegion<'_, F> where
-    F: embedded_storage::nor_flash::MultiwriteNorFlash
-{
+#[cfg(feature = "embedded-storage")]
+mod embedded_storage_traits {
+    use ::embedded_storage::{
+        ReadStorage,
+        Region,
+        Storage,
+        nor_flash::{
+            ErrorType,
+            MultiwriteNorFlash,
+            NorFlash,
+            NorFlashError,
+            NorFlashErrorKind,
+            ReadNorFlash,
+        },
+    };
+
+    use super::*;
+
+    impl Region for FlashRegion<'_, '_> {
+        fn contains(&self, address: u32) -> bool {
+            self.range().contains(&address)
+        }
+    }
+
+    impl ReadStorage for FlashRegion<'_, '_> {
+        type Error = Error;
+
+        fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error> {
+            FlashRegion::read(self, offset, bytes)
+        }
+
+        fn capacity(&self) -> usize {
+            FlashRegion::capacity(self)
+        }
+    }
+
+    impl Storage for FlashRegion<'_, '_> {
+        fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error> {
+            FlashRegion::write(self, offset, bytes)
+        }
+    }
+
+    impl NorFlashError for Error {
+        fn kind(&self) -> NorFlashErrorKind {
+            match self {
+                Error::OutOfBounds => NorFlashErrorKind::OutOfBounds,
+                _ => NorFlashErrorKind::Other,
+            }
+        }
+    }
+
+    impl ErrorType for FlashRegion<'_, '_> {
+        type Error = Error;
+    }
+
+    impl ReadNorFlash for FlashRegion<'_, '_> {
+        const READ_SIZE: usize = esp_storage::FlashStorage::READ_SIZE;
+
+        fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error> {
+            let address = offset + self.raw.offset();
+
+            if !self.in_range(address, bytes.len()) {
+                return Err(Error::OutOfBounds);
+            }
+
+            self.flash
+                .read_nor(address, bytes)
+                .map_err(|_e| Error::StorageError)
+        }
+
+        fn capacity(&self) -> usize {
+            FlashRegion::capacity(self)
+        }
+    }
+
+    impl NorFlash for FlashRegion<'_, '_> {
+        const WRITE_SIZE: usize = esp_storage::FlashStorage::WRITE_SIZE;
+        const ERASE_SIZE: usize = esp_storage::FlashStorage::ERASE_SIZE;
+
+        fn erase(&mut self, from: u32, to: u32) -> Result<(), Self::Error> {
+            FlashRegion::erase(self, from, to)
+        }
+
+        fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error> {
+            let address = offset + self.raw.offset();
+
+            if self.raw.is_read_only() {
+                return Err(Error::WriteProtected);
+            }
+
+            if !self.in_range(address, bytes.len()) {
+                return Err(Error::OutOfBounds);
+            }
+
+            self.flash
+                .write_nor(address, bytes)
+                .map_err(|_e| Error::StorageError)
+        }
+    }
+
+    impl MultiwriteNorFlash for FlashRegion<'_, '_> {}
 }
 
 #[cfg(test)]
@@ -887,46 +920,22 @@ mod tests {
 
 #[cfg(test)]
 mod storage_tests {
-    use embedded_storage::{ReadStorage, Storage};
+    use esp_storage::{Flash, FlashStorage};
 
     use super::*;
 
-    struct MockFlash {
-        data: [u8; 0x10000],
-    }
-
-    impl MockFlash {
-        fn new() -> Self {
-            let mut data = [23u8; 0x10000];
-            data[PARTITION_TABLE_OFFSET as usize..][..PARTITION_TABLE_MAX_LEN as usize]
-                .copy_from_slice(include_bytes!("../testdata/single_factory_no_ota.bin"));
-            Self { data }
-        }
-    }
-
-    impl embedded_storage::Storage for MockFlash {
-        fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error> {
-            self.data[offset as usize..][..bytes.len()].copy_from_slice(bytes);
-            Ok(())
-        }
-    }
-
-    impl embedded_storage::ReadStorage for MockFlash {
-        type Error = crate::partitions::Error;
-        fn read(&mut self, offset: u32, buffer: &mut [u8]) -> Result<(), Self::Error> {
-            let l = buffer.len();
-            buffer[..l].copy_from_slice(&self.data[offset as usize..][..l]);
-            Ok(())
-        }
-
-        fn capacity(&self) -> usize {
-            unimplemented!()
-        }
+    fn test_flash() -> FlashStorage<'static> {
+        let mut flash = FlashStorage::new(Flash::new());
+        let mut data = [23u8; 0x10000];
+        data[PARTITION_TABLE_OFFSET as usize..][..PARTITION_TABLE_MAX_LEN]
+            .copy_from_slice(include_bytes!("../testdata/single_factory_no_ota.bin"));
+        flash.write(0, &data).unwrap();
+        flash
     }
 
     #[test]
     fn can_read_write_all_of_nvs() {
-        let mut storage = MockFlash::new();
+        let mut storage = test_flash();
 
         let mut buffer = [0u8; PARTITION_TABLE_MAX_LEN];
         let pt = read_partition_table(&mut storage, &mut buffer).unwrap();
@@ -935,7 +944,7 @@ mod storage_tests {
             .find_partition(PartitionType::Data(DataPartitionSubType::Nvs))
             .unwrap()
             .unwrap();
-        let mut nvs_partition = nvs.as_embedded_storage(&mut storage);
+        let mut nvs_partition = nvs.as_flash_region(&mut storage);
         assert_eq!(nvs_partition.raw.offset(), 36864);
 
         assert_eq!(nvs_partition.capacity(), 24576);
@@ -944,7 +953,7 @@ mod storage_tests {
         nvs_partition.read(0, &mut buffer).unwrap();
         assert!(buffer.iter().all(|v| *v == 23));
         buffer.fill(42);
-        nvs_partition.write(0, &mut buffer).unwrap();
+        nvs_partition.write(0, &buffer).unwrap();
         let mut buffer = [0u8; 24576];
         nvs_partition.read(0, &mut buffer).unwrap();
         assert!(buffer.iter().all(|v| *v == 42));
@@ -952,7 +961,7 @@ mod storage_tests {
 
     #[test]
     fn cannot_read_write_more_than_partition_size() {
-        let mut storage = MockFlash::new();
+        let mut storage = test_flash();
 
         let mut buffer = [0u8; PARTITION_TABLE_MAX_LEN];
         let pt = read_partition_table(&mut storage, &mut buffer).unwrap();
@@ -961,7 +970,7 @@ mod storage_tests {
             .find_partition(PartitionType::Data(DataPartitionSubType::Nvs))
             .unwrap()
             .unwrap();
-        let mut nvs_partition = nvs.as_embedded_storage(&mut storage);
+        let mut nvs_partition = nvs.as_flash_region(&mut storage);
         assert_eq!(nvs_partition.raw.offset(), 36864);
 
         assert_eq!(nvs_partition.capacity(), 24576);

--- a/esp-bootloader-esp-idf/src/partitions.rs
+++ b/esp-bootloader-esp-idf/src/partitions.rs
@@ -112,15 +112,6 @@ impl<'a> PartitionEntry<'a> {
     ) -> FlashRegion<'a, 'd> {
         FlashRegion { raw: self, flash }
     }
-
-    /// Alias for [`Self::as_flash_region`].
-    #[deprecated(note = "renamed to `as_flash_region`")]
-    pub fn as_embedded_storage<'d>(
-        self,
-        flash: &'a mut esp_storage::FlashStorage<'d>,
-    ) -> FlashRegion<'a, 'd> {
-        self.as_flash_region(flash)
-    }
 }
 
 impl core::fmt::Debug for PartitionEntry<'_> {

--- a/esp-storage/Cargo.toml
+++ b/esp-storage/Cargo.toml
@@ -13,21 +13,23 @@ license       = "MIT OR Apache-2.0"
 [package.metadata.espressif]
 check-configs = [
     { features = [] },
+    { features = ["embedded-storage"] },
     { features = ["critical-section"] },
     { features = ["bytewise-read"] },
-    { features = ["critical-section", "bytewise-read"] },
+    { features = ["embedded-storage", "critical-section"] },
+    { features = ["embedded-storage", "critical-section", "bytewise-read"] },
 ]
-clippy-configs = [{ features = ["critical-section", "bytewise-read"] }]
+clippy-configs = [{ features = ["embedded-storage", "critical-section", "bytewise-read"] }]
 
 [package.metadata.docs.rs]
 default-target = "riscv32imac-unknown-none-elf"
-features       = ["esp32c6"]
+features       = ["esp32c6", "embedded-storage"]
 
 [lib]
 bench = false
 
 [dependencies]
-embedded-storage = "0.3.1"
+embedded-storage = { version = "0.3.1", optional = true }
 procmacros       = { version = "0.22.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
 esp-hal = { version = "~1.1.0", path = "../esp-hal", default-features = false, optional = true}
 
@@ -50,6 +52,9 @@ critical-section = []
 
 ## Bytewise read emulation
 bytewise-read = []
+
+## Implement traits from `embedded-storage` for [`FlashStorage`].
+embedded-storage = ["dep:embedded-storage"]
 
 ## Implement `defmt::Format` on certain types.
 defmt = ["dep:defmt"]

--- a/esp-storage/README.md
+++ b/esp-storage/README.md
@@ -6,7 +6,7 @@
 ![Crates.io](https://img.shields.io/crates/l/esp-storage?labelColor=1C2C2E&style=flat-square)
 [![Matrix](https://img.shields.io/matrix/esp-rs:matrix.org?label=join%20matrix&labelColor=1C2C2E&color=BEC5C9&logo=matrix&style=flat-square)](https://matrix.to/#/#esp-rs:matrix.org)
 
-This crate functionality to access unencrypted ESP32 flash. Enable the
+This crate provides functionality to access unencrypted ESP32 flash. Enable the
 `embedded-storage` feature for [`embedded-storage`](https://github.com/rust-embedded-community/embedded-storage) trait implementations.
 
 ## Important

--- a/esp-storage/README.md
+++ b/esp-storage/README.md
@@ -6,11 +6,8 @@
 ![Crates.io](https://img.shields.io/crates/l/esp-storage?labelColor=1C2C2E&style=flat-square)
 [![Matrix](https://img.shields.io/matrix/esp-rs:matrix.org?label=join%20matrix&labelColor=1C2C2E&color=BEC5C9&logo=matrix&style=flat-square)](https://matrix.to/#/#esp-rs:matrix.org)
 
-This implements [`embedded-storage`](https://github.com/rust-embedded-community/embedded-storage) traits to access unencrypted ESP32 flash.
-
-## Current support
-
-ESP32, ESP32-C2, ESP32-C3, ESP32-C6, ESP32-H2, ESP32-S2 and ESP32-S3 are supported in `esp-storage`
+This crate functionality to access unencrypted ESP32 flash. Enable the
+`embedded-storage` feature for [`embedded-storage`](https://github.com/rust-embedded-community/embedded-storage) trait implementations.
 
 ## Important
 

--- a/esp-storage/src/common.rs
+++ b/esp-storage/src/common.rs
@@ -66,16 +66,6 @@ impl<'d> Flash<'d> {
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 /// Flash storage abstraction.
-///
-/// This only implements traits from [`embedded_storage`].
-/// If you need to use this struct where traits from [`embedded_storage_async`] are needed, you can
-/// use [`embassy_embedded_hal::adapter::BlockingAsync`] or
-/// [`embassy_embedded_hal::adapter::YieldingAsync`] wrappers.
-///
-/// [`embedded_storage`]: https://docs.rs/embedded-storage/latest/embedded_storage/
-/// [`embedded_storage_async`]: https://docs.rs/embedded-storage-async/latest/embedded_storage_async/
-/// [`embassy_embedded_hal::adapter::BlockingAsync`]: https://docs.rs/embassy-embedded-hal/latest/embassy_embedded_hal/adapter/struct.BlockingAsync.html
-/// [`embassy_embedded_hal::adapter::YieldingAsync`]: https://docs.rs/embassy-embedded-hal/latest/embassy_embedded_hal/adapter/struct.YieldingAsync.html
 pub struct FlashStorage<'d> {
     pub(crate) capacity: usize,
     unlocked: bool,

--- a/esp-storage/src/lib.rs
+++ b/esp-storage/src/lib.rs
@@ -1,3 +1,20 @@
+//! `esp-storage` contains API functions related to reading, writing and erasing memory for data in
+//! the external flash.
+//!
+//! For higher-level functionality which works with partitions defined in the partition table, see
+//! `esp-bootloader-esp-idf`.
+//!
+//! The `embedded-storage` feature flag only implements traits from [`embedded_storage`].
+//!
+//! If you need to use this struct where traits from [`embedded_storage_async`] are needed, you can
+//! use [`embassy_embedded_hal::adapter::BlockingAsync`] or
+//! [`embassy_embedded_hal::adapter::YieldingAsync`] wrappers.
+//!
+//! [`embedded_storage`]: https://docs.rs/embedded-storage/latest/embedded_storage/
+//! [`embedded_storage_async`]: https://docs.rs/embedded-storage-async/latest/embedded_storage_async/
+//! [`embassy_embedded_hal::adapter::BlockingAsync`]: https://docs.rs/embassy-embedded-hal/latest/embassy_embedded_hal/adapter/struct.BlockingAsync.html
+//! [`embassy_embedded_hal::adapter::YieldingAsync`]: https://docs.rs/embassy-embedded-hal/latest/embassy_embedded_hal/adapter/struct.YieldingAsync.html
+//!
 //! ## Feature Flags
 #![doc = document_features::document_features!(feature_label = r#"<span class="stab portability"><code>{feature}</code></span>"#)]
 #![doc(html_logo_url = "https://docs.espressif.com/projects/rust/esp-rs-grey-bg.svg")]
@@ -10,7 +27,7 @@ mod chip_specific;
 mod buffer;
 mod common;
 
-pub use common::{FlashStorage, FlashStorageError};
+pub use common::{Flash, FlashStorage, FlashStorageError};
 
 pub mod ll;
 mod nor_flash;

--- a/esp-storage/src/nor_flash.rs
+++ b/esp-storage/src/nor_flash.rs
@@ -1,12 +1,3 @@
-use embedded_storage::nor_flash::{
-    ErrorType,
-    MultiwriteNorFlash,
-    NorFlash,
-    NorFlashError,
-    NorFlashErrorKind,
-    ReadNorFlash,
-};
-
 #[cfg(feature = "bytewise-read")]
 use crate::buffer::FlashWordBuffer;
 use crate::{
@@ -16,35 +7,30 @@ use crate::{
 };
 
 impl FlashStorage<'_> {
+    #[cfg(not(feature = "bytewise-read"))]
+    /// Minimum read size in bytes for [`FlashStorage::read_nor`].
+    pub const READ_SIZE: usize = Self::WORD_SIZE as _;
+
+    #[cfg(feature = "bytewise-read")]
+    /// Minimum read size in bytes for [`FlashStorage::read_nor`].
+    pub const READ_SIZE: usize = 1;
+
+    /// Minimum write size in bytes for [`FlashStorage::write_nor`].
+    pub const WRITE_SIZE: usize = Self::WORD_SIZE as _;
+
+    /// Minimum erase size in bytes for [`FlashStorage::erase`].
+    pub const ERASE_SIZE: usize = Self::SECTOR_SIZE as _;
+
     #[inline(always)]
     fn is_word_aligned(bytes: &[u8]) -> bool {
         // TODO: Use is_aligned_to when stabilized (see `pointer_is_aligned`)
         (bytes.as_ptr() as usize).is_multiple_of(Self::WORD_SIZE as usize)
     }
-}
 
-impl NorFlashError for FlashStorageError {
-    fn kind(&self) -> NorFlashErrorKind {
-        match self {
-            Self::NotAligned => NorFlashErrorKind::NotAligned,
-            Self::OutOfBounds => NorFlashErrorKind::OutOfBounds,
-            _ => NorFlashErrorKind::Other,
-        }
-    }
-}
-
-impl ErrorType for FlashStorage<'_> {
-    type Error = FlashStorageError;
-}
-
-impl ReadNorFlash for FlashStorage<'_> {
-    #[cfg(not(feature = "bytewise-read"))]
-    const READ_SIZE: usize = Self::WORD_SIZE as _;
-
-    #[cfg(feature = "bytewise-read")]
-    const READ_SIZE: usize = 1;
-
-    fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error> {
+    /// Read bytes from flash using NOR flash semantics.
+    ///
+    /// Offset and length must be aligned to [`Self::READ_SIZE`].
+    pub fn read_nor(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), FlashStorageError> {
         const RS: u32 = FlashStorage::READ_SIZE as u32;
         self.check_alignment::<{ RS }>(offset, bytes.len())?;
         self.check_bounds(offset, bytes.len())?;
@@ -131,16 +117,11 @@ impl ReadNorFlash for FlashStorage<'_> {
         Ok(())
     }
 
-    fn capacity(&self) -> usize {
-        self.capacity
-    }
-}
-
-impl NorFlash for FlashStorage<'_> {
-    const WRITE_SIZE: usize = Self::WORD_SIZE as _;
-    const ERASE_SIZE: usize = Self::SECTOR_SIZE as _;
-
-    fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error> {
+    /// Write bytes to flash using NOR flash semantics.
+    ///
+    /// The target region must be erased beforehand. Offset and length must be
+    /// aligned to [`Self::WRITE_SIZE`].
+    pub fn write_nor(&mut self, offset: u32, bytes: &[u8]) -> Result<(), FlashStorageError> {
         const WS: u32 = FlashStorage::WORD_SIZE;
         self.check_alignment::<{ WS }>(offset, bytes.len())?;
         self.check_bounds(offset, bytes.len())?;
@@ -174,7 +155,10 @@ impl NorFlash for FlashStorage<'_> {
         Ok(())
     }
 
-    fn erase(&mut self, from: u32, to: u32) -> Result<(), Self::Error> {
+    /// Erase flash from `from` up to but not including `to`.
+    ///
+    /// Both addresses must be aligned to [`Self::ERASE_SIZE`].
+    pub fn erase(&mut self, from: u32, to: u32) -> Result<(), FlashStorageError> {
         let len = (to - from) as _;
         const SZ: u32 = FlashStorage::SECTOR_SIZE;
         self.check_alignment::<{ SZ }>(from, len)?;
@@ -203,7 +187,60 @@ impl NorFlash for FlashStorage<'_> {
     }
 }
 
-impl MultiwriteNorFlash for FlashStorage<'_> {}
+#[cfg(feature = "embedded-storage")]
+mod embedded_storage_traits {
+    use ::embedded_storage::nor_flash::{
+        ErrorType,
+        MultiwriteNorFlash,
+        NorFlash,
+        NorFlashError,
+        NorFlashErrorKind,
+        ReadNorFlash,
+    };
+
+    use super::*;
+
+    impl NorFlashError for FlashStorageError {
+        fn kind(&self) -> NorFlashErrorKind {
+            match self {
+                FlashStorageError::NotAligned => NorFlashErrorKind::NotAligned,
+                FlashStorageError::OutOfBounds => NorFlashErrorKind::OutOfBounds,
+                _ => NorFlashErrorKind::Other,
+            }
+        }
+    }
+
+    impl ErrorType for FlashStorage<'_> {
+        type Error = FlashStorageError;
+    }
+
+    impl ReadNorFlash for FlashStorage<'_> {
+        const READ_SIZE: usize = FlashStorage::READ_SIZE;
+
+        fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error> {
+            FlashStorage::read_nor(self, offset, bytes)
+        }
+
+        fn capacity(&self) -> usize {
+            FlashStorage::capacity(self)
+        }
+    }
+
+    impl NorFlash for FlashStorage<'_> {
+        const WRITE_SIZE: usize = FlashStorage::WRITE_SIZE;
+        const ERASE_SIZE: usize = FlashStorage::ERASE_SIZE;
+
+        fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error> {
+            FlashStorage::write_nor(self, offset, bytes)
+        }
+
+        fn erase(&mut self, from: u32, to: u32) -> Result<(), Self::Error> {
+            FlashStorage::erase(self, from, to)
+        }
+    }
+
+    impl MultiwriteNorFlash for FlashStorage<'_> {}
+}
 
 // Run the tests with `--test-threads=1` - the emulation is not multithread safe
 #[cfg(test)]
@@ -290,10 +327,10 @@ mod tests {
         let mut data = TestBuffer::default();
 
         flash.erase(0, FLASH_SIZE).unwrap();
-        flash.write(0, &src.data).unwrap();
+        flash.write_nor(0, &src.data).unwrap();
 
         for (off, len) in range_gen::<WORD_SIZE, MAX_OFFSET, MAX_LENGTH>(Some(true)) {
-            flash.read(off, &mut data.data[..len as usize]).unwrap();
+            flash.read_nor(off, &mut data.data[..len as usize]).unwrap();
             assert_eq!(
                 data.data[..len as usize],
                 src.data[off as usize..][..len as usize]
@@ -309,7 +346,9 @@ mod tests {
         let mut data = TestBuffer::default();
 
         for (off, len) in range_gen::<WORD_SIZE, MAX_OFFSET, MAX_LENGTH>(Some(false)) {
-            flash.read(off, &mut data.data[..len as usize]).unwrap_err();
+            flash
+                .read_nor(off, &mut data.data[..len as usize])
+                .unwrap_err();
         }
     }
 
@@ -322,11 +361,11 @@ mod tests {
         let mut data = TestBuffer::default();
 
         flash.erase(0, FLASH_SIZE).unwrap();
-        flash.write(0, &src.data).unwrap();
+        flash.write_nor(0, &src.data).unwrap();
 
         for (off, len) in range_gen::<WORD_SIZE, MAX_OFFSET, MAX_LENGTH>(Some(true)) {
             flash
-                .read(off, &mut data.data[1..][..len as usize])
+                .read_nor(off, &mut data.data[1..][..len as usize])
                 .unwrap();
             assert_eq!(
                 data.data[1..][..len as usize],
@@ -345,10 +384,10 @@ mod tests {
         let mut data = TestBuffer::default();
 
         flash.erase(0, FLASH_SIZE).unwrap();
-        flash.write(0, &src.data).unwrap();
+        flash.write_nor(0, &src.data).unwrap();
 
         for (off, len) in range_gen::<WORD_SIZE, MAX_OFFSET, MAX_LENGTH>(None) {
-            flash.read(off, &mut data.data[..len as usize]).unwrap();
+            flash.read_nor(off, &mut data.data[..len as usize]).unwrap();
             assert_eq!(
                 data.data[..len as usize],
                 src.data[off as usize..][..len as usize]
@@ -366,11 +405,11 @@ mod tests {
         let mut data = TestBuffer::default();
 
         flash.erase(0, FLASH_SIZE).unwrap();
-        flash.write(0, &src.data).unwrap();
+        flash.write_nor(0, &src.data).unwrap();
 
         for (off, len) in range_gen::<WORD_SIZE, MAX_OFFSET, MAX_LENGTH>(None) {
             flash
-                .read(off, &mut data.data[1..][..len as usize])
+                .read_nor(off, &mut data.data[1..][..len as usize])
                 .unwrap();
             assert_eq!(
                 data.data[1..][..len as usize],
@@ -387,9 +426,9 @@ mod tests {
         let write_data = TestBuffer::seq();
 
         flash.erase(0, FLASH_SIZE).unwrap();
-        flash.write(0, &write_data.data[1..129]).unwrap();
+        flash.write_nor(0, &write_data.data[1..129]).unwrap();
 
-        flash.read(0, &mut read_data.data[..128]).unwrap();
+        flash.read_nor(0, &mut read_data.data[..128]).unwrap();
 
         assert_eq!(&read_data.data[..128], &write_data.data[1..129]);
     }
@@ -407,9 +446,9 @@ mod tests {
 
         // Clear area before and after erase
         flash.erase(from - SECTOR_SIZE, from).unwrap();
-        flash.write(from - SECTOR_SIZE, &write_data).unwrap();
+        flash.write_nor(from - SECTOR_SIZE, &write_data).unwrap();
         flash.erase(to, to + SECTOR_SIZE).unwrap();
-        flash.write(to, &write_data).unwrap();
+        flash.write_nor(to, &write_data).unwrap();
 
         // Erase and verify that only the desired parts were touched
         flash.erase(from, to).unwrap();

--- a/esp-storage/src/storage.rs
+++ b/esp-storage/src/storage.rs
@@ -1,11 +1,10 @@
-use embedded_storage::{ReadStorage, Storage};
-
 use crate::{FlashStorage, FlashStorageError, buffer::FlashSectorBuffer};
 
-impl ReadStorage for FlashStorage<'_> {
-    type Error = FlashStorageError;
-
-    fn read(&mut self, offset: u32, mut bytes: &mut [u8]) -> Result<(), Self::Error> {
+impl FlashStorage<'_> {
+    /// Read bytes from flash.
+    ///
+    /// Unaligned offsets and lengths are supported.
+    pub fn read(&mut self, offset: u32, mut bytes: &mut [u8]) -> Result<(), FlashStorageError> {
         self.check_bounds(offset, bytes.len())?;
 
         let mut data_offset = offset % Self::WORD_SIZE;
@@ -39,13 +38,14 @@ impl ReadStorage for FlashStorage<'_> {
     /// The SPI flash size is configured by writing a field in the software
     /// bootloader image header. This is done during flashing in espflash /
     /// esptool.
-    fn capacity(&self) -> usize {
+    pub fn capacity(&self) -> usize {
         self.capacity
     }
-}
 
-impl Storage for FlashStorage<'_> {
-    fn write(&mut self, offset: u32, mut bytes: &[u8]) -> Result<(), Self::Error> {
+    /// Write bytes to flash.
+    ///
+    /// Performs read-modify-write on affected sectors and erases before writing.
+    pub fn write(&mut self, offset: u32, mut bytes: &[u8]) -> Result<(), FlashStorageError> {
         self.check_bounds(offset, bytes.len())?;
 
         let mut data_offset = offset % Self::SECTOR_SIZE;
@@ -70,5 +70,30 @@ impl Storage for FlashStorage<'_> {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(feature = "embedded-storage")]
+mod embedded_storage_traits {
+    use ::embedded_storage::{ReadStorage, Storage};
+
+    use super::*;
+
+    impl ReadStorage for FlashStorage<'_> {
+        type Error = FlashStorageError;
+
+        fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error> {
+            FlashStorage::read(self, offset, bytes)
+        }
+
+        fn capacity(&self) -> usize {
+            FlashStorage::capacity(self)
+        }
+    }
+
+    impl Storage for FlashStorage<'_> {
+        fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error> {
+            FlashStorage::write(self, offset, bytes)
+        }
     }
 }

--- a/examples/ota/update/Cargo.toml
+++ b/examples/ota/update/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2024"
 publish = false
 
 [dependencies]
-embedded-storage = "0.3.1"
 esp-backtrace = { path = "../../../esp-backtrace", features = [
     "panic-handler",
     "println",

--- a/examples/ota/update/src/main.rs
+++ b/examples/ota/update/src/main.rs
@@ -34,7 +34,6 @@
 #![no_std]
 #![no_main]
 
-use embedded_storage::Storage;
 use esp_backtrace as _;
 use esp_hal::{
     gpio::{Input, InputConfig, Pull},

--- a/examples/peripheral/flash_read_write/Cargo.toml
+++ b/examples/peripheral/flash_read_write/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2024"
 publish = false
 
 [dependencies]
-embedded-storage = "0.3.1"
 esp-backtrace = { path = "../../../esp-backtrace", features = [
     "panic-handler",
     "println",

--- a/examples/peripheral/flash_read_write/src/main.rs
+++ b/examples/peripheral/flash_read_write/src/main.rs
@@ -5,7 +5,6 @@
 #![no_std]
 #![no_main]
 
-use embedded_storage::{ReadStorage, Storage};
 use esp_backtrace as _;
 use esp_bootloader_esp_idf::partitions;
 use esp_hal::main;
@@ -40,7 +39,7 @@ fn main() -> ! {
     ))
     .unwrap()
     .unwrap()
-    .as_embedded_storage(&mut flash)
+    .as_flash_region(&mut flash)
     .read(32, &mut app_desc)
     .unwrap();
     println!("App descriptor dump {:02x?}", app_desc);
@@ -52,7 +51,7 @@ fn main() -> ! {
         ))
         .unwrap()
         .unwrap();
-    let mut nvs_partition = nvs.as_embedded_storage(&mut flash);
+    let mut nvs_partition = nvs.as_flash_region(&mut flash);
 
     let mut bytes = [0u8; 32];
     println!("NVS partition size = {}", nvs_partition.capacity());

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -93,7 +93,6 @@ defmt              = "1.0.1"
 defmt-rtt          = { version = "1.0.0", optional = true }
 embassy-executor   = { version = "0.10.0", default-features = false }
 embassy-futures    = "0.1"
-embedded-storage   = "0.3.1"
 embassy-sync       = "0.7.0" # TODO: update after trouble-host has been released
 embassy-time       = "0.5.0"
 embedded-hal       = "1.0.0"

--- a/hil-test/src/bin/alloc_psram.rs
+++ b/hil-test/src/bin/alloc_psram.rs
@@ -145,7 +145,6 @@ mod tests {
 #[cfg(feature = "esp-storage")]
 #[embedded_test::tests]
 mod storage_tests {
-    use embedded_storage::*;
     use esp_bootloader_esp_idf::partitions;
     use esp_hal::peripherals::FLASH;
     use esp_storage::FlashStorage;
@@ -178,7 +177,7 @@ mod storage_tests {
         ))
         .unwrap()
         .unwrap()
-        .as_embedded_storage(&mut flash)
+        .as_flash_region(&mut flash)
         .read(32, &mut app_desc)
         .unwrap();
 

--- a/hil-test/src/bin/misc_non_drivers/simple.rs
+++ b/hil-test/src/bin/misc_non_drivers/simple.rs
@@ -146,6 +146,7 @@ mod tests {
         assert_eq!(crc_smbus, 0xf4);
     }
 
+    #[cfg(not(esp32p4))]
     #[test]
     fn test_crc_rom_function() {
         let crc = esp_bootloader_esp_idf::Crc32ForTesting::new();

--- a/hil-test/src/bin/storage_read_app_desc.rs
+++ b/hil-test/src/bin/storage_read_app_desc.rs
@@ -9,7 +9,6 @@
 #![no_std]
 #![no_main]
 
-use embedded_storage::ReadStorage;
 use esp_bootloader_esp_idf::EspAppDesc;
 use esp_storage::FlashStorage;
 use hil_test as _;

--- a/qa-test/Cargo.toml
+++ b/qa-test/Cargo.toml
@@ -31,7 +31,6 @@ esp-radio = { path = "../esp-radio", features = [
     "unstable",
 ], optional = true }
 esp-storage = { path = "../esp-storage", optional = true }
-embedded-storage = "0.3.1"
 lis3dh-async = "0.9.3"
 ssd1306 = "0.10.0"
 static_cell = "2.1.1"

--- a/qa-test/src/bin/multicore_flash.rs
+++ b/qa-test/src/bin/multicore_flash.rs
@@ -16,7 +16,6 @@
 
 use core::ptr::addr_of_mut;
 
-use embedded_storage::nor_flash::NorFlash;
 use esp_backtrace as _;
 use esp_hal::{
     clock::CpuClock,
@@ -116,7 +115,7 @@ fn flash_access(flash: esp_hal::peripherals::FLASH) {
 
         let mut foo = [0u8; 0x4000];
 
-        let res = flash.write(0x9000, &mut foo);
+        let res = flash.write_nor(0x9000, &foo);
         println!("Writing to flash result: {:?}", res);
     }
 }

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -879,6 +879,8 @@ pub fn run_host_tests(workspace: &Path, package: Package) -> Result<()> {
                     .arg("--lib")
                     .arg("--tests")
                     .features(&vec!["std".into()])
+                    .arg("--")
+                    .arg("--test-threads=1")
                     .build(),
                 &package_path,
             );


### PR DESCRIPTION
This is the very first (quite mechanical and thus LLM assisted) step towards #4713











# Changelog

## esp-bootloader-esp-idf

- Added: Inherent `read`, `write`, and `capacity` methods on [`FlashRegion`](crate::partitions::FlashRegion)
- Changed: `esp-bootloader-esp-idf` now directly depends on `esp-storage`
- Changed: `embedded-storage` trait implementations are now an opt-in feature (non-default)
- Changed: `PartitionEntry::as_embedded_storage` is deprecated in favor of [`PartitionEntry::as_flash_region`](crate::partitions::PartitionEntry::as_flash_region)
- Removed: `as_embedded_storage` - use `as_flash_region` instead

## esp-storage

- Added: Inherent flash I/O methods on `FlashStorage`: `read`, `write`, `capacity`, `read_nor`, `write_nor`, and `erase`
- Changed: `embedded-storage` trait implementations are now an opt-in feature (non-default)

