### PR TITLE
Implement Peripheral signal traits explicitly, without unstable

### DIFF
--- a/esp-hal/src/gpio/interconnect.rs
+++ b/esp-hal/src/gpio/interconnect.rs
@@ -106,18 +106,7 @@ use enumset::{EnumSet, EnumSetType};
 #[cfg(feature = "unstable")]
 use crate::gpio::{Input, Output};
 use crate::{
-    gpio::{
-        self,
-        AlternateFunction,
-        AnyPin,
-        Flex,
-        InputPin,
-        Level,
-        NoPin,
-        OutputPin,
-        Pin,
-        PinGuard,
-    },
+    gpio::{self, AlternateFunction, AnyPin, Flex, Level, NoPin, OutputPin, Pin, PinGuard},
     peripherals::GPIO,
     private::{self, Sealed},
 };
@@ -167,32 +156,6 @@ pub trait PeripheralOutput<'d>: Into<OutputSignal<'d>> + PeripheralSignal<'d> {
     /// peripheral remain intact.
     #[doc(hidden)] // Considered unstable
     fn disconnect_from_peripheral_output(&self);
-}
-
-// Pins
-impl<'d, P> PeripheralSignal<'d> for P
-where
-    P: Pin + 'd,
-{
-    fn connect_input_to_peripheral(&self, signal: gpio::InputSignal) {
-        let pin = unsafe { AnyPin::steal(self.number()) };
-        InputSignal::new(pin).connect_input_to_peripheral(signal);
-    }
-}
-impl<'d, P> PeripheralInput<'d> for P where P: InputPin + 'd {}
-
-impl<'d, P> PeripheralOutput<'d> for P
-where
-    P: OutputPin + 'd,
-{
-    fn connect_peripheral_to_output(&self, signal: gpio::OutputSignal) {
-        let pin = unsafe { AnyPin::steal(self.number()) };
-        OutputSignal::new(pin).connect_peripheral_to_output(signal);
-    }
-    fn disconnect_from_peripheral_output(&self) {
-        let pin = unsafe { AnyPin::steal(self.number()) };
-        OutputSignal::new(pin).disconnect_from_peripheral_output();
-    }
 }
 
 // Pin drivers

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -2216,3 +2216,66 @@ for_each_gpio! {
 }
 
 define_io_mux_reg!();
+
+// Implement the signal traits outside of interconnect, so that the impls
+// don't inherit the module-level instability.
+mod io_matrix_impls {
+    use crate::gpio::{
+        self,
+        AnyPin,
+        interconnect::{
+            InputSignal,
+            OutputSignal,
+            PeripheralInput,
+            PeripheralOutput,
+            PeripheralSignal,
+        },
+    };
+
+    impl<'d> PeripheralSignal<'d> for AnyPin<'d> {
+        fn connect_input_to_peripheral(&self, signal: gpio::InputSignal) {
+            let pin = unsafe { self.clone_unchecked() };
+            InputSignal::new(pin).connect_input_to_peripheral(signal);
+        }
+    }
+    impl<'d> PeripheralInput<'d> for AnyPin<'d> {}
+
+    impl<'d> PeripheralOutput<'d> for AnyPin<'d> {
+        fn connect_peripheral_to_output(&self, signal: gpio::OutputSignal) {
+            let pin = unsafe { self.clone_unchecked() };
+            OutputSignal::new(pin).connect_peripheral_to_output(signal);
+        }
+        fn disconnect_from_peripheral_output(&self) {
+            let pin = unsafe { self.clone_unchecked() };
+            OutputSignal::new(pin).disconnect_from_peripheral_output();
+        }
+    }
+
+    for_each_gpio! {
+        ($n:literal, $gpio:ident $($_rest:tt)*) => {
+            impl<'d> PeripheralSignal<'d> for crate::peripherals::$gpio<'d> {
+                fn connect_input_to_peripheral(&self, signal: gpio::InputSignal) {
+                    let pin = unsafe { AnyPin::steal($n) };
+                    pin.connect_input_to_peripheral(signal);
+                }
+            }
+            impl<'d> PeripheralInput<'d> for crate::peripherals::$gpio<'d> {}
+        };
+    }
+
+    for_each_gpio! {
+        ($n:literal, $gpio:ident $_af_ins:tt $_af_outs:tt ($input:tt [Output])) => {
+            impl<'d> PeripheralOutput<'d> for crate::peripherals::$gpio<'d>
+            {
+                fn connect_peripheral_to_output(&self, signal: gpio::OutputSignal) {
+                    let pin = unsafe { AnyPin::steal($n) };
+                    pin.connect_peripheral_to_output(signal);
+                }
+                fn disconnect_from_peripheral_output(&self) {
+                    let pin = unsafe { AnyPin::steal($n) };
+                    pin.disconnect_from_peripheral_output();
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
Improves documentation readability by removing the blanket impl, spelling out the applicable pins, and removing the weird "Available on crate feature unstable only" note from the stable part.

Before:

<img width="1006" height="1149" alt="image" src="https://github.com/user-attachments/assets/5b4737a5-f65e-48e8-a9da-2be1cc9635f1" />

After:

<img width="998" height="1259" alt="image" src="https://github.com/user-attachments/assets/2b10e7d9-f8e7-4d2d-807d-d5c7041a5d97" />

# Changelog

## esp-hal/Documentation

- Fixed: `PeripheralInput/PeripheralOutput` implementations no longer show up as unstable for GPIOs.
- Changed: `PeripheralInput/PeripheralOutput` now list what GPIOs implement them, instead of showing a blanket implementation.