### PR TITLE
esp-bootloader-esp-idf: fix erase bounds

### DIFF
--- a/esp-bootloader-esp-idf/src/partitions.rs
+++ b/esp-bootloader-esp-idf/src/partitions.rs
@@ -682,11 +682,14 @@ impl<'a, 'd> FlashRegion<'a, 'd> {
             return Err(Error::WriteProtected);
         }
 
-        if !self.range().contains(&address_from) {
+        let range = self.range();
+
+        if !range.contains(&address_from) {
             return Err(Error::OutOfBounds);
         }
 
-        if !self.range().contains(&address_to) {
+        // `to` is exclusive, so it may point one past the end of the partition.
+        if address_to > range.end || address_to < address_from {
             return Err(Error::OutOfBounds);
         }
 
@@ -1121,6 +1124,55 @@ mod storage_tests {
         let mut buffer = [0u8; 24577];
         assert!(nvs_partition.read(0, &mut buffer) == Err(Error::OutOfBounds));
     }
+
+    #[test]
+    fn can_erase_up_to_partition_end() {
+        let mut storage = test_flash();
+
+        let mut buffer = [0u8; PARTITION_TABLE_MAX_LEN];
+        let pt = read_partition_table(&mut storage, &mut buffer).unwrap();
+
+        let nvs = pt
+            .find_partition(PartitionType::Data(DataPartitionSubType::Nvs))
+            .unwrap()
+            .unwrap();
+        let mut nvs_partition = nvs.as_flash_region(&mut storage);
+
+        let capacity = nvs_partition.capacity() as u32;
+        assert_eq!(capacity, 24576);
+
+        nvs_partition.write(0, &[42u8; 24576]).unwrap();
+
+        nvs_partition.erase(capacity - 4096, capacity).unwrap();
+        let mut buffer = [0u8; 4096];
+        nvs_partition.read(capacity - 4096, &mut buffer).unwrap();
+        assert!(buffer.iter().all(|v| *v == 0xff));
+
+        nvs_partition.erase(0, capacity).unwrap();
+        let mut buffer = [0u8; 24576];
+        nvs_partition.read(0, &mut buffer).unwrap();
+        assert!(buffer.iter().all(|v| *v == 0xff));
+    }
+
+    #[test]
+    fn cannot_erase_out_of_bounds() {
+        let mut storage = test_flash();
+
+        let mut buffer = [0u8; PARTITION_TABLE_MAX_LEN];
+        let pt = read_partition_table(&mut storage, &mut buffer).unwrap();
+
+        let nvs = pt
+            .find_partition(PartitionType::Data(DataPartitionSubType::Nvs))
+            .unwrap()
+            .unwrap();
+        let mut nvs_partition = nvs.as_flash_region(&mut storage);
+
+        let capacity = nvs_partition.capacity() as u32;
+
+        assert!(nvs_partition.erase(0, capacity + 4096) == Err(Error::OutOfBounds));
+        assert!(nvs_partition.erase(capacity, capacity + 4096) == Err(Error::OutOfBounds));
+        assert!(nvs_partition.erase(4096, 0) == Err(Error::OutOfBounds));
+    }
 }
 
 #[cfg(all(test, feature = "embedded-storage"))]
@@ -1182,5 +1234,29 @@ mod nor_flash_tests {
             <EncryptedNorFlashRegion<'static, 'static, 'static> as ReadNorFlash>::READ_SIZE,
             <FlashStorage<'static> as FlashAccess>::READ_SIZE
         );
+    }
+
+    #[test]
+    fn nor_flash_erase_bounds() {
+        let mut storage = test_flash();
+
+        let mut buffer = [0u8; PARTITION_TABLE_MAX_LEN];
+        let pt = read_partition_table(&mut storage, &mut buffer).unwrap();
+
+        let nvs = pt
+            .find_partition(PartitionType::Data(DataPartitionSubType::Nvs))
+            .unwrap()
+            .unwrap();
+        let mut nvs_partition = nvs.as_flash_region(&mut storage);
+        let capacity = nvs_partition.capacity() as u32;
+        let mut nor_flash = nvs_partition.as_nor_flash().unwrap();
+
+        nor_flash.erase(0, capacity).unwrap();
+        let mut buffer = [0u8; 4096];
+        nor_flash.read(capacity - 4096, &mut buffer).unwrap();
+        assert!(buffer.iter().all(|v| *v == 0xff));
+
+        assert!(nor_flash.erase(0, capacity + 4096) == Err(Error::OutOfBounds));
+        assert!(nor_flash.erase(4096, 0) == Err(Error::OutOfBounds));
     }
 }

--- a/esp-bootloader-esp-idf/src/partitions.rs
+++ b/esp-bootloader-esp-idf/src/partitions.rs
@@ -682,14 +682,11 @@ impl<'a, 'd> FlashRegion<'a, 'd> {
             return Err(Error::WriteProtected);
         }
 
-        let range = self.range();
-
-        if !range.contains(&address_from) {
+        if from > to {
             return Err(Error::OutOfBounds);
         }
 
-        // `to` is exclusive, so it may point one past the end of the partition.
-        if address_to > range.end || address_to < address_from {
+        if !self.in_range(address_from, (address_to - address_from) as usize) {
             return Err(Error::OutOfBounds);
         }
 

--- a/esp-storage/src/nor_flash.rs
+++ b/esp-storage/src/nor_flash.rs
@@ -202,8 +202,12 @@ impl FlashStorage<'_> {
     /// not aligned to [`Self::ERASE_SIZE`].
     ///
     /// Returns [`FlashStorageError::OutOfBounds`] if the range would extend past
-    /// the end of the flash.
+    /// the end of the flash, or if `to` is less than `from`.
     pub fn erase(&mut self, from: u32, to: u32) -> Result<(), FlashStorageError> {
+        if to < from {
+            return Err(FlashStorageError::OutOfBounds);
+        }
+
         let len = (to - from) as _;
         const SZ: u32 = FlashStorage::SECTOR_SIZE;
         self.check_alignment::<{ SZ }>(from, len)?;
@@ -476,6 +480,68 @@ mod tests {
         flash.read_nor(0, &mut read_data.data[..128]).unwrap();
 
         assert_eq!(&read_data.data[..128], &write_data.data[1..129]);
+    }
+
+    #[test]
+    fn erase_up_to_end_of_flash() {
+        let mut flash = FlashStorage::new(Flash::new());
+        flash.capacity = FLASH_SIZE as usize;
+        let mut read_data = TestBuffer::default();
+        let write_data = [0u8; SECTOR_SIZE as usize];
+
+        flash.erase(FLASH_SIZE - BLOCK_SIZE, FLASH_SIZE).unwrap();
+        flash
+            .write_nor(FLASH_SIZE - 2 * SECTOR_SIZE, &write_data)
+            .unwrap();
+        flash
+            .write_nor(FLASH_SIZE - SECTOR_SIZE, &write_data)
+            .unwrap();
+
+        // Erasing the last sector of the flash must be allowed
+        flash.erase(FLASH_SIZE - SECTOR_SIZE, FLASH_SIZE).unwrap();
+
+        flash
+            .read(
+                FLASH_SIZE - 2 * SECTOR_SIZE,
+                &mut read_data.data[..(2 * SECTOR_SIZE) as usize],
+            )
+            .unwrap();
+        assert!(
+            read_data.data[..SECTOR_SIZE as usize]
+                .iter()
+                .all(|v| *v == 0x0)
+        );
+        assert!(
+            read_data.data[SECTOR_SIZE as usize..(2 * SECTOR_SIZE) as usize]
+                .iter()
+                .all(|v| *v == 0xFF)
+        );
+
+        // Erasing the last block of the flash must be allowed
+        flash.erase(FLASH_SIZE - BLOCK_SIZE, FLASH_SIZE).unwrap();
+
+        flash
+            .read(
+                FLASH_SIZE - 2 * SECTOR_SIZE,
+                &mut read_data.data[..(2 * SECTOR_SIZE) as usize],
+            )
+            .unwrap();
+        assert!(
+            read_data.data[..(2 * SECTOR_SIZE) as usize]
+                .iter()
+                .all(|v| *v == 0xFF)
+        );
+    }
+
+    #[test]
+    fn erase_reversed_range_is_rejected() {
+        let mut flash = FlashStorage::new(Flash::new());
+        flash.capacity = FLASH_SIZE as usize;
+
+        assert_eq!(
+            flash.erase(SECTOR_SIZE, 0),
+            Err(FlashStorageError::OutOfBounds)
+        );
     }
 
     #[test]

--- a/qa-test/Cargo.toml
+++ b/qa-test/Cargo.toml
@@ -74,6 +74,7 @@ esp32c2 = [
     "esp-rtos/esp32c2",
     "esp-println/esp32c2",
     "esp-radio?/esp32c2",
+    "esp-storage?/esp32c2",
 ]
 esp32c3 = [
     "esp-backtrace/esp32c3",
@@ -82,6 +83,7 @@ esp32c3 = [
     "esp-rtos/esp32c3",
     "esp-println/esp32c3",
     "esp-radio?/esp32c3",
+    "esp-storage?/esp32c3",
 ]
 esp32c5 = [
     "esp-backtrace/esp32c5",
@@ -90,6 +92,7 @@ esp32c5 = [
     "esp-rtos/esp32c5",
     "esp-println/esp32c5",
     "esp-radio?/esp32c5",
+    "esp-storage?/esp32c5",
 ]
 esp32c6 = [
     "esp-backtrace/esp32c6",
@@ -98,6 +101,7 @@ esp32c6 = [
     "esp-rtos/esp32c6",
     "esp-println/esp32c6",
     "esp-radio?/esp32c6",
+    "esp-storage?/esp32c6",
 ]
 esp32c61 = [
     "esp-backtrace/esp32c61",
@@ -106,6 +110,7 @@ esp32c61 = [
     "esp-rtos/esp32c61",
     "esp-println/esp32c61",
     "esp-radio?/esp32c61",
+    "esp-storage?/esp32c61",
 ]
 esp32h2 = [
     "esp-backtrace/esp32h2",
@@ -114,6 +119,7 @@ esp32h2 = [
     "esp-rtos/esp32h2",
     "esp-println/esp32h2",
     "esp-radio?/esp32h2",
+    "esp-storage?/esp32h2",
 ]
 esp32p4 = [
     "esp-backtrace/esp32p4",
@@ -130,6 +136,7 @@ esp32s2 = [
     "esp-rtos/esp32s2",
     "esp-println/esp32s2",
     "esp-radio?/esp32s2",
+    "esp-storage?/esp32s2",
 ]
 esp32s3 = [
     "esp-backtrace/esp32s3",

--- a/qa-test/src/bin/nvs_partition_erase.rs
+++ b/qa-test/src/bin/nvs_partition_erase.rs
@@ -1,0 +1,106 @@
+//! Regression test for https://github.com/esp-rs/esp-hal/issues/4094
+//!
+//! `FlashRegion::erase` takes an exclusive end address, so erasing up to the
+//! end of the partition (e.g. the last sector, or the whole partition) must
+//! not fail with `Error::OutOfBounds`.
+//!
+//! Assumes the device is flashed with a partition table containing an NVS
+//! partition (which is the case for the default partition table).
+//!
+//! Also exercises `esp_storage::FlashStorage::erase` on the last sector of the
+//! whole flash - an area nothing occupies with the default partition table.
+//!
+//! NOTE: This test erases the NVS partition and the last sector of the flash!
+
+//% FEATURES: esp-storage
+
+#![no_std]
+#![no_main]
+
+use esp_backtrace as _;
+use esp_bootloader_esp_idf::partitions::{
+    DataPartitionSubType,
+    Error,
+    PARTITION_TABLE_MAX_LEN,
+    PartitionType,
+    read_partition_table,
+};
+use esp_hal::main;
+use esp_println::println;
+use esp_storage::FlashStorageError;
+
+esp_bootloader_esp_idf::esp_app_desc!();
+
+const SECTOR_SIZE: u32 = 4096;
+
+#[main]
+fn main() -> ! {
+    esp_println::logger::init_logger_from_env();
+    let peripherals = esp_hal::init(esp_hal::Config::default());
+
+    let mut flash = esp_storage::FlashStorage::new(peripherals.FLASH);
+
+    let mut buffer = [0u8; PARTITION_TABLE_MAX_LEN];
+    let pt = read_partition_table(&mut flash, &mut buffer).unwrap();
+
+    let nvs = pt
+        .find_partition(PartitionType::Data(DataPartitionSubType::Nvs))
+        .unwrap()
+        .expect("No NVS partition found");
+
+    let mut region = nvs.as_flash_region(&mut flash);
+    let len = region.partition_size() as u32;
+    println!("NVS partition: {} bytes", len);
+    assert!(len >= 2 * SECTOR_SIZE);
+
+    let mut sector = [0u8; SECTOR_SIZE as usize];
+
+    // Erasing the whole partition must succeed (#4094)
+    region.erase(0, len).unwrap();
+    region.read(0, &mut sector).unwrap();
+    assert!(sector.iter().all(|&b| b == 0xff));
+    region.read(len - SECTOR_SIZE, &mut sector).unwrap();
+    assert!(sector.iter().all(|&b| b == 0xff));
+
+    // Erasing only the last sector must succeed and leave the rest untouched
+    region
+        .write(len - 2 * SECTOR_SIZE, &[0x5a; SECTOR_SIZE as usize])
+        .unwrap();
+    region
+        .write(len - SECTOR_SIZE, &[0x5a; SECTOR_SIZE as usize])
+        .unwrap();
+
+    region.erase(len - SECTOR_SIZE, len).unwrap();
+
+    region.read(len - 2 * SECTOR_SIZE, &mut sector).unwrap();
+    assert!(sector.iter().all(|&b| b == 0x5a));
+    region.read(len - SECTOR_SIZE, &mut sector).unwrap();
+    assert!(sector.iter().all(|&b| b == 0xff));
+
+    // Out-of-bounds and reversed ranges must still be rejected
+    assert_eq!(region.erase(0, len + SECTOR_SIZE), Err(Error::OutOfBounds));
+    assert_eq!(
+        region.erase(len, len + SECTOR_SIZE),
+        Err(Error::OutOfBounds)
+    );
+    assert_eq!(region.erase(SECTOR_SIZE, 0), Err(Error::OutOfBounds));
+
+    // The same boundary conditions apply to `FlashStorage` itself: erasing the
+    // last sector of the flash must succeed
+    let capacity = flash.capacity() as u32;
+    flash
+        .write(capacity - SECTOR_SIZE, &[0xa5; SECTOR_SIZE as usize])
+        .unwrap();
+    flash.erase(capacity - SECTOR_SIZE, capacity).unwrap();
+    flash.read(capacity - SECTOR_SIZE, &mut sector).unwrap();
+    assert!(sector.iter().all(|&b| b == 0xff));
+
+    assert_eq!(
+        flash.erase(SECTOR_SIZE, 0),
+        Err(FlashStorageError::OutOfBounds)
+    );
+
+    println!("Test passed");
+
+    loop {}
+}


### PR DESCRIPTION
Closes #4094
Supersedes #5580
Supersedes #4055


# Changelog

## esp-bootloader-esp-idf
- Fixed: `FlashRegion::erase` no longer fails when erasing up to the end of the partition (e.g. the last sector or the whole partition)

## esp-storage
- Fixed: `FlashStorage::erase` rejects reversed ranges (`to < from`)


