### PR TITLE
Handle GPIO interrupts on the core that listens to them

### DIFF
--- a/esp-hal/src/gpio/asynch.rs
+++ b/esp-hal/src/gpio/asynch.rs
@@ -90,7 +90,7 @@ impl Flex<'_> {
         // Start listening for the event. We only need to do this once, as disabling
         // the interrupt will signal the future to complete.
         self.pin
-            .listen_with_options(event, true, false, options.wake_enable)?;
+            .listen_with_options(event, true, options.wake_enable)?;
 
         // Hold a wake lock for the duration of the wait so automatic light sleep does
         // not gate the GPIO interrupt. When the pin is configured as a light-sleep wake

--- a/esp-hal/src/gpio/interrupt.rs
+++ b/esp-hal/src/gpio/interrupt.rs
@@ -55,13 +55,7 @@ use portable_atomic::{AtomicPtr, Ordering};
 use strum::EnumCount;
 
 use crate::{
-    gpio::{
-        AnyPin,
-        GPIO_LOCK,
-        GpioBank,
-        InputPin,
-        low_level::{InterruptStatusRegisterAccess, set_int_enable},
-    },
+    gpio::{AnyPin, GPIO_LOCK, GpioBank, InputPin, low_level::set_int_enable},
     interrupt::{self, Priority},
     peripherals::Interrupt,
     ram,
@@ -241,10 +235,10 @@ pub(super) unsafe fn wake_pin_impl(pin: u8) {
 }
 
 fn interrupt_status() -> [(GpioBank, u32); GpioBank::COUNT] {
-    let intrs_bank0 = InterruptStatusRegisterAccess::Bank0.interrupt_status_read();
+    let intrs_bank0 = GpioBank::_0.read_interrupt_status_of_current_cpu();
 
     #[cfg(gpio_has_bank_1)]
-    let intrs_bank1 = InterruptStatusRegisterAccess::Bank1.interrupt_status_read();
+    let intrs_bank1 = GpioBank::_1.read_interrupt_status_of_current_cpu();
 
     [
         (GpioBank::_0, intrs_bank0),

--- a/esp-hal/src/gpio/interrupt.rs
+++ b/esp-hal/src/gpio/interrupt.rs
@@ -112,9 +112,7 @@ pub(crate) fn bind_default_interrupt_handler() {
         return;
     }
 
-    interrupt::bind_handler(Interrupt::GPIO, default_gpio_interrupt_handler);
-
-    super::low_level::enable_interrupt_on_second_core(Priority::Priority1);
+    super::low_level::enable_interrupt(default_gpio_interrupt_handler);
 }
 
 /// Configures the given peripheral interrupt to trigger the vectored handler of given priority.

--- a/esp-hal/src/gpio/interrupt.rs
+++ b/esp-hal/src/gpio/interrupt.rs
@@ -120,10 +120,7 @@ pub(crate) fn bind_default_interrupt_handler() {
 
     interrupt::bind_handler(Interrupt::GPIO, default_gpio_interrupt_handler);
 
-    // On ESP32, there are separate interrupt status registers for each core, we need to enable the
-    // interrupt handler on each core otherwise GPIOs listening on the App CPU will not receive
-    // interrupts.
-    super::low_level::enable_additional_default_interrupts(Interrupt::GPIO, Priority::Priority1);
+    super::low_level::enable_interrupt_on_second_core(Priority::Priority1);
 }
 
 /// Configures the given peripheral interrupt to trigger the vectored handler of given priority.

--- a/esp-hal/src/gpio/interrupt.rs
+++ b/esp-hal/src/gpio/interrupt.rs
@@ -62,15 +62,13 @@ use crate::{
         InputPin,
         low_level::{InterruptStatusRegisterAccess, set_int_enable},
     },
-    interrupt::Priority,
+    interrupt::{self, Priority},
     peripherals::Interrupt,
     ram,
+    system::Cpu,
 };
 #[cfg(feature = "rt")]
-use crate::{
-    handler,
-    interrupt::{self, DEFAULT_INTERRUPT_HANDLER},
-};
+use crate::{handler, interrupt::DEFAULT_INTERRUPT_HANDLER};
 
 /// Convenience constant for `Option::None` pin
 pub(super) static USER_INTERRUPT_HANDLER: CFnPtr = CFnPtr::new();
@@ -109,11 +107,11 @@ pub(crate) fn bind_default_interrupt_handler() {
     // The vector table doesn't contain a custom entry. Still, the
     // peripheral interrupt may already be bound to something else.
     let mut is_mapped = false;
-    super::low_level::for_each_interrupt_core(|cpu| {
+    for cpu in Cpu::all() {
         if interrupt::mapped_to(cpu, Interrupt::GPIO).is_some() {
             is_mapped = true;
         }
-    });
+    }
 
     if is_mapped {
         info!("Not using default GPIO interrupt handler: peripheral interrupt already in use");
@@ -130,13 +128,13 @@ pub(crate) fn bind_default_interrupt_handler() {
 
 /// Configures the given peripheral interrupt to trigger the vectored handler of given priority.
 pub(super) fn set_interrupt_priority(interrupt: Interrupt, priority: Priority) {
-    super::low_level::for_each_interrupt_core(|cpu| {
+    for cpu in Cpu::all() {
         // Only change priority if the interrupt is mapped to the core, otherwise we would enable
         // the interrupt unconditionally, which we don't want to do.
-        if crate::interrupt::mapped_to(cpu, interrupt).is_some() {
-            crate::interrupt::enable_on_cpu(cpu, interrupt, priority);
+        if interrupt::mapped_to(cpu, interrupt).is_some() {
+            interrupt::enable_on_cpu(cpu, interrupt, priority);
         }
-    });
+    }
 }
 
 /// The default GPIO interrupt handler, when the user has not set one.

--- a/esp-hal/src/gpio/low_level/mod.rs
+++ b/esp-hal/src/gpio/low_level/mod.rs
@@ -152,10 +152,6 @@ pub(crate) fn gpio_intr_enable(int_enable: bool, nmi_enable: bool) -> u8 {
     version::gpio_intr_enable(int_enable, nmi_enable)
 }
 
-pub(crate) fn for_each_interrupt_core(f: impl FnMut(crate::system::Cpu)) {
-    version::for_each_interrupt_core(f);
-}
-
 #[cfg(feature = "rt")]
 pub(crate) fn enable_additional_default_interrupts(
     interrupt: crate::peripherals::Interrupt,

--- a/esp-hal/src/gpio/low_level/mod.rs
+++ b/esp-hal/src/gpio/low_level/mod.rs
@@ -5,8 +5,8 @@ mod version;
 
 use portable_atomic::AtomicU32;
 use strum::EnumCount;
+pub(crate) use version::{enable_interrupt_on_second_core, gpio_intr_enable, prepare_pin_pull};
 
-use super::AnyPin;
 use crate::peripherals::GPIO;
 
 #[doc(hidden)]
@@ -142,22 +142,6 @@ pub(crate) fn bank(_gpio_num: u8) -> GpioBank {
     }
 
     GpioBank::_0
-}
-
-pub(crate) fn prepare_pin_pull(pin: &AnyPin<'_>, pull_up: bool, pull_down: bool) {
-    version::prepare_pin_pull(pin, pull_up, pull_down);
-}
-
-pub(crate) fn gpio_intr_enable(int_enable: bool) -> u8 {
-    version::gpio_intr_enable(int_enable)
-}
-
-#[cfg(feature = "rt")]
-pub(crate) fn enable_additional_default_interrupts(
-    interrupt: crate::peripherals::Interrupt,
-    priority: crate::interrupt::Priority,
-) {
-    version::enable_additional_default_interrupts(interrupt, priority);
 }
 
 /// Set GPIO event listening.

--- a/esp-hal/src/gpio/low_level/mod.rs
+++ b/esp-hal/src/gpio/low_level/mod.rs
@@ -85,6 +85,10 @@ impl GpioBank {
         version::read_bank_interrupt_status(self)
     }
 
+    pub(crate) fn read_interrupt_status_of_current_cpu(self) -> u32 {
+        version::read_interrupt_status_of_current_cpu(self)
+    }
+
     pub(crate) fn write_interrupt_status_clear(self, word: u32) {
         match self {
             Self::_0 => GPIO::regs()
@@ -119,19 +123,6 @@ impl GpioBank {
             #[cfg(gpio_has_bank_1)]
             Self::_1 => GPIO::regs().out1_w1tc().write(|w| unsafe { w.bits(word) }),
         };
-    }
-}
-
-#[derive(Clone, Copy)]
-pub(crate) enum InterruptStatusRegisterAccess {
-    Bank0,
-    #[cfg(gpio_has_bank_1)]
-    Bank1,
-}
-
-impl InterruptStatusRegisterAccess {
-    pub(crate) fn interrupt_status_read(self) -> u32 {
-        version::read_interrupt_status(self)
     }
 }
 

--- a/esp-hal/src/gpio/low_level/mod.rs
+++ b/esp-hal/src/gpio/low_level/mod.rs
@@ -5,7 +5,9 @@ mod version;
 
 use portable_atomic::AtomicU32;
 use strum::EnumCount;
-pub(crate) use version::{enable_interrupt_on_second_core, gpio_intr_enable, prepare_pin_pull};
+#[cfg(feature = "rt")]
+pub(crate) use version::enable_interrupt;
+pub(crate) use version::{gpio_intr_enable, prepare_pin_pull};
 
 use crate::peripherals::GPIO;
 

--- a/esp-hal/src/gpio/low_level/mod.rs
+++ b/esp-hal/src/gpio/low_level/mod.rs
@@ -148,8 +148,8 @@ pub(crate) fn prepare_pin_pull(pin: &AnyPin<'_>, pull_up: bool, pull_down: bool)
     version::prepare_pin_pull(pin, pull_up, pull_down);
 }
 
-pub(crate) fn gpio_intr_enable(int_enable: bool, nmi_enable: bool) -> u8 {
-    version::gpio_intr_enable(int_enable, nmi_enable)
+pub(crate) fn gpio_intr_enable(int_enable: bool) -> u8 {
+    version::gpio_intr_enable(int_enable)
 }
 
 #[cfg(feature = "rt")]

--- a/esp-hal/src/gpio/low_level/v1.rs
+++ b/esp-hal/src/gpio/low_level/v1.rs
@@ -1,5 +1,5 @@
 use super::{GpioBank, InterruptStatusRegisterAccess};
-use crate::{gpio::AnyPin, peripherals::GPIO};
+use crate::{gpio::AnyPin, peripherals::GPIO, system::Cpu};
 
 pub(super) fn read_bank_interrupt_status(bank: GpioBank) -> u32 {
     match bank {
@@ -21,10 +21,10 @@ pub(super) fn prepare_pin_pull(pin: &AnyPin<'_>, pull_up: bool, pull_down: bool)
     crate::soc::gpio::errata36(unsafe { pin.clone_unchecked() }, pull_up, pull_down);
 }
 
-pub(super) fn gpio_intr_enable(int_enable: bool, nmi_enable: bool) -> u8 {
-    match crate::system::Cpu::current() {
-        crate::system::Cpu::AppCpu => int_enable as u8 | ((nmi_enable as u8) << 1),
-        crate::system::Cpu::ProCpu => ((int_enable as u8) << 2) | ((nmi_enable as u8) << 3),
+pub(super) fn gpio_intr_enable(int_enable: bool) -> u8 {
+    match Cpu::current() {
+        Cpu::AppCpu => int_enable as u8,
+        Cpu::ProCpu => ((int_enable as u8) << 2),
     }
 }
 
@@ -33,5 +33,5 @@ pub(super) fn enable_additional_default_interrupts(
     interrupt: crate::peripherals::Interrupt,
     priority: crate::interrupt::Priority,
 ) {
-    crate::interrupt::enable_on_cpu(crate::system::Cpu::AppCpu, interrupt, priority);
+    crate::interrupt::enable_on_cpu(Cpu::AppCpu, interrupt, priority);
 }

--- a/esp-hal/src/gpio/low_level/v1.rs
+++ b/esp-hal/src/gpio/low_level/v1.rs
@@ -1,7 +1,11 @@
 use super::{GpioBank, InterruptStatusRegisterAccess};
-use crate::{gpio::AnyPin, peripherals::GPIO, system::Cpu};
+use crate::{
+    gpio::AnyPin,
+    peripherals::{GPIO, Interrupt},
+    system::Cpu,
+};
 
-pub(super) fn read_bank_interrupt_status(bank: GpioBank) -> u32 {
+pub(crate) fn read_bank_interrupt_status(bank: GpioBank) -> u32 {
     match bank {
         GpioBank::_0 => GPIO::regs().status().read().bits(),
         #[cfg(gpio_has_bank_1)]
@@ -9,7 +13,7 @@ pub(super) fn read_bank_interrupt_status(bank: GpioBank) -> u32 {
     }
 }
 
-pub(super) fn read_interrupt_status(access: InterruptStatusRegisterAccess) -> u32 {
+pub(crate) fn read_interrupt_status(access: InterruptStatusRegisterAccess) -> u32 {
     match access {
         InterruptStatusRegisterAccess::Bank0 => GPIO::regs().status().read().bits(),
         #[cfg(gpio_has_bank_1)]
@@ -17,11 +21,11 @@ pub(super) fn read_interrupt_status(access: InterruptStatusRegisterAccess) -> u3
     }
 }
 
-pub(super) fn prepare_pin_pull(pin: &AnyPin<'_>, pull_up: bool, pull_down: bool) {
+pub(crate) fn prepare_pin_pull(pin: &AnyPin<'_>, pull_up: bool, pull_down: bool) {
     errata36(pin, pull_up, pull_down);
 }
 
-pub(super) fn gpio_intr_enable(int_enable: bool) -> u8 {
+pub(crate) fn gpio_intr_enable(int_enable: bool) -> u8 {
     match Cpu::current() {
         Cpu::AppCpu => int_enable as u8,
         Cpu::ProCpu => (int_enable as u8) << 2,
@@ -29,11 +33,8 @@ pub(super) fn gpio_intr_enable(int_enable: bool) -> u8 {
 }
 
 #[cfg(feature = "rt")]
-pub(super) fn enable_additional_default_interrupts(
-    interrupt: crate::peripherals::Interrupt,
-    priority: crate::interrupt::Priority,
-) {
-    crate::interrupt::enable_on_cpu(Cpu::AppCpu, interrupt, priority);
+pub(crate) fn enable_interrupt_on_second_core(priority: crate::interrupt::Priority) {
+    crate::interrupt::enable_on_cpu(Cpu::AppCpu, Interrupt::GPIO, priority);
 }
 
 fn errata36(pin: &AnyPin<'_>, pull_up: bool, pull_down: bool) {

--- a/esp-hal/src/gpio/low_level/v1.rs
+++ b/esp-hal/src/gpio/low_level/v1.rs
@@ -18,13 +18,13 @@ pub(super) fn read_interrupt_status(access: InterruptStatusRegisterAccess) -> u3
 }
 
 pub(super) fn prepare_pin_pull(pin: &AnyPin<'_>, pull_up: bool, pull_down: bool) {
-    crate::soc::gpio::errata36(unsafe { pin.clone_unchecked() }, pull_up, pull_down);
+    errata36(pin, pull_up, pull_down);
 }
 
 pub(super) fn gpio_intr_enable(int_enable: bool) -> u8 {
     match Cpu::current() {
         Cpu::AppCpu => int_enable as u8,
-        Cpu::ProCpu => ((int_enable as u8) << 2),
+        Cpu::ProCpu => (int_enable as u8) << 2,
     }
 }
 
@@ -34,4 +34,19 @@ pub(super) fn enable_additional_default_interrupts(
     priority: crate::interrupt::Priority,
 ) {
     crate::interrupt::enable_on_cpu(Cpu::AppCpu, interrupt, priority);
+}
+
+fn errata36(pin: &AnyPin<'_>, pull_up: bool, pull_down: bool) {
+    use crate::gpio::{Pin, RtcPinWithResistors};
+
+    for_each_lp_function! {
+        (all_expanded $( (($_sig:ident, RTC_GPIOn, $_n:literal), $gpio:ident) ),* ) => {
+            const RTC_IO_PINS: &[u8] = &[ $( $crate::peripherals::$gpio::NUMBER ),* ];
+        };
+    };
+
+    if RTC_IO_PINS.contains(&pin.number()) && pin.is_output() {
+        pin.rtcio_pullup(pull_up);
+        pin.rtcio_pulldown(pull_down);
+    }
 }

--- a/esp-hal/src/gpio/low_level/v1.rs
+++ b/esp-hal/src/gpio/low_level/v1.rs
@@ -28,12 +28,6 @@ pub(super) fn gpio_intr_enable(int_enable: bool, nmi_enable: bool) -> u8 {
     }
 }
 
-pub(super) fn for_each_interrupt_core(mut f: impl FnMut(crate::system::Cpu)) {
-    for cpu in crate::system::Cpu::all() {
-        f(cpu);
-    }
-}
-
 #[cfg(feature = "rt")]
 pub(super) fn enable_additional_default_interrupts(
     interrupt: crate::peripherals::Interrupt,

--- a/esp-hal/src/gpio/low_level/v1.rs
+++ b/esp-hal/src/gpio/low_level/v1.rs
@@ -1,8 +1,9 @@
 use super::GpioBank;
+use crate::{gpio::AnyPin, peripherals::GPIO, system::Cpu};
+#[cfg(feature = "rt")]
 use crate::{
-    gpio::AnyPin,
-    peripherals::{GPIO, Interrupt},
-    system::Cpu,
+    interrupt::{self, InterruptHandler},
+    peripherals::Interrupt,
 };
 
 pub(crate) fn read_bank_interrupt_status(bank: GpioBank) -> u32 {
@@ -33,8 +34,9 @@ pub(crate) fn gpio_intr_enable(int_enable: bool) -> u8 {
 }
 
 #[cfg(feature = "rt")]
-pub(crate) fn enable_interrupt_on_second_core(priority: crate::interrupt::Priority) {
-    crate::interrupt::enable_on_cpu(Cpu::AppCpu, Interrupt::GPIO, priority);
+pub(crate) fn enable_interrupt(handler: InterruptHandler) {
+    interrupt::bind_handler(Interrupt::GPIO, handler);
+    interrupt::enable_on_cpu(Cpu::AppCpu, Interrupt::GPIO, handler.priority());
 }
 
 fn errata36(pin: &AnyPin<'_>, pull_up: bool, pull_down: bool) {

--- a/esp-hal/src/gpio/low_level/v1.rs
+++ b/esp-hal/src/gpio/low_level/v1.rs
@@ -1,4 +1,4 @@
-use super::{GpioBank, InterruptStatusRegisterAccess};
+use super::GpioBank;
 use crate::{
     gpio::AnyPin,
     peripherals::{GPIO, Interrupt},
@@ -8,16 +8,16 @@ use crate::{
 pub(crate) fn read_bank_interrupt_status(bank: GpioBank) -> u32 {
     match bank {
         GpioBank::_0 => GPIO::regs().status().read().bits(),
-        #[cfg(gpio_has_bank_1)]
         GpioBank::_1 => GPIO::regs().status1().read().bits(),
     }
 }
 
-pub(crate) fn read_interrupt_status(access: InterruptStatusRegisterAccess) -> u32 {
-    match access {
-        InterruptStatusRegisterAccess::Bank0 => GPIO::regs().status().read().bits(),
-        #[cfg(gpio_has_bank_1)]
-        InterruptStatusRegisterAccess::Bank1 => GPIO::regs().status1().read().bits(),
+pub(crate) fn read_interrupt_status_of_current_cpu(bank: GpioBank) -> u32 {
+    match (Cpu::current(), bank) {
+        (Cpu::AppCpu, GpioBank::_0) => GPIO::regs().acpu_int().read().bits(),
+        (Cpu::AppCpu, GpioBank::_1) => GPIO::regs().acpu_int1().read().bits(),
+        (Cpu::ProCpu, GpioBank::_0) => GPIO::regs().pcpu_int().read().bits(),
+        (Cpu::ProCpu, GpioBank::_1) => GPIO::regs().pcpu_int1().read().bits(),
     }
 }
 

--- a/esp-hal/src/gpio/low_level/v2.rs
+++ b/esp-hal/src/gpio/low_level/v2.rs
@@ -1,5 +1,10 @@
 use super::GpioBank;
 use crate::{gpio::AnyPin, peripherals::GPIO};
+#[cfg(feature = "rt")]
+use crate::{
+    interrupt::{self, InterruptHandler},
+    peripherals::Interrupt,
+};
 
 pub(crate) fn read_bank_interrupt_status(bank: GpioBank) -> u32 {
     match bank {
@@ -24,4 +29,6 @@ pub(crate) fn gpio_intr_enable(int_enable: bool) -> u8 {
 }
 
 #[cfg(feature = "rt")]
-pub(crate) fn enable_interrupt_on_second_core(_priority: crate::interrupt::Priority) {}
+pub(crate) fn enable_interrupt(handler: InterruptHandler) {
+    interrupt::bind_handler(Interrupt::GPIO, handler);
+}

--- a/esp-hal/src/gpio/low_level/v2.rs
+++ b/esp-hal/src/gpio/low_level/v2.rs
@@ -1,7 +1,7 @@
 use super::{GpioBank, InterruptStatusRegisterAccess};
 use crate::{gpio::AnyPin, peripherals::GPIO};
 
-pub(super) fn read_bank_interrupt_status(bank: GpioBank) -> u32 {
+pub(crate) fn read_bank_interrupt_status(bank: GpioBank) -> u32 {
     match bank {
         GpioBank::_0 => GPIO::regs().status().read().bits(),
         #[cfg(gpio_has_bank_1)]
@@ -9,7 +9,7 @@ pub(super) fn read_bank_interrupt_status(bank: GpioBank) -> u32 {
     }
 }
 
-pub(super) fn read_interrupt_status(access: InterruptStatusRegisterAccess) -> u32 {
+pub(crate) fn read_interrupt_status(access: InterruptStatusRegisterAccess) -> u32 {
     match access {
         InterruptStatusRegisterAccess::Bank0 => GPIO::regs().pcpu_int().read().bits(),
         #[cfg(gpio_has_bank_1)]
@@ -17,15 +17,11 @@ pub(super) fn read_interrupt_status(access: InterruptStatusRegisterAccess) -> u3
     }
 }
 
-pub(super) fn prepare_pin_pull(_pin: &AnyPin<'_>, _pull_up: bool, _pull_down: bool) {}
+pub(crate) fn prepare_pin_pull(_pin: &AnyPin<'_>, _pull_up: bool, _pull_down: bool) {}
 
-pub(super) fn gpio_intr_enable(int_enable: bool) -> u8 {
+pub(crate) fn gpio_intr_enable(int_enable: bool) -> u8 {
     int_enable as u8
 }
 
 #[cfg(feature = "rt")]
-pub(super) fn enable_additional_default_interrupts(
-    _interrupt: crate::peripherals::Interrupt,
-    _priority: crate::interrupt::Priority,
-) {
-}
+pub(crate) fn enable_interrupt_on_second_core(_priority: crate::interrupt::Priority) {}

--- a/esp-hal/src/gpio/low_level/v2.rs
+++ b/esp-hal/src/gpio/low_level/v2.rs
@@ -23,10 +23,6 @@ pub(super) fn gpio_intr_enable(int_enable: bool, nmi_enable: bool) -> u8 {
     int_enable as u8 | ((nmi_enable as u8) << 1)
 }
 
-pub(super) fn for_each_interrupt_core(mut f: impl FnMut(crate::system::Cpu)) {
-    f(crate::system::Cpu::current());
-}
-
 #[cfg(feature = "rt")]
 pub(super) fn enable_additional_default_interrupts(
     _interrupt: crate::peripherals::Interrupt,

--- a/esp-hal/src/gpio/low_level/v2.rs
+++ b/esp-hal/src/gpio/low_level/v2.rs
@@ -1,4 +1,4 @@
-use super::{GpioBank, InterruptStatusRegisterAccess};
+use super::GpioBank;
 use crate::{gpio::AnyPin, peripherals::GPIO};
 
 pub(crate) fn read_bank_interrupt_status(bank: GpioBank) -> u32 {
@@ -9,11 +9,11 @@ pub(crate) fn read_bank_interrupt_status(bank: GpioBank) -> u32 {
     }
 }
 
-pub(crate) fn read_interrupt_status(access: InterruptStatusRegisterAccess) -> u32 {
-    match access {
-        InterruptStatusRegisterAccess::Bank0 => GPIO::regs().pcpu_int().read().bits(),
+pub(crate) fn read_interrupt_status_of_current_cpu(bank: GpioBank) -> u32 {
+    match bank {
+        GpioBank::_0 => GPIO::regs().pcpu_int().read().bits(),
         #[cfg(gpio_has_bank_1)]
-        InterruptStatusRegisterAccess::Bank1 => GPIO::regs().pcpu_int1().read().bits(),
+        GpioBank::_1 => GPIO::regs().pcpu_int1().read().bits(),
     }
 }
 

--- a/esp-hal/src/gpio/low_level/v2.rs
+++ b/esp-hal/src/gpio/low_level/v2.rs
@@ -19,8 +19,8 @@ pub(super) fn read_interrupt_status(access: InterruptStatusRegisterAccess) -> u3
 
 pub(super) fn prepare_pin_pull(_pin: &AnyPin<'_>, _pull_up: bool, _pull_down: bool) {}
 
-pub(super) fn gpio_intr_enable(int_enable: bool, nmi_enable: bool) -> u8 {
-    int_enable as u8 | ((nmi_enable as u8) << 1)
+pub(super) fn gpio_intr_enable(int_enable: bool) -> u8 {
+    int_enable as u8
 }
 
 #[cfg(feature = "rt")]

--- a/esp-hal/src/gpio/low_level/v3.rs
+++ b/esp-hal/src/gpio/low_level/v3.rs
@@ -1,5 +1,10 @@
 use super::GpioBank;
-use crate::{gpio::AnyPin, peripherals::GPIO};
+use crate::{gpio::AnyPin, peripherals::GPIO, system::Cpu};
+#[cfg(feature = "rt")]
+use crate::{
+    interrupt::{self, InterruptHandler},
+    peripherals::Interrupt,
+};
 
 pub(crate) fn read_bank_interrupt_status(bank: GpioBank) -> u32 {
     match bank {
@@ -10,18 +15,31 @@ pub(crate) fn read_bank_interrupt_status(bank: GpioBank) -> u32 {
 }
 
 pub(crate) fn read_interrupt_status_of_current_cpu(bank: GpioBank) -> u32 {
-    match bank {
-        GpioBank::_0 => GPIO::regs().intr_0().read().bits(),
+    match (Cpu::current(), bank) {
+        (Cpu::ProCpu, GpioBank::_0) => GPIO::regs().intr_0().read().bits(),
+        (Cpu::AppCpu, GpioBank::_0) => GPIO::regs().intr_1().read().bits(),
+
         #[cfg(gpio_has_bank_1)]
-        GpioBank::_1 => GPIO::regs().intr1_0().read().bits(),
+        (Cpu::ProCpu, GpioBank::_1) => GPIO::regs().intr1_0().read().bits(),
+        #[cfg(gpio_has_bank_1)]
+        (Cpu::AppCpu, GpioBank::_1) => GPIO::regs().intr1_1().read().bits(),
     }
 }
 
 pub(crate) fn prepare_pin_pull(_pin: &AnyPin<'_>, _pull_up: bool, _pull_down: bool) {}
 
 pub(crate) fn gpio_intr_enable(int_enable: bool) -> u8 {
-    int_enable as u8
+    match Cpu::current() {
+        Cpu::ProCpu => int_enable as u8,
+        Cpu::AppCpu => (int_enable as u8) << 1,
+    }
 }
 
 #[cfg(feature = "rt")]
-pub(crate) fn enable_interrupt_on_second_core(_priority: crate::interrupt::Priority) {}
+pub(crate) fn enable_interrupt(handler: InterruptHandler) {
+    interrupt::bind_handler(Interrupt::GPIO, handler);
+    interrupt::bind_handler(Interrupt::GPIO_INT1, handler);
+
+    interrupt::disable(Cpu::ProCpu, Interrupt::GPIO_INT1);
+    interrupt::enable_on_cpu(Cpu::AppCpu, Interrupt::GPIO_INT1, handler.priority());
+}

--- a/esp-hal/src/gpio/low_level/v3.rs
+++ b/esp-hal/src/gpio/low_level/v3.rs
@@ -1,7 +1,7 @@
 use super::{GpioBank, InterruptStatusRegisterAccess};
 use crate::{gpio::AnyPin, peripherals::GPIO};
 
-pub(super) fn read_bank_interrupt_status(bank: GpioBank) -> u32 {
+pub(crate) fn read_bank_interrupt_status(bank: GpioBank) -> u32 {
     match bank {
         GpioBank::_0 => GPIO::regs().status().read().bits(),
         #[cfg(gpio_has_bank_1)]
@@ -9,7 +9,7 @@ pub(super) fn read_bank_interrupt_status(bank: GpioBank) -> u32 {
     }
 }
 
-pub(super) fn read_interrupt_status(access: InterruptStatusRegisterAccess) -> u32 {
+pub(crate) fn read_interrupt_status(access: InterruptStatusRegisterAccess) -> u32 {
     match access {
         InterruptStatusRegisterAccess::Bank0 => GPIO::regs().intr_0().read().bits(),
         #[cfg(gpio_has_bank_1)]
@@ -17,15 +17,11 @@ pub(super) fn read_interrupt_status(access: InterruptStatusRegisterAccess) -> u3
     }
 }
 
-pub(super) fn prepare_pin_pull(_pin: &AnyPin<'_>, _pull_up: bool, _pull_down: bool) {}
+pub(crate) fn prepare_pin_pull(_pin: &AnyPin<'_>, _pull_up: bool, _pull_down: bool) {}
 
-pub(super) fn gpio_intr_enable(int_enable: bool) -> u8 {
+pub(crate) fn gpio_intr_enable(int_enable: bool) -> u8 {
     int_enable as u8
 }
 
 #[cfg(feature = "rt")]
-pub(super) fn enable_additional_default_interrupts(
-    _interrupt: crate::peripherals::Interrupt,
-    _priority: crate::interrupt::Priority,
-) {
-}
+pub(crate) fn enable_interrupt_on_second_core(_priority: crate::interrupt::Priority) {}

--- a/esp-hal/src/gpio/low_level/v3.rs
+++ b/esp-hal/src/gpio/low_level/v3.rs
@@ -23,10 +23,6 @@ pub(super) fn gpio_intr_enable(int_enable: bool, nmi_enable: bool) -> u8 {
     int_enable as u8 | ((nmi_enable as u8) << 1)
 }
 
-pub(super) fn for_each_interrupt_core(mut f: impl FnMut(crate::system::Cpu)) {
-    f(crate::system::Cpu::current());
-}
-
 #[cfg(feature = "rt")]
 pub(super) fn enable_additional_default_interrupts(
     _interrupt: crate::peripherals::Interrupt,

--- a/esp-hal/src/gpio/low_level/v3.rs
+++ b/esp-hal/src/gpio/low_level/v3.rs
@@ -1,4 +1,4 @@
-use super::{GpioBank, InterruptStatusRegisterAccess};
+use super::GpioBank;
 use crate::{gpio::AnyPin, peripherals::GPIO};
 
 pub(crate) fn read_bank_interrupt_status(bank: GpioBank) -> u32 {
@@ -9,11 +9,11 @@ pub(crate) fn read_bank_interrupt_status(bank: GpioBank) -> u32 {
     }
 }
 
-pub(crate) fn read_interrupt_status(access: InterruptStatusRegisterAccess) -> u32 {
-    match access {
-        InterruptStatusRegisterAccess::Bank0 => GPIO::regs().intr_0().read().bits(),
+pub(crate) fn read_interrupt_status_of_current_cpu(bank: GpioBank) -> u32 {
+    match bank {
+        GpioBank::_0 => GPIO::regs().intr_0().read().bits(),
         #[cfg(gpio_has_bank_1)]
-        InterruptStatusRegisterAccess::Bank1 => GPIO::regs().intr1_0().read().bits(),
+        GpioBank::_1 => GPIO::regs().intr1_0().read().bits(),
     }
 }
 

--- a/esp-hal/src/gpio/low_level/v3.rs
+++ b/esp-hal/src/gpio/low_level/v3.rs
@@ -19,8 +19,8 @@ pub(super) fn read_interrupt_status(access: InterruptStatusRegisterAccess) -> u3
 
 pub(super) fn prepare_pin_pull(_pin: &AnyPin<'_>, _pull_up: bool, _pull_down: bool) {}
 
-pub(super) fn gpio_intr_enable(int_enable: bool, nmi_enable: bool) -> u8 {
-    int_enable as u8 | ((nmi_enable as u8) << 1)
+pub(super) fn gpio_intr_enable(int_enable: bool) -> u8 {
+    int_enable as u8
 }
 
 #[cfg(feature = "rt")]

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -1360,7 +1360,7 @@ impl<'d> Flex<'d> {
     pub fn listen(&mut self, event: Event) {
         // Unwrap can't fail currently as listen_with_options is only supposed to return
         // an error if wake_up_from_light_sleep is true.
-        unwrap!(self.pin.listen_with_options(event, true, false, false));
+        unwrap!(self.pin.listen_with_options(event, true, false));
     }
 
     /// Stop listening for interrupts.
@@ -1413,8 +1413,7 @@ impl<'d> Flex<'d> {
     #[inline]
     #[instability::unstable]
     pub fn wakeup_enable(&mut self, enable: bool, event: WakeEvent) -> Result<(), WakeConfigError> {
-        self.pin
-            .listen_with_options(event.into(), false, false, enable)
+        self.pin.listen_with_options(event.into(), false, enable)
     }
 
     // Output functions
@@ -1888,7 +1887,6 @@ impl<'lt> AnyPin<'lt> {
         &self,
         event: Event,
         int_enable: bool,
-        nmi_enable: bool,
         wake_up_from_light_sleep: bool,
     ) -> Result<(), WakeConfigError> {
         if wake_up_from_light_sleep {
@@ -1908,7 +1906,7 @@ impl<'lt> AnyPin<'lt> {
 
             set_int_enable(
                 self.number(),
-                Some(gpio_intr_enable(int_enable, nmi_enable)),
+                Some(gpio_intr_enable(int_enable)),
                 event as u8,
                 wake_up_from_light_sleep,
             );

--- a/esp-hal/src/soc/esp32/gpio.rs
+++ b/esp-hal/src/soc/esp32/gpio.rs
@@ -274,21 +274,6 @@ macro_rules! touch {
     };
 }
 
-pub(crate) fn errata36(pin: crate::gpio::AnyPin<'_>, pull_up: bool, pull_down: bool) {
-    use crate::gpio::{Pin, RtcPinWithResistors};
-
-    for_each_lp_function! {
-        (all_expanded $( (($_sig:ident, RTC_GPIOn, $_n:literal), $gpio:ident) ),* ) => {
-            const RTC_IO_PINS: &[u8] = &[ $( $crate::peripherals::$gpio::NUMBER ),* ];
-        };
-    };
-
-    if RTC_IO_PINS.contains(&pin.number()) && pin.is_output() {
-        pin.rtcio_pullup(pull_up);
-        pin.rtcio_pulldown(pull_down);
-    }
-}
-
 rtcio_analog! {
     (GPIO36, 0,  sensor_pads(),    sense1_, sense1    )
     (GPIO37, 1,  sensor_pads(),    sense2_, sense2    )


### PR DESCRIPTION
This PR does:

- Clean up some of the nonsense in the GPIO driver
- Removes the NMI interrupt configuration that we don't use
- Removes a type in favour of another GpioBank method
- Generalizes ESP32's per-core interrupt handling to P4