### PR TITLE
Drain/suspend UARTs while in sleep

### DIFF
--- a/esp-hal/src/rtc_cntl/mod.rs
+++ b/esp-hal/src/rtc_cntl/mod.rs
@@ -416,6 +416,8 @@ impl<'d> Rtc<'d> {
 
         config.apply();
 
+        sleep_uart_prepare();
+
         // Latch the systimer value *before* sleeping. The systimer keeps running during
         // the sleep enter/exit sequences, so we must not advance from the post-wake
         // value (that would count the enter/exit time twice). Instead we set an absolute
@@ -433,6 +435,7 @@ impl<'d> Rtc<'d> {
         let slept_ticks = crate::time::implem::us_to_ticks(slept_us);
 
         unsafe { crate::time::implem::update_counter(before_ticks + slept_ticks) };
+        sleep_uart_resume();
     }
 
     pub(crate) const RTC_DISABLE_ROM_LOG: u32 = 1;
@@ -1027,5 +1030,29 @@ impl Default for WakeLock {
 impl Drop for WakeLock {
     fn drop(&mut self) {
         Self::release();
+    }
+}
+
+#[cfg(sleep_driver_supported)]
+fn sleep_uart_prepare() {
+    use crate::uart::Instance;
+    for_each_uart! {
+        ($id:literal, $inst:ident, $peri:ident, $rxd:ident, $txd:ident, $cts:ident, $rts:ident) => {
+            unsafe {
+                crate::peripherals::$inst::steal().info().suspend_for_sleep();
+            }
+        };
+    }
+}
+
+#[cfg(sleep_driver_supported)]
+fn sleep_uart_resume() {
+    use crate::uart::Instance;
+    for_each_uart! {
+        ($id:literal, $inst:ident, $peri:ident, $rxd:ident, $txd:ident, $cts:ident, $rts:ident) => {
+            unsafe {
+                crate::peripherals::$inst::steal().info().resume_from_sleep();
+            }
+        };
     }
 }

--- a/esp-hal/src/uart/low_level/mod.rs
+++ b/esp-hal/src/uart/low_level/mod.rs
@@ -749,6 +749,17 @@ impl Info {
 
         Ok(to_read)
     }
+
+    #[cfg(sleep_driver_supported)]
+    pub(crate) fn suspend_for_sleep(&self) {
+        version::suspend(self, true);
+        version::wait_for_suspended(self);
+    }
+
+    #[cfg(sleep_driver_supported)]
+    pub(crate) fn resume_from_sleep(&self) {
+        version::suspend(self, false);
+    }
 }
 
 impl PartialEq for Info {

--- a/esp-hal/src/uart/low_level/v1.rs
+++ b/esp-hal/src/uart/low_level/v1.rs
@@ -117,9 +117,10 @@ pub(super) fn change_flow_control(
             xon_threshold,
             xoff_threshold,
         } => {
-            info.regs()
-                .flow_conf()
-                .modify(|_, w| w.xonoff_del().set_bit().sw_flow_con_en().set_bit());
+            info.regs().flow_conf().modify(|_, w| {
+                w.xonoff_del().set_bit();
+                w.sw_flow_con_en().set_bit()
+            });
 
             cfg_select! {
                 esp32 => {
@@ -164,6 +165,24 @@ pub(super) fn change_flow_control(
     }
 
     sync_regs(info.regs());
+}
+
+#[cfg(sleep_driver_supported)]
+pub(super) fn suspend(_info: &Info, _en: bool) {
+    // We drain the entire FIFO, so we have nothing to disable.
+}
+
+#[cfg(sleep_driver_supported)]
+pub(super) fn wait_for_suspended(info: &Info) {
+    // Wait for FIFO to drain completely.
+    while info.regs().status().read().txfifo_cnt().bits() > 0 {}
+
+    let fsm_status = cfg_select! {
+        esp32 => info.regs().status(),
+        _ => info.regs().fsm_status(),
+    };
+
+    while fsm_status.read().st_utx_out().bits() != 0 {}
 }
 
 fn configure_rts_flow_ctrl(info: &Info, enable: bool, threshold: Option<u8>) {

--- a/esp-hal/src/uart/low_level/v2.rs
+++ b/esp-hal/src/uart/low_level/v2.rs
@@ -114,10 +114,15 @@ pub(super) fn suspend(info: &Info, en: bool) {
         w.sw_flow_con_en().bit(en);
         w.force_xoff().bit(en)
     });
-    info.regs()
-        .swfc_conf0()
-        .modify(|_, w| w.force_xon().bit(false));
     sync_regs(info.regs());
+
+    if !en {
+        // If we are resuming, we are toggling the XON bit, so clear it.
+        info.regs()
+            .swfc_conf0()
+            .modify(|_, w| w.force_xon().bit(false));
+        sync_regs(info.regs());
+    }
 }
 
 #[cfg(sleep_driver_supported)]

--- a/esp-hal/src/uart/low_level/v2.rs
+++ b/esp-hal/src/uart/low_level/v2.rs
@@ -80,10 +80,8 @@ pub(super) fn change_flow_control(
                 .swfc_conf0()
                 .modify(|_, w| w.xonoff_del().set_bit().sw_flow_con_en().set_bit());
             info.regs().swfc_conf1().modify(|_, w| unsafe {
-                w.xon_threshold()
-                    .bits(xon_threshold)
-                    .xoff_threshold()
-                    .bits(xoff_threshold)
+                w.xon_threshold().bits(xon_threshold);
+                w.xoff_threshold().bits(xoff_threshold)
             });
             info.regs()
                 .swfc_conf0()
@@ -107,6 +105,31 @@ pub(super) fn change_flow_control(
     }
 
     sync_regs(info.regs());
+}
+
+#[cfg(sleep_driver_supported)]
+pub(super) fn suspend(info: &Info, en: bool) {
+    info.regs().swfc_conf0().modify(|_, w| {
+        w.force_xon().bit(!en);
+        w.sw_flow_con_en().bit(en);
+        w.force_xoff().bit(en)
+    });
+    info.regs()
+        .swfc_conf0()
+        .modify(|_, w| w.force_xon().bit(false));
+    sync_regs(info.regs());
+}
+
+#[cfg(sleep_driver_supported)]
+pub(super) fn wait_for_suspended(info: &Info) {
+    const FSM_IDLE: u8 = 0;
+    const FSM_TX_WAIT_SEND: u8 = 0x0F;
+    loop {
+        let bits = info.regs().fsm_status().read().st_utx_out().bits();
+        if [FSM_TX_WAIT_SEND, FSM_IDLE].contains(&bits) {
+            return;
+        }
+    }
 }
 
 fn configure_rts_flow_ctrl(info: &Info, enable: bool, threshold: Option<u8>) {

--- a/esp-hal/src/uart/mod.rs
+++ b/esp-hal/src/uart/mod.rs
@@ -85,6 +85,7 @@ use crate::{
     pac::uart0::RegisterBlock,
     private::DropGuard,
     ram,
+    rtc_cntl::WakeLock,
     soc::clocks::{self, ClockTree},
     system::PeripheralGuard,
 };
@@ -502,6 +503,7 @@ where
                 phantom: PhantomData,
                 guard: rx_guard,
                 peri_clock_guard: peri_clock_guard.clone(),
+                _wake_lock: WakeLock::new(),
             },
             tx: UartTx {
                 uart: self.uart,
@@ -558,6 +560,8 @@ pub struct UartRx<'d, Dm: DriverMode> {
     phantom: PhantomData<Dm>,
     guard: PeripheralGuard,
     peri_clock_guard: UartClockGuard<'d>,
+    // Receiving data continuously, the peripheral can't let the system to sleep.
+    _wake_lock: WakeLock,
 }
 
 /// A configuration error.
@@ -1021,6 +1025,7 @@ impl<'d> UartRx<'d, Blocking> {
             phantom: PhantomData,
             guard: self.guard,
             peri_clock_guard: self.peri_clock_guard,
+            _wake_lock: self._wake_lock,
         }
     }
 }
@@ -1042,6 +1047,7 @@ impl<'d> UartRx<'d, Async> {
             phantom: PhantomData,
             guard: self.guard,
             peri_clock_guard: self.peri_clock_guard,
+            _wake_lock: self._wake_lock,
         }
     }
 


### PR DESCRIPTION
This PR flushed UARTv1 output, and suspends UARTv2 output. It adds a wake lock to UartRx, because it continuously receives data - suspending it should be an explicit action we have to implement in the future. UartTx does not need such a wake lock, exactly because of the flush/suspend when entering sleep.

# Changelog

## esp-hal/Sleep

- Fixed: going to light sleep now flushes or suspends UART output