### PR TITLE
Allow running esp-rtos on the second core only

### DIFF
--- a/esp-rtos/src/embassy/mod.rs
+++ b/esp-rtos/src/embassy/mod.rs
@@ -178,7 +178,9 @@ pub trait Callbacks {
     multi_core,
     doc = r"
 
-If you want to start the executor on the second core, you will need to start the second core using [`crate::start_second_core`].
+If you want to start the executor on the second core, you will need to start the second core using
+[`crate::start_second_core`], or [`crate::start_on_second_core_only`] if the first core should stay
+bare-metal.
 If you are looking for a way to run code on the second core without the scheduler, use the [`InterruptExecutor`].
 "
 )]
@@ -270,11 +272,11 @@ impl Executor {
             ))
         };
 
+        // The main task may start the scheduler from inside this executor, so we cannot require the
+        // scheduler to run already. We can, however, refuse to run on a CPU that the scheduler
+        // never runs on.
         #[cfg(multi_core)]
-        if Cpu::current() != Cpu::ProCpu
-            && crate::SCHEDULER
-                .with(|scheduler| !scheduler.per_cpu[Cpu::current() as usize].initialized)
-        {
+        if crate::SCHEDULER.with(|scheduler| !scheduler.active_cores.contains(Cpu::current())) {
             panic!("Executor cannot be started: the scheduler is not running on the current CPU.");
         }
 

--- a/esp-rtos/src/esp_radio/mod.rs
+++ b/esp-rtos/src/esp_radio/mod.rs
@@ -34,8 +34,8 @@ impl esp_radio_rtos_driver::SchedulerImplementation for Scheduler {
                 return false;
             }
 
-            let current_cpu = Cpu::current() as usize;
-            if !scheduler.per_cpu[current_cpu].initialized {
+            let current_cpu = Cpu::current();
+            if !scheduler.active_cores.contains(current_cpu) {
                 error!(
                     "Trying to initialize esp-radio on {:?} but esp-rtos is not running on this core",
                     current_cpu

--- a/esp-rtos/src/lib.rs
+++ b/esp-rtos/src/lib.rs
@@ -57,6 +57,13 @@ esp_rtos::start_second_core(
 //! This will create a thread-mode executor on the main thread. Note that, to create async tasks, you will need
 //! the `task` macro from the `embassy-executor` crate. Do NOT enable any of the `arch-*` features on `embassy-executor`.
 #![cfg_attr(
+    multi_core,
+    doc = r"
+The scheduler can also run on the second core alone, which keeps the first core free for bare-metal
+code. See [`start_on_second_core_only`] for that configuration and its restrictions.
+"
+)]
+#![cfg_attr(
     sleep_light_sleep,
     doc = r"
 ## Automatic Light Sleep (experimental)
@@ -187,6 +194,8 @@ use esp_hal::{
 #[cfg(feature = "embassy")]
 #[cfg_attr(docsrs, doc(cfg(feature = "embassy")))]
 pub use macros::main;
+#[cfg(multi_core)]
+use scheduler::ActiveCores;
 pub(crate) use scheduler::SCHEDULER;
 pub use task::CurrentThreadHandle;
 
@@ -333,6 +342,32 @@ impl TimerSource for Alarm<'static> {
     }
 }
 
+fn init_tracing() {
+    #[cfg(feature = "rtos-trace")]
+    {
+        rtos_trace::trace::name_marker(TraceEvents::YieldTask as u32, "yield task");
+        rtos_trace::trace::name_marker(TraceEvents::RunSchedule as u32, "run scheduler");
+        rtos_trace::trace::name_marker(TraceEvents::TimerTickHandler as u32, "timer tick handler");
+        rtos_trace::trace::name_marker(
+            TraceEvents::ProcessTimerQueue as u32,
+            "process timer queue",
+        );
+        rtos_trace::trace::name_marker(
+            TraceEvents::ProcessEmbassyTimerQueue as u32,
+            "process embassy timer queue",
+        );
+        rtos_trace::trace::start();
+    }
+}
+
+fn assert_thread_mode(function: &str) {
+    assert!(
+        esp_hal::interrupt::RunLevel::current().is_thread(),
+        "{} must not be called from an interrupt handler",
+        function
+    );
+}
+
 /// Starts the scheduler.
 ///
 /// The current context will be converted into the main task, and will be pinned to the first core.
@@ -370,32 +405,11 @@ pub fn start_with_idle_hook(
     int0: SoftwareInterrupt<'static, 0>,
     idle_hook: IdleFn,
 ) {
-    #[cfg(feature = "rtos-trace")]
-    {
-        rtos_trace::trace::name_marker(TraceEvents::YieldTask as u32, "yield task");
-        rtos_trace::trace::name_marker(TraceEvents::RunSchedule as u32, "run scheduler");
-        rtos_trace::trace::name_marker(TraceEvents::TimerTickHandler as u32, "timer tick handler");
-        rtos_trace::trace::name_marker(
-            TraceEvents::ProcessTimerQueue as u32,
-            "process timer queue",
-        );
-        rtos_trace::trace::name_marker(
-            TraceEvents::ProcessEmbassyTimerQueue as u32,
-            "process embassy timer queue",
-        );
-        rtos_trace::trace::start();
-    }
-
-    fn is_thread_mode() -> bool {
-        esp_hal::interrupt::RunLevel::current().is_thread()
-    }
+    init_tracing();
 
     trace!("Starting scheduler for the first core");
     assert_eq!(Cpu::current(), Cpu::ProCpu);
-    assert!(
-        is_thread_mode(),
-        "esp_rtos::start must not be called from an interrupt handler"
-    );
+    assert_thread_mode("esp_rtos::start");
 
     SCHEDULER.with(move |scheduler| {
         scheduler.setup(TimeDriver::new(timer.timer()), idle_hook);
@@ -451,6 +465,73 @@ pub fn start_second_core<const STACK_SIZE: usize>(
     start_second_core_with_stack_guard_offset::<STACK_SIZE>(cpu_control, int1, stack, None, func);
 }
 
+/// The stack of the second core, in a form that can be moved into the second core's main function.
+#[cfg(multi_core)]
+struct SecondCoreStack {
+    stack: *mut [MaybeUninit<u32>],
+}
+
+#[cfg(multi_core)]
+unsafe impl Send for SecondCoreStack {}
+
+#[cfg(multi_core)]
+impl SecondCoreStack {
+    fn new<const STACK_SIZE: usize>(stack: &mut Stack<STACK_SIZE>) -> Self {
+        Self {
+            stack: core::ptr::slice_from_raw_parts_mut(
+                stack.bottom().cast::<MaybeUninit<u32>>(),
+                STACK_SIZE / 4,
+            ),
+        }
+    }
+
+    /// Turns the current context of the second core into its main task.
+    ///
+    /// This takes `self` by value, so that a `move` closure captures the whole struct instead of
+    /// its `!Send` field only.
+    fn allocate_main_task(self, scheduler: &mut scheduler::SchedulerState, guard_offset: usize) {
+        // esp-hal may be configured to use a watchpoint. To work around that, we read the memory at
+        // the stack guard, and we'll use whatever we find as the main task's stack guard value,
+        // instead of writing our own stack guard value.
+        let stack_bottom = self.stack.cast::<u32>();
+        let stack_guard = unsafe { stack_bottom.byte_add(guard_offset) };
+
+        task::allocate_main_task(scheduler, self.stack, guard_offset, unsafe {
+            stack_guard.read()
+        });
+    }
+}
+
+#[cfg(multi_core)]
+fn default_stack_guard_offset() -> usize {
+    esp_config::esp_config_int!(usize, "ESP_HAL_CONFIG_STACK_GUARD_OFFSET")
+}
+
+/// Waits for the scheduler of the second core to start.
+#[cfg(multi_core)]
+fn wait_for_second_core_scheduler() {
+    let start = Instant::now();
+
+    while start.elapsed() < Duration::from_secs(1) {
+        if SCHEDULER.with(|s| s.active_cores.contains(Cpu::AppCpu)) {
+            return;
+        }
+        esp_hal::rom::ets_delay_us(1);
+    }
+
+    panic!(
+        "Second core scheduler failed to initialize. \
+        This can happen if its main function overflowed the stack."
+    );
+}
+
+#[cfg(multi_core)]
+fn suspend_main_task() {
+    loop {
+        SCHEDULER.sleep_until(Instant::EPOCH + Duration::MAX);
+    }
+}
+
 /// Starts the scheduler on the second CPU core.
 ///
 /// Note that the scheduler must be started first, before starting the second core.
@@ -475,21 +556,13 @@ pub fn start_second_core_with_stack_guard_offset<const STACK_SIZE: usize>(
 ) {
     trace!("Starting scheduler for the second core");
 
-    struct SecondCoreStack {
-        stack: *mut [MaybeUninit<u32>],
+    match SCHEDULER.with(|scheduler| scheduler.active_cores) {
+        ActiveCores::Single(Cpu::ProCpu) => {}
+        _ => unreachable!(),
     }
-    unsafe impl Send for SecondCoreStack {}
-    let stack_ptrs = SecondCoreStack {
-        stack: core::ptr::slice_from_raw_parts_mut(
-            stack.bottom().cast::<MaybeUninit<u32>>(),
-            STACK_SIZE / 4,
-        ),
-    };
 
-    let stack_guard_offset = stack_guard_offset.unwrap_or(esp_config::esp_config_int!(
-        usize,
-        "ESP_HAL_CONFIG_STACK_GUARD_OFFSET"
-    ));
+    let stack_ptrs = SecondCoreStack::new(stack);
+    let stack_guard_offset = stack_guard_offset.unwrap_or_else(default_stack_guard_offset);
 
     let mut cpu_control = CpuControl::new(cpu_control);
     let guard = cpu_control
@@ -497,50 +570,141 @@ pub fn start_second_core_with_stack_guard_offset<const STACK_SIZE: usize>(
             trace!("Second core running");
             SCHEDULER.with(move |scheduler| {
                 task::setup_smp(int1);
-                // Make sure the whole struct is captured, not just a !Send field.
-                let ptrs = stack_ptrs;
                 assert!(
                     scheduler.time_driver.is_some(),
                     "The scheduler must be started on the first core first."
                 );
 
-                // esp-hal may be configured to use a watchpoint. To work around that, we read the
-                // memory at the stack guard, and we'll use whatever we find as the main task's
-                // stack guard value, instead of writing our own stack guard value.
-                let stack_bottom = ptrs.stack.cast::<u32>();
-                let stack_guard = unsafe { stack_bottom.byte_add(stack_guard_offset) };
+                scheduler.active_cores = ActiveCores::All;
 
-                task::allocate_main_task(scheduler, ptrs.stack, stack_guard_offset, unsafe {
-                    stack_guard.read()
-                });
+                stack_ptrs.allocate_main_task(scheduler, stack_guard_offset);
                 task::yield_task();
                 trace!("Second core scheduler initialized");
             });
 
             func();
-
-            loop {
-                SCHEDULER.sleep_until(Instant::EPOCH + Duration::MAX);
-            }
+            suspend_main_task();
         })
         .unwrap();
 
-    // Spin until the second core scheduler is initialized
-    let start = Instant::now();
+    wait_for_second_core_scheduler();
 
-    while start.elapsed() < Duration::from_secs(1) {
-        if SCHEDULER.with(|s| s.per_cpu[1].initialized) {
-            break;
-        }
-        esp_hal::rom::ets_delay_us(1);
-    }
+    core::mem::forget(guard);
+}
 
-    if !SCHEDULER.with(|s| s.per_cpu[1].initialized) {
-        panic!(
-            "Second core scheduler failed to initialize. \
-            This can happen if its main function overflowed the stack."
-        );
-    }
+/// Starts the scheduler on the second CPU core only.
+///
+/// Use this function if you want to keep the first core free for bare-metal code, and run all
+/// RTOS-managed work on the second core. Call it from the first core. It returns on the first core,
+/// which then continues to run bare-metal code.
+///
+/// The scheduler does not run on the first core in this configuration. This function must not be
+/// combined with [`start`] or [`start_second_core`]; either combination panics.
+///
+/// The supplied stack and function become the main thread of the second core. The thread is pinned
+/// to the second core. For the list of accepted timer sources, see [`start_with_idle_hook`].
+///
+/// You can return from the second core's main thread function. This will cause the scheduler to
+/// enter the idle state, but the second core will continue to run interrupt handlers and other
+/// tasks.
+///
+/// ## Restrictions
+///
+/// - The first core must not call any `esp-rtos` API, not even to wake a task that runs on the
+///   second core. The scheduler protects its state with a lock that disables interrupts and spins,
+///   which would break the timing of the bare-metal code on the first core.
+/// - Automatic light sleep is not available, because this function takes no idle hook.
+/// - The Wi-Fi and Bluetooth LE drivers of `esp-radio` are not supported.
+/// - `#[esp_rtos::main]` on an `async fn` cannot be used, because it creates a thread-mode executor
+///   on the first core. Create the thread-mode executor (`embassy::Executor`) inside `func`
+///   instead.
+///
+/// ## Example
+///
+/// ```rust, no_run
+#[doc = esp_hal::before_snippet!()]
+/// # struct FakeHeap;
+/// # unsafe impl core::alloc::GlobalAlloc for FakeHeap {
+/// #     unsafe fn alloc(&self, _: core::alloc::Layout) -> *mut u8 {
+/// #         unimplemented!()
+/// #     }
+/// #     unsafe fn dealloc(&self, _: *mut u8, _: core::alloc::Layout) {
+/// #         unimplemented!()
+/// #     }
+/// # }
+/// # #[global_allocator]
+/// # static ALLOCATOR: FakeHeap = FakeHeap;
+/// use esp_hal::{
+///     interrupt::software::SoftwareInterruptControl,
+///     system::Stack,
+///     timer::timg::TimerGroup,
+/// };
+/// use static_cell::ConstStaticCell;
+///
+/// static STACK: ConstStaticCell<Stack<8192>> = ConstStaticCell::new(Stack::new());
+///
+/// let timg0 = TimerGroup::new(peripherals.TIMG0);
+/// let software_interrupt = SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
+///
+/// esp_rtos::start_on_second_core_only(
+///     peripherals.CPU_CTRL,
+///     software_interrupt.software_interrupt1,
+///     timg0.timer0,
+///     STACK.take(),
+///     || {
+///         // The main thread of the second core.
+///     },
+/// );
+///
+/// // The first core continues here, and must not call any esp-rtos API.
+#[doc = esp_hal::after_snippet!()]
+/// ```
+#[cfg(multi_core)]
+pub fn start_on_second_core_only<const STACK_SIZE: usize>(
+    cpu_control: CPU_CTRL<'static>,
+    int1: SoftwareInterrupt<'static, 1>,
+    timer: impl TimerSource + Send,
+    stack: &'static mut Stack<STACK_SIZE>,
+    func: impl FnOnce() + Send + 'static,
+) {
+    init_tracing();
+
+    trace!("Starting scheduler for the second core only");
+    assert_eq!(Cpu::current(), Cpu::ProCpu);
+    assert_thread_mode("esp_rtos::start_on_second_core_only");
+    assert!(
+        SCHEDULER.with(|scheduler| scheduler.time_driver.is_none()),
+        "The scheduler has already been started. \
+        esp_rtos::start_on_second_core_only must not be combined with esp_rtos::start."
+    );
+
+    let stack_ptrs = SecondCoreStack::new(stack);
+    let stack_guard_offset = default_stack_guard_offset();
+
+    let mut cpu_control = CpuControl::new(cpu_control);
+    let guard = cpu_control
+        .start_app_core_with_stack_guard_offset(stack, Some(stack_guard_offset), move || {
+            trace!("Second core running");
+            SCHEDULER.with(move |scheduler| {
+                task::setup_multitasking(int1);
+
+                // The time driver must be created here, and not on the first core:
+                // `Timer::set_interrupt_handler` binds the timer interrupt to the core that calls
+                // it.
+                scheduler.setup(TimeDriver::new(timer.timer()), crate::task::idle_hook);
+                syscall::setup_syscalls();
+
+                stack_ptrs.allocate_main_task(scheduler, stack_guard_offset);
+                task::yield_task();
+                trace!("Second core scheduler initialized");
+            });
+
+            func();
+            suspend_main_task();
+        })
+        .unwrap();
+
+    wait_for_second_core_scheduler();
 
     core::mem::forget(guard);
 }

--- a/esp-rtos/src/run_queue.rs
+++ b/esp-rtos/src/run_queue.rs
@@ -1,7 +1,7 @@
 use esp_hal::system::Cpu;
 
 use crate::{
-    scheduler::CpuState,
+    scheduler::{ActiveCores, CpuState},
     task::{TaskExt, TaskPtr, TaskQueue, TaskReadyQueueElement, TaskState},
 };
 
@@ -160,6 +160,7 @@ impl RunQueue {
     pub(crate) fn mark_task_ready(
         &mut self,
         _state: &[CpuState; Cpu::COUNT],
+        active_cores: ActiveCores,
         ready_task: TaskPtr,
     ) -> RunSchedulerOn {
         let priority = ready_task.priority(self);
@@ -177,18 +178,11 @@ impl RunQueue {
         }
         self.ready_tasks[priority_n].push(ready_task);
 
-        cfg_select! {
-            multi_core => {
-                let run_on = if _state[1].initialized {
-                    self.select_scheduler_trigger_multi_core(_state, ready_task)
-                } else {
-                    self.select_scheduler_trigger_single_core(priority_n)
-                };
-            }
-            _ => {
-                let run_on = self.select_scheduler_trigger_single_core(priority_n);
-            }
-        }
+        let run_on = match active_cores {
+            #[cfg(multi_core)]
+            ActiveCores::All => self.select_scheduler_trigger_multi_core(_state, ready_task),
+            ActiveCores::Single(cpu) => self.select_scheduler_trigger_single_core(cpu, priority_n),
+        };
 
         self.ready_priority.mark_ready(priority);
 
@@ -240,11 +234,11 @@ impl RunQueue {
     }
 
     #[esp_hal::ram]
-    fn select_scheduler_trigger_single_core(&self, priority: usize) -> RunSchedulerOn {
+    fn select_scheduler_trigger_single_core(&self, cpu: Cpu, priority: usize) -> RunSchedulerOn {
         // Run the scheduler if the new priority is >= current maximum priority. This will trigger a
         // run even if the new task's priority is equal, to make sure time slicing is set up.
         if priority >= self.ready_priority.ready() {
-            RunSchedulerOn::RunOnCore(Cpu::ProCpu)
+            RunSchedulerOn::RunOnCore(cpu)
         } else {
             RunSchedulerOn::DontRun
         }

--- a/esp-rtos/src/scheduler.rs
+++ b/esp-rtos/src/scheduler.rs
@@ -39,6 +39,38 @@ use crate::{
     timer::TimeDriver,
 };
 
+/// The set of CPUs that run the scheduler.
+///
+/// The start functions of the scheduler decide this set, and it does not change afterwards.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ActiveCores {
+    /// The scheduler runs on one CPU only. The other CPUs, if any, run bare-metal code.
+    Single(Cpu),
+
+    /// The scheduler runs on every CPU.
+    #[cfg(multi_core)]
+    All,
+}
+
+impl ActiveCores {
+    /// Returns whether `cpu` runs the scheduler.
+    #[inline]
+    pub(crate) fn contains(self, cpu: Cpu) -> bool {
+        match self {
+            Self::Single(single) => single == cpu,
+            #[cfg(multi_core)]
+            Self::All => true,
+        }
+    }
+
+    /// Returns whether the scheduler runs on every CPU.
+    #[cfg(multi_core)]
+    #[inline]
+    pub(crate) fn is_smp(self) -> bool {
+        matches!(self, Self::All)
+    }
+}
+
 pub(crate) struct SchedulerState {
     /// A list of all allocated tasks
     pub(crate) all_tasks: TaskList<TaskAllocListElement>,
@@ -49,10 +81,16 @@ pub(crate) struct SchedulerState {
     pub(crate) time_driver: Option<TimeDriver>,
 
     pub(crate) per_cpu: [CpuState; Cpu::COUNT],
+
+    /// The CPUs that run the scheduler.
+    ///
+    /// The start functions set this once, together with `time_driver`. Until then it names the
+    /// boot core, because a thread-mode executor can be created before the main task starts the
+    /// scheduler. Use `time_driver.is_some()` to tell the two cases apart.
+    pub(crate) active_cores: ActiveCores,
 }
 
 pub(crate) struct CpuState {
-    pub(crate) initialized: bool,
     idle_context: CpuContext,
 
     /// A pointer to the current task.
@@ -81,7 +119,6 @@ pub(crate) struct CpuState {
 impl CpuState {
     const fn new() -> Self {
         Self {
-            initialized: false,
             idle_context: CpuContext::new(),
             to_delete: TaskList::new(),
             idle: false,
@@ -131,6 +168,8 @@ impl SchedulerState {
             time_driver: None,
 
             per_cpu: [const { CpuState::new() }; Cpu::COUNT],
+
+            active_cores: ActiveCores::Single(Cpu::ProCpu),
         }
     }
 
@@ -154,6 +193,7 @@ impl SchedulerState {
             "The scheduler has already been started"
         );
         self.time_driver = Some(time_driver);
+        self.active_cores = ActiveCores::Single(Cpu::current());
         for cpu in 0..Cpu::COUNT {
             task::set_idle_hook_entry(&mut self.per_cpu[cpu].idle_context, idle_hook);
         }
@@ -171,8 +211,9 @@ impl SchedulerState {
     ) -> TaskPtr {
         if let Some(cpu) = pinned_to {
             assert!(
-                self.per_cpu[cpu as usize].initialized,
-                "Cannot create task on uninitialized CPU"
+                self.active_cores.contains(cpu),
+                "Cannot create a task on {:?}, because the scheduler does not run on it",
+                cpu
             );
         }
 
@@ -194,7 +235,9 @@ impl SchedulerState {
         rtos_trace::trace::task_new(task_ptr.rtos_trace_id());
 
         self.all_tasks.push(task_ptr);
-        let run_scheduler = self.run_queue.mark_task_ready(&self.per_cpu, task_ptr);
+        let run_scheduler =
+            self.run_queue
+                .mark_task_ready(&self.per_cpu, self.active_cores, task_ptr);
         task::trigger_scheduler(run_scheduler);
 
         debug!("Task '{}' created: {:?}", name, task_ptr);
@@ -287,7 +330,8 @@ impl SchedulerState {
         {
             // Current task is still ready, mark it as such.
             debug!("re-queueing current task: {:?}", current_task);
-            self.run_queue.mark_task_ready(&self.per_cpu, current_task);
+            self.run_queue
+                .mark_task_ready(&self.per_cpu, self.active_cores, current_task);
         }
 
         let mut arm_next_timeslice_tick = false;
@@ -306,8 +350,11 @@ impl SchedulerState {
                 // while it might try to restore a partially saved context.
                 #[cfg(multi_core)]
                 let current_ref = unsafe { current.as_ref() };
+                // The other core can only pick up the task we switch away from if it runs the
+                // scheduler, too.
                 #[cfg(multi_core)]
-                if current_ref.pinned_to.is_none()
+                if self.active_cores.is_smp()
+                    && current_ref.pinned_to.is_none()
                     && current_ref.priority
                         >= Self::priority_of_core(&self.per_cpu, 1 - current_cpu)
                 {
@@ -476,7 +523,9 @@ impl SchedulerState {
         let timer_queue = unwrap!(self.time_driver.as_mut());
         timer_queue.timer_queue.remove(task);
 
-        let run_scheduler = self.run_queue.mark_task_ready(&self.per_cpu, task);
+        let run_scheduler = self
+            .run_queue
+            .mark_task_ready(&self.per_cpu, self.active_cores, task);
         task::trigger_scheduler(run_scheduler);
     }
 
@@ -549,9 +598,15 @@ impl SchedulerState {
 
     #[cfg(all(multi_core, sleep_light_sleep))]
     pub(crate) fn cpu_idle(&self, cpu: Cpu) -> bool {
-        let per_cpu = &self.per_cpu[cpu as usize];
-        // A CPU that never started the scheduler has no work to do, so it counts as idle.
-        !per_cpu.initialized || per_cpu.idle
+        if self.active_cores.contains(cpu) {
+            return self.per_cpu[cpu as usize].idle;
+        }
+
+        // The boot core is outside the set only if the scheduler runs on the second core alone. In
+        // that case the boot core runs bare-metal code that must keep running, so it is never idle.
+        // A second core that the scheduler does not run on may be parked, which counts as idle. If
+        // it runs bare-metal code instead, the user must take a `WakeLock`.
+        cpu != Cpu::ProCpu
     }
 }
 

--- a/esp-rtos/src/sleep.rs
+++ b/esp-rtos/src/sleep.rs
@@ -142,7 +142,7 @@ extern "C" fn auto_light_sleep_hook() -> ! {
                 multi_core => {
                     let mut cpu_control = CpuControl::new(unsafe { CPU_CTRL::steal() });
                     for cpu in Cpu::other() {
-                        if scheduler.per_cpu[cpu as usize].initialized {
+                        if scheduler.active_cores.contains(cpu) {
                             unsafe { cpu_control.park_core(cpu) };
                             // FIXME: this is insufficient when we power down the CPU - we will
                             // need to force the other core to be parked in a known place, saving
@@ -180,7 +180,7 @@ extern "C" fn auto_light_sleep_hook() -> ! {
             // the system back to sleep immediately.
             #[cfg(multi_core)]
             for cpu in Cpu::other() {
-                if scheduler.per_cpu[cpu as usize].initialized {
+                if scheduler.active_cores.contains(cpu) {
                     cpu_control.unpark_core(cpu);
                     task::trigger_scheduler(RunSchedulerOn::RunOnCore(cpu));
                 }

--- a/esp-rtos/src/task/mod.rs
+++ b/esp-rtos/src/task/mod.rs
@@ -606,13 +606,6 @@ pub(super) fn allocate_main_task(
     let cpu = Cpu::current();
     let current_cpu = cpu as usize;
 
-    debug_assert!(
-        !scheduler.per_cpu[current_cpu].initialized,
-        "Tried to allocate main task multiple times"
-    );
-
-    scheduler.per_cpu[current_cpu].initialized = true;
-
     // Reset main task properties. The rest should be cleared when the task is deleted.
     scheduler.per_cpu[current_cpu].main_task.priority = Priority::ZERO;
     scheduler.per_cpu[current_cpu].main_task.state = TaskState::Ready;
@@ -657,7 +650,7 @@ pub(super) fn allocate_main_task(
     scheduler.set_current_task(cpu, Some(main_task_ptr));
     scheduler
         .run_queue
-        .mark_task_ready(&scheduler.per_cpu, main_task_ptr);
+        .mark_task_ready(&scheduler.per_cpu, scheduler.active_cores, main_task_ptr);
 }
 
 /// A handle to the current thread.

--- a/esp-rtos/src/timer/mod.rs
+++ b/esp-rtos/src/timer/mod.rs
@@ -10,6 +10,7 @@ use crate::{
     SCHEDULER,
     TICK_RATE,
     TimeBase,
+    run_queue::RunSchedulerOn,
     task::{self, TaskExt, TaskPtr, TaskQueue, TaskState, TaskTimerQueueElement},
 };
 
@@ -258,6 +259,7 @@ extern "C" fn timer_tick_handler() {
         let mut scheduler = global_state.scheduler();
         let scheduler = &mut *scheduler;
 
+        let active_cores = scheduler.active_cores;
         let time_driver = unwrap!(scheduler.time_driver.as_mut());
 
         time_driver.timer.clear_interrupt();
@@ -276,9 +278,10 @@ extern "C" fn timer_tick_handler() {
 
             debug!("Task {:?} is ready", ready_task);
 
-            let run_scheduler = scheduler
-                .run_queue
-                .mark_task_ready(&scheduler.per_cpu, ready_task);
+            let run_scheduler =
+                scheduler
+                    .run_queue
+                    .mark_task_ready(&scheduler.per_cpu, active_cores, ready_task);
             task::trigger_scheduler(run_scheduler);
         });
 
@@ -292,13 +295,14 @@ extern "C" fn timer_tick_handler() {
         #[cfg(feature = "rtos-trace")]
         rtos_trace::trace::marker_end(TraceEvents::ProcessTimerQueue as u32);
 
-        if now >= time_driver.timer_queue.time_slice_target[0] {
-            crate::task::yield_task();
-        }
-
-        #[cfg(multi_core)]
-        if now >= time_driver.timer_queue.time_slice_target[1] {
-            crate::task::schedule_other_core();
+        // This handler can run on any CPU that runs the scheduler, so we must trigger the
+        // scheduler on the CPU whose time slice ran out, not on a fixed one.
+        for cpu in Cpu::all() {
+            if active_cores.contains(cpu)
+                && now >= time_driver.timer_queue.time_slice_target[cpu as usize]
+            {
+                task::trigger_scheduler(RunSchedulerOn::RunOnCore(cpu));
+            }
         }
 
         // Re-arm the timer. This should be relatively cheap, and ensures that the timer will keep

--- a/hil-test/src/bin/radio_basic/esp_rtos.rs
+++ b/hil-test/src/bin/radio_basic/esp_rtos.rs
@@ -866,3 +866,161 @@ mod tests {
         }
     }
 }
+
+/// Tests for the configuration where the scheduler runs on the second core only, and the first core
+/// stays bare-metal.
+///
+/// The test functions run on the first core, so they must not use any esp-rtos API. They observe
+/// the second core through atomics instead.
+#[cfg(multi_core)]
+#[embedded_test::tests(default_timeout = 3)]
+mod second_core_only {
+    use core::ffi::c_void;
+
+    use esp_hal::{
+        clock::CpuClock,
+        interrupt::software::{SoftwareInterrupt, SoftwareInterruptControl},
+        peripherals::CPU_CTRL,
+        system::Cpu,
+        time::Duration,
+        timer::timg::{Timer, TimerGroup},
+    };
+    use esp_radio_rtos_driver as preempt;
+    use esp_rtos::CurrentThreadHandle;
+    use portable_atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    struct Context {
+        cpu_control: CPU_CTRL<'static>,
+        sw_int1: SoftwareInterrupt<'static, 1>,
+        timer: Timer<'static>,
+    }
+
+    #[init]
+    fn init() -> Context {
+        crate::init_heap();
+
+        let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
+        let p = esp_hal::init(config);
+
+        let sw_ints = SoftwareInterruptControl::new(p.SW_INTERRUPT);
+        let timg0 = TimerGroup::new(p.TIMG0);
+
+        Context {
+            cpu_control: p.CPU_CTRL,
+            sw_int1: sw_ints.software_interrupt1,
+            timer: timg0.timer0,
+        }
+    }
+
+    fn start_on_second_core(ctx: Context, func: impl FnOnce() + Send + 'static) {
+        esp_rtos::start_on_second_core_only(
+            ctx.cpu_control,
+            ctx.sw_int1,
+            ctx.timer,
+            #[allow(static_mut_refs)]
+            unsafe {
+                &mut crate::APP_CORE_STACK
+            },
+            func,
+        );
+    }
+
+    fn spawn(name: &str, task: extern "C" fn(*mut c_void), priority: u32) {
+        unsafe { preempt::task_create(name, task, core::ptr::null_mut(), priority, None, 4096) };
+    }
+
+    #[test]
+    fn task_runs_on_the_second_core(ctx: Context) {
+        static FINISHED: AtomicBool = AtomicBool::new(false);
+        static RAN_ON_SECOND_CORE: AtomicBool = AtomicBool::new(false);
+
+        extern "C" fn task(_: *mut c_void) {
+            RAN_ON_SECOND_CORE.store(Cpu::current() == Cpu::AppCpu, Ordering::SeqCst);
+            FINISHED.store(true, Ordering::SeqCst);
+        }
+
+        start_on_second_core(ctx, || spawn("task", task, 1));
+
+        while !FINISHED.load(Ordering::SeqCst) {}
+
+        hil_test::assert!(RAN_ON_SECOND_CORE.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn time_slicing_on_the_second_core(ctx: Context) {
+        // Two tasks of the same priority must both make progress. Each task counts up until the
+        // counter jumps, which means the other task ran in between.
+        static FINISHED: AtomicUsize = AtomicUsize::new(0);
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+        extern "C" fn task(_: *mut c_void) {
+            let mut expected_value = None;
+
+            loop {
+                let was = COUNTER.fetch_add(1, Ordering::SeqCst);
+
+                if let Some(expected) = expected_value {
+                    // Not the first iteration. Check that the counter matches the expected value.
+                    if was == expected {
+                        expected_value = Some(was + 1);
+                    } else {
+                        break;
+                    }
+                } else {
+                    // First iteration, just grab the initial value.
+                    expected_value = Some(was + 1);
+                }
+            }
+
+            FINISHED.fetch_add(1, Ordering::SeqCst);
+        }
+
+        start_on_second_core(ctx, || {
+            // The tasks run at the priority of the main thread, so that the main thread can create
+            // the second task.
+            spawn("task1", task, 0);
+            spawn("task2", task, 0);
+        });
+
+        while FINISHED.load(Ordering::SeqCst) < 2 {}
+    }
+
+    #[test]
+    fn the_first_core_keeps_running(ctx: Context) {
+        static FIRST_CORE_COUNTER: AtomicUsize = AtomicUsize::new(0);
+        static FIRST_CORE_ADVANCED: AtomicBool = AtomicBool::new(false);
+        static FINISHED: AtomicBool = AtomicBool::new(false);
+
+        extern "C" fn observer(_: *mut c_void) {
+            let before = FIRST_CORE_COUNTER.load(Ordering::Relaxed);
+
+            // Sleeping proves that the scheduler of the second core works while the first core runs
+            // its own code.
+            CurrentThreadHandle::get().delay(Duration::from_millis(50));
+
+            let after = FIRST_CORE_COUNTER.load(Ordering::Relaxed);
+            FIRST_CORE_ADVANCED.store(after > before, Ordering::SeqCst);
+            FINISHED.store(true, Ordering::SeqCst);
+        }
+
+        start_on_second_core(ctx, || spawn("observer", observer, 1));
+
+        while !FINISHED.load(Ordering::SeqCst) {
+            FIRST_CORE_COUNTER.fetch_add(1, Ordering::Relaxed);
+        }
+
+        hil_test::assert!(FIRST_CORE_ADVANCED.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    #[should_panic]
+    fn thread_mode_executor_on_the_first_core_panics(ctx: Context) {
+        use esp_rtos::embassy::Executor;
+        use static_cell::StaticCell;
+
+        start_on_second_core(ctx, || {});
+
+        static EXECUTOR: StaticCell<Executor> = StaticCell::new();
+        EXECUTOR.init(Executor::new()).run(|_| {});
+    }
+}


### PR DESCRIPTION
Closes #6035

# Changelog

## esp-rtos

- Added: `start_on_second_core_only` on multi-core chips, for applications where it is simler to keep the first core bare metal.