### PR TITLE
Prefer blocking for short hd spi transfers

### DIFF
--- a/esp-hal/src/spi/master/dma.rs
+++ b/esp-hal/src/spi/master/dma.rs
@@ -662,6 +662,18 @@ impl<'d> SpiDma<'d, Async> {
             return Ok(());
         }
 
+        // Small transfers that fit in the FIFO can skip the DMA setup cost entirely.
+        if self.use_blocking_transfer(buffer.len()) {
+            if buffer.len() <= FIFO_SIZE {
+                self.dma_driver().disable_dma();
+                return self
+                    .driver()
+                    .half_duplex_read(data_mode, cmd, address, dummy, buffer);
+            } else {
+                warn!("Buffer size exceeds FIFO size, skipping blocking transfer");
+            }
+        }
+
         let operation = DmaOperationKind::for_read(buffer);
         let mut descriptors = [DmaDescriptor::EMPTY; LINK_DESCRIPTOR_COUNT];
         let mut maybe_copy_buffer = match operation {
@@ -716,6 +728,18 @@ impl<'d> SpiDma<'d, Async> {
             self.half_duplex_write_dma_async(data_mode, cmd, address, dummy, 0, tx_buffer)
                 .await?;
             return Ok(());
+        }
+
+        // Small transfers that fit in the FIFO can skip the DMA setup cost entirely.
+        if self.use_blocking_transfer(buffer.len()) {
+            if buffer.len() <= FIFO_SIZE {
+                self.dma_driver().disable_dma();
+                return self
+                    .driver()
+                    .half_duplex_write(data_mode, cmd, address, dummy, buffer);
+            } else {
+                warn!("Buffer size exceeds FIFO size, skipping blocking transfer");
+            }
         }
 
         let operation = DmaOperationKind::for_write(buffer);

--- a/esp-hal/src/spi/master/low_level/mod.rs
+++ b/esp-hal/src/spi/master/low_level/mod.rs
@@ -496,6 +496,113 @@ impl Driver {
         Ok(())
     }
 
+    /// Blocking, FIFO-based half-duplex read.
+    ///
+    /// Performs the command, address, dummy, and data phases as a single SPI
+    /// transaction without involving the DMA engine. Because the FIFO is used,
+    /// `buffer` must not exceed [`FIFO_SIZE`].
+    #[cfg_attr(place_spi_master_driver_in_ram, ram)]
+    pub(super) fn half_duplex_read(
+        &self,
+        data_mode: DataMode,
+        cmd: Command,
+        address: Address,
+        dummy: u8,
+        buffer: &mut [u8],
+    ) -> Result<(), Error> {
+        if buffer.len() > FIFO_SIZE {
+            return Err(Error::FifoSizeExeeded);
+        }
+
+        if buffer.is_empty() {
+            error!("Half-duplex mode does not support empty buffer");
+            return Err(Error::Unsupported);
+        }
+
+        self.flush()?;
+        self.setup_half_duplex(
+            false,
+            cmd,
+            address,
+            false,
+            dummy,
+            buffer.is_empty(),
+            data_mode,
+        )?;
+
+        self.configure_datalen(buffer.len(), 0);
+        self.start_operation();
+        self.flush()?;
+        self.read_from_fifo(buffer)
+    }
+
+    /// Blocking, FIFO-based half-duplex write.
+    ///
+    /// Performs the command, address, dummy, and data phases as a single SPI
+    /// transaction without involving the DMA engine. Because the FIFO is used,
+    /// `buffer` must not exceed [`FIFO_SIZE`].
+    #[cfg_attr(place_spi_master_driver_in_ram, ram)]
+    pub(super) fn half_duplex_write(
+        &self,
+        data_mode: DataMode,
+        cmd: Command,
+        address: Address,
+        dummy: u8,
+        buffer: &[u8],
+    ) -> Result<(), Error> {
+        if buffer.len() > FIFO_SIZE {
+            return Err(Error::FifoSizeExeeded);
+        }
+
+        self.flush()?;
+
+        cfg_select! {
+            all(spi_master_version = "1", spi_address_workaround) => {
+                let mut buffer = buffer;
+                let mut data_mode = data_mode;
+                let mut address = address;
+                let addr_bytes;
+                if buffer.is_empty() && !address.is_none() {
+                    // If the buffer is empty, we need to send a dummy byte
+                    // to trigger the address phase.
+                    let bytes_to_write = address.width().div_ceil(8);
+                    // The address register is read in big-endian order,
+                    // we have to prepare the emulated write in the same way.
+                    addr_bytes = address.value().to_be_bytes();
+                    buffer = &addr_bytes[4 - bytes_to_write..][..bytes_to_write];
+                    data_mode = address.mode();
+                    address = Address::None;
+                }
+
+                if dummy > 0 {
+                    // FIXME: https://github.com/esp-rs/esp-hal/issues/2240
+                    error!("Dummy bits are not supported without data");
+                    return Err(Error::Unsupported);
+                }
+            }
+            _ => {}
+        }
+
+        self.setup_half_duplex(
+            true,
+            cmd,
+            address,
+            false,
+            dummy,
+            buffer.is_empty(),
+            data_mode,
+        )?;
+
+        if !buffer.is_empty() {
+            self.configure_datalen(0, buffer.len());
+            self.fill_fifo(buffer);
+        }
+
+        self.start_operation();
+
+        self.flush()
+    }
+
     #[cfg_attr(place_spi_master_driver_in_ram, ram)]
     pub(super) async fn transfer_in_place_async(&self, words: &mut [u8]) -> Result<(), Error> {
         for chunk in words.chunks_mut(FIFO_SIZE) {

--- a/esp-hal/src/spi/master/mod.rs
+++ b/esp-hal/src/spi/master/mod.rs
@@ -460,7 +460,9 @@ pub struct Config {
     /// async context-switch cost exceeds the benefit. For
     /// [`SpiDma`][crate::spi::master::dma::SpiDma], the threshold applies in
     /// both blocking and async DMA modes: when met, DMA is disabled and the
-    /// transfer is performed by the CPU.
+    /// transfer is performed by the CPU. This applies to both full-duplex and
+    /// half-duplex transfers; for half-duplex transfers the CPU-driven path is
+    /// only taken when the data also fits in the hardware FIFO.
     ///
     /// A value of `0` (the default) disables the threshold — all transfers use
     /// the driver's default method.
@@ -1217,30 +1219,8 @@ where
         dummy: u8,
         buffer: &mut [u8],
     ) -> Result<(), Error> {
-        if buffer.len() > FIFO_SIZE {
-            return Err(Error::FifoSizeExeeded);
-        }
-
-        if buffer.is_empty() {
-            error!("Half-duplex mode does not support empty buffer");
-            return Err(Error::Unsupported);
-        }
-
-        self.flush()?;
-        self.driver().setup_half_duplex(
-            false,
-            cmd,
-            address,
-            false,
-            dummy,
-            buffer.is_empty(),
-            data_mode,
-        )?;
-
-        self.driver().configure_datalen(buffer.len(), 0);
-        self.driver().start_operation();
-        self.driver().flush()?;
-        self.driver().read_from_fifo(buffer)
+        self.driver()
+            .half_duplex_read(data_mode, cmd, address, dummy, buffer)
     }
 
     /// Half-duplex write.
@@ -1262,57 +1242,8 @@ where
         dummy: u8,
         buffer: &[u8],
     ) -> Result<(), Error> {
-        if buffer.len() > FIFO_SIZE {
-            return Err(Error::FifoSizeExeeded);
-        }
-
-        self.flush()?;
-
-        cfg_select! {
-            all(spi_master_version = "1", spi_address_workaround) => {
-                let mut buffer = buffer;
-                let mut data_mode = data_mode;
-                let mut address = address;
-                let addr_bytes;
-                if buffer.is_empty() && !address.is_none() {
-                    // If the buffer is empty, we need to send a dummy byte
-                    // to trigger the address phase.
-                    let bytes_to_write = address.width().div_ceil(8);
-                    // The address register is read in big-endian order,
-                    // we have to prepare the emulated write in the same way.
-                    addr_bytes = address.value().to_be_bytes();
-                    buffer = &addr_bytes[4 - bytes_to_write..][..bytes_to_write];
-                    data_mode = address.mode();
-                    address = Address::None;
-                }
-
-                if dummy > 0 {
-                    // FIXME: https://github.com/esp-rs/esp-hal/issues/2240
-                    error!("Dummy bits are not supported without data");
-                    return Err(Error::Unsupported);
-                }
-            }
-            _ => {}
-        }
-
-        self.driver().setup_half_duplex(
-            true,
-            cmd,
-            address,
-            false,
-            dummy,
-            buffer.is_empty(),
-            data_mode,
-        )?;
-
-        if !buffer.is_empty() {
-            self.driver().configure_datalen(0, buffer.len());
-            self.driver().fill_fifo(buffer);
-        }
-
-        self.driver().start_operation();
-
-        self.driver().flush()
+        self.driver()
+            .half_duplex_write(data_mode, cmd, address, dummy, buffer)
     }
 
     fn use_blocking_transfer(&self, transfer_size: usize) -> bool {


### PR DESCRIPTION
# Changelog

## esp-hal/SPI master

- Changed: the `min_async_transfer_size` config option now also applies to async half-duplex DMA transfers, branching to blocking/CPU driven mode for small transfers that fit in the FIFO.