### PR TITLE
S3: Only handle GPIO interrupts on one core

### DIFF
--- a/esp-hal/src/gpio/low_level/v2.rs
+++ b/esp-hal/src/gpio/low_level/v2.rs
@@ -3,6 +3,7 @@ use crate::{
     gpio::AnyPin,
     interrupt::{self, InterruptHandler, Priority},
     peripherals::{GPIO, Interrupt},
+    system::Cpu,
 };
 
 pub(crate) fn read_bank_interrupt_status(bank: GpioBank) -> u32 {
@@ -28,9 +29,15 @@ pub(crate) fn gpio_intr_enable(int_enable: bool) -> u8 {
 }
 
 pub(crate) fn enable_interrupt(handler: InterruptHandler) {
+    for cpu in Cpu::other() {
+        interrupt::disable(cpu, Interrupt::GPIO);
+    }
     interrupt::bind_handler(Interrupt::GPIO, handler);
 }
 
 pub(crate) fn set_interrupt_priority(priority: Priority) {
+    for cpu in Cpu::other() {
+        interrupt::disable(cpu, Interrupt::GPIO);
+    }
     interrupt::enable(Interrupt::GPIO, priority);
 }

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -530,8 +530,8 @@ impl<'d> Io<'d> {
     }
 
     #[doc = cfg_select!(
-        multi_core => "Sets the the interrupt priority and enables GPIO interrupts on all cores.",
-        _ => "Sets the interrupt priority and enables GPIO interrupts.",
+        any(single_core, esp32s3) => "Sets the the interrupt priority and enables GPIO interrupts.",
+        _ => "Sets the interrupt priority and enables GPIO interrupts on all cores.",
     )]
     #[instability::unstable]
     pub fn set_interrupt_priority(&self, prio: Priority) {
@@ -539,8 +539,8 @@ impl<'d> Io<'d> {
     }
 
     #[doc = cfg_select!(
-        multi_core => "Registers an interrupt handler for all GPIO pins. Enables interrupts on all cores.",
-        _ => "Registers an interrupt handler for all GPIO pins.",
+        any(single_core, esp32s3) => "Registers an interrupt handler for all GPIO pins.",
+        _ => "Registers an interrupt handler for all GPIO pins. Enables interrupts on all cores.",
     )]
     #[doc = ""]
     /// Note that when using interrupt handlers registered by this function, or

--- a/hil-test/src/bin/gpio_custom_handler.rs
+++ b/hil-test/src/bin/gpio_custom_handler.rs
@@ -78,9 +78,9 @@ extern "C" fn gpio_isr() {
             // to clear the GPIO interrupts by hand and we deliberately do
             // *not* wake any async future.
             let peripherals = unsafe { esp_hal::peripherals::Peripherals::steal() };
-            let (gpio1, _) = hil_test::common_test_pins!(peripherals);
-            let mut gpio1 = Flex::new(gpio1);
-            gpio1.unlisten();
+            let (gpio, _) = hil_test::common_test_pins!(peripherals);
+            let mut gpio = Flex::new(gpio);
+            gpio.unlisten();
         }
     }
 }
@@ -271,5 +271,62 @@ mod tests {
             "user-defined GPIO() handler was never invoked"
         );
         assert_eq!(counter, 5);
+    }
+
+    #[test]
+    #[cfg(multi_core)]
+    async fn user_handler_runs_once() {
+        use embassy_sync::signal::Signal;
+        use esp_hal::{gpio::Event, system::Stack};
+        use static_cell::ConstStaticCell;
+
+        rebind_user_gpio_handler();
+        HANDLER_MODE.store(HandlerMode::UnlistenOnly as u8, Ordering::Relaxed);
+
+        let peripherals = esp_hal::init(esp_hal::Config::default());
+
+        let (gpio1, gpio2) = hil_test::common_test_pins!(peripherals);
+
+        let sw_int = SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
+        let timg0 = TimerGroup::new(peripherals.TIMG0);
+        esp_rtos::start(timg0.timer0, sw_int.software_interrupt0);
+
+        static IO_SET_UP: ConstStaticCell<Signal<CriticalSectionRawMutex, ()>> =
+            ConstStaticCell::new(Signal::<CriticalSectionRawMutex, ()>::new());
+        let io_set_up = &*IO_SET_UP.take();
+
+        // Run the ISR on the second core.
+        let mut io = Io::new(peripherals.IO_MUX);
+        esp_rtos::start_second_core(
+            peripherals.CPU_CTRL,
+            sw_int.software_interrupt1,
+            mk_static!(Stack<4096>, Stack::new()),
+            move || {
+                // Set the interrupt handler for GPIO.
+                io.set_interrupt_handler(InterruptHandler::new(gpio_isr, Priority::Priority1));
+                io_set_up.signal(());
+            },
+        );
+
+        io_set_up.wait().await;
+
+        // is_listening is not implemented on Input
+        let mut test_gpio1 = Flex::new(gpio1);
+        test_gpio1.apply_input_config(&InputConfig::default().with_pull(Pull::Down));
+        test_gpio1.set_input_enable(true);
+        let mut test_gpio2 = Output::new(gpio2, Level::Low, OutputConfig::default());
+
+        // Set up and trigger.
+        test_gpio1.listen(Event::HighLevel);
+        test_gpio2.set_level(Level::High);
+
+        // This loop exits once the interrupt handler has finished on either core and is NOT
+        // running on this one (or we'd be in that handler, not in thread mode code).
+        while test_gpio1.is_listening() {}
+
+        // Wait for a bit in case the interrupt handler runs on the other core as well.
+        Timer::after(Duration::from_millis(50)).await;
+
+        assert_eq!(HANDLER_INVOCATIONS.load(Ordering::Relaxed), 1);
     }
 }


### PR DESCRIPTION
Fixes #5888

On S3, we don't have a mechanism to inspect which core should handle the GPIO interrupt, so let's fall back to one core handling GPIO interrupts.

ESP32 seems smart - it's using one interrupt, but per-core interrupt status and the interrupt only triggers on the intended core. P4 has separate interrupt signals as well as separate status registers.