### PR TITLE
Define wakeup sources / triggers in metadata

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -96,17 +96,19 @@ Prefer these over `#[cfg(feature = "esp32c3")]` where possible.
 
 ## Changelog & migration
 
-- Add entries to `CHANGELOG.md` under `## [Unreleased]` > `### Added/Changed/Fixed/Removed`
-- Format: `- Description. (#PR_NUMBER)` — amend existing entries when modifying same feature: `(#789, #1234)`
-- Breaking changes: add migration steps to `MIGRATING-*.md` in the affected crate root
-- Breaking changes to stable API require a `breaking-change-<crate-name>` PR label
+- Changelog entries go in the **PR description**, not in `CHANGELOG.md` (those files are generated at release time — never edit them directly).
+- Use a `# Changelog` section with H2 crate headings (e.g. `## esp-hal`). Each entry starts with a kind prefix: `Added`, `Changed`, `Fixed`, or `Removed` — e.g. `- Added: Support for the Foo peripheral.` Do not include a PR number.
+- If a touched crate needs no user-visible entry, add `- No changelog necessary.` as the sole item in its section.
+- Breaking changes: add a `# Migration guide` section with an H2 `## crate/area` heading (e.g. `## esp-hal/SPI driver`) and an H3 `### Title` per change, followed by migration steps.
+- Breaking changes to stable API require a `breaking-change-<crate-name>` PR label.
+- Validate with `cargo xtask check-pr-changelog` (pipe the body in, or pass `--pr <number>`).
 
 ## PR checklist
 
 1. `cargo xtask fmt-packages`
 2. `cargo xtask lint-packages --chips <affected>` — fix all warnings
 3. `cargo xtask update-metadata --check` — if metadata changed
-4. `cargo xtask check-changelog` — add changelog entry if API changed
+4. `cargo xtask check-pr-changelog` — add changelog entries to the PR description if API changed
 5. Build affected examples/tests for relevant chips
 6. `cargo xtask host-tests` — if host-side code changed; when adding `#[test]` to a package for the first time, register it in `run_host_tests` (`xtask/src/lib.rs`)
 

--- a/esp-hal/src/rtc_cntl/mod.rs
+++ b/esp-hal/src/rtc_cntl/mod.rs
@@ -148,74 +148,72 @@ cfg_select! {
     }
 }
 
-bitflags::bitflags! {
-    /// The source(s) that caused the most recent wakeup from sleep.
-    ///
-    /// Returned by [`wakeup_cause`].
-    ///
-    /// Note that the available flags depend on the target chip.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-    pub struct WakeupReason: u32 {
-        /// The chip was not woken from sleep.
-        const NoSleep     = 0;
-        #[cfg(pm_support_ext0_wakeup)]
-        /// EXT0 wakeup, via an RTC GPIO (`RTC_IO`).
-        const Ext0        = 1 << 0;
-        #[cfg(all(pm_support_ext1_wakeup, not(esp32p4)))]
-        /// EXT1 wakeup, via one or more RTC GPIOs (`RTC_CNTL`).
-        const Ext1        = 1 << 1;
-        #[cfg(esp32p4)]
-        /// EXT1 wakeup (ESP32-P4 PMU bitmap).
-        const Ext1        = 1 << 12;
-        /// GPIO wakeup.
-        const Gpio        = 1 << 2;
-        // The wakeup-cause bit layout follows `WakeTriggers`: the timer bit is 3 on the
-        // RTC_CNTL-based chips, 4 on the PMU-based chips, and 13 on the ESP32-P4 PMU bitmap.
-        #[cfg(not(soc_has_pmu))]
-        /// Timer wakeup.
-        const Timer       = 1 << 3;
-        #[cfg(all(soc_has_pmu, not(esp32p4)))]
-        /// Timer wakeup.
-        const Timer       = 1 << 4;
-        #[cfg(esp32p4)]
-        /// Timer wakeup (ESP32-P4 PMU bitmap: PMU_RTC_TIMER_WAKEUP_EN).
-        const Timer       = 1 << 13;
-        #[cfg(pm_support_wifi_wakeup)]
-        /// Wi-Fi (MAC) wakeup.
-        const Wifi        = 1 << 5;
-        #[cfg(not(esp32p4))]
-        /// UART0 wakeup.
-        const Uart0       = 1 << 6;
-        #[cfg(esp32p4)]
-        /// UART0 wakeup (ESP32-P4 PMU bitmap).
-        const Uart0       = 1 << 8;
-        /// UART1 wakeup.
-        const Uart1       = 1 << 7;
-        #[cfg(all(pm_support_touch_sensor_wakeup, not(esp32p4)))]
-        /// Touch sensor wakeup.
-        const Touch       = 1 << 8;
-        #[cfg(all(pm_support_touch_sensor_wakeup, esp32p4))]
-        /// Touch sensor wakeup (ESP32-P4 PMU bitmap).
-        const Touch       = 1 << 11;
-        #[cfg(ulp_supported)]
-        /// ULP wakeup.
-        const Ulp         = 1 << 9;
-        #[cfg(pm_support_bt_wakeup)]
-        /// Bluetooth wakeup.
-        const Bluetooth   = 1 << 10;
-        #[cfg(riscv_coproc_supported)]
-        /// ULP RISC-V coprocessor wakeup.
-        const Cocpu       = 1 << 11;
-        #[cfg(riscv_coproc_supported)]
-        /// ULP RISC-V coprocessor trap (crash) wakeup.
-        const CocpuTrap   = 1 << 13;
-    }
+#[rustfmt::skip]
+macro_rules! wakeup_docstring {
+    (Ext0)          => { "EXT0 wakeup" };
+    (Ext1)          => { "EXT1 wakeup, via one or more RTC GPIOs (`RTC_CNTL`)." };
+    (Gpio)          => { "GPIO wakeup." };
+    (Timer)         => { "Timer wakeup." };
+    (Sdio)          => { "SDIO wakeup." };
+    (Wifi)          => { "Wi-Fi (MAC) wakeup." };
+    (WifiBeacon)    => { "Wi-Fi beacon wakeup." };
+    (Uart0)         => { "UART0 wakeup." };
+    (Uart1)         => { "UART1 wakeup." };
+    (Touch)         => { "Touch sensor wakeup." };
+    (Ulp)           => { "ULP wakeup." };
+    (UlpRiscv)      => { "ULP RISC-V coprocessor wakeup." };
+    (UlpRiscvTrap)  => { "ULP RISC-V coprocessor trap (crash) wakeup." };
+    (Bt)            => { "Bluetooth wakeup." };
+    (LpCore)        => { "LP core wakeup." };
+    (Usb)           => { "USB wakeup." };
+    ($($other:tt)*) => { compile_error!(concat!("Unknown wakeup source: ", stringify!($($other)*))) };
 }
 
-#[cfg(feature = "defmt")]
-impl defmt::Format for WakeupReason {
-    fn format(&self, fmt: defmt::Formatter<'_>) {
-        defmt::write!(fmt, "WakeupReason({=u32:#x})", self.bits());
+for_each_wakeup_source! {
+    (all $( ($variant:ident, $bit:literal) ),*) => {
+        /// A source that can wake the chip from sleep.
+        ///
+        /// Each variant models a single bit in the wakeup registers. This enum is the internal
+        /// representation shared by [`WakeTriggers`][crate::rtc_cntl::sleep::WakeTriggers] (the
+        /// sources configured to end a sleep) and [`WakeupReason`] (the source(s) that caused the
+        /// most recent wakeup, see [`wakeup_cause`]).
+        ///
+        /// Note that the available variants depend on the target chip.
+        #[derive(Debug, enumset::EnumSetType)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+        pub enum WakeupSource {
+            $(
+                #[doc = wakeup_docstring!($variant)]
+                $variant = $bit,
+            )*
+        }
+    };
+}
+
+/// The source(s) that caused the most recent wakeup from sleep.
+///
+/// Returned by [`wakeup_cause`]. This is a thin wrapper around the set of [`WakeupSource`]s that
+/// were reported by the hardware. The set is empty if the chip was not woken from sleep.
+///
+/// Note that the available sources depend on the target chip.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct WakeupReason(enumset::EnumSet<WakeupSource>);
+
+impl WakeupReason {
+    /// Returns `true` if the chip was not woken from sleep by any source.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns `true` if the given source caused the most recent wakeup.
+    pub fn contains(&self, source: WakeupSource) -> bool {
+        self.0.contains(source)
+    }
+
+    /// Returns an iterator over the sources that caused the most recent wakeup.
+    pub fn iter(&self) -> impl Iterator<Item = WakeupSource> {
+        self.0.iter()
     }
 }
 
@@ -718,14 +716,14 @@ static LIGHT_SLEEP_WAKEUP: portable_atomic::AtomicBool = portable_atomic::Atomic
 
 /// Return the cause(s) of the most recent wakeup.
 ///
-/// A sleep can be ended by more than one source simultaneously, so all matching flags are returned.
-/// The result is [`WakeupReason::NoSleep`] (an empty set) if the chip was not woken from sleep (for
-/// example on a cold boot, or after a reset unrelated to deep sleep).
+/// A sleep can be ended by more than one source simultaneously, so all matching sources are
+/// returned. The result is empty if the chip was not woken from sleep (for example on a cold boot,
+/// or after a reset unrelated to deep sleep).
 pub fn wakeup_cause() -> WakeupReason {
     if reset_reason(Cpu::ProCpu) != Some(SocResetReason::CoreDeepSleep)
         && !LIGHT_SLEEP_WAKEUP.load(portable_atomic::Ordering::Relaxed)
     {
-        return WakeupReason::NoSleep;
+        return WakeupReason::default();
     }
 
     let reg = cfg_select! {
@@ -737,7 +735,7 @@ pub fn wakeup_cause() -> WakeupReason {
     #[allow(clippy::unnecessary_cast)]
     let wakeup_cause_bits = reg.read().wakeup_cause().bits() as u32;
 
-    WakeupReason::from_bits_truncate(wakeup_cause_bits)
+    WakeupReason(enumset::EnumSet::from_u32_truncated(wakeup_cause_bits))
 }
 
 #[cfg(sleep_light_sleep)]

--- a/esp-hal/src/rtc_cntl/sleep/esp32.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32.rs
@@ -2,7 +2,7 @@ use super::{Ext0WakeupSource, Ext1WakeupSource, WakeSource, WakeTriggers};
 use crate::{
     gpio::{RtcFunction, RtcPin},
     peripherals::{BB, DPORT, I2S0, LPWR, NRX, RTC_IO},
-    rtc_cntl::{Rtc, sleep::WakeupLevel},
+    rtc_cntl::{Rtc, WakeupSource, sleep::WakeupLevel},
 };
 
 // Approximate mapping of voltages to RTC_CNTL_DBIAS_WAK, RTC_CNTL_DBIAS_SLP,
@@ -78,7 +78,7 @@ impl<P: RtcPin> WakeSource for Ext0WakeupSource<P> {
     ) {
         // don't power down RTC peripherals
         sleep_config.set_rtc_peri_pd_en(false);
-        triggers.set_ext0(true);
+        triggers.insert(WakeupSource::Ext0);
 
         // set pin to RTC function
         self.pin
@@ -116,7 +116,7 @@ impl WakeSource for Ext1WakeupSource<'_, '_> {
         triggers: &mut WakeTriggers,
         _sleep_config: &mut RtcSleepConfig,
     ) {
-        triggers.set_ext1(true);
+        triggers.insert(WakeupSource::Ext1);
 
         // set pins to RTC function
         let mut pins = self.pins.borrow_mut();
@@ -538,7 +538,7 @@ impl RtcSleepConfig {
         // set bits for what can wake us up
         LPWR::regs()
             .wakeup_state()
-            .modify(|_, w| unsafe { w.wakeup_ena().bits(wakeup_triggers.0) });
+            .modify(|_, w| unsafe { w.wakeup_ena().bits(wakeup_triggers.as_u32() as u16) });
 
         LPWR::regs().state0().modify(|_, w| w.sleep_en().set_bit());
     }

--- a/esp-hal/src/rtc_cntl/sleep/esp32c2.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c2.rs
@@ -2,7 +2,7 @@ use super::{WakeSource, WakeTriggers, WakeupLevel};
 use crate::{
     gpio::{RtcFunction, RtcPinWithResistors},
     peripherals::{APB_CTRL, BB, EXTMEM, GPIO, IO_MUX, LPWR, SPI0, SPI1, SYSTEM},
-    rtc_cntl::{Rtc, sleep::RtcioWakeupSource},
+    rtc_cntl::{Rtc, WakeupSource, sleep::RtcioWakeupSource},
     soc::regi2c,
 };
 
@@ -163,7 +163,7 @@ impl WakeSource for RtcioWakeupSource<'_, '_> {
             return;
         }
 
-        triggers.set_gpio(true);
+        triggers.insert(WakeupSource::Gpio);
 
         // If deep sleep is enabled, esp_start_sleep calls
         // gpio_deep_sleep_wakeup_prepare which sets these pullup and
@@ -698,9 +698,10 @@ impl RtcSleepConfig {
 
     pub(crate) fn start_sleep(&self, wakeup_triggers: WakeTriggers) {
         // set bits for what can wake us up
-        LPWR::regs()
-            .wakeup_state()
-            .modify(|_, w| unsafe { w.wakeup_ena().bits(wakeup_triggers.0.into()) });
+        LPWR::regs().wakeup_state().modify(|_, w| unsafe {
+            w.wakeup_ena()
+                .bits((wakeup_triggers.as_u32() as u16).into())
+        });
 
         LPWR::regs().state0().modify(|_, w| w.sleep_en().set_bit());
     }

--- a/esp-hal/src/rtc_cntl/sleep/esp32c3.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c3.rs
@@ -2,7 +2,7 @@ use super::{WakeSource, WakeTriggers, WakeupLevel};
 use crate::{
     gpio::{RtcFunction, RtcPinWithResistors},
     peripherals::{APB_CTRL, BB, EXTMEM, FE, FE2, GPIO, IO_MUX, LPWR, NRX, SPI0, SPI1, SYSTEM},
-    rtc_cntl::{Rtc, sleep::RtcioWakeupSource},
+    rtc_cntl::{Rtc, WakeupSource, sleep::RtcioWakeupSource},
     soc::regi2c,
 };
 
@@ -163,7 +163,7 @@ impl WakeSource for RtcioWakeupSource<'_, '_> {
             return;
         }
 
-        triggers.set_gpio(true);
+        triggers.insert(WakeupSource::Gpio);
 
         // If deep sleep is enabled, esp_start_sleep calls
         // gpio_deep_sleep_wakeup_prepare which sets these pullup and
@@ -803,9 +803,10 @@ impl RtcSleepConfig {
 
     pub(crate) fn start_sleep(&self, wakeup_triggers: WakeTriggers) {
         // set bits for what can wake us up
-        LPWR::regs()
-            .wakeup_state()
-            .modify(|_, w| unsafe { w.wakeup_ena().bits(wakeup_triggers.0.into()) });
+        LPWR::regs().wakeup_state().modify(|_, w| unsafe {
+            w.wakeup_ena()
+                .bits((wakeup_triggers.as_u32() as u16).into())
+        });
 
         LPWR::regs().state0().modify(|_, w| w.sleep_en().set_bit());
     }

--- a/esp-hal/src/rtc_cntl/sleep/esp32c5.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c5.rs
@@ -858,7 +858,7 @@ impl RtcSleepConfig {
             | PMU_LP_CORE_WAKEUP_EN
             | PMU_USB_WAKEUP_EN;
 
-        let wakeup_mask = wakeup_triggers.0 as u32;
+        let wakeup_mask = wakeup_triggers.as_u32();
         let reject_mask = if self.deep {
             0
         } else {

--- a/esp-hal/src/rtc_cntl/sleep/esp32c6.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c6.rs
@@ -7,6 +7,7 @@ use crate::{
     private::DropGuard,
     rtc_cntl::{
         Rtc,
+        WakeupSource,
         rtc::{HpAnalog, HpSysCntlReg, HpSysPower, LpAnalog, LpSysPower},
         sleep::{
             Ext1WakeupSource,
@@ -59,7 +60,7 @@ impl WakeSource for Ext1WakeupSource<'_, '_> {
         _sleep_config: &mut RtcSleepConfig,
     ) {
         // We don't have to keep the LP domain powered if we hold the wakeup pin states.
-        triggers.set_ext1(true);
+        triggers.insert(WakeupSource::Ext1);
 
         // set pins to RTC function
         let mut pins = self.pins.borrow_mut();
@@ -110,7 +111,7 @@ impl WakeSource for WakeFromLpCoreWakeupSource {
         triggers: &mut WakeTriggers,
         _sleep_config: &mut RtcSleepConfig,
     ) {
-        triggers.set_lp_core(true);
+        triggers.insert(WakeupSource::LpCore);
     }
 }
 
@@ -932,7 +933,7 @@ impl RtcSleepConfig {
             | PMU_LP_CORE_WAKEUP_EN
             | PMU_USB_WAKEUP_EN;
 
-        let wakeup_mask = wakeup_triggers.0 as u32;
+        let wakeup_mask = wakeup_triggers.as_u32();
         let reject_mask = if self.deep {
             0
         } else {

--- a/esp-hal/src/rtc_cntl/sleep/esp32c61.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c61.rs
@@ -860,7 +860,7 @@ impl RtcSleepConfig {
             | PMU_LP_CORE_WAKEUP_EN
             | PMU_USB_WAKEUP_EN;
 
-        let wakeup_mask = wakeup_triggers.0 as u32;
+        let wakeup_mask = wakeup_triggers.as_u32();
         let reject_mask = if self.deep {
             0
         } else {

--- a/esp-hal/src/rtc_cntl/sleep/esp32h2.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32h2.rs
@@ -7,6 +7,7 @@ use crate::{
     private::DropGuard,
     rtc_cntl::{
         Rtc,
+        WakeupSource,
         rtc::{HpSysCntlReg, HpSysPower, LpSysPower},
         sleep::{Ext1WakeupSource, WakeSource, WakeTriggers, WakeupLevel},
     },
@@ -55,7 +56,7 @@ impl WakeSource for Ext1WakeupSource<'_, '_> {
         triggers: &mut WakeTriggers,
         _sleep_config: &mut RtcSleepConfig,
     ) {
-        triggers.set_ext1(true);
+        triggers.insert(WakeupSource::Ext1);
 
         // ext1_wakeup_prepare
         let mut pins = self.pins.borrow_mut();
@@ -693,7 +694,7 @@ impl RtcSleepConfig {
             | PMU_UART1_WAKEUP_EN
             | PMU_BLE_SOC_WAKEUP_EN;
 
-        let wakeup_mask = wakeup_triggers.0 as u32;
+        let wakeup_mask = wakeup_triggers.as_u32();
         let reject_mask = if self.deep {
             0
         } else {

--- a/esp-hal/src/rtc_cntl/sleep/esp32p4.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32p4.rs
@@ -976,7 +976,7 @@ impl RtcSleepConfig {
             | PMU_SDIO_WAKEUP_EN
             | PMU_USB_WAKEUP_EN;
 
-        let wakeup_mask = wakeup_triggers.0 as u32;
+        let wakeup_mask = wakeup_triggers.as_u32();
         let reject_mask = if self.deep {
             0
         } else {

--- a/esp-hal/src/rtc_cntl/sleep/esp32s2.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32s2.rs
@@ -9,7 +9,7 @@ use super::{
 use crate::{
     gpio::{RtcFunction, RtcPin},
     peripherals::{EXTMEM, LPWR, RTC_IO, SENS, SPI0, SPI1, SYSTEM},
-    rtc_cntl::{Rtc, sleep::RtcioWakeupSource},
+    rtc_cntl::{Rtc, WakeupSource, sleep::RtcioWakeupSource},
     soc::regi2c,
 };
 
@@ -80,8 +80,12 @@ impl WakeSource for UlpWakeupSource {
         triggers: &mut WakeTriggers,
         sleep_config: &mut RtcSleepConfig,
     ) {
-        triggers.set_ulp(self.wake_on_interrupt);
-        triggers.set_ulp_riscv_trap(self.wake_on_trap);
+        if self.wake_on_interrupt {
+            triggers.insert(WakeupSource::UlpRiscv);
+        }
+        if self.wake_on_trap {
+            triggers.insert(WakeupSource::UlpRiscvTrap);
+        }
 
         if self.clear_interrupts_on_sleep {
             self.clear_interrupts();
@@ -101,7 +105,7 @@ impl<P: RtcPin> WakeSource for Ext0WakeupSource<P> {
         sleep_config: &mut RtcSleepConfig,
     ) {
         sleep_config.set_rtc_peri_pd_en(false);
-        triggers.set_ext0(true);
+        triggers.insert(WakeupSource::Ext0);
 
         // TODO: disable clock when not in use
         SENS::regs()
@@ -147,7 +151,7 @@ impl WakeSource for Ext1WakeupSource<'_, '_> {
         triggers: &mut WakeTriggers,
         _sleep_config: &mut RtcSleepConfig,
     ) {
-        triggers.set_ext1(true);
+        triggers.insert(WakeupSource::Ext1);
 
         // TODO: disable clock when not in use
         SENS::regs()
@@ -222,7 +226,7 @@ impl WakeSource for RtcioWakeupSource<'_, '_> {
 
         // don't power down RTC peripherals
         sleep_config.set_rtc_peri_pd_en(false);
-        triggers.set_gpio(true);
+        triggers.insert(WakeupSource::Gpio);
 
         // Since we only use RTCIO pins, we can keep deep sleep enabled.
         let sens = crate::peripherals::SENS::regs();
@@ -770,9 +774,10 @@ impl RtcSleepConfig {
                 .modify(|_, w| w.procpu_stat_vector_sel().set_bit());
 
             // set bits for what can wake us up
-            LPWR::regs()
-                .wakeup_state()
-                .modify(|_, w| w.wakeup_ena().bits(wakeup_triggers.0.into()));
+            LPWR::regs().wakeup_state().modify(|_, w| {
+                w.wakeup_ena()
+                    .bits((wakeup_triggers.as_u32() as u16).into())
+            });
 
             LPWR::regs().state0().modify(|_, w| w.sleep_en().set_bit());
         }

--- a/esp-hal/src/rtc_cntl/sleep/esp32s3.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32s3.rs
@@ -9,7 +9,7 @@ use super::{
 use crate::{
     gpio::{RtcFunction, RtcPin},
     peripherals::{APB_CTRL, EXTMEM, LPWR, RTC_IO, SPI0, SPI1, SYSTEM},
-    rtc_cntl::{Rtc, sleep::RtcioWakeupSource},
+    rtc_cntl::{Rtc, WakeupSource, sleep::RtcioWakeupSource},
     soc::regi2c,
 };
 
@@ -88,9 +88,13 @@ impl WakeSource for UlpWakeupSource {
         triggers: &mut WakeTriggers,
         sleep_config: &mut RtcSleepConfig,
     ) {
-        triggers.set_ulp_fsm(self.wake_on_interrupt);
-        triggers.set_ulp_riscv(self.wake_on_interrupt);
-        triggers.set_ulp_riscv_trap(self.wake_on_trap);
+        if self.wake_on_interrupt {
+            triggers.insert(WakeupSource::Ulp);
+            triggers.insert(WakeupSource::UlpRiscv);
+        }
+        if self.wake_on_trap {
+            triggers.insert(WakeupSource::UlpRiscvTrap);
+        }
 
         if self.clear_interrupts_on_sleep {
             self.clear_interrupts();
@@ -111,7 +115,7 @@ impl<P: RtcPin> WakeSource for Ext0WakeupSource<P> {
     ) {
         // don't power down RTC peripherals
         sleep_config.set_rtc_peri_pd_en(false);
-        triggers.set_ext0(true);
+        triggers.insert(WakeupSource::Ext0);
 
         // set pin to RTC function
         self.pin
@@ -151,7 +155,7 @@ impl WakeSource for Ext1WakeupSource<'_, '_> {
         triggers: &mut WakeTriggers,
         _sleep_config: &mut RtcSleepConfig,
     ) {
-        triggers.set_ext1(true);
+        triggers.insert(WakeupSource::Ext1);
 
         // set pins to RTC function
         let mut pins = self.pins.borrow_mut();
@@ -222,7 +226,7 @@ impl WakeSource for RtcioWakeupSource<'_, '_> {
 
         // don't power down RTC peripherals
         sleep_config.set_rtc_peri_pd_en(false);
-        triggers.set_gpio(true);
+        triggers.insert(WakeupSource::Gpio);
 
         // Since we only use RTCIO pins, we can keep deep sleep enabled.
         let sens = crate::peripherals::SENS::regs();
@@ -810,9 +814,10 @@ impl RtcSleepConfig {
                 .modify(|_, w| w.procpu_stat_vector_sel().set_bit());
 
             // set bits for what can wake us up
-            LPWR::regs()
-                .wakeup_state()
-                .modify(|_, w| w.wakeup_ena().bits(wakeup_triggers.0.into()));
+            LPWR::regs().wakeup_state().modify(|_, w| {
+                w.wakeup_ena()
+                    .bits((wakeup_triggers.as_u32() as u16).into())
+            });
 
             LPWR::regs().state0().modify(|_, w| w.sleep_en().set_bit());
         }

--- a/esp-hal/src/rtc_cntl/sleep/mod.rs
+++ b/esp-hal/src/rtc_cntl/sleep/mod.rs
@@ -18,11 +18,16 @@
 #[cfg(not(any(esp32c5, esp32c61, esp32p4)))]
 use core::cell::RefCell;
 
+use enumset::EnumSet;
+
 #[cfg(any(esp32, esp32s2, esp32s3))]
 use crate::gpio::RtcPin as RtcIoWakeupPinType;
 #[cfg(any(esp32c3, esp32c6, esp32c2, esp32h2))]
 use crate::gpio::RtcPinWithResistors as RtcIoWakeupPinType;
-use crate::{peripherals::LPWR, rtc_cntl::Rtc};
+use crate::{
+    peripherals::LPWR,
+    rtc_cntl::{Rtc, WakeupSource},
+};
 
 #[cfg_attr(esp32, path = "esp32.rs")]
 #[cfg_attr(esp32s2, path = "esp32s2.rs")]
@@ -411,7 +416,7 @@ impl WakeSource for GpioWakeupSource {
         triggers: &mut WakeTriggers,
         _sleep_config: &mut RtcSleepConfig,
     ) {
-        triggers.set_gpio(true);
+        triggers.insert(WakeupSource::Gpio);
     }
 }
 
@@ -457,7 +462,7 @@ macro_rules! uart_wakeup_impl {
 
             impl WakeSource for [< Uart $num WakeupSource >] {
                 fn apply(&self, _rtc: &Rtc<'_>, triggers: &mut WakeTriggers, _sleep_config: &mut RtcSleepConfig) {
-                    triggers.[< set_uart $num >](true);
+                    triggers.insert(WakeupSource::[< Uart $num >]);
                     let uart = crate::peripherals::[< UART $num >]::regs();
 
                     #[cfg(any(esp32, esp32s2, esp32s3, esp32c2, esp32c3))]
@@ -478,164 +483,29 @@ macro_rules! uart_wakeup_impl {
 uart_wakeup_impl!(0);
 uart_wakeup_impl!(1);
 
-#[cfg(esp32s2)]
-bitfield::bitfield! {
-    /// Represents the wakeup triggers.
-    #[derive(Default, Clone, Copy)]
-    pub struct WakeTriggers(u16);
-    impl Debug;
-    /// EXT0 GPIO wakeup
-    pub ext0, set_ext0: 0;
-    /// EXT1 GPIO wakeup
-    pub ext1, set_ext1: 1;
-    /// GPIO wakeup (l5ght sleep only)
-    pub gpio, set_gpio: 2;
-    /// Timer wakeup
-    pub timer, set_timer: 3;
-    /// WiFi SoC wakeup
-    pub wifi_soc, set_wifi_soc: 5;
-    /// UART0 wakeup (light sleep only)
-    pub uart0, set_uart0: 6;
-    /// UART1 wakeup (light sleep only)
-    pub uart1, set_uart1: 7;
-    /// Touch wakeup
-    pub touch, set_touch: 8;
-    /// ULP-FSM or ULP-RISCV wakeup
-    pub ulp, set_ulp: 11;
-    /// ULP-RISCV trap wakeup
-    pub ulp_riscv_trap, set_ulp_riscv_trap: 13;
-    /// USB wakeup
-    pub usb, set_usb: 15;
-}
+/// The set of wakeup sources configured to end a sleep.
+///
+/// This is a thin wrapper around a set of [`WakeupSource`]s. Wakeup source implementations enable
+/// the sources they need via [`WakeTriggers::insert`] from within [`WakeSource::apply`].
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct WakeTriggers(EnumSet<WakeupSource>);
 
-#[cfg(esp32s3)]
-bitfield::bitfield! {
-    /// Represents the wakeup triggers.
-    #[derive(Default, Clone, Copy)]
-    pub struct WakeTriggers(u16);
-    impl Debug;
-    /// EXT0 GPIO wakeup
-    pub ext0, set_ext0: 0;
-    /// EXT1 GPIO wakeup
-    pub ext1, set_ext1: 1;
-    /// GPIO wakeup (light sleep only)
-    pub gpio, set_gpio: 2;
-    /// Timer wakeup
-    pub timer, set_timer: 3;
-    /// SDIO wakeup (light sleep only)
-    pub sdio, set_sdio: 4;
-    /// MAC wakeup (light sleep only)
-    pub mac, set_mac: 5;
-    /// UART0 wakeup (light sleep only)
-    pub uart0, set_uart0: 6;
-    /// UART1 wakeup (light sleep only)
-    pub uart1, set_uart1: 7;
-    /// Touch wakeup
-    pub touch, set_touch: 8;
-    /// ULP-FSM wakeup
-    pub ulp_fsm, set_ulp_fsm: 9;
-    /// BT wakeup (light sleep only)
-    pub bt, set_bt: 10;
-    /// ULP-RISCV wakeup
-    pub ulp_riscv, set_ulp_riscv: 11;
-    /// ULP-RISCV trap wakeup
-    pub ulp_riscv_trap, set_ulp_riscv_trap: 13;
-}
+impl WakeTriggers {
+    /// Enables the given source as a wakeup trigger.
+    pub fn insert(&mut self, source: WakeupSource) {
+        self.0.insert(source);
+    }
 
-#[cfg(any(esp32, esp32c2, esp32c3))]
-bitfield::bitfield! {
-    /// Represents the wakeup triggers.
-    #[derive(Default, Clone, Copy)]
-    pub struct WakeTriggers(u16);
-    impl Debug;
-    /// EXT0 GPIO wakeup
-    pub ext0, set_ext0: 0;
-    /// EXT1 GPIO wakeup
-    pub ext1, set_ext1: 1;
-    /// GPIO wakeup (light sleep only)
-    pub gpio, set_gpio: 2;
-    /// Timer wakeup
-    pub timer, set_timer: 3;
-    /// SDIO wakeup (light sleep only)
-    pub sdio, set_sdio: 4;
-    /// MAC wakeup (light sleep only)
-    pub mac, set_mac: 5;
-    /// UART0 wakeup (light sleep only)
-    pub uart0, set_uart0: 6;
-    /// UART1 wakeup (light sleep only)
-    pub uart1, set_uart1: 7;
-    /// Touch wakeup
-    pub touch, set_touch: 8;
-    /// ULP-FSM wakeup
-    pub ulp, set_ulp: 9;
-    /// BT wakeup (light sleep only)
-    pub bt, set_bt: 10;
-}
+    /// Returns `true` if the given source is enabled as a wakeup trigger.
+    pub fn contains(&self, source: WakeupSource) -> bool {
+        self.0.contains(source)
+    }
 
-#[cfg(all(soc_has_pmu, not(esp32p4)))]
-bitfield::bitfield! {
-    /// Represents the wakeup triggers.
-    #[derive(Default, Clone, Copy)]
-    pub struct WakeTriggers(u16);
-    impl Debug;
-
-    /// EXT0 GPIO wakeup
-    pub ext0, set_ext0: 0;
-    /// EXT1 GPIO wakeup
-    pub ext1, set_ext1: 1;
-    /// GPIO wakeup
-    pub gpio, set_gpio: 2;
-    /// WiFi beacon wakeup
-    pub wifi_beacon, set_wifi_beacon: 3;
-    /// Timer wakeup
-    pub timer, set_timer: 4;
-    /// WiFi SoC wakeup
-    pub wifi_soc, set_wifi_soc: 5;
-    /// UART0 wakeup
-    pub uart0, set_uart0: 6;
-    /// UART1 wakeup
-    pub uart1, set_uart1: 7;
-    /// SDIO wakeup
-    pub sdio, set_sdio: 8;
-    /// BT wakeup
-    pub bt, set_bt: 10;
-    /// LP core wakeup
-    pub lp_core, set_lp_core: 11;
-    /// USB wakeup
-    pub usb, set_usb: 14;
-}
-
-// ESP32-P4 has a different PMU wakeup-source bitmap than the other PMU chips.
-// In particular the LP/RTC timer wakeup is bit 13 (PMU_RTC_TIMER_WAKEUP_EN),
-// not bit 4. See esp-idf `pmu_bit_defs.h` for the ESP32-P4.
-#[cfg(esp32p4)]
-bitfield::bitfield! {
-    /// Represents the wakeup triggers.
-    #[derive(Default, Clone, Copy)]
-    pub struct WakeTriggers(u16);
-    impl Debug;
-
-    /// SDIO wakeup
-    pub sdio, set_sdio: 0;
-    /// GPIO wakeup
-    pub gpio, set_gpio: 2;
-    /// USB wakeup
-    pub usb, set_usb: 3;
-    /// UART1 wakeup
-    pub uart1, set_uart1: 7;
-    /// UART0 wakeup
-    pub uart0, set_uart0: 8;
-    /// EXT1 GPIO wakeup
-    pub ext1, set_ext1: 12;
-    /// Timer (LP/RTC timer) wakeup
-    pub timer, set_timer: 13;
-    // The following sources do not exist on ESP32-P4. They are declared so the
-    // shared wake-source code keeps compiling; they are never set on this
-    // target, so their (overlapping, unused bit 1) position is irrelevant.
-    /// EXT0 GPIO wakeup (unused on ESP32-P4)
-    pub ext0, set_ext0: 1;
-    /// LP core wakeup (unused on ESP32-P4)
-    pub lp_core, set_lp_core: 1;
+    /// Returns the raw wakeup-enable register bitmask.
+    pub(crate) fn as_u32(&self) -> u32 {
+        self.0.as_u32()
+    }
 }
 
 /// Trait representing a wakeup source.

--- a/esp-hal/src/rtc_cntl/sleep/wakeup_sources/timer/v1.rs
+++ b/esp-hal/src/rtc_cntl/sleep/wakeup_sources/timer/v1.rs
@@ -1,7 +1,7 @@
 use super::TimerWakeupSource;
 use crate::{
     peripherals::RTC_TIMER,
-    rtc_cntl::{Rtc, RtcSleepConfig, WakeSource, WakeTriggers},
+    rtc_cntl::{Rtc, RtcSleepConfig, WakeSource, WakeTriggers, WakeupSource},
 };
 
 impl WakeSource for TimerWakeupSource {
@@ -9,7 +9,7 @@ impl WakeSource for TimerWakeupSource {
         // don't power down RTC peripherals
         sleep_config.set_rtc_peri_pd_en(false);
 
-        triggers.set_timer(true);
+        triggers.insert(WakeupSource::Timer);
 
         let ticks = crate::clock::us_to_rtc_ticks(self.duration.as_micros());
         let now = rtc.time_since_boot_raw();

--- a/esp-hal/src/rtc_cntl/sleep/wakeup_sources/timer/v2.rs
+++ b/esp-hal/src/rtc_cntl/sleep/wakeup_sources/timer/v2.rs
@@ -1,7 +1,7 @@
 use super::TimerWakeupSource;
 use crate::{
     peripherals::RTC_TIMER,
-    rtc_cntl::{Rtc, RtcSleepConfig, WakeSource, WakeTriggers},
+    rtc_cntl::{Rtc, RtcSleepConfig, WakeSource, WakeTriggers, WakeupSource},
 };
 
 impl WakeSource for TimerWakeupSource {
@@ -11,7 +11,7 @@ impl WakeSource for TimerWakeupSource {
         triggers: &mut WakeTriggers,
         _sleep_config: &mut RtcSleepConfig,
     ) {
-        triggers.set_timer(true);
+        triggers.insert(WakeupSource::Timer);
 
         let ticks = crate::clock::us_to_rtc_ticks(self.duration.as_micros());
         let now = rtc.time_since_boot_raw();

--- a/esp-hal/src/system.rs
+++ b/esp-hal/src/system.rs
@@ -419,8 +419,8 @@ pub fn reset_reason() -> Option<SocResetReason> {
 
 /// Retrieves the cause(s) of the last wakeup event.
 ///
-/// Returns the set of [`WakeupReason`][crate::rtc_cntl::WakeupReason] flags that ended the most
-/// recent sleep. The result is empty if the chip was not woken from sleep.
+/// Returns the [`WakeupReason`][crate::rtc_cntl::WakeupReason] describing the source(s) that ended
+/// the most recent sleep. The result is empty if the chip was not woken from sleep.
 #[instability::unstable]
 #[inline]
 pub fn wakeup_cause() -> crate::rtc_cntl::WakeupReason {

--- a/esp-metadata-generated/src/_generated_esp32.rs
+++ b/esp-metadata-generated/src/_generated_esp32.rs
@@ -701,6 +701,23 @@ macro_rules! for_each_sha_algorithm {
     };
 }
 #[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_wakeup_source {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner_wakeup_source { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_wakeup_source!((Ext0, 0));
+        _for_each_inner_wakeup_source!((Ext1, 1)); _for_each_inner_wakeup_source!((Gpio,
+        2)); _for_each_inner_wakeup_source!((Timer, 3));
+        _for_each_inner_wakeup_source!((Sdio, 4)); _for_each_inner_wakeup_source!((Wifi,
+        5)); _for_each_inner_wakeup_source!((Uart0, 6));
+        _for_each_inner_wakeup_source!((Uart1, 7));
+        _for_each_inner_wakeup_source!((Touch, 8)); _for_each_inner_wakeup_source!((Ulp,
+        9)); _for_each_inner_wakeup_source!((Bt, 10));
+        _for_each_inner_wakeup_source!((all(Ext0, 0), (Ext1, 1), (Gpio, 2), (Timer, 3),
+        (Sdio, 4), (Wifi, 5), (Uart0, 6), (Uart1, 7), (Touch, 8), (Ulp, 9), (Bt, 10)));
+    };
+}
+#[macro_export]
 /// ESP-HAL must provide implementation for the following functions:
 /// ```rust, no_run
 /// // XTAL_CLK

--- a/esp-metadata-generated/src/_generated_esp32c2.rs
+++ b/esp-metadata-generated/src/_generated_esp32c2.rs
@@ -637,6 +637,23 @@ macro_rules! for_each_sha_algorithm {
     };
 }
 #[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_wakeup_source {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner_wakeup_source { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_wakeup_source!((Ext0, 0));
+        _for_each_inner_wakeup_source!((Ext1, 1)); _for_each_inner_wakeup_source!((Gpio,
+        2)); _for_each_inner_wakeup_source!((Timer, 3));
+        _for_each_inner_wakeup_source!((Sdio, 4)); _for_each_inner_wakeup_source!((Wifi,
+        5)); _for_each_inner_wakeup_source!((Uart0, 6));
+        _for_each_inner_wakeup_source!((Uart1, 7));
+        _for_each_inner_wakeup_source!((Touch, 8)); _for_each_inner_wakeup_source!((Ulp,
+        9)); _for_each_inner_wakeup_source!((Bt, 10));
+        _for_each_inner_wakeup_source!((all(Ext0, 0), (Ext1, 1), (Gpio, 2), (Timer, 3),
+        (Sdio, 4), (Wifi, 5), (Uart0, 6), (Uart1, 7), (Touch, 8), (Ulp, 9), (Bt, 10)));
+    };
+}
+#[macro_export]
 /// ESP-HAL must provide implementation for the following functions:
 /// ```rust, no_run
 /// // XTAL_CLK

--- a/esp-metadata-generated/src/_generated_esp32c3.rs
+++ b/esp-metadata-generated/src/_generated_esp32c3.rs
@@ -1001,6 +1001,23 @@ macro_rules! for_each_sha_algorithm {
     };
 }
 #[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_wakeup_source {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner_wakeup_source { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_wakeup_source!((Ext0, 0));
+        _for_each_inner_wakeup_source!((Ext1, 1)); _for_each_inner_wakeup_source!((Gpio,
+        2)); _for_each_inner_wakeup_source!((Timer, 3));
+        _for_each_inner_wakeup_source!((Sdio, 4)); _for_each_inner_wakeup_source!((Wifi,
+        5)); _for_each_inner_wakeup_source!((Uart0, 6));
+        _for_each_inner_wakeup_source!((Uart1, 7));
+        _for_each_inner_wakeup_source!((Touch, 8)); _for_each_inner_wakeup_source!((Ulp,
+        9)); _for_each_inner_wakeup_source!((Bt, 10));
+        _for_each_inner_wakeup_source!((all(Ext0, 0), (Ext1, 1), (Gpio, 2), (Timer, 3),
+        (Sdio, 4), (Wifi, 5), (Uart0, 6), (Uart1, 7), (Touch, 8), (Ulp, 9), (Bt, 10)));
+    };
+}
+#[macro_export]
 /// ESP-HAL must provide implementation for the following functions:
 /// ```rust, no_run
 /// // XTAL_CLK

--- a/esp-metadata-generated/src/_generated_esp32c5.rs
+++ b/esp-metadata-generated/src/_generated_esp32c5.rs
@@ -1134,6 +1134,25 @@ macro_rules! for_each_sha_algorithm {
     };
 }
 #[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_wakeup_source {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner_wakeup_source { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_wakeup_source!((Ext0, 0));
+        _for_each_inner_wakeup_source!((Ext1, 1)); _for_each_inner_wakeup_source!((Gpio,
+        2)); _for_each_inner_wakeup_source!((WifiBeacon, 3));
+        _for_each_inner_wakeup_source!((Timer, 4)); _for_each_inner_wakeup_source!((Wifi,
+        5)); _for_each_inner_wakeup_source!((Uart0, 6));
+        _for_each_inner_wakeup_source!((Uart1, 7)); _for_each_inner_wakeup_source!((Sdio,
+        8)); _for_each_inner_wakeup_source!((Bt, 10));
+        _for_each_inner_wakeup_source!((LpCore, 11));
+        _for_each_inner_wakeup_source!((Usb, 14));
+        _for_each_inner_wakeup_source!((all(Ext0, 0), (Ext1, 1), (Gpio, 2), (WifiBeacon,
+        3), (Timer, 4), (Wifi, 5), (Uart0, 6), (Uart1, 7), (Sdio, 8), (Bt, 10), (LpCore,
+        11), (Usb, 14)));
+    };
+}
+#[macro_export]
 /// ESP-HAL must provide implementation for the following functions:
 /// ```rust, no_run
 /// // XTAL_CLK

--- a/esp-metadata-generated/src/_generated_esp32c6.rs
+++ b/esp-metadata-generated/src/_generated_esp32c6.rs
@@ -1080,6 +1080,25 @@ macro_rules! for_each_sha_algorithm {
     };
 }
 #[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_wakeup_source {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner_wakeup_source { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_wakeup_source!((Ext0, 0));
+        _for_each_inner_wakeup_source!((Ext1, 1)); _for_each_inner_wakeup_source!((Gpio,
+        2)); _for_each_inner_wakeup_source!((WifiBeacon, 3));
+        _for_each_inner_wakeup_source!((Timer, 4)); _for_each_inner_wakeup_source!((Wifi,
+        5)); _for_each_inner_wakeup_source!((Uart0, 6));
+        _for_each_inner_wakeup_source!((Uart1, 7)); _for_each_inner_wakeup_source!((Sdio,
+        8)); _for_each_inner_wakeup_source!((Bt, 10));
+        _for_each_inner_wakeup_source!((LpCore, 11));
+        _for_each_inner_wakeup_source!((Usb, 14));
+        _for_each_inner_wakeup_source!((all(Ext0, 0), (Ext1, 1), (Gpio, 2), (WifiBeacon,
+        3), (Timer, 4), (Wifi, 5), (Uart0, 6), (Uart1, 7), (Sdio, 8), (Bt, 10), (LpCore,
+        11), (Usb, 14)));
+    };
+}
+#[macro_export]
 /// ESP-HAL must provide implementation for the following functions:
 /// ```rust, no_run
 /// // XTAL_CLK

--- a/esp-metadata-generated/src/_generated_esp32c61.rs
+++ b/esp-metadata-generated/src/_generated_esp32c61.rs
@@ -727,6 +727,25 @@ macro_rules! for_each_sha_algorithm {
     };
 }
 #[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_wakeup_source {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner_wakeup_source { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_wakeup_source!((Ext0, 0));
+        _for_each_inner_wakeup_source!((Ext1, 1)); _for_each_inner_wakeup_source!((Gpio,
+        2)); _for_each_inner_wakeup_source!((WifiBeacon, 3));
+        _for_each_inner_wakeup_source!((Timer, 4)); _for_each_inner_wakeup_source!((Wifi,
+        5)); _for_each_inner_wakeup_source!((Uart0, 6));
+        _for_each_inner_wakeup_source!((Uart1, 7)); _for_each_inner_wakeup_source!((Sdio,
+        8)); _for_each_inner_wakeup_source!((Bt, 10));
+        _for_each_inner_wakeup_source!((LpCore, 11));
+        _for_each_inner_wakeup_source!((Usb, 14));
+        _for_each_inner_wakeup_source!((all(Ext0, 0), (Ext1, 1), (Gpio, 2), (WifiBeacon,
+        3), (Timer, 4), (Wifi, 5), (Uart0, 6), (Uart1, 7), (Sdio, 8), (Bt, 10), (LpCore,
+        11), (Usb, 14)));
+    };
+}
+#[macro_export]
 /// ESP-HAL must provide implementation for the following functions:
 /// ```rust, no_run
 /// // XTAL_CLK

--- a/esp-metadata-generated/src/_generated_esp32h2.rs
+++ b/esp-metadata-generated/src/_generated_esp32h2.rs
@@ -1069,6 +1069,25 @@ macro_rules! for_each_sha_algorithm {
     };
 }
 #[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_wakeup_source {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner_wakeup_source { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_wakeup_source!((Ext0, 0));
+        _for_each_inner_wakeup_source!((Ext1, 1)); _for_each_inner_wakeup_source!((Gpio,
+        2)); _for_each_inner_wakeup_source!((WifiBeacon, 3));
+        _for_each_inner_wakeup_source!((Timer, 4)); _for_each_inner_wakeup_source!((Wifi,
+        5)); _for_each_inner_wakeup_source!((Uart0, 6));
+        _for_each_inner_wakeup_source!((Uart1, 7)); _for_each_inner_wakeup_source!((Sdio,
+        8)); _for_each_inner_wakeup_source!((Bt, 10));
+        _for_each_inner_wakeup_source!((LpCore, 11));
+        _for_each_inner_wakeup_source!((Usb, 14));
+        _for_each_inner_wakeup_source!((all(Ext0, 0), (Ext1, 1), (Gpio, 2), (WifiBeacon,
+        3), (Timer, 4), (Wifi, 5), (Uart0, 6), (Uart1, 7), (Sdio, 8), (Bt, 10), (LpCore,
+        11), (Usb, 14)));
+    };
+}
+#[macro_export]
 /// ESP-HAL must provide implementation for the following functions:
 /// ```rust, no_run
 /// // XTAL_CLK

--- a/esp-metadata-generated/src/_generated_esp32p4.rs
+++ b/esp-metadata-generated/src/_generated_esp32p4.rs
@@ -1156,6 +1156,22 @@ macro_rules! for_each_sha_algorithm {
     };
 }
 #[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_wakeup_source {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner_wakeup_source { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_wakeup_source!((Sdio, 0));
+        _for_each_inner_wakeup_source!((Gpio, 2)); _for_each_inner_wakeup_source!((Usb,
+        3)); _for_each_inner_wakeup_source!((Uart1, 7));
+        _for_each_inner_wakeup_source!((Uart0, 8));
+        _for_each_inner_wakeup_source!((Touch, 11));
+        _for_each_inner_wakeup_source!((Ext1, 12));
+        _for_each_inner_wakeup_source!((Timer, 13));
+        _for_each_inner_wakeup_source!((all(Sdio, 0), (Gpio, 2), (Usb, 3), (Uart1, 7),
+        (Uart0, 8), (Touch, 11), (Ext1, 12), (Timer, 13)));
+    };
+}
+#[macro_export]
 /// ESP-HAL must provide implementation for the following functions:
 /// ```rust, no_run
 /// // XTAL_CLK

--- a/esp-metadata-generated/src/_generated_esp32s2.rs
+++ b/esp-metadata-generated/src/_generated_esp32s2.rs
@@ -913,6 +913,25 @@ macro_rules! for_each_sha_algorithm {
     };
 }
 #[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_wakeup_source {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner_wakeup_source { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_wakeup_source!((Ext0, 0));
+        _for_each_inner_wakeup_source!((Ext1, 1)); _for_each_inner_wakeup_source!((Gpio,
+        2)); _for_each_inner_wakeup_source!((Timer, 3));
+        _for_each_inner_wakeup_source!((Wifi, 5)); _for_each_inner_wakeup_source!((Uart0,
+        6)); _for_each_inner_wakeup_source!((Uart1, 7));
+        _for_each_inner_wakeup_source!((Touch, 8)); _for_each_inner_wakeup_source!((Ulp,
+        9)); _for_each_inner_wakeup_source!((UlpRiscv, 11));
+        _for_each_inner_wakeup_source!((UlpRiscvTrap, 13));
+        _for_each_inner_wakeup_source!((Usb, 15));
+        _for_each_inner_wakeup_source!((all(Ext0, 0), (Ext1, 1), (Gpio, 2), (Timer, 3),
+        (Wifi, 5), (Uart0, 6), (Uart1, 7), (Touch, 8), (Ulp, 9), (UlpRiscv, 11),
+        (UlpRiscvTrap, 13), (Usb, 15)));
+    };
+}
+#[macro_export]
 /// ESP-HAL must provide implementation for the following functions:
 /// ```rust, no_run
 /// // XTAL_CLK

--- a/esp-metadata-generated/src/_generated_esp32s3.rs
+++ b/esp-metadata-generated/src/_generated_esp32s3.rs
@@ -1136,6 +1136,26 @@ macro_rules! for_each_sha_algorithm {
     };
 }
 #[macro_export]
+#[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
+macro_rules! for_each_wakeup_source {
+    ($($pattern:tt => $code:tt;)*) => {
+        macro_rules! _for_each_inner_wakeup_source { $(($pattern) => $code;)* ($other :
+        tt) => {} } _for_each_inner_wakeup_source!((Ext0, 0));
+        _for_each_inner_wakeup_source!((Ext1, 1)); _for_each_inner_wakeup_source!((Gpio,
+        2)); _for_each_inner_wakeup_source!((Timer, 3));
+        _for_each_inner_wakeup_source!((Sdio, 4)); _for_each_inner_wakeup_source!((Wifi,
+        5)); _for_each_inner_wakeup_source!((Uart0, 6));
+        _for_each_inner_wakeup_source!((Uart1, 7));
+        _for_each_inner_wakeup_source!((Touch, 8)); _for_each_inner_wakeup_source!((Ulp,
+        9)); _for_each_inner_wakeup_source!((Bt, 10));
+        _for_each_inner_wakeup_source!((UlpRiscv, 11));
+        _for_each_inner_wakeup_source!((UlpRiscvTrap, 13));
+        _for_each_inner_wakeup_source!((all(Ext0, 0), (Ext1, 1), (Gpio, 2), (Timer, 3),
+        (Sdio, 4), (Wifi, 5), (Uart0, 6), (Uart1, 7), (Touch, 8), (Ulp, 9), (Bt, 10),
+        (UlpRiscv, 11), (UlpRiscvTrap, 13)));
+    };
+}
+#[macro_export]
 /// ESP-HAL must provide implementation for the following functions:
 /// ```rust, no_run
 /// // XTAL_CLK

--- a/esp-metadata/devices/esp32/soc.toml
+++ b/esp-metadata/devices/esp32/soc.toml
@@ -724,6 +724,19 @@ apb_cycle_wait_num = 16 # TODO
 support_status = "partial"
 light_sleep = true
 deep_sleep = true
+wakeup_sources = {
+    Ext0 = 0,
+    Ext1 = 1,
+    Gpio = 2,
+    Timer = 3,
+    Sdio = 4,
+    Wifi = 5,
+    Uart0 = 6,
+    Uart1 = 7,
+    Touch = 8,
+    Ulp = 9,
+    Bt = 10,
+}
 
 # Other drivers which are partially supported but have no other configuration:
 

--- a/esp-metadata/devices/esp32c2/soc.toml
+++ b/esp-metadata/devices/esp32c2/soc.toml
@@ -345,6 +345,19 @@ apb_cycle_wait_num = 16 # TODO
 support_status = "partial"
 light_sleep = true
 deep_sleep = true
+wakeup_sources = {
+    Ext0 = 0,
+    Ext1 = 1,
+    Gpio = 2,
+    Timer = 3,
+    Sdio = 4,
+    Wifi = 5,
+    Uart0 = 6,
+    Uart1 = 7,
+    Touch = 8,
+    Ulp = 9,
+    Bt = 10,
+}
 
 # Other drivers which are partially supported but have no other configuration:
 

--- a/esp-metadata/devices/esp32c3/soc.toml
+++ b/esp-metadata/devices/esp32c3/soc.toml
@@ -422,6 +422,19 @@ apb_cycle_wait_num = 16 # TODO
 support_status = "partial"
 light_sleep = true
 deep_sleep = true
+wakeup_sources = {
+    Ext0 = 0,
+    Ext1 = 1,
+    Gpio = 2,
+    Timer = 3,
+    Sdio = 4,
+    Wifi = 5,
+    Uart0 = 6,
+    Uart1 = 7,
+    Touch = 8,
+    Ulp = 9,
+    Bt = 10,
+}
 
 # Other drivers which are partially supported but have no other configuration:
 

--- a/esp-metadata/devices/esp32c5/soc.toml
+++ b/esp-metadata/devices/esp32c5/soc.toml
@@ -595,6 +595,20 @@ support_status = { status = "not_supported", issue = 5154 }
 support_status = "partial"
 light_sleep = true
 deep_sleep = true
+wakeup_sources = {
+    Ext0 = 0,
+    Ext1 = 1,
+    Gpio = 2,
+    WifiBeacon = 3,
+    Timer = 4,
+    Wifi = 5,
+    Uart0 = 6,
+    Uart1 = 7,
+    Sdio = 8,
+    Bt = 10,
+    LpCore = 11,
+    Usb = 14,
+}
 
 [device.etm]
 support_status = { status = "not_supported", issue = 5167 }

--- a/esp-metadata/devices/esp32c6/soc.toml
+++ b/esp-metadata/devices/esp32c6/soc.toml
@@ -588,6 +588,20 @@ is_lp_sys = true
 support_status = "partial"
 light_sleep = true
 deep_sleep = true
+wakeup_sources = {
+    Ext0 = 0,
+    Ext1 = 1,
+    Gpio = 2,
+    WifiBeacon = 3,
+    Timer = 4,
+    Wifi = 5,
+    Uart0 = 6,
+    Uart1 = 7,
+    Sdio = 8,
+    Bt = 10,
+    LpCore = 11,
+    Usb = 14,
+}
 
 [device.parl_io]
 support_status = "partial"

--- a/esp-metadata/devices/esp32c61/soc.toml
+++ b/esp-metadata/devices/esp32c61/soc.toml
@@ -331,6 +331,20 @@ support_status = { status = "not_supported", issue = 5419 }
 support_status = "partial"
 light_sleep = true
 deep_sleep = true
+wakeup_sources = {
+    Ext0 = 0,
+    Ext1 = 1,
+    Gpio = 2,
+    WifiBeacon = 3,
+    Timer = 4,
+    Wifi = 5,
+    Uart0 = 6,
+    Uart1 = 7,
+    Sdio = 8,
+    Bt = 10,
+    LpCore = 11,
+    Usb = 14,
+}
 
 [device.rng]
 support_status = "partial"

--- a/esp-metadata/devices/esp32h2/soc.toml
+++ b/esp-metadata/devices/esp32h2/soc.toml
@@ -515,6 +515,20 @@ version = 2
 support_status = "partial"
 light_sleep = true
 deep_sleep = true
+wakeup_sources = {
+    Ext0 = 0,
+    Ext1 = 1,
+    Gpio = 2,
+    WifiBeacon = 3,
+    Timer = 4,
+    Wifi = 5,
+    Uart0 = 6,
+    Uart1 = 7,
+    Sdio = 8,
+    Bt = 10,
+    LpCore = 11,
+    Usb = 14,
+}
 
 # Other drivers which are partially supported but have no other configuration:
 

--- a/esp-metadata/devices/esp32p4/soc.toml
+++ b/esp-metadata/devices/esp32p4/soc.toml
@@ -135,7 +135,6 @@ peripherals = [
 [device.soc.clocks]
 # {include clocks.toml}
 
-# UART: 5 instances (UART0-4), 128-byte FIFO
 [device.uart]
 support_status = "partial"
 instances = [
@@ -405,6 +404,17 @@ support_status = { status = "not_supported", issue = 2370 }
 support_status = "partial"  # PMU eco5 sleep: timer wakeup (light + deep)
 light_sleep = true
 deep_sleep = true
+wakeup_sources = {
+    # TODO: other sources
+    Sdio = 0,
+    Gpio = 2,
+    Usb = 3,
+    Uart1 = 7,
+    Uart0 = 8,
+    Touch = 11,
+    Ext1 = 12,
+    Timer = 13,
+}
 
 [device.spi_slave]
 support_status = "not_supported"

--- a/esp-metadata/devices/esp32s2/soc.toml
+++ b/esp-metadata/devices/esp32s2/soc.toml
@@ -580,6 +580,20 @@ apb_cycle_wait_num = 16 # TODO
 support_status = "partial"
 light_sleep = true
 deep_sleep = true
+wakeup_sources = {
+    Ext0 = 0,
+    Ext1 = 1,
+    Gpio = 2,
+    Timer = 3,
+    Wifi = 5,
+    Uart0 = 6,
+    Uart1 = 7,
+    Touch = 8,
+    Ulp = 9,
+    UlpRiscv = 11,
+    UlpRiscvTrap = 13,
+    Usb = 15,
+}
 
 # Other drivers which are partially supported but have no other configuration:
 

--- a/esp-metadata/devices/esp32s3/soc.toml
+++ b/esp-metadata/devices/esp32s3/soc.toml
@@ -750,6 +750,21 @@ apb_cycle_wait_num = 16 # TODO
 support_status = "partial"
 light_sleep = true
 deep_sleep = true
+wakeup_sources = {
+    Ext0 = 0,
+    Ext1 = 1,
+    Gpio = 2,
+    Timer = 3,
+    Sdio = 4,
+    Wifi = 5,
+    Uart0 = 6,
+    Uart1 = 7,
+    Touch = 8,
+    Ulp = 9,
+    Bt = 10,
+    UlpRiscv = 11,
+    UlpRiscvTrap = 13
+}
 
 # Other drivers which are partially supported but have no other configuration:
 

--- a/esp-metadata/src/cfg.rs
+++ b/esp-metadata/src/cfg.rs
@@ -9,6 +9,7 @@ pub(crate) mod rmt;
 pub(crate) mod rsa;
 pub(crate) mod sdmmc;
 pub(crate) mod sha;
+pub(crate) mod sleep;
 pub(crate) mod soc;
 pub(crate) mod spi_master;
 pub(crate) mod spi_slave;
@@ -25,6 +26,7 @@ pub(crate) use interrupt::*;
 pub(crate) use rmt::*;
 pub(crate) use sdmmc::*;
 pub(crate) use sha::*;
+pub(crate) use sleep::*;
 pub(crate) use soc::*;
 pub(crate) use spi_master::*;
 pub(crate) use spi_slave::*;
@@ -681,6 +683,8 @@ driver_configs![
             light_sleep: bool,
             #[serde(default)]
             deep_sleep: bool,
+            #[serde(default)]
+            wakeup_sources: WakeupSources,
         }
     },
     SocProperties {

--- a/esp-metadata/src/cfg/sleep.rs
+++ b/esp-metadata/src/cfg/sleep.rs
@@ -1,0 +1,55 @@
+use indexmap::IndexMap;
+use quote::{format_ident, quote};
+use serde::{Deserialize, Serialize};
+
+use crate::{generate_for_each_macro, number};
+
+/// The set of wakeup sources supported by a chip.
+///
+/// A wakeup source occupies a single bit in both the wakeup-enable ("config")
+/// register and the wakeup-cause register. The two registers share their bit
+/// layout, so a single `WakeupSource` enum variant models both the configurable
+/// trigger and the reported wakeup cause.
+///
+/// This maps each supported source to its bit position in the wakeup registers;
+/// a source that a chip lacks is simply absent from the map. The variant
+/// documentation lives in `esp-hal` (see the `for_each_wakeup_source!`
+/// invocation in `rtc_cntl`), not here.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub(crate) struct WakeupSources {
+    /// Maps a `WakeupSource` enum variant name to its bit position.
+    ///
+    /// Each key is used verbatim as the generated enum variant identifier, so it
+    /// must be a valid PascalCase Rust identifier. An `IndexMap` is used to
+    /// preserve the order in which sources are declared in `soc.toml`; that
+    /// order becomes the variant order of the generated enum.
+    #[serde(flatten)]
+    sources: IndexMap<String, u8>,
+}
+
+/// Generates `for_each_wakeup_source!`, which drives the `WakeupSource` enum in
+/// `esp-hal`. The `all` branch yields one `(variant, bit)` pair per source this
+/// chip supports; the variant documentation is supplied by `esp-hal`.
+impl super::GenericProperty for WakeupSources {
+    fn macros(&self) -> Option<proc_macro2::TokenStream> {
+        let sources = self
+            .sources
+            .iter()
+            .map(|(name, bit)| {
+                let variant = format_ident!("{name}");
+                let bit = number(bit);
+                quote! { #variant, #bit }
+            })
+            .collect::<Vec<_>>();
+
+        // Chips without any wakeup source don't get the macro at all.
+        if sources.is_empty() {
+            return None;
+        }
+
+        Some(generate_for_each_macro(
+            "wakeup_source",
+            &[("all", &sources)],
+        ))
+    }
+}

--- a/examples/async/embassy_auto_light_sleep/src/main.rs
+++ b/examples/async/embassy_auto_light_sleep/src/main.rs
@@ -9,8 +9,8 @@
 //! guard is alive, the idle hook falls back to `WFI` and the chip never sleeps.
 //!
 //! Both the `periodic` and `gpio` tasks print `wakeup_cause()`, so you can
-//! observe the chip waking from light sleep via the timer (`WakeupReason::Timer`)
-//! or via the BOOT button (`WakeupReason::Gpio`).
+//! observe the chip waking from light sleep via the timer (`WakeupSource::Timer`)
+//! or via the BOOT button (`WakeupSource::Gpio`).
 //!
 //! Use the UART port for this example - USB Serial/JTAG will break when the device enters sleep.
 


### PR DESCRIPTION
No need to list the same info twice, this PR introduces a single enum that defines the wakeup bits. Verified on ESP32 with the auto-sleep example, which prints the wakeup cause.

# Changelog

## esp-hal

- Added: `WakeupSource`, an enum modelling a single wakeup source/trigger bit. It is generated from chip metadata and shared by `WakeTriggers` and `WakeupReason`.
- Changed: `WakeupReason` is now a set-like wrapper over `WakeupSource` (with `is_empty`, `contains`, and `iter`) instead of a `bitflags` type.
- Changed: `WakeTriggers` is now a set-like wrapper over `WakeupSource` (with `insert` and `contains`) instead of a per-chip `bitfield`.
- Removed: The `WakeupReason::NoSleep` flag and the per-chip `WakeTriggers` bitfield accessors (`set_gpio`, `set_timer`, `set_uart0`, …).

# Migration guide

## esp-hal/Sleep

### `WakeupReason` is now a set of `WakeupSource`

`WakeupReason` is no longer a `bitflags` type. Wakeup causes are now modelled by the
`WakeupSource` enum, and `WakeupReason` is a thin wrapper around a set of them.

- To iterate over all sources that caused the wakeup, use `wakeup_cause().iter()`.
- Replace `WakeupReason::<Flag>` constants with `WakeupSource::<Flag>` and query the
  set instead of comparing bits:

```diff
-if wakeup_cause() == WakeupReason::NoSleep { /* ... */ }
+if wakeup_cause().is_empty() { /* ... */ }

-if wakeup_cause().contains(WakeupReason::Timer) { /* ... */ }
+if wakeup_cause().contains(WakeupSource::Timer) { /* ... */ }
```

### `WakeTriggers` uses `insert` instead of per-source setters

`WakeTriggers` is now a set of `WakeupSource`. Custom `WakeSource` implementations that
configured triggers via the generated setters must use `insert`:

```diff
-triggers.set_gpio(true);
+triggers.insert(WakeupSource::Gpio);
```