### PR TITLE
CI(radio-hil): Reset before running tests

### DIFF
--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -344,6 +344,40 @@ jobs:
             echo "value=" >> $GITHUB_OUTPUT
           fi
 
+      - name: Reset ESP USB-JTAG devices
+        if: steps.guard.outputs.skip != 'true'
+        timeout-minutes: 1
+        shell: bash
+        run: |
+          # The support firmware runs forever on the harness probe; a previous
+          # run can leave the in-chip USB-Serial-JTAG bridge wedged so the next
+          # flash hangs. Issue USBDEVFS_RESET to force a clean re-enumeration.
+          python3 - <<'PY'
+          import fcntl, glob, os, time
+          USBDEVFS_RESET = (ord('U') << 8) | 20  # _IO('U', 20)
+          reset_any = False
+          for dev in glob.glob('/sys/bus/usb/devices/*'):
+              try:
+                  vid = open(os.path.join(dev, 'idVendor')).read().strip().lower()
+                  pid = open(os.path.join(dev, 'idProduct')).read().strip().lower()
+              except OSError:
+                  continue
+              if (vid, pid) != ('303a', '1001'):
+                  continue
+              busnum = int(open(os.path.join(dev, 'busnum')).read())
+              devnum = int(open(os.path.join(dev, 'devnum')).read())
+              node = f'/dev/bus/usb/{busnum:03d}/{devnum:03d}'
+              try:
+                  with open(node, 'wb') as f:
+                      fcntl.ioctl(f, USBDEVFS_RESET, 0)
+                  print(f'reset {node} ({vid}:{pid})')
+                  reset_any = True
+              except OSError as e:
+                  print(f'failed to reset {node}: {e}')
+          if reset_any:
+              time.sleep(2)  # allow udev to re-enumerate before probe-rs runs
+          PY
+
       - name: Run Radio Tests
         if: steps.guard.outputs.skip != 'true'
         id: run-tests


### PR DESCRIPTION
I'm not proud of this, but it seems to solve the support probe losing JTAG communication after some time: https://github.com/esp-rs/esp-hal/actions/runs/28237198482/job/83658724408

It resets and re-enumerates the USB ports, which should bring JTAG back to a healthy state.
