### PR TITLE
CI: Don't use trace level log in radio-hil

### DIFF
--- a/hil-test-radio/.cargo/config.toml
+++ b/hil-test-radio/.cargo/config.toml
@@ -21,7 +21,11 @@ rustflags = [
 ]
 
 [env]
-DEFMT_LOG = "info,embedded_test=warn"
+# `force = true` so this INFO level wins over any `DEFMT_LOG` inherited from the
+# environment (CI exports `DEFMT_LOG=trace` globally). Without it the radio test
+# ELFs are built with trace-level defmt, which floods the USB-JTAG link and
+# causes probe communication failures.
+DEFMT_LOG = { value = "info,embedded_test=warn", force = true }
 
 [unstable]
 build-std = ["core", "alloc"]

--- a/hil-test-radio/.cargo/config.toml
+++ b/hil-test-radio/.cargo/config.toml
@@ -20,13 +20,6 @@ rustflags = [
     "-C", "link-arg=-Wl,-Tlinkall.x",
 ]
 
-[env]
-# `force = true` so this INFO level wins over any `DEFMT_LOG` inherited from the
-# environment (CI exports `DEFMT_LOG=trace` globally). Without it the radio test
-# ELFs are built with trace-level defmt, which floods the USB-JTAG link and
-# causes probe communication failures.
-DEFMT_LOG = { value = "info,embedded_test=warn", force = true }
-
 [unstable]
 build-std = ["core", "alloc"]
 

--- a/hil-test-radio/src/bin/support/ble_peripheral_support.rs
+++ b/hil-test-radio/src/bin/support/ble_peripheral_support.rs
@@ -2,7 +2,6 @@
 //% SUPPORT-FIRMWARE: true
 //% FEATURES: unstable esp-alloc embassy
 //% FEATURES(has_wifi_ble): esp-radio/ble esp-radio esp-radio-unstable
-//% FEATURES(has_wifi_ble): esp-radio/defmt defmt
 //% ENV: ESP_HAL_CONFIG_STACK_GUARD_OFFSET=4
 
 #![no_std]
@@ -74,7 +73,6 @@ where
     C: Controller,
 {
     let address = Address::random(PERIPHERAL_ADDRESS);
-    defmt::info!("[BLE-SUPPORT] address configured");
 
     let mut resources: HostResources<DefaultPacketPool, 1, 2> = HostResources::new();
     let stack = trouble_host::new(controller, &mut resources).set_random_address(address);
@@ -93,9 +91,7 @@ where
         loop {
             match advertise(&mut peripheral, &server).await {
                 Ok(conn) => {
-                    defmt::info!("[BLE-SUPPORT] connected");
                     gatt_events_task(&server, &conn).await;
-                    defmt::info!("[BLE-SUPPORT] disconnected");
                 }
                 Err(_) => Timer::after(Duration::from_millis(100)).await,
             }
@@ -107,7 +103,6 @@ where
 async fn ble_task<C: Controller, P: PacketPool>(mut runner: Runner<'_, C, P>) {
     loop {
         if runner.run().await.is_err() {
-            defmt::warn!("[BLE-SUPPORT] runner stopped");
             Timer::after(Duration::from_millis(100)).await;
         }
     }
@@ -140,7 +135,7 @@ where
         )
         .await?;
 
-    defmt::info!("[BLE-SUPPORT] advertising");
+    hil_test::signal_harness_ready();
     Ok(advertiser.accept().await?.with_attribute_server(server)?)
 }
 
@@ -153,13 +148,11 @@ async fn gatt_events_task<P: PacketPool>(server: &Server<'_>, conn: &GattConnect
             GattConnectionEvent::Gatt { event } => {
                 if let GattEvent::Read(event) = &event
                     && event.handle() == level.handle
-                {
-                    defmt::info!("[BLE-SUPPORT] battery level read");
-                }
+                {}
 
                 match event.accept() {
                     Ok(reply) => reply.send().await,
-                    Err(_) => defmt::warn!("[BLE-SUPPORT] failed to accept GATT event"),
+                    Err(_) => {}
                 }
             }
             _ => {}

--- a/hil-test-radio/src/bin/support/wifi_ap_support.rs
+++ b/hil-test-radio/src/bin/support/wifi_ap_support.rs
@@ -2,7 +2,6 @@
 //% SUPPORT-FIRMWARE: true
 //% FEATURES: unstable esp-alloc embassy
 //% FEATURES(has_wifi_ble): esp-radio/wifi esp-radio/ble esp-radio esp-radio-unstable
-//% FEATURES(has_wifi_ble): esp-radio/defmt defmt esp-radio/csi
 //% ENV: ESP_HAL_CONFIG_STACK_GUARD_OFFSET=4
 
 #![no_std]
@@ -94,7 +93,7 @@ async fn main(spawner: Spawner) -> ! {
     spawner.spawn(run_dhcp(stack, gw_ip_addr_str).unwrap());
 
     stack.wait_config_up().await;
-    defmt::info!("[AP-SUPPORT] ready at {}:8080", gw_ip_addr_str);
+    hil_test::signal_harness_ready();
 
     let mut rx_buffer = [0u8; 1536];
     let mut tx_buffer = [0u8; 1536];

--- a/hil-test-radio/src/bin/tests/ble.rs
+++ b/hil-test-radio/src/bin/tests/ble.rs
@@ -9,7 +9,6 @@
 
 //% FEATURES: unstable esp-alloc embassy
 //% FEATURES(has_wifi_ble): esp-radio/ble esp-radio esp-radio-unstable
-//% FEATURES(has_wifi_ble): esp-radio/defmt defmt
 
 //% ENV: ESP_HAL_CONFIG_STACK_GUARD_OFFSET=4
 
@@ -36,126 +35,6 @@ fn init_heap() {
     }
 }
 
-#[embedded_test::tests(default_timeout = 30, executor = esp_rtos::embassy::Executor::new())]
-mod tests {
-    use embassy_futures::select::select;
-    use embassy_time::{Duration, Timer, with_timeout};
-    use esp_hal::{
-        clock::CpuClock,
-        interrupt::software::SoftwareInterruptControl,
-        peripherals::Peripherals,
-        timer::timg::TimerGroup,
-    };
-    use esp_radio::ble::controller::BleConnector;
-    use trouble_host::prelude::*;
-
-    #[init]
-    fn init() -> Peripherals {
-        crate::init_heap();
-
-        let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
-        esp_hal::init(config)
-    }
-
-    #[test]
-    async fn ble_central_connects_to_peripheral(p: Peripherals) {
-        defmt::info!("[BLE-CENTRAL] starting BLE central connect test");
-
-        let timg0 = TimerGroup::new(p.TIMG0);
-        let sw_ints = SoftwareInterruptControl::new(p.SW_INTERRUPT);
-        esp_rtos::start(timg0.timer0, sw_ints.software_interrupt0);
-
-        let connector = BleConnector::new(p.BT, Default::default()).unwrap();
-        let controller: ExternalController<_, 1> = ExternalController::new(connector);
-
-        let address = Address::random(crate::PERIPHERAL_ADDRESS);
-        let mut resources: HostResources<DefaultPacketPool, 1, 2> = HostResources::new();
-        let stack = trouble_host::new(controller, &mut resources)
-            .set_random_address(Address::random([0xff, 0x48, 0x49, 0x4c, 0x43, 0xff]));
-
-        let Host {
-            mut central,
-            runner,
-            ..
-        } = stack.build();
-
-        let _ = select(ble_task(runner), async {
-            let accept_list = [(address.kind, &address.addr)];
-            let connect_config = ConnectConfig {
-                scan_config: ScanConfig {
-                    filter_accept_list: &accept_list,
-                    active: true,
-                    phys: PhySet::M1,
-                    interval: Duration::from_millis(100),
-                    window: Duration::from_millis(100),
-                    timeout: Duration::from_secs(10),
-                },
-                connect_params: RequestedConnParams::default(),
-            };
-
-            let conn = with_timeout(Duration::from_secs(15), central.connect(&connect_config))
-                .await
-                .expect("BLE connect timed out")
-                .expect("BLE connect failed");
-
-            assert_eq!(conn.peer_address(), address.addr);
-            assert!(conn.is_connected());
-
-            defmt::info!("[BLE-CENTRAL] connected to support peripheral");
-            let client = GattClient::<_, DefaultPacketPool, 4>::new(&stack, &conn)
-                .await
-                .expect("GATT client setup failed");
-
-            let _ = select(client.task(), async {
-                let services = client
-                    .services_by_uuid(&Uuid::new_short(crate::BATTERY_SERVICE_UUID))
-                    .await
-                    .expect("Battery service discovery failed");
-                let service = services.first().expect("Battery service not found");
-                let level = client
-                    .characteristic_by_uuid::<u8>(
-                        service,
-                        &Uuid::new_short(crate::BATTERY_LEVEL_UUID),
-                    )
-                    .await
-                    .expect("Battery Level characteristic not found");
-
-                let mut initial_level = [0];
-                let len = client
-                    .read_characteristic(&level, &mut initial_level)
-                    .await
-                    .expect("Battery Level read failed");
-
-                assert_eq!(len, initial_level.len());
-                assert!(initial_level[0] <= 100);
-                defmt::info!("[BLE-CENTRAL] battery level read PASS");
-
-                let mut second_level = [0];
-                let len = client
-                    .read_characteristic(&level, &mut second_level)
-                    .await
-                    .expect("Second Battery Level read failed");
-
-                assert_eq!(len, second_level.len());
-                assert!(second_level[0] <= 100);
-                assert_eq!(second_level, initial_level);
-                defmt::info!("[BLE-CENTRAL] repeated battery level read PASS");
-            })
-            .await;
-
-            Timer::after(Duration::from_millis(250)).await;
-        })
-        .await;
-
-        defmt::info!("[BLE-CENTRAL] TEST_DONE: PASS");
-    }
-
-    async fn ble_task<C: Controller, P: PacketPool>(mut runner: Runner<'_, C, P>) {
-        loop {
-            if runner.run().await.is_err() {
-                defmt::warn!("[BLE-CENTRAL] runner stopped");
-                Timer::after(Duration::from_millis(100)).await;
-            }
-        }
-    }
-}
+#[cfg(soc_has_bt)]
+#[path = "ble/gatt.rs"]
+mod ble_gatt;

--- a/hil-test-radio/src/bin/tests/ble/gatt.rs
+++ b/hil-test-radio/src/bin/tests/ble/gatt.rs
@@ -1,0 +1,115 @@
+#[embedded_test::tests(default_timeout = 30, executor = esp_rtos::embassy::Executor::new())]
+mod tests {
+    use embassy_futures::select::select;
+    use embassy_time::{Duration, Timer, with_timeout};
+    use esp_hal::{
+        clock::CpuClock,
+        interrupt::software::SoftwareInterruptControl,
+        peripherals::Peripherals,
+        timer::timg::TimerGroup,
+    };
+    use esp_radio::ble::controller::BleConnector;
+    use trouble_host::prelude::*;
+
+    #[init]
+    fn init() -> Peripherals {
+        crate::init_heap();
+
+        let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
+        esp_hal::init(config)
+    }
+
+    #[test]
+    async fn ble_central_connects_to_peripheral(p: Peripherals) {
+        let timg0 = TimerGroup::new(p.TIMG0);
+        let sw_ints = SoftwareInterruptControl::new(p.SW_INTERRUPT);
+        esp_rtos::start(timg0.timer0, sw_ints.software_interrupt0);
+
+        let connector = BleConnector::new(p.BT, Default::default()).unwrap();
+        let controller: ExternalController<_, 1> = ExternalController::new(connector);
+
+        let address = Address::random(crate::PERIPHERAL_ADDRESS);
+        let mut resources: HostResources<DefaultPacketPool, 1, 2> = HostResources::new();
+        let stack = trouble_host::new(controller, &mut resources)
+            .set_random_address(Address::random([0xff, 0x48, 0x49, 0x4c, 0x43, 0xff]));
+
+        let Host {
+            mut central,
+            runner,
+            ..
+        } = stack.build();
+
+        let _ = select(ble_task(runner), async {
+            let accept_list = [(address.kind, &address.addr)];
+            let connect_config = ConnectConfig {
+                scan_config: ScanConfig {
+                    filter_accept_list: &accept_list,
+                    active: true,
+                    phys: PhySet::M1,
+                    interval: Duration::from_millis(100),
+                    window: Duration::from_millis(100),
+                    timeout: Duration::from_secs(10),
+                },
+                connect_params: RequestedConnParams::default(),
+            };
+
+            let conn = with_timeout(Duration::from_secs(15), central.connect(&connect_config))
+                .await
+                .expect("BLE connect timed out")
+                .expect("BLE connect failed");
+
+            assert_eq!(conn.peer_address(), address.addr);
+            assert!(conn.is_connected());
+
+            let client = GattClient::<_, DefaultPacketPool, 4>::new(&stack, &conn)
+                .await
+                .expect("GATT client setup failed");
+
+            let _ = select(client.task(), async {
+                let services = client
+                    .services_by_uuid(&Uuid::new_short(crate::BATTERY_SERVICE_UUID))
+                    .await
+                    .expect("Battery service discovery failed");
+                let service = services.first().expect("Battery service not found");
+                let level = client
+                    .characteristic_by_uuid::<u8>(
+                        service,
+                        &Uuid::new_short(crate::BATTERY_LEVEL_UUID),
+                    )
+                    .await
+                    .expect("Battery Level characteristic not found");
+
+                let mut initial_level = [0];
+                let len = client
+                    .read_characteristic(&level, &mut initial_level)
+                    .await
+                    .expect("Battery Level read failed");
+
+                assert_eq!(len, initial_level.len());
+                assert!(initial_level[0] <= 100);
+
+                let mut second_level = [0];
+                let len = client
+                    .read_characteristic(&level, &mut second_level)
+                    .await
+                    .expect("Second Battery Level read failed");
+
+                assert_eq!(len, second_level.len());
+                assert!(second_level[0] <= 100);
+                assert_eq!(second_level, initial_level);
+            })
+            .await;
+
+            Timer::after(Duration::from_millis(250)).await;
+        })
+        .await;
+    }
+
+    async fn ble_task<C: Controller, P: PacketPool>(mut runner: Runner<'_, C, P>) {
+        loop {
+            if runner.run().await.is_err() {
+                Timer::after(Duration::from_millis(100)).await;
+            }
+        }
+    }
+}

--- a/hil-test-radio/src/bin/tests/wifi.rs
+++ b/hil-test-radio/src/bin/tests/wifi.rs
@@ -9,7 +9,6 @@
 
 //% FEATURES: unstable esp-alloc embassy
 //% FEATURES(has_wifi_ble): esp-radio/wifi esp-radio/ble esp-radio esp-radio-unstable
-//% FEATURES(has_wifi_ble): esp-radio/defmt defmt esp-radio/csi
 
 // Even if the defaults change, keep this at a low-ish value for
 // the esp_rtos/moving_data_to_second_core test

--- a/hil-test-radio/src/bin/tests/wifi/dhcp.rs
+++ b/hil-test-radio/src/bin/tests/wifi/dhcp.rs
@@ -47,26 +47,17 @@ mod tests {
 
     #[embassy_executor::task]
     async fn net_task(mut runner: Runner<'static, Interface>) {
-        defmt::debug!("[STA] Starting network task");
         runner.run().await
     }
 
     #[embassy_executor::task]
     async fn connection(mut controller: WifiController<'static>) {
-        defmt::debug!("[STA] Start connection task");
-
         loop {
             match controller.connect_async().await {
                 Ok(_) => {
-                    defmt::info!("[STA] Wifi connected to");
-
-                    // wait until we're no longer connected
                     controller.wait_for_disconnect_async().await.ok();
-                    defmt::info!("[STA] Disconnected");
                 }
-                Err(e) => {
-                    defmt::info!("[STA] Failed to connect to wifi: {:?}", e);
-                }
+                Err(_) => {}
             }
 
             Timer::after(Duration::from_millis(1500)).await
@@ -101,8 +92,7 @@ mod tests {
 
         let scan_config = ScanConfig::default().with_max(10);
         let result = controller.scan_async(&scan_config).await.unwrap();
-
-        defmt::debug!("[STA] Scan complete, found {} networks", result.len());
+        let _ = result;
 
         spawner.spawn(connection(controller).unwrap());
         spawner.spawn(net_task(runner).unwrap());
@@ -144,7 +134,6 @@ mod tests {
 
     #[test]
     async fn wifi_dhcp_http_test(p: Peripherals) {
-        defmt::info!("[STA] Starting Wi-Fi DHCP HTTP test");
         let spawner = unsafe { embassy_executor::Spawner::for_current_executor().await };
 
         let timg0 = TimerGroup::new(p.TIMG0);
@@ -159,14 +148,10 @@ mod tests {
         .unwrap();
 
         run_http_smoke_test(spawner, controller, wifi_interface).await;
-
-        defmt::info!("[STA] TEST_DONE: PASS");
     }
 
     #[test]
     async fn wifi_drop(p: Peripherals) {
-        defmt::info!("[STA] Starting Wi-Fi Drop test");
-
         let timg0 = TimerGroup::new(p.TIMG0);
         let sw_ints = SoftwareInterruptControl::new(p.SW_INTERRUPT);
         esp_rtos::start(timg0.timer0, sw_ints.software_interrupt0);
@@ -195,7 +180,5 @@ mod tests {
         .unwrap();
 
         run_http_smoke_test(spawner, controller, wifi_interface).await;
-
-        defmt::info!("[STA] Wi-Fi drop + recovery PASS");
     }
 }

--- a/hil-test-radio/src/lib.rs
+++ b/hil-test-radio/src/lib.rs
@@ -49,6 +49,13 @@ macro_rules! assert_eq {
     ($($t:tt)*) => { ::core::assert_eq!($($t)*) }
 }
 
+/// Signal to the radio HIL runner that harness firmware is ready.
+///
+/// The runner waits for this semihosting line before starting the DUT test.
+pub fn signal_harness_ready() {
+    semihosting::println!("[HARNESS-READY]");
+}
+
 #[macro_export]
 macro_rules! mk_static {
     ($t:ty,$val:expr) => {{

--- a/xtask/src/radio_hil_runner.rs
+++ b/xtask/src/radio_hil_runner.rs
@@ -196,21 +196,22 @@ pub fn resolve_release_binary(workspace: &Path, target: &str, artifact_name: &st
     release_dir.join(base_name)
 }
 
-// Maximum time we wait for the harness firmware to flash and emit its
-// first defmt log line before giving up.
+// Maximum time we wait for the harness firmware to flash and signal readiness
+// via semihosting before giving up.
 const HARNESS_BOOT_TIMEOUT: Duration = Duration::from_secs(90);
+const HARNESS_READY_MARKER: &str = "[HARNESS-READY]";
 const PROBE_LIST_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Spawn `probe-rs run` for the harness, capture its stdout, and block
-/// until the firmware emits its first defmt log line (i.e. flashing is
-/// complete and the support firmware is actually running).
+/// until the firmware prints a `[HARNESS-READY]` semihosting line (i.e.
+/// flashing is complete and the support firmware is actually running).
 fn spawn_harness_and_wait_until_ready(
     binary_path: &Path,
     probe: &str,
     boot_timeout: Duration,
 ) -> Result<Child> {
     log::info!(
-        "[HARNESS] probe-rs run --preverify --probe {probe} {} (waiting for first defmt line, timeout {}s)",
+        "[HARNESS] probe-rs run --preverify --probe {probe} {} (waiting for {HARNESS_READY_MARKER}, timeout {}s)",
         binary_path.display(),
         boot_timeout.as_secs(),
     );
@@ -239,7 +240,7 @@ fn spawn_harness_and_wait_until_ready(
                 Ok(0) => break,
                 Ok(_) => {
                     print!("[HARNESS] {line}");
-                    if !signaled && looks_like_defmt_line(&line) {
+                    if !signaled && line.contains(HARNESS_READY_MARKER) {
                         let _ = ready_tx.send(());
                         signaled = true;
                     }
@@ -258,25 +259,16 @@ fn spawn_harness_and_wait_until_ready(
             let _ = child.kill();
             let _ = child.wait();
             bail!(
-                "[HARNESS] firmware did not produce any defmt output within {}s",
+                "[HARNESS] firmware did not signal readiness within {}s",
                 boot_timeout.as_secs()
             );
         }
         Err(mpsc::RecvTimeoutError::Disconnected) => {
             let _ = child.kill();
             let _ = child.wait();
-            bail!("[HARNESS] probe-rs exited before producing any defmt output");
+            bail!("[HARNESS] probe-rs exited before firmware signaled readiness");
         }
     }
-}
-
-fn looks_like_defmt_line(line: &str) -> bool {
-    let trimmed = line.trim_start();
-    trimmed.starts_with("[INFO ")
-        || trimmed.starts_with("[WARN ")
-        || trimmed.starts_with("[ERROR]")
-        || trimmed.starts_with("[DEBUG]")
-        || trimmed.starts_with("[TRACE]")
 }
 
 struct HarnessGuard {

--- a/xtask/src/radio_hil_runner.rs
+++ b/xtask/src/radio_hil_runner.rs
@@ -218,7 +218,6 @@ fn spawn_harness_and_wait_until_ready(
     let mut child = Command::new("probe-rs")
         .args(["run", "--preverify", "--probe", probe])
         .arg(binary_path)
-        .env("DEFMT_LOG", "info")
         .stdout(Stdio::piped())
         .stderr(Stdio::inherit())
         .spawn()
@@ -311,7 +310,6 @@ fn spawn_probe_run(name: &str, binary_path: &Path, probe: &str) -> Result<Child>
     Command::new("probe-rs")
         .args(["run", "--preverify", "--probe", probe])
         .arg(binary_path)
-        .env("DEFMT_LOG", "info")
         .spawn()
         .map_err(|e| anyhow!("[{name}] failed to spawn probe-rs run: {e}"))
 }


### PR DESCRIPTION
Setting `DEFMT_LOG` to `trace` causing problems in `radio-hil`s JTAG communication. https://github.com/esp-rs/esp-hal/blob/73c2fd9a74b70f217d877a2b95d44eb53a594edf/.github/workflows/ci.yml#L24
Let's use `info` there instead. I hope this _really_ overrides it.
