### PR TITLE
Allow arbitrary half-duplex transfer lengths

### DIFF
--- a/esp-hal/src/spi/master/dma.rs
+++ b/esp-hal/src/spi/master/dma.rs
@@ -663,16 +663,12 @@ impl<'d> SpiDma<'d, Async> {
             return Ok(());
         }
 
-        // Small transfers that fit in the FIFO can skip the DMA setup cost entirely.
+        // Transfers below the configured threshold can skip the DMA setup cost entirely.
         if self.use_blocking_transfer(buffer.len()) {
-            if buffer.len() <= FIFO_SIZE {
-                self.dma_driver().disable_dma();
-                return self
-                    .driver()
-                    .half_duplex_read(data_mode, cmd, address, dummy, buffer);
-            } else {
-                warn!("Buffer size exceeds FIFO size, skipping blocking transfer");
-            }
+            self.dma_driver().disable_dma();
+            return self
+                .driver()
+                .half_duplex_read(data_mode, cmd, address, dummy, buffer);
         }
 
         let operation = DmaOperationKind::for_read(buffer);
@@ -731,16 +727,12 @@ impl<'d> SpiDma<'d, Async> {
             return Ok(());
         }
 
-        // Small transfers that fit in the FIFO can skip the DMA setup cost entirely.
+        // Transfers below the configured threshold can skip the DMA setup cost entirely.
         if self.use_blocking_transfer(buffer.len()) {
-            if buffer.len() <= FIFO_SIZE {
-                self.dma_driver().disable_dma();
-                return self
-                    .driver()
-                    .half_duplex_write(data_mode, cmd, address, dummy, buffer);
-            } else {
-                warn!("Buffer size exceeds FIFO size, skipping blocking transfer");
-            }
+            self.dma_driver().disable_dma();
+            return self
+                .driver()
+                .half_duplex_write(data_mode, cmd, address, dummy, buffer);
         }
 
         let operation = DmaOperationKind::for_write(buffer);

--- a/esp-hal/src/spi/master/low_level/mod.rs
+++ b/esp-hal/src/spi/master/low_level/mod.rs
@@ -510,11 +510,24 @@ impl Driver {
         Ok(())
     }
 
+    fn prepare_half_duplex_chunk(&self, first: bool, last: bool) {
+        self.regs().user().modify(|_, w| {
+            if !first {
+                w.usr_command().clear_bit();
+                w.usr_addr().clear_bit();
+                w.usr_dummy().clear_bit();
+                w.cs_setup().clear_bit();
+            }
+            w.cs_hold().bit(last)
+        });
+        version::set_cs_keep_active(self, !last);
+    }
+
     /// Blocking, FIFO-based half-duplex read.
     ///
-    /// Performs the command, address, dummy, and data phases as a single SPI
-    /// transaction without involving the DMA engine. Because the FIFO is used,
-    /// `buffer` must not exceed [`FIFO_SIZE`].
+    /// Performs the command, address, dummy, and data phases as a single SPI transaction without
+    /// involving the DMA engine. Transfers larger than the FIFO are split into chunks while keeping
+    /// CS asserted.
     #[cfg_attr(place_spi_master_driver_in_ram, ram)]
     pub(super) fn half_duplex_read(
         &self,
@@ -524,10 +537,6 @@ impl Driver {
         dummy: u8,
         buffer: &mut [u8],
     ) -> Result<(), Error> {
-        if buffer.len() > FIFO_SIZE {
-            return Err(Error::FifoSizeExeeded);
-        }
-
         if buffer.is_empty() {
             error!("Half-duplex mode does not support empty buffer");
             return Err(Error::Unsupported);
@@ -543,17 +552,26 @@ impl Driver {
             data_mode,
         )?;
 
-        self.configure_datalen(buffer.len(), 0);
-        self.start_operation();
-        self.flush()?;
-        self.read_from_fifo(buffer)
+        let _keep_cs_guard = DropGuard::new((), |_| version::set_cs_keep_active(self, false));
+        let mut first = true;
+        let mut chunks = buffer.chunks_mut(FIFO_SIZE).peekable();
+        while let Some(chunk) = chunks.next() {
+            let last = chunks.peek().is_none();
+            self.prepare_half_duplex_chunk(first, last);
+            self.configure_datalen(chunk.len(), 0);
+            self.start_operation();
+            self.flush()?;
+            self.read_from_fifo(chunk)?;
+            first = false;
+        }
+        Ok(())
     }
 
     /// Blocking, FIFO-based half-duplex write.
     ///
-    /// Performs the command, address, dummy, and data phases as a single SPI
-    /// transaction without involving the DMA engine. Because the FIFO is used,
-    /// `buffer` must not exceed [`FIFO_SIZE`].
+    /// Performs the command, address, dummy, and data phases as a single SPI transaction without
+    /// involving the DMA engine. Transfers larger than the FIFO are split into chunks while keeping
+    /// CS asserted.
     #[cfg_attr(place_spi_master_driver_in_ram, ram)]
     pub(super) fn half_duplex_write(
         &self,
@@ -563,10 +581,6 @@ impl Driver {
         dummy: u8,
         buffer: &[u8],
     ) -> Result<(), Error> {
-        if buffer.len() > FIFO_SIZE {
-            return Err(Error::FifoSizeExeeded);
-        }
-
         cfg_select! {
             all(spi_master_version = "1", spi_address_workaround) => {
                 let mut buffer = buffer;
@@ -604,14 +618,25 @@ impl Driver {
             data_mode,
         )?;
 
-        if !buffer.is_empty() {
-            self.configure_datalen(0, buffer.len());
-            self.fill_fifo(buffer);
+        let _keep_cs_guard = DropGuard::new((), |_| version::set_cs_keep_active(self, false));
+        if buffer.is_empty() {
+            self.prepare_half_duplex_chunk(true, true);
+            self.start_operation();
+            self.flush()?;
+        } else {
+            let mut first = true;
+            let mut chunks = buffer.chunks(FIFO_SIZE).peekable();
+            while let Some(chunk) = chunks.next() {
+                let last = chunks.peek().is_none();
+                self.prepare_half_duplex_chunk(first, last);
+                self.configure_datalen(0, chunk.len());
+                self.fill_fifo(chunk);
+                self.start_operation();
+                self.flush()?;
+                first = false;
+            }
         }
-
-        self.start_operation();
-
-        self.flush()
+        Ok(())
     }
 
     #[cfg_attr(place_spi_master_driver_in_ram, ram)]

--- a/esp-hal/src/spi/master/low_level/v1.rs
+++ b/esp-hal/src/spi/master/low_level/v1.rs
@@ -200,6 +200,13 @@ pub(super) fn prepare_half_duplex(driver: &Driver, is_write: bool, dummy: u8) ->
 
 pub(super) fn setup_half_duplex(_driver: &Driver) {}
 
+pub(super) fn set_cs_keep_active(driver: &Driver, keep_active: bool) {
+    driver
+        .regs()
+        .pin()
+        .modify(|_, w| w.cs_keep_active().bit(keep_active));
+}
+
 pub(super) fn write_address(driver: &Driver, addr: u32) {
     driver.regs().addr().write(|w| unsafe { w.bits(addr) });
 }

--- a/esp-hal/src/spi/master/low_level/v2.rs
+++ b/esp-hal/src/spi/master/low_level/v2.rs
@@ -69,6 +69,13 @@ pub(super) fn setup_half_duplex(driver: &Driver) {
     driver.regs().misc().write(|w| unsafe { w.bits(0) });
 }
 
+pub(super) fn set_cs_keep_active(driver: &Driver, keep_active: bool) {
+    driver
+        .regs()
+        .misc()
+        .modify(|_, w| w.cs_keep_active().bit(keep_active));
+}
+
 pub(super) fn write_address(driver: &Driver, addr: u32) {
     driver
         .regs()

--- a/esp-hal/src/spi/master/low_level/v3.rs
+++ b/esp-hal/src/spi/master/low_level/v3.rs
@@ -71,6 +71,13 @@ pub(super) fn setup_half_duplex(driver: &Driver) {
     driver.regs().misc().write(|w| unsafe { w.bits(0) });
 }
 
+pub(super) fn set_cs_keep_active(driver: &Driver, keep_active: bool) {
+    driver
+        .regs()
+        .misc()
+        .modify(|_, w| w.cs_keep_active().bit(keep_active));
+}
+
 pub(super) fn write_address(driver: &Driver, addr: u32) {
     driver
         .regs()

--- a/esp-hal/src/spi/master/mod.rs
+++ b/esp-hal/src/spi/master/mod.rs
@@ -462,8 +462,7 @@ pub struct Config {
     /// [`SpiDma`][crate::spi::master::dma::SpiDma], the threshold applies in
     /// both blocking and async DMA modes: when met, DMA is disabled and the
     /// transfer is performed by the CPU. This applies to both full-duplex and
-    /// half-duplex transfers; for half-duplex transfers the CPU-driven path is
-    /// only taken when the data also fits in the hardware FIFO.
+    /// half-duplex transfers.
     ///
     /// A value of `0` (the default) disables the threshold — all transfers use
     /// the driver's default method.
@@ -1192,12 +1191,14 @@ where
 
     /// Half-duplex read.
     ///
+    /// Transfers larger than the hardware FIFO are split into chunks. CS remains asserted across
+    /// chunks, but the clock pauses while the CPU prepares each subsequent chunk.
+    ///
     /// # Errors
     ///
-    /// [`Error::FifoSizeExeeded`] or [`Error::Unsupported`] will be returned if
-    /// passed buffer is bigger than FIFO size or if buffer is empty (currently
-    /// unsupported). `DataMode::Single` cannot be combined with any other
-    /// [`DataMode`], otherwise [`Error::Unsupported`] will be returned.
+    /// [`Error::Unsupported`] will be returned if the buffer is empty (currently unsupported).
+    /// `DataMode::Single` cannot be combined with any other [`DataMode`], otherwise
+    /// [`Error::Unsupported`] will be returned.
     #[instability::unstable]
     pub fn half_duplex_read(
         &mut self,
@@ -1214,10 +1215,13 @@ where
 
     /// Half-duplex write.
     ///
+    /// Transfers larger than the hardware FIFO are split into chunks. CS remains asserted across
+    /// chunks, but the clock pauses while the CPU prepares each subsequent chunk.
+    ///
     /// # Errors
     ///
-    /// [`Error::FifoSizeExeeded`] will be returned if
-    /// passed buffer is bigger than FIFO size.
+    /// [`Error::Unsupported`] will be returned for unsupported combinations of command, address,
+    /// dummy, and data modes.
     #[cfg_attr(
         esp32,
         doc = "Dummy phase configuration is currently not supported, only value `0` is valid (see issue [#2240](https://github.com/esp-rs/esp-hal/issues/2240))."

--- a/hil-test/src/bin/spi.rs
+++ b/hil-test/src/bin/spi.rs
@@ -1698,7 +1698,7 @@ mod read {
 
     #[test]
     fn test_spi_reads_correctly_from_gpio_pin(mut ctx: Context) {
-        const BUFFER_SIZE: usize = 4;
+        const BUFFER_SIZE: usize = 145;
 
         ctx.miso_mirror.set_low();
 
@@ -1901,6 +1901,8 @@ mod write {
         spi: Spi<'static, Blocking>,
         pcnt_unit: Unit<'static, 0>,
         pcnt_source: InputSignal<'static>,
+        cs_unit: Unit<'static, 1>,
+        cs_source: InputSignal<'static>,
 
         #[cfg(spi_master_supports_dma)]
         dma_channel: DmaChannel<'static>,
@@ -1910,8 +1912,8 @@ mod write {
     fn init() -> Context {
         let peripherals = esp_hal::init(esp_hal::Config::default());
 
-        let sclk = peripherals.GPIO0;
         let (mosi, _) = hil_test::common_test_pins!(peripherals);
+        let (sclk, cs) = hil_test::i2c_pins!(peripherals);
 
         let pcnt = Pcnt::new(peripherals.PCNT);
 
@@ -1933,6 +1935,11 @@ mod write {
         mosi.set_output_enable(true);
         let mosi_loopback = mosi.peripheral_input();
 
+        let mut cs = Flex::new(cs);
+        cs.set_input_enable(true);
+        cs.set_output_enable(true);
+        let cs_loopback = cs.peripheral_input();
+
         let spi = Spi::new(
             peripherals.SPI2,
             Config::default()
@@ -1941,26 +1948,34 @@ mod write {
         )
         .unwrap()
         .with_sck(sclk)
-        .with_sio0(mosi);
+        .with_sio0(mosi)
+        .with_cs(cs);
 
         Context {
             spi,
             pcnt_unit: pcnt.unit0,
             pcnt_source: mosi_loopback,
+            cs_unit: pcnt.unit1,
+            cs_source: cs_loopback,
             #[cfg(spi_master_supports_dma)]
             dma_channel,
         }
     }
 
     fn perform_spi_writes_are_correctly_by_pcnt(ctx: Context, mode: DataMode) {
-        const BUFFER_SIZE: usize = 4;
+        const BUFFER_SIZE: usize = 145;
 
         let tx_buf = &mut [0; BUFFER_SIZE];
         let unit = ctx.pcnt_unit;
+        let cs_unit = ctx.cs_unit;
         let mut spi = ctx.spi;
 
         unit.channel0.set_edge_signal(ctx.pcnt_source);
         unit.channel0
+            .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
+        cs_unit.channel0.set_edge_signal(ctx.cs_source);
+        cs_unit
+            .channel0
             .set_input_mode(EdgeMode::Hold, EdgeMode::Increment);
 
         tx_buf.fill(0b0110_1010);
@@ -1969,11 +1984,13 @@ mod write {
             .unwrap();
 
         assert_eq!(unit.value(), (3 * BUFFER_SIZE) as _);
+        assert_eq!(cs_unit.value(), 1);
 
         spi.half_duplex_write(mode, Command::None, Address::None, 0, tx_buf)
             .unwrap();
 
         assert_eq!(unit.value(), (6 * BUFFER_SIZE) as _);
+        assert_eq!(cs_unit.value(), 2);
     }
 
     #[cfg(spi_master_supports_dma)]
@@ -2552,7 +2569,7 @@ mod qspi_dma {
         write: u8,
         data_on_multiple_pins: bool,
     ) {
-        const BUFFER_SIZE: usize = 4;
+        const BUFFER_SIZE: usize = 145;
 
         let tx_buf = [write; BUFFER_SIZE];
 
@@ -2560,15 +2577,15 @@ mod qspi_dma {
             unit0.clear();
             unit1.clear();
             spi = transfer_write_cpu(spi, &tx_buf, write, command_data_mode);
-            assert_eq!(unit0.value() + unit1.value(), 8);
+            assert_eq!(unit0.value() + unit1.value(), (BUFFER_SIZE + 4) as _);
 
             if data_on_multiple_pins {
                 if command_data_mode == DataMode::SingleTwoDataLines {
                     assert_eq!(unit0.value(), 1);
-                    assert_eq!(unit1.value(), 7);
+                    assert_eq!(unit1.value(), (BUFFER_SIZE + 3) as _);
                 } else {
                     assert_eq!(unit0.value(), 0);
-                    assert_eq!(unit1.value(), 8);
+                    assert_eq!(unit1.value(), (BUFFER_SIZE + 4) as _);
                 }
             }
 
@@ -2639,6 +2656,21 @@ mod qspi_dma {
     }
 
     #[test]
+    fn test_spi_reads_correctly_from_gpio_pin_0_with_cpu(ctx: Context) {
+        const BUFFER_SIZE: usize = 145;
+
+        let [pin, pin_mirror, _] = ctx.gpios;
+        let _pin_mirror = Output::new(pin_mirror, Level::High, OutputConfig::default());
+        let mut spi = ctx.spi.with_sio0(pin);
+        let mut buffer = [0; BUFFER_SIZE];
+
+        spi.half_duplex_read(DataMode::Quad, Command::None, Address::None, 0, &mut buffer)
+            .unwrap();
+
+        assert_eq!(buffer, [0b0001_0001; BUFFER_SIZE]);
+    }
+
+    #[test]
     async fn test_spi_reads_correctly_from_gpio_pin_0_async(ctx: Context) {
         const BUFFER_SIZE: usize = 4;
 
@@ -2664,6 +2696,31 @@ mod qspi_dma {
         spi.half_duplex_read_async(DataMode::Quad, Command::None, Address::None, 0, &mut buffer)
             .await
             .unwrap();
+        assert_eq!(buffer, [0b0001_0001; BUFFER_SIZE]);
+    }
+
+    #[test]
+    async fn test_spi_reads_correctly_from_gpio_pin_0_async_with_cpu_fallback(mut ctx: Context) {
+        const BUFFER_SIZE: usize = 145;
+
+        let [pin, pin_mirror, _] = ctx.gpios;
+        let _pin_mirror = Output::new(pin_mirror, Level::High, OutputConfig::default());
+        ctx.spi
+            .apply_config(
+                &Config::default().with_min_async_transfer_size(BUFFER_SIZE.saturating_add(1)),
+            )
+            .unwrap();
+        let mut spi = ctx
+            .spi
+            .with_sio0(pin)
+            .with_dma(ctx.dma_channel)
+            .into_async();
+        let mut buffer = [0; BUFFER_SIZE];
+
+        spi.half_duplex_read_async(DataMode::Quad, Command::None, Address::None, 0, &mut buffer)
+            .await
+            .unwrap();
+
         assert_eq!(buffer, [0b0001_0001; BUFFER_SIZE]);
     }
 


### PR DESCRIPTION
# Changelog

## esp-hal/SPI

- Changed: half-duplex SPI can now transfer more than a FIFO's worth of data