### PR TITLE
Generate `at_least_version` macro

### DIFF
--- a/esp-hal/build.rs
+++ b/esp-hal/build.rs
@@ -1,4 +1,3 @@
-use std::error::Error;
 #[cfg(feature = "rt")]
 use std::{
     collections::HashMap,
@@ -7,6 +6,7 @@ use std::{
     io::Write,
     path::{Path, PathBuf},
 };
+use std::{error::Error, fmt::Write as _};
 
 #[cfg(feature = "rt")]
 use esp_config::Value;
@@ -31,6 +31,8 @@ fn main() {
 }
 
 fn try_main() -> Result<(), Box<dyn Error>> {
+    generate_version_macro()?;
+
     // if using '"rust-analyzer.cargo.buildScripts.useRustcWrapper": true' we can detect this
     let suppress_panics = std::env::var("RUSTC_WRAPPER")
         .unwrap_or_default()
@@ -135,6 +137,71 @@ fn try_main() -> Result<(), Box<dyn Error>> {
 
 // ----------------------------------------------------------------------------
 // Helper Functions
+fn generate_version_macro() -> Result<(), Box<dyn Error>> {
+    let major = std::env::var("CARGO_PKG_VERSION_MAJOR")?.parse::<u64>()?;
+    let minor = std::env::var("CARGO_PKG_VERSION_MINOR")?.parse::<u64>()?;
+    let patch = std::env::var("CARGO_PKG_VERSION_PATCH")?.parse::<u64>()?;
+    let mut source = String::from(
+        r#"
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __esp_hal_at_least_version {
+"#,
+    );
+
+    // Any minor version of an earlier major version satisfies the requirement.
+    for accepted_major in 0..major {
+        writeln!(
+            source,
+            r#"    (({accepted_major}, $_minor:literal, $_patch:literal) => {{ $($selected:tt)* }} $($rest:tt)*) => {{
+        $($selected)*
+    }};"#
+        )?;
+    }
+
+    // Any patch version of an earlier minor version of the current major satisfies it.
+    for accepted_minor in 0..minor {
+        writeln!(
+            source,
+            r#"    (({major}, {accepted_minor}, $_patch:literal) => {{ $($selected:tt)* }} $($rest:tt)*) => {{
+        $($selected)*
+    }};"#
+        )?;
+    }
+
+    // For the current major and minor version, only this and earlier patches satisfy it.
+    for accepted_patch in 0..=patch {
+        writeln!(
+            source,
+            r#"    (({major}, {minor}, {accepted_patch}) => {{ $($selected:tt)* }} $($rest:tt)*) => {{
+        $($selected)*
+    }};"#
+        )?;
+    }
+
+    source.push_str(
+        r#"    (($major:literal, $minor:literal, $patch:literal) => { $($skipped:tt)* } $($rest:tt)*) => {
+        $crate::__esp_hal_at_least_version! { $($rest)* }
+    };
+    (, $($rest:tt)*) => {
+        $crate::__esp_hal_at_least_version! { $($rest)* }
+    };
+    (_ => { $($fallback:tt)* } $(,)?) => {
+        $($fallback)*
+    };
+}
+"#,
+    );
+
+    let out_dir = std::env::var_os("OUT_DIR").ok_or("OUT_DIR is not set")?;
+    std::fs::write(
+        std::path::PathBuf::from(out_dir).join("version_macro.rs"),
+        source,
+    )?;
+
+    Ok(())
+}
+
 #[cfg(feature = "rt")]
 fn copy_dir_all(
     chip: Chip,

--- a/esp-hal/src/macros.rs
+++ b/esp-hal/src/macros.rs
@@ -287,6 +287,40 @@ macro_rules! if_set {
     };
 }
 
+#[cfg(feature = "unstable")]
+include!(concat!(env!("OUT_DIR"), "/version_macro.rs"));
+
+#[doc_replace]
+/// Selects code based on the `esp-hal` version.
+///
+/// Branches are considered from top to bottom. The first branch whose version
+/// is less than or equal to the current `esp-hal` version is
+/// expanded. The fallback branch is expanded if no version branch matches.
+///
+/// Version branches should be listed in descending order.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// # {before_snippet}
+/// use esp_hal::at_least_version;
+///
+/// let description = at_least_version! {
+///     (2, 0, 0) => { "esp-hal 2.0.0 or newer" }
+///     (1, 1, 0) => { "esp-hal 1.1.0 or newer" }
+///     _ => { "an older esp-hal version" }
+/// };
+/// # {after_snippet}
+/// ```
+#[macro_export]
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
+macro_rules! at_least_version {
+    ($($branch:tt)*) => {
+        $crate::__esp_hal_at_least_version! { $($branch)* }
+    };
+}
+
 /// Macro to ignore tokens.
 ///
 /// This is useful when we need existence of a metavariable (to expand a
@@ -579,6 +613,8 @@ macro_rules! impl_dma_channel_trait {
     };
 }
 pub(crate) use impl_dma_channel_trait;
+#[cfg(feature = "unstable")]
+use procmacros::doc_replace;
 
 /// Macro to allow using unstable HAL features conditionally. Other crates can
 /// use this to "detect" the esp-hal/unstable feature.


### PR DESCRIPTION
This PR introduces a macro, which allows conditional code generation depending on esp-hal version. This macro is intended to be used in libraries that require unstable features, so that those libraries can depend on an older esp-hal, while simultaneously support future versions of unstable APIs, should they change between minor releases.

For example, esp-foo would require at least esp-hal 1.2 for the stable APIs it uses, but this macro would allow esp-foo to keep supporting 1.2 even if 1.3 changes an unstable API used by esp-foo. The library will not need to raise the minimum supported esp-hal version, it can add conditional code based on version to adapt to the unstable API.

# Changelog

## esp-hal

- Added: `at_least_version` macro that allows conditional compilation based on esp-hal version.