### PR TITLE
Format fix

### DIFF
--- a/esp-alloc/src/lib.rs
+++ b/esp-alloc/src/lib.rs
@@ -475,23 +475,19 @@ impl EspHeapInner {
         }
 
         cfg_select! {
-            feature = "internal-heap-stats" => {
-                HeapStats {
-                    region_stats,
-                    size: free + used,
-                    current_usage: used,
-                    max_usage: self.internal_heap_stats.max_usage,
-                    total_allocated: self.internal_heap_stats.total_allocated,
-                    total_freed: self.internal_heap_stats.total_freed,
-                }
-            }
-            _ => {
-                HeapStats {
-                    region_stats,
-                    size: free + used,
-                    current_usage: used,
-                }
-            }
+            feature = "internal-heap-stats" => HeapStats {
+                region_stats,
+                size: free + used,
+                current_usage: used,
+                max_usage: self.internal_heap_stats.max_usage,
+                total_allocated: self.internal_heap_stats.total_allocated,
+                total_freed: self.internal_heap_stats.total_freed,
+            },
+            _ => HeapStats {
+                region_stats,
+                size: free + used,
+                current_usage: used,
+            },
         }
     }
 


### PR DESCRIPTION
The fmt check is currently failing:
```rust
[2026-08-02T12:18:59Z INFO  esp_devtool] Formatting package: esp-alloc
Diff in /home/runner/work/esp-hal/esp-hal/esp-alloc/src/lib.rs:475:
         }
 
         cfg_select! {
-            feature = "internal-heap-stats" => {
-                HeapStats {
-                    region_stats,
-                    size: free + used,
-                    current_usage: used,
-                    max_usage: self.internal_heap_stats.max_usage,
-                    total_allocated: self.internal_heap_stats.total_allocated,
-                    total_freed: self.internal_heap_stats.total_freed,
-                }
-            }
-            _ => {
-                HeapStats {
-                    region_stats,
-                    size: free + used,
-                    current_usage: used,
-                }
-            }
+            feature = "internal-heap-stats" => HeapStats {
+                region_stats,
+                size: free + used,
+                current_usage: used,
+                max_usage: self.internal_heap_stats.max_usage,
+                total_allocated: self.internal_heap_stats.total_allocated,
+                total_freed: self.internal_heap_stats.total_freed,
+            },
+            _ => HeapStats {
+                region_stats,
+                size: free + used,
+                current_usage: used,
+            },
         }
     }
 
Diff in /home/runner/work/esp-hal/esp-hal/esp-alloc/src/lib.rs:475:
         }
 
         cfg_select! {
-            feature = "internal-heap-stats" => {
-                HeapStats {
-                    region_stats,
-                    size: free + used,
-                    current_usage: used,
-                    max_usage: self.internal_heap_stats.max_usage,
-                    total_allocated: self.internal_heap_stats.total_allocated,
-                    total_freed: self.internal_heap_stats.total_freed,
-                }
-            }
-            _ => {
-                HeapStats {
-                    region_stats,
-                    size: free + used,
-                    current_usage: used,
-                }
-            }
+            feature = "internal-heap-stats" => HeapStats {
+                region_stats,
+                size: free + used,
+                current_usage: used,
+                max_usage: self.internal_heap_stats.max_usage,
+                total_allocated: self.internal_heap_stats.total_allocated,
+                total_freed: self.internal_heap_stats.total_freed,
+            },
+            _ => HeapStats {
+                region_stats,
+                size: free + used,
+                current_usage: used,
+            },
         }
     }
 ```