### PR TITLE
fix(esp-bootloader-esp-idf): interpret SOURCE_DATE_EPOCH as seconds

### DIFF
--- a/esp-bootloader-esp-idf/build.rs
+++ b/esp-bootloader-esp-idf/build.rs
@@ -12,8 +12,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     // implementation detail.
     assert_unique_features!("log-04", "defmt");
 
+    // `SOURCE_DATE_EPOCH` is defined by the reproducible-builds spec as the number of
+    // *seconds* since the Unix epoch.
+    println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
     let build_time = match env::var("SOURCE_DATE_EPOCH") {
-        Ok(val) => Timestamp::from_microsecond(val.parse::<i64>()?).unwrap(),
+        Ok(val) => Timestamp::from_second(val.parse::<i64>()?)?,
         Err(_) => Timestamp::now(),
     };
 


### PR DESCRIPTION
### Description

`SOURCE_DATE_EPOCH` is defined by the [reproducible-builds specification](https://reproducible-builds.org/docs/source-date-epoch/) as the number of **seconds** since the Unix epoch, but `esp-bootloader-esp-idf/build.rs` parsed it with `Timestamp::from_microsecond`. Every realistic value was therefore interpreted as a moment in the first half hour of 1970, so `ESP_BOOTLOADER_BUILD_DATE` / `ESP_BOOTLOADER_BUILD_TIME` — the strings the bootloader prints on boot — were wrong for any build that set the variable, which defeats the purpose of setting it.

The same block was also missing `cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH`. The build script already emits a `cargo:rerun-if-changed` directive, which disables cargo's default change detection, so changing `SOURCE_DATE_EPOCH` did not re-run the build script and the stale timestamp was reused.

While here, `.unwrap()` became `?`: `main` already returns `Result` and the neighbouring `parse::<i64>()` uses `?`, so an out-of-range value now reports an error instead of panicking.

Fixes #6014

### Testing

The parsing change is observable directly. With `SOURCE_DATE_EPOCH=1735689600` (2025-01-01T00:00:00Z), on jiff 0.2.13:

```
before: 1970-01-01 00:28:55
after : 2025-01-01 00:00:00
```

# Changelog

## esp-bootloader-esp-idf

- Fixed: `SOURCE_DATE_EPOCH` is now interpreted as seconds since the Unix epoch, as the reproducible-builds specification requires, and changing it re-runs the build script.
