### PR TITLE
Work around interrupt::free warning

### DIFF
--- a/esp-hal/src/interrupt/riscv.rs
+++ b/esp-hal/src/interrupt/riscv.rs
@@ -18,6 +18,9 @@ pub use esp_riscv_rt::TrapFrame;
 #[cfg_attr(interrupt_controller = "clic", path = "riscv/clic.rs")]
 mod cpu_int;
 
+// The software-interrupt driver is the only caller on this architecture, and that driver is
+// unstable.
+#[cfg(feature = "unstable")]
 pub(crate) use riscv::interrupt::free;
 
 use crate::{


### PR DESCRIPTION
LLMs waste way too many tokens figuring out this is a non-issue, so let's fix it :)