### PR TITLE
Release 7 packages

### DIFF
--- a/esp-alloc/CHANGELOG.md
+++ b/esp-alloc/CHANGELOG.md
@@ -9,17 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Support for ESP32-P4 (#5523)
 
 ### Changed
 
 
 ### Fixed
 
-- Fixed `realloc_with_caps` over-reading issue (#5502)
 
 ### Removed
 
+
+## [v0.11.0] - 2026-08-25
+
+### Added
+
+- Support for ESP32-P4 (#5523)
+- `DmaCompatibleInternalMemory` and `DmaCompatibleExternalMemory` allocators that ensure the returned variable is properly aligned as a DMA buffer. (#6068)
+- ESP32-S31 support (#5959)
+
+### Changed
+
+- The chip selector feature(s) are now mandatory. (#6068)
+- updated defmt to 1.1 (#5752)
+
+### Fixed
+
+- Fixed `realloc_with_caps` over-reading issue (#5502)
+- Memory allocated from a secondary heap region could not always be freed, causing a silent leak. (#6018)
+- Freeing memory could affect the wrong heap when using multiple adjacent memory regions (#6018)
 
 ## [v0.10.0] - 2026-04-16
 
@@ -110,4 +127,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v0.8.0]: https://github.com/esp-rs/esp-hal/compare/esp-alloc-v0.7.0...esp-alloc-v0.8.0
 [v0.9.0]: https://github.com/esp-rs/esp-hal/compare/esp-alloc-v0.8.0...esp-alloc-v0.9.0
 [v0.10.0]: https://github.com/esp-rs/esp-hal/compare/esp-alloc-v0.9.0...esp-alloc-v0.10.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-alloc-v0.10.0...HEAD
+[v0.11.0]: https://github.com/esp-rs/esp-hal/compare/esp-alloc-v0.10.0...esp-alloc-v0.11.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-alloc-v0.11.0...HEAD

--- a/esp-alloc/Cargo.toml
+++ b/esp-alloc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-alloc"
-version       = "0.10.0"
+version       = "0.11.0"
 edition       = "2024"
 rust-version  = "1.95.0"
 description   = "A heap allocator for Espressif devices"

--- a/esp-backtrace/CHANGELOG.md
+++ b/esp-backtrace/CHANGELOG.md
@@ -9,8 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Initial ESP32-P4 (chip revision v3.0+) support (#5400)
-- Add ESP32-S31 support (#5922)
 
 ### Changed
 
@@ -20,6 +18,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+
+## [v0.20.0] - 2026-08-25
+
+### Added
+
+- Initial ESP32-P4 (chip revision v3.0+) support (#5400)
+- Add ESP32-S31 support (#5922)
+
+### Changed
+
+- updated defmt to 1.1 (#5752)
+
+### Fixed
+
+- Xtensa: Fixed an issue that could corrupt a register value (#6027)
 
 ## [v0.19.0] - 2026-04-16
 
@@ -123,4 +136,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v0.18.0]: https://github.com/esp-rs/esp-hal/compare/esp-backtrace-v0.17.0...esp-backtrace-v0.18.0
 [v0.18.1]: https://github.com/esp-rs/esp-hal/compare/esp-backtrace-v0.18.0...esp-backtrace-v0.18.1
 [v0.19.0]: https://github.com/esp-rs/esp-hal/compare/esp-backtrace-v0.18.1...esp-backtrace-v0.19.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-backtrace-v0.19.0...HEAD
+[v0.20.0]: https://github.com/esp-rs/esp-hal/compare/esp-backtrace-v0.19.0...esp-backtrace-v0.20.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-backtrace-v0.20.0...HEAD

--- a/esp-backtrace/Cargo.toml
+++ b/esp-backtrace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-backtrace"
-version       = "0.19.0"
+version       = "0.20.0"
 edition       = "2024"
 rust-version  = "1.95.0"
 description   = "Bare-metal backtrace support for Espressif devices"
@@ -37,7 +37,7 @@ test  = false
 defmt       = { version = "1.1", optional = true }
 esp-config  = { version = "0.8.0", path = "../esp-config" }
 esp-metadata-generated = { version = "0.5.0", path = "../esp-metadata-generated" }
-esp-println = { version = "0.17.0", optional = true, default-features = false, path = "../esp-println" }
+esp-println = { version = "0.18.0", optional = true, default-features = false, path = "../esp-println" }
 heapless    = "0.9"
 semihosting = { version = "0.1.20", optional = true }
 document-features = "0.2"

--- a/esp-bootloader-esp-idf/CHANGELOG.md
+++ b/esp-bootloader-esp-idf/CHANGELOG.md
@@ -9,17 +9,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add ESP32-S31 support (#5922)
 
 ### Changed
 
-- ESP32-P4: Use ROM CRC32 / MD5 functions instead of the software fallback (#5400)
 
 ### Fixed
 
 
 ### Removed
 
+
+## [v0.6.0] - 2026-08-25
+
+### Added
+
+- Add ESP32-S31 support (#5922)
+- `PartitionEntry::sha256()` for partition integrity checks (#6061)
+- FlashRegion::as_nor_flash() and FlashRegion::as_nor_flash_encrypted() for NOR flash access with correct encryption semantics. (#5857)
+- FlashRegionPlainNorFlash and FlashRegionEncryptedNorFlash wrapper types. (#5857)
+- Error::NotSupported for incompatible partition/accessor combinations. (#5857)
+- `OtaUpdater::reset_data()` to erase the OTA data partition and select the factory app (#5767)
+- OTA / partition table support for ESP32-P4 (#5751)
+- Inherent `read`, `write`, and `capacity` methods on [`FlashRegion`](crate::partitions::FlashRegion) (#5739)
+
+### Changed
+
+- ESP32-P4: Use ROM CRC32 / MD5 functions instead of the software fallback (#5400)
+- `PartitionEntry` is now no longer lifetime-tied to `PartitionTable`. (#6056)
+- `FlashRegion` supports transparent encryption support (#5810)
+- updated defmt to 1.1 (#5752)
+- `esp-bootloader-esp-idf` now directly depends on `esp-storage` (#5739)
+- `embedded-storage` trait implementations are now an opt-in feature (non-default) (#5739)
+- `PartitionEntry::as_embedded_storage` is deprecated in favor of [`PartitionEntry::as_flash_region`](crate::partitions::PartitionEntry::as_flash_region) (#5739)
+
+### Fixed
+
+- `FlashRegion::erase` no longer fails when erasing up to the end of the partition (e.g. the last sector or the whole partition) (#6045)
+- `SOURCE_DATE_EPOCH` is now interpreted as seconds since the Unix epoch, as the reproducible-builds specification requires, and changing it re-runs the build script. (#6017)
+- OTA select entries are now validated (CRC and state) before being read into Rust types, avoiding UB on corrupted flash (#5767)
+
+### Removed
+
+- Direct ReadNorFlash, NorFlash, and MultiwriteNorFlash impls on FlashRegion. (#5857)
+- `as_embedded_storage` - use `as_flash_region` instead (#5739)
 
 ## [v0.5.0] - 2026-04-16
 
@@ -100,4 +132,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v0.3.0]: https://github.com/esp-rs/esp-hal/compare/esp-bootloader-esp-idf-v0.2.0...esp-bootloader-esp-idf-v0.3.0
 [v0.4.0]: https://github.com/esp-rs/esp-hal/compare/esp-bootloader-esp-idf-v0.3.0...esp-bootloader-esp-idf-v0.4.0
 [v0.5.0]: https://github.com/esp-rs/esp-hal/compare/esp-bootloader-esp-idf-v0.4.0...esp-bootloader-esp-idf-v0.5.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-bootloader-esp-idf-v0.5.0...HEAD
+[v0.6.0]: https://github.com/esp-rs/esp-hal/compare/esp-bootloader-esp-idf-v0.5.0...esp-bootloader-esp-idf-v0.6.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-bootloader-esp-idf-v0.6.0...HEAD

--- a/esp-bootloader-esp-idf/Cargo.toml
+++ b/esp-bootloader-esp-idf/Cargo.toml
@@ -37,7 +37,7 @@ esp-hal-procmacros = { version = "0.23.0", path = "../esp-hal-procmacros", featu
 esp-metadata-generated = { version = "0.5.0", path = "../esp-metadata-generated" }
 esp-rom-sys = { version = "~0.1", path = "../esp-rom-sys", optional = true }
 embedded-storage = { version = "0.3.1", optional = true }
-esp-storage = { path = "../esp-storage", default-features = false, optional = true }
+esp-storage = { version = "0.9.0", path = "../esp-storage", default-features = false, optional = true }
 log-04 = { package = "log", version = "0.4", optional = true }
 strum = { version = "0.27", default-features = false, features = ["derive"] }
 

--- a/esp-bootloader-esp-idf/Cargo.toml
+++ b/esp-bootloader-esp-idf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "esp-bootloader-esp-idf"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.95.0"
 description = "Functionality related to the esp-idf bootloader"
@@ -37,7 +37,7 @@ esp-hal-procmacros = { version = "0.23.0", path = "../esp-hal-procmacros", featu
 esp-metadata-generated = { version = "0.5.0", path = "../esp-metadata-generated" }
 esp-rom-sys = { version = "~0.1", path = "../esp-rom-sys", optional = true }
 embedded-storage = { version = "0.3.1", optional = true }
-esp-storage = { version = "0.9.0", path = "../esp-storage", default-features = false, optional = true }
+esp-storage = { version = "0.10.0", path = "../esp-storage", default-features = false, optional = true }
 log-04 = { package = "log", version = "0.4", optional = true }
 strum = { version = "0.27", default-features = false, features = ["derive"] }
 

--- a/esp-println/CHANGELOG.md
+++ b/esp-println/CHANGELOG.md
@@ -9,8 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Initial ESP32-P4 (chip revision v3.0+) support (#5400)
-- Add ESP32-S31 support (#5922)
 
 ### Changed
 
@@ -20,6 +18,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+
+## [v0.18.0] - 2026-08-25
+
+### Added
+
+- Initial ESP32-P4 (chip revision v3.0+) support (#5400)
+- Add ESP32-S31 support (#5922)
+- USB Serial/JTAG support for ESP32-S31 (#6184)
+
+### Changed
+
+- updated defmt to 1.1 (#5752)
 
 ## [v0.17.0] - 2026-04-16
 
@@ -136,4 +146,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v0.16.0]: https://github.com/esp-rs/esp-hal/compare/esp-println-v0.15.0...esp-println-v0.16.0
 [v0.16.1]: https://github.com/esp-rs/esp-hal/compare/esp-println-v0.16.0...esp-println-v0.16.1
 [v0.17.0]: https://github.com/esp-rs/esp-hal/compare/esp-println-v0.16.1...esp-println-v0.17.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-println-v0.17.0...HEAD
+[v0.18.0]: https://github.com/esp-rs/esp-hal/compare/esp-println-v0.17.0...esp-println-v0.18.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-println-v0.18.0...HEAD

--- a/esp-println/Cargo.toml
+++ b/esp-println/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-println"
-version       = "0.17.0"
+version       = "0.18.0"
 edition       = "2024"
 rust-version  = "1.95.0"
 description   = "Provides `print!` and `println!` implementations for various Espressif devices"

--- a/esp-radio-rtos-driver/CHANGELOG.md
+++ b/esp-radio-rtos-driver/CHANGELOG.md
@@ -19,6 +19,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 
+## [v0.4.0] - 2026-08-25
+
+### Added
+
+- Configurable `CompatTimer` thread priority. (#5908)
+
+### Changed
+
+- Made `CompatTimer` const-generic (the thread priority) (#5908)
+- updated defmt to 1.1 (#5752)
+
+### Removed
+
+- `CompatTimer::new` (#5908)
+
 ## [v0.3.0] - 2026-04-16
 
 ### Added
@@ -62,4 +77,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v0.1.0]: https://github.com/esp-rs/esp-hal/releases/tag/esp-radio-rtos-driver-v0.1.0
 [v0.2.0]: https://github.com/esp-rs/esp-hal/compare/esp-radio-rtos-driver-v0.1.0...esp-radio-rtos-driver-v0.2.0
 [v0.3.0]: https://github.com/esp-rs/esp-hal/compare/esp-radio-rtos-driver-v0.2.0...esp-radio-rtos-driver-v0.3.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-radio-rtos-driver-v0.3.0...HEAD
+[v0.4.0]: https://github.com/esp-rs/esp-hal/compare/esp-radio-rtos-driver-v0.3.0...esp-radio-rtos-driver-v0.4.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-radio-rtos-driver-v0.4.0...HEAD

--- a/esp-radio-rtos-driver/Cargo.toml
+++ b/esp-radio-rtos-driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-radio-rtos-driver"
-version       = "0.3.0"
+version       = "0.4.0"
 edition       = "2024"
 rust-version  = "1.95.0"
 description   = "Task scheduler interface for esp-radio"

--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -58,14 +58,14 @@ portable-atomic = { version = "1.11", default-features = false }
 enumset = { version = "1.1", default-features = false, optional = true }
 
 # ⚠️ Unstable dependencies
-esp-radio-rtos-driver = { version = "0.3.0", path = "../esp-radio-rtos-driver" }
+esp-radio-rtos-driver = { version = "0.4.0", path = "../esp-radio-rtos-driver" }
 instability = "0.3.12"
 
 # Unstable dependencies that are not (strictly) part of the public API
 allocator-api2 = { version = "0.3.0", default-features = false, features = ["alloc"] }
 docsplay = { version = "0.1", default-features = false }
 document-features  = "0.2"
-esp-alloc = { version = "0.10.0", path = "../esp-alloc", optional = true, default-features = false }
+esp-alloc = { version = "0.11.0", path = "../esp-alloc", optional = true, default-features = false }
 esp-config = { version = "0.8.0", path = "../esp-config" }
 esp-metadata-generated = { version = "0.5.0", path = "../esp-metadata-generated" }
 esp-rom-sys = { version = "=0.1.5", path = "../esp-rom-sys" }
@@ -119,7 +119,7 @@ esp-config = { version = "0.8.0", path = "../esp-config", features = ["build"] }
 esp-metadata-generated = { version = "0.5.0", path = "../esp-metadata-generated", features = ["build-script"] }
 
 [dev-dependencies]
-esp-rtos = { version = "0.3.0", path = "../esp-rtos" }
+esp-rtos = { version = "0.4.0", path = "../esp-rtos" }
 
 [features]
 default = ["esp-alloc"]

--- a/esp-rtos/CHANGELOG.md
+++ b/esp-rtos/CHANGELOG.md
@@ -9,8 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Initial support for ESP32-P4 (#5523, #5535)
-- Add ESP32-S31 support (#5922)
 
 ### Changed
 
@@ -20,6 +18,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+
+## [v0.4.0] - 2026-08-25
+
+### Added
+
+- Initial support for ESP32-P4 (#5523, #5535)
+- Add ESP32-S31 support (#5922)
+- `start_on_second_core_only` on multi-core chips, for applications where it is simler to keep the first core bare metal. (#6044)
+- Configuration for the esp-radio timer thread priority. (#5908)
+- Sleep: enabled auto-lightsleep when esp-rtos runs on multiple cores (#5825)
+- `rearm_alarm` to manually adjust the time base after waking up from light sleep (#5778)
+- ESP32-C6, ESP32-H2: `auto_light_sleep`, an idle-hook factory that puts the system into light sleep when idle long enough, restoring timekeeping and re-arming the scheduler timer on wake. (#5756)
+- `ESP_RTOS_CONFIG_LIGHT_SLEEP_MIN_US` config option setting the minimum residency below which light sleep is skipped. (#5756)
+
+### Changed
+
+- `start` functions and `InterruptExecutor::new` now take `FROM_CPU_INTRn` singletons instead of `SoftwareInterrupt` structs. (#6142)
+- `DeepSleep::deep_sleep` no longer takes a list of wakeup sources. (#6060)
+- The automatic light sleep hook owns one wakeup source, the timer deadline, and leaves every (#6060)
+- `auto_light_sleep` has been removed. Instead, the `sleep` module now has a `configure` function that returns `Sleep`. `Sleep` holds the idle hook function, as well as a deep sleep handle. (#5839)
+- updated defmt to 1.1 (#5752)
+
+### Fixed
+
+- the main task can no longer be deleted (on either core) (#6032)
+- deleting a task no longer allows reallocating its stack memory while the stack may be in use. (#6032)
+- a task deleting itself no longer blocks going to sleep (#6032)
+- deleting the other core's current task now triggers switching away from that task (#6032)
+- main task stack sizes are correctly tracked (#6027)
+- the idle tasks now perform stack overflow checking (#6027)
+- fixed a potential crash on RISC-V devices (#5641)
 
 ## [v0.3.0] - 2026-04-16
 
@@ -87,4 +116,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v0.1.1]: https://github.com/esp-rs/esp-hal/compare/esp-rtos-v0.1.0...esp-rtos-v0.1.1
 [v0.2.0]: https://github.com/esp-rs/esp-hal/compare/esp-rtos-v0.1.1...esp-rtos-v0.2.0
 [v0.3.0]: https://github.com/esp-rs/esp-hal/compare/esp-rtos-v0.2.0...esp-rtos-v0.3.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-rtos-v0.3.0...HEAD
+[v0.4.0]: https://github.com/esp-rs/esp-hal/compare/esp-rtos-v0.3.0...esp-rtos-v0.4.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-rtos-v0.4.0...HEAD

--- a/esp-rtos/Cargo.toml
+++ b/esp-rtos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-rtos"
-version       = "0.3.0"
+version       = "0.4.0"
 edition       = "2024"
 rust-version  = "1.95.0"
 description   = "A task scheduler for Espressif devices"
@@ -48,10 +48,10 @@ rtos-trace = { version = "0.2.0", optional = true }
 allocator-api2 = { version = "0.3.0", default-features = false, features = ["alloc"], optional = true }
 document-features  = "0.2"
 embassy-sync = "0.8"
-esp-alloc = { version = "0.10.0", path = "../esp-alloc", optional = true, default-features = false }
+esp-alloc = { version = "0.11.0", path = "../esp-alloc", optional = true, default-features = false }
 esp-config = { version = "0.8.0", path = "../esp-config" }
 esp-sync = { version = "0.3.0", path = "../esp-sync" }
-esp-radio-rtos-driver = { version = "0.3.0", path = "../esp-radio-rtos-driver", features = ["ipc-implementations"], optional = true }
+esp-radio-rtos-driver = { version = "0.4.0", path = "../esp-radio-rtos-driver", features = ["ipc-implementations"], optional = true }
 macros = { version = "0.23.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
 portable-atomic = { version = "1.11", default-features = false }
 

--- a/esp-storage/CHANGELOG.md
+++ b/esp-storage/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add ESP32-S31 support (#5922)
 
 ### Changed
 
@@ -19,6 +18,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+
+## [v0.10.0] - 2026-08-25
+
+### Added
+
+- Add ESP32-S31 support (#5922)
+- `FlashStorage::read_encrypted` and `FlashStorage::write_encrypted` for transparent flash encryption read/write (#5810)
+- `flash_encryption()` helper to query whether flash encryption is enabled in eFuses (#5810)
+- Support for ESP32-P4 (#5751)
+- Inherent flash I/O methods on `FlashStorage`: `read`, `write`, `capacity`, `read_nor`, `write_nor`, and `erase` (#5739)
+
+### Changed
+
+- `FlashStorage::read_encrypted` now follows the multi-core strategy, so it can return `OtherCoreRunning`. (#6120)
+- esp-storage can now be built with any opt-level (#5911)
+- updated defmt to 1.1 (#5752)
+- `embedded-storage` trait implementations are now an opt-in feature (non-default) (#5739)
+
+### Fixed
+
+- On ESP32, reading and writing encrypted flash no longer hangs. The flash MMU and the cache are now changed with the cache turned off, as the hardware requires. (#6120)
+- `FlashStorage::erase` rejects reversed ranges (`to < from`) (#6045)
 
 ## [v0.9.0] - 2026-04-16
 
@@ -96,4 +117,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v0.8.0]: https://github.com/esp-rs/esp-hal/compare/esp-storage-v0.7.0...esp-storage-v0.8.0
 [v0.8.1]: https://github.com/esp-rs/esp-hal/compare/esp-storage-v0.8.0...esp-storage-v0.8.1
 [v0.9.0]: https://github.com/esp-rs/esp-hal/compare/esp-storage-v0.8.1...esp-storage-v0.9.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-storage-v0.9.0...HEAD
+[v0.10.0]: https://github.com/esp-rs/esp-hal/compare/esp-storage-v0.9.0...esp-storage-v0.10.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-storage-v0.10.0...HEAD

--- a/esp-storage/Cargo.toml
+++ b/esp-storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-storage"
-version       = "0.9.0"
+version       = "0.10.0"
 edition       = "2024"
 rust-version  = "1.95.0"
 description   = "Access ESP32 flash, including encrypted read/write. Optionally implements esp-storage traits for unencrypted flash."


### PR DESCRIPTION
This pull request prepares the following packages for release:

- esp-radio-rtos-driver: 0.3.0 → 0.4.0
- esp-alloc: 0.10.0 → 0.11.0
- esp-println: 0.17.0 → 0.18.0
- esp-rtos: 0.3.0 → 0.4.0
- esp-storage: 0.9.0 → 0.10.0
- esp-backtrace: 0.19.0 → 0.20.0
- esp-bootloader-esp-idf: 0.5.0 → 0.6.0

<details>

<summary>Release plan (click to expand)</summary>

```jsonc
{
  "base": "main",
  "slug": "t9telr",
  "packages": [
    {
      "package": "esp-radio-rtos-driver",
      "semver_checked": false,
      "current_version": "0.3.0",
      "new_version": "0.4.0",
      "tag_name": "esp-radio-rtos-driver-v0.4.0",
      "bump": {
        "base": "Minor",
        "pre": null
      }
    },
    {
      "package": "esp-alloc",
      "semver_checked": false,
      "current_version": "0.10.0",
      "new_version": "0.11.0",
      "tag_name": "esp-alloc-v0.11.0",
      "bump": {
        "base": "Minor",
        "pre": null
      }
    },
    {
      "package": "esp-println",
      "semver_checked": false,
      "current_version": "0.17.0",
      "new_version": "0.18.0",
      "tag_name": "esp-println-v0.18.0",
      "bump": {
        "base": "Minor",
        "pre": null
      }
    },
    {
      "package": "esp-rtos",
      "semver_checked": false,
      "current_version": "0.3.0",
      "new_version": "0.4.0",
      "tag_name": "esp-rtos-v0.4.0",
      "bump": {
        "base": "Minor",
        "pre": null
      }
    },
    {
      "package": "esp-storage",
      "semver_checked": false,
      "current_version": "0.9.0",
      "new_version": "0.10.0",
      "tag_name": "esp-storage-v0.10.0",
      "bump": {
        "base": "Minor",
        "pre": null
      }
    },
    {
      "package": "esp-backtrace",
      "semver_checked": false,
      "current_version": "0.19.0",
      "new_version": "0.20.0",
      "tag_name": "esp-backtrace-v0.20.0",
      "bump": {
        "base": "Minor",
        "pre": null
      }
    },
    {
      "package": "esp-bootloader-esp-idf",
      "semver_checked": false,
      "current_version": "0.5.0",
      "new_version": "0.6.0",
      "tag_name": "esp-bootloader-esp-idf-v0.6.0",
      "bump": {
        "base": "Minor",
        "pre": null
      }
    }
  ]
}
```

</details>

Please review the changes and merge them into the `main` branch.

After merging, please make sure you have this release plan in the repo root,
then run the following command on the `main` branch to tag and publish the packages:

```
cargo xrelease publish-plan --no-dry-run
```
