### PR TITLE
Use the probe-rs server to run tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   MSRV: "1.95.0"
   DEFMT_LOG: trace
+  PROBE_RS_CONFIG_PRESET: local-hil
 
 # Cancel any currently running workflows from the same PR, branch, or
 # tag when a new workflow is triggered.

--- a/.github/workflows/hil.yml
+++ b/.github/workflows/hil.yml
@@ -69,6 +69,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  PROBE_RS_CONFIG_PRESET: local-hil
 
 jobs:
   build:


### PR DESCRIPTION
This PR configures probe-rs to connect to the local server. The goal is to apply a 10 minute probe access timeout, to prevent immediate failure in case we are using the DUT while a HIL test is starting.