### PR TITLE
USB-serial: prevent async data loss under bidirectional load

### DIFF
--- a/esp-hal/src/usb/usb_serial_jtag.rs
+++ b/esp-hal/src/usb/usb_serial_jtag.rs
@@ -121,6 +121,7 @@
 use core::task::Poll;
 use core::{convert::Infallible, marker::PhantomData};
 
+use esp_sync::RawMutex;
 use procmacros::handler;
 
 use crate::{
@@ -709,6 +710,7 @@ where
 // Static instance of the waker for each component of the peripheral:
 static WAKER_TX: AtomicWaker = AtomicWaker::new();
 static WAKER_RX: AtomicWaker = AtomicWaker::new();
+static INT_ENA_LOCK: RawMutex = RawMutex::new();
 
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 struct UsbSerialJtagWriteFuture<'d> {
@@ -722,7 +724,7 @@ impl<'d> UsbSerialJtagWriteFuture<'d> {
         //
         // INT_ENA is also modified by the interrupt handler. Synchronize this
         // register-level read-modify-write so neither side can restore stale bits.
-        critical_section::with(|_| {
+        INT_ENA_LOCK.lock(|| {
             peripheral
                 .register_block()
                 .int_ena()
@@ -770,7 +772,7 @@ impl<'d> UsbSerialJtagReadFuture<'d> {
         //
         // INT_ENA is also modified by the interrupt handler. Synchronize this
         // register-level read-modify-write so neither side can restore stale bits.
-        critical_section::with(|_| {
+        INT_ENA_LOCK.lock(|| {
             peripheral
                 .register_block()
                 .int_ena()
@@ -965,7 +967,7 @@ fn async_interrupt_handler() {
     let tx = interrupts.serial_in_empty().bit_is_set();
     let rx = interrupts.serial_out_recv_pkt().bit_is_set();
 
-    critical_section::with(|_| {
+    INT_ENA_LOCK.lock(|| {
         usb.int_ena().modify(|_, w| {
             if tx {
                 w.serial_in_empty().clear_bit();

--- a/esp-hal/src/usb/usb_serial_jtag.rs
+++ b/esp-hal/src/usb/usb_serial_jtag.rs
@@ -827,6 +827,18 @@ impl<'d> UsbSerialJtag<'d, Async> {
 }
 
 impl UsbSerialJtagTx<'_, Async> {
+    async fn wait_tx_ready(&mut self) {
+        while self
+            .regs()
+            .ep1_conf()
+            .read()
+            .serial_in_ep_data_free()
+            .bit_is_clear()
+        {
+            UsbSerialJtagWriteFuture::new(self.peripheral.reborrow()).await;
+        }
+    }
+
     async fn write_async(&mut self, words: &[u8]) -> Result<(), Error> {
         for chunk in words.chunks(64) {
             for byte in chunk {
@@ -837,6 +849,7 @@ impl UsbSerialJtagTx<'_, Async> {
             self.regs().ep1_conf().modify(|_, w| w.wr_done().set_bit());
 
             UsbSerialJtagWriteFuture::new(self.peripheral.reborrow()).await;
+            self.wait_tx_ready().await;
         }
 
         Ok(())
@@ -846,16 +859,8 @@ impl UsbSerialJtagTx<'_, Async> {
         // If write_async transfers a multiple of 64 bytes, flush needs to trigger sending a
         // zero-length packet for the host to consider the transfer complete
         self.regs().ep1_conf().modify(|_, w| w.wr_done().set_bit());
-
-        if self
-            .regs()
-            .ep1_conf()
-            .read()
-            .serial_in_ep_data_free()
-            .bit_is_clear()
-        {
-            UsbSerialJtagWriteFuture::new(self.peripheral.reborrow()).await;
-        }
+        UsbSerialJtagWriteFuture::new(self.peripheral.reborrow()).await;
+        self.wait_tx_ready().await;
 
         Ok(())
     }

--- a/esp-hal/src/usb/usb_serial_jtag.rs
+++ b/esp-hal/src/usb/usb_serial_jtag.rs
@@ -719,10 +719,15 @@ impl<'d> UsbSerialJtagWriteFuture<'d> {
     fn new(peripheral: USB_DEVICE<'d>) -> Self {
         // Set the interrupt enable bit for the USB_SERIAL_JTAG_SERIAL_IN_EMPTY_INT
         // interrupt
-        peripheral
-            .register_block()
-            .int_ena()
-            .modify(|_, w| w.serial_in_empty().set_bit());
+        //
+        // INT_ENA is also modified by the interrupt handler. Synchronize this
+        // register-level read-modify-write so neither side can restore stale bits.
+        critical_section::with(|_| {
+            peripheral
+                .register_block()
+                .int_ena()
+                .modify(|_, w| w.serial_in_empty().set_bit());
+        });
 
         Self { peripheral }
     }
@@ -762,10 +767,15 @@ impl<'d> UsbSerialJtagReadFuture<'d> {
     fn new(peripheral: USB_DEVICE<'d>) -> Self {
         // Set the interrupt enable bit for the USB_SERIAL_JTAG_SERIAL_OUT_RECV_PKT
         // interrupt
-        peripheral
-            .register_block()
-            .int_ena()
-            .modify(|_, w| w.serial_out_recv_pkt().set_bit());
+        //
+        // INT_ENA is also modified by the interrupt handler. Synchronize this
+        // register-level read-modify-write so neither side can restore stale bits.
+        critical_section::with(|_| {
+            peripheral
+                .register_block()
+                .int_ena()
+                .modify(|_, w| w.serial_out_recv_pkt().set_bit());
+        });
 
         Self { peripheral }
     }
@@ -950,13 +960,17 @@ fn async_interrupt_handler() {
     let tx = interrupts.serial_in_empty().bit_is_set();
     let rx = interrupts.serial_out_recv_pkt().bit_is_set();
 
-    if tx {
-        usb.int_ena().modify(|_, w| w.serial_in_empty().clear_bit());
-    }
-    if rx {
-        usb.int_ena()
-            .modify(|_, w| w.serial_out_recv_pkt().clear_bit());
-    }
+    critical_section::with(|_| {
+        usb.int_ena().modify(|_, w| {
+            if tx {
+                w.serial_in_empty().clear_bit();
+            }
+            if rx {
+                w.serial_out_recv_pkt().clear_bit();
+            }
+            w
+        });
+    });
 
     usb.int_clr().write(|w| {
         if tx {

--- a/esp-hal/src/usb/usb_serial_jtag.rs
+++ b/esp-hal/src/usb/usb_serial_jtag.rs
@@ -710,6 +710,9 @@ where
 // Static instance of the waker for each component of the peripheral:
 static WAKER_TX: AtomicWaker = AtomicWaker::new();
 static WAKER_RX: AtomicWaker = AtomicWaker::new();
+// TX and RX interrupts are enabled independently. Once either is enabled, its
+// handler can preempt the other side's INT_ENA read-modify-write and cause
+// stale enable bits to be restored. Serialize all INT_ENA updates.
 static INT_ENA_LOCK: RawMutex = RawMutex::new();
 
 #[must_use = "futures do nothing unless you `.await` or poll them"]
@@ -721,9 +724,6 @@ impl<'d> UsbSerialJtagWriteFuture<'d> {
     fn new(peripheral: USB_DEVICE<'d>) -> Self {
         // Set the interrupt enable bit for the USB_SERIAL_JTAG_SERIAL_IN_EMPTY_INT
         // interrupt
-        //
-        // INT_ENA is also modified by the interrupt handler. Synchronize this
-        // register-level read-modify-write so neither side can restore stale bits.
         INT_ENA_LOCK.lock(|| {
             peripheral
                 .register_block()
@@ -769,9 +769,6 @@ impl<'d> UsbSerialJtagReadFuture<'d> {
     fn new(peripheral: USB_DEVICE<'d>) -> Self {
         // Set the interrupt enable bit for the USB_SERIAL_JTAG_SERIAL_OUT_RECV_PKT
         // interrupt
-        //
-        // INT_ENA is also modified by the interrupt handler. Synchronize this
-        // register-level read-modify-write so neither side can restore stale bits.
         INT_ENA_LOCK.lock(|| {
             peripheral
                 .register_block()
@@ -830,14 +827,22 @@ impl<'d> UsbSerialJtag<'d, Async> {
 
 impl UsbSerialJtagTx<'_, Async> {
     async fn wait_tx_ready(&mut self) {
-        while self
-            .regs()
-            .ep1_conf()
-            .read()
-            .serial_in_ep_data_free()
-            .bit_is_clear()
-        {
+        loop {
+            // Immediately after WR_DONE, DATA_FREE may still reflect the previous
+            // transfer's ready state. Wait for a new IN_EMPTY event before trusting it.
             UsbSerialJtagWriteFuture::new(self.peripheral.reborrow()).await;
+
+            // A pending or early interrupt can wake the future before the FIFO is
+            // actually ready. Keep waiting until the hardware confirms readiness.
+            if self
+                .regs()
+                .ep1_conf()
+                .read()
+                .serial_in_ep_data_free()
+                .bit_is_set()
+            {
+                break;
+            }
         }
     }
 
@@ -850,7 +855,6 @@ impl UsbSerialJtagTx<'_, Async> {
             }
             self.regs().ep1_conf().modify(|_, w| w.wr_done().set_bit());
 
-            UsbSerialJtagWriteFuture::new(self.peripheral.reborrow()).await;
             self.wait_tx_ready().await;
         }
 
@@ -861,7 +865,6 @@ impl UsbSerialJtagTx<'_, Async> {
         // If write_async transfers a multiple of 64 bytes, flush needs to trigger sending a
         // zero-length packet for the host to consider the transfer complete
         self.regs().ep1_conf().modify(|_, w| w.wr_done().set_bit());
-        UsbSerialJtagWriteFuture::new(self.peripheral.reborrow()).await;
         self.wait_tx_ready().await;
 
         Ok(())


### PR DESCRIPTION
## Thank you for your contribution!

### Submission Checklist 📝

- [x] I have updated existing examples or added new ones (not applicable: this does not change the public API or example usage).
- [x] I have used `cargo xtask fmt-packages` to ensure that all changed code is formatted correctly.
- [x] I have added a changelog entry below.
- [x] My changes are in accordance with the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md).

#### Extra:

- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

This fixes intermittent data corruption, packet loss, and stalls in the
asynchronous USB Serial/JTAG driver under sustained bidirectional traffic.

The issue was reproduced in
[Lamella](https://github.com/okhsunrog/lamella), an ESP32-C3 Wi-Fi-to-USB bridge
which transports Ethernet frames over an Ergot serial connection. Under load,
truncated serial frames surfaced as Ergot `DeserFailed` errors. A readiness-only
test later also reproduced complete loss of forward progress without frame
corruption.

The investigation found two related problems:

1. `INT_ENA` was modified independently by the TX/RX futures and the interrupt
   handler using unsynchronized read-modify-write operations. An interrupt
   occurring between the read and write could cause one side to restore stale
   enable bits or lose the other side's update.

   This change serializes those updates with an interrupt-disabling lock and updates both
   USB Serial/JTAG interrupt-enable bits in one register operation in the
   interrupt handler.

2. A completed `UsbSerialJtagWriteFuture` was treated as sufficient proof that
   the TX FIFO was writable. A pending or early interrupt could wake the future
   before the hardware reported the endpoint as available.

   The TX path now checks `SERIAL_IN_EP_DATA_FREE` after waking and continues
   waiting until the hardware reports that the FIFO is ready. The same
   readiness check is used for normal writes and flushes.


The hardware behavior is described in the
[ESP32-C3 Technical Reference Manual, chapter 30, pages 774 and 777](https://www.espressif.com/sites/default/files/documentation/esp32-c3_technical_reference_manual_en.pdf):
`WR_DONE` commits the TX FIFO contents, while `SERIAL_IN_EP_DATA_FREE` indicates
whether the FIFO can accept another packet.

#### Testing

Tested on a physical ESP32-C3 using Lamella and Ergot over the built-in USB
Serial/JTAG peripheral. The complete setup, commands, experimental variants,
negative results, limitations, and measurements are documented in
[Lamella's USB Serial/JTAG A/B test report](https://github.com/okhsunrog/lamella/blob/1275d4e3f6744933831b15120443ce76d4565e8d/docs/usb-serial-jtag-ab-testing.md).

Relevant downstream source:

- [Host bidirectional throughput and integrity test](https://github.com/okhsunrog/lamella/blob/1275d4e3f6744933831b15120443ce76d4565e8d/host/src/bin/ergot_throughput_test.rs)
- [ESP32-C3 test firmware](https://github.com/okhsunrog/lamella/blob/1275d4e3f6744933831b15120443ce76d4565e8d/firmware-c3/src/bin/ergot_test.rs)
- [End-to-end HTTP test](https://github.com/okhsunrog/lamella/blob/1275d4e3f6744933831b15120443ce76d4565e8d/host/src/test_mode.rs)
- [Exact combined esp-hal revision used by production firmware](https://github.com/okhsunrog/lamella/blob/1275d4e3f6744933831b15120443ce76d4565e8d/firmware-c3/Cargo.toml)

The primary reproducer downloads a 16 MiB file over Wi-Fi and transports its
Ethernet frames through Ergot and USB Serial/JTAG. Deserialization events are
counted at the original `recv_raw deserialize failed` site so the same error is
not counted again as it propagates through Ergot.

Initial driver A/B, with `INT_ENA` synchronization present in every variant:

| esp-hal variant | Result for one 16 MiB download |
| --- | --- |
| `3a9d8b1e`, existing `#6097` TX wait | 7 deserialization failures / 7 retries |
| `3a9d8b1e`, experimental flush-only wait | 5 deserialization failures / 5 retries |
| Both commits in this PR | Five consecutive downloads, 80 MiB total, zero deserialization failures and zero retries |

A follow-up tested TX-readiness without the `INT_ENA` synchronization by
cherry-picking only the second commit onto upstream `f05b3976`:

- Three of five 16 MiB downloads completed without corruption or retries.
- Two of five stalled permanently, at 15.21 MiB and 2.85 MiB respectively.
- No `DeserFailed` occurred in the stalled runs; received frames remained
  intact, but the async data path stopped making progress.
- The board remained alive and emitted RTT keepalives during the first stall.
- Restoring both commits produced a clean 16 MiB control run in 68.78 seconds,
  with zero deserialization failures and zero retries.

The stalls are consistent with the lost `INT_ENA` update fixed by the first
commit. This attribution is an inference from the A/B behavior and the
register-level race; no direct register trace was captured during a stall.

A separate 180-second simultaneous bidirectional stress test with both commits
completed with:

- Device to host: 28,849 frames / 40,388,600 bytes.
- Host to device: 28,849 frames / 40,388,600 bytes.
- Zero retries, timeouts, endpoint errors, transaction mismatches, or payload
  integrity errors.
- No response at or above the 250 ms deadline.

The readiness-only variant also passed this synthetic full-duplex test. This
matches an earlier negative result: the synthetic request/response workload is
useful as a high-volume integrity regression test, but the end-to-end Wi-Fi
download is the more reliable reproducer for the progress failure.

Local checks:

- `cargo xtask check-packages esp-hal --chips esp32c3`
- `cargo xtask lint-packages esp-hal --chips esp32c3`
- Formatting check for the changed driver
- `git diff --check`

The existing HIL test only verifies that constructing the asynchronous USB
Serial/JTAG peripheral does not break the debug connection; it does not
exercise host-driven transfers or concurrent RX/TX. The tests above use a
physical host-to-device USB connection and validate transferred payloads end
to end. 

#### AI assistance disclosure

OpenAI GPT-5.6-sol with `xhigh` reasoning effort was used to investigate and
localize the bug, develop the experimental matrix, assist with the
implementation, automate hardware testing, and prepare this pull request. I
reviewed the resulting changes and tested them on physical ESP32-C3 hardware.

---

# Changelog

## esp-hal/USB Serial/JTAG

- Fixed: Prevented data loss and stalls during concurrent asynchronous USB Serial/JTAG transmission and reception.
