### PR TITLE
ci: update xtensa toolchain to 1.98.0.0

### DIFF
--- a/.github/actions/setup-toolchains/action.yml
+++ b/.github/actions/setup-toolchains/action.yml
@@ -10,7 +10,7 @@ inputs:
   current-xtensa-version:
     description: Xtensa Rust release for the "current" channel.
     required: false
-    default: "1.97.0.0"
+    default: "1.98.0.0"
   xtensa:
     description: When "true", install the Xtensa toolchain.
     required: false

--- a/.github/workflows/api-baseline-generation.yml
+++ b/.github/workflows/api-baseline-generation.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Install xtensa toolchain
         uses: esp-rs/xtensa-toolchain@v1.6
         with:
-          version: 1.97.0.0
+          version: 1.98.0.0
 
       - name: Check if baseline generation is needed
         id: check-generation

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -39,7 +39,7 @@ reqwest = { version = "0.12.12", features = [
 ], optional = true }
 
 # This pulls a gazillion crates - don't include it by default
-cargo-semver-checks = { version = "0.46.0", optional = true }
+cargo-semver-checks = { version = "0.49.0", optional = true }
 
 flate2 = { version = "1.1.1", optional = true }
 temp-file = { version = "0.1.9", optional = true }


### PR DESCRIPTION
Update cargo-semver-checks so API checks support rustdoc JSON v60.

Draft until the release is out the door.

## Attention

Will require a regen of the baselines (at the current commit for each crate, post merge)