### PR TITLE
esp-radio: add sta_disconnected_pm/espnow_max_encrypt_num to runtime cfg

### DIFF
--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -113,6 +113,14 @@ mod internal;
 
 const MTU: usize = esp_config_int!(usize, "ESP_RADIO_CONFIG_WIFI_MTU");
 
+// The total hardware encryption key slots available that are shared between
+// ESP-NOW encrypted peers and the AP connections.
+// See https://github.com/espressif/esp-idf/blob/master/components/esp_wifi/Kconfig#L589
+#[cfg(esp32c2)]
+const TOTAL_HW_ENCRYPT_KEYS: u8 = 4;
+#[cfg(not(esp32c2))]
+const TOTAL_HW_ENCRYPT_KEYS: u8 = 17;
+
 /// The link state of a network device.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, PartialOrd, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -2227,6 +2235,18 @@ pub struct ControllerConfig {
     #[builder_lite(unstable)]
     rx_ba_win: u8,
 
+    /// Enable WiFi Power Management for station at disconnected status.
+    #[builder_lite(unstable)]
+    sta_disconnected_pm: bool,
+
+    /// Maximum encrypt number of peers supported by ESP-NOW.
+    ///
+    /// There are a fixed number of hardware encryption keys, and they are shared between ESP-NOW
+    /// and SoftAP. SoftAP will use however many are left over by ESP-NOW (unless configured to use
+    /// fewer).
+    #[builder_lite(unstable)]
+    espnow_max_encrypt_num: u8,
+
     /// Initial Wi-Fi configuration.
     #[builder_lite(reference)]
     initial_config: Config,
@@ -2250,6 +2270,12 @@ impl Default for ControllerConfig {
 
             rx_ba_win: 6,
 
+            sta_disconnected_pm: crate::sys::include::CONFIG_ESP_WIFI_STA_DISCONNECTED_PM_ENABLE
+                == 1,
+
+            espnow_max_encrypt_num: crate::sys::include::CONFIG_ESP_WIFI_ESPNOW_MAX_ENCRYPT_NUM
+                as _,
+
             country_info: CountryInfo::from(*b"CN"),
 
             initial_config: Config::Station(StationConfig::default()),
@@ -2264,6 +2290,9 @@ impl ControllerConfig {
         }
         if self.rx_ba_win as u16 >= 2 * (self.static_rx_buf_num as u16) {
             warn!("RX BA window size should be less than twice the number of static RX buffers.");
+        }
+        if self.espnow_max_encrypt_num > TOTAL_HW_ENCRYPT_KEYS {
+            warn!("ESP-NOW max encrypted peers should be at most the number of hardware keys.");
         }
     }
 }
@@ -2375,9 +2404,8 @@ impl<'d> WifiController<'d> {
                 beacon_max_len: crate::sys::include::WIFI_SOFTAP_BEACON_MAX_LEN as i32,
                 mgmt_sbuf_num: crate::sys::include::WIFI_MGMT_SBUF_NUM as i32,
                 feature_caps: internal::__ESP_RADIO_G_WIFI_FEATURE_CAPS,
-                sta_disconnected_pm: false,
-                espnow_max_encrypt_num: crate::sys::include::CONFIG_ESP_WIFI_ESPNOW_MAX_ENCRYPT_NUM
-                    as i32,
+                sta_disconnected_pm: config.sta_disconnected_pm as _,
+                espnow_max_encrypt_num: config.espnow_max_encrypt_num as _,
 
                 tx_hetb_queue_num: 3,
                 dump_hesigb_enable: false,
@@ -3164,20 +3192,12 @@ ignored."
         Err(WifiError::Failed)
     }
 
-    // The total hardware encryption key slots available that are shared between
-    // ESP-NOW encrypted peers and the AP connections.
-    // See https://github.com/espressif/esp-idf/blob/master/components/esp_wifi/Kconfig#L589
-    #[cfg(esp32c2)]
-    const TOTAL_HW_ENCRYPT_KEYS: u8 = 4;
-    #[cfg(not(esp32c2))]
-    const TOTAL_HW_ENCRYPT_KEYS: u8 = 17;
-
-    // The upper limit of connections available for the AP. The user set limit in apply_ap_config
-    // is clipped to this value
-    const AP_MAX_CONNECTIONS: u8 =
-        Self::TOTAL_HW_ENCRYPT_KEYS.saturating_sub(CONFIG_ESP_WIFI_ESPNOW_MAX_ENCRYPT_NUM as u8);
-
     fn apply_ap_config(&mut self, config: &AccessPointConfig) -> Result<(), WifiError> {
+        // The upper limit of connections available for the AP. The user set limit in
+        // apply_ap_config is clipped to this value
+        let ap_max_connections = TOTAL_HW_ENCRYPT_KEYS
+            .saturating_sub(unsafe { internal::G_CONFIG.espnow_max_encrypt_num } as _);
+
         let mut cfg = wifi_config_t {
             ap: wifi_ap_config_t {
                 ssid: [0; 32],
@@ -3188,7 +3208,7 @@ ignored."
                 ssid_hidden: if config.ssid_hidden { 1 } else { 0 },
                 // Clip max_connection in the same way as done internally in esp_wifi_set_config.
                 // Doing this here so that we can do easy comparisons below
-                max_connection: (config.max_connections as u8).min(Self::AP_MAX_CONNECTIONS),
+                max_connection: (config.max_connections as u8).min(ap_max_connections),
                 beacon_interval: 100,
                 pairwise_cipher: wifi_cipher_type_t_WIFI_CIPHER_TYPE_CCMP,
                 ftm_responder: false,

--- a/hil-test/src/bin/radio_basic.rs
+++ b/hil-test/src/bin/radio_basic.rs
@@ -6,10 +6,10 @@
 
 //% FEATURES: unstable esp-alloc embassy
 //% FEATURES(no_radio): rtos-radio-driver
-//% FEATURES(no_ble): esp-radio/wifi esp-radio esp-radio-unstable
+//% FEATURES(no_ble): esp-radio/wifi esp-radio/esp-now esp-radio esp-radio-unstable
 //% FEATURES(no_wifi): esp-radio/ble esp-radio esp-radio-unstable trouble-host
 //% FEATURES(has_wifi_ble): esp-radio/wifi esp-radio/ble esp-radio/coex esp-radio-unstable
-//% FEATURES(has_wifi_ble): trouble-host
+//% FEATURES(has_wifi_ble): trouble-host esp-radio/esp-now
 //% FEATURES(stable_wifi): esp-radio/wifi esp-radio
 
 // Even if the defaults change, keep this at a low-ish value for
@@ -57,6 +57,11 @@ mod ble_controller;
 #[path = "radio_basic/wifi_controller.rs"]
 #[cfg(feature = "esp-radio")]
 mod wifi_controller;
+
+#[cfg(soc_has_wifi)]
+#[path = "radio_basic/esp_now_config.rs"]
+#[cfg(feature = "esp-radio-unstable")]
+mod esp_now_config;
 
 #[cfg(xtensa)]
 #[path = "radio_basic/fpu.rs"]

--- a/hil-test/src/bin/radio_basic/esp_now_config.rs
+++ b/hil-test/src/bin/radio_basic/esp_now_config.rs
@@ -1,0 +1,103 @@
+#[embedded_test::tests(default_timeout = 10, executor = hil_test::Executor::new())]
+mod tests {
+    use esp_hal::{
+        clock::CpuClock,
+        interrupt::software::SoftwareInterruptControl,
+        peripherals::Peripherals,
+        timer::timg::TimerGroup,
+    };
+    use esp_radio::{
+        esp_now::{Error, EspNowError, EspNowWifiInterface, PeerInfo},
+        wifi::{ControllerConfig, WifiController},
+    };
+
+    const PMK: [u8; 16] = [0x42; 16];
+    const LMK: [u8; 16] = [0x11; 16];
+
+    fn peer(index: u8, encrypt: bool) -> PeerInfo {
+        PeerInfo {
+            interface: EspNowWifiInterface::Station,
+            peer_address: [0x02, 0x00, 0x00, 0x00, 0x00, index],
+            lmk: encrypt.then_some(LMK),
+            channel: None,
+            encrypt,
+        }
+    }
+
+    #[init]
+    fn init() -> Peripherals {
+        crate::init_heap();
+
+        let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
+        esp_hal::init(config)
+    }
+
+    #[test]
+    fn espnow_max_encrypt_num_is_honored(p: Peripherals) {
+        let timg0 = TimerGroup::new(p.TIMG0);
+        let sw_ints = SoftwareInterruptControl::new(p.SW_INTERRUPT);
+        esp_rtos::start(timg0.timer0, sw_ints.software_interrupt0);
+
+        let controller = WifiController::new(
+            p.WIFI,
+            ControllerConfig::default().with_espnow_max_encrypt_num(2),
+        )
+        .unwrap();
+
+        let esp_now = controller.esp_now();
+        esp_now.set_pmk(&PMK).unwrap();
+
+        esp_now.add_peer(peer(1, true)).unwrap();
+        esp_now.add_peer(peer(2, true)).unwrap();
+
+        assert_eq!(
+            esp_now.add_peer(peer(3, true)),
+            Err(EspNowError::Error(Error::PeerListFull))
+        );
+
+        esp_now.add_peer(peer(3, false)).unwrap();
+
+        let count = esp_now.peer_count().unwrap();
+        assert_eq!(count.encrypted_count, 2);
+    }
+
+    #[test]
+    fn espnow_max_encrypt_num_raises_the_limit(p: Peripherals) {
+        let timg0 = TimerGroup::new(p.TIMG0);
+        let sw_ints = SoftwareInterruptControl::new(p.SW_INTERRUPT);
+        esp_rtos::start(timg0.timer0, sw_ints.software_interrupt0);
+
+        let controller = WifiController::new(
+            p.WIFI,
+            ControllerConfig::default().with_espnow_max_encrypt_num(4),
+        )
+        .unwrap();
+
+        let esp_now = controller.esp_now();
+        esp_now.set_pmk(&PMK).unwrap();
+
+        for index in 1..=4 {
+            esp_now.add_peer(peer(index, true)).unwrap();
+        }
+
+        assert_eq!(esp_now.peer_count().unwrap().encrypted_count, 4);
+    }
+
+    #[test]
+    fn sta_disconnected_pm_can_be_configured(p: Peripherals) {
+        let timg0 = TimerGroup::new(p.TIMG0);
+        let sw_ints = SoftwareInterruptControl::new(p.SW_INTERRUPT);
+        esp_rtos::start(timg0.timer0, sw_ints.software_interrupt0);
+
+        let mut wifi = p.WIFI;
+        for enabled in [true, false] {
+            let controller = WifiController::new(
+                wifi.reborrow(),
+                ControllerConfig::default().with_sta_disconnected_pm(enabled),
+            )
+            .unwrap();
+
+            drop(controller);
+        }
+    }
+}


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` or `manual-changelog` label as appropriate.
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

I am porting some C code that uses ESP-NOW to Rust. For this I need power management without being connected to wifi, and the ability to increase the number of ESP-NOW encrypted peers. They are exposed under `ControllerConfig`. The default values come from the `CONFIG` values, but they can be modified at runtime as needed.

#### Testing

HIL, though I don't have anything to measure if the power saving setting is actually working, so I'm operating under the assumption that the underlying esp-idf wifi_init call works as advertised.

---

# Changelog

## esp-radio

- Added: `sta_disconnected_pm` and `espnow_max_encrypt_num` to `ControllerConfig`
- Changed: `sta_disconnected_pm` now defaults to `CONFIG_ESP_WIFI_STA_DISCONNECTED_PM_ENABLE`, previously it was always `false`.
