### PR TITLE
Generalize fractional divider calculations

### DIFF
--- a/esp-hal/src/clock/dividers.rs
+++ b/esp-hal/src/clock/dividers.rs
@@ -16,6 +16,32 @@ pub(crate) struct Fraction {
     pub denominator: u32,
 }
 
+/// A candidate fraction, paired with how far it sits from the target.
+///
+/// The distance is `|target - fraction|` scaled by `target.denominator * fraction.denominator`,
+/// which is why comparing two candidates has to undo the differing denominators.
+#[derive(Clone, Copy)]
+struct Candidate {
+    fraction: Fraction,
+    error: u32,
+}
+
+impl Candidate {
+    /// Returns whichever of `self` and `other` is closer to the target, preferring `self` on a
+    /// tie.
+    fn closer_of(self, other: Candidate) -> Candidate {
+        // This is cheaper than it looks, both architectures implement
+        // widening multiplication cheaply.
+        if self.error as u64 * other.fraction.denominator as u64
+            <= other.error as u64 * self.fraction.denominator as u64
+        {
+            self
+        } else {
+            other
+        }
+    }
+}
+
 /// Returns the fraction closest to `target` for each denominator from 1 to `max_denominator`,
 /// stopping early if one of them represents `target` exactly.
 ///
@@ -23,7 +49,7 @@ pub(crate) struct Fraction {
 /// of these is closest.
 ///
 /// `target` must be between 0 and 1.
-fn candidates(target: Fraction, max_denominator: u32) -> impl Iterator<Item = Fraction> {
+fn candidates(target: Fraction, max_denominator: u32) -> impl Iterator<Item = Candidate> {
     let Fraction {
         numerator: n,
         denominator: d,
@@ -57,30 +83,22 @@ fn candidates(target: Fraction, max_denominator: u32) -> impl Iterator<Item = Fr
         exact = acc == 0;
 
         // Round to nearest: `acc` is how far the target is above `whole`, `d - acc` how far it
-        // is below the next integer.
-        let numerator = if acc <= d - acc { whole } else { whole + 1 };
+        // is below the next integer. Either way that distance is the candidate's error.
+        let below = d - acc;
+        let (numerator, error) = if acc <= below {
+            (whole, acc)
+        } else {
+            (whole + 1, below)
+        };
 
-        Some(Fraction {
-            numerator,
-            denominator,
+        Some(Candidate {
+            fraction: Fraction {
+                numerator,
+                denominator,
+            },
+            error,
         })
     })
-}
-
-/// Returns whichever of `a` and `b` is closer to `target`, preferring `a` on a tie.
-fn closer_to(target: Fraction, a: Fraction, b: Fraction) -> Fraction {
-    // |t_num/t_den - num/den| = |t_num * den - num * t_den| / (t_den * den). The common `t_den`
-    // factor cancels, so the errors compare as `err_a * b_den` against `err_b * a_den`.
-    let error = |f: Fraction| {
-        (target.numerator as u64 * f.denominator as u64)
-            .abs_diff(f.numerator as u64 * target.denominator as u64)
-    };
-
-    if error(a) * b.denominator as u64 <= error(b) * a.denominator as u64 {
-        a
-    } else {
-        b
-    }
 }
 
 /// A clock divider of the form `N + B/A`.
@@ -120,13 +138,18 @@ impl FractionalDivider {
             return Self::integral(integer);
         }
 
-        let zero = Fraction {
-            numerator: 0,
-            denominator: 1,
+        // Dropping the remainder entirely is always an option, and is the yardstick the
+        // candidates are measured against.
+        let dropped = Candidate {
+            fraction: Fraction {
+                numerator: 0,
+                denominator: 1,
+            },
+            error: remainder.numerator,
         };
-        let closest = candidates(remainder, max_denominator).fold(zero, |best, candidate| {
-            closer_to(remainder, best, candidate)
-        });
+        let closest = candidates(remainder, max_denominator)
+            .fold(dropped, Candidate::closer_of)
+            .fraction;
 
         if closest.numerator == closest.denominator {
             // The remainder rounds up to a whole step.

--- a/esp-hal/src/clock/dividers.rs
+++ b/esp-hal/src/clock/dividers.rs
@@ -6,8 +6,8 @@
 // Which parts of this module are used depends on the set of drivers supported by the target chip.
 #![allow(dead_code)]
 
-/// The largest denominator [`FractionalDivider::new`] can be asked for, so that scaling a
-/// numerator by a denominator stays within a `u64`. Hardware fields are far narrower than this.
+/// The largest denominator [`FractionalDivider::new`] can be asked for, so that comparing the
+/// error of two candidates stays within a `u64`. Hardware fields are far narrower than this.
 const MAX_DENOMINATOR: u32 = 1 << 16;
 
 #[derive(Clone, Copy)]
@@ -16,22 +16,54 @@ pub(crate) struct Fraction {
     pub denominator: u32,
 }
 
-/// Returns the fraction closest to `target` for every denominator from 1 to `max_denominator`.
+/// Returns the fraction closest to `target` for each denominator from 1 to `max_denominator`,
+/// stopping early if one of them represents `target` exactly.
 ///
 /// A denominator only admits one closest numerator, so the closest fraction overall is whichever
 /// of these is closest.
 ///
 /// `target` must be between 0 and 1.
 fn candidates(target: Fraction, max_denominator: u32) -> impl Iterator<Item = Fraction> {
-    (1..=max_denominator).map(move |denominator| {
-        // The closest numerator is `target * denominator`, rounded to the nearest integer.
-        let scaled = target.numerator as u64 * denominator as u64;
-        let numerator = (scaled + target.denominator as u64 / 2) / target.denominator as u64;
+    let Fraction {
+        numerator: n,
+        denominator: d,
+    } = target;
 
-        Fraction {
-            numerator: numerator as u32,
-            denominator,
+    // `acc` tracks `denominator * n % d` and `whole` tracks `denominator * n / d`, so that no
+    // division is needed per candidate. Stepping `acc` by `n` without overflowing means
+    // subtracting the complement whenever it would wrap past `d` instead of adding to it.
+    let complement = d - n;
+    let mut acc = 0_u32;
+    let mut whole = 0_u32;
+
+    let mut denominator = 0;
+    let mut exact = false;
+
+    core::iter::from_fn(move || {
+        if exact || denominator == max_denominator {
+            return None;
         }
+        denominator += 1;
+
+        if acc >= complement {
+            acc -= complement;
+            whole += 1;
+        } else {
+            acc += n;
+        }
+
+        // A zero remainder means this denominator represents the target exactly, so no larger
+        // one can do better.
+        exact = acc == 0;
+
+        // Round to nearest: `acc` is how far the target is above `whole`, `d - acc` how far it
+        // is below the next integer.
+        let numerator = if acc <= d - acc { whole } else { whole + 1 };
+
+        Some(Fraction {
+            numerator,
+            denominator,
+        })
     })
 }
 

--- a/esp-hal/src/clock/dividers.rs
+++ b/esp-hal/src/clock/dividers.rs
@@ -1,0 +1,138 @@
+//! Helpers for calculating fractional clock divider values.
+//!
+//! Several peripherals (LCD_CAM, I2S, ...) divide their source clock by `N + B/A`, where `B/A`
+//! is a proper fraction whose numerator and denominator are limited to a few bits.
+
+// Which parts of this module are used depends on the set of drivers supported by the target chip.
+#![allow(dead_code)]
+
+/// The largest denominator [`FractionalDivider::new`] can be asked for, so that scaling a
+/// numerator by a denominator stays within a `u64`. Hardware fields are far narrower than this.
+const MAX_DENOMINATOR: u32 = 1 << 16;
+
+#[derive(Clone, Copy)]
+pub(crate) struct Fraction {
+    pub numerator: u32,
+    pub denominator: u32,
+}
+
+/// Returns the fraction closest to `target` for every denominator from 1 to `max_denominator`.
+///
+/// A denominator only admits one closest numerator, so the closest fraction overall is whichever
+/// of these is closest.
+///
+/// `target` must be between 0 and 1.
+fn candidates(target: Fraction, max_denominator: u32) -> impl Iterator<Item = Fraction> {
+    (1..=max_denominator).map(move |denominator| {
+        // The closest numerator is `target * denominator`, rounded to the nearest integer.
+        let scaled = target.numerator as u64 * denominator as u64;
+        let numerator = (scaled + target.denominator as u64 / 2) / target.denominator as u64;
+
+        Fraction {
+            numerator: numerator as u32,
+            denominator,
+        }
+    })
+}
+
+/// Returns whichever of `a` and `b` is closer to `target`, preferring `a` on a tie.
+fn closer_to(target: Fraction, a: Fraction, b: Fraction) -> Fraction {
+    // |t_num/t_den - num/den| = |t_num * den - num * t_den| / (t_den * den). The common `t_den`
+    // factor cancels, so the errors compare as `err_a * b_den` against `err_b * a_den`.
+    let error = |f: Fraction| {
+        (target.numerator as u64 * f.denominator as u64)
+            .abs_diff(f.numerator as u64 * target.denominator as u64)
+    };
+
+    if error(a) * b.denominator as u64 <= error(b) * a.denominator as u64 {
+        a
+    } else {
+        b
+    }
+}
+
+/// A clock divider of the form `N + B/A`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct FractionalDivider {
+    /// The integral part of the divider, `N`.
+    pub integer: u32,
+
+    /// The numerator of the fractional part, `B`. Zero if the divider is integral.
+    pub numerator: u32,
+
+    /// The denominator of the fractional part, `A`. Zero if the divider is integral.
+    pub denominator: u32,
+}
+
+impl FractionalDivider {
+    /// Calculates the divider that takes `source` closest to `target`.
+    ///
+    /// `max_denominator` is the largest value the hardware's `A` field can hold. Callers are
+    /// responsible for checking [`Self::integer`] against the range of the hardware's `N`
+    /// field: the divider is rounded up to the next integer when the fractional part cannot
+    /// be represented, so the result may be one larger than `source / target`.
+    ///
+    /// `target` must not be 0, and `max_denominator` must be between 1 and
+    /// [`MAX_DENOMINATOR`].
+    pub(crate) fn new(source: u32, target: u32, max_denominator: u32) -> Self {
+        debug_assert!(target != 0);
+        debug_assert!((1..=MAX_DENOMINATOR).contains(&max_denominator));
+
+        let integer = source / target;
+
+        let remainder = Fraction {
+            numerator: source % target,
+            denominator: target,
+        };
+        if remainder.numerator == 0 {
+            return Self::integral(integer);
+        }
+
+        let zero = Fraction {
+            numerator: 0,
+            denominator: 1,
+        };
+        let closest = candidates(remainder, max_denominator).fold(zero, |best, candidate| {
+            closer_to(remainder, best, candidate)
+        });
+
+        if closest.numerator == closest.denominator {
+            // The remainder rounds up to a whole step.
+            Self::integral(integer + 1)
+        } else if closest.numerator == 0 {
+            // The remainder is too small to represent, so it rounds away.
+            Self::integral(integer)
+        } else {
+            Self {
+                integer,
+                numerator: closest.numerator,
+                denominator: closest.denominator,
+            }
+        }
+    }
+
+    const fn integral(integer: u32) -> Self {
+        Self {
+            integer,
+            numerator: 0,
+            denominator: 0,
+        }
+    }
+
+    /// Returns the frequency this divider produces from `source`.
+    pub(crate) fn output_frequency(&self, source: u32) -> u32 {
+        if self.numerator == 0 || self.denominator == 0 {
+            return source / self.integer;
+        }
+
+        // OUTPUT = SOURCE / (N + B/A) = (SOURCE * A) / (N * A + B)
+        //
+        // u64 is required to fit the numbers from this arithmetic.
+        let source = source as u64;
+        let n = self.integer as u64;
+        let b = self.numerator as u64;
+        let a = self.denominator as u64;
+
+        ((source * a) / (n * a + b)) as u32
+    }
+}

--- a/esp-hal/src/clock/mod.rs
+++ b/esp-hal/src/clock/mod.rs
@@ -53,6 +53,8 @@ use clocks::RtcSlowClkConfig;
 use clocks::TimgFunctionClockConfig;
 use portable_atomic::AtomicU32;
 
+pub(crate) mod dividers;
+
 /// # Low-level clock control
 ///
 /// <section class="warning">

--- a/esp-hal/src/i2s/master/mod.rs
+++ b/esp-hal/src/i2s/master/mod.rs
@@ -159,6 +159,7 @@ use crate::{
     Async,
     Blocking,
     DriverMode,
+    clock::dividers::FractionalDivider,
     dma::{
         Channel,
         ChannelRx,
@@ -1812,8 +1813,6 @@ pub(crate) mod private {
         pub fn new(sample_rate: Rate, channels: u8, data_bits: u8) -> I2sClockDividers {
             // this loosely corresponds to `i2s_std_calculate_clock` and
             // `i2s_ll_tx_set_mclk` in esp-idf
-            //
-            // main difference is we are using fixed-point arithmetic here
 
             // If data_bits is a power of two, use 256 as the mclk_multiple
             // If data_bits is 24, use 192 (24 * 8) as the mclk_multiple
@@ -1824,51 +1823,18 @@ pub(crate) mod private {
 
             let bclk = rate * channels as u32 * data_bits as u32;
             let mclk = rate * mclk_multiple;
-            let bclk_divider = mclk / bclk;
-            let mut mclk_divider = sclk / mclk;
 
-            let mut ma: u32;
-            let mut mb: u32;
-            let mut denominator: u32 = 0;
-            let mut numerator: u32 = 0;
+            I2sClockDividers::from_frequencies(sclk, mclk, mclk / bclk)
+        }
 
-            let freq_diff = sclk.abs_diff(mclk * mclk_divider);
-
-            if freq_diff != 0 {
-                let decimal = freq_diff as u64 * 10000 / mclk as u64;
-
-                // Carry bit if the decimal is greater than 1.0 - 1.0 / (63.0 * 2) = 125.0 /
-                // 126.0
-                if decimal > 1250000 / 126 {
-                    mclk_divider += 1;
-                } else {
-                    let mut min: u32 = !0;
-
-                    for a in 2..=I2S_LL_MCLK_DIVIDER_MAX {
-                        let b = (a as u64) * (freq_diff as u64 * 10000u64 / mclk as u64) + 5000;
-                        ma = ((freq_diff as u64 * 10000u64 * a as u64) / 10000) as u32;
-                        mb = (mclk as u64 * (b / 10000)) as u32;
-
-                        if ma == mb {
-                            denominator = a as u32;
-                            numerator = (b / 10000) as u32;
-                            break;
-                        }
-
-                        if mb.abs_diff(ma) < min {
-                            denominator = a as u32;
-                            numerator = (b / 10000) as u32;
-                            min = mb.abs_diff(ma);
-                        }
-                    }
-                }
-            }
+        pub(crate) fn from_frequencies(sclk: u32, mclk: u32, bclk_divider: u32) -> Self {
+            let divider = FractionalDivider::new(sclk, mclk, I2S_LL_MCLK_DIVIDER_MAX as u32);
 
             I2sClockDividers {
-                mclk_divider,
+                mclk_divider: divider.integer,
                 bclk_divider,
-                denominator,
-                numerator,
+                denominator: divider.denominator,
+                numerator: divider.numerator,
             }
         }
     }

--- a/esp-hal/src/i2s/parallel.rs
+++ b/esp-hal/src/i2s/parallel.rs
@@ -97,6 +97,7 @@ use crate::{
     Blocking,
     DriverMode,
     RegisterToggle,
+    clock::dividers::FractionalDivider,
     dma::{ChannelTx, DmaEligiblePeripheral, DmaError, DmaTxBuffer, asynch::DmaTxFuture},
     gpio::{
         OutputConfig,
@@ -417,60 +418,23 @@ pub struct I2sClockDividers {
 
 fn calculate_clock(sample_rate: Rate, data_bits: u8) -> I2sClockDividers {
     // this loosely corresponds to `i2s_std_calculate_clock` and
-    // `i2s_ll_tx_set_mclk` in esp-idf
-    //
-    // main difference is we are using fixed-point arithmetic here
-    // plus adjusted for parallel interface clocking
+    // `i2s_ll_tx_set_mclk` in esp-idf, adjusted for parallel interface clocking
 
     let sclk = crate::soc::i2s_sclk_frequency();
-
-    let rate = sample_rate.as_hz();
-
-    let mclk = rate * 2;
+    let mclk = sample_rate.as_hz() * 2;
     let bclk_divider: u32 = if data_bits == 8 { 2 } else { 1 };
-    let mut mclk_divider = sclk / mclk;
 
-    let mut ma: u32;
-    let mut mb: u32;
-    let mut denominator: u32 = 0;
-    let mut numerator: u32 = 0;
-
-    let freq_diff = sclk.abs_diff(mclk * mclk_divider);
-
-    if freq_diff != 0 {
-        let decimal = freq_diff as u64 * 10000 / mclk as u64;
-        // Carry bit if the decimal is greater than 1.0 - 1.0 / (63.0 * 2) = 125.0 /
-        // 126.0
-        if decimal > 1250000 / 126 {
-            mclk_divider += 1;
-        } else {
-            let mut min: u32 = !0;
-
-            for a in 2..=crate::i2s::master::I2S_LL_MCLK_DIVIDER_MAX {
-                let b = (a as u64) * (freq_diff as u64 * 10000u64 / mclk as u64) + 5000;
-                ma = ((freq_diff as u64 * 10000u64 * a as u64) / 10000) as u32;
-                mb = (mclk as u64 * (b / 10000)) as u32;
-
-                if ma == mb {
-                    denominator = a as u32;
-                    numerator = (b / 10000) as u32;
-                    break;
-                }
-
-                if mb.abs_diff(ma) < min {
-                    denominator = a as u32;
-                    numerator = b as u32;
-                    min = mb.abs_diff(ma);
-                }
-            }
-        }
-    }
+    let divider = FractionalDivider::new(
+        sclk,
+        mclk,
+        crate::i2s::master::I2S_LL_MCLK_DIVIDER_MAX as u32,
+    );
 
     I2sClockDividers {
-        mclk_divider,
+        mclk_divider: divider.integer,
         bclk_divider,
-        denominator,
-        numerator,
+        denominator: divider.denominator,
+        numerator: divider.numerator,
     }
 }
 #[doc(hidden)]

--- a/esp-hal/src/i2s/pdm/clock.rs
+++ b/esp-hal/src/i2s/pdm/clock.rs
@@ -1,11 +1,7 @@
 //! PDM clock calculations.
 
 use super::{PdmDownsampleRate, PdmError, PdmRxClockConfig, PdmTxClockConfig};
-use crate::{
-    i2s::master::{I2S_LL_MCLK_DIVIDER_MAX, private::I2sClockDividers},
-    soc,
-    time::Rate,
-};
+use crate::{i2s::master::private::I2sClockDividers, soc, time::Rate};
 
 pub(crate) const PDM_BCK_FACTOR: u32 = 64;
 pub(crate) const PDM_TX_BCLK_DIV_MIN: u32 = 8;
@@ -20,75 +16,19 @@ pub(crate) struct PdmRxClockResult {
     pub dividers: I2sClockDividers,
 }
 
-fn gcd(mut a: u32, mut b: u32) -> u32 {
-    while b != 0 {
-        (a, b) = (b, a % b);
-    }
-    a
-}
-
 fn calculate_mclk_dividers(sclk: u32, mclk: u32) -> Result<I2sClockDividers, PdmError> {
     // Require `sclk > mclk * 1.99` — use integer math to avoid soft-float.
     if (sclk as u64) * 100 <= (mclk as u64) * 199 {
         return Err(PdmError::InvalidClock);
     }
 
-    let mut mclk_divider = sclk / mclk;
-    if mclk_divider >= 256 {
+    let dividers = I2sClockDividers::from_frequencies(sclk, mclk, 0);
+
+    if dividers.mclk_divider >= 256 {
         return Err(PdmError::InvalidClock);
     }
 
-    let freq_diff = sclk.abs_diff(mclk * mclk_divider);
-    let mut denominator = 0u32;
-    let mut numerator = 0u32;
-
-    if freq_diff != 0 {
-        let decimal = freq_diff as u64 * 10000 / mclk as u64;
-        if decimal > 1250000 / 126 {
-            mclk_divider += 1;
-            if mclk_divider >= 256 {
-                return Err(PdmError::InvalidClock);
-            }
-        } else {
-            let max_fract = I2S_LL_MCLK_DIVIDER_MAX as u32;
-            let common = gcd(freq_diff, mclk);
-            let exact_num = freq_diff / common;
-            let exact_den = mclk / common;
-            if (2..=max_fract).contains(&exact_den) {
-                numerator = exact_num;
-                denominator = exact_den;
-            } else {
-                let mut min = u32::MAX;
-                for a in 2..=max_fract {
-                    // Best rational approximation of `freq_diff / mclk` with denominator `a`.
-                    let b = ((freq_diff as u64 * a as u64) + mclk as u64 / 2) / mclk as u64;
-                    if b == 0 || b >= a as u64 {
-                        continue;
-                    }
-                    let ma = freq_diff as u64 * a as u64;
-                    let mb = mclk as u64 * b;
-                    if ma == mb {
-                        denominator = a;
-                        numerator = b as u32;
-                        break;
-                    }
-                    let err = ma.abs_diff(mb);
-                    if err < min as u64 {
-                        denominator = a;
-                        numerator = b as u32;
-                        min = err as u32;
-                    }
-                }
-            }
-        }
-    }
-
-    Ok(I2sClockDividers {
-        mclk_divider,
-        bclk_divider: 0,
-        denominator,
-        numerator,
-    })
+    Ok(dividers)
 }
 
 pub(crate) fn calculate_tx_clock(

--- a/esp-hal/src/lcd_cam/mod.rs
+++ b/esp-hal/src/lcd_cam/mod.rs
@@ -11,6 +11,7 @@ use crate::{
     Async,
     Blocking,
     asynch::AtomicWaker,
+    clock::dividers::FractionalDivider,
     handler,
     interrupt::InterruptHandler,
     lcd_cam::{cam::Cam, lcd::Lcd},
@@ -206,6 +207,18 @@ pub(crate) struct ClockDivider {
     pub div_a: u32,
 }
 
+impl ClockDivider {
+    fn new(divider: FractionalDivider) -> Self {
+        Self {
+            div_num: divider.integer,
+            div_b: divider.numerator,
+            // An integral divider has no denominator, but the clock tree only accepts
+            // denominators of 1 or more.
+            div_a: divider.denominator.max(1),
+        }
+    }
+}
+
 /// Clock configuration errors.
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -222,117 +235,42 @@ pub(crate) fn calculate_clkm(
     let mut result = None;
 
     for (i, &source_frequency) in source_frequencies.iter().enumerate() {
-        let div = calculate_closest_divider(source_frequency, desired_frequency);
-        if let Some(div) = div {
-            let freq = calculate_output_frequency(source_frequency, &div);
-            if result.is_none() || freq > result_freq {
-                result = Some((i, div));
-                result_freq = freq;
-            }
+        let Some(divider) = calculate_closest_divider(source_frequency, desired_frequency) else {
+            continue;
+        };
+
+        let freq = divider.output_frequency(source_frequency);
+        if result.is_none() || freq > result_freq {
+            result = Some((i, divider));
+            result_freq = freq;
         }
     }
 
-    result.ok_or(ClockError::FrequencyTooLow)
-}
+    let (index, divider) = result.ok_or(ClockError::FrequencyTooLow)?;
 
-fn calculate_output_frequency(source_frequency: u32, divider: &ClockDivider) -> u32 {
-    // OUTPUT = SOURCE / (N + B/A)
-    // OUTPUT = SOURCE / ((NA + B)/A)
-    // OUTPUT = (SOURCE * A) / (NA + B)
-
-    // u64 is required to fit the numbers from this arithmetic.
-    let source = source_frequency as u64;
-    let n = divider.div_num as u64;
-    let a = divider.div_a as u64;
-    let b = divider.div_b as u64;
-
-    ((source * a) / (n * a + b)) as u32
+    Ok((index, ClockDivider::new(divider)))
 }
 
 fn calculate_closest_divider(
     source_frequency: u32,
     desired_frequency: u32,
-) -> Option<ClockDivider> {
-    let div_num = source_frequency / desired_frequency;
+) -> Option<FractionalDivider> {
     // For current chips, LCD and CAM have the same divider range.
     let (min_divider, max_divider) = property!("clock_tree.lcd_cam.lcd_clock.div_num");
-    let (_, max_denom) = property!("clock_tree.lcd_cam.lcd_clock.div_a");
-    if div_num < min_divider {
+    let (_, max_denominator) = property!("clock_tree.lcd_cam.lcd_clock.div_a");
+
+    if source_frequency / desired_frequency < min_divider {
         // Source clock isn't fast enough to reach the desired frequency.
         // Return max output.
-        return Some(ClockDivider {
-            div_num: min_divider,
-            div_b: 0,
-            div_a: 1,
+        return Some(FractionalDivider {
+            integer: min_divider,
+            numerator: 0,
+            denominator: 0,
         });
     }
-    if div_num > max_divider {
-        // Source is too fast to divide to the desired frequency. Return None.
-        return None;
-    }
 
-    let div_fraction = {
-        let div_remainder = source_frequency % desired_frequency;
-        let gcd = hcf(div_remainder, desired_frequency);
-        Fraction {
-            numerator: div_remainder / gcd,
-            denominator: desired_frequency / gcd,
-        }
-    };
+    let divider = FractionalDivider::new(source_frequency, desired_frequency, max_denominator);
 
-    let divider = if div_fraction.numerator == 0 {
-        ClockDivider {
-            div_num,
-            div_b: 0,
-            div_a: 1,
-        }
-    } else {
-        let target = div_fraction;
-        let closest = farey_sequence(max_denom).find(|curr| {
-            // https://en.wikipedia.org/wiki/Fraction#Adding_unlike_quantities
-
-            let new_curr_num = curr.numerator * target.denominator;
-            let new_target_num = target.numerator * curr.denominator;
-            new_curr_num >= new_target_num
-        });
-
-        let closest = unwrap!(closest, "The fraction must be between 0 and 1");
-
-        ClockDivider {
-            div_num,
-            div_b: closest.numerator,
-            div_a: closest.denominator,
-        }
-    };
-    Some(divider)
-}
-
-// https://en.wikipedia.org/wiki/Euclidean_algorithm
-const fn hcf(a: u32, b: u32) -> u32 {
-    if b != 0 { hcf(b, a % b) } else { a }
-}
-
-struct Fraction {
-    pub numerator: u32,
-    pub denominator: u32,
-}
-
-// https://en.wikipedia.org/wiki/Farey_sequence#Next_term
-fn farey_sequence(denominator: u32) -> impl Iterator<Item = Fraction> {
-    let mut a = 0;
-    let mut b = 1;
-    let mut c = 1;
-    let mut d = denominator;
-    core::iter::from_fn(move || {
-        if a > denominator {
-            return None;
-        }
-        let next = Fraction {
-            numerator: a,
-            denominator: b,
-        };
-        let k = (denominator + b) / d;
-        (a, b, c, d) = (c, d, k * c - a, k * d - b);
-        Some(next)
-    })
+    // Source is too fast to divide down to the desired frequency.
+    (divider.integer <= max_divider).then_some(divider)
 }

--- a/esp-hal/src/lcd_cam/mod.rs
+++ b/esp-hal/src/lcd_cam/mod.rs
@@ -231,7 +231,7 @@ pub(crate) fn calculate_clkm(
     desired_frequency: u32,
     source_frequencies: &[u32],
 ) -> Result<(usize, ClockDivider), ClockError> {
-    let mut result_freq = 0;
+    let mut result_error = 0;
     let mut result = None;
 
     for (i, &source_frequency) in source_frequencies.iter().enumerate() {
@@ -239,10 +239,14 @@ pub(crate) fn calculate_clkm(
             continue;
         };
 
-        let freq = divider.output_frequency(source_frequency);
-        if result.is_none() || freq > result_freq {
+        // A divider may land either side of the desired frequency, so pick the source that gets
+        // closest to it.
+        let error = divider
+            .output_frequency(source_frequency)
+            .abs_diff(desired_frequency);
+        if result.is_none() || error < result_error {
             result = Some((i, divider));
-            result_freq = freq;
+            result_error = error;
         }
     }
 


### PR DESCRIPTION
# Changelog

## esp-hal

- Fixed: The I2S drivers now pick the closest representable MCLK divider, so sample rates that do not divide the source clock evenly are reproduced more accurately.
- Fixed: `I2sParallel` generated an incorrect fractional MCLK divider (and therefore a wrong output rate) for sample rates that could not be represented exactly.