### PR TITLE
Clarify 802.15.4 / BLE coexistence, hard fail if coex is enabled but Wi-Fi and/or BLE is not

### DIFF
--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -296,6 +296,7 @@ ble = ["esp-hal/__bluetooth", "dep:bt-hci", "dep:bt-hci-transport", "__has_unsta
 
 #DOC_IF has("bt_driver_supported") && has("wifi_driver_supported")
 ## Software controls Wi-Fi/Bluetooth coexistence.
+## Only valid if both Wi-Fi and BLE are enabled.
 ## See [ESP-IDF Programming Guide](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/kconfig-reference.html#config-esp-coex-sw-coexist-enable) for details.
 ##
 ## ⚠️ This feature is considered unstable.

--- a/esp-radio/build.rs
+++ b/esp-radio/build.rs
@@ -11,9 +11,11 @@ use esp_metadata_generated::{Chip, assert_unique_features};
 
 fn main() -> Result<(), Box<dyn Error>> {
     // if using '"rust-analyzer.cargo.buildScripts.useRustcWrapper": true' we can detect this
+    // otherwise you can set ESP_RADIO_SUPPRESS_PANICS env var to suppress panics in your IDE
     let suppress_panics = std::env::var("RUSTC_WRAPPER")
         .unwrap_or_default()
-        .contains("rust-analyzer");
+        .contains("rust-analyzer")
+        || std::env::var("ESP_RADIO_SUPPRESS_PANICS").is_ok();
 
     // Load the configuration file for the configured device:
     let chip = Chip::from_cargo_feature()?;
@@ -117,10 +119,22 @@ fn main() -> Result<(), Box<dyn Error>> {
         );
 
         #[cfg(not(feature = "wifi"))]
-        println!("cargo:warning=coex is enabled but wifi is not");
+        panic!(
+            r#"
+
+            COEX is enabled but Wi-Fi is not
+
+            "#
+        );
 
         #[cfg(not(feature = "ble"))]
-        println!("cargo:warning=coex is enabled but ble is not");
+        panic!(
+            r#"
+
+            COEX is enabled but BLE is not
+
+            "#
+        );
     }
 
     // emit config

--- a/esp-radio/src/ble/mod.rs
+++ b/esp-radio/src/ble/mod.rs
@@ -1,6 +1,4 @@
 //! Bluetooth Low Energy HCI interface
-//!
-//! The usage of BLE is currently incompatible with the usage of IEEE 802.15.4.
 
 #[cfg(bt_controller = "btdm")]
 pub(crate) mod btdm;

--- a/esp-radio/src/ieee802154/mod.rs
+++ b/esp-radio/src/ieee802154/mod.rs
@@ -9,8 +9,7 @@
 //! Note that this module requires the `unstable` feature on both `esp-radio`
 //! and `esp-hal`.
 //!
-//! NOTE: Coexistence with Wi-Fi or Bluetooth is currently not possible. If you do it anyway,
-//! things will break.
+//! NOTE: Coexistence with Wi-Fi is currently not supported.
 //!
 //! [IEEE 802.15.4]: https://en.wikipedia.org/wiki/IEEE_802.15.4
 //! [openthread]: https://github.com/esp-rs/openthread
@@ -123,8 +122,7 @@ pub struct Ieee802154<'a> {
 impl<'a> Ieee802154<'a> {
     /// Construct a new driver, enabling the IEEE 802.15.4 radio in the process
     ///
-    /// NOTE: Coexistence with Wi-Fi or Bluetooth is currently not possible. If you do it anyway,
-    /// things will break.
+    /// NOTE: Coexistence with Wi-Fi is currently not supported.
     #[instability::unstable]
     pub fn new(radio: IEEE802154<'a>) -> Self {
         let (_phy_clock_guard, _phy_init_guard, _radio_clock_guard) = esp_ieee802154_enable(radio);


### PR DESCRIPTION
Closes #5464

Clarify radio coexistence documentation and enforce `coex` feature requirements at build time.

# Changelog

## esp-radio

- Changed: Enabling the `coex` feature without both `wifi` and `ble` now fails with a clear error instead of hard to decrypt compiler errors (and an easy to miss warning)
- Fixed: IEEE 802.15.4 documentation: coexistence with BLE is supported, coexistence with Wi‑Fi remains unsupported.


