### PR TITLE
P4: Invalidate cache on startup

### DIFF
--- a/esp-hal/src/soc/esp32p4/mod.rs
+++ b/esp-hal/src/soc/esp32p4/mod.rs
@@ -12,6 +12,11 @@ pub(crate) mod regi2c;
 pub(crate) use esp32p4 as pac;
 
 pub(crate) fn pre_init() {
+    // workaround: this shouldn't be needed - done by the 2nd stage bootloader
+    unsafe {
+        cache_invalidate_addr(0x40000000, 64 * 1024 * 1024);
+    }
+
     #[cfg(multi_core)]
     unsafe {
         // Stall Core 1 first (PMU stall), then disable its clock and assert


### PR DESCRIPTION
Fixes #5762 

This shouldn't be needed but even with a 5.5.4 bootloader it makes the difference

`invalidate_all` doesn't work (ends up crashing)

