### PR TITLE
Remove all the "circular" remains from the DMA macros

### DIFF
--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -464,31 +464,6 @@ macro_rules! dma_buffers {
 }
 
 #[procmacros::doc_replace]
-/// Convenience macro to create circular DMA buffers and descriptors.
-///
-/// ## Usage
-/// ```rust,no_run
-/// # {before_snippet}
-/// use esp_hal::dma_circular_buffers;
-///
-/// // RX and TX buffers are 32000 bytes - passing only one parameter makes RX
-/// // and TX the same size.
-/// let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) =
-///     dma_circular_buffers!(32000, 32000);
-/// # {after_snippet}
-/// ```
-#[macro_export]
-macro_rules! dma_circular_buffers {
-    ($rx_size:expr, $tx_size:expr) => {
-        $crate::dma_circular_buffers_chunk_size!($rx_size, $tx_size, $crate::dma::CHUNK_SIZE)
-    };
-
-    ($size:expr) => {
-        $crate::dma_circular_buffers_chunk_size!($size, $size, $crate::dma::CHUNK_SIZE)
-    };
-}
-
-#[procmacros::doc_replace]
 /// Convenience macro to create DMA descriptors.
 ///
 /// ## Usage
@@ -513,30 +488,6 @@ macro_rules! dma_descriptors {
 }
 
 #[procmacros::doc_replace]
-/// Convenience macro to create circular DMA descriptors.
-///
-/// ## Usage
-/// ```rust,no_run
-/// # {before_snippet}
-/// use esp_hal::dma_circular_descriptors;
-///
-/// // Create RX and TX descriptors for transactions up to 32000
-/// // bytes - passing only one parameter assumes RX and TX are the same size.
-/// let (rx_descriptors, tx_descriptors) = dma_circular_descriptors!(32000, 32000);
-/// # {after_snippet}
-/// ```
-#[macro_export]
-macro_rules! dma_circular_descriptors {
-    ($rx_size:expr, $tx_size:expr) => {
-        $crate::dma_circular_descriptors_chunk_size!($rx_size, $tx_size, $crate::dma::CHUNK_SIZE)
-    };
-
-    ($size:expr) => {
-        $crate::dma_circular_descriptors_chunk_size!($size, $size, $crate::dma::CHUNK_SIZE)
-    };
-}
-
-#[procmacros::doc_replace]
 /// Convenience macro to create DMA buffers and descriptors with specific chunk
 /// size.
 ///
@@ -553,33 +504,11 @@ macro_rules! dma_circular_descriptors {
 /// ```
 #[macro_export]
 macro_rules! dma_buffers_chunk_size {
-    ($rx_size:expr, $tx_size:expr, $chunk_size:expr) => {{ $crate::dma_buffers_impl!($rx_size, $tx_size, $chunk_size, is_circular = false) }};
+    ($rx_size:expr, $tx_size:expr, $chunk_size:expr) => {{ $crate::dma_buffers_impl!($rx_size, $tx_size, $chunk_size) }};
 
     ($size:expr, $chunk_size:expr) => {
         $crate::dma_buffers_chunk_size!($size, $size, $chunk_size)
     };
-}
-
-#[procmacros::doc_replace]
-/// Convenience macro to create circular DMA buffers and descriptors with
-/// specific chunk size.
-///
-/// ## Usage
-/// ```rust,no_run
-/// # {before_snippet}
-/// use esp_hal::dma_circular_buffers_chunk_size;
-///
-/// // RX and TX buffers are 32000 bytes - passing only one parameter makes RX
-/// // and TX the same size.
-/// let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) =
-///     dma_circular_buffers_chunk_size!(32000, 32000, 4032);
-/// # {after_snippet}
-/// ```
-#[macro_export]
-macro_rules! dma_circular_buffers_chunk_size {
-    ($rx_size:expr, $tx_size:expr, $chunk_size:expr) => {{ $crate::dma_buffers_impl!($rx_size, $tx_size, $chunk_size, is_circular = true) }};
-
-    ($size:expr, $chunk_size:expr) => {{ $crate::dma_circular_buffers_chunk_size!($size, $size, $chunk_size) }};
 }
 
 #[procmacros::doc_replace]
@@ -597,33 +526,10 @@ macro_rules! dma_circular_buffers_chunk_size {
 /// ```
 #[macro_export]
 macro_rules! dma_descriptors_chunk_size {
-    ($rx_size:expr, $tx_size:expr, $chunk_size:expr) => {{ $crate::dma_descriptors_impl!($rx_size, $tx_size, $chunk_size, is_circular = false) }};
+    ($rx_size:expr, $tx_size:expr, $chunk_size:expr) => {{ $crate::dma_descriptors_impl!($rx_size, $tx_size, $chunk_size) }};
 
     ($size:expr, $chunk_size:expr) => {
         $crate::dma_descriptors_chunk_size!($size, $size, $chunk_size)
-    };
-}
-
-#[procmacros::doc_replace]
-/// Convenience macro to create circular DMA descriptors with specific chunk
-/// size
-///
-/// ## Usage
-/// ```rust,no_run
-/// # {before_snippet}
-/// use esp_hal::dma_circular_descriptors_chunk_size;
-///
-/// // Create RX and TX descriptors for transactions up to 32000 bytes - passing
-/// // only one parameter assumes RX and TX are the same size.
-/// let (rx_descriptors, tx_descriptors) = dma_circular_descriptors_chunk_size!(32000, 32000, 4032);
-/// # {after_snippet}
-/// ```
-#[macro_export]
-macro_rules! dma_circular_descriptors_chunk_size {
-    ($rx_size:expr, $tx_size:expr, $chunk_size:expr) => {{ $crate::dma_descriptors_impl!($rx_size, $tx_size, $chunk_size, is_circular = true) }};
-
-    ($size:expr, $chunk_size:expr) => {
-        $crate::dma_circular_descriptors_chunk_size!($size, $size, $chunk_size)
     };
 }
 
@@ -677,13 +583,13 @@ impl<const N: usize> InternalMemoryBuffer<N> {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! dma_buffers_impl {
-    ($rx_size:expr, $tx_size:expr, $chunk_size:expr, is_circular = $circular:tt) => {{
-        let rx = $crate::dma_buffers_impl!($rx_size, $chunk_size, is_circular = $circular);
-        let tx = $crate::dma_buffers_impl!($tx_size, $chunk_size, is_circular = $circular);
+    ($rx_size:expr, $tx_size:expr, $chunk_size:expr) => {{
+        let rx = $crate::dma_buffers_impl!($rx_size, $chunk_size);
+        let tx = $crate::dma_buffers_impl!($tx_size, $chunk_size);
         (rx.0, rx.1, tx.0, tx.1)
     }};
 
-    ($size:expr, $chunk_size:expr, is_circular = $circular:tt) => {{
+    ($size:expr, $chunk_size:expr) => {{
         unsafe {
             (
                 {
@@ -694,16 +600,15 @@ macro_rules! dma_buffers_impl {
                     // be a single mutable reference to this buffer.
                     unsafe { BUFFER.get_mut() }
                 },
-                $crate::dma_descriptors_impl!($size, $chunk_size, is_circular = $circular),
+                $crate::dma_descriptors_impl!($size, $chunk_size),
             )
         }
     }};
 
-    ($size:expr, is_circular = $circular:tt) => {
+    ($size:expr) => {
         $crate::dma_buffers_impl!(
             $size,
-            $crate::dma::BurstConfig::DEFAULT.max_compatible_chunk_size(),
-            is_circular = $circular
+            $crate::dma::BurstConfig::DEFAULT.max_compatible_chunk_size()
         );
     };
 }
@@ -711,20 +616,19 @@ macro_rules! dma_buffers_impl {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! dma_descriptors_impl {
-    ($rx_size:expr, $tx_size:expr, $chunk_size:expr, is_circular = $circular:tt) => {{
-        let rx = $crate::dma_descriptors_impl!($rx_size, $chunk_size, is_circular = $circular);
-        let tx = $crate::dma_descriptors_impl!($tx_size, $chunk_size, is_circular = $circular);
+    ($rx_size:expr, $tx_size:expr, $chunk_size:expr) => {{
+        let rx = $crate::dma_descriptors_impl!($rx_size, $chunk_size);
+        let tx = $crate::dma_descriptors_impl!($tx_size, $chunk_size);
         (rx, tx)
     }};
 
-    ($size:expr, $chunk_size:expr, is_circular = $circular:tt) => {{
+    ($size:expr, $chunk_size:expr) => {{
         use $crate::{
             __macro_implementation::static_cell::ConstStaticCell,
             dma::{DmaDescriptor, InternalMemoryCachelineAligned},
         };
 
-        const COUNT: usize =
-            $crate::dma_descriptor_count!($size, $chunk_size, is_circular = $circular);
+        const COUNT: usize = $crate::dma_descriptor_count!($size, $chunk_size);
 
         static DESCRIPTORS: ConstStaticCell<
             InternalMemoryCachelineAligned<[DmaDescriptor; COUNT]>,
@@ -739,7 +643,7 @@ macro_rules! dma_descriptors_impl {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! dma_descriptor_count {
-    ($size:expr, $chunk_size:expr, is_circular = $is_circular:tt) => {{
+    ($size:expr, $chunk_size:expr) => {{
         const {
             ::core::assert!($chunk_size <= 4095, "chunk size must be <= 4095");
             ::core::assert!($chunk_size > 0, "chunk size must be > 0");
@@ -749,7 +653,7 @@ macro_rules! dma_descriptor_count {
         if $size == 0 {
             0
         } else {
-            $crate::dma::descriptor_count($size, $chunk_size, $is_circular)
+            $crate::dma::descriptor_count($size, $chunk_size)
         }
     }};
 }
@@ -769,7 +673,7 @@ macro_rules! dma_descriptor_count {
 #[macro_export]
 macro_rules! dma_tx_buffer {
     ($tx_size:expr) => {{
-        let (tx_buffer, tx_descriptors) = $crate::dma_buffers_impl!($tx_size, is_circular = false);
+        let (tx_buffer, tx_descriptors) = $crate::dma_buffers_impl!($tx_size);
 
         $crate::dma::DmaTxBuf::new(tx_descriptors, tx_buffer)
     }};
@@ -798,8 +702,7 @@ macro_rules! dma_rx_stream_buffer {
         $crate::dma_rx_stream_buffer!($rx_size, 4095)
     };
     ($rx_size:expr, $chunk_size:expr) => {{
-        let (buffer, descriptors) =
-            $crate::dma_buffers_impl!($rx_size, $chunk_size, is_circular = false);
+        let (buffer, descriptors) = $crate::dma_buffers_impl!($rx_size, $chunk_size);
 
         $crate::dma::DmaRxStreamBuf::new(descriptors, buffer).unwrap()
     }};
@@ -828,8 +731,7 @@ macro_rules! dma_tx_stream_buffer {
         $crate::dma_tx_stream_buffer!($tx_size, 4095)
     };
     ($tx_size:expr, $chunk_size:expr) => {{
-        let (buffer, descriptors) =
-            $crate::dma_buffers_impl!($tx_size, $chunk_size, is_circular = false);
+        let (buffer, descriptors) = $crate::dma_buffers_impl!($tx_size, $chunk_size);
 
         $crate::dma::DmaTxStreamBuf::new(descriptors, buffer).unwrap()
     }};
@@ -854,7 +756,7 @@ macro_rules! dma_loop_buffer {
             ::core::assert!($size > 0, "size must be > 0");
         }
 
-        let (buffer, descriptors) = $crate::dma_buffers_impl!($size, $size, is_circular = false);
+        let (buffer, descriptors) = $crate::dma_buffers_impl!($size, $size);
 
         $crate::dma::DmaLoopBuf::new(&mut descriptors[0], buffer).unwrap()
     }};
@@ -946,11 +848,7 @@ impl From<u32> for Owner {
 
 /// Computes the number of descriptors required for a given buffer size with
 /// a given chunk size.
-pub const fn descriptor_count(buffer_size: usize, chunk_size: usize, is_circular: bool) -> usize {
-    if is_circular && buffer_size <= chunk_size * 2 {
-        return 3;
-    }
-
+pub const fn descriptor_count(buffer_size: usize, chunk_size: usize) -> usize {
     if buffer_size < chunk_size {
         // At least one descriptor is always required.
         return 1;
@@ -1035,7 +933,7 @@ impl<'a> DescriptorSet<'a> {
         buffer: &mut [u8],
         chunk_size: usize,
     ) -> Result<(), DmaBufError> {
-        Self::set_up_buffer_ptrs(buffer, self.descriptors, chunk_size, false)
+        Self::set_up_buffer_ptrs(buffer, self.descriptors, chunk_size)
     }
 
     /// Prepares descriptors for transferring `len` bytes of data.
@@ -1047,7 +945,7 @@ impl<'a> DescriptorSet<'a> {
         chunk_size: usize,
         prepare: fn(&mut DmaDescriptor, usize),
     ) -> Result<(), DmaBufError> {
-        Self::set_up_descriptors(self.descriptors, len, chunk_size, false, prepare)
+        Self::set_up_descriptors(self.descriptors, len, chunk_size, prepare)
     }
 
     /// Prepares descriptors for reading `len` bytes of data.
@@ -1073,10 +971,9 @@ impl<'a> DescriptorSet<'a> {
         descriptors: &mut [DmaDescriptor],
         len: usize,
         chunk_size: usize,
-        is_circular: bool,
     ) -> Result<&mut [DmaDescriptor], DmaBufError> {
         // First, pick enough descriptors to cover the buffer.
-        let required_descriptors = descriptor_count(len, chunk_size, is_circular);
+        let required_descriptors = descriptor_count(len, chunk_size);
         if descriptors.len() < required_descriptors {
             return Err(DmaBufError::InsufficientDescriptors);
         }
@@ -1094,18 +991,12 @@ impl<'a> DescriptorSet<'a> {
         descriptors: &mut [DmaDescriptor],
         len: usize,
         chunk_size: usize,
-        is_circular: bool,
         prepare: impl Fn(&mut DmaDescriptor, usize),
     ) -> Result<(), DmaBufError> {
-        let descriptors =
-            Self::descriptors_for_buffer_len(descriptors, len, chunk_size, is_circular)?;
+        let descriptors = Self::descriptors_for_buffer_len(descriptors, len, chunk_size)?;
 
         // Link up the descriptors.
-        let mut next = if is_circular {
-            descriptors.as_mut_ptr()
-        } else {
-            core::ptr::null_mut()
-        };
+        let mut next = core::ptr::null_mut();
         for desc in descriptors.iter_mut().rev() {
             desc.next = next;
             next = desc;
@@ -1138,10 +1029,8 @@ impl<'a> DescriptorSet<'a> {
         buffer: &mut [u8],
         descriptors: &mut [DmaDescriptor],
         chunk_size: usize,
-        is_circular: bool,
     ) -> Result<(), DmaBufError> {
-        let descriptors =
-            Self::descriptors_for_buffer_len(descriptors, buffer.len(), chunk_size, is_circular)?;
+        let descriptors = Self::descriptors_for_buffer_len(descriptors, buffer.len(), chunk_size)?;
 
         let chunks = buffer.chunks_mut(chunk_size);
         for (desc, chunk) in descriptors.iter_mut().zip(chunks) {

--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -454,6 +454,8 @@ pub const CHUNK_SIZE: usize = 4092;
 /// # {after_snippet}
 /// ```
 #[macro_export]
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 macro_rules! dma_buffers {
     ($rx_size:expr, $tx_size:expr) => {
         $crate::dma_buffers_chunk_size!($rx_size, $tx_size, $crate::dma::CHUNK_SIZE)
@@ -477,6 +479,8 @@ macro_rules! dma_buffers {
 /// # {after_snippet}
 /// ```
 #[macro_export]
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 macro_rules! dma_descriptors {
     ($rx_size:expr, $tx_size:expr) => {
         $crate::dma_descriptors_chunk_size!($rx_size, $tx_size, $crate::dma::CHUNK_SIZE)
@@ -503,6 +507,8 @@ macro_rules! dma_descriptors {
 /// # {after_snippet}
 /// ```
 #[macro_export]
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 macro_rules! dma_buffers_chunk_size {
     ($rx_size:expr, $tx_size:expr, $chunk_size:expr) => {{ $crate::dma_buffers_impl!($rx_size, $tx_size, $chunk_size) }};
 
@@ -525,6 +531,8 @@ macro_rules! dma_buffers_chunk_size {
 /// # {after_snippet}
 /// ```
 #[macro_export]
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 macro_rules! dma_descriptors_chunk_size {
     ($rx_size:expr, $tx_size:expr, $chunk_size:expr) => {{ $crate::dma_descriptors_impl!($rx_size, $tx_size, $chunk_size) }};
 
@@ -582,6 +590,8 @@ impl<const N: usize> InternalMemoryBuffer<N> {
 
 #[doc(hidden)]
 #[macro_export]
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 macro_rules! dma_buffers_impl {
     ($rx_size:expr, $tx_size:expr, $chunk_size:expr) => {{
         let rx = $crate::dma_buffers_impl!($rx_size, $chunk_size);
@@ -615,6 +625,8 @@ macro_rules! dma_buffers_impl {
 
 #[doc(hidden)]
 #[macro_export]
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 macro_rules! dma_descriptors_impl {
     ($rx_size:expr, $tx_size:expr, $chunk_size:expr) => {{
         let rx = $crate::dma_descriptors_impl!($rx_size, $chunk_size);
@@ -642,6 +654,8 @@ macro_rules! dma_descriptors_impl {
 
 #[doc(hidden)]
 #[macro_export]
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 macro_rules! dma_descriptor_count {
     ($size:expr, $chunk_size:expr) => {{
         const {
@@ -671,6 +685,8 @@ macro_rules! dma_descriptor_count {
 /// # {after_snippet}
 /// ```
 #[macro_export]
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 macro_rules! dma_tx_buffer {
     ($tx_size:expr) => {{
         let (tx_buffer, tx_descriptors) = $crate::dma_buffers_impl!($tx_size);
@@ -697,6 +713,8 @@ macro_rules! dma_tx_buffer {
 /// # {after_snippet}
 /// ```
 #[macro_export]
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 macro_rules! dma_rx_stream_buffer {
     ($rx_size:expr) => {
         $crate::dma_rx_stream_buffer!($rx_size, 4095)
@@ -726,6 +744,8 @@ macro_rules! dma_rx_stream_buffer {
 /// # {after_snippet}
 /// ```
 #[macro_export]
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 macro_rules! dma_tx_stream_buffer {
     ($tx_size:expr) => {
         $crate::dma_tx_stream_buffer!($tx_size, 4095)
@@ -749,6 +769,8 @@ macro_rules! dma_tx_stream_buffer {
 /// # {after_snippet}
 /// ```
 #[macro_export]
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 macro_rules! dma_loop_buffer {
     ($size:expr) => {{
         const {

--- a/hil-test/src/bin/misc_non_drivers/dma_buffers.rs
+++ b/hil-test/src/bin/misc_non_drivers/dma_buffers.rs
@@ -108,8 +108,7 @@ mod tests {
 
     #[test]
     fn test_dma_rx_stream_buf_insufficient_descriptors() {
-        let (buffer, descriptors) =
-            esp_hal::dma_buffers_impl!(BUFFER_SIZE, CHUNK_SIZE * 2, is_circular = false);
+        let (buffer, descriptors) = esp_hal::dma_buffers_impl!(BUFFER_SIZE, CHUNK_SIZE * 2);
         match DmaRxStreamBuf::new(descriptors, buffer) {
             Err(DmaBufError::InsufficientDescriptors) => (),
             _ => core::panic!("expected InsufficientDescriptors"),
@@ -118,8 +117,7 @@ mod tests {
 
     #[test]
     fn test_dma_tx_stream_buf_insufficient_descriptors() {
-        let (buffer, descriptors) =
-            esp_hal::dma_buffers_impl!(BUFFER_SIZE, CHUNK_SIZE * 2, is_circular = false);
+        let (buffer, descriptors) = esp_hal::dma_buffers_impl!(BUFFER_SIZE, CHUNK_SIZE * 2);
         match DmaTxStreamBuf::new(descriptors, buffer) {
             Err(DmaBufError::InsufficientDescriptors) => (),
             _ => core::panic!("expected InsufficientDescriptors"),

--- a/hil-test/src/bin/misc_non_drivers/dma_macros.rs
+++ b/hil-test/src/bin/misc_non_drivers/dma_macros.rs
@@ -6,13 +6,6 @@ mod tests {
         size.div_ceil(chunk_size)
     }
 
-    pub(crate) const fn compute_circular_size(size: usize, chunk_size: usize) -> usize {
-        if size > chunk_size * 2 {
-            size.div_ceil(chunk_size)
-        } else {
-            3
-        }
-    }
     // defmt::* is load-bearing, it ensures that the assert in dma_buffers! is not
     // using defmt's non-const assert. Doing so would result in a compile error.
     #[allow(unused_imports)]
@@ -44,37 +37,6 @@ mod tests {
     }
 
     #[test]
-    fn test_dma_circular_descriptors_same_size() {
-        use esp_hal::dma::CHUNK_SIZE;
-        let (rx_descriptors, tx_descriptors) = esp_hal::dma_circular_descriptors!(DATA_SIZE);
-        core::assert_eq!(rx_descriptors.len(), tx_descriptors.len());
-        core::assert_eq!(
-            rx_descriptors.len(),
-            compute_circular_size(DATA_SIZE, CHUNK_SIZE)
-        );
-        core::assert_eq!(
-            tx_descriptors.len(),
-            compute_circular_size(DATA_SIZE, CHUNK_SIZE)
-        );
-    }
-
-    #[test]
-    fn test_dma_circular_descriptors_different_size() {
-        use esp_hal::dma::CHUNK_SIZE;
-        const RX_SIZE: usize = DATA_SIZE / 2;
-        const TX_SIZE: usize = CHUNK_SIZE * 2;
-        let (rx_descriptors, tx_descriptors) = esp_hal::dma_circular_descriptors!(RX_SIZE, TX_SIZE);
-        core::assert_eq!(
-            rx_descriptors.len(),
-            compute_circular_size(RX_SIZE, CHUNK_SIZE)
-        );
-        core::assert_eq!(
-            tx_descriptors.len(),
-            compute_circular_size(TX_SIZE, CHUNK_SIZE)
-        );
-    }
-
-    #[test]
     fn test_dma_buffers_same_size() {
         use esp_hal::dma::CHUNK_SIZE;
         let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) =
@@ -101,43 +63,6 @@ mod tests {
     }
 
     #[test]
-    fn test_dma_circular_buffers_same_size() {
-        use esp_hal::dma::CHUNK_SIZE;
-        let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) =
-            esp_hal::dma_circular_buffers!(DATA_SIZE);
-        core::assert_eq!(rx_buffer.len(), DATA_SIZE);
-        core::assert_eq!(tx_buffer.len(), DATA_SIZE);
-        core::assert_eq!(rx_descriptors.len(), tx_descriptors.len());
-        core::assert_eq!(
-            rx_descriptors.len(),
-            compute_circular_size(DATA_SIZE, CHUNK_SIZE)
-        );
-        core::assert_eq!(
-            tx_descriptors.len(),
-            compute_circular_size(DATA_SIZE, CHUNK_SIZE)
-        );
-    }
-
-    #[test]
-    fn test_dma_circular_buffers_different_size() {
-        use esp_hal::dma::CHUNK_SIZE;
-        const RX_SIZE: usize = CHUNK_SIZE * 2;
-        const TX_SIZE: usize = CHUNK_SIZE * 4;
-        let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) =
-            esp_hal::dma_circular_buffers!(RX_SIZE, TX_SIZE);
-        core::assert_eq!(rx_buffer.len(), RX_SIZE);
-        core::assert_eq!(tx_buffer.len(), TX_SIZE);
-        core::assert_eq!(
-            rx_descriptors.len(),
-            compute_circular_size(RX_SIZE, CHUNK_SIZE)
-        );
-        core::assert_eq!(
-            tx_descriptors.len(),
-            compute_circular_size(TX_SIZE, CHUNK_SIZE)
-        );
-    }
-
-    #[test]
     fn test_dma_descriptors_chunk_size_same_size() {
         const CHUNK_SIZE: usize = 2048;
         let (rx_descriptors, tx_descriptors) =
@@ -156,43 +81,6 @@ mod tests {
             esp_hal::dma_descriptors_chunk_size!(RX_SIZE, TX_SIZE, CHUNK_SIZE);
         core::assert_eq!(rx_descriptors.len(), compute_size(RX_SIZE, CHUNK_SIZE));
         core::assert_eq!(tx_descriptors.len(), compute_size(TX_SIZE, CHUNK_SIZE));
-    }
-
-    #[test]
-    fn test_dma_circular_buffers_chunk_size_same_size() {
-        const CHUNK_SIZE: usize = 2048;
-        let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) =
-            esp_hal::dma_circular_buffers_chunk_size!(DATA_SIZE, CHUNK_SIZE);
-        core::assert_eq!(rx_buffer.len(), DATA_SIZE);
-        core::assert_eq!(tx_buffer.len(), DATA_SIZE);
-        core::assert_eq!(rx_descriptors.len(), tx_descriptors.len());
-        core::assert_eq!(
-            rx_descriptors.len(),
-            compute_circular_size(DATA_SIZE, CHUNK_SIZE)
-        );
-        core::assert_eq!(
-            tx_descriptors.len(),
-            compute_circular_size(DATA_SIZE, CHUNK_SIZE)
-        );
-    }
-
-    #[test]
-    fn test_dma_circular_buffers_chunk_size_different_size() {
-        const CHUNK_SIZE: usize = 2048;
-        const RX_SIZE: usize = DATA_SIZE / 2;
-        const TX_SIZE: usize = DATA_SIZE;
-        let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) =
-            esp_hal::dma_circular_buffers_chunk_size!(RX_SIZE, TX_SIZE, CHUNK_SIZE);
-        core::assert_eq!(rx_buffer.len(), RX_SIZE);
-        core::assert_eq!(tx_buffer.len(), TX_SIZE);
-        core::assert_eq!(
-            rx_descriptors.len(),
-            compute_circular_size(RX_SIZE, CHUNK_SIZE)
-        );
-        core::assert_eq!(
-            tx_descriptors.len(),
-            compute_circular_size(TX_SIZE, CHUNK_SIZE)
-        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #5741

Previously (before the I2S refactoring) we still used the circular descriptor lists - that's no more (we now use the streaming buffer impls) - therefore we can get rid of all the `circular` quirks in the DMA macros

# Changelog

## esp-hal

- Removed: `dma_circular_buffers!`, `dma_circular_descriptors!`, `dma_circular_buffers_chunk_size!`, and `dma_circular_descriptors_chunk_size!` macros.
- Changed: Reverted accidental stabilization of `dma_*` macros.
