### PR TITLE
TWAI debugging implementation

### DIFF
--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -648,13 +648,13 @@ impl defmt::Format for EspTwaiFrame {
     fn format(&self, f: defmt::Formatter<'_>) {
         defmt::write!(
             f,
-            "EspTwaiFrame {{ id: {1=u32}, EFF: {0=7..8}, RTR: {0=6..7}, SR: {0=4..5}, DLC: {0=0..4}, DATA: {2=[u8]} }}",
+            "EspTwaiFrame {{ id: {1=u32}, EFF: {0=7..8}, RTR: {0=6..7}, SR: {0=4..5}, DLC: {0=0..4}, data: {2=[u8]:#x} }}",
             self.info(),
             match self.identifier() {
                 Id::Standard(id) => id.as_raw() as u32,
                 Id::Extended(id) => id.as_raw(),
             },
-            self.data()
+            self.data(),
         );
     }
 }

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -648,9 +648,9 @@ impl defmt::Format for EspTwaiFrame {
     fn format(&self, f: defmt::Formatter<'_>) {
         defmt::write!(
             f,
-            "EspTwaiFrame {{ EFF: {0=7..8}, RTR: {0=6..7}, SR: {0=4..5}, DLC: {0=0..4}, ID: {1=u32} DATA: {2=[u8]} }}",
+            "EspTwaiFrame {{ id: {1=u32}, EFF: {0=7..8}, RTR: {0=6..7}, SR: {0=4..5}, DLC: {0=0..4}, DATA: {2=[u8]} }}",
             self.info(),
-            match self.identifier().into() {
+            match self.identifier() {
                 Id::Standard(id) => id.as_raw() as u32,
                 Id::Extended(id) => id.as_raw(),
             },

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -648,7 +648,7 @@ impl defmt::Format for EspTwaiFrame {
     fn format(&self, f: defmt::Formatter<'_>) {
         defmt::write!(
             f,
-            "EspTwaiFrame {{ EFF: {0=7..8}, RTR: {0=6..7}, SR: {0=4..5}, DLC: {0=1..4}, ID: {1=u32} DATA: {2=[u8]} }}",
+            "EspTwaiFrame {{ EFF: {0=7..8}, RTR: {0=6..7}, SR: {0=4..5}, DLC: {0=0..4}, ID: {1=u32} DATA: {2=[u8]} }}",
             self.info(),
             match self.identifier().into() {
                 Id::Standard(id) => id.as_raw() as u32,

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -648,13 +648,14 @@ impl defmt::Format for EspTwaiFrame {
     fn format(&self, f: defmt::Formatter<'_>) {
         defmt::write!(
             f,
-            "EspTwaiFrame {{ id: {1=u32}, EFF: {0=7..8}, RTR: {0=6..7}, SR: {0=4..5}, DLC: {0=0..4}, data: {2=[u8]:#x} }}",
+            "EspTwaiFrame {{ id: {1=u32}, EFF: {0=7..8}, RTR: {0=6..7}, SR: {0=4..5}, DLC: {0=0..4}, data: {2=[u8]:#x}, raw: {3=[u8]:#x} }}",
             self.info(),
             match self.identifier() {
                 Id::Standard(id) => id.as_raw() as u32,
                 Id::Extended(id) => id.as_raw(),
             },
             self.data(),
+            self.as_slice(),
         );
     }
 }

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -440,7 +440,7 @@ impl embedded_can::Frame for EspTwaiFrame {
 /// A RAM buffer for a TWAI frame.
 ///
 /// Mirror image of the 13 TWAI_DATA_x_REG registers.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy)]
 pub struct EspTwaiFrame {
     bytes: [u8; 13],
 }
@@ -657,6 +657,26 @@ impl defmt::Format for EspTwaiFrame {
             self.data(),
             self.as_slice(),
         );
+    }
+}
+
+impl core::fmt::Debug for EspTwaiFrame {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("EspTwaiFrame")
+            .field(
+                "id",
+                &match self.identifier() {
+                    Id::Standard(id) => id.as_raw() as u32,
+                    Id::Extended(id) => id.as_raw(),
+                },
+            )
+            .field("EFF", &(self.is_extended_format() as u8))
+            .field("RTR", &(self.is_remote_request() as u8))
+            .field("SR", &(self.is_self_reception() as u8))
+            .field("DLC", &self.data_length_code())
+            .field("data", &format_args!("{:02x?}", self.data()))
+            .field("raw", &format_args!("{:02x?}", self.as_slice()))
+            .finish()
     }
 }
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` or `manual-changelog` label as appropriate.
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
This PR continues implementing debugging facilities for `EspTwaiFrame`, as discussed.

It changes the `defmt::Format` implementation as follows:
- It fixes a bug in the `defmt::Format` implementation (DLC field was incorrect).
- It changes the "field order" for improved clarity
- It displays [u8] slices in hexadecimal
- It adds a "raw" field, displaying the full binary content of the frame

It also adds a `core::fmt::Debug` implementation (aiming for an identical format as defmt's).

#### Testing
Debugging tested on a live CAN bus (defmt only, as my project depends on it).
HIL tests ok.

---

# Changelog

## esp-hal

- No changelog necessary.
