### PR TITLE
Assert if stack is too small

### DIFF
--- a/esp-hal/esp_config.yml
+++ b/esp-hal/esp_config.yml
@@ -52,6 +52,14 @@ options:
       - value: 3740121773
     display_hint: Hex
 
+  - name: ensure-main-stack-minimum
+    description: Prevent successful build if the main stack is smaller than the configured minimum number of bytes.
+    default:
+      - value: 8192
+    constraints:
+      - type:
+          validator: non_negative_integer
+
   - name: init-stack-ptr-range-check
     description: Check that the stack pointer is in range during initialization.
     default:

--- a/esp-hal/ld/sections/stack.x
+++ b/esp-hal/ld/sections/stack.x
@@ -8,6 +8,8 @@ SECTIONS {
     /* The stack_guard for `stack-protector` mitigation - https://doc.rust-lang.org/rustc/exploit-mitigations.html#stack-smashing-protection */
     __stack_chk_guard = ABSOLUTE(_stack_end) + ${ESP_HAL_CONFIG_STACK_GUARD_OFFSET};
 
+    ASSERT(_stack_start - _stack_end >= ${ESP_HAL_CONFIG_ENSURE_MAIN_STACK_MINIMUM}, "Main stack is smaller than ${ESP_HAL_CONFIG_ENSURE_MAIN_STACK_MINIMUM} bytes.");
+
     . = ORIGIN(RWDATA) + LENGTH(RWDATA);
 
     . = ALIGN (4);

--- a/examples/wifi/embassy_sntp/src/main.rs
+++ b/examples/wifi/embassy_sntp/src/main.rs
@@ -27,6 +27,7 @@ use esp_backtrace as _;
 use esp_hal::{
     clock::CpuClock,
     interrupt::software::SoftwareInterruptControl,
+    ram,
     rng::Rng,
     rtc_cntl::Rtc,
     timer::timg::TimerGroup,
@@ -91,7 +92,8 @@ async fn main(spawner: Spawner) -> ! {
     let peripherals = esp_hal::init(config);
     let rtc = Rtc::new(peripherals.RTC_TIMER);
 
-    esp_alloc::heap_allocator!(size: 72 * 1024);
+    esp_alloc::heap_allocator!(#[ram(reclaimed)] size: 64 * 1024);
+    esp_alloc::heap_allocator!(size: 36 * 1024);
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     let sw_int = SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);


### PR DESCRIPTION
Closes #5616

# Changelog

## esp-hal

- Added: Configure the minimum main stack size with `ESP_HAL_CONFIG_ENSURE_MAIN_STACK_MINIMUM`. The linker will assert that there is at least this much stack available. Default: 9182 bytes.