### PR TITLE
USB-serial: flush_tx_async did not work when the last sent packet was exactly 64 bytes

### DIFF
--- a/esp-hal/src/usb/usb_serial_jtag.rs
+++ b/esp-hal/src/usb/usb_serial_jtag.rs
@@ -833,6 +833,8 @@ impl UsbSerialJtagTx<'_, Async> {
     }
 
     async fn flush_tx_async(&mut self) -> Result<(), Error> {
+        self.regs().ep1_conf().modify(|_, w| w.wr_done().set_bit());
+
         if self
             .regs()
             .ep1_conf()

--- a/esp-hal/src/usb/usb_serial_jtag.rs
+++ b/esp-hal/src/usb/usb_serial_jtag.rs
@@ -846,15 +846,17 @@ impl UsbSerialJtagTx<'_, Async> {
     async fn flush_tx_async(&mut self) -> Result<(), Error> {
         // Necessary even if `write_async` does set this bit after each chunk.
         //
-        // Reason is, if the last written chunk happens to be exactly 64 bytes, then this transaction is considered _incomplete_.
-        // What that means is, the hardware will process the FIFO queue, send an interrupt when the queue is emptied,
-        // but the packet will stay in the **other peer** internal buffers, waiting for the transaction to "complete".
-        // A completion of such a transaction is signalled by writing 0 or more bytes to the FIFO, and then setting 
-        // the `wr_done` bit.
-        // 
-        // Therefore, an explicit `wr_done` bit set here makes sure that if the last `write_async` ended up filling exactly 64 bytes,
-        // they are flushed here. If `write_async` ended up writing less than 64 bytes, then this `wr_done` bit set here is redundant,
-        // but harmless.
+        // Reason is, if the last written chunk happens to be exactly 64 bytes, then this
+        // transaction is considered _incomplete_. What that means is, the hardware will
+        // process the FIFO queue, send an interrupt when the queue is emptied,
+        // but the packet will stay in the **other peer** internal buffers, waiting for the
+        // transaction to "complete". A completion of such a transaction is signalled by
+        // writing 0 or more bytes to the FIFO, and then setting the `wr_done` bit.
+        //
+        // Therefore, an explicit `wr_done` bit set here makes sure that if the last `write_async`
+        // ended up filling exactly 64 bytes, they are flushed here. If `write_async` ended
+        // up writing less than 64 bytes, then this `wr_done` bit set here is redundant, but
+        // harmless.
         //
         // Places in ESP-IDF where this behavior is documented:
         // - https://github.com/espressif/esp-idf/blob/08e0d30a74ad0bfd5a34933142b80f45619ee410/components/esp_hal_usb/esp32c6/include/hal/usb_serial_jtag_ll.h#L168-L182

--- a/esp-hal/src/usb/usb_serial_jtag.rs
+++ b/esp-hal/src/usb/usb_serial_jtag.rs
@@ -848,7 +848,7 @@ impl UsbSerialJtagTx<'_, Async> {
         //
         // Reason is, if the last written chunk happens to be exactly 64 bytes, then this transaction is considered _incomplete_.
         // What that means is, the hardware will process the FIFO queue, send an interrupt when the queue is emptied,
-        // but will NOT actually send those 64 bytes to the other peer. It would wait instead for the transaction to "complete".
+        // but the packet will stay in the **other peer** internal buffers, waiting for the transaction to "complete".
         // A completion of such a transaction is signalled by writing 0 or more bytes to the FIFO, and then setting 
         // the `wr_done` bit.
         // 

--- a/esp-hal/src/usb/usb_serial_jtag.rs
+++ b/esp-hal/src/usb/usb_serial_jtag.rs
@@ -818,6 +818,17 @@ impl<'d> UsbSerialJtag<'d, Async> {
 
 impl UsbSerialJtagTx<'_, Async> {
     async fn write_async(&mut self, words: &[u8]) -> Result<(), Error> {
+        // TODO: Not cancel safe.
+        // If the future is dropped, the FIFO will be left in an inconsistent state,
+        // because `write_async` assumes the queue is completely empty upon its entry.
+        //
+        // Perhaps, rewrite to look a bit like `write_byte_nb`, i.e.:
+        // 1. Check that the FIFO is not full, or else async-wait for it to become not-full;
+        // 2. Write in the FIFO until either the FIFO is full or all bytes are written;
+        // 3. Return the number of bytes written.
+        //
+        // This way, `write_async` will never write more than 64 bytes,
+        // but `Write::write_all` compensates for that.
         for chunk in words.chunks(64) {
             for byte in chunk {
                 self.regs()

--- a/esp-hal/src/usb/usb_serial_jtag.rs
+++ b/esp-hal/src/usb/usb_serial_jtag.rs
@@ -833,6 +833,22 @@ impl UsbSerialJtagTx<'_, Async> {
     }
 
     async fn flush_tx_async(&mut self) -> Result<(), Error> {
+        // Necessary even if `write_async` does set this bit after each chunk.
+        //
+        // Reason is, if the last written chunk happens to be exactly 64 bytes, then this transaction is considered _incomplete_.
+        // What that means is, the hardware will process the FIFO queue, send an interrupt when the queue is emptied,
+        // but will NOT actually send those 64 bytes to the other peer. It would wait instead for the transaction to "complete".
+        // A completion of such a transaction is signalled by writing 0 or more bytes to the FIFO, and then setting 
+        // the `wr_done` bit.
+        // 
+        // Therefore, an explicit `wr_done` bit set here makes sure that if the last `write_async` ended up filling exactly 64 bytes,
+        // they are flushed here. If `write_async` ended up writing less than 64 bytes, then this `wr_done` bit set here is redundant,
+        // but harmless.
+        //
+        // Places in ESP-IDF where this behavior is documented:
+        // - https://github.com/espressif/esp-idf/blob/08e0d30a74ad0bfd5a34933142b80f45619ee410/components/esp_hal_usb/esp32c6/include/hal/usb_serial_jtag_ll.h#L168-L182
+        // - https://github.com/espressif/esp-idf/blob/08e0d30a74ad0bfd5a34933142b80f45619ee410/components/esp_driver_usb_serial_jtag/src/usb_serial_jtag.c#L113-L118
+        // - https://github.com/espressif/esp-idf/blob/08e0d30a74ad0bfd5a34933142b80f45619ee410/components/esp_driver_usb_serial_jtag/src/usb_serial_jtag_vfs.c#L347-L350
         self.regs().ep1_conf().modify(|_, w| w.wr_done().set_bit());
 
         if self

--- a/esp-hal/src/usb/usb_serial_jtag.rs
+++ b/esp-hal/src/usb/usb_serial_jtag.rs
@@ -818,17 +818,6 @@ impl<'d> UsbSerialJtag<'d, Async> {
 
 impl UsbSerialJtagTx<'_, Async> {
     async fn write_async(&mut self, words: &[u8]) -> Result<(), Error> {
-        // TODO: Not cancel safe.
-        // If the future is dropped, the FIFO will be left in an inconsistent state,
-        // because `write_async` assumes the queue is completely empty upon its entry.
-        //
-        // Perhaps, rewrite to look a bit like `write_byte_nb`, i.e.:
-        // 1. Check that the FIFO is not full, or else async-wait for it to become not-full;
-        // 2. Write in the FIFO until either the FIFO is full or all bytes are written;
-        // 3. Return the number of bytes written.
-        //
-        // This way, `write_async` will never write more than 64 bytes,
-        // but `Write::write_all` compensates for that.
         for chunk in words.chunks(64) {
             for byte in chunk {
                 self.regs()
@@ -844,24 +833,8 @@ impl UsbSerialJtagTx<'_, Async> {
     }
 
     async fn flush_tx_async(&mut self) -> Result<(), Error> {
-        // Necessary even if `write_async` does set this bit after each chunk.
-        //
-        // Reason is, if the last written chunk happens to be exactly 64 bytes, then this
-        // transaction is considered _incomplete_. What that means is, the hardware will
-        // process the FIFO queue, send an interrupt when the queue is emptied,
-        // but the packet will stay in the **other peer** internal buffers, waiting for the
-        // transaction to "complete". A completion of such a transaction is signalled by
-        // writing 0 or more bytes to the FIFO, and then setting the `wr_done` bit.
-        //
-        // Therefore, an explicit `wr_done` bit set here makes sure that if the last `write_async`
-        // ended up filling exactly 64 bytes, they are flushed here. If `write_async` ended
-        // up writing less than 64 bytes, then this `wr_done` bit set here is redundant, but
-        // harmless.
-        //
-        // Places in ESP-IDF where this behavior is documented:
-        // - https://github.com/espressif/esp-idf/blob/08e0d30a74ad0bfd5a34933142b80f45619ee410/components/esp_hal_usb/esp32c6/include/hal/usb_serial_jtag_ll.h#L168-L182
-        // - https://github.com/espressif/esp-idf/blob/08e0d30a74ad0bfd5a34933142b80f45619ee410/components/esp_driver_usb_serial_jtag/src/usb_serial_jtag.c#L113-L118
-        // - https://github.com/espressif/esp-idf/blob/08e0d30a74ad0bfd5a34933142b80f45619ee410/components/esp_driver_usb_serial_jtag/src/usb_serial_jtag_vfs.c#L347-L350
+        // If write_async transfers a multiple of 64 bytes, flush needs to trigger sending a
+        // zero-length packet for the host to consider the transfer complete
         self.regs().ep1_conf().modify(|_, w| w.wr_done().set_bit());
 
         if self


### PR DESCRIPTION
## Thank you for your contribution!

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` or `manual-changelog` label as appropriate.
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

A missing `wr_done` bit set in `flush_tx_async` which is present elsewhere: in all of `flush_tx`, `flush_tx_nb`, `write*` etc.

This one also found by Fable, but... this is **not** theoretical. Because of this bug, and as a workaround, the AI had developed a whole heartbeat infra, it is in the process of removing now, as I pushed back.

In Draft for the next 15-20 mins until the HIL tests prove the fix works with all heartbeat stuff removed.

#### Testing

With the upcoming e2e OT HIL test suite: https://github.com/esp-rs/openthread/pull/109

---

<!-- ============================================================
  Changelog and migration guide entries live here in the PR body.
  They will be collected automatically at release time.
  Delete any section that doesn't apply to your PR.
  ============================================================ -->

# Changelog

## esp-hal/USB Serial/JTAG

- Fixed: USB-serial: `flush_tx_async` did not work when the last sent packet was exactly 64 bytes