### PR TITLE
Add DMA-compatible allocators

### DIFF
--- a/esp-alloc/Cargo.toml
+++ b/esp-alloc/Cargo.toml
@@ -44,7 +44,8 @@ linked_list_allocator = { version = "0.10.5", default-features = false, features
 rlsf = { version = "0.2", features = ["unstable"] }
 
 [build-dependencies]
-esp-config   = { version = "0.7.0", path = "../esp-config", features = ["build"] }
+esp-config             = { version = "0.7.0", path = "../esp-config", features = ["build"] }
+esp-metadata-generated = { version = "0.4.0", path = "../esp-metadata-generated", features = ["build-script"] }
 
 [features]
 default = ["compat", "global-allocator"]
@@ -109,24 +110,24 @@ alloc-hooks = []
 #! One of the following features must be enabled to select the target chip:
 
 ##
-esp32c2   = ["esp-sync/esp32c2"]
+esp32c2  = ["esp-sync/esp32c2", "esp-metadata-generated/esp32c2"]
 ##
-esp32c3   = ["esp-sync/esp32c3"]
+esp32c3  = ["esp-sync/esp32c3", "esp-metadata-generated/esp32c3"]
 ##
-esp32c5   = ["esp-sync/esp32c5"]
+esp32c5  = ["esp-sync/esp32c5", "esp-metadata-generated/esp32c5"]
 ##
-esp32c6   = ["esp-sync/esp32c6"]
+esp32c6  = ["esp-sync/esp32c6", "esp-metadata-generated/esp32c6"]
 ##
-esp32c61  = ["esp-sync/esp32c61"]
+esp32c61 = ["esp-sync/esp32c61", "esp-metadata-generated/esp32c61"]
 ##
-esp32h2   = ["esp-sync/esp32h2"]
+esp32h2  = ["esp-sync/esp32h2", "esp-metadata-generated/esp32h2"]
 ##
-esp32p4     = ["esp-sync/esp32p4"]
+esp32p4  = ["esp-sync/esp32p4", "esp-metadata-generated/esp32p4"]
 ##
-esp32s31    = ["esp-sync/esp32s31"]
+esp32s31 = ["esp-sync/esp32s31", "esp-metadata-generated/esp32s31"]
 ##
-esp32     = ["esp-sync/esp32"]
+esp32    = ["esp-sync/esp32", "esp-metadata-generated/esp32"]
 ##
-esp32s2   = ["esp-sync/esp32s2"]
+esp32s2  = ["esp-sync/esp32s2", "esp-metadata-generated/esp32s2"]
 ##
-esp32s3   = ["esp-sync/esp32s3"]
+esp32s3  = ["esp-sync/esp32s3", "esp-metadata-generated/esp32s3"]

--- a/esp-alloc/Cargo.toml
+++ b/esp-alloc/Cargo.toml
@@ -27,7 +27,7 @@ clippy-configs = [
 
 [package.metadata.docs.rs]
 default-target = "riscv32imc-unknown-none-elf"
-features       = ["nightly"]
+features       = ["esp32c6", "nightly"]
 
 [lib]
 bench = false
@@ -44,7 +44,8 @@ linked_list_allocator = { version = "0.10.5", default-features = false, features
 rlsf = { version = "0.2", features = ["unstable"] }
 
 [build-dependencies]
-esp-config   = { version = "0.7.0", path = "../esp-config", features = ["build"] }
+esp-config             = { version = "0.7.0", path = "../esp-config", features = ["build"] }
+esp-metadata-generated = { version = "0.4.0", path = "../esp-metadata-generated", features = ["build-script"] }
 
 [features]
 default = ["compat", "global-allocator"]
@@ -109,24 +110,24 @@ alloc-hooks = []
 #! One of the following features must be enabled to select the target chip:
 
 ##
-esp32c2   = ["esp-sync/esp32c2"]
+esp32c2  = ["esp-sync/esp32c2", "esp-metadata-generated/esp32c2"]
 ##
-esp32c3   = ["esp-sync/esp32c3"]
+esp32c3  = ["esp-sync/esp32c3", "esp-metadata-generated/esp32c3"]
 ##
-esp32c5   = ["esp-sync/esp32c5"]
+esp32c5  = ["esp-sync/esp32c5", "esp-metadata-generated/esp32c5"]
 ##
-esp32c6   = ["esp-sync/esp32c6"]
+esp32c6  = ["esp-sync/esp32c6", "esp-metadata-generated/esp32c6"]
 ##
-esp32c61  = ["esp-sync/esp32c61"]
+esp32c61 = ["esp-sync/esp32c61", "esp-metadata-generated/esp32c61"]
 ##
-esp32h2   = ["esp-sync/esp32h2"]
+esp32h2  = ["esp-sync/esp32h2", "esp-metadata-generated/esp32h2"]
 ##
-esp32p4     = ["esp-sync/esp32p4"]
+esp32p4  = ["esp-sync/esp32p4", "esp-metadata-generated/esp32p4"]
 ##
-esp32s31    = ["esp-sync/esp32s31"]
+esp32s31 = ["esp-sync/esp32s31", "esp-metadata-generated/esp32s31"]
 ##
-esp32     = ["esp-sync/esp32"]
+esp32    = ["esp-sync/esp32", "esp-metadata-generated/esp32"]
 ##
-esp32s2   = ["esp-sync/esp32s2"]
+esp32s2  = ["esp-sync/esp32s2", "esp-metadata-generated/esp32s2"]
 ##
-esp32s3   = ["esp-sync/esp32s3"]
+esp32s3  = ["esp-sync/esp32s3", "esp-metadata-generated/esp32s3"]

--- a/esp-alloc/build.rs
+++ b/esp-alloc/build.rs
@@ -1,9 +1,19 @@
+use std::error::Error;
+
 use esp_config::generate_config_from_yaml_definition;
 
-fn main() {
+fn main() -> Result<(), Box<dyn Error>> {
+    // Ensure that exactly one chip has been specified:
+    let chip = esp_metadata_generated::Chip::from_cargo_feature()?;
+
+    // Define all necessary configuration symbols for the configured device:
+    chip.define_cfgs();
+
     // emit config
     println!("cargo:rerun-if-changed=./esp_config.yml");
     let cfg_yaml = std::fs::read_to_string("./esp_config.yml")
         .expect("Failed to read esp_config.yml for esp-alloc");
     generate_config_from_yaml_definition(&cfg_yaml, true, true, None).unwrap();
+
+    Ok(())
 }

--- a/esp-alloc/src/allocators.rs
+++ b/esp-alloc/src/allocators.rs
@@ -133,3 +133,109 @@ unsafe impl CoreAllocator for ExternalMemory {
         }
     }
 }
+
+/// A DMA-compatible allocator that uses internal memory only.
+///
+/// This allocator adjusts the allocation alignment and size to be safe for use with DMA.
+pub struct DmaCompatibleInternalMemory;
+
+fn align(layout: Layout, min_alignment: usize) -> Layout {
+    let alignment = layout.align().max(min_alignment);
+    Layout::from_size_align(layout.size().next_multiple_of(alignment), alignment).unwrap()
+}
+
+impl DmaCompatibleInternalMemory {
+    fn align(layout: Layout) -> Layout {
+        align(
+            layout,
+            cfg_select! {
+                soc_internal_memory_cached => 64,
+                _ => 4,
+            },
+        )
+    }
+}
+
+unsafe impl Allocator for DmaCompatibleInternalMemory {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        allocate_caps(
+            EnumSet::from(MemoryCapability::Internal),
+            Self::align(layout),
+        )
+    }
+
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        unsafe {
+            crate::HEAP.dealloc(ptr.as_ptr(), Self::align(layout));
+        }
+    }
+}
+
+#[cfg(feature = "nightly")]
+unsafe impl CoreAllocator for DmaCompatibleInternalMemory {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, CoreAllocError> {
+        allocate_caps(
+            EnumSet::from(MemoryCapability::Internal),
+            Self::align(layout),
+        )
+        .map_err(|_| CoreAllocError)
+    }
+
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        unsafe {
+            crate::HEAP.dealloc(ptr.as_ptr(), Self::align(layout));
+        }
+    }
+}
+
+/// A DMA-compatible allocator that uses external (PSRAM) memory only.
+///
+/// This allocator adjusts the allocation alignment and size to be safe for use with DMA.
+pub struct DmaCompatibleExternalMemory;
+
+impl DmaCompatibleExternalMemory {
+    fn align(layout: Layout) -> Layout {
+        // Pessimistic alignment based on maximum possible cache line size
+        // TODO: relax by stealing the `data-cache-size` config from esp-hal
+        align(
+            layout,
+            cfg_select! {
+                esp32p4 => 128,
+                any(esp32s3, esp32s31) => 64,
+                _ => 32,
+            },
+        )
+    }
+}
+
+unsafe impl Allocator for DmaCompatibleExternalMemory {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        allocate_caps(
+            EnumSet::from(MemoryCapability::External),
+            Self::align(layout),
+        )
+    }
+
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        unsafe {
+            crate::HEAP.dealloc(ptr.as_ptr(), Self::align(layout));
+        }
+    }
+}
+
+#[cfg(feature = "nightly")]
+unsafe impl CoreAllocator for DmaCompatibleExternalMemory {
+    fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, CoreAllocError> {
+        allocate_caps(
+            EnumSet::from(MemoryCapability::External),
+            Self::align(layout),
+        )
+        .map_err(|_| CoreAllocError)
+    }
+
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
+        unsafe {
+            crate::HEAP.dealloc(ptr.as_ptr(), Self::align(layout));
+        }
+    }
+}

--- a/esp-hal/src/dma/aligned.rs
+++ b/esp-hal/src/dma/aligned.rs
@@ -91,6 +91,7 @@ pub(crate) fn region_dma_alignment(addr: usize) -> Option<usize> {
             // larger, always-safe value until the L2 line size is
             // available.
             soc_internal_memory_cached => 128,
+            esp32s31 => 64,
             any(esp32, esp32c5, esp32c61) => 32, /* TODO: fixed 32-bytes, metadata-ify */
             _ => crate::soc::CONFIG_DATA_CACHE_LINE_SIZE,
         });

--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -165,6 +165,7 @@ print-logs-from-driver = [
 esp32 = [
   "dep:esp32",
   "esp-hal/esp32",
+  "esp-alloc?/esp32",
   "esp-rtos/esp32",
   "esp-radio-rtos-driver/esp32",
   "esp-phy/esp32",
@@ -176,6 +177,7 @@ esp32 = [
 esp32c2 = [
   "dep:esp32c2",
   "esp-hal/esp32c2",
+  "esp-alloc?/esp32c2",
   "esp-rtos/esp32c2",
   "esp-radio-rtos-driver/esp32c2",
   "esp-phy/esp32c2",
@@ -186,6 +188,7 @@ esp32c2 = [
 esp32c3 = [
   "dep:esp32c3",
   "esp-hal/esp32c3",
+  "esp-alloc?/esp32c3",
   "esp-rtos/esp32c3",
   "esp-radio-rtos-driver/esp32c3",
   "esp-phy/esp32c3",
@@ -196,6 +199,7 @@ esp32c3 = [
 esp32c5 = [
   "dep:esp32c5",
   "esp-hal/esp32c5",
+  "esp-alloc?/esp32c5",
   "esp-rtos/esp32c5",
   "esp-radio-rtos-driver/esp32c5",
   "esp-phy/esp32c5",
@@ -206,6 +210,7 @@ esp32c5 = [
 esp32c6 = [
   "dep:esp32c6",
   "esp-hal/esp32c6",
+  "esp-alloc?/esp32c6",
   "esp-rtos/esp32c6",
   "esp-radio-rtos-driver/esp32c6",
   "esp-phy/esp32c6",
@@ -216,6 +221,7 @@ esp32c6 = [
 esp32c61 = [
   "dep:esp32c61",
   "esp-hal/esp32c61",
+  "esp-alloc?/esp32c61",
   "esp-rtos/esp32c61",
   "esp-radio-rtos-driver/esp32c61",
   "esp-phy/esp32c61",
@@ -226,6 +232,7 @@ esp32c61 = [
 esp32h2 = [
   "dep:esp32h2",
   "esp-hal/esp32h2",
+  "esp-alloc?/esp32h2",
   "esp-rtos/esp32h2",
   "esp-radio-rtos-driver/esp32h2",
   "esp-phy/esp32h2",
@@ -236,6 +243,7 @@ esp32h2 = [
 esp32s2 = [
   "dep:esp32s2",
   "esp-hal/esp32s2",
+  "esp-alloc?/esp32s2",
   "esp-rtos/esp32s2",
   "esp-radio-rtos-driver/esp32s2",
   "esp-phy/esp32s2",
@@ -247,6 +255,7 @@ esp32s2 = [
 esp32s3 = [
   "dep:esp32s3",
   "esp-hal/esp32s3",
+  "esp-alloc?/esp32s3",
   "esp-rtos/esp32s3",
   "esp-radio-rtos-driver/esp32s3",
   "esp-phy/esp32s3",

--- a/esp-rtos/Cargo.toml
+++ b/esp-rtos/Cargo.toml
@@ -107,27 +107,82 @@ rtos-trace = ["dep:rtos-trace"]
 #! One of the following features must be enabled to select the target chip:
 
 ##
-esp32 = ["esp-hal/esp32", "esp-metadata-generated/esp32", "esp-rom-sys/esp32"]
+esp32 = [
+    "esp-hal/esp32",
+    "esp-alloc?/esp32",
+    "esp-metadata-generated/esp32",
+    "esp-rom-sys/esp32",
+]
 ##
-esp32c2 = ["esp-hal/esp32c2", "esp-metadata-generated/esp32c2", "esp-rom-sys/esp32c2"]
+esp32c2 = [
+    "esp-hal/esp32c2",
+    "esp-alloc?/esp32c2",
+    "esp-metadata-generated/esp32c2",
+    "esp-rom-sys/esp32c2",
+]
 ##
-esp32c3 = ["esp-hal/esp32c3", "esp-metadata-generated/esp32c3", "esp-rom-sys/esp32c3"]
+esp32c3 = [
+    "esp-hal/esp32c3",
+    "esp-alloc?/esp32c3",
+    "esp-metadata-generated/esp32c3",
+    "esp-rom-sys/esp32c3",
+]
 ##
-esp32c5 = ["esp-hal/esp32c5", "esp-metadata-generated/esp32c5", "esp-rom-sys/esp32c5"]
+esp32c5 = [
+    "esp-hal/esp32c5",
+    "esp-alloc?/esp32c5",
+    "esp-metadata-generated/esp32c5",
+    "esp-rom-sys/esp32c5",
+]
 ##
-esp32c6 = ["esp-hal/esp32c6", "esp-metadata-generated/esp32c6", "esp-rom-sys/esp32c6"]
+esp32c6 = [
+    "esp-hal/esp32c6",
+    "esp-alloc?/esp32c6",
+    "esp-metadata-generated/esp32c6",
+    "esp-rom-sys/esp32c6",
+]
 ##
-esp32c61 = ["esp-hal/esp32c61", "esp-metadata-generated/esp32c61", "esp-rom-sys/esp32c61"]
+esp32c61 = [
+    "esp-hal/esp32c61",
+    "esp-alloc?/esp32c61",
+    "esp-metadata-generated/esp32c61",
+    "esp-rom-sys/esp32c61",
+]
 ##
-esp32h2 = ["esp-hal/esp32h2", "esp-metadata-generated/esp32h2", "esp-rom-sys/esp32h2"]
+esp32h2 = [
+    "esp-hal/esp32h2",
+    "esp-alloc?/esp32h2",
+    "esp-metadata-generated/esp32h2",
+    "esp-rom-sys/esp32h2",
+]
 ##
-esp32p4 = ["esp-hal/esp32p4", "esp-metadata-generated/esp32p4", "esp-rom-sys/esp32p4"]
+esp32p4 = [
+    "esp-hal/esp32p4",
+    "esp-alloc?/esp32p4",
+    "esp-metadata-generated/esp32p4",
+    "esp-rom-sys/esp32p4",
+]
 ##
-esp32s2 = ["esp-hal/esp32s2", "esp-metadata-generated/esp32s2", "esp-rom-sys/esp32s2"]
+esp32s2 = [
+    "esp-hal/esp32s2",
+    "esp-alloc?/esp32s2",
+    "esp-metadata-generated/esp32s2",
+    "esp-rom-sys/esp32s2",
+]
 ##
-esp32s3 = ["esp-hal/esp32s3", "esp-metadata-generated/esp32s3", "esp-rom-sys/esp32s3"]
+esp32s3 = [
+    "esp-hal/esp32s3",
+    "esp-alloc?/esp32s3",
+    "esp-metadata-generated/esp32s3",
+    "esp-rom-sys/esp32s3",
+]
 ##
-esp32s31 = ["esp-hal/esp32s31", "esp-metadata-generated/esp32s31", "esp-rom-sys/esp32s31"]
+esp32s31 = [
+    "esp-hal/esp32s31",
+    "esp-alloc?/esp32s31",
+    "esp-metadata-generated/esp32s31",
+    "esp-rom-sys/esp32s31",
+]
 
 #! ### Logging Feature Flags
 ## Enable logging output using version 0.4 of the `log` crate.

--- a/examples/async/embassy_ethernet/Cargo.toml
+++ b/examples/async/embassy_ethernet/Cargo.toml
@@ -31,6 +31,7 @@ static_cell = "2.1.0"
 
 [features]
 esp32 = [
+    "esp-alloc/esp32",
     "esp-println/esp32",
     "esp-backtrace/esp32",
     "esp-bootloader-esp-idf/esp32",
@@ -39,6 +40,7 @@ esp32 = [
 ]
 
 esp32p4 = [
+    "esp-alloc/esp32p4",
     "esp-println/esp32p4",
     "esp-backtrace/esp32p4",
     "esp-bootloader-esp-idf/esp32p4",

--- a/examples/ble/bas_peripheral/Cargo.toml
+++ b/examples/ble/bas_peripheral/Cargo.toml
@@ -33,6 +33,7 @@ static_cell = "2.1.1"
 
 [features]
 esp32 = [
+    "esp-alloc/esp32",
     "esp-backtrace/esp32",
     "esp-bootloader-esp-idf/esp32",
     "esp-hal/esp32",
@@ -40,6 +41,7 @@ esp32 = [
     "esp-radio/esp32",
 ]
 esp32c2 = [
+    "esp-alloc/esp32c2",
     "esp-backtrace/esp32c2",
     "esp-bootloader-esp-idf/esp32c2",
     "esp-hal/esp32c2",
@@ -47,6 +49,7 @@ esp32c2 = [
     "esp-radio/esp32c2",
 ]
 esp32c3 = [
+    "esp-alloc/esp32c3",
     "esp-backtrace/esp32c3",
     "esp-bootloader-esp-idf/esp32c3",
     "esp-hal/esp32c3",
@@ -54,6 +57,7 @@ esp32c3 = [
     "esp-radio/esp32c3",
 ]
 esp32c5 = [
+    "esp-alloc/esp32c5",
     "esp-backtrace/esp32c5",
     "esp-bootloader-esp-idf/esp32c5",
     "esp-hal/esp32c5",
@@ -61,6 +65,7 @@ esp32c5 = [
     "esp-radio/esp32c5",
 ]
 esp32c6 = [
+    "esp-alloc/esp32c6",
     "esp-backtrace/esp32c6",
     "esp-bootloader-esp-idf/esp32c6",
     "esp-hal/esp32c6",
@@ -68,6 +73,7 @@ esp32c6 = [
     "esp-radio/esp32c6",
 ]
 esp32c61 = [
+    "esp-alloc/esp32c61",
     "esp-backtrace/esp32c61",
     "esp-bootloader-esp-idf/esp32c61",
     "esp-hal/esp32c61",
@@ -75,6 +81,7 @@ esp32c61 = [
     "esp-radio/esp32c61",
 ]
 esp32h2 = [
+    "esp-alloc/esp32h2",
     "esp-backtrace/esp32h2",
     "esp-bootloader-esp-idf/esp32h2",
     "esp-hal/esp32h2",
@@ -82,6 +89,7 @@ esp32h2 = [
     "esp-radio/esp32h2",
 ]
 esp32s3 = [
+    "esp-alloc/esp32s3",
     "esp-backtrace/esp32s3",
     "esp-bootloader-esp-idf/esp32s3",
     "esp-hal/esp32s3",

--- a/examples/ble/scanner/Cargo.toml
+++ b/examples/ble/scanner/Cargo.toml
@@ -33,6 +33,7 @@ trouble-host = { version = "0.7.0", features = [
 
 [features]
 esp32 = [
+    "esp-alloc/esp32",
     "esp-backtrace/esp32",
     "esp-bootloader-esp-idf/esp32",
     "esp-hal/esp32",
@@ -40,6 +41,7 @@ esp32 = [
     "esp-radio/esp32",
 ]
 esp32c2 = [
+    "esp-alloc/esp32c2",
     "esp-backtrace/esp32c2",
     "esp-bootloader-esp-idf/esp32c2",
     "esp-hal/esp32c2",
@@ -47,6 +49,7 @@ esp32c2 = [
     "esp-radio/esp32c2",
 ]
 esp32c3 = [
+    "esp-alloc/esp32c3",
     "esp-backtrace/esp32c3",
     "esp-bootloader-esp-idf/esp32c3",
     "esp-hal/esp32c3",
@@ -54,6 +57,7 @@ esp32c3 = [
     "esp-radio/esp32c3",
 ]
 esp32c5 = [
+    "esp-alloc/esp32c5",
     "esp-backtrace/esp32c5",
     "esp-bootloader-esp-idf/esp32c5",
     "esp-hal/esp32c5",
@@ -61,6 +65,7 @@ esp32c5 = [
     "esp-radio/esp32c5",
 ]
 esp32c6 = [
+    "esp-alloc/esp32c6",
     "esp-backtrace/esp32c6",
     "esp-bootloader-esp-idf/esp32c6",
     "esp-hal/esp32c6",
@@ -68,6 +73,7 @@ esp32c6 = [
     "esp-radio/esp32c6",
 ]
 esp32c61 = [
+    "esp-alloc/esp32c61",
     "esp-backtrace/esp32c61",
     "esp-bootloader-esp-idf/esp32c61",
     "esp-hal/esp32c61",
@@ -75,6 +81,7 @@ esp32c61 = [
     "esp-radio/esp32c61",
 ]
 esp32h2 = [
+    "esp-alloc/esp32h2",
     "esp-backtrace/esp32h2",
     "esp-bootloader-esp-idf/esp32h2",
     "esp-hal/esp32h2",
@@ -82,6 +89,7 @@ esp32h2 = [
     "esp-radio/esp32h2",
 ]
 esp32s3 = [
+    "esp-alloc/esp32s3",
     "esp-backtrace/esp32s3",
     "esp-bootloader-esp-idf/esp32s3",
     "esp-hal/esp32s3",

--- a/examples/esp-now/embassy_esp_now/Cargo.toml
+++ b/examples/esp-now/embassy_esp_now/Cargo.toml
@@ -26,6 +26,7 @@ esp-radio = { path = "../../../esp-radio", features = [
 
 [features]
 esp32 = [
+    "esp-alloc/esp32",
     "esp-backtrace/esp32",
     "esp-bootloader-esp-idf/esp32",
     "esp-hal/esp32",
@@ -33,6 +34,7 @@ esp32 = [
     "esp-radio/esp32",
 ]
 esp32c2 = [
+    "esp-alloc/esp32c2",
     "esp-backtrace/esp32c2",
     "esp-bootloader-esp-idf/esp32c2",
     "esp-hal/esp32c2",
@@ -40,6 +42,7 @@ esp32c2 = [
     "esp-radio/esp32c2",
 ]
 esp32c3 = [
+    "esp-alloc/esp32c3",
     "esp-backtrace/esp32c3",
     "esp-bootloader-esp-idf/esp32c3",
     "esp-hal/esp32c3",
@@ -47,6 +50,7 @@ esp32c3 = [
     "esp-radio/esp32c3",
 ]
 esp32c5 = [
+    "esp-alloc/esp32c5",
     "esp-backtrace/esp32c5",
     "esp-bootloader-esp-idf/esp32c5",
     "esp-hal/esp32c5",
@@ -54,6 +58,7 @@ esp32c5 = [
     "esp-radio/esp32c5",
 ]
 esp32c6 = [
+    "esp-alloc/esp32c6",
     "esp-backtrace/esp32c6",
     "esp-bootloader-esp-idf/esp32c6",
     "esp-hal/esp32c6",
@@ -61,6 +66,7 @@ esp32c6 = [
     "esp-radio/esp32c6",
 ]
 esp32c61 = [
+    "esp-alloc/esp32c61",
     "esp-backtrace/esp32c61",
     "esp-bootloader-esp-idf/esp32c61",
     "esp-hal/esp32c61",
@@ -68,6 +74,7 @@ esp32c61 = [
     "esp-radio/esp32c61",
 ]
 esp32s2 = [
+    "esp-alloc/esp32s2",
     "esp-backtrace/esp32s2",
     "esp-bootloader-esp-idf/esp32s2",
     "esp-hal/esp32s2",
@@ -75,6 +82,7 @@ esp32s2 = [
     "esp-radio/esp32s2",
 ]
 esp32s3 = [
+    "esp-alloc/esp32s3",
     "esp-backtrace/esp32s3",
     "esp-bootloader-esp-idf/esp32s3",
     "esp-hal/esp32s3",

--- a/examples/esp-now/embassy_esp_now_duplex/Cargo.toml
+++ b/examples/esp-now/embassy_esp_now_duplex/Cargo.toml
@@ -27,6 +27,7 @@ static_cell = "2.1.0"
 
 [features]
 esp32 = [
+    "esp-alloc/esp32",
     "esp-backtrace/esp32",
     "esp-bootloader-esp-idf/esp32",
     "esp-hal/esp32",
@@ -34,6 +35,7 @@ esp32 = [
     "esp-radio/esp32",
 ]
 esp32c2 = [
+    "esp-alloc/esp32c2",
     "esp-backtrace/esp32c2",
     "esp-bootloader-esp-idf/esp32c2",
     "esp-hal/esp32c2",
@@ -41,6 +43,7 @@ esp32c2 = [
     "esp-radio/esp32c2",
 ]
 esp32c3 = [
+    "esp-alloc/esp32c3",
     "esp-backtrace/esp32c3",
     "esp-bootloader-esp-idf/esp32c3",
     "esp-hal/esp32c3",
@@ -48,6 +51,7 @@ esp32c3 = [
     "esp-radio/esp32c3",
 ]
 esp32c5 = [
+    "esp-alloc/esp32c5",
     "esp-backtrace/esp32c5",
     "esp-bootloader-esp-idf/esp32c5",
     "esp-hal/esp32c5",
@@ -55,6 +59,7 @@ esp32c5 = [
     "esp-radio/esp32c5",
 ]
 esp32c6 = [
+    "esp-alloc/esp32c6",
     "esp-backtrace/esp32c6",
     "esp-bootloader-esp-idf/esp32c6",
     "esp-hal/esp32c6",
@@ -62,6 +67,7 @@ esp32c6 = [
     "esp-radio/esp32c6",
 ]
 esp32c61 = [
+    "esp-alloc/esp32c61",
     "esp-backtrace/esp32c61",
     "esp-bootloader-esp-idf/esp32c61",
     "esp-hal/esp32c61",
@@ -69,6 +75,7 @@ esp32c61 = [
     "esp-radio/esp32c61",
 ]
 esp32s2 = [
+    "esp-alloc/esp32s2",
     "esp-backtrace/esp32s2",
     "esp-bootloader-esp-idf/esp32s2",
     "esp-hal/esp32s2",
@@ -76,6 +83,7 @@ esp32s2 = [
     "esp-radio/esp32s2",
 ]
 esp32s3 = [
+    "esp-alloc/esp32s3",
     "esp-backtrace/esp32s3",
     "esp-bootloader-esp-idf/esp32s3",
     "esp-hal/esp32s3",

--- a/examples/ieee802154/ieee802154_receive_all_frames/Cargo.toml
+++ b/examples/ieee802154/ieee802154_receive_all_frames/Cargo.toml
@@ -20,18 +20,21 @@ esp-radio = { path = "../../../esp-radio", features = [
 
 [features]
 esp32c5 = [
+    "esp-alloc/esp32c5",
     "esp-backtrace/esp32c5",
     "esp-bootloader-esp-idf/esp32c5",
     "esp-hal/esp32c5",
     "esp-radio/esp32c5",
 ]
 esp32c6 = [
+    "esp-alloc/esp32c6",
     "esp-backtrace/esp32c6",
     "esp-bootloader-esp-idf/esp32c6",
     "esp-hal/esp32c6",
     "esp-radio/esp32c6",
 ]
 esp32h2 = [
+    "esp-alloc/esp32h2",
     "esp-backtrace/esp32h2",
     "esp-bootloader-esp-idf/esp32h2",
     "esp-hal/esp32h2",

--- a/examples/ieee802154/ieee802154_receive_frame/Cargo.toml
+++ b/examples/ieee802154/ieee802154_receive_frame/Cargo.toml
@@ -20,18 +20,21 @@ esp-radio = { path = "../../../esp-radio", features = [
 
 [features]
 esp32c5 = [
+    "esp-alloc/esp32c5",
     "esp-backtrace/esp32c5",
     "esp-bootloader-esp-idf/esp32c5",
     "esp-hal/esp32c5",
     "esp-radio/esp32c5",
 ]
 esp32c6 = [
+    "esp-alloc/esp32c6",
     "esp-backtrace/esp32c6",
     "esp-bootloader-esp-idf/esp32c6",
     "esp-hal/esp32c6",
     "esp-radio/esp32c6",
 ]
 esp32h2 = [
+    "esp-alloc/esp32h2",
     "esp-backtrace/esp32h2",
     "esp-bootloader-esp-idf/esp32h2",
     "esp-hal/esp32h2",

--- a/examples/ieee802154/ieee802154_send_broadcast_frame/Cargo.toml
+++ b/examples/ieee802154/ieee802154_send_broadcast_frame/Cargo.toml
@@ -21,18 +21,21 @@ ieee802154 = "0.6.1"
 
 [features]
 esp32c5 = [
+    "esp-alloc/esp32c5",
     "esp-backtrace/esp32c5",
     "esp-bootloader-esp-idf/esp32c5",
     "esp-hal/esp32c5",
     "esp-radio/esp32c5",
 ]
 esp32c6 = [
+    "esp-alloc/esp32c6",
     "esp-backtrace/esp32c6",
     "esp-bootloader-esp-idf/esp32c6",
     "esp-hal/esp32c6",
     "esp-radio/esp32c6",
 ]
 esp32h2 = [
+    "esp-alloc/esp32h2",
     "esp-backtrace/esp32h2",
     "esp-bootloader-esp-idf/esp32h2",
     "esp-hal/esp32h2",

--- a/examples/ieee802154/ieee802154_send_frame/Cargo.toml
+++ b/examples/ieee802154/ieee802154_send_frame/Cargo.toml
@@ -21,18 +21,21 @@ ieee802154 = "0.6.1"
 
 [features]
 esp32c5 = [
+    "esp-alloc/esp32c5",
     "esp-backtrace/esp32c5",
     "esp-bootloader-esp-idf/esp32c5",
     "esp-hal/esp32c5",
     "esp-radio/esp32c5",
 ]
 esp32c6 = [
+    "esp-alloc/esp32c6",
     "esp-backtrace/esp32c6",
     "esp-bootloader-esp-idf/esp32c6",
     "esp-hal/esp32c6",
     "esp-radio/esp32c6",
 ]
 esp32h2 = [
+    "esp-alloc/esp32h2",
     "esp-backtrace/esp32h2",
     "esp-bootloader-esp-idf/esp32h2",
     "esp-hal/esp32h2",

--- a/examples/ieee802154/ieee802154_sniffer/Cargo.toml
+++ b/examples/ieee802154/ieee802154_sniffer/Cargo.toml
@@ -21,18 +21,21 @@ ieee802154 = "0.6.1"
 
 [features]
 esp32c5 = [
+    "esp-alloc/esp32c5",
     "esp-backtrace/esp32c5",
     "esp-bootloader-esp-idf/esp32c5",
     "esp-hal/esp32c5",
     "esp-radio/esp32c5",
 ]
 esp32c6 = [
+    "esp-alloc/esp32c6",
     "esp-backtrace/esp32c6",
     "esp-bootloader-esp-idf/esp32c6",
     "esp-hal/esp32c6",
     "esp-radio/esp32c6",
 ]
 esp32h2 = [
+    "esp-alloc/esp32h2",
     "esp-backtrace/esp32h2",
     "esp-bootloader-esp-idf/esp32h2",
     "esp-hal/esp32h2",

--- a/examples/peripheral/dma/extmem2mem/Cargo.toml
+++ b/examples/peripheral/dma/extmem2mem/Cargo.toml
@@ -21,26 +21,31 @@ log = "0.4.27"
 
 [features]
 esp32s3 = [
+    "esp-alloc/esp32s3",
     "esp-backtrace/esp32s3",
     "esp-bootloader-esp-idf/esp32s3",
     "esp-hal/esp32s3",
 ]
 esp32c5 = [
+    "esp-alloc/esp32c5",
     "esp-backtrace/esp32c5",
     "esp-bootloader-esp-idf/esp32c5",
     "esp-hal/esp32c5",
 ]
 esp32c61 = [
+    "esp-alloc/esp32c61",
     "esp-backtrace/esp32c61",
     "esp-bootloader-esp-idf/esp32c61",
     "esp-hal/esp32c61",
 ]
 esp32p4 = [
+    "esp-alloc/esp32p4",
     "esp-backtrace/esp32p4",
     "esp-bootloader-esp-idf/esp32p4",
     "esp-hal/esp32p4",
 ]
 esp32s2 = [
+    "esp-alloc/esp32s2",
     "esp-backtrace/esp32s2",
     "esp-bootloader-esp-idf/esp32s2",
     "esp-hal/esp32s2",

--- a/examples/peripheral/spi/loopback_dma_psram/Cargo.toml
+++ b/examples/peripheral/spi/loopback_dma_psram/Cargo.toml
@@ -16,30 +16,37 @@ esp-hal = { path = "../../../../esp-hal", features = [
     "unstable",
 ] }
 esp-println = { path = "../../../../esp-println", features = ["log-04"] }
+
+allocator-api2 = { version = "0.3.0", default-features = false, features = ["alloc"] }
 log = "0.4.27"
 
 [features]
 esp32s3 = [
+    "esp-alloc/esp32s3",
     "esp-backtrace/esp32s3",
     "esp-bootloader-esp-idf/esp32s3",
     "esp-hal/esp32s3",
 ]
 esp32s2 = [
+    "esp-alloc/esp32s2",
     "esp-backtrace/esp32s2",
     "esp-bootloader-esp-idf/esp32s2",
     "esp-hal/esp32s2",
 ]
 esp32c5 = [
+    "esp-alloc/esp32c5",
     "esp-backtrace/esp32c5",
     "esp-bootloader-esp-idf/esp32c5",
     "esp-hal/esp32c5",
 ]
 esp32c61 = [
+    "esp-alloc/esp32c61",
     "esp-backtrace/esp32c61",
     "esp-bootloader-esp-idf/esp32c61",
     "esp-hal/esp32c61",
 ]
 esp32p4 = [
+    "esp-alloc/esp32p4",
     "esp-backtrace/esp32p4",
     "esp-bootloader-esp-idf/esp32p4",
     "esp-hal/esp32p4",

--- a/examples/peripheral/spi/loopback_dma_psram/src/main.rs
+++ b/examples/peripheral/spi/loopback_dma_psram/src/main.rs
@@ -22,10 +22,12 @@
 
 extern crate alloc;
 
+use allocator_api2::boxed::Box;
+use esp_alloc::DmaCompatibleExternalMemory;
 use esp_backtrace as _;
 use esp_hal::{
     delay::Delay,
-    dma::ExternalBurstConfig,
+    dma::{DmaTxBuf, ExternalBurstConfig, aligned::DmaAlignedMut},
     dma_rx_buffer,
     main,
     spi::{
@@ -37,28 +39,6 @@ use esp_hal::{
 use log::*;
 
 esp_bootloader_esp_idf::esp_app_desc!();
-
-macro_rules! dma_alloc_tx_buffer {
-    ($size:expr, $align:expr) => {{
-        let layout = core::alloc::Layout::from_size_align($size, $align as usize).unwrap();
-        let buffer = unsafe {
-            let ptr = alloc::alloc::alloc(layout);
-            if ptr.is_null() {
-                error!("dma_alloc_buffer: alloc failed");
-                alloc::alloc::handle_alloc_error(layout);
-            }
-            core::slice::from_raw_parts_mut(ptr, $size)
-        };
-
-        const DMA_CHUNK_SIZE: usize = 4096 - $align as usize;
-        let descriptors = esp_hal::dma_descriptors_impl!($size, DMA_CHUNK_SIZE);
-        esp_hal::dma::DmaTxBuf::new_with_config(
-            descriptors,
-            unsafe { esp_hal::dma::aligned::DmaAlignedMut::new_unchecked(buffer) },
-            $align,
-        )
-    }};
-}
 
 const DMA_BUFFER_SIZE: usize = 8192;
 const DMA_ALIGNMENT: ExternalBurstConfig = cfg_select! {
@@ -89,7 +69,19 @@ fn main() -> ! {
         _ => peripherals.DMA_CH0,
     };
 
-    let mut dma_tx_buf = dma_alloc_tx_buffer!(DMA_BUFFER_SIZE, DMA_ALIGNMENT).unwrap();
+    let buffer = Box::leak(Box::new_in(
+        [0u8; DMA_BUFFER_SIZE],
+        DmaCompatibleExternalMemory,
+    ));
+
+    const DMA_CHUNK_SIZE: usize = 4096 - DMA_ALIGNMENT as usize;
+    let descriptors = esp_hal::dma_descriptors_impl!(DMA_BUFFER_SIZE, DMA_CHUNK_SIZE);
+    let mut dma_tx_buf = DmaTxBuf::new_with_config(
+        descriptors,
+        DmaAlignedMut::new(buffer).unwrap().unsize(),
+        DMA_ALIGNMENT,
+    )
+    .unwrap();
     let mut dma_rx_buf = dma_rx_buffer!(DMA_BUFFER_SIZE).unwrap();
     // Need to set miso first so that mosi can overwrite the
     // output connection (because we are using the same pin to loop back)

--- a/examples/wifi/80211_tx/Cargo.toml
+++ b/examples/wifi/80211_tx/Cargo.toml
@@ -25,6 +25,7 @@ ieee80211 = { version = "0.4.0", default-features = false }
 
 [features]
 esp32 = [
+    "esp-alloc/esp32",
     "esp-backtrace/esp32",
     "esp-bootloader-esp-idf/esp32",
     "esp-hal/esp32",
@@ -32,6 +33,7 @@ esp32 = [
     "esp-radio/esp32",
 ]
 esp32c2 = [
+    "esp-alloc/esp32c2",
     "esp-backtrace/esp32c2",
     "esp-bootloader-esp-idf/esp32c2",
     "esp-hal/esp32c2",
@@ -39,6 +41,7 @@ esp32c2 = [
     "esp-radio/esp32c2",
 ]
 esp32c3 = [
+    "esp-alloc/esp32c3",
     "esp-backtrace/esp32c3",
     "esp-bootloader-esp-idf/esp32c3",
     "esp-hal/esp32c3",
@@ -46,6 +49,7 @@ esp32c3 = [
     "esp-radio/esp32c3",
 ]
 esp32c5 = [
+    "esp-alloc/esp32c5",
     "esp-backtrace/esp32c5",
     "esp-bootloader-esp-idf/esp32c5",
     "esp-hal/esp32c5",
@@ -53,6 +57,7 @@ esp32c5 = [
     "esp-radio/esp32c5",
 ]
 esp32c6 = [
+    "esp-alloc/esp32c6",
     "esp-backtrace/esp32c6",
     "esp-bootloader-esp-idf/esp32c6",
     "esp-hal/esp32c6",
@@ -60,6 +65,7 @@ esp32c6 = [
     "esp-radio/esp32c6",
 ]
 esp32c61 = [
+    "esp-alloc/esp32c61",
     "esp-backtrace/esp32c61",
     "esp-bootloader-esp-idf/esp32c61",
     "esp-hal/esp32c61",
@@ -67,6 +73,7 @@ esp32c61 = [
     "esp-radio/esp32c61",
 ]
 esp32s2 = [
+    "esp-alloc/esp32s2",
     "esp-backtrace/esp32s2",
     "esp-bootloader-esp-idf/esp32s2",
     "esp-hal/esp32s2",
@@ -74,6 +81,7 @@ esp32s2 = [
     "esp-radio/esp32s2",
 ]
 esp32s3 = [
+    "esp-alloc/esp32s3",
     "esp-backtrace/esp32s3",
     "esp-bootloader-esp-idf/esp32s3",
     "esp-hal/esp32s3",

--- a/examples/wifi/embassy_access_point/Cargo.toml
+++ b/examples/wifi/embassy_access_point/Cargo.toml
@@ -35,6 +35,7 @@ static_cell = "2.1.0"
 
 [features]
 esp32 = [
+    "esp-alloc/esp32",
     "esp-backtrace/esp32",
     "esp-bootloader-esp-idf/esp32",
     "esp-hal/esp32",
@@ -42,6 +43,7 @@ esp32 = [
     "esp-radio/esp32",
 ]
 esp32c2 = [
+    "esp-alloc/esp32c2",
     "esp-backtrace/esp32c2",
     "esp-bootloader-esp-idf/esp32c2",
     "esp-hal/esp32c2",
@@ -49,6 +51,7 @@ esp32c2 = [
     "esp-radio/esp32c2",
 ]
 esp32c3 = [
+    "esp-alloc/esp32c3",
     "esp-backtrace/esp32c3",
     "esp-bootloader-esp-idf/esp32c3",
     "esp-hal/esp32c3",
@@ -56,6 +59,7 @@ esp32c3 = [
     "esp-radio/esp32c3",
 ]
 esp32c5 = [
+    "esp-alloc/esp32c5",
     "esp-backtrace/esp32c5",
     "esp-bootloader-esp-idf/esp32c5",
     "esp-hal/esp32c5",
@@ -63,6 +67,7 @@ esp32c5 = [
     "esp-radio/esp32c5",
 ]
 esp32c6 = [
+    "esp-alloc/esp32c6",
     "esp-backtrace/esp32c6",
     "esp-bootloader-esp-idf/esp32c6",
     "esp-hal/esp32c6",
@@ -70,6 +75,7 @@ esp32c6 = [
     "esp-radio/esp32c6",
 ]
 esp32c61 = [
+    "esp-alloc/esp32c61",
     "esp-backtrace/esp32c61",
     "esp-bootloader-esp-idf/esp32c61",
     "esp-hal/esp32c61",
@@ -77,6 +83,7 @@ esp32c61 = [
     "esp-radio/esp32c61",
 ]
 esp32s2 = [
+    "esp-alloc/esp32s2",
     "esp-backtrace/esp32s2",
     "esp-bootloader-esp-idf/esp32s2",
     "esp-hal/esp32s2",
@@ -84,6 +91,7 @@ esp32s2 = [
     "esp-radio/esp32s2",
 ]
 esp32s3 = [
+    "esp-alloc/esp32s3",
     "esp-backtrace/esp32s3",
     "esp-bootloader-esp-idf/esp32s3",
     "esp-hal/esp32s3",

--- a/examples/wifi/embassy_access_point_with_sta/Cargo.toml
+++ b/examples/wifi/embassy_access_point_with_sta/Cargo.toml
@@ -33,6 +33,7 @@ static_cell = "2.1.0"
 
 [features]
 esp32 = [
+    "esp-alloc/esp32",
     "esp-backtrace/esp32",
     "esp-bootloader-esp-idf/esp32",
     "esp-hal/esp32",
@@ -40,6 +41,7 @@ esp32 = [
     "esp-radio/esp32",
 ]
 esp32c2 = [
+    "esp-alloc/esp32c2",
     "esp-backtrace/esp32c2",
     "esp-bootloader-esp-idf/esp32c2",
     "esp-hal/esp32c2",
@@ -47,6 +49,7 @@ esp32c2 = [
     "esp-radio/esp32c2",
 ]
 esp32c3 = [
+    "esp-alloc/esp32c3",
     "esp-backtrace/esp32c3",
     "esp-bootloader-esp-idf/esp32c3",
     "esp-hal/esp32c3",
@@ -54,6 +57,7 @@ esp32c3 = [
     "esp-radio/esp32c3",
 ]
 esp32c5 = [
+    "esp-alloc/esp32c5",
     "esp-backtrace/esp32c5",
     "esp-bootloader-esp-idf/esp32c5",
     "esp-hal/esp32c5",
@@ -61,6 +65,7 @@ esp32c5 = [
     "esp-radio/esp32c5",
 ]
 esp32c6 = [
+    "esp-alloc/esp32c6",
     "esp-backtrace/esp32c6",
     "esp-bootloader-esp-idf/esp32c6",
     "esp-hal/esp32c6",
@@ -68,6 +73,7 @@ esp32c6 = [
     "esp-radio/esp32c6",
 ]
 esp32c61 = [
+    "esp-alloc/esp32c61",
     "esp-backtrace/esp32c61",
     "esp-bootloader-esp-idf/esp32c61",
     "esp-hal/esp32c61",
@@ -75,6 +81,7 @@ esp32c61 = [
     "esp-radio/esp32c61",
 ]
 esp32s2 = [
+    "esp-alloc/esp32s2",
     "esp-backtrace/esp32s2",
     "esp-bootloader-esp-idf/esp32s2",
     "esp-hal/esp32s2",
@@ -82,6 +89,7 @@ esp32s2 = [
     "esp-radio/esp32s2",
 ]
 esp32s3 = [
+    "esp-alloc/esp32s3",
     "esp-backtrace/esp32s3",
     "esp-bootloader-esp-idf/esp32s3",
     "esp-hal/esp32s3",

--- a/examples/wifi/embassy_coex/Cargo.toml
+++ b/examples/wifi/embassy_coex/Cargo.toml
@@ -41,6 +41,7 @@ trouble-host = { version = "0.7.0", features = [
 
 [features]
 esp32 = [
+    "esp-alloc/esp32",
     "esp-backtrace/esp32",
     "esp-bootloader-esp-idf/esp32",
     "esp-hal/esp32",
@@ -48,6 +49,7 @@ esp32 = [
     "esp-radio/esp32",
 ]
 esp32c2 = [
+    "esp-alloc/esp32c2",
     "esp-backtrace/esp32c2",
     "esp-bootloader-esp-idf/esp32c2",
     "esp-hal/esp32c2",
@@ -55,6 +57,7 @@ esp32c2 = [
     "esp-radio/esp32c2",
 ]
 esp32c3 = [
+    "esp-alloc/esp32c3",
     "esp-backtrace/esp32c3",
     "esp-bootloader-esp-idf/esp32c3",
     "esp-hal/esp32c3",
@@ -62,6 +65,7 @@ esp32c3 = [
     "esp-radio/esp32c3",
 ]
 esp32c5 = [
+    "esp-alloc/esp32c5",
     "esp-backtrace/esp32c5",
     "esp-bootloader-esp-idf/esp32c5",
     "esp-hal/esp32c5",
@@ -69,6 +73,7 @@ esp32c5 = [
     "esp-radio/esp32c5",
 ]
 esp32c6 = [
+    "esp-alloc/esp32c6",
     "esp-backtrace/esp32c6",
     "esp-bootloader-esp-idf/esp32c6",
     "esp-hal/esp32c6",
@@ -76,6 +81,7 @@ esp32c6 = [
     "esp-radio/esp32c6",
 ]
 esp32c61 = [
+    "esp-alloc/esp32c61",
     "esp-backtrace/esp32c61",
     "esp-bootloader-esp-idf/esp32c61",
     "esp-hal/esp32c61",
@@ -83,6 +89,7 @@ esp32c61 = [
     "esp-radio/esp32c61",
 ]
 esp32s3 = [
+    "esp-alloc/esp32s3",
     "esp-backtrace/esp32s3",
     "esp-bootloader-esp-idf/esp32s3",
     "esp-hal/esp32s3",

--- a/examples/wifi/embassy_dhcp/Cargo.toml
+++ b/examples/wifi/embassy_dhcp/Cargo.toml
@@ -32,6 +32,7 @@ static_cell = "2.1.0"
 
 [features]
 esp32 = [
+    "esp-alloc/esp32",
     "esp-backtrace/esp32",
     "esp-bootloader-esp-idf/esp32",
     "esp-hal/esp32",
@@ -39,6 +40,7 @@ esp32 = [
     "esp-radio/esp32",
 ]
 esp32c2 = [
+    "esp-alloc/esp32c2",
     "esp-backtrace/esp32c2",
     "esp-bootloader-esp-idf/esp32c2",
     "esp-hal/esp32c2",
@@ -46,6 +48,7 @@ esp32c2 = [
     "esp-radio/esp32c2",
 ]
 esp32c3 = [
+    "esp-alloc/esp32c3",
     "esp-backtrace/esp32c3",
     "esp-bootloader-esp-idf/esp32c3",
     "esp-hal/esp32c3",
@@ -53,6 +56,7 @@ esp32c3 = [
     "esp-radio/esp32c3",
 ]
 esp32c5 = [
+    "esp-alloc/esp32c5",
     "esp-backtrace/esp32c5",
     "esp-bootloader-esp-idf/esp32c5",
     "esp-hal/esp32c5",
@@ -60,6 +64,7 @@ esp32c5 = [
     "esp-radio/esp32c5",
 ]
 esp32c6 = [
+    "esp-alloc/esp32c6",
     "esp-backtrace/esp32c6",
     "esp-bootloader-esp-idf/esp32c6",
     "esp-hal/esp32c6",
@@ -67,6 +72,7 @@ esp32c6 = [
     "esp-radio/esp32c6",
 ]
 esp32c61 = [
+    "esp-alloc/esp32c61",
     "esp-backtrace/esp32c61",
     "esp-bootloader-esp-idf/esp32c61",
     "esp-hal/esp32c61",
@@ -74,6 +80,7 @@ esp32c61 = [
     "esp-radio/esp32c61",
 ]
 esp32s2 = [
+    "esp-alloc/esp32s2",
     "esp-backtrace/esp32s2",
     "esp-bootloader-esp-idf/esp32s2",
     "esp-hal/esp32s2",
@@ -81,6 +88,7 @@ esp32s2 = [
     "esp-radio/esp32s2",
 ]
 esp32s3 = [
+    "esp-alloc/esp32s3",
     "esp-backtrace/esp32s3",
     "esp-bootloader-esp-idf/esp32s3",
     "esp-hal/esp32s3",

--- a/examples/wifi/embassy_sntp/Cargo.toml
+++ b/examples/wifi/embassy_sntp/Cargo.toml
@@ -34,6 +34,7 @@ jiff = { version = "0.2.10", default-features = false, features = ["static"] }
 
 [features]
 esp32 = [
+    "esp-alloc/esp32",
     "esp-backtrace/esp32",
     "esp-bootloader-esp-idf/esp32",
     "esp-hal/esp32",
@@ -41,6 +42,7 @@ esp32 = [
     "esp-radio/esp32",
 ]
 esp32c2 = [
+    "esp-alloc/esp32c2",
     "esp-backtrace/esp32c2",
     "esp-bootloader-esp-idf/esp32c2",
     "esp-hal/esp32c2",
@@ -48,6 +50,7 @@ esp32c2 = [
     "esp-radio/esp32c2",
 ]
 esp32c3 = [
+    "esp-alloc/esp32c3",
     "esp-backtrace/esp32c3",
     "esp-bootloader-esp-idf/esp32c3",
     "esp-hal/esp32c3",
@@ -55,6 +58,7 @@ esp32c3 = [
     "esp-radio/esp32c3",
 ]
 esp32c6 = [
+    "esp-alloc/esp32c6",
     "esp-backtrace/esp32c6",
     "esp-bootloader-esp-idf/esp32c6",
     "esp-hal/esp32c6",
@@ -62,6 +66,7 @@ esp32c6 = [
     "esp-radio/esp32c6",
 ]
 esp32s2 = [
+    "esp-alloc/esp32s2",
     "esp-backtrace/esp32s2",
     "esp-bootloader-esp-idf/esp32s2",
     "esp-hal/esp32s2",
@@ -69,6 +74,7 @@ esp32s2 = [
     "esp-radio/esp32s2",
 ]
 esp32s3 = [
+    "esp-alloc/esp32s3",
     "esp-backtrace/esp32s3",
     "esp-bootloader-esp-idf/esp32s3",
     "esp-hal/esp32s3",
@@ -76,6 +82,7 @@ esp32s3 = [
     "esp-radio/esp32s3",
 ]
 esp32c5 = [
+    "esp-alloc/esp32c5",
     "esp-backtrace/esp32c5",
     "esp-bootloader-esp-idf/esp32c5",
     "esp-hal/esp32c5",
@@ -83,6 +90,7 @@ esp32c5 = [
     "esp-radio/esp32c5",
 ]
 esp32c61 = [
+    "esp-alloc/esp32c61",
     "esp-backtrace/esp32c61",
     "esp-bootloader-esp-idf/esp32c61",
     "esp-hal/esp32c61",

--- a/examples/wifi/sniffer/Cargo.toml
+++ b/examples/wifi/sniffer/Cargo.toml
@@ -26,6 +26,7 @@ ieee80211 = { version = "0.4.0", default-features = false }
 
 [features]
 esp32 = [
+    "esp-alloc/esp32",
     "esp-backtrace/esp32",
     "esp-bootloader-esp-idf/esp32",
     "esp-hal/esp32",
@@ -33,6 +34,7 @@ esp32 = [
     "esp-radio/esp32",
 ]
 esp32c2 = [
+    "esp-alloc/esp32c2",
     "esp-backtrace/esp32c2",
     "esp-bootloader-esp-idf/esp32c2",
     "esp-hal/esp32c2",
@@ -40,6 +42,7 @@ esp32c2 = [
     "esp-radio/esp32c2",
 ]
 esp32c3 = [
+    "esp-alloc/esp32c3",
     "esp-backtrace/esp32c3",
     "esp-bootloader-esp-idf/esp32c3",
     "esp-hal/esp32c3",
@@ -47,6 +50,7 @@ esp32c3 = [
     "esp-radio/esp32c3",
 ]
 esp32c5 = [
+    "esp-alloc/esp32c5",
     "esp-backtrace/esp32c5",
     "esp-bootloader-esp-idf/esp32c5",
     "esp-hal/esp32c5",
@@ -54,6 +58,7 @@ esp32c5 = [
     "esp-radio/esp32c5",
 ]
 esp32c6 = [
+    "esp-alloc/esp32c6",
     "esp-backtrace/esp32c6",
     "esp-bootloader-esp-idf/esp32c6",
     "esp-hal/esp32c6",
@@ -61,6 +66,7 @@ esp32c6 = [
     "esp-radio/esp32c6",
 ]
 esp32c61 = [
+    "esp-alloc/esp32c61",
     "esp-backtrace/esp32c61",
     "esp-bootloader-esp-idf/esp32c61",
     "esp-hal/esp32c61",
@@ -68,6 +74,7 @@ esp32c61 = [
     "esp-radio/esp32c61",
 ]
 esp32s2 = [
+    "esp-alloc/esp32s2",
     "esp-backtrace/esp32s2",
     "esp-bootloader-esp-idf/esp32s2",
     "esp-hal/esp32s2",
@@ -75,6 +82,7 @@ esp32s2 = [
     "esp-radio/esp32s2",
 ]
 esp32s3 = [
+    "esp-alloc/esp32s3",
     "esp-backtrace/esp32s3",
     "esp-bootloader-esp-idf/esp32s3",
     "esp-hal/esp32s3",

--- a/qa-test/Cargo.toml
+++ b/qa-test/Cargo.toml
@@ -59,6 +59,7 @@ esp-radio = [
 ]
 
 esp32 = [
+    "esp-alloc/esp32",
     "esp-backtrace/esp32",
     "esp-bootloader-esp-idf/esp32",
     "esp-hal/esp32",
@@ -68,6 +69,7 @@ esp32 = [
     "esp-storage?/esp32",
 ]
 esp32c2 = [
+    "esp-alloc/esp32c2",
     "esp-backtrace/esp32c2",
     "esp-bootloader-esp-idf/esp32c2",
     "esp-hal/esp32c2",
@@ -77,6 +79,7 @@ esp32c2 = [
     "esp-storage?/esp32c2",
 ]
 esp32c3 = [
+    "esp-alloc/esp32c3",
     "esp-backtrace/esp32c3",
     "esp-bootloader-esp-idf/esp32c3",
     "esp-hal/esp32c3",
@@ -86,6 +89,7 @@ esp32c3 = [
     "esp-storage?/esp32c3",
 ]
 esp32c5 = [
+    "esp-alloc/esp32c5",
     "esp-backtrace/esp32c5",
     "esp-bootloader-esp-idf/esp32c5",
     "esp-hal/esp32c5",
@@ -95,6 +99,7 @@ esp32c5 = [
     "esp-storage?/esp32c5",
 ]
 esp32c6 = [
+    "esp-alloc/esp32c6",
     "esp-backtrace/esp32c6",
     "esp-bootloader-esp-idf/esp32c6",
     "esp-hal/esp32c6",
@@ -104,6 +109,7 @@ esp32c6 = [
     "esp-storage?/esp32c6",
 ]
 esp32c61 = [
+    "esp-alloc/esp32c61",
     "esp-backtrace/esp32c61",
     "esp-bootloader-esp-idf/esp32c61",
     "esp-hal/esp32c61",
@@ -113,6 +119,7 @@ esp32c61 = [
     "esp-storage?/esp32c61",
 ]
 esp32h2 = [
+    "esp-alloc/esp32h2",
     "esp-backtrace/esp32h2",
     "esp-bootloader-esp-idf/esp32h2",
     "esp-hal/esp32h2",
@@ -122,6 +129,7 @@ esp32h2 = [
     "esp-storage?/esp32h2",
 ]
 esp32p4 = [
+    "esp-alloc/esp32p4",
     "esp-backtrace/esp32p4",
     "esp-bootloader-esp-idf/esp32p4",
     "esp-hal/esp32p4",
@@ -130,6 +138,7 @@ esp32p4 = [
     "esp-storage?/esp32p4",
 ]
 esp32s2 = [
+    "esp-alloc/esp32s2",
     "esp-backtrace/esp32s2",
     "esp-bootloader-esp-idf/esp32s2",
     "esp-hal/esp32s2",
@@ -139,6 +148,7 @@ esp32s2 = [
     "esp-storage?/esp32s2",
 ]
 esp32s3 = [
+    "esp-alloc/esp32s3",
     "esp-backtrace/esp32s3",
     "esp-bootloader-esp-idf/esp32s3",
     "esp-hal/esp32s3",
@@ -148,6 +158,7 @@ esp32s3 = [
     "esp-storage?/esp32s3",
 ]
 esp32s31 = [
+    "esp-alloc/esp32s31",
     "esp-backtrace/esp32s31",
     "esp-bootloader-esp-idf/esp32s31",
     "esp-hal/esp32s31",


### PR DESCRIPTION
A bit on the lazy side - since cache line sizes are sometimes configurable, this PR just uses the pessimistic upper limit, so it has a bit of wasteage.

# Changelog

## esp-alloc

- Added: `DmaCompatibleInternalMemory` and `DmaCompatibleExternalMemory` allocators that ensure the returned variable is properly aligned as a DMA buffer.
- Changed: The chip selector feature(s) are now mandatory.

## esp-rtos

- No changelog necessary.

## esp-hal

- No changelog necessary.

## esp-radio

- No changelog necessary.
