### PR TITLE
Clock tree: Add missing common operators to expressions

### DIFF
--- a/esp-metadata/src/cfg/soc/clock_tree/expr_compiler.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/expr_compiler.rs
@@ -94,7 +94,13 @@ impl<'ctx> ExprCompiler<'ctx> {
             "/" => quote! { / },
             "%" => quote! { % },
             "&&" => quote! { && },
+            "||" => quote! { || },
             "==" => quote! { == },
+            "!=" => quote! { != },
+            "<" => quote! { < },
+            ">" => quote! { > },
+            "<=" => quote! { <= },
+            ">=" => quote! { >= },
             other => todo!("Unsupported binary operator: {other}"),
         };
 


### PR DESCRIPTION
Claude identified this as a gap that we may or may not bump against in the future.