### PR TITLE
Do not run build in MQ

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,13 @@ jobs:
           LABELS: ${{ steps.labels.outputs.labels }}
         run: |
           BUILD=true; DOCS=true; MSRV=true; HOST=true
-          HIL=true; CHANGELOG=true; SEMVER=true
+          CHANGELOG=true; SEMVER=true
+          HIL=false
+
+          if [[ "${{ github.event_name }}" == "merge_group" ]]; then
+            BUILD=false
+            HIL=true
+          fi
 
           # `skip-ci-non-code-change` only skips building/testing; API checks (semver) still run.
           # Use the dedicated `skip-semver-checks` label to skip semver checks.
@@ -402,9 +408,7 @@ jobs:
 
   hil-build:
     needs: calculate
-    if: >
-      github.event_name == 'merge_group' &&
-      needs.calculate.outputs.run-hil == 'true'
+    if: needs.calculate.outputs.run-hil == 'true'
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.chips.outputs.matrix }}


### PR DESCRIPTION
We only place PRs into the merge queue that build cleanly. Since the MACs are our current bottlenecks, let's try to not run the basic checks in the merge queue, instead use the MAC(s) to build HIL tests.

I believe the clippy/docs/HIL build is enough to catch most cases where two PRs end up interfering with each other.