### PR TITLE
Don't enable `esp-hal/unstable` in esp-storage

### DIFF
--- a/esp-bootloader-esp-idf/Cargo.toml
+++ b/esp-bootloader-esp-idf/Cargo.toml
@@ -11,14 +11,14 @@ repository = "https://github.com/esp-rs/esp-hal"
 license = "MIT OR Apache-2.0"
 
 [package.metadata.espressif]
-doc-config = { features = ["defmt", "validation"] }
+doc-config = { features = ["esp-hal/unstable", "esp-hal/rt", "defmt", "validation"] }
 check-configs = [
-    { features = [] },
-    { features = ["log-04"] },
-    { features = ["defmt", "validation"] },
+    { features = ["esp-hal/unstable"] },
+    { features = ["esp-hal/unstable", "log-04"] },
+    { features = ["esp-hal/unstable", "defmt", "validation"] },
 ]
 clippy-configs = [
-    { features = ["defmt", "validation"] },
+    { features = ["esp-hal/unstable", "defmt", "validation"] },
 ]
 
 [package.metadata.docs.rs]
@@ -42,6 +42,11 @@ strum = { version = "0.27", default-features = false, features = ["derive"] }
 
 crc = { version = "3.3.0", optional = true }
 md-5 = { version = "0.10.6", default-features = false, optional = true }
+
+# Not used by library code. Optional so CI `check-configs` can pass `esp-hal/unstable`
+# (Cargo only forwards dependency features from direct deps; dev-dependencies are not used by `cargo check`).
+[target.'cfg(any(target_arch = "riscv32", target_arch = "xtensa"))'.dependencies]
+esp-hal = { version = "~1.1.0", path = "../esp-hal", default-features = false, optional = true }
 
 [build-dependencies]
 jiff       = { version = "0.2.13", default-features = false, features = ["std"] }
@@ -74,25 +79,25 @@ embedded-storage = ["dep:embedded-storage", "esp-storage/embedded-storage"]
 #! One of the following features must be enabled to select the target chip:
 
 ##
-esp32c2   = ["esp-rom-sys/esp32c2", "esp-metadata-generated/esp32c2", "esp-hal/esp32c2", "esp-storage/esp32c2"]
+esp32c2   = ["esp-rom-sys/esp32c2", "esp-metadata-generated/esp32c2", "esp-storage/esp32c2"]
 ##
-esp32c3   = ["esp-rom-sys/esp32c3", "esp-metadata-generated/esp32c3", "esp-hal/esp32c3", "esp-storage/esp32c3"]
+esp32c3   = ["esp-rom-sys/esp32c3", "esp-metadata-generated/esp32c3", "esp-storage/esp32c3"]
 ##
-esp32c5   = ["esp-rom-sys/esp32c5", "esp-metadata-generated/esp32c5", "esp-hal/esp32c5", "esp-storage/esp32c5"]
+esp32c5   = ["esp-rom-sys/esp32c5", "esp-metadata-generated/esp32c5", "esp-storage/esp32c5"]
 ##
-esp32c6   = ["esp-rom-sys/esp32c6", "esp-metadata-generated/esp32c6", "esp-hal/esp32c6", "esp-storage/esp32c6"]
+esp32c6   = ["esp-rom-sys/esp32c6", "esp-metadata-generated/esp32c6", "esp-storage/esp32c6"]
 ##
-esp32c61   = ["esp-rom-sys/esp32c61", "esp-metadata-generated/esp32c61", "esp-hal/esp32c61", "esp-storage/esp32c61"]
+esp32c61   = ["esp-rom-sys/esp32c61", "esp-metadata-generated/esp32c61", "esp-storage/esp32c61"]
 ##
-esp32h2   = ["esp-rom-sys/esp32h2", "esp-metadata-generated/esp32h2", "esp-hal/esp32h2", "esp-storage/esp32h2"]
+esp32h2   = ["esp-rom-sys/esp32h2", "esp-metadata-generated/esp32h2", "esp-storage/esp32h2"]
 ##
-esp32p4   = ["esp-rom-sys/esp32p4", "esp-metadata-generated/esp32p4", "esp-hal/esp32p4", "esp-storage/esp32p4"]
+esp32p4   = ["esp-rom-sys/esp32p4", "esp-metadata-generated/esp32p4", "esp-storage/esp32p4"]
 ##
-esp32     = ["esp-rom-sys/esp32", "esp-metadata-generated/esp32", "esp-hal/esp32", "esp-storage/esp32"]
+esp32     = ["esp-rom-sys/esp32", "esp-metadata-generated/esp32", "esp-storage/esp32"]
 ##
-esp32s2   = ["esp-rom-sys/esp32s2", "esp-metadata-generated/esp32s2", "esp-hal/esp32s2", "esp-storage/esp32s2"]
+esp32s2   = ["esp-rom-sys/esp32s2", "esp-metadata-generated/esp32s2", "esp-storage/esp32s2"]
 ##
-esp32s3   = ["esp-rom-sys/esp32s3", "esp-metadata-generated/esp32s3", "esp-hal/esp32s3", "esp-storage/esp32s3"]
+esp32s3   = ["esp-rom-sys/esp32s3", "esp-metadata-generated/esp32s3", "esp-storage/esp32s3"]
 
 # "md-5" is hidden behind `std` feature and `cargo machete` incorrectly marks it as unused.
 [package.metadata.cargo-machete]

--- a/esp-bootloader-esp-idf/Cargo.toml
+++ b/esp-bootloader-esp-idf/Cargo.toml
@@ -46,7 +46,7 @@ md-5 = { version = "0.10.6", default-features = false, optional = true }
 # Not used by library code. Optional so CI `check-configs` can pass `esp-hal/unstable`
 # (Cargo only forwards dependency features from direct deps; dev-dependencies are not used by `cargo check`).
 [target.'cfg(any(target_arch = "riscv32", target_arch = "xtensa"))'.dependencies]
-esp-hal = { version = "~1.1.0", path = "../esp-hal", default-features = false, optional = true }
+esp-hal = { version = "~1.1.0", path = "../esp-hal", default-features = false, optional = true, features = ["requires-unstable"] }
 
 [build-dependencies]
 jiff       = { version = "0.2.13", default-features = false, features = ["std"] }

--- a/esp-bootloader-esp-idf/README.md
+++ b/esp-bootloader-esp-idf/README.md
@@ -8,6 +8,11 @@
 
 This offers additional support for the ESP-IDF 2nd stage bootloader.
 
+## `esp-hal/unstable` requirement
+
+Chip features pull in `esp-storage`, which depends on unstable `esp-hal` APIs.
+Application crates must enable `esp-hal/unstable` when using this crate on a device.
+
 ## Minimum Supported Rust Version (MSRV)
 
 This crate is guaranteed to compile when using the latest stable Rust version at the time of the crate's release. It _might_ compile with older versions, but that may change in any new release, including patches.

--- a/esp-bootloader-esp-idf/src/lib.rs
+++ b/esp-bootloader-esp-idf/src/lib.rs
@@ -9,6 +9,11 @@
 //! - read the partition table
 //! - conveniently use a partition to read and write flash contents
 //!
+//! ## `esp-hal/unstable` requirement
+//!
+//! Chip features enable `esp-storage`, which depends on unstable `esp-hal` APIs.
+//! Application crates must enable `esp-hal/unstable` when using this crate on a device.
+//!
 //! ## Examples
 //!
 //! ### Populating the Application Descriptor

--- a/esp-storage/Cargo.toml
+++ b/esp-storage/Cargo.toml
@@ -11,6 +11,7 @@ repository    = "https://github.com/esp-rs/esp-hal"
 license       = "MIT OR Apache-2.0"
 
 [package.metadata.espressif]
+doc-config = { features = ["esp-hal/unstable", "embedded-storage"] }
 check-configs = [
     { features = ["esp-hal/unstable"] },
     { features = ["esp-hal/unstable", "embedded-storage"] },
@@ -31,7 +32,7 @@ bench = false
 [dependencies]
 embedded-storage = { version = "0.3.1", optional = true }
 procmacros       = { version = "0.22.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
-esp-hal = { version = "~1.1.0", path = "../esp-hal", default-features = false, optional = true}
+esp-hal = { version = "~1.1.0", path = "../esp-hal", default-features = false, optional = true, features = ["requires-unstable"] }
 
 # Optional dependencies
 esp-sync         = { version = "0.2.1", path = "../esp-sync", optional = true }
@@ -74,25 +75,25 @@ defmt = ["dep:defmt"]
 #! One of the following features must be enabled to select the target chip:
 
 ##
-esp32c2   = ["esp-hal/esp32c2", "esp-hal/requires-unstable", "esp-rom-sys/esp32c2", "esp-sync/esp32c2", "dep:esp32c2"]
+esp32c2   = ["esp-hal/esp32c2", "esp-rom-sys/esp32c2", "esp-sync/esp32c2", "dep:esp32c2"]
 ##
-esp32c3   = ["esp-hal/esp32c3", "esp-hal/requires-unstable", "esp-rom-sys/esp32c3", "esp-sync/esp32c3", "dep:esp32c3"]
+esp32c3   = ["esp-hal/esp32c3", "esp-rom-sys/esp32c3", "esp-sync/esp32c3", "dep:esp32c3"]
 ##
-esp32c5   = ["esp-hal/esp32c5", "esp-hal/requires-unstable", "esp-rom-sys/esp32c5", "esp-sync/esp32c5", "dep:esp32c5"]
+esp32c5   = ["esp-hal/esp32c5", "esp-rom-sys/esp32c5", "esp-sync/esp32c5", "dep:esp32c5"]
 ##
-esp32c6   = ["esp-hal/esp32c6", "esp-hal/requires-unstable", "esp-rom-sys/esp32c6", "esp-sync/esp32c6", "dep:esp32c6"]
+esp32c6   = ["esp-hal/esp32c6", "esp-rom-sys/esp32c6", "esp-sync/esp32c6", "dep:esp32c6"]
 ##
-esp32c61  = ["esp-hal/esp32c61", "esp-hal/requires-unstable", "esp-rom-sys/esp32c61", "esp-sync/esp32c61", "dep:esp32c61"]
+esp32c61  = ["esp-hal/esp32c61", "esp-rom-sys/esp32c61", "esp-sync/esp32c61", "dep:esp32c61"]
 ##
-esp32h2   = ["esp-hal/esp32h2", "esp-hal/requires-unstable", "esp-rom-sys/esp32h2", "esp-sync/esp32h2", "dep:esp32h2"]
+esp32h2   = ["esp-hal/esp32h2", "esp-rom-sys/esp32h2", "esp-sync/esp32h2", "dep:esp32h2"]
 ##
-esp32p4   = ["esp-hal/esp32p4", "esp-hal/requires-unstable", "esp-rom-sys/esp32p4", "esp-sync/esp32p4", "dep:esp32p4"]
+esp32p4   = ["esp-hal/esp32p4", "esp-rom-sys/esp32p4", "esp-sync/esp32p4", "dep:esp32p4"]
 ##
-esp32     = ["esp-hal/esp32", "esp-hal/requires-unstable", "esp-rom-sys/esp32", "esp-sync/esp32", "dep:esp32"]
+esp32     = ["esp-hal/esp32", "esp-rom-sys/esp32", "esp-sync/esp32", "dep:esp32"]
 ##
-esp32s2   = ["esp-hal/esp32s2", "esp-hal/requires-unstable", "esp-rom-sys/esp32s2", "esp-sync/esp32s2", "dep:esp32s2"]
+esp32s2   = ["esp-hal/esp32s2", "esp-rom-sys/esp32s2", "esp-sync/esp32s2", "dep:esp32s2"]
 ##
-esp32s3   = ["esp-hal/esp32s3", "esp-hal/requires-unstable", "esp-rom-sys/esp32s3", "esp-sync/esp32s3", "dep:esp32s3"]
+esp32s3   = ["esp-hal/esp32s3", "esp-rom-sys/esp32s3", "esp-sync/esp32s3", "dep:esp32s3"]
 ## Used for testing on a host.
 emulation = []
 

--- a/esp-storage/Cargo.toml
+++ b/esp-storage/Cargo.toml
@@ -12,18 +12,18 @@ license       = "MIT OR Apache-2.0"
 
 [package.metadata.espressif]
 check-configs = [
-    { features = [] },
-    { features = ["embedded-storage"] },
-    { features = ["critical-section"] },
-    { features = ["bytewise-read"] },
-    { features = ["embedded-storage", "critical-section"] },
-    { features = ["embedded-storage", "critical-section", "bytewise-read"] },
+    { features = ["esp-hal/unstable"] },
+    { features = ["esp-hal/unstable", "embedded-storage"] },
+    { features = ["esp-hal/unstable", "critical-section"] },
+    { features = ["esp-hal/unstable", "bytewise-read"] },
+    { features = ["esp-hal/unstable", "embedded-storage", "critical-section"] },
+    { features = ["esp-hal/unstable", "embedded-storage", "critical-section", "bytewise-read"] },
 ]
-clippy-configs = [{ features = ["embedded-storage", "critical-section", "bytewise-read"] }]
+clippy-configs = [{ features = ["esp-hal/unstable", "embedded-storage", "critical-section", "bytewise-read"] }]
 
 [package.metadata.docs.rs]
 default-target = "riscv32imac-unknown-none-elf"
-features       = ["esp32c6", "embedded-storage"]
+features       = ["esp32c6", "embedded-storage", "esp-hal/unstable"]
 
 [lib]
 bench = false
@@ -74,25 +74,25 @@ defmt = ["dep:defmt"]
 #! One of the following features must be enabled to select the target chip:
 
 ##
-esp32c2   = ["esp-hal/esp32c2", "esp-hal/unstable", "esp-rom-sys/esp32c2", "esp-sync/esp32c2", "dep:esp32c2"]
+esp32c2   = ["esp-hal/esp32c2", "esp-hal/requires-unstable", "esp-rom-sys/esp32c2", "esp-sync/esp32c2", "dep:esp32c2"]
 ##
-esp32c3   = ["esp-hal/esp32c3", "esp-hal/unstable", "esp-rom-sys/esp32c3", "esp-sync/esp32c3", "dep:esp32c3"]
+esp32c3   = ["esp-hal/esp32c3", "esp-hal/requires-unstable", "esp-rom-sys/esp32c3", "esp-sync/esp32c3", "dep:esp32c3"]
 ##
-esp32c5   = ["esp-hal/esp32c5", "esp-hal/unstable", "esp-rom-sys/esp32c5", "esp-sync/esp32c5", "dep:esp32c5"]
+esp32c5   = ["esp-hal/esp32c5", "esp-hal/requires-unstable", "esp-rom-sys/esp32c5", "esp-sync/esp32c5", "dep:esp32c5"]
 ##
-esp32c6   = ["esp-hal/esp32c6", "esp-hal/unstable", "esp-rom-sys/esp32c6", "esp-sync/esp32c6", "dep:esp32c6"]
+esp32c6   = ["esp-hal/esp32c6", "esp-hal/requires-unstable", "esp-rom-sys/esp32c6", "esp-sync/esp32c6", "dep:esp32c6"]
 ##
-esp32c61  = ["esp-hal/esp32c61", "esp-hal/unstable", "esp-rom-sys/esp32c61", "esp-sync/esp32c61", "dep:esp32c61"]
+esp32c61  = ["esp-hal/esp32c61", "esp-hal/requires-unstable", "esp-rom-sys/esp32c61", "esp-sync/esp32c61", "dep:esp32c61"]
 ##
-esp32h2   = ["esp-hal/esp32h2", "esp-hal/unstable", "esp-rom-sys/esp32h2", "esp-sync/esp32h2", "dep:esp32h2"]
+esp32h2   = ["esp-hal/esp32h2", "esp-hal/requires-unstable", "esp-rom-sys/esp32h2", "esp-sync/esp32h2", "dep:esp32h2"]
 ##
-esp32p4   = ["esp-hal/esp32p4", "esp-hal/unstable", "esp-rom-sys/esp32p4", "esp-sync/esp32p4", "dep:esp32p4"]
+esp32p4   = ["esp-hal/esp32p4", "esp-hal/requires-unstable", "esp-rom-sys/esp32p4", "esp-sync/esp32p4", "dep:esp32p4"]
 ##
-esp32     = ["esp-hal/esp32", "esp-hal/unstable", "esp-rom-sys/esp32", "esp-sync/esp32", "dep:esp32"]
+esp32     = ["esp-hal/esp32", "esp-hal/requires-unstable", "esp-rom-sys/esp32", "esp-sync/esp32", "dep:esp32"]
 ##
-esp32s2   = ["esp-hal/esp32s2", "esp-hal/unstable", "esp-rom-sys/esp32s2", "esp-sync/esp32s2", "dep:esp32s2"]
+esp32s2   = ["esp-hal/esp32s2", "esp-hal/requires-unstable", "esp-rom-sys/esp32s2", "esp-sync/esp32s2", "dep:esp32s2"]
 ##
-esp32s3   = ["esp-hal/esp32s3", "esp-hal/unstable", "esp-rom-sys/esp32s3", "esp-sync/esp32s3", "dep:esp32s3"]
+esp32s3   = ["esp-hal/esp32s3", "esp-hal/requires-unstable", "esp-rom-sys/esp32s3", "esp-sync/esp32s3", "dep:esp32s3"]
 ## Used for testing on a host.
 emulation = []
 

--- a/esp-storage/README.md
+++ b/esp-storage/README.md
@@ -9,6 +9,13 @@
 This crate provides functionality to access ESP32 flash. Enable the
 `embedded-storage` feature for [`embedded-storage`](https://github.com/rust-embedded-community/embedded-storage) trait implementations.
 
+## `esp-hal/unstable` requirement
+
+`esp-storage` depends on unstable `esp-hal` APIs (for example the `FLASH` peripheral
+and flash encryption helpers). The crate enables `esp-hal/requires-unstable` via its
+chip features; **application crates must enable `esp-hal/unstable`** when building
+for a device.
+
 ## Minimum Supported Rust Version (MSRV)
 
 This crate is guaranteed to compile when using the latest stable Rust version at the time of the crate's release. It _might_ compile with older versions, but that may change in any new release, including patches.

--- a/esp-storage/src/lib.rs
+++ b/esp-storage/src/lib.rs
@@ -4,6 +4,12 @@
 //! For higher-level functionality which works with partitions defined in the partition table, see
 //! `esp-bootloader-esp-idf`.
 //!
+//! ## `esp-hal/unstable` requirement
+//!
+//! This crate uses unstable `esp-hal` APIs and enables `esp-hal/requires-unstable` via its chip
+//! features. Application crates must enable `esp-hal/unstable` when using `esp-storage` on a
+//! device.
+//!
 //! Encrypted flash read/write is available on chips with hardware flash encryption support when
 //! flash encryption is enabled in eFuses. See [`FlashStorage::read_encrypted`] and
 //! [`FlashStorage::write_encrypted`].


### PR DESCRIPTION
This technically fixes #5875 - at least we are not violating our own guidelines anymore

For stabilization we will need a way to not rely on anything unstable  - but that's a problem to solve for the stabilization story
