### PR TITLE
ci: skip CI on draft pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,10 @@ jobs:
   # Centralized entry point — fetches labels once, decides which downstream
   # jobs and reusable workflows run.  Every other job/workflow in this file
   # gates on `calculate` outputs.
+  # Draft PRs run no CI at all: every other job needs `calculate`, so skipping
+  # it skips them too.
   calculate:
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     outputs:
       labels: ${{ steps.labels.outputs.labels }}


### PR DESCRIPTION
I also toyed with changing what calculate does based on a draft pull request but I think this is the simplest solution for right now. In the future we may want to choose to do some cheaper checks like formatting or linting even when it's in draft.