### PR TITLE
ESP32-P4: set `min-chip-revision` to 300

### DIFF
--- a/esp-hal/esp_config.yml
+++ b/esp-hal/esp_config.yml
@@ -205,6 +205,8 @@ options:
     default:
       - value: 300
         if: "esp32"
+      - value: 300
+        if: "esp32p4"
       - value: 0
 
   - name: use_rwdata_ld_hook


### PR DESCRIPTION
We do it already for ESP32, so why not for P4
