### PR TITLE
Calibrate RC_FAST clock on boot and before deep sleep

### DIFF
--- a/esp-hal/src/clock/mod.rs
+++ b/esp-hal/src/clock/mod.rs
@@ -51,6 +51,7 @@ use clocks::LpSlowClkConfig;
 use clocks::RtcSlowClkConfig;
 #[cfg(soc_has_clock_node_timg_function_clock)]
 use clocks::TimgFunctionClockConfig;
+use portable_atomic::AtomicU32;
 
 /// # Low-level clock control
 ///
@@ -134,20 +135,17 @@ use crate::soc::clocks::TimgCalibrationClockConfig;
 
 /// RTC Watchdog Timer driver.
 impl RtcClock {
-    const CAL_FRACT: u32 = 19;
+    pub(crate) const CAL_FRACT: u32 = 19;
 
     /// Get the nominal value of the RTC_SLOW_CLK source.
     #[instability::unstable]
     #[cfg(any(soc_has_clock_node_lp_slow_clk, soc_has_clock_node_rtc_slow_clk))]
     pub fn slow_freq() -> Rate {
-        cfg_select! {
-            soc_has_clock_node_rtc_slow_clk => {
-                let freq = clocks::rtc_slow_clk_frequency();
-            }
-            _ => {
-                let freq = clocks::lp_slow_clk_frequency();
-            }
-        }
+        let freq = cfg_select! {
+            soc_has_clock_node_rtc_slow_clk => clocks::rtc_slow_clk_frequency(),
+            _ => clocks::lp_slow_clk_frequency(),
+        };
+
         Rate::from_hz(freq)
     }
 
@@ -238,6 +236,7 @@ pub(crate) fn init(cpu_clock_config: ClockConfig) {
     });
 
     calibrate_rtc_slow_clock();
+    calibrate_rtc_fast_clock();
 }
 
 impl RtcClock {
@@ -480,7 +479,9 @@ pub(crate) fn calibrate_rtc_slow_clock() {
         _ => {}
     }
 
-    let cal_val = RtcClock::calibrate(slow_clk, 1024);
+    // Clock is in order of 30-150kHz.
+    const SLOW_CLK_SRC_CAL_CYCLES: u32 = 16;
+    let cal_val = RtcClock::calibrate(slow_clk, SLOW_CLK_SRC_CAL_CYCLES);
 
     let reg = cfg_select! {
         esp32p4 => LP_AON::regs().lp_store1(),
@@ -488,6 +489,26 @@ pub(crate) fn calibrate_rtc_slow_clock() {
     };
 
     reg.write(|w| unsafe { w.bits(cal_val) });
+}
+
+static RC_FAST_CAL_VAL: AtomicU32 = AtomicU32::new(0);
+
+#[cfg(soc_has_clock_node_timg_calibration_clock)]
+pub(crate) fn calibrate_rtc_fast_clock() {
+    // Clock is in order of 10 MHz
+    const FAST_CLK_SRC_CAL_CYCLES: u32 = 128;
+
+    let cal_val = RtcClock::calibrate(
+        TimgCalibrationClockConfig::RcFastDivClk,
+        FAST_CLK_SRC_CAL_CYCLES,
+    );
+
+    RC_FAST_CAL_VAL.store(cal_val, core::sync::atomic::Ordering::Relaxed);
+}
+
+#[cfg(not(soc_has_clock_node_timg_calibration_clock))]
+fn calibrate_rtc_fast_clock() {
+    // Do nothing until TIMG_CALIBRATION_CLOCK is added to device metadata.
 }
 
 /// The CPU clock frequency.
@@ -513,6 +534,12 @@ pub(crate) fn rtc_slow_cal_period() -> u32 {
     };
 
     reg.read().bits()
+}
+
+/// Read the calibrated RTC fast clock period from memory.
+#[cfg_attr(not(soc_has_pmu), expect(dead_code))]
+pub(crate) fn rtc_fast_cal_period() -> u32 {
+    RC_FAST_CAL_VAL.load(core::sync::atomic::Ordering::Relaxed)
 }
 
 /// Convert RTC slow clock ticks to microseconds using the calibrated period.

--- a/esp-hal/src/clock/mod.rs
+++ b/esp-hal/src/clock/mod.rs
@@ -82,6 +82,15 @@ use crate::{
     time::Rate,
 };
 
+cfg_select! {
+    soc_has_lp_aon => {
+        use crate::peripherals::LP_AON;
+    }
+    _ => {
+        use crate::peripherals::LPWR as LP_AON;
+    }
+}
+
 impl CpuClock {
     #[procmacros::doc_replace]
     /// Use the highest possible frequency for a particular chip.
@@ -473,23 +482,10 @@ fn calibrate_rtc_slow_clock() {
 
     let cal_val = RtcClock::calibrate(slow_clk, 1024);
 
-    cfg_select! {
-        soc_has_lp_aon => {
-            use crate::peripherals::LP_AON;
-        }
-        _ => {
-            use crate::peripherals::LPWR as LP_AON;
-        }
-    }
-
-    cfg_select! {
-        esp32p4 => {
-            let reg = LP_AON::regs().lp_store1();
-        }
-        _ => {
-            let reg = LP_AON::regs().store1();
-        }
-    }
+    let reg = cfg_select! {
+        esp32p4 => LP_AON::regs().lp_store1(),
+        _ => LP_AON::regs().store1(),
+    };
 
     reg.write(|w| unsafe { w.bits(cal_val) });
 }
@@ -510,36 +506,19 @@ pub fn xtal_clock() -> Rate {
 /// with `RtcClock::CAL_FRACT` fractional bits.
 ///
 /// Written by [`calibrate_rtc_slow_clock`] during clock initialization.
-fn rtc_slow_cal_period() -> u64 {
-    cfg_select! {
-        soc_has_lp_aon => {
-            use crate::peripherals::LP_AON;
-        }
-        _ => {
-            use crate::peripherals::LPWR as LP_AON;
-        }
-    }
+pub(crate) fn rtc_slow_cal_period() -> u32 {
+    let reg = cfg_select! {
+        esp32p4 => LP_AON::regs().lp_store1(),
+        _ => LP_AON::regs().store1(),
+    };
 
-    // P4: LP_SYS (mapped as LP_AON in esp-hal) names its scratch registers
-    // `lp_store0..lp_store14`, while every other chip names them `store0..N`.
-    // TODO: file an esp-pacs issue/PR to rename the P4 fields to match.
-    // Once that lands this cfg branch can disappear.
-    cfg_select! {
-        esp32p4 => {
-            let reg = LP_AON::regs().lp_store1();
-        }
-        _ => {
-            let reg = LP_AON::regs().store1();
-        }
-    }
-
-    reg.read().bits() as u64
+    reg.read().bits()
 }
 
 /// Convert RTC slow clock ticks to microseconds using the calibrated period.
 #[cfg(lp_timer_driver_supported)]
 pub(crate) fn rtc_ticks_to_us(ticks: u64) -> u64 {
-    let period = rtc_slow_cal_period();
+    let period = rtc_slow_cal_period() as u64;
 
     // The LP timer is a 48-bit counter running from RTC_SLOW_CLK.
     // `period` is a fixed point number with 19 fractional bits, it may be a 24-bit value if
@@ -557,7 +536,7 @@ pub(crate) fn rtc_ticks_to_us(ticks: u64) -> u64 {
 
 /// Convert microseconds to RTC slow clock ticks using the calibrated period.
 pub(crate) fn us_to_rtc_ticks(time_in_us: u64) -> u64 {
-    let period = rtc_slow_cal_period();
+    let period = rtc_slow_cal_period() as u64;
 
     if time_in_us > (u64::MAX >> RtcClock::CAL_FRACT) {
         ((time_in_us / period) << RtcClock::CAL_FRACT)

--- a/esp-hal/src/clock/mod.rs
+++ b/esp-hal/src/clock/mod.rs
@@ -161,15 +161,15 @@ impl RtcClock {
     /// issue, or lack of 32 XTAL on board).
     #[cfg(soc_has_clock_node_timg_calibration_clock)]
     pub(crate) fn calibrate(cal_clk: TimgCalibrationClockConfig, slowclk_cycles: u32) -> u32 {
-        ClockTree::with(|clocks| {
-            #[cfg(not(esp32c2))]
-            if cal_clk == TimgCalibrationClockConfig::Xtal32kClk {
-                debug!("Assuming Xtal32k has precisely 32.768kHz instead of calibrating");
-                let freq_hz: u64 = 32_768;
-                let period_64 = (1_000_000u64 << RtcClock::CAL_FRACT) / freq_hz;
-                return period_64 as u32;
-            }
+        #[cfg(not(esp32c2))]
+        if cal_clk == TimgCalibrationClockConfig::Xtal32kClk {
+            debug!("Assuming Xtal32k has precisely 32.768kHz instead of calibrating");
+            let freq_hz: u64 = 32_768;
+            let period_64 = (1_000_000u64 << RtcClock::CAL_FRACT) / freq_hz;
+            return period_64 as u32;
+        }
 
+        ClockTree::with(|clocks| {
             let xtal_freq = Rate::from_hz(clocks::xtal_clk_frequency());
 
             let (xtal_cycles, _) = RtcClock::measure_rtc_clock(
@@ -452,7 +452,7 @@ fn calibrate_rtc_slow_clock() {
 }
 
 #[cfg(soc_has_clock_node_timg_calibration_clock)]
-fn calibrate_rtc_slow_clock() {
+pub(crate) fn calibrate_rtc_slow_clock() {
     // Unfortunate device specific mapping.
     // TODO: fix it by generating cfgs for each mux input?
     cfg_select! {

--- a/esp-hal/src/rtc_cntl/sleep/esp32c5.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c5.rs
@@ -1,15 +1,14 @@
 use core::ops::Not;
 
 use crate::{
-    clock::{RtcClock, calibrate_rtc_slow_clock, rtc_slow_cal_period},
     peripherals::{LP_AON, PMU},
     private::DropGuard,
     rtc_cntl::{
         Rtc,
         rtc::{HpAnalog, HpSysCntlReg, HpSysPower, LpAnalog, LpSysPower},
-        sleep::WakeTriggers,
+        sleep::{WakeTriggers, pmu_common::SleepTimeConfig},
     },
-    soc::clocks::{self, ClockTree, HpRootClkConfig, LpSlowClkConfig, TimgCalibrationClockConfig},
+    soc::clocks::{self, ClockTree, HpRootClkConfig, LpSlowClkConfig},
 };
 
 /// Configuration for controlling the behavior during sleep modes.
@@ -506,75 +505,11 @@ impl ParamSleepConfig {
     }
 }
 
-#[derive(Clone, Copy)]
-struct SleepTimeConfig {
-    sleep_time_adjustment: u32,
-    // TODO: esp-idf does some calibration here to determine slowclk_period
-    slowclk_period: u32,
-    fastclk_period: u32,
-}
-
-const CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ: u32 = 160;
-
 impl SleepTimeConfig {
-    const RTC_CLK_CAL_FRACT: u32 = 19;
+    pub(crate) const CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ: u32 = 160;
+    pub(crate) const LIGHT_SLEEP_TIME_OVERHEAD_US: u32 = 56;
 
-    fn rtc_clk_cal_fast() -> u32 {
-        // Calibrate rtc fast clock, only PMU supported chips sleep process is needed.
-        const FAST_CLK_SRC_CAL_CYCLES: u32 = 2048;
-        RtcClock::calibrate(
-            TimgCalibrationClockConfig::RcFastDivClk,
-            FAST_CLK_SRC_CAL_CYCLES,
-        )
-    }
-
-    fn rtc_clk_cal_slow() -> u32 {
-        calibrate_rtc_slow_clock();
-        rtc_slow_cal_period()
-    }
-
-    fn new() -> Self {
-        Self {
-            sleep_time_adjustment: 0,
-            slowclk_period: Self::rtc_clk_cal_slow(),
-            fastclk_period: Self::rtc_clk_cal_fast(),
-        }
-    }
-
-    fn light_sleep(pd_flags: PowerDownFlags) -> Self {
-        const LIGHT_SLEEP_TIME_OVERHEAD_US: u32 = 56;
-
-        let mut this = Self::new();
-
-        let sw = LIGHT_SLEEP_TIME_OVERHEAD_US; // TODO
-        let hw = this.pmu_sleep_calculate_hw_wait_time(pd_flags);
-
-        this.sleep_time_adjustment = sw + hw;
-
-        this
-    }
-
-    fn deep_sleep() -> Self {
-        let mut this = Self::new();
-
-        this.sleep_time_adjustment = 250 + 100 * 240 / CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ;
-
-        this
-    }
-
-    fn us_to_slowclk(&self, us: u32) -> u32 {
-        (us << Self::RTC_CLK_CAL_FRACT) / self.slowclk_period
-    }
-
-    fn slowclk_to_us(&self, rtc_cycles: u32) -> u32 {
-        (rtc_cycles * self.slowclk_period) >> Self::RTC_CLK_CAL_FRACT
-    }
-
-    fn us_to_fastclk(&self, us: u32) -> u32 {
-        (us << Self::RTC_CLK_CAL_FRACT) / self.fastclk_period
-    }
-
-    fn pmu_sleep_calculate_hw_wait_time(&self, pd_flags: PowerDownFlags) -> u32 {
+    pub(crate) fn pmu_sleep_calculate_hw_wait_time(&self, pd_flags: PowerDownFlags) -> u32 {
         // LP core hardware wait time, microsecond
         let lp_wakeup_wait_time_us = self.slowclk_to_us(MachineConstants::LP_WAKEUP_WAIT_CYCLE);
         let lp_clk_switch_time_us = self.slowclk_to_us(MachineConstants::LP_CLK_SWITCH_CYCLE);

--- a/esp-hal/src/rtc_cntl/sleep/esp32c5.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c5.rs
@@ -1,7 +1,7 @@
 use core::ops::Not;
 
 use crate::{
-    clock::{RtcClock, rtc_slow_cal_period},
+    clock::{RtcClock, calibrate_rtc_slow_clock, rtc_slow_cal_period},
     peripherals::{LP_AON, PMU},
     private::DropGuard,
     rtc_cntl::{
@@ -519,28 +519,32 @@ const CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ: u32 = 160;
 impl SleepTimeConfig {
     const RTC_CLK_CAL_FRACT: u32 = 19;
 
-    fn rtc_clk_cal_fast(slowclk_cycles: u32) -> u32 {
-        RtcClock::calibrate(TimgCalibrationClockConfig::RcFastDivClk, slowclk_cycles)
-    }
-
-    fn new(_deep: bool) -> Self {
-        let slowclk_period = rtc_slow_cal_period();
-
+    fn rtc_clk_cal_fast() -> u32 {
         // Calibrate rtc fast clock, only PMU supported chips sleep process is needed.
         const FAST_CLK_SRC_CAL_CYCLES: u32 = 2048;
-        let fastclk_period = Self::rtc_clk_cal_fast(FAST_CLK_SRC_CAL_CYCLES);
+        RtcClock::calibrate(
+            TimgCalibrationClockConfig::RcFastDivClk,
+            FAST_CLK_SRC_CAL_CYCLES,
+        )
+    }
 
+    fn rtc_clk_cal_slow() -> u32 {
+        calibrate_rtc_slow_clock();
+        rtc_slow_cal_period()
+    }
+
+    fn new() -> Self {
         Self {
             sleep_time_adjustment: 0,
-            slowclk_period,
-            fastclk_period,
+            slowclk_period: Self::rtc_clk_cal_slow(),
+            fastclk_period: Self::rtc_clk_cal_fast(),
         }
     }
 
     fn light_sleep(pd_flags: PowerDownFlags) -> Self {
         const LIGHT_SLEEP_TIME_OVERHEAD_US: u32 = 56;
 
-        let mut this = Self::new(false);
+        let mut this = Self::new();
 
         let sw = LIGHT_SLEEP_TIME_OVERHEAD_US; // TODO
         let hw = this.pmu_sleep_calculate_hw_wait_time(pd_flags);
@@ -551,7 +555,7 @@ impl SleepTimeConfig {
     }
 
     fn deep_sleep() -> Self {
-        let mut this = Self::new(true);
+        let mut this = Self::new();
 
         this.sleep_time_adjustment = 250 + 100 * 240 / CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ;
 

--- a/esp-hal/src/rtc_cntl/sleep/esp32c5.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c5.rs
@@ -1,7 +1,7 @@
 use core::ops::Not;
 
 use crate::{
-    clock::RtcClock,
+    clock::{RtcClock, rtc_slow_cal_period},
     peripherals::{LP_AON, PMU},
     private::DropGuard,
     rtc_cntl::{
@@ -524,11 +524,7 @@ impl SleepTimeConfig {
     }
 
     fn new(_deep: bool) -> Self {
-        // https://github.com/espressif/esp-idf/commit/e1d24ebd7f43c7c7ded183bc8800b20af3bf014b
-
-        // Calibrate rtc slow clock
-        // TODO: do an actual calibration instead of a read
-        let slowclk_period = LP_AON::regs().store1().read().data().bits();
+        let slowclk_period = rtc_slow_cal_period();
 
         // Calibrate rtc fast clock, only PMU supported chips sleep process is needed.
         const FAST_CLK_SRC_CAL_CYCLES: u32 = 2048;

--- a/esp-hal/src/rtc_cntl/sleep/esp32c6.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c6.rs
@@ -1,7 +1,7 @@
 use core::ops::Not;
 
 use crate::{
-    clock::{RtcClock, rtc_slow_cal_period},
+    clock::{RtcClock, calibrate_rtc_slow_clock, rtc_slow_cal_period},
     gpio::RtcFunction,
     peripherals::{LP_AON, PMU},
     private::DropGuard,
@@ -607,28 +607,32 @@ const CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ: u32 = 160;
 impl SleepTimeConfig {
     const RTC_CLK_CAL_FRACT: u32 = 19;
 
-    fn rtc_clk_cal_fast(slowclk_cycles: u32) -> u32 {
-        RtcClock::calibrate(TimgCalibrationClockConfig::RcFastDivClk, slowclk_cycles)
-    }
-
-    fn new(_deep: bool) -> Self {
-        let slowclk_period = rtc_slow_cal_period();
-
+    fn rtc_clk_cal_fast() -> u32 {
         // Calibrate rtc fast clock, only PMU supported chips sleep process is needed.
         const FAST_CLK_SRC_CAL_CYCLES: u32 = 2048;
-        let fastclk_period = Self::rtc_clk_cal_fast(FAST_CLK_SRC_CAL_CYCLES);
+        RtcClock::calibrate(
+            TimgCalibrationClockConfig::RcFastDivClk,
+            FAST_CLK_SRC_CAL_CYCLES,
+        )
+    }
 
+    fn rtc_clk_cal_slow() -> u32 {
+        calibrate_rtc_slow_clock();
+        rtc_slow_cal_period()
+    }
+
+    fn new() -> Self {
         Self {
             sleep_time_adjustment: 0,
-            slowclk_period,
-            fastclk_period,
+            slowclk_period: Self::rtc_clk_cal_slow(),
+            fastclk_period: Self::rtc_clk_cal_fast(),
         }
     }
 
     fn light_sleep(pd_flags: PowerDownFlags) -> Self {
         const LIGHT_SLEEP_TIME_OVERHEAD_US: u32 = 56;
 
-        let mut this = Self::new(false);
+        let mut this = Self::new();
 
         let sw = LIGHT_SLEEP_TIME_OVERHEAD_US; // TODO
         let hw = this.pmu_sleep_calculate_hw_wait_time(pd_flags);
@@ -639,7 +643,7 @@ impl SleepTimeConfig {
     }
 
     fn deep_sleep() -> Self {
-        let mut this = Self::new(true);
+        let mut this = Self::new();
 
         this.sleep_time_adjustment = 250 + 100 * 240 / CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ;
 

--- a/esp-hal/src/rtc_cntl/sleep/esp32c6.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c6.rs
@@ -1,7 +1,7 @@
 use core::ops::Not;
 
 use crate::{
-    clock::RtcClock,
+    clock::{RtcClock, rtc_slow_cal_period},
     gpio::RtcFunction,
     peripherals::{LP_AON, PMU},
     private::DropGuard,
@@ -612,11 +612,7 @@ impl SleepTimeConfig {
     }
 
     fn new(_deep: bool) -> Self {
-        // https://github.com/espressif/esp-idf/commit/e1d24ebd7f43c7c7ded183bc8800b20af3bf014b
-
-        // Calibrate rtc slow clock
-        // TODO: do an actual calibration instead of a read
-        let slowclk_period = LP_AON::regs().store1().read().data().bits();
+        let slowclk_period = rtc_slow_cal_period();
 
         // Calibrate rtc fast clock, only PMU supported chips sleep process is needed.
         const FAST_CLK_SRC_CAL_CYCLES: u32 = 2048;

--- a/esp-hal/src/rtc_cntl/sleep/esp32c6.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c6.rs
@@ -1,7 +1,6 @@
 use core::ops::Not;
 
 use crate::{
-    clock::{RtcClock, calibrate_rtc_slow_clock, rtc_slow_cal_period},
     gpio::RtcFunction,
     peripherals::{LP_AON, PMU},
     private::DropGuard,
@@ -15,9 +14,10 @@ use crate::{
             WakeSource,
             WakeTriggers,
             WakeupLevel,
+            pmu_common::SleepTimeConfig,
         },
     },
-    soc::clocks::{self, ClockTree, LpSlowClkConfig, SocRootClkConfig, TimgCalibrationClockConfig},
+    soc::clocks::{self, ClockTree, LpSlowClkConfig, SocRootClkConfig},
 };
 
 impl Ext1WakeupSource<'_, '_> {
@@ -594,75 +594,11 @@ impl ParamSleepConfig {
     }
 }
 
-#[derive(Clone, Copy)]
-struct SleepTimeConfig {
-    sleep_time_adjustment: u32,
-    // TODO: esp-idf does some calibration here to determine slowclk_period
-    slowclk_period: u32,
-    fastclk_period: u32,
-}
-
-const CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ: u32 = 160;
-
 impl SleepTimeConfig {
-    const RTC_CLK_CAL_FRACT: u32 = 19;
+    pub(crate) const CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ: u32 = 160;
+    pub(crate) const LIGHT_SLEEP_TIME_OVERHEAD_US: u32 = 56;
 
-    fn rtc_clk_cal_fast() -> u32 {
-        // Calibrate rtc fast clock, only PMU supported chips sleep process is needed.
-        const FAST_CLK_SRC_CAL_CYCLES: u32 = 2048;
-        RtcClock::calibrate(
-            TimgCalibrationClockConfig::RcFastDivClk,
-            FAST_CLK_SRC_CAL_CYCLES,
-        )
-    }
-
-    fn rtc_clk_cal_slow() -> u32 {
-        calibrate_rtc_slow_clock();
-        rtc_slow_cal_period()
-    }
-
-    fn new() -> Self {
-        Self {
-            sleep_time_adjustment: 0,
-            slowclk_period: Self::rtc_clk_cal_slow(),
-            fastclk_period: Self::rtc_clk_cal_fast(),
-        }
-    }
-
-    fn light_sleep(pd_flags: PowerDownFlags) -> Self {
-        const LIGHT_SLEEP_TIME_OVERHEAD_US: u32 = 56;
-
-        let mut this = Self::new();
-
-        let sw = LIGHT_SLEEP_TIME_OVERHEAD_US; // TODO
-        let hw = this.pmu_sleep_calculate_hw_wait_time(pd_flags);
-
-        this.sleep_time_adjustment = sw + hw;
-
-        this
-    }
-
-    fn deep_sleep() -> Self {
-        let mut this = Self::new();
-
-        this.sleep_time_adjustment = 250 + 100 * 240 / CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ;
-
-        this
-    }
-
-    fn us_to_slowclk(&self, us: u32) -> u32 {
-        (us << Self::RTC_CLK_CAL_FRACT) / self.slowclk_period
-    }
-
-    fn slowclk_to_us(&self, rtc_cycles: u32) -> u32 {
-        (rtc_cycles * self.slowclk_period) >> Self::RTC_CLK_CAL_FRACT
-    }
-
-    fn us_to_fastclk(&self, us: u32) -> u32 {
-        (us << Self::RTC_CLK_CAL_FRACT) / self.fastclk_period
-    }
-
-    fn pmu_sleep_calculate_hw_wait_time(&self, pd_flags: PowerDownFlags) -> u32 {
+    pub(crate) fn pmu_sleep_calculate_hw_wait_time(&self, pd_flags: PowerDownFlags) -> u32 {
         // LP core hardware wait time, microsecond
         let lp_wakeup_wait_time_us = self.slowclk_to_us(MachineConstants::LP_WAKEUP_WAIT_CYCLE);
         let lp_clk_switch_time_us = self.slowclk_to_us(MachineConstants::LP_CLK_SWITCH_CYCLE);

--- a/esp-hal/src/rtc_cntl/sleep/esp32c61.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c61.rs
@@ -1,7 +1,7 @@
 use core::ops::Not;
 
 use crate::{
-    clock::RtcClock,
+    clock::{RtcClock, rtc_slow_cal_period},
     peripherals::{LP_AON, PMU},
     private::DropGuard,
     rtc_cntl::{
@@ -526,11 +526,7 @@ impl SleepTimeConfig {
     }
 
     fn new(_deep: bool) -> Self {
-        // https://github.com/espressif/esp-idf/commit/e1d24ebd7f43c7c7ded183bc8800b20af3bf014b
-
-        // Calibrate rtc slow clock
-        // TODO: do an actual calibration instead of a read
-        let slowclk_period = LP_AON::regs().store1().read().lp_aon_store1().bits();
+        let slowclk_period = rtc_slow_cal_period();
 
         // Calibrate rtc fast clock, only PMU supported chips sleep process is needed.
         const FAST_CLK_SRC_CAL_CYCLES: u32 = 2048;

--- a/esp-hal/src/rtc_cntl/sleep/esp32c61.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c61.rs
@@ -1,7 +1,7 @@
 use core::ops::Not;
 
 use crate::{
-    clock::{RtcClock, rtc_slow_cal_period},
+    clock::{RtcClock, calibrate_rtc_slow_clock, rtc_slow_cal_period},
     peripherals::{LP_AON, PMU},
     private::DropGuard,
     rtc_cntl::{
@@ -521,28 +521,32 @@ const CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ: u32 = 160;
 impl SleepTimeConfig {
     const RTC_CLK_CAL_FRACT: u32 = 19;
 
-    fn rtc_clk_cal_fast(slowclk_cycles: u32) -> u32 {
-        RtcClock::calibrate(TimgCalibrationClockConfig::RcFastDivClk, slowclk_cycles)
-    }
-
-    fn new(_deep: bool) -> Self {
-        let slowclk_period = rtc_slow_cal_period();
-
+    fn rtc_clk_cal_fast() -> u32 {
         // Calibrate rtc fast clock, only PMU supported chips sleep process is needed.
         const FAST_CLK_SRC_CAL_CYCLES: u32 = 2048;
-        let fastclk_period = Self::rtc_clk_cal_fast(FAST_CLK_SRC_CAL_CYCLES);
+        RtcClock::calibrate(
+            TimgCalibrationClockConfig::RcFastDivClk,
+            FAST_CLK_SRC_CAL_CYCLES,
+        )
+    }
 
+    fn rtc_clk_cal_slow() -> u32 {
+        calibrate_rtc_slow_clock();
+        rtc_slow_cal_period()
+    }
+
+    fn new() -> Self {
         Self {
             sleep_time_adjustment: 0,
-            slowclk_period,
-            fastclk_period,
+            slowclk_period: Self::rtc_clk_cal_slow(),
+            fastclk_period: Self::rtc_clk_cal_fast(),
         }
     }
 
     fn light_sleep(pd_flags: PowerDownFlags) -> Self {
         const LIGHT_SLEEP_TIME_OVERHEAD_US: u32 = 56;
 
-        let mut this = Self::new(false);
+        let mut this = Self::new();
 
         let sw = LIGHT_SLEEP_TIME_OVERHEAD_US; // TODO
         let hw = this.pmu_sleep_calculate_hw_wait_time(pd_flags);
@@ -553,7 +557,7 @@ impl SleepTimeConfig {
     }
 
     fn deep_sleep() -> Self {
-        let mut this = Self::new(true);
+        let mut this = Self::new();
 
         this.sleep_time_adjustment = 250 + 100 * 240 / CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ;
 

--- a/esp-hal/src/rtc_cntl/sleep/esp32c61.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c61.rs
@@ -1,15 +1,14 @@
 use core::ops::Not;
 
 use crate::{
-    clock::{RtcClock, calibrate_rtc_slow_clock, rtc_slow_cal_period},
     peripherals::{LP_AON, PMU},
     private::DropGuard,
     rtc_cntl::{
         Rtc,
         rtc::{HpAnalog, HpSysCntlReg, HpSysPower, LpAnalog, LpSysPower},
-        sleep::WakeTriggers,
+        sleep::{WakeTriggers, pmu_common::SleepTimeConfig},
     },
-    soc::clocks::{self, ClockTree, HpRootClkConfig, LpSlowClkConfig, TimgCalibrationClockConfig},
+    soc::clocks::{self, ClockTree, HpRootClkConfig, LpSlowClkConfig},
 };
 
 /// Configuration for controlling the behavior during sleep modes.
@@ -508,75 +507,11 @@ impl ParamSleepConfig {
     }
 }
 
-#[derive(Clone, Copy)]
-struct SleepTimeConfig {
-    sleep_time_adjustment: u32,
-    // TODO: esp-idf does some calibration here to determine slowclk_period
-    slowclk_period: u32,
-    fastclk_period: u32,
-}
-
-const CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ: u32 = 160;
-
 impl SleepTimeConfig {
-    const RTC_CLK_CAL_FRACT: u32 = 19;
+    pub(crate) const CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ: u32 = 160;
+    pub(crate) const LIGHT_SLEEP_TIME_OVERHEAD_US: u32 = 56;
 
-    fn rtc_clk_cal_fast() -> u32 {
-        // Calibrate rtc fast clock, only PMU supported chips sleep process is needed.
-        const FAST_CLK_SRC_CAL_CYCLES: u32 = 2048;
-        RtcClock::calibrate(
-            TimgCalibrationClockConfig::RcFastDivClk,
-            FAST_CLK_SRC_CAL_CYCLES,
-        )
-    }
-
-    fn rtc_clk_cal_slow() -> u32 {
-        calibrate_rtc_slow_clock();
-        rtc_slow_cal_period()
-    }
-
-    fn new() -> Self {
-        Self {
-            sleep_time_adjustment: 0,
-            slowclk_period: Self::rtc_clk_cal_slow(),
-            fastclk_period: Self::rtc_clk_cal_fast(),
-        }
-    }
-
-    fn light_sleep(pd_flags: PowerDownFlags) -> Self {
-        const LIGHT_SLEEP_TIME_OVERHEAD_US: u32 = 56;
-
-        let mut this = Self::new();
-
-        let sw = LIGHT_SLEEP_TIME_OVERHEAD_US; // TODO
-        let hw = this.pmu_sleep_calculate_hw_wait_time(pd_flags);
-
-        this.sleep_time_adjustment = sw + hw;
-
-        this
-    }
-
-    fn deep_sleep() -> Self {
-        let mut this = Self::new();
-
-        this.sleep_time_adjustment = 250 + 100 * 240 / CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ;
-
-        this
-    }
-
-    fn us_to_slowclk(&self, us: u32) -> u32 {
-        (us << Self::RTC_CLK_CAL_FRACT) / self.slowclk_period
-    }
-
-    fn slowclk_to_us(&self, rtc_cycles: u32) -> u32 {
-        (rtc_cycles * self.slowclk_period) >> Self::RTC_CLK_CAL_FRACT
-    }
-
-    fn us_to_fastclk(&self, us: u32) -> u32 {
-        (us << Self::RTC_CLK_CAL_FRACT) / self.fastclk_period
-    }
-
-    fn pmu_sleep_calculate_hw_wait_time(&self, pd_flags: PowerDownFlags) -> u32 {
+    pub(crate) fn pmu_sleep_calculate_hw_wait_time(&self, pd_flags: PowerDownFlags) -> u32 {
         // LP core hardware wait time, microsecond
         let lp_wakeup_wait_time_us = self.slowclk_to_us(MachineConstants::LP_WAKEUP_WAIT_CYCLE);
         let lp_clk_switch_time_us = self.slowclk_to_us(MachineConstants::LP_CLK_SWITCH_CYCLE);

--- a/esp-hal/src/rtc_cntl/sleep/esp32h2.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32h2.rs
@@ -1,7 +1,7 @@
 use core::ops::Not;
 
 use crate::{
-    clock::RtcClock,
+    clock::{RtcClock, rtc_slow_cal_period},
     gpio::{AnyPin, Input, InputConfig, Pull, RtcPin},
     peripherals::{LP_AON, PMU},
     private::DropGuard,
@@ -473,7 +473,7 @@ impl SleepTimeConfig {
     }
 
     fn new() -> Self {
-        let slowclk_period = LP_AON::regs().store1().read().data().bits();
+        let slowclk_period = rtc_slow_cal_period();
 
         // Calibrate rtc fast clock, only PMU supported chips sleep process is needed.
         const FAST_CLK_SRC_CAL_CYCLES: u32 = 2048;

--- a/esp-hal/src/rtc_cntl/sleep/esp32h2.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32h2.rs
@@ -1,7 +1,6 @@
 use core::ops::Not;
 
 use crate::{
-    clock::{RtcClock, calibrate_rtc_slow_clock, rtc_slow_cal_period},
     gpio::{AnyPin, Input, InputConfig, Pull, RtcPin},
     peripherals::{LP_AON, PMU},
     private::DropGuard,
@@ -9,16 +8,15 @@ use crate::{
         Rtc,
         WakeupSource,
         rtc::{HpSysCntlReg, HpSysPower, LpSysPower},
-        sleep::{Ext1WakeupSource, WakeSource, WakeTriggers, WakeupLevel},
+        sleep::{
+            Ext1WakeupSource,
+            WakeSource,
+            WakeTriggers,
+            WakeupLevel,
+            pmu_common::SleepTimeConfig,
+        },
     },
-    soc::clocks::{
-        self,
-        ClockTree,
-        CpuClkConfig,
-        HpRootClkConfig,
-        LpSlowClkConfig,
-        TimgCalibrationClockConfig,
-    },
+    soc::clocks::{self, ClockTree, CpuClkConfig, HpRootClkConfig, LpSlowClkConfig},
 };
 
 impl Ext1WakeupSource<'_, '_> {
@@ -456,74 +454,11 @@ impl ParamSleepConfig {
     }
 }
 
-#[derive(Clone, Copy)]
-struct SleepTimeConfig {
-    sleep_time_adjustment: u32, // TODO: use this adjustment for calculating wakeup time
-    slowclk_period: u32,
-    fastclk_period: u32,
-}
-
-const CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ: u32 = 96;
-
 impl SleepTimeConfig {
-    const RTC_CLK_CAL_FRACT: u32 = 19;
+    pub(crate) const CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ: u32 = 96;
+    pub(crate) const LIGHT_SLEEP_TIME_OVERHEAD_US: u32 = 9;
 
-    fn rtc_clk_cal_fast() -> u32 {
-        // Calibrate rtc fast clock, only PMU supported chips sleep process is needed.
-        const FAST_CLK_SRC_CAL_CYCLES: u32 = 2048;
-        RtcClock::calibrate(
-            TimgCalibrationClockConfig::RcFastDivClk,
-            FAST_CLK_SRC_CAL_CYCLES,
-        )
-    }
-
-    fn rtc_clk_cal_slow() -> u32 {
-        calibrate_rtc_slow_clock();
-        rtc_slow_cal_period()
-    }
-
-    fn new() -> Self {
-        Self {
-            sleep_time_adjustment: 0,
-            slowclk_period: Self::rtc_clk_cal_slow(),
-            fastclk_period: Self::rtc_clk_cal_fast(),
-        }
-    }
-
-    fn light_sleep(pd_flags: PowerDownFlags) -> Self {
-        const LIGHT_SLEEP_TIME_OVERHEAD_US: u32 = 9;
-
-        let mut this = Self::new();
-
-        let sw = LIGHT_SLEEP_TIME_OVERHEAD_US;
-        let hw = this.pmu_sleep_calculate_hw_wait_time(pd_flags);
-
-        this.sleep_time_adjustment = sw + hw;
-
-        this
-    }
-
-    fn deep_sleep() -> Self {
-        let mut this = Self::new();
-
-        this.sleep_time_adjustment = 250 + 100 * 240 / CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ;
-
-        this
-    }
-
-    fn us_to_slowclk(&self, us: u32) -> u32 {
-        (us << Self::RTC_CLK_CAL_FRACT) / self.slowclk_period
-    }
-
-    fn slowclk_to_us(&self, rtc_cycles: u32) -> u32 {
-        (rtc_cycles * self.slowclk_period) >> Self::RTC_CLK_CAL_FRACT
-    }
-
-    fn us_to_fastclk(&self, us: u32) -> u32 {
-        (us << Self::RTC_CLK_CAL_FRACT) / self.fastclk_period
-    }
-
-    fn pmu_sleep_calculate_hw_wait_time(&self, pd_flags: PowerDownFlags) -> u32 {
+    pub(crate) fn pmu_sleep_calculate_hw_wait_time(&self, pd_flags: PowerDownFlags) -> u32 {
         let lp_clk_switch_time_us = self.slowclk_to_us(machine_constants::LP_CLK_SWITCH_CYCLE);
         let lp_clk_power_on_wait_time_us = if pd_flags.pd_xtal() {
             machine_constants::LP_XTAL_WAIT_STABLE_TIME_US

--- a/esp-hal/src/rtc_cntl/sleep/esp32h2.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32h2.rs
@@ -1,7 +1,7 @@
 use core::ops::Not;
 
 use crate::{
-    clock::{RtcClock, rtc_slow_cal_period},
+    clock::{RtcClock, calibrate_rtc_slow_clock, rtc_slow_cal_period},
     gpio::{AnyPin, Input, InputConfig, Pull, RtcPin},
     peripherals::{LP_AON, PMU},
     private::DropGuard,
@@ -468,21 +468,25 @@ const CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ: u32 = 96;
 impl SleepTimeConfig {
     const RTC_CLK_CAL_FRACT: u32 = 19;
 
-    fn rtc_clk_cal_fast(slowclk_cycles: u32) -> u32 {
-        RtcClock::calibrate(TimgCalibrationClockConfig::RcFastDivClk, slowclk_cycles)
+    fn rtc_clk_cal_fast() -> u32 {
+        // Calibrate rtc fast clock, only PMU supported chips sleep process is needed.
+        const FAST_CLK_SRC_CAL_CYCLES: u32 = 2048;
+        RtcClock::calibrate(
+            TimgCalibrationClockConfig::RcFastDivClk,
+            FAST_CLK_SRC_CAL_CYCLES,
+        )
+    }
+
+    fn rtc_clk_cal_slow() -> u32 {
+        calibrate_rtc_slow_clock();
+        rtc_slow_cal_period()
     }
 
     fn new() -> Self {
-        let slowclk_period = rtc_slow_cal_period();
-
-        // Calibrate rtc fast clock, only PMU supported chips sleep process is needed.
-        const FAST_CLK_SRC_CAL_CYCLES: u32 = 2048;
-        let fastclk_period = Self::rtc_clk_cal_fast(FAST_CLK_SRC_CAL_CYCLES);
-
         Self {
             sleep_time_adjustment: 0,
-            slowclk_period,
-            fastclk_period,
+            slowclk_period: Self::rtc_clk_cal_slow(),
+            fastclk_period: Self::rtc_clk_cal_fast(),
         }
     }
 

--- a/esp-hal/src/rtc_cntl/sleep/esp32p4.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32p4.rs
@@ -10,15 +10,14 @@ use core::{
 };
 
 use crate::{
-    clock::RtcClock,
     peripherals::{HP_SYS_CLKRST, LP_AON_CLKRST, PMU, USB_DEVICE},
     private::DropGuard,
     rtc_cntl::{
         Rtc,
         rtc::{HpAnalog, HpSysCntlReg, HpSysPower, LpAnalog, LpSysPower},
-        sleep::WakeTriggers,
+        sleep::{WakeTriggers, pmu_common::SleepTimeConfig},
     },
-    soc::clocks::{self, ClockTree, CpuRootClkConfig, LpSlowClkConfig, TimgCalibrationClockConfig},
+    soc::clocks::{self, ClockTree, CpuRootClkConfig, LpSlowClkConfig},
 };
 
 // ----------------------------------------------------------------------------
@@ -695,69 +694,11 @@ impl ParamSleepConfig {
     }
 }
 
-#[derive(Clone, Copy)]
-struct SleepTimeConfig {
-    sleep_time_adjustment: u32,
-    slowclk_period: u32,
-    fastclk_period: u32,
-}
-
-const CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ: u32 = 360;
-
 impl SleepTimeConfig {
-    const RTC_CLK_CAL_FRACT: u32 = 19;
+    pub(crate) const CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ: u32 = 360;
+    pub(crate) const LIGHT_SLEEP_TIME_OVERHEAD_US: u32 = 56;
 
-    fn rtc_clk_cal_fast(slowclk_cycles: u32) -> u32 {
-        RtcClock::calibrate(TimgCalibrationClockConfig::RcFastClk, slowclk_cycles)
-    }
-
-    fn new(_deep: bool) -> Self {
-        // rtc slow clock period (saved during clock init in the LP_AON store1).
-        let slowclk_period = crate::peripherals::LP_AON::regs()
-            .lp_store1()
-            .read()
-            .lp_scratch1()
-            .bits();
-
-        const FAST_CLK_SRC_CAL_CYCLES: u32 = 2048;
-        let fastclk_period = Self::rtc_clk_cal_fast(FAST_CLK_SRC_CAL_CYCLES);
-
-        Self {
-            sleep_time_adjustment: 0,
-            slowclk_period,
-            fastclk_period,
-        }
-    }
-
-    fn light_sleep(pd_flags: PowerDownFlags) -> Self {
-        const LIGHT_SLEEP_TIME_OVERHEAD_US: u32 = 56;
-
-        let mut this = Self::new(false);
-        let sw = LIGHT_SLEEP_TIME_OVERHEAD_US;
-        let hw = this.pmu_sleep_calculate_hw_wait_time(pd_flags);
-        this.sleep_time_adjustment = sw + hw;
-        this
-    }
-
-    fn deep_sleep() -> Self {
-        let mut this = Self::new(true);
-        this.sleep_time_adjustment = 250 + 100 * 240 / CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ;
-        this
-    }
-
-    fn us_to_slowclk(&self, us: u32) -> u32 {
-        (us << Self::RTC_CLK_CAL_FRACT) / self.slowclk_period
-    }
-
-    fn slowclk_to_us(&self, rtc_cycles: u32) -> u32 {
-        (rtc_cycles * self.slowclk_period) >> Self::RTC_CLK_CAL_FRACT
-    }
-
-    fn us_to_fastclk(&self, us: u32) -> u32 {
-        (us << Self::RTC_CLK_CAL_FRACT) / self.fastclk_period
-    }
-
-    fn pmu_sleep_calculate_hw_wait_time(&self, pd_flags: PowerDownFlags) -> u32 {
+    pub(crate) fn pmu_sleep_calculate_hw_wait_time(&self, pd_flags: PowerDownFlags) -> u32 {
         // LP core hardware wait time, microseconds.
         let lp_wakeup_wait_time_us = self.slowclk_to_us(MachineConstants::LP_WAKEUP_WAIT_CYCLE);
         let lp_clk_switch_time_us = self.slowclk_to_us(MachineConstants::LP_CLK_SWITCH_CYCLE);

--- a/esp-hal/src/rtc_cntl/sleep/mod.rs
+++ b/esp-hal/src/rtc_cntl/sleep/mod.rs
@@ -29,6 +29,9 @@ use crate::{
     rtc_cntl::{Rtc, WakeupSource},
 };
 
+#[cfg(soc_has_pmu)]
+mod pmu_common;
+
 #[cfg_attr(esp32, path = "esp32.rs")]
 #[cfg_attr(esp32s2, path = "esp32s2.rs")]
 #[cfg_attr(esp32s3, path = "esp32s3.rs")]

--- a/esp-hal/src/rtc_cntl/sleep/pmu_common.rs
+++ b/esp-hal/src/rtc_cntl/sleep/pmu_common.rs
@@ -1,0 +1,74 @@
+use crate::{
+    clock::{
+        RtcClock,
+        calibrate_rtc_fast_clock,
+        calibrate_rtc_slow_clock,
+        rtc_fast_cal_period,
+        rtc_slow_cal_period,
+    },
+    rtc_cntl::sleep::PowerDownFlags,
+};
+
+#[derive(Clone, Copy)]
+pub(super) struct SleepTimeConfig {
+    pub sleep_time_adjustment: u32,
+    pub slowclk_period: u32,
+    pub fastclk_period: u32,
+}
+
+impl SleepTimeConfig {
+    fn rtc_clk_cal_fast(deep: bool) -> u32 {
+        if deep {
+            calibrate_rtc_fast_clock();
+        }
+
+        rtc_fast_cal_period()
+    }
+
+    fn rtc_clk_cal_slow(deep: bool) -> u32 {
+        if deep {
+            calibrate_rtc_slow_clock();
+        }
+
+        rtc_slow_cal_period()
+    }
+
+    pub fn new(deep: bool) -> Self {
+        Self {
+            sleep_time_adjustment: 0,
+            slowclk_period: Self::rtc_clk_cal_slow(deep),
+            fastclk_period: Self::rtc_clk_cal_fast(deep),
+        }
+    }
+
+    pub fn light_sleep(pd_flags: PowerDownFlags) -> Self {
+        let mut this = Self::new(false);
+
+        let sw = Self::LIGHT_SLEEP_TIME_OVERHEAD_US; // TODO
+        let hw = this.pmu_sleep_calculate_hw_wait_time(pd_flags);
+
+        this.sleep_time_adjustment = sw + hw;
+
+        this
+    }
+
+    pub fn deep_sleep() -> Self {
+        let mut this = Self::new(true);
+
+        this.sleep_time_adjustment = 250 + 100 * 240 / Self::CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ;
+
+        this
+    }
+
+    pub fn us_to_slowclk(&self, us: u32) -> u32 {
+        (us << RtcClock::CAL_FRACT) / self.slowclk_period
+    }
+
+    pub fn slowclk_to_us(&self, rtc_cycles: u32) -> u32 {
+        (rtc_cycles * self.slowclk_period) >> RtcClock::CAL_FRACT
+    }
+
+    pub fn us_to_fastclk(&self, us: u32) -> u32 {
+        (us << RtcClock::CAL_FRACT) / self.fastclk_period
+    }
+}

--- a/esp-hal/src/soc/esp32p4/clocks.rs
+++ b/esp-hal/src/soc/esp32p4/clocks.rs
@@ -591,7 +591,7 @@ fn configure_timg_calibration_clock_impl(
                 TimgCalibrationClockConfig::MpllClk => 0,
                 TimgCalibrationClockConfig::SpllClk => 1,
                 TimgCalibrationClockConfig::CpllClk => 2,
-                TimgCalibrationClockConfig::RcFastClk => 7,
+                TimgCalibrationClockConfig::RcFastDivClk => 7,
                 TimgCalibrationClockConfig::RcSlowClk => 8,
                 TimgCalibrationClockConfig::Xtal32kClk => 10,
             })

--- a/esp-metadata-generated/src/_generated_esp32p4.rs
+++ b/esp-metadata-generated/src/_generated_esp32p4.rs
@@ -1783,7 +1783,7 @@ macro_rules! define_clock_tree_types {
             /// Selects `CPLL_CLK`.
             CpllClk,
             /// Selects `RC_FAST_CLK`.
-            RcFastClk,
+            RcFastDivClk,
             /// Selects `LP_SLOW_CLK`.
             RcSlowClk,
             /// Selects `XTAL32K_CLK`.
@@ -2964,7 +2964,7 @@ macro_rules! define_clock_tree_types {
                     TimgCalibrationClockConfig::MpllClk => request_mpll_clk(clocks),
                     TimgCalibrationClockConfig::SpllClk => request_spll_clk(clocks),
                     TimgCalibrationClockConfig::CpllClk => request_cpll_clk(clocks),
-                    TimgCalibrationClockConfig::RcFastClk => request_rc_fast_clk(clocks),
+                    TimgCalibrationClockConfig::RcFastDivClk => request_rc_fast_clk(clocks),
                     TimgCalibrationClockConfig::RcSlowClk => request_lp_slow_clk(clocks),
                     TimgCalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
                 }
@@ -2974,7 +2974,7 @@ macro_rules! define_clock_tree_types {
                         TimgCalibrationClockConfig::MpllClk => release_mpll_clk(clocks),
                         TimgCalibrationClockConfig::SpllClk => release_spll_clk(clocks),
                         TimgCalibrationClockConfig::CpllClk => release_cpll_clk(clocks),
-                        TimgCalibrationClockConfig::RcFastClk => release_rc_fast_clk(clocks),
+                        TimgCalibrationClockConfig::RcFastDivClk => release_rc_fast_clk(clocks),
                         TimgCalibrationClockConfig::RcSlowClk => release_lp_slow_clk(clocks),
                         TimgCalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
                     }
@@ -2997,7 +2997,7 @@ macro_rules! define_clock_tree_types {
                     TimgCalibrationClockConfig::MpllClk => request_mpll_clk(clocks),
                     TimgCalibrationClockConfig::SpllClk => request_spll_clk(clocks),
                     TimgCalibrationClockConfig::CpllClk => request_cpll_clk(clocks),
-                    TimgCalibrationClockConfig::RcFastClk => request_rc_fast_clk(clocks),
+                    TimgCalibrationClockConfig::RcFastDivClk => request_rc_fast_clk(clocks),
                     TimgCalibrationClockConfig::RcSlowClk => request_lp_slow_clk(clocks),
                     TimgCalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
                 }
@@ -3014,7 +3014,7 @@ macro_rules! define_clock_tree_types {
                     TimgCalibrationClockConfig::MpllClk => release_mpll_clk(clocks),
                     TimgCalibrationClockConfig::SpllClk => release_spll_clk(clocks),
                     TimgCalibrationClockConfig::CpllClk => release_cpll_clk(clocks),
-                    TimgCalibrationClockConfig::RcFastClk => release_rc_fast_clk(clocks),
+                    TimgCalibrationClockConfig::RcFastDivClk => release_rc_fast_clk(clocks),
                     TimgCalibrationClockConfig::RcSlowClk => release_lp_slow_clk(clocks),
                     TimgCalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
                 }
@@ -3029,7 +3029,7 @@ macro_rules! define_clock_tree_types {
                 TimgCalibrationClockConfig::MpllClk => mpll_clk_frequency(),
                 TimgCalibrationClockConfig::SpllClk => spll_clk_frequency(),
                 TimgCalibrationClockConfig::CpllClk => cpll_clk_frequency(),
-                TimgCalibrationClockConfig::RcFastClk => rc_fast_clk_frequency(),
+                TimgCalibrationClockConfig::RcFastDivClk => rc_fast_clk_frequency(),
                 TimgCalibrationClockConfig::RcSlowClk => lp_slow_clk_frequency(),
                 TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
             }
@@ -3042,7 +3042,7 @@ macro_rules! define_clock_tree_types {
                 TimgCalibrationClockConfig::MpllClk => mpll_clk_frequency(),
                 TimgCalibrationClockConfig::SpllClk => spll_clk_frequency(),
                 TimgCalibrationClockConfig::CpllClk => cpll_clk_frequency(),
-                TimgCalibrationClockConfig::RcFastClk => rc_fast_clk_frequency(),
+                TimgCalibrationClockConfig::RcFastDivClk => rc_fast_clk_frequency(),
                 TimgCalibrationClockConfig::RcSlowClk => lp_slow_clk_frequency(),
                 TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
             }

--- a/esp-metadata/devices/esp32p4/clocks.toml
+++ b/esp-metadata/devices/esp32p4/clocks.toml
@@ -64,7 +64,7 @@ system_clocks = { clock_tree = [
         #{ name = "SDIO_PLL0_CLK",   outputs = "SDIO_PLL0_CLK" },
         #{ name = "SDIO_PLL1_CLK",   outputs = "SDIO_PLL1_CLK" },
         #{ name = "SDIO_PLL2_CLK",   outputs = "SDIO_PLL2_CLK" },
-        { name = "RC_FAST_CLK",     outputs = "RC_FAST_CLK" },
+        { name = "RC_FAST_DIV_CLK", outputs = "RC_FAST_CLK" },
         { name = "RC_SLOW_CLK",     outputs = "LP_SLOW_CLK" },
         { name = "XTAL32K_CLK",     outputs = "XTAL32K_CLK" },
         #{ name = "PLL_LP_CLK",      outputs = "PLL_LP_CLK" },


### PR DESCRIPTION
On PMU devices, we need to calibrate the RC_FAST_CLK before sleeping, as they determine hardware wait times. This PR adds this calibration, but only for the deep sleep path to avoid adding excessive latency. Additionally, RC_FAST_CLK is now calibrated on boot as well.

# Changelog

## esp-hal

- Changed: shortened clock calibration periods
- Changed: RTC_FAST is now calibrated on startup and before entering deep sleep