### PR TITLE
Define IROM and DROM memory ranges for all the chips (pre-espflash fix)

### DIFF
--- a/esp-metadata-generated/src/_build_script_utils.rs
+++ b/esp-metadata-generated/src/_build_script_utils.rs
@@ -6044,7 +6044,7 @@ impl Chip {
                         (
                             "drom",
                             MemoryRegion {
-                                address_range: 0x3F000000..0x3FF80000,
+                                address_range: 0x3F000000..0x3F400000,
                             },
                         ),
                     ],

--- a/esp-metadata-generated/src/_build_script_utils.rs
+++ b/esp-metadata-generated/src/_build_script_utils.rs
@@ -3310,13 +3310,13 @@ impl Chip {
                         (
                             "irom",
                             MemoryRegion {
-                                address_range: 0x42000000..0x42800000,
+                                address_range: 0x42000000..0x43000000,
                             },
                         ),
                         (
                             "drom",
                             MemoryRegion {
-                                address_range: 0x42800000..0x43000000,
+                                address_range: 0x42000000..0x43000000,
                             },
                         ),
                     ],
@@ -4636,13 +4636,13 @@ impl Chip {
                         (
                             "irom",
                             MemoryRegion {
-                                address_range: 0x42000000..0x42800000,
+                                address_range: 0x42000000..0x43000000,
                             },
                         ),
                         (
                             "drom",
                             MemoryRegion {
-                                address_range: 0x42800000..0x43000000,
+                                address_range: 0x42000000..0x43000000,
                             },
                         ),
                     ],
@@ -6038,13 +6038,13 @@ impl Chip {
                         (
                             "irom",
                             MemoryRegion {
-                                address_range: 0x40080000..0x40400000,
+                                address_range: 0x40080000..0x40800000,
                             },
                         ),
                         (
                             "drom",
                             MemoryRegion {
-                                address_range: 0x3F000000..0x3F400000,
+                                address_range: 0x3F000000..0x3FF80000,
                             },
                         ),
                     ],
@@ -7280,13 +7280,13 @@ impl Chip {
                         (
                             "irom",
                             MemoryRegion {
-                                address_range: 0x40000000..0x44000000,
+                                address_range: 0x40000000..0x50000000,
                             },
                         ),
                         (
                             "drom",
                             MemoryRegion {
-                                address_range: 0x40000000..0x44000000,
+                                address_range: 0x40000000..0x50000000,
                             },
                         ),
                     ],

--- a/esp-metadata-generated/src/_build_script_utils.rs
+++ b/esp-metadata-generated/src/_build_script_utils.rs
@@ -426,6 +426,8 @@ impl Chip {
                     "soc_has_clock_node_spi_function_clock",
                     "has_dram_region",
                     "has_dram2_uninit_region",
+                    "has_irom_region",
+                    "has_drom_region",
                     "spi_master_version=\"1\"",
                     "spi_master_fifo_size=\"64\"",
                     "spi_master_bit_order_is_bool",
@@ -661,6 +663,8 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_clock_node_spi_function_clock",
                     "cargo:rustc-cfg=has_dram_region",
                     "cargo:rustc-cfg=has_dram2_uninit_region",
+                    "cargo:rustc-cfg=has_irom_region",
+                    "cargo:rustc-cfg=has_drom_region",
                     "cargo:rustc-cfg=spi_master_version=\"1\"",
                     "cargo:rustc-cfg=spi_master_fifo_size=\"64\"",
                     "cargo:rustc-cfg=spi_master_bit_order_is_bool",
@@ -683,6 +687,18 @@ impl Chip {
                             "dram2_uninit",
                             MemoryRegion {
                                 address_range: 0x3FFE7E30..0x40000000,
+                            },
+                        ),
+                        (
+                            "irom",
+                            MemoryRegion {
+                                address_range: 0x400D0000..0x40400000,
+                            },
+                        ),
+                        (
+                            "drom",
+                            MemoryRegion {
+                                address_range: 0x3F400000..0x3F800000,
                             },
                         ),
                     ],
@@ -1002,6 +1018,8 @@ impl Chip {
                     "soc_has_clock_node_spi_function_clock",
                     "has_dram_region",
                     "has_dram2_uninit_region",
+                    "has_irom_region",
+                    "has_drom_region",
                     "spi_master_version=\"3\"",
                     "spi_master_fifo_size=\"64\"",
                     "spi_master_has_app_interrupts",
@@ -1183,6 +1201,8 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_clock_node_spi_function_clock",
                     "cargo:rustc-cfg=has_dram_region",
                     "cargo:rustc-cfg=has_dram2_uninit_region",
+                    "cargo:rustc-cfg=has_irom_region",
+                    "cargo:rustc-cfg=has_drom_region",
                     "cargo:rustc-cfg=spi_master_version=\"3\"",
                     "cargo:rustc-cfg=spi_master_fifo_size=\"64\"",
                     "cargo:rustc-cfg=spi_master_has_app_interrupts",
@@ -1207,6 +1227,18 @@ impl Chip {
                             "dram2_uninit",
                             MemoryRegion {
                                 address_range: 0x3FCCE800..0x3FCDEB70,
+                            },
+                        ),
+                        (
+                            "irom",
+                            MemoryRegion {
+                                address_range: 0x42000000..0x42400000,
+                            },
+                        ),
+                        (
+                            "drom",
+                            MemoryRegion {
+                                address_range: 0x3C000000..0x3C400000,
                             },
                         ),
                     ],
@@ -1531,6 +1563,8 @@ impl Chip {
                     "soc_has_clock_node_spi_function_clock",
                     "has_dram_region",
                     "has_dram2_uninit_region",
+                    "has_irom_region",
+                    "has_drom_region",
                     "spi_master_version=\"3\"",
                     "spi_master_fifo_size=\"64\"",
                     "spi_master_bit_order_is_bool",
@@ -1775,6 +1809,8 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_clock_node_spi_function_clock",
                     "cargo:rustc-cfg=has_dram_region",
                     "cargo:rustc-cfg=has_dram2_uninit_region",
+                    "cargo:rustc-cfg=has_irom_region",
+                    "cargo:rustc-cfg=has_drom_region",
                     "cargo:rustc-cfg=spi_master_version=\"3\"",
                     "cargo:rustc-cfg=spi_master_fifo_size=\"64\"",
                     "cargo:rustc-cfg=spi_master_bit_order_is_bool",
@@ -1801,6 +1837,18 @@ impl Chip {
                             "dram2_uninit",
                             MemoryRegion {
                                 address_range: 0x3FCCE400..0x3FCDE710,
+                            },
+                        ),
+                        (
+                            "irom",
+                            MemoryRegion {
+                                address_range: 0x42000000..0x42800000,
+                            },
+                        ),
+                        (
+                            "drom",
+                            MemoryRegion {
+                                address_range: 0x3C000000..0x3C800000,
                             },
                         ),
                     ],
@@ -2171,6 +2219,8 @@ impl Chip {
                     "soc_has_clock_node_spi_function_clock",
                     "has_dram_region",
                     "has_dram2_uninit_region",
+                    "has_irom_region",
+                    "has_drom_region",
                     "spi_master_version=\"3\"",
                     "spi_master_fifo_size=\"64\"",
                     "spi_master_has_app_interrupts",
@@ -2461,6 +2511,8 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_clock_node_spi_function_clock",
                     "cargo:rustc-cfg=has_dram_region",
                     "cargo:rustc-cfg=has_dram2_uninit_region",
+                    "cargo:rustc-cfg=has_irom_region",
+                    "cargo:rustc-cfg=has_drom_region",
                     "cargo:rustc-cfg=spi_master_version=\"3\"",
                     "cargo:rustc-cfg=spi_master_fifo_size=\"64\"",
                     "cargo:rustc-cfg=spi_master_has_app_interrupts",
@@ -2491,6 +2543,18 @@ impl Chip {
                             "dram2_uninit",
                             MemoryRegion {
                                 address_range: 0x4084E5A0..0x4085E5A0,
+                            },
+                        ),
+                        (
+                            "irom",
+                            MemoryRegion {
+                                address_range: 0x42000000..0x44000000,
+                            },
+                        ),
+                        (
+                            "drom",
+                            MemoryRegion {
+                                address_range: 0x42000000..0x44000000,
                             },
                         ),
                     ],
@@ -2906,6 +2970,8 @@ impl Chip {
                     "soc_has_clock_node_spi_function_clock",
                     "has_dram_region",
                     "has_dram2_uninit_region",
+                    "has_irom_region",
+                    "has_drom_region",
                     "spi_master_version=\"3\"",
                     "spi_master_fifo_size=\"64\"",
                     "spi_master_has_app_interrupts",
@@ -3210,6 +3276,8 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_clock_node_spi_function_clock",
                     "cargo:rustc-cfg=has_dram_region",
                     "cargo:rustc-cfg=has_dram2_uninit_region",
+                    "cargo:rustc-cfg=has_irom_region",
+                    "cargo:rustc-cfg=has_drom_region",
                     "cargo:rustc-cfg=spi_master_version=\"3\"",
                     "cargo:rustc-cfg=spi_master_fifo_size=\"64\"",
                     "cargo:rustc-cfg=spi_master_has_app_interrupts",
@@ -3237,6 +3305,18 @@ impl Chip {
                             "dram2_uninit",
                             MemoryRegion {
                                 address_range: 0x4086E610..0x4087E610,
+                            },
+                        ),
+                        (
+                            "irom",
+                            MemoryRegion {
+                                address_range: 0x42000000..0x42800000,
+                            },
+                        ),
+                        (
+                            "drom",
+                            MemoryRegion {
+                                address_range: 0x42800000..0x43000000,
                             },
                         ),
                     ],
@@ -3582,6 +3662,8 @@ impl Chip {
                     "soc_has_clock_node_spi_function_clock",
                     "has_dram_region",
                     "has_dram2_uninit_region",
+                    "has_irom_region",
+                    "has_drom_region",
                     "spi_master_version=\"3\"",
                     "spi_master_fifo_size=\"64\"",
                     "spi_master_has_app_interrupts",
@@ -3810,6 +3892,8 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_clock_node_spi_function_clock",
                     "cargo:rustc-cfg=has_dram_region",
                     "cargo:rustc-cfg=has_dram2_uninit_region",
+                    "cargo:rustc-cfg=has_irom_region",
+                    "cargo:rustc-cfg=has_drom_region",
                     "cargo:rustc-cfg=spi_master_version=\"3\"",
                     "cargo:rustc-cfg=spi_master_fifo_size=\"64\"",
                     "cargo:rustc-cfg=spi_master_has_app_interrupts",
@@ -3839,6 +3923,18 @@ impl Chip {
                             "dram2_uninit",
                             MemoryRegion {
                                 address_range: 0x4083EA70..0x4084EA70,
+                            },
+                        ),
+                        (
+                            "irom",
+                            MemoryRegion {
+                                address_range: 0x42000000..0x44000000,
+                            },
+                        ),
+                        (
+                            "drom",
+                            MemoryRegion {
+                                address_range: 0x42000000..0x44000000,
                             },
                         ),
                     ],
@@ -4231,6 +4327,8 @@ impl Chip {
                     "soc_has_clock_node_spi_function_clock",
                     "has_dram_region",
                     "has_dram2_uninit_region",
+                    "has_irom_region",
+                    "has_drom_region",
                     "spi_master_version=\"3\"",
                     "spi_master_fifo_size=\"64\"",
                     "spi_master_has_app_interrupts",
@@ -4506,6 +4604,8 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_clock_node_spi_function_clock",
                     "cargo:rustc-cfg=has_dram_region",
                     "cargo:rustc-cfg=has_dram2_uninit_region",
+                    "cargo:rustc-cfg=has_irom_region",
+                    "cargo:rustc-cfg=has_drom_region",
                     "cargo:rustc-cfg=spi_master_version=\"3\"",
                     "cargo:rustc-cfg=spi_master_fifo_size=\"64\"",
                     "cargo:rustc-cfg=spi_master_has_app_interrupts",
@@ -4531,6 +4631,18 @@ impl Chip {
                             "dram2_uninit",
                             MemoryRegion {
                                 address_range: 0x4083EFD0..0x4084FEE0,
+                            },
+                        ),
+                        (
+                            "irom",
+                            MemoryRegion {
+                                address_range: 0x42000000..0x42800000,
+                            },
+                        ),
+                        (
+                            "drom",
+                            MemoryRegion {
+                                address_range: 0x42800000..0x43000000,
                             },
                         ),
                     ],
@@ -4880,6 +4992,8 @@ impl Chip {
                     "soc_has_clock_node_mipi_dsi_phy_cfg_clk",
                     "has_dram_region",
                     "has_dram2_uninit_region",
+                    "has_irom_region",
+                    "has_drom_region",
                     "spi_master_version=\"3\"",
                     "spi_master_fifo_size=\"64\"",
                     "timergroup_timg_has_timer1",
@@ -5145,6 +5259,8 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_clock_node_mipi_dsi_phy_cfg_clk",
                     "cargo:rustc-cfg=has_dram_region",
                     "cargo:rustc-cfg=has_dram2_uninit_region",
+                    "cargo:rustc-cfg=has_irom_region",
+                    "cargo:rustc-cfg=has_drom_region",
                     "cargo:rustc-cfg=spi_master_version=\"3\"",
                     "cargo:rustc-cfg=spi_master_fifo_size=\"64\"",
                     "cargo:rustc-cfg=timergroup_timg_has_timer1",
@@ -5167,6 +5283,18 @@ impl Chip {
                             "dram2_uninit",
                             MemoryRegion {
                                 address_range: 0x4FF00000..0x4FF40000,
+                            },
+                        ),
+                        (
+                            "irom",
+                            MemoryRegion {
+                                address_range: 0x40000000..0x44000000,
+                            },
+                        ),
+                        (
+                            "drom",
+                            MemoryRegion {
+                                address_range: 0x40000000..0x44000000,
                             },
                         ),
                     ],
@@ -5630,6 +5758,8 @@ impl Chip {
                     "soc_has_clock_node_spi_function_clock",
                     "has_dram_region",
                     "has_dram2_uninit_region",
+                    "has_irom_region",
+                    "has_drom_region",
                     "spi_master_version=\"2\"",
                     "spi_master_fifo_size=\"72\"",
                     "spi_master_bit_order_is_bool",
@@ -5876,6 +6006,8 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_clock_node_spi_function_clock",
                     "cargo:rustc-cfg=has_dram_region",
                     "cargo:rustc-cfg=has_dram2_uninit_region",
+                    "cargo:rustc-cfg=has_irom_region",
+                    "cargo:rustc-cfg=has_drom_region",
                     "cargo:rustc-cfg=spi_master_version=\"2\"",
                     "cargo:rustc-cfg=spi_master_fifo_size=\"72\"",
                     "cargo:rustc-cfg=spi_master_bit_order_is_bool",
@@ -5901,6 +6033,18 @@ impl Chip {
                             "dram2_uninit",
                             MemoryRegion {
                                 address_range: 0x3FFDE000..0x40000000,
+                            },
+                        ),
+                        (
+                            "irom",
+                            MemoryRegion {
+                                address_range: 0x40080000..0x40400000,
+                            },
+                        ),
+                        (
+                            "drom",
+                            MemoryRegion {
+                                address_range: 0x3F000000..0x3F400000,
                             },
                         ),
                     ],
@@ -6361,6 +6505,8 @@ impl Chip {
                     "soc_has_clock_node_spi_function_clock",
                     "has_dram_region",
                     "has_dram2_uninit_region",
+                    "has_irom_region",
+                    "has_drom_region",
                     "spi_master_version=\"3\"",
                     "spi_master_fifo_size=\"64\"",
                     "spi_master_has_octal",
@@ -6654,6 +6800,8 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_clock_node_spi_function_clock",
                     "cargo:rustc-cfg=has_dram_region",
                     "cargo:rustc-cfg=has_dram2_uninit_region",
+                    "cargo:rustc-cfg=has_irom_region",
+                    "cargo:rustc-cfg=has_drom_region",
                     "cargo:rustc-cfg=spi_master_version=\"3\"",
                     "cargo:rustc-cfg=spi_master_fifo_size=\"64\"",
                     "cargo:rustc-cfg=spi_master_has_octal",
@@ -6681,6 +6829,18 @@ impl Chip {
                             "dram2_uninit",
                             MemoryRegion {
                                 address_range: 0x3FCDB700..0x3FCED710,
+                            },
+                        ),
+                        (
+                            "irom",
+                            MemoryRegion {
+                                address_range: 0x42000000..0x44000000,
+                            },
+                        ),
+                        (
+                            "drom",
+                            MemoryRegion {
+                                address_range: 0x3C000000..0x3E000000,
                             },
                         ),
                     ],
@@ -6980,6 +7140,8 @@ impl Chip {
                     "soc_has_clock_node_i2c_function_clock",
                     "has_dram_region",
                     "has_dram2_uninit_region",
+                    "has_irom_region",
+                    "has_drom_region",
                     "timergroup_timg_has_divcnt_rst",
                     "timergroup_rc_fast_calibration_divider",
                     "timergroup_rc_fast_calibration_is_set",
@@ -7094,6 +7256,8 @@ impl Chip {
                     "cargo:rustc-cfg=soc_has_clock_node_i2c_function_clock",
                     "cargo:rustc-cfg=has_dram_region",
                     "cargo:rustc-cfg=has_dram2_uninit_region",
+                    "cargo:rustc-cfg=has_irom_region",
+                    "cargo:rustc-cfg=has_drom_region",
                     "cargo:rustc-cfg=timergroup_timg_has_divcnt_rst",
                     "cargo:rustc-cfg=timergroup_rc_fast_calibration_divider",
                     "cargo:rustc-cfg=timergroup_rc_fast_calibration_is_set",
@@ -7111,6 +7275,18 @@ impl Chip {
                             "dram2_uninit",
                             MemoryRegion {
                                 address_range: 0x2F07AFC0..0x2F07CFB0,
+                            },
+                        ),
+                        (
+                            "irom",
+                            MemoryRegion {
+                                address_range: 0x40000000..0x44000000,
+                            },
+                        ),
+                        (
+                            "drom",
+                            MemoryRegion {
+                                address_range: 0x40000000..0x44000000,
                             },
                         ),
                     ],
@@ -7560,6 +7736,8 @@ impl Chip {
             "soc_has_clock_node_spi_function_clock",
             "has_dram_region",
             "has_dram2_uninit_region",
+            "has_irom_region",
+            "has_drom_region",
             "spi_master_bit_order_is_bool",
             "timergroup_timg_has_timer1",
             "timergroup_rc_fast_calibration_is_set",

--- a/esp-metadata-generated/src/_generated_esp32.rs
+++ b/esp-metadata-generated/src/_generated_esp32.rs
@@ -3968,6 +3968,18 @@ macro_rules! memory_range {
     (size as str, "DRAM2_UNINIT") => {
         "98768"
     };
+    ("IROM") => {
+        0x400D0000..0x40400000
+    };
+    (size as str, "IROM") => {
+        "3342336"
+    };
+    ("DROM") => {
+        0x3F400000..0x3F800000
+    };
+    (size as str, "DROM") => {
+        "4194304"
+    };
 }
 /// This macro can be used to generate code for each peripheral instance of the I2C master driver.
 ///

--- a/esp-metadata-generated/src/_generated_esp32c2.rs
+++ b/esp-metadata-generated/src/_generated_esp32c2.rs
@@ -3488,6 +3488,18 @@ macro_rules! memory_range {
     (size as str, "DRAM2_UNINIT") => {
         "66416"
     };
+    ("IROM") => {
+        0x42000000..0x42400000
+    };
+    (size as str, "IROM") => {
+        "4194304"
+    };
+    ("DROM") => {
+        0x3C000000..0x3C400000
+    };
+    (size as str, "DROM") => {
+        "4194304"
+    };
 }
 /// This macro can be used to generate code for each peripheral instance of the I2C master driver.
 ///

--- a/esp-metadata-generated/src/_generated_esp32c3.rs
+++ b/esp-metadata-generated/src/_generated_esp32c3.rs
@@ -3989,6 +3989,18 @@ macro_rules! memory_range {
     (size as str, "DRAM2_UNINIT") => {
         "66320"
     };
+    ("IROM") => {
+        0x42000000..0x42800000
+    };
+    (size as str, "IROM") => {
+        "8388608"
+    };
+    ("DROM") => {
+        0x3C000000..0x3C800000
+    };
+    (size as str, "DROM") => {
+        "8388608"
+    };
 }
 /// This macro can be used to generate code for each peripheral instance of the I2C master driver.
 ///

--- a/esp-metadata-generated/src/_generated_esp32c5.rs
+++ b/esp-metadata-generated/src/_generated_esp32c5.rs
@@ -4133,6 +4133,18 @@ macro_rules! memory_range {
     (size as str, "DRAM2_UNINIT") => {
         "65536"
     };
+    ("IROM") => {
+        0x42000000..0x44000000
+    };
+    (size as str, "IROM") => {
+        "33554432"
+    };
+    ("DROM") => {
+        0x42000000..0x44000000
+    };
+    (size as str, "DROM") => {
+        "33554432"
+    };
 }
 /// This macro can be used to generate code for each peripheral instance of the I2C master driver.
 ///

--- a/esp-metadata-generated/src/_generated_esp32c6.rs
+++ b/esp-metadata-generated/src/_generated_esp32c6.rs
@@ -5015,16 +5015,16 @@ macro_rules! memory_range {
         "65536"
     };
     ("IROM") => {
-        0x42000000..0x42800000
+        0x42000000..0x43000000
     };
     (size as str, "IROM") => {
-        "8388608"
+        "16777216"
     };
     ("DROM") => {
-        0x42800000..0x43000000
+        0x42000000..0x43000000
     };
     (size as str, "DROM") => {
-        "8388608"
+        "16777216"
     };
 }
 /// This macro can be used to generate code for each peripheral instance of the I2C master driver.

--- a/esp-metadata-generated/src/_generated_esp32c6.rs
+++ b/esp-metadata-generated/src/_generated_esp32c6.rs
@@ -5014,6 +5014,18 @@ macro_rules! memory_range {
     (size as str, "DRAM2_UNINIT") => {
         "65536"
     };
+    ("IROM") => {
+        0x42000000..0x42800000
+    };
+    (size as str, "IROM") => {
+        "8388608"
+    };
+    ("DROM") => {
+        0x42800000..0x43000000
+    };
+    (size as str, "DROM") => {
+        "8388608"
+    };
 }
 /// This macro can be used to generate code for each peripheral instance of the I2C master driver.
 ///

--- a/esp-metadata-generated/src/_generated_esp32c61.rs
+++ b/esp-metadata-generated/src/_generated_esp32c61.rs
@@ -3076,6 +3076,18 @@ macro_rules! memory_range {
     (size as str, "DRAM2_UNINIT") => {
         "65536"
     };
+    ("IROM") => {
+        0x42000000..0x44000000
+    };
+    (size as str, "IROM") => {
+        "33554432"
+    };
+    ("DROM") => {
+        0x42000000..0x44000000
+    };
+    (size as str, "DROM") => {
+        "33554432"
+    };
 }
 /// This macro can be used to generate code for each peripheral instance of the I2C master driver.
 ///

--- a/esp-metadata-generated/src/_generated_esp32h2.rs
+++ b/esp-metadata-generated/src/_generated_esp32h2.rs
@@ -3991,16 +3991,16 @@ macro_rules! memory_range {
         "69392"
     };
     ("IROM") => {
-        0x42000000..0x42800000
+        0x42000000..0x43000000
     };
     (size as str, "IROM") => {
-        "8388608"
+        "16777216"
     };
     ("DROM") => {
-        0x42800000..0x43000000
+        0x42000000..0x43000000
     };
     (size as str, "DROM") => {
-        "8388608"
+        "16777216"
     };
 }
 /// This macro can be used to generate code for each peripheral instance of the I2C master driver.

--- a/esp-metadata-generated/src/_generated_esp32h2.rs
+++ b/esp-metadata-generated/src/_generated_esp32h2.rs
@@ -3990,6 +3990,18 @@ macro_rules! memory_range {
     (size as str, "DRAM2_UNINIT") => {
         "69392"
     };
+    ("IROM") => {
+        0x42000000..0x42800000
+    };
+    (size as str, "IROM") => {
+        "8388608"
+    };
+    ("DROM") => {
+        0x42800000..0x43000000
+    };
+    (size as str, "DROM") => {
+        "8388608"
+    };
 }
 /// This macro can be used to generate code for each peripheral instance of the I2C master driver.
 ///

--- a/esp-metadata-generated/src/_generated_esp32p4.rs
+++ b/esp-metadata-generated/src/_generated_esp32p4.rs
@@ -4708,6 +4708,18 @@ macro_rules! memory_range {
     (size as str, "DRAM2_UNINIT") => {
         "262144"
     };
+    ("IROM") => {
+        0x40000000..0x44000000
+    };
+    (size as str, "IROM") => {
+        "67108864"
+    };
+    ("DROM") => {
+        0x40000000..0x44000000
+    };
+    (size as str, "DROM") => {
+        "67108864"
+    };
 }
 /// This macro can be used to generate code for each peripheral instance of the I2C master driver.
 ///

--- a/esp-metadata-generated/src/_generated_esp32s2.rs
+++ b/esp-metadata-generated/src/_generated_esp32s2.rs
@@ -4079,16 +4079,16 @@ macro_rules! memory_range {
         "139264"
     };
     ("IROM") => {
-        0x40080000..0x40400000
+        0x40080000..0x40800000
     };
     (size as str, "IROM") => {
-        "3670016"
+        "7864320"
     };
     ("DROM") => {
-        0x3F000000..0x3F400000
+        0x3F000000..0x3FF80000
     };
     (size as str, "DROM") => {
-        "4194304"
+        "16252928"
     };
 }
 /// This macro can be used to generate code for each peripheral instance of the I2C master driver.

--- a/esp-metadata-generated/src/_generated_esp32s2.rs
+++ b/esp-metadata-generated/src/_generated_esp32s2.rs
@@ -4078,6 +4078,18 @@ macro_rules! memory_range {
     (size as str, "DRAM2_UNINIT") => {
         "139264"
     };
+    ("IROM") => {
+        0x40080000..0x40400000
+    };
+    (size as str, "IROM") => {
+        "3670016"
+    };
+    ("DROM") => {
+        0x3F000000..0x3F400000
+    };
+    (size as str, "DROM") => {
+        "4194304"
+    };
 }
 /// This macro can be used to generate code for each peripheral instance of the I2C master driver.
 ///

--- a/esp-metadata-generated/src/_generated_esp32s2.rs
+++ b/esp-metadata-generated/src/_generated_esp32s2.rs
@@ -4085,10 +4085,10 @@ macro_rules! memory_range {
         "7864320"
     };
     ("DROM") => {
-        0x3F000000..0x3FF80000
+        0x3F000000..0x3F400000
     };
     (size as str, "DROM") => {
-        "16252928"
+        "4194304"
     };
 }
 /// This macro can be used to generate code for each peripheral instance of the I2C master driver.

--- a/esp-metadata-generated/src/_generated_esp32s3.rs
+++ b/esp-metadata-generated/src/_generated_esp32s3.rs
@@ -4340,6 +4340,18 @@ macro_rules! memory_range {
     (size as str, "DRAM2_UNINIT") => {
         "73744"
     };
+    ("IROM") => {
+        0x42000000..0x44000000
+    };
+    (size as str, "IROM") => {
+        "33554432"
+    };
+    ("DROM") => {
+        0x3C000000..0x3E000000
+    };
+    (size as str, "DROM") => {
+        "33554432"
+    };
 }
 /// This macro can be used to generate code for each peripheral instance of the I2C master driver.
 ///

--- a/esp-metadata-generated/src/_generated_esp32s31.rs
+++ b/esp-metadata-generated/src/_generated_esp32s31.rs
@@ -2683,6 +2683,18 @@ macro_rules! memory_range {
     (size as str, "DRAM2_UNINIT") => {
         "8176"
     };
+    ("IROM") => {
+        0x40000000..0x44000000
+    };
+    (size as str, "IROM") => {
+        "67108864"
+    };
+    ("DROM") => {
+        0x40000000..0x44000000
+    };
+    (size as str, "DROM") => {
+        "67108864"
+    };
 }
 /// This macro can be used to generate code for each peripheral instance of the UART driver.
 ///

--- a/esp-metadata-generated/src/_generated_esp32s31.rs
+++ b/esp-metadata-generated/src/_generated_esp32s31.rs
@@ -2684,16 +2684,16 @@ macro_rules! memory_range {
         "8176"
     };
     ("IROM") => {
-        0x40000000..0x44000000
+        0x40000000..0x50000000
     };
     (size as str, "IROM") => {
-        "67108864"
+        "268435456"
     };
     ("DROM") => {
-        0x40000000..0x44000000
+        0x40000000..0x50000000
     };
     (size as str, "DROM") => {
-        "67108864"
+        "268435456"
     };
 }
 /// This macro can be used to generate code for each peripheral instance of the UART driver.

--- a/esp-metadata/devices/esp32/soc.toml
+++ b/esp-metadata/devices/esp32/soc.toml
@@ -24,6 +24,8 @@ multi_core_enabled = true
 memory_map = { ranges = [
     { name = "dram", start = 0x3FFA_E000, end = 0x4000_0000 },
     { name = "dram2_uninit", start = 0x3FFE_7E30, end = 0x4000_0000 },
+    { name = "irom", start = 0x400D_0000, end = 0x4040_0000 },
+    { name = "drom", start = 0x3F40_0000, end = 0x3F80_0000 },
 ] }
 
 peripherals = [

--- a/esp-metadata/devices/esp32c2/soc.toml
+++ b/esp-metadata/devices/esp32c2/soc.toml
@@ -26,6 +26,8 @@ has_swd_watchdog = true
 memory_map = { ranges = [
     { name = "dram", start = 0x3FCA_0000, end = 0x3FCE_0000 },
     { name = "dram2_uninit", start = 0x3FCC_E800, end = 0x3FCD_EB70 },
+    { name = "irom", start = 0x4200_0000, end = 0x4240_0000 },
+    { name = "drom", start = 0x3C00_0000, end = 0x3C40_0000 },
 ] }
 
 peripherals = [

--- a/esp-metadata/devices/esp32c3/soc.toml
+++ b/esp-metadata/devices/esp32c3/soc.toml
@@ -27,6 +27,8 @@ has_swd_watchdog = true
 memory_map = { ranges = [
     { name = "dram", start = 0x3FC8_0000, end = 0x3FCE_0000 },
     { name = "dram2_uninit", start = 0x3FCCE400, end = 0x3FCD_E710 },
+    { name = "irom", start = 0x4200_0000, end = 0x4280_0000 },
+    { name = "drom", start = 0x3C00_0000, end = 0x3C80_0000 },
 ] }
 
 peripherals = [

--- a/esp-metadata/devices/esp32c5/soc.toml
+++ b/esp-metadata/devices/esp32c5/soc.toml
@@ -30,6 +30,8 @@ memory_map = { ranges = [
     { name = "dram", start = 0x4080_0000, end = 0x4086_0000 },
     # start address from correct bootloader commit: https://github.com/espressif/esp-idf/blob/d66ebb8/components/bootloader/subproject/main/ld/esp32c5/bootloader.ld#L32
     { name = "dram2_uninit", start = 0x4084_E5A0, end = 0x4085_E5A0 },
+    { name = "irom", start = 0x4200_0000, end = 0x4400_0000 },
+    { name = "drom", start = 0x4200_0000, end = 0x4400_0000 },
 ] }
 
 peripherals = [

--- a/esp-metadata/devices/esp32c6/soc.toml
+++ b/esp-metadata/devices/esp32c6/soc.toml
@@ -28,6 +28,8 @@ has_swd_watchdog = true
 memory_map = { ranges = [
     { name = "dram", start = 0x4080_0000, end = 0x4088_0000 },
     { name = "dram2_uninit", start = 0x4086_E610, end = 0x4087_E610 },
+    { name = "irom", start = 0x4200_0000, end = 0x4280_0000 },
+    { name = "drom", start = 0x4280_0000, end = 0x4300_0000 },
 ] }
 
 peripherals = [

--- a/esp-metadata/devices/esp32c6/soc.toml
+++ b/esp-metadata/devices/esp32c6/soc.toml
@@ -28,8 +28,8 @@ has_swd_watchdog = true
 memory_map = { ranges = [
     { name = "dram", start = 0x4080_0000, end = 0x4088_0000 },
     { name = "dram2_uninit", start = 0x4086_E610, end = 0x4087_E610 },
-    { name = "irom", start = 0x4200_0000, end = 0x4280_0000 },
-    { name = "drom", start = 0x4280_0000, end = 0x4300_0000 },
+    { name = "irom", start = 0x4200_0000, end = 0x4300_0000 },
+    { name = "drom", start = 0x4200_0000, end = 0x4300_0000 },
 ] }
 
 peripherals = [

--- a/esp-metadata/devices/esp32c61/soc.toml
+++ b/esp-metadata/devices/esp32c61/soc.toml
@@ -30,6 +30,8 @@ memory_map = { ranges = [
     { name = "dram", start = 0x4080_0000, end = 0x4085_0000 },
     # start address from correct bootloader commit: https://github.com/espressif/esp-idf/blob/d66ebb8/components/bootloader/subproject/main/ld/esp32c61/bootloader.ld#L32
     { name = "dram2_uninit", start = 0x4083_EA70, end = 0x4084_EA70 },
+    { name = "irom", start = 0x4200_0000, end = 0x4400_0000 },
+    { name = "drom", start = 0x4200_0000, end = 0x4400_0000 },
 ] }
 
 peripherals = [

--- a/esp-metadata/devices/esp32h2/soc.toml
+++ b/esp-metadata/devices/esp32h2/soc.toml
@@ -28,6 +28,8 @@ has_swd_watchdog = true
 memory_map = { ranges = [
     { name = "dram", start = 0x4080_0000, end = 0x4085_0000 },
     { name = "dram2_uninit", start = 0x4083_EFD0, end = 0x4084_FEE0 },
+    { name = "irom", start = 0x4200_0000, end = 0x4280_0000 },
+    { name = "drom", start = 0x4280_0000, end = 0x4300_0000 },
 ] }
 
 peripherals = [

--- a/esp-metadata/devices/esp32h2/soc.toml
+++ b/esp-metadata/devices/esp32h2/soc.toml
@@ -28,8 +28,8 @@ has_swd_watchdog = true
 memory_map = { ranges = [
     { name = "dram", start = 0x4080_0000, end = 0x4085_0000 },
     { name = "dram2_uninit", start = 0x4083_EFD0, end = 0x4084_FEE0 },
-    { name = "irom", start = 0x4200_0000, end = 0x4280_0000 },
-    { name = "drom", start = 0x4280_0000, end = 0x4300_0000 },
+    { name = "irom", start = 0x4200_0000, end = 0x4300_0000 },
+    { name = "drom", start = 0x4200_0000, end = 0x4300_0000 },
 ] }
 
 peripherals = [

--- a/esp-metadata/devices/esp32p4/soc.toml
+++ b/esp-metadata/devices/esp32p4/soc.toml
@@ -49,6 +49,8 @@ has_swd_watchdog = true
 memory_map = { ranges = [
     { name = "dram", start = 0x4FF4_0000, end = 0x4FFC_0000 },
     { name = "dram2_uninit", start = 0x4FF0_0000, end = 0x4FF4_0000 },
+    { name = "irom", start = 0x4000_0000, end = 0x4400_0000 },
+    { name = "drom", start = 0x4000_0000, end = 0x4400_0000 },
 ] }
 
 peripherals = [

--- a/esp-metadata/devices/esp32s2/soc.toml
+++ b/esp-metadata/devices/esp32s2/soc.toml
@@ -22,7 +22,7 @@ memory_map = { ranges = [
     { name = "dram", start = 0x3FFB_0000, end = 0x4000_0000 },
     { name = "dram2_uninit", start = 0x3FFD_E000, end = 0x4000_0000 },
     { name = "irom", start = 0x4008_0000, end = 0x4080_0000 },
-    { name = "drom", start = 0x3F00_0000, end = 0x3FF8_0000 },
+    { name = "drom", start = 0x3F00_0000, end = 0x3F40_0000 },
 ] }
 has_swd_watchdog = true
 

--- a/esp-metadata/devices/esp32s2/soc.toml
+++ b/esp-metadata/devices/esp32s2/soc.toml
@@ -21,8 +21,8 @@ has_md5_bsd = true
 memory_map = { ranges = [
     { name = "dram", start = 0x3FFB_0000, end = 0x4000_0000 },
     { name = "dram2_uninit", start = 0x3FFD_E000, end = 0x4000_0000 },
-    { name = "irom", start = 0x4008_0000, end = 0x4040_0000 },
-    { name = "drom", start = 0x3F00_0000, end = 0x3F40_0000 },
+    { name = "irom", start = 0x4008_0000, end = 0x4080_0000 },
+    { name = "drom", start = 0x3F00_0000, end = 0x3FF8_0000 },
 ] }
 has_swd_watchdog = true
 

--- a/esp-metadata/devices/esp32s2/soc.toml
+++ b/esp-metadata/devices/esp32s2/soc.toml
@@ -21,6 +21,8 @@ has_md5_bsd = true
 memory_map = { ranges = [
     { name = "dram", start = 0x3FFB_0000, end = 0x4000_0000 },
     { name = "dram2_uninit", start = 0x3FFD_E000, end = 0x4000_0000 },
+    { name = "irom", start = 0x4008_0000, end = 0x4040_0000 },
+    { name = "drom", start = 0x3F00_0000, end = 0x3F40_0000 },
 ] }
 has_swd_watchdog = true
 

--- a/esp-metadata/devices/esp32s3/soc.toml
+++ b/esp-metadata/devices/esp32s3/soc.toml
@@ -25,6 +25,8 @@ has_swd_watchdog = true
 memory_map = { ranges = [
     { name = "dram", start = 0x3FC8_8000, end = 0x3FD0_0000 },
     { name = "dram2_uninit", start = 0x3FCD_B700, end = 0x3FCE_D710 },
+    { name = "irom", start = 0x4200_0000, end = 0x4400_0000 },
+    { name = "drom", start = 0x3C00_0000, end = 0x3E00_0000 },
 ] }
 
 peripherals = [

--- a/esp-metadata/devices/esp32s31/soc.toml
+++ b/esp-metadata/devices/esp32s31/soc.toml
@@ -33,8 +33,8 @@ has_swd_watchdog = true
 memory_map = { ranges = [
     { name = "dram", start = 0x2F00_0000, end = 0x2F07_AFC0 },
     { name = "dram2_uninit", start = 0x2F07_AFC0, end = 0x2F07_CFB0 },
-    { name = "irom", start = 0x4000_0000, end = 0x4400_0000 },
-    { name = "drom", start = 0x4000_0000, end = 0x4400_0000 },
+    { name = "irom", start = 0x4000_0000, end = 0x5000_0000 },
+    { name = "drom", start = 0x4000_0000, end = 0x5000_0000 },
 ] }
 
 peripherals = [

--- a/esp-metadata/devices/esp32s31/soc.toml
+++ b/esp-metadata/devices/esp32s31/soc.toml
@@ -33,6 +33,8 @@ has_swd_watchdog = true
 memory_map = { ranges = [
     { name = "dram", start = 0x2F00_0000, end = 0x2F07_AFC0 },
     { name = "dram2_uninit", start = 0x2F07_AFC0, end = 0x2F07_CFB0 },
+    { name = "irom", start = 0x4000_0000, end = 0x4400_0000 },
+    { name = "drom", start = 0x4000_0000, end = 0x4400_0000 },
 ] }
 
 peripherals = [


### PR DESCRIPTION
progress towards https://github.com/esp-rs/espflash/issues/1047

Also fixing these ranges, making them aligned with what IDF has in `components/soc/<CHIP>/include/soc/soc.h` files