### PR TITLE
IO: affect interrupt settings on all cores

### DIFF
--- a/esp-hal/src/gpio/interrupt.rs
+++ b/esp-hal/src/gpio/interrupt.rs
@@ -56,13 +56,15 @@ use strum::EnumCount;
 
 use crate::{
     gpio::{AnyPin, GPIO_LOCK, GpioBank, InputPin, low_level::set_int_enable},
-    interrupt::{self, Priority},
-    peripherals::Interrupt,
     ram,
-    system::Cpu,
 };
 #[cfg(feature = "rt")]
-use crate::{handler, interrupt::DEFAULT_INTERRUPT_HANDLER};
+use crate::{
+    handler,
+    interrupt::{self, DEFAULT_INTERRUPT_HANDLER},
+    peripherals::Interrupt,
+    system::Cpu,
+};
 
 /// Convenience constant for `Option::None` pin
 pub(super) static USER_INTERRUPT_HANDLER: CFnPtr = CFnPtr::new();
@@ -113,17 +115,6 @@ pub(crate) fn bind_default_interrupt_handler() {
     }
 
     super::low_level::enable_interrupt(default_gpio_interrupt_handler);
-}
-
-/// Configures the given peripheral interrupt to trigger the vectored handler of given priority.
-pub(super) fn set_interrupt_priority(interrupt: Interrupt, priority: Priority) {
-    for cpu in Cpu::all() {
-        // Only change priority if the interrupt is mapped to the core, otherwise we would enable
-        // the interrupt unconditionally, which we don't want to do.
-        if interrupt::mapped_to(cpu, interrupt).is_some() {
-            interrupt::enable_on_cpu(cpu, interrupt, priority);
-        }
-    }
 }
 
 /// The default GPIO interrupt handler, when the user has not set one.

--- a/esp-hal/src/gpio/low_level/mod.rs
+++ b/esp-hal/src/gpio/low_level/mod.rs
@@ -5,9 +5,12 @@ mod version;
 
 use portable_atomic::AtomicU32;
 use strum::EnumCount;
-#[cfg(feature = "rt")]
-pub(crate) use version::enable_interrupt;
-pub(crate) use version::{gpio_intr_enable, prepare_pin_pull};
+pub(crate) use version::{
+    enable_interrupt,
+    gpio_intr_enable,
+    prepare_pin_pull,
+    set_interrupt_priority,
+};
 
 use crate::peripherals::GPIO;
 

--- a/esp-hal/src/gpio/low_level/v1.rs
+++ b/esp-hal/src/gpio/low_level/v1.rs
@@ -1,9 +1,9 @@
 use super::GpioBank;
-use crate::{gpio::AnyPin, peripherals::GPIO, system::Cpu};
-#[cfg(feature = "rt")]
 use crate::{
-    interrupt::{self, InterruptHandler},
-    peripherals::Interrupt,
+    gpio::AnyPin,
+    interrupt::{self, InterruptHandler, Priority},
+    peripherals::{GPIO, Interrupt},
+    system::Cpu,
 };
 
 pub(crate) fn read_bank_interrupt_status(bank: GpioBank) -> u32 {
@@ -33,10 +33,15 @@ pub(crate) fn gpio_intr_enable(int_enable: bool) -> u8 {
     }
 }
 
-#[cfg(feature = "rt")]
 pub(crate) fn enable_interrupt(handler: InterruptHandler) {
     interrupt::bind_handler(Interrupt::GPIO, handler);
-    interrupt::enable_on_cpu(Cpu::AppCpu, Interrupt::GPIO, handler.priority());
+
+    set_interrupt_priority(handler.priority());
+}
+
+pub(crate) fn set_interrupt_priority(priority: Priority) {
+    interrupt::enable_on_cpu(Cpu::ProCpu, Interrupt::GPIO, priority);
+    interrupt::enable_on_cpu(Cpu::AppCpu, Interrupt::GPIO, priority);
 }
 
 fn errata36(pin: &AnyPin<'_>, pull_up: bool, pull_down: bool) {

--- a/esp-hal/src/gpio/low_level/v2.rs
+++ b/esp-hal/src/gpio/low_level/v2.rs
@@ -1,9 +1,8 @@
 use super::GpioBank;
-use crate::{gpio::AnyPin, peripherals::GPIO};
-#[cfg(feature = "rt")]
 use crate::{
-    interrupt::{self, InterruptHandler},
-    peripherals::Interrupt,
+    gpio::AnyPin,
+    interrupt::{self, InterruptHandler, Priority},
+    peripherals::{GPIO, Interrupt},
 };
 
 pub(crate) fn read_bank_interrupt_status(bank: GpioBank) -> u32 {
@@ -28,7 +27,10 @@ pub(crate) fn gpio_intr_enable(int_enable: bool) -> u8 {
     int_enable as u8
 }
 
-#[cfg(feature = "rt")]
 pub(crate) fn enable_interrupt(handler: InterruptHandler) {
     interrupt::bind_handler(Interrupt::GPIO, handler);
+}
+
+pub(crate) fn set_interrupt_priority(priority: Priority) {
+    interrupt::enable(Interrupt::GPIO, priority);
 }

--- a/esp-hal/src/gpio/low_level/v3.rs
+++ b/esp-hal/src/gpio/low_level/v3.rs
@@ -1,9 +1,9 @@
 use super::GpioBank;
-use crate::{gpio::AnyPin, peripherals::GPIO, system::Cpu};
-#[cfg(feature = "rt")]
 use crate::{
-    interrupt::{self, InterruptHandler},
-    peripherals::Interrupt,
+    gpio::AnyPin,
+    interrupt::{self, InterruptHandler, Priority},
+    peripherals::{GPIO, Interrupt},
+    system::Cpu,
 };
 
 pub(crate) fn read_bank_interrupt_status(bank: GpioBank) -> u32 {
@@ -35,11 +35,17 @@ pub(crate) fn gpio_intr_enable(int_enable: bool) -> u8 {
     }
 }
 
-#[cfg(feature = "rt")]
 pub(crate) fn enable_interrupt(handler: InterruptHandler) {
     interrupt::bind_handler(Interrupt::GPIO, handler);
     interrupt::bind_handler(Interrupt::GPIO_INT1, handler);
 
+    interrupt::disable(Cpu::AppCpu, Interrupt::GPIO);
     interrupt::disable(Cpu::ProCpu, Interrupt::GPIO_INT1);
-    interrupt::enable_on_cpu(Cpu::AppCpu, Interrupt::GPIO_INT1, handler.priority());
+
+    set_interrupt_priority(handler.priority());
+}
+
+pub(crate) fn set_interrupt_priority(priority: Priority) {
+    interrupt::enable_on_cpu(Cpu::ProCpu, Interrupt::GPIO, priority);
+    interrupt::enable_on_cpu(Cpu::AppCpu, Interrupt::GPIO_INT1, priority);
 }

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -87,7 +87,7 @@ pub use placeholder::NoPin;
 use crate::{
     asynch::AtomicWaker,
     interrupt::{InterruptHandler, Priority},
-    peripherals::{GPIO, IO_MUX, Interrupt},
+    peripherals::{GPIO, IO_MUX},
     private::{self, Sealed},
 };
 
@@ -529,22 +529,18 @@ impl<'d> Io<'d> {
         Io { _io_mux }
     }
 
-    /// Set the interrupt priority for GPIO interrupts.
+    #[doc = cfg_select!(
+        multi_core => "Sets the the interrupt priority and enables GPIO interrupts on all cores.",
+        _ => "Sets the interrupt priority and enables GPIO interrupts.",
+    )]
     #[instability::unstable]
     pub fn set_interrupt_priority(&self, prio: Priority) {
-        // FIXME: this sets priority on all cores where the handler may be running. Should we only
-        // change it on the current core? Should that enable the interrupt if it's not already
-        // enabled?
-        interrupt::set_interrupt_priority(Interrupt::GPIO, prio);
+        low_level::set_interrupt_priority(prio);
     }
 
-    #[cfg_attr(
-        not(multi_core),
-        doc = "Registers an interrupt handler for all GPIO pins."
-    )]
-    #[cfg_attr(
-        multi_core,
-        doc = "Registers an interrupt handler for all GPIO pins. Enables interrupts on all cores."
+    #[doc = cfg_select!(
+        multi_core => "Registers an interrupt handler for all GPIO pins. Enables interrupts on all cores.",
+        _ => "Registers an interrupt handler for all GPIO pins.",
     )]
     #[doc = ""]
     /// Note that when using interrupt handlers registered by this function, or

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -544,7 +544,7 @@ impl<'d> Io<'d> {
     )]
     #[cfg_attr(
         multi_core,
-        doc = "Registers an interrupt handler for all GPIO pins. Enables the interrupt on the current core."
+        doc = "Registers an interrupt handler for all GPIO pins. Enables interrupts on all cores."
     )]
     #[doc = ""]
     /// Note that when using interrupt handlers registered by this function, or
@@ -564,15 +564,11 @@ impl<'d> Io<'d> {
     /// [`is_interrupt_set()`]: Input::is_interrupt_set
     #[instability::unstable]
     pub fn set_interrupt_handler(&mut self, handler: InterruptHandler) {
-        for core in crate::system::Cpu::other() {
-            crate::interrupt::disable(core, Interrupt::GPIO);
-        }
         USER_INTERRUPT_HANDLER.store(handler.handler().callback());
-
-        crate::interrupt::bind_handler(
-            Interrupt::GPIO,
-            InterruptHandler::new(user_gpio_interrupt_handler, handler.priority()),
-        );
+        low_level::enable_interrupt(InterruptHandler::new(
+            user_gpio_interrupt_handler,
+            handler.priority(),
+        ));
     }
 }
 

--- a/esp-hal/src/interrupt/mod.rs
+++ b/esp-hal/src/interrupt/mod.rs
@@ -411,10 +411,12 @@ pub(super) fn map_raw(core: Cpu, interrupt: Interrupt, cpu_interrupt: u32) {
 }
 
 /// Get cpu interrupt assigned to peripheral interrupt
+#[cfg(feature = "rt")]
 pub(crate) fn mapped_to(cpu: Cpu, interrupt: Interrupt) -> Option<CpuInterrupt> {
     mapped_to_raw(cpu, interrupt as u32)
 }
 
+#[cfg(feature = "rt")]
 pub(crate) fn mapped_to_raw(cpu: Cpu, interrupt: u32) -> Option<CpuInterrupt> {
     let cpu_intr = match cpu {
         Cpu::ProCpu => INTERRUPT_CORE0::regs()

--- a/esp-hal/src/interrupt/xtensa.rs
+++ b/esp-hal/src/interrupt/xtensa.rs
@@ -69,6 +69,7 @@ pub enum CpuInterrupt {
 }
 
 impl CpuInterrupt {
+    #[cfg(feature = "rt")]
     pub(super) fn from_u32(n: u32) -> Option<Self> {
         match n {
             0 => Some(Self::Interrupt0LevelPriority1),

--- a/hil-test/src/bin/gpio.rs
+++ b/hil-test/src/bin/gpio.rs
@@ -23,6 +23,10 @@ cfg_select! {
             handler,
             timer::timg::TimerGroup,
         };
+        #[cfg(multi_core)]
+        use esp_hal::system::Stack;
+        #[cfg(multi_core)]
+        use hil_test::mk_static;
         use portable_atomic::{AtomicUsize, Ordering};
 
         static COUNTER: Mutex<RefCell<u32>> = Mutex::new(RefCell::new(0));
@@ -51,10 +55,13 @@ struct Context {
     io: Io<'static>,
     #[cfg(all(dedicated_gpio_driver_supported, feature = "unstable"))]
     dedicated_gpio: DedicatedGpio<'static>,
-    #[cfg(all(dedicated_gpio_driver_supported, multi_core, feature = "unstable"))]
+
+    #[cfg(all(multi_core, feature = "unstable"))]
     int1: esp_hal::interrupt::software::SoftwareInterrupt<'static, 1>,
-    #[cfg(all(dedicated_gpio_driver_supported, multi_core, feature = "unstable"))]
+    #[cfg(all(multi_core, feature = "unstable"))]
     cpu_ctrl: esp_hal::peripherals::CPU_CTRL<'static>,
+    #[cfg(all(multi_core, feature = "unstable"))]
+    app_core_stack: &'static mut Stack<4096>,
 }
 
 #[cfg_attr(feature = "unstable", handler)]
@@ -150,10 +157,7 @@ mod tests {
         let io = Io::new(peripherals.IO_MUX);
 
         #[cfg(feature = "unstable")]
-        #[cfg_attr(
-            any(single_core, not(dedicated_gpio_driver_supported)),
-            expect(unused_variables)
-        )]
+        #[cfg_attr(not(all(multi_core, feature = "unstable")), expect(unused_variables))]
         let int1 = {
             let sw_int = esp_hal::interrupt::software::SoftwareInterruptControl::new(
                 peripherals.SW_INTERRUPT,
@@ -166,11 +170,6 @@ mod tests {
             int1
         };
 
-        #[cfg(all(dedicated_gpio_driver_supported, feature = "unstable"))]
-        let dedicated_gpio = DedicatedGpio::new(peripherals.GPIO_DEDICATED);
-        #[cfg(all(dedicated_gpio_driver_supported, multi_core, feature = "unstable"))]
-        let cpu_ctrl = peripherals.CPU_CTRL;
-
         Context {
             test_gpio1: gpio1.degrade(),
             test_gpio2: gpio2.degrade(),
@@ -179,11 +178,13 @@ mod tests {
             #[cfg(feature = "unstable")]
             io,
             #[cfg(all(dedicated_gpio_driver_supported, feature = "unstable"))]
-            dedicated_gpio,
-            #[cfg(all(dedicated_gpio_driver_supported, multi_core, feature = "unstable"))]
+            dedicated_gpio: DedicatedGpio::new(peripherals.GPIO_DEDICATED),
+            #[cfg(all(multi_core, feature = "unstable"))]
             int1,
-            #[cfg(all(dedicated_gpio_driver_supported, multi_core, feature = "unstable"))]
-            cpu_ctrl,
+            #[cfg(all(multi_core, feature = "unstable"))]
+            cpu_ctrl: peripherals.CPU_CTRL,
+            #[cfg(all(multi_core, feature = "unstable"))]
+            app_core_stack: mk_static!(Stack<4096>, Stack::new()),
         }
     }
 
@@ -335,6 +336,57 @@ mod tests {
     #[cfg(feature = "unstable")] // Interrupts are unstable
     fn gpio_interrupt(mut ctx: Context) {
         ctx.io.set_interrupt_handler(interrupt_handler);
+
+        let mut test_gpio1 =
+            Input::new(ctx.test_gpio1, InputConfig::default().with_pull(Pull::Down));
+        let mut test_gpio2 = Output::new(ctx.test_gpio2, Level::Low, OutputConfig::default());
+
+        critical_section::with(|cs| {
+            *COUNTER.borrow_ref_mut(cs) = 0;
+            test_gpio1.listen(Event::AnyEdge);
+            INPUT_PIN.borrow_ref_mut(cs).replace(test_gpio1);
+        });
+        test_gpio2.set_high();
+        ctx.delay.delay_millis(1);
+        test_gpio2.set_low();
+        ctx.delay.delay_millis(1);
+        test_gpio2.set_high();
+        ctx.delay.delay_millis(1);
+        test_gpio2.set_low();
+        ctx.delay.delay_millis(1);
+        test_gpio2.set_high();
+        ctx.delay.delay_millis(1);
+        test_gpio2.set_low();
+        ctx.delay.delay_millis(1);
+        test_gpio2.set_high();
+        ctx.delay.delay_millis(1);
+        test_gpio2.set_low();
+        ctx.delay.delay_millis(1);
+        test_gpio2.set_high();
+        ctx.delay.delay_millis(1);
+
+        let count = critical_section::with(|cs| *COUNTER.borrow_ref(cs));
+        assert_eq!(count, 9);
+
+        let mut test_gpio1 =
+            critical_section::with(|cs| INPUT_PIN.borrow_ref_mut(cs).take().unwrap());
+        test_gpio1.unlisten();
+    }
+
+    // https://github.com/esp-rs/esp-hal/issues/5881
+    #[test]
+    #[cfg(all(feature = "unstable", multi_core))] // Interrupts are unstable
+    async fn gpio_interrupt_enabled_on_other_core(mut ctx: Context) {
+        let io_set_up = &*mk_static!(Signal::<CriticalSectionRawMutex, ()>, Signal::new());
+
+        esp_rtos::start_second_core(ctx.cpu_ctrl, ctx.int1, ctx.app_core_stack, move || {
+            // Set the interrupt handler for GPIO.
+            ctx.io.set_interrupt_handler(interrupt_handler);
+            io_set_up.signal(());
+        });
+
+        // Wait for the second core to set up the interrupt handler.
+        io_set_up.wait().await;
 
         let mut test_gpio1 =
             Input::new(ctx.test_gpio1, InputConfig::default().with_pull(Pull::Down));
@@ -687,19 +739,15 @@ mod tests {
         debug_assertions
     ))]
     async fn dedicated_gpio_different_cores_panics(ctx: Context) {
-        use esp_hal::system::Stack;
-        use hil_test::mk_static;
-
         let pin1 = ctx.test_gpio1;
         let driver_signal = &*mk_static!(
             Signal<CriticalSectionRawMutex, DedicatedGpioInput<'static>>,
             Signal::new()
         );
-        let app_core_stack = mk_static!(Stack<4096>, Stack::new());
 
         // creating the driver at core1, and then use it at core
         // this should panic
-        esp_rtos::start_second_core(ctx.cpu_ctrl, ctx.int1, app_core_stack, move || {
+        esp_rtos::start_second_core(ctx.cpu_ctrl, ctx.int1, ctx.app_core_stack, move || {
             let input = Input::new(pin1, InputConfig::default().with_pull(Pull::Down));
             let driver = DedicatedGpioInput::new(ctx.dedicated_gpio.channel1.input, input);
 


### PR DESCRIPTION
Closes #5881

# Changelog

## esp-hal/GPIO

- Changed: `Io::{set_interrupt_priority, set_interrupt_handler}` now affect all cores.
- Changed: `Io::set_interrupt_priority` now enables the GPIO interrupts if they weren't before.