### PR TITLE
Add async SPI half-duplex DMA transfers

### DIFF
--- a/esp-hal/src/spi/master/dma.rs
+++ b/esp-hal/src/spi/master/dma.rs
@@ -630,6 +630,111 @@ impl<'d> SpiDma<'d, Async> {
         Ok(())
     }
 
+    /// Half-duplex read.
+    ///
+    /// This performs the command, address, dummy, and data phases as a single
+    /// SPI transaction. Because command and address phases cannot be split
+    /// across multiple DMA transfers, `buffer` must fit in one DMA transfer or
+    /// in the configured internal RX copy buffer.
+    #[instability::unstable]
+    pub async fn half_duplex_read_async(
+        &mut self,
+        data_mode: DataMode,
+        cmd: Command,
+        address: Address,
+        dummy: u8,
+        buffer: &mut [u8],
+    ) -> Result<(), Error> {
+        self.wait_for_idle_async().await;
+
+        if buffer.is_empty() {
+            let rx_buffer = unsafe { NoBuffer(self.spi.dma_state().rx_buffer().prepare()) };
+            self.half_duplex_read_dma_async(data_mode, cmd, address, dummy, 0, rx_buffer)
+                .await?;
+            return Ok(());
+        }
+
+        let operation = DmaOperationKind::for_read(buffer);
+        let mut descriptors = [DmaDescriptor::EMPTY; LINK_DESCRIPTOR_COUNT];
+        let mut maybe_copy_buffer = match operation {
+            DmaOperationKind::Copied => {
+                MaybeCopyRxBuf::Copy(unsafe { self.spi.dma_state().rx_buffer() })
+            }
+            DmaOperationKind::InPlace => MaybeCopyRxBuf::Direct {
+                descriptors: &mut descriptors,
+                #[cfg(dma_can_access_psram)]
+                align_buffer: [const { None }; 2],
+            },
+        };
+
+        let chunk_size = maybe_copy_buffer.chunk_size();
+        if chunk_size == 0 {
+            return Err(Error::from(DmaError::BufferTooSmall));
+        }
+        if buffer.len() > chunk_size {
+            return match operation {
+                DmaOperationKind::Copied => Err(Error::from(DmaError::Overflow)),
+                DmaOperationKind::InPlace => Err(Error::MaxDmaTransferSizeExceeded),
+            };
+        }
+
+        let rx_buffer = unsafe { maybe_copy_buffer.setup(NonNull::from(&mut *buffer)) };
+        self.half_duplex_read_dma_async(data_mode, cmd, address, dummy, buffer.len(), rx_buffer)
+            .await?;
+        maybe_copy_buffer.finish(buffer);
+
+        Ok(())
+    }
+
+    /// Half-duplex write.
+    ///
+    /// This performs the command, address, dummy, and data phases as a single
+    /// SPI transaction. Because command and address phases cannot be split
+    /// across multiple DMA transfers, `buffer` must fit in one DMA transfer or
+    /// in the configured internal TX copy buffer.
+    #[instability::unstable]
+    pub async fn half_duplex_write_async(
+        &mut self,
+        data_mode: DataMode,
+        cmd: Command,
+        address: Address,
+        dummy: u8,
+        buffer: &[u8],
+    ) -> Result<(), Error> {
+        self.wait_for_idle_async().await;
+
+        if buffer.is_empty() {
+            let tx_buffer = unsafe { NoBuffer(self.spi.dma_state().tx_buffer().prepare()) };
+            self.half_duplex_write_dma_async(data_mode, cmd, address, dummy, 0, tx_buffer)
+                .await?;
+            return Ok(());
+        }
+
+        let operation = DmaOperationKind::for_write(buffer);
+        let mut descriptors = [DmaDescriptor::EMPTY; LINK_DESCRIPTOR_COUNT];
+        let mut maybe_copy_buffer = match operation {
+            DmaOperationKind::Copied => {
+                MaybeCopyTxBuf::Copy(unsafe { self.spi.dma_state().tx_buffer() })
+            }
+            DmaOperationKind::InPlace => MaybeCopyTxBuf::Direct(&mut descriptors),
+        };
+
+        let chunk_size = maybe_copy_buffer.chunk_size();
+        if chunk_size == 0 {
+            return Err(Error::from(DmaError::BufferTooSmall));
+        }
+        if buffer.len() > chunk_size {
+            return match operation {
+                DmaOperationKind::Copied => Err(Error::from(DmaError::Overflow)),
+                DmaOperationKind::InPlace => Err(Error::MaxDmaTransferSizeExceeded),
+            };
+        }
+
+        let tx_buffer = unsafe { maybe_copy_buffer.setup(NonNull::from(buffer)) };
+        self.half_duplex_write_dma_async(data_mode, cmd, address, dummy, buffer.len(), tx_buffer)
+            .await
+    }
+
     async fn transfer_buffers_dma_async(
         &mut self,
         read_bytes: usize,
@@ -640,6 +745,56 @@ impl<'d> SpiDma<'d, Async> {
         let mut spi = DropGuard::new(&mut *self, |spi| spi.cancel_transfer());
         unsafe {
             spi.start_dma_transfer(read_bytes, write_bytes, &mut rx_buffer, &mut tx_buffer)?;
+        }
+        spi.wait_for_idle_async().await;
+        spi.defuse();
+        Ok(())
+    }
+
+    async fn half_duplex_read_dma_async(
+        &mut self,
+        data_mode: DataMode,
+        cmd: Command,
+        address: Address,
+        dummy: u8,
+        bytes_to_read: usize,
+        mut rx_buffer: impl DmaRxBuffer,
+    ) -> Result<(), Error> {
+        let mut spi = DropGuard::new(&mut *self, |spi| spi.cancel_transfer());
+        unsafe {
+            spi.start_half_duplex_read(
+                data_mode,
+                cmd,
+                address,
+                dummy,
+                bytes_to_read,
+                &mut rx_buffer,
+            )?;
+        }
+        spi.wait_for_idle_async().await;
+        spi.defuse();
+        Ok(())
+    }
+
+    async fn half_duplex_write_dma_async(
+        &mut self,
+        data_mode: DataMode,
+        cmd: Command,
+        address: Address,
+        dummy: u8,
+        bytes_to_write: usize,
+        mut tx_buffer: impl DmaTxBuffer,
+    ) -> Result<(), Error> {
+        let mut spi = DropGuard::new(&mut *self, |spi| spi.cancel_transfer());
+        unsafe {
+            spi.start_half_duplex_write(
+                data_mode,
+                cmd,
+                address,
+                dummy,
+                bytes_to_write,
+                &mut tx_buffer,
+            )?;
         }
         spi.wait_for_idle_async().await;
         spi.defuse();
@@ -743,6 +898,7 @@ impl<'a> MaybeCopyRxBuf<'a> {
     }
 }
 
+#[derive(Clone, Copy)]
 enum DmaOperationKind {
     /// The entire slice must be copied into the internal buffer first
     Copied,

--- a/hil-test/src/bin/spi_half_duplex_slave_qspi.rs
+++ b/hil-test/src/bin/spi_half_duplex_slave_qspi.rs
@@ -711,7 +711,7 @@ mod spi_slave {
     }
 }
 
-#[embedded_test::tests(default_timeout = 3)]
+#[embedded_test::tests(default_timeout = 3, executor = hil_test::Executor::new())]
 #[cfg(spi_master_supports_dma)]
 mod qspi_dma {
     #[cfg(pcnt_driver_supported)]
@@ -922,6 +922,77 @@ mod qspi_dma {
     }
 
     #[cfg(pcnt_driver_supported)]
+    async fn execute_write_async(
+        unit0: Unit<'_, 0>,
+        unit1: Unit<'_, 1>,
+        mut spi: SpiDma<'_, esp_hal::Async>,
+        write: u8,
+        data_on_multiple_pins: bool,
+    ) {
+        const BUFFER_SIZE: usize = 4;
+
+        let tx_buf = [write; BUFFER_SIZE];
+
+        for command_data_mode in COMMAND_DATA_MODES {
+            // Send command + address + data.
+            // Should read 8 high bits: 1 command bit, 3 address bits, 4 data bits
+            unit0.clear();
+            unit1.clear();
+            spi.half_duplex_write_async(
+                DataMode::Quad,
+                Command::_8Bit(write as u16, command_data_mode),
+                Address::_24Bit(
+                    write as u32 | (write as u32) << 8 | (write as u32) << 16,
+                    DataMode::Quad,
+                ),
+                0,
+                &tx_buf,
+            )
+            .await
+            .unwrap();
+            assert_eq!(unit0.value() + unit1.value(), 8);
+
+            if data_on_multiple_pins {
+                if command_data_mode == DataMode::SingleTwoDataLines {
+                    assert_eq!(unit0.value(), 1);
+                    assert_eq!(unit1.value(), 7);
+                } else {
+                    assert_eq!(unit0.value(), 0);
+                    assert_eq!(unit1.value(), 8);
+                }
+            }
+
+            // Send command + address only
+            // Should read 4 bits high: 1 command bit, 3 address bits
+            unit0.clear();
+            unit1.clear();
+            spi.half_duplex_write_async(
+                DataMode::Quad,
+                Command::_8Bit(write as u16, command_data_mode),
+                Address::_24Bit(
+                    write as u32 | (write as u32) << 8 | (write as u32) << 16,
+                    DataMode::Quad,
+                ),
+                0,
+                &[],
+            )
+            .await
+            .unwrap();
+            assert_eq!(unit0.value() + unit1.value(), 4);
+
+            if data_on_multiple_pins {
+                if command_data_mode == DataMode::SingleTwoDataLines {
+                    assert_eq!(unit0.value(), 1);
+                    assert_eq!(unit1.value(), 3);
+                } else {
+                    assert_eq!(unit0.value(), 0);
+                    assert_eq!(unit1.value(), 4);
+                }
+            }
+        }
+    }
+
+    #[cfg(pcnt_driver_supported)]
     fn execute_write_with_cpu(
         unit0: Unit<'_, 0>,
         unit1: Unit<'_, 1>,
@@ -1023,6 +1094,36 @@ mod qspi_dma {
     }
 
     #[test]
+    async fn test_spi_reads_correctly_from_gpio_pin_0_async(ctx: Context) {
+        const BUFFER_SIZE: usize = 4;
+
+        let [pin, pin_mirror, _] = ctx.gpios;
+        let mut pin_mirror = Output::new(pin_mirror, Level::Low, OutputConfig::default());
+
+        let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(BUFFER_SIZE);
+        let dma_rx_buf = DmaRxBuf::new(rx_descriptors, rx_buffer).unwrap();
+        let dma_tx_buf = DmaTxBuf::new(tx_descriptors, tx_buffer).unwrap();
+        let mut spi = ctx
+            .spi
+            .with_sio0(pin)
+            .with_dma(ctx.dma_channel)
+            .with_buffers(dma_rx_buf, dma_tx_buf)
+            .into_async();
+
+        let mut buffer = [0; BUFFER_SIZE];
+        spi.half_duplex_read_async(DataMode::Quad, Command::None, Address::None, 0, &mut buffer)
+            .await
+            .unwrap();
+        assert_eq!(buffer, [0; BUFFER_SIZE]);
+
+        pin_mirror.set_high();
+        spi.half_duplex_read_async(DataMode::Quad, Command::None, Address::None, 0, &mut buffer)
+            .await
+            .unwrap();
+        assert_eq!(buffer, [0b0001_0001; BUFFER_SIZE]);
+    }
+
+    #[test]
     fn test_spi_reads_correctly_from_gpio_pin_1(ctx: Context) {
         let [pin, pin_mirror, _] = ctx.gpios;
         let pin_mirror = Output::new(pin_mirror, Level::High, OutputConfig::default());
@@ -1116,6 +1217,42 @@ mod qspi_dma {
         let spi = ctx.spi.with_sio0(mosi).with_dma(ctx.dma_channel);
 
         execute_write(unit0, unit1, spi, 0b0000_0001, false);
+    }
+
+    #[test]
+    #[cfg(pcnt_driver_supported)]
+    async fn test_spi_writes_correctly_to_pin_0_async(ctx: Context) {
+        const BUFFER_SIZE: usize = 4;
+
+        // For PCNT-using tests we swap the pins around so that the PCNT is not pulled
+        // up by a resistor if the command phase doesn't drive its line.
+        let [_, _, mosi] = ctx.gpios;
+
+        let pcnt = Pcnt::new(ctx.pcnt);
+        let unit0 = pcnt.unit0;
+        let unit1 = pcnt.unit1;
+
+        let mut mosi = Flex::new(mosi);
+        mosi.set_input_enable(true);
+        mosi.set_output_enable(true);
+        let mosi_loopback = mosi.peripheral_input();
+
+        unit0.channel0.set_edge_signal(mosi_loopback);
+        unit0
+            .channel0
+            .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
+
+        let (rx_buffer, rx_descriptors, tx_buffer, tx_descriptors) = dma_buffers!(BUFFER_SIZE);
+        let dma_rx_buf = DmaRxBuf::new(rx_descriptors, rx_buffer).unwrap();
+        let dma_tx_buf = DmaTxBuf::new(tx_descriptors, tx_buffer).unwrap();
+        let spi = ctx
+            .spi
+            .with_sio0(mosi)
+            .with_dma(ctx.dma_channel)
+            .with_buffers(dma_rx_buf, dma_tx_buf)
+            .into_async();
+
+        execute_write_async(unit0, unit1, spi, 0b0000_0001, false).await;
     }
 
     #[test]


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` or `manual-changelog` label as appropriate.
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
 Adds async half-duplex SPI DMA APIs:                                                                                                                                                                                                                                                                                                                                                                                                                
 - SpiDma::half_duplex_read_async                                                                                                                                                                                                                         
 - SpiDma::half_duplex_write_async    

#### Testing
HIL
---

# Changelog

## esp-hal/SPI

- Added: `SpiDma::half_duplex_read_async` and `SpiDma::half_duplex_write_async`