### PR TITLE
fix(esp-alloc): don't stop deallocation at the first empty region slot

### DIFF
--- a/esp-alloc/src/heap/llff.rs
+++ b/esp-alloc/src/heap/llff.rs
@@ -30,7 +30,8 @@ impl LlffHeap {
     }
 
     pub(crate) unsafe fn try_deallocate(&mut self, ptr: NonNull<u8>, layout: Layout) -> bool {
-        if self.heap.bottom() <= ptr.as_ptr() && self.heap.top() >= ptr.as_ptr() {
+        // `top()` is one past the last byte of the heap, so the bound is exclusive.
+        if self.heap.bottom() <= ptr.as_ptr() && self.heap.top() > ptr.as_ptr() {
             unsafe { self.heap.deallocate(ptr, layout) };
             true
         } else {

--- a/esp-alloc/src/lib.rs
+++ b/esp-alloc/src/lib.rs
@@ -674,9 +674,9 @@ impl EspHeap {
         self.inner.with(|this| {
             #[cfg(feature = "internal-heap-stats")]
             let before = this.used();
-            let mut iter = this.heap.iter_mut();
-
-            while let Some(Some(region)) = iter.next() {
+            // Skip empty slots instead of stopping at the first one - the region array is
+            // not necessarily densely populated.
+            for region in this.heap.iter_mut().filter_map(|region| region.as_mut()) {
                 if unsafe { region.try_deallocate(ptr, layout) } {
                     break;
                 }


### PR DESCRIPTION
### Description

Two related region-bookkeeping bugs in `esp-alloc`, both of which make a `dealloc` silently do nothing (leaking the allocation) or charge the wrong region.

**1. `dealloc` stops at the first empty region slot.**

`EspHeap::dealloc` walked the region array with:

```rust
let mut iter = this.heap.iter_mut();
while let Some(Some(region)) = iter.next() { ... }
```

`while let` stops as soon as the pattern fails to match, so the loop ends at the first `None` slot rather than skipping it. `alloc_caps` uses `.filter_map(|region| region.as_mut())` and therefore happily allocates from regions *past* an empty slot. Any pointer handed out by such a region could never be freed: the loop stopped before reaching its owner, `try_deallocate` was never called, and the memory leaked. This is reachable whenever the region array is not densely populated — e.g. `add_region` on a heap whose earlier slot was left empty.

The fix makes `dealloc` iterate exactly the way `alloc_caps` does.

**2. The linked-list-first-fit backend's upper bound is off by one.**

```rust
if self.heap.bottom() <= ptr.as_ptr() && self.heap.top() >= ptr.as_ptr() {
```

`linked_list_allocator::Heap::top()` is one past the last byte of the region — its own `size()` is defined as `top() - bottom()`. The bound must therefore be exclusive. As written, a pointer at exactly `top()`, which is the first byte of an adjacent region, is claimed by the wrong `LlffHeap` and passed to its `deallocate`. The TLSF backend already gets this right (`heap/tlsf.rs`: `self.pool_start <= addr && self.pool_end > addr`); this makes llff match.

Fixes #6015

### Testing

`cargo check` and `cargo clippy` are clean for `esp-alloc` on `riscv32imc-unknown-none-elf` across the feature combinations from `check-configs`/`clippy-configs`, including `internal-heap-stats` and `alloc-hooks` (the `#[cfg]` blocks that surround the changed loop).

Both changes align an outlier with an existing correct implementation in the same crate, so behaviour for a single, densely-populated region — the common case, and the one the existing tests exercise — is unchanged.

# Changelog

## esp-alloc

- Fixed: Memory allocated from a secondary heap region could not always be freed, causing a silent leak.
- Fixed: Freeing memory could affect the wrong heap when using multiple adjacent memory regions
