### PR TITLE
On wifi set_config only update sta and ap config when something changes

### DIFF
--- a/esp-phy/Cargo.toml
+++ b/esp-phy/Cargo.toml
@@ -35,15 +35,15 @@ esp-metadata-generated = { version = "0.4.0", path = "../esp-metadata-generated"
 esp-sync = { version = "0.2.1", path = "../esp-sync" }
 
 # Make sure these are aligned with esp-radio's dependencies, too!
-esp-wifi-sys-esp32 = { version = "0.2.0", optional = true }
-esp-wifi-sys-esp32c2 = { version = "0.2.0", optional = true }
-esp-wifi-sys-esp32c3 = { version = "0.2.0", optional = true }
-esp-wifi-sys-esp32c5 = { version = "0.2.0", optional = true }
-esp-wifi-sys-esp32c6 = { version = "0.2.0", optional = true }
-esp-wifi-sys-esp32c61 = { version = "0.2.0", optional = true }
-esp-wifi-sys-esp32h2 = { version = "0.2.0", optional = true }
-esp-wifi-sys-esp32s2 = { version = "0.2.0", optional = true }
-esp-wifi-sys-esp32s3 = { version = "0.2.0", optional = true }
+esp-wifi-sys-esp32 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "2ea8e3e" }
+esp-wifi-sys-esp32c2 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "2ea8e3e" }
+esp-wifi-sys-esp32c3 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "2ea8e3e" }
+esp-wifi-sys-esp32c5 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "2ea8e3e" }
+esp-wifi-sys-esp32c6 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "2ea8e3e" }
+esp-wifi-sys-esp32c61 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "2ea8e3e" }
+esp-wifi-sys-esp32h2 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "2ea8e3e" }
+esp-wifi-sys-esp32s2 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "2ea8e3e" }
+esp-wifi-sys-esp32s3 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "2ea8e3e" }
 
 esp32   = { version = "0.40", features = ["critical-section"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "30cb7c5" }
 esp32c2 = { version = "0.29", features = ["critical-section"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "30cb7c5" }

--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -80,15 +80,15 @@ ieee802154 = { version = "0.6.1", optional = true }
 heapless = "0.9"
 embassy-sync = "0.8"
 # Make sure these are aligned with esp-phy's dependencies, too!
-esp-wifi-sys-esp32 = { version = "0.2.0", optional = true }
-esp-wifi-sys-esp32c2 = { version = "0.2.0", optional = true }
-esp-wifi-sys-esp32c3 = { version = "0.2.0", optional = true }
-esp-wifi-sys-esp32c5 = { version = "0.2.0", optional = true }
-esp-wifi-sys-esp32c6 = { version = "0.2.0", optional = true }
-esp-wifi-sys-esp32c61 = { version = "0.2.0", optional = true }
-esp-wifi-sys-esp32h2 = { version = "0.2.0", optional = true }
-esp-wifi-sys-esp32s2 = { version = "0.2.0", optional = true }
-esp-wifi-sys-esp32s3 = { version = "0.2.0", optional = true }
+esp-wifi-sys-esp32 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "2ea8e3e" }
+esp-wifi-sys-esp32c2 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "2ea8e3e" }
+esp-wifi-sys-esp32c3 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "2ea8e3e" }
+esp-wifi-sys-esp32c5 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "2ea8e3e" }
+esp-wifi-sys-esp32c6 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "2ea8e3e" }
+esp-wifi-sys-esp32c61 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "2ea8e3e" }
+esp-wifi-sys-esp32h2 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "2ea8e3e" }
+esp-wifi-sys-esp32s2 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "2ea8e3e" }
+esp-wifi-sys-esp32s3 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "2ea8e3e" }
 
 esp32   = { version = "0.40", features = ["critical-section"], optional = true , git = "https://github.com/esp-rs/esp-pacs", rev = "30cb7c5" }
 esp32c2 = { version = "0.29", features = ["critical-section"], optional = true , git = "https://github.com/esp-rs/esp-pacs", rev = "30cb7c5" }

--- a/esp-radio/src/wifi/ap.rs
+++ b/esp-radio/src/wifi/ap.rs
@@ -53,6 +53,9 @@ pub struct AccessPointConfig {
     #[builder_lite(reference)]
     pub(crate) password: String,
     /// The maximum number of connections allowed on the access point.
+    /// When set, this number can be clipped to a true upper limit because
+    /// ESPNow and access point connections share a common pool of hardware
+    /// encryption keys.
     #[builder_lite(unstable)]
     pub(crate) max_connections: u16,
     /// Dtim period of the access point (Range: 1 ~ 10).

--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -3225,7 +3225,8 @@ ignored."
             // Compare the new ap config with the current. Only update if something is changing.
             // This avoids unnecessary connection issues.
             let mut current: wifi_config_t = core::mem::zeroed();
-            if esp_wifi_get_config(wifi_interface_t_WIFI_IF_AP, &mut current) == include::ESP_OK as i32
+            if esp_wifi_get_config(wifi_interface_t_WIFI_IF_AP, &mut current)
+                == include::ESP_OK as i32
                 && current.ap == cfg.ap
             {
                 return Ok(());
@@ -3278,7 +3279,8 @@ ignored."
             // Compare the new sta config with the current. Only update if something is changing.
             // This avoids unnecessary connection issues.
             let mut current: wifi_config_t = core::mem::zeroed();
-            if esp_wifi_get_config(wifi_interface_t_WIFI_IF_STA, &mut current) == include::ESP_OK as i32
+            if esp_wifi_get_config(wifi_interface_t_WIFI_IF_STA, &mut current)
+                == include::ESP_OK as i32
                 && current.sta == cfg.sta
             {
                 return Ok(());

--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -3168,6 +3168,19 @@ ignored."
         Err(WifiError::Failed)
     }
 
+    // The total hardware encryption key slots available that are shared between
+    // ESP-NOW encrypted peers and the AP connections.
+    // See https://github.com/espressif/esp-idf/blob/master/components/esp_wifi/Kconfig#L589
+    #[cfg(esp32c2)]
+    const TOTAL_HW_ENCRYPT_KEYS: u8 = 4;
+    #[cfg(not(esp32c2))]
+    const TOTAL_HW_ENCRYPT_KEYS: u8 = 17;
+
+    // The upper limit of connections available for the AP. The user set limit in apply_ap_config
+    // is clipped to this value
+    const AP_MAX_CONNECTIONS: u8 =
+        Self::TOTAL_HW_ENCRYPT_KEYS.saturating_sub(CONFIG_ESP_WIFI_ESPNOW_MAX_ENCRYPT_NUM as u8);
+
     fn apply_ap_config(&mut self, config: &AccessPointConfig) -> Result<(), WifiError> {
         let mut cfg = wifi_config_t {
             ap: wifi_ap_config_t {
@@ -3177,7 +3190,9 @@ ignored."
                 channel: config.channel,
                 authmode: config.auth_method.to_raw(),
                 ssid_hidden: if config.ssid_hidden { 1 } else { 0 },
-                max_connection: config.max_connections as u8,
+                // Clip max_connection in the same way as done internally in esp_wifi_set_config.
+                // Doing this here so that we can do easy comparisons below
+                max_connection: (config.max_connections as u8).min(Self::AP_MAX_CONNECTIONS),
                 beacon_interval: 100,
                 pairwise_cipher: wifi_cipher_type_t_WIFI_CIPHER_TYPE_CCMP,
                 ftm_responder: false,
@@ -3206,6 +3221,15 @@ ignored."
             cfg.ap.ssid[0..(config.ssid.len())].copy_from_slice(config.ssid.as_bytes());
             cfg.ap.ssid_len = config.ssid.len() as u8;
             cfg.ap.password[0..(config.password.len())].copy_from_slice(config.password.as_bytes());
+
+            // Compare the new ap config with the current. Only update if something is changing.
+            // This avoids unnecessary connection issues.
+            let mut current: wifi_config_t = core::mem::zeroed();
+            if esp_wifi_get_config(wifi_interface_t_WIFI_IF_AP, &mut current) == include::ESP_OK as i32
+                && current.ap == cfg.ap
+            {
+                return Ok(());
+            }
 
             esp_wifi_result!(esp_wifi_set_config(wifi_interface_t_WIFI_IF_AP, &mut cfg))
         }
@@ -3250,6 +3274,15 @@ ignored."
             cfg.sta.ssid[0..(config.ssid.len())].copy_from_slice(config.ssid.as_bytes());
             cfg.sta.password[0..(config.password.len())]
                 .copy_from_slice(config.password.as_bytes());
+
+            // Compare the new sta config with the current. Only update if something is changing.
+            // This avoids unnecessary connection issues.
+            let mut current: wifi_config_t = core::mem::zeroed();
+            if esp_wifi_get_config(wifi_interface_t_WIFI_IF_STA, &mut current) == include::ESP_OK as i32
+                && current.sta == cfg.sta
+            {
+                return Ok(());
+            }
 
             esp_wifi_result!(esp_wifi_set_config(wifi_interface_t_WIFI_IF_STA, &mut cfg))
         }


### PR DESCRIPTION


### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` or `manual-changelog` label as appropriate.
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
This avoids needless connection interruptions when calling `WifiController::set_config`. Most useful in combined AP/Station mode when setting the config of the station and you don't want to interrupt the AP connection.

A common solution for provisioning a device is you start the wifi in a combined access point (AP) and station mode. This way the user can connect to the AP, access a web server running on the device, choose a wifi network and the device then uses the station to try connecting to that network.

Currently, when you're running in a combined AP/station mode and you update the station part of the config under the hood it will update the AP config as well even though nothing has changed there. This causes a connection interruption on the AP side which isn't always necessary.

The solution is simply to update the AP and station parts of the config separately (as they currently are) but only apply a change if it the configuration is different than the current state.

This PR depends on a [currently open PR in esp-wifi-sys](https://github.com/esp-rs/esp-wifi-sys/pull/504). If that change isn't okay I'm obviously happy to reimplement this PR so that it doesn't depend on `PartialEq` being added to a few structs though it would obviously make it a little bit more long-winded! :-)

Since this is my first PR on this project I have undoubtedly done a number of things wrong.

Things I'm most likely to have done wrong:
* Added consts `TOTAL_HW_ENCRYPT_KEYS` and `AP_MAX_CONNECTIONS` that matches my best understanding from the docs and from testing on an esp32 how the max connection for the AP and ESP-NOW are shared. See https://github.com/espressif/esp-idf/blob/master/components/esp_wifi/Kconfig#L589
* Are these values available somewhere else? I've looked up and down but I see nothing that looks like it.
* Should these consts instead be made available in esp-wifi-sys somehow rather than being hardcoded here?


#### Testing
Tested with esp32 hardware. A browser client connected to the device's soft-AP stays connected across repeated `set_config` calls with an unchanged config, where before it would get disconnected.

---

# Changelog

## esp-radio

- Fixed: WifiController set_config only updates AP and STA config on changes

## esp-phy

- No changelog necessary.
