### PR TITLE
TWAI ISR: Rx path improvements

### DIFF
--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -1798,19 +1798,15 @@ mod asynch {
                 .bits()
                 > 0
             {
-                if status_reg.read().miss_st().bit_is_set() {
+                let msg = if status_reg.read().miss_st().bit_is_set() {
                     // Current frame is incomplete (Rx FIFO has overrun)
                     release_receive_fifo(register_block);
-                    let _ = rx_queue.try_send(Err(EspTwaiError::EmbeddedHAL(ErrorKind::Overrun)));
-                    continue;
-                }
-                // Current frame is complete
-                match read_frame(register_block) {
-                    Ok(frame) => {
-                        let _ = rx_queue.try_send(Ok(frame));
-                    }
-                    Err(e) => warn!("Error reading frame: {:?}", e),
-                }
+                    Err(EspTwaiError::EmbeddedHAL(ErrorKind::Overrun))
+                } else {
+                    // Current frame is complete
+                    read_frame(register_block)
+                };
+                let _ = rx_queue.try_send(msg);
             }
         }
 

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -1767,15 +1767,11 @@ mod asynch {
     }
 
     pub(super) fn handle_interrupt(register_block: &RegisterBlock, async_state: &TwaiAsyncState) {
-        let intr_status = register_block.int_raw().read();
-
+        let int_raw = register_block.int_raw().read();
         let int_ena_reg = register_block.int_ena();
-        let tx_int_status = intr_status.tx_int_st();
-        let rx_int_status = intr_status.rx_int_st();
+        let int_ena = int_ena_reg.read();
 
-        let intr_enable = int_ena_reg.read();
-
-        if rx_int_status.bit_is_set() {
+        if int_raw.rx_int_st().bit_is_set() {
             let status_reg = register_block.status();
             let status = status_reg.read();
 
@@ -1784,7 +1780,7 @@ mod asynch {
             if status.bus_off_st().bit_is_set() {
                 let _ = rx_queue.try_send(Err(EspTwaiError::BusOff));
                 // Abort transmissions and wake senders if we are in bus-off state.
-                if !status.tx_buf_st().bit_is_set() {
+                if status.tx_buf_st().bit_is_clear() {
                     register_block.cmd().write(|w| w.abort_tx().set_bit());
                     async_state.tx_waker.wake();
                 }
@@ -1813,11 +1809,11 @@ mod asynch {
             }
         }
 
-        if tx_int_status.bit_is_set() {
+        if int_raw.tx_int_st().bit_is_set() {
             async_state.tx_waker.wake();
         }
 
-        if intr_status.bits() & 0b10110100 > 0 {
+        if int_raw.bits() & 0b10110100 > 0 {
             // We might want to use the error code to gather statistics in the
             // future.
             let _ = register_block.err_code_cap().read();
@@ -1826,7 +1822,7 @@ mod asynch {
 
         // Clear interrupt request bits
         unsafe {
-            int_ena_reg.modify(|_, w| w.bits(intr_enable.bits() & (!intr_status.bits() | 1)));
+            int_ena_reg.modify(|_, w| w.bits(int_ena.bits() & (!int_raw.bits() | 1)));
         }
     }
 }

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -1802,7 +1802,7 @@ mod asynch {
                     // Current frame is complete
                     read_frame(register_block)
                 };
-                // Rx queue is full? Stop consumming Rx frames
+                // Rx queue is full? Stop consuming Rx frames
                 if rx_queue.try_send(msg).is_err() {
                     break;
                 }

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -1794,8 +1794,8 @@ mod asynch {
             }
 
             if status.miss_st().bit_is_set() {
-                let _ = rx_queue.try_send(Err(EspTwaiError::EmbeddedHAL(ErrorKind::Overrun)));
                 release_receive_fifo(register_block);
+                let _ = rx_queue.try_send(Err(EspTwaiError::EmbeddedHAL(ErrorKind::Overrun)));
             } else {
                 match read_frame(register_block) {
                     Ok(frame) => {

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -1806,7 +1806,10 @@ mod asynch {
                     // Current frame is complete
                     read_frame(register_block)
                 };
-                let _ = rx_queue.try_send(msg);
+                // Rx queue is full? Stop consumming Rx frames
+                if rx_queue.try_send(msg).is_err() {
+                    break;
+                }
             }
         }
 

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -1776,7 +1776,8 @@ mod asynch {
         let intr_enable = int_ena_reg.read();
 
         if rx_int_status.bit_is_set() {
-            let status = register_block.status().read();
+            let status_reg = register_block.status();
+            let status = status_reg.read();
 
             let rx_queue = &async_state.rx_queue;
 
@@ -1789,10 +1790,21 @@ mod asynch {
                 }
             }
 
-            if status.miss_st().bit_is_set() {
-                release_receive_fifo(register_block);
-                let _ = rx_queue.try_send(Err(EspTwaiError::EmbeddedHAL(ErrorKind::Overrun)));
-            } else {
+            // Consumme all pending frames in the Rx FIFO
+            while register_block
+                .rx_message_cnt()
+                .read()
+                .rx_message_counter()
+                .bits()
+                > 0
+            {
+                if status_reg.read().miss_st().bit_is_set() {
+                    // Current frame is incomplete (Rx FIFO has overrun)
+                    release_receive_fifo(register_block);
+                    let _ = rx_queue.try_send(Err(EspTwaiError::EmbeddedHAL(ErrorKind::Overrun)));
+                    continue;
+                }
+                // Current frame is complete
                 match read_frame(register_block) {
                     Ok(frame) => {
                         let _ = rx_queue.try_send(Ok(frame));

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -1775,10 +1775,6 @@ mod asynch {
 
         let intr_enable = int_ena_reg.read();
 
-        if tx_int_status.bit_is_set() {
-            async_state.tx_waker.wake();
-        }
-
         if rx_int_status.bit_is_set() {
             let status = register_block.status().read();
 
@@ -1804,6 +1800,10 @@ mod asynch {
                     Err(e) => warn!("Error reading frame: {:?}", e),
                 }
             }
+        }
+
+        if tx_int_status.bit_is_set() {
+            async_state.tx_waker.wake();
         }
 
         if intr_status.bits() & 0b10110100 > 0 {


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` or `manual-changelog` label as appropriate.
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

These are the first TWAI ISR improvements (as discussed in #5949 and #5950), aiming at lowering the probability of a missed bit:
- Prioritize the (hot) Rx path, following [esp-idf implementation](https://github.com/espressif/esp-idf/blob/102122904ade11fd1ae373848f34ffd7dfb18aeb/components/esp_driver_twai/esp_twai_onchip.c#L268)
- Release the hardware RX buffer asap (#5950)
- Attempt to empty the Rx buffer entirely every time the ISR runs (#5949)

Additionally, on failure of parsing/validation of an incoming frame, the error is now forwarded through the `rx_queue` instead of being silently dropped (but for logging a warning). This change would be temporary if we later moved forward with #5948, as frame parsing/validation would completely move out of the ISR.

#### Testing
This has been tested on a live 250kb/s CAN bus (NMEA2000) with a ESP32-S3.

---

# Changelog

## esp-hal
 - No changelog necessary.

# Migration guide
 - No migration necessary.