### PR TITLE
Internal cleanup

### DIFF
--- a/esp-hal/src/clock/mod.rs
+++ b/esp-hal/src/clock/mod.rs
@@ -195,7 +195,7 @@ impl RtcClock {
 
 pub(crate) fn init(cpu_clock_config: ClockConfig) {
     ClockTree::with(|clocks| {
-        crate::rtc_cntl::rtc::init();
+        crate::rtc_cntl::rtc::init(&cpu_clock_config);
 
         cpu_clock_config.configure(clocks);
 

--- a/esp-hal/src/rtc_cntl/rtc/esp32.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32.rs
@@ -1,6 +1,8 @@
 use strum::FromRepr;
 
-pub(crate) fn init() {}
+use crate::soc::clocks::ClockConfig;
+
+pub(crate) fn init(_config: &ClockConfig) {}
 
 // Terminology:
 //

--- a/esp-hal/src/rtc_cntl/rtc/esp32c2.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32c2.rs
@@ -2,10 +2,10 @@ use strum::FromRepr;
 
 use crate::{
     peripherals::{APB_CTRL, EXTMEM, LPWR, SPI0, SPI1, SYSTEM},
-    soc::regi2c,
+    soc::{clocks::ClockConfig, regi2c},
 };
 
-pub(crate) fn init() {
+pub(crate) fn init(_config: &ClockConfig) {
     let rtc_cntl = LPWR::regs();
 
     regi2c::I2C_DIG_REG_XPD_DIG_REG.write_field(0);

--- a/esp-hal/src/rtc_cntl/rtc/esp32c3.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32c3.rs
@@ -2,10 +2,10 @@ use strum::FromRepr;
 
 use crate::{
     peripherals::{APB_CTRL, EXTMEM, LPWR, SPI0, SPI1, SYSTEM},
-    soc::regi2c,
+    soc::{clocks::ClockConfig, regi2c},
 };
 
-pub(crate) fn init() {
+pub(crate) fn init(_config: &ClockConfig) {
     let rtc_cntl = LPWR::regs();
 
     regi2c::I2C_DIG_REG_XPD_DIG_REG.write_field(0);

--- a/esp-hal/src/rtc_cntl/rtc/esp32c5.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32c5.rs
@@ -3,7 +3,7 @@ use strum::FromRepr;
 use crate::{
     peripherals::{LP_CLKRST, MODEM_LPCON, MODEM_SYSCON, PCR, PMU},
     soc::{
-        clocks::{ClockTree, HpRootClkConfig},
+        clocks::{ClockConfig, ClockTree, HpRootClkConfig, LpSlowClkConfig},
         regi2c,
     },
 };
@@ -99,36 +99,6 @@ fn modem_clock_domain_power_state_icg_map_init() {
         });
 }
 
-enum RtcSlowClockSource {
-    /// Select RC_SLOW_CLK as RTC_SLOW_CLK source
-    RcSlow  = 0,
-
-    /// Select XTAL32K_CLK as RTC_SLOW_CLK source
-    XTAL32K = 1,
-
-    /// Select RC32K_CLK as RTC_SLOW_CLK source
-    RC32K   = 2,
-
-    /// Select OSC_SLOW_CLK (external slow clock) as RTC_SLOW_CLK source
-    OscSlow = 3,
-
-    /// Invalid RTC_SLOW_CLK source
-    Invalid,
-}
-
-impl RtcSlowClockSource {
-    fn current() -> Self {
-        // clk_ll_rtc_slow_get_src()
-        match LP_CLKRST::regs().lp_clk_conf().read().slow_clk_sel().bits() {
-            0 => Self::RcSlow,
-            1 => Self::XTAL32K,
-            2 => Self::RC32K,
-            3 => Self::OscSlow,
-            _ => Self::Invalid,
-        }
-    }
-}
-
 #[allow(unused)]
 enum ModemClockLpclkSource {
     RcSlow = 0,
@@ -139,14 +109,12 @@ enum ModemClockLpclkSource {
     EXT32K,
 }
 
-impl From<RtcSlowClockSource> for ModemClockLpclkSource {
-    fn from(src: RtcSlowClockSource) -> Self {
+impl From<LpSlowClkConfig> for ModemClockLpclkSource {
+    fn from(src: LpSlowClkConfig) -> Self {
         match src {
-            RtcSlowClockSource::RcSlow => Self::RcSlow,
-            RtcSlowClockSource::XTAL32K => Self::XTAL32K,
-            RtcSlowClockSource::RC32K => Self::RC32K,
-            RtcSlowClockSource::OscSlow => Self::EXT32K,
-            _ => Self::RcSlow,
+            LpSlowClkConfig::RcSlow => Self::RcSlow,
+            LpSlowClkConfig::Xtal32k => Self::XTAL32K,
+            LpSlowClkConfig::OscSlow => Self::EXT32K,
         }
     }
 }
@@ -1015,11 +983,12 @@ impl LpSystemInit {
     }
 }
 
-pub(crate) fn init() {
+pub(crate) fn init(config: &ClockConfig) {
     // pmu_init()
-    PMU::regs()
-        .rf_pwc()
-        .modify(|_, w| w.perif_i2c_rstb().set_bit().xpd_perif_i2c().set_bit());
+    PMU::regs().rf_pwc().modify(|_, w| {
+        w.perif_i2c_rstb().set_bit();
+        w.xpd_perif_i2c().set_bit()
+    });
 
     regi2c::I2C_DIG_REG_ENIF_RTC_DREG.write_field(1);
     regi2c::I2C_DIG_REG_ENIF_DIG_DREG.write_field(1);
@@ -1041,10 +1010,9 @@ pub(crate) fn init() {
     //  oscillator (40 MHz) to provide the clock during the sleep process in some
     //  scenarios), the module needs to switch to the required clock source by
     //  itself.
-    // TODO - WIFI-5233
-    let modem_lpclk_src = ModemClockLpclkSource::from(RtcSlowClockSource::current());
+    let lpclk_src = config.lp_slow_clk.unwrap_or(LpSlowClkConfig::RcSlow);
 
-    modem_clock_select_lp_clock_source_wifi(modem_lpclk_src, 0);
+    modem_clock_select_lp_clock_source_wifi(ModemClockLpclkSource::from(lpclk_src), 0);
     modem_clk_domain_active_state_icg_map_preinit();
 
     PCR::regs()
@@ -1065,10 +1033,8 @@ fn modem_clk_domain_active_state_icg_map_preinit() {
             .clk_conf_power_st()
             .modify(|_, w| w.clk_modem_apb_st_map().bits(1 << ICG_MODEM_CODE_ACTIVE));
         MODEM_LPCON::regs().clk_conf_power_st().modify(|_, w| {
-            w.clk_i2c_mst_st_map()
-                .bits(1 << ICG_MODEM_CODE_ACTIVE)
-                .clk_lp_apb_st_map()
-                .bits(1 << ICG_MODEM_CODE_ACTIVE)
+            w.clk_i2c_mst_st_map().bits(1 << ICG_MODEM_CODE_ACTIVE);
+            w.clk_lp_apb_st_map().bits(1 << ICG_MODEM_CODE_ACTIVE)
         });
 
         // Software trigger force update modem ICG code and ICG switch

--- a/esp-hal/src/rtc_cntl/rtc/esp32c5.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32c5.rs
@@ -3,7 +3,7 @@ use strum::FromRepr;
 use crate::{
     peripherals::{LP_CLKRST, MODEM_LPCON, MODEM_SYSCON, PCR, PMU},
     soc::{
-        clocks::{ClockConfig, ClockTree, HpRootClkConfig, LpSlowClkConfig},
+        clocks::{ClockConfig, LpSlowClkConfig},
         regi2c,
     },
 };
@@ -1127,25 +1127,4 @@ pub enum SocResetReason {
     PowerGlitch   = 0x19,
     /// CPU lockup reset
     CpuLockup     = 0x1A,
-}
-
-#[derive(Clone, Copy)]
-pub(crate) struct SavedClockConfig {
-    /// The clock from which CPU clock is derived
-    old_hp_root_clk: Option<HpRootClkConfig>,
-}
-
-impl SavedClockConfig {
-    pub(crate) fn save(clocks: &ClockTree) -> Self {
-        let old_hp_root_clk = clocks.hp_root_clk();
-
-        SavedClockConfig { old_hp_root_clk }
-    }
-
-    // rtc_clk_cpu_freq_set_config
-    pub(crate) fn restore(self, clocks: &mut ClockTree) {
-        if let Some(old_hp_root_clk) = self.old_hp_root_clk {
-            crate::soc::clocks::configure_hp_root_clk(clocks, old_hp_root_clk);
-        }
-    }
 }

--- a/esp-hal/src/rtc_cntl/rtc/esp32c6.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32c6.rs
@@ -3,10 +3,7 @@ use strum::FromRepr;
 use crate::{
     clock::ClockConfig,
     peripherals::{LP_CLKRST, MODEM_LPCON, MODEM_SYSCON, PCR, PMU},
-    soc::{
-        clocks::{ClockTree, LpSlowClkConfig, SocRootClkConfig},
-        regi2c,
-    },
+    soc::{clocks::LpSlowClkConfig, regi2c},
 };
 
 fn pmu_power_domain_force_default() {
@@ -1117,25 +1114,4 @@ pub enum SocResetReason {
     CoreUsbJtag   = 0x16,
     /// JTAG resets CPU
     Cpu0JtagCpu   = 0x18,
-}
-
-#[derive(Clone, Copy)]
-pub(crate) struct SavedClockConfig {
-    /// The clock from which CPU clock is derived
-    old_soc_root_clk: Option<SocRootClkConfig>,
-}
-
-impl SavedClockConfig {
-    pub(crate) fn save(clocks: &ClockTree) -> Self {
-        let old_soc_root_clk = clocks.soc_root_clk();
-
-        SavedClockConfig { old_soc_root_clk }
-    }
-
-    // rtc_clk_cpu_freq_set_config
-    pub(crate) fn restore(self, clocks: &mut ClockTree) {
-        if let Some(old_soc_root_clk) = self.old_soc_root_clk {
-            crate::soc::clocks::configure_soc_root_clk(clocks, old_soc_root_clk);
-        }
-    }
 }

--- a/esp-hal/src/rtc_cntl/rtc/esp32c6.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32c6.rs
@@ -1,9 +1,10 @@
 use strum::FromRepr;
 
 use crate::{
+    clock::ClockConfig,
     peripherals::{LP_CLKRST, MODEM_LPCON, MODEM_SYSCON, PCR, PMU},
     soc::{
-        clocks::{ClockTree, SocRootClkConfig},
+        clocks::{ClockTree, LpSlowClkConfig, SocRootClkConfig},
         regi2c,
     },
 };
@@ -99,36 +100,6 @@ fn modem_clock_domain_power_state_icg_map_init() {
         });
 }
 
-enum RtcSlowClockSource {
-    /// Select RC_SLOW_CLK as RTC_SLOW_CLK source
-    RcSlow  = 0,
-
-    /// Select XTAL32K_CLK as RTC_SLOW_CLK source
-    XTAL32K = 1,
-
-    /// Select RC32K_CLK as RTC_SLOW_CLK source
-    RC32K   = 2,
-
-    /// Select OSC_SLOW_CLK (external slow clock) as RTC_SLOW_CLK source
-    OscSlow = 3,
-
-    /// Invalid RTC_SLOW_CLK source
-    Invalid,
-}
-
-impl RtcSlowClockSource {
-    fn current() -> Self {
-        // clk_ll_rtc_slow_get_src()
-        match LP_CLKRST::regs().lp_clk_conf().read().slow_clk_sel().bits() {
-            0 => Self::RcSlow,
-            1 => Self::XTAL32K,
-            2 => Self::RC32K,
-            3 => Self::OscSlow,
-            _ => Self::Invalid,
-        }
-    }
-}
-
 #[allow(unused)]
 enum ModemClockLpclkSource {
     RcSlow = 0,
@@ -139,14 +110,12 @@ enum ModemClockLpclkSource {
     EXT32K,
 }
 
-impl From<RtcSlowClockSource> for ModemClockLpclkSource {
-    fn from(src: RtcSlowClockSource) -> Self {
+impl From<LpSlowClkConfig> for ModemClockLpclkSource {
+    fn from(src: LpSlowClkConfig) -> Self {
         match src {
-            RtcSlowClockSource::RcSlow => Self::RcSlow,
-            RtcSlowClockSource::XTAL32K => Self::XTAL32K,
-            RtcSlowClockSource::RC32K => Self::RC32K,
-            RtcSlowClockSource::OscSlow => Self::EXT32K,
-            _ => Self::RcSlow,
+            LpSlowClkConfig::RcSlow => Self::RcSlow,
+            LpSlowClkConfig::Xtal32k => Self::XTAL32K,
+            LpSlowClkConfig::OscSlow => Self::EXT32K,
         }
     }
 }
@@ -1010,11 +979,12 @@ impl LpSystemInit {
     }
 }
 
-pub(crate) fn init() {
+pub(crate) fn init(config: &ClockConfig) {
     // pmu_init()
-    PMU::regs()
-        .rf_pwc()
-        .modify(|_, w| w.perif_i2c_rstb().set_bit().xpd_perif_i2c().set_bit());
+    PMU::regs().rf_pwc().modify(|_, w| {
+        w.perif_i2c_rstb().set_bit();
+        w.xpd_perif_i2c().set_bit()
+    });
 
     regi2c::I2C_DIG_REG_ENIF_RTC_DREG.write_field(1);
     regi2c::I2C_DIG_REG_ENIF_DIG_DREG.write_field(1);
@@ -1036,10 +1006,9 @@ pub(crate) fn init() {
     //  oscillator (40 MHz) to provide the clock during the sleep process in some
     //  scenarios), the module needs to switch to the required clock source by
     //  itself.
-    // TODO - WIFI-5233
-    let modem_lpclk_src = ModemClockLpclkSource::from(RtcSlowClockSource::current());
+    let lpclk_src = config.lp_slow_clk.unwrap_or(LpSlowClkConfig::RcSlow);
 
-    modem_clock_select_lp_clock_source_wifi(modem_lpclk_src, 0);
+    modem_clock_select_lp_clock_source_wifi(ModemClockLpclkSource::from(lpclk_src), 0);
     modem_clk_domain_active_state_icg_map_preinit();
 }
 
@@ -1056,10 +1025,8 @@ fn modem_clk_domain_active_state_icg_map_preinit() {
             .clk_conf_power_st()
             .modify(|_, w| w.clk_modem_apb_st_map().bits(1 << ICG_MODEM_CODE_ACTIVE));
         MODEM_LPCON::regs().clk_conf_power_st().modify(|_, w| {
-            w.clk_i2c_mst_st_map()
-                .bits(1 << ICG_MODEM_CODE_ACTIVE)
-                .clk_lp_apb_st_map()
-                .bits(1 << ICG_MODEM_CODE_ACTIVE)
+            w.clk_i2c_mst_st_map().bits(1 << ICG_MODEM_CODE_ACTIVE);
+            w.clk_lp_apb_st_map().bits(1 << ICG_MODEM_CODE_ACTIVE)
         });
 
         // Software trigger force update modem ICG code and ICG switch

--- a/esp-hal/src/rtc_cntl/rtc/esp32c61.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32c61.rs
@@ -3,7 +3,7 @@ use strum::FromRepr;
 use crate::{
     peripherals::{LP_CLKRST, MODEM_LPCON, MODEM_SYSCON, PCR, PMU},
     soc::{
-        clocks::{ClockTree, HpRootClkConfig},
+        clocks::{ClockConfig, ClockTree, HpRootClkConfig, LpSlowClkConfig},
         regi2c,
     },
 };
@@ -99,36 +99,6 @@ fn modem_clock_domain_power_state_icg_map_init() {
         });
 }
 
-enum RtcSlowClockSource {
-    /// Select RC_SLOW_CLK as RTC_SLOW_CLK source
-    RcSlow  = 0,
-
-    /// Select XTAL32K_CLK as RTC_SLOW_CLK source
-    XTAL32K = 1,
-
-    /// Select RC32K_CLK as RTC_SLOW_CLK source
-    RC32K   = 2,
-
-    /// Select OSC_SLOW_CLK (external slow clock) as RTC_SLOW_CLK source
-    OscSlow = 3,
-
-    /// Invalid RTC_SLOW_CLK source
-    Invalid,
-}
-
-impl RtcSlowClockSource {
-    fn current() -> Self {
-        // clk_ll_rtc_slow_get_src()
-        match LP_CLKRST::regs().lp_clk_conf().read().slow_clk_sel().bits() {
-            0 => Self::RcSlow,
-            1 => Self::XTAL32K,
-            2 => Self::RC32K,
-            3 => Self::OscSlow,
-            _ => Self::Invalid,
-        }
-    }
-}
-
 #[allow(unused)]
 enum ModemClockLpclkSource {
     RcSlow = 0,
@@ -139,14 +109,12 @@ enum ModemClockLpclkSource {
     EXT32K,
 }
 
-impl From<RtcSlowClockSource> for ModemClockLpclkSource {
-    fn from(src: RtcSlowClockSource) -> Self {
+impl From<LpSlowClkConfig> for ModemClockLpclkSource {
+    fn from(src: LpSlowClkConfig) -> Self {
         match src {
-            RtcSlowClockSource::RcSlow => Self::RcSlow,
-            RtcSlowClockSource::XTAL32K => Self::XTAL32K,
-            RtcSlowClockSource::RC32K => Self::RC32K,
-            RtcSlowClockSource::OscSlow => Self::EXT32K,
-            _ => Self::RcSlow,
+            LpSlowClkConfig::RcSlow => Self::RcSlow,
+            LpSlowClkConfig::Xtal32k => Self::XTAL32K,
+            LpSlowClkConfig::OscSlow => Self::EXT32K,
         }
     }
 }
@@ -1015,11 +983,12 @@ impl LpSystemInit {
     }
 }
 
-pub(crate) fn init() {
+pub(crate) fn init(config: &ClockConfig) {
     // pmu_init()
-    PMU::regs()
-        .rf_pwc()
-        .modify(|_, w| w.perif_i2c_rstb().set_bit().xpd_perif_i2c().set_bit());
+    PMU::regs().rf_pwc().modify(|_, w| {
+        w.perif_i2c_rstb().set_bit();
+        w.xpd_perif_i2c().set_bit()
+    });
 
     regi2c::I2C_DIG_REG_ENIF_RTC_DREG.write_field(1);
     regi2c::I2C_DIG_REG_ENIF_DIG_DREG.write_field(1);
@@ -1041,10 +1010,9 @@ pub(crate) fn init() {
     //  oscillator (40 MHz) to provide the clock during the sleep process in some
     //  scenarios), the module needs to switch to the required clock source by
     //  itself.
-    // TODO - WIFI-5233
-    let modem_lpclk_src = ModemClockLpclkSource::from(RtcSlowClockSource::current());
+    let lpclk_src = config.lp_slow_clk.unwrap_or(LpSlowClkConfig::RcSlow);
 
-    modem_clock_select_lp_clock_source_wifi(modem_lpclk_src, 0);
+    modem_clock_select_lp_clock_source_wifi(ModemClockLpclkSource::from(lpclk_src), 0);
     modem_clk_domain_active_state_icg_map_preinit();
 
     PCR::regs()
@@ -1065,10 +1033,8 @@ fn modem_clk_domain_active_state_icg_map_preinit() {
             .clk_conf_power_st()
             .modify(|_, w| w.clk_modem_apb_st_map().bits(1 << ICG_MODEM_CODE_ACTIVE));
         MODEM_LPCON::regs().clk_conf_power_st().modify(|_, w| {
-            w.clk_i2c_mst_st_map()
-                .bits(1 << ICG_MODEM_CODE_ACTIVE)
-                .clk_lp_apb_st_map()
-                .bits(1 << ICG_MODEM_CODE_ACTIVE)
+            w.clk_i2c_mst_st_map().bits(1 << ICG_MODEM_CODE_ACTIVE);
+            w.clk_lp_apb_st_map().bits(1 << ICG_MODEM_CODE_ACTIVE)
         });
 
         // Software trigger force update modem ICG code and ICG switch

--- a/esp-hal/src/rtc_cntl/rtc/esp32c61.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32c61.rs
@@ -3,7 +3,7 @@ use strum::FromRepr;
 use crate::{
     peripherals::{LP_CLKRST, MODEM_LPCON, MODEM_SYSCON, PCR, PMU},
     soc::{
-        clocks::{ClockConfig, ClockTree, HpRootClkConfig, LpSlowClkConfig},
+        clocks::{ClockConfig, LpSlowClkConfig},
         regi2c,
     },
 };
@@ -1127,25 +1127,4 @@ pub enum SocResetReason {
     PowerGlitch   = 0x19,
     /// CPU lockup reset
     CpuLockup     = 0x1A,
-}
-
-#[derive(Clone, Copy)]
-pub(crate) struct SavedClockConfig {
-    /// The clock from which CPU clock is derived
-    old_hp_root_clk: Option<HpRootClkConfig>,
-}
-
-impl SavedClockConfig {
-    pub(crate) fn save(clocks: &ClockTree) -> Self {
-        let old_hp_root_clk = clocks.hp_root_clk();
-
-        SavedClockConfig { old_hp_root_clk }
-    }
-
-    // rtc_clk_cpu_freq_set_config
-    pub(crate) fn restore(self, clocks: &mut ClockTree) {
-        if let Some(old_hp_root_clk) = self.old_hp_root_clk {
-            crate::soc::clocks::configure_hp_root_clk(clocks, old_hp_root_clk);
-        }
-    }
 }

--- a/esp-hal/src/rtc_cntl/rtc/esp32h2.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32h2.rs
@@ -2,10 +2,7 @@ use strum::FromRepr;
 
 use crate::{
     peripherals::{PCR, PMU},
-    soc::{
-        clocks::{ClockConfig, ClockTree, CpuClkConfig, HpRootClkConfig},
-        regi2c,
-    },
+    soc::{clocks::ClockConfig, regi2c},
 };
 
 pub(crate) fn init(_config: &ClockConfig) {
@@ -196,35 +193,4 @@ bitfield::bitfield! {
     pub bool, dig_pad_slp_sel, set_dig_pad_slp_sel: 27;
     pub bool, dig_pause_wdt  , set_dig_pause_wdt  : 28;
     pub bool, dig_cpu_stall  , set_dig_cpu_stall  : 29;
-}
-
-#[derive(Clone, Copy)]
-pub(crate) struct SavedClockConfig {
-    /// The clock from which CPU clock is derived
-    old_hp_root_clk: Option<HpRootClkConfig>,
-
-    /// CPU divider
-    old_cpu_divider: Option<CpuClkConfig>,
-}
-
-impl SavedClockConfig {
-    pub(crate) fn save(clocks: &ClockTree) -> Self {
-        let old_hp_root_clk = clocks.hp_root_clk();
-        let old_cpu_divider = clocks.cpu_clk();
-
-        SavedClockConfig {
-            old_hp_root_clk,
-            old_cpu_divider,
-        }
-    }
-
-    // rtc_clk_cpu_freq_set_config
-    pub(crate) fn restore(self, clocks: &mut ClockTree) {
-        if let Some(old_hp_root_clk) = self.old_hp_root_clk {
-            crate::soc::clocks::configure_hp_root_clk(clocks, old_hp_root_clk);
-        }
-        if let Some(old_cpu_divider) = self.old_cpu_divider {
-            crate::soc::clocks::configure_cpu_clk(clocks, old_cpu_divider);
-        }
-    }
 }

--- a/esp-hal/src/rtc_cntl/rtc/esp32h2.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32h2.rs
@@ -2,10 +2,13 @@ use strum::FromRepr;
 
 use crate::{
     peripherals::{PCR, PMU},
-    soc::regi2c,
+    soc::{
+        clocks::{ClockConfig, ClockTree, CpuClkConfig, HpRootClkConfig},
+        regi2c,
+    },
 };
 
-pub(crate) fn init() {
+pub(crate) fn init(_config: &ClockConfig) {
     // * No peripheral reg i2c power up required on the target */
     regi2c::I2C_PMU_EN_I2C_RTC_DREG.write_field(0);
     regi2c::I2C_PMU_EN_I2C_DIG_DREG.write_field(0);
@@ -31,40 +34,27 @@ pub(crate) fn init() {
             .modify(|_, w| w.hp_sleep_lp_regulator_dbias().bits(26));
 
         pmu.hp_sleep_dig_power().modify(|_, w| {
-            w.hp_sleep_vdd_spi_pd_en()
-                .set_bit()
-                .hp_sleep_pd_hp_wifi_pd_en()
-                .set_bit()
-                .hp_sleep_pd_hp_cpu_pd_en()
-                .set_bit()
-                .hp_sleep_pd_top_pd_en()
-                .set_bit()
+            w.hp_sleep_vdd_spi_pd_en().set_bit();
+            w.hp_sleep_pd_hp_wifi_pd_en().set_bit();
+            w.hp_sleep_pd_hp_cpu_pd_en().set_bit();
+            w.hp_sleep_pd_top_pd_en().set_bit()
         });
 
         pmu.hp_active_hp_ck_power().modify(|_, w| {
-            w.hp_active_xpd_bbpll()
-                .set_bit()
-                .hp_active_xpd_bb_i2c()
-                .set_bit()
-                .hp_active_xpd_bbpll_i2c()
-                .set_bit()
+            w.hp_active_xpd_bbpll().set_bit();
+            w.hp_active_xpd_bb_i2c().set_bit();
+            w.hp_active_xpd_bbpll_i2c().set_bit()
         });
 
         pmu.hp_active_sysclk().modify(|_, w| {
-            w.hp_active_icg_sys_clock_en()
-                .set_bit()
-                .hp_active_sys_clk_slp_sel()
-                .clear_bit()
-                .hp_active_icg_slp_sel()
-                .clear_bit()
+            w.hp_active_icg_sys_clock_en().set_bit();
+            w.hp_active_sys_clk_slp_sel().clear_bit();
+            w.hp_active_icg_slp_sel().clear_bit()
         });
         pmu.hp_sleep_sysclk().modify(|_, w| {
-            w.hp_sleep_icg_sys_clock_en()
-                .clear_bit()
-                .hp_sleep_sys_clk_slp_sel()
-                .set_bit()
-                .hp_sleep_icg_slp_sel()
-                .set_bit()
+            w.hp_sleep_icg_sys_clock_en().clear_bit();
+            w.hp_sleep_sys_clk_slp_sel().set_bit();
+            w.hp_sleep_icg_slp_sel().set_bit()
         });
 
         pmu.slp_wakeup_cntl5()
@@ -206,4 +196,35 @@ bitfield::bitfield! {
     pub bool, dig_pad_slp_sel, set_dig_pad_slp_sel: 27;
     pub bool, dig_pause_wdt  , set_dig_pause_wdt  : 28;
     pub bool, dig_cpu_stall  , set_dig_cpu_stall  : 29;
+}
+
+#[derive(Clone, Copy)]
+pub(crate) struct SavedClockConfig {
+    /// The clock from which CPU clock is derived
+    old_hp_root_clk: Option<HpRootClkConfig>,
+
+    /// CPU divider
+    old_cpu_divider: Option<CpuClkConfig>,
+}
+
+impl SavedClockConfig {
+    pub(crate) fn save(clocks: &ClockTree) -> Self {
+        let old_hp_root_clk = clocks.hp_root_clk();
+        let old_cpu_divider = clocks.cpu_clk();
+
+        SavedClockConfig {
+            old_hp_root_clk,
+            old_cpu_divider,
+        }
+    }
+
+    // rtc_clk_cpu_freq_set_config
+    pub(crate) fn restore(self, clocks: &mut ClockTree) {
+        if let Some(old_hp_root_clk) = self.old_hp_root_clk {
+            crate::soc::clocks::configure_hp_root_clk(clocks, old_hp_root_clk);
+        }
+        if let Some(old_cpu_divider) = self.old_cpu_divider {
+            crate::soc::clocks::configure_cpu_clk(clocks, old_cpu_divider);
+        }
+    }
 }

--- a/esp-hal/src/rtc_cntl/rtc/esp32p4.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32p4.rs
@@ -2,10 +2,7 @@ use strum::FromRepr;
 
 use crate::{
     peripherals::PMU,
-    soc::{
-        clocks::{self, ClockConfig, ClockTree, CpuRootClkConfig},
-        regi2c,
-    },
+    soc::{clocks::ClockConfig, regi2c},
 };
 
 // `dig_sysclk_sel` codes (SOC_CPU_CLK_SRC_*).
@@ -495,27 +492,4 @@ pub(crate) fn init(_config: &ClockConfig) {
         w.tie_high_xpd_pll().bits(0xF);
         w.tie_high_xpd_pll_i2c().bits(0xF)
     });
-}
-
-/// Saves and restores the CPU root clock source around sleep.
-///
-/// Before entering sleep the CPU root clock is switched to XTAL (the PMU runs
-/// the sleep FSM from a known clock); on wake we restore the previous source.
-#[derive(Clone, Copy)]
-pub(crate) struct SavedClockConfig {
-    old_cpu_root_clk: Option<CpuRootClkConfig>,
-}
-
-impl SavedClockConfig {
-    pub(crate) fn save(clocks: &ClockTree) -> Self {
-        SavedClockConfig {
-            old_cpu_root_clk: clocks.cpu_root_clk(),
-        }
-    }
-
-    pub(crate) fn restore(self, clocks: &mut ClockTree) {
-        if let Some(old) = self.old_cpu_root_clk {
-            clocks::configure_cpu_root_clk(clocks, old);
-        }
-    }
 }

--- a/esp-hal/src/rtc_cntl/rtc/esp32p4.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32p4.rs
@@ -3,7 +3,7 @@ use strum::FromRepr;
 use crate::{
     peripherals::PMU,
     soc::{
-        clocks::{self, ClockTree, CpuRootClkConfig},
+        clocks::{self, ClockConfig, ClockTree, CpuRootClkConfig},
         regi2c,
     },
 };
@@ -468,7 +468,8 @@ fn pmu_lp_system_init() {
 }
 
 /// Minimal init for bare-metal boot.
-pub(crate) fn init() {
+
+pub(crate) fn init(_config: &ClockConfig) {
     pmu_power_domain_force_default();
 
     // Force the analog dig regulators on via regi2c (XPD off => regulated by

--- a/esp-hal/src/rtc_cntl/rtc/esp32p4.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32p4.rs
@@ -465,7 +465,6 @@ fn pmu_lp_system_init() {
 }
 
 /// Minimal init for bare-metal boot.
-
 pub(crate) fn init(_config: &ClockConfig) {
     pmu_power_domain_force_default();
 

--- a/esp-hal/src/rtc_cntl/rtc/esp32s2.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32s2.rs
@@ -1,6 +1,8 @@
 use strum::FromRepr;
 
-pub(crate) fn init() {}
+use crate::soc::clocks::ClockConfig;
+
+pub(crate) fn init(_config: &ClockConfig) {}
 
 // Terminology:
 //

--- a/esp-hal/src/rtc_cntl/rtc/esp32s3.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32s3.rs
@@ -1,6 +1,8 @@
 use strum::FromRepr;
 
-pub(crate) fn init() {}
+use crate::soc::clocks::ClockConfig;
+
+pub(crate) fn init(_config: &ClockConfig) {}
 
 // Terminology:
 //

--- a/esp-hal/src/rtc_cntl/sleep/esp32c3.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c3.rs
@@ -683,48 +683,46 @@ impl RtcSleepConfig {
 
         if self.wifi_pd_en() {
             rtc_cntl.dig_iso().modify(|_, w| {
-                w.wifi_force_noiso()
-                    .clear_bit()
-                    .wifi_force_iso()
-                    .clear_bit()
+                w.wifi_force_noiso().clear_bit();
+                w.wifi_force_iso().clear_bit()
             });
 
-            rtc_cntl
-                .dig_pwc()
-                .modify(|_, w| w.wifi_force_pu().clear_bit().wifi_pd_en().set_bit());
+            rtc_cntl.dig_pwc().modify(|_, w| {
+                w.wifi_force_pu().clear_bit();
+                w.wifi_pd_en().set_bit()
+            });
         } else {
             rtc_cntl.dig_pwc().modify(|_, w| w.wifi_pd_en().clear_bit());
         }
         if self.bt_pd_en() {
-            rtc_cntl
-                .dig_iso()
-                .modify(|_, w| w.bt_force_noiso().clear_bit().bt_force_iso().clear_bit());
+            rtc_cntl.dig_iso().modify(|_, w| {
+                w.bt_force_noiso().clear_bit();
+                w.bt_force_iso().clear_bit()
+            });
 
-            rtc_cntl
-                .dig_pwc()
-                .modify(|_, w| w.bt_force_pu().clear_bit().bt_pd_en().set_bit());
+            rtc_cntl.dig_pwc().modify(|_, w| {
+                w.bt_force_pu().clear_bit();
+                w.bt_pd_en().set_bit()
+            });
         } else {
             rtc_cntl.dig_pwc().modify(|_, w| w.bt_pd_en().clear_bit());
         }
 
-        rtc_cntl
-            .dig_pwc()
-            .modify(|_, w| w.cpu_top_pd_en().bit(self.cpu_pd_en()));
-
-        rtc_cntl
-            .dig_pwc()
-            .modify(|_, w| w.dg_peri_pd_en().bit(self.dig_peri_pd_en()));
+        rtc_cntl.dig_pwc().modify(|_, w| {
+            w.cpu_top_pd_en().bit(self.cpu_pd_en());
+            w.dg_peri_pd_en().bit(self.dig_peri_pd_en())
+        });
 
         unsafe {
             rtc_cntl.bias_conf().modify(|_, w| {
                 w.dbg_atten_monitor()
-                    .bits(RTC_CNTL_DBG_ATTEN_MONITOR_DEFAULT)
-                    // We have config values for this in self, so I don't know why we're setting
-                    // hardcoded defaults for these next two. It's what IDF does...
-                    .bias_sleep_monitor()
-                    .bit(RTC_CNTL_BIASSLP_MONITOR_DEFAULT)
-                    .pd_cur_monitor()
-                    .bit(RTC_CNTL_PD_CUR_MONITOR_DEFAULT)
+                    .bits(RTC_CNTL_DBG_ATTEN_MONITOR_DEFAULT);
+
+                // We have config values for this in self, so I don't know why we're setting
+                // hardcoded defaults for these next two. It's what IDF does...
+
+                w.bias_sleep_monitor().bit(RTC_CNTL_BIASSLP_MONITOR_DEFAULT);
+                w.pd_cur_monitor().bit(RTC_CNTL_PD_CUR_MONITOR_DEFAULT)
             });
 
             assert!(!self.pd_cur_slp() || self.bias_sleep_slp());
@@ -733,12 +731,9 @@ impl RtcSleepConfig {
             regi2c::I2C_DIG_REG_EXT_DIG_DREG_SLEEP.write_field(self.dig_dbias_slp());
 
             rtc_cntl.bias_conf().modify(|_, w| {
-                w.dbg_atten_deep_slp()
-                    .bits(self.dbg_atten_slp())
-                    .bias_sleep_deep_slp()
-                    .bit(self.bias_sleep_slp())
-                    .pd_cur_deep_slp()
-                    .bit(self.pd_cur_slp())
+                w.dbg_atten_deep_slp().bits(self.dbg_atten_slp());
+                w.bias_sleep_deep_slp().bit(self.bias_sleep_slp());
+                w.pd_cur_deep_slp().bit(self.pd_cur_slp())
             });
 
             if self.deep_slp() {
@@ -749,14 +744,10 @@ impl RtcSleepConfig {
                     .modify(|_, w| w.dg_wrap_pd_en().set_bit());
 
                 rtc_cntl.ana_conf().modify(|_, w| {
-                    w.ckgen_i2c_pu()
-                        .clear_bit()
-                        .pll_i2c_pu()
-                        .clear_bit()
-                        .rfrx_pbus_pu()
-                        .clear_bit()
-                        .txrf_i2c_pu()
-                        .clear_bit()
+                    w.ckgen_i2c_pu().clear_bit();
+                    w.pll_i2c_pu().clear_bit();
+                    w.rfrx_pbus_pu().clear_bit();
+                    w.txrf_i2c_pu().clear_bit()
                 });
 
                 rtc_cntl
@@ -764,10 +755,8 @@ impl RtcSleepConfig {
                     .modify(|_, w| w.bb_i2c_force_pu().clear_bit());
             } else {
                 rtc_cntl.bias_conf().modify(|_, w| {
-                    w.dg_vdd_drv_b_slp_en()
-                        .set_bit()
-                        .dg_vdd_drv_b_slp()
-                        .bits(RTC_CNTL_DG_VDD_DRV_B_SLP_DEFAULT)
+                    w.dg_vdd_drv_b_slp_en().set_bit();
+                    w.dg_vdd_drv_b_slp().bits(RTC_CNTL_DG_VDD_DRV_B_SLP_DEFAULT)
                 });
 
                 rtc_cntl
@@ -786,26 +775,20 @@ impl RtcSleepConfig {
                 .modify(|_, w| w.regulator_force_pu().bit(self.rtc_regulator_fpu()));
 
             rtc_cntl.clk_conf().modify(|_, w| {
-                w.ck8m_force_pu()
-                    .bit(!self.int_8m_pd_en())
-                    .ck8m_force_nogating()
-                    .bit(!self.int_8m_pd_en())
+                w.ck8m_force_pu().bit(!self.int_8m_pd_en());
+                w.ck8m_force_nogating().bit(!self.int_8m_pd_en())
             });
 
             // enable VDDSDIO control by state machine
 
             rtc_cntl.sdio_conf().modify(|_, w| {
-                w.sdio_force()
-                    .clear_bit()
-                    .sdio_reg_pd_en()
-                    .bit(self.vddsdio_pd_en())
+                w.sdio_force().clear_bit();
+                w.sdio_reg_pd_en().bit(self.vddsdio_pd_en())
             });
 
             rtc_cntl.slp_reject_conf().modify(|_, w| {
-                w.deep_slp_reject_en()
-                    .bit(self.deep_slp_reject())
-                    .light_slp_reject_en()
-                    .bit(self.light_slp_reject())
+                w.deep_slp_reject_en().bit(self.deep_slp_reject());
+                w.light_slp_reject_en().bit(self.light_slp_reject())
             });
 
             rtc_cntl

--- a/esp-hal/src/rtc_cntl/sleep/esp32c5.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c5.rs
@@ -2,9 +2,10 @@ use core::ops::Not;
 
 use crate::{
     clock::RtcClock,
+    private::DropGuard,
     rtc_cntl::{
         Rtc,
-        rtc::{HpAnalog, HpSysCntlReg, HpSysPower, LpAnalog, LpSysPower, SavedClockConfig},
+        rtc::{HpAnalog, HpSysCntlReg, HpSysPower, LpAnalog, LpSysPower},
         sleep::WakeTriggers,
     },
     soc::clocks::{self, ClockTree, HpRootClkConfig, LpSlowClkConfig, TimgCalibrationClockConfig},
@@ -867,10 +868,19 @@ impl RtcSleepConfig {
             wakeup_mask & reject_mask
         };
 
-        let cpu_freq_config = ClockTree::with(|clocks| {
-            let cpu_freq_config = SavedClockConfig::save(clocks);
-            crate::soc::clocks::configure_hp_root_clk(clocks, HpRootClkConfig::Xtal);
-            cpu_freq_config
+        let _restore_clock_config = ClockTree::with(|clocks| {
+            let old_root = clocks.hp_root_clk();
+
+            clocks::configure_hp_root_clk(clocks, HpRootClkConfig::Xtal);
+
+            // Restore the old clock settings when we return
+            DropGuard::new((), move |_| {
+                ClockTree::with(|clocks| {
+                    if let Some(old_root) = old_root {
+                        clocks::configure_hp_root_clk(clocks, old_root);
+                    }
+                });
+            })
         });
 
         // pmu_sleep_config_default + pmu_sleep_init.
@@ -914,10 +924,8 @@ impl RtcSleepConfig {
 
             // pmu_ll_hp_set_reject_enable
             pmu().slp_wakeup_cntl1().modify(|_, w| {
-                w.slp_reject_en()
-                    .bit(true)
-                    .sleep_reject_ena()
-                    .bits(reject_mask)
+                w.slp_reject_en().bit(true);
+                w.sleep_reject_ena().bits(reject_mask)
             });
 
             // pmu_ll_hp_clear_reject_cause
@@ -926,12 +934,12 @@ impl RtcSleepConfig {
                 .write(|w| w.slp_reject_cause_clr().bit(true));
 
             pmu().int_clr().write(|w| {
-                w.sw() // pmu_ll_hp_clear_sw_intr_status
-                    .clear_bit_by_one()
-                    .soc_sleep_reject() // pmu_ll_hp_clear_reject_intr_status
-                    .clear_bit_by_one()
-                    .soc_wakeup() // pmu_ll_hp_clear_wakeup_intr_status
-                    .clear_bit_by_one()
+                // pmu_ll_hp_clear_sw_intr_status
+                w.sw().clear_bit_by_one();
+                // pmu_ll_hp_clear_reject_intr_status
+                w.soc_sleep_reject().clear_bit_by_one();
+                // pmu_ll_hp_clear_wakeup_intr_status
+                w.soc_wakeup().clear_bit_by_one()
             });
 
             // misc_modules_sleep_prepare
@@ -957,12 +965,6 @@ impl RtcSleepConfig {
                 }
             }
         }
-
-        // esp-idf returns if the sleep was rejected, we don't return anything
-
-        ClockTree::with(|clocks| {
-            cpu_freq_config.restore(clocks);
-        });
     }
 
     /// Cleans up after sleep

--- a/esp-hal/src/rtc_cntl/sleep/esp32c5.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c5.rs
@@ -2,6 +2,7 @@ use core::ops::Not;
 
 use crate::{
     clock::RtcClock,
+    peripherals::{LP_AON, PMU},
     private::DropGuard,
     rtc_cntl::{
         Rtc,
@@ -106,53 +107,60 @@ impl AnalogSleepConfig {
     fn apply(&self) {
         // pmu_sleep_analog_init
 
-        unsafe {
-            // HP SLEEP (hp_sleep_*)
-            pmu().hp_sleep_bias().modify(|_, w| {
-                w.hp_sleep_dbg_atten() // pmu_ll_hp_set_dbg_atten
-                    .bits(self.hp_sys.bias.dbg_atten())
-                    .hp_sleep_pd_cur() // pmu_ll_hp_set_current_power_off
-                    .bit(self.hp_sys.bias.pd_cur())
-                    .sleep() // pmu_ll_hp_set_bias_sleep_enable
-                    .bit(self.hp_sys.bias.bias_sleep())
-            });
-            pmu().hp_sleep_hp_regulator0().modify(|_, w| {
-                w.hp_sleep_hp_regulator_xpd() // pmu_ll_hp_set_regulator_xpd
-                    .bit(self.hp_sys.regulator0.xpd())
-                    .hp_sleep_hp_regulator_dbias() // pmu_ll_hp_set_regulator_dbias
-                    .bits(self.hp_sys.regulator0.dbias())
-            });
-            pmu().hp_sleep_hp_regulator1().modify(|_, w| {
-                w.hp_sleep_hp_regulator_drv_b() // pmu_ll_hp_set_regulator_driver_bar
-                    .bits(self.hp_sys.regulator1.drv_b())
-            });
+        // HP SLEEP (hp_sleep_*)
+        PMU::regs().hp_sleep_bias().modify(|_, w| unsafe {
+            // pmu_ll_hp_set_dbg_atten
+            w.hp_sleep_dbg_atten().bits(self.hp_sys.bias.dbg_atten());
+            // pmu_ll_hp_set_current_power_off
+            w.hp_sleep_pd_cur().bit(self.hp_sys.bias.pd_cur());
+            // pmu_ll_hp_set_bias_sleep_enable
+            w.sleep().bit(self.hp_sys.bias.bias_sleep())
+        });
+        PMU::regs().hp_sleep_hp_regulator0().modify(|_, w| unsafe {
+            // pmu_ll_hp_set_regulator_xpd
+            w.hp_sleep_hp_regulator_xpd()
+                .bit(self.hp_sys.regulator0.xpd());
+            // pmu_ll_hp_set_regulator_dbias
+            w.hp_sleep_hp_regulator_dbias()
+                .bits(self.hp_sys.regulator0.dbias())
+        });
+        PMU::regs().hp_sleep_hp_regulator1().modify(|_, w| unsafe {
+            // pmu_ll_hp_set_regulator_driver_bar
+            w.hp_sleep_hp_regulator_drv_b()
+                .bits(self.hp_sys.regulator1.drv_b())
+        });
 
-            // LP SLEEP (lp_sleep_*)
-            pmu().lp_sleep_bias().modify(|_, w| {
-                w.lp_sleep_dbg_atten() // pmu_ll_lp_set_dbg_atten
-                    .bits(self.lp_sys_sleep.bias.dbg_atten())
-                    .lp_sleep_pd_cur() // pmu_ll_lp_set_current_power_off
-                    .bit(self.lp_sys_sleep.bias.pd_cur())
-                    .sleep() // pmu_ll_lp_set_bias_sleep_enable
-                    .bit(self.lp_sys_sleep.bias.bias_sleep())
-            });
+        // LP SLEEP (lp_sleep_*)
+        PMU::regs().lp_sleep_bias().modify(|_, w| unsafe {
+            // pmu_ll_lp_set_dbg_atten
+            w.lp_sleep_dbg_atten()
+                .bits(self.lp_sys_sleep.bias.dbg_atten());
+            // pmu_ll_lp_set_current_power_off
+            w.lp_sleep_pd_cur().bit(self.lp_sys_sleep.bias.pd_cur());
+            // pmu_ll_lp_set_bias_sleep_enable
+            w.sleep().bit(self.lp_sys_sleep.bias.bias_sleep())
+        });
 
-            pmu().lp_sleep_lp_regulator0().modify(|_, w| {
-                w.lp_sleep_lp_regulator_slp_xpd() // pmu_ll_lp_set_regulator_slp_xpd
-                    .bit(self.lp_sys_sleep.regulator0.slp_xpd())
-                    .lp_sleep_lp_regulator_xpd() // pmu_ll_lp_set_regulator_xpd
-                    .bit(self.lp_sys_sleep.regulator0.xpd())
-                    .lp_sleep_lp_regulator_slp_dbias() // pmu_ll_lp_set_regulator_sleep_dbias
-                    .bits(self.lp_sys_sleep.regulator0.slp_dbias())
-                    .lp_sleep_lp_regulator_dbias() // pmu_ll_lp_set_regulator_dbias
-                    .bits(self.lp_sys_sleep.regulator0.dbias())
-            });
+        PMU::regs().lp_sleep_lp_regulator0().modify(|_, w| unsafe {
+            // pmu_ll_lp_set_regulator_slp_xpd
+            w.lp_sleep_lp_regulator_slp_xpd()
+                .bit(self.lp_sys_sleep.regulator0.slp_xpd());
+            // pmu_ll_lp_set_regulator_xpd
+            w.lp_sleep_lp_regulator_xpd()
+                .bit(self.lp_sys_sleep.regulator0.xpd());
+            // pmu_ll_lp_set_regulator_sleep_dbias
+            w.lp_sleep_lp_regulator_slp_dbias()
+                .bits(self.lp_sys_sleep.regulator0.slp_dbias());
+            // pmu_ll_lp_set_regulator_dbias
+            w.lp_sleep_lp_regulator_dbias()
+                .bits(self.lp_sys_sleep.regulator0.dbias())
+        });
 
-            pmu().lp_sleep_lp_regulator1().modify(|_, w| {
-                w.lp_sleep_lp_regulator_drv_b() // pmu_ll_lp_set_regulator_driver_bar
-                    .bits(self.lp_sys_sleep.regulator1.drv_b())
-            });
-        }
+        PMU::regs().lp_sleep_lp_regulator1().modify(|_, w| unsafe {
+            // pmu_ll_lp_set_regulator_driver_bar
+            w.lp_sleep_lp_regulator_drv_b()
+                .bits(self.lp_sys_sleep.regulator1.drv_b())
+        });
     }
 }
 
@@ -181,12 +189,10 @@ impl DigitalSleepConfig {
 
     fn apply(&self) {
         // pmu_sleep_digital_init
-        unsafe {
-            pmu().hp_sleep_hp_sys_cntl().modify(|_, w| {
-                w.hp_sleep_dig_pad_slp_sel()
-                    .bit(self.syscntl.dig_pad_slp_sel())
-            })
-        };
+        PMU::regs().hp_sleep_hp_sys_cntl().modify(|_, w| {
+            w.hp_sleep_dig_pad_slp_sel()
+                .bit(self.syscntl.dig_pad_slp_sel())
+        });
     }
 }
 
@@ -256,37 +262,35 @@ impl PowerSleepConfig {
     fn apply(&self) {
         // pmu_sleep_power_init
 
-        unsafe {
-            // HP SLEEP (hp_sleep_*)
-            pmu()
-                .hp_sleep_dig_power()
-                .modify(|_, w| w.bits(self.hp_sys.dig_power.0));
-            pmu()
-                .hp_sleep_hp_ck_power()
-                .modify(|_, w| w.bits(self.hp_sys.clk.0));
-            pmu()
-                .hp_sleep_xtal()
-                .modify(|_, w| w.hp_sleep_xpd_xtal().bit(self.hp_sys.xtal.xpd_xtal()));
+        // HP SLEEP (hp_sleep_*)
+        PMU::regs()
+            .hp_sleep_dig_power()
+            .modify(|_, w| unsafe { w.bits(self.hp_sys.dig_power.0) });
+        PMU::regs()
+            .hp_sleep_hp_ck_power()
+            .modify(|_, w| unsafe { w.bits(self.hp_sys.clk.0) });
+        PMU::regs()
+            .hp_sleep_xtal()
+            .modify(|_, w| w.hp_sleep_xpd_xtal().bit(self.hp_sys.xtal.xpd_xtal()));
 
-            // LP ACTIVE (hp_sleep_lp_*)
-            pmu()
-                .hp_sleep_lp_dig_power()
-                .modify(|_, w| w.bits(self.lp_sys_active.dig_power.0));
-            pmu()
-                .hp_sleep_lp_ck_power()
-                .modify(|_, w| w.bits(self.lp_sys_active.clk_power.0));
+        // LP ACTIVE (hp_sleep_lp_*)
+        PMU::regs()
+            .hp_sleep_lp_dig_power()
+            .modify(|_, w| unsafe { w.bits(self.lp_sys_active.dig_power.0) });
+        PMU::regs()
+            .hp_sleep_lp_ck_power()
+            .modify(|_, w| unsafe { w.bits(self.lp_sys_active.clk_power.0) });
 
-            // LP SLEEP (lp_sleep_*)
-            pmu()
-                .lp_sleep_lp_dig_power()
-                .modify(|_, w| w.bits(self.lp_sys_sleep.dig_power.0));
-            pmu()
-                .lp_sleep_lp_ck_power()
-                .modify(|_, w| w.bits(self.lp_sys_sleep.clk_power.0));
-            pmu()
-                .lp_sleep_xtal()
-                .modify(|_, w| w.lp_sleep_xpd_xtal().bit(self.lp_sys_sleep.xtal.xpd_xtal()));
-        }
+        // LP SLEEP (lp_sleep_*)
+        PMU::regs()
+            .lp_sleep_lp_dig_power()
+            .modify(|_, w| unsafe { w.bits(self.lp_sys_sleep.dig_power.0) });
+        PMU::regs()
+            .lp_sleep_lp_ck_power()
+            .modify(|_, w| unsafe { w.bits(self.lp_sys_sleep.clk_power.0) });
+        PMU::regs()
+            .lp_sleep_xtal()
+            .modify(|_, w| w.lp_sleep_xpd_xtal().bit(self.lp_sys_sleep.xtal.xpd_xtal()));
     }
 }
 
@@ -392,58 +396,61 @@ impl ParamSleepConfig {
     fn apply(&self) {
         // pmu_sleep_param_init
 
-        unsafe {
-            pmu().slp_wakeup_cntl3().modify(|_, w| {
-                w.hp_min_slp_val() // pmu_ll_hp_set_min_sleep_cycle
-                    .bits(self.hp_sys.min_slp_slow_clk_cycle)
-                    .lp_min_slp_val() // pmu_ll_lp_set_min_sleep_cycle
-                    .bits(self.lp_sys.min_slp_slow_clk_cycle)
-            });
+        PMU::regs().slp_wakeup_cntl3().modify(|_, w| unsafe {
+            // pmu_ll_hp_set_min_sleep_cycle
+            w.hp_min_slp_val().bits(self.hp_sys.min_slp_slow_clk_cycle);
+            // pmu_ll_lp_set_min_sleep_cycle
+            w.lp_min_slp_val().bits(self.lp_sys.min_slp_slow_clk_cycle)
+        });
 
-            pmu().slp_wakeup_cntl7().modify(|_, w| {
-                w.ana_wait_target() // pmu_ll_hp_set_analog_wait_target_cycle
-                    .bits(self.hp_sys.analog_wait_target_cycle)
-            });
+        PMU::regs().slp_wakeup_cntl7().modify(|_, w| unsafe {
+            // pmu_ll_hp_set_analog_wait_target_cycle
+            w.ana_wait_target()
+                .bits(self.hp_sys.analog_wait_target_cycle)
+        });
 
-            pmu().power_wait_timer0().modify(|_, w| {
-                w.dg_hp_pd_wait_timer() // pmu_ll_hp_set_digital_power_supply_wait_cycle
-                    .bits(self.hp_sys.digital_power_supply_wait_cycle)
-                    .dg_hp_powerup_timer() // pmu_ll_hp_set_digital_power_up_wait_cycle
-                    .bits(self.hp_sys.digital_power_up_wait_cycle)
-            });
+        PMU::regs().power_wait_timer0().modify(|_, w| unsafe {
+            // pmu_ll_hp_set_digital_power_supply_wait_cycle
+            w.dg_hp_pd_wait_timer()
+                .bits(self.hp_sys.digital_power_supply_wait_cycle);
+            // pmu_ll_hp_set_digital_power_up_wait_cycle
+            w.dg_hp_powerup_timer()
+                .bits(self.hp_sys.digital_power_up_wait_cycle)
+        });
 
-            pmu().power_wait_timer1().modify(|_, w| {
-                w.dg_lp_pd_wait_timer() // pmu_ll_lp_set_digital_power_supply_wait_cycle
-                    .bits(self.lp_sys.digital_power_supply_wait_cycle)
-                    .dg_lp_powerup_timer() // pmu_ll_lp_set_digital_power_up_wait_cycle
-                    .bits(self.lp_sys.digital_power_up_wait_cycle)
-            });
+        PMU::regs().power_wait_timer1().modify(|_, w| unsafe {
+            // pmu_ll_lp_set_digital_power_supply_wait_cycle
+            w.dg_lp_pd_wait_timer()
+                .bits(self.lp_sys.digital_power_supply_wait_cycle);
+            // pmu_ll_lp_set_digital_power_up_wait_cycle
+            w.dg_lp_powerup_timer()
+                .bits(self.lp_sys.digital_power_up_wait_cycle)
+        });
 
-            // pmu_hal_hp/lp_set_control_ready_wait_cycle (new on ESP32-C5)
-            pmu().power_wait_timer2().modify(|_, w| {
-                w.dg_hp_iso_wait_timer()
-                    .bits(self.hp_sys.isolate_wait_cycle)
-                    .dg_hp_rst_wait_timer()
-                    .bits(self.hp_sys.reset_wait_cycle)
-                    .dg_lp_iso_wait_timer()
-                    .bits(self.lp_sys.isolate_wait_cycle)
-                    .dg_lp_rst_wait_timer()
-                    .bits(self.lp_sys.reset_wait_cycle)
-            });
+        // pmu_hal_hp/lp_set_control_ready_wait_cycle (new on ESP32-C5)
+        PMU::regs().power_wait_timer2().modify(|_, w| unsafe {
+            w.dg_hp_iso_wait_timer()
+                .bits(self.hp_sys.isolate_wait_cycle);
+            w.dg_hp_rst_wait_timer().bits(self.hp_sys.reset_wait_cycle);
+            w.dg_lp_iso_wait_timer()
+                .bits(self.lp_sys.isolate_wait_cycle);
+            w.dg_lp_rst_wait_timer().bits(self.lp_sys.reset_wait_cycle)
+        });
 
-            pmu().slp_wakeup_cntl5().modify(|_, w| {
-                w.lp_ana_wait_target() // pmu_ll_lp_set_analog_wait_target_cycle
-                    .bits(self.lp_sys.analog_wait_target_cycle)
-                    .modem_wait_target() // pmu_ll_hp_set_modem_wakeup_wait_cycle
-                    .bits(self.hp_sys.modem_wakeup_wait_cycle)
-            });
-            pmu().power_ck_wait_cntl().modify(|_, w| {
-                w.wait_xtl_stable() // pmu_ll_hp_set_xtal_stable_wait_cycle
-                    .bits(self.hp_lp.xtal_stable_wait_cycle)
-                    .wait_pll_stable() // pmu_ll_hp_set_pll_stable_wait_cycle
-                    .bits(self.hp_sys.pll_stable_wait_cycle)
-            });
-        }
+        PMU::regs().slp_wakeup_cntl5().modify(|_, w| unsafe {
+            // pmu_ll_lp_set_analog_wait_target_cycle
+            w.lp_ana_wait_target()
+                .bits(self.lp_sys.analog_wait_target_cycle);
+            // pmu_ll_hp_set_modem_wakeup_wait_cycle
+            w.modem_wait_target()
+                .bits(self.hp_sys.modem_wakeup_wait_cycle)
+        });
+        PMU::regs().power_ck_wait_cntl().modify(|_, w| unsafe {
+            // pmu_ll_hp_set_xtal_stable_wait_cycle
+            w.wait_xtl_stable().bits(self.hp_lp.xtal_stable_wait_cycle);
+            // pmu_ll_hp_set_pll_stable_wait_cycle
+            w.wait_pll_stable().bits(self.hp_sys.pll_stable_wait_cycle)
+        });
     }
 
     fn defaults(config: SleepTimeConfig, pd_flags: PowerDownFlags, pd_xtal: bool) -> Self {
@@ -521,7 +528,7 @@ impl SleepTimeConfig {
 
         // Calibrate rtc slow clock
         // TODO: do an actual calibration instead of a read
-        let slowclk_period = unsafe { lp_aon().store1().read().data().bits() };
+        let slowclk_period = LP_AON::regs().store1().read().data().bits();
 
         // Calibrate rtc fast clock, only PMU supported chips sleep process is needed.
         const FAST_CLK_SRC_CAL_CYCLES: u32 = 2048;
@@ -662,14 +669,6 @@ impl Default for RtcSleepConfig {
             pd_flags: PowerDownFlags(0),
         }
     }
-}
-
-unsafe fn pmu<'a>() -> &'a esp32c5::pmu::RegisterBlock {
-    unsafe { &*esp32c5::PMU::ptr() }
-}
-
-unsafe fn lp_aon<'a>() -> &'a esp32c5::lp_aon::RegisterBlock {
-    unsafe { &*esp32c5::LP_AON::ptr() }
 }
 
 bitfield::bitfield! {
@@ -913,56 +912,50 @@ impl RtcSleepConfig {
 
         // like esp-idf pmu_sleep_start()
 
-        unsafe {
-            // lp_aon_hal_inform_wakeup_type - tells ROM which wakeup stub to run
-            lp_aon()
-                .store9()
-                .modify(|r, w| w.bits(r.bits() & !0x01 | self.deep as u32));
+        // lp_aon_hal_inform_wakeup_type - tells ROM which wakeup stub to run
+        LP_AON::regs()
+            .store9()
+            .modify(|r, w| unsafe { w.bits(r.bits() & !0x01 | self.deep as u32) });
 
-            // pmu_ll_hp_set_wakeup_enable
-            pmu().slp_wakeup_cntl2().write(|w| w.bits(wakeup_mask));
+        // pmu_ll_hp_set_wakeup_enable
+        PMU::regs()
+            .slp_wakeup_cntl2()
+            .write(|w| unsafe { w.bits(wakeup_mask) });
 
-            // pmu_ll_hp_set_reject_enable
-            pmu().slp_wakeup_cntl1().modify(|_, w| {
-                w.slp_reject_en().bit(true);
-                w.sleep_reject_ena().bits(reject_mask)
-            });
+        // pmu_ll_hp_set_reject_enable
+        PMU::regs().slp_wakeup_cntl1().modify(|_, w| unsafe {
+            w.slp_reject_en().bit(true);
+            w.sleep_reject_ena().bits(reject_mask)
+        });
 
-            // pmu_ll_hp_clear_reject_cause
-            pmu()
-                .slp_wakeup_cntl4()
-                .write(|w| w.slp_reject_cause_clr().bit(true));
+        // pmu_ll_hp_clear_reject_cause
+        PMU::regs()
+            .slp_wakeup_cntl4()
+            .write(|w| w.slp_reject_cause_clr().bit(true));
 
-            pmu().int_clr().write(|w| {
-                // pmu_ll_hp_clear_sw_intr_status
-                w.sw().clear_bit_by_one();
-                // pmu_ll_hp_clear_reject_intr_status
-                w.soc_sleep_reject().clear_bit_by_one();
-                // pmu_ll_hp_clear_wakeup_intr_status
-                w.soc_wakeup().clear_bit_by_one()
-            });
+        PMU::regs().int_clr().write(|w| {
+            // pmu_ll_hp_clear_sw_intr_status
+            w.sw().clear_bit_by_one();
+            // pmu_ll_hp_clear_reject_intr_status
+            w.soc_sleep_reject().clear_bit_by_one();
+            // pmu_ll_hp_clear_wakeup_intr_status
+            w.soc_wakeup().clear_bit_by_one()
+        });
 
-            // misc_modules_sleep_prepare
+        // misc_modules_sleep_prepare
 
-            // TODO: IDF-7370
-            #[cfg(not(soc_has_pmu))]
-            if !(self.deep && wakeup_triggers.touch) {
-                APB_SARADC::regs()
-                    .ctrl()
-                    .modify(|_, w| w.saradc2_pwdet_drv().bit(false));
-            }
+        // Start entry into sleep mode
 
-            // Start entry into sleep mode
+        // pmu_ll_hp_set_sleep_enable
+        PMU::regs()
+            .slp_wakeup_cntl0()
+            .write(|w| w.sleep_req().bit(true));
 
-            // pmu_ll_hp_set_sleep_enable
-            pmu().slp_wakeup_cntl0().write(|w| w.sleep_req().bit(true));
-
-            // In pd_cpu lightsleep and deepsleep mode, we never get here
-            loop {
-                let int_raw = pmu().int_raw().read();
-                if int_raw.soc_wakeup().bit_is_set() || int_raw.soc_sleep_reject().bit_is_set() {
-                    break;
-                }
+        // In pd_cpu lightsleep and deepsleep mode, we never get here
+        loop {
+            let int_raw = PMU::regs().int_raw().read();
+            if int_raw.soc_wakeup().bit_is_set() || int_raw.soc_sleep_reject().bit_is_set() {
+                break;
             }
         }
     }

--- a/esp-hal/src/rtc_cntl/sleep/esp32c6.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c6.rs
@@ -3,9 +3,10 @@ use core::ops::Not;
 use crate::{
     clock::RtcClock,
     gpio::RtcFunction,
+    private::DropGuard,
     rtc_cntl::{
         Rtc,
-        rtc::{HpAnalog, HpSysCntlReg, HpSysPower, LpAnalog, LpSysPower, SavedClockConfig},
+        rtc::{HpAnalog, HpSysCntlReg, HpSysPower, LpAnalog, LpSysPower},
         sleep::{
             Ext1WakeupSource,
             WakeFromLpCoreWakeupSource,
@@ -14,7 +15,7 @@ use crate::{
             WakeupLevel,
         },
     },
-    soc::clocks::{self, ClockTree, LpSlowClkConfig, TimgCalibrationClockConfig},
+    soc::clocks::{self, ClockTree, LpSlowClkConfig, SocRootClkConfig, TimgCalibrationClockConfig},
 };
 
 impl Ext1WakeupSource<'_, '_> {
@@ -934,13 +935,19 @@ impl RtcSleepConfig {
             wakeup_mask & reject_mask
         };
 
-        let cpu_freq_config = ClockTree::with(|clocks| {
-            let cpu_freq_config = SavedClockConfig::save(clocks);
-            crate::soc::clocks::configure_soc_root_clk(
-                clocks,
-                crate::soc::clocks::SocRootClkConfig::Xtal,
-            );
-            cpu_freq_config
+        let _restore_clock_config = ClockTree::with(|clocks| {
+            let old_root = clocks.soc_root_clk();
+
+            clocks::configure_soc_root_clk(clocks, SocRootClkConfig::Xtal);
+
+            // Restore the old clock settings when we return
+            DropGuard::new((), move |_| {
+                ClockTree::with(|clocks| {
+                    if let Some(old_root) = old_root {
+                        clocks::configure_soc_root_clk(clocks, old_root);
+                    }
+                });
+            })
         });
 
         // pmu_sleep_config_default + pmu_sleep_init.
@@ -996,12 +1003,16 @@ impl RtcSleepConfig {
                 .write(|w| w.slp_reject_cause_clr().bit(true));
 
             pmu().int_clr().write(|w| {
-                w.sw() // pmu_ll_hp_clear_sw_intr_status
+                // pmu_ll_hp_clear_sw_intr_status
+                w.sw()
                     .clear_bit_by_one()
-                    .soc_sleep_reject() // pmu_ll_hp_clear_reject_intr_status
+                    // pmu_ll_hp_clear_reject_intr_status
+                ;
+                w.soc_sleep_reject()
                     .clear_bit_by_one()
-                    .soc_wakeup() // pmu_ll_hp_clear_wakeup_intr_status
-                    .clear_bit_by_one()
+                    // pmu_ll_hp_clear_wakeup_intr_status
+                ;
+                w.soc_wakeup().clear_bit_by_one()
             });
 
             // misc_modules_sleep_prepare
@@ -1027,12 +1038,6 @@ impl RtcSleepConfig {
                 }
             }
         }
-
-        // esp-idf returns if the sleep was rejected, we don't return anything
-
-        ClockTree::with(|clocks| {
-            cpu_freq_config.restore(clocks);
-        });
     }
 
     /// Cleans up after sleep

--- a/esp-hal/src/rtc_cntl/sleep/esp32c6.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c6.rs
@@ -3,6 +3,7 @@ use core::ops::Not;
 use crate::{
     clock::RtcClock,
     gpio::RtcFunction,
+    peripherals::{LP_AON, PMU},
     private::DropGuard,
     rtc_cntl::{
         Rtc,
@@ -21,7 +22,11 @@ use crate::{
 impl Ext1WakeupSource<'_, '_> {
     /// Returns the currently configured wakeup pins.
     fn wakeup_pins() -> u8 {
-        unsafe { lp_aon().ext_wakeup_cntl().read().ext_wakeup_sel().bits() }
+        LP_AON::regs()
+            .ext_wakeup_cntl()
+            .read()
+            .ext_wakeup_sel()
+            .bits()
     }
 
     fn wake_io_reset() {
@@ -71,20 +76,18 @@ impl WakeSource for Ext1WakeupSource<'_, '_> {
             pin.rtcio_pad_hold(true);
         }
 
-        unsafe {
-            // clear previous wakeup status
-            lp_aon()
-                .ext_wakeup_cntl()
-                .modify(|_, w| w.ext_wakeup_status_clr().set_bit());
+        // clear previous wakeup status
+        LP_AON::regs()
+            .ext_wakeup_cntl()
+            .modify(|_, w| w.ext_wakeup_status_clr().set_bit());
 
-            // set pin + level register fields
-            lp_aon().ext_wakeup_cntl().modify(|r, w| {
-                w.ext_wakeup_sel()
-                    .bits(r.ext_wakeup_sel().bits() | pin_mask)
-                    .ext_wakeup_lv()
-                    .bits(r.ext_wakeup_lv().bits() & !pin_mask | level_mask)
-            });
-        }
+        // set pin + level register fields
+        LP_AON::regs().ext_wakeup_cntl().modify(|r, w| unsafe {
+            w.ext_wakeup_sel()
+                .bits(r.ext_wakeup_sel().bits() | pin_mask);
+            w.ext_wakeup_lv()
+                .bits(r.ext_wakeup_lv().bits() & !pin_mask | level_mask)
+        });
     }
 }
 
@@ -204,48 +207,57 @@ impl AnalogSleepConfig {
 
         unsafe {
             // HP SLEEP (hp_sleep_*)
-            pmu().hp_sleep_bias().modify(|_, w| {
-                w.hp_sleep_dbg_atten() // pmu_ll_hp_set_dbg_atten
-                    .bits(self.hp_sys.bias.dbg_atten())
-                    .hp_sleep_pd_cur() // pmu_ll_hp_set_current_power_off
-                    .bit(self.hp_sys.bias.pd_cur())
-                    .sleep() // pmu_ll_hp_set_bias_sleep_enable
-                    .bit(self.hp_sys.bias.bias_sleep())
+            PMU::regs().hp_sleep_bias().modify(|_, w| {
+                // pmu_ll_hp_set_dbg_atten
+                w.hp_sleep_dbg_atten().bits(self.hp_sys.bias.dbg_atten());
+                // pmu_ll_hp_set_current_power_off
+                w.hp_sleep_pd_cur().bit(self.hp_sys.bias.pd_cur());
+                // pmu_ll_hp_set_bias_sleep_enable
+                w.sleep().bit(self.hp_sys.bias.bias_sleep())
             });
-            pmu().hp_sleep_hp_regulator0().modify(|_, w| {
-                w.hp_sleep_hp_regulator_xpd() // pmu_ll_hp_set_regulator_xpd
-                    .bit(self.hp_sys.regulator0.xpd())
-                    .hp_sleep_hp_regulator_dbias() // pmu_ll_hp_set_regulator_dbias
+            PMU::regs().hp_sleep_hp_regulator0().modify(|_, w| {
+                // pmu_ll_hp_set_regulator_xpd
+                w.hp_sleep_hp_regulator_xpd()
+                    .bit(self.hp_sys.regulator0.xpd());
+                // pmu_ll_hp_set_regulator_dbias
+                w.hp_sleep_hp_regulator_dbias()
                     .bits(self.hp_sys.regulator0.dbias())
             });
-            pmu().hp_sleep_hp_regulator1().modify(|_, w| {
-                w.hp_sleep_hp_regulator_drv_b() // pmu_ll_hp_set_regulator_driver_bar
+            PMU::regs().hp_sleep_hp_regulator1().modify(|_, w| {
+                // pmu_ll_hp_set_regulator_driver_bar
+                w.hp_sleep_hp_regulator_drv_b()
                     .bits(self.hp_sys.regulator1.drv_b())
             });
 
             // LP SLEEP (lp_sleep_*)
-            pmu().lp_sleep_bias().modify(|_, w| {
-                w.lp_sleep_dbg_atten() // pmu_ll_lp_set_dbg_atten
-                    .bits(self.lp_sys_sleep.bias.dbg_atten())
-                    .lp_sleep_pd_cur() // pmu_ll_lp_set_current_power_off
-                    .bit(self.lp_sys_sleep.bias.pd_cur())
-                    .sleep() // pmu_ll_lp_set_bias_sleep_enable
-                    .bit(self.lp_sys_sleep.bias.bias_sleep())
+            PMU::regs().lp_sleep_bias().modify(|_, w| {
+                // pmu_ll_lp_set_dbg_atten
+                w.lp_sleep_dbg_atten()
+                    .bits(self.lp_sys_sleep.bias.dbg_atten());
+                // pmu_ll_lp_set_current_power_off
+                w.lp_sleep_pd_cur().bit(self.lp_sys_sleep.bias.pd_cur());
+                // pmu_ll_lp_set_bias_sleep_enable
+                w.sleep().bit(self.lp_sys_sleep.bias.bias_sleep())
             });
 
-            pmu().lp_sleep_lp_regulator0().modify(|_, w| {
-                w.lp_sleep_lp_regulator_slp_xpd() // pmu_ll_lp_set_regulator_slp_xpd
-                    .bit(self.lp_sys_sleep.regulator0.slp_xpd())
-                    .lp_sleep_lp_regulator_xpd() // pmu_ll_lp_set_regulator_xpd
-                    .bit(self.lp_sys_sleep.regulator0.xpd())
-                    .lp_sleep_lp_regulator_slp_dbias() // pmu_ll_lp_set_regulator_sleep_dbias
-                    .bits(self.lp_sys_sleep.regulator0.slp_dbias())
-                    .lp_sleep_lp_regulator_dbias() // pmu_ll_lp_set_regulator_dbias
+            PMU::regs().lp_sleep_lp_regulator0().modify(|_, w| {
+                // pmu_ll_lp_set_regulator_slp_xpd
+                w.lp_sleep_lp_regulator_slp_xpd()
+                    .bit(self.lp_sys_sleep.regulator0.slp_xpd());
+                // pmu_ll_lp_set_regulator_xpd
+                w.lp_sleep_lp_regulator_xpd()
+                    .bit(self.lp_sys_sleep.regulator0.xpd());
+                // pmu_ll_lp_set_regulator_sleep_dbias
+                w.lp_sleep_lp_regulator_slp_dbias()
+                    .bits(self.lp_sys_sleep.regulator0.slp_dbias());
+                // pmu_ll_lp_set_regulator_dbias
+                w.lp_sleep_lp_regulator_dbias()
                     .bits(self.lp_sys_sleep.regulator0.dbias())
             });
 
-            pmu().lp_sleep_lp_regulator1().modify(|_, w| {
-                w.lp_sleep_lp_regulator_drv_b() // pmu_ll_lp_set_regulator_driver_bar
+            PMU::regs().lp_sleep_lp_regulator1().modify(|_, w| {
+                // pmu_ll_lp_set_regulator_driver_bar
+                w.lp_sleep_lp_regulator_drv_b()
                     .bits(self.lp_sys_sleep.regulator1.drv_b())
             });
         }
@@ -277,12 +289,10 @@ impl DigitalSleepConfig {
 
     fn apply(&self) {
         // pmu_sleep_digital_init
-        unsafe {
-            pmu().hp_sleep_hp_sys_cntl().modify(|_, w| {
-                w.hp_sleep_dig_pad_slp_sel()
-                    .bit(self.syscntl.dig_pad_slp_sel())
-            })
-        };
+        PMU::regs().hp_sleep_hp_sys_cntl().modify(|_, w| {
+            w.hp_sleep_dig_pad_slp_sel()
+                .bit(self.syscntl.dig_pad_slp_sel())
+        });
     }
 }
 
@@ -368,37 +378,35 @@ impl PowerSleepConfig {
     fn apply(&self) {
         // pmu_sleep_power_init
 
-        unsafe {
-            // HP SLEEP (hp_sleep_*)
-            pmu()
-                .hp_sleep_dig_power()
-                .modify(|_, w| w.bits(self.hp_sys.dig_power.0));
-            pmu()
-                .hp_sleep_hp_ck_power()
-                .modify(|_, w| w.bits(self.hp_sys.clk.0));
-            pmu()
-                .hp_sleep_xtal()
-                .modify(|_, w| w.hp_sleep_xpd_xtal().bit(self.hp_sys.xtal.xpd_xtal()));
+        // HP SLEEP (hp_sleep_*)
+        PMU::regs()
+            .hp_sleep_dig_power()
+            .modify(|_, w| unsafe { w.bits(self.hp_sys.dig_power.0) });
+        PMU::regs()
+            .hp_sleep_hp_ck_power()
+            .modify(|_, w| unsafe { w.bits(self.hp_sys.clk.0) });
+        PMU::regs()
+            .hp_sleep_xtal()
+            .modify(|_, w| w.hp_sleep_xpd_xtal().bit(self.hp_sys.xtal.xpd_xtal()));
 
-            // LP ACTIVE (hp_sleep_lp_*)
-            pmu()
-                .hp_sleep_lp_dig_power()
-                .modify(|_, w| w.bits(self.lp_sys_active.dig_power.0));
-            pmu()
-                .hp_sleep_lp_ck_power()
-                .modify(|_, w| w.bits(self.lp_sys_active.clk_power.0));
+        // LP ACTIVE (hp_sleep_lp_*)
+        PMU::regs()
+            .hp_sleep_lp_dig_power()
+            .modify(|_, w| unsafe { w.bits(self.lp_sys_active.dig_power.0) });
+        PMU::regs()
+            .hp_sleep_lp_ck_power()
+            .modify(|_, w| unsafe { w.bits(self.lp_sys_active.clk_power.0) });
 
-            // LP SLEEP (lp_sleep_*)
-            pmu()
-                .lp_sleep_lp_dig_power()
-                .modify(|_, w| w.bits(self.lp_sys_sleep.dig_power.0));
-            pmu()
-                .lp_sleep_lp_ck_power()
-                .modify(|_, w| w.bits(self.lp_sys_sleep.clk_power.0));
-            pmu()
-                .lp_sleep_xtal()
-                .modify(|_, w| w.lp_sleep_xpd_xtal().bit(self.lp_sys_sleep.xtal.xpd_xtal()));
-        }
+        // LP SLEEP (lp_sleep_*)
+        PMU::regs()
+            .lp_sleep_lp_dig_power()
+            .modify(|_, w| unsafe { w.bits(self.lp_sys_sleep.dig_power.0) });
+        PMU::regs()
+            .lp_sleep_lp_ck_power()
+            .modify(|_, w| unsafe { w.bits(self.lp_sys_sleep.clk_power.0) });
+        PMU::regs()
+            .lp_sleep_xtal()
+            .modify(|_, w| w.lp_sleep_xpd_xtal().bit(self.lp_sys_sleep.xtal.xpd_xtal()));
     }
 }
 
@@ -493,43 +501,49 @@ impl ParamSleepConfig {
         // pmu_sleep_param_init
 
         unsafe {
-            pmu().slp_wakeup_cntl3().modify(|_, w| {
-                w.hp_min_slp_val() // pmu_ll_hp_set_min_sleep_cycle
-                    .bits(self.hp_sys.min_slp_slow_clk_cycle)
-                    .lp_min_slp_val() // pmu_ll_lp_set_min_sleep_cycle
-                    .bits(self.lp_sys.min_slp_slow_clk_cycle)
+            PMU::regs().slp_wakeup_cntl3().modify(|_, w| {
+                // pmu_ll_hp_set_min_sleep_cycle
+                w.hp_min_slp_val().bits(self.hp_sys.min_slp_slow_clk_cycle);
+                // pmu_ll_lp_set_min_sleep_cycle
+                w.lp_min_slp_val().bits(self.lp_sys.min_slp_slow_clk_cycle)
             });
 
-            pmu().slp_wakeup_cntl7().modify(|_, w| {
+            PMU::regs().slp_wakeup_cntl7().modify(|_, w| {
                 w.ana_wait_target() // pmu_ll_hp_set_analog_wait_target_cycle
                     .bits(self.hp_sys.analog_wait_target_cycle)
             });
 
-            pmu().power_wait_timer0().modify(|_, w| {
-                w.dg_hp_wait_timer() // pmu_ll_hp_set_digital_power_supply_wait_cycle
-                    .bits(self.hp_sys.digital_power_supply_wait_cycle)
-                    .dg_hp_powerup_timer() // pmu_ll_hp_set_digital_power_up_wait_cycle
+            PMU::regs().power_wait_timer0().modify(|_, w| {
+                // pmu_ll_hp_set_digital_power_supply_wait_cycle
+                w.dg_hp_wait_timer()
+                    .bits(self.hp_sys.digital_power_supply_wait_cycle);
+                // pmu_ll_hp_set_digital_power_up_wait_cycle
+                w.dg_hp_powerup_timer()
                     .bits(self.hp_sys.digital_power_up_wait_cycle)
             });
 
-            pmu().power_wait_timer1().modify(|_, w| {
-                w.dg_lp_wait_timer() // pmu_ll_lp_set_digital_power_supply_wait_cycle
-                    .bits(self.lp_sys.digital_power_supply_wait_cycle)
-                    .dg_lp_powerup_timer() // pmu_ll_lp_set_digital_power_up_wait_cycle
+            PMU::regs().power_wait_timer1().modify(|_, w| {
+                // pmu_ll_lp_set_digital_power_supply_wait_cycle
+                w.dg_lp_wait_timer()
+                    .bits(self.lp_sys.digital_power_supply_wait_cycle);
+                // pmu_ll_lp_set_digital_power_up_wait_cycle
+                w.dg_lp_powerup_timer()
                     .bits(self.lp_sys.digital_power_up_wait_cycle)
             });
 
-            pmu().slp_wakeup_cntl5().modify(|_, w| {
-                w.lp_ana_wait_target() // pmu_ll_lp_set_analog_wait_target_cycle
-                    .bits(self.lp_sys.analog_wait_target_cycle)
-                    .modem_wait_target() // pmu_ll_hp_set_modem_wakeup_wait_cycle
+            PMU::regs().slp_wakeup_cntl5().modify(|_, w| {
+                // pmu_ll_lp_set_analog_wait_target_cycle
+                w.lp_ana_wait_target()
+                    .bits(self.lp_sys.analog_wait_target_cycle);
+                // pmu_ll_hp_set_modem_wakeup_wait_cycle
+                w.modem_wait_target()
                     .bits(self.hp_sys.modem_wakeup_wait_cycle)
             });
-            pmu().power_ck_wait_cntl().modify(|_, w| {
-                w.wait_xtl_stable() // pmu_ll_hp_set_xtal_stable_wait_cycle
-                    .bits(self.hp_lp.xtal_stable_wait_cycle)
-                    .wait_pll_stable() // pmu_ll_hp_set_pll_stable_wait_cycle
-                    .bits(self.hp_sys.pll_stable_wait_cycle)
+            PMU::regs().power_ck_wait_cntl().modify(|_, w| {
+                // pmu_ll_hp_set_xtal_stable_wait_cycle
+                w.wait_xtl_stable().bits(self.hp_lp.xtal_stable_wait_cycle);
+                // pmu_ll_hp_set_pll_stable_wait_cycle
+                w.wait_pll_stable().bits(self.hp_sys.pll_stable_wait_cycle)
             });
         }
     }
@@ -601,7 +615,7 @@ impl SleepTimeConfig {
 
         // Calibrate rtc slow clock
         // TODO: do an actual calibration instead of a read
-        let slowclk_period = unsafe { lp_aon().store1().read().data().bits() };
+        let slowclk_period = LP_AON::regs().store1().read().data().bits();
 
         // Calibrate rtc fast clock, only PMU supported chips sleep process is needed.
         const FAST_CLK_SRC_CAL_CYCLES: u32 = 2048;
@@ -735,14 +749,6 @@ impl Default for RtcSleepConfig {
             pd_flags: PowerDownFlags(0),
         }
     }
-}
-
-unsafe fn pmu<'a>() -> &'a esp32c6::pmu::RegisterBlock {
-    unsafe { &*esp32c6::PMU::ptr() }
-}
-
-unsafe fn lp_aon<'a>() -> &'a esp32c6::lp_aon::RegisterBlock {
-    unsafe { &*esp32c6::LP_AON::ptr() }
 }
 
 bitfield::bitfield! {
@@ -980,62 +986,50 @@ impl RtcSleepConfig {
 
         // like esp-idf pmu_sleep_start()
 
-        unsafe {
-            // lp_aon_hal_inform_wakeup_type - tells ROM which wakeup stub to run
-            lp_aon()
-                .store9()
-                .modify(|r, w| w.bits(r.bits() & !0x01 | self.deep as u32));
+        // lp_aon_hal_inform_wakeup_type - tells ROM which wakeup stub to run
+        LP_AON::regs()
+            .store9()
+            .modify(|r, w| unsafe { w.bits(r.bits() & !0x01 | self.deep as u32) });
 
-            // pmu_ll_hp_set_wakeup_enable
-            pmu().slp_wakeup_cntl2().write(|w| w.bits(wakeup_mask));
+        // pmu_ll_hp_set_wakeup_enable
+        PMU::regs()
+            .slp_wakeup_cntl2()
+            .write(|w| unsafe { w.bits(wakeup_mask) });
 
-            // pmu_ll_hp_set_reject_enable
-            pmu().slp_wakeup_cntl1().modify(|_, w| {
-                w.slp_reject_en()
-                    .bit(true)
-                    .sleep_reject_ena()
-                    .bits(reject_mask)
-            });
+        // pmu_ll_hp_set_reject_enable
+        PMU::regs().slp_wakeup_cntl1().modify(|_, w| unsafe {
+            w.slp_reject_en().bit(true);
+            w.sleep_reject_ena().bits(reject_mask)
+        });
 
-            // pmu_ll_hp_clear_reject_cause
-            pmu()
-                .slp_wakeup_cntl4()
-                .write(|w| w.slp_reject_cause_clr().bit(true));
+        // pmu_ll_hp_clear_reject_cause
+        PMU::regs()
+            .slp_wakeup_cntl4()
+            .write(|w| w.slp_reject_cause_clr().bit(true));
 
-            pmu().int_clr().write(|w| {
-                // pmu_ll_hp_clear_sw_intr_status
-                w.sw()
-                    .clear_bit_by_one()
-                    // pmu_ll_hp_clear_reject_intr_status
-                ;
-                w.soc_sleep_reject()
-                    .clear_bit_by_one()
-                    // pmu_ll_hp_clear_wakeup_intr_status
-                ;
-                w.soc_wakeup().clear_bit_by_one()
-            });
+        PMU::regs().int_clr().write(|w| {
+            // pmu_ll_hp_clear_sw_intr_status
+            w.sw().clear_bit_by_one();
+            // pmu_ll_hp_clear_reject_intr_status
+            w.soc_sleep_reject().clear_bit_by_one();
+            // pmu_ll_hp_clear_wakeup_intr_status
+            w.soc_wakeup().clear_bit_by_one()
+        });
 
-            // misc_modules_sleep_prepare
+        // misc_modules_sleep_prepare
 
-            // TODO: IDF-7370
-            #[cfg(not(soc_has_pmu))]
-            if !(self.deep && wakeup_triggers.touch) {
-                APB_SARADC::regs()
-                    .ctrl()
-                    .modify(|_, w| w.saradc2_pwdet_drv().bit(false));
-            }
+        // Start entry into sleep mode
 
-            // Start entry into sleep mode
+        // pmu_ll_hp_set_sleep_enable
+        PMU::regs()
+            .slp_wakeup_cntl0()
+            .write(|w| w.sleep_req().bit(true));
 
-            // pmu_ll_hp_set_sleep_enable
-            pmu().slp_wakeup_cntl0().write(|w| w.sleep_req().bit(true));
-
-            // In pd_cpu lightsleep and deepsleep mode, we never get here
-            loop {
-                let int_raw = pmu().int_raw().read();
-                if int_raw.soc_wakeup().bit_is_set() || int_raw.soc_sleep_reject().bit_is_set() {
-                    break;
-                }
+        // In pd_cpu lightsleep and deepsleep mode, we never get here
+        loop {
+            let int_raw = PMU::regs().int_raw().read();
+            if int_raw.soc_wakeup().bit_is_set() || int_raw.soc_sleep_reject().bit_is_set() {
+                break;
             }
         }
     }

--- a/esp-hal/src/rtc_cntl/sleep/esp32c61.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c61.rs
@@ -2,6 +2,7 @@ use core::ops::Not;
 
 use crate::{
     clock::RtcClock,
+    peripherals::{LP_AON, PMU},
     private::DropGuard,
     rtc_cntl::{
         Rtc,
@@ -108,48 +109,57 @@ impl AnalogSleepConfig {
 
         unsafe {
             // HP SLEEP (hp_sleep_*)
-            pmu().hp_sleep_bias().modify(|_, w| {
-                w.hp_sleep_dbg_atten() // pmu_ll_hp_set_dbg_atten
-                    .bits(self.hp_sys.bias.dbg_atten())
-                    .hp_sleep_pd_cur() // pmu_ll_hp_set_current_power_off
-                    .bit(self.hp_sys.bias.pd_cur())
-                    .sleep() // pmu_ll_hp_set_bias_sleep_enable
-                    .bit(self.hp_sys.bias.bias_sleep())
+            PMU::regs().hp_sleep_bias().modify(|_, w| {
+                // pmu_ll_hp_set_dbg_atten
+                w.hp_sleep_dbg_atten().bits(self.hp_sys.bias.dbg_atten());
+                // pmu_ll_hp_set_current_power_off
+                w.hp_sleep_pd_cur().bit(self.hp_sys.bias.pd_cur());
+                // pmu_ll_hp_set_bias_sleep_enable
+                w.sleep().bit(self.hp_sys.bias.bias_sleep())
             });
-            pmu().hp_sleep_hp_regulator0().modify(|_, w| {
-                w.hp_sleep_hp_regulator_xpd() // pmu_ll_hp_set_regulator_xpd
-                    .bit(self.hp_sys.regulator0.xpd())
-                    .hp_sleep_hp_regulator_dbias() // pmu_ll_hp_set_regulator_dbias
+            PMU::regs().hp_sleep_hp_regulator0().modify(|_, w| {
+                // pmu_ll_hp_set_regulator_xpd
+                w.hp_sleep_hp_regulator_xpd()
+                    .bit(self.hp_sys.regulator0.xpd());
+                // pmu_ll_hp_set_regulator_dbias
+                w.hp_sleep_hp_regulator_dbias()
                     .bits(self.hp_sys.regulator0.dbias())
             });
-            pmu().hp_sleep_hp_regulator1().modify(|_, w| {
-                w.hp_sleep_hp_regulator_drv_b() // pmu_ll_hp_set_regulator_driver_bar
+            PMU::regs().hp_sleep_hp_regulator1().modify(|_, w| {
+                // pmu_ll_hp_set_regulator_driver_bar
+                w.hp_sleep_hp_regulator_drv_b()
                     .bits(self.hp_sys.regulator1.drv_b())
             });
 
             // LP SLEEP (lp_sleep_*)
-            pmu().lp_sleep_bias().modify(|_, w| {
-                w.lp_sleep_dbg_atten() // pmu_ll_lp_set_dbg_atten
-                    .bits(self.lp_sys_sleep.bias.dbg_atten())
-                    .lp_sleep_pd_cur() // pmu_ll_lp_set_current_power_off
-                    .bit(self.lp_sys_sleep.bias.pd_cur())
-                    .sleep() // pmu_ll_lp_set_bias_sleep_enable
-                    .bit(self.lp_sys_sleep.bias.bias_sleep())
+            PMU::regs().lp_sleep_bias().modify(|_, w| {
+                // pmu_ll_lp_set_dbg_atten
+                w.lp_sleep_dbg_atten()
+                    .bits(self.lp_sys_sleep.bias.dbg_atten());
+                // pmu_ll_lp_set_current_power_off
+                w.lp_sleep_pd_cur().bit(self.lp_sys_sleep.bias.pd_cur());
+                // pmu_ll_lp_set_bias_sleep_enable
+                w.sleep().bit(self.lp_sys_sleep.bias.bias_sleep())
             });
 
-            pmu().lp_sleep_lp_regulator0().modify(|_, w| {
-                w.lp_sleep_lp_regulator_slp_xpd() // pmu_ll_lp_set_regulator_slp_xpd
-                    .bit(self.lp_sys_sleep.regulator0.slp_xpd())
-                    .lp_sleep_lp_regulator_xpd() // pmu_ll_lp_set_regulator_xpd
-                    .bit(self.lp_sys_sleep.regulator0.xpd())
-                    .lp_sleep_lp_regulator_slp_dbias() // pmu_ll_lp_set_regulator_sleep_dbias
-                    .bits(self.lp_sys_sleep.regulator0.slp_dbias())
-                    .lp_sleep_lp_regulator_dbias() // pmu_ll_lp_set_regulator_dbias
+            PMU::regs().lp_sleep_lp_regulator0().modify(|_, w| {
+                // pmu_ll_lp_set_regulator_slp_xpd
+                w.lp_sleep_lp_regulator_slp_xpd()
+                    .bit(self.lp_sys_sleep.regulator0.slp_xpd());
+                // pmu_ll_lp_set_regulator_xpd
+                w.lp_sleep_lp_regulator_xpd()
+                    .bit(self.lp_sys_sleep.regulator0.xpd());
+                // pmu_ll_lp_set_regulator_sleep_dbias
+                w.lp_sleep_lp_regulator_slp_dbias()
+                    .bits(self.lp_sys_sleep.regulator0.slp_dbias());
+                // pmu_ll_lp_set_regulator_dbias
+                w.lp_sleep_lp_regulator_dbias()
                     .bits(self.lp_sys_sleep.regulator0.dbias())
             });
 
-            pmu().lp_sleep_lp_regulator1().modify(|_, w| {
-                w.lp_sleep_lp_regulator_drv_b() // pmu_ll_lp_set_regulator_driver_bar
+            PMU::regs().lp_sleep_lp_regulator1().modify(|_, w| {
+                // pmu_ll_lp_set_regulator_driver_bar
+                w.lp_sleep_lp_regulator_drv_b()
                     .bits(self.lp_sys_sleep.regulator1.drv_b())
             });
         }
@@ -181,12 +191,10 @@ impl DigitalSleepConfig {
 
     fn apply(&self) {
         // pmu_sleep_digital_init
-        unsafe {
-            pmu().hp_sleep_hp_sys_cntl().modify(|_, w| {
-                w.hp_sleep_dig_pad_slp_sel()
-                    .bit(self.syscntl.dig_pad_slp_sel())
-            })
-        };
+        PMU::regs().hp_sleep_hp_sys_cntl().modify(|_, w| {
+            w.hp_sleep_dig_pad_slp_sel()
+                .bit(self.syscntl.dig_pad_slp_sel())
+        });
     }
 }
 
@@ -256,37 +264,35 @@ impl PowerSleepConfig {
     fn apply(&self) {
         // pmu_sleep_power_init
 
-        unsafe {
-            // HP SLEEP (hp_sleep_*)
-            pmu()
-                .hp_sleep_dig_power()
-                .modify(|_, w| w.bits(self.hp_sys.dig_power.0));
-            pmu()
-                .hp_sleep_hp_ck_power()
-                .modify(|_, w| w.bits(self.hp_sys.clk.0));
-            pmu()
-                .hp_sleep_xtal()
-                .modify(|_, w| w.hp_sleep_xpd_xtal().bit(self.hp_sys.xtal.xpd_xtal()));
+        // HP SLEEP (hp_sleep_*)
+        PMU::regs()
+            .hp_sleep_dig_power()
+            .modify(|_, w| unsafe { w.bits(self.hp_sys.dig_power.0) });
+        PMU::regs()
+            .hp_sleep_hp_ck_power()
+            .modify(|_, w| unsafe { w.bits(self.hp_sys.clk.0) });
+        PMU::regs()
+            .hp_sleep_xtal()
+            .modify(|_, w| w.hp_sleep_xpd_xtal().bit(self.hp_sys.xtal.xpd_xtal()));
 
-            // LP ACTIVE (hp_sleep_lp_*)
-            pmu()
-                .hp_sleep_lp_dig_power()
-                .modify(|_, w| w.bits(self.lp_sys_active.dig_power.0));
-            pmu()
-                .hp_sleep_lp_ck_power()
-                .modify(|_, w| w.bits(self.lp_sys_active.clk_power.0));
+        // LP ACTIVE (hp_sleep_lp_*)
+        PMU::regs()
+            .hp_sleep_lp_dig_power()
+            .modify(|_, w| unsafe { w.bits(self.lp_sys_active.dig_power.0) });
+        PMU::regs()
+            .hp_sleep_lp_ck_power()
+            .modify(|_, w| unsafe { w.bits(self.lp_sys_active.clk_power.0) });
 
-            // LP SLEEP (lp_sleep_*)
-            pmu()
-                .lp_sleep_lp_dig_power()
-                .modify(|_, w| w.bits(self.lp_sys_sleep.dig_power.0));
-            pmu()
-                .lp_sleep_lp_ck_power()
-                .modify(|_, w| w.bits(self.lp_sys_sleep.clk_power.0));
-            pmu()
-                .lp_sleep_xtal()
-                .modify(|_, w| w.lp_sleep_xpd_xtal().bit(self.lp_sys_sleep.xtal.xpd_xtal()));
-        }
+        // LP SLEEP (lp_sleep_*)
+        PMU::regs()
+            .lp_sleep_lp_dig_power()
+            .modify(|_, w| unsafe { w.bits(self.lp_sys_sleep.dig_power.0) });
+        PMU::regs()
+            .lp_sleep_lp_ck_power()
+            .modify(|_, w| unsafe { w.bits(self.lp_sys_sleep.clk_power.0) });
+        PMU::regs()
+            .lp_sleep_xtal()
+            .modify(|_, w| w.lp_sleep_xpd_xtal().bit(self.lp_sys_sleep.xtal.xpd_xtal()));
     }
 }
 
@@ -392,58 +398,61 @@ impl ParamSleepConfig {
     fn apply(&self) {
         // pmu_sleep_param_init
 
-        unsafe {
-            pmu().slp_wakeup_cntl3().modify(|_, w| {
-                w.hp_min_slp_val() // pmu_ll_hp_set_min_sleep_cycle
-                    .bits(self.hp_sys.min_slp_slow_clk_cycle)
-                    .lp_min_slp_val() // pmu_ll_lp_set_min_sleep_cycle
-                    .bits(self.lp_sys.min_slp_slow_clk_cycle)
-            });
+        PMU::regs().slp_wakeup_cntl3().modify(|_, w| unsafe {
+            // pmu_ll_hp_set_min_sleep_cycle
+            w.hp_min_slp_val().bits(self.hp_sys.min_slp_slow_clk_cycle);
+            // pmu_ll_lp_set_min_sleep_cycle
+            w.lp_min_slp_val().bits(self.lp_sys.min_slp_slow_clk_cycle)
+        });
 
-            pmu().slp_wakeup_cntl7().modify(|_, w| {
-                w.ana_wait_target() // pmu_ll_hp_set_analog_wait_target_cycle
-                    .bits(self.hp_sys.analog_wait_target_cycle)
-            });
+        PMU::regs().slp_wakeup_cntl7().modify(|_, w| unsafe {
+            // pmu_ll_hp_set_analog_wait_target_cycle
+            w.ana_wait_target()
+                .bits(self.hp_sys.analog_wait_target_cycle)
+        });
 
-            pmu().power_wait_timer0().modify(|_, w| {
-                w.dg_hp_pd_wait_timer() // pmu_ll_hp_set_digital_power_supply_wait_cycle
-                    .bits(self.hp_sys.digital_power_supply_wait_cycle)
-                    .dg_hp_powerup_timer() // pmu_ll_hp_set_digital_power_up_wait_cycle
-                    .bits(self.hp_sys.digital_power_up_wait_cycle)
-            });
+        PMU::regs().power_wait_timer0().modify(|_, w| unsafe {
+            // pmu_ll_hp_set_digital_power_supply_wait_cycle
+            w.dg_hp_pd_wait_timer()
+                .bits(self.hp_sys.digital_power_supply_wait_cycle);
+            // pmu_ll_hp_set_digital_power_up_wait_cycle
+            w.dg_hp_powerup_timer()
+                .bits(self.hp_sys.digital_power_up_wait_cycle)
+        });
 
-            pmu().power_wait_timer1().modify(|_, w| {
-                w.dg_lp_pd_wait_timer() // pmu_ll_lp_set_digital_power_supply_wait_cycle
-                    .bits(self.lp_sys.digital_power_supply_wait_cycle)
-                    .dg_lp_powerup_timer() // pmu_ll_lp_set_digital_power_up_wait_cycle
-                    .bits(self.lp_sys.digital_power_up_wait_cycle)
-            });
+        PMU::regs().power_wait_timer1().modify(|_, w| unsafe {
+            // pmu_ll_lp_set_digital_power_supply_wait_cycle
+            w.dg_lp_pd_wait_timer()
+                .bits(self.lp_sys.digital_power_supply_wait_cycle);
+            // pmu_ll_lp_set_digital_power_up_wait_cycle
+            w.dg_lp_powerup_timer()
+                .bits(self.lp_sys.digital_power_up_wait_cycle)
+        });
 
-            // pmu_hal_hp/lp_set_control_ready_wait_cycle
-            pmu().power_wait_timer2().modify(|_, w| {
-                w.dg_hp_iso_wait_timer()
-                    .bits(self.hp_sys.isolate_wait_cycle)
-                    .dg_hp_rst_wait_timer()
-                    .bits(self.hp_sys.reset_wait_cycle)
-                    .dg_lp_iso_wait_timer()
-                    .bits(self.lp_sys.isolate_wait_cycle)
-                    .dg_lp_rst_wait_timer()
-                    .bits(self.lp_sys.reset_wait_cycle)
-            });
+        // pmu_hal_hp/lp_set_control_ready_wait_cycle
+        PMU::regs().power_wait_timer2().modify(|_, w| unsafe {
+            w.dg_hp_iso_wait_timer()
+                .bits(self.hp_sys.isolate_wait_cycle);
+            w.dg_hp_rst_wait_timer().bits(self.hp_sys.reset_wait_cycle);
+            w.dg_lp_iso_wait_timer()
+                .bits(self.lp_sys.isolate_wait_cycle);
+            w.dg_lp_rst_wait_timer().bits(self.lp_sys.reset_wait_cycle)
+        });
 
-            pmu().slp_wakeup_cntl5().modify(|_, w| {
-                w.lp_ana_wait_target() // pmu_ll_lp_set_analog_wait_target_cycle
-                    .bits(self.lp_sys.analog_wait_target_cycle)
-                    .modem_wait_target() // pmu_ll_hp_set_modem_wakeup_wait_cycle
-                    .bits(self.hp_sys.modem_wakeup_wait_cycle)
-            });
-            pmu().power_ck_wait_cntl().modify(|_, w| {
-                w.wait_xtl_stable() // pmu_ll_hp_set_xtal_stable_wait_cycle
-                    .bits(self.hp_lp.xtal_stable_wait_cycle)
-                    .wait_pll_stable() // pmu_ll_hp_set_pll_stable_wait_cycle
-                    .bits(self.hp_sys.pll_stable_wait_cycle)
-            });
-        }
+        PMU::regs().slp_wakeup_cntl5().modify(|_, w| unsafe {
+            // pmu_ll_lp_set_analog_wait_target_cycle
+            w.lp_ana_wait_target()
+                .bits(self.lp_sys.analog_wait_target_cycle);
+            // pmu_ll_hp_set_modem_wakeup_wait_cycle
+            w.modem_wait_target()
+                .bits(self.hp_sys.modem_wakeup_wait_cycle)
+        });
+        PMU::regs().power_ck_wait_cntl().modify(|_, w| unsafe {
+            // pmu_ll_hp_set_xtal_stable_wait_cycle
+            w.wait_xtl_stable().bits(self.hp_lp.xtal_stable_wait_cycle);
+            // pmu_ll_hp_set_pll_stable_wait_cycle
+            w.wait_pll_stable().bits(self.hp_sys.pll_stable_wait_cycle)
+        });
     }
 
     fn defaults(config: SleepTimeConfig, pd_flags: PowerDownFlags, pd_xtal: bool) -> Self {
@@ -521,7 +530,7 @@ impl SleepTimeConfig {
 
         // Calibrate rtc slow clock
         // TODO: do an actual calibration instead of a read
-        let slowclk_period = unsafe { lp_aon().store1().read().lp_aon_store1().bits() };
+        let slowclk_period = LP_AON::regs().store1().read().lp_aon_store1().bits();
 
         // Calibrate rtc fast clock, only PMU supported chips sleep process is needed.
         const FAST_CLK_SRC_CAL_CYCLES: u32 = 2048;
@@ -662,14 +671,6 @@ impl Default for RtcSleepConfig {
             pd_flags: PowerDownFlags(0),
         }
     }
-}
-
-unsafe fn pmu<'a>() -> &'a esp32c61::pmu::RegisterBlock {
-    unsafe { &*esp32c61::PMU::ptr() }
-}
-
-unsafe fn lp_aon<'a>() -> &'a esp32c61::lp_aon::RegisterBlock {
-    unsafe { &*esp32c61::LP_AON::ptr() }
 }
 
 bitfield::bitfield! {
@@ -913,56 +914,50 @@ impl RtcSleepConfig {
 
         // like esp-idf pmu_sleep_start()
 
-        unsafe {
-            // lp_aon_hal_inform_wakeup_type - tells ROM which wakeup stub to run
-            lp_aon()
-                .store9()
-                .modify(|r, w| w.bits(r.bits() & !0x01 | self.deep as u32));
+        // lp_aon_hal_inform_wakeup_type - tells ROM which wakeup stub to run
+        LP_AON::regs()
+            .store9()
+            .modify(|r, w| unsafe { w.bits(r.bits() & !0x01 | self.deep as u32) });
 
-            // pmu_ll_hp_set_wakeup_enable
-            pmu().slp_wakeup_cntl2().write(|w| w.bits(wakeup_mask));
+        // pmu_ll_hp_set_wakeup_enable
+        PMU::regs()
+            .slp_wakeup_cntl2()
+            .write(|w| unsafe { w.bits(wakeup_mask) });
 
-            // pmu_ll_hp_set_reject_enable
-            pmu().slp_wakeup_cntl1().modify(|_, w| {
-                w.slp_reject_en().bit(true);
-                w.sleep_reject_ena().bits(reject_mask)
-            });
+        // pmu_ll_hp_set_reject_enable
+        PMU::regs().slp_wakeup_cntl1().modify(|_, w| unsafe {
+            w.slp_reject_en().bit(true);
+            w.sleep_reject_ena().bits(reject_mask)
+        });
 
-            // pmu_ll_hp_clear_reject_cause
-            pmu()
-                .slp_wakeup_cntl4()
-                .write(|w| w.slp_reject_cause_clr().bit(true));
+        // pmu_ll_hp_clear_reject_cause
+        PMU::regs()
+            .slp_wakeup_cntl4()
+            .write(|w| w.slp_reject_cause_clr().bit(true));
 
-            pmu().int_clr().write(|w| {
-                // pmu_ll_hp_clear_sw_intr_status
-                w.sw().clear_bit_by_one();
-                // pmu_ll_hp_clear_reject_intr_status
-                w.soc_sleep_reject().clear_bit_by_one();
-                // pmu_ll_hp_clear_wakeup_intr_status
-                w.soc_wakeup().clear_bit_by_one()
-            });
+        PMU::regs().int_clr().write(|w| {
+            // pmu_ll_hp_clear_sw_intr_status
+            w.sw().clear_bit_by_one();
+            // pmu_ll_hp_clear_reject_intr_status
+            w.soc_sleep_reject().clear_bit_by_one();
+            // pmu_ll_hp_clear_wakeup_intr_status
+            w.soc_wakeup().clear_bit_by_one()
+        });
 
-            // misc_modules_sleep_prepare
+        // misc_modules_sleep_prepare
 
-            // TODO: IDF-7370
-            #[cfg(not(soc_has_pmu))]
-            if !(self.deep && wakeup_triggers.touch) {
-                APB_SARADC::regs()
-                    .ctrl()
-                    .modify(|_, w| w.saradc2_pwdet_drv().bit(false));
-            }
+        // Start entry into sleep mode
 
-            // Start entry into sleep mode
+        // pmu_ll_hp_set_sleep_enable
+        PMU::regs()
+            .slp_wakeup_cntl0()
+            .write(|w| w.sleep_req().bit(true));
 
-            // pmu_ll_hp_set_sleep_enable
-            pmu().slp_wakeup_cntl0().write(|w| w.sleep_req().bit(true));
-
-            // In pd_cpu lightsleep and deepsleep mode, we never get here
-            loop {
-                let int_raw = pmu().int_raw().read();
-                if int_raw.soc_wakeup().bit_is_set() || int_raw.soc_sleep_reject().bit_is_set() {
-                    break;
-                }
+        // In pd_cpu lightsleep and deepsleep mode, we never get here
+        loop {
+            let int_raw = PMU::regs().int_raw().read();
+            if int_raw.soc_wakeup().bit_is_set() || int_raw.soc_sleep_reject().bit_is_set() {
+                break;
             }
         }
     }

--- a/esp-hal/src/rtc_cntl/sleep/esp32c61.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c61.rs
@@ -2,9 +2,10 @@ use core::ops::Not;
 
 use crate::{
     clock::RtcClock,
+    private::DropGuard,
     rtc_cntl::{
         Rtc,
-        rtc::{HpAnalog, HpSysCntlReg, HpSysPower, LpAnalog, LpSysPower, SavedClockConfig},
+        rtc::{HpAnalog, HpSysCntlReg, HpSysPower, LpAnalog, LpSysPower},
         sleep::WakeTriggers,
     },
     soc::clocks::{self, ClockTree, HpRootClkConfig, LpSlowClkConfig, TimgCalibrationClockConfig},
@@ -867,10 +868,19 @@ impl RtcSleepConfig {
             wakeup_mask & reject_mask
         };
 
-        let cpu_freq_config = ClockTree::with(|clocks| {
-            let cpu_freq_config = SavedClockConfig::save(clocks);
-            crate::soc::clocks::configure_hp_root_clk(clocks, HpRootClkConfig::Xtal);
-            cpu_freq_config
+        let _restore_clock_config = ClockTree::with(|clocks| {
+            let old_root = clocks.hp_root_clk();
+
+            clocks::configure_hp_root_clk(clocks, HpRootClkConfig::Xtal);
+
+            // Restore the old clock settings when we return
+            DropGuard::new((), move |_| {
+                ClockTree::with(|clocks| {
+                    if let Some(old_root) = old_root {
+                        clocks::configure_hp_root_clk(clocks, old_root);
+                    }
+                });
+            })
         });
 
         // pmu_sleep_config_default + pmu_sleep_init.
@@ -914,10 +924,8 @@ impl RtcSleepConfig {
 
             // pmu_ll_hp_set_reject_enable
             pmu().slp_wakeup_cntl1().modify(|_, w| {
-                w.slp_reject_en()
-                    .bit(true)
-                    .sleep_reject_ena()
-                    .bits(reject_mask)
+                w.slp_reject_en().bit(true);
+                w.sleep_reject_ena().bits(reject_mask)
             });
 
             // pmu_ll_hp_clear_reject_cause
@@ -926,12 +934,12 @@ impl RtcSleepConfig {
                 .write(|w| w.slp_reject_cause_clr().bit(true));
 
             pmu().int_clr().write(|w| {
-                w.sw() // pmu_ll_hp_clear_sw_intr_status
-                    .clear_bit_by_one()
-                    .soc_sleep_reject() // pmu_ll_hp_clear_reject_intr_status
-                    .clear_bit_by_one()
-                    .soc_wakeup() // pmu_ll_hp_clear_wakeup_intr_status
-                    .clear_bit_by_one()
+                // pmu_ll_hp_clear_sw_intr_status
+                w.sw().clear_bit_by_one();
+                // pmu_ll_hp_clear_reject_intr_status
+                w.soc_sleep_reject().clear_bit_by_one();
+                // pmu_ll_hp_clear_wakeup_intr_status
+                w.soc_wakeup().clear_bit_by_one()
             });
 
             // misc_modules_sleep_prepare
@@ -957,12 +965,6 @@ impl RtcSleepConfig {
                 }
             }
         }
-
-        // esp-idf returns if the sleep was rejected, we don't return anything
-
-        ClockTree::with(|clocks| {
-            cpu_freq_config.restore(clocks);
-        });
     }
 
     /// Cleans up after sleep

--- a/esp-hal/src/rtc_cntl/sleep/esp32h2.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32h2.rs
@@ -4,12 +4,20 @@ use crate::{
     clock::RtcClock,
     gpio::{AnyPin, Input, InputConfig, Pull, RtcPin},
     peripherals::APB_SARADC,
+    private::DropGuard,
     rtc_cntl::{
         Rtc,
-        rtc::{HpSysCntlReg, HpSysPower, LpSysPower, SavedClockConfig},
+        rtc::{HpSysCntlReg, HpSysPower, LpSysPower},
         sleep::{Ext1WakeupSource, WakeSource, WakeTriggers, WakeupLevel},
     },
-    soc::clocks::{self, ClockTree, LpSlowClkConfig, TimgCalibrationClockConfig},
+    soc::clocks::{
+        self,
+        ClockTree,
+        CpuClkConfig,
+        HpRootClkConfig,
+        LpSlowClkConfig,
+        TimgCalibrationClockConfig,
+    },
 };
 
 impl Ext1WakeupSource<'_, '_> {
@@ -701,14 +709,24 @@ impl RtcSleepConfig {
             wakeup_mask & reject_mask
         };
 
-        let cpu_freq_config = ClockTree::with(|clocks| {
-            let cpu_freq_config = SavedClockConfig::save(clocks);
-            crate::soc::clocks::configure_hp_root_clk(
-                clocks,
-                crate::soc::clocks::HpRootClkConfig::Xtal,
-            );
-            crate::soc::clocks::configure_cpu_clk(clocks, crate::soc::clocks::CpuClkConfig::new(0));
-            cpu_freq_config
+        let _restore_clock_config = ClockTree::with(|clocks| {
+            let old_hp_root_clk = clocks.hp_root_clk();
+            let old_cpu_divider = clocks.cpu_clk();
+
+            clocks::configure_hp_root_clk(clocks, HpRootClkConfig::Xtal);
+            clocks::configure_cpu_clk(clocks, CpuClkConfig::new(0));
+
+            // Restore the old clock settings when we return
+            DropGuard::new((), move |_| {
+                ClockTree::with(|clocks| {
+                    if let Some(old_hp_root_clk) = old_hp_root_clk {
+                        clocks::configure_hp_root_clk(clocks, old_hp_root_clk);
+                    }
+                    if let Some(old_cpu_divider) = old_cpu_divider {
+                        clocks::configure_cpu_clk(clocks, old_cpu_divider);
+                    }
+                });
+            })
         });
 
         // misc_modules_sleep_prepare
@@ -783,12 +801,6 @@ impl RtcSleepConfig {
                 }
             }
         }
-
-        // esp-idf returns if the sleep was rejected, we don't return anything
-
-        ClockTree::with(|clocks| {
-            cpu_freq_config.restore(clocks);
-        });
     }
 
     /// Cleans up after sleep

--- a/esp-hal/src/rtc_cntl/sleep/esp32h2.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32h2.rs
@@ -3,7 +3,7 @@ use core::ops::Not;
 use crate::{
     clock::RtcClock,
     gpio::{AnyPin, Input, InputConfig, Pull, RtcPin},
-    peripherals::APB_SARADC,
+    peripherals::{LP_AON, PMU},
     private::DropGuard,
     rtc_cntl::{
         Rtc,
@@ -23,7 +23,11 @@ use crate::{
 impl Ext1WakeupSource<'_, '_> {
     /// Returns the currently configured wakeup pins.
     fn wakeup_pins() -> u8 {
-        unsafe { lp_aon().ext_wakeup_cntl().read().ext_wakeup_sel().bits() }
+        LP_AON::regs()
+            .ext_wakeup_cntl()
+            .read()
+            .ext_wakeup_sel()
+            .bits()
     }
 
     /// Resets the pins that had been configured as wakeup trigger to their default state.
@@ -74,20 +78,18 @@ impl WakeSource for Ext1WakeupSource<'_, '_> {
             );
         }
 
-        unsafe {
-            // clear previous wakeup status
-            lp_aon()
-                .ext_wakeup_cntl()
-                .modify(|_, w| w.ext_wakeup_status_clr().set_bit());
+        // clear previous wakeup status
+        LP_AON::regs()
+            .ext_wakeup_cntl()
+            .modify(|_, w| w.ext_wakeup_status_clr().set_bit());
 
-            // set pin + level register fields
-            lp_aon().ext_wakeup_cntl().modify(|r, w| {
-                w.ext_wakeup_sel()
-                    .bits(r.ext_wakeup_sel().bits() | pin_mask)
-                    .ext_wakeup_lv()
-                    .bits(r.ext_wakeup_lv().bits() & !pin_mask | level_mask)
-            });
-        }
+        // set pin + level register fields
+        LP_AON::regs().ext_wakeup_cntl().modify(|r, w| unsafe {
+            w.ext_wakeup_sel()
+                .bits(r.ext_wakeup_sel().bits() | pin_mask);
+            w.ext_wakeup_lv()
+                .bits(r.ext_wakeup_lv().bits() & !pin_mask | level_mask)
+        });
     }
 }
 
@@ -130,12 +132,10 @@ impl AnalogSleepConfig {
 
     fn apply(&self) {
         // based on pmu_sleep_analog_init, with undocumented registers omitted
-        unsafe {
-            pmu().hp_sleep_hp_regulator0().modify(|_, w| {
-                w.hp_sleep_hp_regulator_xpd() // pmu_ll_hp_set_regulator_xpd
-                    .bit(self.regulator_xpd)
-            });
-        }
+        PMU::regs().hp_sleep_hp_regulator0().modify(|_, w| {
+            w.hp_sleep_hp_regulator_xpd() // pmu_ll_hp_set_regulator_xpd
+                .bit(self.regulator_xpd)
+        });
     }
 }
 
@@ -179,20 +179,18 @@ impl DigitalSleepConfig {
 
     fn apply(&self) {
         // pmu_sleep_digital_init
-        unsafe {
-            pmu().hp_sleep_sysclk().modify(|_, w| {
-                w.hp_sleep_icg_sys_clock_en().bit(self.icg_func != 0) // pmu_ll_hp_set_icg_sysclk_enable
+        PMU::regs().hp_sleep_sysclk().modify(|_, w| {
+            w.hp_sleep_icg_sys_clock_en().bit(self.icg_func != 0) // pmu_ll_hp_set_icg_sysclk_enable
+        });
+        PMU::regs().hp_sleep_icg_hp_func().modify(|_, w| unsafe {
+            w.hp_sleep_dig_icg_func_en().bits(self.icg_func) // pmu_ll_hp_set_icg_func
+        });
+        if !self.deep_sleep {
+            PMU::regs().hp_sleep_hp_sys_cntl().modify(|_, w| {
+                w.hp_sleep_dig_pad_slp_sel()
+                    .bit(self.syscntl.dig_pad_slp_sel()) // pmu_ll_hp_set_dig_pad_slp_sel
             });
-            pmu().hp_sleep_icg_hp_func().modify(|_, w| {
-                w.hp_sleep_dig_icg_func_en().bits(self.icg_func) // pmu_ll_hp_set_icg_func
-            });
-            if !self.deep_sleep {
-                pmu().hp_sleep_hp_sys_cntl().modify(|_, w| {
-                    w.hp_sleep_dig_pad_slp_sel()
-                        .bit(self.syscntl.dig_pad_slp_sel()) // pmu_ll_hp_set_dig_pad_slp_sel
-                });
-            }
-        };
+        }
     }
 }
 
@@ -254,37 +252,35 @@ impl PowerSleepConfig {
 
     fn apply(&self) {
         // pmu_sleep_power_init
-        unsafe {
-            // HP SLEEP (hp_sleep_*)
-            pmu()
-                .hp_sleep_dig_power()
-                .modify(|_, w| w.bits(self.hp_sys.dig_power.0));
-            pmu()
-                .hp_sleep_hp_ck_power()
-                .modify(|_, w| w.bits(self.hp_sys.clk.0));
-            pmu()
-                .hp_sleep_xtal()
-                .modify(|_, w| w.hp_sleep_xpd_xtal().bit(self.hp_sys.xtal.xpd_xtal()));
+        // HP SLEEP (hp_sleep_*)
+        PMU::regs()
+            .hp_sleep_dig_power()
+            .modify(|_, w| unsafe { w.bits(self.hp_sys.dig_power.0) });
+        PMU::regs()
+            .hp_sleep_hp_ck_power()
+            .modify(|_, w| unsafe { w.bits(self.hp_sys.clk.0) });
+        PMU::regs()
+            .hp_sleep_xtal()
+            .modify(|_, w| w.hp_sleep_xpd_xtal().bit(self.hp_sys.xtal.xpd_xtal()));
 
-            // LP ACTIVE (hp_sleep_lp_*)
-            pmu()
-                .hp_sleep_lp_dig_power()
-                .modify(|_, w| w.bits(self.lp_sys_active.dig_power.0));
-            pmu()
-                .hp_sleep_lp_ck_power()
-                .modify(|_, w| w.bits(self.lp_sys_active.clk_power.0));
+        // LP ACTIVE (hp_sleep_lp_*)
+        PMU::regs()
+            .hp_sleep_lp_dig_power()
+            .modify(|_, w| unsafe { w.bits(self.lp_sys_active.dig_power.0) });
+        PMU::regs()
+            .hp_sleep_lp_ck_power()
+            .modify(|_, w| unsafe { w.bits(self.lp_sys_active.clk_power.0) });
 
-            // LP SLEEP (lp_sleep_*)
-            pmu()
-                .lp_sleep_lp_dig_power()
-                .modify(|_, w| w.bits(self.lp_sys_sleep.dig_power.0));
-            pmu()
-                .lp_sleep_lp_ck_power()
-                .modify(|_, w| w.bits(self.lp_sys_sleep.clk_power.0));
-            pmu()
-                .lp_sleep_xtal()
-                .modify(|_, w| w.lp_sleep_xpd_xtal().bit(self.lp_sys_sleep.xtal.xpd_xtal()));
-        }
+        // LP SLEEP (lp_sleep_*)
+        PMU::regs()
+            .lp_sleep_lp_dig_power()
+            .modify(|_, w| unsafe { w.bits(self.lp_sys_sleep.dig_power.0) });
+        PMU::regs()
+            .lp_sleep_lp_ck_power()
+            .modify(|_, w| unsafe { w.bits(self.lp_sys_sleep.clk_power.0) });
+        PMU::regs()
+            .lp_sleep_xtal()
+            .modify(|_, w| w.lp_sleep_xpd_xtal().bit(self.lp_sys_sleep.xtal.xpd_xtal()));
     }
 }
 
@@ -378,42 +374,46 @@ impl ParamSleepConfig {
     fn apply(&self) {
         // pmu_sleep_param_init
         unsafe {
-            pmu().slp_wakeup_cntl3().modify(|_, w| {
-                w.hp_min_slp_val() // pmu_ll_hp_set_min_sleep_cycle
-                    .bits(self.hp_sys.min_slp_slow_clk_cycle)
-                    .lp_min_slp_val() // pmu_ll_lp_set_min_sleep_cycle
-                    .bits(self.lp_sys.min_slp_slow_clk_cycle)
+            PMU::regs().slp_wakeup_cntl3().modify(|_, w| {
+                // pmu_ll_hp_set_min_sleep_cycle
+                w.hp_min_slp_val().bits(self.hp_sys.min_slp_slow_clk_cycle);
+                // pmu_ll_lp_set_min_sleep_cycle
+                w.lp_min_slp_val().bits(self.lp_sys.min_slp_slow_clk_cycle)
             });
 
-            pmu().slp_wakeup_cntl7().modify(|_, w| {
+            PMU::regs().slp_wakeup_cntl7().modify(|_, w| {
                 w.ana_wait_target() // pmu_ll_hp_set_analog_wait_target_cycle
                     .bits(self.hp_sys.analog_wait_target_cycle)
             });
 
-            pmu().slp_wakeup_cntl5().modify(|_, w| {
+            PMU::regs().slp_wakeup_cntl5().modify(|_, w| {
                 w.lp_ana_wait_target() // pmu_ll_lp_set_analog_wait_target_cycle
                     .bits(self.lp_sys.analog_wait_target_cycle)
             });
 
-            pmu().power_wait_timer0().modify(|_, w| {
-                w.dg_hp_wait_timer() // pmu_ll_hp_set_digital_power_supply_wait_cycle
-                    .bits(self.hp_sys.digital_power_supply_wait_cycle)
-                    .dg_hp_powerup_timer() // pmu_ll_hp_set_digital_power_up_wait_cycle
+            PMU::regs().power_wait_timer0().modify(|_, w| {
+                // pmu_ll_hp_set_digital_power_supply_wait_cycle
+                w.dg_hp_wait_timer()
+                    .bits(self.hp_sys.digital_power_supply_wait_cycle);
+                // pmu_ll_hp_set_digital_power_up_wait_cycle
+                w.dg_hp_powerup_timer()
                     .bits(self.hp_sys.digital_power_up_wait_cycle)
             });
 
-            pmu().power_wait_timer1().modify(|_, w| {
-                w.dg_lp_wait_timer() // pmu_ll_lp_set_digital_power_supply_wait_cycle
-                    .bits(self.lp_sys.digital_power_supply_wait_cycle)
-                    .dg_lp_powerup_timer() // pmu_ll_lp_set_digital_power_up_wait_cycle
+            PMU::regs().power_wait_timer1().modify(|_, w| {
+                // pmu_ll_lp_set_digital_power_supply_wait_cycle
+                w.dg_lp_wait_timer()
+                    .bits(self.lp_sys.digital_power_supply_wait_cycle);
+                // pmu_ll_lp_set_digital_power_up_wait_cycle
+                w.dg_lp_powerup_timer()
                     .bits(self.lp_sys.digital_power_up_wait_cycle)
             });
 
-            pmu().power_ck_wait_cntl().modify(|_, w| {
-                w.wait_xtl_stable() // pmu_ll_set_xtal_stable_wait_cycle
-                    .bits(self.hp_lp.xtal_stable_wait_cycle)
-                    .wait_pll_stable() // pmu_ll_set_pll_stable_wait_cycle
-                    .bits(self.hp_sys.pll_stable_wait_cycle)
+            PMU::regs().power_ck_wait_cntl().modify(|_, w| {
+                // pmu_ll_set_xtal_stable_wait_cycle
+                w.wait_xtl_stable().bits(self.hp_lp.xtal_stable_wait_cycle);
+                // pmu_ll_set_pll_stable_wait_cycle
+                w.wait_pll_stable().bits(self.hp_sys.pll_stable_wait_cycle)
             });
         }
     }
@@ -472,7 +472,7 @@ impl SleepTimeConfig {
     }
 
     fn new() -> Self {
-        let slowclk_period = unsafe { lp_aon().store1().read().data().bits() };
+        let slowclk_period = LP_AON::regs().store1().read().data().bits();
 
         // Calibrate rtc fast clock, only PMU supported chips sleep process is needed.
         const FAST_CLK_SRC_CAL_CYCLES: u32 = 2048;
@@ -574,14 +574,6 @@ impl Default for RtcSleepConfig {
             need_pd_top: false,
         }
     }
-}
-
-unsafe fn pmu<'a>() -> &'a esp32h2::pmu::RegisterBlock {
-    unsafe { &*esp32h2::PMU::ptr() }
-}
-
-unsafe fn lp_aon<'a>() -> &'a esp32h2::lp_aon::RegisterBlock {
-    unsafe { &*esp32h2::LP_AON::ptr() }
 }
 
 bitfield::bitfield! {
@@ -730,11 +722,6 @@ impl RtcSleepConfig {
         });
 
         // misc_modules_sleep_prepare
-        // TODO: IDF-7370
-
-        APB_SARADC::regs()
-            .ctrl()
-            .modify(|_, w| w.saradc2_pwdet_drv().bit(false));
 
         // pmu_sleep_config_default + pmu_sleep_init
 
@@ -762,43 +749,45 @@ impl RtcSleepConfig {
 
         // pmu_sleep_start
 
-        unsafe {
-            // lp_aon_hal_inform_wakeup_type - tells ROM which wakeup stub to run
-            lp_aon()
-                .store9()
-                .modify(|r, w| w.bits(r.bits() & !0x01 | self.deep as u32));
+        // lp_aon_hal_inform_wakeup_type - tells ROM which wakeup stub to run
+        LP_AON::regs()
+            .store9()
+            .modify(|r, w| unsafe { w.bits(r.bits() & !0x01 | self.deep as u32) });
 
-            // pmu_ll_hp_set_wakeup_enable
-            pmu().slp_wakeup_cntl2().write(|w| w.bits(wakeup_mask));
+        // pmu_ll_hp_set_wakeup_enable
+        PMU::regs()
+            .slp_wakeup_cntl2()
+            .write(|w| unsafe { w.bits(wakeup_mask) });
 
-            // pmu_ll_hp_set_reject_enable
-            pmu().slp_wakeup_cntl1().modify(|_, w| {
-                w.slp_reject_en().bit(true);
-                w.sleep_reject_ena().bits(reject_mask)
-            });
+        // pmu_ll_hp_set_reject_enable
+        PMU::regs().slp_wakeup_cntl1().modify(|_, w| unsafe {
+            w.slp_reject_en().bit(true);
+            w.sleep_reject_ena().bits(reject_mask)
+        });
 
-            pmu().int_clr().write(|w| {
-                // pmu_ll_hp_clear_wakeup_intr_status
-                w.soc_wakeup().clear_bit_by_one();
-                // pmu_ll_hp_clear_reject_intr_status
-                w.soc_sleep_reject().clear_bit_by_one()
-            });
+        PMU::regs().int_clr().write(|w| {
+            // pmu_ll_hp_clear_wakeup_intr_status
+            w.soc_wakeup().clear_bit_by_one();
+            // pmu_ll_hp_clear_reject_intr_status
+            w.soc_sleep_reject().clear_bit_by_one()
+        });
 
-            // pmu_ll_hp_clear_reject_cause
-            pmu()
-                .slp_wakeup_cntl4()
-                .write(|w| w.slp_reject_cause_clr().bit(true));
+        // pmu_ll_hp_clear_reject_cause
+        PMU::regs()
+            .slp_wakeup_cntl4()
+            .write(|w| w.slp_reject_cause_clr().bit(true));
 
-            // Start entry into sleep mode
+        // Start entry into sleep mode
 
-            // pmu_ll_hp_set_sleep_enable
-            pmu().slp_wakeup_cntl0().write(|w| w.sleep_req().bit(true));
+        // pmu_ll_hp_set_sleep_enable
+        PMU::regs()
+            .slp_wakeup_cntl0()
+            .write(|w| w.sleep_req().bit(true));
 
-            loop {
-                let int_raw = pmu().int_raw().read();
-                if int_raw.soc_wakeup().bit_is_set() || int_raw.soc_sleep_reject().bit_is_set() {
-                    break;
-                }
+        loop {
+            let int_raw = PMU::regs().int_raw().read();
+            if int_raw.soc_wakeup().bit_is_set() || int_raw.soc_sleep_reject().bit_is_set() {
+                break;
             }
         }
     }

--- a/esp-hal/src/rtc_cntl/sleep/esp32h2.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32h2.rs
@@ -6,17 +6,10 @@ use crate::{
     peripherals::APB_SARADC,
     rtc_cntl::{
         Rtc,
-        rtc::{HpSysCntlReg, HpSysPower, LpSysPower},
+        rtc::{HpSysCntlReg, HpSysPower, LpSysPower, SavedClockConfig},
         sleep::{Ext1WakeupSource, WakeSource, WakeTriggers, WakeupLevel},
     },
-    soc::clocks::{
-        self,
-        ClockTree,
-        CpuClkConfig,
-        HpRootClkConfig,
-        LpSlowClkConfig,
-        TimgCalibrationClockConfig,
-    },
+    soc::clocks::{self, ClockTree, LpSlowClkConfig, TimgCalibrationClockConfig},
 };
 
 impl Ext1WakeupSource<'_, '_> {
@@ -762,17 +755,15 @@ impl RtcSleepConfig {
 
             // pmu_ll_hp_set_reject_enable
             pmu().slp_wakeup_cntl1().modify(|_, w| {
-                w.slp_reject_en()
-                    .bit(true)
-                    .sleep_reject_ena()
-                    .bits(reject_mask)
+                w.slp_reject_en().bit(true);
+                w.sleep_reject_ena().bits(reject_mask)
             });
 
             pmu().int_clr().write(|w| {
-                w.soc_wakeup() // pmu_ll_hp_clear_wakeup_intr_status
-                    .clear_bit_by_one()
-                    .soc_sleep_reject() // pmu_ll_hp_clear_reject_intr_status
-                    .clear_bit_by_one()
+                // pmu_ll_hp_clear_wakeup_intr_status
+                w.soc_wakeup().clear_bit_by_one();
+                // pmu_ll_hp_clear_reject_intr_status
+                w.soc_sleep_reject().clear_bit_by_one()
             });
 
             // pmu_ll_hp_clear_reject_cause
@@ -803,36 +794,5 @@ impl RtcSleepConfig {
     /// Cleans up after sleep
     pub(crate) fn finish_sleep(&self) {
         Self::wake_io_reset();
-    }
-}
-
-#[derive(Clone, Copy)]
-pub(crate) struct SavedClockConfig {
-    /// The clock from which CPU clock is derived
-    old_hp_root_clk: Option<HpRootClkConfig>,
-
-    /// CPU divider
-    old_cpu_divider: Option<CpuClkConfig>,
-}
-
-impl SavedClockConfig {
-    pub(crate) fn save(clocks: &ClockTree) -> Self {
-        let old_hp_root_clk = clocks.hp_root_clk();
-        let old_cpu_divider = clocks.cpu_clk();
-
-        SavedClockConfig {
-            old_hp_root_clk,
-            old_cpu_divider,
-        }
-    }
-
-    // rtc_clk_cpu_freq_set_config
-    pub(crate) fn restore(self, clocks: &mut ClockTree) {
-        if let Some(old_hp_root_clk) = self.old_hp_root_clk {
-            crate::soc::clocks::configure_hp_root_clk(clocks, old_hp_root_clk);
-        }
-        if let Some(old_cpu_divider) = self.old_cpu_divider {
-            crate::soc::clocks::configure_cpu_clk(clocks, old_cpu_divider);
-        }
     }
 }

--- a/esp-hal/src/rtc_cntl/sleep/esp32p4.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32p4.rs
@@ -4,21 +4,22 @@
 //! driver and adapted to the P4 PMU (DCDC, no wireless modem, no regdma
 //! retention) using the esp-idf `pmu_sleep.c` / `pmu_param.h` references.
 
-use core::ops::Not;
+use core::{
+    ops::Not,
+    sync::atomic::{AtomicBool, Ordering},
+};
 
 use crate::{
     clock::RtcClock,
+    peripherals::{HP_SYS_CLKRST, LP_AON_CLKRST, PMU, USB_DEVICE},
+    private::DropGuard,
     rtc_cntl::{
         Rtc,
-        rtc::{HpAnalog, HpSysCntlReg, HpSysPower, LpAnalog, LpSysPower, SavedClockConfig},
+        rtc::{HpAnalog, HpSysCntlReg, HpSysPower, LpAnalog, LpSysPower},
         sleep::WakeTriggers,
     },
     soc::clocks::{self, ClockTree, CpuRootClkConfig, LpSlowClkConfig, TimgCalibrationClockConfig},
 };
-
-unsafe fn pmu<'a>() -> &'a esp32p4::pmu::RegisterBlock {
-    unsafe { &*esp32p4::PMU::ptr() }
-}
 
 // ----------------------------------------------------------------------------
 // USB-Serial-JTAG pad handling across light sleep.
@@ -32,14 +33,12 @@ unsafe fn pmu<'a>() -> &'a esp32p4::pmu::RegisterBlock {
 // support keeping USJ alive across light sleep, so this is unconditional.
 // ----------------------------------------------------------------------------
 
-use core::sync::atomic::{AtomicBool, Ordering};
-
 static USJ_CLOCK_WAS_ENABLED: AtomicBool = AtomicBool::new(false);
 static USJ_PAD_WAS_ENABLED: AtomicBool = AtomicBool::new(false);
 
 fn usj_module_is_enabled() -> bool {
-    let clkrst = crate::peripherals::HP_SYS_CLKRST::regs();
-    let aon = crate::peripherals::LP_AON_CLKRST::regs();
+    let clkrst = HP_SYS_CLKRST::regs();
+    let aon = LP_AON_CLKRST::regs();
     clkrst
         .soc_clk_ctrl2()
         .read()
@@ -53,17 +52,17 @@ fn usj_module_is_enabled() -> bool {
 }
 
 fn usj_enable_bus_clock(enable: bool) {
-    crate::peripherals::HP_SYS_CLKRST::regs()
+    HP_SYS_CLKRST::regs()
         .soc_clk_ctrl2()
         .modify(|_, w| w.usb_device_apb_clk_en().bit(enable));
     // PHY 48 MHz clock for USB FSLS PHY 0.
-    crate::peripherals::LP_AON_CLKRST::regs()
+    LP_AON_CLKRST::regs()
         .lp_aonclkrst_hp_usb_clkrst_ctrl0()
         .modify(|_, w| w.lp_aonclkrst_usb_device_48m_clk_en().bit(enable));
 }
 
 fn usj_reset_register() {
-    let aon = crate::peripherals::LP_AON_CLKRST::regs();
+    let aon = LP_AON_CLKRST::regs();
     aon.lp_aonclkrst_hp_usb_clkrst_ctrl1()
         .modify(|_, w| w.lp_aonclkrst_rst_en_usb_device().set_bit());
     aon.lp_aonclkrst_hp_usb_clkrst_ctrl1()
@@ -71,13 +70,13 @@ fn usj_reset_register() {
 }
 
 fn usj_set_pad_enable(enable: bool) {
-    crate::peripherals::USB_DEVICE::regs()
+    USB_DEVICE::regs()
         .conf0()
         .modify(|_, w| w.usb_pad_enable().bit(enable));
 }
 
 fn usj_pad_is_enabled() -> bool {
-    crate::peripherals::USB_DEVICE::regs()
+    USB_DEVICE::regs()
         .conf0()
         .read()
         .usb_pad_enable()
@@ -239,7 +238,7 @@ fn install_mspi_workaround_stub() {
 /// `lp_clkrst_ll_boot_from_lp_ram`: `hpcore0_stat_vector_sel = !boot_from_lp_ram`
 /// (0 -> boot from LP SPM RAM 0x50108000, 1 -> boot from HP ROM 0x4FC00000).
 fn set_boot_from_lp_ram(boot_from_lp_ram: bool) {
-    crate::peripherals::LP_AON_CLKRST::regs()
+    LP_AON_CLKRST::regs()
         .lp_aonclkrst_hpcpu_reset_ctrl0()
         .modify(|_, w| {
             w.lp_aonclkrst_hpcore0_stat_vector_sel()
@@ -267,15 +266,16 @@ fn pmu_sleep_dcdc_to_ldo_handover() {
     const LDO_TAKEOVER_DBIAS: u8 = 30;
     const LDO_TAKEOVER_DCM_VSET: u8 = 24;
 
-    let pmu = unsafe { pmu() };
-
     // pmu_sleep_increase_ldo_volt(): raise the HP LDO and pre-lower the DCDC
     // voltage so the LDO can take over without overshoot.
-    pmu.hp_active_hp_regulator0()
+    PMU::regs()
+        .hp_active_hp_regulator0()
         .modify(|_, w| unsafe { w.hp_active_hp_regulator_dbias().bits(LDO_TAKEOVER_DBIAS) });
-    pmu.hp_active_hp_regulator0()
+    PMU::regs()
+        .hp_active_hp_regulator0()
         .modify(|_, w| w.hp_active_hp_regulator_xpd().set_bit());
-    pmu.hp_active_bias()
+    PMU::regs()
+        .hp_active_bias()
         .modify(|_, w| unsafe { w.hp_active_dcm_vset().bits(LDO_TAKEOVER_DCM_VSET) });
 
     crate::rom::ets_delay_us(LDO_TAKEOVER_PREPARATION_TIME_US);
@@ -283,11 +283,12 @@ fn pmu_sleep_dcdc_to_ldo_handover() {
     // pmu_sleep_shutdown_dcdc(): request the DCDC off (done_force latches it off,
     // the dcdc_switch stays on and is disabled by the PMU when sleep is entered)
     // and drop the HP LDO back to the active default voltage.
-    pmu.dcm_ctrl().modify(|_, w| {
+    PMU::regs().dcm_ctrl().modify(|_, w| {
         w.dcdc_off_req().set_bit();
         w.dcdc_done_force().set_bit()
     });
-    pmu.hp_active_hp_regulator0()
+    PMU::regs()
+        .hp_active_hp_regulator0()
         .modify(|_, w| unsafe { w.hp_active_hp_regulator_dbias().bits(HP_CALI_ACTIVE_DBIAS) });
 }
 
@@ -376,58 +377,57 @@ impl AnalogSleepConfig {
 
     fn apply(&self, dslp: bool) {
         // pmu_sleep_analog_init
-        unsafe {
-            // HP_ACTIVE dcm_mode (deep sleep forces 0, otherwise 1).
-            pmu()
-                .hp_active_bias()
-                .modify(|_, w| w.hp_active_dcm_mode().bits(if dslp { 0 } else { 1 }));
 
-            pmu().hp_sleep_bias().modify(|_, w| {
-                w.hp_sleep_dcm_mode().bits(self.hp_sys.bias.dcm_mode());
-                w.hp_sleep_dcm_vset().bits(self.hp_sys.bias.dcm_vset());
-                w.hp_sleep_dbg_atten().bits(self.hp_sys.bias.dbg_atten());
-                w.hp_sleep_pd_cur().bit(self.hp_sys.bias.pd_cur());
-                w.sleep().bit(self.hp_sys.bias.bias_sleep())
-            });
-            pmu().hp_sleep_hp_regulator0().modify(|_, w| {
-                w.hp_sleep_hp_regulator_slp_mem_xpd()
-                    .bit(self.hp_sys.regulator0.slp_mem_xpd());
-                w.hp_sleep_hp_regulator_slp_logic_xpd()
-                    .bit(self.hp_sys.regulator0.slp_logic_xpd());
-                w.hp_sleep_hp_regulator_xpd()
-                    .bit(self.hp_sys.regulator0.xpd());
-                w.hp_sleep_hp_regulator_slp_logic_dbias()
-                    .bits(self.hp_sys.regulator0.slp_logic_dbias());
-                w.hp_sleep_hp_regulator_dbias()
-                    .bits(self.hp_sys.regulator0.dbias())
-            });
-            pmu().hp_sleep_hp_regulator1().modify(|_, w| {
-                w.hp_sleep_hp_regulator_drv_b()
-                    .bits(self.hp_sys.regulator1.drv_b())
-            });
+        // HP_ACTIVE dcm_mode (deep sleep forces 0, otherwise 1).
+        PMU::regs()
+            .hp_active_bias()
+            .modify(|_, w| unsafe { w.hp_active_dcm_mode().bits(if dslp { 0 } else { 1 }) });
 
-            // LP_SLEEP
-            pmu().lp_sleep_bias().modify(|_, w| {
-                w.lp_sleep_dbg_atten()
-                    .bits(self.lp_sys_sleep.bias.dbg_atten());
-                w.lp_sleep_pd_cur().bit(self.lp_sys_sleep.bias.pd_cur());
-                w.sleep().bit(self.lp_sys_sleep.bias.bias_sleep())
-            });
-            pmu().lp_sleep_lp_regulator0().modify(|_, w| {
-                w.lp_sleep_lp_regulator_slp_xpd()
-                    .bit(self.lp_sys_sleep.regulator0.slp_xpd());
-                w.lp_sleep_lp_regulator_xpd()
-                    .bit(self.lp_sys_sleep.regulator0.xpd());
-                w.lp_sleep_lp_regulator_slp_dbias()
-                    .bits(self.lp_sys_sleep.regulator0.slp_dbias());
-                w.lp_sleep_lp_regulator_dbias()
-                    .bits(self.lp_sys_sleep.regulator0.dbias())
-            });
-            pmu().lp_sleep_lp_regulator1().modify(|_, w| {
-                w.lp_sleep_lp_regulator_drv_b()
-                    .bits(self.lp_sys_sleep.regulator1.drv_b())
-            });
-        }
+        PMU::regs().hp_sleep_bias().modify(|_, w| unsafe {
+            w.hp_sleep_dcm_mode().bits(self.hp_sys.bias.dcm_mode());
+            w.hp_sleep_dcm_vset().bits(self.hp_sys.bias.dcm_vset());
+            w.hp_sleep_dbg_atten().bits(self.hp_sys.bias.dbg_atten());
+            w.hp_sleep_pd_cur().bit(self.hp_sys.bias.pd_cur());
+            w.sleep().bit(self.hp_sys.bias.bias_sleep())
+        });
+        PMU::regs().hp_sleep_hp_regulator0().modify(|_, w| unsafe {
+            w.hp_sleep_hp_regulator_slp_mem_xpd()
+                .bit(self.hp_sys.regulator0.slp_mem_xpd());
+            w.hp_sleep_hp_regulator_slp_logic_xpd()
+                .bit(self.hp_sys.regulator0.slp_logic_xpd());
+            w.hp_sleep_hp_regulator_xpd()
+                .bit(self.hp_sys.regulator0.xpd());
+            w.hp_sleep_hp_regulator_slp_logic_dbias()
+                .bits(self.hp_sys.regulator0.slp_logic_dbias());
+            w.hp_sleep_hp_regulator_dbias()
+                .bits(self.hp_sys.regulator0.dbias())
+        });
+        PMU::regs().hp_sleep_hp_regulator1().modify(|_, w| unsafe {
+            w.hp_sleep_hp_regulator_drv_b()
+                .bits(self.hp_sys.regulator1.drv_b())
+        });
+
+        // LP_SLEEP
+        PMU::regs().lp_sleep_bias().modify(|_, w| unsafe {
+            w.lp_sleep_dbg_atten()
+                .bits(self.lp_sys_sleep.bias.dbg_atten());
+            w.lp_sleep_pd_cur().bit(self.lp_sys_sleep.bias.pd_cur());
+            w.sleep().bit(self.lp_sys_sleep.bias.bias_sleep())
+        });
+        PMU::regs().lp_sleep_lp_regulator0().modify(|_, w| unsafe {
+            w.lp_sleep_lp_regulator_slp_xpd()
+                .bit(self.lp_sys_sleep.regulator0.slp_xpd());
+            w.lp_sleep_lp_regulator_xpd()
+                .bit(self.lp_sys_sleep.regulator0.xpd());
+            w.lp_sleep_lp_regulator_slp_dbias()
+                .bits(self.lp_sys_sleep.regulator0.slp_dbias());
+            w.lp_sleep_lp_regulator_dbias()
+                .bits(self.lp_sys_sleep.regulator0.dbias())
+        });
+        PMU::regs().lp_sleep_lp_regulator1().modify(|_, w| unsafe {
+            w.lp_sleep_lp_regulator_drv_b()
+                .bits(self.lp_sys_sleep.regulator1.drv_b())
+        });
     }
 }
 
@@ -456,15 +456,14 @@ impl DigitalSleepConfig {
 
     fn apply(&self) {
         // pmu_sleep_digital_init
-        unsafe {
-            pmu().hp_sleep_hp_sys_cntl().modify(|_, w| {
-                w.hp_sleep_dig_pad_slp_sel()
-                    .bit(self.syscntl.dig_pad_slp_sel());
-                w.hp_sleep_lp_pad_hold_all()
-                    .bit(self.syscntl.lp_pad_hold_all());
-                w.hp_sleep_dig_pause_wdt().bit(self.syscntl.dig_pause_wdt())
-            });
-        }
+
+        PMU::regs().hp_sleep_hp_sys_cntl().modify(|_, w| {
+            w.hp_sleep_dig_pad_slp_sel()
+                .bit(self.syscntl.dig_pad_slp_sel());
+            w.hp_sleep_lp_pad_hold_all()
+                .bit(self.syscntl.lp_pad_hold_all());
+            w.hp_sleep_dig_pause_wdt().bit(self.syscntl.dig_pause_wdt())
+        });
     }
 }
 
@@ -538,37 +537,36 @@ impl PowerSleepConfig {
 
     fn apply(&self) {
         // pmu_sleep_power_init
-        unsafe {
-            // HP_SLEEP
-            pmu()
-                .hp_sleep_dig_power()
-                .modify(|_, w| w.bits(self.hp_sys.dig_power.0));
-            pmu()
-                .hp_sleep_hp_ck_power()
-                .modify(|_, w| w.bits(self.hp_sys.clk.0));
-            pmu()
-                .hp_sleep_xtal()
-                .modify(|_, w| w.hp_sleep_xpd_xtal().bit(self.hp_sys.xtal.xpd_xtal()));
 
-            // LP_ACTIVE (hp_sleep_lp_*)
-            pmu()
-                .hp_sleep_lp_dig_power()
-                .modify(|_, w| w.bits(self.lp_sys_active.dig_power.0));
-            pmu()
-                .hp_sleep_lp_ck_power()
-                .modify(|_, w| w.bits(self.lp_sys_active.clk_power.0));
+        // HP_SLEEP
+        PMU::regs()
+            .hp_sleep_dig_power()
+            .modify(|_, w| unsafe { w.bits(self.hp_sys.dig_power.0) });
+        PMU::regs()
+            .hp_sleep_hp_ck_power()
+            .modify(|_, w| unsafe { w.bits(self.hp_sys.clk.0) });
+        PMU::regs()
+            .hp_sleep_xtal()
+            .modify(|_, w| w.hp_sleep_xpd_xtal().bit(self.hp_sys.xtal.xpd_xtal()));
 
-            // LP_SLEEP
-            pmu()
-                .lp_sleep_lp_dig_power()
-                .modify(|_, w| w.bits(self.lp_sys_sleep.dig_power.0));
-            pmu()
-                .lp_sleep_lp_ck_power()
-                .modify(|_, w| w.bits(self.lp_sys_sleep.clk_power.0));
-            pmu()
-                .lp_sleep_xtal()
-                .modify(|_, w| w.lp_sleep_xpd_xtal().bit(self.lp_sys_sleep.xtal.xpd_xtal()));
-        }
+        // LP_ACTIVE (hp_sleep_lp_*)
+        PMU::regs()
+            .hp_sleep_lp_dig_power()
+            .modify(|_, w| unsafe { w.bits(self.lp_sys_active.dig_power.0) });
+        PMU::regs()
+            .hp_sleep_lp_ck_power()
+            .modify(|_, w| unsafe { w.bits(self.lp_sys_active.clk_power.0) });
+
+        // LP_SLEEP
+        PMU::regs()
+            .lp_sleep_lp_dig_power()
+            .modify(|_, w| unsafe { w.bits(self.lp_sys_sleep.dig_power.0) });
+        PMU::regs()
+            .lp_sleep_lp_ck_power()
+            .modify(|_, w| unsafe { w.bits(self.lp_sys_sleep.clk_power.0) });
+        PMU::regs()
+            .lp_sleep_xtal()
+            .modify(|_, w| w.lp_sleep_xpd_xtal().bit(self.lp_sys_sleep.xtal.xpd_xtal()));
     }
 }
 
@@ -608,45 +606,41 @@ pub struct ParamSleepConfig {
 impl ParamSleepConfig {
     fn apply(&self) {
         // pmu_sleep_param_init
-        unsafe {
-            pmu().slp_wakeup_cntl3().modify(|_, w| {
-                w.hp_min_slp_val()
-                    .bits(self.hp_sys.min_slp_slow_clk_cycle)
-                    .lp_min_slp_val()
-                    .bits(self.lp_sys.min_slp_slow_clk_cycle)
-            });
+        PMU::regs().slp_wakeup_cntl3().modify(|_, w| unsafe {
+            w.hp_min_slp_val().bits(self.hp_sys.min_slp_slow_clk_cycle);
+            w.lp_min_slp_val().bits(self.lp_sys.min_slp_slow_clk_cycle)
+        });
 
-            pmu().slp_wakeup_cntl7().modify(|_, w| {
-                w.ana_wait_target()
-                    .bits(self.hp_sys.analog_wait_target_cycle)
-            });
+        PMU::regs().slp_wakeup_cntl7().modify(|_, w| unsafe {
+            w.ana_wait_target()
+                .bits(self.hp_sys.analog_wait_target_cycle)
+        });
 
-            pmu().power_wait_timer0().modify(|_, w| {
-                w.dg_hp_wait_timer()
-                    .bits(self.hp_sys.digital_power_supply_wait_cycle)
-                    .dg_hp_powerup_timer()
-                    .bits(self.hp_sys.digital_power_up_wait_cycle)
-            });
+        PMU::regs().power_wait_timer0().modify(|_, w| unsafe {
+            w.dg_hp_wait_timer()
+                .bits(self.hp_sys.digital_power_supply_wait_cycle);
+            w.dg_hp_powerup_timer()
+                .bits(self.hp_sys.digital_power_up_wait_cycle)
+        });
 
-            pmu().power_wait_timer1().modify(|_, w| {
-                w.dg_lp_wait_timer()
-                    .bits(self.lp_sys.digital_power_supply_wait_cycle)
-                    .dg_lp_powerup_timer()
-                    .bits(self.lp_sys.digital_power_up_wait_cycle)
-            });
+        PMU::regs().power_wait_timer1().modify(|_, w| unsafe {
+            w.dg_lp_wait_timer()
+                .bits(self.lp_sys.digital_power_supply_wait_cycle);
+            w.dg_lp_powerup_timer()
+                .bits(self.lp_sys.digital_power_up_wait_cycle)
+        });
 
-            pmu().slp_wakeup_cntl5().modify(|_, w| {
-                w.lp_ana_wait_target()
-                    .bits(self.lp_sys.analog_wait_target_cycle)
-            });
+        PMU::regs().slp_wakeup_cntl5().modify(|_, w| unsafe {
+            w.lp_ana_wait_target()
+                .bits(self.lp_sys.analog_wait_target_cycle)
+        });
 
-            pmu().power_ck_wait_cntl().modify(|_, w| {
-                w.pmu_wait_xtl_stable()
-                    .bits(self.hp_lp.xtal_stable_wait_cycle)
-                    .pmu_wait_pll_stable()
-                    .bits(self.hp_sys.pll_stable_wait_cycle)
-            });
-        }
+        PMU::regs().power_ck_wait_cntl().modify(|_, w| unsafe {
+            w.pmu_wait_xtl_stable()
+                .bits(self.hp_lp.xtal_stable_wait_cycle);
+            w.pmu_wait_pll_stable()
+                .bits(self.hp_sys.pll_stable_wait_cycle)
+        });
     }
 
     fn defaults(config: SleepTimeConfig, pd_flags: PowerDownFlags, pd_xtal: bool) -> Self {
@@ -990,10 +984,19 @@ impl RtcSleepConfig {
         };
 
         // Switch the CPU root clock to XTAL for the duration of sleep.
-        let cpu_freq_config = ClockTree::with(|clocks| {
-            let cpu_freq_config = SavedClockConfig::save(clocks);
+        let _restore_clock_config = ClockTree::with(|clocks| {
+            let old_cpu_root_clk = clocks.cpu_root_clk();
+
             clocks::configure_cpu_root_clk(clocks, CpuRootClkConfig::Xtal);
-            cpu_freq_config
+
+            // Restore the old clock settings when we return
+            DropGuard::new((), move |_| {
+                ClockTree::with(|clocks| {
+                    if let Some(old) = old_cpu_root_clk {
+                        clocks::configure_cpu_root_clk(clocks, old);
+                    }
+                });
+            })
         });
 
         let power = PowerSleepConfig::defaults(self.pd_flags);
@@ -1034,68 +1037,73 @@ impl RtcSleepConfig {
         }
 
         // like esp-idf pmu_sleep_start()
-        unsafe {
-            // lp_aon_hal_inform_wakeup_type: on P4 RTC_SLEEP_MODE_REG is
-            // LP_SYSTEM_REG_LP_STORE8 (bit0 = run deep-sleep wake stub). The ROM
-            // reads this on wake to pick the deep vs light wake path.
-            crate::peripherals::LP_AON::regs()
-                .lp_store8()
-                .modify(|r, w| w.bits(r.bits() & !0x01 | self.deep as u32));
 
-            pmu().slp_wakeup_cntl2().write(|w| w.bits(wakeup_mask));
+        // lp_aon_hal_inform_wakeup_type: on P4 RTC_SLEEP_MODE_REG is
+        // LP_SYSTEM_REG_LP_STORE8 (bit0 = run deep-sleep wake stub). The ROM
+        // reads this on wake to pick the deep vs light wake path.
+        crate::peripherals::LP_AON::regs()
+            .lp_store8()
+            .modify(|r, w| unsafe { w.bits(r.bits() & !0x01 | self.deep as u32) });
 
-            pmu().slp_wakeup_cntl1().modify(|_, w| {
-                w.slp_reject_en().bit(true);
-                w.sleep_reject_ena().bits(reject_mask)
-            });
+        PMU::regs()
+            .slp_wakeup_cntl2()
+            .write(|w| unsafe { w.bits(wakeup_mask) });
 
-            pmu()
-                .slp_wakeup_cntl4()
-                .write(|w| w.slp_reject_cause_clr().bit(true));
+        PMU::regs().slp_wakeup_cntl1().modify(|_, w| unsafe {
+            w.slp_reject_en().bit(true);
+            w.sleep_reject_ena().bits(reject_mask)
+        });
 
-            pmu().int_clr().write(|w| {
-                w.sw().clear_bit_by_one();
-                w.soc_sleep_reject().clear_bit_by_one();
-                w.soc_wakeup().clear_bit_by_one()
-            });
+        PMU::regs()
+            .slp_wakeup_cntl4()
+            .write(|w| w.slp_reject_cause_clr().bit(true));
 
-            // ESP32-P4 deep-sleep DCDC -> LDO supply handover. The HP digital rail
-            // is normally fed by the on-chip DCDC; if it is left running while the
-            // PMU powers down the DCDC switch on deep-sleep entry, the rail glitches
-            // when the LDO takes over on wake-up and the chip fails to reboot (it
-            // looks like it "never wakes"). esp-idf raises the HP LDO so it can take
-            // over, waits for it to settle, then disables the DCDC before entering
-            // deep sleep (pmu_sleep_increase_ldo_volt + pmu_sleep_shutdown_dcdc).
-            // C-series parts have no DCDC and skip this.
-            if self.deep {
-                pmu_sleep_dcdc_to_ldo_handover();
-            }
+        PMU::regs().int_clr().write(|w| {
+            w.sw().clear_bit_by_one();
+            w.soc_sleep_reject().clear_bit_by_one();
+            w.soc_wakeup().clear_bit_by_one()
+        });
 
-            // Light sleep keeps the HP domain (and thus the USJ PHY) powered, so
-            // de-enumerate USB-Serial-JTAG cleanly before sleeping and restore it
-            // in `finish_sleep`. Deep sleep powers the PHY off on its own.
-            if !self.deep {
-                usj_pad_backup_and_disable();
-            }
+        // ESP32-P4 deep-sleep DCDC -> LDO supply handover. The HP digital rail
+        // is normally fed by the on-chip DCDC; if it is left running while the
+        // PMU powers down the DCDC switch on deep-sleep entry, the rail glitches
+        // when the LDO takes over on wake-up and the chip fails to reboot (it
+        // looks like it "never wakes"). esp-idf raises the HP LDO so it can take
+        // over, waits for it to settle, then disables the DCDC before entering
+        // deep sleep (pmu_sleep_increase_ldo_volt + pmu_sleep_shutdown_dcdc).
+        // C-series parts have no DCDC and skip this.
+        if self.deep {
+            pmu_sleep_dcdc_to_ldo_handover();
+        }
 
-            // The PMU FSM switches the pads to their sleep setting and holds IOs
-            // at the same stage; trigger the pad sleep selection first so the IOs
-            // do not get held in an indeterminate state.
-            pmu()
-                .imm_pad_hold_all()
-                .write(|w| w.tie_high_pad_slp_sel().set_bit());
+        // Light sleep keeps the HP domain (and thus the USJ PHY) powered, so
+        // de-enumerate USB-Serial-JTAG cleanly before sleeping and restore it
+        // in `finish_sleep`. Deep sleep powers the PHY off on its own.
+        if !self.deep {
+            usj_pad_backup_and_disable();
+        }
 
-            // FIXME HERE
+        // The PMU FSM switches the pads to their sleep setting and holds IOs
+        // at the same stage; trigger the pad sleep selection first so the IOs
+        // do not get held in an indeterminate state.
 
-            // Start entry into sleep mode.
-            pmu().slp_wakeup_cntl0().write(|w| w.sleep_req().bit(true));
+        PMU::regs()
+            .imm_pad_hold_all()
+            .write(|w| w.tie_high_pad_slp_sel().set_bit());
 
-            // In deep sleep we never get here.
-            loop {
-                let int_raw = pmu().int_raw().read();
-                if int_raw.soc_wakeup().bit_is_set() || int_raw.soc_sleep_reject().bit_is_set() {
-                    break;
-                }
+        // FIXME HERE
+
+        // Start entry into sleep mode.
+
+        PMU::regs()
+            .slp_wakeup_cntl0()
+            .write(|w| w.sleep_req().bit(true));
+
+        // In deep sleep we never get here.
+        loop {
+            let int_raw = PMU::regs().int_raw().read();
+            if int_raw.soc_wakeup().bit_is_set() || int_raw.soc_sleep_reject().bit_is_set() {
+                break;
             }
         }
 
@@ -1105,10 +1113,6 @@ impl RtcSleepConfig {
         if mspi_workaround {
             set_boot_from_lp_ram(false);
         }
-
-        ClockTree::with(|clocks| {
-            cpu_freq_config.restore(clocks);
-        });
     }
 
     /// Cleans up after sleep.
@@ -1116,11 +1120,10 @@ impl RtcSleepConfig {
     pub(crate) fn finish_sleep(&self) {
         // like esp-idf pmu_sleep_finish(): switch the pad configuration back from
         // the sleep state to the active state. In deep sleep we never get here.
-        unsafe {
-            pmu()
-                .imm_pad_hold_all()
-                .write(|w| w.tie_low_pad_slp_sel().set_bit());
-        }
+
+        PMU::regs()
+            .imm_pad_hold_all()
+            .write(|w| w.tie_low_pad_slp_sel().set_bit());
 
         // Re-enumerate USB-Serial-JTAG (only disabled for light sleep; in deep
         // sleep we never reach here).

--- a/esp-hal/src/soc/esp32c6/trng.rs
+++ b/esp-hal/src/soc/esp32c6/trng.rs
@@ -1,5 +1,5 @@
 use crate::{
-    peripherals::{APB_SARADC, PCR, PMU},
+    peripherals::{APB_SARADC, PCR},
     soc::regi2c,
 };
 
@@ -12,7 +12,6 @@ const PATTERN_BIT_WIDTH: u32 = 6;
 /// Blocks `ADC` usage.
 pub(crate) fn ensure_randomness() {
     let pcr = PCR::regs();
-    let pmu = PMU::regs();
     let apb_saradc = APB_SARADC::regs();
 
     unsafe {
@@ -38,12 +37,6 @@ pub(crate) fn ensure_randomness() {
         // changed)
         pcr.saradc_clkm_conf()
             .modify(|_, w| w.saradc_clkm_div_num().bits(0));
-
-        // some ADC sensor registers are in power group PERIF_I2C and need to be enabled
-        // via PMU
-        pmu.rf_pwc().modify(|_, w| w.perif_i2c_rstb().set_bit());
-
-        pmu.rf_pwc().modify(|_, w| w.xpd_perif_i2c().set_bit());
 
         // Config ADC circuit (Analog part) with I2C(HOST ID 0x69) and chose internal
         // voltage as sampling source

--- a/esp-radio/src/radio_clocks/clocks_ll/esp32c5.rs
+++ b/esp-radio/src/radio_clocks/clocks_ll/esp32c5.rs
@@ -62,9 +62,7 @@ pub(crate) fn reset_wifi_mac() {
 }
 
 pub(crate) fn init_clocks() {
-    regs!(MODEM_LPCON)
-        .clk_conf()
-        .modify(|_, w| w.clk_i2c_mst_en().set_bit().clk_wifipwr_en().set_bit());
+    // done in esp-hal
 }
 
 pub(crate) fn ble_rtc_clk_init() {

--- a/esp-radio/src/radio_clocks/clocks_ll/esp32c6.rs
+++ b/esp-radio/src/radio_clocks/clocks_ll/esp32c6.rs
@@ -82,54 +82,7 @@ pub(crate) fn reset_wifi_mac() {
 }
 
 pub(crate) fn init_clocks() {
-    unsafe {
-        regs!(PMU)
-            .hp_sleep_icg_modem()
-            .modify(|_, w| w.hp_sleep_dig_icg_modem_code().bits(0));
-        regs!(PMU)
-            .hp_modem_icg_modem()
-            .modify(|_, w| w.hp_modem_dig_icg_modem_code().bits(1));
-        regs!(PMU)
-            .hp_active_icg_modem()
-            .modify(|_, w| w.hp_active_dig_icg_modem_code().bits(2));
-        regs!(PMU)
-            .imm_modem_icg()
-            .write(|w| w.update_dig_icg_modem_en().set_bit());
-        regs!(PMU)
-            .imm_sleep_sysclk()
-            .write(|w| w.update_dig_icg_switch().set_bit());
-
-        regs!(MODEM_SYSCON).clk_conf_power_st().modify(|_, w| {
-            w.clk_modem_apb_st_map().bits(6);
-            w.clk_modem_peri_st_map().bits(4);
-            w.clk_wifi_st_map().bits(6);
-            w.clk_bt_st_map().bits(6);
-            w.clk_fe_st_map().bits(6);
-            w.clk_zb_st_map().bits(6)
-        });
-
-        regs!(MODEM_LPCON).clk_conf_power_st().modify(|_, w| {
-            w.clk_lp_apb_st_map().bits(6);
-            w.clk_i2c_mst_st_map().bits(6);
-            w.clk_coex_st_map().bits(6);
-            w.clk_wifipwr_st_map().bits(6)
-        });
-
-        regs!(MODEM_LPCON).wifi_lp_clk_conf().modify(|_, w| {
-            w.clk_wifipwr_lp_sel_osc_slow().set_bit();
-            w.clk_wifipwr_lp_sel_osc_fast().set_bit();
-            w.clk_wifipwr_lp_sel_xtal32k().set_bit();
-            w.clk_wifipwr_lp_sel_xtal().set_bit()
-        });
-
-        regs!(MODEM_LPCON)
-            .wifi_lp_clk_conf()
-            .modify(|_, w| w.clk_wifipwr_lp_div_num().bits(0));
-
-        regs!(MODEM_LPCON)
-            .clk_conf()
-            .modify(|_, w| w.clk_wifipwr_en().set_bit());
-    }
+    // done in esp-hal
 }
 
 pub(crate) fn ble_rtc_clk_init() {

--- a/esp-radio/src/radio_clocks/clocks_ll/esp32c61.rs
+++ b/esp-radio/src/radio_clocks/clocks_ll/esp32c61.rs
@@ -37,9 +37,7 @@ pub(crate) fn reset_wifi_mac() {
 }
 
 pub(crate) fn init_clocks() {
-    regs!(MODEM_LPCON)
-        .clk_conf()
-        .modify(|_, w| w.clk_i2c_mst_en().set_bit().clk_wifipwr_en().set_bit());
+    // done in esp-hal
 }
 
 pub(crate) fn ble_rtc_clk_init() {


### PR DESCRIPTION
Mostly cosmetic (breaking up a bunch of `x.y().bit(foo).z().bit(foo)` trains, removing unnecessary helper functions), but also deduplicates clock setup between esp-hal and esp-radio.