### PR TITLE
Release I2C clocks when not in use

### DIFF
--- a/esp-hal/src/i2c/master/eh.rs
+++ b/esp-hal/src/i2c/master/eh.rs
@@ -1,6 +1,7 @@
 use embedded_hal::i2c::Operation as EhalOperation;
 
 use super::{Async, DriverMode, Error, I2c, I2cAddress, Operation};
+use crate::i2c::master::I2cClockGuard;
 
 impl embedded_hal::i2c::Error for Error {
     fn kind(&self) -> embedded_hal::i2c::ErrorKind {
@@ -35,6 +36,7 @@ impl<Dm: DriverMode> embedded_hal::i2c::I2c for I2c<'_, Dm> {
         address: u8,
         operations: &mut [embedded_hal::i2c::Operation<'_>],
     ) -> Result<(), Self::Error> {
+        let _clock_guard = I2cClockGuard::new(self.i2c.reborrow());
         self.driver()
             .transaction_impl(
                 I2cAddress::SevenBit(address),
@@ -50,6 +52,7 @@ impl embedded_hal_async::i2c::I2c for I2c<'_, Async> {
         address: u8,
         operations: &mut [EhalOperation<'_>],
     ) -> Result<(), Self::Error> {
+        let _clock_guard = I2cClockGuard::new(self.i2c.reborrow());
         self.driver()
             .transaction_impl_async(address.into(), operations.iter_mut().map(Operation::from))
             .await

--- a/esp-hal/src/i2c/master/low_level/mod.rs
+++ b/esp-hal/src/i2c/master/low_level/mod.rs
@@ -1,8 +1,5 @@
 use super::*;
-use crate::{
-    rtc_cntl::WakeLock,
-    soc::clocks::{ClockTree, I2cFunctionClockConfig},
-};
+use crate::{rtc_cntl::WakeLock, soc::clocks::ClockTree};
 
 #[cfg_attr(i2c_master_version = "1", path = "v1.rs")]
 #[cfg_attr(i2c_master_version = "2", path = "v2.rs")]
@@ -358,35 +355,21 @@ impl PartialEq for Info {
 
 unsafe impl Sync for Info {}
 
-#[derive(Debug)]
-pub(super) struct I2cClockGuard<'t> {
-    i2c: AnyI2c<'t>,
+pub(super) struct I2cClockGuard {
+    clock: crate::clock::ll::I2cInstance,
 }
 
-impl<'t> I2cClockGuard<'t> {
-    pub(super) fn new(i2c: AnyI2c<'t>) -> Self {
-        ClockTree::with(|clocks| {
-            let clock = i2c.info().clock_instance;
-            let config = I2cFunctionClockConfig::new(
-                Default::default(),
-                #[cfg(i2c_master_version = "3")]
-                0,
-            );
-            clock.configure_function_clock(clocks, config);
-            clock.request_function_clock(clocks);
-        });
-        Self { i2c }
+impl I2cClockGuard {
+    pub(super) fn new(i2c: AnyI2c<'_>) -> Self {
+        let clock = i2c.info().clock_instance;
+        ClockTree::with(|clocks| clock.request_function_clock(clocks));
+        Self { clock }
     }
 }
 
-impl Drop for I2cClockGuard<'_> {
+impl Drop for I2cClockGuard {
     fn drop(&mut self) {
-        ClockTree::with(|clocks| {
-            self.i2c
-                .info()
-                .clock_instance
-                .release_function_clock(clocks);
-        });
+        ClockTree::with(|clocks| self.clock.release_function_clock(clocks));
     }
 }
 

--- a/esp-hal/src/i2c/master/mod.rs
+++ b/esp-hal/src/i2c/master/mod.rs
@@ -127,6 +127,7 @@ use crate::{
     Blocking,
     DriverMode,
     asynch::AtomicWaker,
+    clock::ll::{ClockTree, I2cFunctionClockConfig},
     gpio::{
         DriveMode,
         InputSignal,
@@ -678,7 +679,6 @@ pub struct I2c<'d, Dm: DriverMode> {
     i2c: AnyI2c<'d>,
     phantom: PhantomData<Dm>,
     guard: PeripheralGuard,
-    clock_guard: I2cClockGuard<'d>,
     config: DriverConfig,
 }
 
@@ -712,17 +712,25 @@ impl<'d> I2c<'d, Blocking> {
     pub fn new(i2c: impl Instance + 'd, config: Config) -> Result<Self, ConfigError> {
         let guard = PeripheralGuard::new(i2c.info().peripheral);
 
+        ClockTree::with(|clocks| {
+            let clock = i2c.info().clock_instance;
+            let config = I2cFunctionClockConfig::new(
+                Default::default(),
+                #[cfg(i2c_master_version = "3")]
+                0,
+            );
+            clock.configure_function_clock(clocks, config);
+        });
+
         let sda_pin = PinGuard::new_unconnected();
         let scl_pin = PinGuard::new_unconnected();
 
         let i2c_any = i2c.degrade();
-        let clock_guard = I2cClockGuard::new(unsafe { i2c_any.clone_unchecked() });
 
         let i2c = I2c {
             i2c: i2c_any,
             phantom: PhantomData,
             guard,
-            clock_guard,
             config: DriverConfig {
                 config,
                 sda_pin,
@@ -750,7 +758,6 @@ impl<'d> I2c<'d, Blocking> {
             i2c: self.i2c,
             phantom: PhantomData,
             guard: self.guard,
-            clock_guard: self.clock_guard,
             config: self.config,
         }
     }
@@ -843,7 +850,6 @@ impl<'d> I2c<'d, Async> {
             i2c: self.i2c,
             phantom: PhantomData,
             guard: self.guard,
-            clock_guard: self.clock_guard,
             config: self.config,
         }
     }
@@ -1006,6 +1012,7 @@ impl<'d> I2c<'d, Async> {
         address: A,
         operations: impl IntoIterator<Item = &'a mut Operation<'a>>,
     ) -> Result<(), Error> {
+        let _clock_guard = I2cClockGuard::new(self.i2c.reborrow());
         self.driver()
             .transaction_impl_async(address.into(), operations.into_iter().map(Operation::from))
             .await
@@ -1268,6 +1275,7 @@ where
         address: A,
         operations: impl IntoIterator<Item = &'a mut Operation<'a>>,
     ) -> Result<(), Error> {
+        let _clock_guard = I2cClockGuard::new(self.i2c.reborrow());
         self.driver()
             .transaction_impl(address.into(), operations.into_iter().map(Operation::from))
             .inspect_err(|error| self.internal_recover(error))


### PR DESCRIPTION
# Changelog

## esp-hal/I2C

- Changed: The I2C driver no longer holds its clock active clock while idle.