### PR TITLE
Test I2S1/I2S2 (TDM only)

### DIFF
--- a/hil-test/src/bin/i2s.rs
+++ b/hil-test/src/bin/i2s.rs
@@ -9,6 +9,54 @@
 #![no_std]
 #![no_main]
 
+macro_rules! i2s_test_dma_channel {
+    ($peripherals:ident, I2S0) => {
+        cfg_select! {
+            i2s_dma_engine = "I2S_DMA" => {
+                $peripherals.DMA_I2S0.into()
+            }
+            _ => {
+                $peripherals.DMA_CH0.into()
+            }
+        }
+    };
+    ($peripherals:ident, I2S1) => {
+        cfg_select! {
+            i2s_dma_engine = "I2S_DMA" => {
+                $peripherals.DMA_I2S1.into()
+            }
+            _ => {
+                $peripherals.DMA_CH0.into()
+            }
+        }
+    };
+    ($peripherals:ident, I2S2) => {
+        $peripherals.DMA_CH0.into()
+    };
+}
+
+macro_rules! i2s_instance_resources {
+    ($i2s:ident) => {{
+        let peripherals = esp_hal::init(
+            esp_hal::Config::default().with_cpu_clock(esp_hal::clock::CpuClock::max()),
+        );
+        let i2s: esp_hal::i2s::AnyI2s<'static> = peripherals.$i2s.into();
+        let dma_channel = i2s_test_dma_channel!(peripherals, $i2s);
+
+        #[cfg(not(esp32c5))]
+        let (_, dout) = hil_test::common_test_pins!(peripherals);
+
+        // there are some random pulses counted on ESP32-C5 in our HIL setup
+        // with the common test pin, so just use a fixed GPIO pin which is not used for anything
+        // else in this test on that chip in the hope it will fix it
+        #[cfg(esp32c5)]
+        let dout = peripherals.GPIO6;
+
+        let dout = dout.degrade();
+        (i2s, dma_channel, dout)
+    }};
+}
+
 #[embedded_test::tests(default_timeout = 3, executor = hil_test::Executor::new())]
 mod tests {
     use esp_hal::{
@@ -18,17 +66,19 @@ mod tests {
         dma_rx_stream_buffer,
         dma_tx_stream_buffer,
         gpio::{AnyPin, NoPin, Pin},
-        i2s::master::{Channels, DataFormat, I2s, I2sTx, TdmConfig},
-        peripherals::I2S0,
+        i2s::{
+            AnyI2s,
+            master::{Channels, DataFormat, I2s, I2sTx, TdmConfig},
+        },
         time::Rate,
     };
 
     cfg_select! {
-        any(esp32, esp32s2) => {
-            type DmaChannel0<'d> = esp_hal::peripherals::DMA_I2S0<'d>;
+        i2s_dma_engine = "I2S_DMA" => {
+            type AnyI2sDmaChannel<'d> = esp_hal::dma::I2sDmaChannel<'d>;
         }
         _ => {
-            type DmaChannel0<'d> = esp_hal::peripherals::DMA_CH0<'d>;
+            type AnyI2sDmaChannel<'d> = esp_hal::dma::AhbGdmaChannel<'d>;
         }
     }
 
@@ -91,49 +141,19 @@ mod tests {
         }
     }
 
-    struct Context {
+    async fn run_test_i2s_loopback_async(
+        i2s: AnyI2s<'static>,
+        dma_channel: AnyI2sDmaChannel<'static>,
         dout: AnyPin<'static>,
-        dma_channel: DmaChannel0<'static>,
-        i2s: I2S0<'static>,
-    }
-
-    #[init]
-    fn init() -> Context {
-        let peripherals = esp_hal::init(
-            esp_hal::Config::default().with_cpu_clock(esp_hal::clock::CpuClock::max()),
-        );
-
-        let dma_channel = cfg_select! {
-            i2s_dma_engine = "I2S_DMA" => peripherals.DMA_I2S0,
-            _ => peripherals.DMA_CH0,
-        };
-
-        #[cfg(not(esp32c5))]
-        let (_, dout) = hil_test::common_test_pins!(peripherals);
-
-        // there are some random pulses counted on ESP32-C5 in our HIL setup
-        // with the common test pin, so just use a fixed GPIO pin which is not used for anything
-        // else in this test on that chip in the hope it will fix it
-        #[cfg(esp32c5)]
-        let dout = peripherals.GPIO6;
-
-        Context {
-            dout: dout.degrade(),
-            dma_channel,
-            i2s: peripherals.I2S0,
-        }
-    }
-
-    #[test]
-    async fn test_i2s_loopback_async(ctx: Context) {
+    ) {
         let spawner = unsafe { embassy_executor::Spawner::for_current_executor().await };
 
         let rx_buffer = dma_rx_stream_buffer!(BUFFER_SIZE, 128);
         let tx_buffer = dma_tx_stream_buffer!(BUFFER_SIZE, 128);
 
         let i2s = I2s::new(
-            ctx.i2s,
-            ctx.dma_channel,
+            i2s,
+            dma_channel,
             TdmConfig::new_tdm_philips()
                 .with_signal_loopback(true)
                 .with_sample_rate(Rate::from_hz(16000))
@@ -143,7 +163,7 @@ mod tests {
         .unwrap()
         .into_async();
 
-        let (din, dout) = unsafe { ctx.dout.split() };
+        let (din, dout) = unsafe { dout.split() };
 
         let i2s_tx = i2s
             .i2s_tx
@@ -193,14 +213,17 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_i2s_loopback(ctx: Context) {
+    fn run_test_i2s_loopback(
+        i2s: AnyI2s<'static>,
+        dma_channel: AnyI2sDmaChannel<'static>,
+        dout: AnyPin<'static>,
+    ) {
         let rx_buffer = dma_rx_stream_buffer!(BUFFER_SIZE * 4, 1000);
         let mut tx_buffer = dma_tx_stream_buffer!(BUFFER_SIZE * 4, 1000);
 
         let i2s = I2s::new(
-            ctx.i2s,
-            ctx.dma_channel,
+            i2s,
+            dma_channel,
             TdmConfig::new_tdm_philips()
                 .with_signal_loopback(true)
                 .with_sample_rate(Rate::from_hz(16000))
@@ -209,7 +232,7 @@ mod tests {
         )
         .unwrap();
 
-        let (din, dout) = unsafe { ctx.dout.split() };
+        let (din, dout) = unsafe { dout.split() };
         let mut counter = super::EdgeCounter::new(din.clone());
 
         let i2s_tx = i2s
@@ -321,14 +344,16 @@ mod tests {
         counter.check(0);
     }
 
-    #[test]
     #[cfg(not(any(esp32, esp32s2)))]
-    fn test_i2s_rx_half_sample_bits_regression(ctx: Context) {
+    fn run_test_i2s_rx_half_sample_bits_regression(
+        i2s: AnyI2s<'static>,
+        dma_channel: AnyI2sDmaChannel<'static>,
+    ) {
         // Regression test for rx_half_sample_bits configuration bug.
         // Validates that TX and RX half_sample_bits registers are configured identically.
         let _i2s = I2s::new(
-            ctx.i2s,
-            ctx.dma_channel,
+            i2s,
+            dma_channel,
             TdmConfig::new_tdm_philips()
                 .with_sample_rate(Rate::from_hz(16000))
                 .with_data_format(DataFormat::Data16Channel16)
@@ -365,8 +390,11 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_i2s_read_one_shot_multiple(ctx: Context) {
+    fn run_test_i2s_read_one_shot_multiple(
+        i2s: AnyI2s<'static>,
+        dma_channel: AnyI2sDmaChannel<'static>,
+        dout: AnyPin<'static>,
+    ) {
         let buffer =
             hil_test::mk_static!(InternalMemory<[u8; 8000]>, InternalMemory::new([0; 8000]));
         let descr = hil_test::mk_static!(
@@ -377,8 +405,8 @@ mod tests {
             DmaRxBuf::new(descr.get_mut().unsize(), buffer.get_mut().unsize()).unwrap();
 
         let i2s = I2s::new(
-            ctx.i2s,
-            ctx.dma_channel,
+            i2s,
+            dma_channel,
             TdmConfig::new_tdm_philips()
                 .with_sample_rate(Rate::from_hz(16000))
                 .with_data_format(DataFormat::Data16Channel16)
@@ -388,7 +416,7 @@ mod tests {
 
         // reading WS as input will generate a certain bit pattern on the data line which we can
         // check was received correctly
-        let (din, ws) = unsafe { ctx.dout.split() };
+        let (din, ws) = unsafe { dout.split() };
 
         let mut i2s_rx = i2s
             .i2s_rx
@@ -422,8 +450,11 @@ mod tests {
         }
     }
 
-    #[test]
-    async fn test_i2s_read_one_shot_multiple_async(ctx: Context) {
+    async fn run_test_i2s_read_one_shot_multiple_async(
+        i2s: AnyI2s<'static>,
+        dma_channel: AnyI2sDmaChannel<'static>,
+        dout: AnyPin<'static>,
+    ) {
         let buffer =
             hil_test::mk_static!(InternalMemory<[u8; 8000]>, InternalMemory::new([0; 8000]));
         let descr = hil_test::mk_static!(
@@ -434,8 +465,8 @@ mod tests {
             DmaRxBuf::new(descr.get_mut().unsize(), buffer.get_mut().unsize()).unwrap();
 
         let i2s = I2s::new(
-            ctx.i2s,
-            ctx.dma_channel,
+            i2s,
+            dma_channel,
             TdmConfig::new_tdm_philips()
                 .with_sample_rate(Rate::from_hz(16000))
                 .with_data_format(DataFormat::Data16Channel16)
@@ -446,7 +477,7 @@ mod tests {
 
         // reading WS as input will generate a certain bit pattern on the data line which we can
         // check was received correctly
-        let (din, ws) = unsafe { ctx.dout.split() };
+        let (din, ws) = unsafe { dout.split() };
 
         let mut i2s_rx = i2s
             .i2s_rx
@@ -482,10 +513,11 @@ mod tests {
         }
     }
 
-    // On chips supporting PCNT we check the number of written bytes, otherwise just make sure the
-    // write completes.
-    #[test]
-    fn test_i2s_write_one_shot(ctx: Context) {
+    fn run_test_i2s_write_one_shot(
+        i2s: AnyI2s<'static>,
+        dma_channel: AnyI2sDmaChannel<'static>,
+        dout: AnyPin<'static>,
+    ) {
         let buffer =
             hil_test::mk_static!(InternalMemory<[u8; 8000]>, InternalMemory::new([1u8; 8000]));
         let descr = hil_test::mk_static!(
@@ -495,8 +527,8 @@ mod tests {
         let tx_buffer = DmaTxBuf::new(descr.get_mut().unsize(), buffer.get_mut().unsize()).unwrap();
 
         let i2s = I2s::new(
-            ctx.i2s,
-            ctx.dma_channel,
+            i2s,
+            dma_channel,
             TdmConfig::new_tdm_philips()
                 .with_sample_rate(Rate::from_hz(16000))
                 .with_data_format(DataFormat::Data16Channel16)
@@ -504,7 +536,7 @@ mod tests {
         )
         .unwrap();
 
-        let (other, dout) = unsafe { ctx.dout.split() };
+        let (other, dout) = unsafe { dout.split() };
         let mut counter = super::EdgeCounter::new(other);
 
         let i2s_tx = i2s
@@ -524,10 +556,11 @@ mod tests {
         counter.check(8000);
     }
 
-    // On chips supporting PCNT we check the number of written bytes, otherwise just make sure the
-    // write completes.
-    #[test]
-    async fn test_i2s_write_one_shot_async(ctx: Context) {
+    async fn run_test_i2s_write_one_shot_async(
+        i2s: AnyI2s<'static>,
+        dma_channel: AnyI2sDmaChannel<'static>,
+        dout: AnyPin<'static>,
+    ) {
         let buffer =
             hil_test::mk_static!(InternalMemory<[u8; 8000]>, InternalMemory::new([1u8; 8000]));
         let descr = hil_test::mk_static!(
@@ -537,8 +570,8 @@ mod tests {
         let tx_buffer = DmaTxBuf::new(descr.get_mut().unsize(), buffer.get_mut().unsize()).unwrap();
 
         let i2s = I2s::new(
-            ctx.i2s,
-            ctx.dma_channel,
+            i2s,
+            dma_channel,
             TdmConfig::new_tdm_philips()
                 .with_sample_rate(Rate::from_hz(16000))
                 .with_data_format(DataFormat::Data16Channel16)
@@ -547,7 +580,7 @@ mod tests {
         .unwrap()
         .into_async();
 
-        let (other, dout) = unsafe { ctx.dout.split() };
+        let (other, dout) = unsafe { dout.split() };
         let mut counter = super::EdgeCounter::new(other);
 
         let i2s_tx = i2s
@@ -568,10 +601,11 @@ mod tests {
         counter.check(8000);
     }
 
-    // On chips supporting PCNT we check the number of written bytes, otherwise just make sure the
-    // write completes.
-    #[test]
-    async fn test_i2s_write_one_shot_multiple(ctx: Context) {
+    async fn run_test_i2s_write_one_shot_multiple(
+        i2s: AnyI2s<'static>,
+        dma_channel: AnyI2sDmaChannel<'static>,
+        dout: AnyPin<'static>,
+    ) {
         let buffer = hil_test::mk_static!(InternalMemory<[u8; 4]>, InternalMemory::new([1u8; 4]));
         let descr = hil_test::mk_static!(
             InternalMemory<[DmaDescriptor; 4]>,
@@ -581,8 +615,8 @@ mod tests {
             DmaTxBuf::new(descr.get_mut().unsize(), buffer.get_mut().unsize()).unwrap();
 
         let i2s = I2s::new(
-            ctx.i2s,
-            ctx.dma_channel,
+            i2s,
+            dma_channel,
             TdmConfig::new_tdm_philips()
                 .with_sample_rate(Rate::from_hz(16000))
                 .with_data_format(DataFormat::Data16Channel16)
@@ -590,7 +624,7 @@ mod tests {
         )
         .unwrap();
 
-        let (other, dout) = unsafe { ctx.dout.split() };
+        let (other, dout) = unsafe { dout.split() };
         let mut counter = super::EdgeCounter::new(other);
 
         let mut i2s_tx = i2s
@@ -616,10 +650,11 @@ mod tests {
         }
     }
 
-    // On chips supporting PCNT we check the number of written bytes, otherwise just make sure the
-    // write completes.
-    #[test]
-    async fn test_i2s_write_one_shot_multiple_async(ctx: Context) {
+    async fn run_test_i2s_write_one_shot_multiple_async(
+        i2s: AnyI2s<'static>,
+        dma_channel: AnyI2sDmaChannel<'static>,
+        dout: AnyPin<'static>,
+    ) {
         let buffer = hil_test::mk_static!(InternalMemory<[u8; 4]>, InternalMemory::new([1u8; 4]));
         let descr = hil_test::mk_static!(
             InternalMemory<[DmaDescriptor; 4]>,
@@ -629,8 +664,8 @@ mod tests {
             DmaTxBuf::new(descr.get_mut().unsize(), buffer.get_mut().unsize()).unwrap();
 
         let i2s = I2s::new(
-            ctx.i2s,
-            ctx.dma_channel,
+            i2s,
+            dma_channel,
             TdmConfig::new_tdm_philips()
                 .with_sample_rate(Rate::from_hz(16000))
                 .with_data_format(DataFormat::Data16Channel16)
@@ -639,7 +674,7 @@ mod tests {
         .unwrap()
         .into_async();
 
-        let (other, dout) = unsafe { ctx.dout.split() };
+        let (other, dout) = unsafe { dout.split() };
         let mut counter = super::EdgeCounter::new(other);
 
         let mut i2s_tx = i2s
@@ -665,44 +700,205 @@ mod tests {
             i2s_tx = i2s_tx_back;
         }
     }
+
+    #[test]
+    #[cfg(soc_has_i2s0)]
+    async fn test_i2s_loopback_async_i2s0() {
+        let (i2s, dma_channel, dout) = i2s_instance_resources!(I2S0);
+        run_test_i2s_loopback_async(i2s, dma_channel, dout).await;
+    }
+
+    #[test]
+    #[cfg(soc_has_i2s1)]
+    async fn test_i2s_loopback_async_i2s1() {
+        let (i2s, dma_channel, dout) = i2s_instance_resources!(I2S1);
+        run_test_i2s_loopback_async(i2s, dma_channel, dout).await;
+    }
+
+    #[test]
+    #[cfg(soc_has_i2s2)]
+    async fn test_i2s_loopback_async_i2s2() {
+        let (i2s, dma_channel, dout) = i2s_instance_resources!(I2S2);
+        run_test_i2s_loopback_async(i2s, dma_channel, dout).await;
+    }
+
+    #[test]
+    #[cfg(soc_has_i2s0)]
+    fn test_i2s_loopback_i2s0() {
+        let (i2s, dma_channel, dout) = i2s_instance_resources!(I2S0);
+        run_test_i2s_loopback(i2s, dma_channel, dout);
+    }
+
+    #[test]
+    #[cfg(soc_has_i2s1)]
+    fn test_i2s_loopback_i2s1() {
+        let (i2s, dma_channel, dout) = i2s_instance_resources!(I2S1);
+        run_test_i2s_loopback(i2s, dma_channel, dout);
+    }
+
+    #[test]
+    #[cfg(soc_has_i2s2)]
+    fn test_i2s_loopback_i2s2() {
+        let (i2s, dma_channel, dout) = i2s_instance_resources!(I2S2);
+        run_test_i2s_loopback(i2s, dma_channel, dout);
+    }
+
+    #[test]
+    #[cfg(soc_has_i2s0)]
+    fn test_i2s_read_one_shot_multiple_i2s0() {
+        let (i2s, dma_channel, dout) = i2s_instance_resources!(I2S0);
+        run_test_i2s_read_one_shot_multiple(i2s, dma_channel, dout);
+    }
+
+    #[test]
+    #[cfg(soc_has_i2s1)]
+    fn test_i2s_read_one_shot_multiple_i2s1() {
+        let (i2s, dma_channel, dout) = i2s_instance_resources!(I2S1);
+        run_test_i2s_read_one_shot_multiple(i2s, dma_channel, dout);
+    }
+
+    #[test]
+    #[cfg(soc_has_i2s2)]
+    fn test_i2s_read_one_shot_multiple_i2s2() {
+        let (i2s, dma_channel, dout) = i2s_instance_resources!(I2S2);
+        run_test_i2s_read_one_shot_multiple(i2s, dma_channel, dout);
+    }
+
+    #[test]
+    #[cfg(soc_has_i2s0)]
+    async fn test_i2s_read_one_shot_multiple_async_i2s0() {
+        let (i2s, dma_channel, dout) = i2s_instance_resources!(I2S0);
+        run_test_i2s_read_one_shot_multiple_async(i2s, dma_channel, dout).await;
+    }
+
+    #[test]
+    #[cfg(soc_has_i2s1)]
+    async fn test_i2s_read_one_shot_multiple_async_i2s1() {
+        let (i2s, dma_channel, dout) = i2s_instance_resources!(I2S1);
+        run_test_i2s_read_one_shot_multiple_async(i2s, dma_channel, dout).await;
+    }
+
+    #[test]
+    #[cfg(soc_has_i2s2)]
+    async fn test_i2s_read_one_shot_multiple_async_i2s2() {
+        let (i2s, dma_channel, dout) = i2s_instance_resources!(I2S2);
+        run_test_i2s_read_one_shot_multiple_async(i2s, dma_channel, dout).await;
+    }
+
+    #[test]
+    #[cfg(soc_has_i2s0)]
+    fn test_i2s_write_one_shot_i2s0() {
+        let (i2s, dma_channel, dout) = i2s_instance_resources!(I2S0);
+        run_test_i2s_write_one_shot(i2s, dma_channel, dout);
+    }
+
+    #[test]
+    #[cfg(soc_has_i2s1)]
+    fn test_i2s_write_one_shot_i2s1() {
+        let (i2s, dma_channel, dout) = i2s_instance_resources!(I2S1);
+        run_test_i2s_write_one_shot(i2s, dma_channel, dout);
+    }
+
+    #[test]
+    #[cfg(soc_has_i2s2)]
+    fn test_i2s_write_one_shot_i2s2() {
+        let (i2s, dma_channel, dout) = i2s_instance_resources!(I2S2);
+        run_test_i2s_write_one_shot(i2s, dma_channel, dout);
+    }
+
+    #[test]
+    #[cfg(soc_has_i2s0)]
+    async fn test_i2s_write_one_shot_async_i2s0() {
+        let (i2s, dma_channel, dout) = i2s_instance_resources!(I2S0);
+        run_test_i2s_write_one_shot_async(i2s, dma_channel, dout).await;
+    }
+
+    #[test]
+    #[cfg(soc_has_i2s1)]
+    async fn test_i2s_write_one_shot_async_i2s1() {
+        let (i2s, dma_channel, dout) = i2s_instance_resources!(I2S1);
+        run_test_i2s_write_one_shot_async(i2s, dma_channel, dout).await;
+    }
+
+    #[test]
+    #[cfg(soc_has_i2s2)]
+    async fn test_i2s_write_one_shot_async_i2s2() {
+        let (i2s, dma_channel, dout) = i2s_instance_resources!(I2S2);
+        run_test_i2s_write_one_shot_async(i2s, dma_channel, dout).await;
+    }
+
+    #[test]
+    #[cfg(soc_has_i2s0)]
+    async fn test_i2s_write_one_shot_multiple_i2s0() {
+        let (i2s, dma_channel, dout) = i2s_instance_resources!(I2S0);
+        run_test_i2s_write_one_shot_multiple(i2s, dma_channel, dout).await;
+    }
+
+    #[test]
+    #[cfg(soc_has_i2s1)]
+    async fn test_i2s_write_one_shot_multiple_i2s1() {
+        let (i2s, dma_channel, dout) = i2s_instance_resources!(I2S1);
+        run_test_i2s_write_one_shot_multiple(i2s, dma_channel, dout).await;
+    }
+
+    #[test]
+    #[cfg(soc_has_i2s2)]
+    async fn test_i2s_write_one_shot_multiple_i2s2() {
+        let (i2s, dma_channel, dout) = i2s_instance_resources!(I2S2);
+        run_test_i2s_write_one_shot_multiple(i2s, dma_channel, dout).await;
+    }
+
+    #[test]
+    #[cfg(soc_has_i2s0)]
+    async fn test_i2s_write_one_shot_multiple_async_i2s0() {
+        let (i2s, dma_channel, dout) = i2s_instance_resources!(I2S0);
+        run_test_i2s_write_one_shot_multiple_async(i2s, dma_channel, dout).await;
+    }
+
+    #[test]
+    #[cfg(soc_has_i2s1)]
+    async fn test_i2s_write_one_shot_multiple_async_i2s1() {
+        let (i2s, dma_channel, dout) = i2s_instance_resources!(I2S1);
+        run_test_i2s_write_one_shot_multiple_async(i2s, dma_channel, dout).await;
+    }
+
+    #[test]
+    #[cfg(soc_has_i2s2)]
+    async fn test_i2s_write_one_shot_multiple_async_i2s2() {
+        let (i2s, dma_channel, dout) = i2s_instance_resources!(I2S2);
+        run_test_i2s_write_one_shot_multiple_async(i2s, dma_channel, dout).await;
+    }
+
+    #[test]
+    #[cfg(all(soc_has_i2s0, not(any(esp32, esp32s2))))]
+    fn test_i2s_rx_half_sample_bits_regression_i2s0() {
+        let (i2s, dma_channel, _) = i2s_instance_resources!(I2S0);
+        run_test_i2s_rx_half_sample_bits_regression(i2s, dma_channel);
+    }
 }
 
 #[cfg(esp32)]
 #[embedded_test::tests(default_timeout = 3, executor = hil_test::Executor::new())]
-mod parallel_tests {
+mod i2s_parallel_tests {
     use esp_hal::{
+        dma::I2sDmaChannel,
         gpio::NoPin,
-        i2s::parallel::{I2sParallel, TxSixteenBits},
-        peripherals::{DMA_I2S0, I2S0},
+        i2s::{
+            AnyI2s,
+            parallel::{I2sParallel, TxSixteenBits},
+        },
         time::Rate,
     };
-    struct Context {
-        dma_channel: DMA_I2S0<'static>,
-        i2s: I2S0<'static>,
-    }
 
-    #[init]
-    fn init() -> Context {
-        let peripherals = esp_hal::init(
-            esp_hal::Config::default().with_cpu_clock(esp_hal::clock::CpuClock::max()),
-        );
-
-        let dma_channel = peripherals.DMA_I2S0;
-
-        Context {
-            dma_channel,
-            i2s: peripherals.I2S0,
-        }
-    }
-
-    #[test]
-    async fn driver_does_not_hang_when_async(ctx: Context) {
+    async fn run_driver_does_not_hang_when_async(
+        i2s: AnyI2s<'static>,
+        dma_channel: I2sDmaChannel<'static>,
+    ) {
         let pins = TxSixteenBits::new(
             NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin,
             NoPin, NoPin, NoPin, NoPin,
         );
-        let i2s = I2sParallel::new(ctx.i2s, ctx.dma_channel, Rate::from_mhz(20), pins, NoPin)
-            .into_async();
+        let i2s = I2sParallel::new(i2s, dma_channel, Rate::from_mhz(20), pins, NoPin).into_async();
 
         // Try sending an empty buffer, as an edge case
         let tx_buf = esp_hal::dma_tx_buffer!(4096).unwrap();
@@ -722,6 +918,28 @@ mod parallel_tests {
             .map_err(|_| "failed to send buffer")
             .unwrap();
         xfer.wait_for_done().await.unwrap();
+    }
+
+    #[test]
+    #[cfg(soc_has_i2s0)]
+    async fn driver_does_not_hang_when_async_i2s0() {
+        let peripherals = esp_hal::init(
+            esp_hal::Config::default().with_cpu_clock(esp_hal::clock::CpuClock::max()),
+        );
+        let i2s = peripherals.I2S0.into();
+        let dma_channel: esp_hal::dma::I2sDmaChannel<'static> = peripherals.DMA_I2S0.into();
+        run_driver_does_not_hang_when_async(i2s, dma_channel).await;
+    }
+
+    #[test]
+    #[cfg(soc_has_i2s1)]
+    async fn driver_does_not_hang_when_async_i2s1() {
+        let peripherals = esp_hal::init(
+            esp_hal::Config::default().with_cpu_clock(esp_hal::clock::CpuClock::max()),
+        );
+        let i2s = peripherals.I2S1.into();
+        let dma_channel: esp_hal::dma::I2sDmaChannel<'static> = peripherals.DMA_I2S1.into();
+        run_driver_does_not_hang_when_async(i2s, dma_channel).await;
     }
 }
 

--- a/hil-test/src/bin/i2s.rs
+++ b/hil-test/src/bin/i2s.rs
@@ -12,6 +12,9 @@
 macro_rules! i2s_test_dma_channel {
     ($peripherals:ident, I2S0) => {
         cfg_select! {
+            esp32s2 => {
+                $peripherals.DMA_I2S0
+            }
             i2s_dma_engine = "I2S_DMA" => {
                 $peripherals.DMA_I2S0.into()
             }
@@ -74,6 +77,9 @@ mod tests {
     };
 
     cfg_select! {
+        esp32s2 => {
+            type AnyI2sDmaChannel<'d> = esp_hal::peripherals::DMA_I2S0<'d>;
+        }
         i2s_dma_engine = "I2S_DMA" => {
             type AnyI2sDmaChannel<'d> = esp_hal::dma::I2sDmaChannel<'d>;
         }


### PR DESCRIPTION
A simpler approach to #5900

Not pretty but does the job - not even trying to do something smart on purpose

PDM tests are untouched since we (as per the docs) currently only support PDM for I2S0
