### PR TITLE
Deploy git documentation on push

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,6 +1,9 @@
 name: Documentation
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
@@ -21,6 +24,10 @@ on:
           - preview
           - production
 
+concurrency:
+  group: ${{ github.event_name == 'push' && 'docs-main' || format('docs-{0}', github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'push' }}
+
 env:
   CARGO_TERM_COLOR: always
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -28,7 +35,7 @@ env:
 jobs:
   setup:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'release:docs')) }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'release:docs')) }}
     # required for this step, as stdout is captured by `hal-xtask release tag-releases`
     env:
       RUST_LOG: off
@@ -49,14 +56,14 @@ jobs:
           repository: esp-rs/esp-hal
       - name: Build xtask
         run: |
-          cargo build --package=xtask --features=deploy-docs
-          cp target/debug/xtask ~/.cargo/bin/hal-xtask
+          cargo build --package=esp-devtool --features=deploy-docs
+          cp target/debug/esp-devtool ~/.cargo/bin/hal-xtask
 
       - name: Cache xtask for all jobs
         uses: actions/upload-artifact@v6
         with:
           name: xtask
-          path: target/debug/xtask
+          path: target/debug/esp-devtool
 
       - id: setup_manual
         name: Set up [manual run with specific packages]
@@ -67,18 +74,34 @@ jobs:
 
       - id: setup_pr
         name: Set up [pull request or all packages]
-        if: ${{ github.event_name == 'pull_request' || github.event.inputs.packages == '' }}
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         # Release PRs will ignore the tag values and just check out the latest commit
         run: |
           output=$(hal-xtask release tag-releases)
           echo "packages=${output}" >> "$GITHUB_OUTPUT"
 
+      - id: deploy_target
+        name: Set deploy target
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "base_url=https://docs.espressif.com/projects/rust/" >> "$GITHUB_OUTPUT"
+            echo "channel=main" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event.inputs.server }}" = "production" ]; then
+            echo "base_url=https://docs.espressif.com/projects/rust/" >> "$GITHUB_OUTPUT"
+            echo "channel=" >> "$GITHUB_OUTPUT"
+          else
+            echo "base_url=https://preview-docs.espressif.com/projects/rust/" >> "$GITHUB_OUTPUT"
+            echo "channel=" >> "$GITHUB_OUTPUT"
+          fi
+
     outputs:
       packages: "${{ steps.setup_manual.outputs.packages || steps.setup_pr.outputs.packages }}"
+      base_url: ${{ steps.deploy_target.outputs.base_url }}
+      channel: ${{ steps.deploy_target.outputs.channel }}
 
   build:
     needs: setup
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'release:docs')) }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'release:docs')) }}
     strategy:
       fail-fast: true
       matrix:
@@ -106,7 +129,7 @@ jobs:
       # If running a release PR, we want to build docs for the latest commit on the released branch.
       - name: Checkout repository
         uses: actions/checkout@v6
-        if: ${{ github.event_name != 'workflow_dispatch' }}
+        if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
         with:
           repository: esp-rs/esp-hal
 
@@ -118,8 +141,12 @@ jobs:
 
       - name: Build documentation
         run: |
-          chmod +x ~/.cargo/bin/xtask
-          ~/.cargo/bin/xtask build documentation --packages=${{ matrix.packages.name }} --base-url ${{ fromJSON('["https://preview-docs.espressif.com/projects/rust/", "https://docs.espressif.com/projects/rust/"]')[github.event.inputs.server == 'production'] }}
+          chmod +x ~/.cargo/bin/esp-devtool
+          CHANNEL_ARGS=""
+          if [ -n "${{ needs.setup.outputs.channel }}" ]; then
+            CHANNEL_ARGS="--channel ${{ needs.setup.outputs.channel }}"
+          fi
+          ~/.cargo/bin/esp-devtool build documentation --packages=${{ matrix.packages.name }} --base-url ${{ needs.setup.outputs.base_url }} $CHANNEL_ARGS
 
       # https://github.com/actions/deploy-pages/issues/303#issuecomment-1951207879
       - name: Remove problematic '.lock' files
@@ -134,7 +161,7 @@ jobs:
   assemble:
     needs: [setup, build]
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'release:docs')) }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'release:docs')) }}
 
     steps:
       # Check out the sources, the xtask reads package versions from the Cargo.toml files
@@ -148,8 +175,8 @@ jobs:
       # Create an index for _all_ packages. Per-package workflows don't upload the landing page.
       - name: Create index.html
         run: |
-          chmod +x docs/xtask/xtask
-          docs/xtask/xtask build documentation-index
+          chmod +x docs/xtask/esp-devtool
+          docs/xtask/esp-devtool build documentation-index --base-url ${{ needs.setup.outputs.base_url }}
           rm -rf docs/xtask
 
       - if: ${{ github.event.inputs.server == 'preview' || github.event_name == 'pull_request' }}
@@ -164,8 +191,8 @@ jobs:
           strip_components: 1 # remove the docs prefix
           overwrite: true
 
-      # Deploying to production server is only allowed for manual runs
-      - if: ${{ github.event.inputs.server == 'production' && github.event_name == 'workflow_dispatch' }}
+      # Deploying to production server is allowed for manual production runs and for pushes to main
+      - if: ${{ (github.event.inputs.server == 'production' && github.event_name == 'workflow_dispatch') || github.event_name == 'push' }}
         name: Deploy to production server
         uses: appleboy/scp-action@v0.1.7
         with:

--- a/resources/select.html.somni
+++ b/resources/select.html.somni
@@ -10,23 +10,22 @@
 
   select.addEventListener("change", (e) => {
     const selected = select.value;
+    const packageName = "{{ package }}";
 
-    // Replace the existing version number in the URL with the newly
-    // selected version:
-    let href = window.location.href;
-    href = href.replace(/[\d]+\.[\d]+\.[\d]+[^\/]*/g, selected);
-
-    // Redirect to the new URL:
-    window.location.href = href;
+    // Path layout is always `<base>/<package>/<version>/<rest>`. Replace only
+    // the version segment after the package directory.
+    const url = new URL(window.location.href);
+    const segments = url.pathname.split("/");
+    const packageIndex = segments.indexOf(packageName);
+    if (packageIndex !== -1 && packageIndex + 1 < segments.length) {
+      segments[packageIndex + 1] = selected;
+      url.pathname = segments.join("/");
+      window.location.href = url.toString();
+    }
   });
 
   document.addEventListener("DOMContentLoaded", (e) => {
     const selected = select.value;
-
-    // Remove any options currently present in the select box:
-    for (let child of select.children) {
-      child.remove();
-    }
 
     // Load the manifest JSON file and re-populate the select box with new
     // options for all available versions:
@@ -34,6 +33,14 @@
     fetch(manifestUrl)
       .then((res) => res.json())
       .then(({ versions }) => {
+        // The manifest of a freshly built version may not list it yet. The box must
+        // show the version of the page the reader is on, so keep it as an option.
+        if (!versions.includes(selected)) {
+          versions = [selected].concat(versions);
+        }
+
+        select.replaceChildren();
+
         for (let version of versions) {
           let option = document.createElement("option");
           option.text = version;

--- a/xtask-mcp-macros/src/lib.rs
+++ b/xtask-mcp-macros/src/lib.rs
@@ -29,22 +29,23 @@ struct ArgInfo {
     value_delimiter: Option<char>,
 }
 
-
 /// Parse a string literal from an expression.
 fn expr_lit_str(expr: &Expr) -> Option<String> {
     if let Expr::Lit(el) = expr
-        && let Lit::Str(s) = &el.lit {
-            return Some(s.value());
-        }
+        && let Lit::Str(s) = &el.lit
+    {
+        return Some(s.value());
+    }
     None
 }
 
 /// Parse a char literal from an expression.
 fn expr_lit_char(expr: &Expr) -> Option<char> {
     if let Expr::Lit(el) = expr
-        && let Lit::Char(c) = &el.lit {
-            return Some(c.value());
-        }
+        && let Lit::Char(c) = &el.lit
+    {
+        return Some(c.value());
+    }
     None
 }
 
@@ -58,9 +59,10 @@ fn extract_doc(attrs: &[Attribute]) -> String {
             }
             if let Meta::NameValue(nv) = &attr.meta
                 && let Expr::Lit(el) = &nv.value
-                    && let Lit::Str(s) = &el.lit {
-                        return Some(s.value().trim().to_string());
-                    }
+                && let Lit::Str(s) = &el.lit
+            {
+                return Some(s.value().trim().to_string());
+            }
             None
         })
         .filter(|s| !s.is_empty())

--- a/xtask-mcp-macros/src/lib.rs
+++ b/xtask-mcp-macros/src/lib.rs
@@ -19,6 +19,7 @@ use syn::{
 // Attribute parsing helpers
 
 /// Parsed information from a `#[arg(...)]` attribute.
+#[derive(Default)]
 struct ArgInfo {
     /// True if `long` (or `long = "name"`) was present.
     has_long: bool,
@@ -28,33 +29,22 @@ struct ArgInfo {
     value_delimiter: Option<char>,
 }
 
-impl Default for ArgInfo {
-    fn default() -> Self {
-        Self {
-            has_long: false,
-            long_name: String::new(),
-            value_delimiter: None,
-        }
-    }
-}
 
 /// Parse a string literal from an expression.
 fn expr_lit_str(expr: &Expr) -> Option<String> {
-    if let Expr::Lit(el) = expr {
-        if let Lit::Str(s) = &el.lit {
+    if let Expr::Lit(el) = expr
+        && let Lit::Str(s) = &el.lit {
             return Some(s.value());
         }
-    }
     None
 }
 
 /// Parse a char literal from an expression.
 fn expr_lit_char(expr: &Expr) -> Option<char> {
-    if let Expr::Lit(el) = expr {
-        if let Lit::Char(c) = &el.lit {
+    if let Expr::Lit(el) = expr
+        && let Lit::Char(c) = &el.lit {
             return Some(c.value());
         }
-    }
     None
 }
 
@@ -66,13 +56,11 @@ fn extract_doc(attrs: &[Attribute]) -> String {
             if !attr.path().is_ident("doc") {
                 return None;
             }
-            if let Meta::NameValue(nv) = &attr.meta {
-                if let Expr::Lit(el) = &nv.value {
-                    if let Lit::Str(s) = &el.lit {
+            if let Meta::NameValue(nv) = &attr.meta
+                && let Expr::Lit(el) = &nv.value
+                    && let Lit::Str(s) = &el.lit {
                         return Some(s.value().trim().to_string());
                     }
-                }
-            }
             None
         })
         .filter(|s| !s.is_empty())
@@ -433,7 +421,7 @@ fn expand_mcp_tool(attrs: McpToolAttrs, item: &ItemStruct) -> syn::Result<TokenS
     let input_type_name = format_ident!("{}McpInput", struct_name);
 
     // Derive the tool name from the command string: spaces/hyphens → underscores.
-    let tool_name = attrs.command.replace(' ', "_").replace('-', "_");
+    let tool_name = attrs.command.replace([' ', '-'], "_");
 
     // Split the command string into individual CLI tokens.
     let command_parts: Vec<String> = attrs

--- a/xtask/src/cargo.rs
+++ b/xtask/src/cargo.rs
@@ -576,6 +576,12 @@ impl CargoCommandBatcher {
     }
 }
 
+impl Default for CargoCommandBatcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Drop for CargoCommandBatcher {
     fn drop(&mut self) {}
 }
@@ -590,8 +596,7 @@ pub struct CargoToml {
     pub manifest: toml_edit::DocumentMut,
 }
 
-const DEPENDENCY_KINDS: [&'static str; 3] =
-    ["dependencies", "dev-dependencies", "build-dependencies"];
+const DEPENDENCY_KINDS: [&str; 3] = ["dependencies", "dev-dependencies", "build-dependencies"];
 
 impl CargoToml {
     /// Load and parse the Cargo.toml for the specified package in the given workspace.
@@ -612,16 +617,10 @@ impl CargoToml {
     }
 
     pub fn espressif_metadata(&self) -> Option<&Table> {
-        let Some(package) = self.manifest.get("package") else {
-            return None;
-        };
-        let Some(metadata) = package.get("metadata") else {
-            return None;
-        };
-        let Some(espressif) = metadata.get("espressif") else {
-            return None;
-        };
-        Some(espressif.as_table()?)
+        let package = self.manifest.get("package")?;
+        let metadata = package.get("metadata")?;
+        let espressif = metadata.get("espressif")?;
+        espressif.as_table()
     }
 
     /// Create a `CargoToml` instance from a manifest string.
@@ -759,10 +758,10 @@ impl CargoToml {
                     name
                 };
 
-                if let Ok(package) = Package::from_str(name, true) {
-                    if !dependencies.contains(&package) {
-                        dependencies.push(package);
-                    }
+                if let Ok(package) = Package::from_str(name, true)
+                    && !dependencies.contains(&package)
+                {
+                    dependencies.push(package);
                 }
             }
         });
@@ -778,7 +777,7 @@ impl CargoToml {
 
         self.visit_dependencies(|_, _, table| {
             // Update dependencies which specify a version:
-            match &mut table[&package_name] {
+            match &mut table[package_name] {
                 Item::Value(Value::String(table)) => {
                     // package = "version"
                     *table = Formatted::new(format_dependency_version(table.value(), version));
@@ -800,15 +799,14 @@ impl CargoToml {
                 Item::None => {
                     // alias = { package = "foo", version = "version" }
                     let update_renamed_dep = table.get_values().iter().find_map(|(k, p)| {
-                        if let Value::InlineTable(table) = p {
-                            if let Some(Value::String(name)) = &table.get("package") {
-                                if name.value() == &package_name {
-                                    // Return the actual key of this dependency, e.g.:
-                                    // `procmacros = { package = "esp-hal-procmacros" }`
-                                    //  ^^^^^^^^^^
-                                    return Some(k.last().unwrap().get().to_string());
-                                }
-                            }
+                        if let Value::InlineTable(table) = p
+                            && let Some(Value::String(name)) = &table.get("package")
+                            && name.value() == package_name
+                        {
+                            // Return the actual key of this dependency, e.g.:
+                            // `procmacros = { package = "esp-hal-procmacros" }`
+                            //  ^^^^^^^^^^
+                            return Some(k.last().unwrap().get().to_string());
                         }
 
                         None

--- a/xtask/src/commands/build.rs
+++ b/xtask/src/commands/build.rs
@@ -183,7 +183,7 @@ pub fn build_examples(
     // Build command list
     for example in examples.iter() {
         let command = crate::generate_build_command(
-            &package_path,
+            package_path,
             chip,
             &target,
             example,

--- a/xtask/src/commands/build.rs
+++ b/xtask/src/commands/build.rs
@@ -23,7 +23,7 @@ pub enum Build {
     Documentation(BuildDocumentationArgs),
     /// Build documentation index.
     #[cfg(feature = "deploy-docs")]
-    DocumentationIndex,
+    DocumentationIndex(BuildDocumentationIndexArgs),
     /// Build all examples for the specified chip.
     Examples(ExamplesArgs),
     /// Build the specified package with the given options.
@@ -54,9 +54,24 @@ pub struct BuildDocumentationArgs {
     /// Base URL of the deployed documentation.
     #[arg(long)]
     pub base_url: Option<String>,
+    /// Documentation channel name (for example `main`).
+    ///
+    /// When set, documentation is written under this name instead of the crate
+    /// version, so a local or CI build cannot overwrite a released docs tree.
+    #[arg(long)]
+    pub channel: Option<String>,
     #[cfg(feature = "preview-docs")]
     #[arg(long)]
     pub serve: bool,
+}
+
+/// Arguments for building the documentation index.
+#[cfg(feature = "deploy-docs")]
+#[derive(Debug, Default, Args)]
+pub struct BuildDocumentationIndexArgs {
+    /// Base URL of the deployed documentation.
+    #[arg(long)]
+    pub base_url: Option<String>,
 }
 
 /// Arguments for building a package.
@@ -100,10 +115,11 @@ pub fn build_documentation(workspace: &Path, mut args: BuildDocumentationArgs) -
         workspace,
         &mut args.packages,
         &mut args.chips,
-        args.base_url,
+        args.base_url.clone(),
+        args.channel,
     )?;
 
-    crate::documentation::build_documentation_index(workspace, &mut args.packages)?;
+    crate::documentation::build_documentation_index(workspace, &mut args.packages, args.base_url)?;
 
     #[cfg(feature = "preview-docs")]
     if args.serve {
@@ -138,9 +154,12 @@ pub fn build_documentation(workspace: &Path, mut args: BuildDocumentationArgs) -
 
 /// Build the documentation index for all packages.
 #[cfg(feature = "deploy-docs")]
-pub fn build_documentation_index(workspace: &Path) -> Result<()> {
+pub fn build_documentation_index(
+    workspace: &Path,
+    args: BuildDocumentationIndexArgs,
+) -> Result<()> {
     let mut packages = Package::iter().collect::<Vec<_>>();
-    crate::documentation::build_documentation_index(workspace, &mut packages)?;
+    crate::documentation::build_documentation_index(workspace, &mut packages, args.base_url)?;
 
     Ok(())
 }

--- a/xtask/src/commands/mod.rs
+++ b/xtask/src/commands/mod.rs
@@ -229,10 +229,10 @@ impl ExamplesPackage {
     }
 
     fn single_project_examples(&self) -> bool {
-        match self {
-            ExamplesPackage::Examples | ExamplesPackage::CompileTests => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            ExamplesPackage::Examples | ExamplesPackage::CompileTests
+        )
     }
 }
 
@@ -417,12 +417,9 @@ pub fn examples(workspace: &Path, mut args: ExamplesArgs, action: CargoAction) -
 
     // Execute the specified action:
     match action {
-        CargoAction::Build(out_path) => build_examples(
-            args,
-            filtered,
-            &package_path,
-            out_path.as_ref().map(|p| p.as_path()),
-        ),
+        CargoAction::Build(out_path) => {
+            build_examples(args, filtered, &package_path, out_path.as_deref())
+        }
         CargoAction::Run => run_examples(args, filtered, &package_path),
     }
 }
@@ -500,15 +497,12 @@ pub fn tests(workspace: &Path, args: TestsArgs, action: CargoAction) -> Result<(
                 &[]
             } else {
                 (action == CargoAction::Run)
-                    .then(|| filter.as_ref().map(|f| std::slice::from_ref(f)))
+                    .then(|| filter.as_ref().map(std::slice::from_ref))
                     .flatten()
                     .unwrap_or(&[])
             };
 
-            let matched: Vec<_> = all_tests
-                .iter()
-                .filter(|t| t.matches(test_arg.as_deref()))
-                .collect();
+            let matched: Vec<_> = all_tests.iter().filter(|t| t.matches(test_arg)).collect();
 
             if matched.is_empty() {
                 if is_radio_package

--- a/xtask/src/commands/release/bump_version.rs
+++ b/xtask/src/commands/release/bump_version.rs
@@ -169,7 +169,7 @@ fn check_crate_before_bumping(manifest: &mut CargoToml) -> Result<()> {
         let mut error_message = String::new();
         for (dep_kind, errors) in errors {
             if !error_message.is_empty() {
-                error_message.push_str("\n");
+                error_message.push('\n');
             }
             writeln!(&mut error_message, "In [{dep_kind}]:").unwrap();
             for (krate, error) in errors {
@@ -193,7 +193,7 @@ fn check_dependency_before_bumping(item: &Item) -> Result<()> {
         Ok(())
     }
 
-    fn check_for_non_version_deps<'a, T: TableLike>(dependency: &T) -> Result<()> {
+    fn check_for_non_version_deps<T: TableLike>(dependency: &T) -> Result<()> {
         if let Some(version) = dependency.get("version") {
             if let Some(version) = version.as_str() {
                 validate_simple_version(version)?;
@@ -280,7 +280,7 @@ fn bump_crate_version(
             let content = fs::read_to_string(&p)
                 .with_context(|| format!("Could not read {}", p.display()))?;
             CargoToml::from_str(&bumped_package.workspace, Package::Examples, &content)
-                .with_context(|| format!("Could not parse Cargo.toml"))
+                .with_context(|| "Could not parse Cargo.toml".to_string())
         }));
 
     for dependent in tomls {
@@ -460,16 +460,16 @@ fn finalize_placeholders(
     let is_prerelease = !new_version.pre.is_empty();
 
     walk_dir(&bumped_package.package_path(), &skip_paths, &mut |path| {
-        if is_prerelease {
-            if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-                if name.starts_with("MIGRATING-") && name.ends_with(".md") {
-                    log::info!(
-                        "  Skipping migration guide {} (pre-release)",
-                        path.display()
-                    );
-                    return;
-                }
-            }
+        if is_prerelease
+            && let Some(name) = path.file_name().and_then(|n| n.to_str())
+            && name.starts_with("MIGRATING-")
+            && name.ends_with(".md")
+        {
+            log::info!(
+                "  Skipping migration guide {} (pre-release)",
+                path.display()
+            );
+            return;
         }
 
         let content = match fs::read_to_string(path) {

--- a/xtask/src/commands/run.rs
+++ b/xtask/src/commands/run.rs
@@ -86,7 +86,7 @@ pub fn run_doc_tests_for_package(workspace: &Path, package: Package, chip: Chip)
     }
 
     // Packages that have doc features are documented. We run doc-tests for these, and only these.
-    let Some(mut doc_config) = package.doc_config_rules(&crate::metadata::Config::for_chip(&chip))
+    let Some(mut doc_config) = package.doc_config_rules(crate::metadata::Config::for_chip(&chip))
     else {
         log::info!("Skipping undocumented package {package}.");
         return Ok(true);

--- a/xtask/src/documentation.rs
+++ b/xtask/src/documentation.rs
@@ -161,11 +161,11 @@ fn build_documentation_for_package(
     manifest: &Manifest,
 ) -> Result<()> {
     // Ensure that the package/chip combination provided are valid:
-    if let Some(chip) = chip {
-        if let Err(err) = package.validate_package_chip(&chip) {
-            log::warn!("{err}");
-            return Ok(());
-        }
+    if let Some(chip) = chip
+        && let Err(err) = package.validate_package_chip(&chip)
+    {
+        log::warn!("{err}");
+        return Ok(());
     }
 
     // Build the documentation for the specified package, targeting the
@@ -444,7 +444,7 @@ fn cargo_doc_without_pre_processing(
 ///
 /// The only currently supported function for expressions is `has(<SYMBOL>)`
 /// e.g. `has("psram")`
-fn pre_process_cargo_toml(chip: Option<Chip>, package_path: &PathBuf) -> Result<(), anyhow::Error> {
+fn pre_process_cargo_toml(chip: Option<Chip>, package_path: &Path) -> Result<(), anyhow::Error> {
     let cargo_toml = std::fs::read_to_string(windows_safe_path(&package_path.join("Cargo.toml")))
         .with_context(|| {
         format!(
@@ -466,11 +466,7 @@ fn pre_process_cargo_toml(chip: Option<Chip>, package_path: &PathBuf) -> Result<
 
     let cargo_toml = cargo_toml.lines();
 
-    let chip_cfg = if let Some(chip) = &chip {
-        Some(Config::for_chip(chip))
-    } else {
-        None
-    };
+    let chip_cfg = chip.as_ref().map(|chip| Config::for_chip(chip));
     let mut processed_cargo_toml = Vec::new();
     let mut engine = somni_expr::Context::new();
     engine.add_function("has", move |cond: &str| -> bool {
@@ -642,7 +638,7 @@ pub fn build_documentation_index(
             continue;
         }
         for version_path in fs::read_dir(&package_docs_path)
-            .with_context(|| format!("Failed to read {}", &package_docs_path.display()))?
+            .with_context(|| format!("Failed to read {}", package_docs_path.display()))?
         {
             let version_path = version_path?.path();
             if version_path.is_file() {

--- a/xtask/src/documentation.rs
+++ b/xtask/src/documentation.rs
@@ -39,6 +39,7 @@ impl Manifest {
         }
     }
 
+    /// Sorts channel names first, then versions from newest to oldest.
     fn normalize_versions(&mut self) {
         self.versions.sort_by_key(|v| {
             let trimmed = v.trim();
@@ -46,14 +47,10 @@ impl Manifest {
             let rank = match trimmed.to_lowercase().as_str() {
                 "main" => 0,
                 "git" => 1,
-                _ => 2,
+                _ if semver.is_some() => 2,
+                _ => 3,
             };
-            (
-                semver.is_none(),
-                std::cmp::Reverse(semver),
-                rank,
-                trimmed.to_lowercase(),
-            )
+            (rank, std::cmp::Reverse(semver), trimmed.to_lowercase())
         });
     }
 }
@@ -64,6 +61,7 @@ pub fn build_documentation(
     packages: &mut [Package],
     chips: &mut [Chip],
     base_url: Option<String>,
+    channel: Option<String>,
 ) -> Result<()> {
     log::info!("Building documentation for packages: {packages:?} on chips: {chips:?}");
     let output_path = workspace.join("docs");
@@ -79,9 +77,13 @@ pub fn build_documentation(
             continue;
         }
 
-        // Download the manifest from the documentation server if able,
-        // otherwise just create a default (empty) manifest:
-        let mut manifest = fetch_manifest(&base_url, package)?;
+        // Download the manifest from the documentation server. A package that was never
+        // deployed has no manifest, but a failed download must not look like an empty
+        // manifest: the manifest decides if this build may claim the `latest` redirect.
+        let mut manifest = match fetch_manifest(&base_url, package)? {
+            ManifestFetch::Found(manifest) => manifest,
+            ManifestFetch::NotFound => Manifest::default(),
+        };
 
         // If the package does not have chip features, then just ignore
         // whichever chip(s) were specified as arguments:
@@ -99,16 +101,32 @@ pub fn build_documentation(
             vec![]
         };
 
-        // Update the package manifest to include the latest version:
         let version = crate::package_version(workspace, *package)?;
-        manifest.insert_version(version.to_string());
+        let version_label = channel.clone().unwrap_or_else(|| version.to_string());
+
+        // Update the package manifest to include the channel or crate version:
+        manifest.insert_version(&version_label);
 
         // Build the documentation for the package:
         if chips.is_empty() {
-            build_documentation_for_package(workspace, package, None)?;
+            build_documentation_for_package(
+                workspace,
+                package,
+                None,
+                &version,
+                channel.as_deref(),
+                &manifest,
+            )?;
         } else {
             for chip in chips {
-                build_documentation_for_package(workspace, package, Some(chip))?;
+                build_documentation_for_package(
+                    workspace,
+                    package,
+                    Some(chip),
+                    &version,
+                    channel.as_deref(),
+                    &manifest,
+                )?;
             }
         }
 
@@ -128,7 +146,7 @@ pub fn build_documentation(
 
         // Patch the generated documentation to include a select box for the version:
         #[cfg(feature = "deploy-docs")]
-        patch_documentation_index_for_package(workspace, package, &version, &base_url)?;
+        patch_documentation_index_for_package(workspace, package, &version_label, &base_url)?;
     }
 
     Ok(())
@@ -138,9 +156,10 @@ fn build_documentation_for_package(
     workspace: &Path,
     package: &Package,
     chip: Option<Chip>,
+    version: &semver::Version,
+    channel: Option<&str>,
+    manifest: &Manifest,
 ) -> Result<()> {
-    let version = crate::package_version(workspace, *package)?;
-
     // Ensure that the package/chip combination provided are valid:
     if let Some(chip) = chip {
         if let Err(err) = package.validate_package_chip(&chip) {
@@ -159,10 +178,11 @@ fn build_documentation_for_package(
         docs_path.display()
     );
 
+    let version_component = docs_version_component(version, channel);
     let mut output_path = workspace
         .join("docs")
         .join(package.to_string())
-        .join(version.to_string());
+        .join(&version_component);
 
     if let Some(chip) = chip {
         // Sometimes we need to specify a chip feature, but it does not affect the
@@ -186,29 +206,83 @@ fn build_documentation_for_package(
         )
     })?;
 
-    // create "/latest" redirect - assuming that the current version is the latest.
-    //
     // Hosted docs rely on nginx to rewrite `/latest/...` deep links to `/latest/?path=...`.
-    let latest_path = if package.chip_features_matter() {
-        output_path
-            .parent()
-            .unwrap()
-            .parent()
-            .unwrap()
-            .join("latest")
-    } else {
-        output_path.parent().unwrap().join("latest")
-    };
-    log::info!("Creating latest version redirect at {:?}", latest_path);
-    create_dir_all(latest_path.clone())
-        .with_context(|| format!("Failed to create dir in {}", latest_path.display()))?;
-    let latest_html = latest_redirect_html(workspace, package, &version)
-        .with_context(|| format!("Failed to render latest redirect for {}", package))?;
-    std::fs::File::create(latest_path.clone().join("index.html"))?
-        .write_all(latest_html.as_bytes())
-        .with_context(|| format!("Failed to create or write to {}", latest_path.display()))?;
+    if should_write_latest_redirect(version, channel, manifest) {
+        let latest_path = if package.chip_features_matter() {
+            output_path
+                .parent()
+                .unwrap()
+                .parent()
+                .unwrap()
+                .join("latest")
+        } else {
+            output_path.parent().unwrap().join("latest")
+        };
+        log::info!("Creating latest version redirect at {:?}", latest_path);
+        create_dir_all(latest_path.clone())
+            .with_context(|| format!("Failed to create dir in {}", latest_path.display()))?;
+        let latest_html = latest_redirect_html(workspace, package, version)
+            .with_context(|| format!("Failed to render latest redirect for {}", package))?;
+        std::fs::File::create(latest_path.clone().join("index.html"))?
+            .write_all(latest_html.as_bytes())
+            .with_context(|| format!("Failed to create or write to {}", latest_path.display()))?;
+    }
 
     Ok(())
+}
+
+/// Directory name under `docs/<package>/` for this build.
+fn docs_version_component(version: &semver::Version, channel: Option<&str>) -> String {
+    match channel {
+        Some(channel) => channel.to_string(),
+        None => version.to_string(),
+    }
+}
+
+/// Whether a version may claim the `latest` redirect or a root-index row.
+///
+/// Any stable release is eligible. A pre-release is eligible only when it is
+/// `X.0.0-pre` for some major version `X >= 1` (for example `1.0.0-beta.0`).
+fn is_eligible_docs_version(version: &semver::Version) -> bool {
+    version.pre.is_empty() || (version.major >= 1 && version.minor == 0 && version.patch == 0)
+}
+
+/// Whether this build should write `latest/index.html`.
+fn should_write_latest_redirect(
+    version: &semver::Version,
+    channel: Option<&str>,
+    manifest: &Manifest,
+) -> bool {
+    if channel.is_some() {
+        return false;
+    }
+    if !is_eligible_docs_version(version) {
+        return false;
+    }
+    // Only a version that may claim the redirect itself can block this build from
+    // claiming it. An ineligible pre-release must not hold `latest` hostage.
+    match highest_eligible_version(manifest) {
+        Some(highest) => *version >= highest,
+        None => true,
+    }
+}
+
+/// Highest eligible semver in `manifest`, if it holds one.
+fn highest_eligible_version(manifest: &Manifest) -> Option<semver::Version> {
+    let mut best: Option<semver::Version> = None;
+    for entry in &manifest.versions {
+        let Ok(ver) = semver::Version::parse(entry) else {
+            continue;
+        };
+        if !is_eligible_docs_version(&ver) {
+            continue;
+        }
+        best = Some(match best {
+            None => ver,
+            Some(b) => ver.max(b),
+        });
+    }
+    best
 }
 
 /// Relative URL from `latest/index.html` to this package's versioned docs root.
@@ -470,14 +544,14 @@ fn restore_cargo_toml(package_path: PathBuf) -> Result<(), anyhow::Error> {
 fn patch_documentation_index_for_package(
     workspace: &Path,
     package: &Package,
-    version: &semver::Version,
+    version: &str,
     base_url: &Option<String>,
 ) -> Result<()> {
     use kuchikiki::traits::*;
 
     let package_name = package.to_string().replace('-', "_");
     let package_path = workspace.join("docs").join(package.to_string());
-    let version_path = package_path.join(version.to_string());
+    let version_path = package_path.join(version);
 
     let mut index_paths = Vec::new();
 
@@ -488,15 +562,15 @@ fn patch_documentation_index_for_package(
             let chip_path = chip_path?.path();
             if chip_path.is_dir() {
                 let path = chip_path.join(&package_name).join("index.html");
-                index_paths.push((version.clone(), path));
+                index_paths.push(path);
             }
         }
     } else {
         let path = version_path.join(&package_name).join("index.html");
-        index_paths.push((version.clone(), path));
+        index_paths.push(path);
     }
 
-    for (version, index_path) in index_paths {
+    for index_path in index_paths {
         let html = fs::read_to_string(&index_path)
             .with_context(|| format!("Failed to read {}", index_path.display()))?;
         let document = kuchikiki::parse_html().one(html);
@@ -529,38 +603,12 @@ fn patch_documentation_index_for_package(
 // ----------------------------------------------------------------------------
 // Build Documentation Index
 
-/// Returns the highest stable (non-prerelease) `semver::Version` found among the version-named
-/// directories under `package_docs_path`. Used to avoid defaulting to pre-releases when a stable
-/// version exists alongside a pre-release.
-fn latest_stable_docs_version(package_docs_path: &Path) -> Option<semver::Version> {
-    let mut best: Option<semver::Version> = None;
-    let entries = fs::read_dir(package_docs_path).ok()?;
-    for entry in entries.flatten() {
-        let path = entry.path();
-        // Skip non-directory entries
-        if !path.is_dir() {
-            continue;
-        }
-        let name = path.file_name()?.to_string_lossy();
-        // Parse the version from the directory name
-        let Ok(ver) = name.parse::<semver::Version>() else {
-            continue;
-        };
-        // Skip pre-release versions
-        if !ver.pre.is_empty() {
-            continue;
-        }
-        // If multiple stable versions exist, return the highest one
-        best = Some(match best {
-            None => ver,
-            Some(b) => ver.max(b),
-        });
-    }
-    best
-}
-
 /// Build the documentation index for all packages.
-pub fn build_documentation_index(workspace: &Path, packages: &mut [Package]) -> Result<()> {
+pub fn build_documentation_index(
+    workspace: &Path,
+    packages: &mut [Package],
+    base_url: Option<String>,
+) -> Result<()> {
     let docs_path = workspace.join("docs");
     let resources_path = workspace.join("resources");
 
@@ -585,7 +633,7 @@ pub fn build_documentation_index(workspace: &Path, packages: &mut [Package]) -> 
         let package_docs_path = docs_path.join(package.as_ref());
 
         // Each path we iterate over should be the directory for a given version of
-        // the package's documentation (non-semver names, e.g. `latest`, are skipped).
+        // the package's documentation (`latest` is skipped).
         if !package_docs_path.exists() {
             log::warn!(
                 "Package documentation path does not exist: '{}', skipping",
@@ -602,6 +650,14 @@ pub fn build_documentation_index(workspace: &Path, packages: &mut [Package]) -> 
                     "Path is not a directory, skipping: '{}'",
                     version_path.display()
                 );
+                continue;
+            }
+
+            let version_label = version_path
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            if version_label == "latest" {
                 continue;
             }
 
@@ -630,22 +686,7 @@ pub fn build_documentation_index(workspace: &Path, packages: &mut [Package]) -> 
 
             chips.sort();
 
-            let channel = version_path
-                .file_name()
-                .map(|n| n.to_string_lossy())
-                .unwrap_or_default();
-            let current_version = match channel.parse::<semver::Version>() {
-                Ok(v) => v,
-                Err(_) => {
-                    log::debug!(
-                        "Skipping package doc directory (not semver): {}",
-                        version_path.display()
-                    );
-                    continue;
-                }
-            };
-
-            let meta = generate_documentation_meta_for_package(*package, &chips, current_version)?;
+            let meta = generate_documentation_meta_for_package(*package, &chips, &version_label)?;
 
             // Render the template to HTML and write it out to the desired path:
             let html = render_template(&resources_path, "package_index.html.somni", {
@@ -672,7 +713,7 @@ pub fn build_documentation_index(workspace: &Path, packages: &mut [Package]) -> 
     )
     .context("Failed to copy esp-rs-grey-bg.svg")?;
 
-    let meta = generate_documentation_meta_for_index(workspace)?;
+    let meta = generate_documentation_meta_for_index(workspace, &base_url)?;
 
     // Render the template to HTML and write it out to the desired path:
     let html = render_template(&resources_path, "index.html.somni", {
@@ -696,14 +737,14 @@ pub fn build_documentation_index(workspace: &Path, packages: &mut [Package]) -> 
 fn generate_documentation_meta_for_package(
     package: Package,
     chips: &[Chip],
-    doc_tree_version: semver::Version,
+    doc_tree_version: &str,
 ) -> Result<Vec<Meta>> {
     let mut metadata = Vec::new();
     let types = &mut TemplateTypes::default();
 
     let name = package.to_string();
     let crate_name = name.replace('-', "_");
-    let version = doc_tree_version.to_string();
+    let version = doc_tree_version;
 
     for chip in chips {
         // Ensure that the package/chip combination provided are valid:
@@ -719,7 +760,7 @@ fn generate_documentation_meta_for_package(
             types,
             Meta {
                 name: name.as_str(),
-                version: version.as_str(),
+                version: version,
                 chip: chip_name.as_str(),
                 chip_pretty: chip.pretty_name(),
                 package: crate_name.as_str(),
@@ -732,7 +773,10 @@ fn generate_documentation_meta_for_package(
     Ok(metadata)
 }
 
-fn generate_documentation_meta_for_index(workspace: &Path) -> Result<Vec<Meta>> {
+fn generate_documentation_meta_for_index(
+    workspace: &Path,
+    base_url: &Option<String>,
+) -> Result<Vec<Meta>> {
     let mut metadata = Vec::new();
     let docs_path = workspace.join("docs");
     let types = &mut TemplateTypes::default();
@@ -743,9 +787,14 @@ fn generate_documentation_meta_for_index(workspace: &Path) -> Result<Vec<Meta>> 
             continue;
         }
 
-        let cargo_version = crate::package_version(workspace, package)?;
-        let package_docs_path = docs_path.join(package.as_ref());
-        let version = latest_stable_docs_version(&package_docs_path).unwrap_or(cargo_version);
+        let manifest = load_manifest_for_index(&docs_path, &package, base_url)?;
+        // A manifest that holds no eligible version must not send the reader to a channel
+        // that this package may never have deployed. The version of this checkout is the
+        // best guess that a release run can make.
+        let version = match highest_eligible_version(&manifest) {
+            Some(version) => version.to_string(),
+            None => crate::package_version(workspace, package)?.to_string(),
+        };
 
         let url = if package.chip_features_matter() {
             format!("{package}/{version}/index.html")
@@ -755,7 +804,6 @@ fn generate_documentation_meta_for_index(workspace: &Path) -> Result<Vec<Meta>> 
         };
 
         let name = package.to_string();
-        let version = version.to_string();
         metadata.push(somni_struct!(
             types,
             Meta {
@@ -771,34 +819,95 @@ fn generate_documentation_meta_for_index(workspace: &Path) -> Result<Vec<Meta>> 
     Ok(metadata)
 }
 
+fn load_manifest_for_index(
+    docs_path: &Path,
+    package: &Package,
+    base_url: &Option<String>,
+) -> Result<Manifest> {
+    let local_path = docs_path.join(package.to_string()).join("manifest.json");
+    if local_path.exists() {
+        let contents = fs::read_to_string(&local_path)
+            .with_context(|| format!("Failed to read {}", local_path.display()))?;
+        return serde_json::from_str(&contents)
+            .with_context(|| format!("Failed to parse {}", local_path.display()));
+    }
+
+    match fetch_manifest(base_url, package)? {
+        ManifestFetch::Found(manifest) => Ok(manifest),
+        ManifestFetch::NotFound => Ok(Manifest::default()),
+    }
+}
+
 // ----------------------------------------------------------------------------
 // Helper Functions
 
-fn fetch_manifest(base_url: &Option<String>, package: &Package) -> Result<Manifest> {
-    let mut manifest_url = base_url
-        .clone()
-        .unwrap_or_default()
-        .trim_end_matches('/')
-        .to_string();
-    manifest_url.push_str(&format!("/{package}/manifest.json"));
+#[derive(Debug)]
+enum ManifestFetch {
+    /// Present when `deploy-docs` successfully downloads a manifest.
+    #[allow(dead_code)]
+    Found(Manifest),
+    /// HTTP 404, missing base URL, or `deploy-docs` disabled.
+    NotFound,
+}
 
-    #[cfg(feature = "deploy-docs")]
-    let manifest = match reqwest::blocking::get(manifest_url) {
-        Ok(resp) if resp.status().is_success() => resp.json::<Manifest>()?,
-        Ok(resp) => {
-            log::warn!("Unable to fetch package manifest: {}", resp.status());
-            Manifest::default()
-        }
-        Err(err) => {
-            log::warn!("Unable to fetch package manifest: {err}");
-            Manifest::default()
-        }
+fn fetch_manifest(base_url: &Option<String>, package: &Package) -> Result<ManifestFetch> {
+    let Some(base_url) = base_url
+        .as_ref()
+        .map(|url| url.trim_end_matches('/'))
+        .filter(|url| !url.is_empty())
+    else {
+        return Ok(ManifestFetch::NotFound);
     };
 
-    #[cfg(not(feature = "deploy-docs"))]
-    let manifest = Manifest::default();
+    let manifest_url = format!("{base_url}/{package}/manifest.json");
 
-    Ok(manifest)
+    #[cfg(feature = "deploy-docs")]
+    {
+        /// A transient failure of the documentation server must not fail a build, but the
+        /// manifest is also too important to give up on. Try this many times.
+        const ATTEMPTS: u32 = 4;
+
+        let mut last_error = None;
+        for attempt in 1..=ATTEMPTS {
+            if attempt > 1 {
+                // Back off for 1s, 2s, then 4s.
+                let delay = std::time::Duration::from_secs(1 << (attempt - 2));
+                log::warn!(
+                    "Retrying manifest download in {}s ({attempt}/{ATTEMPTS})",
+                    delay.as_secs()
+                );
+                std::thread::sleep(delay);
+            }
+
+            last_error = match reqwest::blocking::get(&manifest_url) {
+                Ok(resp) if resp.status().is_success() => {
+                    return Ok(ManifestFetch::Found(resp.json()?));
+                }
+                // The package was never deployed. Retrying cannot change that.
+                Ok(resp) if resp.status() == reqwest::StatusCode::NOT_FOUND => {
+                    return Ok(ManifestFetch::NotFound);
+                }
+                Ok(resp) => Some(anyhow::anyhow!(
+                    "Unable to fetch package manifest from {manifest_url}: {}",
+                    resp.status()
+                )),
+                Err(err) => Some(anyhow::anyhow!(
+                    "Unable to fetch package manifest from {manifest_url}: {err}"
+                )),
+            };
+        }
+
+        Err(last_error.unwrap().context(format!(
+            "Failed to fetch the manifest of {package} in {ATTEMPTS} attempts"
+        )))
+    }
+
+    #[cfg(not(feature = "deploy-docs"))]
+    {
+        let _ = manifest_url;
+        let _ = package;
+        Ok(ManifestFetch::NotFound)
+    }
 }
 
 fn render_template(resources: &Path, template: &str, env: Env) -> Result<String> {
@@ -816,70 +925,143 @@ fn render_template(resources: &Path, template: &str, env: Env) -> Result<String>
 
 #[cfg(test)]
 mod tests {
-    use std::{fs, path::Path};
+    use std::path::Path;
 
     use somni_expr::somni_struct;
     use somni_template::{Env, Iter, TemplateTypes};
-    use tempfile::TempDir;
 
     use super::{
         Manifest,
+        docs_version_component,
         generate_documentation_meta_for_package,
+        highest_eligible_version,
+        is_eligible_docs_version,
         latest_redirect_base,
         latest_redirect_html,
-        latest_stable_docs_version,
         render_template,
+        should_write_latest_redirect,
     };
 
     fn workspace() -> &'static Path {
         Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap()
     }
 
-    fn mkdir(root: &Path, name: &str) {
-        fs::create_dir_all(root.join(name)).unwrap();
+    fn version(s: &str) -> semver::Version {
+        semver::Version::parse(s).unwrap()
+    }
+
+    fn manifest(versions: &[&str]) -> Manifest {
+        let mut manifest = Manifest::default();
+        for v in versions {
+            manifest.insert_version(*v);
+        }
+        manifest
     }
 
     #[test]
-    fn picks_highest_stable_and_ignores_prerelease_and_nonsemver_names() {
-        let tmp = TempDir::new().unwrap();
-        let root = tmp.path();
-        mkdir(root, "0.9.0");
-        mkdir(root, "1.0.0");
-        mkdir(root, "1.1.0-rc.0");
-        mkdir(root, "2.0.0");
-        mkdir(root, "latest");
-        mkdir(root, "main");
+    fn eligible_docs_version_rule() {
+        assert!(is_eligible_docs_version(&version("0.5.0")));
+        assert!(is_eligible_docs_version(&version("1.0.0")));
+        assert!(is_eligible_docs_version(&version("1.0.0-beta.0")));
+        assert!(is_eligible_docs_version(&version("2.0.0-rc.1")));
+        assert!(!is_eligible_docs_version(&version("0.6.0-rc.0")));
+        assert!(!is_eligible_docs_version(&version("1.1.0-rc.0")));
+        assert!(!is_eligible_docs_version(&version("1.0.1-beta.0")));
+    }
+
+    #[test]
+    fn latest_redirect_respects_channel_eligibility_and_manifest() {
+        let empty = Manifest::default();
+        assert!(should_write_latest_redirect(
+            &version("1.0.0-beta.0"),
+            None,
+            &empty
+        ));
+        assert!(!should_write_latest_redirect(
+            &version("1.0.0-beta.0"),
+            Some("main"),
+            &empty
+        ));
+        assert!(!should_write_latest_redirect(
+            &version("1.1.0-rc.0"),
+            None,
+            &empty
+        ));
+        assert!(should_write_latest_redirect(
+            &version("0.5.0"),
+            None,
+            &empty
+        ));
+        assert!(!should_write_latest_redirect(
+            &version("0.6.0-rc.0"),
+            None,
+            &empty
+        ));
+
+        let with_beta = manifest(&["1.0.0-beta.0", "main"]);
+        assert!(!should_write_latest_redirect(
+            &version("0.24.0"),
+            None,
+            &with_beta
+        ));
+        assert!(should_write_latest_redirect(
+            &version("1.0.0"),
+            None,
+            &with_beta
+        ));
+        assert!(!should_write_latest_redirect(
+            &version("1.1.0-rc.0"),
+            None,
+            &with_beta
+        ));
+
+        // A pre-release that cannot claim the redirect must not block a release from
+        // claiming it, even though it sorts higher.
+        let with_rc = manifest(&["1.0.0", "1.1.0-rc.0", "main"]);
+        assert!(should_write_latest_redirect(
+            &version("1.0.1"),
+            None,
+            &with_rc
+        ));
+        // A rebuild of the release that holds the redirect keeps it.
+        assert!(should_write_latest_redirect(
+            &version("1.0.0"),
+            None,
+            &with_rc
+        ));
+        // An older release does not take the redirect from a newer one.
+        assert!(!should_write_latest_redirect(
+            &version("0.9.0"),
+            None,
+            &with_rc
+        ));
+    }
+
+    #[test]
+    fn channel_replaces_version_in_output_path_component() {
         assert_eq!(
-            latest_stable_docs_version(root),
-            Some("2.0.0".parse().unwrap())
+            docs_version_component(&version("1.1.0"), Some("main")),
+            "main"
         );
+        assert_eq!(docs_version_component(&version("1.1.0"), None), "1.1.0");
     }
 
     #[test]
-    fn returns_none_when_only_prereleases() {
-        let tmp = TempDir::new().unwrap();
-        mkdir(tmp.path(), "1.0.0-beta.0");
-        mkdir(tmp.path(), "1.1.0-rc.0");
-        assert_eq!(latest_stable_docs_version(tmp.path()), None);
-    }
-
-    #[test]
-    fn returns_none_for_empty_dir() {
-        let tmp = TempDir::new().unwrap();
-        assert_eq!(latest_stable_docs_version(tmp.path()), None);
-    }
-
-    #[test]
-    fn skips_files_and_unparseable_dir_names() {
-        let tmp = TempDir::new().unwrap();
-        let root = tmp.path();
-        mkdir(root, "1.0.0");
-        fs::write(root.join("not-a-dir"), b"x").unwrap();
-        mkdir(root, "not-a-version");
+    fn index_version_selects_highest_eligible() {
         assert_eq!(
-            latest_stable_docs_version(root),
-            Some("1.0.0".parse().unwrap())
+            highest_eligible_version(&manifest(&["1.0.0-beta.0", "1.1.0-rc.0", "main"])),
+            Some(version("1.0.0-beta.0"))
         );
+        assert_eq!(
+            highest_eligible_version(&manifest(&["0.5.0", "0.6.0-rc.0"])),
+            Some(version("0.5.0"))
+        );
+        assert_eq!(
+            highest_eligible_version(&manifest(&["1.0.0", "1.1.0", "main"])),
+            Some(version("1.1.0"))
+        );
+        assert_eq!(highest_eligible_version(&manifest(&["main"])), None);
+        assert_eq!(highest_eligible_version(&Manifest::default()), None);
     }
 
     #[test]
@@ -932,7 +1114,10 @@ mod tests {
             ),
             "{html}"
         );
+        assert!(html.contains(r#"const packageName = "esp-hal";"#), "{html}");
+        assert!(html.contains("segments.indexOf(packageName)"), "{html}");
         assert!(html.contains(".then(({ versions }) => {"), "{html}");
+        assert!(html.contains("versions.includes(selected)"), "{html}");
     }
 
     #[test]
@@ -941,7 +1126,7 @@ mod tests {
         let meta = generate_documentation_meta_for_package(
             crate::Package::EspHal,
             &[crate::Chip::Esp32c6, crate::Chip::Esp32s3],
-            semver::Version::parse("1.0.0").unwrap(),
+            "1.0.0",
         )
         .unwrap();
 
@@ -967,6 +1152,33 @@ mod tests {
         );
         assert!(
             html.contains("<span class=\"crate-version\">1.0.0</span>"),
+            "{html}"
+        );
+    }
+
+    #[test]
+    fn package_index_renders_channel_label() {
+        let meta = generate_documentation_meta_for_package(
+            crate::Package::EspHal,
+            &[crate::Chip::Esp32c6],
+            "main",
+        )
+        .unwrap();
+
+        let html = render_template(
+            &workspace().join("resources"),
+            "package_index.html.somni",
+            {
+                let mut env = Env::new();
+                env.value("package", "esp_hal")
+                    .value("metadata", Iter(meta));
+                env
+            },
+        )
+        .unwrap();
+
+        assert!(
+            html.contains("<span class=\"crate-version\">main</span>"),
             "{html}"
         );
     }
@@ -1040,6 +1252,8 @@ mod tests {
         assert_eq!(
             manifest.versions,
             vec![
+                "main", // Rank 0
+                "git",  // Rank 1
                 "1.2.0",
                 "1.1.1",
                 "1.1.0",
@@ -1050,9 +1264,7 @@ mod tests {
                 "1.0.0-beta.1",
                 "1.0.0-beta.0",
                 "0.9.0",   // Semver descending
-                "main",    // Rank 0
-                "git",     // Rank 1
-                "nightly"  // Rank 2 + alphabetical
+                "nightly"  // Rank 3 + alphabetical
             ]
         );
     }

--- a/xtask/src/firmware.rs
+++ b/xtask/src/firmware.rs
@@ -405,12 +405,9 @@ fn parse_chips_from_annotation(
     {
         let meta = parse_meta_line(line)
             .with_context(|| format!("Failed to parse line {}", line_no + 1))?;
-        match meta.key.as_str() {
-            "CHIP_FILTER" => {
-                found = true;
-                chips = parse_chips(meta.value.as_str())?;
-            }
-            _ => {}
+        if meta.key.as_str() == "CHIP_FILTER" {
+            found = true;
+            chips = parse_chips(meta.value.as_str())?;
         }
     }
 
@@ -470,7 +467,7 @@ pub fn load_cargo_toml(examples_path: &Path) -> Result<Vec<Metadata>> {
         let chips = cargo_chips.into_iter().filter(|c| {
             chips_from_annotations
                 .as_ref()
-                .map_or(true, |set| set.contains(c))
+                .is_none_or(|set| set.contains(c))
         });
 
         for chip in chips {

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -132,15 +132,15 @@ impl Package {
 
         // This is intended to opt-out in case there are features that look like chip names, but
         // aren't supposed to be handled like them.
-        if let Some(metadata) = toml.espressif_metadata() {
-            if let Some(Item::Value(ov)) = metadata.get("has_chip_features") {
-                let Value::Boolean(ov) = ov else {
-                    log::warn!("Invalid value for 'has_chip_features' in metadata");
-                    return false;
-                };
+        if let Some(metadata) = toml.espressif_metadata()
+            && let Some(Item::Value(ov)) = metadata.get("has_chip_features")
+        {
+            let Value::Boolean(ov) = ov else {
+                log::warn!("Invalid value for 'has_chip_features' in metadata");
+                return false;
+            };
 
-                return *ov.value();
-            }
+            return *ov.value();
         }
 
         features
@@ -230,10 +230,11 @@ impl Package {
 
         // Look for files matching the pattern "MIGRATING-*.md"
         for entry in entries.flatten() {
-            if let Some(file_name) = entry.file_name().to_str() {
-                if file_name.starts_with("MIGRATING-") && file_name.ends_with(".md") {
-                    return true;
-                }
+            if let Some(file_name) = entry.file_name().to_str()
+                && file_name.starts_with("MIGRATING-")
+                && file_name.ends_with(".md")
+            {
+                return true;
             }
         }
 
@@ -256,7 +257,7 @@ impl Package {
             .filter_map(Result::ok)
             .filter(|e| e.path().extension().is_some_and(|ext| ext == "rs"))
             .any(|entry| {
-                std::fs::read_to_string(entry.path()).map_or(false, |src| src.contains("#[test]"))
+                std::fs::read_to_string(entry.path()).is_ok_and(|src| src.contains("#[test]"))
             })
     }
 
@@ -420,9 +421,7 @@ impl Package {
         metadata_key: &str,
     ) -> Option<CheckConfig> {
         let toml = self.toml();
-        let Some(ref toml) = *toml else {
-            return None;
-        };
+        let toml = toml.as_ref()?;
 
         if let Some(metadata) = toml.espressif_metadata()
             && let Some(config_meta) = metadata.get(metadata_key)
@@ -471,9 +470,7 @@ impl Package {
         metadata_key: &str,
     ) -> Option<Vec<CheckConfig>> {
         let toml = self.toml();
-        let Some(ref toml) = *toml else {
-            return None;
-        };
+        let toml = toml.as_ref()?;
         let mut cases = Vec::new();
 
         if let Some(metadata) = toml.espressif_metadata()
@@ -922,35 +919,31 @@ pub fn run_host_tests(workspace: &Path, package: Package) -> Result<()> {
     let cmd = CargoArgsBuilder::default();
 
     match package {
-        Package::EspConfig => {
-            return cargo::run(
-                &cmd.clone()
-                    .subcommand("test")
-                    .features(&vec!["build".into(), "tui".into()])
-                    .build(),
-                &package_path,
-            );
-        }
+        Package::EspConfig => cargo::run(
+            &cmd.clone()
+                .subcommand("test")
+                .features(&["build".into(), "tui".into()])
+                .build(),
+            &package_path,
+        ),
 
-        Package::EspBootloaderEspIdf => {
-            return cargo::run(
-                &cmd.clone()
-                    .subcommand("test")
-                    .arg("--lib")
-                    .arg("--tests")
-                    .features(&vec!["std".into(), "embedded-storage".into()])
-                    .arg("--")
-                    .arg("--test-threads=1")
-                    .build(),
-                &package_path,
-            );
-        }
+        Package::EspBootloaderEspIdf => cargo::run(
+            &cmd.clone()
+                .subcommand("test")
+                .arg("--lib")
+                .arg("--tests")
+                .features(&["std".into(), "embedded-storage".into()])
+                .arg("--")
+                .arg("--test-threads=1")
+                .build(),
+            &package_path,
+        ),
 
         Package::EspStorage => {
             cargo::run(
                 &cmd.clone()
                     .subcommand("test")
-                    .features(&vec!["emulation".into()])
+                    .features(&["emulation".into()])
                     .arg("--")
                     .arg("--test-threads=1")
                     .build(),
@@ -960,7 +953,7 @@ pub fn run_host_tests(workspace: &Path, package: Package) -> Result<()> {
             cargo::run(
                 &cmd.clone()
                     .subcommand("test")
-                    .features(&vec!["emulation".into(), "bytewise-read".into()])
+                    .features(&["emulation".into(), "bytewise-read".into()])
                     .arg("--")
                     .arg("--test-threads=1")
                     .build(),
@@ -974,42 +967,38 @@ pub fn run_host_tests(workspace: &Path, package: Package) -> Result<()> {
                     .toolchain("nightly")
                     .subcommand("miri")
                     .subcommand("test")
-                    .features(&vec!["emulation".into()])
+                    .features(&["emulation".into()])
                     .arg("--")
                     .arg("--test-threads=1")
                     .build(),
                 &package_path,
             )?;
 
-            return cargo::run(
+            cargo::run(
                 &cmd.clone()
                     .toolchain("nightly")
                     .subcommand("miri")
                     .subcommand("test")
-                    .features(&vec!["emulation".into(), "bytewise-read".into()])
+                    .features(&["emulation".into(), "bytewise-read".into()])
                     .arg("--")
                     .arg("--test-threads=1")
                     .build(),
                 &package_path,
-            );
+            )
         }
-        Package::EspHalProcmacros => {
-            return cargo::run(
-                &cmd.clone()
-                    .subcommand("test")
-                    .features(&vec![
-                        "has-lp-core".into(),
-                        "is-lp-core".into(),
-                        "rtc-slow".into(),
-                        "rtc-fast".into(),
-                    ])
-                    .build(),
-                &package_path,
-            );
-        }
-        Package::EspMetadata => {
-            return cargo::run(&cmd.clone().subcommand("test").build(), &package_path);
-        }
+        Package::EspHalProcmacros => cargo::run(
+            &cmd.clone()
+                .subcommand("test")
+                .features(&[
+                    "has-lp-core".into(),
+                    "is-lp-core".into(),
+                    "rtc-slow".into(),
+                    "rtc-fast".into(),
+                ])
+                .build(),
+            &package_path,
+        ),
+        Package::EspMetadata => cargo::run(&cmd.clone().subcommand("test").build(), &package_path),
         _ => Err(anyhow!(
             "Instructions for host testing were not provided for: '{}'",
             package,
@@ -1096,11 +1085,11 @@ pub fn format_package_path(
     log::debug!("{cargo_args:#?}");
 
     if check {
-        return cargo::run(&cargo_args, &package_path);
+        return cargo::run(&cargo_args, package_path);
     }
 
     retry_on_failure(&format!("Formatting {}", package_path.display()), || {
-        cargo::run(&cargo_args, &package_path)
+        cargo::run(&cargo_args, package_path)
     })
 }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -736,8 +736,9 @@ fn run_ci_checks(workspace: &Path, args: CiArgs) -> Result<()> {
         // care about the contents however
         std::fs::create_dir_all("./target")
             .with_context(|| "Failed to create `./target`".to_string())?;
-        std::fs::write("./target/ota_image", "DUMMY")
-            .with_context(|| "Failed to create a dummy file required by ota example!".to_string())?;
+        std::fs::write("./target/ota_image", "DUMMY").with_context(|| {
+            "Failed to create a dummy file required by ota example!".to_string()
+        })?;
 
         examples(
             workspace,
@@ -887,10 +888,11 @@ fn check_global_symbols(chips: &[Chip]) -> Result<()> {
 
             for symbol in obj.symbols().filter(|s| s.is_global() && s.is_definition()) {
                 if let Ok(name) = symbol.name()
-                    && try_demangle(name).is_err() {
-                        let section = symbol.section_index().map(|i| i.0).unwrap_or(0);
-                        problematic_symbols.push((name.to_string(), symbol.kind(), section));
-                    }
+                    && try_demangle(name).is_err()
+                {
+                    let section = symbol.section_index().map(|i| i.0).unwrap_or(0);
+                    problematic_symbols.push((name.to_string(), symbol.kind(), section));
+                }
             }
         }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -123,7 +123,7 @@ fn main() -> Result<()> {
         Cli::Build(build) => match build {
             Build::Documentation(args) => build_documentation(&workspace, args),
             #[cfg(feature = "deploy-docs")]
-            Build::DocumentationIndex => build_documentation_index(&workspace),
+            Build::DocumentationIndex(args) => build_documentation_index(&workspace, args),
             Build::Examples(args) => examples(&workspace, args, CargoAction::Build(None)),
             Build::Package(args) => build_package(&workspace, args),
             Build::Tests(args) => tests(

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -111,7 +111,7 @@ fn main() -> Result<()> {
     builder.init();
 
     let workspace =
-        std::env::current_dir().with_context(|| format!("Failed to get the current dir!"))?;
+        std::env::current_dir().with_context(|| "Failed to get the current dir!".to_string())?;
     let target_path = workspace.join("target");
 
     if std::env::var("CARGO_TARGET_DIR").is_err() {
@@ -224,7 +224,7 @@ fn clean(workspace: &Path, args: CleanArgs) -> Result<()> {
                     .arg(path.join("target").display().to_string())
                     .build();
 
-                xtask::cargo::run(&cargo_args, &path).with_context(|| {
+                xtask::cargo::run(&cargo_args, path).with_context(|| {
                     format!(
                         "Failed to run `cargo run` with {cargo_args:?} in {}",
                         path.display()
@@ -323,7 +323,7 @@ fn build_check_package_command(
         builder = builder.toolchain(toolchain);
     }
 
-    builder = builder.args(&args);
+    builder = builder.args(args);
 
     if !features.is_empty() {
         builder = builder.arg(format!("--features={}", features.join(",")));
@@ -735,9 +735,9 @@ fn run_ci_checks(workspace: &Path, args: CiArgs) -> Result<()> {
         // The `ota_example` expects a file named `target/ota_image` - it doesn't
         // care about the contents however
         std::fs::create_dir_all("./target")
-            .with_context(|| format!("Failed to create `./target`"))?;
+            .with_context(|| "Failed to create `./target`".to_string())?;
         std::fs::write("./target/ota_image", "DUMMY")
-            .with_context(|| format!("Failed to create a dummy file required by ota example!"))?;
+            .with_context(|| "Failed to create a dummy file required by ota example!".to_string())?;
 
         examples(
             workspace,
@@ -820,7 +820,7 @@ fn host_tests(workspace: &Path, args: HostTestsArgs) -> Result<()> {
 fn build_rlib(package: &str, chip: &str, target: &str) -> Result<PathBuf> {
     let workspace = std::env::current_dir().with_context(|| "Failed to get the current dir!")?;
     Command::new("cargo")
-        .args(&[
+        .args([
             "+esp",
             "build",
             "--no-default-features",
@@ -830,7 +830,7 @@ fn build_rlib(package: &str, chip: &str, target: &str) -> Result<PathBuf> {
             target,
             "-Zbuild-std=core",
         ])
-        .current_dir(workspace.join(package.to_string()))
+        .current_dir(workspace.join(package))
         .status()
         .context("Failed to run cargo build")?;
 
@@ -858,7 +858,7 @@ fn check_global_symbols(chips: &[Chip]) -> Result<()> {
     for chip in chips {
         let target = package.target_triple(chip)?;
 
-        let rlib_path = match build_rlib(&package.to_string(), &chip.to_string(), &target) {
+        let rlib_path = match build_rlib(package.as_ref(), chip.as_ref(), &target) {
             Ok(path) => path,
             Err(e) => {
                 println!(
@@ -874,7 +874,7 @@ fn check_global_symbols(chips: &[Chip]) -> Result<()> {
         let data = std::fs::read(&rlib_path)
             .with_context(|| format!("Failed to read {}!", rlib_path.display()))?;
         let archive = ArchiveFile::parse(data.as_slice())
-            .with_context(|| format!("Failed to create archive!"))?;
+            .with_context(|| "Failed to create archive!".to_string())?;
 
         let mut problematic_symbols: Vec<(String, SymbolKind, usize)> = Vec::new();
 
@@ -886,12 +886,11 @@ fn check_global_symbols(chips: &[Chip]) -> Result<()> {
             )?;
 
             for symbol in obj.symbols().filter(|s| s.is_global() && s.is_definition()) {
-                if let Ok(name) = symbol.name() {
-                    if try_demangle(name).is_err() {
+                if let Ok(name) = symbol.name()
+                    && try_demangle(name).is_err() {
                         let section = symbol.section_index().map(|i| i.0).unwrap_or(0);
                         problematic_symbols.push((name.to_string(), symbol.kind(), section));
                     }
-                }
             }
         }
 

--- a/xtask/src/radio_hil_runner.rs
+++ b/xtask/src/radio_hil_runner.rs
@@ -291,7 +291,7 @@ impl Drop for HarnessGuard {
 fn runner_env_key(target: &str) -> String {
     format!(
         "CARGO_TARGET_{}_RUNNER",
-        target.replace('-', "_").replace('.', "_").to_uppercase()
+        target.replace(['-', '.'], "_").to_uppercase()
     )
 }
 


### PR DESCRIPTION
The documentation workflow now runs on a push event to `main`. The workflow should now update the index properly, using the correct base url passed to `build documentation-index`.

The PR overhauls https://github.com/esp-rs/esp-hal/issues/5387 - since we probably want to advertise pre-releases to major versions, those are excluded from the "pre-release is not `latest`" rule.

Deploying will create a new index line for a newly created package - that is the only intended case where the documentation index should have a line saying that `main` is the latest version.

Closes #5393