### PR TITLE
Introduce AuthenticationMethodConfig

### DIFF
--- a/esp-radio/src/wifi/ap.rs
+++ b/esp-radio/src/wifi/ap.rs
@@ -46,7 +46,6 @@ pub struct AccessPointConfig {
     /// The set of protocols supported by the access point.
     pub(crate) protocols: Protocols,
     /// The authentication method to be used by the access point.
-    #[builder_lite(reference)]
     pub(crate) authentication: AuthenticationMethodConfig,
     /// The maximum number of connections allowed on the access point.
     /// When set, this number can be clipped to a true upper limit because

--- a/esp-radio/src/wifi/ap.rs
+++ b/esp-radio/src/wifi/ap.rs
@@ -62,6 +62,13 @@ pub struct AccessPointConfig {
 
 impl AccessPointConfig {
     pub(crate) fn validate(&self) -> Result<(), WifiError> {
+        // Soft-AP doesn't support WEP (nor WAPI/OWE, which
+        // `AuthenticationMethodConfig` doesn't include).
+        if matches!(self.authentication, AuthenticationMethodConfig::Wep(_)) {
+            warn!("WEP is not supported in access point mode.");
+            return Err(WifiError::Unsupported);
+        }
+
         if let Some(password) = self.authentication.password()
             && password.is_empty()
         {
@@ -133,11 +140,10 @@ pub enum EventInfo {
 
 #[allow(non_upper_case_globals)]
 pub(crate) fn convert_ap_info(record: &wifi_ap_record_t) -> AccessPointInfo {
-    let str_len = record
-        .ssid
-        .iter()
-        .position(|&c| c == 0)
-        .unwrap_or(record.ssid.len());
+    // `record.ssid` is 33 bytes to always fit the NUL terminator of a
+    // maximum-length SSID - clamp to 32 in case the driver ever hands us one
+    // without it.
+    let str_len = record.ssid.iter().position(|&c| c == 0).unwrap_or(32);
     let ssid = Ssid::try_from(&record.ssid[..str_len]).expect("SSID length is valid");
 
     AccessPointInfo {

--- a/esp-radio/src/wifi/ap.rs
+++ b/esp-radio/src/wifi/ap.rs
@@ -1,14 +1,11 @@
 //! Wi-Fi access point.
 
-use alloc::string::String;
-use core::fmt;
-
 use procmacros::BuilderLite;
 
 #[cfg(feature = "unstable")]
 use super::CountryInfo;
 use super::{AuthenticationMethod, DisconnectReason, Protocols, SecondaryChannel, Ssid};
-use crate::{WifiError, sys::include::wifi_ap_record_t};
+use crate::{WifiError, sys::include::wifi_ap_record_t, wifi::AuthenticationMethodConfig};
 
 /// Information about a detected Wi-Fi access point.
 #[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
@@ -34,7 +31,8 @@ pub struct AccessPointInfo {
 }
 
 /// Configuration for a Wi-Fi access point.
-#[derive(Clone, PartialEq, Eq, BuilderLite, Hash)]
+#[derive(Clone, PartialEq, Eq, BuilderLite, Hash, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AccessPointConfig {
     /// The SSID of the access point.
     #[builder_lite(skip_setter)]
@@ -48,10 +46,8 @@ pub struct AccessPointConfig {
     /// The set of protocols supported by the access point.
     pub(crate) protocols: Protocols,
     /// The authentication method to be used by the access point.
-    pub(crate) auth_method: AuthenticationMethod,
-    /// The password for securing the access point (if applicable).
     #[builder_lite(reference)]
-    pub(crate) password: String,
+    pub(crate) authentication: AuthenticationMethodConfig,
     /// The maximum number of connections allowed on the access point.
     /// When set, this number can be clipped to a true upper limit because
     /// ESPNow and access point connections share a common pool of hardware
@@ -78,9 +74,7 @@ impl AccessPointConfig {
             return Err(WifiError::InvalidArguments);
         }
 
-        if self.password.len() >= 64 {
-            return Err(WifiError::InvalidArguments);
-        }
+        self.authentication.validate(true)?;
 
         if !(1..=10).contains(&self.dtim_period) {
             return Err(WifiError::InvalidArguments);
@@ -98,59 +92,11 @@ impl Default for AccessPointConfig {
             channel: 1,
             secondary_channel: None,
             protocols: Protocols::default(),
-            auth_method: AuthenticationMethod::None,
-            password: String::new(),
+            authentication: AuthenticationMethodConfig::Open,
             max_connections: 255,
             dtim_period: 2,
             beacon_timeout: 300,
         }
-    }
-}
-
-impl fmt::Debug for AccessPointConfig {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("AccessPointConfig")
-            .field("ssid", &self.ssid)
-            .field("ssid_hidden", &self.ssid_hidden)
-            .field("channel", &self.channel)
-            .field("secondary_channel", &self.secondary_channel)
-            .field("protocols", &self.protocols)
-            .field("auth_method", &self.auth_method)
-            .field("password", &"**REDACTED**")
-            .field("max_connections", &self.max_connections)
-            .field("dtim_period", &self.dtim_period)
-            .field("beacon_timeout", &self.beacon_timeout)
-            .finish()
-    }
-}
-
-#[cfg(feature = "defmt")]
-impl defmt::Format for AccessPointConfig {
-    fn format(&self, fmt: defmt::Formatter<'_>) {
-        defmt::write!(
-            fmt,
-            "AccessPointConfig {{\
-            ssid: {}, \
-            ssid_hidden: {}, \
-            channel: {}, \
-            secondary_channel: {}, \
-            protocols: {}, \
-            auth_method: {}, \
-            password: **REDACTED**, \
-            max_connections: {}, \
-            dtim_period: {}, \
-            beacon_timeout: {} \
-            }}",
-            self.ssid.as_str(),
-            self.ssid_hidden,
-            self.channel,
-            self.secondary_channel,
-            self.protocols,
-            self.auth_method,
-            self.max_connections,
-            self.dtim_period,
-            self.beacon_timeout
-        );
     }
 }
 

--- a/esp-radio/src/wifi/ap.rs
+++ b/esp-radio/src/wifi/ap.rs
@@ -35,7 +35,6 @@ pub struct AccessPointInfo {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AccessPointConfig {
     /// The SSID of the access point.
-    #[builder_lite(skip_setter)]
     pub(crate) ssid: Ssid,
     /// Whether the SSID is hidden or visible.
     pub(crate) ssid_hidden: bool,
@@ -62,18 +61,13 @@ pub struct AccessPointConfig {
 }
 
 impl AccessPointConfig {
-    /// Set the SSID of the access point.
-    pub fn with_ssid(mut self, ssid: impl Into<Ssid>) -> Self {
-        self.ssid = ssid.into();
-        self
-    }
-
     pub(crate) fn validate(&self) -> Result<(), WifiError> {
-        if self.ssid.len() > 32 {
-            return Err(WifiError::InvalidArguments);
+        if let Some(password) = self.authentication.password() {
+            if password.is_empty() {
+                warn!("Access point password is empty.");
+                return Err(WifiError::InvalidPassword);
+            }
         }
-
-        self.authentication.validate(true)?;
 
         if !(1..=10).contains(&self.dtim_period) {
             return Err(WifiError::InvalidArguments);
@@ -86,7 +80,7 @@ impl AccessPointConfig {
 impl Default for AccessPointConfig {
     fn default() -> Self {
         Self {
-            ssid: "iot-device".into(),
+            ssid: "iot-device".try_into().expect("SSID length is valid"),
             ssid_hidden: false,
             channel: 1,
             secondary_channel: None,
@@ -144,7 +138,7 @@ pub(crate) fn convert_ap_info(record: &wifi_ap_record_t) -> AccessPointInfo {
         .iter()
         .position(|&c| c == 0)
         .unwrap_or(record.ssid.len());
-    let ssid = Ssid::from(&record.ssid[..str_len]);
+    let ssid = Ssid::try_from(&record.ssid[..str_len]).expect("SSID length is valid");
 
     AccessPointInfo {
         ssid,

--- a/esp-radio/src/wifi/ap.rs
+++ b/esp-radio/src/wifi/ap.rs
@@ -62,11 +62,11 @@ pub struct AccessPointConfig {
 
 impl AccessPointConfig {
     pub(crate) fn validate(&self) -> Result<(), WifiError> {
-        if let Some(password) = self.authentication.password() {
-            if password.is_empty() {
-                warn!("Access point password is empty.");
-                return Err(WifiError::InvalidPassword);
-            }
+        if let Some(password) = self.authentication.password()
+            && password.is_empty()
+        {
+            warn!("Access point password is empty.");
+            return Err(WifiError::InvalidPassword);
         }
 
         if !(1..=10).contains(&self.dtim_period) {

--- a/esp-radio/src/wifi/event.rs
+++ b/esp-radio/src/wifi/event.rs
@@ -1071,6 +1071,7 @@ impl EventInfo {
                 let ev = unsafe { StationConnected::from_raw_event_data(payload) };
 
                 let Ok(ssid) = Ssid::from_raw(ev.ssid(), ev.ssid_len()) else {
+                    warn!("Dropping StationConnected event: invalid SSID length");
                     return None;
                 };
 
@@ -1086,6 +1087,7 @@ impl EventInfo {
                 let ev = unsafe { StationDisconnected::from_raw_event_data(payload) };
 
                 let Ok(ssid) = Ssid::from_raw(ev.ssid(), ev.ssid_len()) else {
+                    warn!("Dropping StationDisconnected event: invalid SSID length");
                     return None;
                 };
 
@@ -1127,13 +1129,22 @@ impl EventInfo {
                     StationWifiProtectedStatusEnrolleeSuccess::from_raw_event_data(payload)
                 };
                 Some(EventInfo::StationWifiProtectedStatusEnrolleeSuccess {
-                    credentials: Collection(ev
-                        .access_point_cred()[..ev.access_point_cred_cnt() as usize].iter()
-                        .map(|cred| CredentialsInfo {
-                            ssid: cred.ssid().try_into().expect("SSID length is valid"),
-                            passphrase: cred.passphrase().try_into().unwrap(),
-                        })
-                        .collect()),
+                    credentials: Collection(
+                        ev.access_point_cred()[..ev.access_point_cred_cnt() as usize]
+                            .iter()
+                            .filter_map(|cred| {
+                                let Ok(ssid) = Ssid::try_from(cred.ssid()) else {
+                                    warn!("Dropping WPS credential: invalid SSID length");
+                                    return None;
+                                };
+                                let Ok(passphrase) = <[u8; 64]>::try_from(cred.passphrase()) else {
+                                    warn!("Dropping WPS credential: invalid passphrase length");
+                                    return None;
+                                };
+                                Some(CredentialsInfo { ssid, passphrase })
+                            })
+                            .collect(),
+                    ),
                 })
             }
             WifiEvent::StationWifiProtectedStatusEnrolleeFailed => {

--- a/esp-radio/src/wifi/event.rs
+++ b/esp-radio/src/wifi/event.rs
@@ -1070,8 +1070,12 @@ impl EventInfo {
             WifiEvent::StationConnected => {
                 let ev = unsafe { StationConnected::from_raw_event_data(payload) };
 
+                let Ok(ssid) = Ssid::from_raw(ev.ssid(), ev.ssid_len()) else {
+                    return None;
+                };
+
                 Some(EventInfo::StationConnected {
-                    ssid: Ssid::from_raw(ev.ssid(), ev.ssid_len()).expect("SSID length is valid"),
+                    ssid,
                     bssid: ev.bssid().try_into().unwrap(),
                     channel: ev.channel(),
                     authmode: ev.authmode(),
@@ -1080,8 +1084,13 @@ impl EventInfo {
             }
             WifiEvent::StationDisconnected => {
                 let ev = unsafe { StationDisconnected::from_raw_event_data(payload) };
+
+                let Ok(ssid) = Ssid::from_raw(ev.ssid(), ev.ssid_len()) else {
+                    return None;
+                };
+
                 Some(EventInfo::StationDisconnected {
-                    ssid: Ssid::from_raw(ev.ssid(), ev.ssid_len()).expect("SSID length is valid"),
+                    ssid,
                     bssid: ev.bssid().try_into().unwrap(),
                     reason: ev.reason() as u16,
                     rssi: ev.rssi(),

--- a/esp-radio/src/wifi/event.rs
+++ b/esp-radio/src/wifi/event.rs
@@ -1071,7 +1071,7 @@ impl EventInfo {
                 let ev = unsafe { StationConnected::from_raw_event_data(payload) };
 
                 Some(EventInfo::StationConnected {
-                    ssid: Ssid::from_raw(ev.ssid(), ev.ssid_len()),
+                    ssid: Ssid::from_raw(ev.ssid(), ev.ssid_len()).expect("SSID length is valid"),
                     bssid: ev.bssid().try_into().unwrap(),
                     channel: ev.channel(),
                     authmode: ev.authmode(),
@@ -1081,7 +1081,7 @@ impl EventInfo {
             WifiEvent::StationDisconnected => {
                 let ev = unsafe { StationDisconnected::from_raw_event_data(payload) };
                 Some(EventInfo::StationDisconnected {
-                    ssid: Ssid::from_raw(ev.ssid(), ev.ssid_len()),
+                    ssid: Ssid::from_raw(ev.ssid(), ev.ssid_len()).expect("SSID length is valid"),
                     bssid: ev.bssid().try_into().unwrap(),
                     reason: ev.reason() as u16,
                     rssi: ev.rssi(),
@@ -1121,7 +1121,7 @@ impl EventInfo {
                     credentials: Collection(ev
                         .access_point_cred()[..ev.access_point_cred_cnt() as usize].iter()
                         .map(|cred| CredentialsInfo {
-                            ssid: cred.ssid().into(),
+                            ssid: cred.ssid().try_into().expect("SSID length is valid"),
                             passphrase: cred.passphrase().try_into().unwrap(),
                         })
                         .collect()),

--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -48,7 +48,7 @@
 //! range [8, 84]. Note that values above roughly 65 (~16dBm) have been reported to cause
 //! authentication failures on some hardware, so setting it to the maximum is not always better.
 
-use alloc::{borrow::ToOwned, collections::vec_deque::VecDeque, str, vec::Vec};
+use alloc::{borrow::ToOwned, collections::vec_deque::VecDeque, str, string::String, vec::Vec};
 use core::{
     fmt::{Debug, Write},
     marker::PhantomData,
@@ -814,6 +814,97 @@ impl From<&str> for Ssid {
 impl From<&[u8]> for Ssid {
     fn from(ssid: &[u8]) -> Self {
         Self::from_raw(ssid, ssid.len() as u8)
+    }
+}
+
+/// Authentication Configuration for a Wi-Fi network.
+#[derive(Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum AuthenticationMethodConfig {
+    /// Open authentication.
+    Open,
+
+    /// Wired Equivalent Privacy (WEP) authentication and password.
+    Wep(String),
+
+    /// Wi-Fi Protected Access (WPA) authentication and password.
+    Wpa(String),
+
+    /// Wi-Fi Protected Access 2 (WPA2) Personal authentication and password.
+    Wpa2Personal(String),
+
+    /// WPA/WPA2 Personal authentication and password (supports both).
+    WpaWpa2Personal(String),
+}
+
+impl AuthenticationMethodConfig {
+    fn validate(&self, require_non_empty_password: bool) -> Result<(), WifiError> {
+        match self {
+            AuthenticationMethodConfig::Open => Ok(()),
+            AuthenticationMethodConfig::Wep(password)
+            | AuthenticationMethodConfig::Wpa(password)
+            | AuthenticationMethodConfig::Wpa2Personal(password)
+            | AuthenticationMethodConfig::WpaWpa2Personal(password) => {
+                if require_non_empty_password && password.is_empty() {
+                    Err(WifiError::InvalidPassword)
+                } else if password.len() > 64 {
+                    Err(WifiError::InvalidArguments)
+                } else {
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    fn auth_method(&self) -> AuthenticationMethod {
+        match self {
+            AuthenticationMethodConfig::Open => AuthenticationMethod::None,
+            AuthenticationMethodConfig::Wep(_) => AuthenticationMethod::Wep,
+            AuthenticationMethodConfig::Wpa(_) => AuthenticationMethod::Wpa,
+            AuthenticationMethodConfig::Wpa2Personal(_) => AuthenticationMethod::Wpa2Personal,
+            AuthenticationMethodConfig::WpaWpa2Personal(_) => AuthenticationMethod::WpaWpa2Personal,
+        }
+    }
+
+    fn password(&self) -> &str {
+        match self {
+            AuthenticationMethodConfig::Open => "",
+            AuthenticationMethodConfig::Wep(password)
+            | AuthenticationMethodConfig::Wpa(password)
+            | AuthenticationMethodConfig::Wpa2Personal(password)
+            | AuthenticationMethodConfig::WpaWpa2Personal(password) => password.as_str(),
+        }
+    }
+}
+
+impl core::fmt::Debug for AuthenticationMethodConfig {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Open => f.debug_tuple("Open").finish(),
+            Self::Wep(_) => f.debug_tuple("Wep").field(&"**REDACTED**").finish(),
+            Self::Wpa(_) => f.debug_tuple("Wpa").field(&"**REDACTED**").finish(),
+            Self::Wpa2Personal(_) => f
+                .debug_tuple("Wpa2Personal")
+                .field(&"**REDACTED**")
+                .finish(),
+            Self::WpaWpa2Personal(_) => f
+                .debug_tuple("WpaWpa2Personal")
+                .field(&"**REDACTED**")
+                .finish(),
+        }
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for AuthenticationMethodConfig {
+    fn format(&self, fmt: defmt::Formatter<'_>) {
+        match self {
+            Self::Open => defmt::write!(fmt, "Open"),
+            Self::Wep(_) => defmt::write!(fmt, "Wep(**REDACTED**)"),
+            Self::Wpa(_) => defmt::write!(fmt, "Wpa(**REDACTED**)"),
+            Self::Wpa2Personal(_) => defmt::write!(fmt, "Wpa2Personal(**REDACTED**)"),
+            Self::WpaWpa2Personal(_) => defmt::write!(fmt, "WpaWpa2Personal(**REDACTED**)"),
+        }
     }
 }
 
@@ -2667,13 +2758,13 @@ impl WifiController<'_> {
     ///
     /// ```rust,no_run
     /// # {before_snippet}
-    /// # use esp_radio::wifi::{Config, sta::StationConfig};
+    /// # use esp_radio::wifi::{AuthenticationMethodConfig, Config, sta::StationConfig};
     /// # let mut controller =
     /// #    esp_radio::wifi::WifiController::new(peripherals.WIFI, Default::default())?;
     /// let station_config = Config::Station(
     ///     StationConfig::default()
     ///         .with_ssid("SSID")
-    ///         .with_password("PASSWORD".into()),
+    ///         .with_authentication(AuthenticationMethodConfig::Wpa2Personal("PASSWORD".into())),
     /// );
     ///
     /// controller.set_config(&station_config)?;
@@ -3204,7 +3295,7 @@ ignored."
                 password: [0; 64],
                 ssid_len: 0,
                 channel: config.channel,
-                authmode: config.auth_method.to_raw(),
+                authmode: config.authentication.auth_method().to_raw(),
                 ssid_hidden: if config.ssid_hidden { 1 } else { 0 },
                 // Clip max_connection in the same way as done internally in esp_wifi_set_config.
                 // Doing this here so that we can do easy comparisons below
@@ -3229,14 +3320,13 @@ ignored."
             },
         };
 
-        if config.auth_method == AuthenticationMethod::None && !config.password.is_empty() {
-            return Err(WifiError::InvalidArguments);
-        }
+        config.authentication.validate(true)?;
 
         unsafe {
             cfg.ap.ssid[0..(config.ssid.len())].copy_from_slice(config.ssid.as_bytes());
             cfg.ap.ssid_len = config.ssid.len() as u8;
-            cfg.ap.password[0..(config.password.len())].copy_from_slice(config.password.as_bytes());
+            cfg.ap.password[0..(config.authentication.password().len())]
+                .copy_from_slice(config.authentication.password().as_bytes());
 
             // Compare the new ap config with the current. Only update if something is changing.
             // This avoids unnecessary connection issues.
@@ -3265,7 +3355,7 @@ ignored."
                 sort_method: wifi_sort_method_t_WIFI_CONNECT_AP_BY_SIGNAL,
                 threshold: wifi_scan_threshold_t {
                     rssi: -99,
-                    authmode: config.auth_method.to_raw(),
+                    authmode: config.authentication.auth_method().to_raw(),
                     rssi_5g_adjustment: 0,
                 },
                 pmf_cfg: wifi_pmf_config_t {
@@ -3283,14 +3373,12 @@ ignored."
             },
         };
 
-        if config.auth_method == AuthenticationMethod::None && !config.password.is_empty() {
-            return Err(WifiError::InvalidArguments);
-        }
+        config.authentication.validate(false)?;
 
         unsafe {
             cfg.sta.ssid[0..(config.ssid.len())].copy_from_slice(config.ssid.as_bytes());
-            cfg.sta.password[0..(config.password.len())]
-                .copy_from_slice(config.password.as_bytes());
+            cfg.sta.password[0..(config.authentication.password().len())]
+                .copy_from_slice(config.authentication.password().as_bytes());
 
             // Compare the new sta config with the current. Only update if something is changing.
             // This avoids unnecessary connection issues.

--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -48,7 +48,7 @@
 //! range [8, 84]. Note that values above roughly 65 (~16dBm) have been reported to cause
 //! authentication failures on some hardware, so setting it to the maximum is not always better.
 
-use alloc::{borrow::ToOwned, collections::vec_deque::VecDeque, str, string::String, vec::Vec};
+use alloc::{borrow::ToOwned, collections::vec_deque::VecDeque, str, vec::Vec};
 use core::{
     fmt::{Debug, Write},
     marker::PhantomData,
@@ -818,23 +818,23 @@ impl From<&[u8]> for Ssid {
 }
 
 /// Authentication Configuration for a Wi-Fi network.
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum AuthenticationMethodConfig {
     /// Open authentication.
     Open,
 
     /// Wired Equivalent Privacy (WEP) authentication and password.
-    Wep(String),
+    Wep(Password),
 
     /// Wi-Fi Protected Access (WPA) authentication and password.
-    Wpa(String),
+    Wpa(Password),
 
     /// Wi-Fi Protected Access 2 (WPA2) Personal authentication and password.
-    Wpa2Personal(String),
+    Wpa2Personal(Password),
 
     /// WPA/WPA2 Personal authentication and password (supports both).
-    WpaWpa2Personal(String),
+    WpaWpa2Personal(Password),
 }
 
 impl AuthenticationMethodConfig {
@@ -846,9 +846,8 @@ impl AuthenticationMethodConfig {
             | AuthenticationMethodConfig::Wpa2Personal(password)
             | AuthenticationMethodConfig::WpaWpa2Personal(password) => {
                 if require_non_empty_password && password.is_empty() {
+                    warn!("The password is empty");
                     Err(WifiError::InvalidPassword)
-                } else if password.len() > 64 {
-                    Err(WifiError::InvalidArguments)
                 } else {
                     Ok(())
                 }
@@ -866,13 +865,13 @@ impl AuthenticationMethodConfig {
         }
     }
 
-    fn password(&self) -> &str {
+    fn password(&self) -> &[u8] {
         match self {
-            AuthenticationMethodConfig::Open => "",
+            AuthenticationMethodConfig::Open => &[],
             AuthenticationMethodConfig::Wep(password)
             | AuthenticationMethodConfig::Wpa(password)
             | AuthenticationMethodConfig::Wpa2Personal(password)
-            | AuthenticationMethodConfig::WpaWpa2Personal(password) => password.as_str(),
+            | AuthenticationMethodConfig::WpaWpa2Personal(password) => password.as_bytes(),
         }
     }
 }
@@ -905,6 +904,84 @@ impl defmt::Format for AuthenticationMethodConfig {
             Self::Wpa2Personal(_) => defmt::write!(fmt, "Wpa2Personal(**REDACTED**)"),
             Self::WpaWpa2Personal(_) => defmt::write!(fmt, "WpaWpa2Personal(**REDACTED**)"),
         }
+    }
+}
+
+/// A password.
+/// Can be up to 64 bytes long (i.e. not characters).
+/// Longer passwords will be truncated to 64 bytes.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Password {
+    password: [u8; 64],
+    len: u8,
+}
+
+impl Password {
+    pub(crate) fn new(password: &str) -> Self {
+        Self::from_raw(password.as_bytes())
+    }
+
+    pub(crate) fn from_raw(password: &[u8]) -> Self {
+        if password.len() > 64 {
+            warn!("Password is longer than 64 bytes, truncating");
+        }
+
+        let mut pwd_bytes = [0u8; 64];
+        let len = usize::min(64, password.len());
+        pwd_bytes[..len].copy_from_slice(&password[..len]);
+
+        Self {
+            password: pwd_bytes,
+            len: len as u8,
+        }
+    }
+
+    pub(crate) fn as_bytes(&self) -> &[u8] {
+        &self.password[..self.len as usize]
+    }
+
+    /// The length (in bytes) of the password.
+    pub fn len(&self) -> usize {
+        self.len as usize
+    }
+
+    /// Returns true if the password is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+}
+
+impl Default for Password {
+    fn default() -> Self {
+        Self {
+            password: [0u8; 64],
+            len: 0,
+        }
+    }
+}
+
+impl Debug for Password {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("Password( ** REDACTED **)")
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for Password {
+    fn format(&self, fmt: defmt::Formatter<'_>) {
+        defmt::write!(fmt, "Password( ** REDACTED **)")
+    }
+}
+
+impl From<&str> for Password {
+    fn from(password: &str) -> Self {
+        Self::new(password)
+    }
+}
+
+impl From<&[u8]> for Password {
+    fn from(password: &[u8]) -> Self {
+        Self::from_raw(password)
     }
 }
 
@@ -3326,7 +3403,7 @@ ignored."
             cfg.ap.ssid[0..(config.ssid.len())].copy_from_slice(config.ssid.as_bytes());
             cfg.ap.ssid_len = config.ssid.len() as u8;
             cfg.ap.password[0..(config.authentication.password().len())]
-                .copy_from_slice(config.authentication.password().as_bytes());
+                .copy_from_slice(config.authentication.password());
 
             // Compare the new ap config with the current. Only update if something is changing.
             // This avoids unnecessary connection issues.
@@ -3378,7 +3455,7 @@ ignored."
         unsafe {
             cfg.sta.ssid[0..(config.ssid.len())].copy_from_slice(config.ssid.as_bytes());
             cfg.sta.password[0..(config.authentication.password().len())]
-                .copy_from_slice(config.authentication.password().as_bytes());
+                .copy_from_slice(config.authentication.password());
 
             // Compare the new sta config with the current. Only update if something is changing.
             // This avoids unnecessary connection issues.

--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -735,7 +735,9 @@ impl DisconnectReason {
     }
 }
 
-/// Information about a connected station.
+/// A Wi-Fi SSID.
+///
+/// Can be up to 32 bytes long (i.e. not characters). Longer SSIDs are rejected.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Ssid {
@@ -744,24 +746,39 @@ pub struct Ssid {
 }
 
 impl Ssid {
-    pub(crate) fn new(ssid: &str) -> Self {
+    pub(crate) fn new(ssid: &str) -> Result<Self, WifiError> {
         let mut ssid_bytes = [0u8; 32];
         let bytes = ssid.as_bytes();
-        let len = usize::min(32, bytes.len());
+
+        if bytes.len() > 32 {
+            warn!("SSID is longer than 32 bytes");
+            return Err(WifiError::InvalidSsid);
+        }
+
+        let len = bytes.len();
         ssid_bytes[..len].copy_from_slice(bytes);
 
         Self::from_raw(&ssid_bytes, len as u8)
     }
 
-    pub(crate) fn from_raw(ssid: &[u8], len: u8) -> Self {
+    pub(crate) fn from_raw(ssid: &[u8], len: u8) -> Result<Self, WifiError> {
+        let len = len as usize;
+        if len > 32 {
+            warn!("SSID is longer than 32 bytes");
+            return Err(WifiError::InvalidSsid);
+        }
+        if ssid.len() < len {
+            warn!("SSID buffer shorter than reported length");
+            return Err(WifiError::InvalidSsid);
+        }
+
         let mut ssid_bytes = [0u8; 32];
-        let len = usize::min(32, len as usize);
         ssid_bytes[..len].copy_from_slice(&ssid[..len]);
 
-        Self {
+        Ok(Self {
             ssid: ssid_bytes,
             len: len as u8,
-        }
+        })
     }
 
     pub(crate) fn as_bytes(&self) -> &[u8] {
@@ -799,26 +816,38 @@ impl Debug for Ssid {
     }
 }
 
-impl From<alloc::string::String> for Ssid {
-    fn from(ssid: alloc::string::String) -> Self {
+impl TryFrom<alloc::string::String> for Ssid {
+    type Error = WifiError;
+
+    fn try_from(ssid: alloc::string::String) -> Result<Self, Self::Error> {
         Self::new(&ssid)
     }
 }
 
-impl From<&str> for Ssid {
-    fn from(ssid: &str) -> Self {
+impl TryFrom<&str> for Ssid {
+    type Error = WifiError;
+
+    fn try_from(ssid: &str) -> Result<Self, Self::Error> {
         Self::new(ssid)
     }
 }
 
-impl From<&[u8]> for Ssid {
-    fn from(ssid: &[u8]) -> Self {
+impl TryFrom<&[u8]> for Ssid {
+    type Error = WifiError;
+
+    fn try_from(ssid: &[u8]) -> Result<Self, Self::Error> {
+        if ssid.len() > 32 {
+            warn!("SSID is longer than 32 bytes");
+            return Err(WifiError::InvalidSsid);
+        }
+
         Self::from_raw(ssid, ssid.len() as u8)
     }
 }
 
 /// Authentication Configuration for a Wi-Fi network.
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub enum AuthenticationMethodConfig {
     /// Open authentication.
@@ -838,23 +867,6 @@ pub enum AuthenticationMethodConfig {
 }
 
 impl AuthenticationMethodConfig {
-    fn validate(&self, require_non_empty_password: bool) -> Result<(), WifiError> {
-        match self {
-            AuthenticationMethodConfig::Open => Ok(()),
-            AuthenticationMethodConfig::Wep(password)
-            | AuthenticationMethodConfig::Wpa(password)
-            | AuthenticationMethodConfig::Wpa2Personal(password)
-            | AuthenticationMethodConfig::WpaWpa2Personal(password) => {
-                if require_non_empty_password && password.is_empty() {
-                    warn!("The password is empty");
-                    Err(WifiError::InvalidPassword)
-                } else {
-                    Ok(())
-                }
-            }
-        }
-    }
-
     fn auth_method(&self) -> AuthenticationMethod {
         match self {
             AuthenticationMethodConfig::Open => AuthenticationMethod::None,
@@ -865,51 +877,20 @@ impl AuthenticationMethodConfig {
         }
     }
 
-    fn password(&self) -> &[u8] {
+    fn password(&self) -> Option<&[u8]> {
         match self {
-            AuthenticationMethodConfig::Open => &[],
+            AuthenticationMethodConfig::Open => None,
             AuthenticationMethodConfig::Wep(password)
             | AuthenticationMethodConfig::Wpa(password)
             | AuthenticationMethodConfig::Wpa2Personal(password)
-            | AuthenticationMethodConfig::WpaWpa2Personal(password) => password.as_bytes(),
-        }
-    }
-}
-
-impl core::fmt::Debug for AuthenticationMethodConfig {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            Self::Open => f.debug_tuple("Open").finish(),
-            Self::Wep(_) => f.debug_tuple("Wep").field(&"**REDACTED**").finish(),
-            Self::Wpa(_) => f.debug_tuple("Wpa").field(&"**REDACTED**").finish(),
-            Self::Wpa2Personal(_) => f
-                .debug_tuple("Wpa2Personal")
-                .field(&"**REDACTED**")
-                .finish(),
-            Self::WpaWpa2Personal(_) => f
-                .debug_tuple("WpaWpa2Personal")
-                .field(&"**REDACTED**")
-                .finish(),
-        }
-    }
-}
-
-#[cfg(feature = "defmt")]
-impl defmt::Format for AuthenticationMethodConfig {
-    fn format(&self, fmt: defmt::Formatter<'_>) {
-        match self {
-            Self::Open => defmt::write!(fmt, "Open"),
-            Self::Wep(_) => defmt::write!(fmt, "Wep(**REDACTED**)"),
-            Self::Wpa(_) => defmt::write!(fmt, "Wpa(**REDACTED**)"),
-            Self::Wpa2Personal(_) => defmt::write!(fmt, "Wpa2Personal(**REDACTED**)"),
-            Self::WpaWpa2Personal(_) => defmt::write!(fmt, "WpaWpa2Personal(**REDACTED**)"),
+            | AuthenticationMethodConfig::WpaWpa2Personal(password) => Some(password.as_bytes()),
         }
     }
 }
 
 /// A password.
-/// Can be up to 64 bytes long (i.e. not characters).
-/// Longer passwords will be truncated to 64 bytes.
+///
+/// Can be up to 64 bytes long (i.e. not characters). Longer passwords are rejected.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Password {
     password: [u8; 64],
@@ -917,23 +898,24 @@ pub struct Password {
 }
 
 impl Password {
-    pub(crate) fn new(password: &str) -> Self {
+    pub(crate) fn new(password: &str) -> Result<Self, WifiError> {
         Self::from_raw(password.as_bytes())
     }
 
-    pub(crate) fn from_raw(password: &[u8]) -> Self {
+    pub(crate) fn from_raw(password: &[u8]) -> Result<Self, WifiError> {
         if password.len() > 64 {
-            warn!("Password is longer than 64 bytes, truncating");
+            warn!("Password is longer than 64 bytes");
+            return Err(WifiError::InvalidPassword);
         }
 
         let mut pwd_bytes = [0u8; 64];
-        let len = usize::min(64, password.len());
-        pwd_bytes[..len].copy_from_slice(&password[..len]);
+        let len = password.len();
+        pwd_bytes[..len].copy_from_slice(password);
 
-        Self {
+        Ok(Self {
             password: pwd_bytes,
             len: len as u8,
-        }
+        })
     }
 
     pub(crate) fn as_bytes(&self) -> &[u8] {
@@ -962,25 +944,29 @@ impl Default for Password {
 
 impl Debug for Password {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.write_str("Password( ** REDACTED **)")
+        f.write_str("**REDACTED**")
     }
 }
 
 #[cfg(feature = "defmt")]
 impl defmt::Format for Password {
     fn format(&self, fmt: defmt::Formatter<'_>) {
-        defmt::write!(fmt, "Password( ** REDACTED **)")
+        defmt::write!(fmt, "**REDACTED**")
     }
 }
 
-impl From<&str> for Password {
-    fn from(password: &str) -> Self {
+impl TryFrom<&str> for Password {
+    type Error = WifiError;
+
+    fn try_from(password: &str) -> Result<Self, Self::Error> {
         Self::new(password)
     }
 }
 
-impl From<&[u8]> for Password {
-    fn from(password: &[u8]) -> Self {
+impl TryFrom<&[u8]> for Password {
+    type Error = WifiError;
+
+    fn try_from(password: &[u8]) -> Result<Self, Self::Error> {
         Self::from_raw(password)
     }
 }
@@ -2673,7 +2659,7 @@ impl WifiController<'_> {
     /// use esp_radio::wifi::Protocols;
     ///
     /// let controller_config = ControllerConfig::default().with_initial_config(Config::AccessPoint(
-    ///     AccessPointConfig::default().with_ssid("esp-radio"),
+    ///     AccessPointConfig::default().with_ssid("esp-radio".try_into()?),
     /// ));
     /// let mut wifi_controller =
     ///     esp_radio::wifi::WifiController::new(peripherals.WIFI, controller_config)?;
@@ -2840,8 +2826,10 @@ impl WifiController<'_> {
     /// #    esp_radio::wifi::WifiController::new(peripherals.WIFI, Default::default())?;
     /// let station_config = Config::Station(
     ///     StationConfig::default()
-    ///         .with_ssid("SSID")
-    ///         .with_authentication(AuthenticationMethodConfig::Wpa2Personal("PASSWORD".into())),
+    ///         .with_ssid("SSID".try_into()?)
+    ///         .with_authentication(AuthenticationMethodConfig::Wpa2Personal(
+    ///             "PASSWORD".try_into()?,
+    ///         )),
     /// );
     ///
     /// controller.set_config(&station_config)?;
@@ -3361,6 +3349,8 @@ ignored."
     }
 
     fn apply_ap_config(&mut self, config: &AccessPointConfig) -> Result<(), WifiError> {
+        config.validate()?;
+
         // The upper limit of connections available for the AP. The user set limit in
         // apply_ap_config is clipped to this value
         let ap_max_connections = TOTAL_HW_ENCRYPT_KEYS
@@ -3397,13 +3387,12 @@ ignored."
             },
         };
 
-        config.authentication.validate(true)?;
-
         unsafe {
             cfg.ap.ssid[0..(config.ssid.len())].copy_from_slice(config.ssid.as_bytes());
             cfg.ap.ssid_len = config.ssid.len() as u8;
-            cfg.ap.password[0..(config.authentication.password().len())]
-                .copy_from_slice(config.authentication.password());
+            if let Some(password) = config.authentication.password() {
+                cfg.ap.password[0..(password.len())].copy_from_slice(password);
+            }
 
             // Compare the new ap config with the current. Only update if something is changing.
             // This avoids unnecessary connection issues.
@@ -3420,6 +3409,8 @@ ignored."
     }
 
     fn apply_sta_config(&mut self, config: &StationConfig) -> Result<(), WifiError> {
+        config.validate()?;
+
         let mut cfg = wifi_config_t {
             sta: wifi_sta_config_t {
                 ssid: [0; 32],
@@ -3450,12 +3441,11 @@ ignored."
             },
         };
 
-        config.authentication.validate(false)?;
-
         unsafe {
             cfg.sta.ssid[0..(config.ssid.len())].copy_from_slice(config.ssid.as_bytes());
-            cfg.sta.password[0..(config.authentication.password().len())]
-                .copy_from_slice(config.authentication.password());
+            if let Some(password) = config.authentication.password() {
+                cfg.sta.password[0..(password.len())].copy_from_slice(password);
+            }
 
             // Compare the new sta config with the current. Only update if something is changing.
             // This avoids unnecessary connection issues.

--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -739,7 +739,6 @@ impl DisconnectReason {
 ///
 /// Can be up to 32 bytes long (i.e. not characters). Longer SSIDs are rejected.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Default)]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Ssid {
     ssid: [u8; 32],
     len: u8,
@@ -813,6 +812,13 @@ impl Debug for Ssid {
         f.write_char('"')?;
         f.write_str(self.as_str())?;
         f.write_char('"')
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for Ssid {
+    fn format(&self, fmt: defmt::Formatter<'_>) {
+        defmt::write!(fmt, "{}", self.as_str())
     }
 }
 
@@ -891,6 +897,11 @@ impl AuthenticationMethodConfig {
 /// A password.
 ///
 /// Can be up to 64 bytes long (i.e. not characters). Longer passwords are rejected.
+///
+/// Only the maximum length is checked here - further constraints depend on the
+/// authentication method (e.g. WPA requires at least 8 bytes, WEP requires
+/// exactly 5 or 13 bytes) and are rejected by the driver when applying the
+/// configuration.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Password {
     password: [u8; 64],
@@ -952,6 +963,14 @@ impl Debug for Password {
 impl defmt::Format for Password {
     fn format(&self, fmt: defmt::Formatter<'_>) {
         defmt::write!(fmt, "**REDACTED**")
+    }
+}
+
+impl TryFrom<alloc::string::String> for Password {
+    type Error = WifiError;
+
+    fn try_from(password: alloc::string::String) -> Result<Self, Self::Error> {
+        Self::new(&password)
     }
 }
 

--- a/esp-radio/src/wifi/scan.rs
+++ b/esp-radio/src/wifi/scan.rs
@@ -84,7 +84,6 @@ pub struct ScanConfig {
     /// If [`None`] is passed, all SSIDs will be returned.
     /// If [`Some`] is passed, only the APs matching the given SSID will be
     /// returned.
-    #[builder_lite(skip_setter)]
     pub(crate) ssid: Option<Ssid>,
     /// BSSID to filter for.
     /// If [`None`] is passed, all BSSIDs will be returned.
@@ -104,20 +103,6 @@ pub struct ScanConfig {
     /// If [`None`] is passed, all networks will be returned.
     /// If [`Some`] is passed, the specified number of networks will be returned.
     pub(crate) max: Option<usize>,
-}
-
-impl ScanConfig {
-    /// Set the SSID of the access point.
-    pub fn with_ssid(mut self, ssid: impl Into<Ssid>) -> Self {
-        self.ssid = Some(ssid.into());
-        self
-    }
-
-    /// Clears the SSID.
-    pub fn with_ssid_none(mut self) -> Self {
-        self.ssid = None;
-        self
-    }
 }
 
 /// Wi-Fi scan results.

--- a/esp-radio/src/wifi/sta/eap.rs
+++ b/esp-radio/src/wifi/sta/eap.rs
@@ -71,7 +71,6 @@ type CertificateAndKey = (&'static [u8], &'static [u8], Option<&'static [u8]>);
 #[instability::unstable]
 pub struct EapStationConfig {
     /// The SSID of the network the station is connecting to.
-    #[builder_lite(skip_setter)]
     pub(crate) ssid: Ssid,
     /// The BSSID (MAC Address) of the specific access point.
     pub(crate) bssid: Option<[u8; 6]>,
@@ -138,18 +137,7 @@ pub struct EapStationConfig {
 }
 
 impl EapStationConfig {
-    /// Set the SSID of the access point.
-    #[instability::unstable]
-    pub fn with_ssid(mut self, ssid: impl Into<Ssid>) -> Self {
-        self.ssid = ssid.into();
-        self
-    }
-
     pub(crate) fn validate(&self) -> Result<(), WifiError> {
-        if self.ssid.len() > 32 {
-            return Err(WifiError::InvalidArguments);
-        }
-
         if self.identity.as_ref().unwrap_or(&String::new()).len() > 128 {
             return Err(WifiError::InvalidArguments);
         }

--- a/esp-radio/src/wifi/sta/mod.rs
+++ b/esp-radio/src/wifi/sta/mod.rs
@@ -29,7 +29,6 @@ pub enum ScanMethod {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct StationConfig {
     /// The SSID of the Wi-Fi network.
-    #[builder_lite(skip_setter)]
     pub(crate) ssid: Ssid,
     /// The BSSID (MAC address) of the station.
     pub(crate) bssid: Option<[u8; 6]>,
@@ -65,19 +64,7 @@ pub struct StationConfig {
 }
 
 impl StationConfig {
-    /// Set the SSID of the access point.
-    pub fn with_ssid(mut self, ssid: impl Into<Ssid>) -> Self {
-        self.ssid = ssid.into();
-        self
-    }
-
     pub(crate) fn validate(&self) -> Result<(), WifiError> {
-        if self.ssid.len() > 32 {
-            return Err(WifiError::InvalidArguments);
-        }
-
-        self.authentication.validate(false)?;
-
         if !(6..=31).contains(&self.beacon_timeout) {
             return Err(WifiError::InvalidArguments);
         }
@@ -91,7 +78,9 @@ impl Default for StationConfig {
         StationConfig {
             ssid: Ssid::default(),
             bssid: None,
-            authentication: AuthenticationMethodConfig::Wpa2Personal("".into()),
+            authentication: AuthenticationMethodConfig::Wpa2Personal(
+                "".try_into().expect("Password length is valid"),
+            ),
             channel: None,
             protocols: Protocols::default(),
             listen_interval: 3,

--- a/esp-radio/src/wifi/sta/mod.rs
+++ b/esp-radio/src/wifi/sta/mod.rs
@@ -1,12 +1,9 @@
 //! Wi-Fi station.
 
-use alloc::string::String;
-use core::fmt;
-
 use procmacros::BuilderLite;
 
 use super::{AuthenticationMethod, DisconnectReason, Protocols, Ssid};
-use crate::WifiError;
+use crate::{WifiError, wifi::AuthenticationMethodConfig};
 
 unstable_module!(
     #[cfg(feature = "wifi-eap")]
@@ -28,7 +25,8 @@ pub enum ScanMethod {
 }
 
 /// Station configuration for a Wi-Fi connection.
-#[derive(BuilderLite, Clone, Eq, PartialEq, Hash)]
+#[derive(BuilderLite, Clone, Eq, PartialEq, Hash, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct StationConfig {
     /// The SSID of the Wi-Fi network.
     #[builder_lite(skip_setter)]
@@ -36,10 +34,8 @@ pub struct StationConfig {
     /// The BSSID (MAC address) of the station.
     pub(crate) bssid: Option<[u8; 6]>,
     /// The authentication method for the Wi-Fi connection.
-    pub(crate) auth_method: AuthenticationMethod,
-    /// The password for the Wi-Fi connection.
     #[builder_lite(reference)]
-    pub(crate) password: String,
+    pub(crate) authentication: AuthenticationMethodConfig,
     /// The Wi-Fi channel to connect to.
     pub(crate) channel: Option<u8>,
     /// The set of protocols supported by the access point.
@@ -81,9 +77,7 @@ impl StationConfig {
             return Err(WifiError::InvalidArguments);
         }
 
-        if self.password.len() >= 64 {
-            return Err(WifiError::InvalidArguments);
-        }
+        self.authentication.validate(false)?;
 
         if !(6..=31).contains(&self.beacon_timeout) {
             return Err(WifiError::InvalidArguments);
@@ -98,8 +92,7 @@ impl Default for StationConfig {
         StationConfig {
             ssid: Ssid::default(),
             bssid: None,
-            auth_method: AuthenticationMethod::Wpa2Personal,
-            password: String::new(),
+            authentication: AuthenticationMethodConfig::Wpa2Personal("".into()),
             channel: None,
             protocols: Protocols::default(),
             listen_interval: 3,
@@ -107,53 +100,6 @@ impl Default for StationConfig {
             failure_retry_cnt: 1,
             scan_method: ScanMethod::Fast,
         }
-    }
-}
-
-impl fmt::Debug for StationConfig {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("StationConfig")
-            .field("ssid", &self.ssid)
-            .field("bssid", &self.bssid)
-            .field("auth_method", &self.auth_method)
-            .field("password", &"**REDACTED**")
-            .field("channel", &self.channel)
-            .field("protocols", &self.protocols)
-            .field("listen_interval", &self.listen_interval)
-            .field("beacon_timeout", &self.beacon_timeout)
-            .field("failure_retry_cnt", &self.failure_retry_cnt)
-            .field("scan_method", &self.scan_method)
-            .finish()
-    }
-}
-
-#[cfg(feature = "defmt")]
-impl defmt::Format for StationConfig {
-    fn format(&self, fmt: defmt::Formatter<'_>) {
-        defmt::write!(
-            fmt,
-            "StationConfig {{\
-            ssid: {}, \
-            bssid: {:?}, \
-            auth_method: {:?}, \
-            password: **REDACTED**, \
-            channel: {:?}, \
-            protocols: {}, \
-            listen_interval: {}, \
-            beacon_timeout: {}, \
-            failure_retry_cnt: {}, \
-            scan_method: {} \
-            }}",
-            self.ssid.as_str(),
-            self.bssid,
-            self.auth_method,
-            self.channel,
-            self.protocols,
-            self.listen_interval,
-            self.beacon_timeout,
-            self.failure_retry_cnt,
-            self.scan_method
-        )
     }
 }
 

--- a/esp-radio/src/wifi/sta/mod.rs
+++ b/esp-radio/src/wifi/sta/mod.rs
@@ -34,7 +34,6 @@ pub struct StationConfig {
     /// The BSSID (MAC address) of the station.
     pub(crate) bssid: Option<[u8; 6]>,
     /// The authentication method for the Wi-Fi connection.
-    #[builder_lite(reference)]
     pub(crate) authentication: AuthenticationMethodConfig,
     /// The Wi-Fi channel to connect to.
     pub(crate) channel: Option<u8>,

--- a/examples/wifi/embassy_access_point/src/main.rs
+++ b/examples/wifi/embassy_access_point/src/main.rs
@@ -57,8 +57,9 @@ async fn main(spawner: Spawner) -> ! {
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     esp_rtos::start(timg0.timer0, peripherals.FROM_CPU_INTR0);
 
-    let access_point_config =
-        Config::AccessPoint(AccessPointConfig::default().with_ssid("esp-radio"));
+    let access_point_config = Config::AccessPoint(
+        AccessPointConfig::default().with_ssid("esp-radio".try_into().unwrap()),
+    );
 
     println!("Starting wifi");
     let device = esp_radio::wifi::Interface::access_point();

--- a/examples/wifi/embassy_access_point_with_sta/src/main.rs
+++ b/examples/wifi/embassy_access_point_with_sta/src/main.rs
@@ -44,6 +44,7 @@ use esp_backtrace as _;
 use esp_hal::{clock::CpuClock, ram, rng::Rng, timer::timg::TimerGroup};
 use esp_println::{print, println};
 use esp_radio::wifi::{
+    AuthenticationMethodConfig,
     Config,
     ControllerConfig,
     Interface,
@@ -85,7 +86,7 @@ async fn main(spawner: Spawner) -> ! {
     let access_point_station_config = Config::AccessPointStation(
         StationConfig::default()
             .with_ssid(SSID)
-            .with_password(PASSWORD.into()),
+            .with_authentication(AuthenticationMethodConfig::Wpa2Personal(PASSWORD.into())),
         AccessPointConfig::default().with_ssid("esp-radio-apsta"),
     );
 

--- a/examples/wifi/embassy_access_point_with_sta/src/main.rs
+++ b/examples/wifi/embassy_access_point_with_sta/src/main.rs
@@ -85,9 +85,11 @@ async fn main(spawner: Spawner) -> ! {
 
     let access_point_station_config = Config::AccessPointStation(
         StationConfig::default()
-            .with_ssid(SSID)
-            .with_authentication(AuthenticationMethodConfig::Wpa2Personal(PASSWORD.into())),
-        AccessPointConfig::default().with_ssid("esp-radio-apsta"),
+            .with_ssid(SSID.try_into().unwrap())
+            .with_authentication(AuthenticationMethodConfig::Wpa2Personal(
+                PASSWORD.try_into().unwrap(),
+            )),
+        AccessPointConfig::default().with_ssid("esp-radio-apsta".try_into().unwrap()),
     );
 
     println!("Starting wifi");

--- a/examples/wifi/embassy_coex/src/main.rs
+++ b/examples/wifi/embassy_coex/src/main.rs
@@ -26,6 +26,7 @@ use esp_println::println;
 use esp_radio::{
     ble::controller::BleConnector,
     wifi::{
+        AuthenticationMethodConfig,
         Config,
         ControllerConfig,
         Interface,
@@ -105,7 +106,7 @@ async fn main(spawner: Spawner) -> ! {
     let station_config = Config::Station(
         StationConfig::default()
             .with_ssid(SSID)
-            .with_password(PASSWORD.into()),
+            .with_authentication(AuthenticationMethodConfig::Wpa2Personal(PASSWORD.into())),
     );
 
     println!("Starting wifi");

--- a/examples/wifi/embassy_coex/src/main.rs
+++ b/examples/wifi/embassy_coex/src/main.rs
@@ -105,8 +105,10 @@ async fn main(spawner: Spawner) -> ! {
 
     let station_config = Config::Station(
         StationConfig::default()
-            .with_ssid(SSID)
-            .with_authentication(AuthenticationMethodConfig::Wpa2Personal(PASSWORD.into())),
+            .with_ssid(SSID.try_into().unwrap())
+            .with_authentication(AuthenticationMethodConfig::Wpa2Personal(
+                PASSWORD.try_into().unwrap(),
+            )),
     );
 
     println!("Starting wifi");

--- a/examples/wifi/embassy_dhcp/src/main.rs
+++ b/examples/wifi/embassy_dhcp/src/main.rs
@@ -24,6 +24,7 @@ use esp_backtrace as _;
 use esp_hal::{clock::CpuClock, ram, rng::Rng, timer::timg::TimerGroup};
 use esp_println::println;
 use esp_radio::wifi::{
+    AuthenticationMethodConfig,
     Config,
     ControllerConfig,
     Interface,
@@ -88,7 +89,7 @@ async fn main(spawner: Spawner) -> ! {
     let station_config = Config::Station(
         StationConfig::default()
             .with_ssid(SSID)
-            .with_password(PASSWORD.into()),
+            .with_authentication(AuthenticationMethodConfig::Wpa2Personal(PASSWORD.into())),
     );
 
     println!("Starting wifi");

--- a/examples/wifi/embassy_dhcp/src/main.rs
+++ b/examples/wifi/embassy_dhcp/src/main.rs
@@ -88,8 +88,10 @@ async fn main(spawner: Spawner) -> ! {
 
     let station_config = Config::Station(
         StationConfig::default()
-            .with_ssid(SSID)
-            .with_authentication(AuthenticationMethodConfig::Wpa2Personal(PASSWORD.into())),
+            .with_ssid(SSID.try_into().unwrap())
+            .with_authentication(AuthenticationMethodConfig::Wpa2Personal(
+                PASSWORD.try_into().unwrap(),
+            )),
     );
 
     println!("Starting wifi");

--- a/examples/wifi/embassy_sntp/src/main.rs
+++ b/examples/wifi/embassy_sntp/src/main.rs
@@ -94,8 +94,10 @@ async fn main(spawner: Spawner) -> ! {
 
     let station_config = Config::Station(
         StationConfig::default()
-            .with_ssid(SSID)
-            .with_authentication(AuthenticationMethodConfig::Wpa2Personal(PASSWORD.into())),
+            .with_ssid(SSID.try_into().unwrap())
+            .with_authentication(AuthenticationMethodConfig::Wpa2Personal(
+                PASSWORD.try_into().unwrap(),
+            )),
     );
 
     println!("Starting wifi");

--- a/examples/wifi/embassy_sntp/src/main.rs
+++ b/examples/wifi/embassy_sntp/src/main.rs
@@ -27,6 +27,7 @@ use esp_backtrace as _;
 use esp_hal::{clock::CpuClock, ram, rng::Rng, rtc_cntl::Rtc, timer::timg::TimerGroup};
 use esp_println::println;
 use esp_radio::wifi::{
+    AuthenticationMethodConfig,
     Config,
     ControllerConfig,
     Interface,
@@ -94,7 +95,7 @@ async fn main(spawner: Spawner) -> ! {
     let station_config = Config::Station(
         StationConfig::default()
             .with_ssid(SSID)
-            .with_password(PASSWORD.into()),
+            .with_authentication(AuthenticationMethodConfig::Wpa2Personal(PASSWORD.into())),
     );
 
     println!("Starting wifi");

--- a/hil-test-radio/src/bin/support/wifi_ap_support.rs
+++ b/hil-test-radio/src/bin/support/wifi_ap_support.rs
@@ -61,7 +61,7 @@ async fn main(spawner: Spawner) -> ! {
 
     let access_point_config = Config::AccessPoint(
         AccessPointConfig::default()
-            .with_ssid("AP")
+            .with_ssid("AP".try_into().unwrap())
             .with_authentication(AuthenticationMethodConfig::Open),
     );
 

--- a/hil-test-radio/src/bin/support/wifi_ap_support.rs
+++ b/hil-test-radio/src/bin/support/wifi_ap_support.rs
@@ -21,7 +21,14 @@ use embassy_net::{
 };
 use embassy_time::{Duration, Timer};
 use esp_hal::{clock::CpuClock, rng::Rng, timer::timg::TimerGroup};
-use esp_radio::wifi::{Config, ControllerConfig, Interface, WifiController, ap::AccessPointConfig};
+use esp_radio::wifi::{
+    AuthenticationMethodConfig,
+    Config,
+    ControllerConfig,
+    Interface,
+    WifiController,
+    ap::AccessPointConfig,
+};
 use hil_test as _;
 use hil_test::mk_static;
 use semihosting as _;
@@ -55,7 +62,7 @@ async fn main(spawner: Spawner) -> ! {
     let access_point_config = Config::AccessPoint(
         AccessPointConfig::default()
             .with_ssid("AP")
-            .with_auth_method(esp_radio::wifi::AuthenticationMethod::None),
+            .with_authentication(AuthenticationMethodConfig::Open),
     );
 
     let device = esp_radio::wifi::Interface::access_point();

--- a/hil-test-radio/src/bin/tests/wifi/dhcp.rs
+++ b/hil-test-radio/src/bin/tests/wifi/dhcp.rs
@@ -9,6 +9,7 @@ mod tests {
     use embassy_time::{Duration, Timer};
     use esp_hal::{clock::CpuClock, peripherals::Peripherals, rng::Rng, timer::timg::TimerGroup};
     use esp_radio::wifi::{
+        AuthenticationMethodConfig,
         Config,
         ControllerConfig,
         Interface,
@@ -35,7 +36,7 @@ mod tests {
         Config::Station(
             StationConfig::default()
                 .with_ssid("AP")
-                .with_auth_method(esp_radio::wifi::AuthenticationMethod::None),
+                .with_authentication(AuthenticationMethodConfig::Open),
         )
     }
 

--- a/hil-test-radio/src/bin/tests/wifi/dhcp.rs
+++ b/hil-test-radio/src/bin/tests/wifi/dhcp.rs
@@ -35,7 +35,7 @@ mod tests {
     fn station_config() -> Config {
         Config::Station(
             StationConfig::default()
-                .with_ssid("AP")
+                .with_ssid("AP".try_into().unwrap())
                 .with_authentication(AuthenticationMethodConfig::Open),
         )
     }

--- a/qa-test/src/bin/embassy_wifi_bench.rs
+++ b/qa-test/src/bin/embassy_wifi_bench.rs
@@ -80,8 +80,10 @@ async fn main(spawner: Spawner) -> ! {
 
     let station_config = Config::Station(
         StationConfig::default()
-            .with_ssid(SSID)
-            .with_authentication(AuthenticationMethodConfig::Wpa2Personal(PASSWORD.into())),
+            .with_ssid(SSID.try_into().unwrap())
+            .with_authentication(AuthenticationMethodConfig::Wpa2Personal(
+                PASSWORD.try_into().unwrap(),
+            )),
     );
 
     println!("Starting wifi");

--- a/qa-test/src/bin/embassy_wifi_bench.rs
+++ b/qa-test/src/bin/embassy_wifi_bench.rs
@@ -27,7 +27,14 @@ use esp_alloc as _;
 use esp_backtrace as _;
 use esp_hal::{clock::CpuClock, ram, rng::Rng, timer::timg::TimerGroup};
 use esp_println::println;
-use esp_radio::wifi::{Config, ControllerConfig, Interface, WifiController, sta::StationConfig};
+use esp_radio::wifi::{
+    AuthenticationMethodConfig,
+    Config,
+    ControllerConfig,
+    Interface,
+    WifiController,
+    sta::StationConfig,
+};
 
 esp_bootloader_esp_idf::esp_app_desc!();
 
@@ -74,7 +81,7 @@ async fn main(spawner: Spawner) -> ! {
     let station_config = Config::Station(
         StationConfig::default()
             .with_ssid(SSID)
-            .with_password(PASSWORD.into()),
+            .with_authentication(AuthenticationMethodConfig::Wpa2Personal(PASSWORD.into())),
     );
 
     println!("Starting wifi");

--- a/qa-test/src/bin/embassy_wifi_csi.rs
+++ b/qa-test/src/bin/embassy_wifi_csi.rs
@@ -15,6 +15,7 @@ use esp_backtrace as _;
 use esp_hal::{clock::CpuClock, ram, rng::Rng, timer::timg::TimerGroup};
 use esp_println::println;
 use esp_radio::wifi::{
+    AuthenticationMethodConfig,
     Config,
     ControllerConfig,
     Interface,
@@ -54,7 +55,7 @@ async fn main(spawner: Spawner) -> ! {
     let station_config = Config::Station(
         StationConfig::default()
             .with_ssid(SSID)
-            .with_password(PASSWORD.into()),
+            .with_authentication(AuthenticationMethodConfig::Wpa2Personal(PASSWORD.into())),
     );
 
     println!("Starting wifi");

--- a/qa-test/src/bin/embassy_wifi_csi.rs
+++ b/qa-test/src/bin/embassy_wifi_csi.rs
@@ -54,8 +54,10 @@ async fn main(spawner: Spawner) -> ! {
 
     let station_config = Config::Station(
         StationConfig::default()
-            .with_ssid(SSID)
-            .with_authentication(AuthenticationMethodConfig::Wpa2Personal(PASSWORD.into())),
+            .with_ssid(SSID.try_into().unwrap())
+            .with_authentication(AuthenticationMethodConfig::Wpa2Personal(
+                PASSWORD.try_into().unwrap(),
+            )),
     );
 
     println!("Starting wifi");

--- a/qa-test/src/bin/embassy_wifi_drop.rs
+++ b/qa-test/src/bin/embassy_wifi_drop.rs
@@ -11,7 +11,7 @@ use esp_alloc as _;
 use esp_backtrace as _;
 use esp_hal::{clock::CpuClock, ram, timer::timg::TimerGroup};
 use esp_println::println;
-use esp_radio::wifi::{Config, ControllerConfig, sta::StationConfig};
+use esp_radio::wifi::{AuthenticationMethodConfig, Config, ControllerConfig, sta::StationConfig};
 
 esp_bootloader_esp_idf::esp_app_desc!();
 
@@ -36,7 +36,7 @@ async fn main(_spawner: Spawner) {
         let station_config = Config::Station(
             StationConfig::default()
                 .with_ssid(SSID)
-                .with_password(PASSWORD.into()),
+                .with_authentication(AuthenticationMethodConfig::Wpa2Personal(PASSWORD.into())),
         );
 
         let mut wifi_interface = esp_radio::wifi::Interface::station();
@@ -72,7 +72,7 @@ async fn main(_spawner: Spawner) {
         let station_config = Config::Station(
             StationConfig::default()
                 .with_ssid(SSID)
-                .with_password(PASSWORD.into()),
+                .with_authentication(AuthenticationMethodConfig::Wpa2Personal(PASSWORD.into())),
         );
 
         let mut wifi_interface = esp_radio::wifi::Interface::station();

--- a/qa-test/src/bin/embassy_wifi_drop.rs
+++ b/qa-test/src/bin/embassy_wifi_drop.rs
@@ -35,8 +35,10 @@ async fn main(_spawner: Spawner) {
     {
         let station_config = Config::Station(
             StationConfig::default()
-                .with_ssid(SSID)
-                .with_authentication(AuthenticationMethodConfig::Wpa2Personal(PASSWORD.into())),
+                .with_ssid(SSID.try_into().unwrap())
+                .with_authentication(AuthenticationMethodConfig::Wpa2Personal(
+                    PASSWORD.try_into().unwrap(),
+                )),
         );
 
         let mut wifi_interface = esp_radio::wifi::Interface::station();
@@ -71,8 +73,10 @@ async fn main(_spawner: Spawner) {
     {
         let station_config = Config::Station(
             StationConfig::default()
-                .with_ssid(SSID)
-                .with_authentication(AuthenticationMethodConfig::Wpa2Personal(PASSWORD.into())),
+                .with_ssid(SSID.try_into().unwrap())
+                .with_authentication(AuthenticationMethodConfig::Wpa2Personal(
+                    PASSWORD.try_into().unwrap(),
+                )),
         );
 
         let mut wifi_interface = esp_radio::wifi::Interface::station();

--- a/qa-test/src/bin/embassy_wifi_i2s.rs
+++ b/qa-test/src/bin/embassy_wifi_i2s.rs
@@ -174,8 +174,10 @@ async fn main(spawner: Spawner) {
     // WiFi + network stack
     let station_config = Config::Station(
         StationConfig::default()
-            .with_ssid(SSID)
-            .with_authentication(AuthenticationMethodConfig::Wpa2Personal(PASSWORD.into())),
+            .with_ssid(SSID.try_into().unwrap())
+            .with_authentication(AuthenticationMethodConfig::Wpa2Personal(
+                PASSWORD.try_into().unwrap(),
+            )),
     );
 
     println!("Starting wifi");

--- a/qa-test/src/bin/embassy_wifi_i2s.rs
+++ b/qa-test/src/bin/embassy_wifi_i2s.rs
@@ -21,7 +21,14 @@ use esp_hal::{
     timer::timg::TimerGroup,
 };
 use esp_println::println;
-use esp_radio::wifi::{Config, ControllerConfig, Interface, WifiController, sta::StationConfig};
+use esp_radio::wifi::{
+    AuthenticationMethodConfig,
+    Config,
+    ControllerConfig,
+    Interface,
+    WifiController,
+    sta::StationConfig,
+};
 use static_cell::StaticCell;
 
 esp_bootloader_esp_idf::esp_app_desc!();
@@ -168,7 +175,7 @@ async fn main(spawner: Spawner) {
     let station_config = Config::Station(
         StationConfig::default()
             .with_ssid(SSID)
-            .with_password(PASSWORD.into()),
+            .with_authentication(AuthenticationMethodConfig::Wpa2Personal(PASSWORD.into())),
     );
 
     println!("Starting wifi");

--- a/qa-test/src/bin/embassy_wifi_stress.rs
+++ b/qa-test/src/bin/embassy_wifi_stress.rs
@@ -98,8 +98,16 @@ async fn main(_spawner: Spawner) {
                     .with_ssid(best_one.ssid)
                     .with_bssid(best_one.bssid)
                     .with_authentication(match best_one.auth_method {
+                        Some(AuthenticationMethod::Wpa) => {
+                            AuthenticationMethodConfig::Wpa(PASSWORD.try_into().unwrap())
+                        }
                         Some(AuthenticationMethod::Wpa2Personal) => {
                             AuthenticationMethodConfig::Wpa2Personal(PASSWORD.try_into().unwrap())
+                        }
+                        Some(AuthenticationMethod::WpaWpa2Personal) => {
+                            AuthenticationMethodConfig::WpaWpa2Personal(
+                                PASSWORD.try_into().unwrap(),
+                            )
                         }
                         Some(AuthenticationMethod::None) => AuthenticationMethodConfig::Open,
                         _ => {

--- a/qa-test/src/bin/embassy_wifi_stress.rs
+++ b/qa-test/src/bin/embassy_wifi_stress.rs
@@ -64,13 +64,12 @@ async fn main(_spawner: Spawner) {
 
         {
             println!("Connecting to WiFi SSID: {}", SSID);
-            let scan_config =
-                ScanConfig::default()
-                    .with_ssid(SSID)
-                    .with_scan_type(ScanTypeConfig::Active {
-                        min: esp_hal::time::Duration::from_millis(50),
-                        max: esp_hal::time::Duration::from_millis(200),
-                    });
+            let scan_config = ScanConfig::default()
+                .with_ssid(SSID.try_into().unwrap())
+                .with_scan_type(ScanTypeConfig::Active {
+                    min: esp_hal::time::Duration::from_millis(50),
+                    max: esp_hal::time::Duration::from_millis(200),
+                });
             println!("Scanning for WiFi networks");
             let aps = controller
                 .scan_async(&scan_config)
@@ -96,11 +95,11 @@ async fn main(_spawner: Spawner) {
 
             let station_config = Config::Station(
                 StationConfig::default()
-                    .with_ssid(best_one.ssid.clone())
+                    .with_ssid(best_one.ssid)
                     .with_bssid(best_one.bssid)
                     .with_authentication(match best_one.auth_method {
                         Some(AuthenticationMethod::Wpa2Personal) => {
-                            AuthenticationMethodConfig::Wpa2Personal(PASSWORD.into())
+                            AuthenticationMethodConfig::Wpa2Personal(PASSWORD.try_into().unwrap())
                         }
                         Some(AuthenticationMethod::None) => AuthenticationMethodConfig::Open,
                         _ => {

--- a/qa-test/src/bin/embassy_wifi_stress.rs
+++ b/qa-test/src/bin/embassy_wifi_stress.rs
@@ -9,8 +9,6 @@
 
 extern crate alloc;
 
-use alloc::string::ToString;
-
 use embassy_executor::Spawner;
 use embassy_time::{Duration, Timer, WithTimeout};
 use esp_backtrace as _;
@@ -23,6 +21,8 @@ use esp_hal::{
 };
 use esp_println::println;
 use esp_radio::wifi::{
+    AuthenticationMethod,
+    AuthenticationMethodConfig,
     Config,
     scan::{ScanConfig, ScanTypeConfig},
     sta::StationConfig,
@@ -98,8 +98,18 @@ async fn main(_spawner: Spawner) {
                 StationConfig::default()
                     .with_ssid(best_one.ssid.clone())
                     .with_bssid(best_one.bssid)
-                    .with_auth_method(best_one.auth_method.unwrap())
-                    .with_password(PASSWORD.to_string())
+                    .with_authentication(match best_one.auth_method {
+                        Some(AuthenticationMethod::Wpa2Personal) => {
+                            AuthenticationMethodConfig::Wpa2Personal(PASSWORD.into())
+                        }
+                        Some(AuthenticationMethod::None) => AuthenticationMethodConfig::Open,
+                        _ => {
+                            panic!(
+                                "Unsupported authentication method: {:?}",
+                                best_one.auth_method
+                            );
+                        }
+                    })
                     .with_channel(best_one.channel),
             );
             controller.set_config(&station_config).unwrap();

--- a/qa-test/src/bin/sleep_timer_wifi.rs
+++ b/qa-test/src/bin/sleep_timer_wifi.rs
@@ -57,8 +57,10 @@ async fn main(_spawner: Spawner) -> ! {
 
     let station_config = wifi::Config::Station(
         StationConfig::default()
-            .with_ssid("FakeNetwork")
-            .with_authentication(AuthenticationMethodConfig::Wpa2Personal("password".into())),
+            .with_ssid("FakeNetwork".try_into().unwrap())
+            .with_authentication(AuthenticationMethodConfig::Wpa2Personal(
+                "password".try_into().unwrap(),
+            )),
     );
     let _wifi_interface = Interface::station();
     let mut controller = WifiController::new(

--- a/qa-test/src/bin/sleep_timer_wifi.rs
+++ b/qa-test/src/bin/sleep_timer_wifi.rs
@@ -25,6 +25,7 @@ use esp_hal::{
 use esp_println::println;
 use esp_radio::wifi::{
     self,
+    AuthenticationMethodConfig,
     ControllerConfig,
     Interface,
     WifiController,
@@ -57,7 +58,7 @@ async fn main(_spawner: Spawner) -> ! {
     let station_config = wifi::Config::Station(
         StationConfig::default()
             .with_ssid("FakeNetwork")
-            .with_password("password".into()),
+            .with_authentication(AuthenticationMethodConfig::Wpa2Personal("password".into())),
     );
     let _wifi_interface = Interface::station();
     let mut controller = WifiController::new(

--- a/qa-test/src/bin/wifi_ble_modem_handoff.rs
+++ b/qa-test/src/bin/wifi_ble_modem_handoff.rs
@@ -145,7 +145,8 @@ async fn main(_s: Spawner) -> ! {
 
 /// Bring up a Wi-Fi SoftAP and keep it beaconing for `active_ms`.
 async fn run_wifi(wifi: esp_hal::peripherals::WIFI<'static>, active_ms: u32) {
-    let ap_config = Config::AccessPoint(AccessPointConfig::default().with_ssid(AP_SSID));
+    let ap_config =
+        Config::AccessPoint(AccessPointConfig::default().with_ssid(AP_SSID.try_into().unwrap()));
 
     // Creating the controller in AP mode calls `esp_wifi_start()`, so the radio
     // starts beaconing immediately.

--- a/qa-test/src/bin/wifi_survives_ble_drop.rs
+++ b/qa-test/src/bin/wifi_survives_ble_drop.rs
@@ -23,6 +23,7 @@ use esp_println::println;
 use esp_radio::{
     ble::controller::BleConnector,
     wifi::{
+        AuthenticationMethodConfig,
         Config,
         ControllerConfig,
         Interface,
@@ -73,7 +74,7 @@ async fn main(spawner: Spawner) -> ! {
     let station_config = Config::Station(
         StationConfig::default()
             .with_ssid(SSID)
-            .with_password(PASSWORD.into()),
+            .with_authentication(AuthenticationMethodConfig::Wpa2Personal(PASSWORD.into())),
     );
 
     println!("Starting wifi");

--- a/qa-test/src/bin/wifi_survives_ble_drop.rs
+++ b/qa-test/src/bin/wifi_survives_ble_drop.rs
@@ -73,8 +73,10 @@ async fn main(spawner: Spawner) -> ! {
 
     let station_config = Config::Station(
         StationConfig::default()
-            .with_ssid(SSID)
-            .with_authentication(AuthenticationMethodConfig::Wpa2Personal(PASSWORD.into())),
+            .with_ssid(SSID.try_into().unwrap())
+            .with_authentication(AuthenticationMethodConfig::Wpa2Personal(
+                PASSWORD.try_into().unwrap(),
+            )),
     );
 
     println!("Starting wifi");

--- a/qa-test/src/bin/wifi_syslog.rs
+++ b/qa-test/src/bin/wifi_syslog.rs
@@ -13,7 +13,7 @@ use esp_alloc as _;
 use esp_backtrace as _;
 use esp_hal::{clock::CpuClock, ram, timer::timg::TimerGroup};
 use esp_println::println;
-use esp_radio::wifi::{Config, ControllerConfig, sta::StationConfig};
+use esp_radio::wifi::{AuthenticationMethodConfig, Config, ControllerConfig, sta::StationConfig};
 
 esp_bootloader_esp_idf::esp_app_desc!();
 
@@ -35,7 +35,7 @@ async fn main(_spawner: Spawner) {
     let station_config = Config::Station(
         StationConfig::default()
             .with_ssid(SSID)
-            .with_password(PASSWORD.into()),
+            .with_authentication(AuthenticationMethodConfig::Wpa2Personal(PASSWORD.into())),
     );
 
     println!("Creating wifi controller with print-logs-from-driver enabled");

--- a/qa-test/src/bin/wifi_syslog.rs
+++ b/qa-test/src/bin/wifi_syslog.rs
@@ -34,8 +34,10 @@ async fn main(_spawner: Spawner) {
 
     let station_config = Config::Station(
         StationConfig::default()
-            .with_ssid(SSID)
-            .with_authentication(AuthenticationMethodConfig::Wpa2Personal(PASSWORD.into())),
+            .with_ssid(SSID.try_into().unwrap())
+            .with_authentication(AuthenticationMethodConfig::Wpa2Personal(
+                PASSWORD.try_into().unwrap(),
+            )),
     );
 
     println!("Creating wifi controller with print-logs-from-driver enabled");


### PR DESCRIPTION
Closes #6054

A good thing here is that we don't allow the (still unsupported) WPA3 methods anymore.

# Changelog

## esp-radio

- Changed: `StationConfig` and `AccessPointConfig` now take authentication via `AuthenticationMethodConfig` instead of separate `auth_method` and `password` fields.
- Changed: Added a dedicated `Password` type. Oversized passwords are rejected instead of truncated.
- Changed: `Ssid` is constructed via `TryFrom`; oversized SSIDs are rejected instead of truncated.

# Migration guide

## esp-radio/Wi-Fi

### Use `AuthenticationMethodConfig`

```diff
- .with_auth_method(AuthenticationMethod::Wpa2Personal)
- .with_password("PASSWORD".into())
+ .with_authentication(AuthenticationMethodConfig::Wpa2Personal("PASSWORD".try_into()?))
```

Open networks use `AuthenticationMethodConfig::Open`.

### Construct `Ssid` and `Password` with `TryFrom`
```diff
- .with_ssid("SSID")
+ .with_ssid("SSID".try_into()?)
```

SSIDs longer than 32 bytes and passwords longer than 64 bytes now return `WifiError::InvalidSsid` / `WifiError::InvalidPassword` instead of being truncated.
