### PR TITLE
ESP32-S3: default to 64KB data cache

### DIFF
--- a/esp-hal/esp_config.yml
+++ b/esp-hal/esp_config.yml
@@ -124,7 +124,7 @@ options:
     default:
       - value: '"8KB"'
         if: "esp32s2"
-      - value: '"32KB"'
+      - value: '"64KB"'
     constraints:
       - if: "esp32s2"
         type:

--- a/esp-hal/src/soc/esp32s3/mod.rs
+++ b/esp-hal/src/soc/esp32s3/mod.rs
@@ -51,6 +51,17 @@ pub(crate) const CONFIG_DATA_CACHE_LINE_SIZE: usize = cfg_select! {
     data_cache_line_size_16b => 16,
 };
 
+const _: () = {
+    ::core::assert!(
+        !(CONFIG_INSTRUCTION_CACHE_SIZE == 0x8000 && CONFIG_INSTRUCTION_CACHE_LINE_SIZE == 16),
+        "A 16B instruction cache line size requires a 16KB instruction cache"
+    );
+    ::core::assert!(
+        !(CONFIG_DATA_CACHE_SIZE == 0x10000 && CONFIG_DATA_CACHE_LINE_SIZE == 16),
+        "A 16B data cache line size requires a 16KB or 32KB data cache"
+    );
+};
+
 #[unsafe(link_section = ".rwtext")]
 pub(crate) unsafe fn configure_cpu_caches() {
     // this is just the bare minimum we need to run code from flash


### PR DESCRIPTION
The linker already reserves the full 64KB data cache window, so the old 32KB default left 32KB of RAM unused. Compile time asserts reject the invalid cache line and size combinations that ESP-IDF also forbids.

# Changelog

## esp-hal

- Changed: ESP32-S3 default `ESP_HAL_CONFIG_DATA_CACHE_SIZE` is now `64KB` (was `32KB`). The linker already reserves the full 64KB data cache window, so the old default left 32KB of RAM unused.
- Added: ESP32-S3 compile time validation that a 16B cache line size is only used with a supported cache size, matching ESP-IDF.
