### PR TITLE
S3: Allow using non-DCache RAM

### DIFF
--- a/esp-hal-procmacros/Cargo.toml
+++ b/esp-hal-procmacros/Cargo.toml
@@ -43,6 +43,9 @@ rtc-slow = []
 ## Indicates the target device has RTC fast memory available.
 rtc-fast = []
 
+## Indicates the target device has memory reclaimed from .
+dcache-reclaimed = []
+
 #! ### Low-power Core Feature Flags
 ## Indicate that the SoC contains an LP core.
 has-lp-core = ["dep:object"]

--- a/esp-hal-procmacros/Cargo.toml
+++ b/esp-hal-procmacros/Cargo.toml
@@ -43,7 +43,8 @@ rtc-slow = []
 ## Indicates the target device has RTC fast memory available.
 rtc-fast = []
 
-## Indicates the target device has memory reclaimed from .
+## Indicates the target device has a data cache that when not used, is available
+## in a memory section *separate* from DRAM.
 dcache-reclaimed = []
 
 #! ### Low-power Core Feature Flags

--- a/esp-hal-procmacros/src/ram.rs
+++ b/esp-hal-procmacros/src/ram.rs
@@ -190,7 +190,7 @@ pub fn ram(args: TokenStream, input: TokenStream) -> TokenStream {
         Some("zeroable")
     } else if persistent {
         Some("persistable")
-    } else if dram2_uninit {
+    } else if dram2_uninit || dcache_reclaimed {
         Some("uninit")
     } else {
         None

--- a/esp-hal-procmacros/src/ram.rs
+++ b/esp-hal-procmacros/src/ram.rs
@@ -10,6 +10,7 @@ pub fn ram(args: TokenStream, input: TokenStream) -> TokenStream {
     let mut rtc_fast = false;
     let mut rtc_slow = false;
     let mut dram2_uninit = false;
+    let mut dcache_reclaimed = false;
     let mut persistent = false;
     let mut zeroed = false;
 
@@ -38,6 +39,7 @@ pub fn ram(args: TokenStream, input: TokenStream) -> TokenStream {
                                 i if i == "rtc_fast" => &mut rtc_fast,
                                 i if i == "rtc_slow" => &mut rtc_slow,
                                 i if i == "persistent" => &mut persistent,
+                                i if i == "dcache_reclaimed" => &mut dcache_reclaimed,
                                 i if i == "zeroed" => &mut zeroed,
                                 i => {
                                     return syn::Error::new(
@@ -132,22 +134,40 @@ pub fn ram(args: TokenStream, input: TokenStream) -> TokenStream {
         .into_compile_error();
     }
 
+    #[cfg(not(feature = "dcache-reclaimed"))]
+    if dcache_reclaimed {
+        return syn::Error::new(
+            Span::call_site(),
+            "dcache_reclaimed is not available for this target",
+        )
+        .into_compile_error();
+    }
+
     let is_fn = matches!(item, Item::Fn(_));
-    let section_name = match (is_fn, rtc_fast, rtc_slow, dram2_uninit, persistent, zeroed) {
-        (true, false, false, false, false, false) => Ok(".rwtext"),
-        (true, true, false, false, false, false) => Ok(".rtc_fast.text"),
-        (true, false, true, false, false, false) => Ok(".rtc_slow.text"),
+    let section_name = match (
+        is_fn,
+        rtc_fast,
+        rtc_slow,
+        dram2_uninit,
+        dcache_reclaimed,
+        persistent,
+        zeroed,
+    ) {
+        (true, false, false, false, false, false, false) => Ok(".rwtext"),
+        (true, true, false, false, false, false, false) => Ok(".rtc_fast.text"),
+        (true, false, true, false, false, false, false) => Ok(".rtc_slow.text"),
 
-        (false, false, false, false, false, false) => Ok(".data"),
-        (false, false, false, true, false, false) => Ok(".dram2_uninit"),
+        (false, false, false, false, false, false, false) => Ok(".data"),
+        (false, false, false, true, false, false, false) => Ok(".dram2_uninit"),
+        (false, false, false, false, true, false, false) => Ok(".dcache_reclaimed_uninit"),
 
-        (false, true, false, false, false, false) => Ok(".rtc_fast.data"),
-        (false, true, false, false, true, false) => Ok(".rtc_fast.persistent"),
-        (false, true, false, false, false, true) => Ok(".rtc_fast.bss"),
+        (false, true, false, false, false, false, false) => Ok(".rtc_fast.data"),
+        (false, true, false, false, false, true, false) => Ok(".rtc_fast.persistent"),
+        (false, true, false, false, false, false, true) => Ok(".rtc_fast.bss"),
 
-        (false, false, true, false, false, false) => Ok(".rtc_slow.data"),
-        (false, false, true, false, true, false) => Ok(".rtc_slow.persistent"),
-        (false, false, true, false, false, true) => Ok(".rtc_slow.bss"),
+        (false, false, true, false, false, false, false) => Ok(".rtc_slow.data"),
+        (false, false, true, false, false, true, false) => Ok(".rtc_slow.persistent"),
+        (false, false, true, false, false, false, true) => Ok(".rtc_slow.bss"),
 
         _ => Err(()),
     };

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -293,6 +293,7 @@ esp32s3 = [
     "procmacros/has-ulp-core",
     "procmacros/rtc-slow",
     "procmacros/rtc-fast",
+    "procmacros/dcache-reclaimed",
     "__usb_otg",
     "esp-rom-sys/esp32s3",
     "esp-sync/esp32s3",

--- a/esp-hal/build.rs
+++ b/esp-hal/build.rs
@@ -95,9 +95,6 @@ fn main() -> Result<(), Box<dyn Error>> {
         println!("cargo:rustc-link-search={}", out.display());
 
         if chip.is_xtensa() {
-            #[cfg(feature = "esp32")]
-            File::create(out.join("memory_extras.x"))?.write_all(&generate_memory_extras())?;
-
             let (irtc, drtc) = if cfg!(feature = "esp32s3") {
                 ("rtc_fast_seg", "rtc_fast_seg")
             } else {
@@ -191,13 +188,17 @@ fn preprocess_file(
     let mut take = Vec::new();
     take.push(true);
 
+    let vars = std::env::var("CARGO_CFG_FEATURE").unwrap_or_default();
+    let enabled_features = vars.split(',').collect::<Vec<_>>();
+
     for line in std::io::BufReader::new(file).lines() {
         let line = substitute_config(cfg, &line?);
         let trimmed = line.trim();
 
         if let Some(condition) = trimmed.strip_prefix("#IF ") {
             let should_take = take.iter().all(|v| *v);
-            let should_take = should_take && config.iter().any(|c| c == condition);
+            let condition_matches = eval_condition(condition, config, &enabled_features);
+            let should_take = should_take && condition_matches;
             take.push(should_take);
             continue;
         } else if trimmed == "#ELSE" {
@@ -217,6 +218,17 @@ fn preprocess_file(
         }
     }
     Ok(())
+}
+
+#[cfg(feature = "rt")]
+fn eval_condition(condition: &str, config: &[String], features: &[&str]) -> bool {
+    if let Some(feature) = condition.strip_prefix("CARGO_FEATURE(\"")
+        && let Some(feature) = feature.strip_suffix("\")")
+    {
+        return features.contains(&feature);
+    }
+
+    config.iter().any(|c| c == condition)
 }
 
 #[cfg(feature = "rt")]
@@ -255,22 +267,4 @@ fn substitute_config(cfg: &HashMap<String, Value>, line: &str) -> String {
     }
 
     result
-}
-
-#[cfg(all(feature = "esp32", feature = "rt"))]
-fn generate_memory_extras() -> Vec<u8> {
-    let reserve_dram = if cfg!(feature = "__bluetooth") {
-        "0x10000"
-    } else {
-        "0x0"
-    };
-
-    format!(
-        "
-    /* reserved at the start of DRAM for e.g. the BT stack */
-    RESERVE_DRAM = {reserve_dram};
-        "
-    )
-    .as_bytes()
-    .to_vec()
 }

--- a/esp-hal/esp_config.yml
+++ b/esp-hal/esp_config.yml
@@ -141,7 +141,6 @@ options:
       - type:
           validator: enumeration
           value:
-            - "16KB"
             - "32KB"
             - "64KB"
     active: "esp32s2 || esp32s3"

--- a/esp-hal/ld/esp32/memory.x
+++ b/esp-hal/ld/esp32/memory.x
@@ -5,7 +5,12 @@
    for details
    */
 
-INCLUDE "memory_extras.x"
+/* reserved at the start of DRAM for the BT stack */
+#IF CARGO_FEATURE("__bluetooth")
+RESERVE_DRAM = 0x10000;
+#ELSE
+RESERVE_DRAM = 0;
+#ENDIF
 
 /* Specify main memory areas */
 MEMORY

--- a/esp-hal/ld/esp32s3/esp32s3.x
+++ b/esp-hal/ld/esp32s3/esp32s3.x
@@ -50,6 +50,7 @@ INCLUDE "rtc_fast.x"
 INCLUDE "rtc_slow.x"
 INCLUDE "stack.x"
 INCLUDE "dram2.x"
+INCLUDE "dcache_reclaimed.x"
 INCLUDE "metadata.x"
 INCLUDE "eh_frame.x"
 /* End of Shared sections */

--- a/esp-hal/ld/esp32s3/memory.x
+++ b/esp-hal/ld/esp32s3/memory.x
@@ -6,6 +6,14 @@ RESERVE_ICACHE = 0x8000;
 RESERVE_ICACHE = 0x4000;
 #ENDIF
 
+#IF ESP_HAL_CONFIG_DATA_CACHE_SIZE_64KB
+RESERVE_DCACHE = 0x10000;
+#ENDIF
+
+#IF ESP_HAL_CONFIG_DATA_CACHE_SIZE_32KB
+RESERVE_DCACHE = 0x8000;
+#ENDIF
+
 VECTORS_SIZE = 0x400;
 
 /* Specify main memory areas
@@ -17,7 +25,7 @@ VECTORS_SIZE = 0x400;
  memory, but can only be used after app starts.
 
  D cache use the memory from high address, so when it's configured to 16K/32K, the region
- 0x3FCF0000 ~ (3FD00000 - DATA_CACHE_SIZE) should be available. This region is not used as
+ 0x3FCF0000 ~ (3FD00000 - RESERVE_DCACHE) should be available. This region is not used as
  static memory, leaving to the heap.
 */
 MEMORY
@@ -28,6 +36,8 @@ MEMORY
   /* memory available after the 2nd stage bootloader is finished */
   dram2_seg ( RW )       : ORIGIN = 0x3FCDB700, len = 0x3FCED710 - 0x3FCDB700
   dram_seg ( RW )        : ORIGIN = 0x3FC88000 , len = ORIGIN(dram2_seg) - 0x3FC88000
+
+  dcache_reclaimed_seg ( RW ) : ORIGIN = 0x3FCF0000, len = 0x3FD00000 - 0x3FCF0000 - RESERVE_DCACHE
 
   /* external flash
      The 0x20 offset is a convenience for the app binary image generation.

--- a/esp-hal/ld/sections/dcache_reclaimed.x
+++ b/esp-hal/ld/sections/dcache_reclaimed.x
@@ -1,0 +1,6 @@
+/* an uninitialized section of RAM otherwise not useable */
+SECTIONS {
+    .dcache_reclaimed_uninit (NOLOAD) : ALIGN(4) {
+        *(.dcache_reclaimed_uninit)
+    } > dcache_reclaimed_seg
+}

--- a/esp-hal/src/soc/esp32s3/mod.rs
+++ b/esp-hal/src/soc/esp32s3/mod.rs
@@ -39,7 +39,6 @@ pub(crate) const CONFIG_INSTRUCTION_CACHE_LINE_SIZE: usize = cfg_select! {
 pub(crate) const CONFIG_DATA_CACHE_SIZE: usize = cfg_select! {
     data_cache_size_64kb => 0x10000,
     data_cache_size_32kb => 0x8000,
-    data_cache_size_16kb => 0x4000,
 };
 pub(crate) const CONFIG_DCACHE_ASSOCIATED_WAYS: usize = cfg_select! {
     dcache_associated_ways_8 => 8,

--- a/hil-test/src/bin/alloc_dcache_reclaimed.rs
+++ b/hil-test/src/bin/alloc_dcache_reclaimed.rs
@@ -1,0 +1,40 @@
+//! Allocator tests in DCache-reclaimed memory
+
+//% CHIP_FILTER: esp32s3
+//% ENV(esp32s3): ESP_HAL_CONFIG_DATA_CACHE_SIZE=32KB
+//% FEATURES: esp-alloc
+
+#![no_std]
+#![no_main]
+
+use hil_test as _;
+
+extern crate alloc;
+
+#[embedded_test::tests]
+mod dcache_reclaimed {
+    use esp_hal::{clock::CpuClock, ram};
+
+    #[init]
+    fn init() {
+        let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
+        let _p = esp_hal::init(config);
+
+        esp_alloc::heap_allocator!(#[ram(unstable(dcache_reclaimed))] size: 32 * 1024);
+    }
+
+    // alloc::vec::Vec tests
+
+    #[test]
+    fn test_simple() {
+        let mut vec = alloc::vec::Vec::with_capacity(16384);
+
+        for i in 0..16384 {
+            vec.push((i % 256) as u8);
+        }
+
+        for i in 0..16384 {
+            assert_eq!(vec[i], (i % 256) as u8);
+        }
+    }
+}


### PR DESCRIPTION
Closes #4069

# Changelog

## esp-hal

- Removed: ESP32-S3: Removed the 16kB data cache size option
- Added: `#[ram(unstable(dcache_reclaimed))]` to allow using memory not taken up by data cache

## esp-hal-procmacros

- Added: `#[ram(unstable(dcache_reclaimed))]` to allow using memory not taken up by data cache