### PR TITLE
esp-radio: Fix BLE memory leaks on controller re-initialization

### DIFF
--- a/esp-radio/src/ble/controller/mod.rs
+++ b/esp-radio/src/ble/controller/mod.rs
@@ -46,6 +46,7 @@ pub struct BleConnector<'d> {
 impl Drop for BleConnector<'_> {
     fn drop(&mut self) {
         crate::ble::ble_deinit();
+        crate::ble::clear_bt_state();
     }
 }
 impl<'d> BleConnector<'d> {

--- a/esp-radio/src/ble/mod.rs
+++ b/esp-radio/src/ble/mod.rs
@@ -140,6 +140,16 @@ impl defmt::Format for ReceivedPacket {
     }
 }
 
+/// Drops packets the host never read, so they don't outlive the controller.
+pub(crate) fn clear_bt_state() {
+    BT_STATE.with(|state| {
+        state.rx_queue.clear();
+        state.rx_queue.shrink_to_fit();
+        state.hci_read_data.clear();
+        state.hci_read_data.shrink_to_fit();
+    });
+}
+
 /// Checks if there is any HCI data available to read.
 #[instability::unstable]
 pub fn have_hci_read_data() -> bool {

--- a/esp-radio/src/ble/mod.rs
+++ b/esp-radio/src/ble/mod.rs
@@ -144,9 +144,7 @@ impl defmt::Format for ReceivedPacket {
 pub(crate) fn clear_bt_state() {
     BT_STATE.with(|state| {
         state.rx_queue.clear();
-        state.rx_queue.shrink_to_fit();
         state.hci_read_data.clear();
-        state.hci_read_data.shrink_to_fit();
     });
 }
 

--- a/esp-radio/src/ble/npl.rs
+++ b/esp-radio/src/ble/npl.rs
@@ -724,9 +724,21 @@ unsafe extern "C" fn ble_npl_callout_mem_reset(callout: *const ble_npl_callout) 
 }
 
 unsafe extern "C" fn ble_npl_callout_deinit(callout: *const ble_npl_callout) {
-    trace!("ble_npl_callout_deinit");
+    trace!("ble_npl_callout_deinit {:?}", callout);
+
+    if unsafe { (*callout).dummy } == 0 {
+        return;
+    }
+
     unsafe {
         ble_npl_callout_stop(callout);
+
+        let co = (*callout).dummy as *mut Callout;
+        compat::timer_compat::compat_timer_done(&raw mut (*co).timer_handle);
+        ble_npl_event_deinit(&raw const (*co).events);
+        crate::compat::malloc::free(co.cast());
+
+        (*callout.cast_mut()).dummy = 0;
     }
 }
 
@@ -978,6 +990,12 @@ unsafe extern "C" fn ble_npl_eventq_get(
 
 unsafe extern "C" fn ble_npl_eventq_init(queue: *mut ble_npl_eventq) {
     trace!("ble_npl_eventq_init {:?}", queue);
+
+    // The controller re-initializes its event queue on every `ble_controller_init` without
+    // deinitializing it first.
+    if unsafe { (*queue).dummy } != 0 {
+        unsafe { ble_npl_eventq_deinit(queue) };
+    }
 
     let queue_ptr = queue::queue_create(EVENT_QUEUE_SIZE as _, core::mem::size_of::<usize>() as _);
 
@@ -1330,6 +1348,9 @@ pub(crate) fn ble_deinit() {
 
         assert!(res == 0, "ble_controller_deinit returned {}", res);
 
+        #[cfg(esp32c2)]
+        os_msys_buf_free();
+
         npl::esp_unregister_npl_funcs();
 
         npl::esp_unregister_ext_funcs();
@@ -1348,7 +1369,30 @@ fn os_msys_buf_alloc() -> bool {
             core::mem::size_of::<OsMembufT>() * SYSINIT_MSYS_2_MEMPOOL_SIZE,
         ) as *mut u32;
 
-        !(OS_MSYS_INIT_1_DATA.is_null() || OS_MSYS_INIT_2_DATA.is_null())
+        if OS_MSYS_INIT_1_DATA.is_null() || OS_MSYS_INIT_2_DATA.is_null() {
+            os_msys_buf_free();
+            return false;
+        }
+
+        true
+    }
+}
+
+#[cfg(esp32c2)]
+fn os_msys_buf_free() {
+    unsafe {
+        // No C2 ROM revision exposes `os_mempool_unregister`, so drop every registered pool before
+        // releasing the memory it points at.
+        r_os_msys_reset();
+
+        if !OS_MSYS_INIT_1_DATA.is_null() {
+            crate::compat::malloc::free(OS_MSYS_INIT_1_DATA.cast());
+            OS_MSYS_INIT_1_DATA = core::ptr::null_mut();
+        }
+        if !OS_MSYS_INIT_2_DATA.is_null() {
+            crate::compat::malloc::free(OS_MSYS_INIT_2_DATA.cast());
+            OS_MSYS_INIT_2_DATA = core::ptr::null_mut();
+        }
     }
 }
 

--- a/esp-radio/src/ble/npl.rs
+++ b/esp-radio/src/ble/npl.rs
@@ -716,13 +716,17 @@ unsafe extern "C" fn ble_npl_callout_is_active(callout: *const ble_npl_callout) 
     }
 }
 
+// <https://github.com/espressif/esp-idf/blob/6d835d522/components/bt/porting/npl/freertos/src/npl_os_freertos.c#L185-L194>
 unsafe extern "C" fn ble_npl_callout_mem_reset(callout: *const ble_npl_callout) {
-    trace!("ble_npl_callout_mem_reset");
-    unsafe {
-        ble_npl_callout_stop(callout);
-    }
+    trace!("ble_npl_callout_mem_reset {:?}", callout);
+
+    let co = unsafe { (*callout).dummy } as *mut Callout;
+    assert!(!co.is_null());
+
+    unsafe { ble_npl_event_reset(&raw const (*co).events) };
 }
 
+// <https://github.com/espressif/esp-idf/blob/6d835d522/components/bt/porting/npl/freertos/src/npl_os_freertos.c#L962-L998>
 unsafe extern "C" fn ble_npl_callout_deinit(callout: *const ble_npl_callout) {
     trace!("ble_npl_callout_deinit {:?}", callout);
 
@@ -731,8 +735,6 @@ unsafe extern "C" fn ble_npl_callout_deinit(callout: *const ble_npl_callout) {
     }
 
     unsafe {
-        ble_npl_callout_stop(callout);
-
         let co = (*callout).dummy as *mut Callout;
         compat::timer_compat::compat_timer_done(&raw mut (*co).timer_handle);
         ble_npl_event_deinit(&raw const (*co).events);
@@ -991,10 +993,14 @@ unsafe extern "C" fn ble_npl_eventq_get(
 unsafe extern "C" fn ble_npl_eventq_init(queue: *mut ble_npl_eventq) {
     trace!("ble_npl_eventq_init {:?}", queue);
 
-    // The controller re-initializes its event queue on every `ble_controller_init` without
-    // deinitializing it first.
-    if unsafe { (*queue).dummy } != 0 {
-        unsafe { ble_npl_eventq_deinit(queue) };
+    // Keep the existing queue and empty it, the way IDF's `npl_freertos_eventq_init` calls
+    // `xQueueReset` instead of allocating again.
+    // <https://github.com/espressif/esp-idf/blob/6d835d522/components/bt/porting/npl/freertos/src/npl_os_freertos.c#L135-L164>
+    let existing = unsafe { (*queue).dummy };
+    if existing != 0 {
+        let mut event: usize = 0;
+        while queue::queue_receive(existing as *mut c_void, (&raw mut event).cast(), 0) != 0 {}
+        return;
     }
 
     let queue_ptr = queue::queue_create(EVENT_QUEUE_SIZE as _, core::mem::size_of::<usize>() as _);
@@ -1357,6 +1363,7 @@ pub(crate) fn ble_deinit() {
     }
 }
 
+// <https://github.com/espressif/esp-idf/blob/6d835d522/components/bt/porting/mem/os_msys_init.c#L218-L279>
 #[cfg(esp32c2)]
 fn os_msys_buf_alloc() -> bool {
     unsafe {
@@ -1378,6 +1385,7 @@ fn os_msys_buf_alloc() -> bool {
     }
 }
 
+// <https://github.com/espressif/esp-idf/blob/6d835d522/components/bt/porting/mem/os_msys_init.c#L281-L318>
 #[cfg(esp32c2)]
 fn os_msys_buf_free() {
     unsafe {


### PR DESCRIPTION
closes https://github.com/esp-rs/esp-hal/issues/6083

I initially thought only C2 is affected but others NPL had some leaks as well, so this PR tries to address multiple things:
- C2: the `msys_mempool` buffers were allocated on every init but never released
- `ble_npl_callout_deinit` was leaking `Callout`
- `BleConnector::drop` left unread HCI packets in `rx_queue` and `hci_read_data`
- `ble_npl_eventq_init` left the previous queue orphaned when the controller was re-initialized