### PR TITLE
32,C2: Fix RC_FAST calibration

### DIFF
--- a/esp-hal/src/soc/esp32/clocks.rs
+++ b/esp-hal/src/soc/esp32/clocks.rs
@@ -136,20 +136,11 @@ fn detect_xtal_freq(clocks: &mut ClockTree) -> XtalClkConfig {
     // imprecise for reliable detection.
     const CALIBRATION_CYCLES: u32 = 10;
 
-    // The digital path for RC_FAST_D256 must be enabled for TIMG calibration to work.
-    LPWR::regs()
-        .clk_conf()
-        .modify(|_, w| w.dig_clk8m_d256_en().set_bit());
-
     let (xtal_cycles, calibration_clock_frequency) = RtcClock::measure_rtc_clock(
         clocks,
         TimgCalibrationClockConfig::RcFastDivClk,
         CALIBRATION_CYCLES,
     );
-
-    LPWR::regs()
-        .clk_conf()
-        .modify(|_, w| w.dig_clk8m_d256_en().clear_bit());
 
     let mhz = (calibration_clock_frequency * xtal_cycles / CALIBRATION_CYCLES).as_mhz();
 
@@ -648,7 +639,9 @@ fn enable_rc_fast_div_clk_impl(_clocks: &mut ClockTree, en: bool) {
     LPWR::regs().clk_conf().modify(|_, w| {
         // Active-low: clear to enable, set to disable.
         w.enb_ck8m_div().bit(!en);
-        w.ck8m_div().div256()
+        w.ck8m_div().div256();
+        // TIMG calibration uses the digital RC_FAST_D256 path, not the analog divider output.
+        w.dig_clk8m_d256_en().bit(en)
     });
 }
 

--- a/esp-hal/src/soc/esp32c2/clocks.rs
+++ b/esp-hal/src/soc/esp32c2/clocks.rs
@@ -120,21 +120,12 @@ fn detect_xtal_freq(clocks: &mut ClockTree) -> XtalClkConfig {
     // imprecise for reliable detection.
     const CALIBRATION_CYCLES: u32 = 10;
 
-    // The digital path for RC_FAST_D256 must be enabled for TIMG calibration to work.
-    LPWR::regs()
-        .clk_conf()
-        .modify(|_, w| w.dig_clk8m_d256_en().set_bit());
-
     let (xtal_cycles, calibration_clock_frequency) = RtcClock::measure_rtc_clock(
         clocks,
         TimgCalibrationClockConfig::RcFastDivClk,
         TimgFunctionClockConfig::XtalClk,
         CALIBRATION_CYCLES,
     );
-
-    LPWR::regs()
-        .clk_conf()
-        .modify(|_, w| w.dig_clk8m_d256_en().clear_bit());
 
     let mhz = (calibration_clock_frequency * xtal_cycles / CALIBRATION_CYCLES).as_mhz();
 
@@ -331,9 +322,12 @@ fn enable_rc_slow_clk_impl(_clocks: &mut ClockTree, en: bool) {
 // RC_FAST_DIV_CLK
 
 fn enable_rc_fast_div_clk_impl(_clocks: &mut ClockTree, en: bool) {
-    LPWR::regs()
-        .clk_conf()
-        .modify(|_, w| w.enb_ck8m_div().bit(!en));
+    LPWR::regs().clk_conf().modify(|_, w| {
+        // Active-low: clear to enable, set to disable.
+        w.enb_ck8m_div().bit(!en);
+        // TIMG calibration uses the digital RC_FAST_D256 path, not the analog divider output.
+        w.dig_clk8m_d256_en().bit(en)
+    });
 }
 
 // SYSTEM_PRE_DIV_IN


### PR DESCRIPTION
xtal detection turned off RC_FAST_D256, causing RC_FAST calibration to never complete.

# Changelog

## esp-hal

- Fixed: ESP32, ESP32-C2: fixed RcFastDivClk calibration on startup