### PR TITLE
Remove unused free-standing symbols

### DIFF
--- a/esp-hal-procmacros/src/lp_core.rs
+++ b/esp-hal-procmacros/src/lp_core.rs
@@ -333,8 +333,8 @@ pub fn load_lp_code(input: TokenStream, fs: impl Filesystem) -> TokenStream {
     };
     #[cfg(feature = "has-ulp-core")]
     let imports = quote! {
-        use #hal_crate::ulp_core::UlpCore as LpCore;
-        use #hal_crate::ulp_core::UlpCoreWakeupSource as LpCoreWakeupSource;
+        use #hal_crate::lp_core::UlpCore as LpCore;
+        use #hal_crate::lp_core::UlpCoreWakeupSource as LpCoreWakeupSource;
         use #hal_crate::gpio::*;
     };
 

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -486,7 +486,7 @@ pub trait AnalogPin: Pin {
 }
 
 /// Trait implemented by pins which can be used as Touchpad pins
-#[cfg(touch)]
+#[cfg(touch_driver_supported)]
 #[instability::unstable]
 pub trait TouchPin: Pin {
     /// Configure the pin for analog operation

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -319,18 +319,15 @@ mod macros;
 #[instability::unstable]
 pub use procmacros::handler;
 #[instability::unstable]
-#[cfg(any(lp_core, ulp_riscv_core))]
+#[cfg(ulp_riscv_driver_supported)]
 pub use procmacros::load_lp_code;
 #[cfg(feature = "rt")]
 pub use procmacros::main;
 pub use procmacros::ram;
 
 #[instability::unstable]
-#[cfg(lp_core)]
+#[cfg(ulp_riscv_driver_supported)]
 pub use self::soc::lp_core;
-#[instability::unstable]
-#[cfg(ulp_riscv_core)]
-pub use self::soc::ulp_core;
 
 #[cfg(all(feature = "rt", feature = "exception-handler"))]
 mod exception_handler;
@@ -395,7 +392,7 @@ unstable_driver! {
     pub mod rsa;
     #[cfg(sha_driver_supported)]
     pub mod sha;
-    #[cfg(touch)]
+    #[cfg(touch_driver_supported)]
     pub mod touch;
     #[cfg(soc_has_trace0)]
     pub mod trace;

--- a/esp-hal/src/soc/esp32s2/lp_core.rs
+++ b/esp-hal/src/soc/esp32s2/lp_core.rs
@@ -22,7 +22,7 @@
 //!     0xbf, 0x00, 0x00, 0x00, 0x00,
 //! ];
 //!
-//! let mut ulp_core = esp_hal::ulp_core::UlpCore::new(peripherals.ULP_RISCV_CORE);
+//! let mut ulp_core = esp_hal::lp_core::UlpCore::new(peripherals.ULP_RISCV_CORE);
 //! // ulp_core.stop(); currently not implemented for ESP32-S2
 //!
 //! // copy code to RTC ram
@@ -32,7 +32,7 @@
 //! }
 //!
 //! // start ULP core
-//! ulp_core.run(esp_hal::ulp_core::UlpCoreWakeupSource::HpCpu);
+//! ulp_core.run(esp_hal::lp_core::UlpCoreWakeupSource::HpCpu);
 //!
 //! unsafe {
 //!     let data = 0x5000_0010 as *mut u32;

--- a/esp-hal/src/soc/esp32s2/mod.rs
+++ b/esp-hal/src/soc/esp32s2/mod.rs
@@ -8,7 +8,7 @@
 crate::unstable_module! {
     pub mod clocks;
     pub mod trng;
-    pub mod ulp_core;
+    pub mod lp_core;
 }
 pub mod gpio;
 pub(crate) mod regi2c;

--- a/esp-hal/src/soc/esp32s3/lp_core.rs
+++ b/esp-hal/src/soc/esp32s3/lp_core.rs
@@ -22,7 +22,7 @@
 //!     0xbf, 0x00, 0x00, 0x00, 0x00,
 //! ];
 //!
-//! let mut ulp_core = esp_hal::ulp_core::UlpCore::new(peripherals.ULP_RISCV_CORE);
+//! let mut ulp_core = esp_hal::lp_core::UlpCore::new(peripherals.ULP_RISCV_CORE);
 //! ulp_core.stop();
 //!
 //! // copy code to RTC ram
@@ -32,7 +32,7 @@
 //! }
 //!
 //! // start ULP core
-//! ulp_core.run(esp_hal::ulp_core::UlpCoreWakeupSource::HpCpu);
+//! ulp_core.run(esp_hal::lp_core::UlpCoreWakeupSource::HpCpu);
 //!
 //! unsafe {
 //!     let data = 0x5000_0010 as *mut u32;

--- a/esp-hal/src/soc/esp32s3/mod.rs
+++ b/esp-hal/src/soc/esp32s3/mod.rs
@@ -8,7 +8,7 @@
 crate::unstable_module! {
     pub mod clocks;
     pub mod trng;
-    pub mod ulp_core;
+    pub mod lp_core;
 }
 #[cfg(feature = "unstable")]
 pub mod cpu_control;

--- a/esp-lp-hal/Cargo.toml
+++ b/esp-lp-hal/Cargo.toml
@@ -20,7 +20,7 @@ rustdoc-args   = ["--cfg", "docsrs"]
 skip-doctests = true
 targets_lp_core = true
 doc-config = { features = ["embedded-hal"], append = [
-    { features = ["embedded-io"], if = 'lp_core' },
+    { features = ["embedded-io"], if = 'ulp_riscv_driver_supported' },
 ] }
 check-configs = [
     { features = [] },

--- a/esp-lp-hal/examples/blinky.rs
+++ b/esp-lp-hal/examples/blinky.rs
@@ -7,6 +7,8 @@
 //!
 //! Make sure the LP RAM is cleared before loading the code.
 
+//% CHIP_FILTER: ulp_riscv_driver_supported
+
 #![no_std]
 #![no_main]
 

--- a/esp-lp-hal/examples/i2c.rs
+++ b/esp-lp-hal/examples/i2c.rs
@@ -7,7 +7,7 @@
 //! - SDA => GPIO6
 //! - SCL => GPIO7
 
-//% CHIP_FILTER: lp_core
+//% CHIP_FILTER: ulp_riscv_driver_supported && soc_has_lp_i2c0
 
 #![no_std]
 #![no_main]

--- a/esp-lp-hal/examples/i2c_sht30.rs
+++ b/esp-lp-hal/examples/i2c_sht30.rs
@@ -7,7 +7,7 @@
 //! - SDA => GPIO6
 //! - SCL => GPIO7
 
-//% CHIP_FILTER: lp_core
+//% CHIP_FILTER: ulp_riscv_driver_supported && soc_has_lp_i2c0
 
 #![no_std]
 #![no_main]

--- a/esp-lp-hal/examples/uart.rs
+++ b/esp-lp-hal/examples/uart.rs
@@ -5,7 +5,7 @@
 //! It is neccessary to use Serial-Uart bridge connected to TX and RX to see
 //! logs from LP_UART. Make sure the LP RAM is cleared before loading the code.
 
-//% CHIP_FILTER: lp_core
+//% CHIP_FILTER: ulp_riscv_driver_supported && soc_has_lp_uart
 
 #![no_std]
 #![no_main]

--- a/esp-metadata-generated/src/_build_script_utils.rs
+++ b/esp-metadata-generated/src/_build_script_utils.rs
@@ -259,8 +259,6 @@ impl Chip {
                     "soc_has_psram",
                     "soc_has_sw_interrupt",
                     "soc_has_touch",
-                    "phy",
-                    "touch",
                     "rom_crc_le",
                     "rom_crc_be",
                     "rom_md5_bsd",
@@ -476,8 +474,6 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_psram",
                     "cargo:rustc-cfg=soc_has_sw_interrupt",
                     "cargo:rustc-cfg=soc_has_touch",
-                    "cargo:rustc-cfg=phy",
-                    "cargo:rustc-cfg=touch",
                     "cargo:rustc-cfg=rom_crc_le",
                     "cargo:rustc-cfg=rom_crc_be",
                     "cargo:rustc-cfg=rom_md5_bsd",
@@ -830,15 +826,12 @@ impl Chip {
                     "soc_has_gpio_dedicated",
                     "soc_has_sw_interrupt",
                     "soc_has_wifi",
-                    "phy",
                     "swd",
                     "rom_crc_le",
                     "rom_crc_be",
                     "rom_md5_mbedtls",
                     "pm_support_wifi_wakeup",
                     "pm_support_bt_wakeup",
-                    "uart_support_wakeup_int",
-                    "gpio_support_deepsleep_wakeup",
                     "adc_driver_supported",
                     "assist_debug_driver_supported",
                     "bt_driver_supported",
@@ -1001,15 +994,12 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_gpio_dedicated",
                     "cargo:rustc-cfg=soc_has_sw_interrupt",
                     "cargo:rustc-cfg=soc_has_wifi",
-                    "cargo:rustc-cfg=phy",
                     "cargo:rustc-cfg=swd",
                     "cargo:rustc-cfg=rom_crc_le",
                     "cargo:rustc-cfg=rom_crc_be",
                     "cargo:rustc-cfg=rom_md5_mbedtls",
                     "cargo:rustc-cfg=pm_support_wifi_wakeup",
                     "cargo:rustc-cfg=pm_support_bt_wakeup",
-                    "cargo:rustc-cfg=uart_support_wakeup_int",
-                    "cargo:rustc-cfg=gpio_support_deepsleep_wakeup",
                     "cargo:rustc-cfg=adc_driver_supported",
                     "cargo:rustc-cfg=assist_debug_driver_supported",
                     "cargo:rustc-cfg=bt_driver_supported",
@@ -1292,15 +1282,12 @@ impl Chip {
                     "soc_has_sw_interrupt",
                     "soc_has_tsens",
                     "soc_has_wifi",
-                    "phy",
                     "swd",
                     "rom_crc_le",
                     "rom_crc_be",
                     "rom_md5_bsd",
                     "pm_support_wifi_wakeup",
                     "pm_support_bt_wakeup",
-                    "uart_support_wakeup_int",
-                    "gpio_support_deepsleep_wakeup",
                     "adc_driver_supported",
                     "aes_driver_supported",
                     "assist_debug_driver_supported",
@@ -1522,15 +1509,12 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_sw_interrupt",
                     "cargo:rustc-cfg=soc_has_tsens",
                     "cargo:rustc-cfg=soc_has_wifi",
-                    "cargo:rustc-cfg=phy",
                     "cargo:rustc-cfg=swd",
                     "cargo:rustc-cfg=rom_crc_le",
                     "cargo:rustc-cfg=rom_crc_be",
                     "cargo:rustc-cfg=rom_md5_bsd",
                     "cargo:rustc-cfg=pm_support_wifi_wakeup",
                     "cargo:rustc-cfg=pm_support_bt_wakeup",
-                    "cargo:rustc-cfg=uart_support_wakeup_int",
-                    "cargo:rustc-cfg=gpio_support_deepsleep_wakeup",
                     "cargo:rustc-cfg=adc_driver_supported",
                     "cargo:rustc-cfg=aes_driver_supported",
                     "cargo:rustc-cfg=assist_debug_driver_supported",
@@ -1890,10 +1874,7 @@ impl Chip {
                     "rom_crc_be",
                     "rom_md5_bsd",
                     "pm_support_wifi_wakeup",
-                    "pm_support_beacon_wakeup",
                     "pm_support_bt_wakeup",
-                    "gpio_support_deepsleep_wakeup",
-                    "uart_support_wakeup_int",
                     "pm_support_ext1_wakeup",
                     "adc_driver_supported",
                     "aes_driver_supported",
@@ -2168,10 +2149,7 @@ impl Chip {
                     "cargo:rustc-cfg=rom_crc_be",
                     "cargo:rustc-cfg=rom_md5_bsd",
                     "cargo:rustc-cfg=pm_support_wifi_wakeup",
-                    "cargo:rustc-cfg=pm_support_beacon_wakeup",
                     "cargo:rustc-cfg=pm_support_bt_wakeup",
-                    "cargo:rustc-cfg=gpio_support_deepsleep_wakeup",
-                    "cargo:rustc-cfg=uart_support_wakeup_int",
                     "cargo:rustc-cfg=pm_support_ext1_wakeup",
                     "cargo:rustc-cfg=adc_driver_supported",
                     "cargo:rustc-cfg=aes_driver_supported",
@@ -2585,17 +2563,12 @@ impl Chip {
                     "soc_has_sw_interrupt",
                     "soc_has_tsens",
                     "soc_has_wifi",
-                    "phy",
-                    "lp_core",
                     "swd",
                     "rom_crc_le",
                     "rom_crc_be",
                     "rom_md5_bsd",
                     "pm_support_wifi_wakeup",
-                    "pm_support_beacon_wakeup",
                     "pm_support_bt_wakeup",
-                    "gpio_support_deepsleep_wakeup",
-                    "uart_support_wakeup_int",
                     "pm_support_ext1_wakeup",
                     "adc_driver_supported",
                     "aes_driver_supported",
@@ -2878,17 +2851,12 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_sw_interrupt",
                     "cargo:rustc-cfg=soc_has_tsens",
                     "cargo:rustc-cfg=soc_has_wifi",
-                    "cargo:rustc-cfg=phy",
-                    "cargo:rustc-cfg=lp_core",
                     "cargo:rustc-cfg=swd",
                     "cargo:rustc-cfg=rom_crc_le",
                     "cargo:rustc-cfg=rom_crc_be",
                     "cargo:rustc-cfg=rom_md5_bsd",
                     "cargo:rustc-cfg=pm_support_wifi_wakeup",
-                    "cargo:rustc-cfg=pm_support_beacon_wakeup",
                     "cargo:rustc-cfg=pm_support_bt_wakeup",
-                    "cargo:rustc-cfg=gpio_support_deepsleep_wakeup",
-                    "cargo:rustc-cfg=uart_support_wakeup_int",
                     "cargo:rustc-cfg=pm_support_ext1_wakeup",
                     "cargo:rustc-cfg=adc_driver_supported",
                     "cargo:rustc-cfg=aes_driver_supported",
@@ -3300,10 +3268,7 @@ impl Chip {
                     "rom_crc_be",
                     "rom_md5_bsd",
                     "pm_support_wifi_wakeup",
-                    "pm_support_beacon_wakeup",
                     "pm_support_bt_wakeup",
-                    "gpio_support_deepsleep_wakeup",
-                    "uart_support_wakeup_int",
                     "pm_support_ext1_wakeup",
                     "assist_debug_driver_supported",
                     "bt_driver_supported",
@@ -3516,10 +3481,7 @@ impl Chip {
                     "cargo:rustc-cfg=rom_crc_be",
                     "cargo:rustc-cfg=rom_md5_bsd",
                     "cargo:rustc-cfg=pm_support_wifi_wakeup",
-                    "cargo:rustc-cfg=pm_support_beacon_wakeup",
                     "cargo:rustc-cfg=pm_support_bt_wakeup",
-                    "cargo:rustc-cfg=gpio_support_deepsleep_wakeup",
-                    "cargo:rustc-cfg=uart_support_wakeup_int",
                     "cargo:rustc-cfg=pm_support_ext1_wakeup",
                     "cargo:rustc-cfg=assist_debug_driver_supported",
                     "cargo:rustc-cfg=bt_driver_supported",
@@ -3879,7 +3841,6 @@ impl Chip {
                     "soc_has_flash",
                     "soc_has_gpio_dedicated",
                     "soc_has_sw_interrupt",
-                    "phy",
                     "swd",
                     "rom_crc_le",
                     "rom_crc_be",
@@ -4136,7 +4097,6 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_flash",
                     "cargo:rustc-cfg=soc_has_gpio_dedicated",
                     "cargo:rustc-cfg=soc_has_sw_interrupt",
-                    "cargo:rustc-cfg=phy",
                     "cargo:rustc-cfg=swd",
                     "cargo:rustc-cfg=rom_crc_le",
                     "cargo:rustc-cfg=rom_crc_be",
@@ -4497,7 +4457,6 @@ impl Chip {
                     "soc_has_flash",
                     "soc_has_sw_interrupt",
                     "soc_has_cpu_ctrl",
-                    "spi_octal",
                     "rom_crc_le",
                     "rom_crc_be",
                     "rom_md5_bsd",
@@ -4724,7 +4683,6 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_flash",
                     "cargo:rustc-cfg=soc_has_sw_interrupt",
                     "cargo:rustc-cfg=soc_has_cpu_ctrl",
-                    "cargo:rustc-cfg=spi_octal",
                     "cargo:rustc-cfg=rom_crc_le",
                     "cargo:rustc-cfg=rom_crc_be",
                     "cargo:rustc-cfg=rom_md5_bsd",
@@ -5185,15 +5143,12 @@ impl Chip {
                     "soc_has_psram",
                     "soc_has_sw_interrupt",
                     "soc_has_ulp_riscv_core",
-                    "phy",
-                    "ulp_riscv_core",
                     "rom_crc_le",
                     "rom_md5_bsd",
                     "pm_support_ext0_wakeup",
                     "pm_support_ext1_wakeup",
                     "pm_support_touch_sensor_wakeup",
                     "pm_support_wifi_wakeup",
-                    "uart_support_wakeup_int",
                     "ulp_supported",
                     "riscv_coproc_supported",
                     "adc_driver_supported",
@@ -5421,15 +5376,12 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_psram",
                     "cargo:rustc-cfg=soc_has_sw_interrupt",
                     "cargo:rustc-cfg=soc_has_ulp_riscv_core",
-                    "cargo:rustc-cfg=phy",
-                    "cargo:rustc-cfg=ulp_riscv_core",
                     "cargo:rustc-cfg=rom_crc_le",
                     "cargo:rustc-cfg=rom_md5_bsd",
                     "cargo:rustc-cfg=pm_support_ext0_wakeup",
                     "cargo:rustc-cfg=pm_support_ext1_wakeup",
                     "cargo:rustc-cfg=pm_support_touch_sensor_wakeup",
                     "cargo:rustc-cfg=pm_support_wifi_wakeup",
-                    "cargo:rustc-cfg=uart_support_wakeup_int",
                     "cargo:rustc-cfg=ulp_supported",
                     "cargo:rustc-cfg=riscv_coproc_supported",
                     "cargo:rustc-cfg=adc_driver_supported",
@@ -5860,9 +5812,7 @@ impl Chip {
                     "soc_has_sw_interrupt",
                     "soc_has_ulp_riscv_core",
                     "soc_has_wifi",
-                    "phy",
                     "swd",
-                    "ulp_riscv_core",
                     "rom_crc_le",
                     "rom_crc_be",
                     "rom_md5_bsd",
@@ -5871,7 +5821,6 @@ impl Chip {
                     "pm_support_touch_sensor_wakeup",
                     "pm_support_wifi_wakeup",
                     "pm_support_bt_wakeup",
-                    "uart_support_wakeup_int",
                     "ulp_supported",
                     "riscv_coproc_supported",
                     "adc_driver_supported",
@@ -6135,9 +6084,7 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_sw_interrupt",
                     "cargo:rustc-cfg=soc_has_ulp_riscv_core",
                     "cargo:rustc-cfg=soc_has_wifi",
-                    "cargo:rustc-cfg=phy",
                     "cargo:rustc-cfg=swd",
-                    "cargo:rustc-cfg=ulp_riscv_core",
                     "cargo:rustc-cfg=rom_crc_le",
                     "cargo:rustc-cfg=rom_crc_be",
                     "cargo:rustc-cfg=rom_md5_bsd",
@@ -6146,7 +6093,6 @@ impl Chip {
                     "cargo:rustc-cfg=pm_support_touch_sensor_wakeup",
                     "cargo:rustc-cfg=pm_support_wifi_wakeup",
                     "cargo:rustc-cfg=pm_support_bt_wakeup",
-                    "cargo:rustc-cfg=uart_support_wakeup_int",
                     "cargo:rustc-cfg=ulp_supported",
                     "cargo:rustc-cfg=riscv_coproc_supported",
                     "cargo:rustc-cfg=adc_driver_supported",
@@ -6662,8 +6608,6 @@ pub fn emit_check_cfg_directives() {
     println!("cargo:rustc-check-cfg=cfg(soc_has_psram)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_sw_interrupt)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_touch)");
-    println!("cargo:rustc-check-cfg=cfg(phy)");
-    println!("cargo:rustc-check-cfg=cfg(touch)");
     println!("cargo:rustc-check-cfg=cfg(rom_crc_le)");
     println!("cargo:rustc-check-cfg=cfg(rom_crc_be)");
     println!("cargo:rustc-check-cfg=cfg(rom_md5_bsd)");
@@ -6798,8 +6742,6 @@ pub fn emit_check_cfg_directives() {
     println!("cargo:rustc-check-cfg=cfg(rom_md5_mbedtls)");
     println!("cargo:rustc-check-cfg=cfg(pm_support_wifi_wakeup)");
     println!("cargo:rustc-check-cfg=cfg(pm_support_bt_wakeup)");
-    println!("cargo:rustc-check-cfg=cfg(uart_support_wakeup_int)");
-    println!("cargo:rustc-check-cfg=cfg(gpio_support_deepsleep_wakeup)");
     println!("cargo:rustc-check-cfg=cfg(assist_debug_driver_supported)");
     println!("cargo:rustc-check-cfg=cfg(dedicated_gpio_driver_supported)");
     println!("cargo:rustc-check-cfg=cfg(ecc_driver_supported)");
@@ -6907,7 +6849,6 @@ pub fn emit_check_cfg_directives() {
     println!("cargo:rustc-check-cfg=cfg(soc_has_pvt_monitor)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_tee)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_lp_core)");
-    println!("cargo:rustc-check-cfg=cfg(pm_support_beacon_wakeup)");
     println!("cargo:rustc-check-cfg=cfg(ieee802154_driver_supported)");
     println!("cargo:rustc-check-cfg=cfg(lp_i2c_master_driver_supported)");
     println!("cargo:rustc-check-cfg=cfg(parl_io_driver_supported)");
@@ -6958,7 +6899,6 @@ pub fn emit_check_cfg_directives() {
     println!("cargo:rustc-check-cfg=cfg(soc_has_plic_mx)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_trace0)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_twai1)");
-    println!("cargo:rustc-check-cfg=cfg(lp_core)");
     println!("cargo:rustc-check-cfg=cfg(etm_driver_supported)");
     println!("cargo:rustc-check-cfg=cfg(lp_uart_driver_supported)");
     println!("cargo:rustc-check-cfg=cfg(ulp_riscv_driver_supported)");
@@ -6997,7 +6937,6 @@ pub fn emit_check_cfg_directives() {
     println!("cargo:rustc-check-cfg=cfg(soc_has_usb_fs)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_usb_hs)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_usb_wrap)");
-    println!("cargo:rustc-check-cfg=cfg(spi_octal)");
     println!("cargo:rustc-check-cfg=cfg(mipi_dsi_driver_supported)");
     println!("cargo:rustc-check-cfg=cfg(usb_otg_driver_supported)");
     println!("cargo:rustc-check-cfg=cfg(usb_otg_hs_driver_supported)");
@@ -7031,7 +6970,6 @@ pub fn emit_check_cfg_directives() {
     println!("cargo:rustc-check-cfg=cfg(soc_has_pms)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_syscon)");
     println!("cargo:rustc-check-cfg=cfg(soc_has_ulp_riscv_core)");
-    println!("cargo:rustc-check-cfg=cfg(ulp_riscv_core)");
     println!("cargo:rustc-check-cfg=cfg(riscv_coproc_supported)");
     println!("cargo:rustc-check-cfg=cfg(dedicated_gpio_needs_initialization)");
     println!("cargo:rustc-check-cfg=cfg(dma_ext_mem_configurable_block_size)");

--- a/esp-metadata/devices/esp32/soc.toml
+++ b/esp-metadata/devices/esp32/soc.toml
@@ -13,10 +13,6 @@ cores  = 2
 trm    = "https://www.espressif.com/sites/default/files/documentation/esp32_technical_reference_manual_en.pdf"
 
 symbols = [
-    # Additional peripherals defined by us (the developers):
-    "phy",
-    "touch",
-
     # ROM capabilities
     "rom_crc_le",
     "rom_crc_be",

--- a/esp-metadata/devices/esp32c2/soc.toml
+++ b/esp-metadata/devices/esp32c2/soc.toml
@@ -13,8 +13,6 @@ cores  = 1
 trm    = "https://www.espressif.com/sites/default/files/documentation/esp8684_technical_reference_manual_en.pdf"
 
 symbols = [
-    # Additional peripherals defined by us (the developers):
-    "phy",
     "swd",
 
     # ROM capabilities
@@ -25,8 +23,6 @@ symbols = [
     # Wakeup SOC based on ESP-IDF:
     "pm_support_wifi_wakeup",
     "pm_support_bt_wakeup",
-    "uart_support_wakeup_int",
-    "gpio_support_deepsleep_wakeup",
 ]
 
 [device.soc]

--- a/esp-metadata/devices/esp32c3/soc.toml
+++ b/esp-metadata/devices/esp32c3/soc.toml
@@ -13,8 +13,6 @@ cores  = 1
 trm    = "https://www.espressif.com/sites/default/files/documentation/esp32-c3_technical_reference_manual_en.pdf"
 
 symbols = [
-    # Additional peripherals defined by us (the developers):
-    "phy",
     "swd",
 
     # ROM capabilities
@@ -25,8 +23,6 @@ symbols = [
     # Wakeup SOC based on ESP-IDF:
     "pm_support_wifi_wakeup",
     "pm_support_bt_wakeup",
-    "uart_support_wakeup_int",
-    "gpio_support_deepsleep_wakeup",
 ]
 
 [device.soc]

--- a/esp-metadata/devices/esp32c5/soc.toml
+++ b/esp-metadata/devices/esp32c5/soc.toml
@@ -13,9 +13,6 @@ cores  = 1
 trm    = "https://www.espressif.com/sites/default/files/documentation/esp32-c5_technical_reference_manual_en.pdf"
 
 symbols = [
-    # Additional peripherals defined by us (the developers):
-    # "lp_core",
-
     # ROM capabilities
     "rom_crc_le",
     "rom_crc_be",
@@ -23,10 +20,7 @@ symbols = [
 
     # Wakeup SOC based on ESP-IDF:
     "pm_support_wifi_wakeup",
-    "pm_support_beacon_wakeup",
     "pm_support_bt_wakeup",
-    "gpio_support_deepsleep_wakeup",
-    "uart_support_wakeup_int",
     "pm_support_ext1_wakeup",
 ]
 

--- a/esp-metadata/devices/esp32c6/soc.toml
+++ b/esp-metadata/devices/esp32c6/soc.toml
@@ -13,9 +13,6 @@ cores  = 1
 trm    = "https://www.espressif.com/sites/default/files/documentation/esp32-c6_technical_reference_manual_en.pdf"
 
 symbols = [
-    # Additional peripherals defined by us (the developers):
-    "phy",
-    "lp_core",
     "swd",
 
     # ROM capabilities
@@ -25,10 +22,7 @@ symbols = [
 
     # Wakeup SOC based on ESP-IDF:
     "pm_support_wifi_wakeup",
-    "pm_support_beacon_wakeup",
     "pm_support_bt_wakeup",
-    "gpio_support_deepsleep_wakeup",
-    "uart_support_wakeup_int",
     "pm_support_ext1_wakeup", # FIXME https://github.com/esp-rs/esp-hal/issues/5798
 ]
 

--- a/esp-metadata/devices/esp32c61/soc.toml
+++ b/esp-metadata/devices/esp32c61/soc.toml
@@ -21,10 +21,7 @@ symbols = [
 
     # Wakeup SOC based on ESP-IDF:
     "pm_support_wifi_wakeup",
-    "pm_support_beacon_wakeup",
     "pm_support_bt_wakeup",
-    "gpio_support_deepsleep_wakeup",
-    "uart_support_wakeup_int",
     "pm_support_ext1_wakeup",
 ]
 

--- a/esp-metadata/devices/esp32h2/soc.toml
+++ b/esp-metadata/devices/esp32h2/soc.toml
@@ -13,8 +13,6 @@ cores  = 1
 trm    = "https://www.espressif.com/sites/default/files/documentation/esp32-h2_technical_reference_manual_en.pdf"
 
 symbols = [
-    # Additional peripherals defined by us (the developers):
-    "phy",
     "swd",
 
     # ROM capabilities

--- a/esp-metadata/devices/esp32p4/soc.toml
+++ b/esp-metadata/devices/esp32p4/soc.toml
@@ -13,9 +13,6 @@ cores  = 2
 trm   = "https://www.espressif.com/sites/default/files/documentation/esp32-p4_technical_reference_manual_en.pdf"
 
 symbols = [
-    # Additional peripherals defined by us (the developers):
-    "spi_octal",
-
     # ROM capabilities
     "rom_crc_le",
     "rom_crc_be",
@@ -24,12 +21,6 @@ symbols = [
     # Wakeup SOC based on ESP-IDF:
     "pm_support_ext1_wakeup",
     "pm_support_touch_sensor_wakeup",
-
-    # TODO: add the following symbols when investigation and getting ready
-    #   - "lp_core"
-    #   - "swd"
-    #   - "gpio_support_deepsleep_wakeup"
-    #   - "uart_support_wakeup_int"
 ]
 
 [device.interrupts]
@@ -350,7 +341,7 @@ support_status = "not_supported"  # LP_TOUCH 14ch
 [device.uhci]
 support_status = "not_supported"
 [device.ulp_riscv]
-support_status = "not_supported"  # LP-core RISC-V (formerly "swd"/"lp_core")
+support_status = "not_supported"
 
 [device.aes]
 support_status = "partial"

--- a/esp-metadata/devices/esp32s2/soc.toml
+++ b/esp-metadata/devices/esp32s2/soc.toml
@@ -13,10 +13,6 @@ cores  = 1
 trm    = "https://www.espressif.com/sites/default/files/documentation/esp32-s2_technical_reference_manual_en.pdf"
 
 symbols = [
-    # Additional peripherals defined by us (the developers):
-    "phy",
-    "ulp_riscv_core",
-
     # ROM capabilities
     "rom_crc_le",
     "rom_md5_bsd",
@@ -26,7 +22,6 @@ symbols = [
     "pm_support_ext1_wakeup",
     "pm_support_touch_sensor_wakeup",
     "pm_support_wifi_wakeup",
-    "uart_support_wakeup_int",
     "ulp_supported",
     "riscv_coproc_supported",
 ]

--- a/esp-metadata/devices/esp32s3/soc.toml
+++ b/esp-metadata/devices/esp32s3/soc.toml
@@ -13,10 +13,7 @@ cores  = 2
 trm    = "https://www.espressif.com/sites/default/files/documentation/esp32-s3_technical_reference_manual_en.pdf"
 
 symbols = [
-    # Additional peripherals defined by us (the developers):
-    "phy",
     "swd",
-    "ulp_riscv_core",
 
     # ROM capabilities
     "rom_crc_le",
@@ -29,7 +26,6 @@ symbols = [
     "pm_support_touch_sensor_wakeup",
     "pm_support_wifi_wakeup",
     "pm_support_bt_wakeup",
-    "uart_support_wakeup_int",
     "ulp_supported",
     "riscv_coproc_supported",
 ]

--- a/examples/peripheral/lp_core/lp_blinky/src/main.rs
+++ b/examples/peripheral/lp_core/lp_blinky/src/main.rs
@@ -8,22 +8,26 @@
 //! The following wiring is assumed:
 //! - LED => GPIO1
 
-//% CHIP_FILTER: lp_core || ulp_riscv_core
+//% CHIP_FILTER: ulp_riscv_driver_supported
 
 #![no_std]
 #![no_main]
 
 use esp_backtrace as _;
-#[cfg(feature = "esp32c6")]
-use esp_hal::{
-    gpio::lp_io::LowPowerOutput,
-    lp_core::{LpCore, LpCoreWakeupSource},
-};
-#[cfg(any(feature = "esp32s2", feature = "esp32s3"))]
-use esp_hal::{
-    gpio::rtc_io::LowPowerOutput,
-    ulp_core::{UlpCore, UlpCoreWakeupSource},
-};
+cfg_select! {
+    any(feature = "esp32s2", feature = "esp32s3") => {
+        use esp_hal::{
+            gpio::rtc_io::LowPowerOutput,
+            lp_core::{UlpCore, UlpCoreWakeupSource},
+        };
+    }
+    _ => {
+        use esp_hal::{
+            gpio::lp_io::LowPowerOutput,
+            lp_core::{LpCore, LpCoreWakeupSource},
+        };
+    }
+}
 use esp_hal::{load_lp_code, main};
 use esp_println::{print, println};
 
@@ -37,10 +41,10 @@ fn main() -> ! {
     // configure GPIO 1 as LP output pin
     let lp_pin = LowPowerOutput::new(peripherals.GPIO1);
 
-    #[cfg(feature = "esp32c6")]
-    let mut lp_core = LpCore::new(peripherals.LP_CORE);
-    #[cfg(any(feature = "esp32s2", feature = "esp32s3"))]
-    let mut lp_core = UlpCore::new(peripherals.ULP_RISCV_CORE);
+    let mut lp_core = cfg_select! {
+        any(feature = "esp32s2", feature = "esp32s3") => UlpCore::new(peripherals.ULP_RISCV_CORE),
+        _ => LpCore::new(peripherals.LP_CORE),
+    };
 
     #[cfg(not(feature = "esp32s2"))]
     {
@@ -49,27 +53,28 @@ fn main() -> ! {
     }
 
     // load code to LP core
-    #[cfg(feature = "esp32c6")]
-    let lp_core_code = load_lp_code!(
-        "../../../../esp-lp-hal/target/riscv32imac-unknown-none-elf/release/examples/blinky"
-    );
-    #[cfg(any(feature = "esp32s2", feature = "esp32s3"))]
-    let lp_core_code = load_lp_code!(
-        "../../../../esp-lp-hal/target/riscv32imc-unknown-none-elf/release/examples/blinky"
-    );
+    let lp_core_code = cfg_select! {
+        any(feature = "esp32s2", feature = "esp32s3") => load_lp_code!(
+            "../../../../esp-lp-hal/target/riscv32imc-unknown-none-elf/release/examples/blinky"
+        ),
+        _ => load_lp_code!(
+            "../../../../esp-lp-hal/target/riscv32imac-unknown-none-elf/release/examples/blinky"
+        ),
+    };
 
     // start LP core
-    #[cfg(feature = "esp32c6")]
-    lp_core_code.run(&mut lp_core, LpCoreWakeupSource::HpCpu, lp_pin);
-    #[cfg(any(feature = "esp32s2", feature = "esp32s3"))]
-    lp_core_code.run(&mut lp_core, UlpCoreWakeupSource::HpCpu, lp_pin);
+    let wakeup_source = cfg_select! {
+        any(feature = "esp32s2", feature = "esp32s3") => UlpCoreWakeupSource::HpCpu,
+        _ => LpCoreWakeupSource::HpCpu,
+    };
+    lp_core_code.run(&mut lp_core, wakeup_source, lp_pin);
 
     println!("lp core run");
 
-    #[cfg(feature = "esp32c6")]
-    const ADDR: usize = 0x5000_2000;
-    #[cfg(any(feature = "esp32s2", feature = "esp32s3"))]
-    const ADDR: usize = 0x5000_0400;
+    const ADDR: usize = cfg_select! {
+        any(feature = "esp32s2", feature = "esp32s3") => 0x5000_0400,
+        _ => 0x5000_2000,
+    };
 
     let data = (ADDR) as *const u32;
     loop {

--- a/examples/peripheral/lp_core/lp_i2c/src/main.rs
+++ b/examples/peripheral/lp_core/lp_i2c/src/main.rs
@@ -9,7 +9,7 @@
 //! - SDA => GPIO6
 //! - SCL => GPIO7
 
-//% CHIP_FILTER: lp_core
+//% CHIP_FILTER: ulp_riscv_driver_supported && soc_has_lp_i2c0
 
 #![no_std]
 #![no_main]


### PR DESCRIPTION
# Changelog

## esp-hal

- Changed: ESP32-S2/S3: the `ulp_core` module has been renamed to `lp_core`.