### PR TITLE
Compile radio HIL binaries without debuginfo

### DIFF
--- a/hil-test-radio/Cargo.toml
+++ b/hil-test-radio/Cargo.toml
@@ -130,9 +130,10 @@ overflow-checks  = true
 
 [profile.release]
 codegen-units    = 1
-debug            = 2
 debug-assertions = true
 incremental      = false
 opt-level        = 3
 lto              = false # LTO (thin or fat) miscompiles some tests on RISC-V
 overflow-checks  = true
+# We rarely debug HIL binaries, so let's shrink the .ELF size
+debug            = 0


### PR DESCRIPTION
[Sometimes](https://github.com/esp-rs/esp-hal/actions/runs/30361862413/job/90283330622#step:10:30), even the ~40-some MB radio HIL binaries take forever to upload. Let's apply #5914 to them, too