### PR TITLE
ESP32: Don't offload TX checksum generation to hardware

### DIFF
--- a/esp-hal/src/ethernet/dma.rs
+++ b/esp-hal/src/ethernet/dma.rs
@@ -23,8 +23,9 @@ pub const TDES0_IC: u32 = 1 << 30;
 pub const TDES0_LS: u32 = 1 << 29;
 /// TX first-segment flag.
 pub const TDES0_FS: u32 = 1 << 28;
-/// TX checksum insertion control: 3 = IP Header checksum and payload checksum calculation
-/// and insertion are enabled, and pseudo-header checksum is calculated in hardware.
+/// TX checksum insertion control: 3 = IP header and payload checksum calculation
+/// and insertion are enabled, and the pseudo-header checksum is calculated in hardware.
+#[cfg(not(esp32))]
 pub const TDES0_CIC_FULL: u32 = 3 << 22;
 /// TX second-address-chained mode (next descriptor pointer in TDES3).
 pub const TDES0_CHAINED: u32 = 1 << 20;
@@ -139,9 +140,10 @@ impl TDes {
 
     fn set_len_and_flags(&mut self, len: usize) {
         self.tdes1.set(len as u32 & RDES1_BUF1_SIZE_MASK);
-        self.tdes0.set(
-            (self.tdes0.get() & TDES0_CHAINED) | TDES0_FS | TDES0_LS | TDES0_IC | TDES0_CIC_FULL,
-        );
+        // ESP32: leave CIC at 0; the GMAC TX checksum engine is incorrect.
+        let cic = if cfg!(esp32) { 0 } else { TDES0_CIC_FULL };
+        self.tdes0
+            .set((self.tdes0.get() & TDES0_CHAINED) | TDES0_FS | TDES0_LS | TDES0_IC | cic);
     }
 
     fn set_buffer_addr(&mut self, addr: *const u8) {

--- a/esp-hal/src/ethernet/embassy_net.rs
+++ b/esp-hal/src/ethernet/embassy_net.rs
@@ -153,13 +153,18 @@ impl<'d, P: Phy> Driver for Ethernet<'d, Async, P> {
         let mut caps = Capabilities::default();
         caps.max_transmission_unit = MTU;
         caps.max_burst_size = Some(self.tx.len());
-        // Checksums are offloaded to hardware in both directions (RX COE + TX
-        // insertion via the descriptor CIC bits), so smoltcp does neither.
-        caps.checksum.ipv4 = Checksum::None;
-        caps.checksum.tcp = Checksum::None;
-        caps.checksum.udp = Checksum::None;
-        caps.checksum.icmpv4 = Checksum::None;
-        caps.checksum.icmpv6 = Checksum::None;
+        // RX checksum verification stays in hardware (MAC IPC / COE) on both chips.
+        // ESP32: the GMAC TX engine writes incorrect TCP/UDP checksums, so smoltcp fills them.
+        let tx_checksum = if cfg!(esp32) {
+            Checksum::Tx
+        } else {
+            Checksum::None
+        };
+        caps.checksum.ipv4 = tx_checksum;
+        caps.checksum.tcp = tx_checksum;
+        caps.checksum.udp = tx_checksum;
+        caps.checksum.icmpv4 = tx_checksum;
+        caps.checksum.icmpv6 = tx_checksum;
         caps
     }
 


### PR DESCRIPTION
Closes #6173, needs to be verified. Should probably disable for P4, too, since it cannot do store-and-forward due to a small fifo? https://github.com/jethub-iot/esp-emac-rs also doesn't enable hardware RX checksum offloading.