### PR TITLE
CI: Pin nightly version

### DIFF
--- a/.github/actions/setup-nightly/action.yml
+++ b/.github/actions/setup-nightly/action.yml
@@ -1,0 +1,45 @@
+name: Setup nightly
+description: Install the repo-wide pinned Rust nightly toolchain, with an optional `nightly` alias.
+
+inputs:
+  targets:
+    description: Comma-separated list of target triples to install.
+    required: false
+    default: ""
+  components:
+    description: Comma-separated list of toolchain components to install.
+    required: false
+    default: rust-src
+  alias:
+    description: When "true", symlink the pinned toolchain to the reserved `nightly` name so `cargo +nightly` resolves to the pin.
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    # Single source of truth for the nightly version used across all workflows.
+    # Pin: nightly-2026-07-20 regressed docsrs cfg_attr+proc-macro (doc_replace) on
+    # file modules, introduced by rust-lang/rust#158046. Set to `nightly` to unpin
+    # when a fixed nightly ships.
+    - id: version
+      shell: bash
+      run: echo "nightly=nightly-2026-07-19" >> "$GITHUB_OUTPUT"
+
+    - uses: dtolnay/rust-toolchain@v1
+      with:
+        toolchain: ${{ steps.version.outputs.nightly }}
+        targets: ${{ inputs.targets }}
+        components: ${{ inputs.components }}
+
+    # xtask docs/doc-tests call `cargo +nightly`; make that name resolve to the pin.
+    # `rustup toolchain link` rejects the reserved name `nightly`, so symlink directly.
+    - name: Alias pinned nightly as nightly
+      if: inputs.alias == 'true'
+      shell: bash
+      run: |
+        ver='${{ steps.version.outputs.nightly }}'
+        [ "$ver" = nightly ] && exit 0
+        host=$(rustc +"$ver" -vV | sed -n 's/^host: //p')
+        toolchains="$(rustup show home)/toolchains"
+        ln -sfn "$toolchains/$ver-$host" "$toolchains/nightly-$host"

--- a/.github/workflows/ci-nightly.yml
+++ b/.github/workflows/ci-nightly.yml
@@ -41,11 +41,11 @@ jobs:
       - uses: actions/checkout@v6
 
       # Install the Rust nightly toolchain for RISC-V devices:
-      - uses: dtolnay/rust-toolchain@v1
+      - uses: ./.github/actions/setup-nightly
         with:
-          target: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf,riscv32imafc-unknown-none-elf
-          toolchain: nightly
+          targets: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf,riscv32imafc-unknown-none-elf
           components: rust-src, clippy, rustfmt
+          alias: "true"
 
       - name: Build and Check
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,11 +202,11 @@ jobs:
           toolchain: stable
           components: rust-src
       # Install the Rust nightly toolchain for RISC-V devices:
-      - uses: dtolnay/rust-toolchain@v1
+      - uses: ./.github/actions/setup-nightly
         with:
-          target: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf,riscv32imafc-unknown-none-elf
-          toolchain: nightly
+          targets: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf,riscv32imafc-unknown-none-elf
           components: rust-src
+          alias: "true"
 
       - name: Build Xtensa docs
         if: matrix.group == 'xtensa'
@@ -350,10 +350,10 @@ jobs:
       - uses: actions/checkout@v6
       # Some of the configuration items in 'rustfmt.toml' require the 'nightly'
       # release channel, MIRI is only available in nightly
-      - uses: dtolnay/rust-toolchain@v1
+      - uses: ./.github/actions/setup-nightly
         with:
-          toolchain: nightly
           components: rustfmt,miri
+          alias: "true"
 
       # Run xtask tests
       - name: Run xtask tests
@@ -490,11 +490,11 @@ jobs:
           default: true
           version: 1.97.0.0
 
-      - uses: dtolnay/rust-toolchain@v1
+      - uses: ./.github/actions/setup-nightly
         with:
-          target: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf,riscv32imafc-unknown-none-elf
-          toolchain: nightly
+          targets: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf,riscv32imafc-unknown-none-elf
           components: rust-src
+          alias: "true"
 
       - name: Build hil-test tests
         run: |

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -180,13 +180,14 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'release:docs')) }}
     steps:
-      - uses: dtolnay/rust-toolchain@v1
-        with:
-          toolchain: nightly
-          targets: riscv32imac-unknown-none-elf
       - uses: actions/checkout@v6
         with:
           repository: esp-rs/esp-hal
+      - uses: ./.github/actions/setup-nightly
+        with:
+          targets: riscv32imac-unknown-none-elf
+          components: ""
+          alias: "true"
 
       - name: Install cargo-docs-rs
         run: cargo install cargo-docs-rs --locked

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -150,12 +150,12 @@ jobs:
           default: true
           version: 1.97.0.0
 
-      - uses: dtolnay/rust-toolchain@v1
+      - uses: ./.github/actions/setup-nightly
         if: steps.arch.outputs.riscv == 'true'
         with:
-          target: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf,riscv32imafc-unknown-none-elf
-          toolchain: nightly
+          targets: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf,riscv32imafc-unknown-none-elf
           components: rust-src
+          alias: "true"
 
       # Build hil-test ELFs for each requested chip (unless the dispatch
       # asked for radio-only via package=hil-test-radio).

--- a/.github/workflows/pre-rel-check.yml
+++ b/.github/workflows/pre-rel-check.yml
@@ -35,11 +35,11 @@ jobs:
           components: rust-src
 
       # Install the Rust nightly toolchain for RISC-V devices:
-      - uses: dtolnay/rust-toolchain@v1
+      - uses: ./.github/actions/setup-nightly
         with:
-          target: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf,riscv32imafc-unknown-none-elf
-          toolchain: nightly
+          targets: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf,riscv32imafc-unknown-none-elf
           components: rust-src
+          alias: "true"
 
       - name: Setup cargo-batch
         run: |


### PR DESCRIPTION
Let's use the "old working" version until https://github.com/rust-lang/rust/issues/159648
Green nightly run: https://github.com/esp-rs/esp-hal/actions/runs/29822145921

closes https://github.com/esp-rs/esp-hal/issues/5945