### PR TITLE
Allow building specific tests with the stable toolchain

### DIFF
--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -355,13 +355,51 @@ pub struct BuiltCommand {
     pub artifact_name: String,
     pub command: Vec<String>,
     pub env_vars: Vec<(String, String)>,
+    pub artifact_dir: Option<PathBuf>,
 }
 
 impl BuiltCommand {
     pub fn run(&self, capture: bool) -> Result<String> {
         let env_vars = self.env_vars.clone();
         let cwd = std::env::current_dir()?;
-        run_with_env(&self.command, &cwd, env_vars, capture)
+        let output = run_with_env(&self.command, &cwd, env_vars, capture)?;
+
+        if let Some(artifact_dir) = self.artifact_dir.as_deref() {
+            self.copy_artifacts(artifact_dir, &cwd).with_context(|| {
+                format!("Failed to copy artifacts to {}", artifact_dir.display())
+            })?;
+        }
+
+        Ok(output)
+    }
+
+    /// Copies the executables built by this command into `artifact_dir`.
+    ///
+    /// Re-runs the finished build with `--message-format=json` to look up the
+    /// executable paths. The second build is a no-op, so this is quick.
+    fn copy_artifacts(&self, artifact_dir: &Path, cwd: &Path) -> Result<()> {
+        let mut command = self.command.clone();
+        command.push("--message-format=json".to_string());
+
+        let output = run_with_env(&command, cwd, self.env_vars.clone(), true)?;
+
+        std::fs::create_dir_all(artifact_dir)?;
+
+        let mut copied = 0;
+        for line in output.lines() {
+            if let Ok(artifact) = serde_json::from_str::<Artifact>(line)
+                && let Some(file_name) = artifact.executable.file_name()
+            {
+                std::fs::copy(&artifact.executable, artifact_dir.join(file_name))?;
+                copied += 1;
+            }
+        }
+
+        if copied == 0 {
+            bail!("The build did not produce any executables");
+        }
+
+        Ok(())
     }
 }
 
@@ -429,6 +467,7 @@ impl CargoCommandBatcher {
                         artifact_name: String::from("batch"),
                         command: std::mem::take(&mut command),
                         env_vars: key.env_vars.clone(),
+                        artifact_dir: None,
                     });
                 }
 
@@ -466,6 +505,7 @@ impl CargoCommandBatcher {
                     artifact_name: String::from("batch"),
                     command,
                     env_vars: key.env_vars.clone(),
+                    artifact_dir: None,
                 });
             }
         }
@@ -486,22 +526,28 @@ impl CargoCommandBatcher {
     }
 
     pub fn build_one_for_cargo(item: &CargoArgsBuilder) -> BuiltCommand {
+        // `--artifact-dir` is unstable and would require `-Zunstable-options`,
+        // which stable cargo rejects. Strip it from the command and copy the
+        // artifacts after the build, instead.
+        let mut item = item.clone();
+        let artifact_dir = item
+            .args
+            .iter()
+            .position(|arg| arg == "--artifact-dir")
+            .map(|position| {
+                item.args.remove(position);
+                PathBuf::from(item.args.remove(position))
+            });
+
         BuiltCommand {
             artifact_name: item.artifact_name.clone(),
-            command: {
-                let mut args = item.build();
-
-                if item.args.iter().any(|arg| arg == "--artifact-dir") {
-                    args.push("-Zunstable-options".to_string());
-                }
-
-                args
-            },
+            command: item.build(),
             env_vars: item
                 .env_vars
                 .iter()
                 .map(|(k, v)| (k.clone(), v.clone()))
                 .collect(),
+            artifact_dir,
         }
     }
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` or `manual-changelog` label as appropriate.
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

`cargo xtask build tests <chip> --test <name>` fails on the stable toolchain:

```
error: the `-Z` flag is only accepted on the nightly channel of Cargo
```

Single cargo commands (used when cargo-batch is not installed, or when a batch group contains only one command) pass `--artifact-dir`, which needs `-Zunstable-options`. CI never hits this because the HIL jobs run on nightly, but locally on stable any specific test selection fails.

Instead of passing `--artifact-dir` to plain cargo, strip it from the command and copy the executables to the requested directory after the build. The finished build is re-run with `--message-format=json` (a no-op, so it only takes a moment) to look up the executable paths. This is the approach #2901 used before cargo-batch was introduced in #4108, and it reuses the `Artifact` struct that stayed behind after that change. cargo-batch invocations are unchanged, cargo-batch handles `--artifact-dir` fine on its own. The HIL workflow doesn't install cargo-batch, so its build step takes the new path in CI as well; the cost there is one extra no-op cargo run per command.

xtask is not a published crate, so there are no changelog entries.

Closes #4862

#### Testing

`cargo xtask build tests esp32c6 --test gpio` on stable 1.96.1 (previously rejected with the `-Z` error) now passes and produces `target/tests/esp32c6/gpio_stable` and `gpio_unstable`, same as before. Multi-test selection (`--test uart,i2c`) on stable passes as well.

On nightly the produced ELFs are byte-identical to what the previous `--artifact-dir` code emits (compared SHA-256 of `target/tests/esp32c6/*` on the same toolchain, with and without this change).

`cd xtask && cargo test --features release` passes (55 tests), `cargo xtask fmt-packages --check` is clean and `cargo clippy -p xtask` reports no new warnings.
