### PR TITLE
Enable clocks for security engine for esp32h2

### DIFF
--- a/esp-radio/src/radio_clocks/clocks_ll/esp32h2.rs
+++ b/esp-radio/src/radio_clocks/clocks_ll/esp32h2.rs
@@ -1,7 +1,17 @@
 fn ble_ieee802154_clock_enable(en: bool) {
     regs!(MODEM_SYSCON).clk_conf().modify(|_, w| {
         w.clk_zb_apb_en().bit(en);
-        w.clk_zb_mac_en().bit(en)
+        w.clk_zb_mac_en().bit(en);
+        // Modem security engine (AES-ECB/CCM) clocks — required by the BLE
+        // controller's hardware `r_ble_hw_encrypt_block` for link-layer
+        // encryption, and by 802.15.4 frame security. Mirrors esp32c6.
+        w.clk_etm_en().bit(en);
+        w.clk_modem_sec_en().bit(en);
+        w.clk_modem_sec_ecb_en().bit(en);
+        w.clk_modem_sec_ccm_en().bit(en);
+        w.clk_modem_sec_bah_en().bit(en);
+        w.clk_modem_sec_apb_en().bit(en);
+        w.clk_ble_timer_en().bit(en)
     });
 
     regs!(MODEM_SYSCON).clk_conf1().modify(|_, w| {


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` or `manual-changelog` label as appropriate.
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

This PR fixes esp32h2's BLE connection panics when using TrouBLE + security feature:

```
 ====================== PANIC ======================
  panicked at /Users/haobogu/.cargo/git/checkouts/esp-hal-40e7cb45e135de97/b7eec0f/esp-radio/src/ble/npl.rs:435:9:
  ASSERT r_ble_hw_encrypt_block:443 0 0


  Backtrace:

  0x4202e1a8
  esp_radio::ble::npl::osi_assert
      at /Users/haobogu/.cargo/git/checkouts/esp-hal-40e7cb45e135de97/b7eec0f/esp-radio/src/ble/npl.rs:435
  0x40804ec2
  r_ble_hw_encrypt_block
      at ??:??
```

#### Testing

Test in PR https://github.com/HaoboGu/rmk/pull/914

---

<!-- ============================================================
  Changelog and migration guide entries live here in the PR body.
  They will be collected automatically at release time.
  Delete any section that doesn't apply to your PR.
  ============================================================ -->

# Changelog

## esp-radio

- Fixed: Enable clocks for security engine for esp32h2.
