### PR TITLE
Don't use deprecated function anymore, fix rates

### DIFF
--- a/esp-radio/src/esp_now/mod.rs
+++ b/esp-radio/src/esp_now/mod.rs
@@ -176,74 +176,84 @@ pub struct PeerCount {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[instability::unstable]
 pub enum WifiPhyRate {
-    /// < 1 Mbps with long preamble
-    Rate1mL = 0,
-    /// < 2 Mbps with long preamble
-    Rate2m,
-    /// < 5.5 Mbps with long preamble
-    Rate5mL,
-    /// < 11 Mbps with long preamble
-    Rate11mL,
-    /// < 2 Mbps with short preamble
-    Rate2mS,
-    /// < 5.5 Mbps with short preamble
-    Rate5mS,
-    /// < 11 Mbps with short preamble
-    Rate11mS,
-    /// < 48 Mbps
-    Rate48m,
-    /// < 24 Mbps
-    Rate24m,
-    /// < 12 Mbps
-    Rate12m,
-    /// < 6 Mbps
-    Rate6m,
-    /// < 54 Mbps
-    Rate54m,
-    /// < 36 Mbps
-    Rate36m,
-    /// < 18 Mbps
-    Rate18m,
-    /// < 9 Mbps
-    Rate9m,
-    /// < MCS0 with long GI, 6.5 Mbps for 20MHz, 13.5 Mbps for 40MHz
-    RateMcs0Lgi,
-    /// < MCS1 with long GI, 13 Mbps for 20MHz, 27 Mbps for 40MHz
-    RateMcs1Lgi,
-    /// < MCS2 with long GI, 19.5 Mbps for 20MHz, 40.5 Mbps for 40MHz
-    RateMcs2Lgi,
-    /// < MCS3 with long GI, 26 Mbps for 20MHz, 54 Mbps for 40MHz
-    RateMcs3Lgi,
-    /// < MCS4 with long GI, 39 Mbps for 20MHz, 81 Mbps for 40MHz
-    RateMcs4Lgi,
-    /// < MCS5 with long GI, 52 Mbps for 20MHz, 108 Mbps for 40MHz
-    RateMcs5Lgi,
-    /// < MCS6 with long GI, 58.5 Mbps for 20MHz, 121.5 Mbps for 40MHz
-    RateMcs6Lgi,
-    /// < MCS7 with long GI, 65 Mbps for 20MHz, 135 Mbps for 40MHz
-    RateMcs7Lgi,
-    /// < MCS0 with short GI, 7.2 Mbps for 20MHz, 15 Mbps for 40MHz
-    RateMcs0Sgi,
-    /// < MCS1 with short GI, 14.4 Mbps for 20MHz, 30 Mbps for 40MHz
-    RateMcs1Sgi,
-    /// < MCS2 with short GI, 21.7 Mbps for 20MHz, 45 Mbps for 40MHz
-    RateMcs2Sgi,
-    /// < MCS3 with short GI, 28.9 Mbps for 20MHz, 60 Mbps for 40MHz
-    RateMcs3Sgi,
-    /// < MCS4 with short GI, 43.3 Mbps for 20MHz, 90 Mbps for 40MHz
-    RateMcs4Sgi,
-    /// < MCS5 with short GI, 57.8 Mbps for 20MHz, 120 Mbps for 40MHz
-    RateMcs5Sgi,
-    /// < MCS6 with short GI, 65 Mbps for 20MHz, 135 Mbps for 40MHz
-    RateMcs6Sgi,
-    /// < MCS7 with short GI, 72.2 Mbps for 20MHz, 150 Mbps for 40MHz
-    RateMcs7Sgi,
-    /// < 250 Kbps
-    RateLora250k,
-    /// < 500 Kbps
-    RateLora500k,
-    /// Max
-    RateMax,
+    /// 1 Mbps with long preamble
+    Rate1mL      = wifi_phy_rate_t_WIFI_PHY_RATE_1M_L,
+    /// 2 Mbps with long preamble
+    Rate2m       = wifi_phy_rate_t_WIFI_PHY_RATE_2M_L,
+    /// 5.5 Mbps with long preamble
+    Rate5mL      = wifi_phy_rate_t_WIFI_PHY_RATE_5M_L,
+    /// 11 Mbps with long preamble
+    Rate11mL     = wifi_phy_rate_t_WIFI_PHY_RATE_11M_L,
+    /// 2 Mbps with short preamble
+    Rate2mS      = wifi_phy_rate_t_WIFI_PHY_RATE_2M_S,
+    /// 5.5 Mbps with short preamble
+    Rate5mS      = wifi_phy_rate_t_WIFI_PHY_RATE_5M_S,
+    /// 11 Mbps with short preamble
+    Rate11mS     = wifi_phy_rate_t_WIFI_PHY_RATE_11M_S,
+    /// 48 Mbps
+    Rate48m      = wifi_phy_rate_t_WIFI_PHY_RATE_48M,
+    /// 24 Mbps
+    Rate24m      = wifi_phy_rate_t_WIFI_PHY_RATE_24M,
+    /// 12 Mbps
+    Rate12m      = wifi_phy_rate_t_WIFI_PHY_RATE_12M,
+    /// 6 Mbps
+    Rate6m       = wifi_phy_rate_t_WIFI_PHY_RATE_6M,
+    /// 54 Mbps
+    Rate54m      = wifi_phy_rate_t_WIFI_PHY_RATE_54M,
+    /// 36 Mbps
+    Rate36m      = wifi_phy_rate_t_WIFI_PHY_RATE_36M,
+    /// 18 Mbps
+    Rate18m      = wifi_phy_rate_t_WIFI_PHY_RATE_18M,
+    /// 9 Mbps
+    Rate9m       = wifi_phy_rate_t_WIFI_PHY_RATE_9M,
+    /// MCS0 with long GI, 6.5 Mbps for 20MHz, 13.5 Mbps for 40MHz
+    RateMcs0Lgi  = wifi_phy_rate_t_WIFI_PHY_RATE_MCS0_LGI,
+    /// MCS1 with long GI, 13 Mbps for 20MHz, 27 Mbps for 40MHz
+    RateMcs1Lgi  = wifi_phy_rate_t_WIFI_PHY_RATE_MCS1_LGI,
+    /// MCS2 with long GI, 19.5 Mbps for 20MHz, 40.5 Mbps for 40MHz
+    RateMcs2Lgi  = wifi_phy_rate_t_WIFI_PHY_RATE_MCS2_LGI,
+    /// MCS3 with long GI, 26 Mbps for 20MHz, 54 Mbps for 40MHz
+    RateMcs3Lgi  = wifi_phy_rate_t_WIFI_PHY_RATE_MCS3_LGI,
+    /// MCS4 with long GI, 39 Mbps for 20MHz, 81 Mbps for 40MHz
+    RateMcs4Lgi  = wifi_phy_rate_t_WIFI_PHY_RATE_MCS4_LGI,
+    /// MCS5 with long GI, 52 Mbps for 20MHz, 108 Mbps for 40MHz
+    RateMcs5Lgi  = wifi_phy_rate_t_WIFI_PHY_RATE_MCS5_LGI,
+    /// MCS6 with long GI, 58.5 Mbps for 20MHz, 121.5 Mbps for 40MHz
+    RateMcs6Lgi  = wifi_phy_rate_t_WIFI_PHY_RATE_MCS6_LGI,
+    /// MCS7 with long GI, 65 Mbps for 20MHz, 135 Mbps for 40MHz
+    RateMcs7Lgi  = wifi_phy_rate_t_WIFI_PHY_RATE_MCS7_LGI,
+    /// MCS8 with long GI
+    #[cfg(not(wifi_mac_version = "1"))]
+    RateMcs8Lgi  = wifi_phy_rate_t_WIFI_PHY_RATE_MCS8_LGI,
+    /// MCS9 with long GI
+    #[cfg(not(wifi_mac_version = "1"))]
+    RateMcs9Lgi  = wifi_phy_rate_t_WIFI_PHY_RATE_MCS9_LGI,
+    /// MCS0 with short GI, 7.2 Mbps for 20MHz, 15 Mbps for 40MHz
+    RateMcs0Sgi  = wifi_phy_rate_t_WIFI_PHY_RATE_MCS0_SGI,
+    /// MCS1 with short GI, 14.4 Mbps for 20MHz, 30 Mbps for 40MHz
+    RateMcs1Sgi  = wifi_phy_rate_t_WIFI_PHY_RATE_MCS1_SGI,
+    /// MCS2 with short GI, 21.7 Mbps for 20MHz, 45 Mbps for 40MHz
+    RateMcs2Sgi  = wifi_phy_rate_t_WIFI_PHY_RATE_MCS2_SGI,
+    /// MCS3 with short GI, 28.9 Mbps for 20MHz, 60 Mbps for 40MHz
+    RateMcs3Sgi  = wifi_phy_rate_t_WIFI_PHY_RATE_MCS3_SGI,
+    /// MCS4 with short GI, 43.3 Mbps for 20MHz, 90 Mbps for 40MHz
+    RateMcs4Sgi  = wifi_phy_rate_t_WIFI_PHY_RATE_MCS4_SGI,
+    /// MCS5 with short GI, 57.8 Mbps for 20MHz, 120 Mbps for 40MHz
+    RateMcs5Sgi  = wifi_phy_rate_t_WIFI_PHY_RATE_MCS5_SGI,
+    /// MCS6 with short GI, 65 Mbps for 20MHz, 135 Mbps for 40MHz
+    RateMcs6Sgi  = wifi_phy_rate_t_WIFI_PHY_RATE_MCS6_SGI,
+    /// MCS7 with short GI, 72.2 Mbps for 20MHz, 150 Mbps for 40MHz
+    RateMcs7Sgi  = wifi_phy_rate_t_WIFI_PHY_RATE_MCS7_SGI,
+    /// MCS8 with short GI
+    #[cfg(not(wifi_mac_version = "1"))]
+    RateMcs8Sgi  = wifi_phy_rate_t_WIFI_PHY_RATE_MCS8_SGI,
+    /// MCS9 with short GI
+    #[cfg(not(wifi_mac_version = "1"))]
+    RateMcs9Sgi  = wifi_phy_rate_t_WIFI_PHY_RATE_MCS9_SGI,
+    /// 250 Kbps
+    RateLora250k = wifi_phy_rate_t_WIFI_PHY_RATE_LORA_250K,
+    /// 500 Kbps
+    RateLora500k = wifi_phy_rate_t_WIFI_PHY_RATE_LORA_500K,
 }
 
 /// ESP-NOW peer information parameters.
@@ -346,6 +356,46 @@ impl EspNowWifiInterface {
             _ => unreachable!("Unknown interface"),
         }
     }
+}
+
+/// Phy Mode
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u32)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[instability::unstable]
+pub enum PhyMode {
+    /// PHY mode for Low Rate
+    Lr    = wifi_phy_mode_t_WIFI_PHY_MODE_LR,
+    /// PHY mode for 11b
+    _11b  = wifi_phy_mode_t_WIFI_PHY_MODE_11B,
+    /// PHY mode for 11g
+    _11g  = wifi_phy_mode_t_WIFI_PHY_MODE_11G,
+    /// PHY mode for 11a
+    _11a  = wifi_phy_mode_t_WIFI_PHY_MODE_11A,
+    /// PHY mode for Bandwidth HT20
+    Ht20  = wifi_phy_mode_t_WIFI_PHY_MODE_HT20,
+    /// PHY mode for Bandwidth HT40
+    Ht40  = wifi_phy_mode_t_WIFI_PHY_MODE_HT40,
+    /// PHY mode for Bandwidth HE20
+    He20  = wifi_phy_mode_t_WIFI_PHY_MODE_HE20,
+    /// PHY mode for Bandwidth VHT20
+    Vht20 = wifi_phy_mode_t_WIFI_PHY_MODE_VHT20,
+}
+
+/// Rate Config
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[instability::unstable]
+pub struct RateConfig {
+    /// Phy mode
+    pub phy_mode: PhyMode,
+    /// The rate
+    pub rate: WifiPhyRate,
+    /// Using ERSU to send frame, ERSU is a transmission mode related to 802.11 ax. ERSU is always
+    /// used in long distance transmission, and its frame has lower rate compared with SU mode
+    pub ersu: bool,
+    /// Using dcm rate to send frame
+    pub dcm: bool,
 }
 
 /// Manages the `EspNow` instance lifecycle while ensuring it remains active.
@@ -526,10 +576,25 @@ impl EspNowManager<'_> {
         check_error!({ esp_now_set_wake_window(ms as u16) })
     }
 
-    /// Configure ESP-NOW rate.
+    /// Set ESP-NOW rate config for the given peer.
+    /// You need to add the peer first before setting the rate config.
     #[instability::unstable]
-    pub fn set_rate(&self, rate: WifiPhyRate) -> Result<(), EspNowError> {
-        check_error!({ esp_wifi_config_espnow_rate(wifi_interface_t_WIFI_IF_STA, rate as u32,) })
+    pub fn set_peer_rate(
+        &self,
+        peer_address: &[u8; 6],
+        cfg: RateConfig,
+    ) -> Result<(), EspNowError> {
+        check_error!({
+            esp_now_set_peer_rate_config(
+                peer_address.as_ptr(),
+                &mut esp_now_rate_config_t {
+                    phymode: cfg.phy_mode as u32,
+                    rate: cfg.rate as u32,
+                    ersu: cfg.ersu,
+                    dcm: cfg.dcm,
+                },
+            )
+        })
     }
 }
 
@@ -816,10 +881,15 @@ impl<'d> EspNow<'d> {
         self.manager.set_wake_window(wake_window)
     }
 
-    /// Configure ESP-NOW rate.
+    /// Set ESP-NOW rate config for the given peer.
+    /// You need to add the peer first before setting the rate config.
     #[instability::unstable]
-    pub fn set_rate(&self, rate: WifiPhyRate) -> Result<(), EspNowError> {
-        self.manager.set_rate(rate)
+    pub fn set_peer_rate(
+        &self,
+        peer_address: &[u8; 6],
+        cfg: RateConfig,
+    ) -> Result<(), EspNowError> {
+        self.manager.set_peer_rate(peer_address, cfg)
     }
 
     /// Send data to peer.


### PR DESCRIPTION
`esp_set_rate` is deprecated and removed in ESP-IDF 6 - so we shouldn't use it.

The real fix here is to correctly convert `WifiPhyRate` to the desired C enum value.

Fixes #4710

---


# Changelog

## esp-radio

- Fixed: `WifiPhyRate` enum values
- Changed: Replaced `EspNow::set_rate` / `EspNowManager::set_rate` with `set_peer_rate(peer_address, RateConfig)`
- Added: `PhyMode`, `RateConfig`

# Migration guide

## esp-radio/esp_now

### ESP-NOW rate configuration
`set_rate(rate)` configured a global STA interface rate via a deprecated IDF function. Rate configuration is now per-peer:
```rust
// Before
esp_now.set_rate(WifiPhyRate::Rate1mL)?;

// After
esp_now.set_peer_rate(
    &peer_address,
    RateConfig {
        phy_mode: PhyMode::_11b,
        rate: WifiPhyRate::Rate1mL,
        ersu: false,
        dcm: false,
    },
)?;

The peer must be added with `add_peer` before calling `set_peer_rate`.
