### PR TITLE
docs: esp-now with wifi

### DIFF
--- a/esp-radio/src/esp_now/mod.rs
+++ b/esp-radio/src/esp_now/mod.rs
@@ -408,7 +408,9 @@ pub struct EspNowManager<'d> {
 
 impl EspNowManager<'_> {
     /// Set primary Wi-Fi channel.
-    /// Should only be used when using ESP-NOW without access point or station.
+    /// When using ESP-NOW with an access point or station,
+    /// the device cannot switch channels after connecting to Wi-Fi.
+    /// It can only transmit and receive data on the current Wi-Fi channel.
     #[instability::unstable]
     pub fn set_channel(&self, channel: u8) -> Result<(), EspNowError> {
         check_error!({ esp_wifi_set_channel(channel, 0) })


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` or `manual-changelog` label as appropriate.
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

Changed the docs on `EspNowManager`'s `set_channel` to include more context as why to be careful when using esp-now with Wi-Fi, using the explanation from [FAQ](https://docs.espressif.com/projects/esp-faq/en/latest/application-solution/esp-now.html#what-should-i-pay-attention-to-when-using-esp-now-applications).

Motivation: Using `set_channel` when connected to Wi-Fi will result in an error anyway, making it easy to notice. One should however be aware about the channel being changed by connecting to Wi-Fi, which to me wasn't an obvious limitation (see #6123). 

Closes: #6123

#### Testing

N/A

---

<!-- ============================================================
  Changelog and migration guide entries live here in the PR body.
  They will be collected automatically at release time.
  Delete any section that doesn't apply to your PR.
  ============================================================ -->

# Changelog

## esp-radio

- No changelog necessary.
