### PR TITLE
S3: Fix unexpected reset issue in light sleep

### DIFF
--- a/esp-hal/src/rtc_cntl/sleep/esp32s3.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32s3.rs
@@ -342,6 +342,15 @@ impl Default for RtcSleepConfig {
         cfg.set_light_slp_reject(true);
         cfg.set_rtc_dbias_slp(RTC_CNTL_DBIAS_1V10);
         cfg.set_dig_dbias_slp(RTC_CNTL_DBIAS_1V10);
+
+        // This is the light-sleep config. The main XTAL is powered down in sleep
+        // (`xtal_fpu` stays false), so the analog regulator/bias must use the
+        // same XTAL-down settings that `deep()` applies "because of xtal_fpu".
+        cfg.set_rtc_regulator_fpu(true);
+        cfg.set_bias_sleep_monitor(true);
+        cfg.set_pd_cur_monitor(true);
+        cfg.set_bias_sleep_slp(true);
+        cfg.set_pd_cur_slp(true);
         cfg
     }
 }


### PR DESCRIPTION
Closes #5620

# Changelog

## esp-hal/Sleep

- Fixed: fixed sleep configuration of ESP32-S3 to prevent unexpected resets while sleeping