### PR TITLE
esp-radio: fix BLE default TX power on ESP32-C3/S3

### DIFF
--- a/esp-radio/src/ble/os_adapter_esp32c3_s3.rs
+++ b/esp-radio/src/ble/os_adapter_esp32c3_s3.rs
@@ -298,7 +298,6 @@ pub enum TxPower {
     P20,
 }
 
-#[allow(dead_code)]
 impl TxPower {
     fn idx(self) -> esp_power_level_t {
         match self {
@@ -318,6 +317,7 @@ impl TxPower {
         }
     }
 
+    #[allow(dead_code)]
     fn dbm(self) -> i8 {
         match self {
             Self::N15 => -15,
@@ -533,7 +533,9 @@ pub(crate) fn create_ble_config(config: &Config) -> esp_bt_controller_config_t {
         hci_tl_funcs: core::ptr::null_mut(),
         txant_dft: config.default_tx_antenna as u8,
         rxant_dft: config.default_rx_antenna as u8,
-        txpwr_dft: config.default_tx_power as u8,
+        // `txpwr_dft` expects an `esp_power_level_t` index, which is offset by 3
+        // from the plain `TxPower` discriminant (`ESP_PWR_LVL_N15` is 3, not 0).
+        txpwr_dft: config.default_tx_power.idx() as u8,
         cfg_mask: CFG_MASK,
 
         // Bluetooth mesh options, currently not supported


### PR DESCRIPTION
### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable). *(n/a — no example changes needed)*
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` or `manual-changelog` label as appropriate.
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

On the ESP32-C3/S3 BTDM adapter, `create_ble_config` converts the safe `TxPower` enum into the controller's `txpwr_dft` field with a raw `as u8` cast:

```rust
// esp-radio/src/ble/os_adapter_esp32c3_s3.rs
txpwr_dft: config.default_tx_power as u8,
```

`TxPower` has no explicit discriminants — its variants run `N15 = 0 … P20 = 12` — but `txpwr_dft` expects an `esp_power_level_t` **index**, whose scale is `N24 = 0 … P20 = 15`. The two scales are offset by 3, so every configured value lands 3 index steps (9 dB) low:

| Rust `TxPower` | discriminant written | controller reads it as | actual TX power |
|---|---|---|---|
| `N15` | 0 | `ESP_PWR_LVL_N24` | −24 dBm |
| `P9` (**the `#[default]`**) | 8 | `ESP_PWR_LVL_N0` | **0 dBm** |
| `P12` | 9 | `ESP_PWR_LVL_P3` | +3 dBm |
| `P20` | 12 | `ESP_PWR_LVL_P12` | +12 dBm |

Two consequences:

1. Every BLE user of esp-radio on C3/S3 who never touched TX power is transmitting at 0 dBm, not the documented +9 dBm default — a silent 9 dB range loss.
2. The top three power levels (indices 13/14/15 = +15/+18/+20 dBm) are unreachable through the safe API: the largest discriminant any variant produces is 12.

The correct mapper already existed in the same file as dead code, so the fix is to call it:

```rust
txpwr_dft: config.default_tx_power.idx() as u8,
```

plus moving the `#[allow(dead_code)]` from the `impl TxPower` block down to `dbm()` (still unused in this file). The other BLE adapters (C2/C5/C6/C61/H2) are unaffected — they map via `TxPower::dbm()` into the NimBLE controller's dBm-valued field — and the neighbouring `txant_dft`/`rxant_dft` casts are fine because `Antenna` has explicit C-matching discriminants. The bug is present in esp-radio 0.17.0, 0.18.0 and `main`.

#### Testing

Verified on an ESP32-S3 (BLE central, bare-metal esp-radio + trouble-host production firmware) using the controller blob's own accessor (`ble_txpwr_get` in `libbtdm_app.a`, whose enhanced ESP-IDF ≥ 5.3 signature was confirmed by disassembling `rf_txpwr.o`):

- **Before** (unpatched 0.18.0): `ble_txpwr_get(DEFAULT, 0)` returns **8** (`ESP_PWR_LVL_N0`, 0 dBm) with the default config, and **12** (+12 dBm) with `with_default_tx_power(TxPower::P20)`.
- **After** (this change cherry-picked onto the 0.18.0 source and built via `[patch.crates-io]`): `with_default_tx_power(TxPower::P20)` alone yields a readback of **15** (+20 dBm) on live hardware — for the default type and, on a real connection to the peripheral, the connection's power — with no other TX-power code in the firmware.

The blob's internal index→dBm table in `rf_txpwr.o` (`-24 … +12, +15, +18, +21`) confirms the index scale end-to-end. (As an aside: index 15 on the S3 is really +21 dBm, which is presumably why the bindings define `ESP_PWR_LVL_P21` as an alias of `ESP_PWR_LVL_P20 = 15`.)

---

# Changelog

## esp-radio

- Fixed: The default BLE default TX power on ESP32-C3/S3 is now correctly set to +9dBm