### PR TITLE
Revert "Update digest"

### DIFF
--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -49,13 +49,13 @@ bench = false
 test  = false
 
 [dependencies]
-bytemuck                 = "1.25.2"
+bytemuck                 = "1.24"
 critical-section         = { version = "1", features = ["restore-state-u32"], optional = true }
 embedded-hal             = "1.0.0"
 embedded-hal-async       = "1.0.0"
 enumset                  = "1.1"
 paste                    = "1.0.15"
-portable-atomic          = { version = "1.14.0", default-features = false }
+portable-atomic          = { version = "1.11", default-features = false }
 static_cell              = "2"
 
 esp-rom-sys              = { version = "~0.1", path = "../esp-rom-sys" }
@@ -66,9 +66,9 @@ delegate                 = "0.13"
 document-features        = "0.2"
 embassy-futures          = "0.1"
 embassy-sync             = "0.8"
-fugit                    = "0.4.0"
+fugit                    = "0.3.7"
 instability              = "0.3.12"
-strum                    = { version = "0.28.0", default-features = false, features = ["derive"] }
+strum                    = { version = "0.27.1", default-features = false, features = ["derive"] }
 
 esp-config               = { version = "0.7.0", path = "../esp-config" }
 esp-metadata-generated   = { version = "0.4.0", path = "../esp-metadata-generated" }
@@ -77,7 +77,7 @@ procmacros               = { version = "0.22.0", package = "esp-hal-procmacros",
 
 # Dependencies that are optional because they are used by unstable drivers.
 # They are needed when using the `unstable` feature.
-digest                   = { version = "0.11.3", default-features = false, features = ["block-api"], optional = true }
+digest                   = { version = "0.10.7", default-features = false, features = ["core-api"], optional = true }
 embassy-usb-driver       = { version = "0.2", optional = true }
 embassy-usb-synopsys-otg = { version = "0.4.0", optional = true, features = ["host"] }
 embassy-net-driver-02    = { package = "embassy-net-driver", version = "0.2", optional = true }
@@ -90,8 +90,8 @@ defmt                    = { version = "1.1", optional = true }
 log-04                   = { package = "log", version = "0.4", optional = true }
 
 # ESP32-only fallback SHA algorithms
-sha1                     = { version = "0.11", default-features = false, optional = true }
-sha2                     = { version = "0.11", default-features = false, optional = true }
+sha1                     = { version = "0.10", default-features = false, optional = true }
+sha2                     = { version = "0.10", default-features = false, optional = true }
 
 # Optional dependencies that enable ecosystem support.
 # We could support individually enabling them, but there is no big downside to just
@@ -122,7 +122,7 @@ esp32s31 = { version = "0.1", features = ["critical-section"], optional = true, 
 esp32p4 = { version = "0.2",  features = ["critical-section"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "131062119" }
 
 [target.'cfg(target_arch = "riscv32")'.dependencies]
-riscv            = { version = "0.16.1" }
+riscv            = { version = "0.15.0" }
 esp-riscv-rt     = { version = "0.14.0", path = "../esp-riscv-rt", optional = true }
 
 [target.'cfg(target_arch = "xtensa")'.dependencies]
@@ -135,7 +135,7 @@ esp-config   = { version = "0.7.0", path = "../esp-config", features = ["build"]
 somni-template = "0.3.1"
 
 [dev-dependencies]
-crypto-bigint = { version = "0.7.5", default-features = false }
+crypto-bigint = { version = "0.5.5", default-features = false }
 jiff = { version = "0.2", default-features = false, features = ["static"] }
 
 [features]

--- a/esp-hal/src/rsa/mod.rs
+++ b/esp-hal/src/rsa/mod.rs
@@ -1174,14 +1174,11 @@ impl RsaContext {
     ///     let mut d = [0_u32; U512::LIMBS * 2 + 1];
     ///     d[d.len() - 1] = 1;
     ///     let d = Uint::from_words(d);
-    ///     d.wrapping_rem_vartime(&modulus.resize()).resize()
+    ///     d.const_rem(&modulus.resize()).0.resize()
     /// }
     ///
     /// const fn compute_mprime(modulus: &U512) -> u32 {
-    ///     let m_inv = modulus
-    ///         .invert_mod2k(32)
-    ///         .expect_copied("modulus must be odd")
-    ///         .to_words()[0];
+    ///     let m_inv = modulus.inv_mod2k(32).to_words()[0];
     ///     (-1 * m_inv as i64 & (u32::MAX as i64)) as u32
     /// }
     ///

--- a/esp-hal/src/sha.rs
+++ b/esp-hal/src/sha.rs
@@ -84,6 +84,8 @@
 //! # {after_snippet}
 //! ```
 
+#![allow(deprecated, reason = "generic_array 0.14 has been deprecated")]
+
 use core::{
     borrow::BorrowMut,
     convert::Infallible,
@@ -551,7 +553,7 @@ pub trait ShaAlgorithm: crate::private::Sealed {
     const DIGEST_LENGTH: usize;
 
     #[doc(hidden)]
-    type DigestOutputSize: digest::array::ArraySize + 'static;
+    type DigestOutputSize: digest::generic_array::ArrayLength<u8> + 'static;
 }
 
 /// Note: digest has a blanket trait implementation for [digest::Digest] for any
@@ -1287,19 +1289,19 @@ impl<const CHUNK_BYTES: usize, const DIGEST_WORDS: usize> ShaContext<CHUNK_BYTES
         match hasher {
             SoftwareHasher::Sha1(sha) => {
                 let output = sha.finalize_reset();
-                result.copy_from_slice(output.as_ref())
+                result.copy_from_slice(output.as_slice())
             }
             SoftwareHasher::Sha256(sha) => {
                 let output = sha.finalize_reset();
-                result.copy_from_slice(output.as_ref())
+                result.copy_from_slice(output.as_slice())
             }
             SoftwareHasher::Sha384(sha) => {
                 let output = sha.finalize_reset();
-                result.copy_from_slice(output.as_ref())
+                result.copy_from_slice(output.as_slice())
             }
             SoftwareHasher::Sha512(sha) => {
                 let output = sha.finalize_reset();
-                result.copy_from_slice(output.as_ref())
+                result.copy_from_slice(output.as_slice())
             }
         }
     }
@@ -1437,7 +1439,7 @@ macro_rules! impl_worker_context {
             }
         }
 
-        impl digest::block_api::BlockSizeUser for $name {
+        impl digest::core_api::BlockSizeUser for $name {
             type BlockSize = paste::paste!(digest::consts::[< U $block_size >]);
 
             fn block_size() -> usize {

--- a/esp-hal/src/time.rs
+++ b/esp-hal/src/time.rs
@@ -329,7 +329,7 @@ impl core::ops::Sub for Instant {
     #[inline]
     fn sub(self, rhs: Self) -> Self::Output {
         // Avoid "Sub failed! Other > self" panics
-        Duration::from_micros(self.0.as_ticks().wrapping_sub(rhs.0.as_ticks()))
+        Duration::from_micros(self.0.ticks().wrapping_sub(rhs.0.ticks()))
     }
 }
 
@@ -409,7 +409,7 @@ impl Duration {
     /// ```
     #[inline]
     pub const fn from_micros(val: u64) -> Self {
-        Self(InnerDuration::from_micros(val))
+        Self(InnerDuration::micros(val))
     }
 
     #[procmacros::doc_replace]
@@ -425,7 +425,7 @@ impl Duration {
     /// ```
     #[inline]
     pub const fn from_millis(val: u64) -> Self {
-        Self(InnerDuration::from_millis(val))
+        Self(InnerDuration::millis(val))
     }
 
     #[procmacros::doc_replace]
@@ -441,7 +441,7 @@ impl Duration {
     /// ```
     #[inline]
     pub const fn from_secs(val: u64) -> Self {
-        Self(InnerDuration::from_secs(val))
+        Self(InnerDuration::secs(val))
     }
 
     #[procmacros::doc_replace]
@@ -457,7 +457,7 @@ impl Duration {
     /// ```
     #[inline]
     pub const fn from_minutes(val: u64) -> Self {
-        Self(InnerDuration::from_minutes(val))
+        Self(InnerDuration::minutes(val))
     }
 
     #[procmacros::doc_replace]
@@ -473,7 +473,7 @@ impl Duration {
     /// ```
     #[inline]
     pub const fn from_hours(val: u64) -> Self {
-        Self(InnerDuration::from_hours(val))
+        Self(InnerDuration::hours(val))
     }
 
     delegate::delegate! {
@@ -491,7 +491,7 @@ impl Duration {
             /// let micros = duration.as_micros();
             /// # {after_snippet}
             /// ```
-            #[call(as_micros)]
+            #[call(to_micros)]
             pub const fn as_micros(&self) -> u64;
 
             #[procmacros::doc_replace]
@@ -506,7 +506,7 @@ impl Duration {
             /// let millis = duration.as_millis();
             /// # {after_snippet}
             /// ```
-            #[call(as_millis)]
+            #[call(to_millis)]
             pub const fn as_millis(&self) -> u64;
 
             #[procmacros::doc_replace]
@@ -521,7 +521,7 @@ impl Duration {
             /// let secs = duration.as_secs();
             /// # {after_snippet}
             /// ```
-            #[call(as_secs)]
+            #[call(to_secs)]
             pub const fn as_secs(&self) -> u64;
 
             #[procmacros::doc_replace]
@@ -536,7 +536,7 @@ impl Duration {
             /// let minutes = duration.as_minutes();
             /// # {after_snippet}
             /// ```
-            #[call(as_minutes)]
+            #[call(to_minutes)]
             pub const fn as_minutes(&self) -> u64;
 
             #[procmacros::doc_replace]
@@ -551,7 +551,7 @@ impl Duration {
             /// let hours = duration.as_hours();
             /// # {after_snippet}
             /// ```
-            #[call(as_hours)]
+            #[call(to_hours)]
             pub const fn as_hours(&self) -> u64;
         }
     }

--- a/examples/peripheral/hmac/Cargo.toml
+++ b/examples/peripheral/hmac/Cargo.toml
@@ -12,9 +12,9 @@ esp-backtrace = { path = "../../../esp-backtrace", features = [
 esp-bootloader-esp-idf = { path = "../../../esp-bootloader-esp-idf" }
 esp-hal = { path = "../../../esp-hal", features = ["log-04", "unstable"] }
 esp-println = { path = "../../../esp-println", features = ["log-04"] }
-hmac = { version = "0.13.0", default-features = false }
+hmac = { version = "0.12.1", default-features = false }
 nb = "1.1.0"
-sha2 = { version = "0.11.0", default-features = false }
+sha2 = { version = "0.10.8", default-features = false }
 
 [features]
 esp32c3 = [

--- a/examples/peripheral/hmac/src/main.rs
+++ b/examples/peripheral/hmac/src/main.rs
@@ -69,7 +69,7 @@ use esp_hal::{
     time::Instant,
 };
 use esp_println::{print, println};
-use hmac::{Hmac as HmacSw, KeyInit, Mac, SimpleHmac};
+use hmac::{Hmac as HmacSw, Mac, SimpleHmac};
 use nb::block;
 use sha2::Sha256;
 

--- a/hil-test/Cargo.toml
+++ b/hil-test/Cargo.toml
@@ -118,7 +118,7 @@ trouble-host = { version = "0.7.0", features = [
 
 primeorder          = { version = "0.13.0", default-features = false }
 crypto-bigint       = { version = "0.5.5", default-features = false }
-digest              = { version = "0.11.3", default-features = false }
+digest              = { version = "0.10.7", default-features = false }
 elliptic-curve      = { version = "0.13.8", default-features = false, features = ["sec1"] }
 embedded-test       = { version = "0.7.1", default-features = false, features = ["embassy-010", "external-executor", "semihosting"] }
 hex-literal         = "1.0.0"
@@ -126,8 +126,8 @@ nb                  = "1.1.0"
 p192                = { version = "0.13.0", default-features = false, features = ["arithmetic"] }
 p256                = { version = "0.13.2", default-features = false, features = ["arithmetic"] }
 p384                = { version = "0.13.1", default-features = false, features = ["arithmetic"] }
-sha1                = { version = "0.11.0", default-features = false }
-sha2                = { version = "0.11.0", default-features = false }
+sha1                = { version = "0.10.6", default-features = false }
+sha2                = { version = "0.10.8", default-features = false }
 
 paste               = "1.0.15"
 


### PR DESCRIPTION
Reverts esp-rs/esp-hal#5942

This is an annoyingly done PR, touching fugit and stuff, dropping support for digest that is in use by mbedtls-rs, etc.