### PR TITLE
Reusable clock config types

### DIFF
--- a/esp-hal/src/soc/esp32c5/clocks.rs
+++ b/esp-hal/src/soc/esp32c5/clocks.rs
@@ -519,14 +519,14 @@ impl ParlIoInstance {
     fn configure_rx_clock_impl(
         self,
         _clocks: &mut ClockTree,
-        _old_config: Option<ParlIoRxClockConfig>,
-        new_config: ParlIoRxClockConfig,
+        _old_config: Option<ParlIoClkConfig>,
+        new_config: ParlIoClkConfig,
     ) {
         PCR::regs().parl_clk_rx_conf().modify(|_, w| unsafe {
             w.parl_clk_rx_sel().bits(match new_config {
-                ParlIoRxClockConfig::XtalClk => 0,
-                ParlIoRxClockConfig::RcFastClk => 1,
-                ParlIoRxClockConfig::PllF240m => 2,
+                ParlIoClkConfig::XtalClk => 0,
+                ParlIoClkConfig::RcFastClk => 1,
+                ParlIoClkConfig::PllF240m => 2,
             })
         });
     }
@@ -542,14 +542,14 @@ impl ParlIoInstance {
     fn configure_tx_clock_impl(
         self,
         _clocks: &mut ClockTree,
-        _old_config: Option<ParlIoTxClockConfig>,
-        new_config: ParlIoTxClockConfig,
+        _old_config: Option<ParlIoClkConfig>,
+        new_config: ParlIoClkConfig,
     ) {
         PCR::regs().parl_clk_tx_conf().modify(|_, w| unsafe {
             w.parl_clk_tx_sel().bits(match new_config {
-                ParlIoTxClockConfig::XtalClk => 0,
-                ParlIoTxClockConfig::RcFastClk => 1,
-                ParlIoTxClockConfig::PllF240m => 2,
+                ParlIoClkConfig::XtalClk => 0,
+                ParlIoClkConfig::RcFastClk => 1,
+                ParlIoClkConfig::PllF240m => 2,
             })
         });
     }

--- a/esp-hal/src/soc/esp32c6/clocks.rs
+++ b/esp-hal/src/soc/esp32c6/clocks.rs
@@ -607,14 +607,14 @@ impl ParlIoInstance {
     fn configure_rx_clock_impl(
         self,
         _clocks: &mut ClockTree,
-        _old_config: Option<ParlIoRxClockConfig>,
-        new_config: ParlIoRxClockConfig,
+        _old_config: Option<ParlIoClkConfig>,
+        new_config: ParlIoClkConfig,
     ) {
         PCR::regs().parl_clk_rx_conf().modify(|_, w| unsafe {
             w.parl_clk_rx_sel().bits(match new_config {
-                ParlIoRxClockConfig::XtalClk => 0,
-                ParlIoRxClockConfig::RcFastClk => 2,
-                ParlIoRxClockConfig::PllF240m => 1,
+                ParlIoClkConfig::XtalClk => 0,
+                ParlIoClkConfig::RcFastClk => 2,
+                ParlIoClkConfig::PllF240m => 1,
             })
         });
     }
@@ -630,14 +630,14 @@ impl ParlIoInstance {
     fn configure_tx_clock_impl(
         self,
         _clocks: &mut ClockTree,
-        _old_config: Option<ParlIoTxClockConfig>,
-        new_config: ParlIoTxClockConfig,
+        _old_config: Option<ParlIoClkConfig>,
+        new_config: ParlIoClkConfig,
     ) {
         PCR::regs().parl_clk_tx_conf().modify(|_, w| unsafe {
             w.parl_clk_tx_sel().bits(match new_config {
-                ParlIoTxClockConfig::XtalClk => 0,
-                ParlIoTxClockConfig::RcFastClk => 2,
-                ParlIoTxClockConfig::PllF240m => 1,
+                ParlIoClkConfig::XtalClk => 0,
+                ParlIoClkConfig::RcFastClk => 2,
+                ParlIoClkConfig::PllF240m => 1,
             })
         });
     }

--- a/esp-hal/src/soc/esp32h2/clocks.rs
+++ b/esp-hal/src/soc/esp32h2/clocks.rs
@@ -432,14 +432,14 @@ impl ParlIoInstance {
     fn configure_rx_clock_impl(
         self,
         _clocks: &mut ClockTree,
-        _old_config: Option<ParlIoRxClockConfig>,
-        new_config: ParlIoRxClockConfig,
+        _old_config: Option<ParlIoClkConfig>,
+        new_config: ParlIoClkConfig,
     ) {
         PCR::regs().parl_clk_rx_conf().modify(|_, w| unsafe {
             w.parl_clk_rx_sel().bits(match new_config {
-                ParlIoRxClockConfig::XtalClk => 0,
-                ParlIoRxClockConfig::RcFastClk => 2,
-                ParlIoRxClockConfig::PllF96m => 1,
+                ParlIoClkConfig::XtalClk => 0,
+                ParlIoClkConfig::RcFastClk => 2,
+                ParlIoClkConfig::PllF96m => 1,
             })
         });
     }
@@ -455,14 +455,14 @@ impl ParlIoInstance {
     fn configure_tx_clock_impl(
         self,
         _clocks: &mut ClockTree,
-        _old_config: Option<ParlIoTxClockConfig>,
-        new_config: ParlIoTxClockConfig,
+        _old_config: Option<ParlIoClkConfig>,
+        new_config: ParlIoClkConfig,
     ) {
         PCR::regs().parl_clk_tx_conf().modify(|_, w| unsafe {
             w.parl_clk_tx_sel().bits(match new_config {
-                ParlIoTxClockConfig::XtalClk => 0,
-                ParlIoTxClockConfig::RcFastClk => 2,
-                ParlIoTxClockConfig::PllF96m => 1,
+                ParlIoClkConfig::XtalClk => 0,
+                ParlIoClkConfig::RcFastClk => 2,
+                ParlIoClkConfig::PllF96m => 1,
             })
         });
     }

--- a/esp-metadata-generated/src/_generated_esp32c5.rs
+++ b/esp-metadata-generated/src/_generated_esp32c5.rs
@@ -609,14 +609,14 @@ macro_rules! property {
         ::soc::clocks::RmtSclkConfig::PllF80m]
     };
     ("clock_tree.parl_io.rx_clock") => {
-        [crate ::soc::clocks::ParlIoRxClockConfig::XtalClk, crate
-        ::soc::clocks::ParlIoRxClockConfig::RcFastClk, crate
-        ::soc::clocks::ParlIoRxClockConfig::PllF240m]
+        [crate ::soc::clocks::ParlIoClkConfig::XtalClk, crate
+        ::soc::clocks::ParlIoClkConfig::RcFastClk, crate
+        ::soc::clocks::ParlIoClkConfig::PllF240m]
     };
     ("clock_tree.parl_io.tx_clock") => {
-        [crate ::soc::clocks::ParlIoTxClockConfig::XtalClk, crate
-        ::soc::clocks::ParlIoTxClockConfig::RcFastClk, crate
-        ::soc::clocks::ParlIoTxClockConfig::PllF240m]
+        [crate ::soc::clocks::ParlIoClkConfig::XtalClk, crate
+        ::soc::clocks::ParlIoClkConfig::RcFastClk, crate
+        ::soc::clocks::ParlIoClkConfig::PllF240m]
     };
     ("clock_tree.i2c.function_clock.sclk") => {
         [crate ::soc::clocks::I2cFunctionClockSclk::Xtal, crate
@@ -1562,8 +1562,8 @@ macro_rules! for_each_sw_interrupt {
 ///     fn configure_rx_clock_impl(
 ///         self,
 ///         _clocks: &mut ClockTree,
-///         _old_config: Option<ParlIoRxClockConfig>,
-///         _new_config: ParlIoRxClockConfig,
+///         _old_config: Option<ParlIoClkConfig>,
+///         _new_config: ParlIoClkConfig,
 ///     ) {
 ///         todo!()
 ///     }
@@ -1577,8 +1577,8 @@ macro_rules! for_each_sw_interrupt {
 ///     fn configure_tx_clock_impl(
 ///         self,
 ///         _clocks: &mut ClockTree,
-///         _old_config: Option<ParlIoTxClockConfig>,
-///         _new_config: ParlIoTxClockConfig,
+///         _old_config: Option<ParlIoClkConfig>,
+///         _new_config: ParlIoClkConfig,
 ///     ) {
 ///         todo!()
 ///     }
@@ -1927,19 +1927,7 @@ macro_rules! define_clock_tree_types {
         /// The list of clock signals that the `PARL_IO_RX_CLOCK` multiplexer can output.
         #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-        pub enum ParlIoRxClockConfig {
-            /// Selects `XTAL_CLK`.
-            XtalClk,
-            /// Selects `RC_FAST_CLK`.
-            RcFastClk,
-            #[default]
-            /// Selects `PLL_F240M`.
-            PllF240m,
-        }
-        /// The list of clock signals that the `PARL_IO_TX_CLOCK` multiplexer can output.
-        #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
-        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-        pub enum ParlIoTxClockConfig {
+        pub enum ParlIoClkConfig {
             /// Selects `XTAL_CLK`.
             XtalClk,
             /// Selects `RC_FAST_CLK`.
@@ -2093,8 +2081,8 @@ macro_rules! define_clock_tree_types {
             iomux_function_clock: Option<IomuxFunctionClockConfig>,
             timg_calibration_clock: Option<TimgCalibrationClockConfig>,
             i2c_function_clock: [Option<I2cFunctionClockConfig>; 1],
-            parl_io_rx_clock: [Option<ParlIoRxClockConfig>; 1],
-            parl_io_tx_clock: [Option<ParlIoTxClockConfig>; 1],
+            parl_io_rx_clock: [Option<ParlIoClkConfig>; 1],
+            parl_io_tx_clock: [Option<ParlIoClkConfig>; 1],
             rmt_sclk: [Option<RmtSclkConfig>; 1],
             spi_function_clock: [Option<SpiFunctionClockConfig>; 1],
             timg_function_clock: [Option<TimgFunctionClockConfig>; 2],
@@ -2183,11 +2171,11 @@ macro_rules! define_clock_tree_types {
                 self.i2c_function_clock[I2cInstance::I2c0 as usize]
             }
             /// Returns the current configuration of the PARL_IO_RX_CLOCK clock tree node
-            pub fn parl_io_rx_clock(&self) -> Option<ParlIoRxClockConfig> {
+            pub fn parl_io_rx_clock(&self) -> Option<ParlIoClkConfig> {
                 self.parl_io_rx_clock[ParlIoInstance::ParlIo as usize]
             }
             /// Returns the current configuration of the PARL_IO_TX_CLOCK clock tree node
-            pub fn parl_io_tx_clock(&self) -> Option<ParlIoTxClockConfig> {
+            pub fn parl_io_tx_clock(&self) -> Option<ParlIoClkConfig> {
                 self.parl_io_tx_clock[ParlIoInstance::ParlIo as usize]
             }
             /// Returns the current configuration of the RMT_SCLK clock tree node
@@ -3265,32 +3253,28 @@ macro_rules! define_clock_tree_types {
             }
         }
         impl ParlIoInstance {
-            pub fn configure_rx_clock(
-                self,
-                clocks: &mut ClockTree,
-                new_selector: ParlIoRxClockConfig,
-            ) {
+            pub fn configure_rx_clock(self, clocks: &mut ClockTree, new_selector: ParlIoClkConfig) {
                 let old_selector = clocks.parl_io_rx_clock[self as usize].replace(new_selector);
                 refresh_parl_io_rx_clock_downstream(clocks, self);
                 if clocks.parl_io_rx_clock_refcount[self as usize] > 0 {
                     match new_selector {
-                        ParlIoRxClockConfig::XtalClk => request_xtal_clk(clocks),
-                        ParlIoRxClockConfig::RcFastClk => request_rc_fast_clk(clocks),
-                        ParlIoRxClockConfig::PllF240m => request_pll_f240m(clocks),
+                        ParlIoClkConfig::XtalClk => request_xtal_clk(clocks),
+                        ParlIoClkConfig::RcFastClk => request_rc_fast_clk(clocks),
+                        ParlIoClkConfig::PllF240m => request_pll_f240m(clocks),
                     }
                     self.configure_rx_clock_impl(clocks, old_selector, new_selector);
                     if let Some(old_selector) = old_selector {
                         match old_selector {
-                            ParlIoRxClockConfig::XtalClk => release_xtal_clk(clocks),
-                            ParlIoRxClockConfig::RcFastClk => release_rc_fast_clk(clocks),
-                            ParlIoRxClockConfig::PllF240m => release_pll_f240m(clocks),
+                            ParlIoClkConfig::XtalClk => release_xtal_clk(clocks),
+                            ParlIoClkConfig::RcFastClk => release_rc_fast_clk(clocks),
+                            ParlIoClkConfig::PllF240m => release_pll_f240m(clocks),
                         }
                     }
                 } else {
                     self.configure_rx_clock_impl(clocks, old_selector, new_selector);
                 }
             }
-            pub fn rx_clock_config(self, clocks: &mut ClockTree) -> Option<ParlIoRxClockConfig> {
+            pub fn rx_clock_config(self, clocks: &mut ClockTree) -> Option<ParlIoClkConfig> {
                 clocks.parl_io_rx_clock[self as usize]
             }
             pub fn request_rx_clock(self, clocks: &mut ClockTree) {
@@ -3298,9 +3282,9 @@ macro_rules! define_clock_tree_types {
                 if increment_reference_count(&mut clocks.parl_io_rx_clock_refcount[self as usize]) {
                     trace!("Enabling {:?}::RX_CLOCK", self);
                     match unwrap!(clocks.parl_io_rx_clock[self as usize]) {
-                        ParlIoRxClockConfig::XtalClk => request_xtal_clk(clocks),
-                        ParlIoRxClockConfig::RcFastClk => request_rc_fast_clk(clocks),
-                        ParlIoRxClockConfig::PllF240m => request_pll_f240m(clocks),
+                        ParlIoClkConfig::XtalClk => request_xtal_clk(clocks),
+                        ParlIoClkConfig::RcFastClk => request_rc_fast_clk(clocks),
+                        ParlIoClkConfig::PllF240m => request_pll_f240m(clocks),
                     }
                     self.enable_rx_clock_impl(clocks, true);
                 }
@@ -3311,60 +3295,56 @@ macro_rules! define_clock_tree_types {
                     trace!("Disabling {:?}::RX_CLOCK", self);
                     self.enable_rx_clock_impl(clocks, false);
                     match unwrap!(clocks.parl_io_rx_clock[self as usize]) {
-                        ParlIoRxClockConfig::XtalClk => release_xtal_clk(clocks),
-                        ParlIoRxClockConfig::RcFastClk => release_rc_fast_clk(clocks),
-                        ParlIoRxClockConfig::PllF240m => release_pll_f240m(clocks),
+                        ParlIoClkConfig::XtalClk => release_xtal_clk(clocks),
+                        ParlIoClkConfig::RcFastClk => release_rc_fast_clk(clocks),
+                        ParlIoClkConfig::PllF240m => release_pll_f240m(clocks),
                     }
                 }
             }
             #[allow(unused_variables)]
             pub fn rx_clock_config_frequency(
                 clocks: &mut ClockTree,
-                config: ParlIoRxClockConfig,
+                config: ParlIoClkConfig,
             ) -> u32 {
                 match config {
-                    ParlIoRxClockConfig::XtalClk => xtal_clk_frequency(),
-                    ParlIoRxClockConfig::RcFastClk => rc_fast_clk_frequency(),
-                    ParlIoRxClockConfig::PllF240m => pll_f240m_frequency(),
+                    ParlIoClkConfig::XtalClk => xtal_clk_frequency(),
+                    ParlIoClkConfig::RcFastClk => rc_fast_clk_frequency(),
+                    ParlIoClkConfig::PllF240m => pll_f240m_frequency(),
                 }
             }
             pub fn rx_clock_frequency(self) -> u32 {
                 PARL_IO_RX_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
-            pub fn rx_clock_source_frequency(source: ParlIoRxClockConfig) -> u32 {
+            pub fn rx_clock_source_frequency(source: ParlIoClkConfig) -> u32 {
                 match source {
-                    ParlIoRxClockConfig::XtalClk => xtal_clk_frequency(),
-                    ParlIoRxClockConfig::RcFastClk => rc_fast_clk_frequency(),
-                    ParlIoRxClockConfig::PllF240m => pll_f240m_frequency(),
+                    ParlIoClkConfig::XtalClk => xtal_clk_frequency(),
+                    ParlIoClkConfig::RcFastClk => rc_fast_clk_frequency(),
+                    ParlIoClkConfig::PllF240m => pll_f240m_frequency(),
                 }
             }
-            pub fn configure_tx_clock(
-                self,
-                clocks: &mut ClockTree,
-                new_selector: ParlIoTxClockConfig,
-            ) {
+            pub fn configure_tx_clock(self, clocks: &mut ClockTree, new_selector: ParlIoClkConfig) {
                 let old_selector = clocks.parl_io_tx_clock[self as usize].replace(new_selector);
                 refresh_parl_io_tx_clock_downstream(clocks, self);
                 if clocks.parl_io_tx_clock_refcount[self as usize] > 0 {
                     match new_selector {
-                        ParlIoTxClockConfig::XtalClk => request_xtal_clk(clocks),
-                        ParlIoTxClockConfig::RcFastClk => request_rc_fast_clk(clocks),
-                        ParlIoTxClockConfig::PllF240m => request_pll_f240m(clocks),
+                        ParlIoClkConfig::XtalClk => request_xtal_clk(clocks),
+                        ParlIoClkConfig::RcFastClk => request_rc_fast_clk(clocks),
+                        ParlIoClkConfig::PllF240m => request_pll_f240m(clocks),
                     }
                     self.configure_tx_clock_impl(clocks, old_selector, new_selector);
                     if let Some(old_selector) = old_selector {
                         match old_selector {
-                            ParlIoTxClockConfig::XtalClk => release_xtal_clk(clocks),
-                            ParlIoTxClockConfig::RcFastClk => release_rc_fast_clk(clocks),
-                            ParlIoTxClockConfig::PllF240m => release_pll_f240m(clocks),
+                            ParlIoClkConfig::XtalClk => release_xtal_clk(clocks),
+                            ParlIoClkConfig::RcFastClk => release_rc_fast_clk(clocks),
+                            ParlIoClkConfig::PllF240m => release_pll_f240m(clocks),
                         }
                     }
                 } else {
                     self.configure_tx_clock_impl(clocks, old_selector, new_selector);
                 }
             }
-            pub fn tx_clock_config(self, clocks: &mut ClockTree) -> Option<ParlIoTxClockConfig> {
+            pub fn tx_clock_config(self, clocks: &mut ClockTree) -> Option<ParlIoClkConfig> {
                 clocks.parl_io_tx_clock[self as usize]
             }
             pub fn request_tx_clock(self, clocks: &mut ClockTree) {
@@ -3372,9 +3352,9 @@ macro_rules! define_clock_tree_types {
                 if increment_reference_count(&mut clocks.parl_io_tx_clock_refcount[self as usize]) {
                     trace!("Enabling {:?}::TX_CLOCK", self);
                     match unwrap!(clocks.parl_io_tx_clock[self as usize]) {
-                        ParlIoTxClockConfig::XtalClk => request_xtal_clk(clocks),
-                        ParlIoTxClockConfig::RcFastClk => request_rc_fast_clk(clocks),
-                        ParlIoTxClockConfig::PllF240m => request_pll_f240m(clocks),
+                        ParlIoClkConfig::XtalClk => request_xtal_clk(clocks),
+                        ParlIoClkConfig::RcFastClk => request_rc_fast_clk(clocks),
+                        ParlIoClkConfig::PllF240m => request_pll_f240m(clocks),
                     }
                     self.enable_tx_clock_impl(clocks, true);
                 }
@@ -3385,32 +3365,32 @@ macro_rules! define_clock_tree_types {
                     trace!("Disabling {:?}::TX_CLOCK", self);
                     self.enable_tx_clock_impl(clocks, false);
                     match unwrap!(clocks.parl_io_tx_clock[self as usize]) {
-                        ParlIoTxClockConfig::XtalClk => release_xtal_clk(clocks),
-                        ParlIoTxClockConfig::RcFastClk => release_rc_fast_clk(clocks),
-                        ParlIoTxClockConfig::PllF240m => release_pll_f240m(clocks),
+                        ParlIoClkConfig::XtalClk => release_xtal_clk(clocks),
+                        ParlIoClkConfig::RcFastClk => release_rc_fast_clk(clocks),
+                        ParlIoClkConfig::PllF240m => release_pll_f240m(clocks),
                     }
                 }
             }
             #[allow(unused_variables)]
             pub fn tx_clock_config_frequency(
                 clocks: &mut ClockTree,
-                config: ParlIoTxClockConfig,
+                config: ParlIoClkConfig,
             ) -> u32 {
                 match config {
-                    ParlIoTxClockConfig::XtalClk => xtal_clk_frequency(),
-                    ParlIoTxClockConfig::RcFastClk => rc_fast_clk_frequency(),
-                    ParlIoTxClockConfig::PllF240m => pll_f240m_frequency(),
+                    ParlIoClkConfig::XtalClk => xtal_clk_frequency(),
+                    ParlIoClkConfig::RcFastClk => rc_fast_clk_frequency(),
+                    ParlIoClkConfig::PllF240m => pll_f240m_frequency(),
                 }
             }
             pub fn tx_clock_frequency(self) -> u32 {
                 PARL_IO_TX_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
-            pub fn tx_clock_source_frequency(source: ParlIoTxClockConfig) -> u32 {
+            pub fn tx_clock_source_frequency(source: ParlIoClkConfig) -> u32 {
                 match source {
-                    ParlIoTxClockConfig::XtalClk => xtal_clk_frequency(),
-                    ParlIoTxClockConfig::RcFastClk => rc_fast_clk_frequency(),
-                    ParlIoTxClockConfig::PllF240m => pll_f240m_frequency(),
+                    ParlIoClkConfig::XtalClk => xtal_clk_frequency(),
+                    ParlIoClkConfig::RcFastClk => rc_fast_clk_frequency(),
+                    ParlIoClkConfig::PllF240m => pll_f240m_frequency(),
                 }
             }
         }

--- a/esp-metadata-generated/src/_generated_esp32c6.rs
+++ b/esp-metadata-generated/src/_generated_esp32c6.rs
@@ -642,14 +642,14 @@ macro_rules! property {
         ::soc::clocks::McpwmFunctionClockConfig::XtalClk]
     };
     ("clock_tree.parl_io.rx_clock") => {
-        [crate ::soc::clocks::ParlIoRxClockConfig::XtalClk, crate
-        ::soc::clocks::ParlIoRxClockConfig::RcFastClk, crate
-        ::soc::clocks::ParlIoRxClockConfig::PllF240m]
+        [crate ::soc::clocks::ParlIoClkConfig::XtalClk, crate
+        ::soc::clocks::ParlIoClkConfig::RcFastClk, crate
+        ::soc::clocks::ParlIoClkConfig::PllF240m]
     };
     ("clock_tree.parl_io.tx_clock") => {
-        [crate ::soc::clocks::ParlIoTxClockConfig::XtalClk, crate
-        ::soc::clocks::ParlIoTxClockConfig::RcFastClk, crate
-        ::soc::clocks::ParlIoTxClockConfig::PllF240m]
+        [crate ::soc::clocks::ParlIoClkConfig::XtalClk, crate
+        ::soc::clocks::ParlIoClkConfig::RcFastClk, crate
+        ::soc::clocks::ParlIoClkConfig::PllF240m]
     };
     ("clock_tree.i2c.function_clock.sclk") => {
         [crate ::soc::clocks::I2cFunctionClockSclk::Xtal, crate
@@ -1640,8 +1640,8 @@ macro_rules! for_each_sw_interrupt {
 ///     fn configure_rx_clock_impl(
 ///         self,
 ///         _clocks: &mut ClockTree,
-///         _old_config: Option<ParlIoRxClockConfig>,
-///         _new_config: ParlIoRxClockConfig,
+///         _old_config: Option<ParlIoClkConfig>,
+///         _new_config: ParlIoClkConfig,
 ///     ) {
 ///         todo!()
 ///     }
@@ -1655,8 +1655,8 @@ macro_rules! for_each_sw_interrupt {
 ///     fn configure_tx_clock_impl(
 ///         self,
 ///         _clocks: &mut ClockTree,
-///         _old_config: Option<ParlIoTxClockConfig>,
-///         _new_config: ParlIoTxClockConfig,
+///         _old_config: Option<ParlIoClkConfig>,
+///         _new_config: ParlIoClkConfig,
 ///     ) {
 ///         todo!()
 ///     }
@@ -2281,19 +2281,7 @@ macro_rules! define_clock_tree_types {
         /// The list of clock signals that the `PARL_IO_RX_CLOCK` multiplexer can output.
         #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-        pub enum ParlIoRxClockConfig {
-            /// Selects `XTAL_CLK`.
-            XtalClk,
-            /// Selects `RC_FAST_CLK`.
-            RcFastClk,
-            #[default]
-            /// Selects `PLL_F240M`.
-            PllF240m,
-        }
-        /// The list of clock signals that the `PARL_IO_TX_CLOCK` multiplexer can output.
-        #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
-        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-        pub enum ParlIoTxClockConfig {
+        pub enum ParlIoClkConfig {
             /// Selects `XTAL_CLK`.
             XtalClk,
             /// Selects `RC_FAST_CLK`.
@@ -2454,8 +2442,8 @@ macro_rules! define_clock_tree_types {
             timg_calibration_clock: Option<TimgCalibrationClockConfig>,
             i2c_function_clock: [Option<I2cFunctionClockConfig>; 1],
             mcpwm_function_clock: [Option<McpwmFunctionClockConfig>; 1],
-            parl_io_rx_clock: [Option<ParlIoRxClockConfig>; 1],
-            parl_io_tx_clock: [Option<ParlIoTxClockConfig>; 1],
+            parl_io_rx_clock: [Option<ParlIoClkConfig>; 1],
+            parl_io_tx_clock: [Option<ParlIoClkConfig>; 1],
             rmt_sclk: [Option<RmtSclkConfig>; 1],
             spi_function_clock: [Option<SpiFunctionClockConfig>; 1],
             timg_function_clock: [Option<TimgFunctionClockConfig>; 2],
@@ -2573,11 +2561,11 @@ macro_rules! define_clock_tree_types {
                 self.mcpwm_function_clock[McpwmInstance::Mcpwm0 as usize]
             }
             /// Returns the current configuration of the PARL_IO_RX_CLOCK clock tree node
-            pub fn parl_io_rx_clock(&self) -> Option<ParlIoRxClockConfig> {
+            pub fn parl_io_rx_clock(&self) -> Option<ParlIoClkConfig> {
                 self.parl_io_rx_clock[ParlIoInstance::ParlIo as usize]
             }
             /// Returns the current configuration of the PARL_IO_TX_CLOCK clock tree node
-            pub fn parl_io_tx_clock(&self) -> Option<ParlIoTxClockConfig> {
+            pub fn parl_io_tx_clock(&self) -> Option<ParlIoClkConfig> {
                 self.parl_io_tx_clock[ParlIoInstance::ParlIo as usize]
             }
             /// Returns the current configuration of the RMT_SCLK clock tree node
@@ -3920,32 +3908,28 @@ macro_rules! define_clock_tree_types {
             }
         }
         impl ParlIoInstance {
-            pub fn configure_rx_clock(
-                self,
-                clocks: &mut ClockTree,
-                new_selector: ParlIoRxClockConfig,
-            ) {
+            pub fn configure_rx_clock(self, clocks: &mut ClockTree, new_selector: ParlIoClkConfig) {
                 let old_selector = clocks.parl_io_rx_clock[self as usize].replace(new_selector);
                 refresh_parl_io_rx_clock_downstream(clocks, self);
                 if clocks.parl_io_rx_clock_refcount[self as usize] > 0 {
                     match new_selector {
-                        ParlIoRxClockConfig::XtalClk => request_xtal_clk(clocks),
-                        ParlIoRxClockConfig::RcFastClk => request_rc_fast_clk(clocks),
-                        ParlIoRxClockConfig::PllF240m => request_pll_f240m(clocks),
+                        ParlIoClkConfig::XtalClk => request_xtal_clk(clocks),
+                        ParlIoClkConfig::RcFastClk => request_rc_fast_clk(clocks),
+                        ParlIoClkConfig::PllF240m => request_pll_f240m(clocks),
                     }
                     self.configure_rx_clock_impl(clocks, old_selector, new_selector);
                     if let Some(old_selector) = old_selector {
                         match old_selector {
-                            ParlIoRxClockConfig::XtalClk => release_xtal_clk(clocks),
-                            ParlIoRxClockConfig::RcFastClk => release_rc_fast_clk(clocks),
-                            ParlIoRxClockConfig::PllF240m => release_pll_f240m(clocks),
+                            ParlIoClkConfig::XtalClk => release_xtal_clk(clocks),
+                            ParlIoClkConfig::RcFastClk => release_rc_fast_clk(clocks),
+                            ParlIoClkConfig::PllF240m => release_pll_f240m(clocks),
                         }
                     }
                 } else {
                     self.configure_rx_clock_impl(clocks, old_selector, new_selector);
                 }
             }
-            pub fn rx_clock_config(self, clocks: &mut ClockTree) -> Option<ParlIoRxClockConfig> {
+            pub fn rx_clock_config(self, clocks: &mut ClockTree) -> Option<ParlIoClkConfig> {
                 clocks.parl_io_rx_clock[self as usize]
             }
             pub fn request_rx_clock(self, clocks: &mut ClockTree) {
@@ -3954,9 +3938,9 @@ macro_rules! define_clock_tree_types {
                     trace!("Enabling {:?}::RX_CLOCK", self);
                     crate::rtc_cntl::WakeLock::acquire();
                     match unwrap!(clocks.parl_io_rx_clock[self as usize]) {
-                        ParlIoRxClockConfig::XtalClk => request_xtal_clk(clocks),
-                        ParlIoRxClockConfig::RcFastClk => request_rc_fast_clk(clocks),
-                        ParlIoRxClockConfig::PllF240m => request_pll_f240m(clocks),
+                        ParlIoClkConfig::XtalClk => request_xtal_clk(clocks),
+                        ParlIoClkConfig::RcFastClk => request_rc_fast_clk(clocks),
+                        ParlIoClkConfig::PllF240m => request_pll_f240m(clocks),
                     }
                     self.enable_rx_clock_impl(clocks, true);
                 }
@@ -3968,60 +3952,56 @@ macro_rules! define_clock_tree_types {
                     crate::rtc_cntl::WakeLock::release();
                     self.enable_rx_clock_impl(clocks, false);
                     match unwrap!(clocks.parl_io_rx_clock[self as usize]) {
-                        ParlIoRxClockConfig::XtalClk => release_xtal_clk(clocks),
-                        ParlIoRxClockConfig::RcFastClk => release_rc_fast_clk(clocks),
-                        ParlIoRxClockConfig::PllF240m => release_pll_f240m(clocks),
+                        ParlIoClkConfig::XtalClk => release_xtal_clk(clocks),
+                        ParlIoClkConfig::RcFastClk => release_rc_fast_clk(clocks),
+                        ParlIoClkConfig::PllF240m => release_pll_f240m(clocks),
                     }
                 }
             }
             #[allow(unused_variables)]
             pub fn rx_clock_config_frequency(
                 clocks: &mut ClockTree,
-                config: ParlIoRxClockConfig,
+                config: ParlIoClkConfig,
             ) -> u32 {
                 match config {
-                    ParlIoRxClockConfig::XtalClk => xtal_clk_frequency(),
-                    ParlIoRxClockConfig::RcFastClk => rc_fast_clk_frequency(),
-                    ParlIoRxClockConfig::PllF240m => pll_f240m_frequency(),
+                    ParlIoClkConfig::XtalClk => xtal_clk_frequency(),
+                    ParlIoClkConfig::RcFastClk => rc_fast_clk_frequency(),
+                    ParlIoClkConfig::PllF240m => pll_f240m_frequency(),
                 }
             }
             pub fn rx_clock_frequency(self) -> u32 {
                 PARL_IO_RX_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
-            pub fn rx_clock_source_frequency(source: ParlIoRxClockConfig) -> u32 {
+            pub fn rx_clock_source_frequency(source: ParlIoClkConfig) -> u32 {
                 match source {
-                    ParlIoRxClockConfig::XtalClk => xtal_clk_frequency(),
-                    ParlIoRxClockConfig::RcFastClk => rc_fast_clk_frequency(),
-                    ParlIoRxClockConfig::PllF240m => pll_f240m_frequency(),
+                    ParlIoClkConfig::XtalClk => xtal_clk_frequency(),
+                    ParlIoClkConfig::RcFastClk => rc_fast_clk_frequency(),
+                    ParlIoClkConfig::PllF240m => pll_f240m_frequency(),
                 }
             }
-            pub fn configure_tx_clock(
-                self,
-                clocks: &mut ClockTree,
-                new_selector: ParlIoTxClockConfig,
-            ) {
+            pub fn configure_tx_clock(self, clocks: &mut ClockTree, new_selector: ParlIoClkConfig) {
                 let old_selector = clocks.parl_io_tx_clock[self as usize].replace(new_selector);
                 refresh_parl_io_tx_clock_downstream(clocks, self);
                 if clocks.parl_io_tx_clock_refcount[self as usize] > 0 {
                     match new_selector {
-                        ParlIoTxClockConfig::XtalClk => request_xtal_clk(clocks),
-                        ParlIoTxClockConfig::RcFastClk => request_rc_fast_clk(clocks),
-                        ParlIoTxClockConfig::PllF240m => request_pll_f240m(clocks),
+                        ParlIoClkConfig::XtalClk => request_xtal_clk(clocks),
+                        ParlIoClkConfig::RcFastClk => request_rc_fast_clk(clocks),
+                        ParlIoClkConfig::PllF240m => request_pll_f240m(clocks),
                     }
                     self.configure_tx_clock_impl(clocks, old_selector, new_selector);
                     if let Some(old_selector) = old_selector {
                         match old_selector {
-                            ParlIoTxClockConfig::XtalClk => release_xtal_clk(clocks),
-                            ParlIoTxClockConfig::RcFastClk => release_rc_fast_clk(clocks),
-                            ParlIoTxClockConfig::PllF240m => release_pll_f240m(clocks),
+                            ParlIoClkConfig::XtalClk => release_xtal_clk(clocks),
+                            ParlIoClkConfig::RcFastClk => release_rc_fast_clk(clocks),
+                            ParlIoClkConfig::PllF240m => release_pll_f240m(clocks),
                         }
                     }
                 } else {
                     self.configure_tx_clock_impl(clocks, old_selector, new_selector);
                 }
             }
-            pub fn tx_clock_config(self, clocks: &mut ClockTree) -> Option<ParlIoTxClockConfig> {
+            pub fn tx_clock_config(self, clocks: &mut ClockTree) -> Option<ParlIoClkConfig> {
                 clocks.parl_io_tx_clock[self as usize]
             }
             pub fn request_tx_clock(self, clocks: &mut ClockTree) {
@@ -4030,9 +4010,9 @@ macro_rules! define_clock_tree_types {
                     trace!("Enabling {:?}::TX_CLOCK", self);
                     crate::rtc_cntl::WakeLock::acquire();
                     match unwrap!(clocks.parl_io_tx_clock[self as usize]) {
-                        ParlIoTxClockConfig::XtalClk => request_xtal_clk(clocks),
-                        ParlIoTxClockConfig::RcFastClk => request_rc_fast_clk(clocks),
-                        ParlIoTxClockConfig::PllF240m => request_pll_f240m(clocks),
+                        ParlIoClkConfig::XtalClk => request_xtal_clk(clocks),
+                        ParlIoClkConfig::RcFastClk => request_rc_fast_clk(clocks),
+                        ParlIoClkConfig::PllF240m => request_pll_f240m(clocks),
                     }
                     self.enable_tx_clock_impl(clocks, true);
                 }
@@ -4044,32 +4024,32 @@ macro_rules! define_clock_tree_types {
                     crate::rtc_cntl::WakeLock::release();
                     self.enable_tx_clock_impl(clocks, false);
                     match unwrap!(clocks.parl_io_tx_clock[self as usize]) {
-                        ParlIoTxClockConfig::XtalClk => release_xtal_clk(clocks),
-                        ParlIoTxClockConfig::RcFastClk => release_rc_fast_clk(clocks),
-                        ParlIoTxClockConfig::PllF240m => release_pll_f240m(clocks),
+                        ParlIoClkConfig::XtalClk => release_xtal_clk(clocks),
+                        ParlIoClkConfig::RcFastClk => release_rc_fast_clk(clocks),
+                        ParlIoClkConfig::PllF240m => release_pll_f240m(clocks),
                     }
                 }
             }
             #[allow(unused_variables)]
             pub fn tx_clock_config_frequency(
                 clocks: &mut ClockTree,
-                config: ParlIoTxClockConfig,
+                config: ParlIoClkConfig,
             ) -> u32 {
                 match config {
-                    ParlIoTxClockConfig::XtalClk => xtal_clk_frequency(),
-                    ParlIoTxClockConfig::RcFastClk => rc_fast_clk_frequency(),
-                    ParlIoTxClockConfig::PllF240m => pll_f240m_frequency(),
+                    ParlIoClkConfig::XtalClk => xtal_clk_frequency(),
+                    ParlIoClkConfig::RcFastClk => rc_fast_clk_frequency(),
+                    ParlIoClkConfig::PllF240m => pll_f240m_frequency(),
                 }
             }
             pub fn tx_clock_frequency(self) -> u32 {
                 PARL_IO_TX_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
-            pub fn tx_clock_source_frequency(source: ParlIoTxClockConfig) -> u32 {
+            pub fn tx_clock_source_frequency(source: ParlIoClkConfig) -> u32 {
                 match source {
-                    ParlIoTxClockConfig::XtalClk => xtal_clk_frequency(),
-                    ParlIoTxClockConfig::RcFastClk => rc_fast_clk_frequency(),
-                    ParlIoTxClockConfig::PllF240m => pll_f240m_frequency(),
+                    ParlIoClkConfig::XtalClk => xtal_clk_frequency(),
+                    ParlIoClkConfig::RcFastClk => rc_fast_clk_frequency(),
+                    ParlIoClkConfig::PllF240m => pll_f240m_frequency(),
                 }
             }
         }

--- a/esp-metadata-generated/src/_generated_esp32h2.rs
+++ b/esp-metadata-generated/src/_generated_esp32h2.rs
@@ -576,14 +576,14 @@ macro_rules! property {
         ::soc::clocks::McpwmFunctionClockConfig::XtalClk]
     };
     ("clock_tree.parl_io.rx_clock") => {
-        [crate ::soc::clocks::ParlIoRxClockConfig::XtalClk, crate
-        ::soc::clocks::ParlIoRxClockConfig::RcFastClk, crate
-        ::soc::clocks::ParlIoRxClockConfig::PllF96m]
+        [crate ::soc::clocks::ParlIoClkConfig::XtalClk, crate
+        ::soc::clocks::ParlIoClkConfig::RcFastClk, crate
+        ::soc::clocks::ParlIoClkConfig::PllF96m]
     };
     ("clock_tree.parl_io.tx_clock") => {
-        [crate ::soc::clocks::ParlIoTxClockConfig::XtalClk, crate
-        ::soc::clocks::ParlIoTxClockConfig::RcFastClk, crate
-        ::soc::clocks::ParlIoTxClockConfig::PllF96m]
+        [crate ::soc::clocks::ParlIoClkConfig::XtalClk, crate
+        ::soc::clocks::ParlIoClkConfig::RcFastClk, crate
+        ::soc::clocks::ParlIoClkConfig::PllF96m]
     };
     ("clock_tree.i2c.function_clock.sclk") => {
         [crate ::soc::clocks::I2cFunctionClockSclk::Xtal, crate
@@ -1450,8 +1450,8 @@ macro_rules! for_each_sw_interrupt {
 ///     fn configure_rx_clock_impl(
 ///         self,
 ///         _clocks: &mut ClockTree,
-///         _old_config: Option<ParlIoRxClockConfig>,
-///         _new_config: ParlIoRxClockConfig,
+///         _old_config: Option<ParlIoClkConfig>,
+///         _new_config: ParlIoClkConfig,
 ///     ) {
 ///         todo!()
 ///     }
@@ -1465,8 +1465,8 @@ macro_rules! for_each_sw_interrupt {
 ///     fn configure_tx_clock_impl(
 ///         self,
 ///         _clocks: &mut ClockTree,
-///         _old_config: Option<ParlIoTxClockConfig>,
-///         _new_config: ParlIoTxClockConfig,
+///         _old_config: Option<ParlIoClkConfig>,
+///         _new_config: ParlIoClkConfig,
 ///     ) {
 ///         todo!()
 ///     }
@@ -1816,19 +1816,7 @@ macro_rules! define_clock_tree_types {
         /// The list of clock signals that the `PARL_IO_RX_CLOCK` multiplexer can output.
         #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
         #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-        pub enum ParlIoRxClockConfig {
-            /// Selects `XTAL_CLK`.
-            XtalClk,
-            /// Selects `RC_FAST_CLK`.
-            RcFastClk,
-            #[default]
-            /// Selects `PLL_F96M_CLK`.
-            PllF96m,
-        }
-        /// The list of clock signals that the `PARL_IO_TX_CLOCK` multiplexer can output.
-        #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
-        #[cfg_attr(feature = "defmt", derive(defmt::Format))]
-        pub enum ParlIoTxClockConfig {
+        pub enum ParlIoClkConfig {
             /// Selects `XTAL_CLK`.
             XtalClk,
             /// Selects `RC_FAST_CLK`.
@@ -1978,8 +1966,8 @@ macro_rules! define_clock_tree_types {
             timg_calibration_clock: Option<TimgCalibrationClockConfig>,
             i2c_function_clock: [Option<I2cFunctionClockConfig>; 2],
             mcpwm_function_clock: [Option<McpwmFunctionClockConfig>; 1],
-            parl_io_rx_clock: [Option<ParlIoRxClockConfig>; 1],
-            parl_io_tx_clock: [Option<ParlIoTxClockConfig>; 1],
+            parl_io_rx_clock: [Option<ParlIoClkConfig>; 1],
+            parl_io_tx_clock: [Option<ParlIoClkConfig>; 1],
             rmt_sclk: [Option<RmtSclkConfig>; 1],
             spi_function_clock: [Option<SpiFunctionClockConfig>; 1],
             timg_function_clock: [Option<TimgFunctionClockConfig>; 2],
@@ -2061,11 +2049,11 @@ macro_rules! define_clock_tree_types {
                 self.mcpwm_function_clock[McpwmInstance::Mcpwm0 as usize]
             }
             /// Returns the current configuration of the PARL_IO_RX_CLOCK clock tree node
-            pub fn parl_io_rx_clock(&self) -> Option<ParlIoRxClockConfig> {
+            pub fn parl_io_rx_clock(&self) -> Option<ParlIoClkConfig> {
                 self.parl_io_rx_clock[ParlIoInstance::ParlIo as usize]
             }
             /// Returns the current configuration of the PARL_IO_TX_CLOCK clock tree node
-            pub fn parl_io_tx_clock(&self) -> Option<ParlIoTxClockConfig> {
+            pub fn parl_io_tx_clock(&self) -> Option<ParlIoClkConfig> {
                 self.parl_io_tx_clock[ParlIoInstance::ParlIo as usize]
             }
             /// Returns the current configuration of the RMT_SCLK clock tree node
@@ -2977,32 +2965,28 @@ macro_rules! define_clock_tree_types {
             }
         }
         impl ParlIoInstance {
-            pub fn configure_rx_clock(
-                self,
-                clocks: &mut ClockTree,
-                new_selector: ParlIoRxClockConfig,
-            ) {
+            pub fn configure_rx_clock(self, clocks: &mut ClockTree, new_selector: ParlIoClkConfig) {
                 let old_selector = clocks.parl_io_rx_clock[self as usize].replace(new_selector);
                 refresh_parl_io_rx_clock_downstream(clocks, self);
                 if clocks.parl_io_rx_clock_refcount[self as usize] > 0 {
                     match new_selector {
-                        ParlIoRxClockConfig::XtalClk => request_xtal_clk(clocks),
-                        ParlIoRxClockConfig::RcFastClk => request_rc_fast_clk(clocks),
-                        ParlIoRxClockConfig::PllF96m => request_pll_f96m_clk(clocks),
+                        ParlIoClkConfig::XtalClk => request_xtal_clk(clocks),
+                        ParlIoClkConfig::RcFastClk => request_rc_fast_clk(clocks),
+                        ParlIoClkConfig::PllF96m => request_pll_f96m_clk(clocks),
                     }
                     self.configure_rx_clock_impl(clocks, old_selector, new_selector);
                     if let Some(old_selector) = old_selector {
                         match old_selector {
-                            ParlIoRxClockConfig::XtalClk => release_xtal_clk(clocks),
-                            ParlIoRxClockConfig::RcFastClk => release_rc_fast_clk(clocks),
-                            ParlIoRxClockConfig::PllF96m => release_pll_f96m_clk(clocks),
+                            ParlIoClkConfig::XtalClk => release_xtal_clk(clocks),
+                            ParlIoClkConfig::RcFastClk => release_rc_fast_clk(clocks),
+                            ParlIoClkConfig::PllF96m => release_pll_f96m_clk(clocks),
                         }
                     }
                 } else {
                     self.configure_rx_clock_impl(clocks, old_selector, new_selector);
                 }
             }
-            pub fn rx_clock_config(self, clocks: &mut ClockTree) -> Option<ParlIoRxClockConfig> {
+            pub fn rx_clock_config(self, clocks: &mut ClockTree) -> Option<ParlIoClkConfig> {
                 clocks.parl_io_rx_clock[self as usize]
             }
             pub fn request_rx_clock(self, clocks: &mut ClockTree) {
@@ -3011,9 +2995,9 @@ macro_rules! define_clock_tree_types {
                     trace!("Enabling {:?}::RX_CLOCK", self);
                     crate::rtc_cntl::WakeLock::acquire();
                     match unwrap!(clocks.parl_io_rx_clock[self as usize]) {
-                        ParlIoRxClockConfig::XtalClk => request_xtal_clk(clocks),
-                        ParlIoRxClockConfig::RcFastClk => request_rc_fast_clk(clocks),
-                        ParlIoRxClockConfig::PllF96m => request_pll_f96m_clk(clocks),
+                        ParlIoClkConfig::XtalClk => request_xtal_clk(clocks),
+                        ParlIoClkConfig::RcFastClk => request_rc_fast_clk(clocks),
+                        ParlIoClkConfig::PllF96m => request_pll_f96m_clk(clocks),
                     }
                     self.enable_rx_clock_impl(clocks, true);
                 }
@@ -3025,60 +3009,56 @@ macro_rules! define_clock_tree_types {
                     crate::rtc_cntl::WakeLock::release();
                     self.enable_rx_clock_impl(clocks, false);
                     match unwrap!(clocks.parl_io_rx_clock[self as usize]) {
-                        ParlIoRxClockConfig::XtalClk => release_xtal_clk(clocks),
-                        ParlIoRxClockConfig::RcFastClk => release_rc_fast_clk(clocks),
-                        ParlIoRxClockConfig::PllF96m => release_pll_f96m_clk(clocks),
+                        ParlIoClkConfig::XtalClk => release_xtal_clk(clocks),
+                        ParlIoClkConfig::RcFastClk => release_rc_fast_clk(clocks),
+                        ParlIoClkConfig::PllF96m => release_pll_f96m_clk(clocks),
                     }
                 }
             }
             #[allow(unused_variables)]
             pub fn rx_clock_config_frequency(
                 clocks: &mut ClockTree,
-                config: ParlIoRxClockConfig,
+                config: ParlIoClkConfig,
             ) -> u32 {
                 match config {
-                    ParlIoRxClockConfig::XtalClk => xtal_clk_frequency(),
-                    ParlIoRxClockConfig::RcFastClk => rc_fast_clk_frequency(),
-                    ParlIoRxClockConfig::PllF96m => pll_f96m_clk_frequency(),
+                    ParlIoClkConfig::XtalClk => xtal_clk_frequency(),
+                    ParlIoClkConfig::RcFastClk => rc_fast_clk_frequency(),
+                    ParlIoClkConfig::PllF96m => pll_f96m_clk_frequency(),
                 }
             }
             pub fn rx_clock_frequency(self) -> u32 {
                 PARL_IO_RX_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
-            pub fn rx_clock_source_frequency(source: ParlIoRxClockConfig) -> u32 {
+            pub fn rx_clock_source_frequency(source: ParlIoClkConfig) -> u32 {
                 match source {
-                    ParlIoRxClockConfig::XtalClk => xtal_clk_frequency(),
-                    ParlIoRxClockConfig::RcFastClk => rc_fast_clk_frequency(),
-                    ParlIoRxClockConfig::PllF96m => pll_f96m_clk_frequency(),
+                    ParlIoClkConfig::XtalClk => xtal_clk_frequency(),
+                    ParlIoClkConfig::RcFastClk => rc_fast_clk_frequency(),
+                    ParlIoClkConfig::PllF96m => pll_f96m_clk_frequency(),
                 }
             }
-            pub fn configure_tx_clock(
-                self,
-                clocks: &mut ClockTree,
-                new_selector: ParlIoTxClockConfig,
-            ) {
+            pub fn configure_tx_clock(self, clocks: &mut ClockTree, new_selector: ParlIoClkConfig) {
                 let old_selector = clocks.parl_io_tx_clock[self as usize].replace(new_selector);
                 refresh_parl_io_tx_clock_downstream(clocks, self);
                 if clocks.parl_io_tx_clock_refcount[self as usize] > 0 {
                     match new_selector {
-                        ParlIoTxClockConfig::XtalClk => request_xtal_clk(clocks),
-                        ParlIoTxClockConfig::RcFastClk => request_rc_fast_clk(clocks),
-                        ParlIoTxClockConfig::PllF96m => request_pll_f96m_clk(clocks),
+                        ParlIoClkConfig::XtalClk => request_xtal_clk(clocks),
+                        ParlIoClkConfig::RcFastClk => request_rc_fast_clk(clocks),
+                        ParlIoClkConfig::PllF96m => request_pll_f96m_clk(clocks),
                     }
                     self.configure_tx_clock_impl(clocks, old_selector, new_selector);
                     if let Some(old_selector) = old_selector {
                         match old_selector {
-                            ParlIoTxClockConfig::XtalClk => release_xtal_clk(clocks),
-                            ParlIoTxClockConfig::RcFastClk => release_rc_fast_clk(clocks),
-                            ParlIoTxClockConfig::PllF96m => release_pll_f96m_clk(clocks),
+                            ParlIoClkConfig::XtalClk => release_xtal_clk(clocks),
+                            ParlIoClkConfig::RcFastClk => release_rc_fast_clk(clocks),
+                            ParlIoClkConfig::PllF96m => release_pll_f96m_clk(clocks),
                         }
                     }
                 } else {
                     self.configure_tx_clock_impl(clocks, old_selector, new_selector);
                 }
             }
-            pub fn tx_clock_config(self, clocks: &mut ClockTree) -> Option<ParlIoTxClockConfig> {
+            pub fn tx_clock_config(self, clocks: &mut ClockTree) -> Option<ParlIoClkConfig> {
                 clocks.parl_io_tx_clock[self as usize]
             }
             pub fn request_tx_clock(self, clocks: &mut ClockTree) {
@@ -3087,9 +3067,9 @@ macro_rules! define_clock_tree_types {
                     trace!("Enabling {:?}::TX_CLOCK", self);
                     crate::rtc_cntl::WakeLock::acquire();
                     match unwrap!(clocks.parl_io_tx_clock[self as usize]) {
-                        ParlIoTxClockConfig::XtalClk => request_xtal_clk(clocks),
-                        ParlIoTxClockConfig::RcFastClk => request_rc_fast_clk(clocks),
-                        ParlIoTxClockConfig::PllF96m => request_pll_f96m_clk(clocks),
+                        ParlIoClkConfig::XtalClk => request_xtal_clk(clocks),
+                        ParlIoClkConfig::RcFastClk => request_rc_fast_clk(clocks),
+                        ParlIoClkConfig::PllF96m => request_pll_f96m_clk(clocks),
                     }
                     self.enable_tx_clock_impl(clocks, true);
                 }
@@ -3101,32 +3081,32 @@ macro_rules! define_clock_tree_types {
                     crate::rtc_cntl::WakeLock::release();
                     self.enable_tx_clock_impl(clocks, false);
                     match unwrap!(clocks.parl_io_tx_clock[self as usize]) {
-                        ParlIoTxClockConfig::XtalClk => release_xtal_clk(clocks),
-                        ParlIoTxClockConfig::RcFastClk => release_rc_fast_clk(clocks),
-                        ParlIoTxClockConfig::PllF96m => release_pll_f96m_clk(clocks),
+                        ParlIoClkConfig::XtalClk => release_xtal_clk(clocks),
+                        ParlIoClkConfig::RcFastClk => release_rc_fast_clk(clocks),
+                        ParlIoClkConfig::PllF96m => release_pll_f96m_clk(clocks),
                     }
                 }
             }
             #[allow(unused_variables)]
             pub fn tx_clock_config_frequency(
                 clocks: &mut ClockTree,
-                config: ParlIoTxClockConfig,
+                config: ParlIoClkConfig,
             ) -> u32 {
                 match config {
-                    ParlIoTxClockConfig::XtalClk => xtal_clk_frequency(),
-                    ParlIoTxClockConfig::RcFastClk => rc_fast_clk_frequency(),
-                    ParlIoTxClockConfig::PllF96m => pll_f96m_clk_frequency(),
+                    ParlIoClkConfig::XtalClk => xtal_clk_frequency(),
+                    ParlIoClkConfig::RcFastClk => rc_fast_clk_frequency(),
+                    ParlIoClkConfig::PllF96m => pll_f96m_clk_frequency(),
                 }
             }
             pub fn tx_clock_frequency(self) -> u32 {
                 PARL_IO_TX_CLOCK_FREQ_CACHE[self as usize]
                     .load(::core::sync::atomic::Ordering::Acquire)
             }
-            pub fn tx_clock_source_frequency(source: ParlIoTxClockConfig) -> u32 {
+            pub fn tx_clock_source_frequency(source: ParlIoClkConfig) -> u32 {
                 match source {
-                    ParlIoTxClockConfig::XtalClk => xtal_clk_frequency(),
-                    ParlIoTxClockConfig::RcFastClk => rc_fast_clk_frequency(),
-                    ParlIoTxClockConfig::PllF96m => pll_f96m_clk_frequency(),
+                    ParlIoClkConfig::XtalClk => xtal_clk_frequency(),
+                    ParlIoClkConfig::RcFastClk => rc_fast_clk_frequency(),
+                    ParlIoClkConfig::PllF96m => pll_f96m_clk_frequency(),
                 }
             }
         }

--- a/esp-metadata/devices/esp32c5/clocks.toml
+++ b/esp-metadata/devices/esp32c5/clocks.toml
@@ -100,19 +100,23 @@ system_clocks = { clock_tree = [
             { name = "PLL_F80M",    outputs = "PLL_F80M", default = true },
         ] },
     ] },
-    { group = "PARL_IO", clocks = [
-        { name = "RX_CLOCK", type = "mux", variants = [
+    { group = "PARL_IO",
+      presets = {
+        CLK = {
+          type = "mux",
+          variants = [
             { name = "XTAL_CLK",    outputs = "XTAL_CLK" },
             { name = "RC_FAST_CLK", outputs = "RC_FAST_CLK" },
             { name = "PLL_F240M",   outputs = "PLL_F240M", default = true },
-            # TODO: external clock
-        ] },
-        { name = "TX_CLOCK", type = "mux", variants = [
-            { name = "XTAL_CLK",    outputs = "XTAL_CLK" },
-            { name = "RC_FAST_CLK", outputs = "RC_FAST_CLK" },
-            { name = "PLL_F240M",   outputs = "PLL_F240M", default = true },
-        ] },
-    ] },
+            # TODO: external clock (TX and RX may differ)
+          ],
+        },
+      },
+      clocks = [
+        { name = "RX_CLOCK", preset = "CLK" },
+        { name = "TX_CLOCK", preset = "CLK" },
+      ],
+    },
     { group = "I2C", clocks = [
         { name = "FUNCTION_CLOCK", type = "generic", output = "sclk / (div_num + 1)", params = { sclk = [
             { name = "XTAL",    outputs = "XTAL_CLK", default = true },

--- a/esp-metadata/devices/esp32c6/clocks.toml
+++ b/esp-metadata/devices/esp32c6/clocks.toml
@@ -116,19 +116,24 @@ system_clocks = { clock_tree = [
             { name = "XTAL_CLK",    outputs = "XTAL_CLK" },
         ] },
     ] },
-    { group = "PARL_IO", clocks = [
-        { name = "RX_CLOCK", type = "mux", wake_locking = true, variants = [
+    { group = "PARL_IO",
+      presets = {
+        CLK = {
+          type = "mux",
+          wake_locking = true,
+          variants = [
             { name = "XTAL_CLK",    outputs = "XTAL_CLK" },
             { name = "RC_FAST_CLK", outputs = "RC_FAST_CLK" },
             { name = "PLL_F240M",   outputs = "PLL_F240M", default = true },
-            # TODO: external clock
-        ] },
-        { name = "TX_CLOCK", type = "mux", wake_locking = true, variants = [
-            { name = "XTAL_CLK",    outputs = "XTAL_CLK" },
-            { name = "RC_FAST_CLK", outputs = "RC_FAST_CLK" },
-            { name = "PLL_F240M",   outputs = "PLL_F240M", default = true },
-        ] },
-    ] },
+            # TODO: external clock (TX and RX may differ)
+          ],
+        },
+      },
+      clocks = [
+        { name = "RX_CLOCK", preset = "CLK" },
+        { name = "TX_CLOCK", preset = "CLK" },
+      ],
+    },
     { group = "I2C", clocks = [
         { name = "FUNCTION_CLOCK", type = "generic", wake_locking = true, output = "sclk / (div_num + 1)", params = { sclk = [
             { name = "XTAL",    outputs = "XTAL_CLK", default = true },

--- a/esp-metadata/devices/esp32h2/clocks.toml
+++ b/esp-metadata/devices/esp32h2/clocks.toml
@@ -90,19 +90,24 @@ system_clocks = { clock_tree = [
             { name = "XTAL_CLK",    outputs = "XTAL_CLK" },
         ] },
     ] },
-    { group = "PARL_IO", clocks = [
-        { name = "RX_CLOCK", type = "mux", wake_locking = true, variants = [
+    { group = "PARL_IO",
+      presets = {
+        CLK = {
+          type = "mux",
+          wake_locking = true,
+          variants = [
             { name = "XTAL_CLK",    outputs = "XTAL_CLK" },
             { name = "RC_FAST_CLK", outputs = "RC_FAST_CLK" },
             { name = "PLL_F96M",    outputs = "PLL_F96M_CLK", default = true },
-            # TODO: external clock
-        ] },
-        { name = "TX_CLOCK", type = "mux", wake_locking = true, variants = [
-            { name = "XTAL_CLK",    outputs = "XTAL_CLK" },
-            { name = "RC_FAST_CLK", outputs = "RC_FAST_CLK" },
-            { name = "PLL_F96M",    outputs = "PLL_F96M_CLK", default = true },
-        ] },
-    ] },
+            # TODO: external clock (TX and RX may differ)
+          ],
+        },
+      },
+      clocks = [
+        { name = "RX_CLOCK", preset = "CLK" },
+        { name = "TX_CLOCK", preset = "CLK" },
+      ],
+    },
     { group = "I2C", clocks = [
         { name = "FUNCTION_CLOCK", type = "generic", wake_locking = true, output = "sclk / (div_num + 1)", params = { sclk = [
             { name = "XTAL",    outputs = "XTAL_CLK", default = true },

--- a/esp-metadata/src/cfg/soc.rs
+++ b/esp-metadata/src/cfg/soc.rs
@@ -141,7 +141,69 @@ pub struct SystemClocks {
 #[serde(deny_unknown_fields)]
 struct ClockGroup {
     group: String,
-    clocks: Vec<ClockTreeItem>,
+    /// Reusable node definitions for this group. Map keys are preset names (TOML 1.1).
+    #[serde(default)]
+    presets: IndexMap<String, ClockTreeItem>,
+    clocks: Vec<GroupClock>,
+}
+
+/// A clock in a template group: a full node, or an instantiation of a group preset.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+enum GroupClock {
+    Inline(ClockTreeItem),
+    Preset(PresetClockRef),
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PresetClockRef {
+    name: String,
+    preset: String,
+    #[serde(default)]
+    wake_locking: Option<bool>,
+    #[serde(default)]
+    always_on: Option<bool>,
+}
+
+struct ResolvedGroupClock {
+    item: ClockTreeItem,
+    /// Name used to generate `*Config` types (`CLK` → `ParlIoClkConfig`).
+    config_type_stem: String,
+}
+
+impl ClockGroup {
+    fn resolved_clocks(&self) -> Result<Vec<ResolvedGroupClock>> {
+        self.clocks
+            .iter()
+            .map(|clock| match clock {
+                GroupClock::Inline(item) => Ok(ResolvedGroupClock {
+                    config_type_stem: item.name().to_string(),
+                    item: item.clone(),
+                }),
+                GroupClock::Preset(inst) => {
+                    let mut item = self.presets.get(&inst.preset).cloned().ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "Clock group `{}` has no preset `{}`",
+                            self.group,
+                            inst.preset
+                        )
+                    })?;
+                    item.set_name(inst.name.clone());
+                    if let Some(wake_locking) = inst.wake_locking {
+                        item.set_wake_locking(wake_locking);
+                    }
+                    if let Some(always_on) = inst.always_on {
+                        item.set_always_on(always_on);
+                    }
+                    Ok(ResolvedGroupClock {
+                        item,
+                        config_type_stem: inst.preset.clone(),
+                    })
+                }
+            })
+            .collect()
+    }
 }
 
 pub(crate) struct ProcessedClockData {
@@ -176,6 +238,10 @@ pub(crate) struct ClockTreeNodeInstance {
     ///
     /// Must be in CONSTANT_CASE, e.g. UART.
     group_template: String,
+
+    /// Stem for the generated config type. For a preset instantiation this is the preset name
+    /// (e.g. `CLK` → `ParlIoClkConfig`), otherwise the template node name.
+    config_type_stem: String,
 
     properties: ManagementProperties,
 }
@@ -277,7 +343,11 @@ impl ClockTreeNodeInstance {
     /// Returns the name of the clock configuration type. The corresponding field in the
     /// `ClockConfig` struct will have this type.
     fn config_type_name(&self) -> Ident {
-        clock_tree::config_type_name(&self.group_template, self.node.name())
+        clock_tree::config_type_name(&self.group_template, &self.config_type_stem)
+    }
+
+    pub(crate) fn config_type_stem(&self) -> &str {
+        &self.config_type_stem
     }
 
     fn apply_configuration(
@@ -727,6 +797,7 @@ impl SystemClocks {
         let mut system_config_steps = HashMap::new();
 
         let mut first_instances = HashSet::new();
+        let mut emitted_config_types = HashSet::new();
         let mut instance_enums = Vec::new();
 
         for (group_template, instances) in tree.group_instances.iter() {
@@ -759,11 +830,14 @@ impl SystemClocks {
             if is_first_instance {
                 let cfg_attr = clock_item.rustc_cfg_attr();
                 if clock_item.emits_config_type(tree) {
-                    let config_type = clock_item.config_type();
-                    clock_tree_node_defs.push(quote! {
-                        #cfg_attr
-                        #config_type
-                    });
+                    let type_key = clock_item.config_type_name().to_string();
+                    if emitted_config_types.insert(type_key) {
+                        let config_type = clock_item.config_type();
+                        clock_tree_node_defs.push(quote! {
+                            #cfg_attr
+                            #config_type
+                        });
+                    }
                 }
 
                 let instance_count =
@@ -1238,17 +1312,29 @@ impl SystemClocks {
                 "{path}.{}",
                 node.name().from_case(Case::Constant).to_case(Case::Snake)
             );
-            node.property_macro_branches(&path, "")
+            node.property_macro_branches(&path, "", node.name())
         }));
         branches.extend(self.template_groups.iter().flat_map(|group| {
-            group.clocks.iter().map(|node| {
-                let path = format!(
-                    "{path}.{}.{}",
-                    group.group.from_case(Case::Constant).to_case(Case::Snake),
-                    node.name().from_case(Case::Constant).to_case(Case::Snake)
-                );
-                node.property_macro_branches(&path, &group.group)
-            })
+            group
+                .resolved_clocks()
+                .unwrap_or_else(|err| panic!("{err}"))
+                .into_iter()
+                .map(|resolved| {
+                    let path = format!(
+                        "{path}.{}.{}",
+                        group.group.from_case(Case::Constant).to_case(Case::Snake),
+                        resolved
+                            .item
+                            .name()
+                            .from_case(Case::Constant)
+                            .to_case(Case::Snake)
+                    );
+                    resolved.item.property_macro_branches(
+                        &path,
+                        &group.group,
+                        &resolved.config_type_stem,
+                    )
+                })
         }));
         branches
     }
@@ -1501,6 +1587,7 @@ impl DeviceClocks {
                     name: name.clone(),
                     group_instance: String::new(),
                     group_template: String::new(),
+                    config_type_stem: name.clone(),
                     properties: ManagementProperties {
                         name: format_ident!(
                             "{}",
@@ -1531,15 +1618,15 @@ impl DeviceClocks {
 
             // A peripheral can have any number of clock sources. We'll turn them into clock tree
             // nodes here.
-            for def in self
+            for resolved in self
                 .system_clocks
                 .template_groups
                 .iter()
                 .find(|g| g.group == *group_name)
                 .ok_or_else(|| anyhow::anyhow!("Clock group {group_name} not found"))?
-                .clocks
-                .iter()
+                .resolved_clocks()?
             {
+                let def = &resolved.item;
                 let name = format!("{peri_name}_{}", def.name());
                 let instance_ty = format_ident!(
                     "{}Instance",
@@ -1555,6 +1642,7 @@ impl DeviceClocks {
                     name: name.clone(),
                     group_instance: peri_name.clone(),
                     group_template: group_name.clone(),
+                    config_type_stem: resolved.config_type_stem.clone(),
                     properties: ManagementProperties {
                         name: format_ident!(
                             "{}",
@@ -1702,8 +1790,14 @@ impl DeviceClocks {
             push_node_cfgs(node.name().to_string(), node);
         }
         for group in config.clocks.system_clocks.template_groups.iter() {
-            for node in group.clocks.iter() {
-                push_node_cfgs(format!("{}_{}", group.group, node.name()), node);
+            for resolved in group
+                .resolved_clocks()
+                .unwrap_or_else(|err| panic!("{err}"))
+            {
+                push_node_cfgs(
+                    format!("{}_{}", group.group, resolved.item.name()),
+                    &resolved.item,
+                );
             }
         }
 

--- a/esp-metadata/src/cfg/soc/clock_tree.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree.rs
@@ -576,7 +576,15 @@ pub(crate) trait ClockTreeNodeType: Any {
     ///
     /// `group` is the name of the template group the node belongs to, or an empty string for
     /// standalone nodes. It is needed to reconstruct the names of the generated config types.
-    fn property_macro_branches(&self, _path: &str, _group: &str) -> TokenStream {
+    ///
+    /// `config_type_stem` is the clock name used in the generated config type (`PARL_IO` + `CLK` →
+    /// `ParlIoClkConfig`). For a preset instantiation this is the preset name, not the node name.
+    fn property_macro_branches(
+        &self,
+        _path: &str,
+        _group: &str,
+        _config_type_stem: &str,
+    ) -> TokenStream {
         quote! {}
     }
 
@@ -631,12 +639,52 @@ impl ClockTreeItem {
         }
     }
 
-    pub(crate) fn property_macro_branches(&self, path: &str, group: &str) -> TokenStream {
+    pub(crate) fn property_macro_branches(
+        &self,
+        path: &str,
+        group: &str,
+        config_type_stem: &str,
+    ) -> TokenStream {
         match self {
-            ClockTreeItem::Multiplexer(mux) => mux.property_macro_branches(path, group),
-            ClockTreeItem::Source(src) => src.property_macro_branches(path, group),
-            ClockTreeItem::Generic(div) => div.property_macro_branches(path, group),
-            ClockTreeItem::Derived(drv) => drv.property_macro_branches(path, group),
+            ClockTreeItem::Multiplexer(mux) => {
+                mux.property_macro_branches(path, group, config_type_stem)
+            }
+            ClockTreeItem::Source(src) => {
+                src.property_macro_branches(path, group, config_type_stem)
+            }
+            ClockTreeItem::Generic(div) => {
+                div.property_macro_branches(path, group, config_type_stem)
+            }
+            ClockTreeItem::Derived(drv) => {
+                drv.property_macro_branches(path, group, config_type_stem)
+            }
+        }
+    }
+
+    pub(crate) fn set_name(&mut self, name: String) {
+        match self {
+            ClockTreeItem::Multiplexer(mux) => mux.name = name,
+            ClockTreeItem::Source(src) => src.name = name,
+            ClockTreeItem::Generic(div) => div.name = name,
+            ClockTreeItem::Derived(drv) => drv.source_options.name = name,
+        }
+    }
+
+    pub(crate) fn set_wake_locking(&mut self, wake_locking: bool) {
+        match self {
+            ClockTreeItem::Multiplexer(mux) => mux.set_wake_locking(wake_locking),
+            ClockTreeItem::Source(src) => src.set_wake_locking(wake_locking),
+            ClockTreeItem::Generic(div) => div.set_wake_locking(wake_locking),
+            ClockTreeItem::Derived(drv) => drv.source_options.set_wake_locking(wake_locking),
+        }
+    }
+
+    pub(crate) fn set_always_on(&mut self, always_on: bool) {
+        match self {
+            ClockTreeItem::Multiplexer(mux) => mux.set_always_on(always_on),
+            ClockTreeItem::Source(src) => src.set_always_on(always_on),
+            ClockTreeItem::Generic(div) => div.set_always_on(always_on),
+            ClockTreeItem::Derived(drv) => drv.source_options.set_always_on(always_on),
         }
     }
 }

--- a/esp-metadata/src/cfg/soc/clock_tree/generic.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/generic.rs
@@ -99,6 +99,10 @@ impl<'de> Deserialize<'de> for NodeParameter {
 #[serde(deny_unknown_fields)]
 pub struct Generic {
     /// The unique name of the clock tree item.
+    ///
+    /// Empty when this node is a group preset; the map key / instantiating clock supplies the
+    /// name.
+    #[serde(default)]
     pub name: String,
 
     #[serde(default)]
@@ -124,6 +128,16 @@ pub struct Generic {
     /// Variables in the output expression.
     #[serde(default)]
     params: IndexMap<String, NodeParameter>,
+}
+
+impl Generic {
+    pub(crate) fn set_wake_locking(&mut self, wake_locking: bool) {
+        self.wake_locking = wake_locking;
+    }
+
+    pub(crate) fn set_always_on(&mut self, always_on: bool) {
+        self.always_on = always_on;
+    }
 }
 
 impl ClockTreeNodeType for Generic {
@@ -810,7 +824,12 @@ impl ClockTreeNodeType for Generic {
         self.impl_release_upstream(instance, tree, quote! { unwrap!(#config_field) })
     }
 
-    fn property_macro_branches(&self, path: &str, group: &str) -> TokenStream {
+    fn property_macro_branches(
+        &self,
+        path: &str,
+        group: &str,
+        config_type_stem: &str,
+    ) -> TokenStream {
         let mut branches = quote! {};
         for (param_name, param) in self.params.iter() {
             let path = format!("{path}.{param_name}");
@@ -835,7 +854,7 @@ impl ClockTreeNodeType for Generic {
                     }
                 }
                 NodeParameter::Source(variants) => {
-                    let ty = param_type_name(group, &self.name, param_name);
+                    let ty = param_type_name(group, config_type_stem, param_name);
                     let options = variants.iter().map(|variant| {
                         let cfg_attr = variant.cfg_attr();
                         let variant = variant.config_enum_variant_name();
@@ -996,7 +1015,11 @@ impl Generic {
         }
 
         // Enum parameter
-        param_type_name(&instance.group_template, &self.name, param_name)
+        param_type_name(
+            &instance.group_template,
+            instance.config_type_stem(),
+            param_name,
+        )
     }
 
     fn parameter_config_type_impl(

--- a/esp-metadata/src/cfg/soc/clock_tree/mux.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/mux.rs
@@ -25,6 +25,10 @@ use crate::cfg::{
 #[serde(deny_unknown_fields)]
 pub struct Multiplexer {
     /// The unique name of the clock tree item.
+    ///
+    /// Empty when this multiplexer is a group preset; the map key / instantiating clock supplies
+    /// the name.
+    #[serde(default)]
     pub name: String,
 
     #[serde(default)]
@@ -39,6 +43,16 @@ pub struct Multiplexer {
 
     // reject: Option<RejectExpression>,
     pub variants: Vec<MultiplexerVariant>,
+}
+
+impl Multiplexer {
+    pub(crate) fn set_wake_locking(&mut self, wake_locking: bool) {
+        self.wake_locking = wake_locking;
+    }
+
+    pub(crate) fn set_always_on(&mut self, always_on: bool) {
+        self.always_on = always_on;
+    }
 }
 
 impl ClockTreeNodeType for Multiplexer {
@@ -298,12 +312,17 @@ impl ClockTreeNodeType for Multiplexer {
         self.impl_release_upstream(instance, tree, quote! { unwrap!(#config_field) })
     }
 
-    fn property_macro_branches(&self, path: &str, group: &str) -> TokenStream {
+    fn property_macro_branches(
+        &self,
+        path: &str,
+        group: &str,
+        config_type_stem: &str,
+    ) -> TokenStream {
         if !self.is_configurable() {
             return quote! {};
         }
 
-        let ty = config_type_name(group, &self.name);
+        let ty = config_type_name(group, config_type_stem);
         let options = self.variants.iter().map(|variant| {
             let cfg_attr = variant.cfg_attr();
             let variant = variant.config_enum_variant_name();

--- a/esp-metadata/src/cfg/soc/clock_tree/source.rs
+++ b/esp-metadata/src/cfg/soc/clock_tree/source.rs
@@ -58,6 +58,7 @@ use crate::{
 #[derive(Debug, Clone, Deserialize)]
 pub struct Source {
     /// The unique name of the clock tree item.
+    #[serde(default)]
     pub name: String,
 
     #[serde(default)]
@@ -82,6 +83,16 @@ pub struct Source {
     values: Option<ValuesExpression>,
 
     output: OutputExpression,
+}
+
+impl Source {
+    pub(crate) fn set_wake_locking(&mut self, wake_locking: bool) {
+        self.wake_locking = wake_locking;
+    }
+
+    pub(crate) fn set_always_on(&mut self, always_on: bool) {
+        self.always_on = always_on;
+    }
 }
 
 impl ClockTreeNodeType for Source {


### PR DESCRIPTION
Sometimes, a peripheral has multiple clock nodes that have a shared config shape. The best example is I2S, where TX and RX are identical, although PARL_IO is probably close enough to use the same concept.

# Changelog

## esp-hal

- Changed: `ParlIoRxClockConfig` and `ParlIoTxClockConfig` have been replaced by a single `ParlIoClkConfig` type.