### PR TITLE
fix(esp-radio): program the 802.15.4 ext-address filter in on-air octet order

### DIFF
--- a/esp-radio/CHANGELOG.md
+++ b/esp-radio/CHANGELOG.md
@@ -15,8 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- IEEE 802.15.4: program the extended-address acceptance filter in on-air octet order, so unicast frames addressed to the node's extended address are accepted. #5314 changed this to little-endian, which byte-reverses the filter relative to the `openthread` `u64::from_be_bytes` convention: only broadcast frames were then received and an OpenThread node could never attach. Reverts #5314.
-
 
 ### Removed
 

--- a/esp-radio/CHANGELOG.md
+++ b/esp-radio/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- IEEE 802.15.4: program the extended-address acceptance filter in on-air octet order, so unicast frames addressed to the node's extended address are accepted. #5314 changed this to little-endian, which byte-reverses the filter relative to the `openthread` `u64::from_be_bytes` convention: only broadcast frames were then received and an OpenThread node could never attach. Reverts #5314.
+
 
 ### Removed
 

--- a/esp-radio/src/ieee802154/mod.rs
+++ b/esp-radio/src/ieee802154/mod.rs
@@ -156,7 +156,16 @@ impl<'a> Ieee802154<'a> {
 
         if let Some(ext_addr) = cfg.ext_addr {
             let mut address = [0u8; IEEE802154_FRAME_EXT_ADDR_SIZE];
-            address.copy_from_slice(&ext_addr.to_le_bytes());
+            // The hardware extended-address acceptance filter expects the octets in
+            // on-air order (IEEE 802.15.4 transmits addresses least-significant-octet
+            // first, and the first on-air octet goes in the low byte of `extend_addr0`).
+            // `Config::ext_addr` follows the convention established by the `openthread`
+            // consumer, which builds the `u64` from the on-air octets via
+            // `u64::from_be_bytes` (so the first on-air octet is the `u64`'s MSB).
+            // `to_be_bytes` therefore reproduces on-air order; `to_le_bytes` reversed it,
+            // so the filter never matched a unicast frame addressed to this node and only
+            // broadcast frames (which bypass the ext-address filter) were received.
+            address.copy_from_slice(&ext_addr.to_be_bytes());
 
             set_extended_address(0, address);
         }


### PR DESCRIPTION
## Description

Reverts #5314. That PR changed the extended-address filter from `to_be_bytes` to `to_le_bytes` ("use little-endian instead of big-endian"), but the original `to_be_bytes` (which carried a literal `// LE or BE?` comment) was correct.

*Caveat*: This is Claude-generated. I have tested the patch on an Espressif esp32-h2 chip (using no-std), joining an Apple Home setup (on AppleTV) and this fixes the problem for me, but I have no other chips to test against, or technical knowledge of the wider radio context. Apologies for that.

### Claude generated technical details

`Config::ext_addr` follows the convention used by the `openthread` consumer, which builds the u64 from the on-air octets via `u64::from_be_bytes` — both the platform shim (`otPlatRadioSetExtendedAddress`) and the software MAC parser (`MacHeader::dst_ext_addr`) do this, so the first on-air octet is the u64's MSB. `to_le_bytes` then writes it to the LAST filter byte, reversing the filter; `to_be_bytes` reproduces on-air order and the filter matches.

With the LE order the hardware ext-address filter never matched a unicast frame addressed to the node — only broadcast frames (which bypass the ext-address filter) were received. Most visibly, an OpenThread node on ESP32-H2 received broadcast MLE Advertisements but never the unicast MLE Parent Response addressed to its EUI-64, so it stayed Detached indefinitely. Verified on ESP32-H2: with `to_be_bytes` the node attaches as a Child.

## Testing

Tested on an Espressif  esp32-h2 devkit board with full commissioning process and ongoing two-way communications against an Apple Home setup (with Apple TV border router). Cross-compiled under MacOS. We couldn't get it to work without this fix. I can't assert anything about other platforms though.

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` or `manual-changelog` label as appropriate.
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)


#### Testing
Describe how you tested your changes.

---
# Changelog

## esp-radio

- Fixed: IEEE 802.15.4: program the extended-address acceptance filter in on-air octet order.  Reverts #5314.
