### PR TITLE
Fix possible deadlock in esp-radio

### DIFF
--- a/esp-radio-rtos-driver/src/queue.rs
+++ b/esp-radio-rtos-driver/src/queue.rs
@@ -431,6 +431,10 @@ macro_rules! register_queue_implementation {
 /// This handle is used to interact with queues created by the driver implementation.
 #[repr(transparent)]
 pub struct QueueHandle(QueuePtr);
+
+unsafe impl Send for QueueHandle {}
+unsafe impl Sync for QueueHandle {}
+
 impl QueueHandle {
     /// Creates a new queue instance.
     #[inline]

--- a/esp-radio-rtos-driver/src/semaphore.rs
+++ b/esp-radio-rtos-driver/src/semaphore.rs
@@ -325,6 +325,10 @@ macro_rules! register_semaphore_implementation {
 /// This handle is used to interact with semaphores created by the driver implementation.
 #[repr(transparent)]
 pub struct SemaphoreHandle(SemaphorePtr);
+
+unsafe impl Send for SemaphoreHandle {}
+unsafe impl Sync for SemaphoreHandle {}
+
 impl SemaphoreHandle {
     /// Creates a new semaphore instance.
     ///
@@ -445,8 +449,6 @@ impl Drop for SemaphoreHandle {
         unsafe { esp_rtos_semaphore_delete(self.0) };
     }
 }
-
-unsafe impl Send for SemaphoreHandle {}
 
 #[cfg(feature = "ipc-implementations")]
 mod implementation {

--- a/esp-radio/src/wifi/state.rs
+++ b/esp-radio/src/wifi/state.rs
@@ -1,7 +1,7 @@
 use core::sync::atomic::Ordering;
 
+use embassy_sync::lazy_lock::LazyLock;
 use esp_radio_rtos_driver::semaphore::{SemaphoreHandle, SemaphoreKind};
-use esp_sync::NonReentrantMutex;
 use portable_atomic_enum::atomic_enum;
 
 use super::event::WifiEvent;
@@ -113,19 +113,14 @@ pub(crate) fn set_station_state(state: WifiStationState) {
 }
 
 pub(crate) fn locked<R>(f: impl FnOnce() -> R) -> R {
-    static LOCK: NonReentrantMutex<Option<SemaphoreHandle>> = NonReentrantMutex::new(None);
+    static LOCK: LazyLock<SemaphoreHandle> =
+        LazyLock::new(|| SemaphoreHandle::new(SemaphoreKind::Mutex));
 
-    LOCK.with(|sem| {
-        sem.get_or_insert_with(|| SemaphoreHandle::new(SemaphoreKind::Mutex))
-            .take(None)
-    });
+    let sem = LOCK.get();
 
-    let res: R = f();
-
-    LOCK.with(|sem| {
-        sem.get_or_insert_with(|| SemaphoreHandle::new(SemaphoreKind::Mutex))
-            .give()
-    });
+    sem.take(None);
+    let res = f();
+    sem.give();
 
     res
 }


### PR DESCRIPTION
Two nested mutexes are never a good idea. This PR solves a theoretical deadlock, and a practical crash:

Timeline:
- caller A is running the `locked` callback
- caller B enters and takes the LOCK
  - caller A is holding the semaphore, so B yields
  - RTOS crashes because yielding in a critical section is illegal. but, ignore this
- caller A finishes the callback and tries to take LOCK to release the mutex
- `¯\_(ツ)_/¯`

Anyway, even if these never really cause a problem, the end result is lighter, faster, smaller, better.

# Changelog

## esp-radio

- Fixed: fixed a possible deadlock during Wi-Fi initialization/deinitialization

## esp-radio-rtos-driver

- Added: `QueueHandle` and `SemaphoreHandle` are now `Send` and `Sync`