### PR TITLE
Basic light sleep power consumption optimization

### DIFF
--- a/esp-hal/src/rtc_cntl/sleep/esp32.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32.rs
@@ -136,10 +136,8 @@ impl WakeSource for Ext1WakeupSource<'_, '_> {
         &self,
         _rtc: &Rtc<'_>,
         triggers: &mut WakeTriggers,
-        sleep_config: &mut RtcSleepConfig,
+        _sleep_config: &mut RtcSleepConfig,
     ) {
-        // don't power down RTC peripherals
-        sleep_config.set_rtc_peri_pd_en(false);
         triggers.set_ext1(true);
 
         // set pins to RTC function
@@ -147,6 +145,7 @@ impl WakeSource for Ext1WakeupSource<'_, '_> {
         let mut bits = 0u32;
         for pin in pins.iter_mut() {
             pin.rtc_set_config(true, true, RtcFunction::Rtc);
+            pin.rtcio_pad_hold(true);
             bits |= 1 << pin.rtc_number();
         }
 

--- a/esp-hal/src/rtc_cntl/sleep/esp32c5.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c5.rs
@@ -824,6 +824,13 @@ impl RtcSleepConfig {
 
     /// Finalize power-down flags, apply configuration based on the flags.
     pub(crate) fn apply(&mut self) {
+        let lp_slow_uses_xtal32k = ClockTree::with(|clocks| {
+            matches!(
+                clocks::lp_slow_clk_config(clocks),
+                Some(LpSlowClkConfig::Xtal32k)
+            )
+        });
+
         if self.deep {
             // force-disable certain power domains
             self.pd_flags.set_pd_top(true);
@@ -835,15 +842,20 @@ impl RtcSleepConfig {
             self.pd_flags.set_pd_xtal(true);
             self.pd_flags.set_pd_hp_aon(true);
             self.pd_flags.set_pd_lp_periph(true);
-            let lp_slow_uses_xtal32k = ClockTree::with(|clocks| {
-                matches!(
-                    clocks::lp_slow_clk_config(clocks),
-                    Some(LpSlowClkConfig::Xtal32k)
-                )
-            });
             self.pd_flags.set_pd_xtal32k(!lp_slow_uses_xtal32k);
             self.pd_flags.set_pd_rc32k(true);
             self.pd_flags.set_pd_rc_fast(true);
+        } else {
+            // Light sleep: the digital domain (CPU, RAM, peripherals) stays powered
+            // and only clock-gated, so execution resumes in place. To cut power we
+            // turn off the analog clock sources that nothing needs while the core is
+            // gated. Powering down XTAL also makes the analog config drop the HP
+            // regulator to the 0.6 V light-sleep voltage instead of holding it at the
+            // active calibration voltage (see `AnalogSleepConfig::defaults_light_sleep`),
+            // which is the dominant saving.
+            self.pd_flags.set_pd_xtal(true);
+            self.pd_flags.set_pd_rc_fast(true);
+            self.pd_flags.set_pd_xtal32k(!lp_slow_uses_xtal32k);
         }
     }
 

--- a/esp-hal/src/rtc_cntl/sleep/esp32c6.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c6.rs
@@ -876,6 +876,13 @@ impl RtcSleepConfig {
 
     /// Finalize power-down flags, apply configuration based on the flags.
     pub(crate) fn apply(&mut self) {
+        let lp_slow_uses_xtal32k = ClockTree::with(|clocks| {
+            matches!(
+                clocks::lp_slow_clk_config(clocks),
+                Some(LpSlowClkConfig::Xtal32k)
+            )
+        });
+
         if self.deep {
             // force-disable certain power domains
             self.pd_flags.set_pd_top(true);
@@ -887,15 +894,20 @@ impl RtcSleepConfig {
             self.pd_flags.set_pd_xtal(true);
             self.pd_flags.set_pd_hp_aon(true);
             self.pd_flags.set_pd_lp_periph(true);
-            let lp_slow_uses_xtal32k = ClockTree::with(|clocks| {
-                matches!(
-                    clocks::lp_slow_clk_config(clocks),
-                    Some(LpSlowClkConfig::Xtal32k)
-                )
-            });
             self.pd_flags.set_pd_xtal32k(!lp_slow_uses_xtal32k);
             self.pd_flags.set_pd_rc32k(true);
             self.pd_flags.set_pd_rc_fast(true);
+        } else {
+            // Light sleep: the digital domain (CPU, RAM, peripherals) stays powered
+            // and only clock-gated, so execution resumes in place. To cut power we
+            // turn off the analog clock sources that nothing needs while the core is
+            // gated. Powering down XTAL also makes the analog config drop the HP
+            // regulator to the 0.6 V light-sleep voltage instead of holding it at the
+            // active calibration voltage (see `AnalogSleepConfig::defaults_light_sleep`),
+            // which is the dominant saving.
+            self.pd_flags.set_pd_xtal(true);
+            self.pd_flags.set_pd_rc_fast(true);
+            self.pd_flags.set_pd_xtal32k(!lp_slow_uses_xtal32k);
         }
     }
 

--- a/esp-hal/src/rtc_cntl/sleep/esp32c61.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c61.rs
@@ -824,6 +824,13 @@ impl RtcSleepConfig {
 
     /// Finalize power-down flags, apply configuration based on the flags.
     pub(crate) fn apply(&mut self) {
+        let lp_slow_uses_xtal32k = ClockTree::with(|clocks| {
+            matches!(
+                clocks::lp_slow_clk_config(clocks),
+                Some(LpSlowClkConfig::Xtal32k)
+            )
+        });
+
         if self.deep {
             // force-disable certain power domains
             self.pd_flags.set_pd_top(true);
@@ -835,15 +842,20 @@ impl RtcSleepConfig {
             self.pd_flags.set_pd_xtal(true);
             self.pd_flags.set_pd_hp_aon(true);
             self.pd_flags.set_pd_lp_periph(true);
-            let lp_slow_uses_xtal32k = ClockTree::with(|clocks| {
-                matches!(
-                    clocks::lp_slow_clk_config(clocks),
-                    Some(LpSlowClkConfig::Xtal32k)
-                )
-            });
             self.pd_flags.set_pd_xtal32k(!lp_slow_uses_xtal32k);
             self.pd_flags.set_pd_rc32k(true);
             self.pd_flags.set_pd_rc_fast(true);
+        } else {
+            // Light sleep: the digital domain (CPU, RAM, peripherals) stays powered
+            // and only clock-gated, so execution resumes in place. To cut power we
+            // turn off the analog clock sources that nothing needs while the core is
+            // gated. Powering down *both* XTAL and RC_FAST also makes the analog
+            // config drop the HP regulator to the 0.6 V light-sleep voltage instead
+            // of holding it at the active calibration voltage (see
+            // `AnalogSleepConfig::defaults_light_sleep`), which is the dominant saving.
+            self.pd_flags.set_pd_xtal(true);
+            self.pd_flags.set_pd_rc_fast(true);
+            self.pd_flags.set_pd_xtal32k(!lp_slow_uses_xtal32k);
         }
     }
 

--- a/esp-hal/src/rtc_cntl/sleep/esp32h2.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32h2.rs
@@ -82,10 +82,9 @@ impl WakeSource for Ext1WakeupSource<'_, '_> {
         &self,
         _rtc: &Rtc<'_>,
         triggers: &mut WakeTriggers,
-        sleep_config: &mut RtcSleepConfig,
+        _sleep_config: &mut RtcSleepConfig,
     ) {
         triggers.set_ext1(true);
-        sleep_config.need_pd_top = true;
 
         // ext1_wakeup_prepare
         let mut pins = self.pins.borrow_mut();

--- a/esp-hal/src/rtc_cntl/sleep/esp32h2.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32h2.rs
@@ -684,6 +684,13 @@ impl RtcSleepConfig {
 
     /// Finalize power-down flags, apply configuration based on the flags.
     pub(crate) fn apply(&mut self) {
+        let lp_slow_uses_xtal32k = ClockTree::with(|clocks| {
+            matches!(
+                clocks::lp_slow_clk_config(clocks),
+                Some(LpSlowClkConfig::Xtal32k)
+            )
+        });
+
         if self.deep {
             // force-disable certain power domains
             self.pd_flags.set_pd_top(self.need_pd_top.not());
@@ -692,15 +699,17 @@ impl RtcSleepConfig {
             self.pd_flags.set_pd_cpu(true);
             self.pd_flags.set_pd_xtal(true);
             self.pd_flags.set_pd_rc_fast(true);
-            let lp_slow_uses_xtal32k = ClockTree::with(|clocks| {
-                matches!(
-                    clocks::lp_slow_clk_config(clocks),
-                    Some(LpSlowClkConfig::Xtal32k)
-                )
-            });
             self.pd_flags.set_pd_xtal32k(!lp_slow_uses_xtal32k);
-        } else if self.need_pd_top {
-            self.pd_flags.set_pd_top(false);
+        } else {
+            // Light sleep: the digital and top domains stay powered (so execution
+            // resumes in place; the top domain must also stay on for any EXT1/GPIO
+            // wakeup). Power down the analog clock sources nothing needs while the
+            // core is clock-gated to cut power. Unlike the C5/C6 family, H2's
+            // light-sleep analog config does not lower the HP voltage, so this saves
+            // the oscillator current but not regulator power.
+            self.pd_flags.set_pd_xtal(true);
+            self.pd_flags.set_pd_rc_fast(true);
+            self.pd_flags.set_pd_xtal32k(!lp_slow_uses_xtal32k);
         }
     }
 

--- a/esp-hal/src/rtc_cntl/sleep/esp32s2.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32s2.rs
@@ -337,8 +337,15 @@ impl Default for RtcSleepConfig {
         cfg.set_light_slp_reject(true);
         cfg.set_rtc_dbias_slp(RTC_CNTL_DBIAS_1V10);
         cfg.set_dig_dbias_slp(RTC_CNTL_DBIAS_1V10);
-        cfg.set_rtc_slowmem_pd_en(true);
-        cfg.set_rtc_fastmem_pd_en(true);
+
+        // This is the light-sleep config. The main XTAL is powered down in sleep
+        // (`xtal_fpu` stays false), so the analog regulator/bias must use the
+        // same XTAL-down settings that `deep()` applies "because of xtal_fpu".
+        cfg.set_rtc_regulator_fpu(true);
+        cfg.set_bias_sleep_monitor(true);
+        cfg.set_pd_cur_monitor(true);
+        cfg.set_bias_sleep_slp(true);
+        cfg.set_pd_cur_slp(true);
         cfg
     }
 }

--- a/esp-hal/src/rtc_cntl/sleep/esp32s3.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32s3.rs
@@ -181,10 +181,8 @@ impl WakeSource for Ext1WakeupSource<'_, '_> {
         &self,
         _rtc: &Rtc<'_>,
         triggers: &mut WakeTriggers,
-        sleep_config: &mut RtcSleepConfig,
+        _sleep_config: &mut RtcSleepConfig,
     ) {
-        // don't power down RTC peripherals
-        sleep_config.set_rtc_peri_pd_en(false);
         triggers.set_ext1(true);
 
         // set pins to RTC function
@@ -192,6 +190,7 @@ impl WakeSource for Ext1WakeupSource<'_, '_> {
         let mut bits = 0u32;
         for pin in pins.iter_mut() {
             pin.rtc_set_config(true, true, RtcFunction::Rtc);
+            pin.rtcio_pad_hold(true);
             bits |= 1 << pin.rtc_number();
         }
 

--- a/esp-metadata/devices/esp32c6/soc.toml
+++ b/esp-metadata/devices/esp32c6/soc.toml
@@ -29,7 +29,7 @@ symbols = [
     "pm_support_bt_wakeup",
     "gpio_support_deepsleep_wakeup",
     "uart_support_wakeup_int",
-    "pm_support_ext1_wakeup",
+    "pm_support_ext1_wakeup", # FIXME https://github.com/esp-rs/esp-hal/issues/5798
 ]
 
 [device.soc]

--- a/qa-test/src/bin/sleep_timer_lpio.rs
+++ b/qa-test/src/bin/sleep_timer_lpio.rs
@@ -1,10 +1,12 @@
 //! Demonstrates deep sleep with timer, using low and high level pins as wakeup
 //! sources.
 //!
-//! The following wiring is assumed for ESP32-C6:
-//! - ext1 wakeup pin => GPIO2 (low level) / GPIO3 (high level)
-//! The following wiring is assumed for ESP32-H2:
-//! - ext1 wakeup pin => GPIO9 (low level) / GPIO10 (high level)
+//! Wiring
+//!
+//! | Function           | ESP32-C6 | ESP32-H2  |
+//! | ------------------ | -------- | --------- |
+//! | Wake on low level  | GPIO2    | GPIO9     |
+//! | Wake on high level | GPIO3    | GPIO10    |
 
 //% CHIP_FILTER: esp32c6 || esp32h2
 


### PR DESCRIPTION
This PR changes the light-sleep defaults, which result in rather big wins for the riscv chips for a small change.

Closes #5279

# Changelog

## esp-hal/Sleep

- Changed: C6: light sleep powers down XTAL + RC_FAST and drops the HP rail to 0.6
- Changed: H2: the oscillators are powered down in light sleep
- Changed: S2: brought to parity with C3/S3 (bias/regulator into sleep)
- Changed: ESP32, H2 and S3 now power down more of the chip when only Ext1/LPIO wakeup is used