### PR TITLE
adc: add AdcConfig::resolution for ESP32

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -22,7 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for embassy-usb-host (#5283)
 - `handle_gpio_interrupt` and `wake_pin()` for user-defined GPIO ISRs (#5531)
 - GPIO: `Input::wait_for_with_options()` allows waking from light sleep while waiting for event (#5551)
-- ESP32 ADC: Added `AdcConfig::resolution(...)` to configure sampling/readout resolution.
 
 ### Changed
 

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for embassy-usb-host (#5283)
 - `handle_gpio_interrupt` and `wake_pin()` for user-defined GPIO ISRs (#5531)
 - GPIO: `Input::wait_for_with_options()` allows waking from light sleep while waiting for event (#5551)
+- ESP32 ADC: Added `AdcConfig::resolution(...)` to configure sampling/readout resolution.
 
 ### Changed
 

--- a/esp-hal/src/analog/adc/mod.rs
+++ b/esp-hal/src/analog/adc/mod.rs
@@ -142,6 +142,13 @@ impl<ADCX> AdcConfig<ADCX> {
         Self::default()
     }
 
+    /// Set the sampling/readout resolution of the ADC.
+    #[cfg(esp32)]
+    pub fn resolution(&mut self, resolution: Resolution) -> &mut Self {
+        self.resolution = resolution;
+        self
+    }
+
     /// Enable the specified pin with the given attenuation
     pub fn enable_pin<PIN>(&mut self, pin: PIN, attenuation: Attenuation) -> AdcPin<PIN, ADCX>
     where


### PR DESCRIPTION
## Summary
- add public AdcConfig::resolution(...) API for ESP32 ADC configuration
- allow users to select ADC sampling/readout resolution (9/10/11/12-bit via Resolution enum)
- update esp-hal/CHANGELOG.md

## Motivation
On ESP32, Resolution exists and is applied internally, but there is currently no public setter on AdcConfig. This PR exposes a small, targeted API so applications can configure ADC resolution without reaching into internals.

## Testing
- attempted local cargo check --features esp32,unstable in esp-hal/
- build is currently blocked in this environment by toolchain/target constraints in dependencies (esp-sync requiring nightly and xtensa-specific pieces), so this change is validated by compile-time structure and minimal surface area only
