### PR TITLE
Disable PMP for ESP32-S31

### DIFF
--- a/esp-hal/esp_config.yml
+++ b/esp-hal/esp_config.yml
@@ -220,6 +220,9 @@ options:
   - name: enable-pmp
     description: "Protects additional memory regions via Physical Memory Protection (PMP). (Only RISC-V other than ESP32-C2/C3)"
     default:
+      # TODO - investigate why it's not working correctly
+      - value: false
+        if: "esp32s31"
       - value: true
     active: "riscv && !esp32c2 && !esp32c3"
 


### PR DESCRIPTION
Seems that PMP was causing trouble on ESP32-S31 (e.g. for embassy_multicore, the USB enabling PR)

It's not clear why but the fact that there are TODOs in ESP-IDF (and lack of documentation) suggests we shouldn't enable it for now

(We probably want to double check P4,C5,C61 since at least ESP-IDF is using different alignment requirements - but since things seem to work for now I am not disabling them)

