### PR TITLE
S31: Enable embassy-hello-world

### DIFF
--- a/examples/async/embassy_hello_world/Cargo.toml
+++ b/examples/async/embassy_hello_world/Cargo.toml
@@ -77,6 +77,12 @@ esp32s3 = [
     "esp-rtos/esp32s3",
     "esp-hal/esp32s3",
 ]
+esp32s31 = [
+    "esp-backtrace/esp32s31",
+    "esp-bootloader-esp-idf/esp32s31",
+    "esp-rtos/esp32s31",
+    "esp-hal/esp32s31",
+]
 
 [profile.release]
 debug            = true


### PR DESCRIPTION
The multicore example is updated but inactive - I've tried enabling the GPIO driver, but there are some bits renamed so I gave up.

async seems to just work, although I'm not 100% about the timing