### PR TITLE
fix order or registers in dedicated gpio instructions for esp32s3 and esp32s2

### DIFF
--- a/esp-hal/src/gpio/dedicated/low_level/esp32s2.rs
+++ b/esp-hal/src/gpio/dedicated/low_level/esp32s2.rs
@@ -27,5 +27,5 @@ pub(super) fn read_out() -> u32 {
 
 #[inline(always)]
 pub(super) fn write(mask: u32, value: u32) {
-    unsafe { core::arch::asm!("wr_mask_gpio_out {0}, {1}", in(reg) mask, in(reg) value) }
+    unsafe { core::arch::asm!("wr_mask_gpio_out {0}, {1}", in(reg) value, in(reg) mask) }
 }

--- a/esp-hal/src/gpio/dedicated/low_level/esp32s3.rs
+++ b/esp-hal/src/gpio/dedicated/low_level/esp32s3.rs
@@ -22,5 +22,5 @@ pub(super) fn read_out() -> u32 {
 
 #[inline(always)]
 pub(super) fn write(mask: u32, value: u32) {
-    unsafe { core::arch::asm!("ee.wr_mask_gpio_out {0}, {1}", in(reg) mask, in(reg) value) }
+    unsafe { core::arch::asm!("ee.wr_mask_gpio_out {0}, {1}", in(reg) value, in(reg) mask) }
 }

--- a/hil-test/src/bin/gpio.rs
+++ b/hil-test/src/bin/gpio.rs
@@ -754,6 +754,18 @@ mod tests {
         }
         assert_eq!(input_dedicated.level(), Level::High);
         assert_eq!(output_dedicated.output_level(), Level::High);
+        // It used to only be possible for dedicated gpio to drive the pin High, not back to Low
+        // again on the esp32s2 and esp32s3, this makes sure that is not the case
+        output_dedicated.set_level(Level::Low);
+        #[cfg(esp32s2)]
+        unsafe {
+            core::arch::asm!("nop");
+            core::arch::asm!("nop");
+            core::arch::asm!("nop");
+            core::arch::asm!("nop");
+        }
+        assert_eq!(input_dedicated.level(), Level::Low);
+        assert_eq!(output_dedicated.output_level(), Level::Low);
     }
 
     #[test]


### PR DESCRIPTION
### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` or `manual-changelog` label as appropriate.
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
While working with an esp32-s3, I couldn't get the dedicated gpio to work. I could set pins high, but not low again. The code is essentially the following:
```rust
let chans = DedicatedGpio::new(p.GPIO_DEDICATED);
let output = DedicatedGpioOutput::new(chans.channel0.output);

let pin = Output::new(p.GPIO5, Level::Low, OutputConfig::default());

let mut output = output.with_pin(pin);

output.set_level(Level::High);
output.set_level(Level::Low);
// Read the pin with a multimeter/oscilloscope, it will be high.
```

Looking at the relevant sections in the datasheets for the [esp32-s3](https://documentation.espressif.com/esp32-s3_technical_reference_manual_en.pdf#subsection.1.8.213) and [esp32-s2](https://documentation.espressif.com/esp32-s2_technical_reference_manual_en.pdf#subsubsection.5.4.3.2) the register arguments are listed in the opposite order as they are given in this crate. Indeed, swapping the order fixes the issue (on the s3 at least, I don't have an s2 to test with).

I did notice that in the following snippet, dedicated gpio appears to be able to set the pin low:
```rust
let chans = DedicatedGpio::new(p.GPIO_DEDICATED);
let output = DedicatedGpioOutput::new(chans.channel0.output);

let pin = Output::new(p.GPIO5, Level::High, OutputConfig::default());

let mut output = output.with_pin(pin);

output.set_level(Level::Low);
```

In fact, the last line still doesn't do anything, the `with_pin` call does it. The doc comment for that function says
```rust
/// A dedicated GPIO output driver can control any number of GPIO pins. The pins will be
/// released when the driver is dropped. This function does not change the state of the newly
/// added GPIO pin.
```

However, it seems the first line of the function (`pin.set_output_connection(self.signal);`) does actually change the state of the pin. Unless I'm misunderstanding, I believe this comment should be corrected.

I don't have any way to test dedicated gpio on a riscv based esp32, and the method there is completely different, so perhaps somebody else should check over that (but I suspect it's fine).

---

<!-- ============================================================
  Changelog and migration guide entries live here in the PR body.
  They will be collected automatically at release time.
  Delete any section that doesn't apply to your PR.
  ============================================================ -->

# Changelog

<!-- Add one or more ## <crate> or ## <crate>/<area> sections below.
     Each entry must start with one of: Added, Changed, Fixed, Removed.
     To explicitly declare that a crate needs no changelog entry, write:
       - No changelog necessary.
     as the sole item under that crate's heading.
-->
## esp-hal

- Fixed: Order of register arguments to the assembly instructions for dedicated gpio on the esp32-s2 and esp32-s3

