### PR TITLE
Fix a request frame bug introduced recently (a94f6ec).

### DIFF
--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -591,7 +591,7 @@ impl EspTwaiFrame {
         }
         // For data frames, assert that:
         // - Data length smaller than 8 must have equal DLC
-        // - Data length equal to 8 hmust ave DLC >= 8
+        // - Data length equal to 8 must have a DLC >= 8
         if !remote_request
             && (((data_len < 8) & (dlc != data_len)) || ((data_len == 8) & (dlc < 8)))
         {

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -585,11 +585,15 @@ impl EspTwaiFrame {
         if data_len > 8 || (remote_request & (data_len > 0)) {
             return Err(EspTwaiError::InvalidDataLength(data_len as u8));
         }
-        // Assert that:
-        // - Max DLC is 15
+        // Assert that max DLC is 15
+        if dlc > 15 {
+            return Err(EspTwaiError::NonCompliantDlc(dlc as u8));
+        }
+        // For data frames, assert that:
         // - Data length smaller than 8 must have equal DLC
         // - Data length equal to 8 hmust ave DLC >= 8
-        if dlc > 15 || ((data_len < 8) & (dlc != data_len)) || ((data_len == 8) & (dlc < 8)) {
+        if !remote_request && ((data_len < 8) & (dlc != data_len)) || ((data_len == 8) & (dlc < 8))
+        {
             return Err(EspTwaiError::NonCompliantDlc(dlc as u8));
         }
 

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -592,7 +592,7 @@ impl EspTwaiFrame {
         // For data frames, assert that:
         // - Data length smaller than 8 must have equal DLC
         // - Data length equal to 8 hmust ave DLC >= 8
-        if !remote_request && ((data_len < 8) & (dlc != data_len)) || ((data_len == 8) & (dlc < 8))
+        if !remote_request && (((data_len < 8) & (dlc != data_len)) || ((data_len == 8) & (dlc < 8)))
         {
             return Err(EspTwaiError::NonCompliantDlc(dlc as u8));
         }

--- a/esp-hal/src/twai/mod.rs
+++ b/esp-hal/src/twai/mod.rs
@@ -592,7 +592,8 @@ impl EspTwaiFrame {
         // For data frames, assert that:
         // - Data length smaller than 8 must have equal DLC
         // - Data length equal to 8 hmust ave DLC >= 8
-        if !remote_request && (((data_len < 8) & (dlc != data_len)) || ((data_len == 8) & (dlc < 8)))
+        if !remote_request
+            && (((data_len < 8) & (dlc != data_len)) || ((data_len == 8) & (dlc < 8)))
         {
             return Err(EspTwaiError::NonCompliantDlc(dlc as u8));
         }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` or `manual-changelog` label as appropriate.
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

Fix a request frame bug introduced recently (a94f6ec): assertions wrongly fail for Request Frame (`data_len == 0`) with `dlc > 0`.

I introduced that one a couple days ago. :disappointed: 

It is significant that this could not be caught by HIL tests because we do not provide a way to construct a self-reception Request Frame (only self-reception Data Frames) in the first place, therefore there is no test for it. If anything, this bug proves we need to fix this too.

Adding a `new_self_reception_request()` does not seem like the way to go. In fact, `new_self_reception()` (for Data Frames) does not look like it belongs there in the first place. I would rather:
- have a separate method to set the SR bit on an existing (Data or Request) Frame,
- or leave it to the Tx driver, by adding an alternative method to  `transmit()` (some sort of `fake_transmit()`)

Another thing i'm considering (and looking for feedback on) is a type-safe implementation, where Data Frame and Request Frame would have their own type. In which case a `new_self_reception()` method could work…

#### Testing

As it is, only code review could catch that one, and only code review can validate it.

# Changelog

## esp-hal
- No changelog necessary.
