### PR TITLE
H2 LP_IO tweak

### DIFF
--- a/esp-hal/src/gpio/lp_io/low_level/esp32h2.rs
+++ b/esp-hal/src/gpio/lp_io/low_level/esp32h2.rs
@@ -1,5 +1,5 @@
 use crate::{
-    gpio::{RtcPin, RtcPinWithResistors},
+    gpio::{RtcFunction, RtcPin, RtcPinWithResistors},
     peripherals::{GPIO, IO_MUX, LP_AON},
 };
 
@@ -24,10 +24,27 @@ for_each_lp_function! {
                         })
                     });
             }
+
+            fn rtc_set_config(&self, input_enable: bool, _mux: bool, _func: RtcFunction) {
+                IO_MUX::regs().gpio(lp_pin_to_gpio($pin) as usize)
+                    .modify(|_, w| unsafe {
+                        w.slp_sel().bit(false);
+                        w.mcu_sel().bits(1);
+                        w.fun_ie().bit(input_enable)
+                    });
+            }
         }
 
         #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
-        impl RtcPinWithResistors for crate::peripherals::$gpio<'_> {}
+        impl RtcPinWithResistors for crate::peripherals::$gpio<'_> {
+            fn rtcio_pullup(&self, enable: bool) {
+                pullup_enable($pin, enable);
+            }
+
+            fn rtcio_pulldown(&self, enable: bool) {
+                pulldown_enable($pin, enable);
+            }
+        }
     };
 }
 

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -360,7 +360,7 @@ impl TryFrom<usize> for AlternateFunction {
 #[instability::unstable]
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-#[cfg(not(any(esp32h2, esp32c5, esp32c61)))]
+#[cfg(not(any(esp32c5, esp32c61)))]
 pub enum RtcFunction {
     /// RTC mode.
     Rtc     = 0,
@@ -380,7 +380,7 @@ pub trait RtcPin: Pin {
     fn rtc_number(&self) -> u8;
 
     /// Configure the pin
-    #[cfg(any(xtensa, esp32c6, esp32p4))]
+    #[cfg(any(xtensa, esp32c6, esp32h2, esp32p4))]
     #[doc(hidden)]
     fn rtc_set_config(&self, input_enable: bool, mux: bool, func: RtcFunction);
 
@@ -403,11 +403,9 @@ pub trait RtcPin: Pin {
 #[cfg(not(any(esp32c5, esp32c61)))]
 pub trait RtcPinWithResistors: RtcPin {
     /// Enable/disable the internal pull-up resistor
-    #[cfg(not(esp32h2))]
     #[doc(hidden)]
     fn rtcio_pullup(&self, enable: bool);
     /// Enable/disable the internal pull-down resistor
-    #[cfg(not(esp32h2))]
     #[doc(hidden)]
     fn rtcio_pulldown(&self, enable: bool);
 }
@@ -2203,7 +2201,7 @@ macro_rules! for_each_rtcio_pin {
     };
 }
 
-#[cfg(not(any(esp32h2, esp32c5, esp32c61)))]
+#[cfg(not(any(esp32c5, esp32c61)))]
 macro_rules! for_each_rtcio_output_pin {
     (@impl $ident:ident, $target:ident, $gpio:ident, $code:tt, $kind:literal) => {
         if $ident.number() == $crate::peripherals::$gpio::NUMBER {
@@ -2244,7 +2242,7 @@ impl RtcPin for AnyPin<'_> {
         }
     }
 
-    #[cfg(any(xtensa, esp32c6, esp32p4))]
+    #[cfg(any(xtensa, esp32c6, esp32h2, esp32p4))]
     fn rtc_set_config(&self, input_enable: bool, mux: bool, func: RtcFunction) {
         for_each_rtcio_pin! {
             (self, target) => { RtcPin::rtc_set_config(&target, input_enable, mux, func) };
@@ -2267,14 +2265,12 @@ impl RtcPin for AnyPin<'_> {
 
 #[cfg(not(any(esp32c5, esp32c61)))]
 impl RtcPinWithResistors for AnyPin<'_> {
-    #[cfg(not(esp32h2))]
     fn rtcio_pullup(&self, enable: bool) {
         for_each_rtcio_output_pin! {
             (self, target) => { RtcPinWithResistors::rtcio_pullup(&target, enable) };
         }
     }
 
-    #[cfg(not(esp32h2))]
     fn rtcio_pulldown(&self, enable: bool) {
         for_each_rtcio_output_pin! {
             (self, target) => { RtcPinWithResistors::rtcio_pulldown(&target, enable) };

--- a/esp-hal/src/rtc_cntl/sleep/esp32c6.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c6.rs
@@ -41,14 +41,11 @@ impl Ext1WakeupSource<'_, '_> {
         }
 
         let wakeup_pins = Ext1WakeupSource::wakeup_pins();
-        uninit_pin(unsafe { crate::peripherals::GPIO0::steal() }, wakeup_pins);
-        uninit_pin(unsafe { crate::peripherals::GPIO1::steal() }, wakeup_pins);
-        uninit_pin(unsafe { crate::peripherals::GPIO2::steal() }, wakeup_pins);
-        uninit_pin(unsafe { crate::peripherals::GPIO3::steal() }, wakeup_pins);
-        uninit_pin(unsafe { crate::peripherals::GPIO4::steal() }, wakeup_pins);
-        uninit_pin(unsafe { crate::peripherals::GPIO5::steal() }, wakeup_pins);
-        uninit_pin(unsafe { crate::peripherals::GPIO6::steal() }, wakeup_pins);
-        uninit_pin(unsafe { crate::peripherals::GPIO7::steal() }, wakeup_pins);
+        for_each_lp_function! {
+            (($_rtc:ident, LP_GPIOn, $n:literal), $gpio:ident) => {
+                uninit_pin(unsafe { $crate::peripherals::$gpio::steal() }, wakeup_pins);
+            };
+        }
     }
 }
 

--- a/esp-hal/src/rtc_cntl/sleep/esp32h2.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32h2.rs
@@ -1,7 +1,7 @@
 use core::ops::Not;
 
 use crate::{
-    gpio::{AnyPin, Input, InputConfig, Pull, RtcPin},
+    gpio::RtcFunction,
     peripherals::{LP_AON, PMU},
     private::DropGuard,
     rtc_cntl::{
@@ -31,6 +31,8 @@ impl Ext1WakeupSource<'_, '_> {
 
     /// Resets the pins that had been configured as wakeup trigger to their default state.
     fn wake_io_reset() {
+        use crate::gpio::RtcPin;
+
         fn uninit_pin(pin: impl RtcPin, wakeup_pins: u8) {
             if wakeup_pins & (1 << pin.rtc_number()) != 0 {
                 pin.rtcio_pad_hold(false);
@@ -67,14 +69,8 @@ impl WakeSource for Ext1WakeupSource<'_, '_> {
                 WakeupLevel::Low => 0,
             };
 
+            pin.rtc_set_config(true, false, RtcFunction::Rtc);
             pin.rtcio_pad_hold(true);
-            Input::new(
-                unsafe { AnyPin::steal(pin.number()) },
-                InputConfig::default().with_pull(match level {
-                    WakeupLevel::High => Pull::Down,
-                    WakeupLevel::Low => Pull::Up,
-                }),
-            );
         }
 
         // clear previous wakeup status
@@ -98,7 +94,7 @@ impl Drop for Ext1WakeupSource<'_, '_> {
         let mut pins = self.pins.borrow_mut();
         for (pin, _level) in pins.iter_mut() {
             pin.rtcio_pad_hold(false);
-            unsafe { AnyPin::steal(pin.number()) }.init_gpio();
+            pin.rtc_set_config(true, false, RtcFunction::Rtc);
         }
     }
 }


### PR DESCRIPTION
# Changelog

## esp-hal/LP GPIO

- Added: ESP32-H2 implementation of `RtcPinWithResistors` now has pullup/pulldown resistor control methods