### PR TITLE
Fix `SystemTimer::set_unit_value`

### DIFF
--- a/esp-hal/src/timer/systimer.rs
+++ b/esp-hal/src/timer/systimer.rs
@@ -333,28 +333,26 @@ impl Unit {
 
     fn set_count(&self, value: u64) {
         let systimer = SYSTIMER::regs();
-        #[cfg(not(esp32s2))]
-        {
-            let unitload = systimer.unitload(self.channel() as _);
-            let unit_load = systimer.unit_load(self.channel() as _);
 
-            unitload.hi().write(|w| w.load_hi().set((value << 32) as _));
-            unitload
-                .lo()
-                .write(|w| w.load_lo().set((value & 0xFFFF_FFFF) as _));
+        let value_lo = (value & 0xFFFF_FFFF) as _;
+        let value_hi = (value >> 32) as _;
 
-            unit_load.write(|w| w.load().set_bit());
-        }
-        #[cfg(esp32s2)]
-        {
-            systimer
-                .load_hi()
-                .write(|w| w.load_hi().set((value << 32) as _));
-            systimer
-                .load_lo()
-                .write(|w| w.load_lo().set((value & 0xFFFF_FFFF) as _));
+        cfg_select! {
+            esp32s2 => {
+                systimer.load_hi().write(|w| w.load_hi().set(value_hi));
+                systimer.load_lo().write(|w| w.load_lo().set(value_lo));
 
-            systimer.load().write(|w| w.load().set_bit());
+                systimer.load().write(|w| w.load().set_bit());
+            }
+            _ => {
+                let unitload = systimer.unitload(self.channel() as _);
+                let unit_load = systimer.unit_load(self.channel() as _);
+
+                unitload.hi().write(|w| w.load_hi().set(value_hi));
+                unitload.lo().write(|w| w.load_lo().set(value_lo));
+
+                unit_load.write(|w| w.load().set_bit());
+            }
         }
     }
 

--- a/hil-test/src/bin/misc_drivers.rs
+++ b/hil-test/src/bin/misc_drivers.rs
@@ -371,7 +371,7 @@ mod systimer {
         timer::{
             OneShotTimer,
             PeriodicTimer,
-            systimer::{Alarm, SystemTimer},
+            systimer::{Alarm, SystemTimer, Unit},
         },
     };
     use portable_atomic::{AtomicUsize, Ordering};
@@ -505,6 +505,19 @@ mod systimer {
 
         // We'll end the test in the interrupt handler.
         loop {}
+    }
+
+    #[test]
+    fn set_unit_count_does_not_mask_high_bits(_ctx: Context) {
+        unsafe {
+            SystemTimer::set_unit_value(Unit::Unit0, 1 << 32);
+            assert!(SystemTimer::unit_value(Unit::Unit0) >= 1 << 32);
+        }
+        #[cfg(not(esp32s2))]
+        unsafe {
+            SystemTimer::set_unit_value(Unit::Unit1, 1 << 32);
+            assert!(SystemTimer::unit_value(Unit::Unit1) >= 1 << 32);
+        }
     }
 }
 


### PR DESCRIPTION
# Changelog

## esp-hal/Systimer

- Fixed: `SystemTimer::set_unit_value` correctly loads the upper bits of the requested value.