### PR TITLE
Compile HIL binaries without debuginfo

### DIFF
--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -246,9 +246,10 @@ overflow-checks  = true
 
 [profile.release]
 codegen-units    = 1
-debug            = 2
 debug-assertions = true
 incremental      = false
 opt-level        = 3
 lto              = false # LTO (thin or fat) miscompiles some tests on RISC-V
 overflow-checks  = true
+# We rarely debug HIL binaries, so let's shrink the .ELF size
+debug            = 0

--- a/hil-test/src/bin/radio_basic.rs
+++ b/hil-test/src/bin/radio_basic.rs
@@ -35,7 +35,6 @@ fn init_heap() {
             esp_alloc::heap_allocator!(#[ram(reclaimed)] size: 64 * 1024);
             esp_alloc::heap_allocator!(size: 48 * 1024);
         }
-        _ => {}
     }
 }
 


### PR DESCRIPTION
Shrinks ESP32's `gpio_unstable` from 9MB to 210k

Hopefully this can close #5904 as we don't generate nearly as big binaries - so we should save a bit of space.