### PR TITLE
Add option to turn off SP range check

### DIFF
--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -24,6 +24,7 @@ check-configs = [
     { features = ["unstable", "rt"] },
     { features = ["unstable", "rt"], env = { ESP_HAL_CONFIG_PLACE_ANON_IN_RAM = "true", ESP_HAL_CONFIG_PLACE_RMT_DRIVER_IN_RAM = "true", ESP_HAL_CONFIG_PLACE_SPI_MASTER_DRIVER_IN_RAM = "true", ESP_HAL_CONFIG_CLEAR_CRYPTO_SECRETS = "false" } },
     { features = ["unstable", "rt"], env = { ESP_HAL_CONFIG_ENABLE_PMP = "false" }, if = 'riscv && !esp32c2 && !esp32c3' },
+    { features = ["unstable", "rt"], env = { ESP_HAL_CONFIG_INIT_STACK_PTR_RANGE_CHECK = "false" } },
     { features = ["unstable", "rt", "__usb_otg"],   if = 'usb_otg_driver_supported' },
     { features = ["unstable", "rt", "__bluetooth"], if = 'bt_driver_supported' },
     { features = ["unstable", "rt", "__sdmmc"],     if = 'sdmmc_driver_supported' },

--- a/esp-hal/esp_config.yml
+++ b/esp-hal/esp_config.yml
@@ -52,6 +52,11 @@ options:
       - value: 3740121773
     display_hint: Hex
 
+  - name: init-stack-ptr-range-check
+    description: Check that the stack pointer is in range during initialization.
+    default:
+      - value: true
+
   - name: stack-guard-monitoring
     description: Use a data watchpoint to check if the stack guard was overwritten.
     default:

--- a/esp-hal/src/lib.rs
+++ b/esp-hal/src/lib.rs
@@ -745,7 +745,10 @@ pub fn init(config: Config) -> Peripherals {
     #[cfg(soc_cpu_has_branch_predictor)]
     crate::soc::enable_branch_predictor();
 
+    // Have we already overflown the stack?
+    #[cfg(init_stack_ptr_range_check)]
     crate::soc::ensure_stack_pointer_in_range();
+
     #[cfg(stack_guard_monitoring)]
     crate::soc::enable_main_stack_guard_monitoring();
 

--- a/esp-hal/src/soc/mod.rs
+++ b/esp-hal/src/soc/mod.rs
@@ -256,7 +256,7 @@ fn setup_stack_guard() {
     }
 }
 
-#[cfg(feature = "rt")]
+#[cfg(all(init_stack_ptr_range_check, feature = "rt"))]
 pub(crate) fn ensure_stack_pointer_in_range() {
     unsafe extern "C" {
         static _stack_end_cpu0: u32;


### PR DESCRIPTION
# Changelog

## esp-hal

- Added: `ESP_HAL_CONFIG_INIT_STACK_PTR_RANGE_CHECK` (default `true`) for platforms that call `esp_hal::init` from a thread.