### PR TITLE
Model and use P4 PLLs

### DIFF
--- a/esp-hal/src/psram/esp32p4.rs
+++ b/esp-hal/src/psram/esp32p4.rs
@@ -5,6 +5,7 @@
 
 use super::{EXTMEM_ORIGIN, PsramSize};
 use crate::{
+    clock::ll::{ClockTree, mpll_clk_frequency, request_mpll_clk},
     efuse,
     peripherals::{HP_SYS, HP_SYS_CLKRST, LP_AON_CLKRST, PMU},
     soc::{pac, regi2c},
@@ -60,62 +61,33 @@ pub enum PsramMode {
     // Oct,
 }
 
-/// PSRAM bus frequency.
+/// Maximum PSRAM bus frequency.
 ///
-/// Choice ties together MPLL freq + bus divider + chip-side read/write latency.
+/// This value should be tuned together with the MPLL frequency. The effective bus clock
+/// will be at most the SpiRamFreq value, obtained by dividing MPLL using an integer divider.
 ///
 /// | Variant   | MPLL | div | MR0.RL | MR4.WL | RD dummy bits | Use case               |
 /// |-----------|------|-----|--------|--------|---------------|------------------------|
 /// | `Mhz20`   | 400  | 20  | 2      | 2      | 18            | Low-power / debug      |
 /// | `Mhz80`   | 320  | 4   | 2      | 2      | 18            | Conservative SI margin |
 /// | `Mhz200`  | 400  | 2   | 4      | 1      | 26            | IDF default            |
-/// | `Mhz250`  | 500  | 2   | 6      | 3      | 34            | Overclock              |
+/// | `Mhz250`  | 500  | 2   | 6      | 3      | 34            | Default                |
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[instability::unstable]
 pub enum SpiRamFreq {
-    /// 20 MHz bus (MPLL 400 / div 20).
+    /// 20 MHz.
     Mhz20  = 20,
 
-    /// 80 MHz bus (MPLL 320 / div 4).
-    ///
-    /// Conservative; widest timing margin.
+    /// 80 MHz.
     Mhz80  = 80,
 
-    /// 200 MHz bus (MPLL 400 / div 2).
-    ///
-    /// IDF default for AP HEX PSRAM.
-    #[default]
+    /// 200 MHz.
     Mhz200 = 200,
 
-    /// 250 MHz bus (MPLL 500 / div 2).
+    /// 250 MHz.
+    #[default]
     Mhz250 = 250,
-}
-
-/// MPLL target frequency override.
-///
-/// IDF only programs three discrete MPLL frequencies for the PSRAM
-/// clock domain (`MSPI_TIMING_MPLL_FREQ_MHZ` in
-/// `mspi_timing_tuning_configs.h`):
-///
-///   - `Mhz320` -> paired with `SpiRamFreq::Mhz80`
-///   - `Mhz400` -> paired with `SpiRamFreq::Mhz20` / `Mhz200`
-///   - `Mhz500` -> paired with `SpiRamFreq::Mhz250` (silicon v3+)
-///
-/// The MPLL itself can in principle be set to any value that satisfies
-/// the formula `XTAL(40) * (div+1) / (ref_div+1)`, but only these three
-/// have been silicon-validated.
-#[derive(Copy, Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[instability::unstable]
-pub enum MpllFreq {
-    /// 320 MHz. IDF pairing: `SpiRamFreq::Mhz80`.
-    Mhz320 = 320,
-    /// 400 MHz. IDF pairing: `SpiRamFreq::Mhz20` or `Mhz200`. Default
-    /// when `core_clock = None` and `ram_frequency = Mhz200`.
-    Mhz400 = 400,
-    /// 500 MHz. IDF pairing: `SpiRamFreq::Mhz250` (silicon v3.0+).
-    Mhz500 = 500,
 }
 
 /// PSRAM configuration.
@@ -127,10 +99,7 @@ pub struct PsramConfig {
     pub mode: PsramMode,
     /// Size of PSRAM to map. Default: `AutoDetect` via MR2 density.
     pub size: PsramSize,
-    /// MPLL override. `None` (default) derives the MPLL frequency
-    /// from `ram_frequency` per the table on `SpiRamFreq`.
-    pub core_clock: Option<MpllFreq>,
-    /// PSRAM bus frequency. Default: 200 MHz.
+    /// PSRAM bus frequency. Default: 250 MHz.
     pub ram_frequency: SpiRamFreq,
     // TODO: ECC enable.
     // The MSPI0 controller has a ECC engine.
@@ -147,12 +116,9 @@ pub(crate) fn map_psram(config: PsramConfig) -> core::ops::Range<usize> {
     start..start + config.size.get()
 }
 
-/// Per-speed timing parameters. Mirrors IDF's `#if CONFIG_SPIRAM_SPEED_*`
-/// branches in `esp_psram_impl_ap_hex.c` + `mspi_timing_tuning_configs.h`.
+/// Per-speed timing parameters.
 #[derive(Copy, Clone)]
 struct SpeedParams {
-    /// MPLL freq the analog block must run at.
-    mpll_mhz: u32,
     /// Bus clock divider applied to MPLL.
     bus_div: u32,
     /// MR0.read_latency field value (cycles = 2 * value + 6).
@@ -168,11 +134,12 @@ struct SpeedParams {
 }
 
 impl SpeedParams {
-    const fn for_freq(f: SpiRamFreq) -> Self {
+    const fn for_freq(f: SpiRamFreq, mpll_mhz: u32) -> Self {
+        let ram_freq = f as u32;
+        let bus_div = mpll_mhz.div_ceil(ram_freq);
         match f {
             SpiRamFreq::Mhz20 => Self {
-                mpll_mhz: 400,
-                bus_div: 20,
+                bus_div,
                 mr0_rl: 2,
                 mr4_wl: 2,
                 rd_dummy_bits: 18, // 2*(10-1)
@@ -180,8 +147,7 @@ impl SpeedParams {
                 reg_dummy_bits: 8, // 2*(5-1)
             },
             SpiRamFreq::Mhz80 => Self {
-                mpll_mhz: 320,
-                bus_div: 4,
+                bus_div,
                 mr0_rl: 2,
                 mr4_wl: 2,
                 rd_dummy_bits: 18,
@@ -189,8 +155,7 @@ impl SpeedParams {
                 reg_dummy_bits: 8,
             },
             SpiRamFreq::Mhz200 => Self {
-                mpll_mhz: 400,
-                bus_div: 2,
+                bus_div,
                 mr0_rl: 4,
                 mr4_wl: 1,
                 rd_dummy_bits: 26, // 2*(14-1)
@@ -198,8 +163,7 @@ impl SpeedParams {
                 reg_dummy_bits: 12,
             },
             SpiRamFreq::Mhz250 => Self {
-                mpll_mhz: 500,
-                bus_div: 2,
+                bus_div,
                 mr0_rl: 6,
                 mr4_wl: 3,
                 rd_dummy_bits: 34, // 2*(18-1)
@@ -218,19 +182,11 @@ const AP_HEX_CS_HOLD_DELAY: u32 = 3;
 
 #[crate::ram]
 fn init_psram_inner(config: &mut PsramConfig) -> bool {
-    // Resolve the speed parameter set from `ram_frequency`. The MPLL
-    // override (`config.core_clock`) lets the caller bypass the default
-    // pairing (e.g. force 400 MHz MPLL with `Mhz20` bus); `None`
-    // selects the table-default for the chosen `ram_frequency`.
-    let mut params = SpeedParams::for_freq(config.ram_frequency);
-    if let Some(mpll) = config.core_clock {
-        params.mpll_mhz = mpll as u32;
-    }
-
     psram_phy_ldo_init();
-    if !configure_mpll(params.mpll_mhz) {
-        return false;
-    }
+
+    ClockTree::with(request_mpll_clk);
+
+    let params = SpeedParams::for_freq(config.ram_frequency, mpll_clk_frequency() / 1_000_000);
 
     // Module clock + clock source
     HP_SYS_CLKRST::regs()
@@ -796,60 +752,6 @@ fn psram_phy_ldo_init() {
 
     // Allow LDO output to settle before the MSPI PHY is exercised.
     crate::rom::ets_delay_us(50);
-}
-
-/// Configure MPLL to target frequency for PSRAM clock.
-fn configure_mpll(freq_mhz: u32) -> bool {
-    // Power up the MPLL analog block.
-    PMU::regs()
-        .rf_pwc()
-        .modify(|_, w| w.mspi_phy_xpd().set_bit());
-    LP_AON_CLKRST::regs()
-        .lp_aonclkrst_hp_clk_ctrl()
-        .modify(|_, w| w.lp_aonclkrst_hp_mpll_500m_clk_en().set_bit());
-
-    HP_SYS_CLKRST::regs()
-        .ana_pll_ctrl0()
-        .modify(|_, w| w.mspi_cal_stop().clear_bit());
-
-    regi2c::I2C_MPLL_DHREF_DHREF.write_field(3);
-
-    let rstb = regi2c::I2C_MPLL_IR_CAL_RSTB.read();
-    regi2c::I2C_MPLL_IR_CAL_RSTB.write_reg(rstb & 0xDF);
-    regi2c::I2C_MPLL_IR_CAL_RSTB.write_reg(rstb | (1 << 5));
-
-    // div = freq_mhz/20 - 1, ref_div = 1 -> MPLL = XTAL(40) * (div+1) / (ref_div+1)
-    let ref_div: u8 = 1;
-    let div: u8 = (freq_mhz / 20).saturating_sub(1) as u8;
-    let div_val: u8 = (div << 3) | ref_div;
-    regi2c::I2C_MPLL_DIV_REG_ADDR.write_reg(div_val);
-
-    let mut t = 1_000_u32;
-    let mut success = true;
-    while HP_SYS_CLKRST::regs()
-        .ana_pll_ctrl0()
-        .read()
-        .mspi_cal_end()
-        .bit_is_clear()
-    {
-        t = t.saturating_sub(1);
-        if t == 0 {
-            warn!("PSRAM MPLL calibration timeout");
-            success = false;
-            break;
-        }
-        crate::rom::ets_delay_us(1);
-    }
-    HP_SYS_CLKRST::regs()
-        .ana_pll_ctrl0()
-        .modify(|_, w| w.mspi_cal_stop().set_bit());
-
-    if success {
-        debug!("Calibration timeout left: {}us", t);
-        crate::rom::ets_delay_us(10);
-    }
-
-    success
 }
 
 fn reset_psram_mspi() {

--- a/esp-hal/src/psram/esp32p4.rs
+++ b/esp-hal/src/psram/esp32p4.rs
@@ -7,8 +7,8 @@ use super::{EXTMEM_ORIGIN, PsramSize};
 use crate::{
     clock::ll::{ClockTree, mpll_clk_frequency, request_mpll_clk},
     efuse,
-    peripherals::{HP_SYS, HP_SYS_CLKRST, LP_AON_CLKRST, PMU},
-    soc::{pac, regi2c},
+    peripherals::{HP_SYS, HP_SYS_CLKRST, PMU},
+    soc::pac,
 };
 
 /// MMU page size (64 KB)
@@ -61,35 +61,6 @@ pub enum PsramMode {
     // Oct,
 }
 
-/// Maximum PSRAM bus frequency.
-///
-/// This value should be tuned together with the MPLL frequency. The effective bus clock
-/// will be at most the SpiRamFreq value, obtained by dividing MPLL using an integer divider.
-///
-/// | Variant   | MPLL | div | MR0.RL | MR4.WL | RD dummy bits | Use case               |
-/// |-----------|------|-----|--------|--------|---------------|------------------------|
-/// | `Mhz20`   | 400  | 20  | 2      | 2      | 18            | Low-power / debug      |
-/// | `Mhz80`   | 320  | 4   | 2      | 2      | 18            | Conservative SI margin |
-/// | `Mhz200`  | 400  | 2   | 4      | 1      | 26            | IDF default            |
-/// | `Mhz250`  | 500  | 2   | 6      | 3      | 34            | Default                |
-#[derive(Copy, Clone, Debug, Default, PartialEq)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[instability::unstable]
-pub enum SpiRamFreq {
-    /// 20 MHz.
-    Mhz20  = 20,
-
-    /// 80 MHz.
-    Mhz80  = 80,
-
-    /// 200 MHz.
-    Mhz200 = 200,
-
-    /// 250 MHz.
-    #[default]
-    Mhz250 = 250,
-}
-
 /// PSRAM configuration.
 #[derive(Copy, Clone, Debug, Default, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -97,10 +68,12 @@ pub enum SpiRamFreq {
 pub struct PsramConfig {
     /// PSRAM interface mode (Hex 16-line vs Oct 8-line). Default: Hex.
     pub mode: PsramMode,
+
     /// Size of PSRAM to map. Default: `AutoDetect` via MR2 density.
     pub size: PsramSize,
-    /// PSRAM bus frequency. Default: 250 MHz.
-    pub ram_frequency: SpiRamFreq,
+
+    /// PSRAM timing parameters. Default: 250 MHz.
+    pub timing: PsramTimingParams,
     // TODO: ECC enable.
     // The MSPI0 controller has a ECC engine.
     // pub ecc: bool, // or any other enum.
@@ -116,62 +89,96 @@ pub(crate) fn map_psram(config: PsramConfig) -> core::ops::Range<usize> {
     start..start + config.size.get()
 }
 
-/// Per-speed timing parameters.
-#[derive(Copy, Clone)]
-struct SpeedParams {
-    /// Bus clock divider applied to MPLL.
-    bus_div: u32,
+/// PSRAM timing parameters.
+///
+/// These values should be tuned together with the MPLL frequency. The MPLL frequency must be an
+/// integer multiple of the PSRAM frequency.
+///
+/// | Variant   | MPLL | div | MR0.RL | MR4.WL | RD dummy bits
+/// |-----------|------|-----|--------|--------|--------------
+/// | `MHZ_20`  | 400  | 20  | 2      | 2      | 18
+/// | `MHZ_80`  | 320  | 4   | 2      | 2      | 18
+/// | `MHZ_125` | 500  | 4   | 2      | 2      | 18
+/// | `MHZ_200` | 400  | 2   | 4      | 1      | 26
+/// | `MHZ_250` | 500  | 2   | 6      | 3      | 34
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct PsramTimingParams {
+    /// Bus clock frequency in MHz. Must divide MPLL evenly.
+    pub clock: u32,
+
     /// MR0.read_latency field value (cycles = 2 * value + 6).
-    mr0_rl: u8,
+    pub mr0_rl: u8,
+
     /// MR4.wr_latency field value.
-    mr4_wl: u8,
+    pub mr4_wl: u8,
+
     /// Read dummy length in bits for sync data reads (cache path).
-    rd_dummy_bits: u32,
+    pub rd_dummy_bits: u32,
+
     /// Write dummy length in bits for sync data writes (cache path).
-    wr_dummy_bits: u32,
+    pub wr_dummy_bits: u32,
+
     /// Register-read dummy length for direct command path (MSPI3).
-    reg_dummy_bits: u32,
+    pub reg_dummy_bits: u32,
 }
 
-impl SpeedParams {
-    const fn for_freq(f: SpiRamFreq, mpll_mhz: u32) -> Self {
-        let ram_freq = f as u32;
-        let bus_div = mpll_mhz.div_ceil(ram_freq);
-        match f {
-            SpiRamFreq::Mhz20 => Self {
-                bus_div,
-                mr0_rl: 2,
-                mr4_wl: 2,
-                rd_dummy_bits: 18, // 2*(10-1)
-                wr_dummy_bits: 8,  // 2*(5-1)
-                reg_dummy_bits: 8, // 2*(5-1)
-            },
-            SpiRamFreq::Mhz80 => Self {
-                bus_div,
-                mr0_rl: 2,
-                mr4_wl: 2,
-                rd_dummy_bits: 18,
-                wr_dummy_bits: 8,
-                reg_dummy_bits: 8,
-            },
-            SpiRamFreq::Mhz200 => Self {
-                bus_div,
-                mr0_rl: 4,
-                mr4_wl: 1,
-                rd_dummy_bits: 26, // 2*(14-1)
-                wr_dummy_bits: 12, // 2*(7-1)
-                reg_dummy_bits: 12,
-            },
-            SpiRamFreq::Mhz250 => Self {
-                bus_div,
-                mr0_rl: 6,
-                mr4_wl: 3,
-                rd_dummy_bits: 34, // 2*(18-1)
-                wr_dummy_bits: 16, // 2*(9-1)
-                reg_dummy_bits: 16,
-            },
-        }
+impl Default for PsramTimingParams {
+    fn default() -> Self {
+        Self::MHZ_250
     }
+}
+
+impl PsramTimingParams {
+    /// Preset for 20 MHz clock speed.
+    pub const MHZ_20: Self = Self {
+        clock: 20,
+        mr0_rl: 2,
+        mr4_wl: 2,
+        rd_dummy_bits: 18,
+        wr_dummy_bits: 8,
+        reg_dummy_bits: 8,
+    };
+
+    /// Preset for 80 MHz clock speed.
+    pub const MHZ_80: Self = Self {
+        clock: 80,
+        mr0_rl: 2,
+        mr4_wl: 2,
+        rd_dummy_bits: 18,
+        wr_dummy_bits: 8,
+        reg_dummy_bits: 8,
+    };
+
+    /// Preset for 125 MHz clock speed.
+    pub const MHZ_125: Self = Self {
+        clock: 125,
+        mr0_rl: 2,
+        mr4_wl: 2,
+        rd_dummy_bits: 18,
+        wr_dummy_bits: 8,
+        reg_dummy_bits: 8,
+    };
+
+    /// Preset for 200 MHz clock speed.
+    pub const MHZ_200: Self = Self {
+        clock: 200,
+        mr0_rl: 4,
+        mr4_wl: 1,
+        rd_dummy_bits: 26,
+        wr_dummy_bits: 12,
+        reg_dummy_bits: 12,
+    };
+
+    /// Preset for 250 MHz clock speed.
+    pub const MHZ_250: Self = Self {
+        clock: 250,
+        mr0_rl: 6,
+        mr4_wl: 3,
+        rd_dummy_bits: 34,
+        wr_dummy_bits: 16,
+        reg_dummy_bits: 16,
+    };
 }
 
 /// CS timing constants (matches IDF AP_HEX_PSRAM_CS_*). Independent of
@@ -185,8 +192,6 @@ fn init_psram_inner(config: &mut PsramConfig) -> bool {
     psram_phy_ldo_init();
 
     ClockTree::with(request_mpll_clk);
-
-    let params = SpeedParams::for_freq(config.ram_frequency, mpll_clk_frequency() / 1_000_000);
 
     // Module clock + clock source
     HP_SYS_CLKRST::regs()
@@ -204,19 +209,21 @@ fn init_psram_inner(config: &mut PsramConfig) -> bool {
         });
 
     // Controller + PHY pad bring-up.
-    set_bus_clock(params.bus_div);
+    if !set_bus_clock(config.timing.clock) {
+        return false;
+    }
     enable_dll();
     psram_pad_init(); // required for DDR strobe latch
     set_cs_timing();
 
     // SoC MR init (via MSPI3 SPI direct)
-    init_mr_registers(params);
+    init_mr_registers(&config.timing);
 
     if config.size.is_auto() {
-        config.size = PsramSize::Size(psram_detect_size(params));
+        config.size = PsramSize::Size(psram_detect_size(&config.timing));
     }
 
-    configure_psram_mspi(params, MSPI0_BASE); // basic AXI configuration here
+    configure_psram_mspi(&config.timing, MSPI0_BASE); // basic AXI configuration here
 
     // Silicon revision 3.0 (ECO5) requires two dummy PSRAM reads + a controller
     // reset before the real MMU mapping is committed.  Port of IDF's
@@ -235,7 +242,18 @@ fn init_psram_inner(config: &mut PsramConfig) -> bool {
 /// PSRAM_MSPI1 (CLOCK at 0x14). For divider=2 the value is
 /// (N=1)<<16 | (H=0)<<8 | (L=1)<<0 = 0x00010001. For divider=1 the
 /// fast path bit `CLK_EQU_SYSCLK` (bit 31) is set instead.
-fn set_bus_clock(div: u32) {
+fn set_bus_clock(clock: u32) -> bool {
+    let mpll_mhz = mpll_clk_frequency() / 1_000_000;
+    if !mpll_mhz.is_multiple_of(clock) {
+        error!(
+            "MPLL frequency must be an integer multiple of PSRAM frequency. MPLL={} MHz, PSRAM={} MHz",
+            mpll_mhz, clock
+        );
+        return false;
+    }
+
+    let div = mpll_mhz / clock;
+
     const MSPI0_SRAM_CLK: u32 = MSPI0_BASE + 0x50;
     const MSPI1_CLOCK: u32 = MSPI1_BASE + 0x14;
 
@@ -248,6 +266,8 @@ fn set_bus_clock(div: u32) {
         mmio_write_32(MSPI0_SRAM_CLK, val);
         mmio_write_32(MSPI1_CLOCK, val);
     }
+
+    true
 }
 
 /// Enable DLL timing calibration for both controllers. Both DLL bits
@@ -419,8 +439,8 @@ const MR_ADDR_MR8_MR9: u32 = 0x8;
 /// (MR_ADDR_MR4_MR5 / MR_ADDR_MR6 / MR_ADDR_MR8_MR9 — see the table at the
 /// `MR_ADDR_*` constants), the `high` value is don't-care and the
 /// caller should ignore it.
-fn psram_mr_read(speed_params: SpeedParams, mr_addr: u32) -> (u8, u8) {
-    let pair = mspi1_reg_read16(speed_params, mr_addr);
+fn psram_mr_read(timing: &PsramTimingParams, mr_addr: u32) -> (u8, u8) {
+    let pair = mspi1_reg_read16(timing, mr_addr);
     ((pair & 0xFF) as u8, ((pair >> 8) & 0xFF) as u8)
 }
 
@@ -440,23 +460,23 @@ fn psram_mr_write(mr_addr: u32, low: u8, high: u8) {
 /// MR0: drive_str[1:0], read_latency[4:2], lt[5]
 /// MR4: wr_latency[7:5]
 /// MR8: bl[1:0], bt[2], rbx[3], x16[6]
-fn init_mr_registers(speed_params: SpeedParams) {
+fn init_mr_registers(timing: &PsramTimingParams) {
     // Read+modify+write MR0 (preserve MR1 high byte).
-    let (mut mr0, mr1) = psram_mr_read(speed_params, MR_ADDR_MR0_MR1);
+    let (mut mr0, mr1) = psram_mr_read(timing, MR_ADDR_MR0_MR1);
     mr0 &= !(0x3 | (0x7 << 2) | (1 << 5));
-    mr0 |= ((speed_params.mr0_rl & 0x7) << 2) | (1 << 5);
+    mr0 |= ((timing.mr0_rl & 0x7) << 2) | (1 << 5);
     psram_mr_write(MR_ADDR_MR0_MR1, mr0, mr1);
 
     // Read+modify+write MR4 (preserve MR5 reserved high byte).
-    let (mut mr4, mr5) = psram_mr_read(speed_params, MR_ADDR_MR4_MR5);
+    let (mut mr4, mr5) = psram_mr_read(timing, MR_ADDR_MR4_MR5);
     mr4 &= !(0x7 << 5);
-    mr4 |= (speed_params.mr4_wl & 0x7) << 5;
+    mr4 |= (timing.mr4_wl & 0x7) << 5;
     psram_mr_write(MR_ADDR_MR4_MR5, mr4, mr5);
 
     // do nothing for MR6 and MR7
 
     // Read+modify+write MR8 (high byte is reserved/absent — pass 0).
-    let (mut mr8, mr9) = psram_mr_read(speed_params, MR_ADDR_MR8_MR9); // MR9 is unused
+    let (mut mr8, mr9) = psram_mr_read(timing, MR_ADDR_MR8_MR9); // MR9 is unused
     mr8 &= !(0x3 | (1 << 2) | (1 << 3) | (1 << 6));
     mr8 |= 3 // bt = 0
         | (1 << 3) // rbx = 1
@@ -500,10 +520,6 @@ unsafe extern "C" {
 
     /// `Cache_Invalidate_All = 0x4fc00404`. Invalidates all cache levels.
     fn Cache_Invalidate_All();
-}
-
-unsafe fn rom_cache_invalidate_all() {
-    unsafe { Cache_Invalidate_All() }
 }
 
 /// Kick the controller (set `SPI_USR` bit 18 in CMD_REG) and poll
@@ -556,7 +572,7 @@ fn mspi1_kick_and_collect(rx: &mut [u8]) -> Result<(), ()> {
 /// 32-bit address, 16-bit MISO) through `PSRAM_MSPI1`. Setup via ROM
 /// helpers (`set_op_mode` + `cmd_config`); kick + poll done manually
 /// with a timeout (avoids ROM `cmd_start` poll-forever pitfall).
-fn mspi1_reg_read16(speed_params: SpeedParams, addr: u32) -> u16 {
+fn mspi1_reg_read16(timing: &PsramTimingParams, addr: u32) -> u16 {
     const REG_READ_CMD: u16 = 0x4040;
     const CMD_BITLEN: u16 = 16;
     const ADDR_BITLEN: u32 = 32;
@@ -573,7 +589,7 @@ fn mspi1_reg_read16(speed_params: SpeedParams, addr: u32) -> u16 {
         tx_data_bit_len: 0,
         rx_data: rx.as_mut_ptr() as *mut u32,
         rx_data_bit_len: DATA_BITLEN,
-        dummy_bit_len: speed_params.reg_dummy_bits,
+        dummy_bit_len: timing.reg_dummy_bits,
     };
 
     unsafe {
@@ -616,7 +632,7 @@ fn mspi1_reg_write16(addr: u32, data: u16) {
 }
 
 /// Detect PSRAM size by reading mode register MR2 via MSPI1.
-fn psram_detect_size(speed_params: SpeedParams) -> usize {
+fn psram_detect_size(speed_params: &PsramTimingParams) -> usize {
     let (mr2, _mr3) = psram_mr_read(speed_params, MR_ADDR_MR2_MR3);
     match mr2 & 0x7 {
         0x1 => 4 * 1024 * 1024,  //  32 Mbit
@@ -678,7 +694,7 @@ fn mmu_map_psram(config: &PsramConfig) {
         write_psram_mmu_entry(page as u32, page as u16);
     }
     unsafe {
-        rom_cache_invalidate_all();
+        Cache_Invalidate_All();
     }
 }
 
@@ -876,10 +892,10 @@ fn p4_rev3_psram_workaround() {
 ///                    bit 2 `smem_ddr_rdat_swp`, bit 3 `smem_ddr_wdat_swp`.
 ///
 /// `CACHE_FCTRL` (0x3C): bit 0 `mem_axi_req_en`, bit 1 `close_axi_inf_en`.
-fn configure_psram_mspi(speed_params: SpeedParams, base: u32) {
+fn configure_psram_mspi(timing: &PsramTimingParams, base: u32) {
     // Dummy bit-counts come from the active speed parameter table.
-    let rd_dummy_n = speed_params.rd_dummy_bits;
-    let wr_dummy_n = speed_params.wr_dummy_bits;
+    let rd_dummy_n = timing.rd_dummy_bits;
+    let wr_dummy_n = timing.wr_dummy_bits;
 
     unsafe {
         // CACHE_SCTRL.

--- a/esp-hal/src/rtc_cntl/rtc/esp32p4.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32p4.rs
@@ -1,23 +1,7 @@
-//! RTC control for ESP32-P4X (chip revision v3.x / eco5).
-//!
-//! PMU power domain init and WDT disable for bare-metal boot.
-//!
-//! Register names validated against esp32p4 PAC (eco5) and:
-//!   - TRM v0.5 Ch 16 (Low-Power Management)
-//!   - TRM v0.5 Ch 19 (Watchdog Timers)
-//!
-//! eco4 vs eco5 PMU difference:
-//!   eco4: power_pd_hpaon_cntl, power_pd_hpcpu_cntl, power_pd_hpwifi_cntl
-//!   eco5: power_pd_cnnt_cntl, power_pd_lpperi_cntl (hpaon/hpcpu/hpwifi removed)
-//!   Both: power_pd_top_cntl, power_pd_hpmem_cntl
-
-// TODO: REMOVE me when validate well
-// reference florianL21's original eco4 PMU code
-
 use strum::FromRepr;
 
 use crate::{
-    peripherals::{HP_SYS_CLKRST, LP_AON_CLKRST, LP_WDT, PMU, TIMG0, TIMG1},
+    peripherals::PMU,
     soc::{
         clocks::{self, ClockTree, CpuRootClkConfig},
         regi2c,
@@ -483,20 +467,14 @@ fn pmu_lp_system_init() {
         .modify(|_, w| unsafe { w.lp_sleep_lp_regulator_drv_b().bits(0) });
 }
 
-/// Minimal init for bare-metal boot: disable all watchdogs and set power domains.
-///
-/// This is the minimum needed for the chip to not reset itself during startup.
-/// Full clock configuration (PLL, CPU freq) is handled separately.
-///
-/// Ref: TRM v0.5 Ch 19 (WDT), Ch 16 (Power Management)
+/// Minimal init for bare-metal boot.
 pub(crate) fn init() {
-    // 1. Clear all PMU power domain force flags
     pmu_power_domain_force_default();
 
-    // 1b. Force the analog dig regulators on via regi2c (XPD off => regulated by
-    //     PMU) and configure the default per-mode PMU system state (HP/LP active +
-    //     sleep). Required before the PMU can perform a clean sleep/wake transition.
-    //     Ref: IDF rtc_clk_init.c (esp32p4).
+    // Force the analog dig regulators on via regi2c (XPD off => regulated by
+    // PMU) and configure the default per-mode PMU system state (HP/LP active +
+    // sleep). Required before the PMU can perform a clean sleep/wake transition.
+    // Ref: IDF rtc_clk_init.c (esp32p4).
     regi2c::I2C_DIG_REG_FORCE_RTC_DREG.write_field(1);
     regi2c::I2C_DIG_REG_FORCE_DIG_DREG.write_field(1);
     regi2c::I2C_DIG_REG_XPD_RTC_REG.write_field(0);
@@ -504,179 +482,18 @@ pub(crate) fn init() {
     pmu_hp_system_init();
     pmu_lp_system_init();
 
-    // 2. Disable TIMG0 watchdog TIMG WDT write protect key: 0x50D8_3AA1
-    let tg0 = TIMG0::regs();
-    tg0.wdtwprotect().write(|w| unsafe { w.bits(0x50D8_3AA1) });
-    tg0.wdtconfig0().modify(|_, w| w.wdt_en().clear_bit());
-    tg0.wdtwprotect().write(|w| unsafe { w.bits(0) });
-
-    // 3. Disable TIMG1 watchdog
-    let tg1 = TIMG1::regs();
-    tg1.wdtwprotect().write(|w| unsafe { w.bits(0x50D8_3AA1) });
-    tg1.wdtconfig0().modify(|_, w| w.wdt_en().clear_bit());
-    tg1.wdtwprotect().write(|w| unsafe { w.bits(0) });
-
-    // 4. Disable LP_WDT (Low-Power Watchdog) P4 PAC: config0() (not wdtconfig0()), wprotect() (not
-    //    wdtwprotect())
-    let lp_wdt = LP_WDT::regs();
-    lp_wdt.wprotect().write(|w| unsafe { w.bits(0x50D8_3AA1) });
-    lp_wdt.config0().modify(|_, w| unsafe { w.bits(0) });
-    lp_wdt.wprotect().write(|w| unsafe { w.bits(0) });
-
-    // 5. Disable SWD (Super Watchdog) by enabling auto-feed LP_WDT SWD write protect key:
-    //    0x50D8_3AA1 (same key)
-    lp_wdt
-        .swd_wprotect()
-        .write(|w| unsafe { w.bits(0x50D8_3AA1) });
-    lp_wdt
-        .swd_config()
-        .modify(|_, w| w.swd_auto_feed_en().set_bit());
-    lp_wdt.swd_wprotect().write(|w| unsafe { w.bits(0) });
-
-    // 6. Clear DCDC switch force flags PMU_POWER_DCDC_SWITCH_REG (offset 0x10c)
+    // Clear DCDC switch force flags PMU_POWER_DCDC_SWITCH_REG (offset 0x10c)
     PMU::regs().power_dcdc_switch().modify(|_, w| {
         w.force_dcdc_switch_pu().bit(false);
         w.force_dcdc_switch_pd().bit(false)
     });
 
-    // 7. Enable CPLL (400 MHz) and SPLL (480 MHz)
-    cpll_configure(400);
-    spll_configure(480);
-
-    // 8. Set CPU divider to 1 (400 MHz CPU), MEM divider 2, APB divider 2
-    // Set CPU divider: cpu_clk_div_num = divider - 1 = 0
-    // Ref: HP_SYS_CLKRST.root_clk_ctrl0.reg_cpu_clk_div_num
-    HP_SYS_CLKRST::regs()
-        .root_clk_ctrl0()
-        .modify(|_, w| unsafe {
-            w.cpu_clk_div_num().bits(0); // CPU: /1 = 400 MHz
-            w.cpu_clk_div_numerator().bits(0);
-            w.cpu_clk_div_denominator().bits(0)
-        });
-    // Trigger clock divider update
-    HP_SYS_CLKRST::regs()
-        .root_clk_ctrl0()
-        .modify(|_, w| w.soc_clk_div_update().set_bit());
-    while HP_SYS_CLKRST::regs()
-        .root_clk_ctrl0()
-        .read()
-        .soc_clk_div_update()
-        .bit_is_set()
-    {
-        core::hint::spin_loop();
-    }
-
-    // 9. Switch CPU clock source from XTAL to CPLL LP_AON_CLKRST.hp_clk_ctrl.hp_root_clk_src_sel:
-    //    0=XTAL, 1=CPLL, 2=RC_FAST
-    LP_AON_CLKRST::regs()
-        .lp_aonclkrst_hp_clk_ctrl()
-        .modify(|_, w| unsafe { w.lp_aonclkrst_hp_root_clk_src_sel().bits(1) }); // 1 = CPLL
-}
-
-/// Configure CPLL for the given frequency (360 or 400 MHz).
-///
-/// eco5 (v3.x) uses different I2C register values than eco4 (v1.x).
-/// Ref: TRM v0.5 Ch 12 -- CPLL configuration
-fn cpll_configure(freq_mhz: u32) {
-    // 1. Enable CPLL power PMU.imm_hp_ck_power: tie_high_xpd_pll, tie_high_xpd_pll_i2c Note: PAC
-    //    uses "pll" not "cpll" (eco4 PAC, single PLL)
     // PAC: tie_high_xpd_pll is 4-bit field (one bit per PLL: CPLL/SPLL/MPLL/PLLA).
     // Set all bits to enable all PLLs. Same for pll_i2c.
     PMU::regs().imm_hp_ck_power().write(|w| unsafe {
         w.tie_high_xpd_pll().bits(0xF);
         w.tie_high_xpd_pll_i2c().bits(0xF)
     });
-    // Enable global CPLL ICG (clock gating)
-    // Ref: PMU.imm_hp_ck_power.tie_high_global_cpll_icg
-    // Note: this field may not exist in eco4 PAC; use direct bit write if needed
-    // For now, the PLL is enabled via xpd_pll above.
-
-    // 2. Configure CPLL via I2C analog registers
-    // eco5 values (v3.x): div7_0 = 10 (400MHz), 9 (360MHz) with 40MHz XTAL
-    let div7_0: u8 = match freq_mhz {
-        400 => 10, // eco5: 400 MHz
-        360 => 9,  // eco5: 360 MHz
-        _ => 10,   // default to 400 MHz
-    };
-
-    // OC_REF_DIV + DCHGP: (oc_enb_fcal << 7) | (dchgp << 4) | div_ref = 0x50
-    let lref: u8 = 0x50; // dchgp=5, div_ref=0, oc_enb_fcal=0
-
-    // OC_DCUR: (dlref_sel << 6) | (dhref_sel << 4) | dcur = 0x73
-    let dcur: u8 = 0x73; // dlref_sel=1, dhref_sel=3, dcur=3
-
-    regi2c::I2C_CPLL_OC_REF_DIV.write_reg(lref);
-    regi2c::I2C_CPLL_OC_DIV_7_0.write_reg(div7_0);
-    regi2c::I2C_CPLL_OC_DCUR.write_reg(dcur);
-
-    // 3. Run CPLL calibration HP_SYS_CLKRST.ana_pll_ctrl0.cpu_pll_cal_stop
-    // Start calibration: set cpu_pll_cal_stop = 0
-    HP_SYS_CLKRST::regs()
-        .ana_pll_ctrl0()
-        .modify(|_, w| w.cpu_pll_cal_stop().clear_bit());
-
-    // Wait for calibration to complete
-    while !HP_SYS_CLKRST::regs()
-        .ana_pll_ctrl0()
-        .read()
-        .cpu_pll_cal_end()
-        .bit_is_set()
-    {
-        core::hint::spin_loop();
-    }
-
-    // Stop calibration: set cpu_pll_cal_stop = 1
-    HP_SYS_CLKRST::regs()
-        .ana_pll_ctrl0()
-        .modify(|_, w| w.cpu_pll_cal_stop().set_bit());
-
-    // Small delay for PLL to stabilize
-    crate::rom::ets_delay_us(10);
-}
-
-/// Configure SPLL (System PLL) for the given frequency (480 MHz typical).
-///
-/// SPLL provides peripheral clocks: PLL_F240M/160M/120M/80M/20M.
-/// Ref: TRM v0.5 Ch 12 -- SPLL configuration
-fn spll_configure(freq_mhz: u32) {
-    // PLL power already enabled in cpll_configure (PMU xpd_pll bits(0xF) enables all PLLs)
-
-    // Configure SPLL via I2C analog registers
-    // eco5 values: div7_0 = (freq_mhz / 40) - 1, same formula as CPLL
-    let div7_0: u8 = match freq_mhz {
-        480 => 11, // 480 MHz: (480/40) - 1 = 11
-        240 => 5,  // 240 MHz: (240/40) - 1 = 5
-        _ => 11,   // default to 480 MHz
-    };
-
-    // Same OC_REF_DIV and OC_DCUR values as CPLL
-    let lref: u8 = 0x50; // dchgp=5, div_ref=0, oc_enb_fcal=0
-    let dcur: u8 = 0x73; // dlref_sel=1, dhref_sel=3, dcur=3
-
-    regi2c::I2C_SPLL_OC_REF_DIV.write_reg(lref);
-    regi2c::I2C_SPLL_OC_DIV_7_0.write_reg(div7_0);
-    regi2c::I2C_SPLL_OC_DCUR.write_reg(dcur);
-
-    // Run SPLL calibration
-    //      HP_SYS_CLKRST.ana_pll_ctrl0.sys_pll_cal_stop
-    HP_SYS_CLKRST::regs()
-        .ana_pll_ctrl0()
-        .modify(|_, w| w.sys_pll_cal_stop().clear_bit());
-
-    while !HP_SYS_CLKRST::regs()
-        .ana_pll_ctrl0()
-        .read()
-        .sys_pll_cal_end()
-        .bit_is_set()
-    {
-        core::hint::spin_loop();
-    }
-
-    HP_SYS_CLKRST::regs()
-        .ana_pll_ctrl0()
-        .modify(|_, w| w.sys_pll_cal_stop().set_bit());
-
-    crate::rom::ets_delay_us(10);
 }
 
 /// Saves and restores the CPU root clock source around sleep.

--- a/esp-hal/src/soc/esp32p4/clocks.rs
+++ b/esp-hal/src/soc/esp32p4/clocks.rs
@@ -20,7 +20,8 @@
 use esp_rom_sys::rom::ets_update_cpu_frequency_rom;
 
 use crate::{
-    peripherals::{HP_SYS_CLKRST, LP_AON_CLKRST},
+    peripherals::{HP_SYS_CLKRST, LP_AON_CLKRST, PMU},
+    soc::regi2c,
     time::Rate,
 };
 
@@ -49,6 +50,9 @@ impl CpuClock {
     // Preset: 400 MHz CPU, 100 MHz APB
     const PRESET_400: ClockConfig = ClockConfig {
         cpu_root_clk: Some(CpuRootClkConfig::Cpll),
+        cpll_clk: Some(CpllClkConfig::_400),
+        spll_clk: Some(SpllClkConfig::_480),
+        mpll_clk: Some(MpllClkConfig::_500),
         cpu_clk: Some(CpuClkConfig::new(0)), // /1 = 400 MHz
         mem_clk: Some(MemClkConfig::new(1)), // /2 = 200 MHz
         sys_clk: Some(SysClkConfig::new(0)), // /1 = 200 MHz
@@ -62,6 +66,9 @@ impl CpuClock {
 
     const PRESET_200: ClockConfig = ClockConfig {
         cpu_root_clk: Some(CpuRootClkConfig::Cpll),
+        cpll_clk: Some(CpllClkConfig::_400),
+        spll_clk: Some(SpllClkConfig::_480),
+        mpll_clk: Some(MpllClkConfig::_500),
         cpu_clk: Some(CpuClkConfig::new(1)), // /2 = 200 MHz
         mem_clk: Some(MemClkConfig::new(0)), // /1 = 200 MHz
         sys_clk: Some(SysClkConfig::new(0)), // /1 = 200 MHz
@@ -73,6 +80,9 @@ impl CpuClock {
 
     const PRESET_100: ClockConfig = ClockConfig {
         cpu_root_clk: Some(CpuRootClkConfig::Cpll),
+        cpll_clk: Some(CpllClkConfig::_400),
+        spll_clk: Some(SpllClkConfig::_480),
+        mpll_clk: Some(MpllClkConfig::_500),
         cpu_clk: Some(CpuClkConfig::new(3)), // /4 = 100 MHz
         mem_clk: Some(MemClkConfig::new(0)), // /1 = 100 MHz
         sys_clk: Some(SysClkConfig::new(0)), // /1 = 100 MHz
@@ -114,8 +124,154 @@ impl ClockConfig {
     }
 }
 
-// Clock node implementation functions (called from generated macro)
-// These must match the function names that define_clock_tree_types!() expects.
+// CPLL_CLK
+
+fn enable_cpll_clk_impl(_clocks: &mut ClockTree, _en: bool) {
+    // PLLs are always on, for now
+}
+
+fn configure_cpll_clk_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<CpllClkConfig>,
+    new_config: CpllClkConfig,
+) {
+    // div7_0 = (freq_mhz / 40) - 1
+    let div7_0: u8 = match new_config {
+        CpllClkConfig::_360 => 9,
+        CpllClkConfig::_400 => 10,
+    };
+
+    let lref: u8 = 0x50; // dchgp=5, div_ref=0, oc_enb_fcal=0
+    let dcur: u8 = 0x73; // dlref_sel=1, dhref_sel=3, dcur=3
+
+    regi2c::I2C_CPLL_OC_REF_DIV.write_reg(lref);
+    regi2c::I2C_CPLL_OC_DIV_7_0.write_reg(div7_0);
+    regi2c::I2C_CPLL_OC_DCUR.write_reg(dcur);
+
+    HP_SYS_CLKRST::regs()
+        .ana_pll_ctrl0()
+        .modify(|_, w| w.cpu_pll_cal_stop().clear_bit());
+
+    // Wait for calibration to complete
+    while !HP_SYS_CLKRST::regs()
+        .ana_pll_ctrl0()
+        .read()
+        .cpu_pll_cal_end()
+        .bit_is_set()
+    {
+        core::hint::spin_loop();
+    }
+
+    // Stop calibration: set cpu_pll_cal_stop = 1
+    HP_SYS_CLKRST::regs()
+        .ana_pll_ctrl0()
+        .modify(|_, w| w.cpu_pll_cal_stop().set_bit());
+
+    // Small delay for PLL to stabilize
+    crate::rom::ets_delay_us(10);
+}
+
+// SPLL_CLK
+
+fn enable_spll_clk_impl(_clocks: &mut ClockTree, _en: bool) {
+    // PLLs are always on, for now
+}
+
+fn configure_spll_clk_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<SpllClkConfig>,
+    new_config: SpllClkConfig,
+) {
+    // div7_0 = (freq_mhz / 40) - 1
+    let div7_0: u8 = match new_config {
+        SpllClkConfig::_480 => 11,
+        SpllClkConfig::_240 => 5,
+    };
+
+    // Same OC_REF_DIV and OC_DCUR values as CPLL
+    let lref: u8 = 0x50; // dchgp=5, div_ref=0, oc_enb_fcal=0
+    let dcur: u8 = 0x73; // dlref_sel=1, dhref_sel=3, dcur=3
+
+    regi2c::I2C_SPLL_OC_REF_DIV.write_reg(lref);
+    regi2c::I2C_SPLL_OC_DIV_7_0.write_reg(div7_0);
+    regi2c::I2C_SPLL_OC_DCUR.write_reg(dcur);
+
+    // Run SPLL calibration
+    //      HP_SYS_CLKRST.ana_pll_ctrl0.sys_pll_cal_stop
+    HP_SYS_CLKRST::regs()
+        .ana_pll_ctrl0()
+        .modify(|_, w| w.sys_pll_cal_stop().clear_bit());
+
+    while !HP_SYS_CLKRST::regs()
+        .ana_pll_ctrl0()
+        .read()
+        .sys_pll_cal_end()
+        .bit_is_set()
+    {
+        core::hint::spin_loop();
+    }
+
+    HP_SYS_CLKRST::regs()
+        .ana_pll_ctrl0()
+        .modify(|_, w| w.sys_pll_cal_stop().set_bit());
+
+    crate::rom::ets_delay_us(10);
+}
+
+// MPLL_CLK
+
+fn enable_mpll_clk_impl(clocks: &mut ClockTree, en: bool) {
+    PMU::regs().rf_pwc().modify(|_, w| w.mspi_phy_xpd().bit(en));
+    LP_AON_CLKRST::regs()
+        .lp_aonclkrst_hp_clk_ctrl()
+        .modify(|_, w| w.lp_aonclkrst_hp_mpll_500m_clk_en().bit(en));
+
+    if !en {
+        return;
+    }
+
+    regi2c::I2C_MPLL_DHREF_DHREF.write_field(3);
+
+    let rstb = regi2c::I2C_MPLL_IR_CAL_RSTB.read();
+    regi2c::I2C_MPLL_IR_CAL_RSTB.write_reg(rstb & 0xDF);
+    regi2c::I2C_MPLL_IR_CAL_RSTB.write_reg(rstb | (1 << 5));
+
+    // div = freq_mhz/20 - 1, ref_div = 1 -> MPLL = XTAL(40) * (div+1) / (ref_div+1)
+    let ref_div: u8 = 1;
+    let div: u8 = match unwrap!(clocks.mpll_clk) {
+        MpllClkConfig::_320 => 15,
+        MpllClkConfig::_400 => 19,
+        MpllClkConfig::_500 => 24,
+    };
+    let div_val: u8 = (div << 3) | ref_div;
+    regi2c::I2C_MPLL_DIV_REG_ADDR.write_reg(div_val);
+
+    HP_SYS_CLKRST::regs()
+        .ana_pll_ctrl0()
+        .modify(|_, w| w.mspi_cal_stop().clear_bit());
+
+    while HP_SYS_CLKRST::regs()
+        .ana_pll_ctrl0()
+        .read()
+        .mspi_cal_end()
+        .bit_is_clear()
+    {
+        core::hint::spin_loop();
+    }
+    HP_SYS_CLKRST::regs()
+        .ana_pll_ctrl0()
+        .modify(|_, w| w.mspi_cal_stop().set_bit());
+
+    crate::rom::ets_delay_us(10);
+}
+
+fn configure_mpll_clk_impl(
+    _clocks: &mut ClockTree,
+    _old_config: Option<MpllClkConfig>,
+    _new_config: MpllClkConfig,
+) {
+    // Configuration applied in enable_mpll_clk_impl
+}
 
 // CPU_ROOT_CLK (mux: XTAL / CPLL / RC_FAST)
 fn configure_cpu_root_clk_impl(
@@ -416,9 +572,6 @@ fn enable_lp_fast_clk_impl(_clocks: &mut ClockTree, _en: bool) {}
 fn enable_lp_slow_clk_impl(_clocks: &mut ClockTree, _en: bool) {}
 
 // Source clock enable/disable stubs (PLLs, oscillators)
-fn enable_cpll_clk_impl(_clocks: &mut ClockTree, _en: bool) {}
-fn enable_spll_clk_impl(_clocks: &mut ClockTree, _en: bool) {}
-fn enable_mpll_clk_impl(_clocks: &mut ClockTree, _en: bool) {}
 fn enable_rc_fast_clk_impl(_clocks: &mut ClockTree, _en: bool) {}
 fn enable_xtal32k_clk_impl(_clocks: &mut ClockTree, _en: bool) {}
 fn enable_osc_slow_clk_impl(_clocks: &mut ClockTree, _en: bool) {}

--- a/esp-metadata-generated/src/_generated_esp32p4.rs
+++ b/esp-metadata-generated/src/_generated_esp32p4.rs
@@ -1093,15 +1093,39 @@ macro_rules! for_each_sha_algorithm {
 ///     todo!()
 /// }
 ///
+/// fn configure_cpll_clk_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<CpllClkConfig>,
+///     _new_config: CpllClkConfig,
+/// ) {
+///     todo!()
+/// }
+///
 /// // SPLL_CLK
 ///
 /// fn enable_spll_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 ///     todo!()
 /// }
 ///
+/// fn configure_spll_clk_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<SpllClkConfig>,
+///     _new_config: SpllClkConfig,
+/// ) {
+///     todo!()
+/// }
+///
 /// // MPLL_CLK
 ///
 /// fn enable_mpll_clk_impl(_clocks: &mut ClockTree, _en: bool) {
+///     todo!()
+/// }
+///
+/// fn configure_mpll_clk_impl(
+///     _clocks: &mut ClockTree,
+///     _old_config: Option<MpllClkConfig>,
+///     _new_config: MpllClkConfig,
+/// ) {
 ///     todo!()
 /// }
 ///
@@ -1469,6 +1493,60 @@ macro_rules! define_clock_tree_types {
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum MipiDsiInstance {
             MipiDsi = 0,
+        }
+        /// Selects the output frequency of `CPLL_CLK`. Depends on `XTAL_CLK`.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+        pub enum CpllClkConfig {
+            /// 360 MHz
+            _360,
+            /// 400 MHz
+            _400,
+        }
+        impl CpllClkConfig {
+            pub fn value(&self) -> u32 {
+                match self {
+                    CpllClkConfig::_360 => 360000000,
+                    CpllClkConfig::_400 => 400000000,
+                }
+            }
+        }
+        /// Selects the output frequency of `SPLL_CLK`. Depends on `XTAL_CLK`.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+        pub enum SpllClkConfig {
+            /// 240 MHz
+            _240,
+            /// 480 MHz
+            _480,
+        }
+        impl SpllClkConfig {
+            pub fn value(&self) -> u32 {
+                match self {
+                    SpllClkConfig::_240 => 240000000,
+                    SpllClkConfig::_480 => 480000000,
+                }
+            }
+        }
+        /// Selects the output frequency of `MPLL_CLK`. Depends on `XTAL_CLK`.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+        pub enum MpllClkConfig {
+            /// 320 MHz
+            _320,
+            /// 400 MHz
+            _400,
+            /// 500 MHz
+            _500,
+        }
+        impl MpllClkConfig {
+            pub fn value(&self) -> u32 {
+                match self {
+                    MpllClkConfig::_320 => 320000000,
+                    MpllClkConfig::_400 => 400000000,
+                    MpllClkConfig::_500 => 500000000,
+                }
+            }
         }
         /// The list of clock signals that the `CPU_ROOT_CLK` multiplexer can output.
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -1877,6 +1955,9 @@ macro_rules! define_clock_tree_types {
         }
         /// Represents the device's clock tree.
         pub struct ClockTree {
+            cpll_clk: Option<CpllClkConfig>,
+            spll_clk: Option<SpllClkConfig>,
+            mpll_clk: Option<MpllClkConfig>,
             cpu_root_clk: Option<CpuRootClkConfig>,
             cpu_clk: Option<CpuClkConfig>,
             mem_clk: Option<MemClkConfig>,
@@ -1920,6 +2001,18 @@ macro_rules! define_clock_tree_types {
             /// Locks the clock tree for exclusive access.
             pub fn with<R>(f: impl FnOnce(&mut ClockTree) -> R) -> R {
                 CLOCK_TREE.with(f)
+            }
+            /// Returns the current configuration of the CPLL_CLK clock tree node
+            pub fn cpll_clk(&self) -> Option<CpllClkConfig> {
+                self.cpll_clk
+            }
+            /// Returns the current configuration of the SPLL_CLK clock tree node
+            pub fn spll_clk(&self) -> Option<SpllClkConfig> {
+                self.spll_clk
+            }
+            /// Returns the current configuration of the MPLL_CLK clock tree node
+            pub fn mpll_clk(&self) -> Option<MpllClkConfig> {
+                self.mpll_clk
             }
             /// Returns the current configuration of the CPU_ROOT_CLK clock tree node
             pub fn cpu_root_clk(&self) -> Option<CpuRootClkConfig> {
@@ -2040,6 +2133,9 @@ macro_rules! define_clock_tree_types {
         }
         static CLOCK_TREE: ::esp_sync::NonReentrantMutex<ClockTree> =
             ::esp_sync::NonReentrantMutex::new(ClockTree {
+                cpll_clk: None,
+                spll_clk: None,
+                mpll_clk: None,
                 cpu_root_clk: None,
                 cpu_clk: None,
                 mem_clk: None,
@@ -2079,6 +2175,12 @@ macro_rules! define_clock_tree_types {
                 mipi_dsi_phy_pll_refclk_refcount: [0; 1],
                 mipi_dsi_phy_cfg_clk_refcount: [0; 1],
             });
+        static CPLL_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static SPLL_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
+        static MPLL_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
+            ::core::sync::atomic::AtomicU32::new(0);
         static CPU_ROOT_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
             ::core::sync::atomic::AtomicU32::new(0);
         static CPU_CLK_FREQ_CACHE: ::core::sync::atomic::AtomicU32 =
@@ -2118,6 +2220,14 @@ macro_rules! define_clock_tree_types {
         pub fn xtal_clk_frequency() -> u32 {
             40000000
         }
+        pub fn configure_cpll_clk(clocks: &mut ClockTree, config: CpllClkConfig) {
+            let old_config = clocks.cpll_clk.replace(config);
+            refresh_cpll_clk_downstream(clocks);
+            configure_cpll_clk_impl(clocks, old_config, config);
+        }
+        pub fn cpll_clk_config(clocks: &mut ClockTree) -> Option<CpllClkConfig> {
+            clocks.cpll_clk
+        }
         pub fn request_cpll_clk(clocks: &mut ClockTree) {
             trace!("Requesting CPLL_CLK");
             if increment_reference_count(&mut clocks.cpll_clk_refcount) {
@@ -2134,11 +2244,23 @@ macro_rules! define_clock_tree_types {
                 release_xtal_clk(clocks);
             }
         }
+        #[allow(unused_variables)]
+        pub fn cpll_clk_config_frequency(clocks: &mut ClockTree, config: CpllClkConfig) -> u32 {
+            config.value()
+        }
         pub fn cpll_clk_frequency() -> u32 {
-            400000000
+            CPLL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn cpll_clk_source_frequency() -> u32 {
             xtal_clk_frequency()
+        }
+        pub fn configure_spll_clk(clocks: &mut ClockTree, config: SpllClkConfig) {
+            let old_config = clocks.spll_clk.replace(config);
+            refresh_spll_clk_downstream(clocks);
+            configure_spll_clk_impl(clocks, old_config, config);
+        }
+        pub fn spll_clk_config(clocks: &mut ClockTree) -> Option<SpllClkConfig> {
+            clocks.spll_clk
         }
         pub fn request_spll_clk(clocks: &mut ClockTree) {
             trace!("Requesting SPLL_CLK");
@@ -2156,11 +2278,23 @@ macro_rules! define_clock_tree_types {
                 release_xtal_clk(clocks);
             }
         }
+        #[allow(unused_variables)]
+        pub fn spll_clk_config_frequency(clocks: &mut ClockTree, config: SpllClkConfig) -> u32 {
+            config.value()
+        }
         pub fn spll_clk_frequency() -> u32 {
-            480000000
+            SPLL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn spll_clk_source_frequency() -> u32 {
             xtal_clk_frequency()
+        }
+        pub fn configure_mpll_clk(clocks: &mut ClockTree, config: MpllClkConfig) {
+            let old_config = clocks.mpll_clk.replace(config);
+            refresh_mpll_clk_downstream(clocks);
+            configure_mpll_clk_impl(clocks, old_config, config);
+        }
+        pub fn mpll_clk_config(clocks: &mut ClockTree) -> Option<MpllClkConfig> {
+            clocks.mpll_clk
         }
         pub fn request_mpll_clk(clocks: &mut ClockTree) {
             trace!("Requesting MPLL_CLK");
@@ -2178,8 +2312,12 @@ macro_rules! define_clock_tree_types {
                 release_xtal_clk(clocks);
             }
         }
+        #[allow(unused_variables)]
+        pub fn mpll_clk_config_frequency(clocks: &mut ClockTree, config: MpllClkConfig) -> u32 {
+            config.value()
+        }
         pub fn mpll_clk_frequency() -> u32 {
-            500000000
+            MPLL_CLK_FREQ_CACHE.load(::core::sync::atomic::Ordering::Acquire)
         }
         pub fn mpll_clk_source_frequency() -> u32 {
             xtal_clk_frequency()
@@ -3515,6 +3653,12 @@ macro_rules! define_clock_tree_types {
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         #[instability::unstable]
         pub struct ClockConfig {
+            /// `CPLL_CLK` configuration.
+            pub cpll_clk: Option<CpllClkConfig>,
+            /// `SPLL_CLK` configuration.
+            pub spll_clk: Option<SpllClkConfig>,
+            /// `MPLL_CLK` configuration.
+            pub mpll_clk: Option<MpllClkConfig>,
             /// `CPU_ROOT_CLK` configuration.
             pub cpu_root_clk: Option<CpuRootClkConfig>,
             /// `CPU_CLK` configuration.
@@ -3534,6 +3678,15 @@ macro_rules! define_clock_tree_types {
         }
         impl ClockConfig {
             fn apply(&self, clocks: &mut ClockTree) {
+                if let Some(config) = self.cpll_clk {
+                    configure_cpll_clk(clocks, config);
+                }
+                if let Some(config) = self.spll_clk {
+                    configure_spll_clk(clocks, config);
+                }
+                if let Some(config) = self.mpll_clk {
+                    configure_mpll_clk(clocks, config);
+                }
                 if let Some(config) = self.cpu_root_clk {
                     configure_cpu_root_clk(clocks, config);
                 }
@@ -3569,6 +3722,62 @@ macro_rules! define_clock_tree_types {
             *refcount = refcount.saturating_sub(1);
             let last = *refcount == 0;
             last
+        }
+        fn refresh_cpll_clk_downstream(clocks: &mut ClockTree) {
+            if let Some(config) = clocks.cpll_clk {
+                CPLL_CLK_FREQ_CACHE.store(
+                    cpll_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            refresh_cpu_root_clk_downstream(clocks);
+            refresh_timg_calibration_clock_downstream(clocks);
+            for child_instance in [MipiDsiInstance::MipiDsi] {
+                refresh_mipi_dsi_phy_pll_refclk_downstream(clocks, child_instance);
+            }
+        }
+        fn refresh_spll_clk_downstream(clocks: &mut ClockTree) {
+            if let Some(config) = clocks.spll_clk {
+                SPLL_CLK_FREQ_CACHE.store(
+                    spll_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            refresh_timg_calibration_clock_downstream(clocks);
+            for child_instance in [TimgInstance::Timg0, TimgInstance::Timg1] {
+                refresh_timg_function_clock_downstream(clocks, child_instance);
+                refresh_timg_wdt_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [
+                UartInstance::Uart0,
+                UartInstance::Uart1,
+                UartInstance::Uart2,
+                UartInstance::Uart3,
+                UartInstance::Uart4,
+            ] {
+                refresh_uart_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [SpiInstance::Spi2, SpiInstance::Spi3] {
+                refresh_spi_function_clock_downstream(clocks, child_instance);
+            }
+            for child_instance in [MipiDsiInstance::MipiDsi] {
+                refresh_mipi_dsi_dpi_clk_downstream(clocks, child_instance);
+                refresh_mipi_dsi_phy_pll_refclk_downstream(clocks, child_instance);
+                refresh_mipi_dsi_phy_cfg_clk_downstream(clocks, child_instance);
+            }
+        }
+        fn refresh_mpll_clk_downstream(clocks: &mut ClockTree) {
+            if let Some(config) = clocks.mpll_clk {
+                MPLL_CLK_FREQ_CACHE.store(
+                    mpll_clk_config_frequency(clocks, config),
+                    ::core::sync::atomic::Ordering::Release,
+                );
+            }
+            refresh_timg_calibration_clock_downstream(clocks);
+            for child_instance in [MipiDsiInstance::MipiDsi] {
+                refresh_mipi_dsi_phy_pll_refclk_downstream(clocks, child_instance);
+                refresh_mipi_dsi_phy_cfg_clk_downstream(clocks, child_instance);
+            }
         }
         fn refresh_cpu_root_clk_downstream(clocks: &mut ClockTree) {
             if let Some(config) = clocks.cpu_root_clk {

--- a/esp-metadata/devices/esp32p4/clocks.toml
+++ b/esp-metadata/devices/esp32p4/clocks.toml
@@ -1,9 +1,9 @@
 system_clocks = { clock_tree = [
     # High-speed clock sources
     { name = "XTAL_CLK",    type = "source",  output = "40_000_000", always_on = true },
-    { name = "CPLL_CLK",    type = "derived", from = "XTAL_CLK", output = "400_000_000" }, # eco5 default 400MHz
-    { name = "SPLL_CLK",    type = "derived", from = "XTAL_CLK", output = "480_000_000" }, # System PLL
-    { name = "MPLL_CLK",    type = "derived", from = "XTAL_CLK", output = "500_000_000" }, # Media PLL
+    { name = "CPLL_CLK",    type = "derived", from = "XTAL_CLK", values = "360, 400", output = "VALUE * 1_000_000" },
+    { name = "SPLL_CLK",    type = "derived", from = "XTAL_CLK", values = "240, 480", output = "VALUE * 1_000_000" },
+    { name = "MPLL_CLK",    type = "derived", from = "XTAL_CLK", values = "320, 400, 500", output = "VALUE * 1_000_000" },
     { name = "RC_FAST_CLK", type = "source",                     output = "20_000_000" },
 
     # Low-speed clocks
@@ -21,7 +21,7 @@ system_clocks = { clock_tree = [
 
     # MPLL divider taps
     { name = "PLL_F25M",  type = "generic", output = "MPLL_CLK / 20" },
-    { name = "PLL_F50M",  type = "generic", output = "MPLL_CLK / 10"  },
+    { name = "PLL_F50M",  type = "generic", output = "MPLL_CLK / 10" },
 
     # XTAL half
     { name = "XTAL_D2_CLK", type = "generic", output = "XTAL_CLK / 2" },


### PR DESCRIPTION
Since MPLL is shared between PSRAM and MIPI-DSI, we can't just let PSRAM configure it to whatever it wants. This PR integrates CPLL/MPLL/SPLL into the clock tree system, making them configurable.