### PR TITLE
Docs

### DIFF
--- a/esp-storage/src/common.rs
+++ b/esp-storage/src/common.rs
@@ -68,6 +68,19 @@ impl<'d> Flash<'d> {
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 /// Flash storage abstraction.
+///
+/// This type can read and write any location on the SPI flash chip. For
+/// application data, it is recommended to reserve a dedicated
+#[doc = concat!("[partition](https://docs.espressif.com/projects/esp-idf/en/latest/", chip!(), "/api-guides/partition-tables.html)")]
+/// instead of writing to arbitrary addresses. For partition-table helpers, see
+/// `esp-bootloader-esp-idf`.
+///
+/// Use [`FlashStorage::write_nor`] and [`FlashStorage::erase`] for low-level
+/// NOR flash semantics, or [`FlashStorage::write`] for read-modify-write with
+/// automatic sector erasure.
+///
+/// See the [crate-level documentation](crate#buffer-alignment-and-stack-usage)
+/// for stack usage.
 pub struct FlashStorage<'d> {
     pub(crate) capacity: usize,
     unlocked: bool,

--- a/esp-storage/src/common.rs
+++ b/esp-storage/src/common.rs
@@ -71,7 +71,18 @@ impl<'d> Flash<'d> {
 ///
 /// This type can read and write any location on the SPI flash chip. For
 /// application data, it is recommended to reserve a dedicated
-#[doc = concat!("[partition](https://docs.espressif.com/projects/esp-idf/en/latest/", chip!(), "/api-guides/partition-tables.html)")]
+#[cfg_attr(
+    not(feature = "emulation"),
+    doc = concat!(
+        "[partition](https://docs.espressif.com/projects/esp-idf/en/latest/",
+        esp_metadata_generated::chip!(),
+        "/api-guides/partition-tables.html)"
+    )
+)]
+#[cfg_attr(
+    feature = "emulation",
+    doc = "[partition](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/partition-tables.html)"
+)]
 /// instead of writing to arbitrary addresses. For partition-table helpers, see
 /// `esp-bootloader-esp-idf`.
 ///

--- a/esp-storage/src/encrypted.rs
+++ b/esp-storage/src/encrypted.rs
@@ -7,6 +7,17 @@ impl FlashStorage<'_> {
     /// Unaligned offsets and lengths are supported.
     ///
     /// If flash encryption is not enabled this will just read plaintext.
+    ///
+    /// # Note
+    ///
+    /// This function always allocates a [`Self::SECTOR_SIZE`]-byte buffer on
+    /// the stack. See the
+    /// [crate-level documentation](crate#buffer-alignment-and-stack-usage).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FlashStorageError::OutOfBounds`] if the read would extend past
+    /// the end of the flash.
     pub fn read_encrypted(
         &mut self,
         offset: u32,
@@ -39,8 +50,19 @@ impl FlashStorage<'_> {
     /// Performs read-modify-write on affected sectors: reads the current encrypted
     /// content, merges the new bytes, erases the sector, then writes it back encrypted.
     ///
+    /// # Note
+    ///
+    /// This function always allocates a [`Self::SECTOR_SIZE`]-byte buffer on
+    /// the stack. See the
+    /// [crate-level documentation](crate#buffer-alignment-and-stack-usage).
+    ///
     /// # Errors
-    /// - [FlashStorageError::NotSupported] if flash encryption is not enabled
+    ///
+    /// Returns [`FlashStorageError::NotSupported`] if flash encryption is not
+    /// enabled.
+    ///
+    /// Returns [`FlashStorageError::OutOfBounds`] if the write would extend past
+    /// the end of the flash.
     pub fn write_encrypted(
         &mut self,
         offset: u32,

--- a/esp-storage/src/lib.rs
+++ b/esp-storage/src/lib.rs
@@ -9,7 +9,7 @@
 //! [`FlashStorage::write_encrypted`].
 //!
 //! The `embedded-storage` feature flag only implements traits from [`embedded_storage`]
-//! and always assume to access non-encrypted flash.
+//! and always assumes access to non-encrypted flash.
 //!
 //! If you need to use this struct where traits from [`embedded_storage_async`] are needed, you can
 //! use [`embassy_embedded_hal::adapter::BlockingAsync`] or
@@ -19,6 +19,21 @@
 //! [`embedded_storage_async`]: https://docs.rs/embedded-storage-async/latest/embedded_storage_async/
 //! [`embassy_embedded_hal::adapter::BlockingAsync`]: https://docs.rs/embassy-embedded-hal/latest/embassy_embedded_hal/adapter/struct.BlockingAsync.html
 //! [`embassy_embedded_hal::adapter::YieldingAsync`]: https://docs.rs/embassy-embedded-hal/latest/embassy_embedded_hal/adapter/struct.YieldingAsync.html
+//!
+//! ## Buffer alignment and stack usage
+//!
+//! The ESP flash ROM read/write path requires word-aligned (4-byte) buffers.
+//! Several methods accept any `&[u8]` / `&mut [u8]` and, when needed, copy
+//! through a temporary sector-sized buffer on the stack. That cost is not
+//! visible from the slice type and can surprise users in stack-constrained
+//! contexts (for example Embassy tasks with small stacks).
+//!
+//! [`FlashStorage::read_nor`] and [`FlashStorage::write_nor`] only allocate
+//! this fallback when the caller's slice pointer is not word-aligned. Each
+//! fallback is [`FlashStorage::SECTOR_SIZE`] bytes.
+//!
+//! [`FlashStorage::read`], [`FlashStorage::write`], and the encrypted variants
+//! always allocate a sector buffer on the stack for each call.
 //!
 //! ## Feature Flags
 #![doc = document_features::document_features!(feature_label = r#"<span class="stab portability"><code>{feature}</code></span>"#)]

--- a/esp-storage/src/nor_flash.rs
+++ b/esp-storage/src/nor_flash.rs
@@ -29,7 +29,22 @@ impl FlashStorage<'_> {
 
     /// Read bytes from flash using NOR flash semantics.
     ///
-    /// Offset and length must be aligned to [`Self::READ_SIZE`].
+    /// `offset` and `bytes.len()` must be aligned to [`Self::READ_SIZE`].
+    ///
+    /// # Note
+    ///
+    /// If `bytes` is not word-aligned (4-byte), this function allocates a
+    /// [`Self::SECTOR_SIZE`]-byte buffer on the stack and copies through it.
+    /// See the
+    /// [crate-level documentation](crate#buffer-alignment-and-stack-usage).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FlashStorageError::NotAligned`] if `offset` or `bytes.len()` is
+    /// not aligned to [`Self::READ_SIZE`].
+    ///
+    /// Returns [`FlashStorageError::OutOfBounds`] if the read would extend past
+    /// the end of the flash.
     pub fn read_nor(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), FlashStorageError> {
         const RS: u32 = FlashStorage::READ_SIZE as u32;
         self.check_alignment::<{ RS }>(offset, bytes.len())?;
@@ -119,8 +134,28 @@ impl FlashStorage<'_> {
 
     /// Write bytes to flash using NOR flash semantics.
     ///
-    /// The target region must be erased beforehand. Offset and length must be
-    /// aligned to [`Self::WRITE_SIZE`].
+    /// NOR flash can only change bits from 1 to 0. Setting a bit from 0 to 1
+    /// requires erasing the containing sector first (see [`Self::erase`]). Each
+    /// byte is updated by ANDing it with the data being written; if the target
+    /// still contains 0 bits where you need 1s, the stored value will not match
+    /// what you passed in even though the operation succeeds.
+    ///
+    /// `offset` and `bytes.len()` must be aligned to [`Self::WRITE_SIZE`].
+    ///
+    /// # Note
+    ///
+    /// If `bytes` is not word-aligned (4-byte), this function allocates a
+    /// [`Self::SECTOR_SIZE`]-byte buffer on the stack and copies through it.
+    /// See the
+    /// [crate-level documentation](crate#buffer-alignment-and-stack-usage).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FlashStorageError::NotAligned`] if `offset` or `bytes.len()` is
+    /// not aligned to [`Self::WRITE_SIZE`].
+    ///
+    /// Returns [`FlashStorageError::OutOfBounds`] if the write would extend past
+    /// the end of the flash.
     pub fn write_nor(&mut self, offset: u32, bytes: &[u8]) -> Result<(), FlashStorageError> {
         const WS: u32 = FlashStorage::WORD_SIZE;
         self.check_alignment::<{ WS }>(offset, bytes.len())?;
@@ -157,7 +192,17 @@ impl FlashStorage<'_> {
 
     /// Erase flash from `from` up to but not including `to`.
     ///
-    /// Both addresses must be aligned to [`Self::ERASE_SIZE`].
+    /// Erased bytes are set to `0xFF`. Both addresses must be aligned to
+    /// [`Self::ERASE_SIZE`], and `to - from` must be a multiple of
+    /// [`Self::ERASE_SIZE`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FlashStorageError::NotAligned`] if `from` or `to - from` is
+    /// not aligned to [`Self::ERASE_SIZE`].
+    ///
+    /// Returns [`FlashStorageError::OutOfBounds`] if the range would extend past
+    /// the end of the flash.
     pub fn erase(&mut self, from: u32, to: u32) -> Result<(), FlashStorageError> {
         let len = (to - from) as _;
         const SZ: u32 = FlashStorage::SECTOR_SIZE;

--- a/esp-storage/src/storage.rs
+++ b/esp-storage/src/storage.rs
@@ -4,6 +4,17 @@ impl FlashStorage<'_> {
     /// Read bytes from flash.
     ///
     /// Unaligned offsets and lengths are supported.
+    ///
+    /// # Note
+    ///
+    /// This function always allocates a [`Self::SECTOR_SIZE`]-byte buffer on
+    /// the stack. See the
+    /// [crate-level documentation](crate#buffer-alignment-and-stack-usage).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FlashStorageError::OutOfBounds`] if the read would extend past
+    /// the end of the flash.
     pub fn read(&mut self, offset: u32, mut bytes: &mut [u8]) -> Result<(), FlashStorageError> {
         self.check_bounds(offset, bytes.len())?;
 
@@ -44,7 +55,20 @@ impl FlashStorage<'_> {
 
     /// Write bytes to flash.
     ///
-    /// Performs read-modify-write on affected sectors and erases before writing.
+    /// Performs read-modify-write on affected sectors and erases each sector
+    /// before writing. Unlike [`FlashStorage::write_nor`], alignment is not
+    /// required and erasure is handled automatically.
+    ///
+    /// # Note
+    ///
+    /// This function always allocates a [`Self::SECTOR_SIZE`]-byte buffer on
+    /// the stack. See the
+    /// [crate-level documentation](crate#buffer-alignment-and-stack-usage).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FlashStorageError::OutOfBounds`] if the write would extend past
+    /// the end of the flash.
     pub fn write(&mut self, offset: u32, mut bytes: &[u8]) -> Result<(), FlashStorageError> {
         self.check_bounds(offset, bytes.len())?;
 


### PR DESCRIPTION
This basically "resurrects" / supersedes #4447

Back then we more or less rejected the PR because it was basically augmenting the esp-storage docs. Now that we switched to a inherent-functions-first approach it makes sense to have the "truth" documented on our side.

As always a doc-only PR is expected to raise some discussions - however I'm sure we will refine the docs a few times until the reach the desired stabilization.
