### PR TITLE
Release esp-hal: 1.1.1 → 1.1.2

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 
+## [v1.1.2] - 2026-08-05
+
 ## [v1.1.1] - 2026-05-07
 
 ### Fixed
@@ -1637,4 +1639,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v1.1.0-rc.0]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.0.0...esp-hal-v1.1.0-rc.0
 [v1.1.0]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.1.0-rc.0...esp-hal-v1.1.0
 [v1.1.1]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.1.0...esp-hal-v1.1.1
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.1.1...HEAD
+[v1.1.2]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.1.1...esp-hal-v1.1.2
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.1.2...HEAD

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -21,6 +21,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v1.1.2] - 2026-08-05
 
+### Fixed
+
+- timer: `OneShotTimer::into_blocking()` now returns `OneShotTimer<'d, Blocking>` (#5689)
+- SHA: ESP32 implementation no longer powers down the SHA accelerator while in use (#5607)
+- SHA: ESP32 no longer tries to use the hardware accelerator when it's held by another SHA operation. (#5607)
+- RSA: ESP32 now correctly disables its interrupts before disabling the RSA accelerator (#5607)
+- Add missing import when building SPI with `ESP_HAL_CONFIG_PLACE_SPI_MASTER_DRIVER_IN_RAM = "true"` (#5588)
+- SPI: the register block pointer is now taken via `ptr()`, fixing a const-evaluation build failure on recent nightly compilers (#6051)
+
 ## [v1.1.1] - 2026-05-07
 
 ### Fixed

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-hal"
-version       = "1.1.1"
+version       = "1.1.2"
 edition       = "2024"
 rust-version  = "1.88.0"
 description   = "Bare-metal HAL for Espressif devices"


### PR DESCRIPTION
⚠️ This pull request was branched off from `esp-hal-1.1.x`. ⚠️

This pull request prepares the following packages for release:

- esp-hal: 1.1.1 → 1.1.2

<details>

<summary>Release plan (click to expand)</summary>

```jsonc
{
  "base": "esp-hal-1.1.x",
  "slug": "ilrmoa",
  "backport": {
    "package": "esp-hal",
    "major": 1,
    "minor": 1
  },
  "packages": [
    {
      "package": "esp-hal",
      "semver_checked": true,
      "current_version": "1.1.1",
      "new_version": "1.1.2",
      "tag_name": "esp-hal-v1.1.2",
      "bump": {
        "base": "Patch",
        "pre": null
      }
    }
  ]
}
```

</details>

Please review the changes and merge them into the `esp-hal-1.1.x` branch.

After merging, please make sure you have this release plan in the repo root,
then run the following command on the `esp-hal-1.1.x` branch to tag and publish the packages:

```
cargo xrelease publish-plan --no-dry-run
```
