### PR TITLE
Fix empty chip filter issue

### DIFF
--- a/hil-test/src/bin/alloc_psram.rs
+++ b/hil-test/src/bin/alloc_psram.rs
@@ -1,6 +1,6 @@
 //! Allocator and PSRAM-related tests
 
-//% CHIP_FILTER(llff, tlsf): psram_driver_supported
+//% CHIP_FILTER(llff, tlsf): psram_driver_supported && !soc_has_flash
 //% CHIP_FILTER(llff_with_storage, tlsf_with_storage): psram_driver_supported && soc_has_flash
 //% ENV(llff, llff_with_storage): ESP_ALLOC_CONFIG_HEAP_ALGORITHM=LLFF
 //% ENV(tlsf, tlsf_with_storage): ESP_ALLOC_CONFIG_HEAP_ALGORITHM=TLSF

--- a/xtask/src/firmware.rs
+++ b/xtask/src/firmware.rs
@@ -123,7 +123,7 @@ impl Metadata {
 /// A single configuration of an example, as parsed from metadata lines.
 #[derive(Debug, Default, Clone)]
 pub struct Configuration {
-    chips: Vec<Chip>,
+    chips: Option<Vec<Chip>>,
     name: String,
     cargo_config: Vec<String>,
     features: Vec<String>,
@@ -240,7 +240,7 @@ pub fn load(path: &Path) -> Result<Vec<Metadata>> {
         //
         // If there are no named configurations, an unnamed default is created.
         let mut all_configuration = Configuration {
-            chips: Chip::iter().collect::<Vec<_>>(),
+            chips: Some(Chip::iter().collect::<Vec<_>>()),
             ..Configuration::default()
         };
 
@@ -264,7 +264,7 @@ pub fn load(path: &Path) -> Result<Vec<Metadata>> {
             match meta_line.key.as_str() {
                 "CHIP_FILTER" => {
                     let chips = parse_chips(meta_line.value.as_str())?;
-                    relevant_metadata.apply(|meta| meta.chips = chips.clone());
+                    relevant_metadata.apply(|meta| meta.chips = Some(chips.clone()));
                 }
                 // A list of cargo `--config` configurations.
                 "CARGO-CONFIG" => {
@@ -321,8 +321,8 @@ pub fn load(path: &Path) -> Result<Vec<Metadata>> {
 
         // Merge "all" into configurations
         for meta in configurations.values_mut() {
-            // Chips is a filter, inherit if empty
-            if meta.chips.is_empty() {
+            // Chips is a filter, inherit if unset
+            if meta.chips.is_none() {
                 meta.chips = all_configuration.chips.clone();
             }
 
@@ -360,7 +360,7 @@ pub fn load(path: &Path) -> Result<Vec<Metadata>> {
             // Sort the features so they are in a deterministic order:
             configuration.features.sort();
 
-            for chip in &configuration.chips {
+            for chip in configuration.chips.as_deref().unwrap_or(&[]) {
                 examples.push(Metadata {
                     // File properties
                     example_path: path.clone(),


### PR DESCRIPTION
If the `//% CHIP_FILTER` evaluates empty, the previous code fell back to all chips, which is incorrect. Also, there's no reason to run the alloc_psram tests 4 times on chips that have storage, so this PR changes the filter (which triggered the bug).