### PR TITLE
Widen arithmetic where necessary, generate LCD_CAM divider

### DIFF
--- a/esp-hal/src/lcd_cam/cam.rs
+++ b/esp-hal/src/lcd_cam/cam.rs
@@ -67,7 +67,7 @@ use crate::{
     lcd_cam::{BitOrder, ByteOrder, CamDmaRxChannel, ClockError, ErasedRxChannel, calculate_clkm},
     pac,
     peripherals::LCD_CAM,
-    soc::clocks::{ClockTree, LcdCamInstance},
+    soc::clocks::{ClockTree, LcdCamCamClockConfig, LcdCamInstance},
     system::{self, GenericPeripheralGuard},
     time::Rate,
 };
@@ -183,12 +183,14 @@ impl<'d> Camera<'d> {
     /// [`ConfigError::Clock`] will be returned if the frequency passed in
     /// `Config` is too low.
     pub fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError> {
-        let sources = property!("clock_tree.lcd_cam.cam_clock");
+        let sources = property!("clock_tree.lcd_cam.cam_clock.sclk");
         let (i, divider) = calculate_clkm(
-            config.frequency.as_hz() as _,
-            &sources.map(|source| LcdCamInstance::cam_clock_source_frequency(source) as usize),
+            config.frequency.as_hz(),
+            &sources.map(LcdCamInstance::cam_clock_source_frequency),
         )
         .map_err(ConfigError::Clock)?;
+        let clock_config =
+            LcdCamCamClockConfig::new(sources[i], divider.div_num, divider.div_a, divider.div_b);
 
         if let Some(value) = config.line_interrupt
             && value > 0b0111_1111
@@ -199,9 +201,6 @@ impl<'d> Camera<'d> {
         self.regs().cam_ctrl().write(|w| {
             // Force enable the clock for all configuration registers.
             unsafe {
-                w.cam_clkm_div_num().bits(divider.div_num as _);
-                w.cam_clkm_div_b().bits(divider.div_b as _);
-                w.cam_clkm_div_a().bits(divider.div_a as _);
                 if let Some(threshold) = config.vsync_filter_threshold {
                     w.cam_vsync_filter_thres().bits(threshold as _);
                 }
@@ -216,7 +215,7 @@ impl<'d> Camera<'d> {
             }
         });
         ClockTree::with(|clocks| {
-            LcdCamInstance::LcdCam.configure_cam_clock(clocks, sources[i]);
+            LcdCamInstance::LcdCam.configure_cam_clock(clocks, clock_config);
             if !self.cam.clock_requested {
                 LcdCamInstance::LcdCam.request_cam_clock(clocks);
                 self.cam.clock_requested = true;

--- a/esp-hal/src/lcd_cam/lcd/mod.rs
+++ b/esp-hal/src/lcd_cam/lcd/mod.rs
@@ -14,7 +14,7 @@ use crate::{
     Async,
     Blocking,
     DriverMode,
-    clock::ll::{ClockTree, LcdCamInstance},
+    clock::ll::{ClockTree, LcdCamInstance, LcdCamLcdClockConfig},
     lcd_cam::{ClockError, calculate_clkm},
     peripherals::LCD_CAM,
     system,
@@ -63,18 +63,17 @@ impl<'d, Dm: DriverMode> Lcd<'d, Dm> {
     }
 
     fn configure_clocks(&mut self, config: &ClockConfig) -> Result<(), ClockError> {
-        let sources = property!("clock_tree.lcd_cam.lcd_clock");
+        let sources = property!("clock_tree.lcd_cam.lcd_clock.sclk");
         let (i, divider) = calculate_clkm(
-            config.frequency.as_hz() as _,
-            &sources.map(|source| LcdCamInstance::lcd_clock_source_frequency(source) as usize),
+            config.frequency.as_hz(),
+            &sources.map(LcdCamInstance::lcd_clock_source_frequency),
         )?;
+        let clock_config =
+            LcdCamLcdClockConfig::new(sources[i], divider.div_num, divider.div_a, divider.div_b);
 
         self.regs().lcd_clock().write(|w| unsafe {
             // Force enable the clock for all configuration registers.
             w.clk_en().set_bit();
-            w.lcd_clkm_div_num().bits(divider.div_num as _);
-            w.lcd_clkm_div_b().bits(divider.div_b as _);
-            w.lcd_clkm_div_a().bits(divider.div_a as _); // LCD_PCLK = LCD_CLK / 2
             w.lcd_clk_equ_sysclk().clear_bit();
             w.lcd_clkcnt_n().bits(2 - 1); // Must not be 0.
             w.lcd_ck_idle_edge()
@@ -83,7 +82,7 @@ impl<'d, Dm: DriverMode> Lcd<'d, Dm> {
                 .bit(config.clock_mode.phase == Phase::ShiftHigh)
         });
         ClockTree::with(|clocks| {
-            LcdCamInstance::LcdCam.configure_lcd_clock(clocks, sources[i]);
+            LcdCamInstance::LcdCam.configure_lcd_clock(clocks, clock_config);
             if !self.inner.clock_requested {
                 LcdCamInstance::LcdCam.request_lcd_clock(clocks);
                 self.inner.clock_requested = true;

--- a/esp-hal/src/lcd_cam/mod.rs
+++ b/esp-hal/src/lcd_cam/mod.rs
@@ -254,16 +254,19 @@ fn calculate_closest_divider(
     desired_frequency: u32,
 ) -> Option<ClockDivider> {
     let div_num = source_frequency / desired_frequency;
-    if div_num < 2 {
+    // For current chips, LCD and CAM have the same divider range.
+    let (min_divider, max_divider) = property!("clock_tree.lcd_cam.lcd_clock.div_num");
+    let (_, max_denom) = property!("clock_tree.lcd_cam.lcd_clock.div_a");
+    if div_num < min_divider {
         // Source clock isn't fast enough to reach the desired frequency.
         // Return max output.
         return Some(ClockDivider {
-            div_num: 2,
+            div_num: min_divider,
             div_b: 0,
             div_a: 1,
         });
     }
-    if div_num > 256 {
+    if div_num > max_divider {
         // Source is too fast to divide to the desired frequency. Return None.
         return None;
     }
@@ -285,7 +288,7 @@ fn calculate_closest_divider(
         }
     } else {
         let target = div_fraction;
-        let closest = farey_sequence(63).find(|curr| {
+        let closest = farey_sequence(max_denom).find(|curr| {
             // https://en.wikipedia.org/wiki/Fraction#Adding_unlike_quantities
 
             let new_curr_num = curr.numerator * target.denominator;

--- a/esp-hal/src/lcd_cam/mod.rs
+++ b/esp-hal/src/lcd_cam/mod.rs
@@ -196,17 +196,14 @@ impl Instance {
     }
 }
 pub(crate) struct ClockDivider {
-    // Integral LCD clock divider value. (8 bits)
-    // Value 0 is treated as 256
-    // Value 1 is treated as 2
-    // Value N is treated as N
-    pub div_num: usize,
+    /// Integral clock divider value, 2 to 256.
+    pub div_num: u32,
 
-    // Fractional clock divider numerator value. (6 bits)
-    pub div_b: usize,
+    /// Fractional clock divider numerator value, 0 to 63.
+    pub div_b: u32,
 
-    // Fractional clock divider denominator value. (6 bits)
-    pub div_a: usize,
+    /// Fractional clock divider denominator value, 1 to 63.
+    pub div_a: u32,
 }
 
 /// Clock configuration errors.
@@ -218,8 +215,8 @@ pub enum ClockError {
 }
 
 pub(crate) fn calculate_clkm(
-    desired_frequency: usize,
-    source_frequencies: &[usize],
+    desired_frequency: u32,
+    source_frequencies: &[u32],
 ) -> Result<(usize, ClockDivider), ClockError> {
     let mut result_freq = 0;
     let mut result = None;
@@ -238,51 +235,38 @@ pub(crate) fn calculate_clkm(
     result.ok_or(ClockError::FrequencyTooLow)
 }
 
-fn calculate_output_frequency(source_frequency: usize, divider: &ClockDivider) -> usize {
-    let n = match divider.div_num {
-        0 => 256,
-        1 => 2,
-        _ => divider.div_num.min(256),
-    };
+fn calculate_output_frequency(source_frequency: u32, divider: &ClockDivider) -> u32 {
+    // OUTPUT = SOURCE / (N + B/A)
+    // OUTPUT = SOURCE / ((NA + B)/A)
+    // OUTPUT = (SOURCE * A) / (NA + B)
 
-    if divider.div_b != 0 && divider.div_a != 0 {
-        // OUTPUT = SOURCE / (N + B/A)
-        // OUTPUT = SOURCE / ((NA + B)/A)
-        // OUTPUT = (SOURCE * A) / (NA + B)
+    // u64 is required to fit the numbers from this arithmetic.
+    let source = source_frequency as u64;
+    let n = divider.div_num as u64;
+    let a = divider.div_a as u64;
+    let b = divider.div_b as u64;
 
-        // u64 is required to fit the numbers from this arithmetic.
-
-        let source = source_frequency as u64;
-        let n = n as u64;
-        let a = divider.div_b as u64;
-        let b = divider.div_a as u64;
-
-        ((source * a) / (n * a + b)) as _
-    } else {
-        source_frequency / n
-    }
+    ((source * a) / (n * a + b)) as u32
 }
 
 fn calculate_closest_divider(
-    source_frequency: usize,
-    desired_frequency: usize,
+    source_frequency: u32,
+    desired_frequency: u32,
 ) -> Option<ClockDivider> {
     let div_num = source_frequency / desired_frequency;
     if div_num < 2 {
         // Source clock isn't fast enough to reach the desired frequency.
         // Return max output.
         return Some(ClockDivider {
-            div_num: 1,
+            div_num: 2,
             div_b: 0,
-            div_a: 0,
+            div_a: 1,
         });
     }
     if div_num > 256 {
         // Source is too fast to divide to the desired frequency. Return None.
         return None;
     }
-
-    let div_num = if div_num == 256 { 0 } else { div_num };
 
     let div_fraction = {
         let div_remainder = source_frequency % desired_frequency;
@@ -297,7 +281,7 @@ fn calculate_closest_divider(
         ClockDivider {
             div_num,
             div_b: 0,
-            div_a: 0,
+            div_a: 1,
         }
     } else {
         let target = div_fraction;
@@ -321,17 +305,17 @@ fn calculate_closest_divider(
 }
 
 // https://en.wikipedia.org/wiki/Euclidean_algorithm
-const fn hcf(a: usize, b: usize) -> usize {
+const fn hcf(a: u32, b: u32) -> u32 {
     if b != 0 { hcf(b, a % b) } else { a }
 }
 
 struct Fraction {
-    pub numerator: usize,
-    pub denominator: usize,
+    pub numerator: u32,
+    pub denominator: u32,
 }
 
 // https://en.wikipedia.org/wiki/Farey_sequence#Next_term
-fn farey_sequence(denominator: usize) -> impl Iterator<Item = Fraction> {
+fn farey_sequence(denominator: u32) -> impl Iterator<Item = Fraction> {
     let mut a = 0;
     let mut b = 1;
     let mut c = 1;

--- a/esp-hal/src/soc/esp32s3/clocks.rs
+++ b/esp-hal/src/soc/esp32s3/clocks.rs
@@ -786,10 +786,14 @@ impl LcdCamInstance {
         new_config: LcdCamLcdClockConfig,
     ) {
         LCD_CAM::regs().lcd_clock().modify(|_, w| unsafe {
-            w.lcd_clk_sel().bits(match new_config {
-                LcdCamLcdClockConfig::XtalClk => 1,
-                LcdCamLcdClockConfig::PllD2 => 2,
-                LcdCamLcdClockConfig::Pll160m => 3,
+            // The divider is 8 bits wide, the maximum divisor of 256 is encoded as 0.
+            w.lcd_clkm_div_num().bits(new_config.div_num() as u8);
+            w.lcd_clkm_div_a().bits(new_config.div_a() as u8);
+            w.lcd_clkm_div_b().bits(new_config.div_b() as u8);
+            w.lcd_clk_sel().bits(match new_config.sclk() {
+                LcdCamLcdClockSclk::XtalClk => 1,
+                LcdCamLcdClockSclk::PllD2 => 2,
+                LcdCamLcdClockSclk::Pll160m => 3,
             })
         });
     }
@@ -808,10 +812,14 @@ impl LcdCamInstance {
         new_config: LcdCamCamClockConfig,
     ) {
         LCD_CAM::regs().cam_ctrl().modify(|_, w| unsafe {
-            w.cam_clk_sel().bits(match new_config {
-                LcdCamCamClockConfig::XtalClk => 1,
-                LcdCamCamClockConfig::PllD2 => 2,
-                LcdCamCamClockConfig::Pll160m => 3,
+            // The divider is 8 bits wide, the maximum divisor of 256 is encoded as 0.
+            w.cam_clkm_div_num().bits(new_config.div_num() as u8);
+            w.cam_clkm_div_a().bits(new_config.div_a() as u8);
+            w.cam_clkm_div_b().bits(new_config.div_b() as u8);
+            w.cam_clk_sel().bits(match new_config.sclk() {
+                LcdCamCamClockSclk::XtalClk => 1,
+                LcdCamCamClockSclk::PllD2 => 2,
+                LcdCamCamClockSclk::Pll160m => 3,
             })
         });
     }

--- a/esp-metadata-generated/src/_generated_esp32s3.rs
+++ b/esp-metadata-generated/src/_generated_esp32s3.rs
@@ -480,15 +480,33 @@ macro_rules! property {
     ("clock_tree.i2c.function_clock.div_num") => {
         (0, 255)
     };
-    ("clock_tree.lcd_cam.lcd_clock") => {
-        [crate ::soc::clocks::LcdCamLcdClockConfig::XtalClk, crate
-        ::soc::clocks::LcdCamLcdClockConfig::PllD2, crate
-        ::soc::clocks::LcdCamLcdClockConfig::Pll160m]
+    ("clock_tree.lcd_cam.lcd_clock.sclk") => {
+        [crate ::soc::clocks::LcdCamLcdClockSclk::XtalClk, crate
+        ::soc::clocks::LcdCamLcdClockSclk::PllD2, crate
+        ::soc::clocks::LcdCamLcdClockSclk::Pll160m]
     };
-    ("clock_tree.lcd_cam.cam_clock") => {
-        [crate ::soc::clocks::LcdCamCamClockConfig::XtalClk, crate
-        ::soc::clocks::LcdCamCamClockConfig::PllD2, crate
-        ::soc::clocks::LcdCamCamClockConfig::Pll160m]
+    ("clock_tree.lcd_cam.lcd_clock.div_num") => {
+        (2, 256)
+    };
+    ("clock_tree.lcd_cam.lcd_clock.div_a") => {
+        (1, 63)
+    };
+    ("clock_tree.lcd_cam.lcd_clock.div_b") => {
+        (0, 63)
+    };
+    ("clock_tree.lcd_cam.cam_clock.sclk") => {
+        [crate ::soc::clocks::LcdCamCamClockSclk::XtalClk, crate
+        ::soc::clocks::LcdCamCamClockSclk::PllD2, crate
+        ::soc::clocks::LcdCamCamClockSclk::Pll160m]
+    };
+    ("clock_tree.lcd_cam.cam_clock.div_num") => {
+        (2, 256)
+    };
+    ("clock_tree.lcd_cam.cam_clock.div_a") => {
+        (1, 63)
+    };
+    ("clock_tree.lcd_cam.cam_clock.div_b") => {
+        (0, 63)
     };
     ("clock_tree.spi.function_clock") => {
         [crate ::soc::clocks::SpiFunctionClockConfig::Xtal, crate
@@ -1909,10 +1927,9 @@ macro_rules! define_clock_tree_types {
                 self.div_num as u32
             }
         }
-        /// The list of clock signals that the `LCD_CAM_LCD_CLOCK` multiplexer can output.
         #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-        pub enum LcdCamLcdClockConfig {
+        pub enum LcdCamLcdClockSclk {
             #[default]
             /// Selects `XTAL_CLK`.
             XtalClk,
@@ -1921,10 +1938,71 @@ macro_rules! define_clock_tree_types {
             /// Selects `PLL_160M`.
             Pll160m,
         }
-        /// The list of clock signals that the `LCD_CAM_CAM_CLOCK` multiplexer can output.
+        /// Configures the `LCD_CAM_LCD_CLOCK` clock node.
+        ///
+        /// The output is calculated as `OUTPUT = (sclk * div_a) / (div_num * div_a + div_b)`.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+        pub struct LcdCamLcdClockConfig {
+            sclk: LcdCamLcdClockSclk,
+            div_num: u32,
+            div_a: u32,
+            div_b: u32,
+        }
+        impl LcdCamLcdClockConfig {
+            /// Creates a new configuration for the LCD_CLOCK clock node.
+            ///
+            /// ## Panics
+            ///
+            /// Panics if the div_num value is outside the
+            /// valid range (2 ..= 256).
+            ///
+            /// Panics if the div_a value is outside the
+            /// valid range (1 ..= 63).
+            ///
+            /// Panics if the div_b value is outside the
+            /// valid range (0 ..= 63).
+            pub const fn new(
+                sclk: LcdCamLcdClockSclk,
+                div_num: u32,
+                div_a: u32,
+                div_b: u32,
+            ) -> Self {
+                ::core::assert!(
+                    div_num >= 2 && div_num <= 256,
+                    "`LCD_CAM_LCD_CLOCK` div_num must be between 2 and 256 (inclusive)."
+                );
+                ::core::assert!(
+                    div_a >= 1 && div_a <= 63,
+                    "`LCD_CAM_LCD_CLOCK` div_a must be between 1 and 63 (inclusive)."
+                );
+                ::core::assert!(
+                    div_b <= 63,
+                    "`LCD_CAM_LCD_CLOCK` div_b must be between 0 and 63 (inclusive)."
+                );
+                Self {
+                    sclk,
+                    div_num,
+                    div_a,
+                    div_b,
+                }
+            }
+            pub(crate) fn sclk(self) -> LcdCamLcdClockSclk {
+                self.sclk
+            }
+            pub(crate) fn div_num(self) -> u32 {
+                self.div_num as u32
+            }
+            pub(crate) fn div_a(self) -> u32 {
+                self.div_a as u32
+            }
+            pub(crate) fn div_b(self) -> u32 {
+                self.div_b as u32
+            }
+        }
         #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-        pub enum LcdCamCamClockConfig {
+        pub enum LcdCamCamClockSclk {
             #[default]
             /// Selects `XTAL_CLK`.
             XtalClk,
@@ -1932,6 +2010,68 @@ macro_rules! define_clock_tree_types {
             PllD2,
             /// Selects `PLL_160M`.
             Pll160m,
+        }
+        /// Configures the `LCD_CAM_CAM_CLOCK` clock node.
+        ///
+        /// The output is calculated as `OUTPUT = (sclk * div_a) / (div_num * div_a + div_b)`.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+        pub struct LcdCamCamClockConfig {
+            sclk: LcdCamCamClockSclk,
+            div_num: u32,
+            div_a: u32,
+            div_b: u32,
+        }
+        impl LcdCamCamClockConfig {
+            /// Creates a new configuration for the CAM_CLOCK clock node.
+            ///
+            /// ## Panics
+            ///
+            /// Panics if the div_num value is outside the
+            /// valid range (2 ..= 256).
+            ///
+            /// Panics if the div_a value is outside the
+            /// valid range (1 ..= 63).
+            ///
+            /// Panics if the div_b value is outside the
+            /// valid range (0 ..= 63).
+            pub const fn new(
+                sclk: LcdCamCamClockSclk,
+                div_num: u32,
+                div_a: u32,
+                div_b: u32,
+            ) -> Self {
+                ::core::assert!(
+                    div_num >= 2 && div_num <= 256,
+                    "`LCD_CAM_CAM_CLOCK` div_num must be between 2 and 256 (inclusive)."
+                );
+                ::core::assert!(
+                    div_a >= 1 && div_a <= 63,
+                    "`LCD_CAM_CAM_CLOCK` div_a must be between 1 and 63 (inclusive)."
+                );
+                ::core::assert!(
+                    div_b <= 63,
+                    "`LCD_CAM_CAM_CLOCK` div_b must be between 0 and 63 (inclusive)."
+                );
+                Self {
+                    sclk,
+                    div_num,
+                    div_a,
+                    div_b,
+                }
+            }
+            pub(crate) fn sclk(self) -> LcdCamCamClockSclk {
+                self.sclk
+            }
+            pub(crate) fn div_num(self) -> u32 {
+                self.div_num as u32
+            }
+            pub(crate) fn div_a(self) -> u32 {
+                self.div_a as u32
+            }
+            pub(crate) fn div_b(self) -> u32 {
+                self.div_b as u32
+            }
         }
         /// The list of clock signals that the `MCPWM0_FUNCTION_CLOCK` multiplexer can output.
         #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
@@ -3263,29 +3403,25 @@ macro_rules! define_clock_tree_types {
             }
         }
         impl LcdCamInstance {
-            pub fn configure_lcd_clock(
-                self,
-                clocks: &mut ClockTree,
-                new_selector: LcdCamLcdClockConfig,
-            ) {
-                let old_selector = clocks.lcd_cam_lcd_clock[self as usize].replace(new_selector);
+            pub fn configure_lcd_clock(self, clocks: &mut ClockTree, config: LcdCamLcdClockConfig) {
+                let old_config = clocks.lcd_cam_lcd_clock[self as usize].replace(config);
                 refresh_lcd_cam_lcd_clock_downstream(clocks, self);
                 if clocks.lcd_cam_lcd_clock_refcount[self as usize] > 0 {
-                    match new_selector {
-                        LcdCamLcdClockConfig::XtalClk => request_xtal_clk(clocks),
-                        LcdCamLcdClockConfig::PllD2 => request_pll_d2(clocks),
-                        LcdCamLcdClockConfig::Pll160m => request_pll_160m(clocks),
+                    match config.sclk {
+                        LcdCamLcdClockSclk::XtalClk => request_xtal_clk(clocks),
+                        LcdCamLcdClockSclk::PllD2 => request_pll_d2(clocks),
+                        LcdCamLcdClockSclk::Pll160m => request_pll_160m(clocks),
                     }
-                    self.configure_lcd_clock_impl(clocks, old_selector, new_selector);
-                    if let Some(old_selector) = old_selector {
-                        match old_selector {
-                            LcdCamLcdClockConfig::XtalClk => release_xtal_clk(clocks),
-                            LcdCamLcdClockConfig::PllD2 => release_pll_d2(clocks),
-                            LcdCamLcdClockConfig::Pll160m => release_pll_160m(clocks),
+                    self.configure_lcd_clock_impl(clocks, old_config, config);
+                    if let Some(old_config) = old_config {
+                        match old_config.sclk {
+                            LcdCamLcdClockSclk::XtalClk => release_xtal_clk(clocks),
+                            LcdCamLcdClockSclk::PllD2 => release_pll_d2(clocks),
+                            LcdCamLcdClockSclk::Pll160m => release_pll_160m(clocks),
                         }
                     }
                 } else {
-                    self.configure_lcd_clock_impl(clocks, old_selector, new_selector);
+                    self.configure_lcd_clock_impl(clocks, old_config, config);
                 }
             }
             pub fn lcd_clock_config(self, clocks: &mut ClockTree) -> Option<LcdCamLcdClockConfig> {
@@ -3297,10 +3433,10 @@ macro_rules! define_clock_tree_types {
                 {
                     trace!("Enabling {:?}::LCD_CLOCK", self);
                     crate::rtc_cntl::WakeLock::acquire();
-                    match unwrap!(clocks.lcd_cam_lcd_clock[self as usize]) {
-                        LcdCamLcdClockConfig::XtalClk => request_xtal_clk(clocks),
-                        LcdCamLcdClockConfig::PllD2 => request_pll_d2(clocks),
-                        LcdCamLcdClockConfig::Pll160m => request_pll_160m(clocks),
+                    match unwrap!(clocks.lcd_cam_lcd_clock[self as usize]).sclk {
+                        LcdCamLcdClockSclk::XtalClk => request_xtal_clk(clocks),
+                        LcdCamLcdClockSclk::PllD2 => request_pll_d2(clocks),
+                        LcdCamLcdClockSclk::Pll160m => request_pll_160m(clocks),
                     }
                     self.enable_lcd_clock_impl(clocks, true);
                 }
@@ -3312,10 +3448,10 @@ macro_rules! define_clock_tree_types {
                     trace!("Disabling {:?}::LCD_CLOCK", self);
                     crate::rtc_cntl::WakeLock::release();
                     self.enable_lcd_clock_impl(clocks, false);
-                    match unwrap!(clocks.lcd_cam_lcd_clock[self as usize]) {
-                        LcdCamLcdClockConfig::XtalClk => release_xtal_clk(clocks),
-                        LcdCamLcdClockConfig::PllD2 => release_pll_d2(clocks),
-                        LcdCamLcdClockConfig::Pll160m => release_pll_160m(clocks),
+                    match unwrap!(clocks.lcd_cam_lcd_clock[self as usize]).sclk {
+                        LcdCamLcdClockSclk::XtalClk => release_xtal_clk(clocks),
+                        LcdCamLcdClockSclk::PllD2 => release_pll_d2(clocks),
+                        LcdCamLcdClockSclk::Pll160m => release_pll_160m(clocks),
                     }
                 }
             }
@@ -3324,46 +3460,45 @@ macro_rules! define_clock_tree_types {
                 clocks: &mut ClockTree,
                 config: LcdCamLcdClockConfig,
             ) -> u32 {
-                match config {
-                    LcdCamLcdClockConfig::XtalClk => xtal_clk_frequency(),
-                    LcdCamLcdClockConfig::PllD2 => pll_d2_frequency(),
-                    LcdCamLcdClockConfig::Pll160m => pll_160m_frequency(),
-                }
+                (((match config.sclk {
+                    LcdCamLcdClockSclk::XtalClk => xtal_clk_frequency(),
+                    LcdCamLcdClockSclk::PllD2 => pll_d2_frequency(),
+                    LcdCamLcdClockSclk::Pll160m => pll_160m_frequency(),
+                } as u64)
+                    * (config.div_a() as u64))
+                    / (((config.div_num() * config.div_a()) + config.div_b()) as u64))
+                    as u32
             }
             pub fn lcd_clock_frequency(self) -> u32 {
                 LCD_CAM_LCD_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
-            pub fn lcd_clock_source_frequency(source: LcdCamLcdClockConfig) -> u32 {
-                match source {
-                    LcdCamLcdClockConfig::XtalClk => xtal_clk_frequency(),
-                    LcdCamLcdClockConfig::PllD2 => pll_d2_frequency(),
-                    LcdCamLcdClockConfig::Pll160m => pll_160m_frequency(),
+            pub fn lcd_clock_source_frequency(sclk: LcdCamLcdClockSclk) -> u32 {
+                match sclk {
+                    LcdCamLcdClockSclk::XtalClk => xtal_clk_frequency(),
+                    LcdCamLcdClockSclk::PllD2 => pll_d2_frequency(),
+                    LcdCamLcdClockSclk::Pll160m => pll_160m_frequency(),
                 }
             }
-            pub fn configure_cam_clock(
-                self,
-                clocks: &mut ClockTree,
-                new_selector: LcdCamCamClockConfig,
-            ) {
-                let old_selector = clocks.lcd_cam_cam_clock[self as usize].replace(new_selector);
+            pub fn configure_cam_clock(self, clocks: &mut ClockTree, config: LcdCamCamClockConfig) {
+                let old_config = clocks.lcd_cam_cam_clock[self as usize].replace(config);
                 refresh_lcd_cam_cam_clock_downstream(clocks, self);
                 if clocks.lcd_cam_cam_clock_refcount[self as usize] > 0 {
-                    match new_selector {
-                        LcdCamCamClockConfig::XtalClk => request_xtal_clk(clocks),
-                        LcdCamCamClockConfig::PllD2 => request_pll_d2(clocks),
-                        LcdCamCamClockConfig::Pll160m => request_pll_160m(clocks),
+                    match config.sclk {
+                        LcdCamCamClockSclk::XtalClk => request_xtal_clk(clocks),
+                        LcdCamCamClockSclk::PllD2 => request_pll_d2(clocks),
+                        LcdCamCamClockSclk::Pll160m => request_pll_160m(clocks),
                     }
-                    self.configure_cam_clock_impl(clocks, old_selector, new_selector);
-                    if let Some(old_selector) = old_selector {
-                        match old_selector {
-                            LcdCamCamClockConfig::XtalClk => release_xtal_clk(clocks),
-                            LcdCamCamClockConfig::PllD2 => release_pll_d2(clocks),
-                            LcdCamCamClockConfig::Pll160m => release_pll_160m(clocks),
+                    self.configure_cam_clock_impl(clocks, old_config, config);
+                    if let Some(old_config) = old_config {
+                        match old_config.sclk {
+                            LcdCamCamClockSclk::XtalClk => release_xtal_clk(clocks),
+                            LcdCamCamClockSclk::PllD2 => release_pll_d2(clocks),
+                            LcdCamCamClockSclk::Pll160m => release_pll_160m(clocks),
                         }
                     }
                 } else {
-                    self.configure_cam_clock_impl(clocks, old_selector, new_selector);
+                    self.configure_cam_clock_impl(clocks, old_config, config);
                 }
             }
             pub fn cam_clock_config(self, clocks: &mut ClockTree) -> Option<LcdCamCamClockConfig> {
@@ -3375,10 +3510,10 @@ macro_rules! define_clock_tree_types {
                 {
                     trace!("Enabling {:?}::CAM_CLOCK", self);
                     crate::rtc_cntl::WakeLock::acquire();
-                    match unwrap!(clocks.lcd_cam_cam_clock[self as usize]) {
-                        LcdCamCamClockConfig::XtalClk => request_xtal_clk(clocks),
-                        LcdCamCamClockConfig::PllD2 => request_pll_d2(clocks),
-                        LcdCamCamClockConfig::Pll160m => request_pll_160m(clocks),
+                    match unwrap!(clocks.lcd_cam_cam_clock[self as usize]).sclk {
+                        LcdCamCamClockSclk::XtalClk => request_xtal_clk(clocks),
+                        LcdCamCamClockSclk::PllD2 => request_pll_d2(clocks),
+                        LcdCamCamClockSclk::Pll160m => request_pll_160m(clocks),
                     }
                     self.enable_cam_clock_impl(clocks, true);
                 }
@@ -3390,10 +3525,10 @@ macro_rules! define_clock_tree_types {
                     trace!("Disabling {:?}::CAM_CLOCK", self);
                     crate::rtc_cntl::WakeLock::release();
                     self.enable_cam_clock_impl(clocks, false);
-                    match unwrap!(clocks.lcd_cam_cam_clock[self as usize]) {
-                        LcdCamCamClockConfig::XtalClk => release_xtal_clk(clocks),
-                        LcdCamCamClockConfig::PllD2 => release_pll_d2(clocks),
-                        LcdCamCamClockConfig::Pll160m => release_pll_160m(clocks),
+                    match unwrap!(clocks.lcd_cam_cam_clock[self as usize]).sclk {
+                        LcdCamCamClockSclk::XtalClk => release_xtal_clk(clocks),
+                        LcdCamCamClockSclk::PllD2 => release_pll_d2(clocks),
+                        LcdCamCamClockSclk::Pll160m => release_pll_160m(clocks),
                     }
                 }
             }
@@ -3402,21 +3537,24 @@ macro_rules! define_clock_tree_types {
                 clocks: &mut ClockTree,
                 config: LcdCamCamClockConfig,
             ) -> u32 {
-                match config {
-                    LcdCamCamClockConfig::XtalClk => xtal_clk_frequency(),
-                    LcdCamCamClockConfig::PllD2 => pll_d2_frequency(),
-                    LcdCamCamClockConfig::Pll160m => pll_160m_frequency(),
-                }
+                (((match config.sclk {
+                    LcdCamCamClockSclk::XtalClk => xtal_clk_frequency(),
+                    LcdCamCamClockSclk::PllD2 => pll_d2_frequency(),
+                    LcdCamCamClockSclk::Pll160m => pll_160m_frequency(),
+                } as u64)
+                    * (config.div_a() as u64))
+                    / (((config.div_num() * config.div_a()) + config.div_b()) as u64))
+                    as u32
             }
             pub fn cam_clock_frequency(self) -> u32 {
                 LCD_CAM_CAM_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
-            pub fn cam_clock_source_frequency(source: LcdCamCamClockConfig) -> u32 {
-                match source {
-                    LcdCamCamClockConfig::XtalClk => xtal_clk_frequency(),
-                    LcdCamCamClockConfig::PllD2 => pll_d2_frequency(),
-                    LcdCamCamClockConfig::Pll160m => pll_160m_frequency(),
+            pub fn cam_clock_source_frequency(sclk: LcdCamCamClockSclk) -> u32 {
+                match sclk {
+                    LcdCamCamClockSclk::XtalClk => xtal_clk_frequency(),
+                    LcdCamCamClockSclk::PllD2 => pll_d2_frequency(),
+                    LcdCamCamClockSclk::Pll160m => pll_160m_frequency(),
                 }
             }
         }

--- a/esp-metadata/devices/esp32s3/clocks.toml
+++ b/esp-metadata/devices/esp32s3/clocks.toml
@@ -108,18 +108,21 @@ system_clocks = { clock_tree = [
             { name = "RC_FAST", outputs = "RC_FAST_CLK" },
         ], div_num = "0 .. 0x100" } },
     ] },
-    # The LCD and camera halves of LCD_CAM have separate, identical clock muxes.
+    # The LCD and camera halves of LCD_CAM have separate, identical clock muxes and dividers.
+    #
+    # The divider divides by `div_num + div_b / div_a`. `div_num` is the effective divisor, the
+    # HAL translates it to the register encoding where 256 is written as 0.
     { group = "LCD_CAM", clocks = [
-        { name = "LCD_CLOCK", type = "mux", wake_locking = true, variants = [
+        { name = "LCD_CLOCK", type = "generic", wake_locking = true, output = "(sclk * div_a) / (div_num * div_a + div_b)", params = { sclk = [
             { name = "XTAL_CLK", outputs = "XTAL_CLK", default = true },
             { name = "PLL_D2",   outputs = "PLL_D2" },
             { name = "PLL_160M", outputs = "PLL_160M" },
-        ] },
-        { name = "CAM_CLOCK", type = "mux", wake_locking = true, variants = [
+        ], div_num = "2 ..= 256", div_a = "1 ..= 63", div_b = "0 ..= 63" } },
+        { name = "CAM_CLOCK", type = "generic", wake_locking = true, output = "(sclk * div_a) / (div_num * div_a + div_b)", params = { sclk = [
             { name = "XTAL_CLK", outputs = "XTAL_CLK", default = true },
             { name = "PLL_D2",   outputs = "PLL_D2" },
             { name = "PLL_160M", outputs = "PLL_160M" },
-        ] },
+        ], div_num = "2 ..= 256", div_a = "1 ..= 63", div_b = "0 ..= 63" } },
     ] },
     { group = "SPI", clocks = [
         { name = "FUNCTION_CLOCK", type = "mux", wake_locking = true, variants = [

--- a/esp-metadata/src/cfg/soc.rs
+++ b/esp-metadata/src/cfg/soc.rs
@@ -15,6 +15,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     PeripheralDef,
     cfg::clock_tree::{
+        Bounds,
         ClockNodeFunctions,
         ClockTreeItem,
         ClockTreeNodeType,
@@ -664,12 +665,32 @@ impl ClockTreeNodeInstance {
         tree: &'tree ProcessedClockData,
         clock: &str,
     ) -> &'tree ClockTreeNodeInstance {
+        self.try_resolve_node(tree, clock)
+            .unwrap_or_else(|| panic!("Clock node {clock} not found"))
+    }
+
+    fn try_resolve_node<'tree>(
+        &self,
+        tree: &'tree ProcessedClockData,
+        clock: &str,
+    ) -> Option<&'tree ClockTreeNodeInstance> {
         let local_node = format!("{}_{}", self.group_instance, clock);
-        if let Some(node) = tree.try_get_node(&local_node) {
-            node
-        } else {
-            tree.node(clock)
-        }
+        tree.try_get_node(&local_node)
+            .or_else(|| tree.try_get_node(clock))
+    }
+
+    /// Returns the range of frequencies this node can output.
+    pub(super) fn output_bounds(&self, tree: &ProcessedClockData) -> Bounds {
+        self.node.output_bounds(self, tree).as_frequency()
+    }
+
+    /// Returns the range of values `clock` can take, where `clock` names an upstream clock node.
+    ///
+    /// Unknown names resolve to [`Bounds::UNKNOWN`]; the caller may be looking at an expression
+    /// variable that isn't a clock node at all.
+    pub(super) fn upstream_bounds(&self, tree: &ProcessedClockData, clock: &str) -> Bounds {
+        self.try_resolve_node(tree, clock)
+            .map_or(Bounds::UNKNOWN, |node| node.output_bounds(tree))
     }
 
     fn validate_configures_expr(&self, expr: &ConfiguresExpression) -> Result<()> {
@@ -678,12 +699,6 @@ impl ClockTreeNodeInstance {
 }
 
 impl ProcessedClockData {
-    /// Returns a node by its name (e.g. `XTAL_CLK`).
-    fn node(&self, name: &str) -> &ClockTreeNodeInstance {
-        self.try_get_node(name)
-            .unwrap_or_else(|| panic!("Clock node {name} not found"))
-    }
-
     /// Returns a node by its name (e.g. `XTAL_CLK`), or None if not found.
     fn try_get_node(&self, name: &str) -> Option<&ClockTreeNodeInstance> {
         self.clock_tree.get(name)

--- a/esp-metadata/src/cfg/soc/clock_tree.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree.rs
@@ -52,7 +52,7 @@ use somni_parser::{ast, lexer::Token, parser::DefaultTypeSet};
 
 use crate::cfg::{
     clock_tree::{
-        expr_compiler::ExprCompiler,
+        expr_compiler::{ExprCompiler, Operand},
         generic::Generic,
         mux::Multiplexer,
         source::{DerivedClockSource, Source},
@@ -343,9 +343,98 @@ impl ManagementProperties {
     }
 }
 
+/// The range of values an expression or a clock node's output can take.
+///
+/// Bounds are used to decide where 32-bit arithmetic is enough, and where the generated code has
+/// to compute in 64 bits to avoid overflowing. They are conservative: a wider range than the real
+/// one only costs a few casts in the generated code, a narrower one would generate code that
+/// overflows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Bounds {
+    pub min: u64,
+    pub max: u64,
+}
+
+impl Bounds {
+    /// The bounds of a value we know nothing about, other than that it is a `u32`.
+    pub const UNKNOWN: Self = Self {
+        min: 0,
+        max: u32::MAX as u64,
+    };
+
+    pub fn exact(value: u64) -> Self {
+        Self {
+            min: value,
+            max: value,
+        }
+    }
+
+    pub fn new(min: u64, max: u64) -> Self {
+        Self { min, max }
+    }
+
+    /// Widens `self` to also contain `other`.
+    pub fn union(self, other: Self) -> Self {
+        Self {
+            min: self.min.min(other.min),
+            max: self.max.max(other.max),
+        }
+    }
+
+    pub fn fits_in_u32(self) -> bool {
+        self.max <= u32::MAX as u64
+    }
+
+    /// Clamps the bounds to the `u32` range in which frequencies are stored.
+    pub fn as_frequency(self) -> Self {
+        Self {
+            min: self.min.min(u32::MAX as u64),
+            max: self.max.min(u32::MAX as u64),
+        }
+    }
+
+    /// Returns the bounds of `self <op> other`, where `op` is one of the supported arithmetic
+    /// operators. Returns `None` for operators that don't produce a number.
+    pub fn apply_operator(self, operator: &str, other: Self) -> Option<Self> {
+        // Saturate instead of overflowing: a saturated bound is still an upper bound, and it means
+        // the generated code is widened, which is what we want for an expression this extreme.
+        let bounds = match operator {
+            "+" => Self::new(
+                self.min.saturating_add(other.min),
+                self.max.saturating_add(other.max),
+            ),
+            "-" => Self::new(
+                self.min.saturating_sub(other.max),
+                self.max.saturating_sub(other.min),
+            ),
+            "*" => Self::new(
+                self.min.saturating_mul(other.min),
+                self.max.saturating_mul(other.max),
+            ),
+            // A zero divisor panics at runtime, so assume the divisor is at least 1.
+            "/" => Self::new(self.min / other.max.max(1), self.max / other.min.max(1)),
+            "%" => Self::new(0, self.max.min(other.max.saturating_sub(1))),
+            _ => return None,
+        };
+
+        Some(bounds)
+    }
+}
+
 /// Common interface for clock node types.
 pub(crate) trait ClockTreeNodeType: Any {
     fn name(&self) -> &str;
+
+    /// Returns the range of frequencies this node can output.
+    ///
+    /// The default implementation gives up and returns [`Bounds::UNKNOWN`].
+    fn output_bounds(
+        &self,
+        _instance: &ClockTreeNodeInstance,
+        _tree: &ProcessedClockData,
+    ) -> Bounds {
+        Bounds::UNKNOWN
+    }
 
     /// Returns which clock nodes' configurations are affected when this node is configured.
     // TODO: pass instance to apply template naming scheme to returned clocks
@@ -655,6 +744,23 @@ fn human_readable_frequency(mut output: u64) -> (u64, &'static str) {
 pub struct ValuesExpression(Vec<ValueFragment>);
 
 impl ValuesExpression {
+    /// Returns the range of values the parameter can take.
+    fn bounds(&self) -> Bounds {
+        let mut bounds = None;
+        for fragment in self.0.iter() {
+            let fragment = match fragment {
+                ValueFragment::FixedFrequency(value) => Bounds::exact(*value as u64),
+                ValueFragment::Range(min, max) => Bounds::new(*min as u64, *max as u64),
+            };
+            bounds = Some(match bounds {
+                Some(bounds) => Bounds::union(bounds, fragment),
+                None => fragment,
+            });
+        }
+
+        bounds.unwrap_or(Bounds::UNKNOWN)
+    }
+
     fn as_enum_values(&self) -> Option<Vec<u32>> {
         let frequencies = self
             .0
@@ -754,7 +860,7 @@ pub struct RejectExpression(Expression);
 impl RejectExpression {
     fn to_rust<'a>(
         &'a self,
-        mut variables: HashMap<&'a str, TokenStream>,
+        mut variables: HashMap<&'a str, Operand>,
         instance: &ClockTreeNodeInstance,
         tree: &ProcessedClockData,
     ) -> TokenStream {
@@ -765,7 +871,10 @@ impl RejectExpression {
                 // Referring to a node by name resolves to its output frequency.
                 let node = instance.resolve_node(tree, var);
                 let freq_fn = node.frequency_function_name();
-                variables.insert(var, quote! { #freq_fn() });
+                variables.insert(
+                    var,
+                    Operand::new(quote! { #freq_fn() }, node.output_bounds(tree)),
+                );
 
                 // Only run the assert if the referenced nodes have been configured
                 let config_field = node.properties.indexed_config_accessor();
@@ -835,11 +944,88 @@ impl Expression {
 
     fn to_rust(
         &self,
-        variables: HashMap<&str, TokenStream>,
+        variables: HashMap<&str, Operand>,
         instance: &ClockTreeNodeInstance,
         tree: &ProcessedClockData,
     ) -> TokenStream {
         ExprCompiler::new(&variables).compile_expression(self, instance, tree)
+    }
+
+    /// Solves the expression at codegen time, with every variable bound to a fixed value.
+    ///
+    /// Returns `None` if the expression can't be solved, e.g. because it divides by zero or calls
+    /// a function.
+    fn solve(&self, values: &IndexMap<&str, u64>) -> Option<u64> {
+        let mut ctx = somni_expr::Context::new();
+        for (name, value) in values.iter() {
+            ctx.add_variable(name, *value);
+        }
+
+        ctx.evaluate_parsed::<u64>(
+            &self.source,
+            &ast::Expression::Expression {
+                expression: self.expr.clone(),
+            },
+        )
+        .ok()
+    }
+
+    /// Returns the range of values the expression can evaluate to.
+    ///
+    /// The expression is solved at every combination of its variables' extremes. This is more
+    /// accurate than propagating bounds through the operators one by one, because a variable that
+    /// appears multiple times (like `a` in `SOURCE * a / (N * a + b)`) takes the same value in
+    /// every place it appears.
+    fn bounds(&self, variables: &IndexMap<&str, Bounds>) -> Bounds {
+        // Solving 2^n times is only reasonable for the handful of variables a clock node has.
+        if variables.len() > 8 {
+            return Bounds::UNKNOWN;
+        }
+
+        let mut bounds: Option<Bounds> = None;
+        for corner in 0..1u32 << variables.len() {
+            let values = variables
+                .iter()
+                .enumerate()
+                .map(|(index, (name, variable))| {
+                    let value = if corner & (1 << index) == 0 {
+                        variable.min
+                    } else {
+                        variable.max
+                    };
+                    (*name, value)
+                })
+                .collect::<IndexMap<_, _>>();
+
+            if let Some(value) = self.solve(&values) {
+                let value = Bounds::exact(value);
+                bounds = Some(match bounds {
+                    Some(bounds) => bounds.union(value),
+                    None => value,
+                });
+            }
+        }
+
+        bounds.unwrap_or(Bounds::UNKNOWN)
+    }
+
+    /// Returns the bounds of the expression, looking up the bounds of any variable that isn't
+    /// listed in `known` as a clock node's output.
+    fn bounds_in_tree<'s>(
+        &'s self,
+        known: &IndexMap<&'s str, Bounds>,
+        instance: &ClockTreeNodeInstance,
+        tree: &ProcessedClockData,
+    ) -> Bounds {
+        let mut variables = known.clone();
+
+        self.visit_variables(|variable| {
+            if !variables.contains_key(variable) {
+                variables.insert(variable, instance.upstream_bounds(tree, variable));
+            }
+        });
+
+        self.bounds(&variables)
     }
 }
 
@@ -861,5 +1047,61 @@ impl<'de> Deserialize<'de> for Expression {
                 MarkInSource(&s, err.location, "Expression error", &err.error)
             ))),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn expression(source: &str) -> Expression {
+        let ast::Expression::Expression { expression } =
+            somni_parser::parser::parse_expression::<DefaultTypeSet>(source).unwrap()
+        else {
+            unreachable!()
+        };
+
+        Expression {
+            source: source.to_string(),
+            expr: expression,
+        }
+    }
+
+    #[test]
+    fn operator_bounds_are_conservative() {
+        let a = Bounds::new(2, 10);
+        let b = Bounds::new(3, 4);
+
+        assert_eq!(a.apply_operator("+", b), Some(Bounds::new(5, 14)));
+        assert_eq!(a.apply_operator("-", b), Some(Bounds::new(0, 7)));
+        assert_eq!(a.apply_operator("*", b), Some(Bounds::new(6, 40)));
+        assert_eq!(a.apply_operator("/", b), Some(Bounds::new(0, 3)));
+        assert_eq!(a.apply_operator("%", b), Some(Bounds::new(0, 3)));
+
+        // Comparisons don't produce a number.
+        assert_eq!(a.apply_operator("<", b), None);
+    }
+
+    #[test]
+    fn division_by_a_possibly_zero_value_assumes_a_divisor_of_one() {
+        let bounds = Bounds::new(0, 100).apply_operator("/", Bounds::new(0, 4));
+        assert_eq!(bounds, Some(Bounds::new(0, 100)));
+    }
+
+    #[test]
+    fn expression_bounds_account_for_repeated_variables() {
+        let expr = expression("(sclk * div_a) / (div_num * div_a + div_b)");
+
+        let variables = IndexMap::from_iter([
+            ("sclk", Bounds::new(40_000_000, 240_000_000)),
+            ("div_num", Bounds::new(2, 256)),
+            ("div_a", Bounds::new(1, 63)),
+            ("div_b", Bounds::new(0, 63)),
+        ]);
+
+        // The largest output is reached at div_num = 2, div_b = 0, for any div_a. Solving the
+        // expression keeps div_a consistent between the two places it appears, so the result
+        // isn't inflated to sclk * 63.
+        assert_eq!(expr.bounds(&variables), Bounds::new(125_391, 120_000_000));
     }
 }

--- a/esp-metadata/src/cfg/soc/clock_tree/expr_compiler.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/expr_compiler.rs
@@ -6,16 +6,88 @@ use somni_expr::DefaultTypeSet;
 use somni_parser::{ast, lexer::Token};
 
 use crate::{
-    cfg::{ClockTreeNodeInstance, ProcessedClockData, clock_tree::Expression},
+    cfg::{
+        ClockTreeNodeInstance,
+        ProcessedClockData,
+        clock_tree::{Bounds, Expression},
+    },
     number,
 };
 
+/// A variable an expression can refer to: the code that reads it, and the range of values it can
+/// take.
+#[derive(Debug, Clone)]
+pub struct Operand {
+    tokens: TokenStream,
+    bounds: Bounds,
+}
+
+impl Operand {
+    pub fn new(tokens: TokenStream, bounds: Bounds) -> Self {
+        Self { tokens, bounds }
+    }
+}
+
+/// A compiled (sub)expression.
+struct Compiled {
+    tokens: TokenStream,
+    bounds: Bounds,
+    /// Whether `tokens` evaluate to a `u64`. Frequencies and parameters are `u32`, and
+    /// subexpressions stay `u32` unless their bounds don't fit.
+    wide: bool,
+    /// The value of the expression, if it is an integer literal. Literals are widened by writing a
+    /// suffix, which avoids a pointless cast in the generated code.
+    literal: Option<u64>,
+}
+
+impl Compiled {
+    fn number(value: u64) -> Self {
+        Self {
+            tokens: number(value),
+            bounds: Bounds::exact(value),
+            wide: value > u32::MAX as u64,
+            literal: Some(value),
+        }
+    }
+
+    fn boolean(tokens: TokenStream) -> Self {
+        Self {
+            tokens,
+            bounds: Bounds::new(0, 1),
+            wide: false,
+            literal: None,
+        }
+    }
+
+    /// Returns the expression as a `u64`.
+    fn widened(self) -> TokenStream {
+        if self.wide {
+            self.tokens
+        } else if let Some(value) = self.literal {
+            number(format_args!("{value}u64"))
+        } else {
+            let tokens = self.tokens;
+            quote! { (#tokens as u64) }
+        }
+    }
+
+    /// Returns the expression as the `u32` that frequencies and parameter values are stored in.
+    fn narrowed(self) -> TokenStream {
+        if self.wide {
+            let tokens = self.tokens;
+            quote! { (#tokens) as u32 }
+        } else {
+            self.tokens
+        }
+    }
+}
+
 pub struct ExprCompiler<'ctx> {
-    variables: &'ctx HashMap<&'ctx str, TokenStream>,
+    variables: &'ctx HashMap<&'ctx str, Operand>,
 }
 
 impl<'ctx> ExprCompiler<'ctx> {
-    pub fn new(variables: &'ctx HashMap<&'ctx str, TokenStream>) -> Self {
+    pub fn new(variables: &'ctx HashMap<&'ctx str, Operand>) -> Self {
         Self { variables }
     }
 
@@ -26,7 +98,8 @@ impl<'ctx> ExprCompiler<'ctx> {
         tree: &ProcessedClockData,
     ) -> TokenStream {
         let source = expression.source.as_str();
-        self.compile_right_hand_expression(source, &expression.expr, instance, tree)
+        self.compile(source, &expression.expr, instance, tree)
+            .narrowed()
     }
 
     pub fn compile_right_hand_expression(
@@ -36,6 +109,16 @@ impl<'ctx> ExprCompiler<'ctx> {
         instance: &ClockTreeNodeInstance,
         tree: &ProcessedClockData,
     ) -> TokenStream {
+        self.compile(source, expression, instance, tree).narrowed()
+    }
+
+    fn compile(
+        &self,
+        source: &str,
+        expression: &ast::RightHandExpression<DefaultTypeSet>,
+        instance: &ClockTreeNodeInstance,
+        tree: &ProcessedClockData,
+    ) -> Compiled {
         match expression {
             ast::RightHandExpression::Variable { variable } => {
                 self.compile_variable(source, variable)
@@ -54,12 +137,19 @@ impl<'ctx> ExprCompiler<'ctx> {
         }
     }
 
-    fn compile_variable(&self, source: &str, variable: &Token) -> TokenStream {
+    fn compile_variable(&self, source: &str, variable: &Token) -> Compiled {
         let variable_name = variable.source(source);
-        self.variables
+        let operand = self
+            .variables
             .get(variable_name)
-            .cloned()
-            .unwrap_or_else(|| panic!("Variable not found: {variable_name:?}"))
+            .unwrap_or_else(|| panic!("Variable not found: {variable_name:?}"));
+
+        Compiled {
+            tokens: operand.tokens.clone(),
+            bounds: operand.bounds,
+            wide: false,
+            literal: None,
+        }
     }
 
     fn compile_unary_operator(
@@ -69,15 +159,24 @@ impl<'ctx> ExprCompiler<'ctx> {
         operand: &ast::RightHandExpression<DefaultTypeSet>,
         instance: &ClockTreeNodeInstance,
         tree: &ProcessedClockData,
-    ) -> TokenStream {
+    ) -> Compiled {
         let operator = match name.source(source) {
             "!" => quote! { ! },
             "-" => quote! { - },
             other => todo!("Unsupported unary operator: {other}"),
         };
 
-        let operand = self.compile_right_hand_expression(source, operand, instance, tree);
-        quote! { #operator (#operand) }
+        let operand = self.compile(source, operand, instance, tree);
+        let bounds = operand.bounds;
+        let wide = operand.wide;
+        let tokens = operand.tokens;
+
+        Compiled {
+            tokens: quote! { #operator (#tokens) },
+            bounds,
+            wide,
+            literal: None,
+        }
     }
 
     fn compile_binary_operator(
@@ -87,8 +186,9 @@ impl<'ctx> ExprCompiler<'ctx> {
         operands: &[ast::RightHandExpression<DefaultTypeSet>; 2],
         instance: &ClockTreeNodeInstance,
         tree: &ProcessedClockData,
-    ) -> TokenStream {
-        let operator = match name.source(source) {
+    ) -> Compiled {
+        let operator_str = name.source(source);
+        let operator = match operator_str {
             "+" => quote! { + },
             "-" => quote! { - },
             "*" => quote! { * },
@@ -105,17 +205,49 @@ impl<'ctx> ExprCompiler<'ctx> {
             other => todo!("Unsupported binary operator: {other}"),
         };
 
-        let lhs = self.compile_right_hand_expression(source, &operands[0], instance, tree);
-        let rhs = self.compile_right_hand_expression(source, &operands[1], instance, tree);
-        quote! { (#lhs #operator #rhs) }
+        let lhs = self.compile(source, &operands[0], instance, tree);
+        let rhs = self.compile(source, &operands[1], instance, tree);
+
+        let Some(bounds) = lhs.bounds.apply_operator(operator_str, rhs.bounds) else {
+            // Comparisons and logical operators produce a boolean. Their operands still need to
+            // agree on a width.
+            let (lhs, rhs) = if lhs.wide || rhs.wide {
+                (lhs.widened(), rhs.widened())
+            } else {
+                (lhs.tokens, rhs.tokens)
+            };
+
+            return Compiled::boolean(quote! { (#lhs #operator #rhs) });
+        };
+
+        // Compute in 64 bits if the result can't be represented in 32, or if an operand already
+        // had to be widened.
+        let wide = lhs.wide || rhs.wide || !bounds.fits_in_u32();
+        let (lhs, rhs) = if wide {
+            (lhs.widened(), rhs.widened())
+        } else {
+            (lhs.tokens, rhs.tokens)
+        };
+
+        Compiled {
+            tokens: quote! { (#lhs #operator #rhs) },
+            bounds,
+            wide,
+            literal: None,
+        }
     }
 
-    fn compile_literal(&self, value: &ast::Literal<DefaultTypeSet>) -> TokenStream {
+    fn compile_literal(&self, value: &ast::Literal<DefaultTypeSet>) -> Compiled {
         match &value.value {
-            ast::LiteralValue::Integer(n) => number(n),
-            ast::LiteralValue::Float(n) => number(n),
-            ast::LiteralValue::String(s) => quote! { #s },
-            ast::LiteralValue::Boolean(b) => quote! { #b },
+            ast::LiteralValue::Integer(n) => Compiled::number(*n),
+            ast::LiteralValue::Float(n) => Compiled {
+                tokens: number(n),
+                bounds: Bounds::UNKNOWN,
+                wide: false,
+                literal: None,
+            },
+            ast::LiteralValue::String(s) => Compiled::boolean(quote! { #s }),
+            ast::LiteralValue::Boolean(b) => Compiled::boolean(quote! { #b }),
         }
     }
 
@@ -126,7 +258,7 @@ impl<'ctx> ExprCompiler<'ctx> {
         arguments: &[ast::RightHandExpression<DefaultTypeSet>],
         instance: &ClockTreeNodeInstance,
         tree: &ProcessedClockData,
-    ) -> TokenStream {
+    ) -> Compiled {
         // property(NODE)
         let [ast::RightHandExpression::Variable { variable }] = arguments else {
             panic!("Function calls must be of the form property(NODE)")
@@ -135,6 +267,12 @@ impl<'ctx> ExprCompiler<'ctx> {
         let referred_node = instance.resolve_node(tree, variable.source(source));
         let config_accessor = referred_node.properties.indexed_config_accessor();
         let name = quote::format_ident!("{}", name.source(source));
-        quote! { unwrap!(#config_accessor).#name() }
+
+        Compiled {
+            tokens: quote! { unwrap!(#config_accessor).#name() },
+            bounds: Bounds::UNKNOWN,
+            wide: false,
+            literal: None,
+        }
     }
 }

--- a/esp-metadata/src/cfg/soc/clock_tree/generic.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/generic.rs
@@ -18,6 +18,7 @@ use crate::{
     cfg::{
         ClockTreeNodeInstance,
         clock_tree::{
+            Bounds,
             ClockTreeNodeType,
             ConfiguresExpression,
             Expression,
@@ -25,8 +26,8 @@ use crate::{
             SourceFrequencySignature,
             ValidationContext,
             ValuesExpression,
-            expr_compiler::ExprCompiler,
-            mux::MultiplexerVariant,
+            expr_compiler::{ExprCompiler, Operand},
+            mux::{MultiplexerVariant, variant_bounds},
         },
         soc::ProcessedClockData,
     },
@@ -124,6 +125,20 @@ pub struct Generic {
 impl ClockTreeNodeType for Generic {
     fn name(&self) -> &str {
         &self.name
+    }
+
+    fn output_bounds(&self, instance: &ClockTreeNodeInstance, tree: &ProcessedClockData) -> Bounds {
+        let mut variables = IndexMap::new();
+
+        for (name, param) in self.params.iter() {
+            let bounds = match param {
+                NodeParameter::Value(values) => values.bounds(),
+                NodeParameter::Source(variants) => variant_bounds(variants, instance, tree),
+            };
+            variables.insert(name.as_str(), bounds);
+        }
+
+        self.output.bounds_in_tree(&variables, instance, tree)
     }
 
     fn input_clocks(
@@ -322,9 +337,15 @@ impl ClockTreeNodeType for Generic {
         let reject_exprs = self.reject.as_ref().map(|reject| {
             let mut variables = HashMap::new();
 
-            for var in self.params.keys() {
+            for (var, param) in self.params.iter() {
                 let param_fn = format_ident!("{}", var);
-                variables.insert(var.as_str(), quote! { config.#param_fn() });
+                variables.insert(
+                    var.as_str(),
+                    Operand::new(
+                        quote! { config.#param_fn() },
+                        self.param_bounds(param, instance, tree),
+                    ),
+                );
             }
 
             reject.to_rust(variables, instance, tree)
@@ -409,7 +430,10 @@ impl ClockTreeNodeType for Generic {
                     for clock in tree.clock_tree.values() {
                         let clock_name = clock.name_str().as_str();
                         let frequency_fn = clock.frequency_function_name();
-                        variables.insert(clock_name, quote! { #frequency_fn() });
+                        variables.insert(
+                            clock_name,
+                            Operand::new(quote! { #frequency_fn() }, clock.output_bounds(tree)),
+                        );
                     }
 
                     let cfg_expr_code = ExprCompiler::new(&variables)
@@ -612,13 +636,23 @@ impl ClockTreeNodeType for Generic {
                 }
             }
         };
-        variables.insert(source_param_name, source_frequency_tokens);
+        let source_bounds = match self.upstream_clocks() {
+            ClockSource::Fixed(input) => instance.upstream_bounds(tree, input),
+            ClockSource::Mux(inputs) => variant_bounds(inputs, instance, tree),
+        };
+        variables.insert(
+            source_param_name,
+            Operand::new(source_frequency_tokens, source_bounds),
+        );
 
         // Numeric parameters
         variables.extend(self.params.iter().flat_map(|(var, p)| {
-            if let NodeParameter::Value(_) = p {
+            if let NodeParameter::Value(values) = p {
                 let param_fn = format_ident!("{var}");
-                Some((var.as_str(), quote! { config.#param_fn() }))
+                Some((
+                    var.as_str(),
+                    Operand::new(quote! { config.#param_fn() }, values.bounds()),
+                ))
             } else {
                 None
             }
@@ -840,6 +874,19 @@ impl Generic {
                 .iter()
                 .map(|variant| instance.resolve_node(tree, &variant.outputs))
                 .collect(),
+        }
+    }
+
+    /// Returns the range of values a parameter can take.
+    fn param_bounds(
+        &self,
+        param: &NodeParameter,
+        instance: &ClockTreeNodeInstance,
+        tree: &ProcessedClockData,
+    ) -> Bounds {
+        match param {
+            NodeParameter::Value(values) => values.bounds(),
+            NodeParameter::Source(variants) => variant_bounds(variants, instance, tree),
         }
     }
 

--- a/esp-metadata/src/cfg/soc/clock_tree/mux.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/mux.rs
@@ -10,6 +10,7 @@ use somni_parser::ast;
 use crate::cfg::{
     ClockTreeNodeInstance,
     clock_tree::{
+        Bounds,
         ClockTreeNodeType,
         ConfiguresExpression,
         SourceFrequencySignature,
@@ -38,6 +39,10 @@ pub struct Multiplexer {
 impl ClockTreeNodeType for Multiplexer {
     fn name(&self) -> &str {
         &self.name
+    }
+
+    fn output_bounds(&self, instance: &ClockTreeNodeInstance, tree: &ProcessedClockData) -> Bounds {
+        variant_bounds(&self.variants, instance, tree)
     }
 
     fn always_on(&self) -> bool {
@@ -489,6 +494,24 @@ impl Multiplexer {
             }
         }
     }
+}
+
+/// Returns the range of frequencies a mux over `variants` can output.
+pub(super) fn variant_bounds(
+    variants: &[MultiplexerVariant],
+    instance: &ClockTreeNodeInstance,
+    tree: &ProcessedClockData,
+) -> Bounds {
+    let mut bounds = None;
+    for variant in variants {
+        let variant = instance.upstream_bounds(tree, &variant.outputs);
+        bounds = Some(match bounds {
+            Some(bounds) => Bounds::union(bounds, variant),
+            None => variant,
+        });
+    }
+
+    bounds.unwrap_or(Bounds::UNKNOWN)
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/esp-metadata/src/cfg/soc/clock_tree/source.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/source.rs
@@ -31,6 +31,7 @@
 use std::collections::HashMap;
 
 use anyhow::Result;
+use indexmap::IndexMap;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use serde::Deserialize;
@@ -39,12 +40,14 @@ use crate::{
     cfg::{
         ClockTreeNodeInstance,
         clock_tree::{
+            Bounds,
             ClockTreeNodeType,
             Expression,
             RejectExpression,
             SourceFrequencySignature,
             ValidationContext,
             ValuesExpression,
+            expr_compiler::Operand,
             human_readable_frequency,
         },
         soc::ProcessedClockData,
@@ -82,6 +85,15 @@ impl ClockTreeNodeType for Source {
         &self.name
     }
 
+    fn output_bounds(&self, instance: &ClockTreeNodeInstance, tree: &ProcessedClockData) -> Bounds {
+        let mut variables = IndexMap::new();
+        if let Some(values) = self.values.as_ref() {
+            variables.insert("VALUE", values.bounds());
+        }
+
+        self.output.0.bounds_in_tree(&variables, instance, tree)
+    }
+
     fn always_on(&self) -> bool {
         self.always_on
     }
@@ -115,7 +127,14 @@ impl ClockTreeNodeType for Source {
         let reject_exprs = self.reject.as_ref().map(|reject| {
             let mut variables = HashMap::new();
 
-            variables.insert("VALUE", quote! { config.value() });
+            let value_bounds = self
+                .values
+                .as_ref()
+                .map_or(Bounds::UNKNOWN, |values| values.bounds());
+            variables.insert(
+                "VALUE",
+                Operand::new(quote! { config.value() }, value_bounds),
+            );
 
             reject.to_rust(variables, instance, tree)
         });
@@ -313,6 +332,10 @@ pub struct DerivedClockSource {
 impl ClockTreeNodeType for DerivedClockSource {
     fn name(&self) -> &str {
         self.source_options.name()
+    }
+
+    fn output_bounds(&self, instance: &ClockTreeNodeInstance, tree: &ProcessedClockData) -> Bounds {
+        self.source_options.output_bounds(instance, tree)
     }
 
     fn wake_locking(&self) -> bool {


### PR DESCRIPTION
Fractional divider calculations can overflow. This PR teaches the clock tree generator to use u64 arithmetic where necessary.