### PR TITLE
Add macro to detect `esp-hal/unstable`

### DIFF
--- a/esp-hal/build.rs
+++ b/esp-hal/build.rs
@@ -11,6 +11,12 @@ use std::{
 use esp_config::{Value, generate_config_from_yaml_definition};
 use esp_metadata_generated::assert_unique_features;
 
+macro_rules! bail {
+    ($($arg:tt)*) => {
+        return Err(format!($($arg)*).into());
+    };
+}
+
 fn main() -> Result<(), Box<dyn Error>> {
     // if using '"rust-analyzer.cargo.buildScripts.useRustcWrapper": true' we can detect this
     let suppress_panics = std::env::var("RUSTC_WRAPPER")
@@ -30,7 +36,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     // If some library required unstable make sure unstable is actually enabled.
     if !suppress_panics && cfg!(feature = "requires-unstable") && !cfg!(feature = "unstable") {
-        panic!(
+        bail!(
             "\n\nThe `unstable` feature is required by a dependent crate but is not enabled.\n\n"
         );
     }
@@ -44,7 +50,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let chip = esp_metadata_generated::Chip::from_cargo_feature()?;
 
     if !suppress_panics && chip.target() != std::env::var("TARGET").unwrap_or_default().as_str() {
-        panic!("
+        bail!("
         Seems you are building for an unsupported or wrong target (e.g. the host environment).
         Maybe you are missing the `target` in `.cargo/config.toml` or you have configs overriding it?
 

--- a/esp-hal/src/macros.rs
+++ b/esp-hal/src/macros.rs
@@ -579,3 +579,23 @@ macro_rules! impl_dma_channel_trait {
     };
 }
 pub(crate) use impl_dma_channel_trait;
+
+/// Macro to allow using unstable HAL features conditionally. Other crates can
+/// use this to "detect" the esp-hal/unstable feature.
+#[macro_export]
+#[doc(hidden)]
+#[cfg(feature = "unstable")]
+macro_rules! if_unstable_hal {
+    ($($tt:tt)*) => {
+        $($tt)*
+    };
+}
+
+/// Macro to allow using unstable HAL features conditionally. Other crates can
+/// use this to "detect" the esp-hal/unstable feature.
+#[macro_export]
+#[doc(hidden)]
+#[cfg(not(feature = "unstable"))]
+macro_rules! if_unstable_hal {
+    ($($tt:tt)*) => {};
+}

--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -348,8 +348,6 @@ defmt = [
 
 ## Enables APIs that are not stable and thus come with no stability guarantees.
 ## Never enable this feature in a library crate using esp-radio.
-##
-## 💡 This feature should be enabled when using unstable APIs from `esp-hal`.
 unstable = [
   "esp-hal/requires-unstable",
   "dep:embedded-io-06",

--- a/esp-radio/src/lib.rs
+++ b/esp-radio/src/lib.rs
@@ -183,8 +183,6 @@ use esp_hal as hal;
 #[instability::unstable]
 pub use esp_phy::CalibrationResult;
 use esp_radio_rtos_driver as preempt;
-#[cfg(all(esp32, feature = "unstable"))]
-use hal::analog::adc::{release_adc2, try_claim_adc2};
 #[cfg(feature = "wifi")]
 use hal::{after_snippet, before_snippet};
 use sys::include::esp_phy_calibration_data_t;
@@ -301,15 +299,15 @@ const _: () = {
 /// - The function may return an error if interrupts are disabled.
 /// - The function may return an error if initializing the underlying driver fails.
 pub(crate) fn init() {
-    #[cfg(all(esp32, feature = "unstable"))]
-    if try_claim_adc2(unsafe { hal::Internal::conjure() }).is_err() {
-        panic!(
-            "ADC2 is currently in use by esp-hal, but esp-radio requires it for Wi-Fi operation."
-        );
+    esp_hal::if_unstable_hal! {
+        #[cfg(esp32)]
+        if hal::analog::adc::try_claim_adc2(unsafe { hal::Internal::conjure() }).is_err() {
+            panic!(
+                "ADC2 is currently in use by esp-hal, but esp-radio requires it for Wi-Fi operation."
+            );
+        }
+        esp_hal::rtc_cntl::WakeLock::acquire();
     }
-
-    #[cfg(feature = "unstable")]
-    esp_hal::rtc_cntl::WakeLock::acquire();
 
     if !preempt::initialized() {
         panic!("The scheduler must be initialized before initializing the radio.");
@@ -352,12 +350,13 @@ pub(crate) fn deinit() {
     #[cfg(feature = "ble")]
     ble::shutdown_ble_isr();
 
-    #[cfg(all(esp32, feature = "unstable"))]
-    // Allow using `ADC2` again
-    release_adc2(unsafe { esp_hal::Internal::conjure() });
+    esp_hal::if_unstable_hal! {
+        // Allow using `ADC2` again
+        #[cfg(esp32)]
+        hal::analog::adc::release_adc2(unsafe { esp_hal::Internal::conjure() });
 
-    #[cfg(feature = "unstable")]
-    esp_hal::rtc_cntl::WakeLock::release();
+        esp_hal::rtc_cntl::WakeLock::release();
+    }
 
     debug!("Radio deinitialized");
 }

--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -2276,10 +2276,12 @@ impl Drop for WifiController<'_> {
                 warn!("Failed to cleanly deinit wifi: {:?}", e);
             }
 
-            #[cfg(all(rng_trng_supported, feature = "unstable"))]
-            esp_hal::rng::TrngSource::decrease_entropy_source_counter(unsafe {
-                esp_hal::Internal::conjure()
-            });
+            #[cfg(rng_trng_supported)]
+            esp_hal::if_unstable_hal! {
+                esp_hal::rng::TrngSource::decrease_entropy_source_counter(unsafe {
+                    esp_hal::Internal::conjure()
+                });
+            }
         })
     }
 }
@@ -2379,10 +2381,12 @@ impl<'d> WifiController<'d> {
         crate::wifi::wifi_init(device)?;
 
         // At some point the "High-speed ADC" entropy source became available.
-        #[cfg(all(rng_trng_supported, feature = "unstable"))]
-        unsafe {
-            esp_hal::rng::TrngSource::increase_entropy_source_counter()
-        };
+        #[cfg(rng_trng_supported)]
+        esp_hal::if_unstable_hal! {
+            unsafe {
+                esp_hal::rng::TrngSource::increase_entropy_source_counter()
+            };
+        }
 
         // Only create WifiController after we've enabled TRNG - otherwise returning an
         // error from this function will cause panic because WifiController::drop tries

--- a/examples/wifi/embassy_sntp/Cargo.toml
+++ b/examples/wifi/embassy_sntp/Cargo.toml
@@ -25,7 +25,7 @@ esp-rtos = { path = "../../../esp-rtos", features = ["esp-radio", "embassy", "lo
 log = "0.4.17"
 esp-radio = { path = "../../../esp-radio", features = [
     "log-04",
-    "wifi",
+    "wifi"
 ] }
 static_cell = "2.1.0"
 sntpc = { version = "0.8", default-features = false }


### PR DESCRIPTION
`esp-hal/unstable` enables some APIs that should be used in esp-radio (ADC, WakeLock). If `esp-hal/unstable` is enabled, `esp-radio` must add a small amount of code. This PR enforces this with a new macro that conditionally enables a piece of code.

# Changelog

## esp-hal

- Added: Added a new (hidden) macro `if_unstable_hal` that allows using unstable features if the `unstable` Cargo feature is enabled. This can be useful for crates which don't have a way to determine if `esp-hal/unstable` is enabled.

## esp-radio

- No changelog necessary.