### PR TITLE
Implement C6 ADC cali v2, line calibartion

### DIFF
--- a/esp-hal/src/analog/adc/calibration/basic.rs
+++ b/esp-hal/src/analog/adc/calibration/basic.rs
@@ -24,7 +24,7 @@ pub struct AdcCalBasic<ADCX> {
     /// Calibration value to set to ADC unit
     cal_val: u16,
 
-    #[cfg(any(esp32c5, esp32c61))]
+    #[cfg(any(esp32c5, esp32c6, esp32c61, esp32h2))]
     chan_compens: i32,
 
     _phantom: PhantomData<ADCX>,
@@ -37,6 +37,10 @@ where
     ADCX: AdcCalEfuse + CalibrationAccess,
 {
     fn new_cal(atten: Attenuation) -> Self {
+        Self::new_cal_with_channel(atten, 0)
+    }
+
+    fn new_cal_with_channel(atten: Attenuation, _channel: u8) -> Self {
         // Try to get init code (Dout0) from efuse
         // Dout0 means mean raw ADC value when zero voltage applied to input.
         let cal_val = ADCX::init_code(atten).unwrap_or_else(|| {
@@ -44,12 +48,12 @@ where
             AdcConfig::<ADCX>::adc_calibrate(atten, AdcCalSource::Gnd)
         });
 
-        #[cfg(any(esp32c5, esp32c61))]
-        let chan_compens = ADCX::cal_chan_compens(atten, ADCX::ADC_CAL_CHANNEL).unwrap_or(0);
+        #[cfg(any(esp32c5, esp32c6, esp32c61, esp32h2))]
+        let chan_compens = ADCX::cal_chan_compens(atten, _channel).unwrap_or(0);
 
         Self {
             cal_val,
-            #[cfg(any(esp32c5, esp32c61))]
+            #[cfg(any(esp32c5, esp32c6, esp32c61, esp32h2))]
             chan_compens,
             _phantom: PhantomData,
         }
@@ -59,10 +63,8 @@ where
         self.cal_val
     }
 
-    // This is default from the trait for other target than esp32c5 and esp32c61
-    #[cfg(any(esp32c5, esp32c61))]
+    #[cfg(any(esp32c5, esp32c6, esp32c61, esp32h2))]
     fn adc_val(&self, val: u16) -> u16 {
-        val.saturating_sub(self.chan_compens as u16)
-            .clamp(0, ADCX::ADC_VAL_MASK)
+        (val as i32 - self.chan_compens).clamp(0, ADCX::ADC_VAL_MASK as i32) as u16
     }
 }

--- a/esp-hal/src/analog/adc/calibration/curve.rs
+++ b/esp-hal/src/analog/adc/calibration/curve.rs
@@ -33,6 +33,11 @@ pub trait AdcHasCurveCal {
     ///
     /// A sets of coefficients for each attenuation.
     const CURVES_COEFFS: CurvesCoeffs;
+
+    /// Coefficients for the eFuse calibration version on this chip.
+    fn curves_coeffs() -> CurvesCoeffs {
+        Self::CURVES_COEFFS
+    }
 }
 
 /// Curve fitting ADC calibration scheme
@@ -67,9 +72,13 @@ where
     ADCX: AdcCalEfuse + AdcHasLineCal + AdcHasCurveCal + CalibrationAccess,
 {
     fn new_cal(atten: Attenuation) -> Self {
-        let line = AdcCalLine::<ADCX>::new_cal(atten);
+        Self::new_cal_with_channel(atten, 0)
+    }
 
-        let coeff = ADCX::CURVES_COEFFS
+    fn new_cal_with_channel(atten: Attenuation, channel: u8) -> Self {
+        let line = AdcCalLine::<ADCX>::new_cal_with_channel(atten, channel);
+
+        let coeff = ADCX::curves_coeffs()
             .iter()
             .find(|item| item.atten == atten)
             .expect("No curve coefficients for given attenuation")
@@ -132,16 +141,24 @@ mod impls {
 
     impl AdcHasCurveCal for crate::peripherals::ADC1<'_> {
         const CURVES_COEFFS: CurvesCoeffs = CURVES_COEFFS1;
+
+        #[cfg(esp32c6)]
+        fn curves_coeffs() -> CurvesCoeffs {
+            if crate::efuse::rtc_calib_version() == 2 {
+                CURVES_COEFFS1_V2
+            } else {
+                CURVES_COEFFS1
+            }
+        }
     }
 
-    #[cfg(esp32c3)]
+    #[cfg(any(esp32c3, esp32p4, esp32s3))]
     impl AdcHasCurveCal for crate::peripherals::ADC2<'_> {
-        const CURVES_COEFFS: CurvesCoeffs = CURVES_COEFFS1;
-    }
-
-    #[cfg(any(esp32p4, esp32s3))]
-    impl AdcHasCurveCal for crate::peripherals::ADC2<'_> {
-        const CURVES_COEFFS: CurvesCoeffs = CURVES_COEFFS2;
+        const CURVES_COEFFS: CurvesCoeffs = cfg_select! {
+            esp32c3 => CURVES_COEFFS1,
+            esp32p4 => CURVES_COEFFS2,
+            esp32s3 => CURVES_COEFFS2,
+        };
     }
 
     coeff_tables! {
@@ -197,8 +214,7 @@ mod impls {
             ],
         ];
 
-
-        /// Error curve coefficients derived from <https://github.com/espressif/esp-idf/blob/903af13e8/components/esp_adc/esp32c6/curve_fitting_coefficients.c>
+        /// Error curve coefficients derived from <https://github.com/espressif/esp-idf/blob/027613140/components/esp_adc/esp32c6/curve_fitting_coefficients.c#L29-L35>
         #[cfg(esp32c6)]
         CURVES_COEFFS1 [
             _0dB => [
@@ -223,7 +239,6 @@ mod impls {
             ],
         ];
 
-
         /// Error curve coefficients derived from <https://github.com/espressif/esp-idf/blob/1e76669a8b940f5dc25adc35065cb53de3c71423/components/esp_adc/esp32c61/curve_fitting_coefficients.c>
         #[cfg(esp32c61)]
         CURVES_COEFFS1 [
@@ -243,6 +258,25 @@ mod impls {
                 -1.3204544579940347,
                 -0.0011762579610906,
                 0.0000007639928529,
+            ],
+        ];
+
+        /// Error curve coefficients for calibration version 2 derived from <https://github.com/espressif/esp-idf/blob/027613140/components/esp_adc/esp32c6/curve_fitting_coefficients.c#L36-L42>
+        ///
+        /// Version 2 does not apply a second-step polynomial at 0 dB and 2.5 dB.
+        #[cfg(esp32c6)]
+        CURVES_COEFFS1_V2 [
+            _0dB => [],
+            _2p5dB => [],
+            _6dB => [
+                -1.2217864764388775,
+                -0.0001954123107752,
+                0.0000006409679727,
+            ],
+            _11dB => [
+                -0.3915910437042445,
+                -0.0031536470857564,
+                0.0000012493873014,
             ],
         ];
 

--- a/esp-hal/src/analog/adc/calibration/line/esp32.rs
+++ b/esp-hal/src/analog/adc/calibration/line/esp32.rs
@@ -1,0 +1,245 @@
+use core::marker::PhantomData;
+
+use super::AdcHasLineCal;
+use crate::{
+    analog::adc::{AdcCalScheme, Attenuation},
+    efuse,
+};
+
+const COEFF_A_SCALE: u32 = 65536;
+const COEFF_A_ROUND: u32 = COEFF_A_SCALE / 2;
+
+const VREF_MASK: u32 = 0x1F;
+const VREF_STEP_SIZE: i32 = 7;
+const VREF_OFFSET: i32 = 1100;
+
+const TP_LOW1_OFFSET: i32 = 278;
+const TP_LOW2_OFFSET: i32 = 421;
+const TP_LOW_MASK: u32 = 0x7F;
+const TP_LOW_VOLTAGE: u32 = 150;
+const TP_HIGH1_OFFSET: i32 = 3265;
+const TP_HIGH2_OFFSET: i32 = 3406;
+const TP_HIGH_MASK: u32 = 0x1FF;
+const TP_HIGH_VOLTAGE: u32 = 850;
+const TP_STEP_SIZE: i32 = 4;
+
+const LUT_VREF_LOW: i32 = 1000;
+const LUT_VREF_HIGH: i32 = 1200;
+const LUT_ADC_STEP_SIZE: u32 = 64;
+const LUT_POINTS: usize = 20;
+const LUT_LOW_THRESH: u32 = 2880;
+const LUT_HIGH_THRESH: u32 = LUT_LOW_THRESH + LUT_ADC_STEP_SIZE;
+const ADC_12_BIT_RES: u32 = 4096;
+
+const ADC1_TP_ATTEN_SCALE: [u32; 4] = [65504, 86975, 120389, 224310];
+const ADC2_TP_ATTEN_SCALE: [u32; 4] = [65467, 86861, 120416, 224708];
+const ADC1_TP_ATTEN_OFFSET: [u32; 4] = [0, 1, 27, 54];
+const ADC2_TP_ATTEN_OFFSET: [u32; 4] = [0, 9, 26, 66];
+
+const ADC1_VREF_ATTEN_SCALE: [u32; 4] = [57431, 76236, 105481, 196602];
+const ADC2_VREF_ATTEN_SCALE: [u32; 4] = [57236, 76175, 105678, 197170];
+const ADC1_VREF_ATTEN_OFFSET: [u32; 4] = [75, 78, 107, 142];
+const ADC2_VREF_ATTEN_OFFSET: [u32; 4] = [63, 66, 89, 128];
+
+const LUT_ADC1_LOW: [u32; LUT_POINTS] = [
+    2240, 2297, 2352, 2405, 2457, 2512, 2564, 2616, 2664, 2709, 2754, 2795, 2832, 2868, 2903, 2937,
+    2969, 3000, 3030, 3060,
+];
+const LUT_ADC1_HIGH: [u32; LUT_POINTS] = [
+    2667, 2706, 2745, 2780, 2813, 2844, 2873, 2901, 2928, 2956, 2982, 3006, 3032, 3059, 3084, 3110,
+    3135, 3160, 3184, 3209,
+];
+const LUT_ADC2_LOW: [u32; LUT_POINTS] = [
+    2238, 2293, 2347, 2399, 2451, 2507, 2561, 2613, 2662, 2710, 2754, 2792, 2831, 2869, 2904, 2937,
+    2968, 2999, 3029, 3059,
+];
+const LUT_ADC2_HIGH: [u32; LUT_POINTS] = [
+    2657, 2698, 2738, 2774, 2807, 2838, 2867, 2894, 2921, 2946, 2971, 2996, 3020, 3043, 3067, 3092,
+    3116, 3139, 3162, 3185,
+];
+
+/// Line fitting ADC calibration scheme
+///
+/// ESP32 uses two-point or Vref characterization from eFuse, and a lookup table
+/// at 11 dB for the non-linear region. Readings are in mV.
+///
+/// See <https://github.com/espressif/esp-idf/blob/027613140/components/esp_adc/esp32/adc_cali_line_fitting.c#L155>
+#[derive(Clone, Copy)]
+pub struct AdcCalLine<ADCX> {
+    coeff_a: u32,
+    coeff_b: u32,
+    vref: u32,
+    use_lut: bool,
+    unit: u8,
+    _phantom: PhantomData<ADCX>,
+}
+
+fn decode_bits(bits: u32, mask: u32, twos_compl: bool) -> i32 {
+    let sign_bit = !(mask >> 1) & mask;
+    if bits & sign_bit != 0 {
+        if twos_compl {
+            -(((!bits).wrapping_add(1) & (mask >> 1)) as i32)
+        } else {
+            -((bits & (mask >> 1)) as i32)
+        }
+    } else {
+        (bits & (mask >> 1)) as i32
+    }
+}
+
+fn read_efuse_vref() -> u32 {
+    let bits = efuse::read_field_le::<u32>(efuse::ADC_VREF);
+    (VREF_OFFSET + decode_bits(bits, VREF_MASK, false) * VREF_STEP_SIZE) as u32
+}
+
+fn check_efuse_vref() -> bool {
+    efuse::read_field_le::<u32>(efuse::ADC_VREF) != 0
+}
+
+fn check_efuse_tp() -> bool {
+    if !efuse::read_bit(efuse::BLK3_PART_RESERVE) {
+        return false;
+    }
+    efuse::read_field_le::<u32>(efuse::ADC1_TP_LOW) != 0
+        && efuse::read_field_le::<u32>(efuse::ADC2_TP_LOW) != 0
+        && efuse::read_field_le::<u32>(efuse::ADC1_TP_HIGH) != 0
+        && efuse::read_field_le::<u32>(efuse::ADC2_TP_HIGH) != 0
+}
+
+fn read_efuse_tp_low(unit: u8) -> u32 {
+    let (high_offset, efuse) = if unit == 0 {
+        (TP_LOW1_OFFSET, efuse::ADC1_TP_LOW)
+    } else {
+        (TP_LOW2_OFFSET, efuse::ADC2_TP_LOW)
+    };
+
+    let efuse_value = decode_bits(efuse::read_field_le::<u32>(efuse), TP_LOW_MASK, true);
+    (high_offset + efuse_value * TP_STEP_SIZE) as u32
+}
+
+fn read_efuse_tp_high(unit: u8) -> u32 {
+    let (high_offset, efuse) = if unit == 0 {
+        (TP_HIGH1_OFFSET, efuse::ADC1_TP_HIGH)
+    } else {
+        (TP_HIGH2_OFFSET, efuse::ADC2_TP_HIGH)
+    };
+
+    let efuse_value = decode_bits(efuse::read_field_le::<u32>(efuse), TP_HIGH_MASK, true);
+    (high_offset + efuse_value * TP_STEP_SIZE) as u32
+}
+
+fn characterize_using_two_point(unit: u8, atten: usize, high: u32, low: u32) -> (u32, u32) {
+    let (scales, offsets) = if unit == 0 {
+        (&ADC1_TP_ATTEN_SCALE, &ADC1_TP_ATTEN_OFFSET)
+    } else {
+        (&ADC2_TP_ATTEN_SCALE, &ADC2_TP_ATTEN_OFFSET)
+    };
+    let delta_x = high - low;
+    let delta_v = TP_HIGH_VOLTAGE - TP_LOW_VOLTAGE;
+    let coeff_a = (delta_v * scales[atten] + (delta_x / 2)) / delta_x;
+    let coeff_b = TP_HIGH_VOLTAGE - ((delta_v * high + (delta_x / 2)) / delta_x) + offsets[atten];
+    (coeff_a, coeff_b)
+}
+
+fn characterize_using_vref(unit: u8, atten: usize, vref: u32) -> (u32, u32) {
+    let (scales, offsets) = if unit == 0 {
+        (&ADC1_VREF_ATTEN_SCALE, &ADC1_VREF_ATTEN_OFFSET)
+    } else {
+        (&ADC2_VREF_ATTEN_SCALE, &ADC2_VREF_ATTEN_OFFSET)
+    };
+    let coeff_a = (vref * scales[atten]) / ADC_12_BIT_RES;
+    (coeff_a, offsets[atten])
+}
+
+fn calculate_voltage_linear(adc: u32, coeff_a: u32, coeff_b: u32) -> u32 {
+    ((coeff_a * adc + COEFF_A_ROUND) / COEFF_A_SCALE) + coeff_b
+}
+
+fn interpolate_two_points(y1: u32, y2: u32, x_step: u32, x: u32) -> u32 {
+    ((y1 * x_step) + (y2 * x) - (y1 * x) + (x_step / 2)) / x_step
+}
+
+fn calculate_voltage_lut(
+    adc: u32,
+    vref: u32,
+    low: &[u32; LUT_POINTS],
+    high: &[u32; LUT_POINTS],
+) -> u32 {
+    let i = ((adc - LUT_LOW_THRESH) / LUT_ADC_STEP_SIZE) as usize;
+    let i = i.min(LUT_POINTS - 2);
+
+    let x2dist = LUT_VREF_HIGH - vref as i32;
+    let x1dist = vref as i32 - LUT_VREF_LOW;
+    let y2dist = ((i as u32 + 1) * LUT_ADC_STEP_SIZE + LUT_LOW_THRESH) as i32 - adc as i32;
+    let y1dist = adc as i32 - (i as u32 * LUT_ADC_STEP_SIZE + LUT_LOW_THRESH) as i32;
+
+    let q11 = low[i] as i32;
+    let q12 = low[i + 1] as i32;
+    let q21 = high[i] as i32;
+    let q22 = high[i + 1] as i32;
+
+    let mut voltage = (q11 * x2dist * y2dist)
+        + (q21 * x1dist * y2dist)
+        + (q12 * x2dist * y1dist)
+        + (q22 * x1dist * y1dist);
+    voltage += ((LUT_VREF_HIGH - LUT_VREF_LOW) * LUT_ADC_STEP_SIZE as i32) / 2;
+    voltage /= (LUT_VREF_HIGH - LUT_VREF_LOW) * LUT_ADC_STEP_SIZE as i32;
+    voltage as u32
+}
+
+impl<ADCX> crate::private::Sealed for AdcCalLine<ADCX> {}
+
+impl<ADCX> AdcCalScheme<ADCX> for AdcCalLine<ADCX>
+where
+    ADCX: AdcHasLineCal,
+{
+    fn new_cal(atten: Attenuation) -> Self {
+        let unit = ADCX::UNIT;
+        let atten_idx = atten as usize;
+
+        let vref = if check_efuse_vref() {
+            read_efuse_vref()
+        } else {
+            1100
+        };
+
+        let (coeff_a, coeff_b) = if check_efuse_tp() {
+            let high = read_efuse_tp_high(unit);
+            let low = read_efuse_tp_low(unit);
+            characterize_using_two_point(unit, atten_idx, high, low)
+        } else {
+            characterize_using_vref(unit, atten_idx, vref)
+        };
+
+        Self {
+            coeff_a,
+            coeff_b,
+            vref,
+            use_lut: atten == Attenuation::_11dB,
+            unit,
+            _phantom: PhantomData,
+        }
+    }
+
+    fn adc_val(&self, val: u16) -> u16 {
+        let raw = val as u32;
+
+        if self.use_lut && raw >= LUT_LOW_THRESH {
+            let (low, high) = if self.unit == 0 {
+                (&LUT_ADC1_LOW, &LUT_ADC1_HIGH)
+            } else {
+                (&LUT_ADC2_LOW, &LUT_ADC2_HIGH)
+            };
+            let lut_voltage = calculate_voltage_lut(raw, self.vref, low, high);
+            if raw <= LUT_HIGH_THRESH {
+                let linear = calculate_voltage_linear(raw, self.coeff_a, self.coeff_b);
+                interpolate_two_points(linear, lut_voltage, LUT_ADC_STEP_SIZE, raw - LUT_LOW_THRESH)
+                    as u16
+            } else {
+                lut_voltage as u16
+            }
+        } else {
+            calculate_voltage_linear(raw, self.coeff_a, self.coeff_b) as u16
+        }
+    }
+}

--- a/esp-hal/src/analog/adc/calibration/line/mod.rs
+++ b/esp-hal/src/analog/adc/calibration/line/mod.rs
@@ -1,0 +1,21 @@
+#[cfg_attr(esp32, path = "esp32.rs")]
+#[cfg_attr(esp32s2, path = "s2.rs")]
+#[cfg_attr(not(any(esp32, esp32s2)), path = "one_point.rs")]
+mod line_impl;
+pub use line_impl::AdcCalLine;
+
+/// Marker trait for ADC units which support line fitting.
+pub trait AdcHasLineCal: crate::private::Sealed {
+    /// ADC unit index used by the eFuse calibration tables (0 = ADC1, 1 = ADC2).
+    const UNIT: u8;
+}
+
+#[cfg(soc_has_adc1)]
+impl AdcHasLineCal for crate::peripherals::ADC1<'_> {
+    const UNIT: u8 = 0;
+}
+
+#[cfg(soc_has_adc2)]
+impl AdcHasLineCal for crate::peripherals::ADC2<'_> {
+    const UNIT: u8 = 1;
+}

--- a/esp-hal/src/analog/adc/calibration/line/one_point.rs
+++ b/esp-hal/src/analog/adc/calibration/line/one_point.rs
@@ -1,5 +1,6 @@
 use core::marker::PhantomData;
 
+use super::AdcHasLineCal;
 use crate::analog::adc::{
     AdcCalBasic,
     AdcCalEfuse,
@@ -9,12 +10,6 @@ use crate::analog::adc::{
     Attenuation,
     CalibrationAccess,
 };
-
-/// Marker trait for ADC units which support line fitting
-///
-/// Usually it means that reference points are stored in efuse.
-/// See also [`AdcCalLine`].
-pub trait AdcHasLineCal {}
 
 /// We store the gain as a u32, but it's really a fixed-point number.
 const GAIN_SCALE: u32 = 1 << 16;
@@ -55,7 +50,11 @@ where
     ADCX: AdcCalEfuse + AdcHasLineCal + CalibrationAccess,
 {
     fn new_cal(atten: Attenuation) -> Self {
-        let basic = AdcCalBasic::<ADCX>::new_cal(atten);
+        Self::new_cal_with_channel(atten, 0)
+    }
+
+    fn new_cal_with_channel(atten: Attenuation, channel: u8) -> Self {
+        let basic = AdcCalBasic::<ADCX>::new_cal_with_channel(atten, channel);
 
         // Try get the reference point (Dout, Vin) from efuse
         // Dout means mean raw ADC value when specified Vin applied to input.
@@ -96,11 +95,3 @@ where
         (val as u32 * self.gain / GAIN_SCALE) as u16
     }
 }
-
-#[cfg(any(
-    esp32c2, esp32c3, esp32c5, esp32c6, esp32c61, esp32h2, esp32p4, esp32s3
-))]
-impl AdcHasLineCal for crate::peripherals::ADC1<'_> {}
-
-#[cfg(any(esp32c3, esp32p4, esp32s3))]
-impl AdcHasLineCal for crate::peripherals::ADC2<'_> {}

--- a/esp-hal/src/analog/adc/calibration/line/s2.rs
+++ b/esp-hal/src/analog/adc/calibration/line/s2.rs
@@ -1,0 +1,108 @@
+use core::marker::PhantomData;
+
+use super::AdcHasLineCal;
+use crate::analog::adc::{AdcCalBasic, AdcCalEfuse, AdcCalScheme, Attenuation, CalibrationAccess};
+
+const COEFF_A_SCALING: i64 = 65536;
+const COEFF_B_SCALING: i64 = 1024;
+const V_HIGH: [i64; 4] = [600, 800, 1000, 2000];
+const V_LOW: i64 = 250;
+
+/// Line fitting ADC calibration scheme
+///
+/// ESP32-S2 uses two-point characterization (eFuse calibration v1) or
+/// one-point characterization (v2). Readings are in mV.
+///
+/// This scheme also includes basic calibration ([`AdcCalBasic`]).
+///
+/// See <https://github.com/espressif/esp-idf/blob/027613140/components/esp_adc/esp32s2/adc_cali_line_fitting.c#L87>
+#[derive(Clone, Copy)]
+pub struct AdcCalLine<ADCX> {
+    basic: AdcCalBasic<ADCX>,
+    coeff_a: u32,
+    coeff_b: i32,
+    _phantom: PhantomData<ADCX>,
+}
+
+fn characterize_two_point(atten: Attenuation, high: i64, low: i64) -> (u32, i32) {
+    let v_high = V_HIGH[atten as usize];
+    let denom = (high - low).max(1);
+    let coeff_a = (COEFF_A_SCALING * (v_high - V_LOW) / denom) as u32;
+    let coeff_b = (COEFF_B_SCALING * (V_LOW * high - v_high * low) / denom) as i32;
+    (coeff_a, coeff_b)
+}
+
+impl<ADCX> crate::private::Sealed for AdcCalLine<ADCX> {}
+
+impl<ADCX> AdcCalScheme<ADCX> for AdcCalLine<ADCX>
+where
+    ADCX: AdcCalEfuse + AdcHasLineCal + CalibrationAccess,
+{
+    fn new_cal(atten: Attenuation) -> Self {
+        Self::new_cal_with_channel(atten, 0)
+    }
+
+    fn new_cal_with_channel(atten: Attenuation, channel: u8) -> Self {
+        let basic = AdcCalBasic::<ADCX>::new_cal_with_channel(atten, channel);
+        let version = crate::efuse::rtc_calib_version();
+
+        let (coeff_a, coeff_b) = match version {
+            1 => {
+                let low = crate::efuse::rtc_calib_reading(
+                    version,
+                    ADCX::UNIT,
+                    atten,
+                    crate::efuse::RtcCalibParam::Vlow,
+                );
+                let high = crate::efuse::rtc_calib_reading(
+                    version,
+                    ADCX::UNIT,
+                    atten,
+                    crate::efuse::RtcCalibParam::Vhigh,
+                );
+                characterize_two_point(atten, high as i64, low as i64)
+            }
+            2 => {
+                let high = ADCX::cal_code(atten).unwrap_or(1).max(1) as i64;
+                let mv = ADCX::cal_mv(atten) as i64;
+                (((COEFF_A_SCALING * mv) / high) as u32, 0)
+            }
+            _ => {
+                let low = crate::efuse::rtc_calib_reading_inner(
+                    1,
+                    ADCX::UNIT,
+                    atten,
+                    crate::efuse::RtcCalibParam::Vlow,
+                    true,
+                );
+                let high = crate::efuse::rtc_calib_reading_inner(
+                    1,
+                    ADCX::UNIT,
+                    atten,
+                    crate::efuse::RtcCalibParam::Vhigh,
+                    true,
+                );
+                characterize_two_point(atten, high as i64, low as i64)
+            }
+        };
+
+        Self {
+            basic,
+            coeff_a,
+            coeff_b,
+            _phantom: PhantomData,
+        }
+    }
+
+    fn adc_cal(&self) -> u16 {
+        self.basic.adc_cal()
+    }
+
+    fn adc_val(&self, val: u16) -> u16 {
+        let val = self.basic.adc_val(val) as i64;
+        let voltage = (val * self.coeff_a as i64 / (COEFF_A_SCALING / COEFF_B_SCALING)
+            + self.coeff_b as i64)
+            / COEFF_B_SCALING;
+        voltage.clamp(0, u16::MAX as i64) as u16
+    }
+}

--- a/esp-hal/src/analog/adc/calibration/mod.rs
+++ b/esp-hal/src/analog/adc/calibration/mod.rs
@@ -1,21 +1,21 @@
 #[cfg(any(
-    esp32c2, esp32c3, esp32c5, esp32c6, esp32c61, esp32h2, esp32p4, esp32s3
+    esp32c2, esp32c3, esp32c5, esp32c6, esp32c61, esp32h2, esp32p4, esp32s2, esp32s3
 ))]
 pub use self::basic::AdcCalBasic;
 #[cfg(any(esp32c3, esp32c5, esp32c6, esp32c61, esp32h2, esp32p4, esp32s3))]
 pub use self::curve::{AdcCalCurve, AdcHasCurveCal};
 #[cfg(any(
-    esp32c2, esp32c3, esp32c5, esp32c6, esp32c61, esp32h2, esp32p4, esp32s3
+    esp32, esp32c2, esp32c3, esp32c5, esp32c6, esp32c61, esp32h2, esp32p4, esp32s2, esp32s3
 ))]
 pub use self::line::{AdcCalLine, AdcHasLineCal};
 
 #[cfg(any(
-    esp32c2, esp32c3, esp32c5, esp32c6, esp32c61, esp32h2, esp32p4, esp32s3
+    esp32c2, esp32c3, esp32c5, esp32c6, esp32c61, esp32h2, esp32p4, esp32s2, esp32s3
 ))]
 mod basic;
 #[cfg(any(esp32c3, esp32c5, esp32c6, esp32c61, esp32h2, esp32p4, esp32s3))]
 mod curve;
 #[cfg(any(
-    esp32c2, esp32c3, esp32c5, esp32c6, esp32c61, esp32h2, esp32p4, esp32s3
+    esp32, esp32c2, esp32c3, esp32c5, esp32c6, esp32c61, esp32h2, esp32p4, esp32s2, esp32s3
 ))]
 mod line;

--- a/esp-hal/src/analog/adc/esp32.rs
+++ b/esp-hal/src/analog/adc/esp32.rs
@@ -3,13 +3,16 @@ use core::{
     sync::atomic::{AtomicBool, Ordering},
 };
 
-use super::{AdcConfig, Attenuation};
+use super::{AdcCalScheme, AdcConfig, Attenuation};
 use crate::{
     peripherals::{ADC1, ADC2, SENS},
     private,
 };
 
 pub(super) const NUM_ATTENS: usize = 10;
+
+mod calibration;
+pub use self::calibration::*;
 
 // ADC2 cannot be used with `radio` functionality on `esp32`, this global helps us to track it's
 // state to prevent unexpected behaviour
@@ -236,6 +239,7 @@ pub struct Adc<'d, ADC, Dm: crate::DriverMode> {
     _adc: ADC,
     attenuations: [Option<Attenuation>; NUM_ATTENS],
     active_channel: Option<u8>,
+    resolution_bits: u8,
     _phantom: PhantomData<(Dm, &'d mut ())>,
 }
 
@@ -312,6 +316,12 @@ where
             _adc: adc_instance,
             attenuations: config.attenuations,
             active_channel: None,
+            resolution_bits: match config.resolution {
+                Resolution::_9Bit => 9,
+                Resolution::_10Bit => 10,
+                Resolution::_11Bit => 11,
+                Resolution::_12Bit => 12,
+            },
             _phantom: PhantomData,
         }
     }
@@ -321,9 +331,13 @@ where
     /// This method takes an [AdcPin](super::AdcPin) reference, as it is
     /// expected that the ADC will be able to sample whatever channel
     /// underlies the pin.
-    pub fn read_oneshot<PIN>(&mut self, pin: &mut super::AdcPin<PIN, ADCX>) -> nb::Result<u16, ()>
+    pub fn read_oneshot<PIN, CS>(
+        &mut self,
+        pin: &mut super::AdcPin<PIN, ADCX, CS>,
+    ) -> nb::Result<u16, ()>
     where
         PIN: super::AdcChannel,
+        CS: AdcCalScheme<ADCX>,
     {
         if self.attenuations[pin.pin.adc_channel() as usize].is_none() {
             panic!(
@@ -355,13 +369,17 @@ where
             return Err(nb::Error::WouldBlock);
         }
 
-        // Get converted value
-        let converted_value = ADCX::read_data_sar();
+        // Get converted value and scale to 12 bits
+        let mut converted_value = ADCX::read_data_sar() as u32;
+        converted_value <<= 12 - self.resolution_bits;
+        if converted_value > 4095 {
+            converted_value = 4095;
+        }
 
         // Mark that no conversions are currently in progress
         self.active_channel = None;
 
-        Ok(converted_value)
+        Ok(pin.cal_scheme.adc_val(converted_value as u16))
     }
 }
 

--- a/esp-hal/src/analog/adc/mod.rs
+++ b/esp-hal/src/analog/adc/mod.rs
@@ -166,7 +166,6 @@ impl<ADCX> AdcConfig<ADCX> {
 
     /// Enable the specified pin with the given attenuation and calibration
     /// scheme
-    #[cfg(not(esp32))]
     #[cfg(feature = "unstable")]
     pub fn enable_pin_with_cal<PIN, CS>(
         &mut self,
@@ -174,17 +173,17 @@ impl<ADCX> AdcConfig<ADCX> {
         attenuation: Attenuation,
     ) -> AdcPin<PIN, ADCX, CS>
     where
-        ADCX: CalibrationAccess,
         PIN: AdcChannel + AnalogPin,
         CS: AdcCalScheme<ADCX>,
     {
         // TODO revert this on drop
         pin.set_analog(crate::private::Internal);
-        self.attenuations[pin.adc_channel() as usize] = Some(attenuation);
+        let channel = pin.adc_channel();
+        self.attenuations[channel as usize] = Some(attenuation);
 
         AdcPin {
             pin,
-            cal_scheme: CS::new_cal(attenuation),
+            cal_scheme: CS::new_cal_with_channel(attenuation, channel),
             _phantom: PhantomData,
         }
     }
@@ -231,6 +230,14 @@ pub trait AdcCalScheme<ADCX>: Sized + crate::private::Sealed {
     /// Create a new calibration scheme for the given attenuation.
     fn new_cal(atten: Attenuation) -> Self;
 
+    /// Create a new calibration scheme for the given attenuation and ADC
+    /// channel.
+    ///
+    /// The default implementation ignores `channel` and calls [`Self::new_cal`].
+    fn new_cal_with_channel(atten: Attenuation, _channel: u8) -> Self {
+        Self::new_cal(atten)
+    }
+
     /// Return the basic ADC bias value.
     fn adc_cal(&self) -> u16 {
         0
@@ -249,7 +256,7 @@ impl<ADCX> AdcCalScheme<ADCX> for () {
 }
 
 /// A helper trait to get access to ADC calibration efuses.
-#[cfg(not(any(esp32, esp32s2, esp32s31)))]
+#[cfg(not(any(esp32, esp32s31)))]
 trait AdcCalEfuse {
     /// Get ADC calibration init code
     ///
@@ -269,8 +276,8 @@ trait AdcCalEfuse {
     /// Get the ADC channel specific calibration
     ///
     /// Returns digital per channel offset from reference voltage
-    #[cfg(any(esp32c5, esp32c61))]
-    fn cal_chan_compens(atten: Attenuation, channel: u16) -> Option<i32>;
+    #[cfg(any(esp32c5, esp32c6, esp32c61, esp32h2))]
+    fn cal_chan_compens(atten: Attenuation, channel: u8) -> Option<i32>;
 }
 
 for_each_analog_function! {

--- a/esp-hal/src/analog/adc/riscv.rs
+++ b/esp-hal/src/analog/adc/riscv.rs
@@ -446,8 +446,8 @@ impl super::AdcCalEfuse for crate::peripherals::ADC1<'_> {
         crate::efuse::rtc_calib_cal_code(AdcCalibUnit::ADC1, atten)
     }
 
-    #[cfg(any(esp32c5, esp32c61))]
-    fn cal_chan_compens(atten: Attenuation, channel: u16) -> Option<i32> {
+    #[cfg(any(esp32c5, esp32c6, esp32c61, esp32h2))]
+    fn cal_chan_compens(atten: Attenuation, channel: u8) -> Option<i32> {
         crate::efuse::rtc_calib_get_chan_compens(AdcCalibUnit::ADC1, channel, atten)
     }
 }

--- a/esp-hal/src/analog/adc/xtensa.rs
+++ b/esp-hal/src/analog/adc/xtensa.rs
@@ -1,11 +1,9 @@
 use core::marker::PhantomData;
 
-#[cfg(esp32s3)]
 pub use self::calibration::*;
 use super::{AdcCalScheme, AdcCalSource, AdcChannel, AdcConfig, AdcPin, Attenuation};
-#[cfg(esp32s3)]
-use crate::efuse::AdcCalibUnit;
 use crate::{
+    efuse::AdcCalibUnit,
     peripherals::{APB_SARADC, SENS},
     soc::regi2c,
     system::{GenericPeripheralGuard, Peripheral},
@@ -16,12 +14,16 @@ mod calibration;
 pub(super) const NUM_ATTENS: usize = 10;
 
 cfg_select! {
+    esp32s2 => {
+        const ADC_VAL_MASK: u16 = 0x1fff;
+        const ADC_CAL_CNT_MAX: u16 = 32;
+        const ADC_CAL_CHANNEL: u16 = 15;
+    }
     esp32s3 => {
         const ADC_VAL_MASK: u16 = 0xfff;
         const ADC_CAL_CNT_MAX: u16 = 32;
         const ADC_CAL_CHANNEL: u16 = 15;
     }
-    _ => {}
 }
 
 impl<ADCX> AdcConfig<ADCX>
@@ -195,7 +197,6 @@ impl RegisterAccess for crate::peripherals::ADC1<'_> {
     }
 }
 
-#[cfg(esp32s3)]
 impl super::CalibrationAccess for crate::peripherals::ADC1<'_> {
     const ADC_CAL_CNT_MAX: u16 = ADC_CAL_CNT_MAX;
     const ADC_CAL_CHANNEL: u16 = ADC_CAL_CHANNEL;
@@ -303,7 +304,6 @@ impl RegisterAccess for crate::peripherals::ADC2<'_> {
     }
 }
 
-#[cfg(esp32s3)]
 impl super::CalibrationAccess for crate::peripherals::ADC2<'_> {
     const ADC_CAL_CNT_MAX: u16 = ADC_CAL_CNT_MAX;
     const ADC_CAL_CHANNEL: u16 = ADC_CAL_CHANNEL;
@@ -486,7 +486,7 @@ where
     }
 }
 
-#[cfg(esp32s3)]
+#[cfg(any(esp32s2, esp32s3))]
 impl super::AdcCalEfuse for crate::peripherals::ADC1<'_> {
     fn init_code(atten: Attenuation) -> Option<u16> {
         crate::efuse::rtc_calib_init_code(AdcCalibUnit::ADC1, atten)
@@ -501,7 +501,7 @@ impl super::AdcCalEfuse for crate::peripherals::ADC1<'_> {
     }
 }
 
-#[cfg(esp32s3)]
+#[cfg(any(esp32s2, esp32s3))]
 impl super::AdcCalEfuse for crate::peripherals::ADC2<'_> {
     fn init_code(atten: Attenuation) -> Option<u16> {
         crate::efuse::rtc_calib_init_code(AdcCalibUnit::ADC2, atten)

--- a/esp-hal/src/efuse/esp32c5/mod.rs
+++ b/esp-hal/src/efuse/esp32c5/mod.rs
@@ -86,7 +86,7 @@ pub fn rtc_calib_init_code(_unit: AdcCalibUnit, atten: Attenuation) -> Option<u1
 #[instability::unstable]
 pub fn rtc_calib_get_chan_compens(
     _unit: AdcCalibUnit,
-    channel: u16,
+    channel: u8,
     atten: Attenuation,
 ) -> Option<i32> {
     let chan_diff: u32 = super::read_field_le(match channel {

--- a/esp-hal/src/efuse/esp32c6/mod.rs
+++ b/esp-hal/src/efuse/esp32c6/mod.rs
@@ -41,27 +41,45 @@ pub fn block_version() -> (u8, u8) {
     )
 }
 
+/// Get a signed value from the raw data from eFuse.
+///
+/// `sign_bit` is the index of the sign bit, starting from 0.
+fn get_signed_val(data: u32, sign_bit: u32) -> i32 {
+    let sign_mask = 1u32 << sign_bit;
+    if data & sign_mask != 0 {
+        -((data & !sign_mask) as i32)
+    } else {
+        data as i32
+    }
+}
+
 /// Get version of RTC calibration block
 ///
-/// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c6/esp_efuse_rtc_calib.c#L20>
+/// See <https://github.com/espressif/esp-idf/blob/027613140/components/efuse/esp32c6/esp_efuse_rtc_calib.c#L20>
 #[instability::unstable]
 pub fn rtc_calib_version() -> u8 {
     let (_major, minor) = block_version();
-    if minor >= 1 { 1 } else { 0 }
+    if minor == 1 {
+        1
+    } else if minor >= 2 {
+        2
+    } else {
+        0
+    }
 }
 
 /// Get ADC initial code for specified attenuation from efuse
 ///
-/// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c6/esp_efuse_rtc_calib.c#L32>
+/// See <https://github.com/espressif/esp-idf/blob/027613140/components/efuse/esp32c6/esp_efuse_rtc_calib.c#L35>
 #[instability::unstable]
 pub fn rtc_calib_init_code(_unit: AdcCalibUnit, atten: Attenuation) -> Option<u16> {
     let version = rtc_calib_version();
 
-    if version != 1 {
+    if !(1..=2).contains(&version) {
         return None;
     }
 
-    // See <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c6/esp_efuse_table.csv#L147-L152>
+    // See <https://github.com/espressif/esp-idf/blob/027613140/components/efuse/esp32c6/esp_efuse_table.csv#L178-L181>
     let init_code: u16 = super::read_field_le(match atten {
         Attenuation::_0dB => ADC1_INIT_CODE_ATTEN0,
         Attenuation::_2p5dB => ADC1_INIT_CODE_ATTEN1,
@@ -69,48 +87,73 @@ pub fn rtc_calib_init_code(_unit: AdcCalibUnit, atten: Attenuation) -> Option<u1
         Attenuation::_11dB => ADC1_INIT_CODE_ATTEN3,
     });
 
-    Some(init_code + 1600) // version 1 logic
+    Some(init_code + 1600)
+}
+
+/// Get the channel specific calibration compensation
+///
+/// See <https://github.com/espressif/esp-idf/blob/027613140/components/efuse/esp32c6/esp_efuse_rtc_calib.c#L60>
+#[instability::unstable]
+pub fn rtc_calib_get_chan_compens(
+    _unit: AdcCalibUnit,
+    channel: u8,
+    atten: Attenuation,
+) -> Option<i32> {
+    let chan_diff: u32 = super::read_field_le(match channel {
+        0 => ADC1_INIT_CODE_ATTEN0_CH0,
+        1 => ADC1_INIT_CODE_ATTEN0_CH1,
+        2 => ADC1_INIT_CODE_ATTEN0_CH2,
+        3 => ADC1_INIT_CODE_ATTEN0_CH3,
+        4 => ADC1_INIT_CODE_ATTEN0_CH4,
+        5 => ADC1_INIT_CODE_ATTEN0_CH5,
+        _ => ADC1_INIT_CODE_ATTEN0_CH6,
+    });
+
+    Some(get_signed_val(chan_diff, 3) * (4 - atten as i32))
 }
 
 /// Get ADC reference point voltage for specified attenuation in millivolts
 ///
-/// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c6/esp_efuse_rtc_calib.c#L42>
+/// See <https://github.com/espressif/esp-idf/blob/027613140/components/efuse/esp32c6/esp_efuse_rtc_calib.c#L98>
 #[instability::unstable]
 pub fn rtc_calib_cal_mv(_unit: AdcCalibUnit, atten: Attenuation) -> u16 {
-    match atten {
-        Attenuation::_0dB => 400,
-        Attenuation::_2p5dB => 550,
-        Attenuation::_6dB => 750,
-        Attenuation::_11dB => 1370,
-    }
+    let version = rtc_calib_version();
+    let input_vout_mv = match version {
+        2 => [750, 1000, 1500, 2800],
+        _ => [400, 550, 750, 1370],
+    };
+
+    input_vout_mv[atten as usize]
 }
 
 /// Get ADC reference point digital code for specified attenuation
 ///
-/// see <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c6/esp_efuse_rtc_calib.c#L42>
+/// See <https://github.com/espressif/esp-idf/blob/027613140/components/efuse/esp32c6/esp_efuse_rtc_calib.c#L98>
 #[instability::unstable]
 pub fn rtc_calib_cal_code(_unit: AdcCalibUnit, atten: Attenuation) -> Option<u16> {
     let version = rtc_calib_version();
 
-    if version != 1 {
+    if !(1..=2).contains(&version) {
         return None;
     }
 
-    // See <https://github.com/espressif/esp-idf/blob/903af13e8/components/efuse/esp32c6/esp_efuse_table.csv#L153-L156>
-    let cal_code: u16 = super::read_field_le(match atten {
+    // See <https://github.com/espressif/esp-idf/blob/027613140/components/efuse/esp32c6/esp_efuse_table.csv#L182-L185>
+    let cal_vol: u16 = super::read_field_le(match atten {
         Attenuation::_0dB => ADC1_CAL_VOL_ATTEN0,
         Attenuation::_2p5dB => ADC1_CAL_VOL_ATTEN1,
         Attenuation::_6dB => ADC1_CAL_VOL_ATTEN2,
         Attenuation::_11dB => ADC1_CAL_VOL_ATTEN3,
     });
 
-    let cal_code = if cal_code & (1 << 9) != 0 {
-        1500 - (cal_code & !(1 << 9))
+    let chk_offset = if version == 1 {
+        1500
+    } else if atten == Attenuation::_6dB {
+        2900
     } else {
-        1500 + cal_code
+        2850
     };
 
-    Some(cal_code)
+    Some((chk_offset + get_signed_val(cal_vol as u32, 9)) as u16)
 }
 
 /// Returns the major hardware revision

--- a/esp-hal/src/efuse/esp32c61/mod.rs
+++ b/esp-hal/src/efuse/esp32c61/mod.rs
@@ -133,7 +133,7 @@ pub fn rtc_calib_init_code(_unit: AdcCalibUnit, atten: Attenuation) -> Option<u1
 #[instability::unstable]
 pub fn rtc_calib_get_chan_compens(
     _unit: AdcCalibUnit,
-    channel: u16,
+    channel: u8,
     atten: Attenuation,
 ) -> Option<i32> {
     let chan_diff: u32 = super::read_field_le(match channel {

--- a/esp-hal/src/efuse/esp32h2/mod.rs
+++ b/esp-hal/src/efuse/esp32h2/mod.rs
@@ -37,10 +37,21 @@ pub fn block_version() -> (u8, u8) {
     )
 }
 
+/// Get a signed value from the raw data from eFuse.
+///
+/// `sign_bit` is the index of the sign bit, starting from 0.
+fn get_signed_val(data: u32, sign_bit: u32) -> i32 {
+    let sign_mask = 1u32 << sign_bit;
+    if data & sign_mask != 0 {
+        -((data & !sign_mask) as i32)
+    } else {
+        data as i32
+    }
+}
+
 /// Get version of RTC calibration block
 ///
-/// See: <https://github.com/espressif/esp-idf/blob/be06a6f/components/efuse/esp32h2/esp_efuse_rtc_calib.c#L20>
-/// //esp_efuse_rtc_calib_get_ver
+/// See: <https://github.com/espressif/esp-idf/blob/027613140/components/efuse/esp32h2/esp_efuse_rtc_calib.c#L20>
 #[instability::unstable]
 pub fn rtc_calib_version() -> u8 {
     let (_major, minor) = block_version();
@@ -49,16 +60,16 @@ pub fn rtc_calib_version() -> u8 {
 
 /// Get ADC initial code for specified attenuation from efuse
 ///
-/// See: <https://github.com/espressif/esp-idf/blob/be06a6f/components/efuse/esp32h2/esp_efuse_rtc_calib.c#L33>
+/// See: <https://github.com/espressif/esp-idf/blob/027613140/components/efuse/esp32h2/esp_efuse_rtc_calib.c#L33>
 #[instability::unstable]
 pub fn rtc_calib_init_code(_unit: AdcCalibUnit, atten: Attenuation) -> Option<u16> {
     let version = rtc_calib_version();
 
-    if version > 4 {
+    if version != 1 {
         return None;
     }
 
-    // See: <https://github.com/espressif/esp-idf/blob/be06a6f/components/efuse/esp32h2/esp_efuse_table.csv#L76-L79>
+    // See: <https://github.com/espressif/esp-idf/blob/027613140/components/efuse/esp32h2/esp_efuse_table.csv#L184-L187>
     let init_code: u16 = super::read_field_le(match atten {
         Attenuation::_0dB => ADC1_AVE_INITCODE_ATTEN0,
         Attenuation::_2p5dB => ADC1_AVE_INITCODE_ATTEN1,
@@ -66,51 +77,70 @@ pub fn rtc_calib_init_code(_unit: AdcCalibUnit, atten: Attenuation) -> Option<u1
         Attenuation::_11dB => ADC1_AVE_INITCODE_ATTEN3,
     });
 
-    Some(init_code + 1600) // version 1 logic
+    Some(init_code + 1600)
+}
+
+/// Get the channel specific calibration compensation
+///
+/// See: <https://github.com/espressif/esp-idf/blob/027613140/components/efuse/esp32h2/esp_efuse_rtc_calib.c#L58>
+#[instability::unstable]
+pub fn rtc_calib_get_chan_compens(
+    _unit: AdcCalibUnit,
+    channel: u8,
+    atten: Attenuation,
+) -> Option<i32> {
+    let chan_diff: u32 = super::read_field_le(match channel {
+        0 => ADC1_CH0_ATTEN0_INITCODE_DIFF,
+        1 => ADC1_CH1_ATTEN0_INITCODE_DIFF,
+        2 => ADC1_CH2_ATTEN0_INITCODE_DIFF,
+        3 => ADC1_CH3_ATTEN0_INITCODE_DIFF,
+        _ => ADC1_CH4_ATTEN0_INITCODE_DIFF,
+    });
+
+    Some(get_signed_val(chan_diff, 3) * (4 - atten as i32))
 }
 
 /// Get ADC reference point voltage for specified attenuation in millivolts
 ///
-/// See: <https://github.com/espressif/esp-idf/blob/be06a6f/components/efuse/esp32h2/esp_efuse_rtc_calib.c#L91>
+/// See: <https://github.com/espressif/esp-idf/blob/027613140/components/efuse/esp32h2/esp_efuse_rtc_calib.c#L91>
 #[instability::unstable]
 pub fn rtc_calib_cal_mv(_unit: AdcCalibUnit, atten: Attenuation) -> u16 {
-    const INPUT_VOUT_MV: [[u16; 4]; 1] = [
-        [750, 1000, 1500, 2800], // Calibration V1 coefficients
-    ];
-
     let version = rtc_calib_version();
+    let input_vout_mv = match version {
+        1 => [750, 1000, 1500, 2800],
+        _ => {
+            // The required efuse bits for this chip are not burnt.
+            // 1100 is the middle of the reference voltage range.
+            return 1100;
+        }
+    };
 
-    // https://github.com/espressif/esp-idf/blob/master/components/efuse/esp32h2/include/esp_efuse_rtc_calib.h#L15C9-L17
-    // ESP_EFUSE_ADC_CALIB_VER1     1
-    // ESP_EFUSE_ADC_CALIB_VER_MIN  ESP_EFUSE_ADC_CALIB_VER1
-    // ESP_EFUSE_ADC_CALIB_VER_MAX  ESP_EFUSE_ADC_CALIB_VER1
-    if version != 1 {
-        // The required efuse bits for this chip are not burnt.
-        // 1100 is the middle of the reference voltage range.
-        // See: <https://github.com/espressif/esp-idf/blob/465b159cd8771ffab6be70c7675ecf6705b62649/docs/en/api-reference/peripherals/adc_calibration.rst?plain=1#L9>
-        return 1100;
-    }
-
-    INPUT_VOUT_MV[version as usize - 1][atten as usize]
+    input_vout_mv[atten as usize]
 }
 
-/// Returns the call code
+/// Returns the calibration code
 ///
-/// See: <https://github.com/espressif/esp-idf/blob/17a2461297076481858b7f76482676a521cc727a/components/efuse/esp32h2/esp_efuse_rtc_calib.c#L91>
+/// See: <https://github.com/espressif/esp-idf/blob/027613140/components/efuse/esp32h2/esp_efuse_rtc_calib.c#L91>
 #[instability::unstable]
 pub fn rtc_calib_cal_code(_unit: AdcCalibUnit, atten: Attenuation) -> Option<u16> {
-    let cal_code: u16 = super::read_field_le(match atten {
+    let version = rtc_calib_version();
+
+    if version != 1 {
+        return None;
+    }
+
+    let cal_vol: u16 = super::read_field_le(match atten {
         Attenuation::_0dB => ADC1_HI_DOUT_ATTEN0,
         Attenuation::_2p5dB => ADC1_HI_DOUT_ATTEN1,
         Attenuation::_6dB => ADC1_HI_DOUT_ATTEN2,
         Attenuation::_11dB => ADC1_HI_DOUT_ATTEN3,
     });
-    let cal_code: u16 = if atten == Attenuation::_6dB {
-        2970 + cal_code
+    let chk_offset = if atten == Attenuation::_6dB {
+        2970
     } else {
-        2900 + cal_code
+        2900
     };
-    Some(cal_code)
+    Some((chk_offset + get_signed_val(cal_vol as u32, 9)) as u16)
 }
 
 /// Returns the major hardware revision

--- a/esp-hal/src/efuse/esp32s2/mod.rs
+++ b/esp-hal/src/efuse/esp32s2/mod.rs
@@ -1,9 +1,383 @@
-use crate::peripherals::EFUSE;
+use crate::{analog::adc::Attenuation, peripherals::EFUSE};
 
 #[cfg_attr(not(feature = "unstable"), allow(dead_code))]
 mod fields;
 #[instability::unstable]
 pub use fields::*;
+
+/// Selects which ADC we are interested in the efuse calibration data for
+#[instability::unstable]
+pub enum AdcCalibUnit {
+    /// Select efuse calibration data for ADC1
+    ADC1,
+    /// Select efuse calibration data for ADC2
+    ADC2,
+}
+
+impl AdcCalibUnit {
+    fn index(self) -> u8 {
+        match self {
+            Self::ADC1 => 0,
+            Self::ADC2 => 1,
+        }
+    }
+}
+
+/// Parameter selected from the ESP32-S2 RTC calibration table
+#[derive(Clone, Copy)]
+#[instability::unstable]
+pub enum RtcCalibParam {
+    /// Low-voltage ADC reading (calibration v1)
+    Vlow,
+    /// High-voltage ADC reading
+    Vhigh,
+    /// Initial code (calibration v2)
+    Vinit,
+}
+
+struct RtcCalibEntry {
+    begin_bit: u16,
+    length: u8,
+    multiplier: i16,
+    base: i16,
+    depends: u8,
+}
+
+// See <https://github.com/espressif/esp-idf/blob/027613140/components/efuse/esp32s2/esp_efuse_rtc_table.c#L48-L89>
+const RTC_CALIB_MAP: [RtcCalibEntry; 33] = [
+    RtcCalibEntry {
+        begin_bit: 0,
+        length: 0,
+        multiplier: 0,
+        base: 0,
+        depends: 0,
+    },
+    // V1 low (tags 1-8)
+    RtcCalibEntry {
+        begin_bit: 208,
+        length: 6,
+        multiplier: 4,
+        base: 2231,
+        depends: 0,
+    },
+    RtcCalibEntry {
+        begin_bit: 214,
+        length: 6,
+        multiplier: 4,
+        base: 1643,
+        depends: 0,
+    },
+    RtcCalibEntry {
+        begin_bit: 220,
+        length: 6,
+        multiplier: 4,
+        base: 1290,
+        depends: 0,
+    },
+    RtcCalibEntry {
+        begin_bit: 226,
+        length: 6,
+        multiplier: 4,
+        base: 701,
+        depends: 0,
+    },
+    RtcCalibEntry {
+        begin_bit: 232,
+        length: 6,
+        multiplier: 4,
+        base: 2305,
+        depends: 0,
+    },
+    RtcCalibEntry {
+        begin_bit: 238,
+        length: 6,
+        multiplier: 4,
+        base: 1693,
+        depends: 0,
+    },
+    RtcCalibEntry {
+        begin_bit: 244,
+        length: 6,
+        multiplier: 4,
+        base: 1343,
+        depends: 0,
+    },
+    RtcCalibEntry {
+        begin_bit: 250,
+        length: 6,
+        multiplier: 4,
+        base: 723,
+        depends: 0,
+    },
+    // V1 high (tags 9-16)
+    RtcCalibEntry {
+        begin_bit: 144,
+        length: 8,
+        multiplier: 4,
+        base: 5775,
+        depends: 0,
+    },
+    RtcCalibEntry {
+        begin_bit: 152,
+        length: 8,
+        multiplier: 4,
+        base: 5693,
+        depends: 0,
+    },
+    RtcCalibEntry {
+        begin_bit: 160,
+        length: 8,
+        multiplier: 4,
+        base: 5723,
+        depends: 0,
+    },
+    RtcCalibEntry {
+        begin_bit: 168,
+        length: 8,
+        multiplier: 4,
+        base: 6209,
+        depends: 0,
+    },
+    RtcCalibEntry {
+        begin_bit: 176,
+        length: 8,
+        multiplier: 4,
+        base: 5817,
+        depends: 0,
+    },
+    RtcCalibEntry {
+        begin_bit: 184,
+        length: 8,
+        multiplier: 4,
+        base: 5703,
+        depends: 0,
+    },
+    RtcCalibEntry {
+        begin_bit: 192,
+        length: 8,
+        multiplier: 4,
+        base: 5731,
+        depends: 0,
+    },
+    RtcCalibEntry {
+        begin_bit: 200,
+        length: 8,
+        multiplier: 4,
+        base: 6157,
+        depends: 0,
+    },
+    // V2 high (tags 17-24)
+    RtcCalibEntry {
+        begin_bit: 197,
+        length: 6,
+        multiplier: 2,
+        base: 169,
+        depends: 19,
+    },
+    RtcCalibEntry {
+        begin_bit: 203,
+        length: 6,
+        multiplier: 2,
+        base: -26,
+        depends: 19,
+    },
+    RtcCalibEntry {
+        begin_bit: 209,
+        length: 9,
+        multiplier: 2,
+        base: 126,
+        depends: 22,
+    },
+    RtcCalibEntry {
+        begin_bit: 218,
+        length: 7,
+        multiplier: 2,
+        base: 387,
+        depends: 19,
+    },
+    RtcCalibEntry {
+        begin_bit: 225,
+        length: 7,
+        multiplier: 2,
+        base: 177,
+        depends: 22,
+    },
+    RtcCalibEntry {
+        begin_bit: 232,
+        length: 10,
+        multiplier: 2,
+        base: 5815,
+        depends: 0,
+    },
+    RtcCalibEntry {
+        begin_bit: 242,
+        length: 7,
+        multiplier: 2,
+        base: 27,
+        depends: 22,
+    },
+    RtcCalibEntry {
+        begin_bit: 249,
+        length: 7,
+        multiplier: 2,
+        base: 410,
+        depends: 22,
+    },
+    // V2 init (tags 25-32)
+    RtcCalibEntry {
+        begin_bit: 147,
+        length: 8,
+        multiplier: 2,
+        base: 1519,
+        depends: 0,
+    },
+    RtcCalibEntry {
+        begin_bit: 155,
+        length: 6,
+        multiplier: 2,
+        base: 88,
+        depends: 25,
+    },
+    RtcCalibEntry {
+        begin_bit: 161,
+        length: 5,
+        multiplier: 2,
+        base: 8,
+        depends: 26,
+    },
+    RtcCalibEntry {
+        begin_bit: 166,
+        length: 6,
+        multiplier: 2,
+        base: 70,
+        depends: 27,
+    },
+    RtcCalibEntry {
+        begin_bit: 172,
+        length: 8,
+        multiplier: 2,
+        base: 1677,
+        depends: 0,
+    },
+    RtcCalibEntry {
+        begin_bit: 180,
+        length: 6,
+        multiplier: 2,
+        base: 23,
+        depends: 29,
+    },
+    RtcCalibEntry {
+        begin_bit: 186,
+        length: 5,
+        multiplier: 2,
+        base: 6,
+        depends: 30,
+    },
+    RtcCalibEntry {
+        begin_bit: 191,
+        length: 6,
+        multiplier: 2,
+        base: 13,
+        depends: 31,
+    },
+];
+
+fn signed_bit_to_int(number: u32, len: u32) -> i32 {
+    if number >> (len - 1) != 0 {
+        -((number ^ (1 << (len - 1))) as i32)
+    } else {
+        number as i32
+    }
+}
+
+fn rtc_calib_tag(version: u8, unit: u8, atten: Attenuation, param: RtcCalibParam) -> Option<u8> {
+    let atten = atten as u8;
+    let offset = match (version, param) {
+        (1, RtcCalibParam::Vlow) => 1,
+        (1, RtcCalibParam::Vhigh) => 9,
+        (2, RtcCalibParam::Vhigh) => 17,
+        (2, RtcCalibParam::Vinit) => 25,
+        _ => return None,
+    };
+    Some(offset + unit * 4 + atten)
+}
+
+fn rtc_calib_parsed(tag: u8, skip_efuse: bool) -> i32 {
+    if tag == 0 {
+        return 0;
+    }
+    let entry = &RTC_CALIB_MAP[tag as usize];
+    let raw = if skip_efuse {
+        0
+    } else {
+        let field = crate::efuse::EfuseField::new(
+            2,
+            (entry.begin_bit as u32) / 32,
+            entry.begin_bit as u32,
+            entry.length as u32,
+        );
+        let bits = super::read_field_le::<u32>(field);
+        signed_bit_to_int(bits, entry.length as u32) * i32::from(entry.multiplier)
+    };
+    raw + i32::from(entry.base) + rtc_calib_parsed(entry.depends, skip_efuse)
+}
+
+/// Reads a parsed RTC calibration table value.
+///
+/// See <https://github.com/espressif/esp-idf/blob/027613140/components/efuse/esp32s2/esp_efuse_rtc_table.c#L145>
+#[instability::unstable]
+pub fn rtc_calib_reading(version: u8, unit: u8, atten: Attenuation, param: RtcCalibParam) -> i32 {
+    rtc_calib_reading_inner(version, unit, atten, param, false)
+}
+
+pub(crate) fn rtc_calib_reading_inner(
+    version: u8,
+    unit: u8,
+    atten: Attenuation,
+    param: RtcCalibParam,
+    skip_efuse: bool,
+) -> i32 {
+    rtc_calib_tag(version, unit, atten, param)
+        .map(|tag| rtc_calib_parsed(tag, skip_efuse))
+        .unwrap_or(0)
+}
+
+/// Get version of RTC calibration block
+///
+/// See <https://github.com/espressif/esp-idf/blob/027613140/components/efuse/esp32s2/esp_efuse_rtc_table.c#L92>
+#[instability::unstable]
+pub fn rtc_calib_version() -> u8 {
+    super::read_field_le::<u8>(BLK_VERSION_MINOR)
+}
+
+/// Get ADC initial code for specified attenuation from efuse
+#[instability::unstable]
+pub fn rtc_calib_init_code(unit: AdcCalibUnit, atten: Attenuation) -> Option<u16> {
+    if rtc_calib_version() != 2 {
+        return None;
+    }
+    Some(rtc_calib_reading(2, unit.index(), atten, RtcCalibParam::Vinit) as u16)
+}
+
+/// Get ADC reference point voltage for specified attenuation in millivolts
+#[instability::unstable]
+pub fn rtc_calib_cal_mv(_unit: AdcCalibUnit, atten: Attenuation) -> u16 {
+    match atten {
+        Attenuation::_0dB => 600,
+        Attenuation::_2p5dB => 800,
+        Attenuation::_6dB => 1000,
+        Attenuation::_11dB => 2000,
+    }
+}
+
+/// Get ADC reference point digital code for specified attenuation
+#[instability::unstable]
+pub fn rtc_calib_cal_code(unit: AdcCalibUnit, atten: Attenuation) -> Option<u16> {
+    if rtc_calib_version() != 2 {
+        return None;
+    }
+    Some(rtc_calib_reading(2, unit.index(), atten, RtcCalibParam::Vhigh) as u16)
+}
 
 /// Get status of SPI boot encryption.
 #[instability::unstable]

--- a/qa-test/src/bin/embassy_adc.rs
+++ b/qa-test/src/bin/embassy_adc.rs
@@ -15,7 +15,7 @@
 use embassy_executor::Spawner;
 use esp_backtrace as _;
 #[cfg(not(feature = "esp32s31"))]
-use esp_hal::analog::adc::AdcCalBasic;
+use esp_hal::analog::adc::AdcCalLine;
 use esp_hal::{
     analog::adc::{Adc, AdcConfig, Attenuation},
     delay::Delay,
@@ -44,7 +44,7 @@ async fn main(_spawner: Spawner) {
     let mut pin1 = cfg_select! {
         feature = "esp32s31" => adc1_config.enable_pin(adc1_pin, Attenuation::_11dB),
         _ => adc1_config
-            .enable_pin_with_cal::<_, AdcCalBasic<esp_hal::peripherals::ADC1<'static>>>(
+            .enable_pin_with_cal::<_, AdcCalLine<esp_hal::peripherals::ADC1<'static>>>(
                 adc1_pin,
                 Attenuation::_11dB,
             ),


### PR DESCRIPTION
Closes #6145

# Changelog

## esp-hal/ADC

- Added: ADC calibration data v2 for ESP32-C6
- Added: Line-fitting calibration schemes for ESP32 and ESP32-S2