### PR TITLE
Hide XTAL32K and downstream clocks when disabled

### DIFF
--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -26,7 +26,7 @@ check-configs = [
     { features = ["unstable", "rt"], env = { ESP_HAL_CONFIG_PLACE_ANON_IN_RAM = "true", ESP_HAL_CONFIG_PLACE_RMT_DRIVER_IN_RAM = "true", ESP_HAL_CONFIG_PLACE_SPI_MASTER_DRIVER_IN_RAM = "true", ESP_HAL_CONFIG_CLEAR_CRYPTO_SECRETS = "false" } },
     { features = ["unstable", "rt"], env = { ESP_HAL_CONFIG_ENABLE_PMP = "false" }, if = 'riscv && !esp32c2 && !esp32c3' },
     { features = ["unstable", "rt"], env = { ESP_HAL_CONFIG_INIT_STACK_PTR_RANGE_CHECK = "false" } },
-    { features = ["unstable", "rt"], env = { ESP_HAL_CONFIG_USE_XTAL32K = "true" }, if = 'soc_has_xtal32k_pads' },
+    { features = ["unstable", "rt"], env = { ESP_HAL_CONFIG_USE_XTAL32K = "true" }, if = 'soc_has_clock_node_xtal32k_clk' },
     { features = ["unstable", "rt", "__usb_otg"],   if = 'usb_otg_driver_supported' },
     { features = ["unstable", "rt", "__bluetooth"], if = 'bt_driver_supported' },
     { features = ["unstable", "rt", "__sdmmc"],     if = 'sdmmc_driver_supported' },

--- a/esp-hal/esp_config.yml
+++ b/esp-hal/esp_config.yml
@@ -233,7 +233,7 @@ options:
       When disabled (default), XTAL32K stays off so those pins can be used as hi-Z GPIO."
     default:
       - value: false
-    active: "soc_has_xtal32k_pads"
+    active: "soc_has_clock_node_xtal32k_clk"
 
   - name: enable-pmp
     description: "Protects additional memory regions via Physical Memory Protection (PMP). (Only RISC-V other than ESP32-C2/C3)"

--- a/esp-hal/src/clock/mod.rs
+++ b/esp-hal/src/clock/mod.rs
@@ -155,7 +155,7 @@ impl RtcClock {
     /// issue, or lack of 32 XTAL on board).
     #[cfg(soc_has_clock_node_timg_calibration_clock)]
     pub(crate) fn calibrate(cal_clk: TimgCalibrationClockConfig, slowclk_cycles: u32) -> u32 {
-        #[cfg(not(esp32c2))]
+        #[cfg(use_xtal32k)]
         if cal_clk == TimgCalibrationClockConfig::Xtal32kClk {
             debug!("Assuming Xtal32k has precisely 32.768kHz instead of calibrating");
             let freq_hz: u64 = 32_768;
@@ -462,7 +462,7 @@ pub(crate) fn calibrate_rtc_slow_clock() {
             let slow_clk = match unwrap!(ClockTree::with(clocks::rtc_slow_clk_config)) {
                 RtcSlowClkConfig::RcFast => TimgCalibrationClockConfig::RcFastDivClk,
                 RtcSlowClkConfig::RcSlow => TimgCalibrationClockConfig::RcSlowClk,
-                #[cfg(not(esp32c2))]
+                #[cfg(use_xtal32k)]
                 RtcSlowClkConfig::Xtal32k => TimgCalibrationClockConfig::Xtal32kClk,
                 #[cfg(esp32c2)]
                 RtcSlowClkConfig::OscSlow => TimgCalibrationClockConfig::Osc32kClk,
@@ -471,8 +471,11 @@ pub(crate) fn calibrate_rtc_slow_clock() {
         soc_has_clock_node_lp_slow_clk => {
             let slow_clk = match unwrap!(ClockTree::with(clocks::lp_slow_clk_config)) {
                 // on S31, clock can not be calibrated to get OSC_SLOW actual frequency
-                #[cfg(not(esp32s31))]
+                #[cfg(all(not(esp32s31), use_xtal32k))]
                 LpSlowClkConfig::OscSlow => TimgCalibrationClockConfig::Xtal32kClk, //?
+                #[cfg(all(not(esp32s31), not(use_xtal32k)))]
+                LpSlowClkConfig::OscSlow => TimgCalibrationClockConfig::RcSlowClk,
+                #[cfg(use_xtal32k)]
                 LpSlowClkConfig::Xtal32k => TimgCalibrationClockConfig::Xtal32kClk,
                 LpSlowClkConfig::RcSlow => TimgCalibrationClockConfig::RcSlowClk,
             };

--- a/esp-hal/src/rtc_cntl/rtc/esp32c5.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32c5.rs
@@ -114,6 +114,7 @@ impl From<LpSlowClkConfig> for ModemClockLpclkSource {
     fn from(src: LpSlowClkConfig) -> Self {
         match src {
             LpSlowClkConfig::RcSlow => Self::RcSlow,
+            #[cfg(use_xtal32k)]
             LpSlowClkConfig::Xtal32k => Self::XTAL32K,
             LpSlowClkConfig::OscSlow => Self::EXT32K,
         }

--- a/esp-hal/src/rtc_cntl/rtc/esp32c6.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32c6.rs
@@ -111,6 +111,7 @@ impl From<LpSlowClkConfig> for ModemClockLpclkSource {
     fn from(src: LpSlowClkConfig) -> Self {
         match src {
             LpSlowClkConfig::RcSlow => Self::RcSlow,
+            #[cfg(use_xtal32k)]
             LpSlowClkConfig::Xtal32k => Self::XTAL32K,
             LpSlowClkConfig::OscSlow => Self::EXT32K,
         }

--- a/esp-hal/src/rtc_cntl/rtc/esp32c61.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32c61.rs
@@ -114,6 +114,7 @@ impl From<LpSlowClkConfig> for ModemClockLpclkSource {
     fn from(src: LpSlowClkConfig) -> Self {
         match src {
             LpSlowClkConfig::RcSlow => Self::RcSlow,
+            #[cfg(use_xtal32k)]
             LpSlowClkConfig::Xtal32k => Self::XTAL32K,
             LpSlowClkConfig::OscSlow => Self::EXT32K,
         }

--- a/esp-hal/src/rtc_cntl/rtc/esp32s31.rs
+++ b/esp-hal/src/rtc_cntl/rtc/esp32s31.rs
@@ -616,10 +616,14 @@ pub(crate) fn configure_wifi_lp_clock(config: &ClockConfig) {
         w.clk_wifipwr_lp_sel_xtal32k().clear_bit();
         match source {
             LpSlowClkConfig::RcSlow => w.clk_wifipwr_lp_sel_osc_slow().set_bit(),
+            #[cfg(use_xtal32k)]
             LpSlowClkConfig::Xtal32k => w.clk_wifipwr_lp_sel_xtal32k().set_bit(),
         }
     });
-    if source == LpSlowClkConfig::Xtal32k {
+    if cfg_select! {
+        use_xtal32k => source == LpSlowClkConfig::Xtal32k,
+        _ => false,
+    } {
         // The WiFi 32 kHz selector feeds from the shared modem 32 kHz mux.
         // MODEM_CLOCK_XTAL32K_CODE is 0 on S31.
         lpcon

--- a/esp-hal/src/rtc_cntl/sleep/esp32c5.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c5.rs
@@ -9,7 +9,7 @@ use crate::{
         sleep::{SleepKind, pmu_common::SleepTimeConfig},
     },
     soc::{
-        clocks::{self, ClockTree, HpRootClkConfig, LpSlowClkConfig},
+        clocks::{self, ClockTree, HpRootClkConfig},
         xtal32k,
     },
 };
@@ -729,12 +729,15 @@ impl RtcSleepConfig {
 
     /// Finalize power-down flags, apply configuration based on the flags.
     pub(crate) fn apply(&mut self) {
-        let lp_slow_uses_xtal32k = ClockTree::with(|clocks| {
-            matches!(
-                clocks::lp_slow_clk_config(clocks),
-                Some(LpSlowClkConfig::Xtal32k)
-            )
-        });
+        let lp_slow_uses_xtal32k = cfg_select! {
+            use_xtal32k => ClockTree::with(|clocks| {
+                matches!(
+                    clocks::lp_slow_clk_config(clocks),
+                    Some(clocks::LpSlowClkConfig::Xtal32k)
+                )
+            }),
+            _ => false,
+        };
 
         if self.deep {
             // force-disable certain power domains

--- a/esp-hal/src/rtc_cntl/sleep/esp32c6.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c6.rs
@@ -9,7 +9,7 @@ use crate::{
         sleep::{SleepKind, pmu_common::SleepTimeConfig},
     },
     soc::{
-        clocks::{self, ClockTree, LpSlowClkConfig, SocRootClkConfig},
+        clocks::{self, ClockTree, SocRootClkConfig},
         xtal32k,
     },
 };
@@ -703,12 +703,15 @@ impl RtcSleepConfig {
 
     /// Finalize power-down flags, apply configuration based on the flags.
     pub(crate) fn apply(&mut self) {
-        let lp_slow_uses_xtal32k = ClockTree::with(|clocks| {
-            matches!(
-                clocks::lp_slow_clk_config(clocks),
-                Some(LpSlowClkConfig::Xtal32k)
-            )
-        });
+        let lp_slow_uses_xtal32k = cfg_select! {
+            use_xtal32k => ClockTree::with(|clocks| {
+                matches!(
+                    clocks::lp_slow_clk_config(clocks),
+                    Some(clocks::LpSlowClkConfig::Xtal32k)
+                )
+            }),
+            _ => false,
+        };
 
         if self.deep {
             // force-disable certain power domains

--- a/esp-hal/src/rtc_cntl/sleep/esp32c61.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32c61.rs
@@ -9,7 +9,7 @@ use crate::{
         sleep::{SleepKind, pmu_common::SleepTimeConfig},
     },
     soc::{
-        clocks::{self, ClockTree, HpRootClkConfig, LpSlowClkConfig},
+        clocks::{self, ClockTree, HpRootClkConfig},
         xtal32k,
     },
 };
@@ -731,12 +731,15 @@ impl RtcSleepConfig {
 
     /// Finalize power-down flags, apply configuration based on the flags.
     pub(crate) fn apply(&mut self) {
-        let lp_slow_uses_xtal32k = ClockTree::with(|clocks| {
-            matches!(
-                clocks::lp_slow_clk_config(clocks),
-                Some(LpSlowClkConfig::Xtal32k)
-            )
-        });
+        let lp_slow_uses_xtal32k = cfg_select! {
+            use_xtal32k => ClockTree::with(|clocks| {
+                matches!(
+                    clocks::lp_slow_clk_config(clocks),
+                    Some(clocks::LpSlowClkConfig::Xtal32k)
+                )
+            }),
+            _ => false,
+        };
 
         if self.deep {
             // force-disable certain power domains

--- a/esp-hal/src/rtc_cntl/sleep/esp32h2.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32h2.rs
@@ -9,7 +9,7 @@ use crate::{
         sleep::{SleepKind, pmu_common::SleepTimeConfig},
     },
     soc::{
-        clocks::{self, ClockTree, CpuClkConfig, HpRootClkConfig, LpSlowClkConfig},
+        clocks::{self, ClockTree, CpuClkConfig, HpRootClkConfig},
         xtal32k,
     },
 };
@@ -497,12 +497,15 @@ impl RtcSleepConfig {
 
     /// Finalize power-down flags, apply configuration based on the flags.
     pub(crate) fn apply(&mut self) {
-        let lp_slow_uses_xtal32k = ClockTree::with(|clocks| {
-            matches!(
-                clocks::lp_slow_clk_config(clocks),
-                Some(LpSlowClkConfig::Xtal32k)
-            )
-        });
+        let lp_slow_uses_xtal32k = cfg_select! {
+            use_xtal32k => ClockTree::with(|clocks| {
+                matches!(
+                    clocks::lp_slow_clk_config(clocks),
+                    Some(clocks::LpSlowClkConfig::Xtal32k)
+                )
+            }),
+            _ => false,
+        };
 
         if self.deep {
             // force-disable certain power domains

--- a/esp-hal/src/rtc_cntl/sleep/esp32p4.rs
+++ b/esp-hal/src/rtc_cntl/sleep/esp32p4.rs
@@ -17,7 +17,7 @@ use crate::{
         rtc::{HpAnalog, HpSysCntlReg, HpSysPower, LpAnalog, LpSysPower},
         sleep::{SleepKind, pmu_common::SleepTimeConfig},
     },
-    soc::clocks::{self, ClockTree, CpuRootClkConfig, LpSlowClkConfig},
+    soc::clocks::{self, ClockTree, CpuRootClkConfig},
 };
 
 // ----------------------------------------------------------------------------
@@ -878,12 +878,15 @@ impl RtcSleepConfig {
 
     /// Finalize power-down flags, apply configuration based on the flags.
     pub(crate) fn apply(&mut self) {
-        let lp_slow_uses_xtal32k = ClockTree::with(|clocks| {
-            matches!(
-                clocks::lp_slow_clk_config(clocks),
-                Some(LpSlowClkConfig::Xtal32k)
-            )
-        });
+        let lp_slow_uses_xtal32k = cfg_select! {
+            use_xtal32k => ClockTree::with(|clocks| {
+                matches!(
+                    clocks::lp_slow_clk_config(clocks),
+                    Some(clocks::LpSlowClkConfig::Xtal32k)
+                )
+            }),
+            _ => false,
+        };
 
         if self.deep {
             self.pd_flags.set_pd_top(true);

--- a/esp-hal/src/soc/esp32/clocks.rs
+++ b/esp-hal/src/soc/esp32/clocks.rs
@@ -17,10 +17,12 @@
 
 use esp_rom_sys::rom::{ets_delay_us, ets_update_cpu_frequency_rom};
 
+#[cfg(use_xtal32k)]
+use crate::peripherals::RTC_IO;
 use crate::{
     clock::RtcClock,
     efuse::VOL_LEVEL_HP_INV,
-    peripherals::{APB_CTRL, LPWR, RMT, RTC_IO, SYSTEM, TIMG0},
+    peripherals::{APB_CTRL, LPWR, RMT, SYSTEM, TIMG0},
     rtc_cntl::Rtc,
     soc::{regi2c, xtal32k},
     time::Rate,
@@ -595,6 +597,7 @@ fn enable_apb_clk_80m_impl(_clocks: &mut ClockTree, _en: bool) {
 
 // XTAL32K_CLK
 
+#[cfg(use_xtal32k)]
 fn enable_xtal32k_clk_impl(_clocks: &mut ClockTree, en: bool) {
     // RTCIO could be configured to allow an external oscillator to be used. We could model this
     // with a MUX, probably, but this is omitted for now for simplicity.
@@ -671,6 +674,7 @@ fn configure_rtc_slow_clk_impl(
 ) {
     LPWR::regs().clk_conf().modify(|_, w| match new_config {
         RtcSlowClkConfig::RcSlow => w.ana_clk_rtc_sel().slow_ck(),
+        #[cfg(use_xtal32k)]
         RtcSlowClkConfig::Xtal32k => w.ana_clk_rtc_sel().ck_xtal_32k(),
         RtcSlowClkConfig::RcFast => w.ana_clk_rtc_sel().ck8m_d256_out(),
     });
@@ -728,6 +732,7 @@ fn configure_timg_calibration_clock_impl(
         w.rtc_cali_clk_sel().bits(match new_config {
             TimgCalibrationClockConfig::RcSlowClk => 0,
             TimgCalibrationClockConfig::RcFastDivClk => 1,
+            #[cfg(use_xtal32k)]
             TimgCalibrationClockConfig::Xtal32kClk => 2,
         })
     });

--- a/esp-hal/src/soc/esp32c3/clocks.rs
+++ b/esp-hal/src/soc/esp32c3/clocks.rs
@@ -252,6 +252,7 @@ fn enable_rc_fast_clk_impl(_clocks: &mut ClockTree, en: bool) {
 
 // XTAL32K_CLK
 
+#[cfg(use_xtal32k)]
 fn enable_xtal32k_clk_impl(_clocks: &mut ClockTree, en: bool) {
     // RTCIO could be configured to allow an external oscillator to be used. We could model this
     // with a MUX, probably, but this is omitted for now for simplicity.
@@ -487,6 +488,7 @@ fn configure_rtc_slow_clk_impl(
     LPWR::regs().clk_conf().modify(|_, w| unsafe {
         // TODO: variants should be in PAC
         w.ana_clk_rtc_sel().bits(match new_config {
+            #[cfg(use_xtal32k)]
             RtcSlowClkConfig::Xtal32k => 1,
             RtcSlowClkConfig::RcSlow => 0,
             RtcSlowClkConfig::RcFast => 2,
@@ -535,8 +537,12 @@ fn configure_low_power_clk_impl(
             .bit(new_config == LowPowerClkConfig::RtcSlow);
         w.lpclk_sel_xtal()
             .bit(new_config == LowPowerClkConfig::Xtal);
-        w.lpclk_sel_xtal32k()
-            .bit(new_config == LowPowerClkConfig::Xtal32k)
+        w.lpclk_sel_xtal32k().bit({
+            cfg_select! {
+                use_xtal32k => new_config == LowPowerClkConfig::Xtal32k,
+                _ => false,
+            }
+        })
     });
 }
 
@@ -575,6 +581,7 @@ fn configure_timg_calibration_clock_impl(
         w.rtc_cali_clk_sel().bits(match new_config {
             TimgCalibrationClockConfig::RcSlowClk => 0,
             TimgCalibrationClockConfig::RcFastDivClk => 1,
+            #[cfg(use_xtal32k)]
             TimgCalibrationClockConfig::Xtal32kClk => 2,
         })
     });

--- a/esp-hal/src/soc/esp32c5/clocks.rs
+++ b/esp-hal/src/soc/esp32c5/clocks.rs
@@ -227,6 +227,7 @@ fn enable_rc_fast_clk_impl(_clocks: &mut ClockTree, en: bool) {
 
 // XTAL32K_CLK
 
+#[cfg(use_xtal32k)]
 fn enable_xtal32k_clk_impl(_clocks: &mut ClockTree, en: bool) {
     LP_CLKRST::regs()
         .clk_to_hp()
@@ -440,6 +441,7 @@ fn configure_lp_slow_clk_impl(
     LP_CLKRST::regs().lp_clk_conf().modify(|_, w| unsafe {
         w.slow_clk_sel().bits(match new_config {
             LpSlowClkConfig::RcSlow => 0,
+            #[cfg(use_xtal32k)]
             LpSlowClkConfig::Xtal32k => 1,
             // LpSlowClkConfig::Ext32k => 2,
             LpSlowClkConfig::OscSlow => 3,
@@ -496,6 +498,7 @@ fn configure_timg_calibration_clock_impl(
     PCR::regs().ctrl_32k_conf().modify(|_, w| unsafe {
         w._32k_sel().bits(match new_config {
             TimgCalibrationClockConfig::OscSlowClk => 0,
+            #[cfg(use_xtal32k)]
             TimgCalibrationClockConfig::Xtal32kClk => 1,
             // TimgCalibrationClockConfig::Ext32kClk => 2,
             TimgCalibrationClockConfig::RcSlowClk => 3,

--- a/esp-hal/src/soc/esp32c6/clocks.rs
+++ b/esp-hal/src/soc/esp32c6/clocks.rs
@@ -210,6 +210,7 @@ fn enable_rc_fast_clk_impl(_clocks: &mut ClockTree, en: bool) {
 
 // XTAL32K_CLK
 
+#[cfg(use_xtal32k)]
 fn enable_xtal32k_clk_impl(_clocks: &mut ClockTree, en: bool) {
     LP_CLKRST::regs().xtal32k().write(|w| unsafe {
         w.dac_xtal32k().bits(3);
@@ -539,6 +540,7 @@ fn configure_lp_slow_clk_impl(
 ) {
     LP_CLKRST::regs().lp_clk_conf().modify(|_, w| unsafe {
         w.slow_clk_sel().bits(match new_config {
+            #[cfg(use_xtal32k)]
             LpSlowClkConfig::Xtal32k => 1,
             LpSlowClkConfig::RcSlow => 0,
             LpSlowClkConfig::OscSlow => 2,
@@ -562,6 +564,7 @@ fn configure_timg_calibration_clock_impl(
         w.rtc_cali_clk_sel().bits(match new_config {
             TimgCalibrationClockConfig::RcSlowClk => 0,
             TimgCalibrationClockConfig::RcFastDivClk => 1,
+            #[cfg(use_xtal32k)]
             TimgCalibrationClockConfig::Xtal32kClk => 2,
         })
     });

--- a/esp-hal/src/soc/esp32c61/clocks.rs
+++ b/esp-hal/src/soc/esp32c61/clocks.rs
@@ -179,6 +179,7 @@ fn enable_rc_fast_clk_impl(_clocks: &mut ClockTree, en: bool) {
 
 // XTAL32K_CLK
 
+#[cfg(use_xtal32k)]
 fn enable_xtal32k_clk_impl(_clocks: &mut ClockTree, en: bool) {
     LP_CLKRST::regs()
         .clk_to_hp()
@@ -375,6 +376,7 @@ fn configure_lp_slow_clk_impl(
     LP_CLKRST::regs().lp_clk_conf().modify(|_, w| unsafe {
         w.slow_clk_sel().bits(match new_config {
             LpSlowClkConfig::RcSlow => 0,
+            #[cfg(use_xtal32k)]
             LpSlowClkConfig::Xtal32k => 1,
             // LpSlowClkConfig::Ext32k => 2,
             LpSlowClkConfig::OscSlow => 3,
@@ -396,6 +398,7 @@ fn configure_timg_calibration_clock_impl(
     PCR::regs().ctrl_32k_conf().modify(|_, w| unsafe {
         w._32k_sel().bits(match new_config {
             TimgCalibrationClockConfig::OscSlowClk => 0,
+            #[cfg(use_xtal32k)]
             TimgCalibrationClockConfig::Xtal32kClk => 1,
             // TimgCalibrationClockConfig::Ext32kClk => 2,
             TimgCalibrationClockConfig::RcSlowClk => 3,

--- a/esp-hal/src/soc/esp32h2/clocks.rs
+++ b/esp-hal/src/soc/esp32h2/clocks.rs
@@ -183,6 +183,7 @@ fn enable_rc_fast_clk_impl(_clocks: &mut ClockTree, en: bool) {
 
 // XTAL32K_CLK
 
+#[cfg(use_xtal32k)]
 fn enable_xtal32k_clk_impl(_clocks: &mut ClockTree, en: bool) {
     PMU::regs()
         .hp_sleep_lp_ck_power()
@@ -222,6 +223,7 @@ fn enable_rc_slow_clk_impl(_clocks: &mut ClockTree, en: bool) {
 
 // PLL_LP_CLK
 
+#[cfg(use_xtal32k)]
 fn enable_pll_lp_clk_impl(_clocks: &mut ClockTree, en: bool) {
     PMU::regs()
         .hp_sleep_lp_ck_power()
@@ -344,6 +346,7 @@ fn configure_lp_fast_clk_impl(
         w.fast_clk_sel().bits(match new_config {
             LpFastClkConfig::RcFastClk => 0,
             LpFastClkConfig::XtalD2Clk => 1,
+            #[cfg(use_xtal32k)]
             LpFastClkConfig::PllLpClk => 2,
         })
     });
@@ -363,6 +366,7 @@ fn configure_lp_slow_clk_impl(
     LP_CLKRST::regs().lp_clk_conf().modify(|_, w| unsafe {
         w.slow_clk_sel().bits(match new_config {
             LpSlowClkConfig::RcSlow => 0,
+            #[cfg(use_xtal32k)]
             LpSlowClkConfig::Xtal32k => 1,
             LpSlowClkConfig::OscSlow => 2,
         })
@@ -385,6 +389,7 @@ fn configure_timg_calibration_clock_impl(
         w.rtc_cali_clk_sel().bits(match new_config {
             TimgCalibrationClockConfig::RcSlowClk => 0,
             TimgCalibrationClockConfig::RcFastDivClk => 1,
+            #[cfg(use_xtal32k)]
             TimgCalibrationClockConfig::Xtal32kClk => 2,
         })
     });

--- a/esp-hal/src/soc/esp32p4/clocks.rs
+++ b/esp-hal/src/soc/esp32p4/clocks.rs
@@ -434,6 +434,7 @@ fn configure_lp_slow_clk_impl(
         .modify(|_, w| unsafe {
             w.lp_aonclkrst_slow_clk_sel().bits(match new_selector {
                 LpSlowClkConfig::RcSlow => 0,
+                #[cfg(use_xtal32k)]
                 LpSlowClkConfig::Xtal32k => 1,
                 // LpSlowClkConfig::Rc32k => 2,
                 LpSlowClkConfig::OscSlow => 3,
@@ -516,6 +517,7 @@ fn enable_lp_slow_clk_impl(_clocks: &mut ClockTree, _en: bool) {}
 
 // Source clock enable/disable stubs (PLLs, oscillators)
 fn enable_rc_fast_clk_impl(_clocks: &mut ClockTree, _en: bool) {}
+#[cfg(use_xtal32k)]
 fn enable_xtal32k_clk_impl(_clocks: &mut ClockTree, _en: bool) {}
 fn enable_osc_slow_clk_impl(_clocks: &mut ClockTree, _en: bool) {}
 fn enable_rc_slow_clk_impl(_clocks: &mut ClockTree, _en: bool) {}
@@ -638,6 +640,7 @@ fn configure_timg_calibration_clock_impl(
                 TimgCalibrationClockConfig::CpllClk => 2,
                 TimgCalibrationClockConfig::RcFastDivClk => 7,
                 TimgCalibrationClockConfig::RcSlowClk => 8,
+                #[cfg(use_xtal32k)]
                 TimgCalibrationClockConfig::Xtal32kClk => 10,
             })
         });

--- a/esp-hal/src/soc/esp32s2/clocks.rs
+++ b/esp-hal/src/soc/esp32s2/clocks.rs
@@ -502,6 +502,7 @@ fn enable_apb_clk_80m_impl(_clocks: &mut ClockTree, _en: bool) {
 
 // XTAL32K_CLK
 
+#[cfg(use_xtal32k)]
 fn enable_xtal32k_clk_impl(_clocks: &mut ClockTree, en: bool) {
     // This bit only enables the clock for the digital core, what about RTC? Should we split the
     // clock node in two?
@@ -583,6 +584,7 @@ fn configure_rtc_slow_clk_impl(
     LPWR::regs().clk_conf().modify(|_, w| unsafe {
         w.ana_clk_rtc_sel().bits(match new_config {
             RtcSlowClkConfig::RcSlow => 0,
+            #[cfg(use_xtal32k)]
             RtcSlowClkConfig::Xtal32k => 1,
             RtcSlowClkConfig::RcFast => 2,
         })
@@ -644,6 +646,7 @@ fn configure_timg_calibration_clock_impl(
         w.rtc_cali_clk_sel().bits(match new_config {
             TimgCalibrationClockConfig::RtcClk => 0,
             TimgCalibrationClockConfig::RcFastDivClk => 1,
+            #[cfg(use_xtal32k)]
             TimgCalibrationClockConfig::Xtal32kClk => 2,
         })
     });

--- a/esp-hal/src/soc/esp32s3/clocks.rs
+++ b/esp-hal/src/soc/esp32s3/clocks.rs
@@ -280,6 +280,7 @@ fn enable_rc_fast_clk_impl(_clocks: &mut ClockTree, en: bool) {
 
 // XTAL32K_CLK
 
+#[cfg(use_xtal32k)]
 fn enable_xtal32k_clk_impl(_clocks: &mut ClockTree, en: bool) {
     // RTCIO could be configured to allow an external oscillator to be used. We could model this
     // with a MUX, probably, but this is omitted for now for simplicity.
@@ -681,6 +682,7 @@ fn configure_rtc_slow_clk_impl(
     LPWR::regs().clk_conf().modify(|_, w| unsafe {
         // TODO: variants should be in PAC
         w.ana_clk_rtc_sel().bits(match new_config {
+            #[cfg(use_xtal32k)]
             RtcSlowClkConfig::Xtal32k => 1,
             RtcSlowClkConfig::RcSlow => 0,
             RtcSlowClkConfig::RcFast => 2,
@@ -726,8 +728,12 @@ fn configure_low_power_clk_impl(
             .bit(new_config == LowPowerClkConfig::RtcSlow);
         w.lpclk_sel_xtal()
             .bit(new_config == LowPowerClkConfig::Xtal);
-        w.lpclk_sel_xtal32k()
-            .bit(new_config == LowPowerClkConfig::Xtal32k)
+        w.lpclk_sel_xtal32k().bit({
+            cfg_select! {
+                use_xtal32k => new_config == LowPowerClkConfig::Xtal32k,
+                _ => false,
+            }
+        })
     });
 }
 
@@ -766,6 +772,7 @@ fn configure_timg_calibration_clock_impl(
         w.rtc_cali_clk_sel().bits(match new_config {
             TimgCalibrationClockConfig::RcSlowClk => 0,
             TimgCalibrationClockConfig::RcFastDivClk => 1,
+            #[cfg(use_xtal32k)]
             TimgCalibrationClockConfig::Xtal32kClk => 2,
         })
     });

--- a/esp-hal/src/soc/esp32s31/clocks.rs
+++ b/esp-hal/src/soc/esp32s31/clocks.rs
@@ -329,6 +329,7 @@ fn enable_rc_fast_clk_impl(_clocks: &mut ClockTree, en: bool) {
     }
 }
 
+#[cfg(use_xtal32k)]
 fn enable_xtal32k_clk_impl(_clocks: &mut ClockTree, en: bool) {
     if en {
         LP_AON_CLK_RST::regs().xtal32k().modify(|_, w| unsafe {
@@ -483,6 +484,7 @@ fn configure_lp_slow_clk_impl(
         .modify(|_, w| unsafe {
             w.slow_clk_sel().bits(match new {
                 LpSlowClkConfig::RcSlow => 0,
+                #[cfg(use_xtal32k)]
                 LpSlowClkConfig::Xtal32k => 1,
             })
         });
@@ -502,6 +504,7 @@ fn configure_timg_calibration_clock_impl(
     let (source, divider): (u8, u16) = match new {
         TimgCalibrationClockConfig::RcFastDivClk => (7, 50),
         TimgCalibrationClockConfig::RcSlowClk => (8, 1),
+        #[cfg(use_xtal32k)]
         TimgCalibrationClockConfig::Xtal32kClk => (10, 1),
     };
     HP_SYS_CLKRST::regs()

--- a/esp-hal/src/soc/xtal32k.rs
+++ b/esp-hal/src/soc/xtal32k.rs
@@ -17,6 +17,10 @@
 
 /// Whether esp-hal should power and use the external 32 kHz crystal.
 #[inline(always)]
+#[allow(
+    dead_code,
+    reason = "Sleep and RTC code uses this on chips that power-gate XTAL32K."
+)]
 pub(crate) const fn use_xtal32k() -> bool {
     cfg!(use_xtal32k)
 }
@@ -24,19 +28,17 @@ pub(crate) const fn use_xtal32k() -> bool {
 /// The LP slow clock source to select by default.
 #[cfg(soc_has_clock_node_lp_slow_clk)]
 pub(crate) const fn default_lp_slow_clk() -> crate::soc::clocks::LpSlowClkConfig {
-    if use_xtal32k() {
-        crate::soc::clocks::LpSlowClkConfig::Xtal32k
-    } else {
-        crate::soc::clocks::LpSlowClkConfig::RcSlow
+    cfg_select! {
+        use_xtal32k => crate::soc::clocks::LpSlowClkConfig::Xtal32k,
+        _ => crate::soc::clocks::LpSlowClkConfig::RcSlow,
     }
 }
 
 /// The RTC slow clock source to select by default.
 #[cfg(soc_has_clock_node_rtc_slow_clk)]
 pub(crate) const fn default_rtc_slow_clk() -> crate::soc::clocks::RtcSlowClkConfig {
-    if use_xtal32k() {
-        crate::soc::clocks::RtcSlowClkConfig::Xtal32k
-    } else {
-        crate::soc::clocks::RtcSlowClkConfig::RcSlow
+    cfg_select! {
+        use_xtal32k => crate::soc::clocks::RtcSlowClkConfig::Xtal32k,
+        _ => crate::soc::clocks::RtcSlowClkConfig::RcSlow,
     }
 }

--- a/esp-metadata-generated/src/_generated_esp32.rs
+++ b/esp-metadata-generated/src/_generated_esp32.rs
@@ -537,7 +537,7 @@ macro_rules! property {
         crate ::soc::clocks::RefTickConfig::Fosc]
     };
     ("clock_tree.rtc_slow_clk") => {
-        [crate ::soc::clocks::RtcSlowClkConfig::Xtal32k, crate
+        [#[cfg(use_xtal32k)] crate ::soc::clocks::RtcSlowClkConfig::Xtal32k, crate
         ::soc::clocks::RtcSlowClkConfig::RcSlow, crate
         ::soc::clocks::RtcSlowClkConfig::RcFast]
     };
@@ -547,8 +547,8 @@ macro_rules! property {
     };
     ("clock_tree.timg_calibration_clock") => {
         [crate ::soc::clocks::TimgCalibrationClockConfig::RcSlowClk, crate
-        ::soc::clocks::TimgCalibrationClockConfig::RcFastDivClk, crate
-        ::soc::clocks::TimgCalibrationClockConfig::Xtal32kClk]
+        ::soc::clocks::TimgCalibrationClockConfig::RcFastDivClk, #[cfg(use_xtal32k)]
+        crate ::soc::clocks::TimgCalibrationClockConfig::Xtal32kClk]
     };
     ("clock_tree.i2c.function_clock.sclk") => {
         [crate ::soc::clocks::I2cFunctionClockSclk::Apb]
@@ -1074,6 +1074,7 @@ macro_rules! for_each_sw_interrupt {
 ///
 /// // XTAL32K_CLK
 ///
+/// #[cfg(use_xtal32k)]
 /// fn enable_xtal32k_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 ///     todo!()
 /// }
@@ -1555,6 +1556,7 @@ macro_rules! define_clock_tree_types {
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RtcSlowClkConfig {
+            #[cfg(use_xtal32k)]
             /// Selects `XTAL32K_CLK`.
             Xtal32k,
             /// Selects `RC_SLOW_CLK`.
@@ -1587,6 +1589,7 @@ macro_rules! define_clock_tree_types {
             RcSlowClk,
             /// Selects `RC_FAST_DIV_CLK`.
             RcFastDivClk,
+            #[cfg(use_xtal32k)]
             /// Selects `XTAL32K_CLK`.
             Xtal32kClk,
         }
@@ -1736,6 +1739,7 @@ macro_rules! define_clock_tree_types {
             pll_f160m_clk_refcount: u32,
             apb_clk_refcount: u32,
             ref_tick_refcount: u32,
+            #[cfg(use_xtal32k)]
             xtal32k_clk_refcount: u32,
             rc_slow_clk_refcount: u32,
             rc_fast_div_clk_refcount: u32,
@@ -1890,6 +1894,7 @@ macro_rules! define_clock_tree_types {
                 pll_f160m_clk_refcount: 0,
                 apb_clk_refcount: 0,
                 ref_tick_refcount: 0,
+                #[cfg(use_xtal32k)]
                 xtal32k_clk_refcount: 0,
                 rc_slow_clk_refcount: 0,
                 rc_fast_div_clk_refcount: 0,
@@ -2629,6 +2634,7 @@ macro_rules! define_clock_tree_types {
         pub fn apb_clk_80m_source_frequency() -> u32 {
             cpu_clk_frequency()
         }
+        #[cfg(use_xtal32k)]
         pub fn request_xtal32k_clk(clocks: &mut ClockTree) {
             trace!("Requesting XTAL32K_CLK");
             if increment_reference_count(&mut clocks.xtal32k_clk_refcount) {
@@ -2636,6 +2642,7 @@ macro_rules! define_clock_tree_types {
                 enable_xtal32k_clk_impl(clocks, true);
             }
         }
+        #[cfg(use_xtal32k)]
         pub fn release_xtal32k_clk(clocks: &mut ClockTree) {
             trace!("Releasing XTAL32K_CLK");
             if decrement_reference_count(&mut clocks.xtal32k_clk_refcount) {
@@ -2643,6 +2650,7 @@ macro_rules! define_clock_tree_types {
                 enable_xtal32k_clk_impl(clocks, false);
             }
         }
+        #[cfg(use_xtal32k)]
         pub fn xtal32k_clk_frequency() -> u32 {
             32768
         }
@@ -2708,6 +2716,7 @@ macro_rules! define_clock_tree_types {
             refresh_rtc_slow_clk_downstream(clocks);
             if clocks.rtc_slow_clk_refcount > 0 {
                 match new_selector {
+                    #[cfg(use_xtal32k)]
                     RtcSlowClkConfig::Xtal32k => request_xtal32k_clk(clocks),
                     RtcSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
                     RtcSlowClkConfig::RcFast => request_rc_fast_div_clk(clocks),
@@ -2715,6 +2724,7 @@ macro_rules! define_clock_tree_types {
                 configure_rtc_slow_clk_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
                     match old_selector {
+                        #[cfg(use_xtal32k)]
                         RtcSlowClkConfig::Xtal32k => release_xtal32k_clk(clocks),
                         RtcSlowClkConfig::RcSlow => release_rc_slow_clk(clocks),
                         RtcSlowClkConfig::RcFast => release_rc_fast_div_clk(clocks),
@@ -2732,6 +2742,7 @@ macro_rules! define_clock_tree_types {
             if increment_reference_count(&mut clocks.rtc_slow_clk_refcount) {
                 trace!("Enabling RTC_SLOW_CLK");
                 match unwrap!(clocks.rtc_slow_clk) {
+                    #[cfg(use_xtal32k)]
                     RtcSlowClkConfig::Xtal32k => request_xtal32k_clk(clocks),
                     RtcSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
                     RtcSlowClkConfig::RcFast => request_rc_fast_div_clk(clocks),
@@ -2745,6 +2756,7 @@ macro_rules! define_clock_tree_types {
                 trace!("Disabling RTC_SLOW_CLK");
                 enable_rtc_slow_clk_impl(clocks, false);
                 match unwrap!(clocks.rtc_slow_clk) {
+                    #[cfg(use_xtal32k)]
                     RtcSlowClkConfig::Xtal32k => release_xtal32k_clk(clocks),
                     RtcSlowClkConfig::RcSlow => release_rc_slow_clk(clocks),
                     RtcSlowClkConfig::RcFast => release_rc_fast_div_clk(clocks),
@@ -2757,6 +2769,7 @@ macro_rules! define_clock_tree_types {
             config: RtcSlowClkConfig,
         ) -> u32 {
             match config {
+                #[cfg(use_xtal32k)]
                 RtcSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
                 RtcSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
                 RtcSlowClkConfig::RcFast => rc_fast_div_clk_frequency(),
@@ -2767,6 +2780,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn rtc_slow_clk_source_frequency(source: RtcSlowClkConfig) -> u32 {
             match source {
+                #[cfg(use_xtal32k)]
                 RtcSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
                 RtcSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
                 RtcSlowClkConfig::RcFast => rc_fast_div_clk_frequency(),
@@ -2869,6 +2883,7 @@ macro_rules! define_clock_tree_types {
                 match new_selector {
                     TimgCalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
                     TimgCalibrationClockConfig::RcFastDivClk => request_rc_fast_div_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     TimgCalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
                 }
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
@@ -2876,6 +2891,7 @@ macro_rules! define_clock_tree_types {
                     match old_selector {
                         TimgCalibrationClockConfig::RcSlowClk => release_rc_slow_clk(clocks),
                         TimgCalibrationClockConfig::RcFastDivClk => release_rc_fast_div_clk(clocks),
+                        #[cfg(use_xtal32k)]
                         TimgCalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
                     }
                 }
@@ -2896,6 +2912,7 @@ macro_rules! define_clock_tree_types {
                 match unwrap!(clocks.timg_calibration_clock) {
                     TimgCalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
                     TimgCalibrationClockConfig::RcFastDivClk => request_rc_fast_div_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     TimgCalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
                 }
                 enable_timg_calibration_clock_impl(clocks, true);
@@ -2910,6 +2927,7 @@ macro_rules! define_clock_tree_types {
                 match unwrap!(clocks.timg_calibration_clock) {
                     TimgCalibrationClockConfig::RcSlowClk => release_rc_slow_clk(clocks),
                     TimgCalibrationClockConfig::RcFastDivClk => release_rc_fast_div_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     TimgCalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
                 }
             }
@@ -2922,6 +2940,7 @@ macro_rules! define_clock_tree_types {
             match config {
                 TimgCalibrationClockConfig::RcSlowClk => rc_slow_clk_frequency(),
                 TimgCalibrationClockConfig::RcFastDivClk => rc_fast_div_clk_frequency(),
+                #[cfg(use_xtal32k)]
                 TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
             }
         }
@@ -2932,6 +2951,7 @@ macro_rules! define_clock_tree_types {
             match source {
                 TimgCalibrationClockConfig::RcSlowClk => rc_slow_clk_frequency(),
                 TimgCalibrationClockConfig::RcFastDivClk => rc_fast_div_clk_frequency(),
+                #[cfg(use_xtal32k)]
                 TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
             }
         }

--- a/esp-metadata-generated/src/_generated_esp32c3.rs
+++ b/esp-metadata-generated/src/_generated_esp32c3.rs
@@ -516,7 +516,7 @@ macro_rules! property {
         (0, 3)
     };
     ("clock_tree.rtc_slow_clk") => {
-        [crate ::soc::clocks::RtcSlowClkConfig::Xtal32k, crate
+        [#[cfg(use_xtal32k)] crate ::soc::clocks::RtcSlowClkConfig::Xtal32k, crate
         ::soc::clocks::RtcSlowClkConfig::RcSlow, crate
         ::soc::clocks::RtcSlowClkConfig::RcFast]
     };
@@ -526,14 +526,14 @@ macro_rules! property {
     };
     ("clock_tree.low_power_clk") => {
         [crate ::soc::clocks::LowPowerClkConfig::Xtal, crate
-        ::soc::clocks::LowPowerClkConfig::RcFast, crate
+        ::soc::clocks::LowPowerClkConfig::RcFast, #[cfg(use_xtal32k)] crate
         ::soc::clocks::LowPowerClkConfig::Xtal32k, crate
         ::soc::clocks::LowPowerClkConfig::RtcSlow]
     };
     ("clock_tree.timg_calibration_clock") => {
         [crate ::soc::clocks::TimgCalibrationClockConfig::RcSlowClk, crate
-        ::soc::clocks::TimgCalibrationClockConfig::RcFastDivClk, crate
-        ::soc::clocks::TimgCalibrationClockConfig::Xtal32kClk]
+        ::soc::clocks::TimgCalibrationClockConfig::RcFastDivClk, #[cfg(use_xtal32k)]
+        crate ::soc::clocks::TimgCalibrationClockConfig::Xtal32kClk]
     };
     ("clock_tree.timg.function_clock") => {
         [crate ::soc::clocks::TimgFunctionClockConfig::XtalClk, crate
@@ -1192,6 +1192,7 @@ macro_rules! for_each_sw_interrupt {
 ///
 /// // XTAL32K_CLK
 ///
+/// #[cfg(use_xtal32k)]
 /// fn enable_xtal32k_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 ///     todo!()
 /// }
@@ -1682,6 +1683,7 @@ macro_rules! define_clock_tree_types {
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RtcSlowClkConfig {
+            #[cfg(use_xtal32k)]
             /// Selects `XTAL32K_CLK`.
             Xtal32k,
             /// Selects `RC_SLOW_CLK`.
@@ -1706,6 +1708,7 @@ macro_rules! define_clock_tree_types {
             Xtal,
             /// Selects `RC_FAST_CLK`.
             RcFast,
+            #[cfg(use_xtal32k)]
             /// Selects `XTAL32K_CLK`.
             Xtal32k,
             /// Selects `RTC_SLOW_CLK`.
@@ -1727,6 +1730,7 @@ macro_rules! define_clock_tree_types {
             RcSlowClk,
             /// Selects `RC_FAST_DIV_CLK`.
             RcFastDivClk,
+            #[cfg(use_xtal32k)]
             /// Selects `XTAL32K_CLK`.
             Xtal32kClk,
         }
@@ -1916,6 +1920,7 @@ macro_rules! define_clock_tree_types {
             uart_function_clock: [Option<UartFunctionClockConfig>; 2],
             uart_baud_rate_generator: [Option<UartBaudRateGeneratorConfig>; 2],
             rc_fast_clk_refcount: u32,
+            #[cfg(use_xtal32k)]
             xtal32k_clk_refcount: u32,
             rc_slow_clk_refcount: u32,
             rc_fast_div_clk_refcount: u32,
@@ -2061,6 +2066,7 @@ macro_rules! define_clock_tree_types {
                 uart_function_clock: [None; 2],
                 uart_baud_rate_generator: [None; 2],
                 rc_fast_clk_refcount: 0,
+                #[cfg(use_xtal32k)]
                 xtal32k_clk_refcount: 0,
                 rc_slow_clk_refcount: 0,
                 rc_fast_div_clk_refcount: 0,
@@ -2185,6 +2191,7 @@ macro_rules! define_clock_tree_types {
         pub fn rc_fast_clk_frequency() -> u32 {
             17500000
         }
+        #[cfg(use_xtal32k)]
         pub fn request_xtal32k_clk(clocks: &mut ClockTree) {
             trace!("Requesting XTAL32K_CLK");
             if increment_reference_count(&mut clocks.xtal32k_clk_refcount) {
@@ -2192,6 +2199,7 @@ macro_rules! define_clock_tree_types {
                 enable_xtal32k_clk_impl(clocks, true);
             }
         }
+        #[cfg(use_xtal32k)]
         pub fn release_xtal32k_clk(clocks: &mut ClockTree) {
             trace!("Releasing XTAL32K_CLK");
             if decrement_reference_count(&mut clocks.xtal32k_clk_refcount) {
@@ -2199,6 +2207,7 @@ macro_rules! define_clock_tree_types {
                 enable_xtal32k_clk_impl(clocks, false);
             }
         }
+        #[cfg(use_xtal32k)]
         pub fn xtal32k_clk_frequency() -> u32 {
             32768
         }
@@ -2629,6 +2638,7 @@ macro_rules! define_clock_tree_types {
             let old_selector = clocks.rtc_slow_clk.replace(new_selector);
             refresh_rtc_slow_clk_downstream(clocks);
             match new_selector {
+                #[cfg(use_xtal32k)]
                 RtcSlowClkConfig::Xtal32k => request_xtal32k_clk(clocks),
                 RtcSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
                 RtcSlowClkConfig::RcFast => request_rc_fast_div_clk(clocks),
@@ -2636,6 +2646,7 @@ macro_rules! define_clock_tree_types {
             configure_rtc_slow_clk_impl(clocks, old_selector, new_selector);
             if let Some(old_selector) = old_selector {
                 match old_selector {
+                    #[cfg(use_xtal32k)]
                     RtcSlowClkConfig::Xtal32k => release_xtal32k_clk(clocks),
                     RtcSlowClkConfig::RcSlow => release_rc_slow_clk(clocks),
                     RtcSlowClkConfig::RcFast => release_rc_fast_div_clk(clocks),
@@ -2649,6 +2660,7 @@ macro_rules! define_clock_tree_types {
             trace!("Requesting RTC_SLOW_CLK");
             trace!("Enabling RTC_SLOW_CLK");
             match unwrap!(clocks.rtc_slow_clk) {
+                #[cfg(use_xtal32k)]
                 RtcSlowClkConfig::Xtal32k => request_xtal32k_clk(clocks),
                 RtcSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
                 RtcSlowClkConfig::RcFast => request_rc_fast_div_clk(clocks),
@@ -2660,6 +2672,7 @@ macro_rules! define_clock_tree_types {
             trace!("Disabling RTC_SLOW_CLK");
             enable_rtc_slow_clk_impl(clocks, false);
             match unwrap!(clocks.rtc_slow_clk) {
+                #[cfg(use_xtal32k)]
                 RtcSlowClkConfig::Xtal32k => release_xtal32k_clk(clocks),
                 RtcSlowClkConfig::RcSlow => release_rc_slow_clk(clocks),
                 RtcSlowClkConfig::RcFast => release_rc_fast_div_clk(clocks),
@@ -2671,6 +2684,7 @@ macro_rules! define_clock_tree_types {
             config: RtcSlowClkConfig,
         ) -> u32 {
             match config {
+                #[cfg(use_xtal32k)]
                 RtcSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
                 RtcSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
                 RtcSlowClkConfig::RcFast => rc_fast_div_clk_frequency(),
@@ -2681,6 +2695,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn rtc_slow_clk_source_frequency(source: RtcSlowClkConfig) -> u32 {
             match source {
+                #[cfg(use_xtal32k)]
                 RtcSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
                 RtcSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
                 RtcSlowClkConfig::RcFast => rc_fast_div_clk_frequency(),
@@ -2756,6 +2771,7 @@ macro_rules! define_clock_tree_types {
                 match new_selector {
                     LowPowerClkConfig::Xtal => request_xtal_clk(clocks),
                     LowPowerClkConfig::RcFast => request_rc_fast_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     LowPowerClkConfig::Xtal32k => request_xtal32k_clk(clocks),
                     LowPowerClkConfig::RtcSlow => request_rtc_slow_clk(clocks),
                 }
@@ -2764,6 +2780,7 @@ macro_rules! define_clock_tree_types {
                     match old_selector {
                         LowPowerClkConfig::Xtal => release_xtal_clk(clocks),
                         LowPowerClkConfig::RcFast => release_rc_fast_clk(clocks),
+                        #[cfg(use_xtal32k)]
                         LowPowerClkConfig::Xtal32k => release_xtal32k_clk(clocks),
                         LowPowerClkConfig::RtcSlow => release_rtc_slow_clk(clocks),
                     }
@@ -2782,6 +2799,7 @@ macro_rules! define_clock_tree_types {
                 match unwrap!(clocks.low_power_clk) {
                     LowPowerClkConfig::Xtal => request_xtal_clk(clocks),
                     LowPowerClkConfig::RcFast => request_rc_fast_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     LowPowerClkConfig::Xtal32k => request_xtal32k_clk(clocks),
                     LowPowerClkConfig::RtcSlow => request_rtc_slow_clk(clocks),
                 }
@@ -2796,6 +2814,7 @@ macro_rules! define_clock_tree_types {
                 match unwrap!(clocks.low_power_clk) {
                     LowPowerClkConfig::Xtal => release_xtal_clk(clocks),
                     LowPowerClkConfig::RcFast => release_rc_fast_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     LowPowerClkConfig::Xtal32k => release_xtal32k_clk(clocks),
                     LowPowerClkConfig::RtcSlow => release_rtc_slow_clk(clocks),
                 }
@@ -2809,6 +2828,7 @@ macro_rules! define_clock_tree_types {
             match config {
                 LowPowerClkConfig::Xtal => xtal_clk_frequency(),
                 LowPowerClkConfig::RcFast => rc_fast_clk_frequency(),
+                #[cfg(use_xtal32k)]
                 LowPowerClkConfig::Xtal32k => xtal32k_clk_frequency(),
                 LowPowerClkConfig::RtcSlow => rtc_slow_clk_frequency(),
             }
@@ -2820,6 +2840,7 @@ macro_rules! define_clock_tree_types {
             match source {
                 LowPowerClkConfig::Xtal => xtal_clk_frequency(),
                 LowPowerClkConfig::RcFast => rc_fast_clk_frequency(),
+                #[cfg(use_xtal32k)]
                 LowPowerClkConfig::Xtal32k => xtal32k_clk_frequency(),
                 LowPowerClkConfig::RtcSlow => rtc_slow_clk_frequency(),
             }
@@ -2858,6 +2879,7 @@ macro_rules! define_clock_tree_types {
                 match new_selector {
                     TimgCalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
                     TimgCalibrationClockConfig::RcFastDivClk => request_rc_fast_div_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     TimgCalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
                 }
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
@@ -2865,6 +2887,7 @@ macro_rules! define_clock_tree_types {
                     match old_selector {
                         TimgCalibrationClockConfig::RcSlowClk => release_rc_slow_clk(clocks),
                         TimgCalibrationClockConfig::RcFastDivClk => release_rc_fast_div_clk(clocks),
+                        #[cfg(use_xtal32k)]
                         TimgCalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
                     }
                 }
@@ -2885,6 +2908,7 @@ macro_rules! define_clock_tree_types {
                 match unwrap!(clocks.timg_calibration_clock) {
                     TimgCalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
                     TimgCalibrationClockConfig::RcFastDivClk => request_rc_fast_div_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     TimgCalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
                 }
                 enable_timg_calibration_clock_impl(clocks, true);
@@ -2899,6 +2923,7 @@ macro_rules! define_clock_tree_types {
                 match unwrap!(clocks.timg_calibration_clock) {
                     TimgCalibrationClockConfig::RcSlowClk => release_rc_slow_clk(clocks),
                     TimgCalibrationClockConfig::RcFastDivClk => release_rc_fast_div_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     TimgCalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
                 }
             }
@@ -2911,6 +2936,7 @@ macro_rules! define_clock_tree_types {
             match config {
                 TimgCalibrationClockConfig::RcSlowClk => rc_slow_clk_frequency(),
                 TimgCalibrationClockConfig::RcFastDivClk => rc_fast_div_clk_frequency(),
+                #[cfg(use_xtal32k)]
                 TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
             }
         }
@@ -2921,6 +2947,7 @@ macro_rules! define_clock_tree_types {
             match source {
                 TimgCalibrationClockConfig::RcSlowClk => rc_slow_clk_frequency(),
                 TimgCalibrationClockConfig::RcFastDivClk => rc_fast_div_clk_frequency(),
+                #[cfg(use_xtal32k)]
                 TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
             }
         }

--- a/esp-metadata-generated/src/_generated_esp32c5.rs
+++ b/esp-metadata-generated/src/_generated_esp32c5.rs
@@ -559,7 +559,7 @@ macro_rules! property {
         ::soc::clocks::LpFastClkConfig::Xtal]
     };
     ("clock_tree.lp_slow_clk") => {
-        [crate ::soc::clocks::LpSlowClkConfig::RcSlow, crate
+        [crate ::soc::clocks::LpSlowClkConfig::RcSlow, #[cfg(use_xtal32k)] crate
         ::soc::clocks::LpSlowClkConfig::Xtal32k, crate
         ::soc::clocks::LpSlowClkConfig::OscSlow]
     };
@@ -576,8 +576,8 @@ macro_rules! property {
     ("clock_tree.timg_calibration_clock") => {
         [crate ::soc::clocks::TimgCalibrationClockConfig::OscSlowClk, crate
         ::soc::clocks::TimgCalibrationClockConfig::RcSlowClk, crate
-        ::soc::clocks::TimgCalibrationClockConfig::RcFastDivClk, crate
-        ::soc::clocks::TimgCalibrationClockConfig::Xtal32kClk]
+        ::soc::clocks::TimgCalibrationClockConfig::RcFastDivClk, #[cfg(use_xtal32k)]
+        crate ::soc::clocks::TimgCalibrationClockConfig::Xtal32kClk]
     };
     ("clock_tree.uart.function_clock.sclk") => {
         [crate ::soc::clocks::UartFunctionClockSclk::Xtal, crate
@@ -1330,6 +1330,7 @@ macro_rules! for_each_sw_interrupt {
 ///
 /// // XTAL32K_CLK
 ///
+/// #[cfg(use_xtal32k)]
 /// fn enable_xtal32k_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 ///     todo!()
 /// }
@@ -1841,6 +1842,7 @@ macro_rules! define_clock_tree_types {
         pub enum LpSlowClkConfig {
             /// Selects `RC_SLOW_CLK`.
             RcSlow,
+            #[cfg(use_xtal32k)]
             /// Selects `XTAL32K_CLK`.
             Xtal32k,
             /// Selects `OSC_SLOW_CLK`.
@@ -1879,6 +1881,7 @@ macro_rules! define_clock_tree_types {
             RcSlowClk,
             /// Selects `RC_FAST_CLK`.
             RcFastDivClk,
+            #[cfg(use_xtal32k)]
             /// Selects `XTAL32K_CLK`.
             Xtal32kClk,
         }
@@ -2100,6 +2103,7 @@ macro_rules! define_clock_tree_types {
             uart_baud_rate_generator: [Option<UartBaudRateGeneratorConfig>; 2],
             pll_clk_refcount: u32,
             rc_fast_clk_refcount: u32,
+            #[cfg(use_xtal32k)]
             xtal32k_clk_refcount: u32,
             osc_slow_clk_refcount: u32,
             rc_slow_clk_refcount: u32,
@@ -2250,6 +2254,7 @@ macro_rules! define_clock_tree_types {
                 uart_baud_rate_generator: [None; 2],
                 pll_clk_refcount: 0,
                 rc_fast_clk_refcount: 0,
+                #[cfg(use_xtal32k)]
                 xtal32k_clk_refcount: 0,
                 osc_slow_clk_refcount: 0,
                 rc_slow_clk_refcount: 0,
@@ -2373,6 +2378,7 @@ macro_rules! define_clock_tree_types {
         pub fn rc_fast_clk_frequency() -> u32 {
             20000000
         }
+        #[cfg(use_xtal32k)]
         pub fn request_xtal32k_clk(clocks: &mut ClockTree) {
             trace!("Requesting XTAL32K_CLK");
             if increment_reference_count(&mut clocks.xtal32k_clk_refcount) {
@@ -2380,6 +2386,7 @@ macro_rules! define_clock_tree_types {
                 enable_xtal32k_clk_impl(clocks, true);
             }
         }
+        #[cfg(use_xtal32k)]
         pub fn release_xtal32k_clk(clocks: &mut ClockTree) {
             trace!("Releasing XTAL32K_CLK");
             if decrement_reference_count(&mut clocks.xtal32k_clk_refcount) {
@@ -2387,6 +2394,7 @@ macro_rules! define_clock_tree_types {
                 enable_xtal32k_clk_impl(clocks, false);
             }
         }
+        #[cfg(use_xtal32k)]
         pub fn xtal32k_clk_frequency() -> u32 {
             32768
         }
@@ -2884,6 +2892,7 @@ macro_rules! define_clock_tree_types {
             if clocks.lp_slow_clk_refcount > 0 {
                 match new_selector {
                     LpSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     LpSlowClkConfig::Xtal32k => request_xtal32k_clk(clocks),
                     LpSlowClkConfig::OscSlow => request_osc_slow_clk(clocks),
                 }
@@ -2891,6 +2900,7 @@ macro_rules! define_clock_tree_types {
                 if let Some(old_selector) = old_selector {
                     match old_selector {
                         LpSlowClkConfig::RcSlow => release_rc_slow_clk(clocks),
+                        #[cfg(use_xtal32k)]
                         LpSlowClkConfig::Xtal32k => release_xtal32k_clk(clocks),
                         LpSlowClkConfig::OscSlow => release_osc_slow_clk(clocks),
                     }
@@ -2908,6 +2918,7 @@ macro_rules! define_clock_tree_types {
                 trace!("Enabling LP_SLOW_CLK");
                 match unwrap!(clocks.lp_slow_clk) {
                     LpSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     LpSlowClkConfig::Xtal32k => request_xtal32k_clk(clocks),
                     LpSlowClkConfig::OscSlow => request_osc_slow_clk(clocks),
                 }
@@ -2921,6 +2932,7 @@ macro_rules! define_clock_tree_types {
                 enable_lp_slow_clk_impl(clocks, false);
                 match unwrap!(clocks.lp_slow_clk) {
                     LpSlowClkConfig::RcSlow => release_rc_slow_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     LpSlowClkConfig::Xtal32k => release_xtal32k_clk(clocks),
                     LpSlowClkConfig::OscSlow => release_osc_slow_clk(clocks),
                 }
@@ -2933,6 +2945,7 @@ macro_rules! define_clock_tree_types {
         ) -> u32 {
             match config {
                 LpSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
+                #[cfg(use_xtal32k)]
                 LpSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
                 LpSlowClkConfig::OscSlow => osc_slow_clk_frequency(),
             }
@@ -2943,6 +2956,7 @@ macro_rules! define_clock_tree_types {
         pub fn lp_slow_clk_source_frequency(source: LpSlowClkConfig) -> u32 {
             match source {
                 LpSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
+                #[cfg(use_xtal32k)]
                 LpSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
                 LpSlowClkConfig::OscSlow => osc_slow_clk_frequency(),
             }
@@ -3072,6 +3086,7 @@ macro_rules! define_clock_tree_types {
                     TimgCalibrationClockConfig::OscSlowClk => request_osc_slow_clk(clocks),
                     TimgCalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
                     TimgCalibrationClockConfig::RcFastDivClk => request_rc_fast_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     TimgCalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
                 }
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
@@ -3080,6 +3095,7 @@ macro_rules! define_clock_tree_types {
                         TimgCalibrationClockConfig::OscSlowClk => release_osc_slow_clk(clocks),
                         TimgCalibrationClockConfig::RcSlowClk => release_rc_slow_clk(clocks),
                         TimgCalibrationClockConfig::RcFastDivClk => release_rc_fast_clk(clocks),
+                        #[cfg(use_xtal32k)]
                         TimgCalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
                     }
                 }
@@ -3101,6 +3117,7 @@ macro_rules! define_clock_tree_types {
                     TimgCalibrationClockConfig::OscSlowClk => request_osc_slow_clk(clocks),
                     TimgCalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
                     TimgCalibrationClockConfig::RcFastDivClk => request_rc_fast_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     TimgCalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
                 }
                 enable_timg_calibration_clock_impl(clocks, true);
@@ -3116,6 +3133,7 @@ macro_rules! define_clock_tree_types {
                     TimgCalibrationClockConfig::OscSlowClk => release_osc_slow_clk(clocks),
                     TimgCalibrationClockConfig::RcSlowClk => release_rc_slow_clk(clocks),
                     TimgCalibrationClockConfig::RcFastDivClk => release_rc_fast_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     TimgCalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
                 }
             }
@@ -3129,6 +3147,7 @@ macro_rules! define_clock_tree_types {
                 TimgCalibrationClockConfig::OscSlowClk => osc_slow_clk_frequency(),
                 TimgCalibrationClockConfig::RcSlowClk => rc_slow_clk_frequency(),
                 TimgCalibrationClockConfig::RcFastDivClk => rc_fast_clk_frequency(),
+                #[cfg(use_xtal32k)]
                 TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
             }
         }
@@ -3140,6 +3159,7 @@ macro_rules! define_clock_tree_types {
                 TimgCalibrationClockConfig::OscSlowClk => osc_slow_clk_frequency(),
                 TimgCalibrationClockConfig::RcSlowClk => rc_slow_clk_frequency(),
                 TimgCalibrationClockConfig::RcFastDivClk => rc_fast_clk_frequency(),
+                #[cfg(use_xtal32k)]
                 TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
             }
         }

--- a/esp-metadata-generated/src/_generated_esp32c6.rs
+++ b/esp-metadata-generated/src/_generated_esp32c6.rs
@@ -598,14 +598,14 @@ macro_rules! property {
         ::soc::clocks::LpFastClkConfig::XtalD2Clk]
     };
     ("clock_tree.lp_slow_clk") => {
-        [crate ::soc::clocks::LpSlowClkConfig::Xtal32k, crate
+        [#[cfg(use_xtal32k)] crate ::soc::clocks::LpSlowClkConfig::Xtal32k, crate
         ::soc::clocks::LpSlowClkConfig::RcSlow, crate
         ::soc::clocks::LpSlowClkConfig::OscSlow]
     };
     ("clock_tree.timg_calibration_clock") => {
         [crate ::soc::clocks::TimgCalibrationClockConfig::RcSlowClk, crate
-        ::soc::clocks::TimgCalibrationClockConfig::RcFastDivClk, crate
-        ::soc::clocks::TimgCalibrationClockConfig::Xtal32kClk]
+        ::soc::clocks::TimgCalibrationClockConfig::RcFastDivClk, #[cfg(use_xtal32k)]
+        crate ::soc::clocks::TimgCalibrationClockConfig::Xtal32kClk]
     };
     ("clock_tree.uart.function_clock.sclk") => {
         [crate ::soc::clocks::UartFunctionClockSclk::PllF80m, crate
@@ -1318,6 +1318,7 @@ macro_rules! for_each_sw_interrupt {
 ///
 /// // XTAL32K_CLK
 ///
+/// #[cfg(use_xtal32k)]
 /// fn enable_xtal32k_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 ///     todo!()
 /// }
@@ -2206,6 +2207,7 @@ macro_rules! define_clock_tree_types {
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum LpSlowClkConfig {
+            #[cfg(use_xtal32k)]
             /// Selects `XTAL32K_CLK`.
             Xtal32k,
             /// Selects `RC_SLOW_CLK`.
@@ -2221,6 +2223,7 @@ macro_rules! define_clock_tree_types {
             RcSlowClk,
             /// Selects `RC_FAST_CLK`.
             RcFastDivClk,
+            #[cfg(use_xtal32k)]
             /// Selects `XTAL32K_CLK`.
             Xtal32kClk,
         }
@@ -2461,6 +2464,7 @@ macro_rules! define_clock_tree_types {
             uart_baud_rate_generator: [Option<UartBaudRateGeneratorConfig>; 2],
             pll_clk_refcount: u32,
             rc_fast_clk_refcount: u32,
+            #[cfg(use_xtal32k)]
             xtal32k_clk_refcount: u32,
             hp_root_clk_refcount: u32,
             mspi_fast_clk_refcount: u32,
@@ -2649,6 +2653,7 @@ macro_rules! define_clock_tree_types {
                 uart_baud_rate_generator: [None; 2],
                 pll_clk_refcount: 0,
                 rc_fast_clk_refcount: 0,
+                #[cfg(use_xtal32k)]
                 xtal32k_clk_refcount: 0,
                 hp_root_clk_refcount: 0,
                 mspi_fast_clk_refcount: 0,
@@ -2783,6 +2788,7 @@ macro_rules! define_clock_tree_types {
         pub fn rc_fast_clk_frequency() -> u32 {
             17500000
         }
+        #[cfg(use_xtal32k)]
         pub fn request_xtal32k_clk(clocks: &mut ClockTree) {
             trace!("Requesting XTAL32K_CLK");
             if increment_reference_count(&mut clocks.xtal32k_clk_refcount) {
@@ -2790,6 +2796,7 @@ macro_rules! define_clock_tree_types {
                 enable_xtal32k_clk_impl(clocks, true);
             }
         }
+        #[cfg(use_xtal32k)]
         pub fn release_xtal32k_clk(clocks: &mut ClockTree) {
             trace!("Releasing XTAL32K_CLK");
             if decrement_reference_count(&mut clocks.xtal32k_clk_refcount) {
@@ -2797,6 +2804,7 @@ macro_rules! define_clock_tree_types {
                 enable_xtal32k_clk_impl(clocks, false);
             }
         }
+        #[cfg(use_xtal32k)]
         pub fn xtal32k_clk_frequency() -> u32 {
             32768
         }
@@ -3578,6 +3586,7 @@ macro_rules! define_clock_tree_types {
             let old_selector = clocks.lp_slow_clk.replace(new_selector);
             refresh_lp_slow_clk_downstream(clocks);
             match new_selector {
+                #[cfg(use_xtal32k)]
                 LpSlowClkConfig::Xtal32k => request_xtal32k_clk(clocks),
                 LpSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
                 LpSlowClkConfig::OscSlow => request_osc_slow_clk(clocks),
@@ -3585,6 +3594,7 @@ macro_rules! define_clock_tree_types {
             configure_lp_slow_clk_impl(clocks, old_selector, new_selector);
             if let Some(old_selector) = old_selector {
                 match old_selector {
+                    #[cfg(use_xtal32k)]
                     LpSlowClkConfig::Xtal32k => release_xtal32k_clk(clocks),
                     LpSlowClkConfig::RcSlow => release_rc_slow_clk(clocks),
                     LpSlowClkConfig::OscSlow => release_osc_slow_clk(clocks),
@@ -3598,6 +3608,7 @@ macro_rules! define_clock_tree_types {
             trace!("Requesting LP_SLOW_CLK");
             trace!("Enabling LP_SLOW_CLK");
             match unwrap!(clocks.lp_slow_clk) {
+                #[cfg(use_xtal32k)]
                 LpSlowClkConfig::Xtal32k => request_xtal32k_clk(clocks),
                 LpSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
                 LpSlowClkConfig::OscSlow => request_osc_slow_clk(clocks),
@@ -3609,6 +3620,7 @@ macro_rules! define_clock_tree_types {
             trace!("Disabling LP_SLOW_CLK");
             enable_lp_slow_clk_impl(clocks, false);
             match unwrap!(clocks.lp_slow_clk) {
+                #[cfg(use_xtal32k)]
                 LpSlowClkConfig::Xtal32k => release_xtal32k_clk(clocks),
                 LpSlowClkConfig::RcSlow => release_rc_slow_clk(clocks),
                 LpSlowClkConfig::OscSlow => release_osc_slow_clk(clocks),
@@ -3620,6 +3632,7 @@ macro_rules! define_clock_tree_types {
             config: LpSlowClkConfig,
         ) -> u32 {
             match config {
+                #[cfg(use_xtal32k)]
                 LpSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
                 LpSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
                 LpSlowClkConfig::OscSlow => osc_slow_clk_frequency(),
@@ -3630,6 +3643,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn lp_slow_clk_source_frequency(source: LpSlowClkConfig) -> u32 {
             match source {
+                #[cfg(use_xtal32k)]
                 LpSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
                 LpSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
                 LpSlowClkConfig::OscSlow => osc_slow_clk_frequency(),
@@ -3645,6 +3659,7 @@ macro_rules! define_clock_tree_types {
                 match new_selector {
                     TimgCalibrationClockConfig::RcSlowClk => request_lp_slow_clk(clocks),
                     TimgCalibrationClockConfig::RcFastDivClk => request_rc_fast_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     TimgCalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
                 }
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
@@ -3652,6 +3667,7 @@ macro_rules! define_clock_tree_types {
                     match old_selector {
                         TimgCalibrationClockConfig::RcSlowClk => release_lp_slow_clk(clocks),
                         TimgCalibrationClockConfig::RcFastDivClk => release_rc_fast_clk(clocks),
+                        #[cfg(use_xtal32k)]
                         TimgCalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
                     }
                 }
@@ -3672,6 +3688,7 @@ macro_rules! define_clock_tree_types {
                 match unwrap!(clocks.timg_calibration_clock) {
                     TimgCalibrationClockConfig::RcSlowClk => request_lp_slow_clk(clocks),
                     TimgCalibrationClockConfig::RcFastDivClk => request_rc_fast_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     TimgCalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
                 }
                 enable_timg_calibration_clock_impl(clocks, true);
@@ -3686,6 +3703,7 @@ macro_rules! define_clock_tree_types {
                 match unwrap!(clocks.timg_calibration_clock) {
                     TimgCalibrationClockConfig::RcSlowClk => release_lp_slow_clk(clocks),
                     TimgCalibrationClockConfig::RcFastDivClk => release_rc_fast_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     TimgCalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
                 }
             }
@@ -3698,6 +3716,7 @@ macro_rules! define_clock_tree_types {
             match config {
                 TimgCalibrationClockConfig::RcSlowClk => lp_slow_clk_frequency(),
                 TimgCalibrationClockConfig::RcFastDivClk => rc_fast_clk_frequency(),
+                #[cfg(use_xtal32k)]
                 TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
             }
         }
@@ -3708,6 +3727,7 @@ macro_rules! define_clock_tree_types {
             match source {
                 TimgCalibrationClockConfig::RcSlowClk => lp_slow_clk_frequency(),
                 TimgCalibrationClockConfig::RcFastDivClk => rc_fast_clk_frequency(),
+                #[cfg(use_xtal32k)]
                 TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
             }
         }

--- a/esp-metadata-generated/src/_generated_esp32c61.rs
+++ b/esp-metadata-generated/src/_generated_esp32c61.rs
@@ -474,15 +474,15 @@ macro_rules! property {
         ::soc::clocks::LpFastClkConfig::Xtal]
     };
     ("clock_tree.lp_slow_clk") => {
-        [crate ::soc::clocks::LpSlowClkConfig::RcSlow, crate
+        [crate ::soc::clocks::LpSlowClkConfig::RcSlow, #[cfg(use_xtal32k)] crate
         ::soc::clocks::LpSlowClkConfig::Xtal32k, crate
         ::soc::clocks::LpSlowClkConfig::OscSlow]
     };
     ("clock_tree.timg_calibration_clock") => {
         [crate ::soc::clocks::TimgCalibrationClockConfig::OscSlowClk, crate
         ::soc::clocks::TimgCalibrationClockConfig::RcSlowClk, crate
-        ::soc::clocks::TimgCalibrationClockConfig::RcFastDivClk, crate
-        ::soc::clocks::TimgCalibrationClockConfig::Xtal32kClk]
+        ::soc::clocks::TimgCalibrationClockConfig::RcFastDivClk, #[cfg(use_xtal32k)]
+        crate ::soc::clocks::TimgCalibrationClockConfig::Xtal32kClk]
     };
     ("clock_tree.uart.function_clock.sclk") => {
         [crate ::soc::clocks::UartFunctionClockSclk::Xtal, crate
@@ -880,6 +880,7 @@ macro_rules! for_each_sw_interrupt {
 ///
 /// // XTAL32K_CLK
 ///
+/// #[cfg(use_xtal32k)]
 /// fn enable_xtal32k_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 ///     todo!()
 /// }
@@ -1282,6 +1283,7 @@ macro_rules! define_clock_tree_types {
         pub enum LpSlowClkConfig {
             /// Selects `RC_SLOW_CLK`.
             RcSlow,
+            #[cfg(use_xtal32k)]
             /// Selects `XTAL32K_CLK`.
             Xtal32k,
             /// Selects `OSC_SLOW_CLK`.
@@ -1297,6 +1299,7 @@ macro_rules! define_clock_tree_types {
             RcSlowClk,
             /// Selects `RC_FAST_CLK`.
             RcFastDivClk,
+            #[cfg(use_xtal32k)]
             /// Selects `XTAL32K_CLK`.
             Xtal32kClk,
         }
@@ -1475,6 +1478,7 @@ macro_rules! define_clock_tree_types {
             uart_baud_rate_generator: [Option<UartBaudRateGeneratorConfig>; 3],
             rc_fast_clk_refcount: u32,
             pll_clk_refcount: u32,
+            #[cfg(use_xtal32k)]
             xtal32k_clk_refcount: u32,
             osc_slow_clk_refcount: u32,
             rc_slow_clk_refcount: u32,
@@ -1602,6 +1606,7 @@ macro_rules! define_clock_tree_types {
                 uart_baud_rate_generator: [None; 3],
                 rc_fast_clk_refcount: 0,
                 pll_clk_refcount: 0,
+                #[cfg(use_xtal32k)]
                 xtal32k_clk_refcount: 0,
                 osc_slow_clk_refcount: 0,
                 rc_slow_clk_refcount: 0,
@@ -1709,6 +1714,7 @@ macro_rules! define_clock_tree_types {
         pub fn pll_clk_source_frequency() -> u32 {
             xtal_clk_frequency()
         }
+        #[cfg(use_xtal32k)]
         pub fn request_xtal32k_clk(clocks: &mut ClockTree) {
             trace!("Requesting XTAL32K_CLK");
             if increment_reference_count(&mut clocks.xtal32k_clk_refcount) {
@@ -1716,6 +1722,7 @@ macro_rules! define_clock_tree_types {
                 enable_xtal32k_clk_impl(clocks, true);
             }
         }
+        #[cfg(use_xtal32k)]
         pub fn release_xtal32k_clk(clocks: &mut ClockTree) {
             trace!("Releasing XTAL32K_CLK");
             if decrement_reference_count(&mut clocks.xtal32k_clk_refcount) {
@@ -1723,6 +1730,7 @@ macro_rules! define_clock_tree_types {
                 enable_xtal32k_clk_impl(clocks, false);
             }
         }
+        #[cfg(use_xtal32k)]
         pub fn xtal32k_clk_frequency() -> u32 {
             32768
         }
@@ -2174,6 +2182,7 @@ macro_rules! define_clock_tree_types {
             if clocks.lp_slow_clk_refcount > 0 {
                 match new_selector {
                     LpSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     LpSlowClkConfig::Xtal32k => request_xtal32k_clk(clocks),
                     LpSlowClkConfig::OscSlow => request_osc_slow_clk(clocks),
                 }
@@ -2181,6 +2190,7 @@ macro_rules! define_clock_tree_types {
                 if let Some(old_selector) = old_selector {
                     match old_selector {
                         LpSlowClkConfig::RcSlow => release_rc_slow_clk(clocks),
+                        #[cfg(use_xtal32k)]
                         LpSlowClkConfig::Xtal32k => release_xtal32k_clk(clocks),
                         LpSlowClkConfig::OscSlow => release_osc_slow_clk(clocks),
                     }
@@ -2198,6 +2208,7 @@ macro_rules! define_clock_tree_types {
                 trace!("Enabling LP_SLOW_CLK");
                 match unwrap!(clocks.lp_slow_clk) {
                     LpSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     LpSlowClkConfig::Xtal32k => request_xtal32k_clk(clocks),
                     LpSlowClkConfig::OscSlow => request_osc_slow_clk(clocks),
                 }
@@ -2211,6 +2222,7 @@ macro_rules! define_clock_tree_types {
                 enable_lp_slow_clk_impl(clocks, false);
                 match unwrap!(clocks.lp_slow_clk) {
                     LpSlowClkConfig::RcSlow => release_rc_slow_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     LpSlowClkConfig::Xtal32k => release_xtal32k_clk(clocks),
                     LpSlowClkConfig::OscSlow => release_osc_slow_clk(clocks),
                 }
@@ -2223,6 +2235,7 @@ macro_rules! define_clock_tree_types {
         ) -> u32 {
             match config {
                 LpSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
+                #[cfg(use_xtal32k)]
                 LpSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
                 LpSlowClkConfig::OscSlow => osc_slow_clk_frequency(),
             }
@@ -2233,6 +2246,7 @@ macro_rules! define_clock_tree_types {
         pub fn lp_slow_clk_source_frequency(source: LpSlowClkConfig) -> u32 {
             match source {
                 LpSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
+                #[cfg(use_xtal32k)]
                 LpSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
                 LpSlowClkConfig::OscSlow => osc_slow_clk_frequency(),
             }
@@ -2248,6 +2262,7 @@ macro_rules! define_clock_tree_types {
                     TimgCalibrationClockConfig::OscSlowClk => request_osc_slow_clk(clocks),
                     TimgCalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
                     TimgCalibrationClockConfig::RcFastDivClk => request_rc_fast_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     TimgCalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
                 }
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
@@ -2256,6 +2271,7 @@ macro_rules! define_clock_tree_types {
                         TimgCalibrationClockConfig::OscSlowClk => release_osc_slow_clk(clocks),
                         TimgCalibrationClockConfig::RcSlowClk => release_rc_slow_clk(clocks),
                         TimgCalibrationClockConfig::RcFastDivClk => release_rc_fast_clk(clocks),
+                        #[cfg(use_xtal32k)]
                         TimgCalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
                     }
                 }
@@ -2277,6 +2293,7 @@ macro_rules! define_clock_tree_types {
                     TimgCalibrationClockConfig::OscSlowClk => request_osc_slow_clk(clocks),
                     TimgCalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
                     TimgCalibrationClockConfig::RcFastDivClk => request_rc_fast_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     TimgCalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
                 }
                 enable_timg_calibration_clock_impl(clocks, true);
@@ -2292,6 +2309,7 @@ macro_rules! define_clock_tree_types {
                     TimgCalibrationClockConfig::OscSlowClk => release_osc_slow_clk(clocks),
                     TimgCalibrationClockConfig::RcSlowClk => release_rc_slow_clk(clocks),
                     TimgCalibrationClockConfig::RcFastDivClk => release_rc_fast_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     TimgCalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
                 }
             }
@@ -2305,6 +2323,7 @@ macro_rules! define_clock_tree_types {
                 TimgCalibrationClockConfig::OscSlowClk => osc_slow_clk_frequency(),
                 TimgCalibrationClockConfig::RcSlowClk => rc_slow_clk_frequency(),
                 TimgCalibrationClockConfig::RcFastDivClk => rc_fast_clk_frequency(),
+                #[cfg(use_xtal32k)]
                 TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
             }
         }
@@ -2316,6 +2335,7 @@ macro_rules! define_clock_tree_types {
                 TimgCalibrationClockConfig::OscSlowClk => osc_slow_clk_frequency(),
                 TimgCalibrationClockConfig::RcSlowClk => rc_slow_clk_frequency(),
                 TimgCalibrationClockConfig::RcFastDivClk => rc_fast_clk_frequency(),
+                #[cfg(use_xtal32k)]
                 TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
             }
         }

--- a/esp-metadata-generated/src/_generated_esp32h2.rs
+++ b/esp-metadata-generated/src/_generated_esp32h2.rs
@@ -528,19 +528,19 @@ macro_rules! property {
         (0, 255)
     };
     ("clock_tree.lp_fast_clk") => {
-        [crate ::soc::clocks::LpFastClkConfig::RcFastClk, crate
+        [crate ::soc::clocks::LpFastClkConfig::RcFastClk, #[cfg(use_xtal32k)] crate
         ::soc::clocks::LpFastClkConfig::PllLpClk, crate
         ::soc::clocks::LpFastClkConfig::XtalD2Clk]
     };
     ("clock_tree.lp_slow_clk") => {
-        [crate ::soc::clocks::LpSlowClkConfig::Xtal32k, crate
+        [#[cfg(use_xtal32k)] crate ::soc::clocks::LpSlowClkConfig::Xtal32k, crate
         ::soc::clocks::LpSlowClkConfig::RcSlow, crate
         ::soc::clocks::LpSlowClkConfig::OscSlow]
     };
     ("clock_tree.timg_calibration_clock") => {
         [crate ::soc::clocks::TimgCalibrationClockConfig::RcSlowClk, crate
-        ::soc::clocks::TimgCalibrationClockConfig::RcFastDivClk, crate
-        ::soc::clocks::TimgCalibrationClockConfig::Xtal32kClk]
+        ::soc::clocks::TimgCalibrationClockConfig::RcFastDivClk, #[cfg(use_xtal32k)]
+        crate ::soc::clocks::TimgCalibrationClockConfig::Xtal32kClk]
     };
     ("clock_tree.uart.function_clock.sclk") => {
         [crate ::soc::clocks::UartFunctionClockSclk::PllF48m, crate
@@ -1281,6 +1281,7 @@ macro_rules! for_each_sw_interrupt {
 ///
 /// // XTAL32K_CLK
 ///
+/// #[cfg(use_xtal32k)]
 /// fn enable_xtal32k_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 ///     todo!()
 /// }
@@ -1299,6 +1300,7 @@ macro_rules! for_each_sw_interrupt {
 ///
 /// // PLL_LP_CLK
 ///
+/// #[cfg(use_xtal32k)]
 /// fn enable_pll_lp_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 ///     todo!()
 /// }
@@ -1730,6 +1732,7 @@ macro_rules! define_clock_tree_types {
         pub enum LpFastClkConfig {
             /// Selects `RC_FAST_CLK`.
             RcFastClk,
+            #[cfg(use_xtal32k)]
             /// Selects `PLL_LP_CLK`.
             PllLpClk,
             /// Selects `XTAL_D2_CLK`.
@@ -1739,6 +1742,7 @@ macro_rules! define_clock_tree_types {
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum LpSlowClkConfig {
+            #[cfg(use_xtal32k)]
             /// Selects `XTAL32K_CLK`.
             Xtal32k,
             /// Selects `RC_SLOW_CLK`.
@@ -1754,6 +1758,7 @@ macro_rules! define_clock_tree_types {
             RcSlowClk,
             /// Selects `RC_FAST_CLK`.
             RcFastDivClk,
+            #[cfg(use_xtal32k)]
             /// Selects `XTAL32K_CLK`.
             Xtal32kClk,
         }
@@ -1984,6 +1989,7 @@ macro_rules! define_clock_tree_types {
             pll_f96m_clk_refcount: u32,
             pll_f48m_clk_refcount: u32,
             rc_fast_clk_refcount: u32,
+            #[cfg(use_xtal32k)]
             xtal32k_clk_refcount: u32,
             hp_root_clk_refcount: u32,
             apb_clk_refcount: u32,
@@ -2127,6 +2133,7 @@ macro_rules! define_clock_tree_types {
                 pll_f96m_clk_refcount: 0,
                 pll_f48m_clk_refcount: 0,
                 rc_fast_clk_refcount: 0,
+                #[cfg(use_xtal32k)]
                 xtal32k_clk_refcount: 0,
                 hp_root_clk_refcount: 0,
                 apb_clk_refcount: 0,
@@ -2322,6 +2329,7 @@ macro_rules! define_clock_tree_types {
                 IomuxFunctionClockConfig::PllF48m => pll_f48m_clk_frequency(),
             }
         }
+        #[cfg(use_xtal32k)]
         pub fn request_xtal32k_clk(clocks: &mut ClockTree) {
             trace!("Requesting XTAL32K_CLK");
             if increment_reference_count(&mut clocks.xtal32k_clk_refcount) {
@@ -2329,6 +2337,7 @@ macro_rules! define_clock_tree_types {
                 enable_xtal32k_clk_impl(clocks, true);
             }
         }
+        #[cfg(use_xtal32k)]
         pub fn release_xtal32k_clk(clocks: &mut ClockTree) {
             trace!("Releasing XTAL32K_CLK");
             if decrement_reference_count(&mut clocks.xtal32k_clk_refcount) {
@@ -2336,6 +2345,7 @@ macro_rules! define_clock_tree_types {
                 enable_xtal32k_clk_impl(clocks, false);
             }
         }
+        #[cfg(use_xtal32k)]
         pub fn xtal32k_clk_frequency() -> u32 {
             32768
         }
@@ -2365,21 +2375,25 @@ macro_rules! define_clock_tree_types {
         pub fn rc_slow_clk_frequency() -> u32 {
             130000
         }
+        #[cfg(use_xtal32k)]
         pub fn request_pll_lp_clk(clocks: &mut ClockTree) {
             trace!("Requesting PLL_LP_CLK");
             trace!("Enabling PLL_LP_CLK");
             request_xtal32k_clk(clocks);
             enable_pll_lp_clk_impl(clocks, true);
         }
+        #[cfg(use_xtal32k)]
         pub fn release_pll_lp_clk(clocks: &mut ClockTree) {
             trace!("Releasing PLL_LP_CLK");
             trace!("Disabling PLL_LP_CLK");
             enable_pll_lp_clk_impl(clocks, false);
             release_xtal32k_clk(clocks);
         }
+        #[cfg(use_xtal32k)]
         pub fn pll_lp_clk_frequency() -> u32 {
             8000000
         }
+        #[cfg(use_xtal32k)]
         pub fn pll_lp_clk_source_frequency() -> u32 {
             xtal32k_clk_frequency()
         }
@@ -2556,6 +2570,7 @@ macro_rules! define_clock_tree_types {
             if clocks.lp_fast_clk_refcount > 0 {
                 match new_selector {
                     LpFastClkConfig::RcFastClk => request_rc_fast_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     LpFastClkConfig::PllLpClk => request_pll_lp_clk(clocks),
                     LpFastClkConfig::XtalD2Clk => request_xtal_d2_clk(clocks),
                 }
@@ -2563,6 +2578,7 @@ macro_rules! define_clock_tree_types {
                 if let Some(old_selector) = old_selector {
                     match old_selector {
                         LpFastClkConfig::RcFastClk => release_rc_fast_clk(clocks),
+                        #[cfg(use_xtal32k)]
                         LpFastClkConfig::PllLpClk => release_pll_lp_clk(clocks),
                         LpFastClkConfig::XtalD2Clk => release_xtal_d2_clk(clocks),
                     }
@@ -2580,6 +2596,7 @@ macro_rules! define_clock_tree_types {
                 trace!("Enabling LP_FAST_CLK");
                 match unwrap!(clocks.lp_fast_clk) {
                     LpFastClkConfig::RcFastClk => request_rc_fast_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     LpFastClkConfig::PllLpClk => request_pll_lp_clk(clocks),
                     LpFastClkConfig::XtalD2Clk => request_xtal_d2_clk(clocks),
                 }
@@ -2593,6 +2610,7 @@ macro_rules! define_clock_tree_types {
                 enable_lp_fast_clk_impl(clocks, false);
                 match unwrap!(clocks.lp_fast_clk) {
                     LpFastClkConfig::RcFastClk => release_rc_fast_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     LpFastClkConfig::PllLpClk => release_pll_lp_clk(clocks),
                     LpFastClkConfig::XtalD2Clk => release_xtal_d2_clk(clocks),
                 }
@@ -2605,6 +2623,7 @@ macro_rules! define_clock_tree_types {
         ) -> u32 {
             match config {
                 LpFastClkConfig::RcFastClk => rc_fast_clk_frequency(),
+                #[cfg(use_xtal32k)]
                 LpFastClkConfig::PllLpClk => pll_lp_clk_frequency(),
                 LpFastClkConfig::XtalD2Clk => xtal_d2_clk_frequency(),
             }
@@ -2615,6 +2634,7 @@ macro_rules! define_clock_tree_types {
         pub fn lp_fast_clk_source_frequency(source: LpFastClkConfig) -> u32 {
             match source {
                 LpFastClkConfig::RcFastClk => rc_fast_clk_frequency(),
+                #[cfg(use_xtal32k)]
                 LpFastClkConfig::PllLpClk => pll_lp_clk_frequency(),
                 LpFastClkConfig::XtalD2Clk => xtal_d2_clk_frequency(),
             }
@@ -2623,6 +2643,7 @@ macro_rules! define_clock_tree_types {
             let old_selector = clocks.lp_slow_clk.replace(new_selector);
             refresh_lp_slow_clk_downstream(clocks);
             match new_selector {
+                #[cfg(use_xtal32k)]
                 LpSlowClkConfig::Xtal32k => request_xtal32k_clk(clocks),
                 LpSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
                 LpSlowClkConfig::OscSlow => request_osc_slow_clk(clocks),
@@ -2630,6 +2651,7 @@ macro_rules! define_clock_tree_types {
             configure_lp_slow_clk_impl(clocks, old_selector, new_selector);
             if let Some(old_selector) = old_selector {
                 match old_selector {
+                    #[cfg(use_xtal32k)]
                     LpSlowClkConfig::Xtal32k => release_xtal32k_clk(clocks),
                     LpSlowClkConfig::RcSlow => release_rc_slow_clk(clocks),
                     LpSlowClkConfig::OscSlow => release_osc_slow_clk(clocks),
@@ -2643,6 +2665,7 @@ macro_rules! define_clock_tree_types {
             trace!("Requesting LP_SLOW_CLK");
             trace!("Enabling LP_SLOW_CLK");
             match unwrap!(clocks.lp_slow_clk) {
+                #[cfg(use_xtal32k)]
                 LpSlowClkConfig::Xtal32k => request_xtal32k_clk(clocks),
                 LpSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
                 LpSlowClkConfig::OscSlow => request_osc_slow_clk(clocks),
@@ -2654,6 +2677,7 @@ macro_rules! define_clock_tree_types {
             trace!("Disabling LP_SLOW_CLK");
             enable_lp_slow_clk_impl(clocks, false);
             match unwrap!(clocks.lp_slow_clk) {
+                #[cfg(use_xtal32k)]
                 LpSlowClkConfig::Xtal32k => release_xtal32k_clk(clocks),
                 LpSlowClkConfig::RcSlow => release_rc_slow_clk(clocks),
                 LpSlowClkConfig::OscSlow => release_osc_slow_clk(clocks),
@@ -2665,6 +2689,7 @@ macro_rules! define_clock_tree_types {
             config: LpSlowClkConfig,
         ) -> u32 {
             match config {
+                #[cfg(use_xtal32k)]
                 LpSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
                 LpSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
                 LpSlowClkConfig::OscSlow => osc_slow_clk_frequency(),
@@ -2675,6 +2700,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn lp_slow_clk_source_frequency(source: LpSlowClkConfig) -> u32 {
             match source {
+                #[cfg(use_xtal32k)]
                 LpSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
                 LpSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
                 LpSlowClkConfig::OscSlow => osc_slow_clk_frequency(),
@@ -2690,6 +2716,7 @@ macro_rules! define_clock_tree_types {
                 match new_selector {
                     TimgCalibrationClockConfig::RcSlowClk => request_lp_slow_clk(clocks),
                     TimgCalibrationClockConfig::RcFastDivClk => request_rc_fast_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     TimgCalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
                 }
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
@@ -2697,6 +2724,7 @@ macro_rules! define_clock_tree_types {
                     match old_selector {
                         TimgCalibrationClockConfig::RcSlowClk => release_lp_slow_clk(clocks),
                         TimgCalibrationClockConfig::RcFastDivClk => release_rc_fast_clk(clocks),
+                        #[cfg(use_xtal32k)]
                         TimgCalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
                     }
                 }
@@ -2717,6 +2745,7 @@ macro_rules! define_clock_tree_types {
                 match unwrap!(clocks.timg_calibration_clock) {
                     TimgCalibrationClockConfig::RcSlowClk => request_lp_slow_clk(clocks),
                     TimgCalibrationClockConfig::RcFastDivClk => request_rc_fast_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     TimgCalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
                 }
                 enable_timg_calibration_clock_impl(clocks, true);
@@ -2731,6 +2760,7 @@ macro_rules! define_clock_tree_types {
                 match unwrap!(clocks.timg_calibration_clock) {
                     TimgCalibrationClockConfig::RcSlowClk => release_lp_slow_clk(clocks),
                     TimgCalibrationClockConfig::RcFastDivClk => release_rc_fast_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     TimgCalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
                 }
             }
@@ -2743,6 +2773,7 @@ macro_rules! define_clock_tree_types {
             match config {
                 TimgCalibrationClockConfig::RcSlowClk => lp_slow_clk_frequency(),
                 TimgCalibrationClockConfig::RcFastDivClk => rc_fast_clk_frequency(),
+                #[cfg(use_xtal32k)]
                 TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
             }
         }
@@ -2753,6 +2784,7 @@ macro_rules! define_clock_tree_types {
             match source {
                 TimgCalibrationClockConfig::RcSlowClk => lp_slow_clk_frequency(),
                 TimgCalibrationClockConfig::RcFastDivClk => rc_fast_clk_frequency(),
+                #[cfg(use_xtal32k)]
                 TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
             }
         }

--- a/esp-metadata-generated/src/_generated_esp32p4.rs
+++ b/esp-metadata-generated/src/_generated_esp32p4.rs
@@ -552,7 +552,7 @@ macro_rules! property {
         ::soc::clocks::LpFastClkConfig::XtalD2]
     };
     ("clock_tree.lp_slow_clk") => {
-        [crate ::soc::clocks::LpSlowClkConfig::RcSlow, crate
+        [crate ::soc::clocks::LpSlowClkConfig::RcSlow, #[cfg(use_xtal32k)] crate
         ::soc::clocks::LpSlowClkConfig::Xtal32k, crate
         ::soc::clocks::LpSlowClkConfig::OscSlow]
     };
@@ -561,7 +561,7 @@ macro_rules! property {
         ::soc::clocks::TimgCalibrationClockConfig::SpllClk, crate
         ::soc::clocks::TimgCalibrationClockConfig::CpllClk, crate
         ::soc::clocks::TimgCalibrationClockConfig::RcFastDivClk, crate
-        ::soc::clocks::TimgCalibrationClockConfig::RcSlowClk, crate
+        ::soc::clocks::TimgCalibrationClockConfig::RcSlowClk, #[cfg(use_xtal32k)] crate
         ::soc::clocks::TimgCalibrationClockConfig::Xtal32kClk]
     };
     ("clock_tree.psram.function_clock") => {
@@ -1571,6 +1571,7 @@ macro_rules! for_each_sw_interrupt {
 ///
 /// // XTAL32K_CLK
 ///
+/// #[cfg(use_xtal32k)]
 /// fn enable_xtal32k_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 ///     todo!()
 /// }
@@ -2198,6 +2199,7 @@ macro_rules! define_clock_tree_types {
         pub enum LpSlowClkConfig {
             /// Selects `RC_SLOW_CLK`.
             RcSlow,
+            #[cfg(use_xtal32k)]
             /// Selects `XTAL32K_CLK`.
             Xtal32k,
             /// Selects `OSC_SLOW_CLK`.
@@ -2217,6 +2219,7 @@ macro_rules! define_clock_tree_types {
             RcFastDivClk,
             /// Selects `LP_SLOW_CLK`.
             RcSlowClk,
+            #[cfg(use_xtal32k)]
             /// Selects `XTAL32K_CLK`.
             Xtal32kClk,
         }
@@ -2527,6 +2530,7 @@ macro_rules! define_clock_tree_types {
             spll_clk_refcount: u32,
             mpll_clk_refcount: u32,
             rc_fast_clk_refcount: u32,
+            #[cfg(use_xtal32k)]
             xtal32k_clk_refcount: u32,
             rc32k_clk_refcount: u32,
             pll_f80m_refcount: u32,
@@ -2718,6 +2722,7 @@ macro_rules! define_clock_tree_types {
                 spll_clk_refcount: 0,
                 mpll_clk_refcount: 0,
                 rc_fast_clk_refcount: 0,
+                #[cfg(use_xtal32k)]
                 xtal32k_clk_refcount: 0,
                 rc32k_clk_refcount: 0,
                 pll_f80m_refcount: 0,
@@ -2895,6 +2900,7 @@ macro_rules! define_clock_tree_types {
         pub fn rc_fast_clk_frequency() -> u32 {
             20000000
         }
+        #[cfg(use_xtal32k)]
         pub fn request_xtal32k_clk(clocks: &mut ClockTree) {
             trace!("Requesting XTAL32K_CLK");
             if increment_reference_count(&mut clocks.xtal32k_clk_refcount) {
@@ -2902,6 +2908,7 @@ macro_rules! define_clock_tree_types {
                 enable_xtal32k_clk_impl(clocks, true);
             }
         }
+        #[cfg(use_xtal32k)]
         pub fn release_xtal32k_clk(clocks: &mut ClockTree) {
             trace!("Releasing XTAL32K_CLK");
             if decrement_reference_count(&mut clocks.xtal32k_clk_refcount) {
@@ -2909,6 +2916,7 @@ macro_rules! define_clock_tree_types {
                 enable_xtal32k_clk_impl(clocks, false);
             }
         }
+        #[cfg(use_xtal32k)]
         pub fn xtal32k_clk_frequency() -> u32 {
             32768
         }
@@ -3408,6 +3416,7 @@ macro_rules! define_clock_tree_types {
             refresh_lp_slow_clk_downstream(clocks);
             match new_selector {
                 LpSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
+                #[cfg(use_xtal32k)]
                 LpSlowClkConfig::Xtal32k => request_xtal32k_clk(clocks),
                 LpSlowClkConfig::OscSlow => request_osc_slow_clk(clocks),
             }
@@ -3415,6 +3424,7 @@ macro_rules! define_clock_tree_types {
             if let Some(old_selector) = old_selector {
                 match old_selector {
                     LpSlowClkConfig::RcSlow => release_rc_slow_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     LpSlowClkConfig::Xtal32k => release_xtal32k_clk(clocks),
                     LpSlowClkConfig::OscSlow => release_osc_slow_clk(clocks),
                 }
@@ -3428,6 +3438,7 @@ macro_rules! define_clock_tree_types {
             trace!("Enabling LP_SLOW_CLK");
             match unwrap!(clocks.lp_slow_clk) {
                 LpSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
+                #[cfg(use_xtal32k)]
                 LpSlowClkConfig::Xtal32k => request_xtal32k_clk(clocks),
                 LpSlowClkConfig::OscSlow => request_osc_slow_clk(clocks),
             }
@@ -3439,6 +3450,7 @@ macro_rules! define_clock_tree_types {
             enable_lp_slow_clk_impl(clocks, false);
             match unwrap!(clocks.lp_slow_clk) {
                 LpSlowClkConfig::RcSlow => release_rc_slow_clk(clocks),
+                #[cfg(use_xtal32k)]
                 LpSlowClkConfig::Xtal32k => release_xtal32k_clk(clocks),
                 LpSlowClkConfig::OscSlow => release_osc_slow_clk(clocks),
             }
@@ -3450,6 +3462,7 @@ macro_rules! define_clock_tree_types {
         ) -> u32 {
             match config {
                 LpSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
+                #[cfg(use_xtal32k)]
                 LpSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
                 LpSlowClkConfig::OscSlow => osc_slow_clk_frequency(),
             }
@@ -3460,6 +3473,7 @@ macro_rules! define_clock_tree_types {
         pub fn lp_slow_clk_source_frequency(source: LpSlowClkConfig) -> u32 {
             match source {
                 LpSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
+                #[cfg(use_xtal32k)]
                 LpSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
                 LpSlowClkConfig::OscSlow => osc_slow_clk_frequency(),
             }
@@ -3477,6 +3491,7 @@ macro_rules! define_clock_tree_types {
                     TimgCalibrationClockConfig::CpllClk => request_cpll_clk(clocks),
                     TimgCalibrationClockConfig::RcFastDivClk => request_rc_fast_clk(clocks),
                     TimgCalibrationClockConfig::RcSlowClk => request_lp_slow_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     TimgCalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
                 }
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
@@ -3487,6 +3502,7 @@ macro_rules! define_clock_tree_types {
                         TimgCalibrationClockConfig::CpllClk => release_cpll_clk(clocks),
                         TimgCalibrationClockConfig::RcFastDivClk => release_rc_fast_clk(clocks),
                         TimgCalibrationClockConfig::RcSlowClk => release_lp_slow_clk(clocks),
+                        #[cfg(use_xtal32k)]
                         TimgCalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
                     }
                 }
@@ -3510,6 +3526,7 @@ macro_rules! define_clock_tree_types {
                     TimgCalibrationClockConfig::CpllClk => request_cpll_clk(clocks),
                     TimgCalibrationClockConfig::RcFastDivClk => request_rc_fast_clk(clocks),
                     TimgCalibrationClockConfig::RcSlowClk => request_lp_slow_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     TimgCalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
                 }
                 enable_timg_calibration_clock_impl(clocks, true);
@@ -3527,6 +3544,7 @@ macro_rules! define_clock_tree_types {
                     TimgCalibrationClockConfig::CpllClk => release_cpll_clk(clocks),
                     TimgCalibrationClockConfig::RcFastDivClk => release_rc_fast_clk(clocks),
                     TimgCalibrationClockConfig::RcSlowClk => release_lp_slow_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     TimgCalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
                 }
             }
@@ -3542,6 +3560,7 @@ macro_rules! define_clock_tree_types {
                 TimgCalibrationClockConfig::CpllClk => cpll_clk_frequency(),
                 TimgCalibrationClockConfig::RcFastDivClk => rc_fast_clk_frequency(),
                 TimgCalibrationClockConfig::RcSlowClk => lp_slow_clk_frequency(),
+                #[cfg(use_xtal32k)]
                 TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
             }
         }
@@ -3555,6 +3574,7 @@ macro_rules! define_clock_tree_types {
                 TimgCalibrationClockConfig::CpllClk => cpll_clk_frequency(),
                 TimgCalibrationClockConfig::RcFastDivClk => rc_fast_clk_frequency(),
                 TimgCalibrationClockConfig::RcSlowClk => lp_slow_clk_frequency(),
+                #[cfg(use_xtal32k)]
                 TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
             }
         }

--- a/esp-metadata-generated/src/_generated_esp32s2.rs
+++ b/esp-metadata-generated/src/_generated_esp32s2.rs
@@ -532,7 +532,7 @@ macro_rules! property {
         crate ::soc::clocks::RefTickConfig::RcFast]
     };
     ("clock_tree.rtc_slow_clk") => {
-        [crate ::soc::clocks::RtcSlowClkConfig::Xtal32k, crate
+        [#[cfg(use_xtal32k)] crate ::soc::clocks::RtcSlowClkConfig::Xtal32k, crate
         ::soc::clocks::RtcSlowClkConfig::RcSlow, crate
         ::soc::clocks::RtcSlowClkConfig::RcFast]
     };
@@ -542,8 +542,8 @@ macro_rules! property {
     };
     ("clock_tree.timg_calibration_clock") => {
         [crate ::soc::clocks::TimgCalibrationClockConfig::RtcClk, crate
-        ::soc::clocks::TimgCalibrationClockConfig::RcFastDivClk, crate
-        ::soc::clocks::TimgCalibrationClockConfig::Xtal32kClk]
+        ::soc::clocks::TimgCalibrationClockConfig::RcFastDivClk, #[cfg(use_xtal32k)]
+        crate ::soc::clocks::TimgCalibrationClockConfig::Xtal32kClk]
     };
     ("clock_tree.timg.function_clock") => {
         [crate ::soc::clocks::TimgFunctionClockConfig::XtalClk, crate
@@ -1259,6 +1259,7 @@ macro_rules! for_each_sw_interrupt {
 ///
 /// // XTAL32K_CLK
 ///
+/// #[cfg(use_xtal32k)]
 /// fn enable_xtal32k_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 ///     todo!()
 /// }
@@ -1701,6 +1702,7 @@ macro_rules! define_clock_tree_types {
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RtcSlowClkConfig {
+            #[cfg(use_xtal32k)]
             /// Selects `XTAL32K_CLK`.
             Xtal32k,
             /// Selects `RC_SLOW_CLK`.
@@ -1733,6 +1735,7 @@ macro_rules! define_clock_tree_types {
             RtcClk,
             /// Selects `RC_FAST_DIV_CLK`.
             RcFastDivClk,
+            #[cfg(use_xtal32k)]
             /// Selects `XTAL32K_CLK`.
             Xtal32kClk,
         }
@@ -1884,6 +1887,7 @@ macro_rules! define_clock_tree_types {
             rc_fast_clk_refcount: u32,
             apb_clk_refcount: u32,
             ref_tick_refcount: u32,
+            #[cfg(use_xtal32k)]
             xtal32k_clk_refcount: u32,
             rc_fast_div_clk_refcount: u32,
             rtc_fast_clk_refcount: u32,
@@ -2026,6 +2030,7 @@ macro_rules! define_clock_tree_types {
                 rc_fast_clk_refcount: 0,
                 apb_clk_refcount: 0,
                 ref_tick_refcount: 0,
+                #[cfg(use_xtal32k)]
                 xtal32k_clk_refcount: 0,
                 rc_fast_div_clk_refcount: 0,
                 rtc_fast_clk_refcount: 0,
@@ -2673,6 +2678,7 @@ macro_rules! define_clock_tree_types {
         pub fn apb_clk_80m_source_frequency() -> u32 {
             cpu_clk_frequency()
         }
+        #[cfg(use_xtal32k)]
         pub fn request_xtal32k_clk(clocks: &mut ClockTree) {
             trace!("Requesting XTAL32K_CLK");
             if increment_reference_count(&mut clocks.xtal32k_clk_refcount) {
@@ -2680,6 +2686,7 @@ macro_rules! define_clock_tree_types {
                 enable_xtal32k_clk_impl(clocks, true);
             }
         }
+        #[cfg(use_xtal32k)]
         pub fn release_xtal32k_clk(clocks: &mut ClockTree) {
             trace!("Releasing XTAL32K_CLK");
             if decrement_reference_count(&mut clocks.xtal32k_clk_refcount) {
@@ -2687,6 +2694,7 @@ macro_rules! define_clock_tree_types {
                 enable_xtal32k_clk_impl(clocks, false);
             }
         }
+        #[cfg(use_xtal32k)]
         pub fn xtal32k_clk_frequency() -> u32 {
             32768
         }
@@ -2747,6 +2755,7 @@ macro_rules! define_clock_tree_types {
             let old_selector = clocks.rtc_slow_clk.replace(new_selector);
             refresh_rtc_slow_clk_downstream(clocks);
             match new_selector {
+                #[cfg(use_xtal32k)]
                 RtcSlowClkConfig::Xtal32k => request_xtal32k_clk(clocks),
                 RtcSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
                 RtcSlowClkConfig::RcFast => request_rc_fast_div_clk(clocks),
@@ -2754,6 +2763,7 @@ macro_rules! define_clock_tree_types {
             configure_rtc_slow_clk_impl(clocks, old_selector, new_selector);
             if let Some(old_selector) = old_selector {
                 match old_selector {
+                    #[cfg(use_xtal32k)]
                     RtcSlowClkConfig::Xtal32k => release_xtal32k_clk(clocks),
                     RtcSlowClkConfig::RcSlow => release_rc_slow_clk(clocks),
                     RtcSlowClkConfig::RcFast => release_rc_fast_div_clk(clocks),
@@ -2767,6 +2777,7 @@ macro_rules! define_clock_tree_types {
             trace!("Requesting RTC_SLOW_CLK");
             trace!("Enabling RTC_SLOW_CLK");
             match unwrap!(clocks.rtc_slow_clk) {
+                #[cfg(use_xtal32k)]
                 RtcSlowClkConfig::Xtal32k => request_xtal32k_clk(clocks),
                 RtcSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
                 RtcSlowClkConfig::RcFast => request_rc_fast_div_clk(clocks),
@@ -2778,6 +2789,7 @@ macro_rules! define_clock_tree_types {
             trace!("Disabling RTC_SLOW_CLK");
             enable_rtc_slow_clk_impl(clocks, false);
             match unwrap!(clocks.rtc_slow_clk) {
+                #[cfg(use_xtal32k)]
                 RtcSlowClkConfig::Xtal32k => release_xtal32k_clk(clocks),
                 RtcSlowClkConfig::RcSlow => release_rc_slow_clk(clocks),
                 RtcSlowClkConfig::RcFast => release_rc_fast_div_clk(clocks),
@@ -2789,6 +2801,7 @@ macro_rules! define_clock_tree_types {
             config: RtcSlowClkConfig,
         ) -> u32 {
             match config {
+                #[cfg(use_xtal32k)]
                 RtcSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
                 RtcSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
                 RtcSlowClkConfig::RcFast => rc_fast_div_clk_frequency(),
@@ -2799,6 +2812,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn rtc_slow_clk_source_frequency(source: RtcSlowClkConfig) -> u32 {
             match source {
+                #[cfg(use_xtal32k)]
                 RtcSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
                 RtcSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
                 RtcSlowClkConfig::RcFast => rc_fast_div_clk_frequency(),
@@ -2901,6 +2915,7 @@ macro_rules! define_clock_tree_types {
                 match new_selector {
                     TimgCalibrationClockConfig::RtcClk => request_rtc_slow_clk(clocks),
                     TimgCalibrationClockConfig::RcFastDivClk => request_rc_fast_div_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     TimgCalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
                 }
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
@@ -2908,6 +2923,7 @@ macro_rules! define_clock_tree_types {
                     match old_selector {
                         TimgCalibrationClockConfig::RtcClk => release_rtc_slow_clk(clocks),
                         TimgCalibrationClockConfig::RcFastDivClk => release_rc_fast_div_clk(clocks),
+                        #[cfg(use_xtal32k)]
                         TimgCalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
                     }
                 }
@@ -2928,6 +2944,7 @@ macro_rules! define_clock_tree_types {
                 match unwrap!(clocks.timg_calibration_clock) {
                     TimgCalibrationClockConfig::RtcClk => request_rtc_slow_clk(clocks),
                     TimgCalibrationClockConfig::RcFastDivClk => request_rc_fast_div_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     TimgCalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
                 }
                 enable_timg_calibration_clock_impl(clocks, true);
@@ -2942,6 +2959,7 @@ macro_rules! define_clock_tree_types {
                 match unwrap!(clocks.timg_calibration_clock) {
                     TimgCalibrationClockConfig::RtcClk => release_rtc_slow_clk(clocks),
                     TimgCalibrationClockConfig::RcFastDivClk => release_rc_fast_div_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     TimgCalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
                 }
             }
@@ -2954,6 +2972,7 @@ macro_rules! define_clock_tree_types {
             match config {
                 TimgCalibrationClockConfig::RtcClk => rtc_slow_clk_frequency(),
                 TimgCalibrationClockConfig::RcFastDivClk => rc_fast_div_clk_frequency(),
+                #[cfg(use_xtal32k)]
                 TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
             }
         }
@@ -2964,6 +2983,7 @@ macro_rules! define_clock_tree_types {
             match source {
                 TimgCalibrationClockConfig::RtcClk => rtc_slow_clk_frequency(),
                 TimgCalibrationClockConfig::RcFastDivClk => rc_fast_div_clk_frequency(),
+                #[cfg(use_xtal32k)]
                 TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
             }
         }

--- a/esp-metadata-generated/src/_generated_esp32s3.rs
+++ b/esp-metadata-generated/src/_generated_esp32s3.rs
@@ -557,7 +557,7 @@ macro_rules! property {
         (0, 3)
     };
     ("clock_tree.rtc_slow_clk") => {
-        [crate ::soc::clocks::RtcSlowClkConfig::Xtal32k, crate
+        [#[cfg(use_xtal32k)] crate ::soc::clocks::RtcSlowClkConfig::Xtal32k, crate
         ::soc::clocks::RtcSlowClkConfig::RcSlow, crate
         ::soc::clocks::RtcSlowClkConfig::RcFast]
     };
@@ -567,14 +567,14 @@ macro_rules! property {
     };
     ("clock_tree.low_power_clk") => {
         [crate ::soc::clocks::LowPowerClkConfig::Xtal, crate
-        ::soc::clocks::LowPowerClkConfig::RcFast, crate
+        ::soc::clocks::LowPowerClkConfig::RcFast, #[cfg(use_xtal32k)] crate
         ::soc::clocks::LowPowerClkConfig::Xtal32k, crate
         ::soc::clocks::LowPowerClkConfig::RtcSlow]
     };
     ("clock_tree.timg_calibration_clock") => {
         [crate ::soc::clocks::TimgCalibrationClockConfig::RcSlowClk, crate
-        ::soc::clocks::TimgCalibrationClockConfig::RcFastDivClk, crate
-        ::soc::clocks::TimgCalibrationClockConfig::Xtal32kClk]
+        ::soc::clocks::TimgCalibrationClockConfig::RcFastDivClk, #[cfg(use_xtal32k)]
+        crate ::soc::clocks::TimgCalibrationClockConfig::Xtal32kClk]
     };
     ("clock_tree.timg.function_clock") => {
         [crate ::soc::clocks::TimgFunctionClockConfig::XtalClk, crate
@@ -1370,6 +1370,7 @@ macro_rules! for_each_sw_interrupt {
 ///
 /// // XTAL32K_CLK
 ///
+/// #[cfg(use_xtal32k)]
 /// fn enable_xtal32k_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 ///     todo!()
 /// }
@@ -1906,6 +1907,7 @@ macro_rules! define_clock_tree_types {
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
         pub enum RtcSlowClkConfig {
+            #[cfg(use_xtal32k)]
             /// Selects `XTAL32K_CLK`.
             Xtal32k,
             /// Selects `RC_SLOW_CLK`.
@@ -1930,6 +1932,7 @@ macro_rules! define_clock_tree_types {
             Xtal,
             /// Selects `RC_FAST_CLK`.
             RcFast,
+            #[cfg(use_xtal32k)]
             /// Selects `XTAL32K_CLK`.
             Xtal32k,
             /// Selects `RTC_SLOW_CLK`.
@@ -1951,6 +1954,7 @@ macro_rules! define_clock_tree_types {
             RcSlowClk,
             /// Selects `RC_FAST_DIV_CLK`.
             RcFastDivClk,
+            #[cfg(use_xtal32k)]
             /// Selects `XTAL32K_CLK`.
             Xtal32kClk,
         }
@@ -2286,6 +2290,7 @@ macro_rules! define_clock_tree_types {
             uart_baud_rate_generator: [Option<UartBaudRateGeneratorConfig>; 3],
             pll_clk_refcount: u32,
             rc_fast_clk_refcount: u32,
+            #[cfg(use_xtal32k)]
             xtal32k_clk_refcount: u32,
             rc_slow_clk_refcount: u32,
             rc_fast_div_clk_refcount: u32,
@@ -2452,6 +2457,7 @@ macro_rules! define_clock_tree_types {
                 uart_baud_rate_generator: [None; 3],
                 pll_clk_refcount: 0,
                 rc_fast_clk_refcount: 0,
+                #[cfg(use_xtal32k)]
                 xtal32k_clk_refcount: 0,
                 rc_slow_clk_refcount: 0,
                 rc_fast_div_clk_refcount: 0,
@@ -2590,6 +2596,7 @@ macro_rules! define_clock_tree_types {
         pub fn rc_fast_clk_frequency() -> u32 {
             17500000
         }
+        #[cfg(use_xtal32k)]
         pub fn request_xtal32k_clk(clocks: &mut ClockTree) {
             trace!("Requesting XTAL32K_CLK");
             if increment_reference_count(&mut clocks.xtal32k_clk_refcount) {
@@ -2597,6 +2604,7 @@ macro_rules! define_clock_tree_types {
                 enable_xtal32k_clk_impl(clocks, true);
             }
         }
+        #[cfg(use_xtal32k)]
         pub fn release_xtal32k_clk(clocks: &mut ClockTree) {
             trace!("Releasing XTAL32K_CLK");
             if decrement_reference_count(&mut clocks.xtal32k_clk_refcount) {
@@ -2604,6 +2612,7 @@ macro_rules! define_clock_tree_types {
                 enable_xtal32k_clk_impl(clocks, false);
             }
         }
+        #[cfg(use_xtal32k)]
         pub fn xtal32k_clk_frequency() -> u32 {
             32768
         }
@@ -3062,6 +3071,7 @@ macro_rules! define_clock_tree_types {
             let old_selector = clocks.rtc_slow_clk.replace(new_selector);
             refresh_rtc_slow_clk_downstream(clocks);
             match new_selector {
+                #[cfg(use_xtal32k)]
                 RtcSlowClkConfig::Xtal32k => request_xtal32k_clk(clocks),
                 RtcSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
                 RtcSlowClkConfig::RcFast => request_rc_fast_div_clk(clocks),
@@ -3069,6 +3079,7 @@ macro_rules! define_clock_tree_types {
             configure_rtc_slow_clk_impl(clocks, old_selector, new_selector);
             if let Some(old_selector) = old_selector {
                 match old_selector {
+                    #[cfg(use_xtal32k)]
                     RtcSlowClkConfig::Xtal32k => release_xtal32k_clk(clocks),
                     RtcSlowClkConfig::RcSlow => release_rc_slow_clk(clocks),
                     RtcSlowClkConfig::RcFast => release_rc_fast_div_clk(clocks),
@@ -3082,6 +3093,7 @@ macro_rules! define_clock_tree_types {
             trace!("Requesting RTC_SLOW_CLK");
             trace!("Enabling RTC_SLOW_CLK");
             match unwrap!(clocks.rtc_slow_clk) {
+                #[cfg(use_xtal32k)]
                 RtcSlowClkConfig::Xtal32k => request_xtal32k_clk(clocks),
                 RtcSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
                 RtcSlowClkConfig::RcFast => request_rc_fast_div_clk(clocks),
@@ -3093,6 +3105,7 @@ macro_rules! define_clock_tree_types {
             trace!("Disabling RTC_SLOW_CLK");
             enable_rtc_slow_clk_impl(clocks, false);
             match unwrap!(clocks.rtc_slow_clk) {
+                #[cfg(use_xtal32k)]
                 RtcSlowClkConfig::Xtal32k => release_xtal32k_clk(clocks),
                 RtcSlowClkConfig::RcSlow => release_rc_slow_clk(clocks),
                 RtcSlowClkConfig::RcFast => release_rc_fast_div_clk(clocks),
@@ -3104,6 +3117,7 @@ macro_rules! define_clock_tree_types {
             config: RtcSlowClkConfig,
         ) -> u32 {
             match config {
+                #[cfg(use_xtal32k)]
                 RtcSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
                 RtcSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
                 RtcSlowClkConfig::RcFast => rc_fast_div_clk_frequency(),
@@ -3114,6 +3128,7 @@ macro_rules! define_clock_tree_types {
         }
         pub fn rtc_slow_clk_source_frequency(source: RtcSlowClkConfig) -> u32 {
             match source {
+                #[cfg(use_xtal32k)]
                 RtcSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
                 RtcSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
                 RtcSlowClkConfig::RcFast => rc_fast_div_clk_frequency(),
@@ -3189,6 +3204,7 @@ macro_rules! define_clock_tree_types {
                 match new_selector {
                     LowPowerClkConfig::Xtal => request_xtal_clk(clocks),
                     LowPowerClkConfig::RcFast => request_rc_fast_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     LowPowerClkConfig::Xtal32k => request_xtal32k_clk(clocks),
                     LowPowerClkConfig::RtcSlow => request_rtc_slow_clk(clocks),
                 }
@@ -3197,6 +3213,7 @@ macro_rules! define_clock_tree_types {
                     match old_selector {
                         LowPowerClkConfig::Xtal => release_xtal_clk(clocks),
                         LowPowerClkConfig::RcFast => release_rc_fast_clk(clocks),
+                        #[cfg(use_xtal32k)]
                         LowPowerClkConfig::Xtal32k => release_xtal32k_clk(clocks),
                         LowPowerClkConfig::RtcSlow => release_rtc_slow_clk(clocks),
                     }
@@ -3215,6 +3232,7 @@ macro_rules! define_clock_tree_types {
                 match unwrap!(clocks.low_power_clk) {
                     LowPowerClkConfig::Xtal => request_xtal_clk(clocks),
                     LowPowerClkConfig::RcFast => request_rc_fast_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     LowPowerClkConfig::Xtal32k => request_xtal32k_clk(clocks),
                     LowPowerClkConfig::RtcSlow => request_rtc_slow_clk(clocks),
                 }
@@ -3229,6 +3247,7 @@ macro_rules! define_clock_tree_types {
                 match unwrap!(clocks.low_power_clk) {
                     LowPowerClkConfig::Xtal => release_xtal_clk(clocks),
                     LowPowerClkConfig::RcFast => release_rc_fast_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     LowPowerClkConfig::Xtal32k => release_xtal32k_clk(clocks),
                     LowPowerClkConfig::RtcSlow => release_rtc_slow_clk(clocks),
                 }
@@ -3242,6 +3261,7 @@ macro_rules! define_clock_tree_types {
             match config {
                 LowPowerClkConfig::Xtal => xtal_clk_frequency(),
                 LowPowerClkConfig::RcFast => rc_fast_clk_frequency(),
+                #[cfg(use_xtal32k)]
                 LowPowerClkConfig::Xtal32k => xtal32k_clk_frequency(),
                 LowPowerClkConfig::RtcSlow => rtc_slow_clk_frequency(),
             }
@@ -3253,6 +3273,7 @@ macro_rules! define_clock_tree_types {
             match source {
                 LowPowerClkConfig::Xtal => xtal_clk_frequency(),
                 LowPowerClkConfig::RcFast => rc_fast_clk_frequency(),
+                #[cfg(use_xtal32k)]
                 LowPowerClkConfig::Xtal32k => xtal32k_clk_frequency(),
                 LowPowerClkConfig::RtcSlow => rtc_slow_clk_frequency(),
             }
@@ -3291,6 +3312,7 @@ macro_rules! define_clock_tree_types {
                 match new_selector {
                     TimgCalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
                     TimgCalibrationClockConfig::RcFastDivClk => request_rc_fast_div_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     TimgCalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
                 }
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
@@ -3298,6 +3320,7 @@ macro_rules! define_clock_tree_types {
                     match old_selector {
                         TimgCalibrationClockConfig::RcSlowClk => release_rc_slow_clk(clocks),
                         TimgCalibrationClockConfig::RcFastDivClk => release_rc_fast_div_clk(clocks),
+                        #[cfg(use_xtal32k)]
                         TimgCalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
                     }
                 }
@@ -3318,6 +3341,7 @@ macro_rules! define_clock_tree_types {
                 match unwrap!(clocks.timg_calibration_clock) {
                     TimgCalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
                     TimgCalibrationClockConfig::RcFastDivClk => request_rc_fast_div_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     TimgCalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
                 }
                 enable_timg_calibration_clock_impl(clocks, true);
@@ -3332,6 +3356,7 @@ macro_rules! define_clock_tree_types {
                 match unwrap!(clocks.timg_calibration_clock) {
                     TimgCalibrationClockConfig::RcSlowClk => release_rc_slow_clk(clocks),
                     TimgCalibrationClockConfig::RcFastDivClk => release_rc_fast_div_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     TimgCalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
                 }
             }
@@ -3344,6 +3369,7 @@ macro_rules! define_clock_tree_types {
             match config {
                 TimgCalibrationClockConfig::RcSlowClk => rc_slow_clk_frequency(),
                 TimgCalibrationClockConfig::RcFastDivClk => rc_fast_div_clk_frequency(),
+                #[cfg(use_xtal32k)]
                 TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
             }
         }
@@ -3354,6 +3380,7 @@ macro_rules! define_clock_tree_types {
             match source {
                 TimgCalibrationClockConfig::RcSlowClk => rc_slow_clk_frequency(),
                 TimgCalibrationClockConfig::RcFastDivClk => rc_fast_div_clk_frequency(),
+                #[cfg(use_xtal32k)]
                 TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
             }
         }

--- a/esp-metadata-generated/src/_generated_esp32s31.rs
+++ b/esp-metadata-generated/src/_generated_esp32s31.rs
@@ -465,7 +465,7 @@ macro_rules! property {
         ::soc::clocks::LpFastClkConfig::Xtal]
     };
     ("clock_tree.lp_slow_clk") => {
-        [crate ::soc::clocks::LpSlowClkConfig::RcSlow, crate
+        [crate ::soc::clocks::LpSlowClkConfig::RcSlow, #[cfg(use_xtal32k)] crate
         ::soc::clocks::LpSlowClkConfig::Xtal32k]
     };
     ("clock_tree.iomux_function_clock.source") => {
@@ -477,8 +477,8 @@ macro_rules! property {
     };
     ("clock_tree.timg_calibration_clock") => {
         [crate ::soc::clocks::TimgCalibrationClockConfig::RcSlowClk, crate
-        ::soc::clocks::TimgCalibrationClockConfig::RcFastDivClk, crate
-        ::soc::clocks::TimgCalibrationClockConfig::Xtal32kClk]
+        ::soc::clocks::TimgCalibrationClockConfig::RcFastDivClk, #[cfg(use_xtal32k)]
+        crate ::soc::clocks::TimgCalibrationClockConfig::Xtal32kClk]
     };
     ("clock_tree.psram.function_clock") => {
         [crate ::soc::clocks::PsramFunctionClockConfig::Xtal, crate
@@ -1323,6 +1323,7 @@ macro_rules! for_each_sw_interrupt {
 ///
 /// // XTAL32K_CLK
 ///
+/// #[cfg(use_xtal32k)]
 /// fn enable_xtal32k_clk_impl(_clocks: &mut ClockTree, _en: bool) {
 ///     todo!()
 /// }
@@ -1774,6 +1775,7 @@ macro_rules! define_clock_tree_types {
         pub enum LpSlowClkConfig {
             /// Selects `RC_SLOW_CLK`.
             RcSlow,
+            #[cfg(use_xtal32k)]
             /// Selects `XTAL32K_CLK`.
             Xtal32k,
         }
@@ -1824,6 +1826,7 @@ macro_rules! define_clock_tree_types {
             RcSlowClk,
             /// Selects `RC_FAST_CLK`.
             RcFastDivClk,
+            #[cfg(use_xtal32k)]
             /// Selects `XTAL32K_CLK`.
             Xtal32kClk,
         }
@@ -2030,6 +2033,7 @@ macro_rules! define_clock_tree_types {
             cpll_clk_refcount: u32,
             mpll_clk_refcount: u32,
             rc_fast_clk_refcount: u32,
+            #[cfg(use_xtal32k)]
             xtal32k_clk_refcount: u32,
             rc_slow_clk_refcount: u32,
             pll_f20m_refcount: u32,
@@ -2185,6 +2189,7 @@ macro_rules! define_clock_tree_types {
                 cpll_clk_refcount: 0,
                 mpll_clk_refcount: 0,
                 rc_fast_clk_refcount: 0,
+                #[cfg(use_xtal32k)]
                 xtal32k_clk_refcount: 0,
                 rc_slow_clk_refcount: 0,
                 pll_f20m_refcount: 0,
@@ -2328,6 +2333,7 @@ macro_rules! define_clock_tree_types {
         pub fn rc_fast_clk_frequency() -> u32 {
             17500000
         }
+        #[cfg(use_xtal32k)]
         pub fn request_xtal32k_clk(clocks: &mut ClockTree) {
             trace!("Requesting XTAL32K_CLK");
             if increment_reference_count(&mut clocks.xtal32k_clk_refcount) {
@@ -2335,6 +2341,7 @@ macro_rules! define_clock_tree_types {
                 enable_xtal32k_clk_impl(clocks, true);
             }
         }
+        #[cfg(use_xtal32k)]
         pub fn release_xtal32k_clk(clocks: &mut ClockTree) {
             trace!("Releasing XTAL32K_CLK");
             if decrement_reference_count(&mut clocks.xtal32k_clk_refcount) {
@@ -2342,6 +2349,7 @@ macro_rules! define_clock_tree_types {
                 enable_xtal32k_clk_impl(clocks, false);
             }
         }
+        #[cfg(use_xtal32k)]
         pub fn xtal32k_clk_frequency() -> u32 {
             32768
         }
@@ -2750,12 +2758,14 @@ macro_rules! define_clock_tree_types {
             if clocks.lp_slow_clk_refcount > 0 {
                 match new_selector {
                     LpSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     LpSlowClkConfig::Xtal32k => request_xtal32k_clk(clocks),
                 }
                 configure_lp_slow_clk_impl(clocks, old_selector, new_selector);
                 if let Some(old_selector) = old_selector {
                     match old_selector {
                         LpSlowClkConfig::RcSlow => release_rc_slow_clk(clocks),
+                        #[cfg(use_xtal32k)]
                         LpSlowClkConfig::Xtal32k => release_xtal32k_clk(clocks),
                     }
                 }
@@ -2772,6 +2782,7 @@ macro_rules! define_clock_tree_types {
                 trace!("Enabling LP_SLOW_CLK");
                 match unwrap!(clocks.lp_slow_clk) {
                     LpSlowClkConfig::RcSlow => request_rc_slow_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     LpSlowClkConfig::Xtal32k => request_xtal32k_clk(clocks),
                 }
                 enable_lp_slow_clk_impl(clocks, true);
@@ -2784,6 +2795,7 @@ macro_rules! define_clock_tree_types {
                 enable_lp_slow_clk_impl(clocks, false);
                 match unwrap!(clocks.lp_slow_clk) {
                     LpSlowClkConfig::RcSlow => release_rc_slow_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     LpSlowClkConfig::Xtal32k => release_xtal32k_clk(clocks),
                 }
             }
@@ -2795,6 +2807,7 @@ macro_rules! define_clock_tree_types {
         ) -> u32 {
             match config {
                 LpSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
+                #[cfg(use_xtal32k)]
                 LpSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
             }
         }
@@ -2804,6 +2817,7 @@ macro_rules! define_clock_tree_types {
         pub fn lp_slow_clk_source_frequency(source: LpSlowClkConfig) -> u32 {
             match source {
                 LpSlowClkConfig::RcSlow => rc_slow_clk_frequency(),
+                #[cfg(use_xtal32k)]
                 LpSlowClkConfig::Xtal32k => xtal32k_clk_frequency(),
             }
         }
@@ -2861,6 +2875,7 @@ macro_rules! define_clock_tree_types {
                 match new_selector {
                     TimgCalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
                     TimgCalibrationClockConfig::RcFastDivClk => request_rc_fast_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     TimgCalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
                 }
                 configure_timg_calibration_clock_impl(clocks, old_selector, new_selector);
@@ -2868,6 +2883,7 @@ macro_rules! define_clock_tree_types {
                     match old_selector {
                         TimgCalibrationClockConfig::RcSlowClk => release_rc_slow_clk(clocks),
                         TimgCalibrationClockConfig::RcFastDivClk => release_rc_fast_clk(clocks),
+                        #[cfg(use_xtal32k)]
                         TimgCalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
                     }
                 }
@@ -2888,6 +2904,7 @@ macro_rules! define_clock_tree_types {
                 match unwrap!(clocks.timg_calibration_clock) {
                     TimgCalibrationClockConfig::RcSlowClk => request_rc_slow_clk(clocks),
                     TimgCalibrationClockConfig::RcFastDivClk => request_rc_fast_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     TimgCalibrationClockConfig::Xtal32kClk => request_xtal32k_clk(clocks),
                 }
                 enable_timg_calibration_clock_impl(clocks, true);
@@ -2902,6 +2919,7 @@ macro_rules! define_clock_tree_types {
                 match unwrap!(clocks.timg_calibration_clock) {
                     TimgCalibrationClockConfig::RcSlowClk => release_rc_slow_clk(clocks),
                     TimgCalibrationClockConfig::RcFastDivClk => release_rc_fast_clk(clocks),
+                    #[cfg(use_xtal32k)]
                     TimgCalibrationClockConfig::Xtal32kClk => release_xtal32k_clk(clocks),
                 }
             }
@@ -2914,6 +2932,7 @@ macro_rules! define_clock_tree_types {
             match config {
                 TimgCalibrationClockConfig::RcSlowClk => rc_slow_clk_frequency(),
                 TimgCalibrationClockConfig::RcFastDivClk => rc_fast_clk_frequency(),
+                #[cfg(use_xtal32k)]
                 TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
             }
         }
@@ -2924,6 +2943,7 @@ macro_rules! define_clock_tree_types {
             match source {
                 TimgCalibrationClockConfig::RcSlowClk => rc_slow_clk_frequency(),
                 TimgCalibrationClockConfig::RcFastDivClk => rc_fast_clk_frequency(),
+                #[cfg(use_xtal32k)]
                 TimgCalibrationClockConfig::Xtal32kClk => xtal32k_clk_frequency(),
             }
         }

--- a/esp-metadata/devices/esp32/clocks.toml
+++ b/esp-metadata/devices/esp32/clocks.toml
@@ -28,6 +28,8 @@ system_clocks = { clock_tree = [
     #  - `output` is an expression describing how the output frequency is calculated.
     #
     # Each item may have a `reject` list of conditions to validate the clock tree config.
+    # Each clock node and mux variant may have a `cfg` rustc cfg expression. The item is omitted
+    # when that condition is false.
     #
     # Free parameters:
     # - value of XTAL_CLK (can be fixed or "measured")
@@ -101,13 +103,13 @@ system_clocks = { clock_tree = [
     ] },
 
     # Low-speed clocks
-    { name = "XTAL32K_CLK",     type = "source",  output = "32768" },
+    { name = "XTAL32K_CLK",     type = "source",  output = "32768", cfg = "use_xtal32k" },
     { name = "RC_SLOW_CLK",     type = "source",  output = "150_000" },
     { name = "RC_FAST_DIV_CLK", type = "generic", output = "RC_FAST_CLK / 256" },
     { name = "XTAL_DIV_CLK",    type = "generic", output = "XTAL_CLK / 4" }, # source: esp-idf SOC_RTC_FAST_CLK_SRC_XTAL_D4
 
     { name = "RTC_SLOW_CLK", type = "mux", variants = [
-        { name = "XTAL32K", outputs = "XTAL32K_CLK" },
+        { name = "XTAL32K", outputs = "XTAL32K_CLK", cfg = "use_xtal32k" },
         { name = "RC_SLOW", outputs = "RC_SLOW_CLK" },
         { name = "RC_FAST", outputs = "RC_FAST_DIV_CLK" },
     ] },
@@ -134,7 +136,7 @@ system_clocks = { clock_tree = [
     { name = "TIMG_CALIBRATION_CLOCK", type = "mux", wake_locking = true, variants = [
         { name = "RC_SLOW_CLK",     outputs = "RC_SLOW_CLK" },
         { name = "RC_FAST_DIV_CLK", outputs = "RC_FAST_DIV_CLK" },
-        { name = "XTAL32K_CLK",     outputs = "XTAL32K_CLK" },
+        { name = "XTAL32K_CLK",     outputs = "XTAL32K_CLK", cfg = "use_xtal32k" },
     ] },
 ], template_groups = [
     { group = "MCPWM", clocks = [

--- a/esp-metadata/devices/esp32c3/clocks.toml
+++ b/esp-metadata/devices/esp32c3/clocks.toml
@@ -5,7 +5,7 @@ system_clocks = { clock_tree = [
     { name = "RC_FAST_CLK", type = "source",                                          output = "17_500_000" },
 
     # Low-speed clocks
-    { name = "XTAL32K_CLK",     type = "source",  output = "32768" },
+    { name = "XTAL32K_CLK",     type = "source",  output = "32768", cfg = "use_xtal32k" },
     { name = "RC_SLOW_CLK",     type = "source",  output = "136_000" },
     { name = "RC_FAST_DIV_CLK", type = "generic", output = "RC_FAST_CLK / 256" },
 
@@ -43,7 +43,7 @@ system_clocks = { clock_tree = [
     { name = "RC_FAST_CLK_DIV_N", type = "generic", params = { divisor = "0 ..= 3" }, output = "RC_FAST_CLK / (divisor + 1)" },
     { name = "XTAL_DIV_CLK",      type = "generic", output = "XTAL_CLK / 2" },
     { name = "RTC_SLOW_CLK", type = "mux", variants = [
-        { name = "XTAL32K", outputs = "XTAL32K_CLK" },
+        { name = "XTAL32K", outputs = "XTAL32K_CLK", cfg = "use_xtal32k" },
         { name = "RC_SLOW", outputs = "RC_SLOW_CLK" },
         { name = "RC_FAST", outputs = "RC_FAST_DIV_CLK" },
     ] },
@@ -56,7 +56,7 @@ system_clocks = { clock_tree = [
     { name = "LOW_POWER_CLK", type = "mux", variants = [
         { name = "XTAL",     outputs = "XTAL_CLK" },
         { name = "RC_FAST",  outputs = "RC_FAST_CLK" },
-        { name = "XTAL32K",  outputs = "XTAL32K_CLK" },
+        { name = "XTAL32K",  outputs = "XTAL32K_CLK", cfg = "use_xtal32k" },
         { name = "RTC_SLOW", outputs = "RTC_SLOW_CLK" },
     ] },
 
@@ -70,7 +70,7 @@ system_clocks = { clock_tree = [
     { name = "TIMG_CALIBRATION_CLOCK", type = "mux", wake_locking = true, variants = [
         { name = "RC_SLOW_CLK",     outputs = "RC_SLOW_CLK" },
         { name = "RC_FAST_DIV_CLK", outputs = "RC_FAST_DIV_CLK" },
-        { name = "XTAL32K_CLK",     outputs = "XTAL32K_CLK" },
+        { name = "XTAL32K_CLK",     outputs = "XTAL32K_CLK", cfg = "use_xtal32k" },
     ] },
 ], template_groups = [
     { group = "TIMG", clocks = [

--- a/esp-metadata/devices/esp32c5/clocks.toml
+++ b/esp-metadata/devices/esp32c5/clocks.toml
@@ -5,7 +5,7 @@ system_clocks = { clock_tree = [
     { name = "RC_FAST_CLK", type = "source",                     output = "20_000_000" },
 
     # Low-speed clocks
-    { name = "XTAL32K_CLK",  type = "source", output = "32768"   },
+    { name = "XTAL32K_CLK",  type = "source", output = "32768", cfg = "use_xtal32k" },
     { name = "OSC_SLOW_CLK", type = "source", output = "32768"   },
     { name = "RC_SLOW_CLK",  type = "source", output = "130_000" },
     # { name = "EXT32K_CLK",   type = "source", output = "32768" }, # currently unimplemented
@@ -46,7 +46,7 @@ system_clocks = { clock_tree = [
     ] },
     { name = "LP_SLOW_CLK", type = "mux", variants = [
         { name = "RC_SLOW",  outputs = "RC_SLOW_CLK" },
-        { name = "XTAL32K",  outputs = "XTAL32K_CLK" },
+        { name = "XTAL32K",  outputs = "XTAL32K_CLK", cfg = "use_xtal32k" },
         #{ name = "EXT32K",   outputs = "EXT32K_CLK" },
         { name = "OSC_SLOW", outputs = "OSC_SLOW_CLK" },
     ] },
@@ -67,7 +67,7 @@ system_clocks = { clock_tree = [
         { name = "RC_SLOW_CLK",     outputs = "RC_SLOW_CLK" },
         # EXT32K not modeled
         { name = "RC_FAST_DIV_CLK", outputs = "RC_FAST_CLK" },
-        { name = "XTAL32K_CLK",     outputs = "XTAL32K_CLK" },
+        { name = "XTAL32K_CLK",     outputs = "XTAL32K_CLK", cfg = "use_xtal32k" },
     ] },
 ], template_groups = [
     { group = "UART", clocks = [

--- a/esp-metadata/devices/esp32c6/clocks.toml
+++ b/esp-metadata/devices/esp32c6/clocks.toml
@@ -5,7 +5,7 @@ system_clocks = { clock_tree = [
     { name = "RC_FAST_CLK", type = "source",                     output = "17_500_000" },
 
     # Low-speed clocks
-    { name = "XTAL32K_CLK",     type = "source",  output = "32768" },
+    { name = "XTAL32K_CLK",     type = "source",  output = "32768", cfg = "use_xtal32k" },
     { name = "OSC_SLOW_CLK",    type = "source",  output = "32768" },
     { name = "RC_SLOW_CLK",     type = "source",  output = "136_000" },
 
@@ -63,7 +63,7 @@ system_clocks = { clock_tree = [
         { name = "XTAL_D2_CLK", outputs = "XTAL_D2_CLK" },
     ] },
     { name = "LP_SLOW_CLK", type = "mux", variants = [
-        { name = "XTAL32K",  outputs = "XTAL32K_CLK" },
+        { name = "XTAL32K",  outputs = "XTAL32K_CLK", cfg = "use_xtal32k" },
         { name = "RC_SLOW",  outputs = "RC_SLOW_CLK" },
         { name = "OSC_SLOW", outputs = "OSC_SLOW_CLK" },
     ] },
@@ -75,7 +75,7 @@ system_clocks = { clock_tree = [
     { name = "TIMG_CALIBRATION_CLOCK", type = "mux", wake_locking = true, variants = [
         { name = "RC_SLOW_CLK",     outputs = "LP_SLOW_CLK" },
         { name = "RC_FAST_DIV_CLK", outputs = "RC_FAST_CLK" },
-        { name = "XTAL32K_CLK",     outputs = "XTAL32K_CLK" },
+        { name = "XTAL32K_CLK",     outputs = "XTAL32K_CLK", cfg = "use_xtal32k" },
     ] },
 ], template_groups = [
     { group = "UART", clocks = [

--- a/esp-metadata/devices/esp32c61/clocks.toml
+++ b/esp-metadata/devices/esp32c61/clocks.toml
@@ -5,7 +5,7 @@ system_clocks = { clock_tree = [
     { name = "PLL_CLK",     type = "derived", from = "XTAL_CLK", output = "480_000_000" },
 
     # Low-speed clocks
-    { name = "XTAL32K_CLK",  type = "source", output = "32768"   },
+    { name = "XTAL32K_CLK",  type = "source", output = "32768", cfg = "use_xtal32k" },
     { name = "OSC_SLOW_CLK", type = "source", output = "32768"   },
     { name = "RC_SLOW_CLK",  type = "source", output = "136_000" },
 
@@ -40,7 +40,7 @@ system_clocks = { clock_tree = [
     ] },
     { name = "LP_SLOW_CLK", type = "mux", variants = [
         { name = "RC_SLOW",  outputs = "RC_SLOW_CLK" },
-        { name = "XTAL32K",  outputs = "XTAL32K_CLK" },
+        { name = "XTAL32K",  outputs = "XTAL32K_CLK", cfg = "use_xtal32k" },
         { name = "OSC_SLOW", outputs = "OSC_SLOW_CLK" },
     ] },
 
@@ -48,7 +48,7 @@ system_clocks = { clock_tree = [
         { name = "OSC_SLOW_CLK",    outputs = "OSC_SLOW_CLK" },
         { name = "RC_SLOW_CLK",     outputs = "RC_SLOW_CLK" },
         { name = "RC_FAST_DIV_CLK", outputs = "RC_FAST_CLK" },
-        { name = "XTAL32K_CLK",     outputs = "XTAL32K_CLK" },
+        { name = "XTAL32K_CLK",     outputs = "XTAL32K_CLK", cfg = "use_xtal32k" },
     ] },
 ], template_groups = [
     { group = "UART", clocks = [

--- a/esp-metadata/devices/esp32h2/clocks.toml
+++ b/esp-metadata/devices/esp32h2/clocks.toml
@@ -12,10 +12,10 @@ system_clocks = { clock_tree = [
     ] },
     
     # Low-speed clocks
-    { name = "XTAL32K_CLK",     type = "source",                        output = "32768" },
+    { name = "XTAL32K_CLK",     type = "source",                        output = "32768", cfg = "use_xtal32k" },
     { name = "OSC_SLOW_CLK",    type = "source",                        output = "32768" },
     { name = "RC_SLOW_CLK",     type = "source",                        output = "130_000" },
-    { name = "PLL_LP_CLK",      type = "derived", from = "XTAL32K_CLK", output = "8_000_000" },
+    { name = "PLL_LP_CLK",      type = "derived", from = "XTAL32K_CLK", output = "8_000_000", cfg = "use_xtal32k" },
 
     { name = "HP_ROOT_CLK", type = "mux", variants = [
         { name = "PLL96",   outputs = "PLL_F96M_CLK" },
@@ -34,11 +34,11 @@ system_clocks = { clock_tree = [
     { name = "XTAL_D2_CLK", type = "generic", output = "XTAL_CLK / 2" },
     { name = "LP_FAST_CLK", type = "mux", variants = [
         { name = "RC_FAST_CLK", outputs = "RC_FAST_CLK" },
-        { name = "PLL_LP_CLK",  outputs = "PLL_LP_CLK" },
+        { name = "PLL_LP_CLK",  outputs = "PLL_LP_CLK", cfg = "use_xtal32k" },
         { name = "XTAL_D2_CLK", outputs = "XTAL_D2_CLK" },
     ] },
     { name = "LP_SLOW_CLK", type = "mux", variants = [
-        { name = "XTAL32K",  outputs = "XTAL32K_CLK" },
+        { name = "XTAL32K",  outputs = "XTAL32K_CLK", cfg = "use_xtal32k" },
         { name = "RC_SLOW",  outputs = "RC_SLOW_CLK" },
         { name = "OSC_SLOW", outputs = "OSC_SLOW_CLK" },
     ] },
@@ -50,7 +50,7 @@ system_clocks = { clock_tree = [
     { name = "TIMG_CALIBRATION_CLOCK", type = "mux", wake_locking = true, variants = [
         { name = "RC_SLOW_CLK",     outputs = "LP_SLOW_CLK" },
         { name = "RC_FAST_DIV_CLK", outputs = "RC_FAST_CLK" }, #?
-        { name = "XTAL32K_CLK",     outputs = "XTAL32K_CLK" },
+        { name = "XTAL32K_CLK",     outputs = "XTAL32K_CLK", cfg = "use_xtal32k" },
     ] },
 ], template_groups = [
     { group = "UART", clocks = [

--- a/esp-metadata/devices/esp32p4/clocks.toml
+++ b/esp-metadata/devices/esp32p4/clocks.toml
@@ -7,7 +7,7 @@ system_clocks = { clock_tree = [
     { name = "RC_FAST_CLK", type = "source",                     output = "20_000_000" },
 
     # Low-speed clocks
-    { name = "XTAL32K_CLK",  type = "source", output = "32768"   },
+    { name = "XTAL32K_CLK",  type = "source", output = "32768", cfg = "use_xtal32k" },
     { name = "OSC_SLOW_CLK", type = "source", output = "32768"   },
     { name = "RC_SLOW_CLK",  type = "source", output = "136_000" },
     { name = "RC32K_CLK",    type = "source", output = "32768"   },
@@ -61,7 +61,7 @@ system_clocks = { clock_tree = [
     ] },
     { name = "LP_SLOW_CLK", type = "mux", variants = [
         { name = "RC_SLOW",  outputs = "RC_SLOW_CLK" },
-        { name = "XTAL32K",  outputs = "XTAL32K_CLK" },
+        { name = "XTAL32K",  outputs = "XTAL32K_CLK", cfg = "use_xtal32k" },
         #{ name = "RC32K",    outputs = "RC32K_CLK" },
         { name = "OSC_SLOW", outputs = "OSC_SLOW_CLK" },
     ] },
@@ -77,7 +77,7 @@ system_clocks = { clock_tree = [
         #{ name = "SDIO_PLL2_CLK",   outputs = "SDIO_PLL2_CLK" },
         { name = "RC_FAST_DIV_CLK", outputs = "RC_FAST_CLK" },
         { name = "RC_SLOW_CLK",     outputs = "LP_SLOW_CLK" },
-        { name = "XTAL32K_CLK",     outputs = "XTAL32K_CLK" },
+        { name = "XTAL32K_CLK",     outputs = "XTAL32K_CLK", cfg = "use_xtal32k" },
         #{ name = "PLL_LP_CLK",      outputs = "PLL_LP_CLK" },
     ] },
 ], template_groups = [

--- a/esp-metadata/devices/esp32s2/clocks.toml
+++ b/esp-metadata/devices/esp32s2/clocks.toml
@@ -48,13 +48,13 @@ system_clocks = { clock_tree = [
     ] },
 
     # Low-speed clocks
-    { name = "XTAL32K_CLK",     type = "source",  output = "32768" },
+    { name = "XTAL32K_CLK",     type = "source",  output = "32768", cfg = "use_xtal32k" },
     { name = "RC_SLOW_CLK",     type = "source",  output = "90_000" },
     { name = "RC_FAST_DIV_CLK", type = "generic", output = "RC_FAST_CLK / 256" },
     { name = "XTAL_DIV_CLK",    type = "generic", output = "XTAL_CLK / 4" }, # source: esp-idf SOC_RTC_FAST_CLK_SRC_XTAL_D4
 
     { name = "RTC_SLOW_CLK", type = "mux", variants = [
-        { name = "XTAL32K",    outputs = "XTAL32K_CLK" },
+        { name = "XTAL32K",    outputs = "XTAL32K_CLK", cfg = "use_xtal32k" },
         { name = "RC_SLOW", outputs = "RC_SLOW_CLK" },
         { name = "RC_FAST", outputs = "RC_FAST_DIV_CLK" },
     ] },
@@ -74,7 +74,7 @@ system_clocks = { clock_tree = [
     { name = "TIMG_CALIBRATION_CLOCK", type = "mux", wake_locking = true, variants = [
         { name = "RTC_CLK",         outputs = "RTC_SLOW_CLK" },
         { name = "RC_FAST_DIV_CLK", outputs = "RC_FAST_DIV_CLK" },
-        { name = "XTAL32K_CLK",     outputs = "XTAL32K_CLK" },
+        { name = "XTAL32K_CLK",     outputs = "XTAL32K_CLK", cfg = "use_xtal32k" },
     ] },
 ], template_groups = [
     { group = "TIMG", clocks = [

--- a/esp-metadata/devices/esp32s3/clocks.toml
+++ b/esp-metadata/devices/esp32s3/clocks.toml
@@ -5,7 +5,7 @@ system_clocks = { clock_tree = [
     { name = "RC_FAST_CLK", type = "source",                                          output = "17_500_000" },
 
     # Low-speed clocks
-    { name = "XTAL32K_CLK",     type = "source",  output = "32768" },
+    { name = "XTAL32K_CLK",     type = "source",  output = "32768", cfg = "use_xtal32k" },
     { name = "RC_SLOW_CLK",     type = "source",  output = "136_000" },
     { name = "RC_FAST_DIV_CLK", type = "generic", output = "RC_FAST_CLK / 256" },
 
@@ -44,7 +44,7 @@ system_clocks = { clock_tree = [
     { name = "RC_FAST_CLK_DIV_N", type = "generic", params = { divisor = "0 ..= 3" }, output = "RC_FAST_CLK / (divisor + 1)" },
     { name = "XTAL_DIV_CLK",      type = "generic", output = "XTAL_CLK / 2" },
     { name = "RTC_SLOW_CLK", type = "mux", variants = [
-        { name = "XTAL32K", outputs = "XTAL32K_CLK" },
+        { name = "XTAL32K", outputs = "XTAL32K_CLK", cfg = "use_xtal32k" },
         { name = "RC_SLOW", outputs = "RC_SLOW_CLK" },
         { name = "RC_FAST", outputs = "RC_FAST_DIV_CLK" },
     ] },
@@ -57,7 +57,7 @@ system_clocks = { clock_tree = [
     { name = "LOW_POWER_CLK", type = "mux", variants = [
         { name = "XTAL",     outputs = "XTAL_CLK" },
         { name = "RC_FAST",  outputs = "RC_FAST_CLK" },
-        { name = "XTAL32K",  outputs = "XTAL32K_CLK" },
+        { name = "XTAL32K",  outputs = "XTAL32K_CLK", cfg = "use_xtal32k" },
         { name = "RTC_SLOW", outputs = "RTC_SLOW_CLK" },
     ] },
 
@@ -72,7 +72,7 @@ system_clocks = { clock_tree = [
     { name = "TIMG_CALIBRATION_CLOCK", type = "mux", wake_locking = true, variants = [
         { name = "RC_SLOW_CLK",     outputs = "RC_SLOW_CLK" },
         { name = "RC_FAST_DIV_CLK", outputs = "RC_FAST_DIV_CLK" },
-        { name = "XTAL32K_CLK",     outputs = "XTAL32K_CLK" },
+        { name = "XTAL32K_CLK",     outputs = "XTAL32K_CLK", cfg = "use_xtal32k" },
     ] },
 ], template_groups = [
     { group = "MCPWM", clocks = [

--- a/esp-metadata/devices/esp32s31/clocks.toml
+++ b/esp-metadata/devices/esp32s31/clocks.toml
@@ -7,7 +7,7 @@ system_clocks = { clock_tree = [
     { name = "RC_FAST_CLK", type = "source",                     output = "17_500_000" },
 
     # Low-speed clocks
-    { name = "XTAL32K_CLK",  type = "source", output = "32768"   },
+    { name = "XTAL32K_CLK",  type = "source", output = "32768", cfg = "use_xtal32k" },
     { name = "RC_SLOW_CLK",  type = "source", output = "136_000" },
 
     # BBPLL divider taps (480MHz / N)
@@ -43,7 +43,7 @@ system_clocks = { clock_tree = [
     ] },
     { name = "LP_SLOW_CLK", type = "mux", variants = [
         { name = "RC_SLOW",  outputs = "RC_SLOW_CLK" },
-        { name = "XTAL32K",  outputs = "XTAL32K_CLK" },
+        { name = "XTAL32K",  outputs = "XTAL32K_CLK", cfg = "use_xtal32k" },
     ] },
 
     {
@@ -59,7 +59,7 @@ system_clocks = { clock_tree = [
     { name = "TIMG_CALIBRATION_CLOCK", type = "mux", wake_locking = true, variants = [
         { name = "RC_SLOW_CLK",     outputs = "RC_SLOW_CLK" },
         { name = "RC_FAST_DIV_CLK", outputs = "RC_FAST_CLK" },
-        { name = "XTAL32K_CLK",     outputs = "XTAL32K_CLK" },
+        { name = "XTAL32K_CLK",     outputs = "XTAL32K_CLK", cfg = "use_xtal32k" },
     ] },
 ], template_groups = [
     { group = "PSRAM", clocks = [

--- a/esp-metadata/src/cfg/soc.rs
+++ b/esp-metadata/src/cfg/soc.rs
@@ -342,6 +342,10 @@ impl ClockTreeNodeInstance {
         self.suffix_function("frequency")
     }
 
+    fn rustc_cfg_attr(&self) -> TokenStream {
+        clock_tree::rustc_cfg_attr(self.node.rustc_cfg())
+    }
+
     fn config_frequency_function_name(&self) -> Ident {
         self.suffix_function("config_frequency")
     }
@@ -489,6 +493,7 @@ impl ClockTreeNodeInstance {
             } else {
                 None
             },
+            cfg: self.node.rustc_cfg().map(str::to_string),
             request: Function {
                 _name: request_fn_name.to_string(),
                 implementation: if always_on {
@@ -752,8 +757,13 @@ impl SystemClocks {
                 clock_item.node.name()
             ));
             if is_first_instance {
+                let cfg_attr = clock_item.rustc_cfg_attr();
                 if clock_item.emits_config_type(tree) {
-                    clock_tree_node_defs.push(clock_item.config_type());
+                    let config_type = clock_item.config_type();
+                    clock_tree_node_defs.push(quote! {
+                        #cfg_attr
+                        #config_type
+                    });
                 }
 
                 let instance_count =
@@ -765,13 +775,23 @@ impl SystemClocks {
 
                 if let Some(refcount_field) = clock_item.properties.refcount_field() {
                     if let Some(instance_count) = instance_count.as_ref() {
-                        clock_tree_refcount_field_decls
-                            .push(quote! { #refcount_field: [u32; #instance_count] });
-                        clock_tree_refcount_field_inits
-                            .push(quote! { #refcount_field: [0; #instance_count] });
+                        clock_tree_refcount_field_decls.push(quote! {
+                            #cfg_attr
+                            #refcount_field: [u32; #instance_count]
+                        });
+                        clock_tree_refcount_field_inits.push(quote! {
+                            #cfg_attr
+                            #refcount_field: [0; #instance_count]
+                        });
                     } else {
-                        clock_tree_refcount_field_decls.push(quote! { #refcount_field: u32 });
-                        clock_tree_refcount_field_inits.push(quote! { #refcount_field: 0 });
+                        clock_tree_refcount_field_decls.push(quote! {
+                            #cfg_attr
+                            #refcount_field: u32
+                        });
+                        clock_tree_refcount_field_inits.push(quote! {
+                            #cfg_attr
+                            #refcount_field: 0
+                        });
                     }
                 }
 
@@ -827,6 +847,12 @@ impl SystemClocks {
                     if func.is_empty() {
                         continue;
                     }
+                    if let Some(cfg) = clock_item.node.rustc_cfg() {
+                        let cfg_doc = format!(" #[cfg({cfg})]");
+                        doclines.push(quote! {
+                            #[doc = #cfg_doc]
+                        });
+                    }
                     let func = func.to_string();
                     doclines.push(quote! {
                         #[doc = #func]
@@ -861,7 +887,10 @@ impl SystemClocks {
                     quote! { #(#[doc = #doc])* }
                 });
 
+                let cfg_attr = clock_item.rustc_cfg_attr();
+
                 configurables.push(quote! {
+                    #cfg_attr
                     #docline
                     pub #name: Option<#config_type_name>,
                 });
@@ -869,6 +898,7 @@ impl SystemClocks {
                 system_config_steps.insert(
                     clock_item.name_str(),
                     quote! {
+                        #cfg_attr
                         if let Some(config) = self.#name {
                             #config_apply_function_name(clocks, config);
                         }
@@ -942,6 +972,7 @@ impl SystemClocks {
 
             let cache_name = node.freq_cache_static_name();
             let config_freq_fn = node.config_frequency_function_name();
+            let cfg_attr = node.rustc_cfg_attr();
 
             if node.properties.receiver.is_some() {
                 let instances = tree.group_instances.get(&node.group_template).unwrap();
@@ -955,6 +986,7 @@ impl SystemClocks {
                 );
 
                 freq_cache_statics.push(quote! {
+                    #cfg_attr
                     static #cache_name: [::core::sync::atomic::AtomicU32; #instance_count] =
                         [const { ::core::sync::atomic::AtomicU32::new(0) }; #instance_count];
                 });
@@ -979,6 +1011,7 @@ impl SystemClocks {
                 let config_field = node.properties.indexed_config_accessor();
 
                 freq_cache_statics.push(quote! {
+                    #cfg_attr
                     static #cache_name: ::core::sync::atomic::AtomicU32 =
                         ::core::sync::atomic::AtomicU32::new(0);
                 });
@@ -1037,6 +1070,7 @@ impl SystemClocks {
 
             let fn_name = node.refresh_downstream_function_name();
             let self_stmt = refresh_stmt_by_key.get(&template_key).cloned();
+            let cfg_attr = node.rustc_cfg_attr();
 
             // Build calls to direct configurable children's refresh functions.
             let children = tree
@@ -1077,6 +1111,7 @@ impl SystemClocks {
                     child_calls.push(template_group_loop(tree, group, &fns));
                 }
                 downstream_refresh_fns.push(quote! {
+                    #cfg_attr
                     fn #fn_name(clocks: &mut ClockTree, instance: #enum_name) {
                         #self_stmt
                         #(#child_calls)*
@@ -1107,6 +1142,7 @@ impl SystemClocks {
                     child_calls.push(template_group_loop(tree, group, &fns));
                 }
                 downstream_refresh_fns.push(quote! {
+                    #cfg_attr
                     fn #fn_name(clocks: &mut ClockTree) {
                         #self_stmt
                         #(#child_calls)*

--- a/esp-metadata/src/cfg/soc/clock_tree.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree.rs
@@ -64,6 +64,17 @@ mod generic;
 mod mux;
 mod source;
 
+/// Builds `#[cfg(...)]` from a metadata `cfg` property, or an empty token stream.
+pub(crate) fn rustc_cfg_attr(cfg: Option<&str>) -> TokenStream {
+    let Some(cfg) = cfg.filter(|cfg| !cfg.is_empty()) else {
+        return quote! {};
+    };
+    let cfg = TokenStream::from_str(cfg).unwrap_or_else(|err| {
+        panic!("Invalid clock-tree `cfg` expression `{cfg}`: {err}");
+    });
+    quote! { #[cfg(#cfg)] }
+}
+
 /// Returns the name of the config type generated for a node.
 ///
 /// `group` is the template group the node belongs to, or an empty string for standalone nodes.
@@ -99,6 +110,7 @@ pub(crate) enum SourceFrequencySignature {
 
 pub(crate) struct ClockNodeFunctions {
     pub impl_type: Option<Ident>,
+    pub cfg: Option<String>,
 
     pub request: Function,
     pub release: Function,
@@ -112,12 +124,24 @@ pub(crate) struct ClockNodeFunctions {
 
 impl ClockNodeFunctions {
     pub fn implement_functions(&self) -> TokenStream {
-        let request_impl = &self.request.implementation;
-        let release_impl = &self.release.implementation;
-        let apply_impl = &self.apply_config.implementation;
-        let current_config_impl = &self.current_config.implementation;
-        let frequency_impl = &self.frequency.implementation;
-        let source_frequency_impl = &self.source_frequency.implementation;
+        let cfg_attr = rustc_cfg_attr(self.cfg.as_deref());
+        let wrap = |implementation: &TokenStream| {
+            if implementation.is_empty() {
+                quote! {}
+            } else {
+                quote! {
+                    #cfg_attr
+                    #implementation
+                }
+            }
+        };
+
+        let apply_impl = wrap(&self.apply_config.implementation);
+        let current_config_impl = wrap(&self.current_config.implementation);
+        let request_impl = wrap(&self.request.implementation);
+        let release_impl = wrap(&self.release.implementation);
+        let frequency_impl = wrap(&self.frequency.implementation);
+        let source_frequency_impl = wrap(&self.source_frequency.implementation);
 
         quote! {
             #apply_impl
@@ -554,6 +578,11 @@ pub(crate) trait ClockTreeNodeType: Any {
     /// standalone nodes. It is needed to reconstruct the names of the generated config types.
     fn property_macro_branches(&self, _path: &str, _group: &str) -> TokenStream {
         quote! {}
+    }
+
+    /// Optional `#[cfg(...)]` expression that disables this node when false.
+    fn rustc_cfg(&self) -> Option<&str> {
+        None
     }
 }
 

--- a/esp-metadata/src/cfg/soc/clock_tree/generic.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/generic.rs
@@ -107,6 +107,10 @@ pub struct Generic {
     #[serde(default)]
     wake_locking: bool,
 
+    /// Optional `#[cfg(...)]` expression. The node is omitted when the condition is false.
+    #[serde(default)]
+    cfg: Option<String>,
+
     /// The expression that calculates the clock node's output frequency.
     output: Expression,
 
@@ -159,6 +163,10 @@ impl ClockTreeNodeType for Generic {
 
     fn wake_locking(&self) -> bool {
         self.wake_locking
+    }
+
+    fn rustc_cfg(&self) -> Option<&str> {
+        self.cfg.as_deref()
     }
 
     fn validate_source_data(
@@ -287,6 +295,7 @@ impl ClockTreeNodeType for Generic {
                 let mux_param_field = format_ident!("{mux_param}");
                 let param_ty_name = self.param_type_name(instance, mux_param);
                 let branches = mux_inputs.iter().filter_map(|variant| {
+                    let cfg_attr = variant.cfg_attr();
                     let name = variant.config_enum_variant_name();
                     let variant_configures = variant.configures.iter().map(|cfg_expr| {
                         let affected_node = instance.resolve_node(tree, &cfg_expr.effect().node);
@@ -294,6 +303,7 @@ impl ClockTreeNodeType for Generic {
                     });
 
                     Some(quote! {
+                        #cfg_attr
                         #param_ty_name::#name => {
                             #(#variant_configures)*
                         }
@@ -529,12 +539,13 @@ impl ClockTreeNodeType for Generic {
                 let mut variants = Vec::with_capacity(inputs.len());
                 let mut variant_frequencies = Vec::with_capacity(inputs.len());
                 for variant in inputs {
+                    let cfg_attr = variant.cfg_attr();
                     let name = variant.config_enum_variant_name();
                     let source_node = instance.resolve_node(tree, &variant.outputs);
                     let Some(frequency) = source_node.try_frequency_call() else {
                         return SourceFrequencySignature::Skip;
                     };
-                    variants.push(quote! { #ty_name::#name });
+                    variants.push(quote! { #cfg_attr #ty_name::#name });
                     variant_frequencies.push(frequency);
                 }
 
@@ -619,11 +630,12 @@ impl ClockTreeNodeType for Generic {
                 let (variants, variant_frequencies) = inputs
                     .iter()
                     .map(|variant| {
+                        let cfg_attr = variant.cfg_attr();
                         let name = variant.config_enum_variant_name();
                         let source_node = instance.resolve_node(tree, &variant.outputs);
 
                         (
-                            quote! { #ty_name::#name },
+                            quote! { #cfg_attr #ty_name::#name },
                             source_node.frequency_call_with_receiver(frequency_receiver),
                         )
                     })
@@ -825,8 +837,9 @@ impl ClockTreeNodeType for Generic {
                 NodeParameter::Source(variants) => {
                     let ty = param_type_name(group, &self.name, param_name);
                     let options = variants.iter().map(|variant| {
+                        let cfg_attr = variant.cfg_attr();
                         let variant = variant.config_enum_variant_name();
-                        quote! { crate::soc::clocks::#ty::#variant }
+                        quote! { #cfg_attr crate::soc::clocks::#ty::#variant }
                     });
                     branches.extend(quote! {
                         (#path) => {
@@ -926,11 +939,13 @@ impl Generic {
                 let param = self.clock_source_parameter();
                 let ty_name = self.param_type_name(instance, param);
                 let request_upstream_branches = mux_inputs.iter().map(|variant| {
+                    let cfg_attr = variant.cfg_attr();
                     let match_arm = variant.config_enum_variant_name();
                     let upstream_node = instance.resolve_node(tree, &variant.outputs);
                     let upstream_receiver = upstream_node.properties.receiver();
                     let function = op(upstream_node);
                     quote! {
+                        #cfg_attr
                         #ty_name::#match_arm => #(#upstream_receiver.)*#function(clocks)
                     }
                 });

--- a/esp-metadata/src/cfg/soc/clock_tree/mux.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/mux.rs
@@ -16,6 +16,7 @@ use crate::cfg::{
         SourceFrequencySignature,
         ValidationContext,
         config_type_name,
+        rustc_cfg_attr,
     },
     soc::ProcessedClockData,
 };
@@ -31,6 +32,10 @@ pub struct Multiplexer {
 
     #[serde(default)]
     wake_locking: bool,
+
+    /// Optional `#[cfg(...)]` expression. The node is omitted when the condition is false.
+    #[serde(default)]
+    cfg: Option<String>,
 
     // reject: Option<RejectExpression>,
     pub variants: Vec<MultiplexerVariant>,
@@ -51,6 +56,10 @@ impl ClockTreeNodeType for Multiplexer {
 
     fn wake_locking(&self) -> bool {
         self.wake_locking
+    }
+
+    fn rustc_cfg(&self) -> Option<&str> {
+        self.cfg.as_deref()
     }
 
     fn input_clocks(
@@ -173,12 +182,13 @@ impl ClockTreeNodeType for Multiplexer {
         let mut variant_frequencies = Vec::with_capacity(self.variants.len());
         let mut variants = Vec::with_capacity(self.variants.len());
         for variant in &self.variants {
+            let cfg_attr = variant.cfg_attr();
             let name = variant.config_enum_variant_name();
             let upstream_node = instance.resolve_node(tree, &variant.outputs);
             let Some(frequency) = upstream_node.try_frequency_call() else {
                 return SourceFrequencySignature::Skip;
             };
-            variants.push(quote! { #ty_name::#name });
+            variants.push(quote! { #cfg_attr #ty_name::#name });
             variant_frequencies.push(frequency);
         }
 
@@ -212,8 +222,9 @@ impl ClockTreeNodeType for Multiplexer {
             .variants
             .iter()
             .map(|variant| {
+                let cfg_attr = variant.cfg_attr();
                 let name = variant.config_enum_variant_name();
-                quote! { #ty_name::#name }
+                quote! { #cfg_attr #ty_name::#name }
             })
             .collect::<Vec<_>>();
 
@@ -249,11 +260,13 @@ impl ClockTreeNodeType for Multiplexer {
         } else {
             quote! {}
         };
+        let cfg_attr = instance.rustc_cfg_attr();
         let variants = self.variants.iter().map(|v| v.config_enum_variant());
 
         let docline =
             format!("The list of clock signals that the `{clock_name}` multiplexer can output.");
         quote! {
+            #cfg_attr
             #[doc = #docline]
             #[derive(Debug, #derive_default Clone, Copy, PartialEq, Eq, Hash)]
             #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -292,8 +305,9 @@ impl ClockTreeNodeType for Multiplexer {
 
         let ty = config_type_name(group, &self.name);
         let options = self.variants.iter().map(|variant| {
+            let cfg_attr = variant.cfg_attr();
             let variant = variant.config_enum_variant_name();
-            quote! { crate::soc::clocks::#ty::#variant }
+            quote! { #cfg_attr crate::soc::clocks::#ty::#variant }
         });
 
         quote! {
@@ -362,8 +376,10 @@ impl Multiplexer {
                 }
 
                 let name = variant.config_enum_variant_name();
+                let cfg_attr = variant.cfg_attr();
 
                 Some(quote! {
+                    #cfg_attr
                     #ty_name::#name => {
                         #variant_configures
                     }
@@ -422,12 +438,14 @@ impl Multiplexer {
         if self.variants.len() > 1 {
             let ty_name = instance.config_type_name();
             let request_upstream_branches = self.variants.iter().map(|variant| {
+                let cfg_attr = variant.cfg_attr();
                 let match_arm = variant.config_enum_variant_name();
 
                 let upstream_node = instance.resolve_node(tree, &variant.outputs);
                 let receiver = upstream_node.properties.receiver();
                 let func = upstream_node.request_fn_name();
                 quote! {
+                    #cfg_attr
                     #ty_name::#match_arm => #(#receiver.)*#func(clocks)
                 }
             });
@@ -464,11 +482,13 @@ impl Multiplexer {
         if self.variants.len() > 1 {
             let ty_name = instance.config_type_name();
             let release_upstream_branches = self.variants.iter().map(|variant| {
+                let cfg_attr = variant.cfg_attr();
                 let match_arm = variant.config_enum_variant_name();
                 let upstream_node = instance.resolve_node(tree, &variant.outputs);
                 let receiver = upstream_node.properties.receiver();
                 let func = upstream_node.release_fn_name();
                 quote! {
+                    #cfg_attr
                     #ty_name::#match_arm => #(#receiver.)*#func(clocks)
                 }
             });
@@ -522,8 +542,15 @@ pub struct MultiplexerVariant {
     pub configures: Vec<ConfiguresExpression>,
     #[serde(default)]
     pub default: bool,
+    /// Optional `#[cfg(...)]` expression. The variant is omitted when the condition is false.
+    #[serde(default)]
+    pub cfg: Option<String>,
 }
 impl MultiplexerVariant {
+    pub fn cfg_attr(&self) -> TokenStream {
+        rustc_cfg_attr(self.cfg.as_deref())
+    }
+
     pub fn config_enum_variant_name(&self) -> Ident {
         format_ident!(
             "{}",
@@ -540,6 +567,7 @@ impl MultiplexerVariant {
     pub fn config_enum_variant(&self) -> TokenStream {
         let docline = format!(" Selects `{}`.", self.outputs);
         let name = self.config_enum_variant_name();
+        let cfg_attr = self.cfg_attr();
 
         let default = if self.default {
             quote! {
@@ -550,6 +578,7 @@ impl MultiplexerVariant {
         };
 
         quote! {
+            #cfg_attr
             #default
             #[doc = #docline]
             #name,

--- a/esp-metadata/src/cfg/soc/clock_tree/source.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/source.rs
@@ -66,6 +66,10 @@ pub struct Source {
     #[serde(default)]
     wake_locking: bool,
 
+    /// Optional `#[cfg(...)]` expression. The node is omitted when the condition is false.
+    #[serde(default)]
+    cfg: Option<String>,
+
     /// If set, this expression will be used to validate the clock configuration.
     ///
     /// The expression may refer to clock sources, or any of the clock tree item's properties (e.g.
@@ -100,6 +104,10 @@ impl ClockTreeNodeType for Source {
 
     fn wake_locking(&self) -> bool {
         self.wake_locking
+    }
+
+    fn rustc_cfg(&self) -> Option<&str> {
+        self.cfg.as_deref()
     }
 
     fn validate_source_data(
@@ -369,6 +377,10 @@ impl ClockTreeNodeType for DerivedClockSource {
         self.source_options.is_configurable()
     }
 
+    fn rustc_cfg(&self) -> Option<&str> {
+        self.source_options.rustc_cfg()
+    }
+
     fn config_apply_function(
         &self,
         instance: &ClockTreeNodeInstance,
@@ -401,8 +413,14 @@ impl ClockTreeNodeType for DerivedClockSource {
 
     fn config_type(&self, instance: &ClockTreeNodeInstance) -> TokenStream {
         let extra_docs = format!("Depends on `{}`.", self.from);
-        self.source_options
-            .impl_config_type(instance, Some(&extra_docs))
+        let cfg_attr = instance.rustc_cfg_attr();
+        let ty = self
+            .source_options
+            .impl_config_type(instance, Some(&extra_docs));
+        quote! {
+            #cfg_attr
+            #ty
+        }
     }
 
     fn request_direct_dependencies(


### PR DESCRIPTION
# Changelog

## esp-hal

- Fixed: XTAL32K can no longer be configured without enabling `ESP_HAL_CONFIG_USE_XTAL32K`