### PR TITLE
[7/N] Obtain LP tokens from GPIO drivers

### DIFF
--- a/esp-hal-procmacros/src/lp_core.rs
+++ b/esp-hal-procmacros/src/lp_core.rs
@@ -326,8 +326,7 @@ pub fn load_lp_code(input: TokenStream, fs: impl Filesystem) -> TokenStream {
     let imports = quote! {
         use #hal_crate::lp_core::LpCore;
         use #hal_crate::lp_core::LpCoreWakeupSource;
-        use #hal_crate::gpio::lp_io::LowPowerOutput;
-        use #hal_crate::gpio::*;
+        use #hal_crate::gpio::lp_io::{LowPowerInput, LowPowerOutput, LowPowerOutputOpenDrain};
         use #hal_crate::uart::lp_uart::LpUart;
         use #hal_crate::i2c::lp_i2c::LpI2c;
     };
@@ -335,7 +334,7 @@ pub fn load_lp_code(input: TokenStream, fs: impl Filesystem) -> TokenStream {
     let imports = quote! {
         use #hal_crate::lp_core::UlpCore as LpCore;
         use #hal_crate::lp_core::UlpCoreWakeupSource as LpCoreWakeupSource;
-        use #hal_crate::gpio::*;
+        use #hal_crate::gpio::lp_io::{LowPowerInput, LowPowerOutput, LowPowerOutputOpenDrain};
     };
 
     #[cfg(feature = "has-lp-core")]
@@ -463,8 +462,7 @@ mod tests {
                 {
                     use crate::lp_core::LpCore;
                     use crate::lp_core::LpCoreWakeupSource;
-                    use crate::gpio::lp_io::LowPowerOutput;
-                    use crate::gpio::*;
+                    use crate::gpio::lp_io::{LowPowerInput, LowPowerOutput, LowPowerOutputOpenDrain};
                     use crate::uart::lp_uart::LpUart;
                     use crate::i2c::lp_i2c::LpI2c;
 

--- a/esp-hal/src/gpio/lp_io/low_level/esp32.rs
+++ b/esp-hal/src/gpio/lp_io/low_level/esp32.rs
@@ -176,6 +176,7 @@ macro_rules! set_pull_field {
     }};
 }
 
+#[expect(dead_code)]
 pub(super) fn init_pin(pin: &impl crate::gpio::LpPin, input_enable: bool) -> u8 {
     pin.lp_set_config(input_enable, true, LpFunction::LP_GPIO);
     pin.lp_number()
@@ -193,6 +194,7 @@ pub(super) fn output_enable(pin: u8, enable: bool) {
     }
 }
 
+#[expect(dead_code)]
 pub(super) fn input_enable(pin: u8, enable: bool) {
     set_pad_field!(pin, fun_ie, enable);
 }

--- a/esp-hal/src/gpio/lp_io/low_level/esp32h2.rs
+++ b/esp-hal/src/gpio/lp_io/low_level/esp32h2.rs
@@ -70,9 +70,10 @@ for_each_lp_function! {
     };
 }
 
-pub(super) fn init_pin(pin: &impl LpPin, input_enable: bool) -> u8 {
+#[expect(dead_code)]
+pub(super) fn init_pin(pin: &impl LpPin, enable_input: bool) -> u8 {
     let lp_pin = pin.lp_number();
-    input_enable_fn(lp_pin, input_enable);
+    input_enable(lp_pin, enable_input);
     lp_pin
 }
 
@@ -80,6 +81,7 @@ fn lp_pin_to_gpio(pin: u8) -> u8 {
     pin + 7
 }
 
+#[expect(dead_code)]
 pub(super) fn output_enable(pin: u8, enable: bool) {
     let gpio = lp_pin_to_gpio(pin);
     if enable {
@@ -94,10 +96,6 @@ pub(super) fn output_enable(pin: u8, enable: bool) {
 }
 
 pub(super) fn input_enable(pin: u8, enable: bool) {
-    input_enable_fn(pin, enable);
-}
-
-fn input_enable_fn(pin: u8, enable: bool) {
     IO_MUX::regs()
         .gpio(lp_pin_to_gpio(pin) as usize)
         .modify(|_, w| w.fun_ie().bit(enable));
@@ -115,6 +113,7 @@ pub(super) fn pulldown_enable(pin: u8, enable: bool) {
         .modify(|_, w| w.fun_wpd().bit(enable));
 }
 
+#[expect(dead_code)]
 pub(super) fn set_open_drain_output(pin: u8, enable: bool) {
     GPIO::regs()
         .pin(pin as usize)

--- a/esp-hal/src/gpio/lp_io/low_level/v3.rs
+++ b/esp-hal/src/gpio/lp_io/low_level/v3.rs
@@ -56,12 +56,14 @@ for_each_lp_function! {
     };
 }
 
-pub(super) fn init_pin(pin: &impl LpPin, input_enable: bool) -> u8 {
+#[expect(dead_code)]
+pub(super) fn init_pin(pin: &impl LpPin, enable_input: bool) -> u8 {
     let pin = pin.number();
-    input_enable_fn(pin, input_enable);
+    input_enable(pin, enable_input);
     pin
 }
 
+#[expect(dead_code)]
 pub(super) fn output_enable(pin: u8, enable: bool) {
     if enable {
         GPIO::regs()
@@ -75,10 +77,6 @@ pub(super) fn output_enable(pin: u8, enable: bool) {
 }
 
 pub(super) fn input_enable(pin: u8, enable: bool) {
-    input_enable_fn(pin, enable);
-}
-
-fn input_enable_fn(pin: u8, enable: bool) {
     IO_MUX::regs()
         .gpio(pin as usize)
         .modify(|_, w| w.fun_ie().bit(enable));
@@ -96,6 +94,7 @@ pub(super) fn pulldown_enable(pin: u8, enable: bool) {
         .modify(|_, w| w.fun_wpd().bit(enable));
 }
 
+#[expect(dead_code)]
 pub(super) fn set_open_drain_output(pin: u8, enable: bool) {
     GPIO::regs()
         .pin(pin as usize)

--- a/esp-hal/src/gpio/lp_io/low_level/v4.rs
+++ b/esp-hal/src/gpio/lp_io/low_level/v4.rs
@@ -74,11 +74,13 @@ for_each_lp_function! {
     };
 }
 
+#[cfg(any(ulp_riscv_driver_supported, lp_io_has_gpio_matrix))]
 pub(super) fn init_pin(pin: &impl LpPin, input_enable: bool) -> u8 {
     pin.lp_set_config(input_enable, true, LpFunction::LP_GPIO);
     pin.number()
 }
 
+#[cfg(any(ulp_riscv_driver_supported, lp_io_has_gpio_matrix))]
 pub(super) fn output_enable(pin: u8, enable: bool) {
     if enable {
         LP_GPIO::regs()
@@ -91,6 +93,7 @@ pub(super) fn output_enable(pin: u8, enable: bool) {
     }
 }
 
+#[cfg(any(ulp_riscv_driver_supported, lp_io_has_gpio_matrix))]
 pub(super) fn input_enable(pin: u8, enable: bool) {
     LP_IO_MUX::regs()
         .gpio(pin as usize)
@@ -109,6 +112,7 @@ pub(super) fn pulldown_enable(pin: u8, enable: bool) {
         .modify(|_, w| w.fun_wpd().bit(enable));
 }
 
+#[cfg(any(ulp_riscv_driver_supported, lp_io_has_gpio_matrix))]
 pub(super) fn set_open_drain_output(pin: u8, enable: bool) {
     LP_GPIO::regs()
         .pin(pin as usize)

--- a/esp-hal/src/gpio/lp_io/mod.rs
+++ b/esp-hal/src/gpio/lp_io/mod.rs
@@ -4,6 +4,10 @@
         cfg(any(esp32s2, esp32s3)) => "GPIO21",
         cfg(esp32h2) => "GPIO8",
         _ => "GPIO1"
+    },
+    "lp_num" => {
+        cfg(any(esp32s2, esp32s3)) => "21",
+        _ => "1"
     }
 ))]
 //! Low Power IO (LP_IO)
@@ -19,20 +23,45 @@
 //! Low-power pins bypass the regular IO MUX and GPIO matrix so they can be used
 //! by the ULP/LP core and low-power peripherals. They can remain operational
 //! during deep sleep and can be used as wake-up sources.
-//!
-//! ## Examples
-//!
-//! ### Configure a Low-Power Pin as Output
-//!
-//! ```rust, no_run
-//! # {before_snippet}
-//! use esp_hal::gpio::lp_io::LowPowerOutput;
-//! let lp_pin = LowPowerOutput::new(peripherals.__lp_io__);
-//! # {after_snippet}
-//! ```
+#![cfg_attr(
+    ulp_riscv_driver_supported,
+    doc = "
 
+## Handing a pin to the low-power core
+
+[`LowPowerInput`], [`LowPowerOutput`], and [`LowPowerOutputOpenDrain`] are opaque tokens that
+represent a pad owned by the low-power domain. Obtain them by consuming a
+[`Input`](crate::gpio::Input) or [`Output`](crate::gpio::Output) driver with
+[`Input::into_lp`](crate::gpio::Input::into_lp), [`Output::into_lp`](crate::gpio::Output::into_lp),
+or [`Output::into_open_drain_lp`](crate::gpio::Output::into_open_drain_lp). The conversion muxes the
+pad into the low-power domain; afterwards the HP core can no longer drive it.
+
+The `PIN` parameter of the tokens is the low-power pin number, which is how low-power core firmware
+refers to the pin. The conversions verify at runtime that the pad they are given is that pin, and
+hand the driver back when it is not.
+
+The tokens can also be created straight from a pin with `LowPowerInput::new`,
+`LowPowerOutput::new`, and `LowPowerOutputOpenDrain::new`, which check the pin number at compile
+time but leave the pad's configuration up to the token.
+
+## Examples
+
+### Hand a pin to the LP core
+
+```rust, no_run
+# {before_snippet}
+use esp_hal::gpio::{Level, Output, OutputConfig};
+let pin = Output::new(peripherals.__lp_io__, Level::Low, OutputConfig::default());
+let lp_pin = pin.into_lp::<__lp_num__>().unwrap();
+# {after_snippet}
+```
+"
+)]
+
+#[cfg(ulp_riscv_driver_supported)]
 use core::marker::PhantomData;
 
+#[cfg(any(ulp_riscv_driver_supported, lp_io_has_gpio_matrix))]
 use super::{InputPin, LpPin, OutputPin};
 
 define_lp_io_signals!();
@@ -46,13 +75,12 @@ define_lp_functions!();
 #[cfg_attr(lp_io_version = "v4", path = "low_level/v4.rs")]
 mod low_level;
 
-// FIXME: LpPin is necessary only as long as the sleep API takes &dyn LpPin(WithResistors).
-// After that has been resolved, we can simplify this hierarchy to only have LowPowerPin.
-
 /// Trait implemented by pins with a known low-power pin number.
+#[cfg(ulp_riscv_driver_supported)]
 #[doc(hidden)]
 pub trait LowPowerPin<const PIN: u8>: LpPin {}
 
+#[cfg(ulp_riscv_driver_supported)]
 for_each_lp_function! {
     (($_signal:ident, LP_GPIOn, $pin:literal), $gpio:ident, $_af:ident, $_lp_in:tt $_lp_out:tt) => {
         impl LowPowerPin<$pin> for crate::peripherals::$gpio<'_> {}
@@ -147,92 +175,197 @@ fn route_output(lp_pin: u8, output: LpOutputSignal) {
         });
 }
 
-/// A GPIO output pin configured for low-power operation.
-pub struct LowPowerOutput<'d, const PIN: u8> {
-    phantom: PhantomData<&'d mut ()>,
-}
+/// Tokens to hand out a pin to a low-power CPU.
+// FIXME: tokens should be 'static to be handed out.
+#[cfg(ulp_riscv_driver_supported)]
+mod ulp_tokens {
+    use super::*;
+    use crate::gpio::Pin;
 
-impl<'d, const PIN: u8> LowPowerOutput<'d, PIN> {
-    /// Creates a new output pin for use by the low-power core.
+    // Needed because AnyPin::lp_number is infallible
+    fn lp_number(gpio: u8) -> Option<u8> {
+        for_each_lp_function! {
+            (($_signal:ident, LP_GPIOn, $pin:literal), $gpio:ident, $_af:ident, $_lp_in:tt $_lp_out:tt) => {
+                if gpio == crate::peripherals::$gpio::NUMBER {
+                    return Some($pin);
+                }
+            };
+        }
+
+        None
+    }
+
+    impl<'d> crate::gpio::Input<'d> {
+        /// Hands the pin over to the low-power core.
+        ///
+        /// `PIN` is the low-power pin number, which is how low-power core firmware refers to the
+        /// pin.
+        ///
+        /// # Errors
+        ///
+        /// Returns the driver unchanged if the pad is not the low-power pin numbered `PIN`.
+        #[instability::unstable]
+        pub fn into_lp<const PIN: u8>(self) -> Result<LowPowerInput<'d, PIN>, Self> {
+            if lp_number(self.pin.pin.number()) != Some(PIN) {
+                return Err(self);
+            }
+
+            Ok(LowPowerInput::new_untyped(self.pin.pin))
+        }
+    }
+
+    impl<'d> crate::gpio::Output<'d> {
+        /// Hands the pin over to the low-power core.
+        ///
+        /// `PIN` is the low-power pin number, which is how low-power core firmware refers to the
+        /// pin.
+        ///
+        /// # Errors
+        ///
+        /// Returns the driver unchanged if the pad is not the low-power pin numbered `PIN`.
+        #[instability::unstable]
+        pub fn into_lp<const PIN: u8>(self) -> Result<LowPowerOutput<'d, PIN>, Self> {
+            if lp_number(self.pin.pin.number()) != Some(PIN) {
+                return Err(self);
+            }
+
+            Ok(LowPowerOutput::new_untyped(self.pin.pin))
+        }
+
+        /// Hands the pin over to the low-power core as an open-drain output.
+        ///
+        /// `PIN` is the low-power pin number, which is how low-power core firmware refers to the
+        /// pin. The pad's pull-up is enabled, regardless of the driver's configuration.
+        ///
+        /// # Errors
+        ///
+        /// Returns the driver unchanged if the pad is not the low-power pin numbered `PIN`.
+        #[instability::unstable]
+        pub fn into_open_drain_lp<const PIN: u8>(
+            self,
+        ) -> Result<LowPowerOutputOpenDrain<'d, PIN>, Self> {
+            if lp_number(self.pin.pin.number()) != Some(PIN) {
+                return Err(self);
+            }
+
+            Ok(LowPowerOutputOpenDrain::new_untyped(self.pin.pin))
+        }
+    }
+
+    /// A GPIO output pin configured for low-power operation.
     #[instability::unstable]
-    pub fn new<P>(pin: P) -> Self
-    where
-        P: LowPowerPin<PIN> + OutputPin + 'd,
-    {
-        let pin = low_level::init_pin(&pin, false);
-        low_level::output_enable(pin, true);
+    pub struct LowPowerOutput<'d, const PIN: u8> {
+        pub(super) phantom: PhantomData<&'d mut ()>,
+    }
 
-        Self {
-            phantom: PhantomData,
+    impl<'d, const PIN: u8> LowPowerOutput<'d, PIN> {
+        /// Creates a new output pin for use by the low-power core.
+        #[instability::unstable]
+        pub fn new<P>(pin: P) -> Self
+        where
+            P: LowPowerPin<PIN> + OutputPin + 'd,
+        {
+            Self::new_untyped(pin)
+        }
+
+        pub(super) fn new_untyped<P>(pin: P) -> Self
+        where
+            P: LpPin + OutputPin + 'd,
+        {
+            let lp_pin = low_level::init_pin(&pin, false);
+            low_level::output_enable(lp_pin, true);
+
+            Self {
+                phantom: PhantomData,
+            }
+        }
+    }
+
+    /// A GPIO input pin configured for low-power operation.
+    #[instability::unstable]
+    pub struct LowPowerInput<'d, const PIN: u8> {
+        pub(super) phantom: PhantomData<&'d mut ()>,
+    }
+
+    impl<'d, const PIN: u8> LowPowerInput<'d, PIN> {
+        /// Creates a new input pin for use by the low-power core.
+        #[instability::unstable]
+        pub fn new<P>(pin: P) -> Self
+        where
+            P: LowPowerPin<PIN> + InputPin + 'd,
+        {
+            Self::new_untyped(pin)
+        }
+
+        pub(super) fn new_untyped<P>(pin: P) -> Self
+        where
+            P: LpPin + InputPin + 'd,
+        {
+            let lp_pin = low_level::init_pin(&pin, true);
+            low_level::input_enable(lp_pin, true);
+            low_level::pullup_enable(lp_pin, false);
+            low_level::pulldown_enable(lp_pin, false);
+
+            Self {
+                phantom: PhantomData,
+            }
+        }
+
+        /// Enables or disables the internal pull-up resistor.
+        pub fn pullup_enable(&self, enable: bool) {
+            low_level::pullup_enable(PIN, enable);
+        }
+
+        /// Enables or disables the internal pull-down resistor.
+        pub fn pulldown_enable(&self, enable: bool) {
+            low_level::pulldown_enable(PIN, enable);
+        }
+    }
+
+    /// A GPIO open-drain output pin configured for low-power operation.
+    #[instability::unstable]
+    pub struct LowPowerOutputOpenDrain<'d, const PIN: u8> {
+        pub(super) phantom: PhantomData<&'d mut ()>,
+    }
+
+    impl<'d, const PIN: u8> LowPowerOutputOpenDrain<'d, PIN> {
+        /// Creates a new open-drain output pin for use by the low-power core.
+        #[instability::unstable]
+        pub fn new<P>(pin: P) -> Self
+        where
+            P: LowPowerPin<PIN> + InputPin + OutputPin + 'd,
+        {
+            Self::new_untyped(pin)
+        }
+
+        pub(super) fn new_untyped<P>(pin: P) -> Self
+        where
+            P: LpPin + InputPin + OutputPin + 'd,
+        {
+            let gpio = pin.number();
+            let lp_pin = low_level::init_pin(&pin, true);
+            low_level::set_open_drain_output(gpio, true);
+            low_level::input_enable(lp_pin, true);
+            low_level::pullup_enable(lp_pin, true);
+            low_level::pulldown_enable(lp_pin, false);
+            low_level::output_enable(lp_pin, true);
+
+            Self {
+                phantom: PhantomData,
+            }
+        }
+
+        /// Enables or disables the internal pull-up resistor.
+        pub fn pullup_enable(&self, enable: bool) {
+            low_level::pullup_enable(PIN, enable);
+        }
+
+        /// Enables or disables the internal pull-down resistor.
+        pub fn pulldown_enable(&self, enable: bool) {
+            low_level::pulldown_enable(PIN, enable);
         }
     }
 }
 
-/// A GPIO input pin configured for low-power operation.
-pub struct LowPowerInput<'d, const PIN: u8> {
-    phantom: PhantomData<&'d mut ()>,
-}
-
-impl<'d, const PIN: u8> LowPowerInput<'d, PIN> {
-    /// Creates a new input pin for use by the low-power core.
-    #[instability::unstable]
-    pub fn new<P>(pin: P) -> Self
-    where
-        P: LowPowerPin<PIN> + InputPin + 'd,
-    {
-        let pin = low_level::init_pin(&pin, true);
-        low_level::input_enable(pin, true);
-        low_level::pullup_enable(pin, false);
-        low_level::pulldown_enable(pin, false);
-
-        Self {
-            phantom: PhantomData,
-        }
-    }
-
-    /// Enables or disables the internal pull-up resistor.
-    pub fn pullup_enable(&self, enable: bool) {
-        low_level::pullup_enable(PIN, enable);
-    }
-
-    /// Enables or disables the internal pull-down resistor.
-    pub fn pulldown_enable(&self, enable: bool) {
-        low_level::pulldown_enable(PIN, enable);
-    }
-}
-
-/// A GPIO open-drain output pin configured for low-power operation.
-pub struct LowPowerOutputOpenDrain<'d, const PIN: u8> {
-    phantom: PhantomData<&'d mut ()>,
-}
-
-impl<'d, const PIN: u8> LowPowerOutputOpenDrain<'d, PIN> {
-    /// Creates a new open-drain output pin for use by the low-power core.
-    #[instability::unstable]
-    pub fn new<P>(pin: P) -> Self
-    where
-        P: LowPowerPin<PIN> + InputPin + OutputPin + 'd,
-    {
-        let gpio = pin.number();
-        let pin = low_level::init_pin(&pin, true);
-        low_level::set_open_drain_output(gpio, true);
-        low_level::input_enable(pin, true);
-        low_level::pullup_enable(pin, true);
-        low_level::pulldown_enable(pin, false);
-        low_level::output_enable(pin, true);
-
-        Self {
-            phantom: PhantomData,
-        }
-    }
-
-    /// Enables or disables the internal pull-up resistor.
-    pub fn pullup_enable(&self, enable: bool) {
-        low_level::pullup_enable(PIN, enable);
-    }
-
-    /// Enables or disables the internal pull-down resistor.
-    pub fn pulldown_enable(&self, enable: bool) {
-        low_level::pulldown_enable(PIN, enable);
-    }
-}
+#[cfg(ulp_riscv_driver_supported)]
+pub use ulp_tokens::*;

--- a/examples/peripheral/lp_core/lp_blinky/src/main.rs
+++ b/examples/peripheral/lp_core/lp_blinky/src/main.rs
@@ -14,7 +14,11 @@
 #![no_main]
 
 use esp_backtrace as _;
-use esp_hal::{gpio::lp_io::LowPowerOutput, load_lp_code, main};
+use esp_hal::{
+    gpio::{Level, Output, OutputConfig},
+    load_lp_code,
+    main,
+};
 cfg_select! {
     any(feature = "esp32s2", feature = "esp32s3") => {
         use esp_hal::lp_core::{UlpCore, UlpCoreWakeupSource};
@@ -33,7 +37,9 @@ fn main() -> ! {
     let peripherals = esp_hal::init(esp_hal::Config::default());
 
     // configure GPIO 1 as LP output pin
-    let lp_pin = LowPowerOutput::new(peripherals.GPIO1);
+    let lp_pin = Output::new(peripherals.GPIO1, Level::Low, OutputConfig::default())
+        .into_lp::<1>()
+        .unwrap();
 
     let mut lp_core = cfg_select! {
         any(feature = "esp32s2", feature = "esp32s3") => {

--- a/hil-test/src/bin/gpio.rs
+++ b/hil-test/src/bin/gpio.rs
@@ -866,7 +866,10 @@ mod tests {
         esp_metadata_generated::for_each_lp_function! {
             (($_lp:ident, LP_GPIOn, $pin:literal), $gpio:ident, $_af:ident, $_lp_in:tt $_lp_out:tt) => {
                 if !jtag_pins.contains(&$pin) {
-                    esp_hal::gpio::lp_io::LowPowerInput::new(peripherals.$gpio);
+                    esp_hal::gpio::Input::new(
+                        peripherals.$gpio,
+                        esp_hal::gpio::InputConfig::default(),
+                    );
                 }
             };
         }

--- a/hil-test/src/bin/gpio.rs
+++ b/hil-test/src/bin/gpio.rs
@@ -848,11 +848,11 @@ mod tests {
         output_bundle.set_low(0b10); // should panic, only channel0 is configured
     }
 
-    #[cfg(all(lp_io_driver_supported, feature = "unstable"))]
+    #[cfg(all(ulp_riscv_driver_supported, feature = "unstable"))]
     fn no_init() {}
 
     #[test(init = no_init)]
-    #[cfg(all(lp_io_driver_supported, feature = "unstable"))]
+    #[cfg(all(ulp_riscv_driver_supported, feature = "unstable"))]
     fn creating_lpio_does_not_panic() {
         let peripherals = esp_hal::init(esp_hal::Config::default());
 
@@ -869,7 +869,9 @@ mod tests {
                     esp_hal::gpio::Input::new(
                         peripherals.$gpio,
                         esp_hal::gpio::InputConfig::default(),
-                    );
+                    )
+                    .into_lp::<$pin>()
+                    .unwrap();
                 }
             };
         }


### PR DESCRIPTION
This approach commits us to fallible methods for LP_IO-specific functionality in the main GPIO drivers. If we do this, we'll also add fallible `.configure_deep_sleep_wakeup()` functions in the future.

These functions consume the driver instead of reborrowing. Either could work, but it depends whether it is actually safe to have non-static LowPower* types. Currently, I don't believe it is - we hand a pin to the LP core, then it has full unscoped control over it - which means the lifetime on those types is a bug.

Alternatives:
- Typed wrappers - `lp_io::Input<'d, LP_PIN_N>` etc. This is a huge amount of code to maintain in parallel with the main GPIO driver. This could let us control these pins via the LP IOMUX, where it exists, but that actually has a reduced feature set so I'm not sure HP core firmware wants that.
- Optional type erase, have `GpioDriver<'d, M = ()>` or `GpioDriver<'d, LowPowerPin<N>>` - if it's semver-legal to introduce. I think this would be confusing UX.

# Changelog

## esp-hal

- Added: `into_lp*` functions to `gpio::{Input, Output}` drivers.
- Removed: `LowPowerInput`, `LowPowerOutput` and `LowPowerOutputOpenDrain` are no longer available on chips without a supported LP core.

## esp-hal-procmacros

- No changelog necessary.