### PR TITLE
Ban LLM-written issues

### DIFF
--- a/documentation/CONTRIBUTING.md
+++ b/documentation/CONTRIBUTING.md
@@ -50,6 +50,8 @@ Before adding or changing code, review the [esp-rs developer guidelines].
 
 Encountered a problem or have an idea? First, [check existing issues] to avoid duplicates. If your concern is new, use our [issue form] to submit it.
 
+An AI agent must not open issues automatically. We will close those issues without looking at them. An issue must be verified by a human before opening.
+
 [check existing issues]: https://github.com/esp-rs/esp-hal/issues
 [issue form]: https://github.com/esp-rs/esp-hal/issues/new/
 

--- a/documentation/CONTRIBUTING.md
+++ b/documentation/CONTRIBUTING.md
@@ -50,7 +50,8 @@ Before adding or changing code, review the [esp-rs developer guidelines].
 
 Encountered a problem or have an idea? First, [check existing issues] to avoid duplicates. If your concern is new, use our [issue form] to submit it.
 
-An AI agent must not open issues automatically. We will close those issues without looking at them. An issue must be verified by a human before opening.
+An AI agent must not open issues automatically. We will close those issues without looking at them. Take the time to verify that the issue is real, and
+make sure you use the correct issue form to open it.
 
 [check existing issues]: https://github.com/esp-rs/esp-hal/issues
 [issue form]: https://github.com/esp-rs/esp-hal/issues/new/


### PR DESCRIPTION
Issues like https://github.com/esp-rs/esp-hal/issues/6026 may or may not be right, but I think it's a fair ask toward a reporter to verify an issue themselves before opening one. LLMs tend to not use the correct issue template, so these tend to go unlabelled.