### PR TITLE
fix(spi): take register block pointer via ptr() instead of regs()

### DIFF
--- a/esp-hal/src/peripherals/mod.rs
+++ b/esp-hal/src/peripherals/mod.rs
@@ -158,7 +158,7 @@ macro_rules! create_peripheral {
             #[doc = r"Return a reference to the register block"]
             #[inline(always)]
             #[instability::unstable]
-            pub const fn regs<'a>() -> &'a <pac::$base as core::ops::Deref>::Target {
+            pub fn regs<'a>() -> &'a <pac::$base as core::ops::Deref>::Target {
                 unsafe { &*Self::PTR }
             }
 

--- a/esp-hal/src/spi/master/mod.rs
+++ b/esp-hal/src/spi/master/mod.rs
@@ -2466,7 +2466,7 @@ for_each_spi_master! {
                 }
 
                 static INFO: Info = Info {
-                    register_block: crate::peripherals::$peri::regs(),
+                    register_block: crate::peripherals::$peri::ptr(),
                     peripheral: crate::system::Peripheral::$sys,
                     async_handler: irq_handler,
                     sclk: OutputSignal::$sclk,

--- a/esp-hal/src/spi/slave.rs
+++ b/esp-hal/src/spi/slave.rs
@@ -814,7 +814,7 @@ for_each_spi_slave! {
             #[inline(always)]
             fn info(&self) -> &'static Info {
                 static INFO: Info = Info {
-                    register_block: crate::peripherals::$peri::regs(),
+                    register_block: crate::peripherals::$peri::ptr(),
                     peripheral: crate::system::Peripheral::$sys,
                     sclk: InputSignal::$sclk,
                     mosi: InputSignal::$mosi,


### PR DESCRIPTION
Manual backport of #6022 to esp-hal-1.1.x.

rust-lang/rust#160012 made const evaluation check that a reference is dereferenceable at the point it is created. An MMIO address has no provenance, so initialising `Info` in a `static` through `regs()` no longer compiles:

    error[E0080]: reference not dereferenceable: reference must be
    dereferenceable for 244 bytes, but got 0x60024000[noalloc] which is
    a dangling pointer (it has no provenance)

Take the raw pointer via `ptr()` instead, and drop `const` from `regs()` so it cannot be called from const context again.

The upstream PR also carries a `cargo fmt` commit that reflows around 79 unrelated files with a newer rustfmt. That commit is deliberately omitted here.
