### PR TITLE
USB-Serial-JTAG ISR should not clear both interrupt latches unconditionally

### DIFF
--- a/esp-hal/src/usb/usb_serial_jtag.rs
+++ b/esp-hal/src/usb/usb_serial_jtag.rs
@@ -955,10 +955,13 @@ fn async_interrupt_handler() {
     }
 
     usb.int_clr().write(|w| {
-        w.serial_in_empty()
-            .clear_bit_by_one()
-            .serial_out_recv_pkt()
-            .clear_bit_by_one()
+        if tx {
+            w.serial_in_empty().clear_bit_by_one();
+        }
+        if rx {
+            w.serial_out_recv_pkt().clear_bit_by_one();
+        }
+        w
     });
 
     if rx {


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` or `manual-changelog` label as appropriate.
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

This was found by Fable while hunting other issues in the upcoming `openthread` HIL [test harness](https://github.com/esp-rs/openthread/pull/109) which uses the USB-serial console (so that the test harness can instruct the openthread firmware what to do via the OpenThread CLI API).

It does NOT affect the test harness but I think it is right in that this is a latent timing bug. Though I admit the chance of it happening is super-small (timing window is in the order of microseconds to picoseconds?).

We should not unconditionally clear the TX latch if we have not detected a "TX queue is empty event", or else a "TX queue is empty" event **might smuggle in-between** the code earlier in the ISR that checks for it (and might indicate "no such event yet") and the code in the ISR that clears the TX latch unconditionally. No?

EDIT: Ditto for RX of course.

#### Testing

Not tested t.b.h.

---

<!-- ============================================================
  Changelog and migration guide entries live here in the PR body.
  They will be collected automatically at release time.
  Delete any section that doesn't apply to your PR.
  ============================================================ -->

# Changelog

## esp-hal

- Fixed: USB-Serial-JTAG ISR should not clear both interrupt latches unconditionally
