### PR TITLE
Split off `ConnectionError` from `WifiError`

### DIFF
--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -250,7 +250,7 @@ jobs:
         if: needs.binary-size.result == 'success'
         id: combine
         working-directory: ${{ github.workspace }}
-        run: cargo run -p xtask --features report -- generate-report --input results
+        run: cargo run -p esp-devtool --features report -- generate-report --input results
 
       - name: Find and Update Comment with GH CLI
         env:

--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -83,7 +83,6 @@ use self::{
 };
 use crate::{
     RadioRefGuard,
-    WifiError,
     asynch::AtomicWaker,
     hal::ram,
     sys::{
@@ -883,7 +882,7 @@ static DATA_QUEUE_RX_STA: NonReentrantMutex<PacketQueue> =
 #[non_exhaustive]
 pub enum WifiError {
     /// The device disconnected from the network or failed to connect to it.
-    Disconnected(sta::DisconnectedInfo),
+    Disconnected(DisconnectReason),
 
     /// Unsupported operation or mode.
     Unsupported,
@@ -928,6 +927,26 @@ impl WifiError {
 }
 
 impl core::error::Error for WifiError {}
+
+/// Errors that can occur during a Wi-Fi connection.
+#[derive(Display, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub enum ConnectionError {
+    /// The connection failed.
+    Failed(sta::DisconnectedInfo),
+
+    /// A Wi-Fi error occurred.
+    WifiError(WifiError),
+}
+
+impl From<WifiError> for ConnectionError {
+    fn from(error: WifiError) -> Self {
+        ConnectionError::WifiError(error)
+    }
+}
+
+impl core::error::Error for ConnectionError {}
 
 #[cfg(esp32)]
 fn set_mac_time_update_cb(_wifi: crate::hal::peripherals::WIFI<'_>) {
@@ -2958,11 +2977,11 @@ ignored."
     ///         println!("Wifi connected!");
     ///     }
     ///     Err(e) => {
-    ///       println!("Failed to connect to wifi: {e:?}");
+    ///         println!("Failed to connect to wifi: {e:?}");
     ///     }
     /// }
     /// # {after_snippet}
-    pub async fn connect_async(&mut self) -> Result<sta::ConnectedInfo, WifiError> {
+    pub async fn connect_async(&mut self) -> Result<sta::ConnectedInfo, ConnectionError> {
         let mut subscriber = EVENT_CHANNEL
             .subscriber()
             .expect("Unable to subscribe to events - consider increasing the internal event channel subscriber count");
@@ -3003,7 +3022,7 @@ ignored."
                 bssid,
                 reason,
                 rssi,
-            } => Err(WifiError::Disconnected(sta::DisconnectedInfo {
+            } => Err(ConnectionError::Failed(sta::DisconnectedInfo {
                 ssid,
                 bssid,
                 reason: DisconnectReason::from_raw(reason),

--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -881,9 +881,6 @@ static DATA_QUEUE_RX_STA: NonReentrantMutex<PacketQueue> =
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub enum WifiError {
-    /// The device disconnected from the network or failed to connect to it.
-    Disconnected(DisconnectReason),
-
     /// Unsupported operation or mode.
     Unsupported,
 

--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -918,10 +918,7 @@ impl WifiError {
             crate::sys::include::ESP_ERR_WIFI_SSID => WifiError::InvalidSsid,
             crate::sys::include::ESP_ERR_WIFI_PASSWORD => WifiError::InvalidPassword,
             crate::sys::include::ESP_ERR_WIFI_NOT_CONNECT => WifiError::NotConnected,
-            _ => {
-                error!("Unknown error code: {}", code);
-                WifiError::Failed
-            }
+            _ => panic!("Unknown error code: {}", code),
         }
     }
 }

--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -83,6 +83,7 @@ use self::{
 };
 use crate::{
     RadioRefGuard,
+    WifiError,
     asynch::AtomicWaker,
     hal::ram,
     sys::{
@@ -918,7 +919,10 @@ impl WifiError {
             crate::sys::include::ESP_ERR_WIFI_SSID => WifiError::InvalidSsid,
             crate::sys::include::ESP_ERR_WIFI_PASSWORD => WifiError::InvalidPassword,
             crate::sys::include::ESP_ERR_WIFI_NOT_CONNECT => WifiError::NotConnected,
-            _ => panic!("Unknown error code: {}", code),
+            _ => {
+                error!("Unknown error code: {}", code);
+                WifiError::Failed
+            }
         }
     }
 }
@@ -997,7 +1001,7 @@ pub(crate) unsafe extern "C" fn coex_init() -> i32 {
     }
 }
 
-fn wifi_deinit() -> Result<(), crate::WifiError> {
+fn wifi_deinit() -> Result<(), WifiError> {
     esp_wifi_result!(unsafe { esp_wifi_stop() })?;
 
     // Drain RX queues before deinit so that any stale PacketBuffers are freed


### PR DESCRIPTION
# Changelog

## esp-radio/Wifi

- Added: `esp_radio::wifi::ConnectionError`
- Changed: `WifiController::connect_async` now returns `Result<sta::ConnectedInfo, ConnectionError>`
- Changed: `WifiError::Disconnected` no longer carries the AP info.