### PR TITLE
Decouple bootloader from storage

### DIFF
--- a/esp-bootloader-esp-idf/Cargo.toml
+++ b/esp-bootloader-esp-idf/Cargo.toml
@@ -67,7 +67,7 @@ defmt = ["dep:defmt"]
 # Replace ROM functions with pure Rust implementations, needed for tests.
 std = ["dep:crc", "dep:md-5"]
 
-## Implement traits from `embedded-storage` for [`FlashRegion`].
+## Implement traits from `embedded-storage` for [`crate::partitions::FlashRegion`].
 embedded-storage = ["dep:embedded-storage"]
 
 #! ### Chip selection

--- a/esp-bootloader-esp-idf/Cargo.toml
+++ b/esp-bootloader-esp-idf/Cargo.toml
@@ -65,10 +65,10 @@ log-04 = ["dep:log-04"]
 defmt = ["dep:defmt"]
 
 # Replace ROM functions with pure Rust implementations, needed for tests.
-std = ["dep:crc", "dep:md-5", "esp-storage/emulation"]
+std = ["dep:crc", "dep:md-5"]
 
 ## Implement traits from `embedded-storage` for [`FlashRegion`].
-embedded-storage = ["dep:embedded-storage", "esp-storage/embedded-storage"]
+embedded-storage = ["dep:embedded-storage"]
 
 #! ### Chip selection
 #! One of the following features must be enabled to select the target chip:

--- a/esp-bootloader-esp-idf/src/flash/flash_access.rs
+++ b/esp-bootloader-esp-idf/src/flash/flash_access.rs
@@ -2,27 +2,37 @@ use crate::partitions::Error;
 
 /// Internal flash I/O trait used by partition and OTA logic.
 #[doc(hidden)]
-#[cfg_attr(feature = "std", allow(dead_code))]
 pub trait FlashAccess {
-    const READ_SIZE: usize;
-    const WRITE_SIZE: usize;
-    const ERASE_SIZE: usize;
-    const SECTOR_SIZE: u32;
-
     fn flash_read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Error>;
     fn flash_write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Error>;
     fn flash_erase(&mut self, from: u32, to: u32) -> Result<(), Error>;
     fn flash_read_encrypted(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Error>;
     fn flash_write_encrypted(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Error>;
+
+    #[cfg(feature = "embedded-storage")]
+    const READ_SIZE: usize;
+    #[cfg(feature = "embedded-storage")]
+    const WRITE_SIZE: usize;
+    #[cfg(feature = "embedded-storage")]
+    const ERASE_SIZE: usize;
+    #[cfg(feature = "embedded-storage")]
+    const SECTOR_SIZE: u32;
+
+    #[cfg(feature = "embedded-storage")]
     fn flash_read_nor(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Error>;
+    #[cfg(feature = "embedded-storage")]
     fn flash_write_nor(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Error>;
 }
 
 #[cfg(not(feature = "std"))]
 impl FlashAccess for super::FlashStorage<'_> {
+    #[cfg(feature = "embedded-storage")]
     const READ_SIZE: usize = esp_storage::FlashStorage::READ_SIZE;
+    #[cfg(feature = "embedded-storage")]
     const WRITE_SIZE: usize = esp_storage::FlashStorage::WRITE_SIZE;
+    #[cfg(feature = "embedded-storage")]
     const ERASE_SIZE: usize = esp_storage::FlashStorage::ERASE_SIZE;
+    #[cfg(feature = "embedded-storage")]
     const SECTOR_SIZE: u32 = esp_storage::FlashStorage::SECTOR_SIZE;
 
     fn flash_read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Error> {
@@ -47,10 +57,12 @@ impl FlashAccess for super::FlashStorage<'_> {
             .map_err(|_| Error::StorageError)
     }
 
+    #[cfg(feature = "embedded-storage")]
     fn flash_read_nor(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Error> {
         esp_storage::FlashStorage::read_nor(self, offset, bytes).map_err(|_| Error::StorageError)
     }
 
+    #[cfg(feature = "embedded-storage")]
     fn flash_write_nor(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Error> {
         esp_storage::FlashStorage::write_nor(self, offset, bytes).map_err(|_| Error::StorageError)
     }

--- a/esp-bootloader-esp-idf/src/flash/flash_access.rs
+++ b/esp-bootloader-esp-idf/src/flash/flash_access.rs
@@ -1,0 +1,57 @@
+use crate::partitions::Error;
+
+/// Internal flash I/O trait used by partition and OTA logic.
+#[doc(hidden)]
+#[cfg_attr(feature = "std", allow(dead_code))]
+pub trait FlashAccess {
+    const READ_SIZE: usize;
+    const WRITE_SIZE: usize;
+    const ERASE_SIZE: usize;
+    const SECTOR_SIZE: u32;
+
+    fn flash_read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Error>;
+    fn flash_write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Error>;
+    fn flash_erase(&mut self, from: u32, to: u32) -> Result<(), Error>;
+    fn flash_read_encrypted(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Error>;
+    fn flash_write_encrypted(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Error>;
+    fn flash_read_nor(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Error>;
+    fn flash_write_nor(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Error>;
+}
+
+#[cfg(not(feature = "std"))]
+impl FlashAccess for super::FlashStorage<'_> {
+    const READ_SIZE: usize = esp_storage::FlashStorage::READ_SIZE;
+    const WRITE_SIZE: usize = esp_storage::FlashStorage::WRITE_SIZE;
+    const ERASE_SIZE: usize = esp_storage::FlashStorage::ERASE_SIZE;
+    const SECTOR_SIZE: u32 = esp_storage::FlashStorage::SECTOR_SIZE;
+
+    fn flash_read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Error> {
+        esp_storage::FlashStorage::read(self, offset, bytes).map_err(|_| Error::StorageError)
+    }
+
+    fn flash_write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Error> {
+        esp_storage::FlashStorage::write(self, offset, bytes).map_err(|_| Error::StorageError)
+    }
+
+    fn flash_erase(&mut self, from: u32, to: u32) -> Result<(), Error> {
+        esp_storage::FlashStorage::erase(self, from, to).map_err(|_| Error::StorageError)
+    }
+
+    fn flash_read_encrypted(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Error> {
+        esp_storage::FlashStorage::read_encrypted(self, offset, bytes)
+            .map_err(|_| Error::StorageError)
+    }
+
+    fn flash_write_encrypted(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Error> {
+        esp_storage::FlashStorage::write_encrypted(self, offset, bytes)
+            .map_err(|_| Error::StorageError)
+    }
+
+    fn flash_read_nor(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Error> {
+        esp_storage::FlashStorage::read_nor(self, offset, bytes).map_err(|_| Error::StorageError)
+    }
+
+    fn flash_write_nor(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Error> {
+        esp_storage::FlashStorage::write_nor(self, offset, bytes).map_err(|_| Error::StorageError)
+    }
+}

--- a/esp-bootloader-esp-idf/src/flash/mock_flash.rs
+++ b/esp-bootloader-esp-idf/src/flash/mock_flash.rs
@@ -53,9 +53,13 @@ impl MockFlash<'_> {
 }
 
 impl FlashAccess for MockFlash<'_> {
+    #[cfg(feature = "embedded-storage")]
     const READ_SIZE: usize = WORD_SIZE as usize;
+    #[cfg(feature = "embedded-storage")]
     const WRITE_SIZE: usize = WORD_SIZE as usize;
+    #[cfg(feature = "embedded-storage")]
     const ERASE_SIZE: usize = SECTOR_SIZE as usize;
+    #[cfg(feature = "embedded-storage")]
     const SECTOR_SIZE: u32 = SECTOR_SIZE;
 
     fn flash_read(&mut self, offset: u32, mut bytes: &mut [u8]) -> Result<(), Error> {
@@ -145,10 +149,12 @@ impl FlashAccess for MockFlash<'_> {
         self.flash_write(offset, bytes)
     }
 
+    #[cfg(feature = "embedded-storage")]
     fn flash_read_nor(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Error> {
         self.flash_read(offset, bytes)
     }
 
+    #[cfg(feature = "embedded-storage")]
     fn flash_write_nor(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Error> {
         self.flash_write(offset, bytes)
     }

--- a/esp-bootloader-esp-idf/src/flash/mock_flash.rs
+++ b/esp-bootloader-esp-idf/src/flash/mock_flash.rs
@@ -95,10 +95,8 @@ impl FlashAccess for MockFlash<'_> {
             let len = bytes.len().min((Self::SECTOR_SIZE - data_offset) as usize);
 
             Self::with_flash(|flash| {
-                let sector = aligned_offset as usize;
-                let sector_end = sector + Self::SECTOR_SIZE as usize;
-                flash[sector..sector_end].fill(ERASE_BYTE);
-                flash[sector + data_offset as usize..][..len].copy_from_slice(&bytes[..len]);
+                flash[aligned_offset as usize + data_offset as usize..][..len]
+                    .copy_from_slice(&bytes[..len]);
             });
 
             aligned_offset += Self::SECTOR_SIZE;

--- a/esp-bootloader-esp-idf/src/flash/mock_flash.rs
+++ b/esp-bootloader-esp-idf/src/flash/mock_flash.rs
@@ -1,0 +1,155 @@
+use core::marker::PhantomData;
+
+use super::flash_access::FlashAccess;
+use crate::partitions::Error;
+
+const WORD_SIZE: u32 = 4;
+const SECTOR_SIZE: u32 = 4096;
+const BLOCK_SIZE: u32 = 65536;
+const FLASH_SIZE: usize = (BLOCK_SIZE * 4) as usize;
+const ERASE_BYTE: u8 = 0xff;
+
+static mut FLASH_DATA: [u8; FLASH_SIZE] = [ERASE_BYTE; FLASH_SIZE];
+
+/// In-memory flash used by host tests (`std` feature).
+#[derive(Debug)]
+pub struct MockFlash<'d> {
+    _phantom: PhantomData<&'d ()>,
+}
+
+impl MockFlash<'static> {
+    pub fn new() -> Self {
+        Self {
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl MockFlash<'_> {
+    fn with_flash<R>(f: impl FnOnce(&mut [u8; FLASH_SIZE]) -> R) -> R {
+        // Host tests run with `--test-threads=1`.
+        f(unsafe { &mut *core::ptr::addr_of_mut!(FLASH_DATA) })
+    }
+
+    fn check_bounds(offset: u32, length: usize) -> Result<(), Error> {
+        let offset = offset as usize;
+        if length > FLASH_SIZE || offset > FLASH_SIZE - length {
+            return Err(Error::StorageError);
+        }
+        Ok(())
+    }
+
+    pub fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Error> {
+        self.flash_read(offset, bytes)
+    }
+
+    pub fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Error> {
+        self.flash_write(offset, bytes)
+    }
+
+    pub fn erase(&mut self, from: u32, to: u32) -> Result<(), Error> {
+        self.flash_erase(from, to)
+    }
+}
+
+impl FlashAccess for MockFlash<'_> {
+    const READ_SIZE: usize = WORD_SIZE as usize;
+    const WRITE_SIZE: usize = WORD_SIZE as usize;
+    const ERASE_SIZE: usize = SECTOR_SIZE as usize;
+    const SECTOR_SIZE: u32 = SECTOR_SIZE;
+
+    fn flash_read(&mut self, offset: u32, mut bytes: &mut [u8]) -> Result<(), Error> {
+        Self::check_bounds(offset, bytes.len())?;
+
+        let mut data_offset = offset % Self::SECTOR_SIZE;
+        let mut aligned_offset = offset - data_offset;
+
+        while !bytes.is_empty() {
+            let len = bytes.len().min((Self::SECTOR_SIZE - data_offset) as usize);
+
+            Self::with_flash(|flash| {
+                bytes[..len].copy_from_slice(
+                    &flash[aligned_offset as usize..][data_offset as usize..][..len],
+                );
+            });
+
+            aligned_offset += Self::SECTOR_SIZE;
+            data_offset = 0;
+            bytes = &mut bytes[len..];
+        }
+
+        Ok(())
+    }
+
+    fn flash_write(&mut self, offset: u32, mut bytes: &[u8]) -> Result<(), Error> {
+        Self::check_bounds(offset, bytes.len())?;
+
+        let mut data_offset = offset % Self::SECTOR_SIZE;
+        let mut aligned_offset = offset - data_offset;
+
+        while !bytes.is_empty() {
+            let len = bytes.len().min((Self::SECTOR_SIZE - data_offset) as usize);
+
+            Self::with_flash(|flash| {
+                let sector = aligned_offset as usize;
+                let sector_end = sector + Self::SECTOR_SIZE as usize;
+                flash[sector..sector_end].fill(ERASE_BYTE);
+                flash[sector + data_offset as usize..][..len].copy_from_slice(&bytes[..len]);
+            });
+
+            aligned_offset += Self::SECTOR_SIZE;
+            data_offset = 0;
+            bytes = &bytes[len..];
+        }
+
+        Ok(())
+    }
+
+    fn flash_erase(&mut self, from: u32, to: u32) -> Result<(), Error> {
+        let len = (to - from) as usize;
+        Self::check_bounds(from, len)?;
+
+        let mut address = from;
+        while address < to && !address.is_multiple_of(BLOCK_SIZE) {
+            let sector = address as usize;
+            Self::with_flash(|flash| {
+                flash[sector..sector + Self::SECTOR_SIZE as usize].fill(ERASE_BYTE);
+            });
+            address += Self::SECTOR_SIZE;
+        }
+
+        while (to - address) >= BLOCK_SIZE {
+            let block = address as usize;
+            Self::with_flash(|flash| {
+                flash[block..block + BLOCK_SIZE as usize].fill(ERASE_BYTE);
+            });
+            address += BLOCK_SIZE;
+        }
+
+        while address < to {
+            let sector = address as usize;
+            Self::with_flash(|flash| {
+                flash[sector..sector + Self::SECTOR_SIZE as usize].fill(ERASE_BYTE);
+            });
+            address += Self::SECTOR_SIZE;
+        }
+
+        Ok(())
+    }
+
+    fn flash_read_encrypted(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Error> {
+        self.flash_read(offset, bytes)
+    }
+
+    fn flash_write_encrypted(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Error> {
+        self.flash_write(offset, bytes)
+    }
+
+    fn flash_read_nor(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Error> {
+        self.flash_read(offset, bytes)
+    }
+
+    fn flash_write_nor(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Error> {
+        self.flash_write(offset, bytes)
+    }
+}

--- a/esp-bootloader-esp-idf/src/flash/mod.rs
+++ b/esp-bootloader-esp-idf/src/flash/mod.rs
@@ -1,0 +1,16 @@
+mod flash_access;
+#[cfg(feature = "std")]
+mod mock_flash;
+
+pub use flash_access::FlashAccess;
+
+/// Alias for [`esp_storage::FlashStorage`].
+///
+/// Pass this to [`crate::partitions::read_partition_table`],
+/// [`crate::partitions::PartitionEntry::as_flash_region`], [`crate::ota_updater::OtaUpdater`], and
+/// related partition/OTA APIs.
+#[cfg(not(feature = "std"))]
+pub type FlashStorage<'d> = esp_storage::FlashStorage<'d>;
+
+#[cfg(feature = "std")]
+pub type FlashStorage<'d> = mock_flash::MockFlash<'d>;

--- a/esp-bootloader-esp-idf/src/lib.rs
+++ b/esp-bootloader-esp-idf/src/lib.rs
@@ -113,6 +113,8 @@ pub use crypto::Crc32 as Crc32ForTesting;
 #[cfg(feature = "std")]
 pub(crate) use non_rom as crypto;
 
+mod flash;
+
 pub mod partitions;
 
 pub mod ota;

--- a/esp-bootloader-esp-idf/src/non_rom.rs
+++ b/esp-bootloader-esp-idf/src/non_rom.rs
@@ -1,4 +1,5 @@
 use crc::{Algorithm, Crc};
+#[cfg(feature = "validation")]
 use md5::Digest;
 
 static ALGO_CRC32_NORMAL: Algorithm<u32> = Algorithm {
@@ -30,10 +31,12 @@ impl Crc32 {
     }
 }
 
+#[cfg(feature = "validation")]
 pub struct Md5 {
     context: md5::Md5,
 }
 
+#[cfg(feature = "validation")]
 impl Md5 {
     pub fn new() -> Self {
         Self {

--- a/esp-bootloader-esp-idf/src/ota.rs
+++ b/esp-bootloader-esp-idf/src/ota.rs
@@ -385,10 +385,8 @@ impl<'a, 'd> Ota<'a, 'd> {
 
 #[cfg(test)]
 mod tests {
-    use esp_storage::{Flash, FlashStorage};
-
     use super::*;
-    use crate::partitions::PartitionEntry;
+    use crate::partitions::{FlashStorage, PartitionEntry};
 
     const PARTITION_RAW: [u8; 32] = [
         0xaa, 0x50, // MAGIC
@@ -449,7 +447,7 @@ mod tests {
     fn test_initial_state_and_next_slot() {
         let mut binary = PARTITION_RAW;
 
-        let mut flash = FlashStorage::new(Flash::new());
+        let mut flash = FlashStorage::new();
         init_ota_flash(&mut flash);
 
         let mock_region = ota_region(&mut flash, &mut binary);
@@ -488,7 +486,7 @@ mod tests {
     fn test_slot0_valid_next_slot() {
         let mut binary = PARTITION_RAW;
 
-        let mut flash = FlashStorage::new(Flash::new());
+        let mut flash = FlashStorage::new();
         init_ota_flash(&mut flash);
         flash.write(0x0000, SLOT_COUNT_1_VALID).unwrap();
         flash.write(0x1000, SLOT_INITIAL).unwrap();
@@ -519,7 +517,7 @@ mod tests {
     fn test_slot1_new_next_slot() {
         let mut binary = PARTITION_RAW;
 
-        let mut flash = FlashStorage::new(Flash::new());
+        let mut flash = FlashStorage::new();
         init_ota_flash(&mut flash);
         flash.write(0x0000, SLOT_COUNT_1_VALID).unwrap();
         flash.write(0x1000, SLOT_COUNT_2_NEW).unwrap();
@@ -551,7 +549,7 @@ mod tests {
     fn test_multi_updates() {
         let mut binary = PARTITION_RAW;
 
-        let mut flash = FlashStorage::new(Flash::new());
+        let mut flash = FlashStorage::new();
         init_ota_flash(&mut flash);
 
         let mock_region = ota_region(&mut flash, &mut binary);
@@ -609,7 +607,7 @@ mod tests {
     fn test_multi_updates_4_apps() {
         let mut binary = PARTITION_RAW;
 
-        let mut flash = FlashStorage::new(Flash::new());
+        let mut flash = FlashStorage::new();
         init_ota_flash(&mut flash);
 
         let mock_region = ota_region(&mut flash, &mut binary);
@@ -686,7 +684,7 @@ mod tests {
     fn test_multi_updates_skip_parts() {
         let mut binary = PARTITION_RAW;
 
-        let mut flash = FlashStorage::new(Flash::new());
+        let mut flash = FlashStorage::new();
         init_ota_flash(&mut flash);
 
         let mock_region = ota_region(&mut flash, &mut binary);
@@ -736,7 +734,7 @@ mod tests {
     #[test]
     fn test_read_erased_slot() {
         let mut binary = PARTITION_RAW;
-        let mut flash = FlashStorage::new(Flash::new());
+        let mut flash = FlashStorage::new();
         init_ota_flash(&mut flash);
 
         let mut region = ota_region(&mut flash, &mut binary);
@@ -750,7 +748,7 @@ mod tests {
     #[test]
     fn test_read_valid_slot() {
         let mut binary = PARTITION_RAW;
-        let mut flash = FlashStorage::new(Flash::new());
+        let mut flash = FlashStorage::new();
         init_ota_flash(&mut flash);
         flash.write(0x0000, SLOT_COUNT_1_VALID).unwrap();
 
@@ -763,7 +761,7 @@ mod tests {
     #[test]
     fn test_read_rejects_bad_crc() {
         let mut binary = PARTITION_RAW;
-        let mut flash = FlashStorage::new(Flash::new());
+        let mut flash = FlashStorage::new();
         init_ota_flash(&mut flash);
 
         let mut slot = [0u8; 32];
@@ -781,7 +779,7 @@ mod tests {
     #[test]
     fn test_read_rejects_unknown_ota_state() {
         let mut binary = PARTITION_RAW;
-        let mut flash = FlashStorage::new(Flash::new());
+        let mut flash = FlashStorage::new();
         init_ota_flash(&mut flash);
 
         let ota_seq = 1u32;
@@ -802,7 +800,7 @@ mod tests {
     #[test]
     fn test_read_rejects_erased_seq_with_non_erased_state() {
         let mut binary = PARTITION_RAW;
-        let mut flash = FlashStorage::new(Flash::new());
+        let mut flash = FlashStorage::new();
         init_ota_flash(&mut flash);
 
         let mut slot = [0xffu8; 32];
@@ -819,7 +817,7 @@ mod tests {
     #[test]
     fn test_one_corrupt_slot_fails_current_app_partition() {
         let mut binary = PARTITION_RAW;
-        let mut flash = FlashStorage::new(Flash::new());
+        let mut flash = FlashStorage::new();
         init_ota_flash(&mut flash);
 
         let mut corrupt = [0u8; 32];
@@ -839,7 +837,7 @@ mod tests {
     #[test]
     fn test_reset_to_factory_after_corrupt_ota_data() {
         let mut binary = PARTITION_RAW;
-        let mut flash = FlashStorage::new(Flash::new());
+        let mut flash = FlashStorage::new();
         init_ota_flash(&mut flash);
 
         let mut corrupt = [0u8; 32];

--- a/esp-bootloader-esp-idf/src/ota_updater.rs
+++ b/esp-bootloader-esp-idf/src/ota_updater.rs
@@ -61,7 +61,7 @@ impl<'a, 'd> OtaUpdater<'a, 'd> {
         })
     }
 
-    /// Returns an [`Ota`] for accessing the OTA-data partition.
+    /// Returns a [`crate::ota::Ota`] for accessing the OTA-data partition.
     ///
     /// # Errors
     /// [Error::Invalid] if no OTA data partition was found.

--- a/esp-bootloader-esp-idf/src/ota_updater.rs
+++ b/esp-bootloader-esp-idf/src/ota_updater.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     ota::OtaImageState,
-    partitions::{AppPartitionSubType, Error, FlashRegion, PartitionTable},
+    partitions::{AppPartitionSubType, Error, FlashRegion, FlashStorage, PartitionTable},
 };
 
 /// This can be used as more convenient - yet less flexible, way to do OTA updates.
@@ -11,7 +11,7 @@ use crate::{
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct OtaUpdater<'a, 'd> {
-    flash: &'a mut esp_storage::FlashStorage<'d>,
+    flash: &'a mut FlashStorage<'d>,
     pt: PartitionTable<'a>,
     ota_count: usize,
 }
@@ -22,7 +22,7 @@ impl<'a, 'd> OtaUpdater<'a, 'd> {
     /// # Errors
     /// [Error::Invalid] if no OTA data partition or less than two OTA app partition were found.
     pub fn new(
-        flash: &'a mut esp_storage::FlashStorage<'d>,
+        flash: &'a mut FlashStorage<'d>,
         buffer: &'a mut [u8; crate::partitions::PARTITION_TABLE_MAX_LEN],
     ) -> Result<Self, Error> {
         let pt = crate::partitions::read_partition_table(flash, buffer)?;

--- a/esp-bootloader-esp-idf/src/partitions.rs
+++ b/esp-bootloader-esp-idf/src/partitions.rs
@@ -19,6 +19,9 @@ const MD5_MAGIC: u16 = 0xebeb;
 
 const OTA_SUBTYPE_OFFSET: u8 = 0x10;
 
+use crate::flash::FlashAccess;
+pub use crate::flash::FlashStorage;
+
 /// Represents a single partition entry.
 #[derive(Clone, Copy)]
 pub struct PartitionEntry<'a> {
@@ -133,11 +136,8 @@ impl<'a> PartitionEntry<'a> {
     }
 
     /// Provides a "view" into the partition allowing to read/write the
-    /// partition contents using the given [`esp_storage::FlashStorage`].
-    pub fn as_flash_region<'d>(
-        self,
-        flash: &'a mut esp_storage::FlashStorage<'d>,
-    ) -> FlashRegion<'a, 'd> {
+    /// partition contents using the given [`FlashStorage`].
+    pub fn as_flash_region<'d>(self, flash: &'a mut FlashStorage<'d>) -> FlashRegion<'a, 'd> {
         FlashRegion { raw: self, flash }
     }
 }
@@ -580,10 +580,16 @@ impl TryFrom<u8> for PartitionTablePartitionSubType {
 
 /// Read the partition table.
 ///
-/// Pass a [`esp_storage::FlashStorage`] which can read from the whole flash
-/// and provide storage to read the partition table into.
+/// Pass [`FlashStorage`] and a buffer to read the partition table into.
 pub fn read_partition_table<'a, 'd>(
-    flash: &mut esp_storage::FlashStorage<'d>,
+    flash: &mut FlashStorage<'d>,
+    storage: &'a mut [u8],
+) -> Result<PartitionTable<'a>, Error> {
+    read_partition_table_impl(flash, storage)
+}
+
+fn read_partition_table_impl<'a, F: FlashAccess>(
+    flash: &mut F,
     storage: &'a mut [u8],
 ) -> Result<PartitionTable<'a>, Error> {
     #[cfg(feature = "std")]
@@ -593,13 +599,9 @@ pub fn read_partition_table<'a, 'd>(
     let enabled = esp_storage::flash_encryption();
 
     if enabled {
-        flash
-            .read_encrypted(PARTITION_TABLE_OFFSET, storage)
-            .map_err(|_e| Error::StorageError)?;
+        flash.flash_read_encrypted(PARTITION_TABLE_OFFSET, storage)?;
     } else {
-        flash
-            .read(PARTITION_TABLE_OFFSET, storage)
-            .map_err(|_e| Error::StorageError)?;
+        flash.flash_read(PARTITION_TABLE_OFFSET, storage)?;
     }
 
     PartitionTable::new(storage)
@@ -613,10 +615,10 @@ pub fn read_partition_table<'a, 'd>(
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct FlashRegion<'a, 'd> {
     pub(crate) raw: PartitionEntry<'a>,
-    pub(crate) flash: &'a mut esp_storage::FlashStorage<'d>,
+    pub(crate) flash: &'a mut FlashStorage<'d>,
 }
 
-impl FlashRegion<'_, '_> {
+impl<'a, 'd> FlashRegion<'a, 'd> {
     /// Returns the size of the partition in bytes.
     pub fn partition_size(&self) -> usize {
         self.raw.len() as _
@@ -639,13 +641,9 @@ impl FlashRegion<'_, '_> {
         }
 
         if self.raw.is_effectively_encrypted() {
-            self.flash
-                .read_encrypted(address, bytes)
-                .map_err(|_e| Error::StorageError)
+            self.flash.flash_read_encrypted(address, bytes)
         } else {
-            self.flash
-                .read(address, bytes)
-                .map_err(|_e| Error::StorageError)
+            self.flash.flash_read(address, bytes)
         }
     }
 
@@ -662,13 +660,9 @@ impl FlashRegion<'_, '_> {
         }
 
         if self.raw.is_effectively_encrypted() {
-            self.flash
-                .write_encrypted(address, bytes)
-                .map_err(|_e| Error::StorageError)
+            self.flash.flash_write_encrypted(address, bytes)
         } else {
-            self.flash
-                .write(address, bytes)
-                .map_err(|_e| Error::StorageError)
+            self.flash.flash_write(address, bytes)
         }
     }
 
@@ -696,9 +690,7 @@ impl FlashRegion<'_, '_> {
             return Err(Error::OutOfBounds);
         }
 
-        self.flash
-            .erase(address_from, address_to)
-            .map_err(|_e| Error::StorageError)
+        self.flash.flash_erase(address_from, address_to)
     }
 }
 
@@ -711,7 +703,7 @@ pub struct NorFlashRegion<'r, 'a, 'd> {
 #[cfg(feature = "embedded-storage")]
 /// [`NorFlash`] view of an encrypted [`FlashRegion`].
 ///
-/// Write size is 4096 bytes ([`esp_storage::FlashStorage::SECTOR_SIZE`]): the ROM encrypts
+/// Write size is one flash sector ([`esp_storage::FlashStorage::SECTOR_SIZE`]): the ROM encrypts
 /// whole sectors.
 pub struct EncryptedNorFlashRegion<'r, 'a, 'd> {
     region: &'r mut FlashRegion<'a, 'd>,
@@ -734,6 +726,12 @@ mod embedded_storage_traits {
     };
 
     use super::*;
+
+    const NOR_READ_SIZE: usize = <FlashStorage<'static> as FlashAccess>::READ_SIZE;
+    const NOR_WRITE_SIZE: usize = <FlashStorage<'static> as FlashAccess>::WRITE_SIZE;
+    const NOR_ERASE_SIZE: usize = <FlashStorage<'static> as FlashAccess>::ERASE_SIZE;
+    const ENCRYPTED_WRITE_SIZE: usize =
+        <FlashStorage<'static> as FlashAccess>::SECTOR_SIZE as usize;
 
     impl<'a, 'd> FlashRegion<'a, 'd> {
         /// Returns a [`NorFlashRegion`] for [`NorFlash`] access.
@@ -804,7 +802,7 @@ mod embedded_storage_traits {
     }
 
     impl ReadNorFlash for NorFlashRegion<'_, '_, '_> {
-        const READ_SIZE: usize = esp_storage::FlashStorage::READ_SIZE;
+        const READ_SIZE: usize = NOR_READ_SIZE;
 
         fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error> {
             let address = offset + self.region.raw.offset();
@@ -813,10 +811,7 @@ mod embedded_storage_traits {
                 return Err(Error::OutOfBounds);
             }
 
-            self.region
-                .flash
-                .read_nor(address, bytes)
-                .map_err(|_e| Error::StorageError)
+            self.region.flash.flash_read_nor(address, bytes)
         }
 
         fn capacity(&self) -> usize {
@@ -825,8 +820,8 @@ mod embedded_storage_traits {
     }
 
     impl NorFlash for NorFlashRegion<'_, '_, '_> {
-        const WRITE_SIZE: usize = esp_storage::FlashStorage::WRITE_SIZE;
-        const ERASE_SIZE: usize = esp_storage::FlashStorage::ERASE_SIZE;
+        const WRITE_SIZE: usize = NOR_WRITE_SIZE;
+        const ERASE_SIZE: usize = NOR_ERASE_SIZE;
 
         fn erase(&mut self, from: u32, to: u32) -> Result<(), Self::Error> {
             self.region.erase(from, to)
@@ -843,10 +838,7 @@ mod embedded_storage_traits {
                 return Err(Error::OutOfBounds);
             }
 
-            self.region
-                .flash
-                .write_nor(address, bytes)
-                .map_err(|_e| Error::StorageError)
+            self.region.flash.flash_write_nor(address, bytes)
         }
     }
 
@@ -857,7 +849,7 @@ mod embedded_storage_traits {
     }
 
     impl ReadNorFlash for EncryptedNorFlashRegion<'_, '_, '_> {
-        const READ_SIZE: usize = esp_storage::FlashStorage::READ_SIZE;
+        const READ_SIZE: usize = NOR_READ_SIZE;
 
         fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error> {
             let address = offset + self.region.raw.offset();
@@ -866,10 +858,7 @@ mod embedded_storage_traits {
                 return Err(Error::OutOfBounds);
             }
 
-            self.region
-                .flash
-                .read_encrypted(address, bytes)
-                .map_err(|_e| Error::StorageError)
+            self.region.flash.flash_read_encrypted(address, bytes)
         }
 
         fn capacity(&self) -> usize {
@@ -878,8 +867,8 @@ mod embedded_storage_traits {
     }
 
     impl NorFlash for EncryptedNorFlashRegion<'_, '_, '_> {
-        const WRITE_SIZE: usize = esp_storage::FlashStorage::SECTOR_SIZE as usize;
-        const ERASE_SIZE: usize = esp_storage::FlashStorage::ERASE_SIZE;
+        const WRITE_SIZE: usize = ENCRYPTED_WRITE_SIZE;
+        const ERASE_SIZE: usize = NOR_ERASE_SIZE;
 
         fn erase(&mut self, from: u32, to: u32) -> Result<(), Self::Error> {
             self.region.erase(from, to)
@@ -896,10 +885,7 @@ mod embedded_storage_traits {
                 return Err(Error::OutOfBounds);
             }
 
-            self.region
-                .flash
-                .write_encrypted(address, bytes)
-                .map_err(|_e| Error::StorageError)
+            self.region.flash.flash_write_encrypted(address, bytes)
         }
     }
 }
@@ -1079,12 +1065,10 @@ mod tests {
 
 #[cfg(test)]
 mod storage_tests {
-    use esp_storage::{Flash, FlashStorage};
-
     use super::*;
 
     fn test_flash() -> FlashStorage<'static> {
-        let mut flash = FlashStorage::new(Flash::new());
+        let mut flash = FlashStorage::new();
         let mut data = [23u8; 0x10000];
         data[PARTITION_TABLE_OFFSET as usize..][..PARTITION_TABLE_MAX_LEN]
             .copy_from_slice(include_bytes!("../testdata/single_factory_no_ota.bin"));
@@ -1142,12 +1126,11 @@ mod storage_tests {
 #[cfg(all(test, feature = "embedded-storage"))]
 mod nor_flash_tests {
     use embedded_storage::nor_flash::{MultiwriteNorFlash, NorFlash, ReadNorFlash};
-    use esp_storage::{Flash, FlashStorage};
 
     use super::*;
 
     fn test_flash() -> FlashStorage<'static> {
-        let mut flash = FlashStorage::new(Flash::new());
+        let mut flash = FlashStorage::new();
         let mut data = [23u8; 0x10000];
         data[PARTITION_TABLE_OFFSET as usize..][..PARTITION_TABLE_MAX_LEN]
             .copy_from_slice(include_bytes!("../testdata/single_factory_no_ota.bin"));
@@ -1185,19 +1168,19 @@ mod nor_flash_tests {
     fn nor_flash_write_sizes() {
         assert_eq!(
             <NorFlashRegion<'static, 'static, 'static> as NorFlash>::WRITE_SIZE,
-            esp_storage::FlashStorage::WRITE_SIZE
+            <FlashStorage<'static> as FlashAccess>::WRITE_SIZE
         );
         assert_eq!(
             <EncryptedNorFlashRegion<'static, 'static, 'static> as NorFlash>::WRITE_SIZE,
-            esp_storage::FlashStorage::SECTOR_SIZE as usize
+            <FlashStorage<'static> as FlashAccess>::SECTOR_SIZE as usize
         );
         assert_eq!(
             <NorFlashRegion<'static, 'static, 'static> as ReadNorFlash>::READ_SIZE,
-            esp_storage::FlashStorage::READ_SIZE
+            <FlashStorage<'static> as FlashAccess>::READ_SIZE
         );
         assert_eq!(
             <EncryptedNorFlashRegion<'static, 'static, 'static> as ReadNorFlash>::READ_SIZE,
-            esp_storage::FlashStorage::READ_SIZE
+            <FlashStorage<'static> as FlashAccess>::READ_SIZE
         );
     }
 }

--- a/esp-bootloader-esp-idf/src/partitions.rs
+++ b/esp-bootloader-esp-idf/src/partitions.rs
@@ -15,6 +15,7 @@ const PARTITION_TABLE_OFFSET: u32 =
 
 const RAW_ENTRY_LEN: usize = 32;
 const ENTRY_MAGIC: u16 = 0x50aa;
+#[cfg(feature = "validation")]
 const MD5_MAGIC: u16 = 0xebeb;
 
 const OTA_SUBTYPE_OFFSET: u8 = 0x10;
@@ -205,12 +206,12 @@ pub enum Error {
         expected_size: usize,
         expected_type: PartitionType,
     },
-    /// Invalid tate
+    /// Invalid state
     InvalidState,
     /// The given argument is invalid.
     InvalidArgument,
-    /// The operation is not supported for this partition (e.g. wrong [`FlashRegion::as_nor_flash`]
-    /// accessor for an encrypted partition).
+    /// The operation is not supported for this partition (e.g. `as_nor_flash` on an encrypted
+    /// partition).
     NotSupported,
 }
 

--- a/esp-bootloader-esp-idf/src/rom.rs
+++ b/esp-bootloader-esp-idf/src/rom.rs
@@ -1,4 +1,4 @@
-use esp_rom_sys::rom::md5;
+use esp_rom_sys::rom::crc;
 
 pub struct Crc32 {}
 
@@ -8,18 +8,20 @@ impl Crc32 {
     }
 
     pub fn crc(&self, data: &[u8]) -> u32 {
-        esp_rom_sys::rom::crc::crc32_le(u32::MAX, data)
+        crc::crc32_le(u32::MAX, data)
     }
 }
 
+#[cfg(feature = "validation")]
 pub struct Md5 {
-    context: md5::Context,
+    context: esp_rom_sys::rom::md5::Context,
 }
 
+#[cfg(feature = "validation")]
 impl Md5 {
     pub fn new() -> Self {
         Self {
-            context: md5::Context::new(),
+            context: esp_rom_sys::rom::md5::Context::new(),
         }
     }
 

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -938,7 +938,7 @@ pub fn run_host_tests(workspace: &Path, package: Package) -> Result<()> {
                     .subcommand("test")
                     .arg("--lib")
                     .arg("--tests")
-                    .features(&vec!["std".into()])
+                    .features(&vec!["std".into(), "embedded-storage".into()])
                     .arg("--")
                     .arg("--test-threads=1")
                     .build(),


### PR DESCRIPTION
This doesn't really change anything in a user facing way. (Besides a type-alias for FlashStorage)

This decouples the host-side tests in esp-bootloader-esp-idf from the emulation feature in esp-storage.

Background:
We plan to move the functionality from esp-storage to esp-hal - we cannot have those host-tests there and we definitely don't want to carry that emulation feature with us. 

Loosing the host-side tests in esp-storage won't be a big loss (and most can be mitigated by extending HIL-tests) but we want to keep the tests for esp-bootloader.

As a side node: When moving esp-storage we might want to reconsider the bytewise-read feature - most of the host-side tests actually test that. That feature (and the emulation feature) adds a good chunk of complexity with little benefit.

TL;DR This is a preparation step to be able to move esp-storage into esp-hal
