### PR TITLE
restrict sub-v3.0 esp32's on esp-hal side

### DIFF
--- a/esp-hal/esp_config.yml
+++ b/esp-hal/esp_config.yml
@@ -191,6 +191,8 @@ options:
   - name: min-chip-revision
     description: "The minimum chip revision required for the application to run, in format: major * 100 + minor."
     default:
+      - value: 300
+        if: "esp32"
       - value: 0
 
   - name: use_rwdata_ld_hook

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -735,6 +735,18 @@ With the `unstable` feature enabled, this function accepts both [`ClockConfig`] 
 pub fn init(config: Config) -> Peripherals {
     crate::soc::pre_init();
 
+    #[cfg(esp32)]
+    assert!(
+        crate::efuse::chip_revision()
+            >= crate::efuse::ChipRevision::from_combined(
+                esp_config::esp_config_int!(u16, "ESP_HAL_CONFIG_MIN_CHIP_REVISION")
+            ),
+        "esp-hal does not officially support ESP32 chips with hardware revision older than v{}.{}. \
+         See https://github.com/esp-rs/esp-hal/issues/5656.",
+        esp_config::esp_config_int!(u16, "ESP_HAL_CONFIG_MIN_CHIP_REVISION") / 100,
+        esp_config::esp_config_int!(u16, "ESP_HAL_CONFIG_MIN_CHIP_REVISION") % 100,
+    );
+
     #[cfg(soc_cpu_has_branch_predictor)]
     crate::soc::enable_branch_predictor();
 

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -735,17 +735,13 @@ With the `unstable` feature enabled, this function accepts both [`ClockConfig`] 
 pub fn init(config: Config) -> Peripherals {
     crate::soc::pre_init();
 
-    #[cfg(esp32)]
+    let min_rev = esp_config::esp_config_int!(u16, "ESP_HAL_CONFIG_MIN_CHIP_REVISION");
     assert!(
-        crate::efuse::chip_revision()
-            >= crate::efuse::ChipRevision::from_combined(esp_config::esp_config_int!(
-                u16,
-                "ESP_HAL_CONFIG_MIN_CHIP_REVISION"
-            )),
-        "esp-hal does not officially support ESP32 chips with hardware revision older than v{}.{}. \
-         See https://github.com/esp-rs/esp-hal/issues/5656.",
-        esp_config::esp_config_int!(u16, "ESP_HAL_CONFIG_MIN_CHIP_REVISION") / 100,
-        esp_config::esp_config_int!(u16, "ESP_HAL_CONFIG_MIN_CHIP_REVISION") % 100,
+        crate::efuse::chip_revision() >= crate::efuse::ChipRevision::from_combined(min_rev),
+        "This chip's hardware revision is older than the minimum required \
+         v{}.{} (ESP_HAL_CONFIG_MIN_CHIP_REVISION).",
+        min_rev / 100,
+        min_rev % 100,
     );
 
     #[cfg(soc_cpu_has_branch_predictor)]

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -738,9 +738,10 @@ pub fn init(config: Config) -> Peripherals {
     #[cfg(esp32)]
     assert!(
         crate::efuse::chip_revision()
-            >= crate::efuse::ChipRevision::from_combined(
-                esp_config::esp_config_int!(u16, "ESP_HAL_CONFIG_MIN_CHIP_REVISION")
-            ),
+            >= crate::efuse::ChipRevision::from_combined(esp_config::esp_config_int!(
+                u16,
+                "ESP_HAL_CONFIG_MIN_CHIP_REVISION"
+            )),
         "esp-hal does not officially support ESP32 chips with hardware revision older than v{}.{}. \
          See https://github.com/esp-rs/esp-hal/issues/5656.",
         esp_config::esp_config_int!(u16, "ESP_HAL_CONFIG_MIN_CHIP_REVISION") / 100,


### PR DESCRIPTION
closes #5656

as per original issue, we'll also need to adjust espflash to honor this change

# Changelog

## esp-hal/Sleep

- Changed: Drop the support for sub-v3.0 ESP32 chips