### PR TITLE
Correct system time after waking up

### DIFF
--- a/esp-hal/src/rtc_cntl/mod.rs
+++ b/esp-hal/src/rtc_cntl/mod.rs
@@ -421,17 +421,16 @@ impl<'d> Rtc<'d> {
         // value (that would count the enter/exit time twice). Instead we set an absolute
         // target of `before + slept`, measured by the always-running LP timer.
         let before_ticks = crate::time::implem::raw_counter();
-        let before = self.time_since_power_up();
+        let before = self.time_since_boot_raw();
 
         let _uart0_sclk_guard = crate::system::ensure_uart0_sclk_enabled();
         config.start_sleep(wakeup_triggers);
         config.finish_sleep();
 
-        let after = self.time_since_power_up();
+        let after = self.time_since_boot_raw();
 
-        let slept_us = Duration::from_micros(after.as_micros().wrapping_sub(before.as_micros()));
-        info!("Before: {:?}, After: {:?}", before, after);
-        let slept_ticks = crate::time::implem::us_to_ticks(slept_us.as_micros());
+        let slept_us = crate::clock::rtc_ticks_to_us(after.wrapping_sub(before));
+        let slept_ticks = crate::time::implem::us_to_ticks(slept_us);
 
         unsafe { crate::time::implem::update_counter(before_ticks + slept_ticks) };
     }

--- a/esp-hal/src/rtc_cntl/mod.rs
+++ b/esp-hal/src/rtc_cntl/mod.rs
@@ -224,32 +224,45 @@ impl<'d> Rtc<'d> {
     fn time_since_boot_raw(&self) -> u64 {
         let rtc_cntl = LP_TIMER::regs();
 
+        // Load counter value
+        cfg_select! {
+            any(esp32, esp32s2, esp32s3, esp32c2, esp32c3) => {
+                // Keep update high for at least one RTC slowclk period, assumes 150k RTC_SLOWCLK
+                // Without this, this function may return a stale value
+                for _ in 0..10 {
+                    rtc_cntl.time_update().write(|w| w.time_update().set_bit());
+                    crate::rom::ets_delay_us(1);
+                }
+            }
+            _ => {
+                rtc_cntl.update().write(|w| w.main_timer_update().set_bit());
+            }
+        }
+
+        // Read counter value
         cfg_select! {
             esp32 => {
-                rtc_cntl.time_update().write(|w| w.time_update().set_bit());
                 while rtc_cntl.time_update().read().time_valid().bit_is_clear() {
                     // Might take 1 RTC slowclk period, don't flood RTC bus
                     crate::rom::ets_delay_us(1);
                 }
 
+                rtc_cntl.int_clr().write(|w| w.time_valid().clear_bit_by_one());
+
                 let h = rtc_cntl.time1().read().time_hi().bits();
                 let l = rtc_cntl.time0().read().time_lo().bits();
             }
-            any(esp32c5, esp32c6, esp32c61, esp32h2) => {
-                rtc_cntl.update().write(|w| w.main_timer_update().set_bit());
-
+            any(esp32s2, esp32s3, esp32c2, esp32c3) => {
+                let h = rtc_cntl.time_high0().read().timer_value0_high().bits();
+                let l = rtc_cntl.time_low0().read().timer_value0_low().bits();
+            }
+            _ => {
                 let h = rtc_cntl
                     .main_buf0_high()
                     .read()
                     .main_timer_buf0_high()
                     .bits();
                 let l = rtc_cntl.main_buf0_low().read().main_timer_buf0_low().bits();
-            }
-            _ => {
-                rtc_cntl.time_update().write(|w| w.time_update().set_bit());
-
-                let h = rtc_cntl.time_high0().read().timer_value0_high().bits();
-                let l = rtc_cntl.time_low0().read().timer_value0_low().bits();
             }
         }
 
@@ -403,9 +416,24 @@ impl<'d> Rtc<'d> {
 
         config.apply();
 
+        // Latch the systimer value *before* sleeping. The systimer keeps running during
+        // the sleep enter/exit sequences, so we must not advance from the post-wake
+        // value (that would count the enter/exit time twice). Instead we set an absolute
+        // target of `before + slept`, measured by the always-running LP timer.
+        let before_ticks = crate::time::implem::raw_counter();
+        let before = self.time_since_power_up();
+
         let _uart0_sclk_guard = crate::system::ensure_uart0_sclk_enabled();
         config.start_sleep(wakeup_triggers);
         config.finish_sleep();
+
+        let after = self.time_since_power_up();
+
+        let slept_us = Duration::from_micros(after.as_micros().wrapping_sub(before.as_micros()));
+        info!("Before: {:?}, After: {:?}", before, after);
+        let slept_ticks = crate::time::implem::us_to_ticks(slept_us.as_micros());
+
+        unsafe { crate::time::implem::update_counter(before_ticks + slept_ticks) };
     }
 
     pub(crate) const RTC_DISABLE_ROM_LOG: u32 = 1;

--- a/esp-hal/src/time.rs
+++ b/esp-hal/src/time.rs
@@ -772,12 +772,14 @@ pub(crate) mod implem {
     }
 
     #[inline]
+    #[cfg(sleep_light_sleep)]
     pub(crate) fn us_to_ticks(counter: u64) -> u64 {
         counter * 16
     }
 
     /// Callers must ensure this function is not called concurrently.
     #[inline]
+    #[cfg(sleep_light_sleep)]
     pub(crate) unsafe fn update_counter(counter: u64) {
         // On ESP32 the monotonic counter is the LACT timer of TIMG0. To set its
         // value we stage the new 64-bit count in the load registers and then
@@ -813,12 +815,14 @@ pub(crate) mod implem {
     }
 
     #[inline]
+    #[cfg(sleep_light_sleep)]
     pub(crate) fn us_to_ticks(counter: u64) -> u64 {
         SystemTimer::us_to_ticks(counter)
     }
 
     /// Callers must ensure this function is not called concurrently.
     #[inline]
+    #[cfg(sleep_light_sleep)]
     pub(crate) unsafe fn update_counter(counter: u64) {
         unsafe {
             SystemTimer::set_unit_value(Unit::Unit0, counter);

--- a/esp-hal/src/time.rs
+++ b/esp-hal/src/time.rs
@@ -264,7 +264,7 @@ impl Instant {
     /// ```
     #[inline]
     pub fn now() -> Self {
-        implem::now()
+        now()
     }
 
     #[inline]
@@ -710,9 +710,16 @@ impl core::ops::Div<Duration> for Duration {
     }
 }
 
+#[inline]
+pub(crate) fn now() -> Instant {
+    let ticks = implem::raw_counter();
+    let micros = implem::ticks_to_us(ticks);
+
+    Instant::from_ticks(micros)
+}
+
 #[cfg(esp32)]
 pub(crate) mod implem {
-    use super::Instant;
     use crate::peripherals::TIMG0;
 
     #[cfg(feature = "rt")]
@@ -737,7 +744,7 @@ pub(crate) mod implem {
     }
 
     #[inline]
-    pub(super) fn now() -> Instant {
+    pub(crate) fn raw_counter() -> u64 {
         // on ESP32 use LACT
         let tg0 = TIMG0::regs();
         tg0.lactupdate().write(|w| unsafe { w.update().bits(1) });
@@ -756,15 +763,38 @@ pub(crate) mod implem {
         };
         let hi = tg0.lacthi().read().bits();
 
-        let ticks = ((hi as u64) << 32u64) | lo as u64;
+        ((hi as u64) << 32u64) | lo as u64
+    }
 
-        Instant::from_ticks(ticks / 16)
+    #[inline]
+    pub(crate) fn ticks_to_us(ticks: u64) -> u64 {
+        ticks / 16
+    }
+
+    #[inline]
+    pub(crate) fn us_to_ticks(counter: u64) -> u64 {
+        counter * 16
+    }
+
+    /// Callers must ensure this function is not called concurrently.
+    #[inline]
+    pub(crate) unsafe fn update_counter(counter: u64) {
+        // On ESP32 the monotonic counter is the LACT timer of TIMG0. To set its
+        // value we stage the new 64-bit count in the load registers and then
+        // trigger a software reload, which copies the staged value into the
+        // counter immediately.
+        let tg0 = TIMG0::regs();
+
+        tg0.lactloadhi()
+            .write(|w| unsafe { w.load_hi().bits((counter >> 32) as u32) });
+        tg0.lactloadlo()
+            .write(|w| unsafe { w.load_lo().bits(counter as u32) });
+        tg0.lactload().write(|w| unsafe { w.load().bits(1) });
     }
 }
 
 #[cfg(systimer_driver_supported)]
 pub(crate) mod implem {
-    use super::Instant;
     use crate::timer::systimer::{SystemTimer, Unit};
 
     #[cfg(feature = "rt")]
@@ -773,11 +803,25 @@ pub(crate) mod implem {
     }
 
     #[inline]
-    pub(super) fn now() -> Instant {
-        let ticks = SystemTimer::unit_value(Unit::Unit0);
+    pub(crate) fn raw_counter() -> u64 {
+        SystemTimer::unit_value(Unit::Unit0)
+    }
 
-        let micros = SystemTimer::ticks_to_us(ticks);
+    #[inline]
+    pub(crate) fn ticks_to_us(ticks: u64) -> u64 {
+        SystemTimer::ticks_to_us(ticks)
+    }
 
-        Instant::from_ticks(micros)
+    #[inline]
+    pub(crate) fn us_to_ticks(counter: u64) -> u64 {
+        SystemTimer::us_to_ticks(counter)
+    }
+
+    /// Callers must ensure this function is not called concurrently.
+    #[inline]
+    pub(crate) unsafe fn update_counter(counter: u64) {
+        unsafe {
+            SystemTimer::set_unit_value(Unit::Unit0, counter);
+        }
     }
 }

--- a/esp-hal/src/timer/systimer.rs
+++ b/esp-hal/src/timer/systimer.rs
@@ -167,7 +167,7 @@ impl<'d> SystemTimer<'d> {
     }
 
     #[inline]
-    fn us_to_ticks(us: u64) -> u64 {
+    pub(crate) fn us_to_ticks(us: u64) -> u64 {
         // Safety: we only ever write ESP_HAL_SYSTIMER_CORRECTION in `init_timestamp_scaler`, which
         // is called once and only once during startup.
         let correction = unsafe { ESP_HAL_SYSTIMER_CORRECTION };

--- a/esp-rtos/src/lib.rs
+++ b/esp-rtos/src/lib.rs
@@ -461,5 +461,16 @@ pub(crate) fn now() -> u64 {
     Instant::now().duration_since_epoch().as_micros()
 }
 
+/// Rearms the alarm timer.
+///
+/// This function may be necessary to call after waking up from light sleep.
+pub fn rearm_alarm() {
+    SCHEDULER.with(|s| {
+        if let Some(time_driver) = s.time_driver.as_mut() {
+            time_driver.rearm(now());
+        }
+    });
+}
+
 #[cfg(feature = "embassy")]
 embassy_time_driver::time_driver_impl!(static TIMER_QUEUE: crate::timer::embassy::EmbassyTimeDriver = crate::timer::embassy::EmbassyTimeDriver);

--- a/esp-rtos/src/timer/mod.rs
+++ b/esp-rtos/src/timer/mod.rs
@@ -123,6 +123,12 @@ impl TimeDriver {
         }
     }
 
+    /// Force-rearms the alarm timer.
+    pub(crate) fn rearm(&mut self, now: u64) {
+        self.current_alarm = u64::MAX;
+        self.arm_next_wakeup(now);
+    }
+
     pub(crate) fn handle_alarm(&mut self, now: u64, on_task_ready: impl FnMut(TaskPtr)) {
         if now < self.current_alarm {
             trace!(
@@ -293,8 +299,7 @@ extern "C" fn timer_tick_handler() {
         // Re-arm the timer. This should be relatively cheap, and ensures that the timer will keep
         // ticking even if the interrupt doesn't trigger a context switch.
         // FIXME: this SHOULD be relatively cheap, but arming the timer involves u64 division.
-        time_driver.current_alarm = u64::MAX;
-        time_driver.arm_next_wakeup(now);
+        time_driver.rearm(now);
     });
 
     #[cfg(feature = "rtos-trace")]

--- a/hil-test/src/bin/misc_drivers.rs
+++ b/hil-test/src/bin/misc_drivers.rs
@@ -700,3 +700,33 @@ mod twai {
         }
     }
 }
+
+#[cfg(lp_timer_driver_supported)]
+#[embedded_test::tests(default_timeout = 3)]
+mod lp_timekeeping {
+    use esp_hal::{
+        rtc_cntl::Rtc,
+        time::{Duration, Instant},
+    };
+
+    #[init]
+    fn init() -> Rtc<'static> {
+        let peripherals = esp_hal::init(esp_hal::Config::default());
+
+        Rtc::new(peripherals.LPWR)
+    }
+
+    #[test]
+    fn returns_correct_timestamp(rtc: Rtc<'static>) {
+        let start_rtc = rtc.time_since_power_up();
+        let start_instant = Instant::now();
+        while start_instant.elapsed() < Duration::from_millis(10) {}
+
+        let rtc_duration = rtc.time_since_power_up() - start_rtc;
+        assert!(
+            rtc_duration > Duration::from_millis(5),
+            "RTC only advanced by {:?}",
+            rtc_duration
+        );
+    }
+}


### PR DESCRIPTION
Closes #5671

# Changelog

## esp-hal/Sleep

- Fixed: the system time is now corrected by the duration of the light sleep
- Fixed: RTC timer correctly provides the up to date timestamp

## esp-rtos

- Added: `rearm_alarm` to manually adjust the time base after waking up from light sleep