### PR TITLE
[1/N] Avoid hard-coding LP_I2C/LP_UART pins

### DIFF
--- a/esp-hal/src/gpio/low_level/v1.rs
+++ b/esp-hal/src/gpio/low_level/v1.rs
@@ -48,7 +48,7 @@ fn errata36(pin: &AnyPin<'_>, pull_up: bool, pull_down: bool) {
     use crate::gpio::{Pin, RtcPinWithResistors};
 
     for_each_lp_function! {
-        (RTC_GPIOn $( (($_sig:ident, RTC_GPIOn, $_n:literal), $gpio:ident) ),* ) => {
+        (RTC_GPIOn $( (($_sig:ident, RTC_GPIOn, $_n:literal), $gpio:ident, $_af:literal) ),* ) => {
             const RTC_IO_PINS: &[u8] = &[ $( $crate::peripherals::$gpio::NUMBER ),* ];
         };
     };

--- a/esp-hal/src/gpio/lp_io/low_level/esp32h2.rs
+++ b/esp-hal/src/gpio/lp_io/low_level/esp32h2.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 for_each_lp_function! {
-    (($_lp:ident, LP_GPIOn, $pin:literal), $gpio:ident) => {
+    (($_lp:ident, LP_GPIOn, $pin:literal), $gpio:ident, $_af:literal) => {
         #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
         impl RtcPin for crate::peripherals::$gpio<'_> {
             fn rtc_number(&self) -> u8 {

--- a/esp-hal/src/gpio/lp_io/low_level/esp32p4.rs
+++ b/esp-hal/src/gpio/lp_io/low_level/esp32p4.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 for_each_lp_function! {
-    (($lp_pin_name:ident, LP_GPIOn, $lp_pin:literal), $gpio:ident) => {
+    (($lp_pin_name:ident, LP_GPIOn, $lp_pin:literal), $gpio:ident, $_af:literal) => {
         impl RtcPin for crate::peripherals::$gpio<'_> {
             fn rtc_number(&self) -> u8 {
                 $lp_pin

--- a/esp-hal/src/gpio/lp_io/low_level/v2.rs
+++ b/esp-hal/src/gpio/lp_io/low_level/v2.rs
@@ -58,7 +58,7 @@ macro_rules! hold_field {
 // Generates one big match statement because the pin registers have different types.
 for_each_lp_function!(
     (RTC_GPIOn $(
-        (($_rtc:ident, RTC_GPIOn, $n:literal), $gpio:ident)
+        (($_rtc:ident, RTC_GPIOn, $n:literal), $gpio:ident, $_af:literal)
     ),*) => {
         macro_rules! with_pin_reg {
             ($pin:expr, |$reg:ident| $code:expr) => {{
@@ -77,7 +77,7 @@ for_each_lp_function!(
 );
 
 for_each_lp_function! {
-    (($_rtc:ident, RTC_GPIOn, $n:literal), $gpio:ident) => {
+    (($_rtc:ident, RTC_GPIOn, $n:literal), $gpio:ident, $_af:literal) => {
         #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
         impl RtcPin for crate::peripherals::$gpio<'_> {
             fn rtc_number(&self) -> u8 {

--- a/esp-hal/src/gpio/lp_io/low_level/v3.rs
+++ b/esp-hal/src/gpio/lp_io/low_level/v3.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 for_each_lp_function! {
-    (($_rtc:ident, RTC_GPIOn, $pin:literal), $gpio:ident) => {
+    (($_rtc:ident, RTC_GPIOn, $pin:literal), $gpio:ident, $_af:literal) => {
         paste::paste! {
             #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
             impl RtcPin for crate::peripherals::$gpio<'_> {

--- a/esp-hal/src/gpio/lp_io/low_level/v4.rs
+++ b/esp-hal/src/gpio/lp_io/low_level/v4.rs
@@ -13,7 +13,7 @@ cfg_select! {
 }
 
 for_each_lp_function! {
-    (($_lp:ident, LP_GPIOn, $pin:literal), $gpio:ident) => {
+    (($_lp:ident, LP_GPIOn, $pin:literal), $gpio:ident, $_af:literal) => {
         #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
         impl RtcPin for crate::peripherals::$gpio<'_> {
             fn rtc_number(&self) -> u8 {

--- a/esp-hal/src/gpio/lp_io/mod.rs
+++ b/esp-hal/src/gpio/lp_io/mod.rs
@@ -51,10 +51,10 @@ mod low_level;
 pub trait LowPowerPin<const PIN: u8>: RtcPin {}
 
 for_each_lp_function! {
-    (($_signal:ident, RTC_GPIOn, $pin:literal), $gpio:ident) => {
+    (($_signal:ident, RTC_GPIOn, $pin:literal), $gpio:ident, $_af:literal) => {
         impl LowPowerPin<$pin> for crate::peripherals::$gpio<'_> {}
     };
-    (($_signal:ident, LP_GPIOn, $pin:literal), $gpio:ident) => {
+    (($_signal:ident, LP_GPIOn, $pin:literal), $gpio:ident, $_af:literal) => {
         impl LowPowerPin<$pin> for crate::peripherals::$gpio<'_> {}
     };
 }

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -1678,12 +1678,12 @@ impl<'lt> AnyPin<'lt> {
 
         #[cfg(any(xtensa, esp32c5, esp32c6, esp32c61, esp32h2, esp32p4))]
         for_each_lp_function! {
-            (($_signal:ident, LP_GPIOn, $_lp_pin:literal), $gpio:ident) => {
+            (($_signal:ident, LP_GPIOn, $_lp_pin:literal), $gpio:ident, $_af:literal) => {
                 if self.number() == crate::peripherals::$gpio::NUMBER {
                     RtcPin::rtc_set_config(self, false, false, RtcFunction::Digital);
                 }
             };
-            (($_signal:ident, RTC_GPIOn, $_lp_pin:literal), $gpio:ident) => {
+            (($_signal:ident, RTC_GPIOn, $_lp_pin:literal), $gpio:ident, $_af:literal) => {
                 if self.number() == crate::peripherals::$gpio::NUMBER {
                     RtcPin::rtc_set_config(self, false, false, RtcFunction::Digital);
                 }
@@ -2188,10 +2188,10 @@ macro_rules! for_each_rtcio_pin {
 
     (($ident:ident, $target:ident) => $code:tt;) => {
         for_each_lp_function! {
-            (($_sig:ident, RTC_GPIOn, $_n:literal), $gpio:ident) => {
+            (($_sig:ident, RTC_GPIOn, $_n:literal), $gpio:ident, $_af:literal) => {
                 for_each_rtcio_pin!(@impl $ident, $target, $gpio, $code)
             };
-            (($_sig:ident, LP_GPIOn, $_n:literal), $gpio:ident) => {
+            (($_sig:ident, LP_GPIOn, $_n:literal), $gpio:ident, $_af:literal) => {
                 for_each_rtcio_pin!(@impl $ident, $target, $gpio, $code)
             };
         }
@@ -2220,10 +2220,10 @@ macro_rules! for_each_rtcio_output_pin {
 
     (($ident:ident, $target:ident) => $code:tt;) => {
         for_each_lp_function! {
-            (($_sig:ident, RTC_GPIOn, $_n:literal), $gpio:ident) => {
+            (($_sig:ident, RTC_GPIOn, $_n:literal), $gpio:ident, $_af:literal) => {
                 for_each_rtcio_output_pin!(@impl $ident, $target, $gpio, $code, "RTC_IO output")
             };
-            (($_sig:ident, LP_GPIOn, $_n:literal), $gpio:ident) => {
+            (($_sig:ident, LP_GPIOn, $_n:literal), $gpio:ident, $_af:literal) => {
                 for_each_rtcio_output_pin!(@impl $ident, $target, $gpio, $code, "LP_IO output")
             };
         }

--- a/esp-hal/src/i2c/lp_i2c.rs
+++ b/esp-hal/src/i2c/lp_i2c.rs
@@ -1,12 +1,41 @@
 //! Low-power I2C driver
 
 use crate::{
-    gpio::lp_io::LowPowerOutputOpenDrain,
+    gpio::{InputPin, OutputPin, RtcPin},
     peripherals::{LP_AON, LP_I2C0, LP_IO, LP_PERI, LPWR},
     time::Rate,
 };
 
 const LP_I2C_FILTER_CYC_NUM_DEF: u8 = 7;
+
+/// Trait representing the LP_I2C SDA pin.
+pub trait Sda: RtcPin + OutputPin + InputPin {
+    #[doc(hidden)]
+    fn lp_function(&self) -> u8;
+}
+
+/// Trait representing the LP_I2C SCL pin.
+pub trait Scl: RtcPin + OutputPin + InputPin {
+    #[doc(hidden)]
+    fn lp_function(&self) -> u8;
+}
+
+for_each_lp_function! {
+    (LP_I2C_SDA, $gpio:ident, $af:literal) => {
+        impl Sda for crate::peripherals::$gpio<'_> {
+            fn lp_function(&self) -> u8 {
+                $af
+            }
+        }
+    };
+    (LP_I2C_SCL, $gpio:ident, $af:literal) => {
+        impl Scl for crate::peripherals::$gpio<'_> {
+            fn lp_function(&self) -> u8 {
+                $af
+            }
+        }
+    };
+}
 
 /// I2C-specific transmission errors
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -121,25 +150,31 @@ impl LpI2c {
     /// Creates a new instance of the `LpI2c` peripheral.
     pub fn new(
         i2c: LP_I2C0<'static>,
-        _sda: LowPowerOutputOpenDrain<'_, 6>,
-        _scl: LowPowerOutputOpenDrain<'_, 7>,
+        sda: impl Sda + 'static,
+        scl: impl Scl + 'static,
         frequency: Rate,
     ) -> Self {
         let me = Self { i2c };
 
         // Configure LP I2C GPIOs
 
+        let sda_pin = sda.rtc_number() as usize;
+        let scl_pin = scl.rtc_number() as usize;
+
         // Initialize IO Pins
-        // NOTE: We always initialize the SCL pin (GPIO7) first, then the
-        // SDA (GPIO6) pin. This order of initialization is important to
-        // avoid any spurious I2C start conditions on the bus.
-        Self::lp_i2c_configure_io(7, true);
-        Self::lp_i2c_configure_io(6, true);
+        // NOTE: We always initialize the SCL pin first, then the SDA pin. This order of
+        // initialization is important to avoid any spurious I2C start conditions on the bus.
+        Self::lp_i2c_configure_io(scl_pin, true);
+        Self::lp_i2c_configure_io(sda_pin, true);
         unsafe {
             let lp_io = LP_IO::regs();
             // Select LP I2C function for the SDA and SCL pins
-            lp_io.gpio(7).modify(|_, w| w.mcu_sel().bits(1));
-            lp_io.gpio(6).modify(|_, w| w.mcu_sel().bits(1));
+            lp_io
+                .gpio(scl_pin)
+                .modify(|_, w| w.mcu_sel().bits(scl.lp_function()));
+            lp_io
+                .gpio(sda_pin)
+                .modify(|_, w| w.mcu_sel().bits(sda.lp_function()));
         }
 
         // Initialize LP I2C HAL */

--- a/esp-hal/src/i2c/rtc.rs
+++ b/esp-hal/src/i2c/rtc.rs
@@ -92,14 +92,14 @@ pub trait Scl: RtcPin + OutputPin + InputPin {
 }
 
 for_each_lp_function! {
-    (($_func:ident, SAR_I2C_SCL_n, $n:literal), $gpio:ident) => {
+    (($_func:ident, SAR_I2C_SCL_n, $n:literal), $gpio:ident, $_af:literal) => {
         impl Scl for crate::peripherals::$gpio<'_> {
             fn selector(&self) -> u8 {
                 $n
             }
         }
     };
-    (($_func:ident, SAR_I2C_SDA_n, $n:literal), $gpio:ident) => {
+    (($_func:ident, SAR_I2C_SDA_n, $n:literal), $gpio:ident, $_af:literal) => {
         impl Sda for crate::peripherals::$gpio<'_> {
             fn selector(&self) -> u8 {
                 $n

--- a/esp-hal/src/rtc_cntl/sleep/wakeup_sources/ext1/esp32p4.rs
+++ b/esp-hal/src/rtc_cntl/sleep/wakeup_sources/ext1/esp32p4.rs
@@ -26,7 +26,7 @@ impl Ext1WakeupSource<'_, '_> {
 
         let wakeup_pins = Self::wakeup_pins();
         for_each_lp_function! {
-            (($_lp:ident, LP_GPIOn, $_pin:literal), $gpio:ident) => {
+            (($_lp:ident, LP_GPIOn, $_pin:literal), $gpio:ident, $_af:literal) => {
                 uninit_pin(unsafe { $crate::peripherals::$gpio::steal() }, wakeup_pins);
             };
         }

--- a/esp-hal/src/rtc_cntl/sleep/wakeup_sources/ext1/v2.rs
+++ b/esp-hal/src/rtc_cntl/sleep/wakeup_sources/ext1/v2.rs
@@ -35,7 +35,7 @@ impl Ext1WakeupSource<'_, '_> {
 
         let wakeup_pins = Self::wakeup_pins();
         for_each_lp_function! {
-            (($_lp:ident, LP_GPIOn, $_pin:literal), $gpio:ident) => {
+            (($_lp:ident, LP_GPIOn, $_pin:literal), $gpio:ident, $_af:literal) => {
                 uninit_pin(unsafe { $crate::peripherals::$gpio::steal() }, wakeup_pins);
             };
         }

--- a/esp-hal/src/uart/mod.rs
+++ b/esp-hal/src/uart/mod.rs
@@ -2245,10 +2245,39 @@ impl From<TxError> for IoError {
 #[instability::unstable]
 pub mod lp_uart {
     use crate::{
-        gpio::lp_io::{LowPowerInput, LowPowerOutput},
+        gpio::{InputPin, OutputPin, RtcPin},
         peripherals::{LP_AON, LP_CLKRST, LP_IO, LP_UART, LPWR},
         uart::{DataBits, Parity, StopBits},
     };
+
+    /// Trait representing the LP_UART TX pin.
+    pub trait Tx: RtcPin + OutputPin {
+        #[doc(hidden)]
+        fn lp_function(&self) -> u8;
+    }
+
+    /// Trait representing the LP_UART RX pin.
+    pub trait Rx: RtcPin + InputPin {
+        #[doc(hidden)]
+        fn lp_function(&self) -> u8;
+    }
+
+    for_each_lp_function! {
+        (LP_UART_TXD, $gpio:ident, $af:literal) => {
+            impl Tx for crate::peripherals::$gpio<'_> {
+                fn lp_function(&self) -> u8 {
+                    $af
+                }
+            }
+        };
+        (LP_UART_RXD, $gpio:ident, $af:literal) => {
+            impl Rx for crate::peripherals::$gpio<'_> {
+                fn lp_function(&self) -> u8 {
+                    $af
+                }
+            }
+        };
+    }
 
     /// LP-UART Configuration
     #[derive(Debug, Clone, Copy, procmacros::BuilderLite)]
@@ -2306,20 +2335,22 @@ pub mod lp_uart {
         pub fn new(
             uart: LP_UART<'static>,
             config: Config,
-            _tx: LowPowerOutput<'_, 5>,
-            _rx: LowPowerInput<'_, 4>,
+            tx: impl Tx + 'static,
+            rx: impl Rx + 'static,
         ) -> Self {
-            // FIXME: use GPIO APIs to configure pins
-            LP_AON::regs()
-                .gpio_mux()
-                .modify(|r, w| unsafe { w.sel().bits(r.sel().bits() | (1 << 4) | (1 << 5)) });
+            let tx_pin = tx.rtc_number() as usize;
+            let rx_pin = rx.rtc_number() as usize;
+
+            LP_AON::regs().gpio_mux().modify(|r, w| unsafe {
+                w.sel().bits(r.sel().bits() | (1 << tx_pin) | (1 << rx_pin))
+            });
 
             LP_IO::regs()
-                .gpio(4)
-                .modify(|_, w| unsafe { w.mcu_sel().bits(1) });
+                .gpio(rx_pin)
+                .modify(|_, w| unsafe { w.mcu_sel().bits(rx.lp_function()) });
             LP_IO::regs()
-                .gpio(5)
-                .modify(|_, w| unsafe { w.mcu_sel().bits(1) });
+                .gpio(tx_pin)
+                .modify(|_, w| unsafe { w.mcu_sel().bits(tx.lp_function()) });
 
             let mut me = Self { uart };
             let uart = me.uart.register_block();

--- a/esp-metadata-generated/src/_generated_esp32.rs
+++ b/esp-metadata-generated/src/_generated_esp32.rs
@@ -5130,11 +5130,12 @@ macro_rules! for_each_analog_function {
 ///
 /// This macro has two options for its "Individual matcher" case:
 ///
-/// - `all`: `($signal:ident, $gpio:ident)` - simple case where you only need identifiers
-/// - group: `(($signal:ident, $group:ident $(, $number:literal)+), $gpio:ident)` - expanded signal
-///   case, where you need the number(s) of a signal, or the general group to which the signal
-///   belongs. For example, in case of `SAR_I2C_SCL_1` the expanded form looks like `(SAR_I2C_SCL_1,
-///   SAR_I2C_SCL_n, 1)`.
+/// - `all`: `($signal:ident, $gpio:ident, $af:literal)` - simple case where you only need
+///   identifiers, and maybe the function number.
+/// - group: `(($signal:ident, $group:ident $(, $number:literal)+), $gpio:ident, $af:literal)` -
+///   expanded signal case, where you need the number(s) of a signal, or the general group to which
+///   the signal belongs. For example, in case of `SAR_I2C_SCL_1` the expanded form looks like
+///   `(SAR_I2C_SCL_1, SAR_I2C_SCL_n, 1)`.
 ///
 /// Macro fragments:
 ///
@@ -5143,10 +5144,13 @@ macro_rules! for_each_analog_function {
 ///   is `ADCn_CHm`.
 /// - `$number`: the numbers extracted from `$signal`.
 /// - `$gpio`: the name of the GPIO.
+/// - `$af`: the function number, as listed in the LP/RTC IO MUX pad list. On chips with an LP IO
+///   peripheral this is the value to write to the pin's `MCU_SEL` field to select the function. On
+///   chips with an RTC IO peripheral the numbering is not necessarily register-accurate.
 ///
 /// Example data:
-/// - `(RTC_GPIO15, GPIO12)`
-/// - `((RTC_GPIO15, RTC_GPIOn, 15), GPIO12)`
+/// - `(RTC_GPIO15, GPIO12, 0)`
+/// - `((RTC_GPIO15, RTC_GPIOn, 15), GPIO12, 0)`
 ///
 /// The expanded syntax is only available when the signal has at least one numbered component.
 #[macro_export]
@@ -5154,63 +5158,64 @@ macro_rules! for_each_analog_function {
 macro_rules! for_each_lp_function {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_lp_function { $(($pattern) => $code;)* ($other : tt)
-        => {} } _for_each_inner_lp_function!((RTC_GPIO11, GPIO0));
-        _for_each_inner_lp_function!((SAR_I2C_SDA, GPIO0));
-        _for_each_inner_lp_function!((RTC_GPIO12, GPIO2));
-        _for_each_inner_lp_function!((SAR_I2C_SCL, GPIO2));
-        _for_each_inner_lp_function!((RTC_GPIO10, GPIO4));
-        _for_each_inner_lp_function!((SAR_I2C_SCL, GPIO4));
-        _for_each_inner_lp_function!((RTC_GPIO15, GPIO12));
-        _for_each_inner_lp_function!((RTC_GPIO14, GPIO13));
-        _for_each_inner_lp_function!((RTC_GPIO16, GPIO14));
-        _for_each_inner_lp_function!((RTC_GPIO13, GPIO15));
-        _for_each_inner_lp_function!((SAR_I2C_SDA, GPIO15));
-        _for_each_inner_lp_function!((RTC_GPIO6, GPIO25));
-        _for_each_inner_lp_function!((RTC_GPIO7, GPIO26));
-        _for_each_inner_lp_function!((RTC_GPIO17, GPIO27));
-        _for_each_inner_lp_function!((RTC_GPIO9, GPIO32));
-        _for_each_inner_lp_function!((RTC_GPIO8, GPIO33));
-        _for_each_inner_lp_function!((RTC_GPIO4, GPIO34));
-        _for_each_inner_lp_function!((RTC_GPIO5, GPIO35));
-        _for_each_inner_lp_function!((RTC_GPIO0, GPIO36));
-        _for_each_inner_lp_function!((RTC_GPIO1, GPIO37));
-        _for_each_inner_lp_function!((RTC_GPIO2, GPIO38));
-        _for_each_inner_lp_function!((RTC_GPIO3, GPIO39));
-        _for_each_inner_lp_function!(((RTC_GPIO11, RTC_GPIOn, 11), GPIO0));
-        _for_each_inner_lp_function!(((RTC_GPIO12, RTC_GPIOn, 12), GPIO2));
-        _for_each_inner_lp_function!(((RTC_GPIO10, RTC_GPIOn, 10), GPIO4));
-        _for_each_inner_lp_function!(((RTC_GPIO15, RTC_GPIOn, 15), GPIO12));
-        _for_each_inner_lp_function!(((RTC_GPIO14, RTC_GPIOn, 14), GPIO13));
-        _for_each_inner_lp_function!(((RTC_GPIO16, RTC_GPIOn, 16), GPIO14));
-        _for_each_inner_lp_function!(((RTC_GPIO13, RTC_GPIOn, 13), GPIO15));
-        _for_each_inner_lp_function!(((RTC_GPIO6, RTC_GPIOn, 6), GPIO25));
-        _for_each_inner_lp_function!(((RTC_GPIO7, RTC_GPIOn, 7), GPIO26));
-        _for_each_inner_lp_function!(((RTC_GPIO17, RTC_GPIOn, 17), GPIO27));
-        _for_each_inner_lp_function!(((RTC_GPIO9, RTC_GPIOn, 9), GPIO32));
-        _for_each_inner_lp_function!(((RTC_GPIO8, RTC_GPIOn, 8), GPIO33));
-        _for_each_inner_lp_function!(((RTC_GPIO4, RTC_GPIOn, 4), GPIO34));
-        _for_each_inner_lp_function!(((RTC_GPIO5, RTC_GPIOn, 5), GPIO35));
-        _for_each_inner_lp_function!(((RTC_GPIO0, RTC_GPIOn, 0), GPIO36));
-        _for_each_inner_lp_function!(((RTC_GPIO1, RTC_GPIOn, 1), GPIO37));
-        _for_each_inner_lp_function!(((RTC_GPIO2, RTC_GPIOn, 2), GPIO38));
-        _for_each_inner_lp_function!(((RTC_GPIO3, RTC_GPIOn, 3), GPIO39));
-        _for_each_inner_lp_function!((all(RTC_GPIO11, GPIO0), (SAR_I2C_SDA, GPIO0),
-        (RTC_GPIO12, GPIO2), (SAR_I2C_SCL, GPIO2), (RTC_GPIO10, GPIO4), (SAR_I2C_SCL,
-        GPIO4), (RTC_GPIO15, GPIO12), (RTC_GPIO14, GPIO13), (RTC_GPIO16, GPIO14),
-        (RTC_GPIO13, GPIO15), (SAR_I2C_SDA, GPIO15), (RTC_GPIO6, GPIO25), (RTC_GPIO7,
-        GPIO26), (RTC_GPIO17, GPIO27), (RTC_GPIO9, GPIO32), (RTC_GPIO8, GPIO33),
-        (RTC_GPIO4, GPIO34), (RTC_GPIO5, GPIO35), (RTC_GPIO0, GPIO36), (RTC_GPIO1,
-        GPIO37), (RTC_GPIO2, GPIO38), (RTC_GPIO3, GPIO39)));
-        _for_each_inner_lp_function!((RTC_GPIOn((RTC_GPIO11, RTC_GPIOn, 11), GPIO0),
-        ((RTC_GPIO12, RTC_GPIOn, 12), GPIO2), ((RTC_GPIO10, RTC_GPIOn, 10), GPIO4),
-        ((RTC_GPIO15, RTC_GPIOn, 15), GPIO12), ((RTC_GPIO14, RTC_GPIOn, 14), GPIO13),
-        ((RTC_GPIO16, RTC_GPIOn, 16), GPIO14), ((RTC_GPIO13, RTC_GPIOn, 13), GPIO15),
-        ((RTC_GPIO6, RTC_GPIOn, 6), GPIO25), ((RTC_GPIO7, RTC_GPIOn, 7), GPIO26),
-        ((RTC_GPIO17, RTC_GPIOn, 17), GPIO27), ((RTC_GPIO9, RTC_GPIOn, 9), GPIO32),
-        ((RTC_GPIO8, RTC_GPIOn, 8), GPIO33), ((RTC_GPIO4, RTC_GPIOn, 4), GPIO34),
-        ((RTC_GPIO5, RTC_GPIOn, 5), GPIO35), ((RTC_GPIO0, RTC_GPIOn, 0), GPIO36),
-        ((RTC_GPIO1, RTC_GPIOn, 1), GPIO37), ((RTC_GPIO2, RTC_GPIOn, 2), GPIO38),
-        ((RTC_GPIO3, RTC_GPIOn, 3), GPIO39)));
+        => {} } _for_each_inner_lp_function!((RTC_GPIO11, GPIO0, 0));
+        _for_each_inner_lp_function!((SAR_I2C_SDA, GPIO0, 1));
+        _for_each_inner_lp_function!((RTC_GPIO12, GPIO2, 0));
+        _for_each_inner_lp_function!((SAR_I2C_SCL, GPIO2, 1));
+        _for_each_inner_lp_function!((RTC_GPIO10, GPIO4, 0));
+        _for_each_inner_lp_function!((SAR_I2C_SCL, GPIO4, 1));
+        _for_each_inner_lp_function!((RTC_GPIO15, GPIO12, 0));
+        _for_each_inner_lp_function!((RTC_GPIO14, GPIO13, 0));
+        _for_each_inner_lp_function!((RTC_GPIO16, GPIO14, 0));
+        _for_each_inner_lp_function!((RTC_GPIO13, GPIO15, 0));
+        _for_each_inner_lp_function!((SAR_I2C_SDA, GPIO15, 1));
+        _for_each_inner_lp_function!((RTC_GPIO6, GPIO25, 0));
+        _for_each_inner_lp_function!((RTC_GPIO7, GPIO26, 0));
+        _for_each_inner_lp_function!((RTC_GPIO17, GPIO27, 0));
+        _for_each_inner_lp_function!((RTC_GPIO9, GPIO32, 0));
+        _for_each_inner_lp_function!((RTC_GPIO8, GPIO33, 0));
+        _for_each_inner_lp_function!((RTC_GPIO4, GPIO34, 0));
+        _for_each_inner_lp_function!((RTC_GPIO5, GPIO35, 0));
+        _for_each_inner_lp_function!((RTC_GPIO0, GPIO36, 0));
+        _for_each_inner_lp_function!((RTC_GPIO1, GPIO37, 0));
+        _for_each_inner_lp_function!((RTC_GPIO2, GPIO38, 0));
+        _for_each_inner_lp_function!((RTC_GPIO3, GPIO39, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO11, RTC_GPIOn, 11), GPIO0, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO12, RTC_GPIOn, 12), GPIO2, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO10, RTC_GPIOn, 10), GPIO4, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO15, RTC_GPIOn, 15), GPIO12, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO14, RTC_GPIOn, 14), GPIO13, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO16, RTC_GPIOn, 16), GPIO14, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO13, RTC_GPIOn, 13), GPIO15, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO6, RTC_GPIOn, 6), GPIO25, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO7, RTC_GPIOn, 7), GPIO26, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO17, RTC_GPIOn, 17), GPIO27, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO9, RTC_GPIOn, 9), GPIO32, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO8, RTC_GPIOn, 8), GPIO33, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO4, RTC_GPIOn, 4), GPIO34, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO5, RTC_GPIOn, 5), GPIO35, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO0, RTC_GPIOn, 0), GPIO36, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO1, RTC_GPIOn, 1), GPIO37, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO2, RTC_GPIOn, 2), GPIO38, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO3, RTC_GPIOn, 3), GPIO39, 0));
+        _for_each_inner_lp_function!((all(RTC_GPIO11, GPIO0, 0), (SAR_I2C_SDA, GPIO0, 1),
+        (RTC_GPIO12, GPIO2, 0), (SAR_I2C_SCL, GPIO2, 1), (RTC_GPIO10, GPIO4, 0),
+        (SAR_I2C_SCL, GPIO4, 1), (RTC_GPIO15, GPIO12, 0), (RTC_GPIO14, GPIO13, 0),
+        (RTC_GPIO16, GPIO14, 0), (RTC_GPIO13, GPIO15, 0), (SAR_I2C_SDA, GPIO15, 1),
+        (RTC_GPIO6, GPIO25, 0), (RTC_GPIO7, GPIO26, 0), (RTC_GPIO17, GPIO27, 0),
+        (RTC_GPIO9, GPIO32, 0), (RTC_GPIO8, GPIO33, 0), (RTC_GPIO4, GPIO34, 0),
+        (RTC_GPIO5, GPIO35, 0), (RTC_GPIO0, GPIO36, 0), (RTC_GPIO1, GPIO37, 0),
+        (RTC_GPIO2, GPIO38, 0), (RTC_GPIO3, GPIO39, 0)));
+        _for_each_inner_lp_function!((RTC_GPIOn((RTC_GPIO11, RTC_GPIOn, 11), GPIO0, 0),
+        ((RTC_GPIO12, RTC_GPIOn, 12), GPIO2, 0), ((RTC_GPIO10, RTC_GPIOn, 10), GPIO4, 0),
+        ((RTC_GPIO15, RTC_GPIOn, 15), GPIO12, 0), ((RTC_GPIO14, RTC_GPIOn, 14), GPIO13,
+        0), ((RTC_GPIO16, RTC_GPIOn, 16), GPIO14, 0), ((RTC_GPIO13, RTC_GPIOn, 13),
+        GPIO15, 0), ((RTC_GPIO6, RTC_GPIOn, 6), GPIO25, 0), ((RTC_GPIO7, RTC_GPIOn, 7),
+        GPIO26, 0), ((RTC_GPIO17, RTC_GPIOn, 17), GPIO27, 0), ((RTC_GPIO9, RTC_GPIOn, 9),
+        GPIO32, 0), ((RTC_GPIO8, RTC_GPIOn, 8), GPIO33, 0), ((RTC_GPIO4, RTC_GPIOn, 4),
+        GPIO34, 0), ((RTC_GPIO5, RTC_GPIOn, 5), GPIO35, 0), ((RTC_GPIO0, RTC_GPIOn, 0),
+        GPIO36, 0), ((RTC_GPIO1, RTC_GPIOn, 1), GPIO37, 0), ((RTC_GPIO2, RTC_GPIOn, 2),
+        GPIO38, 0), ((RTC_GPIO3, RTC_GPIOn, 3), GPIO39, 0)));
     };
 }
 /// This macro can be used to generate code for each IOMUX digital function of each GPIO.

--- a/esp-metadata-generated/src/_generated_esp32c2.rs
+++ b/esp-metadata-generated/src/_generated_esp32c2.rs
@@ -4216,11 +4216,12 @@ macro_rules! for_each_analog_function {
 ///
 /// This macro has two options for its "Individual matcher" case:
 ///
-/// - `all`: `($signal:ident, $gpio:ident)` - simple case where you only need identifiers
-/// - group: `(($signal:ident, $group:ident $(, $number:literal)+), $gpio:ident)` - expanded signal
-///   case, where you need the number(s) of a signal, or the general group to which the signal
-///   belongs. For example, in case of `SAR_I2C_SCL_1` the expanded form looks like `(SAR_I2C_SCL_1,
-///   SAR_I2C_SCL_n, 1)`.
+/// - `all`: `($signal:ident, $gpio:ident, $af:literal)` - simple case where you only need
+///   identifiers, and maybe the function number.
+/// - group: `(($signal:ident, $group:ident $(, $number:literal)+), $gpio:ident, $af:literal)` -
+///   expanded signal case, where you need the number(s) of a signal, or the general group to which
+///   the signal belongs. For example, in case of `SAR_I2C_SCL_1` the expanded form looks like
+///   `(SAR_I2C_SCL_1, SAR_I2C_SCL_n, 1)`.
 ///
 /// Macro fragments:
 ///
@@ -4229,10 +4230,13 @@ macro_rules! for_each_analog_function {
 ///   is `ADCn_CHm`.
 /// - `$number`: the numbers extracted from `$signal`.
 /// - `$gpio`: the name of the GPIO.
+/// - `$af`: the function number, as listed in the LP/RTC IO MUX pad list. On chips with an LP IO
+///   peripheral this is the value to write to the pin's `MCU_SEL` field to select the function. On
+///   chips with an RTC IO peripheral the numbering is not necessarily register-accurate.
 ///
 /// Example data:
-/// - `(RTC_GPIO15, GPIO12)`
-/// - `((RTC_GPIO15, RTC_GPIOn, 15), GPIO12)`
+/// - `(RTC_GPIO15, GPIO12, 0)`
+/// - `((RTC_GPIO15, RTC_GPIOn, 15), GPIO12, 0)`
 ///
 /// The expanded syntax is only available when the signal has at least one numbered component.
 #[macro_export]
@@ -4240,24 +4244,24 @@ macro_rules! for_each_analog_function {
 macro_rules! for_each_lp_function {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_lp_function { $(($pattern) => $code;)* ($other : tt)
-        => {} } _for_each_inner_lp_function!((RTC_GPIO0, GPIO0));
-        _for_each_inner_lp_function!((RTC_GPIO1, GPIO1));
-        _for_each_inner_lp_function!((RTC_GPIO2, GPIO2));
-        _for_each_inner_lp_function!((RTC_GPIO3, GPIO3));
-        _for_each_inner_lp_function!((RTC_GPIO4, GPIO4));
-        _for_each_inner_lp_function!((RTC_GPIO5, GPIO5));
-        _for_each_inner_lp_function!(((RTC_GPIO0, RTC_GPIOn, 0), GPIO0));
-        _for_each_inner_lp_function!(((RTC_GPIO1, RTC_GPIOn, 1), GPIO1));
-        _for_each_inner_lp_function!(((RTC_GPIO2, RTC_GPIOn, 2), GPIO2));
-        _for_each_inner_lp_function!(((RTC_GPIO3, RTC_GPIOn, 3), GPIO3));
-        _for_each_inner_lp_function!(((RTC_GPIO4, RTC_GPIOn, 4), GPIO4));
-        _for_each_inner_lp_function!(((RTC_GPIO5, RTC_GPIOn, 5), GPIO5));
-        _for_each_inner_lp_function!((all(RTC_GPIO0, GPIO0), (RTC_GPIO1, GPIO1),
-        (RTC_GPIO2, GPIO2), (RTC_GPIO3, GPIO3), (RTC_GPIO4, GPIO4), (RTC_GPIO5, GPIO5)));
-        _for_each_inner_lp_function!((RTC_GPIOn((RTC_GPIO0, RTC_GPIOn, 0), GPIO0),
-        ((RTC_GPIO1, RTC_GPIOn, 1), GPIO1), ((RTC_GPIO2, RTC_GPIOn, 2), GPIO2),
-        ((RTC_GPIO3, RTC_GPIOn, 3), GPIO3), ((RTC_GPIO4, RTC_GPIOn, 4), GPIO4),
-        ((RTC_GPIO5, RTC_GPIOn, 5), GPIO5)));
+        => {} } _for_each_inner_lp_function!((RTC_GPIO0, GPIO0, 0));
+        _for_each_inner_lp_function!((RTC_GPIO1, GPIO1, 0));
+        _for_each_inner_lp_function!((RTC_GPIO2, GPIO2, 0));
+        _for_each_inner_lp_function!((RTC_GPIO3, GPIO3, 0));
+        _for_each_inner_lp_function!((RTC_GPIO4, GPIO4, 0));
+        _for_each_inner_lp_function!((RTC_GPIO5, GPIO5, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO0, RTC_GPIOn, 0), GPIO0, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO1, RTC_GPIOn, 1), GPIO1, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO2, RTC_GPIOn, 2), GPIO2, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO3, RTC_GPIOn, 3), GPIO3, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO4, RTC_GPIOn, 4), GPIO4, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO5, RTC_GPIOn, 5), GPIO5, 0));
+        _for_each_inner_lp_function!((all(RTC_GPIO0, GPIO0, 0), (RTC_GPIO1, GPIO1, 0),
+        (RTC_GPIO2, GPIO2, 0), (RTC_GPIO3, GPIO3, 0), (RTC_GPIO4, GPIO4, 0), (RTC_GPIO5,
+        GPIO5, 0))); _for_each_inner_lp_function!((RTC_GPIOn((RTC_GPIO0, RTC_GPIOn, 0),
+        GPIO0, 0), ((RTC_GPIO1, RTC_GPIOn, 1), GPIO1, 0), ((RTC_GPIO2, RTC_GPIOn, 2),
+        GPIO2, 0), ((RTC_GPIO3, RTC_GPIOn, 3), GPIO3, 0), ((RTC_GPIO4, RTC_GPIOn, 4),
+        GPIO4, 0), ((RTC_GPIO5, RTC_GPIOn, 5), GPIO5, 0)));
     };
 }
 /// This macro can be used to generate code for each IOMUX digital function of each GPIO.

--- a/esp-metadata-generated/src/_generated_esp32c3.rs
+++ b/esp-metadata-generated/src/_generated_esp32c3.rs
@@ -4874,11 +4874,12 @@ macro_rules! for_each_analog_function {
 ///
 /// This macro has two options for its "Individual matcher" case:
 ///
-/// - `all`: `($signal:ident, $gpio:ident)` - simple case where you only need identifiers
-/// - group: `(($signal:ident, $group:ident $(, $number:literal)+), $gpio:ident)` - expanded signal
-///   case, where you need the number(s) of a signal, or the general group to which the signal
-///   belongs. For example, in case of `SAR_I2C_SCL_1` the expanded form looks like `(SAR_I2C_SCL_1,
-///   SAR_I2C_SCL_n, 1)`.
+/// - `all`: `($signal:ident, $gpio:ident, $af:literal)` - simple case where you only need
+///   identifiers, and maybe the function number.
+/// - group: `(($signal:ident, $group:ident $(, $number:literal)+), $gpio:ident, $af:literal)` -
+///   expanded signal case, where you need the number(s) of a signal, or the general group to which
+///   the signal belongs. For example, in case of `SAR_I2C_SCL_1` the expanded form looks like
+///   `(SAR_I2C_SCL_1, SAR_I2C_SCL_n, 1)`.
 ///
 /// Macro fragments:
 ///
@@ -4887,10 +4888,13 @@ macro_rules! for_each_analog_function {
 ///   is `ADCn_CHm`.
 /// - `$number`: the numbers extracted from `$signal`.
 /// - `$gpio`: the name of the GPIO.
+/// - `$af`: the function number, as listed in the LP/RTC IO MUX pad list. On chips with an LP IO
+///   peripheral this is the value to write to the pin's `MCU_SEL` field to select the function. On
+///   chips with an RTC IO peripheral the numbering is not necessarily register-accurate.
 ///
 /// Example data:
-/// - `(RTC_GPIO15, GPIO12)`
-/// - `((RTC_GPIO15, RTC_GPIOn, 15), GPIO12)`
+/// - `(RTC_GPIO15, GPIO12, 0)`
+/// - `((RTC_GPIO15, RTC_GPIOn, 15), GPIO12, 0)`
 ///
 /// The expanded syntax is only available when the signal has at least one numbered component.
 #[macro_export]
@@ -4898,24 +4902,24 @@ macro_rules! for_each_analog_function {
 macro_rules! for_each_lp_function {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_lp_function { $(($pattern) => $code;)* ($other : tt)
-        => {} } _for_each_inner_lp_function!((RTC_GPIO0, GPIO0));
-        _for_each_inner_lp_function!((RTC_GPIO1, GPIO1));
-        _for_each_inner_lp_function!((RTC_GPIO2, GPIO2));
-        _for_each_inner_lp_function!((RTC_GPIO3, GPIO3));
-        _for_each_inner_lp_function!((RTC_GPIO4, GPIO4));
-        _for_each_inner_lp_function!((RTC_GPIO5, GPIO5));
-        _for_each_inner_lp_function!(((RTC_GPIO0, RTC_GPIOn, 0), GPIO0));
-        _for_each_inner_lp_function!(((RTC_GPIO1, RTC_GPIOn, 1), GPIO1));
-        _for_each_inner_lp_function!(((RTC_GPIO2, RTC_GPIOn, 2), GPIO2));
-        _for_each_inner_lp_function!(((RTC_GPIO3, RTC_GPIOn, 3), GPIO3));
-        _for_each_inner_lp_function!(((RTC_GPIO4, RTC_GPIOn, 4), GPIO4));
-        _for_each_inner_lp_function!(((RTC_GPIO5, RTC_GPIOn, 5), GPIO5));
-        _for_each_inner_lp_function!((all(RTC_GPIO0, GPIO0), (RTC_GPIO1, GPIO1),
-        (RTC_GPIO2, GPIO2), (RTC_GPIO3, GPIO3), (RTC_GPIO4, GPIO4), (RTC_GPIO5, GPIO5)));
-        _for_each_inner_lp_function!((RTC_GPIOn((RTC_GPIO0, RTC_GPIOn, 0), GPIO0),
-        ((RTC_GPIO1, RTC_GPIOn, 1), GPIO1), ((RTC_GPIO2, RTC_GPIOn, 2), GPIO2),
-        ((RTC_GPIO3, RTC_GPIOn, 3), GPIO3), ((RTC_GPIO4, RTC_GPIOn, 4), GPIO4),
-        ((RTC_GPIO5, RTC_GPIOn, 5), GPIO5)));
+        => {} } _for_each_inner_lp_function!((RTC_GPIO0, GPIO0, 0));
+        _for_each_inner_lp_function!((RTC_GPIO1, GPIO1, 0));
+        _for_each_inner_lp_function!((RTC_GPIO2, GPIO2, 0));
+        _for_each_inner_lp_function!((RTC_GPIO3, GPIO3, 0));
+        _for_each_inner_lp_function!((RTC_GPIO4, GPIO4, 0));
+        _for_each_inner_lp_function!((RTC_GPIO5, GPIO5, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO0, RTC_GPIOn, 0), GPIO0, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO1, RTC_GPIOn, 1), GPIO1, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO2, RTC_GPIOn, 2), GPIO2, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO3, RTC_GPIOn, 3), GPIO3, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO4, RTC_GPIOn, 4), GPIO4, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO5, RTC_GPIOn, 5), GPIO5, 0));
+        _for_each_inner_lp_function!((all(RTC_GPIO0, GPIO0, 0), (RTC_GPIO1, GPIO1, 0),
+        (RTC_GPIO2, GPIO2, 0), (RTC_GPIO3, GPIO3, 0), (RTC_GPIO4, GPIO4, 0), (RTC_GPIO5,
+        GPIO5, 0))); _for_each_inner_lp_function!((RTC_GPIOn((RTC_GPIO0, RTC_GPIOn, 0),
+        GPIO0, 0), ((RTC_GPIO1, RTC_GPIOn, 1), GPIO1, 0), ((RTC_GPIO2, RTC_GPIOn, 2),
+        GPIO2, 0), ((RTC_GPIO3, RTC_GPIOn, 3), GPIO3, 0), ((RTC_GPIO4, RTC_GPIOn, 4),
+        GPIO4, 0), ((RTC_GPIO5, RTC_GPIOn, 5), GPIO5, 0)));
     };
 }
 /// This macro can be used to generate code for each IOMUX digital function of each GPIO.

--- a/esp-metadata-generated/src/_generated_esp32c5.rs
+++ b/esp-metadata-generated/src/_generated_esp32c5.rs
@@ -5269,9 +5269,9 @@ macro_rules! for_each_lp_function {
         _for_each_inner_lp_function!((LP_UART_CTSN, GPIO3, 0));
         _for_each_inner_lp_function!((LP_GPIO3, GPIO3, 1));
         _for_each_inner_lp_function!((LP_I2C_SCL, GPIO3, 3));
-        _for_each_inner_lp_function!((LP_UART_RXD_PAD, GPIO4, 0));
+        _for_each_inner_lp_function!((LP_UART_RXD, GPIO4, 0));
         _for_each_inner_lp_function!((LP_GPIO4, GPIO4, 1));
-        _for_each_inner_lp_function!((LP_UART_TXD_PAD, GPIO5, 0));
+        _for_each_inner_lp_function!((LP_UART_TXD, GPIO5, 0));
         _for_each_inner_lp_function!((LP_GPIO5, GPIO5, 1));
         _for_each_inner_lp_function!((LP_GPIO6, GPIO6, 1));
         _for_each_inner_lp_function!(((LP_GPIO0, LP_GPIOn, 0), GPIO0, 1));
@@ -5284,13 +5284,12 @@ macro_rules! for_each_lp_function {
         _for_each_inner_lp_function!((all(LP_UART_DTRN, GPIO0, 0), (LP_GPIO0, GPIO0, 1),
         (LP_UART_DSRN, GPIO1, 0), (LP_GPIO1, GPIO1, 1), (LP_UART_RTSN, GPIO2, 0),
         (LP_GPIO2, GPIO2, 1), (LP_I2C_SDA, GPIO2, 3), (LP_UART_CTSN, GPIO3, 0),
-        (LP_GPIO3, GPIO3, 1), (LP_I2C_SCL, GPIO3, 3), (LP_UART_RXD_PAD, GPIO4, 0),
-        (LP_GPIO4, GPIO4, 1), (LP_UART_TXD_PAD, GPIO5, 0), (LP_GPIO5, GPIO5, 1),
-        (LP_GPIO6, GPIO6, 1))); _for_each_inner_lp_function!((LP_GPIOn((LP_GPIO0,
-        LP_GPIOn, 0), GPIO0, 1), ((LP_GPIO1, LP_GPIOn, 1), GPIO1, 1), ((LP_GPIO2,
-        LP_GPIOn, 2), GPIO2, 1), ((LP_GPIO3, LP_GPIOn, 3), GPIO3, 1), ((LP_GPIO4,
-        LP_GPIOn, 4), GPIO4, 1), ((LP_GPIO5, LP_GPIOn, 5), GPIO5, 1), ((LP_GPIO6,
-        LP_GPIOn, 6), GPIO6, 1)));
+        (LP_GPIO3, GPIO3, 1), (LP_I2C_SCL, GPIO3, 3), (LP_UART_RXD, GPIO4, 0), (LP_GPIO4,
+        GPIO4, 1), (LP_UART_TXD, GPIO5, 0), (LP_GPIO5, GPIO5, 1), (LP_GPIO6, GPIO6, 1)));
+        _for_each_inner_lp_function!((LP_GPIOn((LP_GPIO0, LP_GPIOn, 0), GPIO0, 1),
+        ((LP_GPIO1, LP_GPIOn, 1), GPIO1, 1), ((LP_GPIO2, LP_GPIOn, 2), GPIO2, 1),
+        ((LP_GPIO3, LP_GPIOn, 3), GPIO3, 1), ((LP_GPIO4, LP_GPIOn, 4), GPIO4, 1),
+        ((LP_GPIO5, LP_GPIOn, 5), GPIO5, 1), ((LP_GPIO6, LP_GPIOn, 6), GPIO6, 1)));
     };
 }
 /// This macro can be used to generate code for each IOMUX digital function of each GPIO.

--- a/esp-metadata-generated/src/_generated_esp32c5.rs
+++ b/esp-metadata-generated/src/_generated_esp32c5.rs
@@ -5231,11 +5231,12 @@ macro_rules! for_each_analog_function {
 ///
 /// This macro has two options for its "Individual matcher" case:
 ///
-/// - `all`: `($signal:ident, $gpio:ident)` - simple case where you only need identifiers
-/// - group: `(($signal:ident, $group:ident $(, $number:literal)+), $gpio:ident)` - expanded signal
-///   case, where you need the number(s) of a signal, or the general group to which the signal
-///   belongs. For example, in case of `SAR_I2C_SCL_1` the expanded form looks like `(SAR_I2C_SCL_1,
-///   SAR_I2C_SCL_n, 1)`.
+/// - `all`: `($signal:ident, $gpio:ident, $af:literal)` - simple case where you only need
+///   identifiers, and maybe the function number.
+/// - group: `(($signal:ident, $group:ident $(, $number:literal)+), $gpio:ident, $af:literal)` -
+///   expanded signal case, where you need the number(s) of a signal, or the general group to which
+///   the signal belongs. For example, in case of `SAR_I2C_SCL_1` the expanded form looks like
+///   `(SAR_I2C_SCL_1, SAR_I2C_SCL_n, 1)`.
 ///
 /// Macro fragments:
 ///
@@ -5244,10 +5245,13 @@ macro_rules! for_each_analog_function {
 ///   is `ADCn_CHm`.
 /// - `$number`: the numbers extracted from `$signal`.
 /// - `$gpio`: the name of the GPIO.
+/// - `$af`: the function number, as listed in the LP/RTC IO MUX pad list. On chips with an LP IO
+///   peripheral this is the value to write to the pin's `MCU_SEL` field to select the function. On
+///   chips with an RTC IO peripheral the numbering is not necessarily register-accurate.
 ///
 /// Example data:
-/// - `(RTC_GPIO15, GPIO12)`
-/// - `((RTC_GPIO15, RTC_GPIOn, 15), GPIO12)`
+/// - `(RTC_GPIO15, GPIO12, 0)`
+/// - `((RTC_GPIO15, RTC_GPIOn, 15), GPIO12, 0)`
 ///
 /// The expanded syntax is only available when the signal has at least one numbered component.
 #[macro_export]
@@ -5255,37 +5259,38 @@ macro_rules! for_each_analog_function {
 macro_rules! for_each_lp_function {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_lp_function { $(($pattern) => $code;)* ($other : tt)
-        => {} } _for_each_inner_lp_function!((LP_UART_DTRN, GPIO0));
-        _for_each_inner_lp_function!((LP_GPIO0, GPIO0));
-        _for_each_inner_lp_function!((LP_UART_DSRN, GPIO1));
-        _for_each_inner_lp_function!((LP_GPIO1, GPIO1));
-        _for_each_inner_lp_function!((LP_UART_RTSN, GPIO2));
-        _for_each_inner_lp_function!((LP_GPIO2, GPIO2));
-        _for_each_inner_lp_function!((LP_I2C_SDA, GPIO2));
-        _for_each_inner_lp_function!((LP_UART_CTSN, GPIO3));
-        _for_each_inner_lp_function!((LP_GPIO3, GPIO3));
-        _for_each_inner_lp_function!((LP_I2C_SCL, GPIO3));
-        _for_each_inner_lp_function!((LP_UART_RXD_PAD, GPIO4));
-        _for_each_inner_lp_function!((LP_GPIO4, GPIO4));
-        _for_each_inner_lp_function!((LP_UART_TXD_PAD, GPIO5));
-        _for_each_inner_lp_function!((LP_GPIO5, GPIO5));
-        _for_each_inner_lp_function!((LP_GPIO6, GPIO6));
-        _for_each_inner_lp_function!(((LP_GPIO0, LP_GPIOn, 0), GPIO0));
-        _for_each_inner_lp_function!(((LP_GPIO1, LP_GPIOn, 1), GPIO1));
-        _for_each_inner_lp_function!(((LP_GPIO2, LP_GPIOn, 2), GPIO2));
-        _for_each_inner_lp_function!(((LP_GPIO3, LP_GPIOn, 3), GPIO3));
-        _for_each_inner_lp_function!(((LP_GPIO4, LP_GPIOn, 4), GPIO4));
-        _for_each_inner_lp_function!(((LP_GPIO5, LP_GPIOn, 5), GPIO5));
-        _for_each_inner_lp_function!(((LP_GPIO6, LP_GPIOn, 6), GPIO6));
-        _for_each_inner_lp_function!((all(LP_UART_DTRN, GPIO0), (LP_GPIO0, GPIO0),
-        (LP_UART_DSRN, GPIO1), (LP_GPIO1, GPIO1), (LP_UART_RTSN, GPIO2), (LP_GPIO2,
-        GPIO2), (LP_I2C_SDA, GPIO2), (LP_UART_CTSN, GPIO3), (LP_GPIO3, GPIO3),
-        (LP_I2C_SCL, GPIO3), (LP_UART_RXD_PAD, GPIO4), (LP_GPIO4, GPIO4),
-        (LP_UART_TXD_PAD, GPIO5), (LP_GPIO5, GPIO5), (LP_GPIO6, GPIO6)));
-        _for_each_inner_lp_function!((LP_GPIOn((LP_GPIO0, LP_GPIOn, 0), GPIO0),
-        ((LP_GPIO1, LP_GPIOn, 1), GPIO1), ((LP_GPIO2, LP_GPIOn, 2), GPIO2), ((LP_GPIO3,
-        LP_GPIOn, 3), GPIO3), ((LP_GPIO4, LP_GPIOn, 4), GPIO4), ((LP_GPIO5, LP_GPIOn, 5),
-        GPIO5), ((LP_GPIO6, LP_GPIOn, 6), GPIO6)));
+        => {} } _for_each_inner_lp_function!((LP_UART_DTRN, GPIO0, 0));
+        _for_each_inner_lp_function!((LP_GPIO0, GPIO0, 1));
+        _for_each_inner_lp_function!((LP_UART_DSRN, GPIO1, 0));
+        _for_each_inner_lp_function!((LP_GPIO1, GPIO1, 1));
+        _for_each_inner_lp_function!((LP_UART_RTSN, GPIO2, 0));
+        _for_each_inner_lp_function!((LP_GPIO2, GPIO2, 1));
+        _for_each_inner_lp_function!((LP_I2C_SDA, GPIO2, 3));
+        _for_each_inner_lp_function!((LP_UART_CTSN, GPIO3, 0));
+        _for_each_inner_lp_function!((LP_GPIO3, GPIO3, 1));
+        _for_each_inner_lp_function!((LP_I2C_SCL, GPIO3, 3));
+        _for_each_inner_lp_function!((LP_UART_RXD_PAD, GPIO4, 0));
+        _for_each_inner_lp_function!((LP_GPIO4, GPIO4, 1));
+        _for_each_inner_lp_function!((LP_UART_TXD_PAD, GPIO5, 0));
+        _for_each_inner_lp_function!((LP_GPIO5, GPIO5, 1));
+        _for_each_inner_lp_function!((LP_GPIO6, GPIO6, 1));
+        _for_each_inner_lp_function!(((LP_GPIO0, LP_GPIOn, 0), GPIO0, 1));
+        _for_each_inner_lp_function!(((LP_GPIO1, LP_GPIOn, 1), GPIO1, 1));
+        _for_each_inner_lp_function!(((LP_GPIO2, LP_GPIOn, 2), GPIO2, 1));
+        _for_each_inner_lp_function!(((LP_GPIO3, LP_GPIOn, 3), GPIO3, 1));
+        _for_each_inner_lp_function!(((LP_GPIO4, LP_GPIOn, 4), GPIO4, 1));
+        _for_each_inner_lp_function!(((LP_GPIO5, LP_GPIOn, 5), GPIO5, 1));
+        _for_each_inner_lp_function!(((LP_GPIO6, LP_GPIOn, 6), GPIO6, 1));
+        _for_each_inner_lp_function!((all(LP_UART_DTRN, GPIO0, 0), (LP_GPIO0, GPIO0, 1),
+        (LP_UART_DSRN, GPIO1, 0), (LP_GPIO1, GPIO1, 1), (LP_UART_RTSN, GPIO2, 0),
+        (LP_GPIO2, GPIO2, 1), (LP_I2C_SDA, GPIO2, 3), (LP_UART_CTSN, GPIO3, 0),
+        (LP_GPIO3, GPIO3, 1), (LP_I2C_SCL, GPIO3, 3), (LP_UART_RXD_PAD, GPIO4, 0),
+        (LP_GPIO4, GPIO4, 1), (LP_UART_TXD_PAD, GPIO5, 0), (LP_GPIO5, GPIO5, 1),
+        (LP_GPIO6, GPIO6, 1))); _for_each_inner_lp_function!((LP_GPIOn((LP_GPIO0,
+        LP_GPIOn, 0), GPIO0, 1), ((LP_GPIO1, LP_GPIOn, 1), GPIO1, 1), ((LP_GPIO2,
+        LP_GPIOn, 2), GPIO2, 1), ((LP_GPIO3, LP_GPIOn, 3), GPIO3, 1), ((LP_GPIO4,
+        LP_GPIOn, 4), GPIO4, 1), ((LP_GPIO5, LP_GPIOn, 5), GPIO5, 1), ((LP_GPIO6,
+        LP_GPIOn, 6), GPIO6, 1)));
     };
 }
 /// This macro can be used to generate code for each IOMUX digital function of each GPIO.

--- a/esp-metadata-generated/src/_generated_esp32c6.rs
+++ b/esp-metadata-generated/src/_generated_esp32c6.rs
@@ -6131,11 +6131,12 @@ macro_rules! for_each_analog_function {
 ///
 /// This macro has two options for its "Individual matcher" case:
 ///
-/// - `all`: `($signal:ident, $gpio:ident)` - simple case where you only need identifiers
-/// - group: `(($signal:ident, $group:ident $(, $number:literal)+), $gpio:ident)` - expanded signal
-///   case, where you need the number(s) of a signal, or the general group to which the signal
-///   belongs. For example, in case of `SAR_I2C_SCL_1` the expanded form looks like `(SAR_I2C_SCL_1,
-///   SAR_I2C_SCL_n, 1)`.
+/// - `all`: `($signal:ident, $gpio:ident, $af:literal)` - simple case where you only need
+///   identifiers, and maybe the function number.
+/// - group: `(($signal:ident, $group:ident $(, $number:literal)+), $gpio:ident, $af:literal)` -
+///   expanded signal case, where you need the number(s) of a signal, or the general group to which
+///   the signal belongs. For example, in case of `SAR_I2C_SCL_1` the expanded form looks like
+///   `(SAR_I2C_SCL_1, SAR_I2C_SCL_n, 1)`.
 ///
 /// Macro fragments:
 ///
@@ -6144,10 +6145,13 @@ macro_rules! for_each_analog_function {
 ///   is `ADCn_CHm`.
 /// - `$number`: the numbers extracted from `$signal`.
 /// - `$gpio`: the name of the GPIO.
+/// - `$af`: the function number, as listed in the LP/RTC IO MUX pad list. On chips with an LP IO
+///   peripheral this is the value to write to the pin's `MCU_SEL` field to select the function. On
+///   chips with an RTC IO peripheral the numbering is not necessarily register-accurate.
 ///
 /// Example data:
-/// - `(RTC_GPIO15, GPIO12)`
-/// - `((RTC_GPIO15, RTC_GPIOn, 15), GPIO12)`
+/// - `(RTC_GPIO15, GPIO12, 0)`
+/// - `((RTC_GPIO15, RTC_GPIOn, 15), GPIO12, 0)`
 ///
 /// The expanded syntax is only available when the signal has at least one numbered component.
 #[macro_export]
@@ -6155,39 +6159,41 @@ macro_rules! for_each_analog_function {
 macro_rules! for_each_lp_function {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_lp_function { $(($pattern) => $code;)* ($other : tt)
-        => {} } _for_each_inner_lp_function!((LP_GPIO0, GPIO0));
-        _for_each_inner_lp_function!((LP_UART_DTRN, GPIO0));
-        _for_each_inner_lp_function!((LP_GPIO1, GPIO1));
-        _for_each_inner_lp_function!((LP_UART_DSRN, GPIO1));
-        _for_each_inner_lp_function!((LP_GPIO2, GPIO2));
-        _for_each_inner_lp_function!((LP_UART_RTSN, GPIO2));
-        _for_each_inner_lp_function!((LP_GPIO3, GPIO3));
-        _for_each_inner_lp_function!((LP_UART_CTSN, GPIO3));
-        _for_each_inner_lp_function!((LP_GPIO4, GPIO4));
-        _for_each_inner_lp_function!((LP_UART_RXD, GPIO4));
-        _for_each_inner_lp_function!((LP_GPIO5, GPIO5));
-        _for_each_inner_lp_function!((LP_UART_TXD, GPIO5));
-        _for_each_inner_lp_function!((LP_GPIO6, GPIO6));
-        _for_each_inner_lp_function!((LP_I2C_SDA, GPIO6));
-        _for_each_inner_lp_function!((LP_GPIO7, GPIO7));
-        _for_each_inner_lp_function!((LP_I2C_SCL, GPIO7));
-        _for_each_inner_lp_function!(((LP_GPIO0, LP_GPIOn, 0), GPIO0));
-        _for_each_inner_lp_function!(((LP_GPIO1, LP_GPIOn, 1), GPIO1));
-        _for_each_inner_lp_function!(((LP_GPIO2, LP_GPIOn, 2), GPIO2));
-        _for_each_inner_lp_function!(((LP_GPIO3, LP_GPIOn, 3), GPIO3));
-        _for_each_inner_lp_function!(((LP_GPIO4, LP_GPIOn, 4), GPIO4));
-        _for_each_inner_lp_function!(((LP_GPIO5, LP_GPIOn, 5), GPIO5));
-        _for_each_inner_lp_function!(((LP_GPIO6, LP_GPIOn, 6), GPIO6));
-        _for_each_inner_lp_function!(((LP_GPIO7, LP_GPIOn, 7), GPIO7));
-        _for_each_inner_lp_function!((all(LP_GPIO0, GPIO0), (LP_UART_DTRN, GPIO0),
-        (LP_GPIO1, GPIO1), (LP_UART_DSRN, GPIO1), (LP_GPIO2, GPIO2), (LP_UART_RTSN,
-        GPIO2), (LP_GPIO3, GPIO3), (LP_UART_CTSN, GPIO3), (LP_GPIO4, GPIO4),
-        (LP_UART_RXD, GPIO4), (LP_GPIO5, GPIO5), (LP_UART_TXD, GPIO5), (LP_GPIO6, GPIO6),
-        (LP_I2C_SDA, GPIO6), (LP_GPIO7, GPIO7), (LP_I2C_SCL, GPIO7)));
-        _for_each_inner_lp_function!((LP_GPIOn((LP_GPIO0, LP_GPIOn, 0), GPIO0),
-        ((LP_GPIO1, LP_GPIOn, 1), GPIO1), ((LP_GPIO2, LP_GPIOn, 2), GPIO2), ((LP_GPIO3,
-        LP_GPIOn, 3), GPIO3), ((LP_GPIO4, LP_GPIOn, 4), GPIO4), ((LP_GPIO5, LP_GPIOn, 5),
-        GPIO5), ((LP_GPIO6, LP_GPIOn, 6), GPIO6), ((LP_GPIO7, LP_GPIOn, 7), GPIO7)));
+        => {} } _for_each_inner_lp_function!((LP_GPIO0, GPIO0, 0));
+        _for_each_inner_lp_function!((LP_UART_DTRN, GPIO0, 1));
+        _for_each_inner_lp_function!((LP_GPIO1, GPIO1, 0));
+        _for_each_inner_lp_function!((LP_UART_DSRN, GPIO1, 1));
+        _for_each_inner_lp_function!((LP_GPIO2, GPIO2, 0));
+        _for_each_inner_lp_function!((LP_UART_RTSN, GPIO2, 1));
+        _for_each_inner_lp_function!((LP_GPIO3, GPIO3, 0));
+        _for_each_inner_lp_function!((LP_UART_CTSN, GPIO3, 1));
+        _for_each_inner_lp_function!((LP_GPIO4, GPIO4, 0));
+        _for_each_inner_lp_function!((LP_UART_RXD, GPIO4, 1));
+        _for_each_inner_lp_function!((LP_GPIO5, GPIO5, 0));
+        _for_each_inner_lp_function!((LP_UART_TXD, GPIO5, 1));
+        _for_each_inner_lp_function!((LP_GPIO6, GPIO6, 0));
+        _for_each_inner_lp_function!((LP_I2C_SDA, GPIO6, 1));
+        _for_each_inner_lp_function!((LP_GPIO7, GPIO7, 0));
+        _for_each_inner_lp_function!((LP_I2C_SCL, GPIO7, 1));
+        _for_each_inner_lp_function!(((LP_GPIO0, LP_GPIOn, 0), GPIO0, 0));
+        _for_each_inner_lp_function!(((LP_GPIO1, LP_GPIOn, 1), GPIO1, 0));
+        _for_each_inner_lp_function!(((LP_GPIO2, LP_GPIOn, 2), GPIO2, 0));
+        _for_each_inner_lp_function!(((LP_GPIO3, LP_GPIOn, 3), GPIO3, 0));
+        _for_each_inner_lp_function!(((LP_GPIO4, LP_GPIOn, 4), GPIO4, 0));
+        _for_each_inner_lp_function!(((LP_GPIO5, LP_GPIOn, 5), GPIO5, 0));
+        _for_each_inner_lp_function!(((LP_GPIO6, LP_GPIOn, 6), GPIO6, 0));
+        _for_each_inner_lp_function!(((LP_GPIO7, LP_GPIOn, 7), GPIO7, 0));
+        _for_each_inner_lp_function!((all(LP_GPIO0, GPIO0, 0), (LP_UART_DTRN, GPIO0, 1),
+        (LP_GPIO1, GPIO1, 0), (LP_UART_DSRN, GPIO1, 1), (LP_GPIO2, GPIO2, 0),
+        (LP_UART_RTSN, GPIO2, 1), (LP_GPIO3, GPIO3, 0), (LP_UART_CTSN, GPIO3, 1),
+        (LP_GPIO4, GPIO4, 0), (LP_UART_RXD, GPIO4, 1), (LP_GPIO5, GPIO5, 0),
+        (LP_UART_TXD, GPIO5, 1), (LP_GPIO6, GPIO6, 0), (LP_I2C_SDA, GPIO6, 1), (LP_GPIO7,
+        GPIO7, 0), (LP_I2C_SCL, GPIO7, 1)));
+        _for_each_inner_lp_function!((LP_GPIOn((LP_GPIO0, LP_GPIOn, 0), GPIO0, 0),
+        ((LP_GPIO1, LP_GPIOn, 1), GPIO1, 0), ((LP_GPIO2, LP_GPIOn, 2), GPIO2, 0),
+        ((LP_GPIO3, LP_GPIOn, 3), GPIO3, 0), ((LP_GPIO4, LP_GPIOn, 4), GPIO4, 0),
+        ((LP_GPIO5, LP_GPIOn, 5), GPIO5, 0), ((LP_GPIO6, LP_GPIOn, 6), GPIO6, 0),
+        ((LP_GPIO7, LP_GPIOn, 7), GPIO7, 0)));
     };
 }
 /// This macro can be used to generate code for each IOMUX digital function of each GPIO.

--- a/esp-metadata-generated/src/_generated_esp32c61.rs
+++ b/esp-metadata-generated/src/_generated_esp32c61.rs
@@ -4038,11 +4038,12 @@ macro_rules! for_each_analog_function {
 ///
 /// This macro has two options for its "Individual matcher" case:
 ///
-/// - `all`: `($signal:ident, $gpio:ident)` - simple case where you only need identifiers
-/// - group: `(($signal:ident, $group:ident $(, $number:literal)+), $gpio:ident)` - expanded signal
-///   case, where you need the number(s) of a signal, or the general group to which the signal
-///   belongs. For example, in case of `SAR_I2C_SCL_1` the expanded form looks like `(SAR_I2C_SCL_1,
-///   SAR_I2C_SCL_n, 1)`.
+/// - `all`: `($signal:ident, $gpio:ident, $af:literal)` - simple case where you only need
+///   identifiers, and maybe the function number.
+/// - group: `(($signal:ident, $group:ident $(, $number:literal)+), $gpio:ident, $af:literal)` -
+///   expanded signal case, where you need the number(s) of a signal, or the general group to which
+///   the signal belongs. For example, in case of `SAR_I2C_SCL_1` the expanded form looks like
+///   `(SAR_I2C_SCL_1, SAR_I2C_SCL_n, 1)`.
 ///
 /// Macro fragments:
 ///
@@ -4051,10 +4052,13 @@ macro_rules! for_each_analog_function {
 ///   is `ADCn_CHm`.
 /// - `$number`: the numbers extracted from `$signal`.
 /// - `$gpio`: the name of the GPIO.
+/// - `$af`: the function number, as listed in the LP/RTC IO MUX pad list. On chips with an LP IO
+///   peripheral this is the value to write to the pin's `MCU_SEL` field to select the function. On
+///   chips with an RTC IO peripheral the numbering is not necessarily register-accurate.
 ///
 /// Example data:
-/// - `(RTC_GPIO15, GPIO12)`
-/// - `((RTC_GPIO15, RTC_GPIOn, 15), GPIO12)`
+/// - `(RTC_GPIO15, GPIO12, 0)`
+/// - `((RTC_GPIO15, RTC_GPIOn, 15), GPIO12, 0)`
 ///
 /// The expanded syntax is only available when the signal has at least one numbered component.
 #[macro_export]
@@ -4062,26 +4066,27 @@ macro_rules! for_each_analog_function {
 macro_rules! for_each_lp_function {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_lp_function { $(($pattern) => $code;)* ($other : tt)
-        => {} } _for_each_inner_lp_function!((LP_GPIO0, GPIO0));
-        _for_each_inner_lp_function!((LP_GPIO1, GPIO1));
-        _for_each_inner_lp_function!((LP_GPIO2, GPIO2));
-        _for_each_inner_lp_function!((LP_GPIO3, GPIO3));
-        _for_each_inner_lp_function!((LP_GPIO4, GPIO4));
-        _for_each_inner_lp_function!((LP_GPIO5, GPIO5));
-        _for_each_inner_lp_function!((LP_GPIO6, GPIO6));
-        _for_each_inner_lp_function!(((LP_GPIO0, LP_GPIOn, 0), GPIO0));
-        _for_each_inner_lp_function!(((LP_GPIO1, LP_GPIOn, 1), GPIO1));
-        _for_each_inner_lp_function!(((LP_GPIO2, LP_GPIOn, 2), GPIO2));
-        _for_each_inner_lp_function!(((LP_GPIO3, LP_GPIOn, 3), GPIO3));
-        _for_each_inner_lp_function!(((LP_GPIO4, LP_GPIOn, 4), GPIO4));
-        _for_each_inner_lp_function!(((LP_GPIO5, LP_GPIOn, 5), GPIO5));
-        _for_each_inner_lp_function!(((LP_GPIO6, LP_GPIOn, 6), GPIO6));
-        _for_each_inner_lp_function!((all(LP_GPIO0, GPIO0), (LP_GPIO1, GPIO1), (LP_GPIO2,
-        GPIO2), (LP_GPIO3, GPIO3), (LP_GPIO4, GPIO4), (LP_GPIO5, GPIO5), (LP_GPIO6,
-        GPIO6))); _for_each_inner_lp_function!((LP_GPIOn((LP_GPIO0, LP_GPIOn, 0), GPIO0),
-        ((LP_GPIO1, LP_GPIOn, 1), GPIO1), ((LP_GPIO2, LP_GPIOn, 2), GPIO2), ((LP_GPIO3,
-        LP_GPIOn, 3), GPIO3), ((LP_GPIO4, LP_GPIOn, 4), GPIO4), ((LP_GPIO5, LP_GPIOn, 5),
-        GPIO5), ((LP_GPIO6, LP_GPIOn, 6), GPIO6)));
+        => {} } _for_each_inner_lp_function!((LP_GPIO0, GPIO0, 1));
+        _for_each_inner_lp_function!((LP_GPIO1, GPIO1, 1));
+        _for_each_inner_lp_function!((LP_GPIO2, GPIO2, 1));
+        _for_each_inner_lp_function!((LP_GPIO3, GPIO3, 1));
+        _for_each_inner_lp_function!((LP_GPIO4, GPIO4, 1));
+        _for_each_inner_lp_function!((LP_GPIO5, GPIO5, 1));
+        _for_each_inner_lp_function!((LP_GPIO6, GPIO6, 1));
+        _for_each_inner_lp_function!(((LP_GPIO0, LP_GPIOn, 0), GPIO0, 1));
+        _for_each_inner_lp_function!(((LP_GPIO1, LP_GPIOn, 1), GPIO1, 1));
+        _for_each_inner_lp_function!(((LP_GPIO2, LP_GPIOn, 2), GPIO2, 1));
+        _for_each_inner_lp_function!(((LP_GPIO3, LP_GPIOn, 3), GPIO3, 1));
+        _for_each_inner_lp_function!(((LP_GPIO4, LP_GPIOn, 4), GPIO4, 1));
+        _for_each_inner_lp_function!(((LP_GPIO5, LP_GPIOn, 5), GPIO5, 1));
+        _for_each_inner_lp_function!(((LP_GPIO6, LP_GPIOn, 6), GPIO6, 1));
+        _for_each_inner_lp_function!((all(LP_GPIO0, GPIO0, 1), (LP_GPIO1, GPIO1, 1),
+        (LP_GPIO2, GPIO2, 1), (LP_GPIO3, GPIO3, 1), (LP_GPIO4, GPIO4, 1), (LP_GPIO5,
+        GPIO5, 1), (LP_GPIO6, GPIO6, 1)));
+        _for_each_inner_lp_function!((LP_GPIOn((LP_GPIO0, LP_GPIOn, 0), GPIO0, 1),
+        ((LP_GPIO1, LP_GPIOn, 1), GPIO1, 1), ((LP_GPIO2, LP_GPIOn, 2), GPIO2, 1),
+        ((LP_GPIO3, LP_GPIOn, 3), GPIO3, 1), ((LP_GPIO4, LP_GPIOn, 4), GPIO4, 1),
+        ((LP_GPIO5, LP_GPIOn, 5), GPIO5, 1), ((LP_GPIO6, LP_GPIOn, 6), GPIO6, 1)));
     };
 }
 /// This macro can be used to generate code for each IOMUX digital function of each GPIO.

--- a/esp-metadata-generated/src/_generated_esp32h2.rs
+++ b/esp-metadata-generated/src/_generated_esp32h2.rs
@@ -4905,11 +4905,12 @@ macro_rules! for_each_analog_function {
 ///
 /// This macro has two options for its "Individual matcher" case:
 ///
-/// - `all`: `($signal:ident, $gpio:ident)` - simple case where you only need identifiers
-/// - group: `(($signal:ident, $group:ident $(, $number:literal)+), $gpio:ident)` - expanded signal
-///   case, where you need the number(s) of a signal, or the general group to which the signal
-///   belongs. For example, in case of `SAR_I2C_SCL_1` the expanded form looks like `(SAR_I2C_SCL_1,
-///   SAR_I2C_SCL_n, 1)`.
+/// - `all`: `($signal:ident, $gpio:ident, $af:literal)` - simple case where you only need
+///   identifiers, and maybe the function number.
+/// - group: `(($signal:ident, $group:ident $(, $number:literal)+), $gpio:ident, $af:literal)` -
+///   expanded signal case, where you need the number(s) of a signal, or the general group to which
+///   the signal belongs. For example, in case of `SAR_I2C_SCL_1` the expanded form looks like
+///   `(SAR_I2C_SCL_1, SAR_I2C_SCL_n, 1)`.
 ///
 /// Macro fragments:
 ///
@@ -4918,10 +4919,13 @@ macro_rules! for_each_analog_function {
 ///   is `ADCn_CHm`.
 /// - `$number`: the numbers extracted from `$signal`.
 /// - `$gpio`: the name of the GPIO.
+/// - `$af`: the function number, as listed in the LP/RTC IO MUX pad list. On chips with an LP IO
+///   peripheral this is the value to write to the pin's `MCU_SEL` field to select the function. On
+///   chips with an RTC IO peripheral the numbering is not necessarily register-accurate.
 ///
 /// Example data:
-/// - `(RTC_GPIO15, GPIO12)`
-/// - `((RTC_GPIO15, RTC_GPIOn, 15), GPIO12)`
+/// - `(RTC_GPIO15, GPIO12, 0)`
+/// - `((RTC_GPIO15, RTC_GPIOn, 15), GPIO12, 0)`
 ///
 /// The expanded syntax is only available when the signal has at least one numbered component.
 #[macro_export]
@@ -4929,29 +4933,30 @@ macro_rules! for_each_analog_function {
 macro_rules! for_each_lp_function {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_lp_function { $(($pattern) => $code;)* ($other : tt)
-        => {} } _for_each_inner_lp_function!((LP_GPIO0, GPIO7));
-        _for_each_inner_lp_function!((LP_GPIO1, GPIO8));
-        _for_each_inner_lp_function!((LP_GPIO2, GPIO9));
-        _for_each_inner_lp_function!((LP_GPIO3, GPIO10));
-        _for_each_inner_lp_function!((LP_GPIO4, GPIO11));
-        _for_each_inner_lp_function!((LP_GPIO5, GPIO12));
-        _for_each_inner_lp_function!((LP_GPIO6, GPIO13));
-        _for_each_inner_lp_function!((LP_GPIO7, GPIO14));
-        _for_each_inner_lp_function!(((LP_GPIO0, LP_GPIOn, 0), GPIO7));
-        _for_each_inner_lp_function!(((LP_GPIO1, LP_GPIOn, 1), GPIO8));
-        _for_each_inner_lp_function!(((LP_GPIO2, LP_GPIOn, 2), GPIO9));
-        _for_each_inner_lp_function!(((LP_GPIO3, LP_GPIOn, 3), GPIO10));
-        _for_each_inner_lp_function!(((LP_GPIO4, LP_GPIOn, 4), GPIO11));
-        _for_each_inner_lp_function!(((LP_GPIO5, LP_GPIOn, 5), GPIO12));
-        _for_each_inner_lp_function!(((LP_GPIO6, LP_GPIOn, 6), GPIO13));
-        _for_each_inner_lp_function!(((LP_GPIO7, LP_GPIOn, 7), GPIO14));
-        _for_each_inner_lp_function!((all(LP_GPIO0, GPIO7), (LP_GPIO1, GPIO8), (LP_GPIO2,
-        GPIO9), (LP_GPIO3, GPIO10), (LP_GPIO4, GPIO11), (LP_GPIO5, GPIO12), (LP_GPIO6,
-        GPIO13), (LP_GPIO7, GPIO14))); _for_each_inner_lp_function!((LP_GPIOn((LP_GPIO0,
-        LP_GPIOn, 0), GPIO7), ((LP_GPIO1, LP_GPIOn, 1), GPIO8), ((LP_GPIO2, LP_GPIOn, 2),
-        GPIO9), ((LP_GPIO3, LP_GPIOn, 3), GPIO10), ((LP_GPIO4, LP_GPIOn, 4), GPIO11),
-        ((LP_GPIO5, LP_GPIOn, 5), GPIO12), ((LP_GPIO6, LP_GPIOn, 6), GPIO13), ((LP_GPIO7,
-        LP_GPIOn, 7), GPIO14)));
+        => {} } _for_each_inner_lp_function!((LP_GPIO0, GPIO7, 0));
+        _for_each_inner_lp_function!((LP_GPIO1, GPIO8, 0));
+        _for_each_inner_lp_function!((LP_GPIO2, GPIO9, 0));
+        _for_each_inner_lp_function!((LP_GPIO3, GPIO10, 0));
+        _for_each_inner_lp_function!((LP_GPIO4, GPIO11, 0));
+        _for_each_inner_lp_function!((LP_GPIO5, GPIO12, 0));
+        _for_each_inner_lp_function!((LP_GPIO6, GPIO13, 0));
+        _for_each_inner_lp_function!((LP_GPIO7, GPIO14, 0));
+        _for_each_inner_lp_function!(((LP_GPIO0, LP_GPIOn, 0), GPIO7, 0));
+        _for_each_inner_lp_function!(((LP_GPIO1, LP_GPIOn, 1), GPIO8, 0));
+        _for_each_inner_lp_function!(((LP_GPIO2, LP_GPIOn, 2), GPIO9, 0));
+        _for_each_inner_lp_function!(((LP_GPIO3, LP_GPIOn, 3), GPIO10, 0));
+        _for_each_inner_lp_function!(((LP_GPIO4, LP_GPIOn, 4), GPIO11, 0));
+        _for_each_inner_lp_function!(((LP_GPIO5, LP_GPIOn, 5), GPIO12, 0));
+        _for_each_inner_lp_function!(((LP_GPIO6, LP_GPIOn, 6), GPIO13, 0));
+        _for_each_inner_lp_function!(((LP_GPIO7, LP_GPIOn, 7), GPIO14, 0));
+        _for_each_inner_lp_function!((all(LP_GPIO0, GPIO7, 0), (LP_GPIO1, GPIO8, 0),
+        (LP_GPIO2, GPIO9, 0), (LP_GPIO3, GPIO10, 0), (LP_GPIO4, GPIO11, 0), (LP_GPIO5,
+        GPIO12, 0), (LP_GPIO6, GPIO13, 0), (LP_GPIO7, GPIO14, 0)));
+        _for_each_inner_lp_function!((LP_GPIOn((LP_GPIO0, LP_GPIOn, 0), GPIO7, 0),
+        ((LP_GPIO1, LP_GPIOn, 1), GPIO8, 0), ((LP_GPIO2, LP_GPIOn, 2), GPIO9, 0),
+        ((LP_GPIO3, LP_GPIOn, 3), GPIO10, 0), ((LP_GPIO4, LP_GPIOn, 4), GPIO11, 0),
+        ((LP_GPIO5, LP_GPIOn, 5), GPIO12, 0), ((LP_GPIO6, LP_GPIOn, 6), GPIO13, 0),
+        ((LP_GPIO7, LP_GPIOn, 7), GPIO14, 0)));
     };
 }
 /// This macro can be used to generate code for each IOMUX digital function of each GPIO.

--- a/esp-metadata-generated/src/_generated_esp32p4.rs
+++ b/esp-metadata-generated/src/_generated_esp32p4.rs
@@ -5949,11 +5949,12 @@ macro_rules! for_each_analog_function {
 ///
 /// This macro has two options for its "Individual matcher" case:
 ///
-/// - `all`: `($signal:ident, $gpio:ident)` - simple case where you only need identifiers
-/// - group: `(($signal:ident, $group:ident $(, $number:literal)+), $gpio:ident)` - expanded signal
-///   case, where you need the number(s) of a signal, or the general group to which the signal
-///   belongs. For example, in case of `SAR_I2C_SCL_1` the expanded form looks like `(SAR_I2C_SCL_1,
-///   SAR_I2C_SCL_n, 1)`.
+/// - `all`: `($signal:ident, $gpio:ident, $af:literal)` - simple case where you only need
+///   identifiers, and maybe the function number.
+/// - group: `(($signal:ident, $group:ident $(, $number:literal)+), $gpio:ident, $af:literal)` -
+///   expanded signal case, where you need the number(s) of a signal, or the general group to which
+///   the signal belongs. For example, in case of `SAR_I2C_SCL_1` the expanded form looks like
+///   `(SAR_I2C_SCL_1, SAR_I2C_SCL_n, 1)`.
 ///
 /// Macro fragments:
 ///
@@ -5962,10 +5963,13 @@ macro_rules! for_each_analog_function {
 ///   is `ADCn_CHm`.
 /// - `$number`: the numbers extracted from `$signal`.
 /// - `$gpio`: the name of the GPIO.
+/// - `$af`: the function number, as listed in the LP/RTC IO MUX pad list. On chips with an LP IO
+///   peripheral this is the value to write to the pin's `MCU_SEL` field to select the function. On
+///   chips with an RTC IO peripheral the numbering is not necessarily register-accurate.
 ///
 /// Example data:
-/// - `(RTC_GPIO15, GPIO12)`
-/// - `((RTC_GPIO15, RTC_GPIOn, 15), GPIO12)`
+/// - `(RTC_GPIO15, GPIO12, 0)`
+/// - `((RTC_GPIO15, RTC_GPIOn, 15), GPIO12, 0)`
 ///
 /// The expanded syntax is only available when the signal has at least one numbered component.
 #[macro_export]
@@ -5973,34 +5977,35 @@ macro_rules! for_each_analog_function {
 macro_rules! for_each_lp_function {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_lp_function { $(($pattern) => $code;)* ($other : tt)
-        => {} } _for_each_inner_lp_function!((LP_GPIO0, GPIO0));
-        _for_each_inner_lp_function!((LP_GPIO1, GPIO1));
-        _for_each_inner_lp_function!((LP_GPIO2, GPIO2));
-        _for_each_inner_lp_function!((LP_GPIO3, GPIO3));
-        _for_each_inner_lp_function!((LP_GPIO4, GPIO4));
-        _for_each_inner_lp_function!((LP_GPIO5, GPIO5));
-        _for_each_inner_lp_function!((LP_GPIO12, GPIO12));
-        _for_each_inner_lp_function!((LP_GPIO13, GPIO13));
-        _for_each_inner_lp_function!((LP_GPIO14, GPIO14));
-        _for_each_inner_lp_function!((LP_GPIO15, GPIO15));
-        _for_each_inner_lp_function!(((LP_GPIO0, LP_GPIOn, 0), GPIO0));
-        _for_each_inner_lp_function!(((LP_GPIO1, LP_GPIOn, 1), GPIO1));
-        _for_each_inner_lp_function!(((LP_GPIO2, LP_GPIOn, 2), GPIO2));
-        _for_each_inner_lp_function!(((LP_GPIO3, LP_GPIOn, 3), GPIO3));
-        _for_each_inner_lp_function!(((LP_GPIO4, LP_GPIOn, 4), GPIO4));
-        _for_each_inner_lp_function!(((LP_GPIO5, LP_GPIOn, 5), GPIO5));
-        _for_each_inner_lp_function!(((LP_GPIO12, LP_GPIOn, 12), GPIO12));
-        _for_each_inner_lp_function!(((LP_GPIO13, LP_GPIOn, 13), GPIO13));
-        _for_each_inner_lp_function!(((LP_GPIO14, LP_GPIOn, 14), GPIO14));
-        _for_each_inner_lp_function!(((LP_GPIO15, LP_GPIOn, 15), GPIO15));
-        _for_each_inner_lp_function!((all(LP_GPIO0, GPIO0), (LP_GPIO1, GPIO1), (LP_GPIO2,
-        GPIO2), (LP_GPIO3, GPIO3), (LP_GPIO4, GPIO4), (LP_GPIO5, GPIO5), (LP_GPIO12,
-        GPIO12), (LP_GPIO13, GPIO13), (LP_GPIO14, GPIO14), (LP_GPIO15, GPIO15)));
-        _for_each_inner_lp_function!((LP_GPIOn((LP_GPIO0, LP_GPIOn, 0), GPIO0),
-        ((LP_GPIO1, LP_GPIOn, 1), GPIO1), ((LP_GPIO2, LP_GPIOn, 2), GPIO2), ((LP_GPIO3,
-        LP_GPIOn, 3), GPIO3), ((LP_GPIO4, LP_GPIOn, 4), GPIO4), ((LP_GPIO5, LP_GPIOn, 5),
-        GPIO5), ((LP_GPIO12, LP_GPIOn, 12), GPIO12), ((LP_GPIO13, LP_GPIOn, 13), GPIO13),
-        ((LP_GPIO14, LP_GPIOn, 14), GPIO14), ((LP_GPIO15, LP_GPIOn, 15), GPIO15)));
+        => {} } _for_each_inner_lp_function!((LP_GPIO0, GPIO0, 0));
+        _for_each_inner_lp_function!((LP_GPIO1, GPIO1, 0));
+        _for_each_inner_lp_function!((LP_GPIO2, GPIO2, 0));
+        _for_each_inner_lp_function!((LP_GPIO3, GPIO3, 0));
+        _for_each_inner_lp_function!((LP_GPIO4, GPIO4, 0));
+        _for_each_inner_lp_function!((LP_GPIO5, GPIO5, 0));
+        _for_each_inner_lp_function!((LP_GPIO12, GPIO12, 0));
+        _for_each_inner_lp_function!((LP_GPIO13, GPIO13, 0));
+        _for_each_inner_lp_function!((LP_GPIO14, GPIO14, 0));
+        _for_each_inner_lp_function!((LP_GPIO15, GPIO15, 0));
+        _for_each_inner_lp_function!(((LP_GPIO0, LP_GPIOn, 0), GPIO0, 0));
+        _for_each_inner_lp_function!(((LP_GPIO1, LP_GPIOn, 1), GPIO1, 0));
+        _for_each_inner_lp_function!(((LP_GPIO2, LP_GPIOn, 2), GPIO2, 0));
+        _for_each_inner_lp_function!(((LP_GPIO3, LP_GPIOn, 3), GPIO3, 0));
+        _for_each_inner_lp_function!(((LP_GPIO4, LP_GPIOn, 4), GPIO4, 0));
+        _for_each_inner_lp_function!(((LP_GPIO5, LP_GPIOn, 5), GPIO5, 0));
+        _for_each_inner_lp_function!(((LP_GPIO12, LP_GPIOn, 12), GPIO12, 0));
+        _for_each_inner_lp_function!(((LP_GPIO13, LP_GPIOn, 13), GPIO13, 0));
+        _for_each_inner_lp_function!(((LP_GPIO14, LP_GPIOn, 14), GPIO14, 0));
+        _for_each_inner_lp_function!(((LP_GPIO15, LP_GPIOn, 15), GPIO15, 0));
+        _for_each_inner_lp_function!((all(LP_GPIO0, GPIO0, 0), (LP_GPIO1, GPIO1, 0),
+        (LP_GPIO2, GPIO2, 0), (LP_GPIO3, GPIO3, 0), (LP_GPIO4, GPIO4, 0), (LP_GPIO5,
+        GPIO5, 0), (LP_GPIO12, GPIO12, 0), (LP_GPIO13, GPIO13, 0), (LP_GPIO14, GPIO14,
+        0), (LP_GPIO15, GPIO15, 0))); _for_each_inner_lp_function!((LP_GPIOn((LP_GPIO0,
+        LP_GPIOn, 0), GPIO0, 0), ((LP_GPIO1, LP_GPIOn, 1), GPIO1, 0), ((LP_GPIO2,
+        LP_GPIOn, 2), GPIO2, 0), ((LP_GPIO3, LP_GPIOn, 3), GPIO3, 0), ((LP_GPIO4,
+        LP_GPIOn, 4), GPIO4, 0), ((LP_GPIO5, LP_GPIOn, 5), GPIO5, 0), ((LP_GPIO12,
+        LP_GPIOn, 12), GPIO12, 0), ((LP_GPIO13, LP_GPIOn, 13), GPIO13, 0), ((LP_GPIO14,
+        LP_GPIOn, 14), GPIO14, 0), ((LP_GPIO15, LP_GPIOn, 15), GPIO15, 0)));
     };
 }
 /// This macro can be used to generate code for each IOMUX digital function of each GPIO.

--- a/esp-metadata-generated/src/_generated_esp32s2.rs
+++ b/esp-metadata-generated/src/_generated_esp32s2.rs
@@ -5255,11 +5255,12 @@ macro_rules! for_each_analog_function {
 ///
 /// This macro has two options for its "Individual matcher" case:
 ///
-/// - `all`: `($signal:ident, $gpio:ident)` - simple case where you only need identifiers
-/// - group: `(($signal:ident, $group:ident $(, $number:literal)+), $gpio:ident)` - expanded signal
-///   case, where you need the number(s) of a signal, or the general group to which the signal
-///   belongs. For example, in case of `SAR_I2C_SCL_1` the expanded form looks like `(SAR_I2C_SCL_1,
-///   SAR_I2C_SCL_n, 1)`.
+/// - `all`: `($signal:ident, $gpio:ident, $af:literal)` - simple case where you only need
+///   identifiers, and maybe the function number.
+/// - group: `(($signal:ident, $group:ident $(, $number:literal)+), $gpio:ident, $af:literal)` -
+///   expanded signal case, where you need the number(s) of a signal, or the general group to which
+///   the signal belongs. For example, in case of `SAR_I2C_SCL_1` the expanded form looks like
+///   `(SAR_I2C_SCL_1, SAR_I2C_SCL_n, 1)`.
 ///
 /// Macro fragments:
 ///
@@ -5268,10 +5269,13 @@ macro_rules! for_each_analog_function {
 ///   is `ADCn_CHm`.
 /// - `$number`: the numbers extracted from `$signal`.
 /// - `$gpio`: the name of the GPIO.
+/// - `$af`: the function number, as listed in the LP/RTC IO MUX pad list. On chips with an LP IO
+///   peripheral this is the value to write to the pin's `MCU_SEL` field to select the function. On
+///   chips with an RTC IO peripheral the numbering is not necessarily register-accurate.
 ///
 /// Example data:
-/// - `(RTC_GPIO15, GPIO12)`
-/// - `((RTC_GPIO15, RTC_GPIOn, 15), GPIO12)`
+/// - `(RTC_GPIO15, GPIO12, 0)`
+/// - `((RTC_GPIO15, RTC_GPIOn, 15), GPIO12, 0)`
 ///
 /// The expanded syntax is only available when the signal has at least one numbered component.
 #[macro_export]
@@ -5279,69 +5283,70 @@ macro_rules! for_each_analog_function {
 macro_rules! for_each_lp_function {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_lp_function { $(($pattern) => $code;)* ($other : tt)
-        => {} } _for_each_inner_lp_function!((RTC_GPIO0, GPIO0));
-        _for_each_inner_lp_function!((RTC_GPIO1, GPIO1));
-        _for_each_inner_lp_function!((RTC_GPIO2, GPIO2));
-        _for_each_inner_lp_function!((RTC_GPIO3, GPIO3));
-        _for_each_inner_lp_function!((RTC_GPIO4, GPIO4));
-        _for_each_inner_lp_function!((RTC_GPIO5, GPIO5));
-        _for_each_inner_lp_function!((RTC_GPIO6, GPIO6));
-        _for_each_inner_lp_function!((RTC_GPIO7, GPIO7));
-        _for_each_inner_lp_function!((RTC_GPIO8, GPIO8));
-        _for_each_inner_lp_function!((RTC_GPIO9, GPIO9));
-        _for_each_inner_lp_function!((RTC_GPIO10, GPIO10));
-        _for_each_inner_lp_function!((RTC_GPIO11, GPIO11));
-        _for_each_inner_lp_function!((RTC_GPIO12, GPIO12));
-        _for_each_inner_lp_function!((RTC_GPIO13, GPIO13));
-        _for_each_inner_lp_function!((RTC_GPIO14, GPIO14));
-        _for_each_inner_lp_function!((RTC_GPIO15, GPIO15));
-        _for_each_inner_lp_function!((RTC_GPIO16, GPIO16));
-        _for_each_inner_lp_function!((RTC_GPIO17, GPIO17));
-        _for_each_inner_lp_function!((RTC_GPIO18, GPIO18));
-        _for_each_inner_lp_function!((RTC_GPIO19, GPIO19));
-        _for_each_inner_lp_function!((RTC_GPIO20, GPIO20));
-        _for_each_inner_lp_function!((RTC_GPIO21, GPIO21));
-        _for_each_inner_lp_function!(((RTC_GPIO0, RTC_GPIOn, 0), GPIO0));
-        _for_each_inner_lp_function!(((RTC_GPIO1, RTC_GPIOn, 1), GPIO1));
-        _for_each_inner_lp_function!(((RTC_GPIO2, RTC_GPIOn, 2), GPIO2));
-        _for_each_inner_lp_function!(((RTC_GPIO3, RTC_GPIOn, 3), GPIO3));
-        _for_each_inner_lp_function!(((RTC_GPIO4, RTC_GPIOn, 4), GPIO4));
-        _for_each_inner_lp_function!(((RTC_GPIO5, RTC_GPIOn, 5), GPIO5));
-        _for_each_inner_lp_function!(((RTC_GPIO6, RTC_GPIOn, 6), GPIO6));
-        _for_each_inner_lp_function!(((RTC_GPIO7, RTC_GPIOn, 7), GPIO7));
-        _for_each_inner_lp_function!(((RTC_GPIO8, RTC_GPIOn, 8), GPIO8));
-        _for_each_inner_lp_function!(((RTC_GPIO9, RTC_GPIOn, 9), GPIO9));
-        _for_each_inner_lp_function!(((RTC_GPIO10, RTC_GPIOn, 10), GPIO10));
-        _for_each_inner_lp_function!(((RTC_GPIO11, RTC_GPIOn, 11), GPIO11));
-        _for_each_inner_lp_function!(((RTC_GPIO12, RTC_GPIOn, 12), GPIO12));
-        _for_each_inner_lp_function!(((RTC_GPIO13, RTC_GPIOn, 13), GPIO13));
-        _for_each_inner_lp_function!(((RTC_GPIO14, RTC_GPIOn, 14), GPIO14));
-        _for_each_inner_lp_function!(((RTC_GPIO15, RTC_GPIOn, 15), GPIO15));
-        _for_each_inner_lp_function!(((RTC_GPIO16, RTC_GPIOn, 16), GPIO16));
-        _for_each_inner_lp_function!(((RTC_GPIO17, RTC_GPIOn, 17), GPIO17));
-        _for_each_inner_lp_function!(((RTC_GPIO18, RTC_GPIOn, 18), GPIO18));
-        _for_each_inner_lp_function!(((RTC_GPIO19, RTC_GPIOn, 19), GPIO19));
-        _for_each_inner_lp_function!(((RTC_GPIO20, RTC_GPIOn, 20), GPIO20));
-        _for_each_inner_lp_function!(((RTC_GPIO21, RTC_GPIOn, 21), GPIO21));
-        _for_each_inner_lp_function!((all(RTC_GPIO0, GPIO0), (RTC_GPIO1, GPIO1),
-        (RTC_GPIO2, GPIO2), (RTC_GPIO3, GPIO3), (RTC_GPIO4, GPIO4), (RTC_GPIO5, GPIO5),
-        (RTC_GPIO6, GPIO6), (RTC_GPIO7, GPIO7), (RTC_GPIO8, GPIO8), (RTC_GPIO9, GPIO9),
-        (RTC_GPIO10, GPIO10), (RTC_GPIO11, GPIO11), (RTC_GPIO12, GPIO12), (RTC_GPIO13,
-        GPIO13), (RTC_GPIO14, GPIO14), (RTC_GPIO15, GPIO15), (RTC_GPIO16, GPIO16),
-        (RTC_GPIO17, GPIO17), (RTC_GPIO18, GPIO18), (RTC_GPIO19, GPIO19), (RTC_GPIO20,
-        GPIO20), (RTC_GPIO21, GPIO21)));
-        _for_each_inner_lp_function!((RTC_GPIOn((RTC_GPIO0, RTC_GPIOn, 0), GPIO0),
-        ((RTC_GPIO1, RTC_GPIOn, 1), GPIO1), ((RTC_GPIO2, RTC_GPIOn, 2), GPIO2),
-        ((RTC_GPIO3, RTC_GPIOn, 3), GPIO3), ((RTC_GPIO4, RTC_GPIOn, 4), GPIO4),
-        ((RTC_GPIO5, RTC_GPIOn, 5), GPIO5), ((RTC_GPIO6, RTC_GPIOn, 6), GPIO6),
-        ((RTC_GPIO7, RTC_GPIOn, 7), GPIO7), ((RTC_GPIO8, RTC_GPIOn, 8), GPIO8),
-        ((RTC_GPIO9, RTC_GPIOn, 9), GPIO9), ((RTC_GPIO10, RTC_GPIOn, 10), GPIO10),
-        ((RTC_GPIO11, RTC_GPIOn, 11), GPIO11), ((RTC_GPIO12, RTC_GPIOn, 12), GPIO12),
-        ((RTC_GPIO13, RTC_GPIOn, 13), GPIO13), ((RTC_GPIO14, RTC_GPIOn, 14), GPIO14),
-        ((RTC_GPIO15, RTC_GPIOn, 15), GPIO15), ((RTC_GPIO16, RTC_GPIOn, 16), GPIO16),
-        ((RTC_GPIO17, RTC_GPIOn, 17), GPIO17), ((RTC_GPIO18, RTC_GPIOn, 18), GPIO18),
-        ((RTC_GPIO19, RTC_GPIOn, 19), GPIO19), ((RTC_GPIO20, RTC_GPIOn, 20), GPIO20),
-        ((RTC_GPIO21, RTC_GPIOn, 21), GPIO21)));
+        => {} } _for_each_inner_lp_function!((RTC_GPIO0, GPIO0, 0));
+        _for_each_inner_lp_function!((RTC_GPIO1, GPIO1, 0));
+        _for_each_inner_lp_function!((RTC_GPIO2, GPIO2, 0));
+        _for_each_inner_lp_function!((RTC_GPIO3, GPIO3, 0));
+        _for_each_inner_lp_function!((RTC_GPIO4, GPIO4, 0));
+        _for_each_inner_lp_function!((RTC_GPIO5, GPIO5, 0));
+        _for_each_inner_lp_function!((RTC_GPIO6, GPIO6, 0));
+        _for_each_inner_lp_function!((RTC_GPIO7, GPIO7, 0));
+        _for_each_inner_lp_function!((RTC_GPIO8, GPIO8, 0));
+        _for_each_inner_lp_function!((RTC_GPIO9, GPIO9, 0));
+        _for_each_inner_lp_function!((RTC_GPIO10, GPIO10, 0));
+        _for_each_inner_lp_function!((RTC_GPIO11, GPIO11, 0));
+        _for_each_inner_lp_function!((RTC_GPIO12, GPIO12, 0));
+        _for_each_inner_lp_function!((RTC_GPIO13, GPIO13, 0));
+        _for_each_inner_lp_function!((RTC_GPIO14, GPIO14, 0));
+        _for_each_inner_lp_function!((RTC_GPIO15, GPIO15, 0));
+        _for_each_inner_lp_function!((RTC_GPIO16, GPIO16, 0));
+        _for_each_inner_lp_function!((RTC_GPIO17, GPIO17, 0));
+        _for_each_inner_lp_function!((RTC_GPIO18, GPIO18, 0));
+        _for_each_inner_lp_function!((RTC_GPIO19, GPIO19, 0));
+        _for_each_inner_lp_function!((RTC_GPIO20, GPIO20, 0));
+        _for_each_inner_lp_function!((RTC_GPIO21, GPIO21, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO0, RTC_GPIOn, 0), GPIO0, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO1, RTC_GPIOn, 1), GPIO1, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO2, RTC_GPIOn, 2), GPIO2, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO3, RTC_GPIOn, 3), GPIO3, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO4, RTC_GPIOn, 4), GPIO4, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO5, RTC_GPIOn, 5), GPIO5, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO6, RTC_GPIOn, 6), GPIO6, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO7, RTC_GPIOn, 7), GPIO7, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO8, RTC_GPIOn, 8), GPIO8, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO9, RTC_GPIOn, 9), GPIO9, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO10, RTC_GPIOn, 10), GPIO10, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO11, RTC_GPIOn, 11), GPIO11, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO12, RTC_GPIOn, 12), GPIO12, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO13, RTC_GPIOn, 13), GPIO13, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO14, RTC_GPIOn, 14), GPIO14, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO15, RTC_GPIOn, 15), GPIO15, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO16, RTC_GPIOn, 16), GPIO16, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO17, RTC_GPIOn, 17), GPIO17, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO18, RTC_GPIOn, 18), GPIO18, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO19, RTC_GPIOn, 19), GPIO19, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO20, RTC_GPIOn, 20), GPIO20, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO21, RTC_GPIOn, 21), GPIO21, 0));
+        _for_each_inner_lp_function!((all(RTC_GPIO0, GPIO0, 0), (RTC_GPIO1, GPIO1, 0),
+        (RTC_GPIO2, GPIO2, 0), (RTC_GPIO3, GPIO3, 0), (RTC_GPIO4, GPIO4, 0), (RTC_GPIO5,
+        GPIO5, 0), (RTC_GPIO6, GPIO6, 0), (RTC_GPIO7, GPIO7, 0), (RTC_GPIO8, GPIO8, 0),
+        (RTC_GPIO9, GPIO9, 0), (RTC_GPIO10, GPIO10, 0), (RTC_GPIO11, GPIO11, 0),
+        (RTC_GPIO12, GPIO12, 0), (RTC_GPIO13, GPIO13, 0), (RTC_GPIO14, GPIO14, 0),
+        (RTC_GPIO15, GPIO15, 0), (RTC_GPIO16, GPIO16, 0), (RTC_GPIO17, GPIO17, 0),
+        (RTC_GPIO18, GPIO18, 0), (RTC_GPIO19, GPIO19, 0), (RTC_GPIO20, GPIO20, 0),
+        (RTC_GPIO21, GPIO21, 0))); _for_each_inner_lp_function!((RTC_GPIOn((RTC_GPIO0,
+        RTC_GPIOn, 0), GPIO0, 0), ((RTC_GPIO1, RTC_GPIOn, 1), GPIO1, 0), ((RTC_GPIO2,
+        RTC_GPIOn, 2), GPIO2, 0), ((RTC_GPIO3, RTC_GPIOn, 3), GPIO3, 0), ((RTC_GPIO4,
+        RTC_GPIOn, 4), GPIO4, 0), ((RTC_GPIO5, RTC_GPIOn, 5), GPIO5, 0), ((RTC_GPIO6,
+        RTC_GPIOn, 6), GPIO6, 0), ((RTC_GPIO7, RTC_GPIOn, 7), GPIO7, 0), ((RTC_GPIO8,
+        RTC_GPIOn, 8), GPIO8, 0), ((RTC_GPIO9, RTC_GPIOn, 9), GPIO9, 0), ((RTC_GPIO10,
+        RTC_GPIOn, 10), GPIO10, 0), ((RTC_GPIO11, RTC_GPIOn, 11), GPIO11, 0),
+        ((RTC_GPIO12, RTC_GPIOn, 12), GPIO12, 0), ((RTC_GPIO13, RTC_GPIOn, 13), GPIO13,
+        0), ((RTC_GPIO14, RTC_GPIOn, 14), GPIO14, 0), ((RTC_GPIO15, RTC_GPIOn, 15),
+        GPIO15, 0), ((RTC_GPIO16, RTC_GPIOn, 16), GPIO16, 0), ((RTC_GPIO17, RTC_GPIOn,
+        17), GPIO17, 0), ((RTC_GPIO18, RTC_GPIOn, 18), GPIO18, 0), ((RTC_GPIO19,
+        RTC_GPIOn, 19), GPIO19, 0), ((RTC_GPIO20, RTC_GPIOn, 20), GPIO20, 0),
+        ((RTC_GPIO21, RTC_GPIOn, 21), GPIO21, 0)));
     };
 }
 /// This macro can be used to generate code for each IOMUX digital function of each GPIO.

--- a/esp-metadata-generated/src/_generated_esp32s3.rs
+++ b/esp-metadata-generated/src/_generated_esp32s3.rs
@@ -6044,11 +6044,12 @@ macro_rules! for_each_analog_function {
 ///
 /// This macro has two options for its "Individual matcher" case:
 ///
-/// - `all`: `($signal:ident, $gpio:ident)` - simple case where you only need identifiers
-/// - group: `(($signal:ident, $group:ident $(, $number:literal)+), $gpio:ident)` - expanded signal
-///   case, where you need the number(s) of a signal, or the general group to which the signal
-///   belongs. For example, in case of `SAR_I2C_SCL_1` the expanded form looks like `(SAR_I2C_SCL_1,
-///   SAR_I2C_SCL_n, 1)`.
+/// - `all`: `($signal:ident, $gpio:ident, $af:literal)` - simple case where you only need
+///   identifiers, and maybe the function number.
+/// - group: `(($signal:ident, $group:ident $(, $number:literal)+), $gpio:ident, $af:literal)` -
+///   expanded signal case, where you need the number(s) of a signal, or the general group to which
+///   the signal belongs. For example, in case of `SAR_I2C_SCL_1` the expanded form looks like
+///   `(SAR_I2C_SCL_1, SAR_I2C_SCL_n, 1)`.
 ///
 /// Macro fragments:
 ///
@@ -6057,10 +6058,13 @@ macro_rules! for_each_analog_function {
 ///   is `ADCn_CHm`.
 /// - `$number`: the numbers extracted from `$signal`.
 /// - `$gpio`: the name of the GPIO.
+/// - `$af`: the function number, as listed in the LP/RTC IO MUX pad list. On chips with an LP IO
+///   peripheral this is the value to write to the pin's `MCU_SEL` field to select the function. On
+///   chips with an RTC IO peripheral the numbering is not necessarily register-accurate.
 ///
 /// Example data:
-/// - `(RTC_GPIO15, GPIO12)`
-/// - `((RTC_GPIO15, RTC_GPIOn, 15), GPIO12)`
+/// - `(RTC_GPIO15, GPIO12, 0)`
+/// - `((RTC_GPIO15, RTC_GPIOn, 15), GPIO12, 0)`
 ///
 /// The expanded syntax is only available when the signal has at least one numbered component.
 #[macro_export]
@@ -6068,82 +6072,83 @@ macro_rules! for_each_analog_function {
 macro_rules! for_each_lp_function {
     ($($pattern:tt => $code:tt;)*) => {
         macro_rules! _for_each_inner_lp_function { $(($pattern) => $code;)* ($other : tt)
-        => {} } _for_each_inner_lp_function!((RTC_GPIO0, GPIO0));
-        _for_each_inner_lp_function!((SAR_I2C_SCL_0, GPIO0));
-        _for_each_inner_lp_function!((RTC_GPIO1, GPIO1));
-        _for_each_inner_lp_function!((SAR_I2C_SDA_0, GPIO1));
-        _for_each_inner_lp_function!((RTC_GPIO2, GPIO2));
-        _for_each_inner_lp_function!((SAR_I2C_SCL_1, GPIO2));
-        _for_each_inner_lp_function!((RTC_GPIO3, GPIO3));
-        _for_each_inner_lp_function!((SAR_I2C_SDA_1, GPIO3));
-        _for_each_inner_lp_function!((RTC_GPIO4, GPIO4));
-        _for_each_inner_lp_function!((RTC_GPIO5, GPIO5));
-        _for_each_inner_lp_function!((RTC_GPIO6, GPIO6));
-        _for_each_inner_lp_function!((RTC_GPIO7, GPIO7));
-        _for_each_inner_lp_function!((RTC_GPIO8, GPIO8));
-        _for_each_inner_lp_function!((RTC_GPIO9, GPIO9));
-        _for_each_inner_lp_function!((RTC_GPIO10, GPIO10));
-        _for_each_inner_lp_function!((RTC_GPIO11, GPIO11));
-        _for_each_inner_lp_function!((RTC_GPIO12, GPIO12));
-        _for_each_inner_lp_function!((RTC_GPIO13, GPIO13));
-        _for_each_inner_lp_function!((RTC_GPIO14, GPIO14));
-        _for_each_inner_lp_function!((RTC_GPIO15, GPIO15));
-        _for_each_inner_lp_function!((RTC_GPIO16, GPIO16));
-        _for_each_inner_lp_function!((RTC_GPIO17, GPIO17));
-        _for_each_inner_lp_function!((RTC_GPIO18, GPIO18));
-        _for_each_inner_lp_function!((RTC_GPIO19, GPIO19));
-        _for_each_inner_lp_function!((RTC_GPIO20, GPIO20));
-        _for_each_inner_lp_function!((RTC_GPIO21, GPIO21));
-        _for_each_inner_lp_function!(((RTC_GPIO0, RTC_GPIOn, 0), GPIO0));
-        _for_each_inner_lp_function!(((RTC_GPIO1, RTC_GPIOn, 1), GPIO1));
-        _for_each_inner_lp_function!(((RTC_GPIO2, RTC_GPIOn, 2), GPIO2));
-        _for_each_inner_lp_function!(((RTC_GPIO3, RTC_GPIOn, 3), GPIO3));
-        _for_each_inner_lp_function!(((RTC_GPIO4, RTC_GPIOn, 4), GPIO4));
-        _for_each_inner_lp_function!(((RTC_GPIO5, RTC_GPIOn, 5), GPIO5));
-        _for_each_inner_lp_function!(((RTC_GPIO6, RTC_GPIOn, 6), GPIO6));
-        _for_each_inner_lp_function!(((RTC_GPIO7, RTC_GPIOn, 7), GPIO7));
-        _for_each_inner_lp_function!(((RTC_GPIO8, RTC_GPIOn, 8), GPIO8));
-        _for_each_inner_lp_function!(((RTC_GPIO9, RTC_GPIOn, 9), GPIO9));
-        _for_each_inner_lp_function!(((RTC_GPIO10, RTC_GPIOn, 10), GPIO10));
-        _for_each_inner_lp_function!(((RTC_GPIO11, RTC_GPIOn, 11), GPIO11));
-        _for_each_inner_lp_function!(((RTC_GPIO12, RTC_GPIOn, 12), GPIO12));
-        _for_each_inner_lp_function!(((RTC_GPIO13, RTC_GPIOn, 13), GPIO13));
-        _for_each_inner_lp_function!(((RTC_GPIO14, RTC_GPIOn, 14), GPIO14));
-        _for_each_inner_lp_function!(((RTC_GPIO15, RTC_GPIOn, 15), GPIO15));
-        _for_each_inner_lp_function!(((RTC_GPIO16, RTC_GPIOn, 16), GPIO16));
-        _for_each_inner_lp_function!(((RTC_GPIO17, RTC_GPIOn, 17), GPIO17));
-        _for_each_inner_lp_function!(((RTC_GPIO18, RTC_GPIOn, 18), GPIO18));
-        _for_each_inner_lp_function!(((RTC_GPIO19, RTC_GPIOn, 19), GPIO19));
-        _for_each_inner_lp_function!(((RTC_GPIO20, RTC_GPIOn, 20), GPIO20));
-        _for_each_inner_lp_function!(((RTC_GPIO21, RTC_GPIOn, 21), GPIO21));
-        _for_each_inner_lp_function!(((SAR_I2C_SCL_0, SAR_I2C_SCL_n, 0), GPIO0));
-        _for_each_inner_lp_function!(((SAR_I2C_SCL_1, SAR_I2C_SCL_n, 1), GPIO2));
-        _for_each_inner_lp_function!(((SAR_I2C_SDA_0, SAR_I2C_SDA_n, 0), GPIO1));
-        _for_each_inner_lp_function!(((SAR_I2C_SDA_1, SAR_I2C_SDA_n, 1), GPIO3));
-        _for_each_inner_lp_function!((all(RTC_GPIO0, GPIO0), (SAR_I2C_SCL_0, GPIO0),
-        (RTC_GPIO1, GPIO1), (SAR_I2C_SDA_0, GPIO1), (RTC_GPIO2, GPIO2), (SAR_I2C_SCL_1,
-        GPIO2), (RTC_GPIO3, GPIO3), (SAR_I2C_SDA_1, GPIO3), (RTC_GPIO4, GPIO4),
-        (RTC_GPIO5, GPIO5), (RTC_GPIO6, GPIO6), (RTC_GPIO7, GPIO7), (RTC_GPIO8, GPIO8),
-        (RTC_GPIO9, GPIO9), (RTC_GPIO10, GPIO10), (RTC_GPIO11, GPIO11), (RTC_GPIO12,
-        GPIO12), (RTC_GPIO13, GPIO13), (RTC_GPIO14, GPIO14), (RTC_GPIO15, GPIO15),
-        (RTC_GPIO16, GPIO16), (RTC_GPIO17, GPIO17), (RTC_GPIO18, GPIO18), (RTC_GPIO19,
-        GPIO19), (RTC_GPIO20, GPIO20), (RTC_GPIO21, GPIO21)));
-        _for_each_inner_lp_function!((RTC_GPIOn((RTC_GPIO0, RTC_GPIOn, 0), GPIO0),
-        ((RTC_GPIO1, RTC_GPIOn, 1), GPIO1), ((RTC_GPIO2, RTC_GPIOn, 2), GPIO2),
-        ((RTC_GPIO3, RTC_GPIOn, 3), GPIO3), ((RTC_GPIO4, RTC_GPIOn, 4), GPIO4),
-        ((RTC_GPIO5, RTC_GPIOn, 5), GPIO5), ((RTC_GPIO6, RTC_GPIOn, 6), GPIO6),
-        ((RTC_GPIO7, RTC_GPIOn, 7), GPIO7), ((RTC_GPIO8, RTC_GPIOn, 8), GPIO8),
-        ((RTC_GPIO9, RTC_GPIOn, 9), GPIO9), ((RTC_GPIO10, RTC_GPIOn, 10), GPIO10),
-        ((RTC_GPIO11, RTC_GPIOn, 11), GPIO11), ((RTC_GPIO12, RTC_GPIOn, 12), GPIO12),
-        ((RTC_GPIO13, RTC_GPIOn, 13), GPIO13), ((RTC_GPIO14, RTC_GPIOn, 14), GPIO14),
-        ((RTC_GPIO15, RTC_GPIOn, 15), GPIO15), ((RTC_GPIO16, RTC_GPIOn, 16), GPIO16),
-        ((RTC_GPIO17, RTC_GPIOn, 17), GPIO17), ((RTC_GPIO18, RTC_GPIOn, 18), GPIO18),
-        ((RTC_GPIO19, RTC_GPIOn, 19), GPIO19), ((RTC_GPIO20, RTC_GPIOn, 20), GPIO20),
-        ((RTC_GPIO21, RTC_GPIOn, 21), GPIO21)));
-        _for_each_inner_lp_function!((SAR_I2C_SCL_n((SAR_I2C_SCL_0, SAR_I2C_SCL_n, 0),
-        GPIO0), ((SAR_I2C_SCL_1, SAR_I2C_SCL_n, 1), GPIO2)));
+        => {} } _for_each_inner_lp_function!((RTC_GPIO0, GPIO0, 0));
+        _for_each_inner_lp_function!((SAR_I2C_SCL_0, GPIO0, 1));
+        _for_each_inner_lp_function!((RTC_GPIO1, GPIO1, 0));
+        _for_each_inner_lp_function!((SAR_I2C_SDA_0, GPIO1, 1));
+        _for_each_inner_lp_function!((RTC_GPIO2, GPIO2, 0));
+        _for_each_inner_lp_function!((SAR_I2C_SCL_1, GPIO2, 1));
+        _for_each_inner_lp_function!((RTC_GPIO3, GPIO3, 0));
+        _for_each_inner_lp_function!((SAR_I2C_SDA_1, GPIO3, 1));
+        _for_each_inner_lp_function!((RTC_GPIO4, GPIO4, 0));
+        _for_each_inner_lp_function!((RTC_GPIO5, GPIO5, 0));
+        _for_each_inner_lp_function!((RTC_GPIO6, GPIO6, 0));
+        _for_each_inner_lp_function!((RTC_GPIO7, GPIO7, 0));
+        _for_each_inner_lp_function!((RTC_GPIO8, GPIO8, 0));
+        _for_each_inner_lp_function!((RTC_GPIO9, GPIO9, 0));
+        _for_each_inner_lp_function!((RTC_GPIO10, GPIO10, 0));
+        _for_each_inner_lp_function!((RTC_GPIO11, GPIO11, 0));
+        _for_each_inner_lp_function!((RTC_GPIO12, GPIO12, 0));
+        _for_each_inner_lp_function!((RTC_GPIO13, GPIO13, 0));
+        _for_each_inner_lp_function!((RTC_GPIO14, GPIO14, 0));
+        _for_each_inner_lp_function!((RTC_GPIO15, GPIO15, 0));
+        _for_each_inner_lp_function!((RTC_GPIO16, GPIO16, 0));
+        _for_each_inner_lp_function!((RTC_GPIO17, GPIO17, 0));
+        _for_each_inner_lp_function!((RTC_GPIO18, GPIO18, 0));
+        _for_each_inner_lp_function!((RTC_GPIO19, GPIO19, 0));
+        _for_each_inner_lp_function!((RTC_GPIO20, GPIO20, 0));
+        _for_each_inner_lp_function!((RTC_GPIO21, GPIO21, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO0, RTC_GPIOn, 0), GPIO0, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO1, RTC_GPIOn, 1), GPIO1, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO2, RTC_GPIOn, 2), GPIO2, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO3, RTC_GPIOn, 3), GPIO3, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO4, RTC_GPIOn, 4), GPIO4, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO5, RTC_GPIOn, 5), GPIO5, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO6, RTC_GPIOn, 6), GPIO6, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO7, RTC_GPIOn, 7), GPIO7, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO8, RTC_GPIOn, 8), GPIO8, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO9, RTC_GPIOn, 9), GPIO9, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO10, RTC_GPIOn, 10), GPIO10, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO11, RTC_GPIOn, 11), GPIO11, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO12, RTC_GPIOn, 12), GPIO12, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO13, RTC_GPIOn, 13), GPIO13, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO14, RTC_GPIOn, 14), GPIO14, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO15, RTC_GPIOn, 15), GPIO15, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO16, RTC_GPIOn, 16), GPIO16, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO17, RTC_GPIOn, 17), GPIO17, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO18, RTC_GPIOn, 18), GPIO18, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO19, RTC_GPIOn, 19), GPIO19, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO20, RTC_GPIOn, 20), GPIO20, 0));
+        _for_each_inner_lp_function!(((RTC_GPIO21, RTC_GPIOn, 21), GPIO21, 0));
+        _for_each_inner_lp_function!(((SAR_I2C_SCL_0, SAR_I2C_SCL_n, 0), GPIO0, 1));
+        _for_each_inner_lp_function!(((SAR_I2C_SCL_1, SAR_I2C_SCL_n, 1), GPIO2, 1));
+        _for_each_inner_lp_function!(((SAR_I2C_SDA_0, SAR_I2C_SDA_n, 0), GPIO1, 1));
+        _for_each_inner_lp_function!(((SAR_I2C_SDA_1, SAR_I2C_SDA_n, 1), GPIO3, 1));
+        _for_each_inner_lp_function!((all(RTC_GPIO0, GPIO0, 0), (SAR_I2C_SCL_0, GPIO0,
+        1), (RTC_GPIO1, GPIO1, 0), (SAR_I2C_SDA_0, GPIO1, 1), (RTC_GPIO2, GPIO2, 0),
+        (SAR_I2C_SCL_1, GPIO2, 1), (RTC_GPIO3, GPIO3, 0), (SAR_I2C_SDA_1, GPIO3, 1),
+        (RTC_GPIO4, GPIO4, 0), (RTC_GPIO5, GPIO5, 0), (RTC_GPIO6, GPIO6, 0), (RTC_GPIO7,
+        GPIO7, 0), (RTC_GPIO8, GPIO8, 0), (RTC_GPIO9, GPIO9, 0), (RTC_GPIO10, GPIO10, 0),
+        (RTC_GPIO11, GPIO11, 0), (RTC_GPIO12, GPIO12, 0), (RTC_GPIO13, GPIO13, 0),
+        (RTC_GPIO14, GPIO14, 0), (RTC_GPIO15, GPIO15, 0), (RTC_GPIO16, GPIO16, 0),
+        (RTC_GPIO17, GPIO17, 0), (RTC_GPIO18, GPIO18, 0), (RTC_GPIO19, GPIO19, 0),
+        (RTC_GPIO20, GPIO20, 0), (RTC_GPIO21, GPIO21, 0)));
+        _for_each_inner_lp_function!((RTC_GPIOn((RTC_GPIO0, RTC_GPIOn, 0), GPIO0, 0),
+        ((RTC_GPIO1, RTC_GPIOn, 1), GPIO1, 0), ((RTC_GPIO2, RTC_GPIOn, 2), GPIO2, 0),
+        ((RTC_GPIO3, RTC_GPIOn, 3), GPIO3, 0), ((RTC_GPIO4, RTC_GPIOn, 4), GPIO4, 0),
+        ((RTC_GPIO5, RTC_GPIOn, 5), GPIO5, 0), ((RTC_GPIO6, RTC_GPIOn, 6), GPIO6, 0),
+        ((RTC_GPIO7, RTC_GPIOn, 7), GPIO7, 0), ((RTC_GPIO8, RTC_GPIOn, 8), GPIO8, 0),
+        ((RTC_GPIO9, RTC_GPIOn, 9), GPIO9, 0), ((RTC_GPIO10, RTC_GPIOn, 10), GPIO10, 0),
+        ((RTC_GPIO11, RTC_GPIOn, 11), GPIO11, 0), ((RTC_GPIO12, RTC_GPIOn, 12), GPIO12,
+        0), ((RTC_GPIO13, RTC_GPIOn, 13), GPIO13, 0), ((RTC_GPIO14, RTC_GPIOn, 14),
+        GPIO14, 0), ((RTC_GPIO15, RTC_GPIOn, 15), GPIO15, 0), ((RTC_GPIO16, RTC_GPIOn,
+        16), GPIO16, 0), ((RTC_GPIO17, RTC_GPIOn, 17), GPIO17, 0), ((RTC_GPIO18,
+        RTC_GPIOn, 18), GPIO18, 0), ((RTC_GPIO19, RTC_GPIOn, 19), GPIO19, 0),
+        ((RTC_GPIO20, RTC_GPIOn, 20), GPIO20, 0), ((RTC_GPIO21, RTC_GPIOn, 21), GPIO21,
+        0))); _for_each_inner_lp_function!((SAR_I2C_SCL_n((SAR_I2C_SCL_0, SAR_I2C_SCL_n,
+        0), GPIO0, 1), ((SAR_I2C_SCL_1, SAR_I2C_SCL_n, 1), GPIO2, 1)));
         _for_each_inner_lp_function!((SAR_I2C_SDA_n((SAR_I2C_SDA_0, SAR_I2C_SDA_n, 0),
-        GPIO1), ((SAR_I2C_SDA_1, SAR_I2C_SDA_n, 1), GPIO3)));
+        GPIO1, 1), ((SAR_I2C_SDA_1, SAR_I2C_SDA_n, 1), GPIO3, 1)));
     };
 }
 /// This macro can be used to generate code for each IOMUX digital function of each GPIO.

--- a/esp-metadata-generated/src/_generated_esp32s31.rs
+++ b/esp-metadata-generated/src/_generated_esp32s31.rs
@@ -4562,11 +4562,12 @@ macro_rules! for_each_analog_function {
 ///
 /// This macro has two options for its "Individual matcher" case:
 ///
-/// - `all`: `($signal:ident, $gpio:ident)` - simple case where you only need identifiers
-/// - group: `(($signal:ident, $group:ident $(, $number:literal)+), $gpio:ident)` - expanded signal
-///   case, where you need the number(s) of a signal, or the general group to which the signal
-///   belongs. For example, in case of `SAR_I2C_SCL_1` the expanded form looks like `(SAR_I2C_SCL_1,
-///   SAR_I2C_SCL_n, 1)`.
+/// - `all`: `($signal:ident, $gpio:ident, $af:literal)` - simple case where you only need
+///   identifiers, and maybe the function number.
+/// - group: `(($signal:ident, $group:ident $(, $number:literal)+), $gpio:ident, $af:literal)` -
+///   expanded signal case, where you need the number(s) of a signal, or the general group to which
+///   the signal belongs. For example, in case of `SAR_I2C_SCL_1` the expanded form looks like
+///   `(SAR_I2C_SCL_1, SAR_I2C_SCL_n, 1)`.
 ///
 /// Macro fragments:
 ///
@@ -4575,10 +4576,13 @@ macro_rules! for_each_analog_function {
 ///   is `ADCn_CHm`.
 /// - `$number`: the numbers extracted from `$signal`.
 /// - `$gpio`: the name of the GPIO.
+/// - `$af`: the function number, as listed in the LP/RTC IO MUX pad list. On chips with an LP IO
+///   peripheral this is the value to write to the pin's `MCU_SEL` field to select the function. On
+///   chips with an RTC IO peripheral the numbering is not necessarily register-accurate.
 ///
 /// Example data:
-/// - `(RTC_GPIO15, GPIO12)`
-/// - `((RTC_GPIO15, RTC_GPIOn, 15), GPIO12)`
+/// - `(RTC_GPIO15, GPIO12, 0)`
+/// - `((RTC_GPIO15, RTC_GPIOn, 15), GPIO12, 0)`
 ///
 /// The expanded syntax is only available when the signal has at least one numbered component.
 #[macro_export]

--- a/esp-metadata/devices/esp32c5/gpio.toml
+++ b/esp-metadata/devices/esp32c5/gpio.toml
@@ -4,13 +4,13 @@ gpio_function = 1
 constant_0_input = 0x60
 constant_1_input = 0x40
 pins = [
-    { pin =  0,                                                                              analog = { 0 = "XTAL_32K_P" },                 lp = { 0 = "LP_UART_DTRN",    1 = "LP_GPIO0" } },
-    { pin =  1,                                                                              analog = { 0 = "XTAL_32K_N", 1 = "ADC1_CH0" }, lp = { 0 = "LP_UART_DSRN",    1 = "LP_GPIO1" } },
-    { pin =  2,  functions = { 0 = "MTMS",       2 = "FSPIQ" }, limitations = ["strapping"], analog = {                   1 = "ADC1_CH1" }, lp = { 0 = "LP_UART_RTSN",    1 = "LP_GPIO2", 3 = "LP_I2C_SDA" } },
-    { pin =  3,  functions = { 0 = "MTDI" },                    limitations = ["strapping"], analog = {                   1 = "ADC1_CH2" }, lp = { 0 = "LP_UART_CTSN",    1 = "LP_GPIO3", 3 = "LP_I2C_SCL" } },
-    { pin =  4,  functions = { 0 = "MTCK",       2 = "FSPIHD" },                             analog = {                   1 = "ADC1_CH3" }, lp = { 0 = "LP_UART_RXD_PAD", 1 = "LP_GPIO4" } },
-    { pin =  5,  functions = { 0 = "MTDO",       2 = "FSPIWP" },                             analog = {                   1 = "ADC1_CH4" }, lp = { 0 = "LP_UART_TXD_PAD", 1 = "LP_GPIO5" } },
-    { pin =  6,  functions = {                   2 = "FSPICLK" },                            analog = {                   1 = "ADC1_CH5" }, lp = {                        1 = "LP_GPIO6" } },
+    { pin =  0,                                                                              analog = { 0 = "XTAL_32K_P" },                 lp = { 0 = "LP_UART_DTRN", 1 = "LP_GPIO0" } },
+    { pin =  1,                                                                              analog = { 0 = "XTAL_32K_N", 1 = "ADC1_CH0" }, lp = { 0 = "LP_UART_DSRN", 1 = "LP_GPIO1" } },
+    { pin =  2,  functions = { 0 = "MTMS",       2 = "FSPIQ" }, limitations = ["strapping"], analog = {                   1 = "ADC1_CH1" }, lp = { 0 = "LP_UART_RTSN", 1 = "LP_GPIO2", 3 = "LP_I2C_SDA" } },
+    { pin =  3,  functions = { 0 = "MTDI" },                    limitations = ["strapping"], analog = {                   1 = "ADC1_CH2" }, lp = { 0 = "LP_UART_CTSN", 1 = "LP_GPIO3", 3 = "LP_I2C_SCL" } },
+    { pin =  4,  functions = { 0 = "MTCK",       2 = "FSPIHD" },                             analog = {                   1 = "ADC1_CH3" }, lp = { 0 = "LP_UART_RXD",  1 = "LP_GPIO4" } },
+    { pin =  5,  functions = { 0 = "MTDO",       2 = "FSPIWP" },                             analog = {                   1 = "ADC1_CH4" }, lp = { 0 = "LP_UART_TXD",  1 = "LP_GPIO5" } },
+    { pin =  6,  functions = {                   2 = "FSPICLK" },                            analog = {                   1 = "ADC1_CH5" }, lp = {                     1 = "LP_GPIO6" } },
     { pin =  7,  functions = { 0 = "SDIO_DATA1", 2 = "FSPID" }, limitations = ["strapping"] },
     { pin =  8,  functions = { 0 = "SDIO_DATA0" },                                           analog = { 0 = "ZCD0" } },
     { pin =  9,  functions = { 0 = "SDIO_CLK" },                                             analog = { 0 = "ZCD1" } },

--- a/esp-metadata/src/cfg/gpio.rs
+++ b/esp-metadata/src/cfg/gpio.rs
@@ -514,8 +514,15 @@ pub(crate) fn generate_gpios(gpio: &super::GpioProperties) -> TokenStream {
             for af in 0..LowPowerMap::COUNT {
                 if let Some(signal) = pin.lp.get(af) {
                     let signal_name = TokenStream::from_str(signal).unwrap();
-                    lp_functions.push(quote! { #signal_name, #pin_peri });
-                    create_matchers_for_signal(&mut expanded_lp_functions, &pin_peri, signal, None);
+                    let af_number = number(af);
+                    let af_tokens = quote! { #af_number };
+                    lp_functions.push(quote! { #signal_name, #pin_peri, #af_number });
+                    create_matchers_for_signal(
+                        &mut expanded_lp_functions,
+                        &pin_peri,
+                        signal,
+                        Some(&af_tokens),
+                    );
                 }
             }
 
@@ -657,8 +664,8 @@ pub(crate) fn generate_gpios(gpio: &super::GpioProperties) -> TokenStream {
         ///
         /// This macro has two options for its "Individual matcher" case:
         ///
-        /// - `all`: `($signal:ident, $gpio:ident)` - simple case where you only need identifiers
-        /// - group: `(($signal:ident, $group:ident $(, $number:literal)+), $gpio:ident)` - expanded signal case, where you need the number(s) of a signal, or the general group to which the signal belongs. For example, in case of `SAR_I2C_SCL_1` the expanded form looks like `(SAR_I2C_SCL_1, SAR_I2C_SCL_n, 1)`.
+        /// - `all`: `($signal:ident, $gpio:ident, $af:literal)` - simple case where you only need identifiers, and maybe the function number.
+        /// - group: `(($signal:ident, $group:ident $(, $number:literal)+), $gpio:ident, $af:literal)` - expanded signal case, where you need the number(s) of a signal, or the general group to which the signal belongs. For example, in case of `SAR_I2C_SCL_1` the expanded form looks like `(SAR_I2C_SCL_1, SAR_I2C_SCL_n, 1)`.
         ///
         /// Macro fragments:
         ///
@@ -666,10 +673,14 @@ pub(crate) fn generate_gpios(gpio: &super::GpioProperties) -> TokenStream {
         /// - `$group`: the name of the signal, with numbers replaced by placeholders. For `ADC2_CH3` this is `ADCn_CHm`.
         /// - `$number`: the numbers extracted from `$signal`.
         /// - `$gpio`: the name of the GPIO.
+        /// - `$af`: the function number, as listed in the LP/RTC IO MUX pad list. On chips with an
+        ///   LP IO peripheral this is the value to write to the pin's `MCU_SEL` field to select the
+        ///   function. On chips with an RTC IO peripheral the numbering is not necessarily
+        ///   register-accurate.
         ///
         /// Example data:
-        /// - `(RTC_GPIO15, GPIO12)`
-        /// - `((RTC_GPIO15, RTC_GPIOn, 15), GPIO12)`
+        /// - `(RTC_GPIO15, GPIO12, 0)`
+        /// - `((RTC_GPIO15, RTC_GPIOn, 15), GPIO12, 0)`
         ///
         /// The expanded syntax is only available when the signal has at least one numbered component.
         #for_each_lp

--- a/examples/peripheral/lp_core/lp_i2c/src/main.rs
+++ b/examples/peripheral/lp_core/lp_i2c/src/main.rs
@@ -16,7 +16,6 @@
 
 use esp_backtrace as _;
 use esp_hal::{
-    gpio::lp_io::LowPowerOutputOpenDrain,
     i2c::lp_i2c::LpI2c,
     load_lp_code,
     lp_core::{LpCore, LpCoreWakeupSource},
@@ -47,8 +46,8 @@ fn main() -> ! {
     // configure LP I2C
     let i2c = LpI2c::new(
         peripherals.LP_I2C0,
-        LowPowerOutputOpenDrain::new(peripherals.GPIO6),
-        LowPowerOutputOpenDrain::new(peripherals.GPIO7),
+        peripherals.GPIO6,
+        peripherals.GPIO7,
         Rate::from_khz(100),
     );
 

--- a/hil-test/src/bin/gpio.rs
+++ b/hil-test/src/bin/gpio.rs
@@ -863,12 +863,12 @@ mod tests {
         );
 
         esp_metadata_generated::for_each_lp_function! {
-            (($_rtc:ident, RTC_GPIOn, $pin:literal), $gpio:ident) => {
+            (($_rtc:ident, RTC_GPIOn, $pin:literal), $gpio:ident, $_af:literal) => {
                 if !jtag_pins.contains(&$pin) {
                     esp_hal::gpio::lp_io::LowPowerInput::new(peripherals.$gpio);
                 }
             };
-            (($_rtc:ident, LP_GPIOn, $pin:literal), $gpio:ident) => {
+            (($_rtc:ident, LP_GPIOn, $pin:literal), $gpio:ident, $_af:literal) => {
                 if !jtag_pins.contains(&$pin) {
                     esp_hal::gpio::lp_io::LowPowerInput::new(peripherals.$gpio);
                 }


### PR DESCRIPTION
Renames C5 signals to drop the chip-unique _PAD suffix. Introduces $af on for_each_lp_function! arms so that we can query which alternate function index we need to program. LP peripherals no longer take the LowPower* structs, instead we define compatibility marker traits for the supported pins.

# Changelog

## esp-hal

- Changed: `LpI2c::new` and `LpUart::new` take pin singletons, not `LowPowerOutput(OpenDrain)` instances.