### PR TITLE
fix(esp-radio): reliable 802.15.4 receive + enhanced-ACK on ESP32-H2

### DIFF
--- a/esp-radio/CHANGELOG.md
+++ b/esp-radio/CHANGELOG.md
@@ -9,17 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- IEEE 802.15.4: generate and transmit an enhanced ACK for 802.15.4-2015 (frame version 0b10) ack-required frames. The hardware does not auto-ACK these; without a software-generated enhanced ACK a Thread 1.3 parent marks the link failed and evicts the child. Requires `Config::enhance_ack_tx`.
-
 
 ### Changed
 
 
 ### Fixed
-
-- IEEE 802.15.4: unmask all RX-abort events while receiving, so the receiver re-arms after an aborted reception instead of going dead until the next transmit. On ESP32-H2 this was the difference between `RxDone` almost never firing and firing steadily.
-- IEEE 802.15.4: `ensure_receive_enabled()` no longer re-issues `RxStart` on every receive poll, which was aborting frames that were mid-reception (endless `RxSfdDone`/`SfdTimeout` with no `RxDone` on ESP32-H2).
-- IEEE 802.15.4: deliver received frames to the upper layer on `RxDone` for all frames, instead of deferring ACK-required frames to `AckTxDone`. On ESP32-H2 `AckTxDone` does not fire, so ACK-required frames (e.g. a unicast MLE Parent Response) were received but never delivered.
 
 
 ### Removed

--- a/esp-radio/CHANGELOG.md
+++ b/esp-radio/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- IEEE 802.15.4: generate and transmit an enhanced ACK for 802.15.4-2015 (frame version 0b10) ack-required frames. The hardware does not auto-ACK these; without a software-generated enhanced ACK a Thread 1.3 parent marks the link failed and evicts the child. Requires `Config::enhance_ack_tx`.
+
 
 ### Changed
 

--- a/esp-radio/CHANGELOG.md
+++ b/esp-radio/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - IEEE 802.15.4: unmask all RX-abort events while receiving, so the receiver re-arms after an aborted reception instead of going dead until the next transmit. On ESP32-H2 this was the difference between `RxDone` almost never firing and firing steadily.
 - IEEE 802.15.4: `ensure_receive_enabled()` no longer re-issues `RxStart` on every receive poll, which was aborting frames that were mid-reception (endless `RxSfdDone`/`SfdTimeout` with no `RxDone` on ESP32-H2).
+- IEEE 802.15.4: deliver received frames to the upper layer on `RxDone` for all frames, instead of deferring ACK-required frames to `AckTxDone`. On ESP32-H2 `AckTxDone` does not fire, so ACK-required frames (e.g. a unicast MLE Parent Response) were received but never delivered.
 
 
 ### Removed

--- a/esp-radio/CHANGELOG.md
+++ b/esp-radio/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- IEEE 802.15.4: unmask all RX-abort events while receiving, so the receiver re-arms after an aborted reception instead of going dead until the next transmit. On ESP32-H2 this was the difference between `RxDone` almost never firing and firing steadily.
+- IEEE 802.15.4: `ensure_receive_enabled()` no longer re-issues `RxStart` on every receive poll, which was aborting frames that were mid-reception (endless `RxSfdDone`/`SfdTimeout` with no `RxDone` on ESP32-H2).
+
 
 ### Removed
 

--- a/esp-radio/src/ieee802154/hal.rs
+++ b/esp-radio/src/ieee802154/hal.rs
@@ -256,6 +256,17 @@ pub(crate) fn set_tx_addr(addr: *const u8) {
         .modify(|_, w| unsafe { w.txdma_addr().bits(addr as u32) });
 }
 
+/// Notify the hardware that the software-generated enhanced-ACK frame is ready
+/// in the TX DMA buffer, so it can be transmitted in the ACK window.
+///
+/// Mirrors the C driver's `ieee802154_ll_enhack_generate_done_notify()`.
+#[inline(always)]
+pub(crate) fn enhack_generate_done_notify() {
+    IEEE802154::regs()
+        .enhance_ack_cfg()
+        .write(|w| unsafe { w.tx_enh_ack_generate_done_notify().bits(1) });
+}
+
 #[inline(always)]
 pub(crate) fn set_cmd(cmd: Command) {
     IEEE802154::regs()

--- a/esp-radio/src/ieee802154/raw.rs
+++ b/esp-radio/src/ieee802154/raw.rs
@@ -620,20 +620,26 @@ fn isr_handle_rx_done(needs_next_op: &mut bool) {
             // advances the index in isr_handle_rx_done via next_rx_buffer().
             receive_done(state);
 
+            // Deliver the frame to the upper layer immediately, for all frames. It is
+            // already copied into the rx queue by receive_done() above, so there is no
+            // buffer-reuse hazard. Delivery was previously deferred for ACK-required
+            // frames until AckTxDone fired (isr_handle_ack_tx_done), but AckTxDone is not
+            // observed to fire on ESP32-H2, so those frames — e.g. a unicast MLE Parent
+            // Response — were copied but never delivered and the radio stayed in TxAck.
+            // The hardware still transmits the auto-ACK independently of this notification.
+            super::rx_available();
+
             if will_auto_send_ack(frm) {
-                // auto tx ack for frame version 0b00 and 0b01
-                // Frame data already copied above. Defer rx_available()
-                // notification until ACK completes (isr_handle_ack_tx_done).
+                // Frame version 0b00/0b01: the hardware sends an immediate ACK
+                // autonomously. Park in TxAck until AckTxDone re-arms RX.
                 state.state = Ieee802154State::TxAck;
                 *needs_next_op = false;
             } else if should_send_enhanced_ack(frm) {
                 // Enhanced ACK for frame version 0b10 - TODO: full enh-ack support
-                // Frame data already copied above.
                 state.state = Ieee802154State::TxEnhAck;
                 *needs_next_op = false;
             } else {
-                // No ACK needed, notify immediately (data already copied above)
-                super::rx_available();
+                // No ACK needed
                 *needs_next_op = true;
             }
         });
@@ -642,9 +648,9 @@ fn isr_handle_rx_done(needs_next_op: &mut bool) {
 
 /// Handle ACK TX done in ISR - matches C driver's isr_handle_ack_tx_done
 fn isr_handle_ack_tx_done(needs_next_op: &mut bool) {
-    // Frame was already copied to queue in isr_handle_rx_done (we must copy
-    // immediately because we only have one RX buffer). Now notify upper layer.
-    super::rx_available();
+    // The frame was already delivered to the upper layer in isr_handle_rx_done — delivery
+    // is no longer deferred to here (see the comment there). Re-notifying would signal the
+    // same already-queued frame a second time. Just advance to the next radio operation.
     *needs_next_op = true;
 }
 

--- a/esp-radio/src/ieee802154/raw.rs
+++ b/esp-radio/src/ieee802154/raw.rs
@@ -33,6 +33,11 @@ const ACK_TIMEOUT_US: u32 = 200_000;
 
 static mut RX_BUFFER: [u8; FRAME_SIZE] = [0u8; FRAME_SIZE];
 
+/// Buffer holding the software-generated enhanced-ACK frame. Length-prefixed
+/// like the TX buffer ([0] = PSDU length); the hardware transmits it from the
+/// TX DMA address after `enhack_generate_done_notify()`.
+static mut ENH_ACK_BUFFER: [u8; FRAME_SIZE] = [0u8; FRAME_SIZE];
+
 struct PendingTx {
     frame: *const u8,
     cca: bool,
@@ -635,7 +640,20 @@ fn isr_handle_rx_done(needs_next_op: &mut bool) {
                 state.state = Ieee802154State::TxAck;
                 *needs_next_op = false;
             } else if should_send_enhanced_ack(frm) {
-                // Enhanced ACK for frame version 0b10 - TODO: full enh-ack support
+                // Frame version 0b10 (802.15.4-2015): the hardware does NOT auto-ACK
+                // these; software must generate the enhanced ACK and hand it to the MAC.
+                // Thread 1.3 links use version-2 data frames that require an enhanced ACK;
+                // without one the parent marks the link failed, retransmits and evicts the
+                // child, so operational traffic over Thread never completes.
+                //
+                // Build a minimal enhanced ACK (matched by sequence number; no addressing,
+                // no IEs, unsecured), point the TX DMA at it and strobe
+                // enhack_generate_done_notify so the MAC transmits it in the ACK window.
+                // Completion raises AckTxDone (→ re-arm RX), the same path the immediate
+                // ACK above relies on.
+                build_enh_ack(frm);
+                set_tx_addr(core::ptr::addr_of!(ENH_ACK_BUFFER).cast());
+                enhack_generate_done_notify();
                 state.state = Ieee802154State::TxEnhAck;
                 *needs_next_op = false;
             } else {
@@ -823,7 +841,37 @@ fn will_auto_send_ack(frame: &[u8]) -> bool {
 }
 
 fn should_send_enhanced_ack(frame: &[u8]) -> bool {
-    frame_is_ack_required(frame) && frame_get_version(frame) <= FRAME_VERSION_2 && tx_enhance_ack()
+    // Exactly frame version 0b10 (2015): an enhanced ACK is a v2 concept, and we now
+    // actually generate a v2-format ACK frame — a v0/v1 frame must get the immediate ACK
+    // path, not this one. (Was `<= FRAME_VERSION_2`, which also matched v0/v1 when
+    // auto-ack was disabled.)
+    frame_is_ack_required(frame) && frame_get_version(frame) == FRAME_VERSION_2 && tx_enhance_ack()
+}
+
+/// Build a minimal 802.15.4-2015 enhanced ACK into `ENH_ACK_BUFFER`.
+///
+/// `frame` is the length-stripped PSDU of the acknowledged frame: `[0..2]` = FCF,
+/// `[2]` = sequence number. Frame layout written (length-prefixed for the TX DMA):
+///   `[0]` = 5   PSDU length: 2 (FCF) + 1 (seq) + 2 (FCS)
+///   `[1]` = 0x02, `[2]` = 0x20   FCF = 0x2002: frame type = Acknowledgement (0b010),
+///                                frame version = 0b10 (2015); no addressing, no
+///                                security, no IEs.
+///   `[3]` = seq  sequence number copied from the acknowledged frame (DSN match).
+///   `[4]`,`[5]`  FCS placeholders — the hardware computes and writes the CRC.
+///
+/// The recipient matches the ACK by sequence number, exactly like the immediate ACK
+/// (which also carries no addressing). No IEs are needed for an rx-on child with
+/// CSL/link-metrics disabled, and the ACK need not be secured in that case.
+fn build_enh_ack(frame: &[u8]) {
+    let seq = frame.get(2).copied().unwrap_or(0);
+    unsafe {
+        ENH_ACK_BUFFER[0] = 5;
+        ENH_ACK_BUFFER[1] = 0x02;
+        ENH_ACK_BUFFER[2] = 0x20;
+        ENH_ACK_BUFFER[3] = seq;
+        ENH_ACK_BUFFER[4] = 0;
+        ENH_ACK_BUFFER[5] = 0;
+    }
 }
 
 /// Start the ACK receive timeout timer.

--- a/esp-radio/src/ieee802154/raw.rs
+++ b/esp-radio/src/ieee802154/raw.rs
@@ -280,6 +280,15 @@ fn enable_rx() {
     set_next_rx_buffer();
     ieee802154_set_txrx_pti(Ieee802154TxRxScene::Rx);
 
+    // Unmask all RX-abort events while receiving. At init only
+    // TxAckTimeout|TxAckCoexBreak are enabled, so an RX error while waiting for or
+    // receiving a frame (SfdTimeout/CrcError/InvalidLen/FilterFail/NoRss) aborts without
+    // raising the MAC interrupt: the ISR never runs and RX is never re-armed, leaving the
+    // receiver dead until the next TX happens to call enable_rx() again. With these
+    // enabled, each abort fires the interrupt and isr_handle_rx_phase_rx_abort re-arms RX
+    // via next_operation(). On ESP32-H2 this is what takes RxDone from ~never to steady.
+    enable_rx_abort_events(RxAbortReason::all());
+
     set_cmd(Command::RxStart);
 
     // ieee802154_state = IEEE802154_STATE_RX;
@@ -484,15 +493,15 @@ fn next_operation() {
     STATE.with(next_operation_inner);
 }
 
-// FIXME: we shouldn't need this - we need to re-align the original driver with our port
 pub(crate) fn ensure_receive_enabled() {
-    // shouldn't be necessary but avoids a problem with rx stopping
-    // unexpectedly when used together with BLE
-    STATE.with(|state| {
-        if state.state == Ieee802154State::Receive {
-            set_cmd(Command::RxStart);
-        }
-    });
+    // Intentionally a no-op. This is polled from `raw_received()`/`received()` on every
+    // receive poll; re-issuing `RxStart` here while a frame is mid-reception (after
+    // RxSfdDone, before RxDone) restarts the receiver and aborts the in-flight frame. On
+    // ESP32-H2 that manifested as continuous RxSfdDone with rx_abort=SfdTimeout and RxDone
+    // that never fired. The receiver is armed by `enable_rx()` and re-armed on abort (the
+    // RX-abort events unmasked there), so no poll-driven restart is needed. The original
+    // hack was a workaround for "rx stops unexpectedly when used with BLE"; if that recurs
+    // under BLE coexistence it should be fixed at the source rather than by this poll.
 }
 
 #[handler(priority = Priority::Priority1)]


### PR DESCRIPTION
### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` or `manual-changelog` label as appropriate.
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖
## Context and apologies

This comes out of a project where I used an Espressif ESP32-H2 devkit board to drive an actual and sensor, connecting to an Apple Home setup (Apple TV is the border router / 802.15.4 peer). My toolchain is MacOS, and the project is no-std. 

The entire thing was authored by Claude, and while I read the PR, it is AI generated. I achieved a reliable operation in my setup, including over various edge case conditions, including power loss of both ends of the radio link, multiple re-registrations, etc... Without these fixes, even basic pairing into the Apple Home did not work. It now does so reliably. I hope to be able to test it against an OpenThread border router at some point, but haven't yet.

In making these fixes/enhancements, I instructed Claude to analyze the ESP-IDF C code as a reference, in the hope that it is more correct/mature.

I have no ability to test other hardware platforms, so can't claim to know if this is correct on anything else than the esp32-h2.

I'd of course be happy to test any alternative fixes/patches if that would be helpful. Details below (apologies for Claude's verbosity).

## Summary

On ESP32-H2 the 802.15.4 receiver transmits fine but is unreliable at receiving,
and never completes the 802.15.4-2015 (v2) ACK handshake that Thread 1.3 links
depend on. Concretely: it detects the start of most frames (`RxSfdDone`) but the
reception aborts (`rx_abort = SfdTimeout`) and `RxDone` almost never fires; when
a frame *is* completed, ACK-required frames are copied but never delivered; and
version-2 ack-required frames are never acknowledged, so the parent evicts the
child. In practice an OpenThread node cannot attach, and even if it does,
operational CASE/SRP traffic never completes.

Three independent fixes, one commit each:

1. **Re-arm RX after an aborted reception** (`raw.rs`).
2. **Deliver received frames on `RxDone`**, not on the never-firing `AckTxDone`
   (`raw.rs`).
3. **Generate and transmit an enhanced ACK** for 802.15.4-2015 v2 ack-required
   frames (`raw.rs` + `hal.rs`).

They interact (each is necessary but not sufficient on its own) but are cleanly
separable; (1) and (2) are pure correctness fixes, (3) adds a small amount of new
functionality gated on the existing `Config::enhance_ack_tx`.

## Root causes and fixes

### (1) The receiver goes dead after an abort, and a poll-hack aborts live frames

Two related issues in the same area:

- **RX-abort events are masked, so RX never re-arms after an abort.**
  `ieee802154_mac_init` enables only `TxAckTimeout | TxAckCoexBreak` RX-abort
  events. So when RX aborts while waiting for / receiving a frame (`SfdTimeout`,
  `CrcError`, `InvalidLen`, `FilterFail`, `NoRss`), **no MAC interrupt is
  raised**, the ISR never runs, and RX is never re-armed - the receiver goes
  dead until the next TX happens to call `enable_rx()` again. The recovery code
  already exists (`isr_handle_rx_phase_rx_abort` requests
  `next_operation -> enable_rx`); it just never runs because the events are
  masked. **Fix:** unmask all RX-abort events in `enable_rx()`.

- **`ensure_receive_enabled()` aborts in-flight frames.** It is polled from the
  receive poll on **every** call and unconditionally issues
  `set_cmd(Command::RxStart)` while in `Receive`. If a frame is mid-reception
  (after `RxSfdDone`, before `RxDone`), this restarts the receiver and aborts the
  in-flight frame -> `SfdTimeout`, and `RxDone` never fires. The function is
  already flagged with a `FIXME` noting it "shouldn't be necessary." With the
  re-arm mechanism above it is not. **Fix:** make it a no-op.

Together these take `RxDone` on ESP32-H2 from ~never to steady.

### (2) Delivery deferred to auto-ACK never happens (`AckTxDone` doesn't fire on H2)

`isr_handle_rx_done` copies the frame into `rx_queue`, then for ACK-required
frames sets state `TxAck` and **defers** the `rx_available()` notification until
`isr_handle_ack_tx_done` (i.e. until `AckTxDone`). On ESP32-H2 `AckTxDone` is not
observed to fire, so those frames - including a unicast MLE Parent Response -
are copied but **never delivered** to the upper layer, and the radio stays in
`TxAck`. Since the frame is already safely in `rx_queue`, **notify immediately in
all branches**; the hardware still transmits the auto-ACK independently.
`isr_handle_ack_tx_done` correspondingly stops re-notifying (that would signal
the same queued frame twice - observed as OpenThread's "Failed to process UDP:
Duplicated" flood).

### (3) 802.15.4-2015 (v2) frames are never acknowledged (`should_send_enhanced_ack` is a stub)

For a frame-version-`0b10` ack-required frame, `should_send_enhanced_ack`
returned true but the ISR only parked the radio in `TxEnhAck` and never generated
or sent an ACK, so the radio wedged and the frame went unacknowledged. Thread 1.3
links (e.g. Apple border routers) use version-2 data frames that **require** an
enhanced ACK - without one the parent marks the link failed, retransmits, and
evicts the child, so operational traffic over Thread never completes.

**Fix:** build a minimal enhanced ACK (frame type Acknowledgement, version
`0b10`, sequence number matched to the acknowledged frame, no addressing, no IEs,
unsecured) into a dedicated buffer, point the TX DMA at it, and strobe a new
`enhack_generate_done_notify()` (writing
`ENHANCE_ACK_CFG.tx_enh_ack_generate_done_notify`) so the MAC transmits it in the
ACK window - mirroring the ESP-IDF C driver. Completion raises `AckTxDone`, which
re-arms RX via the same path the immediate ACK uses. `should_send_enhanced_ack`
is also tightened from `<= FRAME_VERSION_2` to `== FRAME_VERSION_2`, so a v0/v1
frame gets the immediate-ACK path and never a v2-format enhanced ACK.

A minimal (no-IE, unsecured) enhanced ACK is sufficient for an rx-on (non-sleepy)
child with CSL and link-metrics disabled, which is the common Thread node
configuration; CSL/link-metrics would need IEs and are out of scope here.

## How to reproduce / verify

Bring up OpenThread on an ESP32-H2 via `esp-radio` + `esp-rs/openthread` (plus
the companion ext-addr fix), apply a valid dataset with a Thread 1.3 border
router in range, `enable_thread(true)`.

- **Before:** `RxSfdDone` fires continuously with `rx_abort = SfdTimeout`,
  `RxDone` essentially never; role stuck `Detached`. If patched only up to (2),
  the node attaches but a Thread 1.3 parent drops it during operational traffic
  ("Duplicated" / link-failure churn) because v2 frames go unacknowledged.
- **After (this PR + the ext-addr fix):** `RxDone` fires steadily, frames are
  delivered, v2 frames are acknowledged, and the node reaches `Child` and
  completes CASE/SRP. **Verified on ESP32-H2 hardware.**

Each fix's individual contribution is observable: (1) takes `RxDone` from ~0 to
steady; (2) is required for ACK-bearing unicast frames to be delivered at all;
(3) is required for a Thread 1.3 parent to keep the child.

## Notes for maintainers

- **Splitting.** The branch is already three commits: (1) re-arm, (2) deliver on
  `RxDone`, (3) enhanced ACK. (1) and (2) are pure receive-path correctness with
  no new API surface; (3) adds enhanced-ACK generation behind the existing
  `Config::enhance_ack_tx` flag. Any subset can be taken independently.
- **We did NOT touch coexistence PTI.** An earlier iteration raised the active
  TX/RX coex priority from `IEEE802154_LOW` to `IEEE802154_HIGH` to fight the
  `SfdTimeout` flood. That turned out to be **unnecessary** once the real RX bugs
  (the ext-addr filter and the abort-event re-arm) were fixed, and raising it
  **starved concurrent BLE** advertising/commissioning on the H2's shared radio.
  The PTI values are left at their upstream defaults.
- **`AckTxDone` on H2.** We did not root-cause *why* `AckTxDone` does not fire for
  the immediate-ACK path on H2 - it may be a separate MAC/event-enable issue.
  Delivering on `RxDone` (fix 2) is correct regardless: the frame is already
  queued and the hardware ACKs autonomously. A maintainer who knows why
  `AckTxDone` is absent may want a follow-up.
- **Chip scope.** Observed and fixed on ESP32-H2. The same code paths are shared
  with C6/C5/C61; the fixes are not H2-specific in principle, but only H2 has
  been validated. Worth a check on C6.


# Changelog

## esp-radio

- Added: IEEE 802.15.4: generate and transmit an enhanced ACK for 802.15.4-2015
- Fixed: IEEE 802.15.4: unmask all RX-abort events while receiving
- Fixed: IEEE 802.15.4: `ensure_receive_enabled()` no longer re-issues `RxStart` on every receive poll, 
- Fixed: IEEE 802.15.4: deliver received frames to the upper layer on `RxDone` for all frames, instead of deferring ACK-required frames to `AckTxDone`


