### PR TITLE
UART: prevent resending garbage

### DIFF
--- a/esp-hal/README.md
+++ b/esp-hal/README.md
@@ -83,7 +83,7 @@ For help getting started with this HAL, please refer to [The Rust on ESP Book] a
 
 | Driver          | ESP32 | ESP32-C2 | ESP32-C3 | ESP32-C5 | ESP32-C6 | ESP32-C61 | ESP32-H2 | ESP32-P4 | ESP32-S2 | ESP32-S3 | ESP32-S31 |
 | --------------- |:-----:|:--------:|:--------:|:--------:|:--------:|:---------:|:--------:|:--------:|:--------:|:--------:|:---------:|
-| UART            | ✔️   | ✔️      | ✔️      | ✔️      | ✔️      | ✔️       | ✔️      | ✔️      | ✔️      | ✔️      | ✔️       |
+| UART            | [✔️][6138] [^1] | ✔️      | ✔️      | ✔️      | ✔️      | ✔️       | ✔️      | ✔️      | ✔️      | ✔️      | ✔️       |
 | LP UART         |       |          |          | [❌][5155] [^1] | ⚒️      |           |          | ❌       |          |          | ❌        |
 | UHCI            | ❌    |          | ⚒️      | ⚒️      | ⚒️      |           | ⚒️      | ⚒️      | ❌       | ⚒️      | ⚒️       |
 | I2C master      | ✔️   | ✔️      | ✔️      | ✔️      | ✔️      | ✔️       | ✔️      | ✔️      | ✔️      | ✔️      | ✔️       |
@@ -227,6 +227,7 @@ For help getting started with this HAL, please refer to [The Rust on ESP Book] a
 [5980]: https://github.com/esp-rs/esp-hal/issues/5980
 [5981]: https://github.com/esp-rs/esp-hal/issues/5981
 [5982]: https://github.com/esp-rs/esp-hal/issues/5982
+[6138]: https://github.com/esp-rs/esp-hal/issues/6138
 <!-- end chip support table -->
 
 ## `unstable` feature

--- a/esp-hal/src/uart/low_level/mod.rs
+++ b/esp-hal/src/uart/low_level/mod.rs
@@ -944,16 +944,24 @@ pub(super) struct UartClockGuard<'t> {
 
 impl<'t> UartClockGuard<'t> {
     pub(super) fn new(uart: AnyUart<'t>) -> Self {
+        let this = Self::new_inner(uart, false);
+        crate::rom::ets_delay_us(100);
+        this
+    }
+
+    pub(super) fn new_inner(uart: AnyUart<'t>, clone: bool) -> Self {
         ClockTree::with(|clocks| {
             let clock = uart.info().clock_instance;
 
-            // Apply default SCLK configuration
-            let sclk_config = ClockConfig::new(
-                Default::default(),
-                #[cfg(any(uart_has_sclk_divider, soc_has_pcr, esp32p4, esp32s31))]
-                0,
-            );
-            clock.configure_function_clock(clocks, sclk_config);
+            // Apply default SCLK configuration when first instance is created.
+            if !clone {
+                let sclk_config = ClockConfig::new(
+                    Default::default(),
+                    #[cfg(any(uart_has_sclk_divider, soc_has_pcr, esp32p4, esp32s31))]
+                    0,
+                );
+                clock.configure_function_clock(clocks, sclk_config);
+            }
             clock.request_function_clock(clocks);
             clock.request_baud_rate_generator(clocks);
             #[cfg(soc_has_clock_node_uart_mem_clock)]
@@ -966,7 +974,7 @@ impl<'t> UartClockGuard<'t> {
 
 impl Clone for UartClockGuard<'_> {
     fn clone(&self) -> Self {
-        Self::new(unsafe { self.uart.clone_unchecked() })
+        Self::new_inner(unsafe { self.uart.clone_unchecked() }, true)
     }
 }
 

--- a/esp-hal/src/uart/mod.rs
+++ b/esp-hal/src/uart/mod.rs
@@ -2328,10 +2328,7 @@ where
         self.rx.disable_rx_interrupts();
         self.tx.disable_tx_interrupts();
 
-        // Reset Tx/Rx FIFOs
-        self.rx.uart.info().rxfifo_reset();
-        self.rx.uart.info().txfifo_reset();
-
+        // Applying config also resets Tx/Rx FIFOs
         self.apply_config(&config)?;
 
         // Don't wait after transmissions by default,

--- a/esp-hal/src/uart/mod.rs
+++ b/esp-hal/src/uart/mod.rs
@@ -758,8 +758,15 @@ impl core::fmt::Display for ConfigError {
 }
 
 impl<'d> UartTx<'d, Blocking> {
-    #[procmacros::doc_replace]
+    #[procmacros::doc_replace(
+        "note" => {
+            cfg(esp32) => "**esp32-specific ⚠️**: `UART2` is not recommended for use.",
+            _ => ""
+        }
+    )]
     /// Create a new UART TX instance in [`Blocking`] mode.
+    ///
+    /// __note__
     ///
     /// ## Errors
     ///
@@ -1092,8 +1099,15 @@ where
 }
 
 impl<'d> UartRx<'d, Blocking> {
-    #[procmacros::doc_replace]
+    #[procmacros::doc_replace(
+        "note" => {
+            cfg(esp32) => "**esp32-specific ⚠️**: `UART2` is not recommended for use.",
+            _ => ""
+        }
+    )]
     /// Create a new UART RX instance in [`Blocking`] mode.
+    ///
+    /// __note__
     ///
     /// ## Errors
     ///
@@ -1528,8 +1542,15 @@ where
 }
 
 impl<'d> Uart<'d, Blocking> {
-    #[procmacros::doc_replace]
+    #[procmacros::doc_replace(
+        "note" => {
+            cfg(esp32) => "**esp32-specific ⚠️**: `UART2` is not recommended for use.",
+            _ => ""
+        }
+    )]
     /// Create a new UART instance in [`Blocking`] mode.
+    ///
+    /// __note__
     ///
     /// ## Errors
     ///

--- a/esp-metadata/devices/esp32/soc.toml
+++ b/esp-metadata/devices/esp32/soc.toml
@@ -256,7 +256,7 @@ timg_has_divcnt_rst = false
 instances = [{ name = "timg0" }, { name = "timg1" }]
 
 [device.uart]
-support_status = "supported"
+support_status = { status = "supported", issue = 6138 }
 instances = [
     { name = "uart0", sys_instance = "Uart0", tx = "U0TXD", rx = "U0RXD", cts = "U0CTS", rts = "U0RTS" },
     { name = "uart1", sys_instance = "Uart1", tx = "U1TXD", rx = "U1RXD", cts = "U1CTS", rts = "U1RTS" },

--- a/hil-test/src/bin/uart.rs
+++ b/hil-test/src/bin/uart.rs
@@ -29,11 +29,10 @@ mod tests {
 
     #[init]
     fn init() -> Context {
-        let config =
-            cfg_select! {
-                esp32s31 => esp_hal::Config::default(),
-                _ => esp_hal::Config::default().with_cpu_clock(esp_hal::clock::CpuClock::max()),
-            };
+        let config = cfg_select! {
+            esp32s31 => esp_hal::Config::default(),
+            _ => esp_hal::Config::default().with_cpu_clock(esp_hal::clock::CpuClock::max()),
+        };
         let peripherals = esp_hal::init(config);
 
         let (rx, tx) = hil_test::common_test_pins!(peripherals);
@@ -161,13 +160,12 @@ mod tests {
         // working as expected. We will also using different clock sources
         // while we're at it.
 
-        let fastest_clock_source =
-            cfg_select! {
-                esp32c2 => ClockSource::PllF40m,
-                any(esp32c5, esp32c6, esp32c61, esp32p4, esp32s31) => ClockSource::PllF80m,
-                esp32h2 => ClockSource::PllF48m,
-                _ => ClockSource::Apb,
-            };
+        let fastest_clock_source = cfg_select! {
+            esp32c2 => ClockSource::PllF40m,
+            any(esp32c5, esp32c6, esp32c61, esp32p4, esp32s31) => ClockSource::PllF80m,
+            esp32h2 => ClockSource::PllF48m,
+            _ => ClockSource::Apb,
+        };
 
         let configs = [
             #[cfg(not(soc_has_clock_node_ref_tick))]
@@ -1386,6 +1384,55 @@ mod new_tests {
                 .with_tx(ctx.tx.reborrow())
                 .with_rx(ctx.rx.reborrow());
             inner(i, uart);
+        }
+    }
+
+    #[test]
+    #[timeout(10)]
+    fn creating_uart_clears_fifo(mut ctx: Context) {
+        fn inner(
+            tx_instance: usize,
+            rx: AnyUart<'_>,
+            rx_pin: AnyPin<'_>,
+            mut tx: AnyUart<'_>,
+            mut tx_pin: AnyPin<'_>,
+        ) {
+            info!("Testing UART{}", tx_instance);
+
+            let config = uart::Config::default().with_baudrate(115200);
+            let mut rx = Uart::new(rx, config).unwrap().with_rx(rx_pin);
+
+            for i in 0..50 {
+                let mut uart = Uart::new(tx.reborrow(), config)
+                    .unwrap()
+                    .with_tx(tx_pin.reborrow());
+                uart.write(b"abc").unwrap();
+                uart.flush().unwrap();
+
+                let mut buf = [0u8; 4];
+                let read = rx.read(&mut buf).unwrap();
+
+                assert_eq!(
+                    &buf[..read],
+                    b"abc",
+                    "UART{}: failed in iteration #{}",
+                    tx_instance,
+                    i
+                );
+            }
+
+            info!("UART{} test passed", tx_instance);
+        }
+
+        // Run the test for each UART instance
+        for (tx_num, rx_num) in (0..UART_COUNT).map(|i| (i, (i + 1) % UART_COUNT)) {
+            inner(
+                tx_num,
+                unsafe { ctx.uart[rx_num].clone_unchecked() },
+                ctx.rx.reborrow(),
+                unsafe { ctx.uart[tx_num].clone_unchecked() },
+                ctx.tx.reborrow(),
+            );
         }
     }
 

--- a/hil-test/src/bin/uart.rs
+++ b/hil-test/src/bin/uart.rs
@@ -29,10 +29,11 @@ mod tests {
 
     #[init]
     fn init() -> Context {
-        let config = cfg_select! {
-            esp32s31 => esp_hal::Config::default(),
-            _ => esp_hal::Config::default().with_cpu_clock(esp_hal::clock::CpuClock::max()),
-        };
+        let config =
+            cfg_select! {
+                esp32s31 => esp_hal::Config::default(),
+                _ => esp_hal::Config::default().with_cpu_clock(esp_hal::clock::CpuClock::max()),
+            };
         let peripherals = esp_hal::init(config);
 
         let (rx, tx) = hil_test::common_test_pins!(peripherals);
@@ -160,12 +161,13 @@ mod tests {
         // working as expected. We will also using different clock sources
         // while we're at it.
 
-        let fastest_clock_source = cfg_select! {
-            esp32c2 => ClockSource::PllF40m,
-            any(esp32c5, esp32c6, esp32c61, esp32p4, esp32s31) => ClockSource::PllF80m,
-            esp32h2 => ClockSource::PllF48m,
-            _ => ClockSource::Apb,
-        };
+        let fastest_clock_source =
+            cfg_select! {
+                esp32c2 => ClockSource::PllF40m,
+                any(esp32c5, esp32c6, esp32c61, esp32p4, esp32s31) => ClockSource::PllF80m,
+                esp32h2 => ClockSource::PllF48m,
+                _ => ClockSource::Apb,
+            };
 
         let configs = [
             #[cfg(not(soc_has_clock_node_ref_tick))]
@@ -1425,6 +1427,8 @@ mod new_tests {
         }
 
         // Run the test for each UART instance
+        // https://github.com/esp-rs/esp-hal/issues/6138
+        let uart_count = if cfg!(esp32) { 2 } else { UART_COUNT };
         for (tx_num, rx_num) in (0..UART_COUNT).map(|i| (i, (i + 1) % UART_COUNT)) {
             inner(
                 tx_num,


### PR DESCRIPTION
Closes #6131

Also adds a note to ESP32 that its UART2 is not recommended for use.

# Changelog

## esp-hal/UART

- Fixed: UART clocks are now configured only once, and enough time is left for them to stabilise. This fixes a problem with sending unexpected and possibly incorrect data in some cases.
