### PR TITLE
Mark s2's spi lcd driver as not supported

### DIFF
--- a/esp-hal/README.md
+++ b/esp-hal/README.md
@@ -111,6 +111,7 @@ For help getting started with this HAL, please refer to [The Rust on ESP Book] a
 | SHA                       | ⚒️   | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️       | ⚒️      | ⚒️      | ⚒️      | ⚒️      | [⚒️][5973] [^1] |
 | SDM                       | [❌][2370] [^1] |          | [❌][2370] [^1] | [❌][2370] [^1] | [❌][2370] [^1] |           | [❌][2370] [^1] | [❌][2370] [^1] | [❌][2370] [^1] | [❌][2370] [^1] |           |
 | Light/deep sleep          | ⚒️   | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️       | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ❌        |
+| SPI LCD interface         |       |          |          |          |          |           |          |          | [❌][5374] [^1] |          |           |
 | SPI master                | ✔️   | ✔️      | ✔️      | ✔️      | ✔️      | ✔️       | ✔️      | ✔️      | ✔️      | ✔️      | ✔️       |
 | SPI slave                 | ⚒️   | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️       | ⚒️      | ❌       | ⚒️      | ⚒️      | ❌        |
 | SYSTIMER                  |       | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️       | ⚒️      | ⚒️      | ⚒️      | ⚒️      | ⚒️       |
@@ -151,6 +152,7 @@ For help getting started with this HAL, please refer to [The Rust on ESP Book] a
 [5169]: https://github.com/esp-rs/esp-hal/issues/5169
 [5170]: https://github.com/esp-rs/esp-hal/issues/5170
 [5171]: https://github.com/esp-rs/esp-hal/issues/5171
+[5374]: https://github.com/esp-rs/esp-hal/issues/5374
 [5417]: https://github.com/esp-rs/esp-hal/issues/5417
 [5418]: https://github.com/esp-rs/esp-hal/issues/5418
 [5419]: https://github.com/esp-rs/esp-hal/issues/5419

--- a/esp-metadata/devices/esp32s2/soc.toml
+++ b/esp-metadata/devices/esp32s2/soc.toml
@@ -294,8 +294,11 @@ version = 1
 [device.uhci]
 support_status = "not_supported"
 
-[device.rgb_display] # via SPI and I2S
+[device.rgb_display] # via I2S
 support_status = "not_supported"
+
+[device.spi_lcd] # the LCD mode of GP-SPI2
+support_status = { status = "not_supported", issue = 5374 }
 
 [device.camera] # via I2S
 support_status = "not_supported"

--- a/esp-metadata/src/cfg.rs
+++ b/esp-metadata/src/cfg.rs
@@ -613,7 +613,7 @@ driver_configs![
     },
     RgbProperties {
         driver: rgb_display,
-        name: "RGB display", // LCD_CAM, ESP32 I2S, S2 SPI
+        name: "RGB display", // LCD_CAM, ESP32 I2S, S2 I2S
         properties: {}
     },
     RmtProperties {
@@ -750,6 +750,11 @@ driver_configs![
             #[serde(flatten)]
             config: SocConfig,
         }
+    },
+    SpiLcdProperties {
+        driver: spi_lcd,
+        name: "SPI LCD interface", // The LCD mode of the S2's GP-SPI2
+        properties: {}
     },
     SpiMasterProperties<SpiMasterInstanceConfig> {
         driver: spi_master,


### PR DESCRIPTION
We decided that this would have to be a new driver, so I've made it so in the metadata and closed the referenced issue as not planned with an explanation.