### PR TITLE
Release 3 packages

### DIFF
--- a/esp-alloc/Cargo.toml
+++ b/esp-alloc/Cargo.toml
@@ -45,7 +45,7 @@ rlsf = { version = "0.2", features = ["unstable"] }
 
 [build-dependencies]
 esp-config             = { version = "0.8.0", path = "../esp-config", features = ["build"] }
-esp-metadata-generated = { version = "0.5.0", path = "../esp-metadata-generated", features = ["build-script"] }
+esp-metadata-generated = { version = "0.5.1", path = "../esp-metadata-generated", features = ["build-script"] }
 
 [features]
 default = ["compat", "global-allocator"]

--- a/esp-backtrace/Cargo.toml
+++ b/esp-backtrace/Cargo.toml
@@ -36,7 +36,7 @@ test  = false
 [dependencies]
 defmt       = { version = "1.1", optional = true }
 esp-config  = { version = "0.8.0", path = "../esp-config" }
-esp-metadata-generated = { version = "0.5.0", path = "../esp-metadata-generated" }
+esp-metadata-generated = { version = "0.5.1", path = "../esp-metadata-generated" }
 esp-println = { version = "0.18.0", optional = true, default-features = false, path = "../esp-println" }
 heapless    = "0.9"
 semihosting = { version = "0.1.20", optional = true }
@@ -50,7 +50,7 @@ xtensa-lx        = { version = "0.13.0", path = "../xtensa-lx" }
 
 [build-dependencies]
 esp-config   = { version = "0.8.0", path = "../esp-config", features = ["build"] }
-esp-metadata-generated = { version = "0.5.0", path = "../esp-metadata-generated", features = ["build-script"] }
+esp-metadata-generated = { version = "0.5.1", path = "../esp-metadata-generated", features = ["build-script"] }
 
 [features]
 default = ["colors"]

--- a/esp-bootloader-esp-idf/Cargo.toml
+++ b/esp-bootloader-esp-idf/Cargo.toml
@@ -34,7 +34,7 @@ defmt = { version = "1.1", optional = true }
 document-features = "0.2"
 esp-config = { version = "0.8.0", path = "../esp-config" }
 esp-hal-procmacros = { version = "0.23.0", path = "../esp-hal-procmacros", features = ["__esp_idf_bootloader"] }
-esp-metadata-generated = { version = "0.5.0", path = "../esp-metadata-generated" }
+esp-metadata-generated = { version = "0.5.1", path = "../esp-metadata-generated" }
 esp-rom-sys = { version = "~0.1", path = "../esp-rom-sys", optional = true }
 embedded-storage = { version = "0.3.1", optional = true }
 esp-storage = { version = "0.10.0", path = "../esp-storage", default-features = false, optional = true }
@@ -48,11 +48,11 @@ sha2 = { version = "0.11", default-features = false }
 [build-dependencies]
 jiff       = { version = "0.2.13", default-features = false, features = ["std"] }
 esp-config = { version = "0.8.0", path = "../esp-config", features = ["build"] }
-esp-metadata-generated = { version = "0.5.0", path = "../esp-metadata-generated", features = ["build-script"] }
+esp-metadata-generated = { version = "0.5.1", path = "../esp-metadata-generated", features = ["build-script"] }
 
 # Make doctests & host-tests work together:
 [target.'cfg(any(target_arch = "riscv32", target_arch = "xtensa"))'.dev-dependencies]
-esp-hal = { version = "~1.2.0-rc.0", path = "../esp-hal" }
+esp-hal = { version = "~1.2.0", path = "../esp-hal" }
 
 [features]
 default = ["validation"]

--- a/esp-config/Cargo.toml
+++ b/esp-config/Cargo.toml
@@ -36,7 +36,7 @@ document-features = "0.2"
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 serde_yaml = { version =  "0.9", optional = true }
 somni-expr = { version = "0.3", optional = true }
-esp-metadata-generated = { version = "0.5.0", path = "../esp-metadata-generated", features = ["build-script"], optional = true }
+esp-metadata-generated = { version = "0.5.1", path = "../esp-metadata-generated", features = ["build-script"], optional = true }
 
 # used by the `tui` feature
 clap            = { version = "4.5", features = ["derive"], optional = true }

--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -19,6 +19,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 
+## [v1.2.0] - 2026-09-01
+
+### Fixed
+
+- GPIO: Fixed a breaking change introduced in 1.2.0-rc.0, which prevented writing generic functions for GPIOs. (#6252)
+- A pad that is already at its wake level no longer loses its wake configuration. This fixes a regression in 1.2.0-rc.0. (#6250)
+- SPI: the maximum bus frequency can be configured using the default clock source. (#6245)
+- Power the 32 kHz crystal on ESP32 when it is selected as the RTC slow clock (#6234)
+- UART: Fixed an issue that caused UART TX to send a short low pulse when transmitting shorty after changing configuration. (#6233)
+- PARL_IO: esp-hal now correctly uses pad clock inputs to sample the received signal. (#6227)
+- UART: C2, C3 and S3 now properly synchronize UART register accesses between clock domains. (#6226)
+- XTAL32K can no longer be configured without enabling `ESP_HAL_CONFIG_USE_XTAL32K` (#6194)
+- ESP32, ESP32-C2: fixed RcFastDivClk calibration on startup (#6193)
+
 ## [v1.2.0-rc.0] - 2026-08-24
 
 ### Added
@@ -1875,4 +1889,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v1.0.0]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.0.0-rc.1...esp-hal-v1.0.0
 [v1.1.0]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.0.0...esp-hal-v1.1.0
 [v1.2.0-rc.0]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.1.0...esp-hal-v1.2.0-rc.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.2.0-rc.0...HEAD
+[v1.2.0]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.2.0-rc.0...esp-hal-v1.2.0
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.2.0...HEAD

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-hal"
-version       = "1.2.0-rc.0"
+version       = "1.2.0"
 edition       = "2024"
 rust-version  = "1.95.0"
 description   = "Bare-metal HAL for Espressif devices"
@@ -72,7 +72,7 @@ instability              = "0.3.12"
 strum                    = { version = "0.27.1", default-features = false, features = ["derive"] }
 
 esp-config               = { version = "0.8.0", path = "../esp-config" }
-esp-metadata-generated   = { version = "0.5.0", path = "../esp-metadata-generated" }
+esp-metadata-generated   = { version = "0.5.1", path = "../esp-metadata-generated" }
 esp-sync                 = { version = "0.3.0", path = "../esp-sync" }
 procmacros               = { version = "0.23.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
 
@@ -132,7 +132,7 @@ xtensa-lx        = { version = "0.13.0", path = "../xtensa-lx" }
 xtensa-lx-rt     = { version = "0.23.0", path = "../xtensa-lx-rt", optional = true }
 
 [build-dependencies]
-esp-metadata-generated = { version = "0.5.0", path = "../esp-metadata-generated", features = ["build-script"] }
+esp-metadata-generated = { version = "0.5.1", path = "../esp-metadata-generated", features = ["build-script"] }
 esp-config   = { version = "0.8.0", path = "../esp-config", features = ["build"] }
 somni-template = "0.3.1"
 

--- a/esp-hal/MIGRATING-1.1.0.md
+++ b/esp-hal/MIGRATING-1.1.0.md
@@ -1,4 +1,4 @@
-# Migration Guide from 1.1.0 to {{currentVersion}}
+# Migration Guide from 1.1.0 to 1.2.0
 
 ## `Clocks` struct removed
 

--- a/esp-hal/MIGRATING-1.1.0.md
+++ b/esp-hal/MIGRATING-1.1.0.md
@@ -241,6 +241,73 @@ I2s::new(
 PDM is I2S0-only and simplex (TX **or** RX). Use `I2s::new_pdm` with `PdmConfig::tx_only(...)` or `PdmConfig::rx_only(...)`, and connect pins via `with_clk` plus `with_dout` / `with_din` (or `with_din_line` on multi-line chips).
 PDM validation errors are returned as `ConfigError::Pdm(PdmError)` (e.g. `PdmError::InvalidLine` for invalid data line indices).
 
+### I2S DMA now uses the DmaBuffer API
+
+I2S no longer uses manually passed DMA descriptors or the generic `DmaTransfer*` types. Buffers are
+created with the DMA buffer macros, channels are built without descriptors, and transfers are started
+by consuming the channel.
+
+```diff
+-use esp_hal::dma_buffers;
+-let (mut rx_buffer, rx_descriptors, _, _) = dma_buffers!(4 * 4092, 0);
++use esp_hal::dma_rx_stream_buffer;
++let rx_buffer = dma_rx_stream_buffer!(4 * 4092, 1024);
+ let i2s_rx = i2s
+     .i2s_rx
+     .with_bclk(peripherals.GPIO1)
+     .with_ws(peripherals.GPIO2)
+     .with_din(peripherals.GPIO5)
+-    .build(rx_descriptors);
++    .build();
+```
+
+Use `dma_rx_buffer!` / `dma_tx_buffer!` instead of the `*_stream_buffer!` macros when you need a
+finite, one-shot transfer rather than continuous streaming.
+
+#### Starting transfers
+
+`read` / `write` take ownership of the channel. For async code, call `.into_async()` on `I2s` before
+building the RX/TX channel.
+
+```diff
+-let mut transfer = i2s_rx.read_dma_circular(&mut rx_buffer)?;
++let mut transfer = i2s_rx.read(rx_buffer)?;
+```
+
+On failure, `read` / `write` return `Err((Error, I2sRx, BUF))` (or the TX equivalents), so you can
+recover both the channel and the buffer.
+
+#### Transfer handles and streaming I/O
+
+The generic `DmaTransferRxCircular` / `DmaTransferTxCircular` (and the old `I2sReadDmaTransferAsync` /
+`I2sWriteDmaTransferAsync`) are replaced by `I2sRxDmaTransfer` / `I2sTxDmaTransfer`. These deref to the
+buffer view, exposing `available_bytes()`, `pop()`, `push()`, and `push_with()`.
+
+```diff
+ loop {
+-    transfer.wait_for_data().await?;
+-    let avail = transfer.available()?;
++    transfer.wait_for_available_async().await?;
++    let avail = transfer.available_bytes();
+     if avail > 0 {
+-        transfer.pop(&mut rcv[..avail])?;
++        transfer.pop(&mut rcv[..avail]);
+     }
+ }
+```
+
+#### Finishing a one-shot transfer
+
+`wait` (and `wait_async` in async code) returns the completion result together with the recovered
+peripheral and buffer.
+
+```rust
+let transfer = i2s_rx.read(buffer)?;
+let (result, i2s_rx, buffer) = transfer.wait();
+// or, in async code:
+let (result, i2s_rx, buffer) = transfer.wait_async().await;
+```
+
 ## DMA memory-to-memory
 
 ### `MEM2MEM*` peripherals removed

--- a/esp-hal/MIGRATING-1.1.0.md
+++ b/esp-hal/MIGRATING-1.1.0.md
@@ -288,5 +288,3 @@ let erased = channel.into();
 `PeripheralDmaChannel`/`PeripheralRxChannel`/`PeripheralTxChannel` type aliases have been removed.
 Driver channel bounds are now expressed directly as the driver-specific trait (e.g.
 `SpiDmaChannel`, `I2sDmaChannel`). Update any channel bounds accordingly.
-
-</details>

--- a/esp-lp-hal/Cargo.toml
+++ b/esp-lp-hal/Cargo.toml
@@ -46,7 +46,7 @@ embedded-io-07    = { package = "embedded-io", version = "0.7",  optional = true
 nb                = { version = "1.1.0",  optional = true }
 procmacros        = { version = "0.23.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
 riscv             = { version = "0.15", features = ["critical-section-single-hart"] }
-esp-metadata-generated = { version = "0.5.0", path = "../esp-metadata-generated" }
+esp-metadata-generated = { version = "0.5.1", path = "../esp-metadata-generated" }
 esp32c6-lp        = { version = "0.3.0", features = ["critical-section"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "fc3e6d4" }
 esp32s2-ulp       = { version = "0.3.0", features = ["critical-section"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "fc3e6d4" }
 esp32s3-ulp       = { version = "0.3.0", features = ["critical-section"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "fc3e6d4" }
@@ -55,7 +55,7 @@ esp32s3-ulp       = { version = "0.3.0", features = ["critical-section"], option
 panic-halt = "0.2.0"
 
 [build-dependencies]
-esp-metadata-generated = { version = "0.5.0", path = "../esp-metadata-generated", features = ["build-script"] }
+esp-metadata-generated = { version = "0.5.1", path = "../esp-metadata-generated", features = ["build-script"] }
 
 [features]
 default = ["embedded-hal"]

--- a/esp-metadata-generated/Cargo.toml
+++ b/esp-metadata-generated/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-metadata-generated"
-version       = "0.5.0"
+version       = "0.5.1"
 edition       = "2024"
 rust-version  = "1.95.0"
 description   = "Generated metadata for Espressif devices"

--- a/esp-phy/Cargo.toml
+++ b/esp-phy/Cargo.toml
@@ -31,8 +31,8 @@ bench = false
 [dependencies]
 
 document-features = "0.2"
-esp-hal = { version = "~1.2.0-rc.0", path = "../esp-hal", default-features = false }
-esp-metadata-generated = { version = "0.5.0", path = "../esp-metadata-generated" }
+esp-hal = { version = "~1.2.0", path = "../esp-hal", default-features = false }
+esp-metadata-generated = { version = "0.5.1", path = "../esp-metadata-generated" }
 esp-sync = { version = "0.3.0", path = "../esp-sync" }
 
 # Make sure these are aligned with esp-radio's dependencies, too!
@@ -63,7 +63,7 @@ log-04 = { version = "0.4.27", package = "log", optional = true }
 
 [build-dependencies]
 esp-config   = { version = "0.8.0", path = "../esp-config", features = ["build"] }
-esp-metadata-generated = { version = "0.5.0", path = "../esp-metadata-generated", features = ["build-script"] }
+esp-metadata-generated = { version = "0.5.1", path = "../esp-metadata-generated", features = ["build-script"] }
 
 [features]
 #! ### Logging Feature Flags

--- a/esp-println/Cargo.toml
+++ b/esp-println/Cargo.toml
@@ -51,7 +51,7 @@ defmt  = { version = "1.1", optional = true }
 log-04 = { package = "log", version = "0.4", optional = true }
 
 [build-dependencies]
-esp-metadata-generated = { version = "0.5.0", path = "../esp-metadata-generated", features = ["build-script"] }
+esp-metadata-generated = { version = "0.5.1", path = "../esp-metadata-generated", features = ["build-script"] }
 log-04 = { package = "log", version = "0.4" }
 
 [features]

--- a/esp-radio-rtos-driver/CHANGELOG.md
+++ b/esp-radio-rtos-driver/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 
+## [v0.4.1] - 2026-09-01
+
+### Added
+
+- `QueueHandle` and `SemaphoreHandle` are now `Send` and `Sync` (#6222)
+
 ## [v0.4.0] - 2026-08-25
 
 ### Added
@@ -78,4 +84,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v0.2.0]: https://github.com/esp-rs/esp-hal/compare/esp-radio-rtos-driver-v0.1.0...esp-radio-rtos-driver-v0.2.0
 [v0.3.0]: https://github.com/esp-rs/esp-hal/compare/esp-radio-rtos-driver-v0.2.0...esp-radio-rtos-driver-v0.3.0
 [v0.4.0]: https://github.com/esp-rs/esp-hal/compare/esp-radio-rtos-driver-v0.3.0...esp-radio-rtos-driver-v0.4.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-radio-rtos-driver-v0.4.0...HEAD
+[v0.4.1]: https://github.com/esp-rs/esp-hal/compare/esp-radio-rtos-driver-v0.4.0...esp-radio-rtos-driver-v0.4.1
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-radio-rtos-driver-v0.4.1...HEAD

--- a/esp-radio-rtos-driver/Cargo.toml
+++ b/esp-radio-rtos-driver/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-radio-rtos-driver"
-version       = "0.4.0"
+version       = "0.4.1"
 edition       = "2024"
 rust-version  = "1.95.0"
 description   = "Task scheduler interface for esp-radio"

--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -53,12 +53,12 @@ bench = false
 test  = false
 
 [dependencies]
-esp-hal = { version = "~1.2.0-rc.0", path = "../esp-hal", default-features = false }
+esp-hal = { version = "~1.2.0", path = "../esp-hal", default-features = false }
 portable-atomic = { version = "1.11", default-features = false }
 enumset = { version = "1.1", default-features = false, optional = true }
 
 # ⚠️ Unstable dependencies
-esp-radio-rtos-driver = { version = "0.4.0", path = "../esp-radio-rtos-driver" }
+esp-radio-rtos-driver = { version = "0.4.1", path = "../esp-radio-rtos-driver" }
 instability = "0.3.12"
 
 # Unstable dependencies that are not (strictly) part of the public API
@@ -67,7 +67,7 @@ docsplay = { version = "0.1", default-features = false }
 document-features  = "0.2"
 esp-alloc = { version = "0.11.0", path = "../esp-alloc", optional = true, default-features = false }
 esp-config = { version = "0.8.0", path = "../esp-config" }
-esp-metadata-generated = { version = "0.5.0", path = "../esp-metadata-generated" }
+esp-metadata-generated = { version = "0.5.1", path = "../esp-metadata-generated" }
 esp-rom-sys = { version = "=0.1.5", path = "../esp-rom-sys" }
 esp-sync = { version = "0.3.0", path = "../esp-sync" }
 esp-phy = { version = "0.2.0", path = "../esp-phy/" }
@@ -116,7 +116,7 @@ log-04 = { package = "log", version = "0.4.27", optional = true }
 
 [build-dependencies]
 esp-config = { version = "0.8.0", path = "../esp-config", features = ["build"] }
-esp-metadata-generated = { version = "0.5.0", path = "../esp-metadata-generated", features = ["build-script"] }
+esp-metadata-generated = { version = "0.5.1", path = "../esp-metadata-generated", features = ["build-script"] }
 
 [dev-dependencies]
 esp-rtos = { version = "0.4.0", path = "../esp-rtos" }

--- a/esp-rom-sys/Cargo.toml
+++ b/esp-rom-sys/Cargo.toml
@@ -42,7 +42,7 @@ esp32s31 = { version = "0.2", features = ["critical-section"], optional = true }
 esp32p4 = { version = "0.3",  features = ["critical-section"], optional = true }
 
 [build-dependencies]
-esp-metadata-generated = { version = "0.5.0", path = "../esp-metadata-generated", features = ["build-script"] }
+esp-metadata-generated = { version = "0.5.1", path = "../esp-metadata-generated", features = ["build-script"] }
 
 [features]
 __internal_rom_symbols = []

--- a/esp-rtos/Cargo.toml
+++ b/esp-rtos/Cargo.toml
@@ -35,7 +35,7 @@ features       = ["esp32c6", "embassy", "esp-radio"]
 bench = false
 
 [dependencies]
-esp-hal = { version = "~1.2.0-rc.0", path = "../esp-hal", default-features = false, features = [
+esp-hal = { version = "~1.2.0", path = "../esp-hal", default-features = false, features = [
     # FIXME: rt technically shouldn't be enabled, but rtos requires `TrapFrame`
     # and uses reexported riscv/xtensa-lx from esp-hal
     "requires-unstable", "rt"
@@ -51,7 +51,7 @@ embassy-sync = "0.8"
 esp-alloc = { version = "0.11.0", path = "../esp-alloc", optional = true, default-features = false }
 esp-config = { version = "0.8.0", path = "../esp-config" }
 esp-sync = { version = "0.3.0", path = "../esp-sync" }
-esp-radio-rtos-driver = { version = "0.4.0", path = "../esp-radio-rtos-driver", features = ["ipc-implementations"], optional = true }
+esp-radio-rtos-driver = { version = "0.4.1", path = "../esp-radio-rtos-driver", features = ["ipc-implementations"], optional = true }
 macros = { version = "0.23.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
 portable-atomic = { version = "1.11", default-features = false }
 
@@ -72,10 +72,10 @@ xtensa-lx        = { version = "0.13.0", path = "../xtensa-lx" }
 
 [build-dependencies]
 esp-config             = { version = "0.8.0", path = "../esp-config", features = ["build"] }
-esp-metadata-generated = { version = "0.5.0", path = "../esp-metadata-generated", features = ["build-script"] }
+esp-metadata-generated = { version = "0.5.1", path = "../esp-metadata-generated", features = ["build-script"] }
 
 [dev-dependencies]
-esp-hal = { version = "~1.2.0-rc.0", path = "../esp-hal", features = ["unstable"] }
+esp-hal = { version = "~1.2.0", path = "../esp-hal", features = ["unstable"] }
 static_cell = "2"
 
 [features]

--- a/esp-storage/Cargo.toml
+++ b/esp-storage/Cargo.toml
@@ -32,8 +32,8 @@ bench = false
 [dependencies]
 embedded-storage       = { version = "0.3.1", optional = true }
 procmacros             = { version = "0.23.0", package = "esp-hal-procmacros", path = "../esp-hal-procmacros" }
-esp-hal                = { version = "~1.2.0-rc.0", path = "../esp-hal", default-features = false, optional = true }
-esp-metadata-generated = { version = "0.5.0", path = "../esp-metadata-generated" }
+esp-hal                = { version = "~1.2.0", path = "../esp-hal", default-features = false, optional = true }
+esp-metadata-generated = { version = "0.5.1", path = "../esp-metadata-generated" }
 
 # Optional dependencies
 esp-sync         = { version = "0.3.0", path = "../esp-sync", optional = true }
@@ -56,7 +56,7 @@ esp32p4 = { version = "0.3",  features = ["critical-section"], optional = true }
 document-features = "0.2"
 
 [build-dependencies]
-esp-metadata-generated = { version = "0.5.0", path = "../esp-metadata-generated", features = ["build-script"] }
+esp-metadata-generated = { version = "0.5.1", path = "../esp-metadata-generated", features = ["build-script"] }
 
 [features]
 default = ["critical-section"]

--- a/esp-sync/Cargo.toml
+++ b/esp-sync/Cargo.toml
@@ -20,7 +20,7 @@ clippy-configs = [{ features = ["defmt"] }]
 
 [dependencies]
 document-features = "0.2"
-esp-metadata-generated = { version = "0.5.0", path = "../esp-metadata-generated" }
+esp-metadata-generated = { version = "0.5.1", path = "../esp-metadata-generated" }
 embassy-sync-06 = { package = "embassy-sync", version = "0.6" }
 embassy-sync-07 = { package = "embassy-sync", version = "0.7" }
 embassy-sync-08 = { package = "embassy-sync", version = "0.8" }
@@ -36,7 +36,7 @@ riscv            = { version = "0.15" }
 xtensa-lx        = { version = "0.13.0", path = "../xtensa-lx" }
 
 [build-dependencies]
-esp-metadata-generated = { version = "0.5.0", path = "../esp-metadata-generated", features = ["build-script"] }
+esp-metadata-generated = { version = "0.5.1", path = "../esp-metadata-generated", features = ["build-script"] }
 
 [features]
 #! ### Chip Support Feature Flags


### PR DESCRIPTION
This pull request prepares the following packages for release:

- esp-metadata-generated: 0.5.0 → 0.5.1
- esp-hal: 1.2.0-rc.0 → 1.2.0
- esp-radio-rtos-driver: 0.4.0 → 0.4.1

<details>

<summary>Release plan (click to expand)</summary>

```jsonc
{
  "base": "main",
  "slug": "0hyxo6",
  "packages": [
    {
      "package": "esp-metadata-generated",
      "semver_checked": false,
      "current_version": "0.5.0",
      "new_version": "0.5.1",
      "tag_name": "esp-metadata-generated-v0.5.1",
      "bump": {
        "base": "Patch",
        "pre": null
      }
    },
    {
      "package": "esp-hal",
      "semver_checked": true,
      "current_version": "1.2.0-rc.0",
      "new_version": "1.2.0",
      "tag_name": "esp-hal-v1.2.0",
      "bump": {
        "base": "Minor",
        "pre": null
      }
    },
    {
      "package": "esp-radio-rtos-driver",
      "semver_checked": false,
      "current_version": "0.4.0",
      "new_version": "0.4.1",
      "tag_name": "esp-radio-rtos-driver-v0.4.1",
      "bump": {
        "base": "Patch",
        "pre": null
      }
    }
  ]
}
```

</details>

Please review the changes and merge them into the `main` branch.

After merging, please make sure you have this release plan in the repo root,
then run the following command on the `main` branch to tag and publish the packages:

```
cargo xrelease publish-plan --no-dry-run
```
