### PR TITLE
Unconditionally set the pending bit until we have a pending-bit-table API

### DIFF
--- a/esp-radio/src/ieee802154/hal.rs
+++ b/esp-radio/src/ieee802154/hal.rs
@@ -397,6 +397,13 @@ pub(crate) fn set_pending_mode(enable: bool) {
 }
 
 #[inline(always)]
+pub(crate) fn set_pending_bit(pending: bool) {
+    IEEE802154::regs()
+        .ack_frame_pending_en()
+        .modify(|_, w| w.ack_frame_pending_en().bit(pending));
+}
+
+#[inline(always)]
 pub(crate) fn events() -> u16 {
     IEEE802154::regs().event_status().read().bits() as u16
 }

--- a/esp-radio/src/ieee802154/raw.rs
+++ b/esp-radio/src/ieee802154/raw.rs
@@ -631,6 +631,7 @@ fn isr_handle_rx_done(needs_next_op: &mut bool) {
                 // auto tx ack for frame version 0b00 and 0b01
                 // Frame data already copied above. Defer rx_available()
                 // notification until ACK completes (isr_handle_ack_tx_done).
+                ack_config_pending_bit(frm);
                 state.state = Ieee802154State::TxAck;
                 *needs_next_op = false;
             } else if should_send_enhanced_ack(frm) {
@@ -817,6 +818,22 @@ fn isr_handle_tx_abort(tx_abort_reason: u32, needs_next_op: &mut bool) {
 
 fn freq_to_channel(freq: u8) -> u8 {
     (freq - 3) / 5 + 11
+}
+
+/// Provide the hardware with the frame-pending bit for the ACK it is about
+/// to send.
+///
+/// TODO: Revisit once a pending-address table is exposed by the driver.
+fn ack_config_pending_bit(frame: &[u8]) {
+    // The hardware inserts this value only into acks of version 0b00/0b01
+    // frames; 2015 enhanced ACKs carry it inside the software-built frame.
+    if frame_get_version(frame) <= FRAME_VERSION_1 {
+        // Until the driver exposes the pending-address table, claim pending
+        // for every poller in every mode: a spurious "pending" costs a
+        // sleepy device one idle receive window, while a wrong "nothing
+        // pending" makes it sleep through a frame queued for it.
+        set_pending_bit(true);
+    }
 }
 
 fn will_auto_send_ack(frame: &[u8]) -> bool {


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` or `manual-changelog` label as appropriate.
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

(Originally found and fixed by Fable, then shortened by me to the minimum change necessary.)

This is a bug which only happens when the 802.15.4 radio is used in a device which is a FTD (Full Thread Device).

**TL;DR**: 

- Until I implement the pending-table in the driver, the driver **must** always raise the frame-pending bit in all ACKs it sends. Otherwise, SEDs attached to us (if we are a FTD promoted to a Router) might miss frames as they might go to sleep in the wrong moment.

Found via the HIL tests [here](https://github.com/esp-rs/openthread/pull/109).

===

**Long story** (only if you have time):

A FTD device is a device which is:
- Attached to mains power, and as such, it does **not** need to sleep and therefore its 802.15.4 radio is always active / receiving, as the device does not need to worry about saving the battery by forcing the radio (or the whole controller for that matter) to go into idle / low power state;
-  _and_ it does not mind being promoted to a Thread Router (i.e. has enough memory, flash etc. to keep the extra functionality necessary to act as a Router).

Thread takes advantage of FTD devices to build its mesh network (flawed analogy: FTD routers are kinda like Wifi repeaters).

To each FTD device, there might be 0, 1 or more MTD+SED (Minimal Thread Device + Sleepy End Device) devices "attached" so to say. These devices are running on battery and DO sleep most of the time. And they only "know" about the FTD device they are attached to - this is their router. They actually receive all frames from THAT router device, and send all frames to THAT device, regardless what is the incoming/outgoing ipv6 address of the ipv6 packet.

Since MTD+SED devices sleep most of the time, they might be missing frames with data which is for them. This is solved by the FTD device (their router) having the extra burden to **accumulate** frames destined for MTD+SED devices, and then the MTD+SED devices awakening from time to time and polling their parent "hey, are there incoming frames for me".

Finally, the "frame pending" bit is a bit which is present in every ACK frame sent by the router parent and is used to piggy-back to the child the information that "yes, i received your frame but keep in mind there is data for you, so please stay awake".

Now, ideally we must keep a mapping table in the driver (updated by openthread) which says "for my SED child XYZ there is (or isn't) pending data". And then raise/lower the pending bit according to that table.

But _until_ this table comes, we MUST raise the pending bit unconditionally. Yes, the SED device might stay awake a bit longer, BUT at least it won't be missing frames.

#### Testing

The [upcoming FTD Router HIL tests for the `openthread` crate](https://github.com/esp-rs/openthread/pull/109) pass with this fix.

# Changelog

## esp-radio

- Fixed: 802.15.4 - unconditionally raise the pending bit in all ACKs so that SED children are not missing frames
