### PR TITLE
UART: clear UPDATE_CONTROL bit on C2, C3, S3

### DIFF
--- a/esp-hal/src/uart/low_level/mod.rs
+++ b/esp-hal/src/uart/low_level/mod.rs
@@ -41,10 +41,7 @@ use crate::{
 #[cfg_attr(uart_version = "2", path = "v2.rs")]
 mod version;
 
-#[inline(always)]
-pub(super) fn sync_regs(register_block: &RegisterBlock) {
-    version::sync_regs(register_block);
-}
+pub(super) use version::{enable_register_sync, sync_regs};
 
 #[derive(Debug, EnumSetType)]
 pub(super) enum TxEvent {

--- a/esp-hal/src/uart/low_level/v1.rs
+++ b/esp-hal/src/uart/low_level/v1.rs
@@ -102,53 +102,45 @@ pub(super) fn change_flow_control(
     sw_flow_ctrl: SwFlowControl,
     hw_flow_ctrl: HwFlowControl,
 ) {
-    match sw_flow_ctrl {
-        SwFlowControl::Enabled {
-            xon_char,
-            xoff_char,
-            xon_threshold,
-            xoff_threshold,
-        } => {
-            info.regs().flow_conf().modify(|_, w| {
-                w.xonoff_del().set_bit();
-                w.sw_flow_con_en().set_bit()
-            });
-
-            cfg_select! {
-                esp32 => {
-                    info.regs().swfc_conf().modify(|_, w| unsafe {
-                        w.xon_threshold()
-                            .bits(xon_threshold)
-                            .xoff_threshold()
-                            .bits(xoff_threshold)
-                    });
-                    info.regs().swfc_conf().modify(|_, w| unsafe {
-                        w.xon_char().bits(xon_char).xoff_char().bits(xoff_char)
-                    });
-                }
-                _ => {
-                    info.regs()
-                        .swfc_conf1()
-                        .modify(|_, w| unsafe { w.xon_threshold().bits(xon_threshold as u16) });
-                    info.regs()
-                        .swfc_conf0()
-                        .modify(|_, w| unsafe { w.xoff_threshold().bits(xoff_threshold as u16) });
-                    info.regs()
-                        .swfc_conf1()
-                        .modify(|_, w| unsafe { w.xon_char().bits(xon_char) });
-                    info.regs()
-                        .swfc_conf0()
-                        .modify(|_, w| unsafe { w.xoff_char().bits(xoff_char) });
-                }
+    if let SwFlowControl::Enabled {
+        xon_char,
+        xoff_char,
+        xon_threshold,
+        xoff_threshold,
+    } = sw_flow_ctrl
+    {
+        cfg_select! {
+            esp32 => {
+                info.regs().swfc_conf().modify(|_, w| unsafe {
+                    w.xon_threshold().bits(xon_threshold);
+                    w.xoff_threshold().bits(xoff_threshold);
+                    w.xon_char().bits(xon_char);
+                    w.xoff_char().bits(xoff_char)
+                });
             }
-        }
-        SwFlowControl::Disabled => {
-            let reg = info.regs().flow_conf();
-            reg.modify(|_, w| w.sw_flow_con_en().clear_bit());
-            reg.modify(|_, w| w.xonoff_del().clear_bit());
+            _ => {
+                info.regs()
+                    .swfc_conf1()
+                    .modify(|_, w| unsafe {
+                        w.xon_threshold().bits(xon_threshold as u16);
+                        w.xon_char().bits(xon_char)
+                    });
+                info.regs()
+                    .swfc_conf0()
+                    .modify(|_, w| unsafe {
+                        w.xoff_threshold().bits(xoff_threshold as u16);
+                        w.xoff_char().bits(xoff_char)
+                    });
+            }
         }
     }
 
+    info.regs().flow_conf().modify(|_, w| {
+        w.xonoff_del()
+            .bit(matches!(sw_flow_ctrl, SwFlowControl::Enabled { .. }));
+        w.sw_flow_con_en()
+            .bit(matches!(sw_flow_ctrl, SwFlowControl::Enabled { .. }))
+    });
     info.regs().conf0().modify(|_, w| {
         w.tx_flow_en()
             .bit(matches!(hw_flow_ctrl.cts, CtsConfig::Enabled))

--- a/esp-hal/src/uart/low_level/v1.rs
+++ b/esp-hal/src/uart/low_level/v1.rs
@@ -10,12 +10,28 @@ use crate::uart::{
 };
 
 #[inline(always)]
-pub(super) fn sync_regs(_register_block: &RegisterBlock) {
+pub(crate) fn enable_register_sync(_register_block: &RegisterBlock) {
+    #[cfg(not(any(esp32, esp32s2)))]
+    {
+        // We need to clear "high_speed" (UART_UPDATE_CTRL) for UART_REG_UPDATE
+        // to actually do anything. It's unclear if we have to clear this bit
+        // separately from using `reg_update` but this is cheap and for sure works.
+        _register_block
+            .id()
+            .modify(|_, w| w.high_speed().clear_bit());
+    }
+}
+
+#[inline(always)]
+pub(crate) fn sync_regs(_register_block: &RegisterBlock) {
     #[cfg(not(any(esp32, esp32s2)))]
     {
         let update_reg = _register_block.id();
 
-        update_reg.modify(|_, w| w.reg_update().set_bit());
+        update_reg.write(|w| {
+            w.high_speed().clear_bit();
+            w.reg_update().set_bit()
+        });
 
         while update_reg.read().reg_update().bit_is_set() {
             core::hint::spin_loop();
@@ -119,18 +135,14 @@ pub(super) fn change_flow_control(
                 });
             }
             _ => {
-                info.regs()
-                    .swfc_conf1()
-                    .modify(|_, w| unsafe {
-                        w.xon_threshold().bits(xon_threshold as u16);
-                        w.xon_char().bits(xon_char)
-                    });
-                info.regs()
-                    .swfc_conf0()
-                    .modify(|_, w| unsafe {
-                        w.xoff_threshold().bits(xoff_threshold as u16);
-                        w.xoff_char().bits(xoff_char)
-                    });
+                info.regs().swfc_conf1().modify(|_, w| unsafe {
+                    w.xon_threshold().bits(xon_threshold as u16);
+                    w.xon_char().bits(xon_char)
+                });
+                info.regs().swfc_conf0().modify(|_, w| unsafe {
+                    w.xoff_threshold().bits(xoff_threshold as u16);
+                    w.xoff_char().bits(xoff_char)
+                });
             }
         }
     }

--- a/esp-hal/src/uart/low_level/v2.rs
+++ b/esp-hal/src/uart/low_level/v2.rs
@@ -10,10 +10,13 @@ use crate::uart::{
 };
 
 #[inline(always)]
-pub(super) fn sync_regs(register_block: &RegisterBlock) {
+pub(crate) fn enable_register_sync(_register_block: &RegisterBlock) {}
+
+#[inline(always)]
+pub(crate) fn sync_regs(register_block: &RegisterBlock) {
     let update_reg = register_block.reg_update();
 
-    update_reg.modify(|_, w| w.reg_update().set_bit());
+    update_reg.write(|w| w.reg_update().set_bit());
 
     while update_reg.read().reg_update().bit_is_set() {
         core::hint::spin_loop();

--- a/esp-hal/src/uart/mod.rs
+++ b/esp-hal/src/uart/mod.rs
@@ -71,6 +71,7 @@ use low_level::{
     UartClockGuard,
     UartRxFuture,
     UartTxFuture,
+    enable_register_sync,
     rx_event_check_for_error,
     sync_regs,
 };
@@ -2321,6 +2322,8 @@ where
     fn init(&mut self, config: Config) -> Result<(), ConfigError> {
         self.rx.disable_rx_interrupts();
         self.tx.disable_tx_interrupts();
+
+        enable_register_sync(self.regs());
 
         // Applying config also resets Tx/Rx FIFOs
         self.apply_config(&config)?;


### PR DESCRIPTION
This PR is meant to fix glitches like https://github.com/esp-rs/esp-hal/actions/runs/32968660473/job/98190036296 - it's unclear why the glitch happens, but the reg sync mechanism wasn't working and maybe it contributes to that.

Includes a bit of cleanup, optimizing unnecessary RMW operations.

# Changelog

## esp-hal/UART

- Fixed: C2, C3 and S3 now properly synchronize UART register accesses between clock domains.