### PR TITLE
mcpwm: return FrequencyError instead of panicking on too-high timer frequency

### DIFF
--- a/esp-hal/src/mcpwm/timer.rs
+++ b/esp-hal/src/mcpwm/timer.rs
@@ -168,7 +168,9 @@ impl TimerClockConfig {
         if target_timer_frequency == 0 || target_freq > clock.frequency {
             return Err(FrequencyError);
         }
-        let prescaler = clock.frequency.as_hz() / target_timer_frequency - 1;
+        let prescaler = (clock.frequency.as_hz() / target_timer_frequency)
+            .checked_sub(1)
+            .ok_or(FrequencyError)?;
         if prescaler > u8::MAX as u32 {
             return Err(FrequencyError);
         }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` or `manual-changelog` label as appropriate.
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

Fixes #5632.

`TimerClockConfig::timer_clock_with_frequency` already returns a `Result`, but for some frequency/period combinations it panics with `attempt to subtract with overflow` instead of returning `FrequencyError`.

The guard checks `target_freq > clock.frequency`, but the prescaler is derived from `target_timer_frequency = target_freq * cycle_period`. When `cycle_period > 1`, that product can exceed the clock frequency even though `target_freq` alone does not, so `clock.frequency.as_hz() / target_timer_frequency` is `0` and the following `- 1` underflows.

Using the reproducer from the issue (40 MHz clock, period 20000, `Increase` mode, 50 kHz target): `cycle_period = 20001`, `target_timer_frequency = 1_000_050_000`, `40_000_000 / 1_000_050_000 = 0`, and `0 - 1` panics.

This replaces the unchecked subtraction with `checked_sub(1).ok_or(FrequencyError)?`, so an out-of-range request returns `Err` like the signature promises. Valid inputs are unchanged.

#### Testing

Extracted the arithmetic into a standalone program built with `-C overflow-checks=on`: the original expression panics on the issue's exact inputs, while the `checked_sub` version returns `FrequencyError` for that case and still yields the correct prescaler for valid inputs. The crate itself is `no_std` and only builds for the target chips (host `test = false`), so I couldn't add an in-crate unit test.

# Changelog

## esp-hal

- Fixed: `mcpwm` `timer_clock_with_frequency` returns `FrequencyError` instead of panicking when the requested frequency is too high for the timer clock.
