### PR TITLE
Lift opt level restrictions

### DIFF
--- a/esp-radio/build.rs
+++ b/esp-radio/build.rs
@@ -96,12 +96,10 @@ fn main() -> Result<(), Box<dyn Error>> {
     }
 
     if let Ok(level) = std::env::var("OPT_LEVEL")
-        && level != "2"
-        && level != "3"
-        && level != "s"
+        && !["2", "3", "s", "z"].contains(&level.as_str())
     {
         let message = format!(
-            "esp-radio should be built with optimization level 2, 3 or s - yours is {level}.
+            "esp-radio should be built with optimization level 2, 3, s or z - yours is {level}.
                 See https://github.com/esp-rs/esp-hal/tree/main/esp-radio",
         );
         print_warning(message);

--- a/esp-storage/README.md
+++ b/esp-storage/README.md
@@ -9,17 +9,6 @@
 This crate provides functionality to access ESP32 flash. Enable the
 `embedded-storage` feature for [`embedded-storage`](https://github.com/rust-embedded-community/embedded-storage) trait implementations.
 
-## Important
-
-For ESP32 it is necessary to build with [optimization level](https://doc.rust-lang.org/cargo/reference/profiles.html#opt-level) 2 or 3.
-
-To make it work also for `debug` builds add this to your `Cargo.toml`
-
-```toml
-[profile.dev.package.esp-storage]
-opt-level = 3
-```
-
 ## Minimum Supported Rust Version (MSRV)
 
 This crate is guaranteed to compile when using the latest stable Rust version at the time of the crate's release. It _might_ compile with older versions, but that may change in any new release, including patches.

--- a/esp-storage/build.rs
+++ b/esp-storage/build.rs
@@ -13,20 +13,6 @@ fn main() -> Result<(), String> {
         // Even though we don't have a chip, make sure we're not warned about the config symbols.
         emit_check_cfg_directives();
     }
-    if cfg!(feature = "esp32") {
-        match std::env::var("OPT_LEVEL") {
-            Ok(level) if std::env::var("CI").is_err() => {
-                if level != "2" && level != "3" && level != "s" {
-                    Err(format!(
-                        "Building esp-storage for ESP32 needs optimization level 2, 3 or s - yours is {level}. See https://github.com/esp-rs/esp-storage"
-                    ))
-                } else {
-                    Ok(())
-                }
-            }
-            _ => Ok(()),
-        }
-    } else {
-        Ok(())
-    }
+
+    Ok(())
 }


### PR DESCRIPTION
rust-analyzer doesn't work with esp32 because we return an error from the esp-storage build script. I tried working around that at first, but it seems we can just allow building with opt-level 0 anyway?

# Changelog

## esp-radio

- Changed: esp-radio can now be built with opt-level "z"

## esp-storage

- Changed: esp-storage can now be built with any opt-level