### PR TITLE
Enable ALS with two active cores

### DIFF
--- a/esp-hal/src/rtc_cntl/mod.rs
+++ b/esp-hal/src/rtc_cntl/mod.rs
@@ -459,6 +459,7 @@ impl<'d> Rtc<'d> {
     /// Enter sleep with the provided `config` and wake with the provided
     /// `wake_sources`.
     #[cfg(sleep_driver_supported)]
+    #[crate::ram]
     pub fn sleep(&mut self, config: &RtcSleepConfig, wake_sources: &[&dyn WakeSource]) {
         let mut config = *config;
         let mut wakeup_triggers = WakeTriggers::default();

--- a/esp-hal/src/rtc_cntl/sleep/esp32p4.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32p4.rs
@@ -995,6 +995,7 @@ impl RtcSleepConfig {
     }
 
     /// Configures wakeup options and enters sleep.
+    #[crate::ram]
     pub(crate) fn start_sleep(&self, wakeup_triggers: WakeTriggers) {
         // ESP32-P4 PMU wakeup-source bitmap (esp-idf `pmu_bit_defs.h`).
         const PMU_SDIO_WAKEUP_EN: u32 = 1 << 0;
@@ -1143,6 +1144,7 @@ impl RtcSleepConfig {
     }
 
     /// Cleans up after sleep.
+    #[crate::ram]
     pub(crate) fn finish_sleep(&self) {
         // like esp-idf pmu_sleep_finish(): switch the pad configuration back from
         // the sleep state to the active state. In deep sleep we never get here.

--- a/esp-hal/src/time.rs
+++ b/esp-hal/src/time.rs
@@ -792,13 +792,31 @@ pub(crate) mod implem {
         // value we stage the new 64-bit count in the load registers and then
         // trigger a software reload, which copies the staged value into the
         // counter immediately.
+        //
+        // A manual `LACTLOAD` while the timer is running (`en = 1`) is silently
+        // dropped when executed from the AppCpu, leaving the monotonic clock stuck
+        // (this is why the post-light-sleep time correction is lost on AppCpu). We
+        // therefore disable the timer around the load (preserving the divider) and
+        // re-enable it afterwards, mirroring `time_init`. Callers run this with
+        // interrupts disabled and the other core parked, so the brief disable is
+        // safe from concurrent reads.
         let tg0 = TIMG0::regs();
+
+        let divider = tg0.lactconfig().read().divider().bits();
+        tg0.lactconfig().write(|w| unsafe { w.bits(0) });
 
         tg0.lactloadhi()
             .write(|w| unsafe { w.load_hi().bits((counter >> 32) as u32) });
         tg0.lactloadlo()
             .write(|w| unsafe { w.load_lo().bits(counter as u32) });
         tg0.lactload().write(|w| unsafe { w.load().bits(1) });
+
+        tg0.lactconfig().write(|w| {
+            unsafe { w.divider().bits(divider) };
+            w.increase().bit(true);
+            w.autoreload().bit(true);
+            w.en().bit(true)
+        });
     }
 }
 

--- a/esp-rtos/src/light_sleep.rs
+++ b/esp-rtos/src/light_sleep.rs
@@ -1,3 +1,5 @@
+#[cfg(multi_core)]
+use esp_hal::{peripherals::CPU_CTRL, system::Cpu, system::CpuControl};
 use esp_hal::{
     peripherals::LPWR,
     rtc_cntl::{
@@ -5,10 +7,11 @@ use esp_hal::{
         WakeLock,
         sleep::{GpioWakeupSource, TimerWakeupSource},
     },
-    system::Cpu,
 };
 
 use crate::{SCHEDULER, task::IdleFn};
+#[cfg(multi_core)]
+use crate::{run_queue::RunSchedulerOn, task};
 
 const LIGHT_SLEEP_MIN_US: u64 =
     esp_config::esp_config_int!(u32, "ESP_RTOS_CONFIG_LIGHT_SLEEP_MIN_US") as u64;
@@ -21,7 +24,7 @@ const LIGHT_SLEEP_MIN_US: u64 =
 /// Each time the scheduler runs out of ready tasks, the hook (with interrupts
 /// disabled) checks that:
 /// - no [`WakeLock`] is held,
-/// - this is the primary core and no second core scheduler is running,
+/// - all cores are idle,
 /// - there is a finite next scheduled wakeup, and
 /// - that wakeup is at least `ESP_RTOS_CONFIG_LIGHT_SLEEP_MIN_US` microseconds away.
 ///
@@ -29,10 +32,9 @@ const LIGHT_SLEEP_MIN_US: u64 =
 /// it falls back to `WFI`. The minimum-residency threshold is configurable via the
 /// `ESP_RTOS_CONFIG_LIGHT_SLEEP_MIN_US` build-time option (default `1000`).
 ///
-/// # Limitations
-///
-/// - **Single-core only.** On a system with a started second core, the hook degrades to `WFI` and
-///   never puts the chip to sleep.
+/// On multi-core chips, the core that commits to sleep hardware-stalls the other core(s)
+/// for the duration of the sleep so their CPU state is frozen and restored coherently,
+/// then thaws them on wakeup.
 ///
 /// See [`WakeLock`] for the wake-lock contract that governs when sleeping is safe.
 ///
@@ -49,14 +51,30 @@ extern "C" fn auto_light_sleep_hook() -> ! {
                 return;
             }
 
-            // MVP: only commit to sleep on the primary core, and never while a second
-            // core scheduler is running (it would keep running while the chip sleeps).
-            if Cpu::current() != Cpu::ProCpu {
-                return;
-            }
             #[cfg(multi_core)]
-            if scheduler.per_cpu[1].initialized {
-                return;
+            {
+                if scheduler.run_queue.has_ready_tasks() {
+                    return;
+                }
+                for cpu in Cpu::all() {
+                    if !scheduler.cpu_idle(cpu) {
+                        return;
+                    }
+                }
+
+                // All cores are ready to sleep. Since we are here in a critical section,
+                // the other core must be waiting for the scheduler lock. We will go to sleep,
+                // and after wakeup the other core will reattempt this check.
+
+                // FIXME: We hardware-stall the other core(s) for the duration of the sleep so
+                // their CPU state is frozen and restored coherently. The other core is frozen
+                // wherever it happens to be - including in the middle of an interrupt handler
+                // that holds a cross-core lock (e.g. the clock tree, peripheral refcount, or
+                // UART locks taken by the light-sleep enter/exit path in `Rtc::sleep`). If that
+                // happens, this core will spin forever trying to take that lock during sleep
+                // prep, because the frozen core can never release it. We accept this (unlikely)
+                // deadlock risk for now rather than ordering all lock-taking work before the
+                // stall.
             }
 
             let Some(time_driver) = scheduler.time_driver.as_mut() else {
@@ -73,6 +91,24 @@ extern "C" fn auto_light_sleep_hook() -> ! {
                 return;
             }
 
+            // We have committed to sleeping. Park (hardware-stall) the other core(s) so their
+            // CPU state is frozen and restored coherently across the sleep, then enter light
+            // sleep, then thaw them.
+            cfg_select! {
+                multi_core => {
+                    let mut cpu_control = CpuControl::new(unsafe { CPU_CTRL::steal() });
+                    for cpu in Cpu::other() {
+                        if scheduler.per_cpu[cpu as usize].initialized {
+                            unsafe { cpu_control.park_core(cpu) };
+                            // FIXME: this is insufficient when we power down the CPU - we will
+                            // need to force the other core to be parked in a known place, saving
+                            // its state so we can restore it after wakeup.
+                        }
+                    }
+                }
+                _ => {}
+            }
+
             unsafe {
                 let mut rtc = Rtc::new(LPWR::steal());
                 let timer =
@@ -85,6 +121,16 @@ extern "C" fn auto_light_sleep_hook() -> ! {
             // stale. Force a re-arm against the restored time base so the tick handler
             // fires promptly and drains the timer queue.
             time_driver.rearm(crate::now());
+
+            // Trigger the scheduler on the other core to prevent it from putting
+            // the system back to sleep immediately.
+            #[cfg(multi_core)]
+            for cpu in Cpu::other() {
+                if scheduler.per_cpu[cpu as usize].initialized {
+                    cpu_control.unpark_core(cpu);
+                    task::trigger_scheduler(RunSchedulerOn::RunOnCore(cpu));
+                }
+            }
         });
 
         esp_hal::interrupt::wait_for_interrupt();

--- a/esp-rtos/src/run_queue.rs
+++ b/esp-rtos/src/run_queue.rs
@@ -302,6 +302,12 @@ impl RunQueue {
         self.ready_tasks[level.get()].is_empty()
     }
 
+    /// Returns `true` if any task is ready to run (queued at any priority level).
+    #[cfg(all(multi_core, sleep_light_sleep))]
+    pub(crate) fn has_ready_tasks(&self) -> bool {
+        self.ready_priority.mask != 0
+    }
+
     pub(crate) fn remove(&mut self, to_delete: TaskPtr) {
         let priority = to_delete.priority(self).get();
         self.ready_tasks[priority].remove(to_delete);

--- a/esp-rtos/src/scheduler.rs
+++ b/esp-rtos/src/scheduler.rs
@@ -450,6 +450,12 @@ impl SchedulerState {
             self.resume_task(task);
         }
     }
+
+    #[cfg(all(multi_core, sleep_light_sleep))]
+    pub(crate) fn cpu_idle(&self, cpu: Cpu) -> bool {
+        let per_cpu = &self.per_cpu[cpu as usize];
+        !per_cpu.initialized || per_cpu.current_task.is_null()
+    }
 }
 
 pub(crate) struct GlobalState {

--- a/examples/async/embassy_auto_light_sleep/Cargo.toml
+++ b/examples/async/embassy_auto_light_sleep/Cargo.toml
@@ -14,10 +14,14 @@ esp-backtrace = { path = "../../../esp-backtrace", features = [
 esp-bootloader-esp-idf = { path = "../../../esp-bootloader-esp-idf" }
 esp-hal = { path = "../../../esp-hal", features = ["log-04", "unstable"] }
 esp-rtos = { path = "../../../esp-rtos", features = ["embassy", "log-04"] }
-esp-println = { path = "../../../esp-println", features = ["log-04"] }
+esp-println = { path = "../../../esp-println", default-features = false, features = ["uart", "log-04", "critical-section"] }
+static_cell = { version = "2.1.1", optional = true }
 
 [features]
+multi_core = ["dep:static_cell"]
+
 esp32 = [
+    "multi_core",
     "esp-backtrace/esp32",
     "esp-bootloader-esp-idf/esp32",
     "esp-rtos/esp32",
@@ -60,6 +64,7 @@ esp32h2 = [
     "esp-hal/esp32h2",
 ]
 esp32p4 = [
+    "multi_core",
     "esp-backtrace/esp32p4",
     "esp-bootloader-esp-idf/esp32p4",
     "esp-rtos/esp32p4",
@@ -72,6 +77,7 @@ esp32s2 = [
     "esp-hal/esp32s2",
 ]
 esp32s3 = [
+    "multi_core",
     "esp-backtrace/esp32s3",
     "esp-bootloader-esp-idf/esp32s3",
     "esp-rtos/esp32s3",

--- a/examples/async/embassy_auto_light_sleep/src/main.rs
+++ b/examples/async/embassy_auto_light_sleep/src/main.rs
@@ -26,6 +26,7 @@ use esp_hal::{
     peripherals,
     rtc_cntl::WakeLock,
     system::wakeup_cause,
+    time::Instant,
     timer::timg::TimerGroup,
 };
 
@@ -35,8 +36,8 @@ esp_bootloader_esp_idf::esp_app_desc!();
 async fn periodic() {
     loop {
         esp_println::println!(
-            "tick @ {:?} (wakeup cause: {:?})",
-            esp_hal::time::Instant::now(),
+            "tick @ {} (wakeup cause: {:?})",
+            Instant::now().duration_since_epoch().as_millis(),
             wakeup_cause(),
         );
         Timer::after(Duration::from_millis(1_000)).await;
@@ -84,6 +85,18 @@ async fn gpio(boot_btn: BOOT_GPIO<'static>) {
     }
 }
 
+#[cfg(feature = "multi_core")]
+#[embassy_executor::task]
+async fn periodic_core2() {
+    loop {
+        esp_println::println!(
+            "tick on core 2 @ {}",
+            Instant::now().duration_since_epoch().as_millis()
+        );
+        Timer::after(Duration::from_millis(1_500)).await;
+    }
+}
+
 #[embassy_executor::task]
 async fn wake_lock_demo() {
     loop {
@@ -123,4 +136,27 @@ async fn main(spawner: Spawner) {
     spawner.spawn(gpio(boot_btn).unwrap());
     spawner.spawn(periodic().unwrap());
     spawner.spawn(wake_lock_demo().unwrap());
+
+    #[cfg(feature = "multi_core")]
+    {
+        use esp_hal::system::Stack;
+        use esp_rtos::embassy::Executor;
+        use static_cell::StaticCell;
+
+        static APP_CORE_STACK: StaticCell<Stack<8192>> = StaticCell::new();
+        let app_core_stack = APP_CORE_STACK.init(Stack::new());
+
+        esp_rtos::start_second_core(
+            p.CPU_CTRL,
+            sw_int.software_interrupt1,
+            app_core_stack,
+            move || {
+                static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+                let executor = EXECUTOR.init(Executor::new());
+                executor.run(|spawner| {
+                    spawner.spawn(periodic_core2().unwrap());
+                });
+            },
+        );
+    }
 }

--- a/examples/async/embassy_auto_light_sleep/src/main.rs
+++ b/examples/async/embassy_auto_light_sleep/src/main.rs
@@ -11,6 +11,8 @@
 //! Both the `periodic` and `gpio` tasks print `wakeup_cause()`, so you can
 //! observe the chip waking from light sleep via the timer (`WakeupReason::Timer`)
 //! or via the BOOT button (`WakeupReason::Gpio`).
+//!
+//! Use the UART port for this example - USB Serial/JTAG will break when the device enters sleep.
 
 //% CHIP_FILTER: sleep_light_sleep
 


### PR DESCRIPTION
We don't yet support powering down the CPU, that will need a more substantial change - the sleeping core needs to be able to poke the other core into a place where it can save its state.

This PR works on all 3 multi-core chips, P4 needed the `#[ram]` sprinkling because the app core is a diva.

Closes #5795

# Changelog

## esp-hal

- No changelog necessary.

## esp-rtos/Sleep

- Added: enabled auto-lightsleep when esp-rtos runs on multiple cores