### PR TITLE
Release SPI SCLK between transfers

### DIFF
--- a/esp-hal/src/spi/master/dma.rs
+++ b/esp-hal/src/spi/master/dma.rs
@@ -38,7 +38,7 @@ use crate::{
     pac::spi2::RegisterBlock,
     private::DropGuard,
     soc::is_slice_in_dram,
-    spi::DmaError,
+    spi::{DmaError, master::low_level::SpiClockGuard},
 };
 #[cfg(dma_can_access_psram)]
 use crate::{dma::ManualWritebackBuffer, soc::is_slice_in_psram};
@@ -421,7 +421,8 @@ impl<'d> SpiDma<'d, Async> {
             return Ok(());
         }
 
-        self.wait_for_idle_async().await;
+        let _clock = SpiClockGuard::new(self.spi.info());
+
         self.driver().setup_full_duplex()?;
 
         if self.use_blocking_transfer(words.len()) {
@@ -466,13 +467,13 @@ impl<'d> SpiDma<'d, Async> {
             return Ok(());
         }
 
-        self.wait_for_idle_async().await;
+        let _clock = SpiClockGuard::new(self.spi.info());
+
         self.driver().setup_full_duplex()?;
 
         if self.use_blocking_transfer(words.len()) {
             self.dma_driver().disable_dma();
-            self.driver().write(words)?;
-            return self.driver().flush();
+            return self.driver().write(words);
         }
 
         let mut descriptors = [DmaDescriptor::EMPTY; LINK_DESCRIPTOR_COUNT];
@@ -507,19 +508,19 @@ impl<'d> SpiDma<'d, Async> {
             return Ok(());
         }
 
-        self.wait_for_idle_async().await;
+        let _clock = SpiClockGuard::new(self.spi.info());
+
         self.driver().setup_full_duplex()?;
 
         if self.use_blocking_transfer(read.len().max(write.len())) {
             self.dma_driver().disable_dma();
-            if read.is_empty() {
-                self.driver().write(write)?;
-                return self.driver().flush();
+            return if read.is_empty() {
+                self.driver().write(write)
             } else if write.is_empty() {
-                return self.driver().read(read);
+                self.driver().read(read)
             } else {
-                return self.driver().transfer(read, write);
-            }
+                self.driver().transfer(read, write)
+            };
         }
 
         let common_length = min(read.len(), write.len());
@@ -588,7 +589,7 @@ impl<'d> SpiDma<'d, Async> {
             return Ok(());
         }
 
-        self.wait_for_idle_async().await;
+        let _clock = SpiClockGuard::new(self.spi.info());
         self.driver().setup_full_duplex()?;
 
         if self.use_blocking_transfer(words.len()) {
@@ -653,7 +654,7 @@ impl<'d> SpiDma<'d, Async> {
         dummy: u8,
         buffer: &mut [u8],
     ) -> Result<(), Error> {
-        self.wait_for_idle_async().await;
+        let _clock = SpiClockGuard::new(self.spi.info());
 
         if buffer.is_empty() {
             let rx_buffer = unsafe { NoBuffer(self.spi.dma_state().rx_buffer().prepare()) };
@@ -721,7 +722,7 @@ impl<'d> SpiDma<'d, Async> {
         dummy: u8,
         buffer: &[u8],
     ) -> Result<(), Error> {
-        self.wait_for_idle_async().await;
+        let _clock = SpiClockGuard::new(self.spi.info());
 
         if buffer.is_empty() {
             let tx_buffer = unsafe { NoBuffer(self.spi.dma_state().tx_buffer().prepare()) };
@@ -774,6 +775,8 @@ impl<'d> SpiDma<'d, Async> {
         mut rx_buffer: impl DmaRxBuffer,
         mut tx_buffer: impl DmaTxBuffer,
     ) -> Result<(), Error> {
+        let _clock = SpiClockGuard::new(self.spi.info());
+
         let mut spi = DropGuard::new(&mut *self, |spi| spi.cancel_transfer());
         unsafe {
             spi.start_dma_transfer(read_bytes, write_bytes, &mut rx_buffer, &mut tx_buffer)?;
@@ -792,6 +795,8 @@ impl<'d> SpiDma<'d, Async> {
         bytes_to_read: usize,
         mut rx_buffer: impl DmaRxBuffer,
     ) -> Result<(), Error> {
+        let _clock = SpiClockGuard::new(self.spi.info());
+
         let mut spi = DropGuard::new(&mut *self, |spi| spi.cancel_transfer());
         unsafe {
             spi.start_half_duplex_read(
@@ -817,6 +822,8 @@ impl<'d> SpiDma<'d, Async> {
         bytes_to_write: usize,
         mut tx_buffer: impl DmaTxBuffer,
     ) -> Result<(), Error> {
+        let _clock = SpiClockGuard::new(self.spi.info());
+
         let mut spi = DropGuard::new(&mut *self, |spi| spi.cancel_transfer());
         unsafe {
             spi.start_half_duplex_write(
@@ -1207,12 +1214,13 @@ aligned, otherwise the driver requires copying the entire buffer."
         bytes_to_write: usize,
         mut buffer: TX,
     ) -> Result<SpiDmaTransfer<'d, Dm, TX>, (Error, Self, TX)> {
-        self.wait_for_idle();
+        let clock = SpiClockGuard::new(self.spi.info());
+
         if let Err(e) = self.driver().setup_full_duplex() {
             return Err((e, self, buffer));
         };
         match unsafe { self.start_dma_write(bytes_to_write, &mut buffer) } {
-            Ok(_) => Ok(SpiDmaTransfer::new(self, buffer)),
+            Ok(_) => Ok(SpiDmaTransfer::new(self, buffer, clock)),
             Err(e) => Err((e, self, buffer)),
         }
     }
@@ -1245,12 +1253,13 @@ aligned, otherwise the driver requires copying the entire buffer."
         bytes_to_read: usize,
         mut buffer: RX,
     ) -> Result<SpiDmaTransfer<'d, Dm, RX>, (Error, Self, RX)> {
-        self.wait_for_idle();
+        let clock = SpiClockGuard::new(self.spi.info());
+
         if let Err(e) = self.driver().setup_full_duplex() {
             return Err((e, self, buffer));
         };
         match unsafe { self.start_dma_read(bytes_to_read, &mut buffer) } {
-            Ok(_) => Ok(SpiDmaTransfer::new(self, buffer)),
+            Ok(_) => Ok(SpiDmaTransfer::new(self, buffer, clock)),
             Err(e) => Err((e, self, buffer)),
         }
     }
@@ -1287,7 +1296,8 @@ aligned, otherwise the driver requires copying the entire buffer."
         bytes_to_write: usize,
         mut tx_buffer: TX,
     ) -> Result<SpiDmaTransfer<'d, Dm, (RX, TX)>, (Error, Self, RX, TX)> {
-        self.wait_for_idle();
+        let clock = SpiClockGuard::new(self.spi.info());
+
         if let Err(e) = self.driver().setup_full_duplex() {
             return Err((e, self, rx_buffer, tx_buffer));
         };
@@ -1299,7 +1309,7 @@ aligned, otherwise the driver requires copying the entire buffer."
                 &mut tx_buffer,
             )
         } {
-            Ok(_) => Ok(SpiDmaTransfer::new(self, (rx_buffer, tx_buffer))),
+            Ok(_) => Ok(SpiDmaTransfer::new(self, (rx_buffer, tx_buffer), clock)),
             Err(e) => Err((e, self, rx_buffer, tx_buffer)),
         }
     }
@@ -1346,12 +1356,12 @@ aligned, otherwise the driver requires copying the entire buffer."
         bytes_to_read: usize,
         mut buffer: RX,
     ) -> Result<SpiDmaTransfer<'d, Dm, RX>, (Error, Self, RX)> {
-        self.wait_for_idle();
+        let clock = SpiClockGuard::new(self.spi.info());
 
         match unsafe {
             self.start_half_duplex_read(data_mode, cmd, address, dummy, bytes_to_read, &mut buffer)
         } {
-            Ok(_) => Ok(SpiDmaTransfer::new(self, buffer)),
+            Ok(_) => Ok(SpiDmaTransfer::new(self, buffer, clock)),
             Err(e) => Err((e, self, buffer)),
         }
     }
@@ -1407,7 +1417,7 @@ aligned, otherwise the driver requires copying the entire buffer."
         bytes_to_write: usize,
         mut buffer: TX,
     ) -> Result<SpiDmaTransfer<'d, Dm, TX>, (Error, Self, TX)> {
-        self.wait_for_idle();
+        let clock = SpiClockGuard::new(self.spi.info());
 
         match unsafe {
             self.start_half_duplex_write(
@@ -1419,7 +1429,7 @@ aligned, otherwise the driver requires copying the entire buffer."
                 &mut buffer,
             )
         } {
-            Ok(_) => Ok(SpiDmaTransfer::new(self, buffer)),
+            Ok(_) => Ok(SpiDmaTransfer::new(self, buffer, clock)),
             Err(e) => Err((e, self, buffer)),
         }
     }
@@ -1458,7 +1468,8 @@ aligned, otherwise the driver requires copying the entire buffer."
     /// Reads data from the SPI bus using DMA.
     #[instability::unstable]
     pub fn read(&mut self, words: &mut [u8]) -> Result<(), Error> {
-        self.wait_for_idle();
+        let _clock = SpiClockGuard::new(self.spi.info());
+
         self.driver().setup_full_duplex()?;
 
         if self.use_blocking_transfer(words.len()) {
@@ -1498,13 +1509,13 @@ aligned, otherwise the driver requires copying the entire buffer."
     /// Writes data to the SPI bus using DMA.
     #[instability::unstable]
     pub fn write(&mut self, words: &[u8]) -> Result<(), Error> {
-        self.wait_for_idle();
+        let _clock = SpiClockGuard::new(self.spi.info());
+
         self.driver().setup_full_duplex()?;
 
         if self.use_blocking_transfer(words.len()) {
             self.dma_driver().disable_dma();
-            self.driver().write(words)?;
-            return self.driver().flush();
+            return self.driver().write(words);
         }
 
         let mut descriptors = [DmaDescriptor::EMPTY; LINK_DESCRIPTOR_COUNT];
@@ -1533,14 +1544,14 @@ aligned, otherwise the driver requires copying the entire buffer."
     /// Transfers data to and from the SPI bus simultaneously using DMA.
     #[instability::unstable]
     pub fn transfer(&mut self, read: &mut [u8], write: &[u8]) -> Result<(), Error> {
-        self.wait_for_idle();
+        let _clock = SpiClockGuard::new(self.spi.info());
+
         self.driver().setup_full_duplex()?;
 
         if self.use_blocking_transfer(read.len().max(write.len())) {
             self.dma_driver().disable_dma();
             if read.is_empty() {
-                self.driver().write(write)?;
-                return self.driver().flush();
+                return self.driver().write(write);
             } else if write.is_empty() {
                 return self.driver().read(read);
             } else {
@@ -1608,7 +1619,8 @@ aligned, otherwise the driver requires copying the entire buffer."
     /// Transfers data in place on the SPI bus using DMA.
     #[instability::unstable]
     pub fn transfer_in_place(&mut self, words: &mut [u8]) -> Result<(), Error> {
-        self.wait_for_idle();
+        let _clock = SpiClockGuard::new(self.spi.info());
+
         self.driver().setup_full_duplex()?;
 
         if self.use_blocking_transfer(words.len()) {
@@ -1667,7 +1679,7 @@ aligned, otherwise the driver requires copying the entire buffer."
         dummy: u8,
         buffer: &mut [u8],
     ) -> Result<(), Error> {
-        self.wait_for_idle();
+        let _clock = SpiClockGuard::new(self.spi.info());
 
         let rx_buffer = unsafe { self.dma_driver().rx_buffer() };
         if rx_buffer.capacity() == 0 {
@@ -1698,7 +1710,7 @@ aligned, otherwise the driver requires copying the entire buffer."
         dummy: u8,
         buffer: &[u8],
     ) -> Result<(), Error> {
-        self.wait_for_idle();
+        let _clock = SpiClockGuard::new(self.spi.info());
 
         let tx_buffer = unsafe { self.dma_driver().tx_buffer() };
         if tx_buffer.capacity() == 0 {
@@ -1731,6 +1743,7 @@ where
 {
     spi_dma: ManuallyDrop<SpiDma<'d, Dm>>,
     dma_buf: ManuallyDrop<Buf>,
+    clock: ManuallyDrop<SpiClockGuard>,
 }
 
 impl<Buf> SpiDmaTransfer<'_, Async, Buf> {
@@ -1747,10 +1760,11 @@ impl<'d, Dm, Buf> SpiDmaTransfer<'d, Dm, Buf>
 where
     Dm: DriverMode,
 {
-    fn new(spi_dma: SpiDma<'d, Dm>, dma_buf: Buf) -> Self {
+    fn new(spi_dma: SpiDma<'d, Dm>, dma_buf: Buf, clock: SpiClockGuard) -> Self {
         Self {
             spi_dma: ManuallyDrop::new(spi_dma),
             dma_buf: ManuallyDrop::new(dma_buf),
+            clock: ManuallyDrop::new(clock),
         }
     }
 
@@ -1776,6 +1790,7 @@ where
                 ManuallyDrop::take(&mut self.dma_buf),
             )
         };
+        let _ = unsafe { ManuallyDrop::take(&mut self.clock) };
         core::mem::forget(self);
         retval
     }
@@ -1803,6 +1818,7 @@ where
             ManuallyDrop::drop(&mut self.spi_dma);
             ManuallyDrop::drop(&mut self.dma_buf);
         }
+        let _ = unsafe { ManuallyDrop::take(&mut self.clock) };
     }
 }
 

--- a/esp-hal/src/spi/master/low_level/mod.rs
+++ b/esp-hal/src/spi/master/low_level/mod.rs
@@ -26,6 +26,7 @@ use super::{
 };
 use crate::{
     asynch::AtomicWaker,
+    clock::ll::SpiInstance,
     gpio::{InputSignal, OutputSignal},
     handler,
     interrupt::InterruptHandler,
@@ -96,13 +97,25 @@ impl Drop for SpiWrapper<'_> {
         unsafe {
             // SAFETY: we "own" the state, we are allowed to deinit it
             self.spi.state().deinit();
-            crate::clock::ll::ClockTree::with(|clocks| {
-                self.spi
-                    .info()
-                    .clock_instance
-                    .release_function_clock(clocks);
-            });
         }
+    }
+}
+
+pub(super) struct SpiClockGuard {
+    clock: SpiInstance,
+}
+
+impl SpiClockGuard {
+    pub(super) fn new(spi: &Info) -> Self {
+        let clock = spi.clock_instance;
+        crate::clock::ll::ClockTree::with(|clocks| clock.request_function_clock(clocks));
+        Self { clock }
+    }
+}
+
+impl Drop for SpiClockGuard {
+    fn drop(&mut self) {
+        crate::clock::ll::ClockTree::with(|clocks| self.clock.release_function_clock(clocks));
     }
 }
 
@@ -202,26 +215,29 @@ impl Driver {
     /// Initialize for full-duplex 1 bit mode
     pub(super) fn init(&self) {
         version::enable_peripheral_clock(self);
+
         crate::soc::clocks::ClockTree::with(|clocks| {
             self.info.clock_instance.configure_function_clock(
                 clocks,
                 crate::soc::clocks::SpiFunctionClockConfig::default(),
             );
             self.info.clock_instance.request_function_clock(clocks);
-        });
-        self.regs().user().modify(|_, w| {
-            w.usr_miso_highpart().clear_bit();
-            w.usr_mosi_highpart().clear_bit();
-            w.doutdin().set_bit();
-            w.usr_miso().set_bit();
-            w.usr_mosi().set_bit();
-            w.cs_hold().set_bit();
-            w.usr_dummy_idle().set_bit();
-            w.usr_addr().clear_bit();
-            w.usr_command().clear_bit()
-        });
 
-        version::init(self);
+            self.regs().user().modify(|_, w| {
+                w.usr_miso_highpart().clear_bit();
+                w.usr_mosi_highpart().clear_bit();
+                w.doutdin().set_bit();
+                w.usr_miso().set_bit();
+                w.usr_mosi().set_bit();
+                w.cs_hold().set_bit();
+                w.usr_dummy_idle().set_bit();
+                w.usr_addr().clear_bit();
+                w.usr_command().clear_bit()
+            });
+
+            version::init(self);
+            self.info.clock_instance.release_function_clock(clocks);
+        });
 
         self.regs().slave().write(|w| unsafe { w.bits(0) });
     }
@@ -260,17 +276,20 @@ impl Driver {
             self.info
                 .clock_instance
                 .configure_function_clock(clocks, config.clock_source);
+            self.info.clock_instance.request_function_clock(clocks);
 
             self.regs().clock().write(|w| unsafe { w.bits(raw) });
+
+            self.set_bit_order(config.read_bit_order, config.write_bit_order);
+            self.set_data_mode(config.mode);
+
+            version::apply_config(self);
+            self.info.clock_instance.release_function_clock(clocks);
         });
 
-        self.set_bit_order(config.read_bit_order, config.write_bit_order);
-        self.set_data_mode(config.mode);
         self.state
             .min_async_transfer_size
             .store(config.min_async_transfer_size, Ordering::Relaxed);
-
-        version::apply_config(self);
 
         Ok(())
     }
@@ -349,15 +368,11 @@ impl Driver {
     }
 
     /// Write bytes to SPI.
-    ///
-    /// This function will return before all bytes of the last chunk to transmit
-    /// have been sent to the wire. If you must ensure that the whole
-    /// messages was written correctly, use [`Self::flush`].
     #[cfg_attr(place_spi_master_driver_in_ram, ram)]
     pub(super) fn write(&self, words: &[u8]) -> Result<(), Error> {
         for chunk in words.chunks(FIFO_SIZE) {
-            self.flush()?;
             self.write_one(chunk)?;
+            self.flush()?;
         }
         Ok(())
     }
@@ -474,8 +489,6 @@ impl Driver {
                 break;
             }
 
-            self.flush()?;
-
             if write_inc < read_inc {
                 // Read more than we write, must pad writing part with zeros
                 let mut empty = [EMPTY_WRITE_PAD; FIFO_SIZE];
@@ -485,8 +498,9 @@ impl Driver {
                 self.write_one(&write[write_from..][..write_inc])?;
             }
 
+            self.flush()?;
+
             if read_inc > 0 {
-                self.flush()?;
                 self.read_from_fifo(&mut read[read_from..][..read_inc])?;
             }
 
@@ -519,7 +533,6 @@ impl Driver {
             return Err(Error::Unsupported);
         }
 
-        self.flush()?;
         self.setup_half_duplex(
             false,
             cmd,
@@ -553,8 +566,6 @@ impl Driver {
         if buffer.len() > FIFO_SIZE {
             return Err(Error::FifoSizeExeeded);
         }
-
-        self.flush()?;
 
         cfg_select! {
             all(spi_master_version = "1", spi_address_workaround) => {
@@ -610,7 +621,7 @@ impl Driver {
             // while to ensure the peripheral is idle.
             let cancel_on_drop = DropGuard::new((), |_| {
                 self.abort_transfer();
-                while self.busy() {}
+                let _ = self.flush();
             });
             let res = self.write_one(chunk);
             self.flush_async().await;
@@ -649,8 +660,8 @@ impl Driver {
                 self.write_one(&write[write_from..][..write_inc])?;
             }
 
-            // Preserve previous semantics - see https://github.com/esp-rs/esp-hal/issues/5257
             self.flush_async().await;
+
             if read_inc > 0 {
                 self.read_from_fifo(&mut read[read_from..][..read_inc])?;
             }

--- a/esp-hal/src/spi/master/mod.rs
+++ b/esp-hal/src/spi/master/mod.rs
@@ -65,6 +65,7 @@ use crate::{
     },
     interrupt::InterruptHandler,
     private::Sealed,
+    spi::master::low_level::SpiClockGuard,
     time::Rate,
 };
 
@@ -794,7 +795,6 @@ impl<'d> Spi<'d, Async> {
     /// # {after_snippet}
     /// ```
     pub async fn flush_async(&mut self) -> Result<(), Error> {
-        self.driver().flush_async().await;
         Ok(())
     }
 
@@ -826,9 +826,8 @@ impl<'d> Spi<'d, Async> {
     /// # {after_snippet}
     /// ```
     pub async fn transfer_in_place_async(&mut self, words: &mut [u8]) -> Result<(), Error> {
-        // We need to flush because the blocking transfer functions may return while a
-        // transfer is still in progress.
-        self.driver().flush_async().await;
+        let _clock = SpiClockGuard::new(self.spi.info());
+
         self.driver().setup_full_duplex()?;
 
         if self.use_blocking_transfer(words.len()) {
@@ -841,9 +840,8 @@ impl<'d> Spi<'d, Async> {
     // TODO: These inherent methods should be public
 
     async fn read_async(&mut self, words: &mut [u8]) -> Result<(), Error> {
-        // We need to flush because the blocking transfer functions may return while a
-        // transfer is still in progress.
-        self.driver().flush_async().await;
+        let _clock = SpiClockGuard::new(self.spi.info());
+
         self.driver().setup_full_duplex()?;
 
         if self.use_blocking_transfer(words.len()) {
@@ -854,14 +852,12 @@ impl<'d> Spi<'d, Async> {
     }
 
     async fn write_async(&mut self, words: &[u8]) -> Result<(), Error> {
-        // We need to flush because the blocking transfer functions may return while a
-        // transfer is still in progress.
-        self.driver().flush_async().await;
+        let _clock = SpiClockGuard::new(self.spi.info());
+
         self.driver().setup_full_duplex()?;
 
         if self.use_blocking_transfer(words.len()) {
-            self.driver().write(words)?;
-            return self.driver().flush();
+            return self.driver().write(words);
         }
 
         self.driver().write_async(words).await
@@ -1130,18 +1126,10 @@ where
     /// # {after_snippet}
     /// ```
     pub fn write(&mut self, words: &[u8]) -> Result<(), Error> {
-        self.driver().flush()?;
+        let _clock = SpiClockGuard::new(self.spi.info());
+
         self.driver().setup_full_duplex()?;
-
-        for chunk in words.chunks(FIFO_SIZE) {
-            self.driver().write_one(chunk)?;
-            // NOTE: While we don't need to flush after the last chunk, changing
-            // that would change the behavior of the function.
-            // https://github.com/esp-rs/esp-hal/issues/5257
-            self.driver().flush()?;
-        }
-
-        Ok(())
+        self.driver().write(words)
     }
 
     #[procmacros::doc_replace]
@@ -1168,7 +1156,7 @@ where
     /// # {after_snippet}
     /// ```
     pub fn read(&mut self, words: &mut [u8]) -> Result<(), Error> {
-        self.driver().flush()?;
+        let _clock = SpiClockGuard::new(self.spi.info());
         self.driver().setup_full_duplex()?;
         self.driver().read(words)
     }
@@ -1197,7 +1185,7 @@ where
     /// # {after_snippet}
     /// ```
     pub fn transfer(&mut self, words: &mut [u8]) -> Result<(), Error> {
-        self.driver().flush()?;
+        let _clock = SpiClockGuard::new(self.spi.info());
         self.driver().setup_full_duplex()?;
         self.driver().transfer_in_place(words)
     }
@@ -1219,6 +1207,7 @@ where
         dummy: u8,
         buffer: &mut [u8],
     ) -> Result<(), Error> {
+        let _clock = SpiClockGuard::new(self.spi.info());
         self.driver()
             .half_duplex_read(data_mode, cmd, address, dummy, buffer)
     }
@@ -1242,6 +1231,7 @@ where
         dummy: u8,
         buffer: &[u8],
     ) -> Result<(), Error> {
+        let _clock = SpiClockGuard::new(self.spi.info());
         self.driver()
             .half_duplex_write(data_mode, cmd, address, dummy, buffer)
     }
@@ -1292,19 +1282,11 @@ where
     }
 
     fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
-        // Do not call the inherent `write` method. The trait impl does not flush after.
-        // Flush before starting to ensure the bus is clear before we reconfigure to full duplex.
-        self.driver().flush()?;
-        self.driver().setup_full_duplex()?;
-        for chunk in words.chunks(FIFO_SIZE) {
-            self.driver().flush()?;
-            self.driver().write_one(chunk)?;
-        }
-        Ok(())
+        self.write(words)
     }
 
     fn transfer(&mut self, read: &mut [u8], write: &[u8]) -> Result<(), Self::Error> {
-        self.driver().flush()?;
+        let _clock = SpiClockGuard::new(self.spi.info());
         self.driver().setup_full_duplex()?;
 
         if read.is_empty() {
@@ -1317,13 +1299,13 @@ where
     }
 
     fn transfer_in_place(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
-        self.driver().flush()?;
+        let _clock = SpiClockGuard::new(self.spi.info());
         self.driver().setup_full_duplex()?;
         self.driver().transfer_in_place(words)
     }
 
     fn flush(&mut self) -> Result<(), Self::Error> {
-        self.driver().flush()
+        Ok(())
     }
 }
 
@@ -1337,18 +1319,18 @@ impl SpiBusAsync for Spi<'_, Async> {
     }
 
     async fn transfer(&mut self, read: &mut [u8], write: &[u8]) -> Result<(), Self::Error> {
-        self.driver().flush_async().await;
+        let _clock = SpiClockGuard::new(self.spi.info());
+
         self.driver().setup_full_duplex()?;
 
         if self.use_blocking_transfer(read.len().max(write.len())) {
-            if read.is_empty() {
-                self.driver().write(write)?;
-                return self.driver().flush();
+            return if read.is_empty() {
+                self.driver().write(write)
             } else if write.is_empty() {
-                return self.driver().read(read);
+                self.driver().read(read)
             } else {
-                return self.driver().transfer(read, write);
-            }
+                self.driver().transfer(read, write)
+            };
         }
 
         if read.is_empty() {
@@ -1365,7 +1347,7 @@ impl SpiBusAsync for Spi<'_, Async> {
     }
 
     async fn flush(&mut self) -> Result<(), Self::Error> {
-        self.flush_async().await
+        Ok(())
     }
 }
 

--- a/hil-test/src/bin/spi.rs
+++ b/hil-test/src/bin/spi.rs
@@ -1361,6 +1361,9 @@ mod tests {
         }
 
         fn check_typical_values(ctx: &mut Context, source: SpiFunctionClockConfig) {
+            esp_hal::clock::ll::ClockTree::with(|clocks| {
+                SpiInstance::Spi2.request_function_clock(clocks)
+            });
             let f_min = SpiInstance::function_clock_source_frequency(source) / 1024;
             assert_frequency_roundtrips(ctx, source, f_min);
             assert_frequency_roundtrips(


### PR DESCRIPTION
Closes #5257

Somewhat questionable since we're changing semantics of stable APIs, but this is necessary if we want to let the MCU go to sleep without dropping the SPI driver. An alternative is to force flushing before entering sleep, but I'd prefer not having a peripheral-specific workaround in the sleep code for each peripheral, unless necessary.

# Changelog

## esp-hal/SPI

- Changed: The SPI master drivers no longer hold the function clock active clock while idle.
- Changed: SPI transfer function now flush automatically. `flush` has become a no-op.