### PR TITLE
Implement Display and Error for DMA error types

### DIFF
--- a/esp-hal/src/dma/buffers/mod.rs
+++ b/esp-hal/src/dma/buffers/mod.rs
@@ -36,6 +36,29 @@ pub enum DmaBufError {
     InvalidChunkSize,
 }
 
+impl core::fmt::Display for DmaBufError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            DmaBufError::BufferTooSmall => {
+                write!(f, "the buffer is smaller than the requested size")
+            }
+            DmaBufError::InsufficientDescriptors => {
+                write!(f, "more descriptors are needed for the buffer size")
+            }
+            DmaBufError::UnsupportedMemoryRegion => write!(
+                f,
+                "descriptors or buffers are not located in a supported memory region"
+            ),
+            DmaBufError::InvalidAlignment(x) => write!(f, "{x}"),
+            DmaBufError::InvalidChunkSize => {
+                write!(f, "invalid chunk size: must be > 0 and <= 4095")
+            }
+        }
+    }
+}
+
+impl core::error::Error for DmaBufError {}
+
 /// DMA buffer alignment errors.
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -52,6 +75,17 @@ impl From<DmaAlignmentError> for DmaBufError {
         DmaBufError::InvalidAlignment(err)
     }
 }
+
+impl core::fmt::Display for DmaAlignmentError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            DmaAlignmentError::Address => write!(f, "buffer address is not properly aligned"),
+            DmaAlignmentError::Size => write!(f, "buffer size is not properly aligned"),
+        }
+    }
+}
+
+impl core::error::Error for DmaAlignmentError {}
 
 cfg_select! {
     dma_can_access_psram => {

--- a/esp-hal/src/dma/buffers/mod.rs
+++ b/esp-hal/src/dma/buffers/mod.rs
@@ -40,18 +40,18 @@ impl core::fmt::Display for DmaBufError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             DmaBufError::BufferTooSmall => {
-                write!(f, "the buffer is smaller than the requested size")
+                write!(f, "The buffer is smaller than the requested size")
             }
             DmaBufError::InsufficientDescriptors => {
-                write!(f, "more descriptors are needed for the buffer size")
+                write!(f, "More descriptors are needed for the buffer size")
             }
             DmaBufError::UnsupportedMemoryRegion => write!(
                 f,
-                "descriptors or buffers are not located in a supported memory region"
+                "Descriptors or buffers are not located in a supported memory region"
             ),
             DmaBufError::InvalidAlignment(x) => write!(f, "{x}"),
             DmaBufError::InvalidChunkSize => {
-                write!(f, "invalid chunk size: must be > 0 and <= 4095")
+                write!(f, "Invalid chunk size: must be > 0 and <= 4095")
             }
         }
     }
@@ -79,8 +79,8 @@ impl From<DmaAlignmentError> for DmaBufError {
 impl core::fmt::Display for DmaAlignmentError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
-            DmaAlignmentError::Address => write!(f, "buffer address is not properly aligned"),
-            DmaAlignmentError::Size => write!(f, "buffer size is not properly aligned"),
+            DmaAlignmentError::Address => write!(f, "Buffer address is not properly aligned"),
+            DmaAlignmentError::Size => write!(f, "Buffer size is not properly aligned"),
         }
     }
 }


### PR DESCRIPTION
### Submission Checklist 📝
- [X] I have updated existing examples or added new ones (if applicable).
- [X] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [X] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` or `manual-changelog` label as appropriate.
- [X] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [X] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

Added `Display` and `Error` impls for `DmaBufError` and `DmaAlignmentError`. Copied the display strings from the doc comments.

#### Testing

Built the project. This shouldn't have broken anything.

---

# Changelog

## esp-hal

- Added: `Display` and `Error` impls for `DmaBufError` and `DmaAlignmentError`
