### PR TITLE
Improve time to calculate SPI dividers

### DIFF
--- a/esp-hal/src/spi/master/mod.rs
+++ b/esp-hal/src/spi/master/mod.rs
@@ -490,6 +490,9 @@ impl Default for Config {
 
 impl Config {
     /// Set the frequency of the SPI bus clock.
+    ///
+    /// The closest available frequency that does not exceed `frequency` is used,
+    /// so the bus never runs faster than requested.
     pub fn with_frequency(mut self, frequency: Rate) -> Self {
         self.frequency = frequency;
         self.reg = self.recalculate();
@@ -520,8 +523,8 @@ impl Config {
         // In HW, n, h and l fields range from 1 to 64, pre ranges from 1 to 8K.
         // The value written to register is one lower than the used value.
 
-        if self.frequency > ((source_freq / 4) * 3) {
-            // Using source frequency directly will give us the best result here.
+        if self.frequency >= source_freq {
+            // Bypass the divider, which is exactly the source frequency.
             // Set the SPI_CLK_EQU_SYSCLK bit.
             return Ok(1 << 31);
         }
@@ -540,95 +543,64 @@ impl Config {
             | ((pre - 1) << 18)) // SPI_CLKDIV_PRE
     }
 
-    /// Finds the `(n, pre)` pair whose resulting bus frequency is closest to
-    /// `target_freq_hz`, where `n` is `SPI_CLKCNT_N + 1` and `pre` is
+    /// Finds the `(n, pre)` pair producing the highest bus frequency that does
+    /// not exceed `target_freq_hz`, where `n` is `SPI_CLKCNT_N + 1` and `pre` is
     /// `SPI_CLKDIV_PRE + 1`.
     ///
-    /// The peripheral divides the source clock by `pre * n`. `n` also determines
-    /// the duty cycle resolution, so out of equally accurate pairs we want the
-    /// one with the largest `n`.
+    /// The peripheral divides the source clock by `pre * n`, so this is the
+    /// smallest divider that does not overshoot. `n` also determines the duty
+    /// cycle resolution, so out of pairs forming that divider we want the one
+    /// with the largest `n`.
     ///
-    /// Out-of-range frequencies (see [`Config::validate`]) yield an arbitrary
-    /// in-range pair rather than an error.
+    /// Out-of-range frequencies (see [`Config::validate`]) yield the slowest pair
+    /// available rather than an error.
     fn divider_pair(source_freq_hz: u32, target_freq_hz: u32) -> (u32, u32) {
         // A zero target is rejected by `validate`, but must not divide by zero
-        // here. Answer with the slowest pair available.
+        // here.
         if target_freq_hz == 0 {
             return (64, 16);
         }
 
-        // For a divider `d` the frequency error is `|source / d - target|`, which
-        // we keep as the numerator of `|source - target * d| / d` so that no
-        // division is needed to compare candidates. No candidate divider is more
-        // than one step past the ideal one, which keeps `target * d` below
-        // `2 * source`.
-        let error_numerator = |divider: u32| source_freq_hz.abs_diff(target_freq_hz * divider);
+        // Any smaller divider would run the bus faster than requested. `n` starts
+        // at 2 so that h/l can describe at least one high and one low pulse.
+        let min_divider = source_freq_hz.div_ceil(target_freq_hz).max(2);
 
-        // Comparing two candidates cross-multiplies each error numerator with the
-        // other's divider. These products are the only values here that do not
-        // fit in 32 bits, and widening multiplication is cheap.
-        let closer = |this: (u32, u32), that: (u32, u32)| {
-            let (error, divider) = this;
-            let (other_error, other_divider) = that;
-
-            u64::from(error) * u64::from(other_divider)
-                < u64::from(other_error) * u64::from(divider)
-        };
-
-        let ideal_divider = source_freq_hz / target_freq_hz;
-
-        // `source / (pre * n)` falls as `n` grows, so the best `n` for a given
-        // `pre` is one of the two integers around the ideal, fractional one. Of
-        // the two, the larger is preferred on a tie, for its finer duty cycle
-        // resolution. `n` starts at 2 so that h/l can describe at least one high
-        // and one low pulse.
-        let best_n_for = |pre: u32| {
-            let ideal = ideal_divider / pre;
-            let (n_hi, n_lo) = ((ideal + 1).clamp(2, 64), ideal.clamp(2, 64));
-            let (divider_hi, divider_lo) = (pre * n_hi, pre * n_lo);
-            let (error_hi, error_lo) = (error_numerator(divider_hi), error_numerator(divider_lo));
-
-            if closer((error_lo, divider_lo), (error_hi, divider_hi)) {
-                (n_lo, divider_lo, error_lo)
-            } else {
-                (n_hi, divider_hi, error_hi)
-            }
-        };
-
-        // A `pre` of 1 offers every divider up to 64, so if the ideal divider is
-        // in that range, the best `n` for it is also the best divider overall,
-        // with the largest `n` that can produce it. No need to look further.
-        if ideal_divider < 64 {
-            return (best_n_for(1).0, 1);
+        // A `pre` of 1 offers every divider up to 64, so if the smallest usable
+        // divider is in that range we can form it directly, with the largest `n`
+        // that produces it.
+        if min_divider <= 64 {
+            return (min_divider, 1);
         }
 
         // `n` maxes out at 64, so a smaller `pre` cannot bring the source clock
         // down to the target. As `n` shrinks when `pre` grows, walking `pre`
         // upwards visits the candidates in order of decreasing duty cycle
-        // resolution, which lets us keep the first of several equally accurate
-        // pairs.
+        // resolution, which lets us keep the first of several that share a
+        // divider.
         //
-        // The seed is a divider of 1, which any candidate in range beats, since
-        // `target` is at most three quarters of `source` here.
-        let mut best = (2, 1);
-        let mut best_divider = 1;
-        let mut best_error = source_freq_hz;
+        // The seed is the slowest pair, which also answers requests below the
+        // supported range.
+        let mut best = (64, 16);
+        let mut best_divider = 64 * 16;
 
         // A `for` loop over a range would leave a divide-by-zero check on `pre`
         // in the generated code, as the lower bound is not visible through the
         // range iterator on all targets.
-        let mut pre = (ideal_divider / 64).max(1);
+        let mut pre = min_divider.div_ceil(64);
         while pre <= 16 {
-            let (n, divider, error) = best_n_for(pre);
+            // The smallest `n` that keeps `pre * n` from overshooting. The lower
+            // bound on `pre` keeps this at or below 64.
+            let n = min_divider.div_ceil(pre);
+            let divider = pre * n;
 
-            if closer((error, divider), (best_error, best_divider)) {
+            if divider < best_divider {
                 best = (n, pre);
                 best_divider = divider;
-                best_error = error;
-            }
 
-            if best_error == 0 {
-                break;
+                // Nothing can beat hitting the smallest usable divider exactly.
+                if divider == min_divider {
+                    break;
+                }
             }
 
             pre += 1;

--- a/esp-hal/src/spi/master/mod.rs
+++ b/esp-hal/src/spi/master/mod.rs
@@ -526,8 +526,7 @@ impl Config {
             return Ok(1 << 31);
         }
 
-        let (n, pre) =
-            Self::divider_pair(source_freq.as_hz() as u64, self.frequency.as_hz() as u64);
+        let (n, pre) = Self::divider_pair(source_freq.as_hz(), self.frequency.as_hz());
 
         // In master mode, L == N
         let l = n;
@@ -551,18 +550,30 @@ impl Config {
     ///
     /// Out-of-range frequencies (see [`Config::validate`]) yield an arbitrary
     /// in-range pair rather than an error.
-    fn divider_pair(source_freq_hz: u64, target_freq_hz: u64) -> (u32, u32) {
+    fn divider_pair(source_freq_hz: u32, target_freq_hz: u32) -> (u32, u32) {
         // A zero target is rejected by `validate`, but must not divide by zero
         // here. Answer with the slowest pair available.
         if target_freq_hz == 0 {
             return (64, 16);
         }
 
-        // For a divider `d` the frequency error is `|source / d - target|`. We
-        // avoid the division by keeping the error as the numerator of
-        // `|source - target * d| / d`, and comparing two candidates by
-        // cross-multiplying each numerator with the other's `d`.
-        let error_numerator = |divider: u64| source_freq_hz.abs_diff(target_freq_hz * divider);
+        // For a divider `d` the frequency error is `|source / d - target|`, which
+        // we keep as the numerator of `|source - target * d| / d` so that no
+        // division is needed to compare candidates. No candidate divider is more
+        // than one step past the ideal one, which keeps `target * d` below
+        // `2 * source`.
+        let error_numerator = |divider: u32| source_freq_hz.abs_diff(target_freq_hz * divider);
+
+        // Comparing two candidates cross-multiplies each error numerator with the
+        // other's divider. These products are the only values here that do not
+        // fit in 32 bits, and widening multiplication is cheap.
+        let closer = |this: (u32, u32), that: (u32, u32)| {
+            let (error, divider) = this;
+            let (other_error, other_divider) = that;
+
+            u64::from(error) * u64::from(other_divider)
+                < u64::from(other_error) * u64::from(divider)
+        };
 
         let ideal_divider = source_freq_hz / target_freq_hz;
 
@@ -571,17 +582,16 @@ impl Config {
         // the two, the larger is preferred on a tie, for its finer duty cycle
         // resolution. `n` starts at 2 so that h/l can describe at least one high
         // and one low pulse.
-        let best_n_for = |pre: u64| {
+        let best_n_for = |pre: u32| {
             let ideal = ideal_divider / pre;
-            let (hi, lo) = ((ideal + 1).clamp(2, 64), ideal.clamp(2, 64));
+            let (n_hi, n_lo) = ((ideal + 1).clamp(2, 64), ideal.clamp(2, 64));
+            let (divider_hi, divider_lo) = (pre * n_hi, pre * n_lo);
+            let (error_hi, error_lo) = (error_numerator(divider_hi), error_numerator(divider_lo));
 
-            let (error_hi, error_lo) = (error_numerator(pre * hi), error_numerator(pre * lo));
-
-            // `pre` cancels out of the cross-multiplied comparison.
-            if error_lo * hi < error_hi * lo {
-                (lo, pre * lo, error_lo)
+            if closer((error_lo, divider_lo), (error_hi, divider_hi)) {
+                (n_lo, divider_lo, error_lo)
             } else {
-                (hi, pre * hi, error_hi)
+                (n_hi, divider_hi, error_hi)
             }
         };
 
@@ -589,7 +599,7 @@ impl Config {
         // in that range, the best `n` for it is also the best divider overall,
         // with the largest `n` that can produce it. No need to look further.
         if ideal_divider < 64 {
-            return (best_n_for(1).0 as u32, 1);
+            return (best_n_for(1).0, 1);
         }
 
         // `n` maxes out at 64, so a smaller `pre` cannot bring the source clock
@@ -604,11 +614,15 @@ impl Config {
         let mut best_divider = 1;
         let mut best_error = source_freq_hz;
 
-        for pre in (ideal_divider / 64).max(1)..=16 {
+        // A `for` loop over a range would leave a divide-by-zero check on `pre`
+        // in the generated code, as the lower bound is not visible through the
+        // range iterator on all targets.
+        let mut pre = (ideal_divider / 64).max(1);
+        while pre <= 16 {
             let (n, divider, error) = best_n_for(pre);
 
-            if error * best_divider < best_error * divider {
-                best = (n as u32, pre as u32);
+            if closer((error, divider), (best_error, best_divider)) {
+                best = (n, pre);
                 best_divider = divider;
                 best_error = error;
             }
@@ -616,6 +630,8 @@ impl Config {
             if best_error == 0 {
                 break;
             }
+
+            pre += 1;
         }
 
         best

--- a/esp-hal/src/spi/master/mod.rs
+++ b/esp-hal/src/spi/master/mod.rs
@@ -523,55 +523,102 @@ impl Config {
         if self.frequency > ((source_freq / 4) * 3) {
             // Using source frequency directly will give us the best result here.
             // Set the SPI_CLK_EQU_SYSCLK bit.
-            Ok(1 << 31)
-        } else {
-            // For best duty cycle resolution, we want n to be as close to 32 as
-            // possible, but we also need a pre/n combo that gets us as close as
-            // possible to the intended frequency. To do this, we bruteforce n and
-            // calculate the best pre to go along with that. If there's a choice
-            // between pre/n combos that give the same result, use the one with the
-            // higher n.
+            return Ok(1 << 31);
+        }
 
-            let mut best_n: u32 = 2;
-            let mut best_pre: u32 = 0;
-            let mut best_err: u32 = u32::MAX;
+        let (n, pre) =
+            Self::divider_pair(source_freq.as_hz() as u64, self.frequency.as_hz() as u64);
 
-            let target_freq_hz = self.frequency.as_hz();
-            let source_freq_hz = source_freq.as_hz();
+        // In master mode, L == N
+        let l = n;
 
-            // Start at n = 2. We need to be able to set h/l so we have at least
-            // one high and one low pulse.
+        // In master mode, this field must be floor((SPI_CLKCNT_N + 1)/2 - 1)
+        let h = (n / 2).max(1);
 
-            for n in 2..=64 {
-                let pre = (source_freq_hz / n).div_ceil(target_freq_hz).clamp(1, 16);
+        Ok((l - 1) // SPI_CLKCNT_L
+            | ((h - 1) << 6) // SPI_CLKCNT_H
+            | ((n - 1) << 12) // SPI_CLKCNT_N
+            | ((pre - 1) << 18)) // SPI_CLKDIV_PRE
+    }
 
-                let errval = (source_freq_hz / (pre * n)).abs_diff(target_freq_hz);
-                if errval <= best_err {
-                    best_err = errval;
-                    best_n = n;
-                    best_pre = pre;
+    /// Finds the `(n, pre)` pair whose resulting bus frequency is closest to
+    /// `target_freq_hz`, where `n` is `SPI_CLKCNT_N + 1` and `pre` is
+    /// `SPI_CLKDIV_PRE + 1`.
+    ///
+    /// The peripheral divides the source clock by `pre * n`. `n` also determines
+    /// the duty cycle resolution, so out of equally accurate pairs we want the
+    /// one with the largest `n`.
+    ///
+    /// Out-of-range frequencies (see [`Config::validate`]) yield an arbitrary
+    /// in-range pair rather than an error.
+    fn divider_pair(source_freq_hz: u64, target_freq_hz: u64) -> (u32, u32) {
+        // A zero target is rejected by `validate`, but must not divide by zero
+        // here. Answer with the slowest pair available.
+        if target_freq_hz == 0 {
+            return (64, 16);
+        }
 
-                    if errval == 0 {
-                        break;
-                    }
-                }
+        // For a divider `d` the frequency error is `|source / d - target|`. We
+        // avoid the division by keeping the error as the numerator of
+        // `|source - target * d| / d`, and comparing two candidates by
+        // cross-multiplying each numerator with the other's `d`.
+        let error_numerator = |divider: u64| source_freq_hz.abs_diff(target_freq_hz * divider);
+
+        let ideal_divider = source_freq_hz / target_freq_hz;
+
+        // `source / (pre * n)` falls as `n` grows, so the best `n` for a given
+        // `pre` is one of the two integers around the ideal, fractional one. Of
+        // the two, the larger is preferred on a tie, for its finer duty cycle
+        // resolution. `n` starts at 2 so that h/l can describe at least one high
+        // and one low pulse.
+        let best_n_for = |pre: u64| {
+            let ideal = ideal_divider / pre;
+            let (hi, lo) = ((ideal + 1).clamp(2, 64), ideal.clamp(2, 64));
+
+            let (error_hi, error_lo) = (error_numerator(pre * hi), error_numerator(pre * lo));
+
+            // `pre` cancels out of the cross-multiplied comparison.
+            if error_lo * hi < error_hi * lo {
+                (lo, pre * lo, error_lo)
+            } else {
+                (hi, pre * hi, error_hi)
+            }
+        };
+
+        // A `pre` of 1 offers every divider up to 64, so if the ideal divider is
+        // in that range, the best `n` for it is also the best divider overall,
+        // with the largest `n` that can produce it. No need to look further.
+        if ideal_divider < 64 {
+            return (best_n_for(1).0 as u32, 1);
+        }
+
+        // `n` maxes out at 64, so a smaller `pre` cannot bring the source clock
+        // down to the target. As `n` shrinks when `pre` grows, walking `pre`
+        // upwards visits the candidates in order of decreasing duty cycle
+        // resolution, which lets us keep the first of several equally accurate
+        // pairs.
+        //
+        // The seed is a divider of 1, which any candidate in range beats, since
+        // `target` is at most three quarters of `source` here.
+        let mut best = (2, 1);
+        let mut best_divider = 1;
+        let mut best_error = source_freq_hz;
+
+        for pre in (ideal_divider / 64).max(1)..=16 {
+            let (n, divider, error) = best_n_for(pre);
+
+            if error * best_divider < best_error * divider {
+                best = (n as u32, pre as u32);
+                best_divider = divider;
+                best_error = error;
             }
 
-            // n = SPI_CLKCNT_N + 1
-            let n = best_n;
-            // pre = SPI_CLKDIV_PRE + 1
-            let pre = best_pre;
-            // In master mode, L == N
-            let l = n;
-
-            // In master mode, this field must be floor((SPI_CLKCNT_N + 1)/2 - 1)
-            let h = (n / 2).max(1);
-
-            Ok((l - 1) // SPI_CLKCNT_L
-                | ((h - 1) << 6) // SPI_CLKCNT_H
-                | ((n - 1) << 12) // SPI_CLKCNT_N
-                | ((pre - 1) << 18)) // SPI_CLKDIV_PRE
+            if best_error == 0 {
+                break;
+            }
         }
+
+        best
     }
 
     fn raw_clock_reg_value(&self) -> Result<u32, ConfigError> {


### PR DESCRIPTION
I've unleashed Opus 5 on the SPI clock divider calculation and the end result is massively improved in terms of speed.

<details>
<summary>Testing & results</summary>
Benchmarked with the following QA-test:

```rust
//! Measures how long it takes to compute an SPI clock configuration.
//!
//! `spi::master::Config` caches the clock register value, and recomputes it
//! whenever the target frequency or the clock source changes. This benchmark
//! times that recomputation for a range of target frequencies, so the cost of
//! the divider search can be measured instead of estimated.
//!
//! The search brute-forces the `n` divider and derives `pre` from it, and it
//! stops early on an exact match, so the cost depends heavily on the requested
//! frequency. Frequencies that have no exact divider pair are the worst case.
//!
//! No wiring is required; nothing is written to the SPI peripheral.

//% CHIP_FILTER: spi_master_driver_supported

#![no_std]
#![no_main]

use core::hint::black_box;

use esp_backtrace as _;
use esp_hal::{
    clock::CpuClock,
    main,
    spi::master::Config,
    time::{Instant, Rate},
};

esp_bootloader_esp_idf::esp_app_desc!();

/// Iterations per measurement. `Instant` is backed by the system timer, whose
/// resolution is far coarser than a single calculation, so we average over many
/// runs.
const ITERATIONS: u32 = 10_000;

/// Target frequencies to measure, in kHz. These cover the `CLK_EQU_SYSCLK`
/// shortcut, frequencies with an exact divider pair, and frequencies that force
/// the search to run to completion.
const TARGETS_KHZ: &[u32] = &[
    80_000, 40_000, 26_000, 24_000, 20_000, 10_000, 4_000, 3_000, 1_000, 500, 100,
];

/// Time `ITERATIONS` runs of `f`, returning the average in nanoseconds.
fn measure(mut f: impl FnMut()) -> u64 {
    let start = Instant::now();
    for _ in 0..ITERATIONS {
        f();
    }
    let elapsed = start.elapsed().as_micros();

    elapsed * 1000 / ITERATIONS as u64
}

#[main]
fn main() -> ! {
    esp_println::logger::init_logger_from_env();
    let _peripherals = esp_hal::init(esp_hal::Config::default().with_cpu_clock(CpuClock::max()));

    let cpu_mhz = esp_hal::clock::cpu_clock().as_mhz() as u64;
    esp_println::println!("CPU clock: {} MHz", cpu_mhz);
    esp_println::println!("Averaging over {} iterations each.", ITERATIONS);

    // The empty loop is measured too, so the reported figures can be corrected
    // for loop and `black_box` overhead.
    let overhead = measure(|| {
        black_box(());
    });
    esp_println::println!("Loop overhead: {} ns", overhead);

    // `Config::default()` also runs the calculation, for 1 MHz.
    let default = measure(|| {
        black_box(Config::default());
    });
    esp_println::println!(
        "Config::default(): {} ns ({} cycles)",
        default.saturating_sub(overhead),
        default.saturating_sub(overhead) * cpu_mhz / 1000
    );

    esp_println::println!();
    esp_println::println!(" target      ns   cycles");

    // Built once, so that only `with_frequency` is timed and not `default()`.
    let base = Config::default();

    for &khz in TARGETS_KHZ {
        let rate = Rate::from_khz(khz);

        let ns = measure(|| {
            black_box(black_box(base).with_frequency(black_box(rate)));
        })
        .saturating_sub(overhead);

        esp_println::println!("{:>6} kHz {:>5} {:>8}", khz, ns, ns * cpu_mhz / 1000);
    }

    loop {}
}
```

ESP32-S3:

```
Before:

CPU clock: 240 MHz
Averaging over 10000 iterations each.
Loop overhead: 18 ns
Config::default(): 1054 ns (252 cycles)

 target      ns   cycles
 80000 kHz   239       57
 40000 kHz   236       56
 26000 kHz 17091     4101
 24000 kHz 17090     4101
 20000 kHz   573      137
 10000 kHz   582      139
  4000 kHz   582      139
  3000 kHz 17115     4107
  1000 kHz  1148      275
   500 kHz  1432      343
   100 kHz  7111     1706

After:
CPU clock: 240 MHz
Averaging over 10000 iterations each.
Loop overhead: 18 ns
Config::default(): 248 ns (59 cycles)

 target      ns   cycles
 80000 kHz   173       41
 40000 kHz   169       40
 26000 kHz   291       69
 24000 kHz   290       69
 20000 kHz   290       69
 10000 kHz   298       71
  4000 kHz   298       71
  3000 kHz   298       71
  1000 kHz   298       71
   500 kHz   483      115
   100 kHz   590      141
```

ESP32-C6:

```
Before:
CPU clock: 160 MHz
Averaging over 10000 iterations each.
Loop overhead: 13 ns
Config::default(): 1208 ns (193 cycles)

 target      ns   cycles
 80000 kHz   208       33
 40000 kHz   205       32
 26000 kHz 21662     3465
 24000 kHz 21662     3465
 20000 kHz   699      111
 10000 kHz   699      111
  4000 kHz   699      111
  3000 kHz 21824     3491
  1000 kHz  1524      243
   500 kHz  1887      301
   100 kHz  9887     1581

After:
CPU clock: 160 MHz
Averaging over 10000 iterations each.
Loop overhead: 13 ns
Config::default(): 220 ns (35 cycles)

 target      ns   cycles
 80000 kHz   201       32
 40000 kHz   199       31
 26000 kHz   437       69
 24000 kHz   437       69
 20000 kHz   437       69
 10000 kHz   449       71
  4000 kHz   449       71
  3000 kHz   449       71
  1000 kHz   449       71
   500 kHz   718      114
   100 kHz   880      140
```
</details>


# Changelog

## esp-hal/SPI master

- Changed: Clock divider calculation has been greatly sped up in some cases.
- Fixed: SPI clock calculation no longer overshoots the requested frequency.