### PR TITLE
ESP32-S31: Enable OTA and esp-storage examples

### DIFF
--- a/examples/ota/update/Cargo.toml
+++ b/examples/ota/update/Cargo.toml
@@ -75,6 +75,12 @@ esp32s3 = [
     "esp-hal/esp32s3",
     "esp-storage/esp32s3",
 ]
+esp32s31 = [
+    "esp-backtrace/esp32s31",
+    "esp-bootloader-esp-idf/esp32s31",
+    "esp-hal/esp32s31",
+    "esp-storage/esp32s31",
+]
 
 [profile.release]
 debug            = true

--- a/examples/ota/update/src/main.rs
+++ b/examples/ota/update/src/main.rs
@@ -97,6 +97,7 @@ fn main() -> ! {
         any(feature = "esp32", feature = "esp32s2", feature = "esp32s3") => peripherals.GPIO0,
         feature = "esp32c5" => peripherals.GPIO28,
         feature = "esp32p4" => peripherals.GPIO35,
+        feature = "esp32s31" => peripherals.GPIO61,
         _ => peripherals.GPIO9,
     };
 

--- a/examples/peripheral/flash_read_write/Cargo.toml
+++ b/examples/peripheral/flash_read_write/Cargo.toml
@@ -75,6 +75,12 @@ esp32s3 = [
     "esp-hal/esp32s3",
     "esp-storage/esp32s3",
 ]
+esp32s31 = [
+    "esp-backtrace/esp32s31",
+    "esp-bootloader-esp-idf/esp32s31",
+    "esp-hal/esp32s31",
+    "esp-storage/esp32s31",
+]
 
 [profile.release]
 debug            = true


### PR DESCRIPTION
The functionality was already enabled via the initial PR and the examples work fine
