### PR TITLE
Fix: xtask bump-msrv

### DIFF
--- a/xtask/src/commands/release/bump_msrv.rs
+++ b/xtask/src/commands/release/bump_msrv.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
 use clap::Args;
@@ -50,14 +50,20 @@ pub fn bump_msrv(workspace: &Path, args: BumpMsrvArgs) -> Result<()> {
     add_dependent_crates(workspace, &mut to_process)?;
 
     // don't process crates which are not published
-    let to_process: Vec<Package> = to_process
-        .iter()
-        .filter(|pkg| {
-            let cargo_toml = CargoToml::new(workspace, **pkg).unwrap();
-            cargo_toml.is_published()
-        })
-        .copied()
-        .collect();
+    let to_process = {
+        let mut published = Vec::new();
+        for pkg in to_process
+            .into_iter()
+            .filter(|pkg| !pkg.contains_standalone_projects())
+        {
+            let cargo_toml = CargoToml::new(workspace, pkg)
+                .with_context(|| format!("Could not load Cargo.toml of {pkg}"))?;
+            if cargo_toml.is_published() {
+                published.push(pkg);
+            }
+        }
+        published
+    };
 
     let adjust_ci = to_process.contains(&Package::EspHal);
 
@@ -103,9 +109,14 @@ pub fn bump_msrv(workspace: &Path, args: BumpMsrvArgs) -> Result<()> {
                 }
             }
 
-            if !args.dry_run {
-                if let Some(previous_rust_version) = previous_rust_version {
-                    check_mentions(&package_path, &previous_rust_version)?;
+            if !args.dry_run
+                && let Some(previous_rust_version) = previous_rust_version
+            {
+                for mention in find_mentions(&package_path, &previous_rust_version)? {
+                    println!(
+                        "⚠️ '{previous_rust_version}' found in file {} - might be a false positive, otherwise consider adjusting the xtask.",
+                        mention.display()
+                    );
                 }
             }
         }
@@ -141,13 +152,14 @@ fn add_dependent_crates(
 
             // iterate over ALL known crates
             for package in Package::iter() {
-                let mut cargo_toml =
-                    CargoToml::new(workspace, package.clone()).with_context(|| {
-                        format!(
-                            "Creating Cargo.toml in workspace {} for {package} failed!",
-                            workspace.display()
-                        )
-                    })?;
+                // Directories of standalone projects have no root Cargo.toml, so they cannot be
+                // inspected as crates.
+                if package.contains_standalone_projects() {
+                    continue;
+                }
+
+                let mut cargo_toml = CargoToml::new(workspace, package)
+                    .with_context(|| format!("Could not load Cargo.toml of {package}"))?;
 
                 // iterate the dependencies in the repo
                 for dep in cargo_toml.repo_dependencies() {
@@ -166,11 +178,13 @@ fn add_dependent_crates(
     )
 }
 
-/// Check files in the package and show if we find the version string in any
-/// file. Most probably it will report false positives but maybe not.
-fn check_mentions(package_path: &std::path::PathBuf, previous_rust_version: &str) -> Result<()> {
+/// Find files in the package which mention the version string.
+fn find_mentions(package_path: &Path, previous_rust_version: &str) -> Result<Vec<PathBuf>> {
     use std::ffi::OsStr;
     let disallowed_extensions = [OsStr::new("gz")];
+
+    let mut mentions = Vec::new();
+
     for entry in walkdir::WalkDir::new(package_path)
         .into_iter()
         .filter_map(|entry| {
@@ -193,15 +207,101 @@ fn check_mentions(package_path: &std::path::PathBuf, previous_rust_version: &str
             Some(path)
         })
     {
-        let contents = std::fs::read_to_string(&entry)
-            .with_context(|| format!("Failed to read {}", entry.as_path().display()))?;
+        let contents = match std::fs::read_to_string(&entry) {
+            Ok(contents) => contents,
+            Err(error) if error.kind() == std::io::ErrorKind::InvalidData => continue,
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("Failed to read {}", entry.as_path().display()));
+            }
+        };
         if contents.contains(previous_rust_version) {
-            println!(
-                "⚠️ '{previous_rust_version}' found in file {} - might be a false positive, otherwise consider adjusting the xtask.",
-                entry.display()
-            );
+            mentions.push(entry);
         }
     }
 
-    Ok(())
+    Ok(mentions)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write as _;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn write(package: &TempDir, relative_path: &str, contents: impl AsRef<[u8]>) -> PathBuf {
+        let path = package.path().join(relative_path);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::File::create(&path)
+            .unwrap()
+            .write_all(contents.as_ref())
+            .unwrap();
+        path
+    }
+
+    #[test]
+    fn mentions_of_the_previous_version_are_reported() {
+        let package = TempDir::new().unwrap();
+
+        let manifest = write(&package, "Cargo.toml", "rust-version = \"1.95.0\"\n");
+        write(&package, "src/lib.rs", "//! Needs Rust 1.94.0 or newer.\n");
+
+        let mentions = find_mentions(package.path(), "1.95.0").unwrap();
+
+        assert_eq!(mentions, vec![manifest]);
+    }
+
+    #[test]
+    fn files_which_are_not_utf8_are_skipped() {
+        let package = TempDir::new().unwrap();
+
+        write(&package, "testdata/firmware.bin", [0xE0, 0x80, 0x80, 0xFF]);
+        let readme = write(&package, "README.md", "MSRV-1.95.0-blue\n");
+
+        let mentions = find_mentions(package.path(), "1.95.0").unwrap();
+
+        assert_eq!(mentions, vec![readme]);
+    }
+
+    #[test]
+    fn files_with_a_binary_extension_are_skipped() {
+        let package = TempDir::new().unwrap();
+
+        // Valid UTF-8, so only the extension can rule this file out.
+        write(&package, "api-baseline/esp32.json.gz", "1.95.0\n");
+
+        let mentions = find_mentions(package.path(), "1.95.0").unwrap();
+
+        assert!(mentions.is_empty(), "{mentions:?}");
+    }
+
+    #[test]
+    fn the_target_directory_is_skipped() {
+        let package = TempDir::new().unwrap();
+
+        write(&package, "target/debug/build.log", "1.95.0\n");
+
+        let mentions = find_mentions(package.path(), "1.95.0").unwrap();
+
+        assert!(mentions.is_empty(), "{mentions:?}");
+    }
+
+    #[test]
+    fn dependent_crates_can_be_collected_from_the_real_workspace() {
+        let workspace = crate::repo_root_for_tests();
+
+        let mut packages = vec![Package::EspHal];
+        add_dependent_crates(&workspace, &mut packages).unwrap();
+
+        assert!(
+            packages.len() > 1,
+            "esp-hal should pull in at least one dependent crate, got {packages:?}"
+        );
+        assert!(
+            !packages.iter().any(Package::contains_standalone_projects),
+            "standalone-project collections must not be treated as crates: {packages:?}"
+        );
+    }
 }

--- a/xtask/src/commands/release/bump_version.rs
+++ b/xtask/src/commands/release/bump_version.rs
@@ -267,10 +267,9 @@ fn bump_crate_version(
         .into_iter()
         .map(|p| p.join("Cargo.toml"));
 
-    // skip compile tests, these represent real world projects and therefore serve as a good test
-    // when we try and build them when the new versions are available in our local test registry.
+    // Skip the directories of standalone projects, they have no manifest of their own.
     let tomls = Package::iter()
-        .filter(|&p| p != Package::Examples && p != Package::CompileTests)
+        .filter(|p| !p.contains_standalone_projects())
         .map(|p| {
             CargoToml::new(&bumped_package.workspace, p)
                 .with_context(|| format!("Could not load Cargo.toml of {p}"))

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -167,7 +167,7 @@ impl Package {
     pub fn skip_doctests(&self) -> bool {
         let toml = self.toml();
         let Some(ref toml) = *toml else {
-            // No Cargo.toml in the package, must be the examples
+            // No Cargo.toml in the package; it is a directory of standalone projects.
             return true;
         };
         toml.espressif_metadata_bool("skip-doctests")
@@ -271,6 +271,11 @@ impl Package {
             .as_ref()
             .and_then(|toml| toml.espressif_metadata_bool("chip-features-matter"))
             .unwrap_or(false)
+    }
+
+    /// Is this "package" a directory of standalone projects rather than a single crate?
+    pub fn contains_standalone_projects(&self) -> bool {
+        matches!(self, Package::Examples | Package::CompileTests)
     }
 
     /// Should documentation be built for the package, and should the package be
@@ -528,7 +533,7 @@ impl Package {
     }
 
     fn targets_lp_core(&self) -> bool {
-        if *self == Package::Examples || *self == Package::CompileTests {
+        if self.contains_standalone_projects() {
             return false;
         }
 
@@ -862,7 +867,7 @@ pub fn format_package(
     log::info!("Formatting package: {}", package);
     let package_path = workspace.join(package.as_ref());
 
-    let paths = if package == Package::Examples || package == Package::CompileTests {
+    let paths = if package.contains_standalone_projects() {
         crate::find_packages(&package_path)?
     } else {
         vec![package_path]
@@ -1166,6 +1171,60 @@ impl ChipFilterEval<'_> {
             Err(err) => {
                 Err(anyhow::anyhow!("{err:?}").context("Failed to evaluate chip expression"))
             }
+        }
+    }
+}
+
+/// The repository root, for tests which need to inspect the real workspace.
+#[cfg(test)]
+pub(crate) fn repo_root_for_tests() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("xtask must live in a subdirectory of the repository")
+        .to_path_buf()
+}
+
+#[cfg(test)]
+mod tests {
+    use strum::IntoEnumIterator;
+
+    use super::*;
+
+    #[test]
+    fn packages_are_either_crates_or_collections_of_standalone_projects() {
+        let workspace = repo_root_for_tests();
+
+        for package in Package::iter() {
+            let package_path = workspace.join(package.to_string());
+            assert!(
+                package_path.is_dir(),
+                "package '{package}' has no directory at {}",
+                package_path.display()
+            );
+
+            let has_manifest = package_path.join("Cargo.toml").exists();
+            assert_eq!(
+                has_manifest,
+                !package.contains_standalone_projects(),
+                "package '{package}' has {} Cargo.toml, but contains_standalone_projects() is {}",
+                if has_manifest { "a" } else { "no" },
+                package.contains_standalone_projects(),
+            );
+        }
+    }
+
+    #[test]
+    fn collections_of_standalone_projects_are_not_empty() {
+        let workspace = repo_root_for_tests();
+
+        for package in Package::iter().filter(Package::contains_standalone_projects) {
+            let projects = find_packages(&workspace.join(package.to_string()))
+                .unwrap_or_else(|err| panic!("could not enumerate projects of '{package}': {err}"));
+
+            assert!(
+                !projects.is_empty(),
+                "package '{package}' contains no standalone projects"
+            );
         }
     }
 }


### PR DESCRIPTION
`cargo xrelease bump-msrv --msrv 1.96.0 esp-hal --dry-run` fails with:
```rust
Running `target/debug/esp-devtool release bump-msrv --msrv 1.96.0 esp-hal --dry-run`
Error: Creating Cargo.toml in workspace /Users/jurajsadel/esp-rs/esp-hal for examples failed!

Caused by:
    Could not find Cargo.toml for package examples at /Users/jurajsadel/esp-rs/esp-hal/examples/Cargo.toml
```