### PR TITLE
Move UART, SPI and I2C clocks, impl P4 UART clock config

### DIFF
--- a/esp-hal/src/i2c/clocks/esp32p4.rs
+++ b/esp-hal/src/i2c/clocks/esp32p4.rs
@@ -1,0 +1,44 @@
+use crate::{
+    clock::ll::{ClockTree, I2cFunctionClockConfig, I2cFunctionClockSclk, I2cInstance},
+    peripherals::HP_SYS_CLKRST,
+};
+
+impl I2cInstance {
+    // I2C_FUNCTION_CLOCK
+
+    pub(crate) fn enable_function_clock_impl(self, _clocks: &mut ClockTree, en: bool) {
+        HP_SYS_CLKRST::regs()
+            .peri_clk_ctrl10()
+            .modify(|_, w| match self {
+                I2cInstance::I2c0 => w.i2c0_clk_en().bit(en),
+                I2cInstance::I2c1 => w.i2c1_clk_en().bit(en),
+            });
+    }
+
+    pub(crate) fn configure_function_clock_impl(
+        self,
+        _clocks: &mut ClockTree,
+        _old_config: Option<I2cFunctionClockConfig>,
+        new_config: I2cFunctionClockConfig,
+    ) {
+        let rc_fast = matches!(new_config.sclk(), I2cFunctionClockSclk::RcFast);
+        match self {
+            I2cInstance::I2c0 => {
+                HP_SYS_CLKRST::regs()
+                    .peri_clk_ctrl10()
+                    .modify(|_, w| unsafe {
+                        w.i2c0_clk_src_sel().bit(rc_fast);
+                        w.i2c0_clk_div_num().bits(new_config.div_num() as _)
+                    });
+            }
+            I2cInstance::I2c1 => {
+                HP_SYS_CLKRST::regs()
+                    .peri_clk_ctrl10()
+                    .modify(|_, w| w.i2c1_clk_src_sel().bit(rc_fast));
+                HP_SYS_CLKRST::regs()
+                    .peri_clk_ctrl11()
+                    .modify(|_, w| unsafe { w.i2c1_clk_div_num().bits(new_config.div_num() as _) });
+            }
+        }
+    }
+}

--- a/esp-hal/src/i2c/clocks/v1.rs
+++ b/esp-hal/src/i2c/clocks/v1.rs
@@ -1,0 +1,18 @@
+use crate::clock::ll::{ClockTree, I2cFunctionClockConfig, I2cInstance};
+
+impl I2cInstance {
+    // I2C_FUNCTION_CLOCK
+
+    pub(crate) fn enable_function_clock_impl(self, _clocks: &mut ClockTree, _en: bool) {
+        // Nothing to do.
+    }
+
+    pub(crate) fn configure_function_clock_impl(
+        self,
+        _clocks: &mut ClockTree,
+        _old_config: Option<I2cFunctionClockConfig>,
+        _new_config: I2cFunctionClockConfig,
+    ) {
+        // I2C is hardwired to APB; no clock source selection register.
+    }
+}

--- a/esp-hal/src/i2c/clocks/v2.rs
+++ b/esp-hal/src/i2c/clocks/v2.rs
@@ -1,0 +1,25 @@
+use crate::clock::ll::{ClockTree, I2cFunctionClockConfig, I2cFunctionClockSclk, I2cInstance};
+
+impl I2cInstance {
+    // I2C_FUNCTION_CLOCK
+
+    pub(crate) fn enable_function_clock_impl(self, _clocks: &mut ClockTree, _en: bool) {
+        // No dedicated enable bit on ESP32-S2; clock selection via ref_always_on.
+    }
+
+    pub(crate) fn configure_function_clock_impl(
+        self,
+        _clocks: &mut ClockTree,
+        _old_config: Option<I2cFunctionClockConfig>,
+        new_config: I2cFunctionClockConfig,
+    ) {
+        let regs = match self {
+            I2cInstance::I2c0 => crate::peripherals::I2C0::regs(),
+            I2cInstance::I2c1 => crate::peripherals::I2C1::regs(),
+        };
+        regs.ctr().modify(|_, w| {
+            w.ref_always_on()
+                .bit(!matches!(new_config.sclk(), I2cFunctionClockSclk::RefTick))
+        });
+    }
+}

--- a/esp-hal/src/i2c/clocks/v3.rs
+++ b/esp-hal/src/i2c/clocks/v3.rs
@@ -1,0 +1,35 @@
+use crate::clock::ll::{ClockTree, I2cFunctionClockConfig, I2cFunctionClockSclk, I2cInstance};
+
+impl I2cInstance {
+    // I2C_FUNCTION_CLOCK
+
+    pub(crate) fn enable_function_clock_impl(self, _clocks: &mut ClockTree, en: bool) {
+        let regs = match self {
+            #[cfg(soc_has_i2c0)]
+            I2cInstance::I2c0 => crate::peripherals::I2C0::regs(),
+            #[cfg(soc_has_i2c1)]
+            I2cInstance::I2c1 => crate::peripherals::I2C1::regs(),
+        };
+        regs.clk_conf().modify(|_, w| w.sclk_active().bit(en));
+    }
+
+    pub(crate) fn configure_function_clock_impl(
+        self,
+        _clocks: &mut ClockTree,
+        _old_config: Option<I2cFunctionClockConfig>,
+        new_config: I2cFunctionClockConfig,
+    ) {
+        let regs = match self {
+            #[cfg(soc_has_i2c0)]
+            I2cInstance::I2c0 => crate::peripherals::I2C0::regs(),
+            #[cfg(soc_has_i2c1)]
+            I2cInstance::I2c1 => crate::peripherals::I2C1::regs(),
+        };
+        // sclk_sel: 0 = XTAL, 1 = RC_FAST
+        regs.clk_conf().modify(|_, w| unsafe {
+            w.sclk_sel()
+                .bit(matches!(new_config.sclk(), I2cFunctionClockSclk::RcFast));
+            w.sclk_div_num().bits(new_config.div_num() as _)
+        });
+    }
+}

--- a/esp-hal/src/i2c/clocks/v3_pcr.rs
+++ b/esp-hal/src/i2c/clocks/v3_pcr.rs
@@ -1,0 +1,37 @@
+use crate::{
+    clock::ll::{ClockTree, I2cFunctionClockConfig, I2cFunctionClockSclk, I2cInstance},
+    peripherals::PCR,
+};
+
+impl I2cInstance {
+    // I2C_FUNCTION_CLOCK
+
+    pub(crate) fn enable_function_clock_impl(self, _clocks: &mut ClockTree, en: bool) {
+        let reg = match self {
+            #[cfg(soc_has_i2c0)]
+            I2cInstance::I2c0 => PCR::regs().i2c_sclk_conf(0),
+            #[cfg(soc_has_i2c1)]
+            I2cInstance::I2c1 => PCR::regs().i2c_sclk_conf(1),
+        };
+        reg.modify(|_, w| w.i2c_sclk_en().bit(en));
+    }
+
+    pub(crate) fn configure_function_clock_impl(
+        self,
+        _clocks: &mut ClockTree,
+        _old_config: Option<I2cFunctionClockConfig>,
+        new_config: I2cFunctionClockConfig,
+    ) {
+        let reg = match self {
+            #[cfg(soc_has_i2c0)]
+            I2cInstance::I2c0 => PCR::regs().i2c_sclk_conf(0),
+            #[cfg(soc_has_i2c1)]
+            I2cInstance::I2c1 => PCR::regs().i2c_sclk_conf(1),
+        };
+        reg.modify(|_, w| unsafe {
+            w.i2c_sclk_sel()
+                .bit(matches!(new_config.sclk(), I2cFunctionClockSclk::RcFast));
+            w.i2c_sclk_div_num().bits(new_config.div_num() as _)
+        });
+    }
+}

--- a/esp-hal/src/i2c/mod.rs
+++ b/esp-hal/src/i2c/mod.rs
@@ -26,3 +26,13 @@ crate::unstable_module! {
 crate::unstable_module! {
     pub mod rtc;
 }
+
+#[cfg_attr(i2c_master_version = "1", path = "clocks/v1.rs")]
+#[cfg_attr(i2c_master_version = "2", path = "clocks/v2.rs")]
+#[cfg_attr(
+    all(i2c_master_version = "3", not(any(esp32p4, soc_has_pcr))),
+    path = "clocks/v3.rs"
+)]
+#[cfg_attr(esp32p4, path = "clocks/esp32p4.rs")]
+#[cfg_attr(soc_has_pcr, path = "clocks/v3_pcr.rs")]
+mod clocks;

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -197,11 +197,7 @@ fn main() -> ! {
 #![doc(html_logo_url = "https://docs.espressif.com/projects/rust/esp-rs-grey-bg.svg")]
 #![allow(asm_sub_register, async_fn_in_trait, stable_features)]
 #![cfg_attr(xtensa, feature(asm_experimental_arch))]
-// TODO(esp32p4): fill `[device.clock_tree]` doc strings in esp32p4.toml,
-// then promote back to `deny`. Until then, downgrade to warn for P4 only.
-#![cfg_attr(not(esp32p4), deny(missing_docs))]
-#![cfg_attr(esp32p4, warn(missing_docs))]
-#![deny(rust_2018_idioms, rustdoc::all)]
+#![deny(missing_docs, rust_2018_idioms, rustdoc::all)]
 #![allow(rustdoc::private_doc_tests)] // compile tests are done via rustdoc
 #![cfg_attr(docsrs, feature(doc_cfg, custom_inner_attributes, proc_macro_hygiene))]
 // Don't trip up on broken/private links when running semver-checks

--- a/esp-hal/src/soc/esp32/clocks.rs
+++ b/esp-hal/src/soc/esp32/clocks.rs
@@ -833,20 +833,3 @@ impl UartInstance {
         });
     }
 }
-
-impl I2cInstance {
-    // I2C_FUNCTION_CLOCK
-
-    fn enable_function_clock_impl(self, _clocks: &mut ClockTree, _en: bool) {
-        // Nothing to do.
-    }
-
-    fn configure_function_clock_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<I2cFunctionClockConfig>,
-        _new_config: I2cFunctionClockConfig,
-    ) {
-        // ESP32 I2C is hardwired to APB; no clock source selection register.
-    }
-}

--- a/esp-hal/src/soc/esp32/clocks.rs
+++ b/esp-hal/src/soc/esp32/clocks.rs
@@ -20,7 +20,7 @@ use esp_rom_sys::rom::{ets_delay_us, ets_update_cpu_frequency_rom};
 use crate::{
     clock::RtcClock,
     efuse::VOL_LEVEL_HP_INV,
-    peripherals::{APB_CTRL, LPWR, RMT, RTC_IO, SYSTEM, TIMG0, UART0, UART1, UART2},
+    peripherals::{APB_CTRL, LPWR, RMT, RTC_IO, SYSTEM, TIMG0},
     rtc_cntl::Rtc,
     soc::regi2c,
     time::Rate,
@@ -768,68 +768,5 @@ impl RmtInstance {
                 .chconf1(ch_num)
                 .modify(|_, w| w.ref_always_on().bit(new_config == RmtSclkConfig::ApbClk));
         }
-    }
-}
-
-impl UartInstance {
-    // UART_FUNCTION_CLOCK
-
-    fn enable_function_clock_impl(self, _clocks: &mut ClockTree, _en: bool) {
-        // Nothing to do.
-    }
-
-    fn configure_function_clock_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<UartFunctionClockConfig>,
-        new_config: UartFunctionClockConfig,
-    ) {
-        let regs = match self {
-            Self::Uart0 => UART0::regs(),
-            Self::Uart1 => UART1::regs(),
-            Self::Uart2 => UART2::regs(),
-        };
-        regs.conf0().modify(|_, w| {
-            w.tick_ref_always_on()
-                .bit(new_config.sclk == UartFunctionClockSclk::Apb)
-        });
-    }
-
-    // UART_MEM_CLOCK
-
-    fn enable_mem_clock_impl(self, _clocks: &mut ClockTree, _en: bool) {
-        // Nothing to do.
-    }
-
-    fn configure_mem_clock_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<UartMemClockConfig>,
-        _new_config: UartMemClockConfig,
-    ) {
-        // Nothing to do.
-    }
-
-    // UART_BAUD_RATE_GENERATOR
-
-    fn enable_baud_rate_generator_impl(self, _clocks: &mut ClockTree, _en: bool) {
-        // Nothing to do.
-    }
-
-    fn configure_baud_rate_generator_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<UartBaudRateGeneratorConfig>,
-        new_config: UartBaudRateGeneratorConfig,
-    ) {
-        let regs = match self {
-            Self::Uart0 => UART0::regs(),
-            Self::Uart1 => UART1::regs(),
-            Self::Uart2 => UART2::regs(),
-        };
-        regs.clkdiv().write(|w| unsafe {
-            w.clkdiv().bits(new_config.integral as _);
-            w.frag().bits(new_config.fractional as _)
-        });
     }
 }

--- a/esp-hal/src/soc/esp32/clocks.rs
+++ b/esp-hal/src/soc/esp32/clocks.rs
@@ -850,20 +850,3 @@ impl I2cInstance {
         // ESP32 I2C is hardwired to APB; no clock source selection register.
     }
 }
-
-impl SpiInstance {
-    // SPI_FUNCTION_CLOCK
-
-    fn enable_function_clock_impl(self, _clocks: &mut ClockTree, _en: bool) {
-        // Nothing to do.
-    }
-
-    fn configure_function_clock_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<SpiFunctionClockConfig>,
-        _new_config: SpiFunctionClockConfig,
-    ) {
-        // ESP32 SPI is hardwired to APB; no clock source selection register.
-    }
-}

--- a/esp-hal/src/soc/esp32c2/clocks.rs
+++ b/esp-hal/src/soc/esp32c2/clocks.rs
@@ -761,22 +761,3 @@ impl I2cInstance {
         });
     }
 }
-
-impl SpiInstance {
-    // SPI_FUNCTION_CLOCK
-
-    fn enable_function_clock_impl(self, _clocks: &mut ClockTree, _en: bool) {}
-
-    fn configure_function_clock_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<SpiFunctionClockConfig>,
-        new_config: SpiFunctionClockConfig,
-    ) {
-        let _ = self;
-        SPI2::regs().clk_gate().modify(|_, w| {
-            w.mst_clk_sel()
-                .bit(matches!(new_config, SpiFunctionClockConfig::Pll40m))
-        });
-    }
-}

--- a/esp-hal/src/soc/esp32c2/clocks.rs
+++ b/esp-hal/src/soc/esp32c2/clocks.rs
@@ -19,7 +19,7 @@ use esp_rom_sys::rom::{ets_delay_us, ets_update_cpu_frequency_rom};
 
 use crate::{
     clock::RtcClock,
-    peripherals::{I2C_ANA_MST, I2C0, LPWR, SPI2, SYSTEM, TIMG0, UART0, UART1},
+    peripherals::{I2C_ANA_MST, LPWR, SYSTEM, TIMG0, UART0, UART1},
     rtc_cntl::Rtc,
     soc::regi2c,
     time::Rate,
@@ -735,29 +735,6 @@ impl UartInstance {
         regs.clkdiv().write(|w| unsafe {
             w.clkdiv().bits(new_config.integral as _);
             w.frag().bits(new_config.fractional as _)
-        });
-    }
-}
-
-impl I2cInstance {
-    // I2C_FUNCTION_CLOCK
-
-    fn enable_function_clock_impl(self, _clocks: &mut ClockTree, en: bool) {
-        I2C0::regs()
-            .clk_conf()
-            .modify(|_, w| w.sclk_active().bit(en));
-    }
-
-    fn configure_function_clock_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<I2cFunctionClockConfig>,
-        new_config: I2cFunctionClockConfig,
-    ) {
-        I2C0::regs().clk_conf().modify(|_, w| unsafe {
-            w.sclk_sel()
-                .bit(matches!(new_config.sclk, I2cFunctionClockSclk::RcFast));
-            w.sclk_div_num().bits(new_config.div_num as _)
         });
     }
 }

--- a/esp-hal/src/soc/esp32c2/clocks.rs
+++ b/esp-hal/src/soc/esp32c2/clocks.rs
@@ -19,7 +19,7 @@ use esp_rom_sys::rom::{ets_delay_us, ets_update_cpu_frequency_rom};
 
 use crate::{
     clock::RtcClock,
-    peripherals::{I2C_ANA_MST, LPWR, SYSTEM, TIMG0, UART0, UART1},
+    peripherals::{I2C_ANA_MST, LPWR, SYSTEM, TIMG0},
     rtc_cntl::Rtc,
     soc::regi2c,
     time::Rate,
@@ -666,75 +666,6 @@ impl TimgInstance {
         TIMG0::regs().wdtconfig0().modify(|_, w| {
             w.wdt_use_xtal()
                 .bit(new_config == TimgWdtClockConfig::XtalClk)
-        });
-    }
-}
-
-impl UartInstance {
-    // UART_FUNCTION_CLOCK
-
-    fn enable_function_clock_impl(self, _clocks: &mut ClockTree, en: bool) {
-        let regs = match self {
-            UartInstance::Uart0 => UART0::regs(),
-            UartInstance::Uart1 => UART1::regs(),
-        };
-        regs.clk_conf().modify(|_, w| w.sclk_en().bit(en));
-    }
-
-    fn configure_function_clock_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<UartFunctionClockConfig>,
-        new_config: UartFunctionClockConfig,
-    ) {
-        let regs = match self {
-            UartInstance::Uart0 => UART0::regs(),
-            UartInstance::Uart1 => UART1::regs(),
-        };
-        regs.clk_conf().modify(|_, w| unsafe {
-            w.sclk_sel().bits(match new_config.sclk {
-                UartFunctionClockSclk::PllF40m => 1,
-                UartFunctionClockSclk::RcFast => 2,
-                UartFunctionClockSclk::Xtal => 3,
-            });
-            w.sclk_div_num().bits(new_config.div_num as _)
-        });
-    }
-
-    // UART_MEM_CLOCK
-
-    fn enable_mem_clock_impl(self, _clocks: &mut ClockTree, _en: bool) {
-        // Nothing to do.
-    }
-
-    fn configure_mem_clock_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<UartMemClockConfig>,
-        _new_config: UartMemClockConfig,
-    ) {
-        // Nothing to do.
-    }
-
-    // UART_BAUD_RATE_GENERATOR
-
-    fn enable_baud_rate_generator_impl(self, _clocks: &mut ClockTree, _en: bool) {
-        // Nothing to do.
-    }
-
-    fn configure_baud_rate_generator_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<UartBaudRateGeneratorConfig>,
-        new_config: UartBaudRateGeneratorConfig,
-    ) {
-        let regs = match self {
-            UartInstance::Uart0 => UART0::regs(),
-            UartInstance::Uart1 => UART1::regs(),
-        };
-        regs.clkdiv().write(|w| unsafe {
-            w.clkdiv().bits(new_config.integral as _);
-            w.frag().bits(new_config.fractional as _)
         });
     }
 }

--- a/esp-hal/src/soc/esp32c3/clocks.rs
+++ b/esp-hal/src/soc/esp32c3/clocks.rs
@@ -754,21 +754,3 @@ impl I2cInstance {
         });
     }
 }
-
-impl SpiInstance {
-    // SPI_FUNCTION_CLOCK
-
-    fn enable_function_clock_impl(self, _clocks: &mut ClockTree, _en: bool) {}
-
-    fn configure_function_clock_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<SpiFunctionClockConfig>,
-        new_config: SpiFunctionClockConfig,
-    ) {
-        SPI2::regs().clk_gate().modify(|_, w| {
-            w.mst_clk_sel()
-                .bit(matches!(new_config, SpiFunctionClockConfig::Pll80m))
-        });
-    }
-}

--- a/esp-hal/src/soc/esp32c3/clocks.rs
+++ b/esp-hal/src/soc/esp32c3/clocks.rs
@@ -17,7 +17,7 @@
 use esp_rom_sys::rom::{ets_delay_us, ets_update_cpu_frequency_rom};
 
 use crate::{
-    peripherals::{APB_CTRL, I2C_ANA_MST, I2C0, LPWR, SPI2, SYSTEM, TIMG0, TIMG1, UART0, UART1},
+    peripherals::{APB_CTRL, I2C_ANA_MST, LPWR, SYSTEM, TIMG0, TIMG1, UART0, UART1},
     soc::regi2c,
     time::Rate,
 };
@@ -728,29 +728,6 @@ impl UartInstance {
         regs.clkdiv().write(|w| unsafe {
             w.clkdiv().bits(new_config.integral as _);
             w.frag().bits(new_config.fractional as _)
-        });
-    }
-}
-
-impl I2cInstance {
-    // I2C_FUNCTION_CLOCK
-
-    fn enable_function_clock_impl(self, _clocks: &mut ClockTree, en: bool) {
-        I2C0::regs()
-            .clk_conf()
-            .modify(|_, w| w.sclk_active().bit(en));
-    }
-
-    fn configure_function_clock_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<I2cFunctionClockConfig>,
-        new_config: I2cFunctionClockConfig,
-    ) {
-        I2C0::regs().clk_conf().modify(|_, w| unsafe {
-            w.sclk_sel()
-                .bit(matches!(new_config.sclk, I2cFunctionClockSclk::RcFast));
-            w.sclk_div_num().bits(new_config.div_num as _)
         });
     }
 }

--- a/esp-hal/src/soc/esp32c3/clocks.rs
+++ b/esp-hal/src/soc/esp32c3/clocks.rs
@@ -17,7 +17,7 @@
 use esp_rom_sys::rom::{ets_delay_us, ets_update_cpu_frequency_rom};
 
 use crate::{
-    peripherals::{APB_CTRL, I2C_ANA_MST, LPWR, SYSTEM, TIMG0, TIMG1, UART0, UART1},
+    peripherals::{APB_CTRL, I2C_ANA_MST, LPWR, SYSTEM, TIMG0, TIMG1},
     soc::regi2c,
     time::Rate,
 };
@@ -659,75 +659,6 @@ impl TimgInstance {
         regs.wdtconfig0().modify(|_, w| {
             w.wdt_use_xtal()
                 .bit(new_config == TimgWdtClockConfig::XtalClk)
-        });
-    }
-}
-
-impl UartInstance {
-    // UART_FUNCTION_CLOCK
-
-    fn enable_function_clock_impl(self, _clocks: &mut ClockTree, en: bool) {
-        let regs = match self {
-            UartInstance::Uart0 => UART0::regs(),
-            UartInstance::Uart1 => UART1::regs(),
-        };
-        regs.clk_conf().modify(|_, w| w.sclk_en().bit(en));
-    }
-
-    fn configure_function_clock_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<UartFunctionClockConfig>,
-        new_config: UartFunctionClockConfig,
-    ) {
-        let regs = match self {
-            UartInstance::Uart0 => UART0::regs(),
-            UartInstance::Uart1 => UART1::regs(),
-        };
-        regs.clk_conf().modify(|_, w| unsafe {
-            w.sclk_sel().bits(match new_config.sclk {
-                UartFunctionClockSclk::Apb => 1,
-                UartFunctionClockSclk::RcFast => 2,
-                UartFunctionClockSclk::Xtal => 3,
-            });
-            w.sclk_div_num().bits(new_config.div_num as _)
-        });
-    }
-
-    // UART_MEM_CLOCK
-
-    fn enable_mem_clock_impl(self, _clocks: &mut ClockTree, _en: bool) {
-        // Nothing to do.
-    }
-
-    fn configure_mem_clock_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<UartMemClockConfig>,
-        _new_config: UartMemClockConfig,
-    ) {
-        // Nothing to do.
-    }
-
-    // UART_BAUD_RATE_GENERATOR
-
-    fn enable_baud_rate_generator_impl(self, _clocks: &mut ClockTree, _en: bool) {
-        // Nothing to do.
-    }
-
-    fn configure_baud_rate_generator_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<UartBaudRateGeneratorConfig>,
-        new_config: UartBaudRateGeneratorConfig,
-    ) {
-        let regs = match self {
-            UartInstance::Uart0 => UART0::regs(),
-            UartInstance::Uart1 => UART1::regs(),
-        };
-        regs.clkdiv().write(|w| unsafe {
-            w.clkdiv().bits(new_config.integral as _);
-            w.frag().bits(new_config.fractional as _)
         });
     }
 }

--- a/esp-hal/src/soc/esp32c5/clocks.rs
+++ b/esp-hal/src/soc/esp32c5/clocks.rs
@@ -16,7 +16,7 @@
 // TODO: This is a temporary place for this, should probably be moved into clocks_ll.
 
 use crate::{
-    peripherals::{I2C_ANA_MST, LP_CLKRST, PCR, PMU, UART0, UART1},
+    peripherals::{I2C_ANA_MST, LP_CLKRST, PCR, PMU},
     soc::regi2c,
 };
 
@@ -636,67 +636,5 @@ impl TimgInstance {
                     TimgWdtClockConfig::PllF80m => 2,
                 })
             });
-    }
-}
-
-impl UartInstance {
-    // UART_FUNCTION_CLOCK
-
-    fn enable_function_clock_impl(self, _clocks: &mut ClockTree, en: bool) {
-        let uart = match self {
-            UartInstance::Uart0 => 0,
-            UartInstance::Uart1 => 1,
-        };
-        PCR::regs()
-            .uart(uart)
-            .clk_conf()
-            .modify(|_, w| w.sclk_en().bit(en));
-    }
-
-    fn configure_function_clock_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<UartFunctionClockConfig>,
-        new_config: UartFunctionClockConfig,
-    ) {
-        PCR::regs()
-            .uart(match self {
-                UartInstance::Uart0 => 0,
-                UartInstance::Uart1 => 1,
-            })
-            .clk_conf()
-            .modify(|_, w| unsafe {
-                w.sclk_sel().bits(match new_config.sclk {
-                    UartFunctionClockSclk::Xtal => 0,
-                    UartFunctionClockSclk::RcFast => 1,
-                    UartFunctionClockSclk::PllF80m => 2,
-                });
-                w.sclk_div_a().bits(0);
-                w.sclk_div_b().bits(0);
-                w.sclk_div_num().bits(new_config.div_num as _);
-                w
-            });
-    }
-
-    // UART_BAUD_RATE_GENERATOR
-
-    fn enable_baud_rate_generator_impl(self, _clocks: &mut ClockTree, _en: bool) {
-        // Nothing to do.
-    }
-
-    fn configure_baud_rate_generator_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<UartBaudRateGeneratorConfig>,
-        new_config: UartBaudRateGeneratorConfig,
-    ) {
-        let regs = match self {
-            UartInstance::Uart0 => UART0::regs(),
-            UartInstance::Uart1 => UART1::regs(),
-        };
-        regs.clkdiv().write(|w| unsafe {
-            w.clkdiv().bits(new_config.integral as _);
-            w.frag().bits(new_config.fractional as _)
-        });
     }
 }

--- a/esp-hal/src/soc/esp32c5/clocks.rs
+++ b/esp-hal/src/soc/esp32c5/clocks.rs
@@ -700,26 +700,3 @@ impl UartInstance {
         });
     }
 }
-
-impl I2cInstance {
-    // I2C_FUNCTION_CLOCK
-
-    fn enable_function_clock_impl(self, _clocks: &mut ClockTree, en: bool) {
-        PCR::regs()
-            .i2c_sclk_conf(0)
-            .modify(|_, w| w.i2c_sclk_en().bit(en));
-    }
-
-    fn configure_function_clock_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<I2cFunctionClockConfig>,
-        new_config: I2cFunctionClockConfig,
-    ) {
-        PCR::regs().i2c_sclk_conf(0).modify(|_, w| unsafe {
-            w.i2c_sclk_sel()
-                .bit(matches!(new_config.sclk, I2cFunctionClockSclk::RcFast));
-            w.i2c_sclk_div_num().bits(new_config.div_num as _)
-        });
-    }
-}

--- a/esp-hal/src/soc/esp32c5/clocks.rs
+++ b/esp-hal/src/soc/esp32c5/clocks.rs
@@ -723,34 +723,3 @@ impl I2cInstance {
         });
     }
 }
-
-impl SpiInstance {
-    // SPI_FUNCTION_CLOCK
-
-    fn enable_function_clock_impl(self, _clocks: &mut ClockTree, en: bool) {
-        match self {
-            SpiInstance::Spi2 => PCR::regs()
-                .spi2_clkm_conf()
-                .modify(|_, w| w.spi2_clkm_en().bit(en)),
-        };
-    }
-
-    fn configure_function_clock_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<SpiFunctionClockConfig>,
-        new_config: SpiFunctionClockConfig,
-    ) {
-        match self {
-            SpiInstance::Spi2 => PCR::regs().spi2_clkm_conf().modify(|_, w| unsafe {
-                w.spi2_clkm_div_num().bits(0);
-                w.spi2_clkm_sel().bits(match new_config {
-                    SpiFunctionClockConfig::Xtal => 0,
-                    SpiFunctionClockConfig::PllF160m => 1,
-                    SpiFunctionClockConfig::RcFast => 2,
-                    SpiFunctionClockConfig::PllF120m => 3,
-                })
-            }),
-        };
-    }
-}

--- a/esp-hal/src/soc/esp32c6/clocks.rs
+++ b/esp-hal/src/soc/esp32c6/clocks.rs
@@ -17,7 +17,7 @@
 // TODO: This is a temporary place for this, should probably be moved into clocks_ll.
 
 use crate::{
-    peripherals::{I2C_ANA_MST, LP_CLKRST, PCR, PMU, TIMG0, UART0, UART1},
+    peripherals::{I2C_ANA_MST, LP_CLKRST, PCR, PMU, TIMG0},
     soc::regi2c,
 };
 
@@ -718,65 +718,5 @@ impl TimgInstance {
                     TimgWdtClockConfig::RcFastClk => 2,
                 })
             });
-    }
-}
-
-impl UartInstance {
-    // UART_FUNCTION_CLOCK
-
-    fn enable_function_clock_impl(self, _clocks: &mut ClockTree, en: bool) {
-        let uart = match self {
-            UartInstance::Uart0 => 0,
-            UartInstance::Uart1 => 1,
-        };
-        PCR::regs()
-            .uart(uart)
-            .clk_conf()
-            .modify(|_, w| w.sclk_en().bit(en));
-    }
-
-    fn configure_function_clock_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<UartFunctionClockConfig>,
-        new_config: UartFunctionClockConfig,
-    ) {
-        let uart = match self {
-            UartInstance::Uart0 => 0,
-            UartInstance::Uart1 => 1,
-        };
-        PCR::regs().uart(uart).clk_conf().modify(|_, w| unsafe {
-            w.sclk_sel().bits(match new_config.sclk {
-                UartFunctionClockSclk::PllF80m => 1,
-                UartFunctionClockSclk::RcFast => 2,
-                UartFunctionClockSclk::Xtal => 3,
-            });
-            w.sclk_div_a().bits(0);
-            w.sclk_div_b().bits(0);
-            w.sclk_div_num().bits(new_config.div_num as _);
-            w
-        });
-    }
-
-    // UART_BAUD_RATE_GENERATOR
-
-    fn enable_baud_rate_generator_impl(self, _clocks: &mut ClockTree, _en: bool) {
-        // Nothing to do.
-    }
-
-    fn configure_baud_rate_generator_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<UartBaudRateGeneratorConfig>,
-        new_config: UartBaudRateGeneratorConfig,
-    ) {
-        let regs = match self {
-            UartInstance::Uart0 => UART0::regs(),
-            UartInstance::Uart1 => UART1::regs(),
-        };
-        regs.clkdiv().write(|w| unsafe {
-            w.clkdiv().bits(new_config.integral as _);
-            w.frag().bits(new_config.fractional as _)
-        });
     }
 }

--- a/esp-hal/src/soc/esp32c6/clocks.rs
+++ b/esp-hal/src/soc/esp32c6/clocks.rs
@@ -780,26 +780,3 @@ impl UartInstance {
         });
     }
 }
-
-impl I2cInstance {
-    // I2C_FUNCTION_CLOCK
-
-    fn enable_function_clock_impl(self, _clocks: &mut ClockTree, en: bool) {
-        PCR::regs()
-            .i2c_sclk_conf(0)
-            .modify(|_, w| w.i2c_sclk_en().bit(en));
-    }
-
-    fn configure_function_clock_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<I2cFunctionClockConfig>,
-        new_config: I2cFunctionClockConfig,
-    ) {
-        PCR::regs().i2c_sclk_conf(0).modify(|_, w| unsafe {
-            w.i2c_sclk_sel()
-                .bit(matches!(new_config.sclk, I2cFunctionClockSclk::RcFast));
-            w.i2c_sclk_div_num().bits(new_config.div_num as _)
-        });
-    }
-}

--- a/esp-hal/src/soc/esp32c6/clocks.rs
+++ b/esp-hal/src/soc/esp32c6/clocks.rs
@@ -803,32 +803,3 @@ impl I2cInstance {
         });
     }
 }
-
-impl SpiInstance {
-    // SPI_FUNCTION_CLOCK
-
-    fn enable_function_clock_impl(self, _clocks: &mut ClockTree, en: bool) {
-        match self {
-            SpiInstance::Spi2 => PCR::regs()
-                .spi2_clkm_conf()
-                .modify(|_, w| w.spi2_clkm_en().bit(en)),
-        };
-    }
-
-    fn configure_function_clock_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<SpiFunctionClockConfig>,
-        new_config: SpiFunctionClockConfig,
-    ) {
-        match self {
-            SpiInstance::Spi2 => PCR::regs().spi2_clkm_conf().modify(|_, w| unsafe {
-                w.spi2_clkm_sel().bits(match new_config {
-                    SpiFunctionClockConfig::Xtal => 0,
-                    SpiFunctionClockConfig::PllF80m => 1,
-                    SpiFunctionClockConfig::RcFast => 2,
-                })
-            }),
-        };
-    }
-}

--- a/esp-hal/src/soc/esp32c61/clocks.rs
+++ b/esp-hal/src/soc/esp32c61/clocks.rs
@@ -563,33 +563,3 @@ impl I2cInstance {
         });
     }
 }
-
-impl SpiInstance {
-    // SPI_FUNCTION_CLOCK
-
-    fn enable_function_clock_impl(self, _clocks: &mut ClockTree, en: bool) {
-        match self {
-            SpiInstance::Spi2 => PCR::regs()
-                .spi2_clkm_conf()
-                .modify(|_, w| w.spi2_clkm_en().bit(en)),
-        };
-    }
-
-    fn configure_function_clock_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<SpiFunctionClockConfig>,
-        new_config: SpiFunctionClockConfig,
-    ) {
-        match self {
-            SpiInstance::Spi2 => PCR::regs().spi2_clkm_conf().modify(|_, w| unsafe {
-                w.spi2_clkm_div_num().bits(0);
-                w.spi2_clkm_sel().bits(match new_config {
-                    SpiFunctionClockConfig::Xtal => 0,
-                    SpiFunctionClockConfig::PllF160m => 1,
-                    SpiFunctionClockConfig::RcFast => 2,
-                })
-            }),
-        };
-    }
-}

--- a/esp-hal/src/soc/esp32c61/clocks.rs
+++ b/esp-hal/src/soc/esp32c61/clocks.rs
@@ -540,26 +540,3 @@ impl UartInstance {
         });
     }
 }
-
-impl I2cInstance {
-    // I2C_FUNCTION_CLOCK
-
-    fn enable_function_clock_impl(self, _clocks: &mut ClockTree, en: bool) {
-        PCR::regs()
-            .i2c_sclk_conf(0)
-            .modify(|_, w| w.i2c_sclk_en().bit(en));
-    }
-
-    fn configure_function_clock_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<I2cFunctionClockConfig>,
-        new_config: I2cFunctionClockConfig,
-    ) {
-        PCR::regs().i2c_sclk_conf(0).modify(|_, w| unsafe {
-            w.i2c_sclk_sel()
-                .bit(matches!(new_config.sclk, I2cFunctionClockSclk::RcFast));
-            w.i2c_sclk_div_num().bits(new_config.div_num as _)
-        });
-    }
-}

--- a/esp-hal/src/soc/esp32c61/clocks.rs
+++ b/esp-hal/src/soc/esp32c61/clocks.rs
@@ -14,7 +14,7 @@
 #![allow(missing_docs, reason = "Experimental")]
 
 use crate::{
-    peripherals::{I2C_ANA_MST, LP_CLKRST, PCR, PMU, UART0, UART1},
+    peripherals::{I2C_ANA_MST, LP_CLKRST, PCR, PMU},
     soc::regi2c,
 };
 
@@ -476,67 +476,5 @@ impl TimgInstance {
                     TimgWdtClockConfig::PllF80m => 2,
                 })
             });
-    }
-}
-
-impl UartInstance {
-    // UART_FUNCTION_CLOCK
-
-    fn enable_function_clock_impl(self, _clocks: &mut ClockTree, en: bool) {
-        let uart = match self {
-            UartInstance::Uart0 => 0,
-            UartInstance::Uart1 => 1,
-        };
-        PCR::regs()
-            .uart(uart)
-            .clk_conf()
-            .modify(|_, w| w.sclk_en().bit(en));
-    }
-
-    fn configure_function_clock_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<UartFunctionClockConfig>,
-        new_config: UartFunctionClockConfig,
-    ) {
-        PCR::regs()
-            .uart(match self {
-                UartInstance::Uart0 => 0,
-                UartInstance::Uart1 => 1,
-            })
-            .clk_conf()
-            .modify(|_, w| unsafe {
-                w.sclk_sel().bits(match new_config.sclk {
-                    UartFunctionClockSclk::Xtal => 0,
-                    UartFunctionClockSclk::RcFast => 1,
-                    UartFunctionClockSclk::PllF80m => 2,
-                });
-                w.sclk_div_a().bits(0);
-                w.sclk_div_b().bits(0);
-                w.sclk_div_num().bits(new_config.div_num as _);
-                w
-            });
-    }
-
-    // UART_BAUD_RATE_GENERATOR
-
-    fn enable_baud_rate_generator_impl(self, _clocks: &mut ClockTree, _en: bool) {
-        // Nothing to do.
-    }
-
-    fn configure_baud_rate_generator_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<UartBaudRateGeneratorConfig>,
-        new_config: UartBaudRateGeneratorConfig,
-    ) {
-        let regs = match self {
-            UartInstance::Uart0 => UART0::regs(),
-            UartInstance::Uart1 => UART1::regs(),
-        };
-        regs.clkdiv().write(|w| unsafe {
-            w.clkdiv().bits(new_config.integral as _);
-            w.frag().bits(new_config.fractional as _)
-        });
     }
 }

--- a/esp-hal/src/soc/esp32h2/clocks.rs
+++ b/esp-hal/src/soc/esp32h2/clocks.rs
@@ -15,7 +15,7 @@
 // TODO: This is a temporary place for this, should probably be moved into clocks_ll.
 
 use crate::{
-    peripherals::{I2C_ANA_MST, LP_CLKRST, PCR, PMU, TIMG0, UART0, UART1},
+    peripherals::{I2C_ANA_MST, LP_CLKRST, PCR, PMU, TIMG0},
     soc::regi2c,
 };
 
@@ -548,65 +548,5 @@ impl TimgInstance {
                     TimgWdtClockConfig::PllF48m => 2,
                 })
             });
-    }
-}
-
-impl UartInstance {
-    // UART_FUNCTION_CLOCK
-
-    fn enable_function_clock_impl(self, _clocks: &mut ClockTree, en: bool) {
-        let uart = match self {
-            UartInstance::Uart0 => 0,
-            UartInstance::Uart1 => 1,
-        };
-        PCR::regs()
-            .uart(uart)
-            .clk_conf()
-            .modify(|_, w| w.sclk_en().bit(en));
-    }
-
-    fn configure_function_clock_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<UartFunctionClockConfig>,
-        new_config: UartFunctionClockConfig,
-    ) {
-        let uart = match self {
-            UartInstance::Uart0 => 0,
-            UartInstance::Uart1 => 1,
-        };
-        PCR::regs().uart(uart).clk_conf().modify(|_, w| unsafe {
-            w.sclk_sel().bits(match new_config.sclk {
-                UartFunctionClockSclk::PllF48m => 1,
-                UartFunctionClockSclk::RcFast => 2,
-                UartFunctionClockSclk::Xtal => 3,
-            });
-            w.sclk_div_a().bits(0);
-            w.sclk_div_b().bits(0);
-            w.sclk_div_num().bits(new_config.div_num as _);
-            w
-        });
-    }
-
-    // UART_BAUD_RATE_GENERATOR
-
-    fn enable_baud_rate_generator_impl(self, _clocks: &mut ClockTree, _en: bool) {
-        // Nothing to do.
-    }
-
-    fn configure_baud_rate_generator_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<UartBaudRateGeneratorConfig>,
-        new_config: UartBaudRateGeneratorConfig,
-    ) {
-        let regs = match self {
-            UartInstance::Uart0 => UART0::regs(),
-            UartInstance::Uart1 => UART1::regs(),
-        };
-        regs.clkdiv().write(|w| unsafe {
-            w.clkdiv().bits(new_config.integral as _);
-            w.frag().bits(new_config.fractional as _)
-        });
     }
 }

--- a/esp-hal/src/soc/esp32h2/clocks.rs
+++ b/esp-hal/src/soc/esp32h2/clocks.rs
@@ -641,32 +641,3 @@ impl I2cInstance {
         });
     }
 }
-
-impl SpiInstance {
-    // SPI_FUNCTION_CLOCK
-
-    fn enable_function_clock_impl(self, _clocks: &mut ClockTree, en: bool) {
-        match self {
-            SpiInstance::Spi2 => PCR::regs()
-                .spi2_clkm_conf()
-                .modify(|_, w| w.spi2_clkm_en().bit(en)),
-        };
-    }
-
-    fn configure_function_clock_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<SpiFunctionClockConfig>,
-        new_config: SpiFunctionClockConfig,
-    ) {
-        match self {
-            SpiInstance::Spi2 => PCR::regs().spi2_clkm_conf().modify(|_, w| unsafe {
-                w.spi2_clkm_sel().bits(match new_config {
-                    SpiFunctionClockConfig::Xtal => 0,
-                    SpiFunctionClockConfig::PllF48m => 1,
-                    SpiFunctionClockConfig::RcFast => 2,
-                })
-            }),
-        };
-    }
-}

--- a/esp-hal/src/soc/esp32h2/clocks.rs
+++ b/esp-hal/src/soc/esp32h2/clocks.rs
@@ -610,34 +610,3 @@ impl UartInstance {
         });
     }
 }
-
-impl I2cInstance {
-    // I2C_FUNCTION_CLOCK
-
-    fn enable_function_clock_impl(self, _clocks: &mut ClockTree, en: bool) {
-        let i2c = match self {
-            I2cInstance::I2c0 => 0,
-            I2cInstance::I2c1 => 1,
-        };
-        PCR::regs()
-            .i2c_sclk_conf(i2c)
-            .modify(|_, w| w.i2c_sclk_en().bit(en));
-    }
-
-    fn configure_function_clock_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<I2cFunctionClockConfig>,
-        new_config: I2cFunctionClockConfig,
-    ) {
-        let i2c = match self {
-            I2cInstance::I2c0 => 0,
-            I2cInstance::I2c1 => 1,
-        };
-        PCR::regs().i2c_sclk_conf(i2c).modify(|_, w| unsafe {
-            w.i2c_sclk_sel()
-                .bit(matches!(new_config.sclk, I2cFunctionClockSclk::RcFast));
-            w.i2c_sclk_div_num().bits(new_config.div_num as _)
-        });
-    }
-}

--- a/esp-hal/src/soc/esp32p4/clocks.rs
+++ b/esp-hal/src/soc/esp32p4/clocks.rs
@@ -533,37 +533,6 @@ impl TimgInstance {
     }
 }
 
-impl SpiInstance {
-    // SPI_FUNCTION_CLOCK
-
-    fn enable_function_clock_impl(self, _clocks: &mut ClockTree, _en: bool) {
-        // SPI clock gates are managed by the peripheral clock infrastructure in system.rs.
-    }
-
-    fn configure_function_clock_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<SpiFunctionClockConfig>,
-        new_config: SpiFunctionClockConfig,
-    ) {
-        let source = match new_config {
-            SpiFunctionClockConfig::Xtal => 0,
-            SpiFunctionClockConfig::RcFast => 1,
-            // SDIO_PLL0
-            // APLL
-            SpiFunctionClockConfig::Spll => 4,
-        };
-        HP_SYS_CLKRST::regs()
-            .peri_clk_ctrl116()
-            .modify(|_, w| unsafe {
-                match self {
-                    Self::Spi2 => w.gpspi2_clk_src_sel().bits(source),
-                    Self::Spi3 => w.gpspi3_clk_src_sel().bits(source),
-                }
-            });
-    }
-}
-
 // System clock impl functions
 
 // Mux enable stubs (mux nodes need enable functions too)

--- a/esp-hal/src/soc/esp32p4/clocks.rs
+++ b/esp-hal/src/soc/esp32p4/clocks.rs
@@ -433,37 +433,6 @@ fn configure_lp_slow_clk_impl(
         });
 }
 
-// Per-instance clock impl for UART (called on UartInstance enum)
-
-impl UartInstance {
-    fn enable_function_clock_impl(self, _clocks: &mut ClockTree, _en: bool) {
-        // UART function clock enable is handled by peripheral clock gates in system.rs
-    }
-
-    fn configure_function_clock_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<UartFunctionClockConfig>,
-        _new_config: UartFunctionClockConfig,
-    ) {
-        // TODO: Configure UART clock source selection
-        // HP_SYS_CLKRST PERI_CLK_CTRL110-114 for UART0-4
-    }
-
-    fn enable_baud_rate_generator_impl(self, _clocks: &mut ClockTree, _en: bool) {
-        // Baud rate generator is always on when UART is enabled
-    }
-
-    fn configure_baud_rate_generator_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<UartBaudRateGeneratorConfig>,
-        _new_config: UartBaudRateGeneratorConfig,
-    ) {
-        // Baud rate is configured directly in UART registers, not here
-    }
-}
-
 // Per-instance clock impl for TIMG
 
 impl TimgInstance {

--- a/esp-hal/src/soc/esp32p4/clocks.rs
+++ b/esp-hal/src/soc/esp32p4/clocks.rs
@@ -464,46 +464,6 @@ impl UartInstance {
     }
 }
 
-impl I2cInstance {
-    // I2C_FUNCTION_CLOCK
-
-    fn enable_function_clock_impl(self, _clocks: &mut ClockTree, en: bool) {
-        HP_SYS_CLKRST::regs()
-            .peri_clk_ctrl10()
-            .modify(|_, w| match self {
-                I2cInstance::I2c0 => w.i2c0_clk_en().bit(en),
-                I2cInstance::I2c1 => w.i2c1_clk_en().bit(en),
-            });
-    }
-
-    fn configure_function_clock_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<I2cFunctionClockConfig>,
-        new_config: I2cFunctionClockConfig,
-    ) {
-        let rc_fast = matches!(new_config.sclk, I2cFunctionClockSclk::RcFast);
-        match self {
-            I2cInstance::I2c0 => {
-                HP_SYS_CLKRST::regs()
-                    .peri_clk_ctrl10()
-                    .modify(|_, w| unsafe {
-                        w.i2c0_clk_src_sel().bit(rc_fast);
-                        w.i2c0_clk_div_num().bits(new_config.div_num as _)
-                    });
-            }
-            I2cInstance::I2c1 => {
-                HP_SYS_CLKRST::regs()
-                    .peri_clk_ctrl10()
-                    .modify(|_, w| w.i2c1_clk_src_sel().bit(rc_fast));
-                HP_SYS_CLKRST::regs()
-                    .peri_clk_ctrl11()
-                    .modify(|_, w| unsafe { w.i2c1_clk_div_num().bits(new_config.div_num as _) });
-            }
-        }
-    }
-}
-
 // Per-instance clock impl for TIMG
 
 impl TimgInstance {

--- a/esp-hal/src/soc/esp32s2/clocks.rs
+++ b/esp-hal/src/soc/esp32s2/clocks.rs
@@ -786,20 +786,3 @@ impl I2cInstance {
         });
     }
 }
-
-impl SpiInstance {
-    // SPI_FUNCTION_CLOCK
-
-    fn enable_function_clock_impl(self, _clocks: &mut ClockTree, _en: bool) {
-        // Nothing to do.
-    }
-
-    fn configure_function_clock_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<SpiFunctionClockConfig>,
-        _new_config: SpiFunctionClockConfig,
-    ) {
-        // ESP32-S2 SPI is hardwired to APB; no clock source selection register.
-    }
-}

--- a/esp-hal/src/soc/esp32s2/clocks.rs
+++ b/esp-hal/src/soc/esp32s2/clocks.rs
@@ -18,7 +18,7 @@
 use esp_rom_sys::rom::{ets_delay_us, ets_update_cpu_frequency_rom};
 
 use crate::{
-    peripherals::{I2C_ANA_MST, I2C0, I2C1, LPWR, RMT, SYSCON, SYSTEM, TIMG0, TIMG1, UART0, UART1},
+    peripherals::{I2C_ANA_MST, LPWR, RMT, SYSCON, SYSTEM, TIMG0, TIMG1, UART0, UART1},
     soc::regi2c,
     time::Rate,
 };
@@ -760,29 +760,5 @@ impl UartInstance {
         _new_config: UartMemClockConfig,
     ) {
         // Nothing to do.
-    }
-}
-
-impl I2cInstance {
-    // I2C_FUNCTION_CLOCK
-
-    fn enable_function_clock_impl(self, _clocks: &mut ClockTree, _en: bool) {
-        // No dedicated enable bit on ESP32-S2; clock selection via ref_always_on.
-    }
-
-    fn configure_function_clock_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<I2cFunctionClockConfig>,
-        new_config: I2cFunctionClockConfig,
-    ) {
-        let regs = match self {
-            I2cInstance::I2c0 => I2C0::regs(),
-            I2cInstance::I2c1 => I2C1::regs(),
-        };
-        regs.ctr().modify(|_, w| {
-            w.ref_always_on()
-                .bit(!matches!(new_config.sclk, I2cFunctionClockSclk::RefTick))
-        });
     }
 }

--- a/esp-hal/src/soc/esp32s2/clocks.rs
+++ b/esp-hal/src/soc/esp32s2/clocks.rs
@@ -18,7 +18,7 @@
 use esp_rom_sys::rom::{ets_delay_us, ets_update_cpu_frequency_rom};
 
 use crate::{
-    peripherals::{I2C_ANA_MST, LPWR, RMT, SYSCON, SYSTEM, TIMG0, TIMG1, UART0, UART1},
+    peripherals::{I2C_ANA_MST, LPWR, RMT, SYSCON, SYSTEM, TIMG0, TIMG1},
     soc::regi2c,
     time::Rate,
 };
@@ -699,66 +699,5 @@ impl RmtInstance {
                 .chconf1(ch_num)
                 .modify(|_, w| w.ref_always_on().bit(new_config == RmtSclkConfig::ApbClk));
         }
-    }
-}
-
-impl UartInstance {
-    // UART_FUNCTION_CLOCK
-
-    fn enable_function_clock_impl(self, _clocks: &mut ClockTree, _en: bool) {
-        // Nothing to do.
-    }
-
-    fn configure_function_clock_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<UartFunctionClockConfig>,
-        new_config: UartFunctionClockConfig,
-    ) {
-        let regs = match self {
-            UartInstance::Uart0 => UART0::regs(),
-            UartInstance::Uart1 => UART1::regs(),
-        };
-        regs.conf0().modify(|_, w| {
-            w.tick_ref_always_on()
-                .bit(new_config.sclk == UartFunctionClockSclk::Apb)
-        });
-    }
-
-    // UART_BAUD_RATE_GENERATOR
-
-    fn enable_baud_rate_generator_impl(self, _clocks: &mut ClockTree, _en: bool) {
-        // Nothing to do.
-    }
-
-    fn configure_baud_rate_generator_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<UartBaudRateGeneratorConfig>,
-        new_config: UartBaudRateGeneratorConfig,
-    ) {
-        let regs = match self {
-            UartInstance::Uart0 => UART0::regs(),
-            UartInstance::Uart1 => UART1::regs(),
-        };
-        regs.clkdiv().write(|w| unsafe {
-            w.clkdiv().bits(new_config.integral as _);
-            w.frag().bits(new_config.fractional as _)
-        });
-    }
-
-    // UART_MEM_CLOCK
-
-    fn enable_mem_clock_impl(self, _clocks: &mut ClockTree, _en: bool) {
-        // Nothing to do.
-    }
-
-    fn configure_mem_clock_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<UartMemClockConfig>,
-        _new_config: UartMemClockConfig,
-    ) {
-        // Nothing to do.
     }
 }

--- a/esp-hal/src/soc/esp32s3/clocks.rs
+++ b/esp-hal/src/soc/esp32s3/clocks.rs
@@ -967,25 +967,3 @@ impl I2cInstance {
         });
     }
 }
-
-impl SpiInstance {
-    // SPI_FUNCTION_CLOCK
-
-    fn enable_function_clock_impl(self, _clocks: &mut ClockTree, _en: bool) {}
-
-    fn configure_function_clock_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<SpiFunctionClockConfig>,
-        new_config: SpiFunctionClockConfig,
-    ) {
-        let regs = match self {
-            SpiInstance::Spi2 => SPI2::regs(),
-            SpiInstance::Spi3 => SPI3::regs(),
-        };
-        regs.clk_gate().modify(|_, w| {
-            w.mst_clk_sel()
-                .bit(matches!(new_config, SpiFunctionClockConfig::Apb))
-        });
-    }
-}

--- a/esp-hal/src/soc/esp32s3/clocks.rs
+++ b/esp-hal/src/soc/esp32s3/clocks.rs
@@ -17,21 +17,7 @@
 use esp_rom_sys::rom::{ets_delay_us, ets_update_cpu_frequency_rom};
 
 use crate::{
-    peripherals::{
-        I2C_ANA_MST,
-        I2C0,
-        I2C1,
-        LPWR,
-        RMT,
-        SPI2,
-        SPI3,
-        SYSTEM,
-        TIMG0,
-        TIMG1,
-        UART0,
-        UART1,
-        UART2,
-    },
+    peripherals::{I2C_ANA_MST, LPWR, RMT, SYSTEM, TIMG0, TIMG1, UART0, UART1, UART2},
     soc::regi2c,
     time::Rate,
 };
@@ -934,36 +920,5 @@ impl UartInstance {
         _new_config: UartMemClockConfig,
     ) {
         // Nothing to do.
-    }
-}
-
-impl I2cInstance {
-    // I2C_FUNCTION_CLOCK
-    // Note: on ESP32-S3 both I2C0 and I2C1 share the same sclk_sel hardware bit (HW errata).
-
-    fn enable_function_clock_impl(self, _clocks: &mut ClockTree, en: bool) {
-        let regs = match self {
-            I2cInstance::I2c0 => I2C0::regs(),
-            I2cInstance::I2c1 => I2C1::regs(),
-        };
-        regs.clk_conf().modify(|_, w| w.sclk_active().bit(en));
-    }
-
-    fn configure_function_clock_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<I2cFunctionClockConfig>,
-        new_config: I2cFunctionClockConfig,
-    ) {
-        let regs = match self {
-            I2cInstance::I2c0 => I2C0::regs(),
-            I2cInstance::I2c1 => I2C1::regs(),
-        };
-        // sclk_sel: 0 = XTAL, 1 = RC_FAST
-        regs.clk_conf().modify(|_, w| unsafe {
-            w.sclk_sel()
-                .bit(matches!(new_config.sclk, I2cFunctionClockSclk::RcFast));
-            w.sclk_div_num().bits(new_config.div_num as _)
-        });
     }
 }

--- a/esp-hal/src/soc/esp32s3/clocks.rs
+++ b/esp-hal/src/soc/esp32s3/clocks.rs
@@ -17,7 +17,7 @@
 use esp_rom_sys::rom::{ets_delay_us, ets_update_cpu_frequency_rom};
 
 use crate::{
-    peripherals::{I2C_ANA_MST, LPWR, RMT, SYSTEM, TIMG0, TIMG1, UART0, UART1, UART2},
+    peripherals::{I2C_ANA_MST, LPWR, RMT, SYSTEM, TIMG0, TIMG1},
     soc::regi2c,
     time::Rate,
 };
@@ -845,80 +845,5 @@ impl TimgInstance {
             w.use_xtal()
                 .bit(new_config == TimgFunctionClockConfig::XtalClk)
         });
-    }
-}
-
-impl UartInstance {
-    // UART_FUNCTION_CLOCK
-
-    fn enable_function_clock_impl(self, _clocks: &mut ClockTree, en: bool) {
-        let regs = match self {
-            UartInstance::Uart0 => UART0::regs(),
-            UartInstance::Uart1 => UART1::regs(),
-            UartInstance::Uart2 => UART2::regs(),
-        };
-        regs.clk_conf().modify(|_, w| w.sclk_en().bit(en));
-    }
-
-    fn configure_function_clock_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<UartFunctionClockConfig>,
-        new_config: UartFunctionClockConfig,
-    ) {
-        let regs = match self {
-            UartInstance::Uart0 => UART0::regs(),
-            UartInstance::Uart1 => UART1::regs(),
-            UartInstance::Uart2 => UART2::regs(),
-        };
-        regs.clk_conf().modify(|_, w| unsafe {
-            w.sclk_sel().bits(match new_config.sclk {
-                UartFunctionClockSclk::Apb => 1,
-                UartFunctionClockSclk::RcFast => 2,
-                UartFunctionClockSclk::Xtal => 3,
-            });
-            w.sclk_div_a().bits(0);
-            w.sclk_div_b().bits(0);
-            w.sclk_div_num().bits(new_config.div_num as _);
-            w
-        });
-    }
-
-    // UART_BAUD_RATE_GENERATOR
-
-    fn enable_baud_rate_generator_impl(self, _clocks: &mut ClockTree, _en: bool) {
-        // Nothing to do.
-    }
-
-    fn configure_baud_rate_generator_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<UartBaudRateGeneratorConfig>,
-        new_config: UartBaudRateGeneratorConfig,
-    ) {
-        let regs = match self {
-            UartInstance::Uart0 => UART0::regs(),
-            UartInstance::Uart1 => UART1::regs(),
-            UartInstance::Uart2 => UART2::regs(),
-        };
-        regs.clkdiv().write(|w| unsafe {
-            w.clkdiv().bits(new_config.integral as _);
-            w.frag().bits(new_config.fractional as _)
-        });
-    }
-
-    // UART_MEM_CLOCK
-
-    fn enable_mem_clock_impl(self, _clocks: &mut ClockTree, _en: bool) {
-        // Nothing to do.
-    }
-
-    fn configure_mem_clock_impl(
-        self,
-        _clocks: &mut ClockTree,
-        _old_config: Option<UartMemClockConfig>,
-        _new_config: UartMemClockConfig,
-    ) {
-        // Nothing to do.
     }
 }

--- a/esp-hal/src/spi/clocks/esp32p4.rs
+++ b/esp-hal/src/spi/clocks/esp32p4.rs
@@ -1,0 +1,35 @@
+use crate::{
+    clock::ll::{ClockTree, SpiFunctionClockConfig, SpiInstance},
+    peripherals::HP_SYS_CLKRST,
+};
+
+impl SpiInstance {
+    // SPI_FUNCTION_CLOCK
+
+    pub(crate) fn enable_function_clock_impl(self, _clocks: &mut ClockTree, _en: bool) {
+        // SPI clock gates are managed by the peripheral clock infrastructure in system.rs.
+    }
+
+    pub(crate) fn configure_function_clock_impl(
+        self,
+        _clocks: &mut ClockTree,
+        _old_config: Option<SpiFunctionClockConfig>,
+        new_config: SpiFunctionClockConfig,
+    ) {
+        let source = match new_config {
+            SpiFunctionClockConfig::Xtal => 0,
+            SpiFunctionClockConfig::RcFast => 1,
+            // SDIO_PLL0
+            // APLL
+            SpiFunctionClockConfig::Spll => 4,
+        };
+        HP_SYS_CLKRST::regs()
+            .peri_clk_ctrl116()
+            .modify(|_, w| unsafe {
+                match self {
+                    Self::Spi2 => w.gpspi2_clk_src_sel().bits(source),
+                    Self::Spi3 => w.gpspi3_clk_src_sel().bits(source),
+                }
+            });
+    }
+}

--- a/esp-hal/src/spi/clocks/v1v2.rs
+++ b/esp-hal/src/spi/clocks/v1v2.rs
@@ -1,0 +1,18 @@
+use crate::clock::ll::{ClockTree, SpiFunctionClockConfig, SpiInstance};
+
+impl SpiInstance {
+    // SPI_FUNCTION_CLOCK
+
+    pub(crate) fn enable_function_clock_impl(self, _clocks: &mut ClockTree, _en: bool) {
+        // Nothing to do.
+    }
+
+    pub(crate) fn configure_function_clock_impl(
+        self,
+        _clocks: &mut ClockTree,
+        _old_config: Option<SpiFunctionClockConfig>,
+        _new_config: SpiFunctionClockConfig,
+    ) {
+        // SPI is hardwired to APB; no clock source selection register.
+    }
+}

--- a/esp-hal/src/spi/clocks/v3.rs
+++ b/esp-hal/src/spi/clocks/v3.rs
@@ -1,0 +1,29 @@
+use crate::clock::ll::{ClockTree, SpiFunctionClockConfig, SpiInstance};
+
+impl SpiInstance {
+    // SPI_FUNCTION_CLOCK
+
+    pub(crate) fn enable_function_clock_impl(self, _clocks: &mut ClockTree, _en: bool) {}
+
+    pub(crate) fn configure_function_clock_impl(
+        self,
+        _clocks: &mut ClockTree,
+        _old_config: Option<SpiFunctionClockConfig>,
+        new_config: SpiFunctionClockConfig,
+    ) {
+        let regs = match self {
+            #[cfg(soc_has_spi2)]
+            SpiInstance::Spi2 => crate::peripherals::SPI2::regs(),
+            #[cfg(soc_has_spi3)]
+            SpiInstance::Spi3 => crate::peripherals::SPI3::regs(),
+        };
+        regs.clk_gate().modify(|_, w| {
+            let bit = cfg_select! {
+                esp32c2 => matches!(new_config, SpiFunctionClockConfig::Pll40m),
+                esp32c3 => matches!(new_config, SpiFunctionClockConfig::Pll80m),
+                esp32s3 => matches!(new_config, SpiFunctionClockConfig::Apb),
+            };
+            w.mst_clk_sel().bit(bit)
+        });
+    }
+}

--- a/esp-hal/src/spi/clocks/v3_pcr.rs
+++ b/esp-hal/src/spi/clocks/v3_pcr.rs
@@ -1,0 +1,40 @@
+use crate::{
+    clock::ll::{ClockTree, SpiFunctionClockConfig, SpiInstance},
+    peripherals::PCR,
+};
+
+impl SpiInstance {
+    // SPI_FUNCTION_CLOCK
+
+    pub(crate) fn enable_function_clock_impl(self, _clocks: &mut ClockTree, en: bool) {
+        match self {
+            SpiInstance::Spi2 => PCR::regs()
+                .spi2_clkm_conf()
+                .modify(|_, w| w.spi2_clkm_en().bit(en)),
+        };
+    }
+
+    pub(crate) fn configure_function_clock_impl(
+        self,
+        _clocks: &mut ClockTree,
+        _old_config: Option<SpiFunctionClockConfig>,
+        new_config: SpiFunctionClockConfig,
+    ) {
+        match self {
+            SpiInstance::Spi2 => PCR::regs().spi2_clkm_conf().modify(|_, w| unsafe {
+                w.spi2_clkm_sel().bits(match new_config {
+                    SpiFunctionClockConfig::Xtal => 0,
+                    #[cfg(esp32c6)]
+                    SpiFunctionClockConfig::PllF80m => 1,
+                    #[cfg(esp32h2)]
+                    SpiFunctionClockConfig::PllF48m => 1,
+                    #[cfg(any(esp32c5, esp32c61))]
+                    SpiFunctionClockConfig::PllF160m => 1,
+                    SpiFunctionClockConfig::RcFast => 2,
+                    #[cfg(esp32c5)]
+                    SpiFunctionClockConfig::PllF120m => 3,
+                })
+            }),
+        };
+    }
+}

--- a/esp-hal/src/spi/mod.rs
+++ b/esp-hal/src/spi/mod.rs
@@ -30,7 +30,7 @@ crate::unstable_module! {
 )]
 #[cfg_attr(esp32p4, path = "clocks/esp32p4.rs")]
 #[cfg_attr(soc_has_pcr, path = "clocks/v3_pcr.rs")]
-mod v3_pcr;
+mod clocks;
 
 /// SPI errors
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/esp-hal/src/spi/mod.rs
+++ b/esp-hal/src/spi/mod.rs
@@ -20,6 +20,18 @@ crate::unstable_module! {
     pub mod slave;
 }
 
+#[cfg_attr(
+    any(spi_master_version = "1", spi_master_version = "2"),
+    path = "clocks/v1v2.rs"
+)]
+#[cfg_attr(
+    all(spi_master_version = "3", not(any(esp32p4, soc_has_pcr))),
+    path = "clocks/v3.rs"
+)]
+#[cfg_attr(esp32p4, path = "clocks/esp32p4.rs")]
+#[cfg_attr(soc_has_pcr, path = "clocks/v3_pcr.rs")]
+mod v3_pcr;
+
 /// SPI errors
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]

--- a/esp-hal/src/uart/clocks/v1.rs
+++ b/esp-hal/src/uart/clocks/v1.rs
@@ -1,0 +1,112 @@
+use crate::clock::ll::{
+    ClockTree,
+    UartBaudRateGeneratorConfig,
+    UartFunctionClockConfig,
+    UartFunctionClockSclk,
+    UartInstance,
+    UartMemClockConfig,
+};
+
+impl UartInstance {
+    // UART_FUNCTION_CLOCK
+
+    pub(crate) fn enable_function_clock_impl(self, _clocks: &mut ClockTree, _en: bool) {
+        #[cfg(uart_has_sclk_divider)]
+        {
+            let regs = match self {
+                #[cfg(soc_has_uart0)]
+                Self::Uart0 => crate::peripherals::UART0::regs(),
+                #[cfg(soc_has_uart1)]
+                Self::Uart1 => crate::peripherals::UART1::regs(),
+                #[cfg(soc_has_uart2)]
+                Self::Uart2 => crate::peripherals::UART2::regs(),
+            };
+
+            regs.clk_conf().modify(|_, w| w.sclk_en().bit(_en));
+        }
+    }
+
+    pub(crate) fn configure_function_clock_impl(
+        self,
+        _clocks: &mut ClockTree,
+        _old_config: Option<UartFunctionClockConfig>,
+        new_config: UartFunctionClockConfig,
+    ) {
+        let regs = match self {
+            #[cfg(soc_has_uart0)]
+            Self::Uart0 => crate::peripherals::UART0::regs(),
+            #[cfg(soc_has_uart1)]
+            Self::Uart1 => crate::peripherals::UART1::regs(),
+            #[cfg(soc_has_uart2)]
+            Self::Uart2 => crate::peripherals::UART2::regs(),
+        };
+
+        cfg_select! {
+            uart_has_sclk_divider => {
+                let sel = match new_config.sclk() {
+                    #[cfg(esp32c2)]
+                    UartFunctionClockSclk::PllF40m => 1,
+                    #[cfg(any(esp32c3, esp32s3))]
+                    UartFunctionClockSclk::Apb => 1,
+                    UartFunctionClockSclk::RcFast => 2,
+                    UartFunctionClockSclk::Xtal => 3,
+                };
+
+                regs.clk_conf().modify(|_, w| unsafe {
+                    w.sclk_sel().bits(sel);
+                    w.sclk_div_a().bits(0);
+                    w.sclk_div_b().bits(0);
+                    w.sclk_div_num().bits(new_config.div_num() as _)
+                });
+            }
+
+            _ => {
+                regs.conf0().modify(|_, w| {
+                    w.tick_ref_always_on()
+                        .bit(new_config.sclk() == UartFunctionClockSclk::Apb)
+                });
+            }
+        }
+    }
+
+    // UART_MEM_CLOCK
+
+    pub(crate) fn enable_mem_clock_impl(self, _clocks: &mut ClockTree, _en: bool) {
+        // Nothing to do.
+    }
+
+    pub(crate) fn configure_mem_clock_impl(
+        self,
+        _clocks: &mut ClockTree,
+        _old_config: Option<UartMemClockConfig>,
+        _new_config: UartMemClockConfig,
+    ) {
+        // Nothing to do.
+    }
+
+    // UART_BAUD_RATE_GENERATOR
+
+    pub(crate) fn enable_baud_rate_generator_impl(self, _clocks: &mut ClockTree, _en: bool) {
+        // Nothing to do.
+    }
+
+    pub(crate) fn configure_baud_rate_generator_impl(
+        self,
+        _clocks: &mut ClockTree,
+        _old_config: Option<UartBaudRateGeneratorConfig>,
+        new_config: UartBaudRateGeneratorConfig,
+    ) {
+        let regs = match self {
+            #[cfg(soc_has_uart0)]
+            Self::Uart0 => crate::peripherals::UART0::regs(),
+            #[cfg(soc_has_uart1)]
+            Self::Uart1 => crate::peripherals::UART1::regs(),
+            #[cfg(soc_has_uart2)]
+            Self::Uart2 => crate::peripherals::UART2::regs(),
+        };
+        regs.clkdiv().write(|w| unsafe {
+            w.clkdiv().bits(new_config.integral() as _);
+            w.frag().bits(new_config.fractional() as _)
+        });
+    }
+}

--- a/esp-hal/src/uart/clocks/v2_esp32p4.rs
+++ b/esp-hal/src/uart/clocks/v2_esp32p4.rs
@@ -1,0 +1,37 @@
+use crate::clock::ll::{
+    ClockTree,
+    UartBaudRateGeneratorConfig,
+    UartFunctionClockConfig,
+    UartInstance,
+};
+
+// Per-instance clock impl for UART (called on UartInstance enum)
+
+impl UartInstance {
+    pub(crate) fn enable_function_clock_impl(self, _clocks: &mut ClockTree, _en: bool) {
+        // UART function clock enable is handled by peripheral clock gates in system.rs
+    }
+
+    pub(crate) fn configure_function_clock_impl(
+        self,
+        _clocks: &mut ClockTree,
+        _old_config: Option<UartFunctionClockConfig>,
+        _new_config: UartFunctionClockConfig,
+    ) {
+        // TODO: Configure UART clock source selection
+        // HP_SYS_CLKRST PERI_CLK_CTRL110-114 for UART0-4
+    }
+
+    pub(crate) fn enable_baud_rate_generator_impl(self, _clocks: &mut ClockTree, _en: bool) {
+        // Baud rate generator is always on when UART is enabled
+    }
+
+    pub(crate) fn configure_baud_rate_generator_impl(
+        self,
+        _clocks: &mut ClockTree,
+        _old_config: Option<UartBaudRateGeneratorConfig>,
+        _new_config: UartBaudRateGeneratorConfig,
+    ) {
+        // Baud rate is configured directly in UART registers, not here
+    }
+}

--- a/esp-hal/src/uart/clocks/v2_esp32p4.rs
+++ b/esp-hal/src/uart/clocks/v2_esp32p4.rs
@@ -1,25 +1,77 @@
-use crate::clock::ll::{
-    ClockTree,
-    UartBaudRateGeneratorConfig,
-    UartFunctionClockConfig,
-    UartInstance,
+use crate::{
+    clock::ll::{
+        ClockTree,
+        UartBaudRateGeneratorConfig,
+        UartFunctionClockConfig,
+        UartFunctionClockSclk,
+        UartInstance,
+    },
+    peripherals::HP_SYS_CLKRST,
 };
 
 // Per-instance clock impl for UART (called on UartInstance enum)
 
 impl UartInstance {
-    pub(crate) fn enable_function_clock_impl(self, _clocks: &mut ClockTree, _en: bool) {
-        // UART function clock enable is handled by peripheral clock gates in system.rs
+    pub(crate) fn enable_function_clock_impl(self, _clocks: &mut ClockTree, en: bool) {
+        let regs = HP_SYS_CLKRST::regs();
+        match self {
+            UartInstance::Uart0 => {
+                regs.peri_clk_ctrl110()
+                    .modify(|_, w| w.uart0_clk_en().bit(en));
+            }
+            UartInstance::Uart1 => {
+                regs.peri_clk_ctrl111()
+                    .modify(|_, w| w.uart1_clk_en().bit(en));
+            }
+            UartInstance::Uart2 => {
+                regs.peri_clk_ctrl112()
+                    .modify(|_, w| w.uart2_clk_en().bit(en));
+            }
+            UartInstance::Uart3 => {
+                regs.peri_clk_ctrl113()
+                    .modify(|_, w| w.uart3_clk_en().bit(en));
+            }
+            UartInstance::Uart4 => {
+                regs.peri_clk_ctrl114()
+                    .modify(|_, w| w.uart4_clk_en().bit(en));
+            }
+        }
     }
 
     pub(crate) fn configure_function_clock_impl(
         self,
         _clocks: &mut ClockTree,
         _old_config: Option<UartFunctionClockConfig>,
-        _new_config: UartFunctionClockConfig,
+        new_config: UartFunctionClockConfig,
     ) {
-        // TODO: Configure UART clock source selection
-        // HP_SYS_CLKRST PERI_CLK_CTRL110-114 for UART0-4
+        let sel = match new_config.sclk() {
+            UartFunctionClockSclk::Xtal => 0,
+            UartFunctionClockSclk::PllF80m => 2,
+            UartFunctionClockSclk::RcFast => 1,
+        };
+        let regs = HP_SYS_CLKRST::regs();
+        match self {
+            UartInstance::Uart0 => {
+                regs.peri_clk_ctrl110()
+                    .modify(|_, w| unsafe { w.uart0_clk_src_sel().bits(sel) });
+            }
+            UartInstance::Uart1 => {
+                regs.peri_clk_ctrl111()
+                    .modify(|_, w| unsafe { w.uart1_clk_src_sel().bits(sel) });
+            }
+            UartInstance::Uart2 => {
+                regs.peri_clk_ctrl112()
+                    .modify(|_, w| unsafe { w.uart2_clk_src_sel().bits(sel) });
+            }
+            UartInstance::Uart3 => {
+                regs.peri_clk_ctrl113()
+                    .modify(|_, w| unsafe { w.uart3_clk_src_sel().bits(sel) });
+            }
+            UartInstance::Uart4 => {
+                regs.peri_clk_ctrl114()
+                    .modify(|_, w| unsafe { w.uart4_clk_src_sel().bits(sel) });
+            }
+        }
     }
 
     pub(crate) fn enable_baud_rate_generator_impl(self, _clocks: &mut ClockTree, _en: bool) {
@@ -30,8 +82,18 @@ impl UartInstance {
         self,
         _clocks: &mut ClockTree,
         _old_config: Option<UartBaudRateGeneratorConfig>,
-        _new_config: UartBaudRateGeneratorConfig,
+        new_config: UartBaudRateGeneratorConfig,
     ) {
-        // Baud rate is configured directly in UART registers, not here
+        let regs = match self {
+            UartInstance::Uart0 => crate::peripherals::UART0::regs(),
+            UartInstance::Uart1 => crate::peripherals::UART1::regs(),
+            UartInstance::Uart2 => crate::peripherals::UART2::regs(),
+            UartInstance::Uart3 => crate::peripherals::UART3::regs(),
+            UartInstance::Uart4 => crate::peripherals::UART4::regs(),
+        };
+        regs.clkdiv().write(|w| unsafe {
+            w.clkdiv().bits(new_config.integral() as _);
+            w.clkdiv_frag().bits(new_config.fractional() as _)
+        });
     }
 }

--- a/esp-hal/src/uart/clocks/v2_pcr.rs
+++ b/esp-hal/src/uart/clocks/v2_pcr.rs
@@ -1,0 +1,84 @@
+use crate::{
+    clock::ll::{
+        ClockTree,
+        UartBaudRateGeneratorConfig,
+        UartFunctionClockConfig,
+        UartFunctionClockSclk,
+        UartInstance,
+    },
+    peripherals::{PCR, UART0, UART1},
+};
+
+impl UartInstance {
+    // UART_FUNCTION_CLOCK
+
+    pub(crate) fn enable_function_clock_impl(self, _clocks: &mut ClockTree, en: bool) {
+        let uart = match self {
+            UartInstance::Uart0 => 0,
+            UartInstance::Uart1 => 1,
+        };
+        PCR::regs()
+            .uart(uart)
+            .clk_conf()
+            .modify(|_, w| w.sclk_en().bit(en));
+    }
+
+    pub(crate) fn configure_function_clock_impl(
+        self,
+        _clocks: &mut ClockTree,
+        _old_config: Option<UartFunctionClockConfig>,
+        new_config: UartFunctionClockConfig,
+    ) {
+        let sel = cfg_select! {
+            any(esp32c5, esp32c61) => match new_config.sclk() {
+                UartFunctionClockSclk::Xtal => 0,
+                UartFunctionClockSclk::RcFast => 1,
+                UartFunctionClockSclk::PllF80m => 2,
+            },
+            any(esp32c6, esp32h2) => match new_config.sclk() {
+                #[cfg(esp32c6)]
+                UartFunctionClockSclk::PllF80m => 1,
+                #[cfg(esp32h2)]
+                UartFunctionClockSclk::PllF48m => 1,
+                UartFunctionClockSclk::RcFast => 2,
+                UartFunctionClockSclk::Xtal => 3,
+            }
+        };
+
+        PCR::regs()
+            .uart(match self {
+                UartInstance::Uart0 => 0,
+                UartInstance::Uart1 => 1,
+            })
+            .clk_conf()
+            .modify(|_, w| unsafe {
+                w.sclk_sel().bits(sel);
+                w.sclk_div_a().bits(0);
+                w.sclk_div_b().bits(0);
+                w.sclk_div_num().bits(new_config.div_num() as _);
+                w
+            });
+    }
+
+    // UART_BAUD_RATE_GENERATOR
+
+    pub(crate) fn enable_baud_rate_generator_impl(self, _clocks: &mut ClockTree, _en: bool) {
+        // Nothing to do.
+    }
+
+    pub(crate) fn configure_baud_rate_generator_impl(
+        self,
+        _clocks: &mut ClockTree,
+        _old_config: Option<UartBaudRateGeneratorConfig>,
+        new_config: UartBaudRateGeneratorConfig,
+    ) {
+        let regs = match self {
+            UartInstance::Uart0 => UART0::regs(),
+            UartInstance::Uart1 => UART1::regs(),
+        };
+        regs.clkdiv().write(|w| unsafe {
+            w.clkdiv().bits(new_config.integral() as _);
+            w.frag().bits(new_config.fractional() as _)
+        });
+    }
+}

--- a/esp-hal/src/uart/low_level/mod.rs
+++ b/esp-hal/src/uart/low_level/mod.rs
@@ -1,7 +1,39 @@
+use core::task::Poll;
+
+use enumset::{EnumSet, EnumSetType};
 use portable_atomic::AtomicBool;
 
-use super::*;
-use crate::asynch::AtomicWaker;
+#[cfg(feature = "unstable")]
+use super::BaudrateTolerance;
+use super::{
+    AnyUart,
+    Config,
+    ConfigError,
+    DataBits,
+    HwFlowControl,
+    Parity,
+    RxError,
+    RxErrorKind,
+    StopBits,
+    SwFlowControl,
+    TxError,
+    UartInterrupt,
+    any,
+};
+use crate::{
+    asynch::AtomicWaker,
+    gpio::{InputSignal, OutputSignal},
+    handler,
+    interrupt::InterruptHandler,
+    pac::uart0::RegisterBlock,
+    ram,
+    soc::clocks::{
+        self,
+        ClockTree,
+        UartBaudRateGeneratorConfig as BaudRateConfig,
+        UartFunctionClockConfig as ClockConfig,
+    },
+};
 
 #[cfg_attr(uart_version = "1", path = "v1.rs")]
 #[cfg_attr(uart_version = "2", path = "v2.rs")]

--- a/esp-hal/src/uart/low_level/v1.rs
+++ b/esp-hal/src/uart/low_level/v1.rs
@@ -1,12 +1,12 @@
-use super::{
+use crate::uart::{
     ConfigError,
     CtsConfig,
     HwFlowControl,
-    Info,
     RegisterBlock,
     RtsConfig,
     StopBits,
     SwFlowControl,
+    low_level::Info,
 };
 
 #[inline(always)]
@@ -39,22 +39,19 @@ pub(super) fn set_rx_timeout(
 
     if let Some(timeout) = timeout {
         #[cfg(esp32)]
-        let timeout_reg = timeout;
-        #[cfg(not(esp32))]
-        let timeout_reg = timeout as u16 * _symbol_len as u16;
+        let timeout_reg = cfg_select! {
+            esp32 => timeout,
+            _ => timeout as u16 * _symbol_len as u16,
+        };
 
         if timeout_reg > MAX_THRHD {
             return Err(ConfigError::TimeoutTooLong);
         }
 
-        cfg_select! {
-            esp32 => {
-                let reg_thrhd = info.regs().conf1();
-            }
-            _ => {
-                let reg_thrhd = info.regs().mem_conf();
-            }
-        }
+        let reg_thrhd = cfg_select! {
+            esp32 => info.regs().conf1(),
+            _ => info.regs().mem_conf(),
+        };
         reg_thrhd.modify(|_, w| unsafe { w.rx_tout_thrhd().bits(timeout_reg) });
     }
 
@@ -72,14 +69,10 @@ pub(super) fn rx_timeout_enabled(info: &Info) -> bool {
 }
 
 pub(super) fn is_tx_idle(info: &Info) -> bool {
-    cfg_select! {
-        esp32 => {
-            let status = info.regs().status();
-        }
-        _ => {
-            let status = info.regs().fsm_status();
-        }
-    }
+    let status = cfg_select! {
+        esp32 => info.regs().status(),
+        _ => info.regs().fsm_status(),
+    };
 
     status.read().st_utx_out().bits() == 0x0
 }

--- a/esp-hal/src/uart/low_level/v1.rs
+++ b/esp-hal/src/uart/low_level/v1.rs
@@ -38,7 +38,6 @@ pub(super) fn set_rx_timeout(
     }
 
     if let Some(timeout) = timeout {
-        #[cfg(esp32)]
         let timeout_reg = cfg_select! {
             esp32 => timeout,
             _ => timeout as u16 * _symbol_len as u16,

--- a/esp-hal/src/uart/low_level/v2.rs
+++ b/esp-hal/src/uart/low_level/v2.rs
@@ -1,12 +1,12 @@
-use super::{
+use crate::uart::{
     ConfigError,
     CtsConfig,
     HwFlowControl,
-    Info,
     RegisterBlock,
     RtsConfig,
     StopBits,
     SwFlowControl,
+    low_level::Info,
 };
 
 #[inline(always)]

--- a/esp-hal/src/uart/mod.rs
+++ b/esp-hal/src/uart/mod.rs
@@ -47,10 +47,15 @@ crate::unstable_driver! {
     pub mod uhci;
 }
 
+#[cfg_attr(uart_version = "1", path = "clocks/v1.rs")]
+#[cfg_attr(soc_has_pcr, path = "clocks/v2_pcr.rs")]
+#[cfg_attr(esp32p4, path = "clocks/v2_esp32p4.rs")]
+mod clocks;
+
 mod compat;
 mod low_level;
 
-use core::{marker::PhantomData, sync::atomic::Ordering, task::Poll};
+use core::{marker::PhantomData, sync::atomic::Ordering};
 
 use embedded_hal_async::delay::DelayNs;
 use enumset::{EnumSet, EnumSetType};
@@ -73,20 +78,15 @@ use crate::{
     DriverMode,
     gpio::{
         InputConfig,
-        InputSignal,
         OutputConfig,
-        OutputSignal,
         PinGuard,
         Pull,
         interconnect::{PeripheralInput, PeripheralOutput},
     },
-    handler,
     interrupt::InterruptHandler,
     pac::uart0::RegisterBlock,
     private::DropGuard,
-    ram,
     rtc_cntl::WakeLock,
-    soc::clocks::{self, ClockTree},
     system::PeripheralGuard,
 };
 
@@ -225,10 +225,6 @@ impl core::error::Error for TxError {}
 
 #[instability::unstable]
 pub use crate::soc::clocks::UartFunctionClockSclk as ClockSource;
-use crate::soc::clocks::{
-    UartBaudRateGeneratorConfig as BaudRateConfig,
-    UartFunctionClockConfig as ClockConfig,
-};
 
 /// Number of data bits
 ///

--- a/esp-metadata-generated/src/_generated_esp32.rs
+++ b/esp-metadata-generated/src/_generated_esp32.rs
@@ -1187,7 +1187,7 @@ macro_rules! define_clock_tree_types {
             pub const fn new(divisor: CpuPllDivDivisor) -> Self {
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1222,7 +1222,7 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1272,7 +1272,7 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1298,7 +1298,7 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1324,7 +1324,7 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1350,7 +1350,7 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1426,7 +1426,7 @@ macro_rules! define_clock_tree_types {
             pub const fn new(sclk: I2cFunctionClockSclk) -> Self {
                 Self { sclk }
             }
-            fn sclk(self) -> I2cFunctionClockSclk {
+            pub(crate) fn sclk(self) -> I2cFunctionClockSclk {
                 self.sclk
             }
         }
@@ -1478,7 +1478,7 @@ macro_rules! define_clock_tree_types {
             pub const fn new(sclk: UartFunctionClockSclk) -> Self {
                 Self { sclk }
             }
-            fn sclk(self) -> UartFunctionClockSclk {
+            pub(crate) fn sclk(self) -> UartFunctionClockSclk {
                 self.sclk
             }
         }
@@ -1529,10 +1529,10 @@ macro_rules! define_clock_tree_types {
                     integral,
                 }
             }
-            fn fractional(self) -> u32 {
+            pub(crate) fn fractional(self) -> u32 {
                 self.fractional as u32
             }
-            fn integral(self) -> u32 {
+            pub(crate) fn integral(self) -> u32 {
                 self.integral as u32
             }
         }

--- a/esp-metadata-generated/src/_generated_esp32c2.rs
+++ b/esp-metadata-generated/src/_generated_esp32c2.rs
@@ -1060,7 +1060,7 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1095,7 +1095,7 @@ macro_rules! define_clock_tree_types {
             pub const fn new(divisor: CpuPllDivDivisor) -> Self {
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1159,7 +1159,7 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1247,10 +1247,10 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { sclk, div_num }
             }
-            fn sclk(self) -> I2cFunctionClockSclk {
+            pub(crate) fn sclk(self) -> I2cFunctionClockSclk {
                 self.sclk
             }
-            fn div_num(self) -> u32 {
+            pub(crate) fn div_num(self) -> u32 {
                 self.div_num as u32
             }
         }
@@ -1318,10 +1318,10 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { sclk, div_num }
             }
-            fn sclk(self) -> UartFunctionClockSclk {
+            pub(crate) fn sclk(self) -> UartFunctionClockSclk {
                 self.sclk
             }
-            fn div_num(self) -> u32 {
+            pub(crate) fn div_num(self) -> u32 {
                 self.div_num as u32
             }
         }
@@ -1371,10 +1371,10 @@ macro_rules! define_clock_tree_types {
                     integral,
                 }
             }
-            fn fractional(self) -> u32 {
+            pub(crate) fn fractional(self) -> u32 {
                 self.fractional as u32
             }
-            fn integral(self) -> u32 {
+            pub(crate) fn integral(self) -> u32 {
                 self.integral as u32
             }
         }

--- a/esp-metadata-generated/src/_generated_esp32c3.rs
+++ b/esp-metadata-generated/src/_generated_esp32c3.rs
@@ -1451,7 +1451,7 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1523,7 +1523,7 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1611,10 +1611,10 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { sclk, div_num }
             }
-            fn sclk(self) -> I2cFunctionClockSclk {
+            pub(crate) fn sclk(self) -> I2cFunctionClockSclk {
                 self.sclk
             }
-            fn div_num(self) -> u32 {
+            pub(crate) fn div_num(self) -> u32 {
                 self.div_num as u32
             }
         }
@@ -1694,10 +1694,10 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { sclk, div_num }
             }
-            fn sclk(self) -> UartFunctionClockSclk {
+            pub(crate) fn sclk(self) -> UartFunctionClockSclk {
                 self.sclk
             }
-            fn div_num(self) -> u32 {
+            pub(crate) fn div_num(self) -> u32 {
                 self.div_num as u32
             }
         }
@@ -1747,10 +1747,10 @@ macro_rules! define_clock_tree_types {
                     integral,
                 }
             }
-            fn fractional(self) -> u32 {
+            pub(crate) fn fractional(self) -> u32 {
                 self.fractional as u32
             }
-            fn integral(self) -> u32 {
+            pub(crate) fn integral(self) -> u32 {
                 self.integral as u32
             }
         }

--- a/esp-metadata-generated/src/_generated_esp32c5.rs
+++ b/esp-metadata-generated/src/_generated_esp32c5.rs
@@ -1585,7 +1585,7 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1611,7 +1611,7 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1637,7 +1637,7 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1719,10 +1719,10 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { sclk, div_num }
             }
-            fn sclk(self) -> I2cFunctionClockSclk {
+            pub(crate) fn sclk(self) -> I2cFunctionClockSclk {
                 self.sclk
             }
-            fn div_num(self) -> u32 {
+            pub(crate) fn div_num(self) -> u32 {
                 self.div_num as u32
             }
         }
@@ -1834,10 +1834,10 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { sclk, div_num }
             }
-            fn sclk(self) -> UartFunctionClockSclk {
+            pub(crate) fn sclk(self) -> UartFunctionClockSclk {
                 self.sclk
             }
-            fn div_num(self) -> u32 {
+            pub(crate) fn div_num(self) -> u32 {
                 self.div_num as u32
             }
         }
@@ -1875,10 +1875,10 @@ macro_rules! define_clock_tree_types {
                     integral,
                 }
             }
-            fn fractional(self) -> u32 {
+            pub(crate) fn fractional(self) -> u32 {
                 self.fractional as u32
             }
-            fn integral(self) -> u32 {
+            pub(crate) fn integral(self) -> u32 {
                 self.integral as u32
             }
         }

--- a/esp-metadata-generated/src/_generated_esp32c6.rs
+++ b/esp-metadata-generated/src/_generated_esp32c6.rs
@@ -1619,7 +1619,7 @@ macro_rules! define_clock_tree_types {
             pub const fn new(divisor: HpRootClkDivisor) -> Self {
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1695,7 +1695,7 @@ macro_rules! define_clock_tree_types {
             pub const fn new(divisor: CpuHsDivDivisor) -> Self {
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1742,7 +1742,7 @@ macro_rules! define_clock_tree_types {
             pub const fn new(divisor: CpuLsDivDivisor) -> Self {
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1780,7 +1780,7 @@ macro_rules! define_clock_tree_types {
             pub const fn new(divisor: AhbHsDivDivisor) -> Self {
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1827,7 +1827,7 @@ macro_rules! define_clock_tree_types {
             pub const fn new(divisor: AhbLsDivDivisor) -> Self {
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1865,7 +1865,7 @@ macro_rules! define_clock_tree_types {
             pub const fn new(divisor: ApbClkDivisor) -> Self {
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1903,7 +1903,7 @@ macro_rules! define_clock_tree_types {
             pub const fn new(divisor: MspiFastHsClkDivisor) -> Self {
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1941,7 +1941,7 @@ macro_rules! define_clock_tree_types {
             pub const fn new(divisor: MspiFastLsClkDivisor) -> Self {
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -2019,10 +2019,10 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { sclk, div_num }
             }
-            fn sclk(self) -> I2cFunctionClockSclk {
+            pub(crate) fn sclk(self) -> I2cFunctionClockSclk {
                 self.sclk
             }
-            fn div_num(self) -> u32 {
+            pub(crate) fn div_num(self) -> u32 {
                 self.div_num as u32
             }
         }
@@ -2144,10 +2144,10 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { sclk, div_num }
             }
-            fn sclk(self) -> UartFunctionClockSclk {
+            pub(crate) fn sclk(self) -> UartFunctionClockSclk {
                 self.sclk
             }
-            fn div_num(self) -> u32 {
+            pub(crate) fn div_num(self) -> u32 {
                 self.div_num as u32
             }
         }
@@ -2185,10 +2185,10 @@ macro_rules! define_clock_tree_types {
                     integral,
                 }
             }
-            fn fractional(self) -> u32 {
+            pub(crate) fn fractional(self) -> u32 {
                 self.fractional as u32
             }
-            fn integral(self) -> u32 {
+            pub(crate) fn integral(self) -> u32 {
                 self.integral as u32
             }
         }

--- a/esp-metadata-generated/src/_generated_esp32c61.rs
+++ b/esp-metadata-generated/src/_generated_esp32c61.rs
@@ -1090,7 +1090,7 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1116,7 +1116,7 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1142,7 +1142,7 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1213,10 +1213,10 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { sclk, div_num }
             }
-            fn sclk(self) -> I2cFunctionClockSclk {
+            pub(crate) fn sclk(self) -> I2cFunctionClockSclk {
                 self.sclk
             }
-            fn div_num(self) -> u32 {
+            pub(crate) fn div_num(self) -> u32 {
                 self.div_num as u32
             }
         }
@@ -1290,10 +1290,10 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { sclk, div_num }
             }
-            fn sclk(self) -> UartFunctionClockSclk {
+            pub(crate) fn sclk(self) -> UartFunctionClockSclk {
                 self.sclk
             }
-            fn div_num(self) -> u32 {
+            pub(crate) fn div_num(self) -> u32 {
                 self.div_num as u32
             }
         }
@@ -1331,10 +1331,10 @@ macro_rules! define_clock_tree_types {
                     integral,
                 }
             }
-            fn fractional(self) -> u32 {
+            pub(crate) fn fractional(self) -> u32 {
                 self.fractional as u32
             }
-            fn integral(self) -> u32 {
+            pub(crate) fn integral(self) -> u32 {
                 self.integral as u32
             }
         }

--- a/esp-metadata-generated/src/_generated_esp32h2.rs
+++ b/esp-metadata-generated/src/_generated_esp32h2.rs
@@ -1481,7 +1481,7 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1507,7 +1507,7 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1533,7 +1533,7 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1602,10 +1602,10 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { sclk, div_num }
             }
-            fn sclk(self) -> I2cFunctionClockSclk {
+            pub(crate) fn sclk(self) -> I2cFunctionClockSclk {
                 self.sclk
             }
-            fn div_num(self) -> u32 {
+            pub(crate) fn div_num(self) -> u32 {
                 self.div_num as u32
             }
         }
@@ -1725,10 +1725,10 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { sclk, div_num }
             }
-            fn sclk(self) -> UartFunctionClockSclk {
+            pub(crate) fn sclk(self) -> UartFunctionClockSclk {
                 self.sclk
             }
-            fn div_num(self) -> u32 {
+            pub(crate) fn div_num(self) -> u32 {
                 self.div_num as u32
             }
         }
@@ -1766,10 +1766,10 @@ macro_rules! define_clock_tree_types {
                     integral,
                 }
             }
-            fn fractional(self) -> u32 {
+            pub(crate) fn fractional(self) -> u32 {
                 self.fractional as u32
             }
-            fn integral(self) -> u32 {
+            pub(crate) fn integral(self) -> u32 {
                 self.integral as u32
             }
         }

--- a/esp-metadata-generated/src/_generated_esp32p4.rs
+++ b/esp-metadata-generated/src/_generated_esp32p4.rs
@@ -1581,7 +1581,7 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1607,7 +1607,7 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1633,7 +1633,7 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1659,7 +1659,7 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1758,10 +1758,10 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { sclk, div_num }
             }
-            fn sclk(self) -> UartFunctionClockSclk {
+            pub(crate) fn sclk(self) -> UartFunctionClockSclk {
                 self.sclk
             }
-            fn div_num(self) -> u32 {
+            pub(crate) fn div_num(self) -> u32 {
                 self.div_num as u32
             }
         }
@@ -1799,10 +1799,10 @@ macro_rules! define_clock_tree_types {
                     integral,
                 }
             }
-            fn fractional(self) -> u32 {
+            pub(crate) fn fractional(self) -> u32 {
                 self.fractional as u32
             }
-            fn integral(self) -> u32 {
+            pub(crate) fn integral(self) -> u32 {
                 self.integral as u32
             }
         }
@@ -1850,10 +1850,10 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { sclk, div_num }
             }
-            fn sclk(self) -> I2cFunctionClockSclk {
+            pub(crate) fn sclk(self) -> I2cFunctionClockSclk {
                 self.sclk
             }
-            fn div_num(self) -> u32 {
+            pub(crate) fn div_num(self) -> u32 {
                 self.div_num as u32
             }
         }
@@ -1891,10 +1891,10 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { sclk, div_num }
             }
-            fn sclk(self) -> MipiDsiDpiClkSclk {
+            pub(crate) fn sclk(self) -> MipiDsiDpiClkSclk {
                 self.sclk
             }
-            fn div_num(self) -> u32 {
+            pub(crate) fn div_num(self) -> u32 {
                 self.div_num as u32
             }
         }
@@ -1934,10 +1934,10 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { sclk, div_num }
             }
-            fn sclk(self) -> MipiDsiPhyPllRefclkSclk {
+            pub(crate) fn sclk(self) -> MipiDsiPhyPllRefclkSclk {
                 self.sclk
             }
-            fn div_num(self) -> u32 {
+            pub(crate) fn div_num(self) -> u32 {
                 self.div_num as u32
             }
         }

--- a/esp-metadata-generated/src/_generated_esp32s2.rs
+++ b/esp-metadata-generated/src/_generated_esp32s2.rs
@@ -1406,7 +1406,7 @@ macro_rules! define_clock_tree_types {
             pub const fn new(divisor: CpuPllDivDivisor) -> Self {
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1441,7 +1441,7 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1493,7 +1493,7 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1519,7 +1519,7 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1597,7 +1597,7 @@ macro_rules! define_clock_tree_types {
             pub const fn new(sclk: I2cFunctionClockSclk) -> Self {
                 Self { sclk }
             }
-            fn sclk(self) -> I2cFunctionClockSclk {
+            pub(crate) fn sclk(self) -> I2cFunctionClockSclk {
                 self.sclk
             }
         }
@@ -1651,7 +1651,7 @@ macro_rules! define_clock_tree_types {
             pub const fn new(sclk: UartFunctionClockSclk) -> Self {
                 Self { sclk }
             }
-            fn sclk(self) -> UartFunctionClockSclk {
+            pub(crate) fn sclk(self) -> UartFunctionClockSclk {
                 self.sclk
             }
         }
@@ -1690,10 +1690,10 @@ macro_rules! define_clock_tree_types {
                     integral,
                 }
             }
-            fn fractional(self) -> u32 {
+            pub(crate) fn fractional(self) -> u32 {
                 self.fractional as u32
             }
-            fn integral(self) -> u32 {
+            pub(crate) fn integral(self) -> u32 {
                 self.integral as u32
             }
         }

--- a/esp-metadata-generated/src/_generated_esp32s3.rs
+++ b/esp-metadata-generated/src/_generated_esp32s3.rs
@@ -1522,7 +1522,7 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1597,7 +1597,7 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { divisor }
             }
-            fn divisor(self) -> u32 {
+            pub(crate) fn divisor(self) -> u32 {
                 self.divisor as u32
             }
         }
@@ -1685,10 +1685,10 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { sclk, div_num }
             }
-            fn sclk(self) -> I2cFunctionClockSclk {
+            pub(crate) fn sclk(self) -> I2cFunctionClockSclk {
                 self.sclk
             }
-            fn div_num(self) -> u32 {
+            pub(crate) fn div_num(self) -> u32 {
                 self.div_num as u32
             }
         }
@@ -1766,10 +1766,10 @@ macro_rules! define_clock_tree_types {
                 );
                 Self { sclk, div_num }
             }
-            fn sclk(self) -> UartFunctionClockSclk {
+            pub(crate) fn sclk(self) -> UartFunctionClockSclk {
                 self.sclk
             }
-            fn div_num(self) -> u32 {
+            pub(crate) fn div_num(self) -> u32 {
                 self.div_num as u32
             }
         }
@@ -1807,10 +1807,10 @@ macro_rules! define_clock_tree_types {
                     integral,
                 }
             }
-            fn fractional(self) -> u32 {
+            pub(crate) fn fractional(self) -> u32 {
                 self.fractional as u32
             }
-            fn integral(self) -> u32 {
+            pub(crate) fn integral(self) -> u32 {
                 self.integral as u32
             }
         }

--- a/esp-metadata/src/cfg/soc/clock_tree/generic.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/generic.rs
@@ -657,14 +657,14 @@ impl ClockTreeNodeType for Generic {
             match param {
                 NodeParameter::Value(_) => {
                     quote! {
-                        fn #param_name(self) -> u32 {
+                        pub(crate) fn #param_name(self) -> u32 {
                             self.#param_name as u32
                         }
                     }
                 }
                 NodeParameter::Source(_) => {
                     quote! {
-                        fn #param_name(self) -> #param_ty {
+                        pub(crate) fn #param_name(self) -> #param_ty {
                             self.#param_name
                         }
                     }


### PR DESCRIPTION
Since there is quite a bit of commonality in newer chips, we can probably start grouping their clock implementations. My recommendation is to move the code near the peripheral drivers and loosely follow peripheral versioning.

What I don't like about this approach is the `cfg`s we need because of the different clock source names / register values. There are a few alternatives to improve this:

- Keep `raw_xy_value` functions in the chip-specific files
- Macro-generate the enums
- Rename multiplexer arms (and lose the frequency in the name, e.g. `Pll40m -> Pll`) - not an universal solution