### PR TITLE
Add interrupt handling for I2S parallel peripheral

### DIFF
--- a/esp-hal/src/i2s/parallel.rs
+++ b/esp-hal/src/i2s/parallel.rs
@@ -486,43 +486,49 @@ where
         (i2s, BUF::from_view(view))
     }
 
+    fn stop_peripherals(&mut self) {
+        self.i2s.instance.tx_stop();
+        self.i2s.tx_channel.stop_transfer();
+    }
+}
+
+/// Interrupt management for an ongoing transfer.
+///
+/// The driver itself has been consumed by [`I2sParallel::send`], so these
+/// methods take `&self` and allow an interrupt handler to manage the
+/// interrupt sources through the transfer object.
+#[instability::unstable]
+impl<'d, BUF> I2sParallelTransfer<'d, BUF, Blocking>
+where
+    BUF: DmaTxBuffer,
+{
     /// Sets the interrupt handler for the I2S parallel peripheral.
     ///
     /// The new handler removes the old handler. This method does not turn on
     /// the interrupt sources. Use [`Self::listen`] to turn on interrupt
     /// sources.
-    #[instability::unstable]
     pub fn set_interrupt_handler(&mut self, handler: InterruptHandler) {
         self.i2s.instance.set_interrupt_handler(handler);
     }
 
     /// Turns on the given interrupt sources.
-    #[instability::unstable]
-    pub fn listen(&mut self, interrupts: impl Into<EnumSet<I2sParallelInterrupt>>) {
+    pub fn listen(&self, interrupts: impl Into<EnumSet<I2sParallelInterrupt>>) {
         internal_listen(self.i2s.instance.regs(), interrupts.into(), true);
     }
 
     /// Turns off the given interrupt sources.
-    #[instability::unstable]
-    pub fn unlisten(&mut self, interrupts: impl Into<EnumSet<I2sParallelInterrupt>>) {
+    pub fn unlisten(&self, interrupts: impl Into<EnumSet<I2sParallelInterrupt>>) {
         internal_listen(self.i2s.instance.regs(), interrupts.into(), false);
     }
 
     /// Clears the interrupt flags of the given interrupt sources.
-    #[instability::unstable]
-    pub fn clear_interrupts(&mut self, interrupts: impl Into<EnumSet<I2sParallelInterrupt>>) {
+    pub fn clear_interrupts(&self, interrupts: impl Into<EnumSet<I2sParallelInterrupt>>) {
         internal_clear_interrupts(self.i2s.instance.regs(), interrupts.into());
     }
 
     /// Returns the interrupt sources that are set.
-    #[instability::unstable]
-    pub fn interrupts(&mut self) -> EnumSet<I2sParallelInterrupt> {
+    pub fn interrupts(&self) -> EnumSet<I2sParallelInterrupt> {
         internal_interrupts(self.i2s.instance.regs())
-    }
-
-    fn stop_peripherals(&mut self) {
-        self.i2s.instance.tx_stop();
-        self.i2s.tx_channel.stop_transfer();
     }
 }
 

--- a/esp-hal/src/i2s/parallel.rs
+++ b/esp-hal/src/i2s/parallel.rs
@@ -92,6 +92,8 @@ use core::{
     ops::{Deref, DerefMut},
 };
 
+use enumset::{EnumSet, EnumSetType};
+
 use crate::{
     Async,
     Blocking,
@@ -105,6 +107,7 @@ use crate::{
         interconnect::{self, PeripheralOutput},
     },
     i2s::AnyI2s,
+    interrupt::InterruptHandler,
     pac::i2s0::RegisterBlock,
     peripherals::{I2S0, I2S1},
     system::PeripheralGuard,
@@ -231,6 +234,80 @@ impl<'d> TxPins<'d> for TxEightBits<'d> {
     }
 }
 
+/// Interrupts from the I2S parallel peripheral.
+#[derive(Debug, EnumSetType)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum I2sParallelInterrupt {
+    /// The DMA finishes the out descriptor chain (OUT_DONE).
+    Done,
+
+    /// The DMA uses a descriptor with the suc_eof flag set (OUT_EOF).
+    ///
+    /// The peripheral sets the OUT_EOF flag for every descriptor with suc_eof
+    /// set. This interrupt also works on a circular DMA chain. On a circular
+    /// chain, the transfer does not end. The peripheral does not set
+    /// OUT_TOTAL_EOF on a circular chain.
+    Eof,
+
+    /// The DMA gets a descriptor with an error (OUT_DSCR_ERR).
+    DescriptorError,
+
+    /// The DMA sends all the data of the transfer (OUT_TOTAL_EOF).
+    ///
+    /// On a circular DMA chain, the transfer does not end. The peripheral does
+    /// not set OUT_TOTAL_EOF on a circular chain. Use [`Self::Eof`] with a
+    /// circular chain.
+    TotalEof,
+}
+
+fn internal_listen(regs: &RegisterBlock, interrupts: EnumSet<I2sParallelInterrupt>, enable: bool) {
+    regs.int_ena().modify(|_, w| {
+        for interrupt in interrupts {
+            match interrupt {
+                I2sParallelInterrupt::Done => w.out_done().bit(enable),
+                I2sParallelInterrupt::Eof => w.out_eof().bit(enable),
+                I2sParallelInterrupt::DescriptorError => w.out_dscr_err().bit(enable),
+                I2sParallelInterrupt::TotalEof => w.out_total_eof().bit(enable),
+            };
+        }
+        w
+    });
+}
+
+fn internal_interrupts(regs: &RegisterBlock) -> EnumSet<I2sParallelInterrupt> {
+    let mut result = EnumSet::new();
+    let ints = regs.int_st().read();
+
+    if ints.out_done().bit() {
+        result.insert(I2sParallelInterrupt::Done);
+    }
+    if ints.out_eof().bit() {
+        result.insert(I2sParallelInterrupt::Eof);
+    }
+    if ints.out_dscr_err().bit() {
+        result.insert(I2sParallelInterrupt::DescriptorError);
+    }
+    if ints.out_total_eof().bit() {
+        result.insert(I2sParallelInterrupt::TotalEof);
+    }
+
+    result
+}
+
+fn internal_clear_interrupts(regs: &RegisterBlock, interrupts: EnumSet<I2sParallelInterrupt>) {
+    regs.int_clr().write(|w| {
+        for interrupt in interrupts {
+            match interrupt {
+                I2sParallelInterrupt::Done => w.out_done().clear_bit_by_one(),
+                I2sParallelInterrupt::Eof => w.out_eof().clear_bit_by_one(),
+                I2sParallelInterrupt::DescriptorError => w.out_dscr_err().clear_bit_by_one(),
+                I2sParallelInterrupt::TotalEof => w.out_total_eof().clear_bit_by_one(),
+            };
+        }
+        w
+    });
+}
+
 /// I2S Parallel Interface
 pub struct I2sParallel<'d, Dm>
 where
@@ -280,6 +357,49 @@ impl<'d> I2sParallel<'d, Blocking> {
             tx_channel: self.tx_channel.into_async(),
             _guard: self._guard,
         }
+    }
+
+    /// Sets the interrupt handler for the I2S parallel peripheral.
+    ///
+    /// The new handler removes the old handler. This method does not turn on
+    /// the interrupt sources. Use [`Self::listen`] to turn on interrupt
+    /// sources.
+    #[instability::unstable]
+    pub fn set_interrupt_handler(&mut self, handler: InterruptHandler) {
+        self.instance.set_interrupt_handler(handler);
+    }
+
+    /// Turns on the given interrupt sources.
+    #[instability::unstable]
+    pub fn listen(&mut self, interrupts: impl Into<EnumSet<I2sParallelInterrupt>>) {
+        internal_listen(self.instance.regs(), interrupts.into(), true);
+    }
+
+    /// Turns off the given interrupt sources.
+    #[instability::unstable]
+    pub fn unlisten(&mut self, interrupts: impl Into<EnumSet<I2sParallelInterrupt>>) {
+        internal_listen(self.instance.regs(), interrupts.into(), false);
+    }
+
+    /// Tells you the interrupt sources that are set.
+    #[instability::unstable]
+    pub fn interrupts(&mut self) -> EnumSet<I2sParallelInterrupt> {
+        internal_interrupts(self.instance.regs())
+    }
+
+    /// Clears the interrupt flags of the given interrupt sources.
+    #[instability::unstable]
+    pub fn clear_interrupts(&mut self, interrupts: impl Into<EnumSet<I2sParallelInterrupt>>) {
+        internal_clear_interrupts(self.instance.regs(), interrupts.into());
+    }
+}
+
+impl crate::private::Sealed for I2sParallel<'_, Blocking> {}
+
+#[instability::unstable]
+impl crate::interrupt::InterruptConfigurable for I2sParallel<'_, Blocking> {
+    fn set_interrupt_handler(&mut self, handler: crate::interrupt::InterruptHandler) {
+        I2sParallel::set_interrupt_handler(self, handler);
     }
 }
 
@@ -349,6 +469,12 @@ where
         let view = unsafe { ManuallyDrop::take(&mut self.buf_view) };
         core::mem::forget(self);
         (i2s, BUF::from_view(view))
+    }
+
+    /// Clears the interrupt flags of the given interrupt sources.
+    #[instability::unstable]
+    pub fn clear_interrupts(&mut self, interrupts: impl Into<EnumSet<I2sParallelInterrupt>>) {
+        internal_clear_interrupts(self.i2s.instance.regs(), interrupts.into());
     }
 
     fn stop_peripherals(&mut self) {
@@ -443,6 +569,8 @@ pub trait PrivateInstance: crate::private::Sealed {
     fn peripheral(&self) -> crate::system::Peripheral;
     fn ws_signal(&self) -> OutputSignal;
     fn data_out_signal(&self, i: usize, bits: u8) -> OutputSignal;
+
+    fn set_interrupt_handler(&self, handler: crate::interrupt::InterruptHandler);
 
     fn rx_reset(&self) {
         self.regs().conf().toggle(|w, bit| w.rx_reset().bit(bit));
@@ -655,6 +783,11 @@ impl PrivateInstance for I2S0<'_> {
             other => panic!("Invalid I2S0 Dout pin {}", other),
         }
     }
+
+    fn set_interrupt_handler(&self, handler: crate::interrupt::InterruptHandler) {
+        self.disable_peri_interrupt_on_all_cores();
+        self.bind_peri_interrupt(handler);
+    }
 }
 
 impl PrivateInstance for I2S1<'_> {
@@ -707,6 +840,11 @@ impl PrivateInstance for I2S1<'_> {
             other => panic!("Invalid I2S1 Dout pin {}", other),
         }
     }
+
+    fn set_interrupt_handler(&self, handler: crate::interrupt::InterruptHandler) {
+        self.disable_peri_interrupt_on_all_cores();
+        self.bind_peri_interrupt(handler);
+    }
 }
 
 impl PrivateInstance for AnyI2s<'_> {
@@ -719,6 +857,7 @@ impl PrivateInstance for AnyI2s<'_> {
             fn peripheral(&self) -> crate::system::Peripheral;
             fn ws_signal(&self) -> OutputSignal;
             fn data_out_signal(&self, i: usize, bits: u8) -> OutputSignal ;
+            fn set_interrupt_handler(&self, handler: crate::interrupt::InterruptHandler);
         }
     }
 }

--- a/esp-hal/src/i2s/parallel.rs
+++ b/esp-hal/src/i2s/parallel.rs
@@ -2,11 +2,11 @@
 //! # Parallel Interface (via I2S)
 //!
 //! ## Overview
-//! The I2S parallel interface allows for high-speed data transfer between the
-//! ESP32 and external devices. It is commonly used to external devices such as
-//! LED matrix, LCD display, and Printer. Only TX is implemented. Each
-//! unit can have up to 8 or 16 data signals (depending on your target hardware)
-//! plus 1 clock signal.
+//! The I2S parallel interface provides high-speed data transfer between the
+//! ESP32 and external devices. It is commonly used with devices such as LED
+//! matrices, LCD displays, and printers. Only TX is implemented. Each
+//! unit can have up to 8 or 16 data signals (depending on the target hardware)
+//! plus one clock signal.
 //!
 //! ## Notes
 //!
@@ -20,13 +20,13 @@
 )]
 #![cfg_attr(
     esp32,
-    doc = "you should use I2S1.  If you have to use I2S0, it will only output the even"
+    doc = "you should use I2S1.  If you have to use I2S0, it only outputs the even"
 )]
-#![cfg_attr(esp32, doc = "bytes! so [A, B, C, D] will be output as [A, C]!!!!")]
+#![cfg_attr(esp32, doc = "bytes! so [A, B, C, D] is output as [A, C]!")]
 #![cfg_attr(esp32, doc = "")]
 //! ## Configuration
 //!
-//! The driver uses DMA (Direct Memory Access) for efficient data transfer and
+//! The driver uses DMA for efficient data transfer and
 //! supports various configurations, such as different data formats, standards
 //! (e.g., Philips) and pin configurations. It relies on other peripheral
 //! modules, such as
@@ -67,7 +67,7 @@
 //! let mut tx_buf = dma_tx_buffer!(BUFFER_SIZE).unwrap();
 //! for (i, data) in tx_buf.as_mut_slice().chunks_mut(4).enumerate() {
 //!     let offset = i * 4;
-//!     // i2s parallel driver expects the buffer to be interleaved
+//!     // I2S parallel driver expects the buffer to be interleaved
 //!     data[0] = (offset + 2) as u8;
 //!     data[1] = (offset + 3) as u8;
 //!     data[2] = offset as u8;
@@ -195,7 +195,7 @@ pub struct TxEightBits<'d> {
 
 impl<'d> TxEightBits<'d> {
     #[expect(clippy::too_many_arguments)]
-    /// Creates a new `TxSEightBits` instance with the provided output pins.
+    /// Creates a new [`TxEightBits`] instance with the provided output pins.
     pub fn new(
         pin_0: impl PeripheralOutput<'d>,
         pin_1: impl PeripheralOutput<'d>,
@@ -312,7 +312,7 @@ fn internal_clear_interrupts(regs: &RegisterBlock, interrupts: EnumSet<I2sParall
     });
 }
 
-/// I2S Parallel Interface
+/// I2S parallel interface
 #[instability::unstable]
 pub struct I2sParallel<'d, Dm>
 where
@@ -355,7 +355,7 @@ impl<'d> I2sParallel<'d, Blocking> {
         }
     }
 
-    /// Converts the I2S instance into async mode.
+    /// Converts the I2S parallel instance into [`Async`] mode.
     pub fn into_async(self) -> I2sParallel<'d, Async> {
         I2sParallel {
             instance: self.instance,
@@ -386,7 +386,7 @@ impl<'d> I2sParallel<'d, Blocking> {
         internal_listen(self.instance.regs(), interrupts.into(), false);
     }
 
-    /// Tells you the interrupt sources that are set.
+    /// Returns the interrupt sources that are set.
     #[instability::unstable]
     pub fn interrupts(&mut self) -> EnumSet<I2sParallelInterrupt> {
         internal_interrupts(self.instance.regs())
@@ -409,7 +409,7 @@ impl crate::interrupt::InterruptConfigurable for I2sParallel<'_, Blocking> {
 }
 
 impl<'d> I2sParallel<'d, Async> {
-    /// Converts the I2S instance into blocking mode.
+    /// Converts the I2S parallel instance into [`Blocking`] mode.
     pub fn into_blocking(self) -> I2sParallel<'d, Blocking> {
         I2sParallel {
             instance: self.instance,
@@ -423,7 +423,15 @@ impl<'d, Dm> I2sParallel<'d, Dm>
 where
     Dm: DriverMode,
 {
-    /// Writes data to the I2S peripheral.
+    /// Starts a DMA transfer that writes the buffer to the I2S parallel
+    /// interface and returns an [`I2sParallelTransfer`] that can be used to
+    /// wait for the transfer to complete.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`DmaError`] when the buffer cannot be prepared for the
+    /// transfer or the transfer cannot be started. On error, the driver and
+    /// the buffer are returned together with the error.
     pub fn send<BUF: DmaTxBuffer>(
         mut self,
         mut data: BUF,
@@ -446,8 +454,8 @@ where
     }
 }
 
-/// Represents an ongoing (or potentially finished) transfer using the i2s
-/// parallel interface
+/// Represents an ongoing (or potentially finished) transfer using the I2S
+/// parallel interface.
 #[instability::unstable]
 pub struct I2sParallelTransfer<'d, BUF, Dm>
 where
@@ -463,12 +471,13 @@ where
     BUF: DmaTxBuffer,
     Dm: DriverMode,
 {
-    /// Returns whether [`Self::wait`] will not block.
+    /// Returns whether the transfer is complete.
     pub fn is_done(&self) -> bool {
         self.i2s.instance.is_tx_done()
     }
 
-    /// Waits for the transfer to finish.
+    /// Waits for the transfer to finish and returns the driver and the
+    /// buffer.
     pub fn wait(mut self) -> (I2sParallel<'d, Dm>, BUF::Final) {
         self.i2s.instance.tx_wait_done();
         let i2s = unsafe { ManuallyDrop::take(&mut self.i2s) };
@@ -505,7 +514,7 @@ where
         internal_clear_interrupts(self.i2s.instance.regs(), interrupts.into());
     }
 
-    /// Tells you the interrupt sources that are set.
+    /// Returns the interrupt sources that are set.
     #[instability::unstable]
     pub fn interrupts(&mut self) -> EnumSet<I2sParallelInterrupt> {
         internal_interrupts(self.i2s.instance.regs())
@@ -521,7 +530,17 @@ impl<BUF> I2sParallelTransfer<'_, BUF, Async>
 where
     BUF: DmaTxBuffer,
 {
-    /// Waits for the transfer to finish.
+    /// Waits for [`Self::is_done`] to return true.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`DmaError`] when the transfer ends with a descriptor error.
+    ///
+    /// # Cancellation Safety
+    ///
+    /// This method is cancellation safe. Dropping the future does not stop
+    /// the transfer, and the method can be called again to wait for the
+    /// transfer to complete.
     pub async fn wait_for_done(&mut self) -> Result<(), DmaError> {
         DmaTxFuture::new(&mut self.i2s.tx_channel).await
     }
@@ -941,7 +960,11 @@ for_each_i2s! {
 }
 
 impl<'d> I2sParallel<'d, crate::Blocking> {
-    /// Creates a new I2S Parallel Interface.
+    /// Creates a new [`I2sParallel`] instance.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the DMA channel is not compatible with the I2S instance.
     pub fn new<I: Instance + 'd>(
         i2s: I,
         channel: impl I2sParallelDmaChannel<'d, I>,

--- a/esp-hal/src/i2s/parallel.rs
+++ b/esp-hal/src/i2s/parallel.rs
@@ -122,6 +122,7 @@ pub trait TxPins<'d> {
 
 /// Represents a group of 16 output pins configured for 16-bit parallel data
 /// transmission.
+#[instability::unstable]
 pub struct TxSixteenBits<'d> {
     pins: [interconnect::OutputSignal<'d>; 16],
 }
@@ -187,6 +188,7 @@ impl<'d> TxPins<'d> for TxSixteenBits<'d> {
 
 /// Represents a group of 8 output pins configured for 8-bit parallel data
 /// transmission.
+#[instability::unstable]
 pub struct TxEightBits<'d> {
     pins: [interconnect::OutputSignal<'d>; 8],
 }
@@ -237,6 +239,8 @@ impl<'d> TxPins<'d> for TxEightBits<'d> {
 /// Interrupts from the I2S parallel peripheral.
 #[derive(Debug, EnumSetType)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+#[instability::unstable]
 pub enum I2sParallelInterrupt {
     /// The DMA finishes the out descriptor chain (OUT_DONE).
     Done,
@@ -309,6 +313,7 @@ fn internal_clear_interrupts(regs: &RegisterBlock, interrupts: EnumSet<I2sParall
 }
 
 /// I2S Parallel Interface
+#[instability::unstable]
 pub struct I2sParallel<'d, Dm>
 where
     Dm: DriverMode,
@@ -443,6 +448,7 @@ where
 
 /// Represents an ongoing (or potentially finished) transfer using the i2s
 /// parallel interface
+#[instability::unstable]
 pub struct I2sParallelTransfer<'d, BUF, Dm>
 where
     BUF: DmaTxBuffer,
@@ -471,10 +477,38 @@ where
         (i2s, BUF::from_view(view))
     }
 
+    /// Sets the interrupt handler for the I2S parallel peripheral.
+    ///
+    /// The new handler removes the old handler. This method does not turn on
+    /// the interrupt sources. Use [`Self::listen`] to turn on interrupt
+    /// sources.
+    #[instability::unstable]
+    pub fn set_interrupt_handler(&mut self, handler: InterruptHandler) {
+        self.i2s.instance.set_interrupt_handler(handler);
+    }
+
+    /// Turns on the given interrupt sources.
+    #[instability::unstable]
+    pub fn listen(&mut self, interrupts: impl Into<EnumSet<I2sParallelInterrupt>>) {
+        internal_listen(self.i2s.instance.regs(), interrupts.into(), true);
+    }
+
+    /// Turns off the given interrupt sources.
+    #[instability::unstable]
+    pub fn unlisten(&mut self, interrupts: impl Into<EnumSet<I2sParallelInterrupt>>) {
+        internal_listen(self.i2s.instance.regs(), interrupts.into(), false);
+    }
+
     /// Clears the interrupt flags of the given interrupt sources.
     #[instability::unstable]
     pub fn clear_interrupts(&mut self, interrupts: impl Into<EnumSet<I2sParallelInterrupt>>) {
         internal_clear_interrupts(self.i2s.instance.regs(), interrupts.into());
+    }
+
+    /// Tells you the interrupt sources that are set.
+    #[instability::unstable]
+    pub fn interrupts(&mut self) -> EnumSet<I2sParallelInterrupt> {
+        internal_interrupts(self.i2s.instance.regs())
     }
 
     fn stop_peripherals(&mut self) {

--- a/hil-test/src/bin/i2s.rs
+++ b/hil-test/src/bin/i2s.rs
@@ -877,15 +877,121 @@ mod tests {
 #[cfg(esp32)]
 #[embedded_test::tests(default_timeout = 3, executor = hil_test::Executor::new())]
 mod i2s_parallel_tests {
+    use core::cell::RefCell;
+
+    use critical_section::Mutex as CsMutex;
     use esp_hal::{
+        Blocking,
         dma::I2sDmaChannel,
         gpio::NoPin,
         i2s::{
             AnyI2s,
-            parallel::{I2sParallel, TxSixteenBits},
+            parallel::{I2sParallel, I2sParallelInterrupt, I2sParallelTransfer, TxSixteenBits},
         },
+        interrupt::{InterruptHandler, Priority},
         time::Rate,
     };
+    use portable_atomic::{AtomicUsize, Ordering};
+
+    static ISR_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+    type BlockingTransfer = I2sParallelTransfer<'static, esp_hal::dma::DmaTxBuf, Blocking>;
+
+    // The ongoing transfer, so the ISR can query and clear interrupt flags
+    // through it (the driver itself is consumed by `send`).
+    static TRANSFER: CsMutex<RefCell<Option<BlockingTransfer>>> = CsMutex::new(RefCell::new(None));
+
+    extern "C" fn i2s_parallel_isr() {
+        critical_section::with(|cs| {
+            if let Some(xfer) = TRANSFER.borrow_ref(cs).as_ref() {
+                let active = xfer.interrupts();
+                xfer.clear_interrupts(active);
+            }
+        });
+        ISR_COUNT.fetch_add(1, Ordering::Relaxed);
+    }
+
+    fn poll_until(mut condition: impl FnMut() -> bool, message: &str) {
+        let delay = esp_hal::delay::Delay::new();
+        for _ in 0..1000 {
+            if condition() {
+                return;
+            }
+            delay.delay_millis(1);
+        }
+        panic!("{}", message);
+    }
+
+    fn run_i2s_parallel_interrupt(i2s: AnyI2s<'static>, dma_channel: I2sDmaChannel<'static>) {
+        ISR_COUNT.store(0, Ordering::Relaxed);
+        critical_section::with(|cs| TRANSFER.replace(cs, None));
+
+        let pins = TxSixteenBits::new(
+            NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin, NoPin,
+            NoPin, NoPin, NoPin, NoPin,
+        );
+        let mut i2s = I2sParallel::new(i2s, dma_channel, Rate::from_mhz(20), pins, NoPin);
+        i2s.set_interrupt_handler(InterruptHandler::new(i2s_parallel_isr, Priority::Priority1));
+
+        let mut tx_buf = esp_hal::dma_tx_buffer!(4096).unwrap();
+        tx_buf.fill(&[0x55; 512]);
+
+        // Publish the transfer so the ISR can use it, then listen.
+        // The transfer may complete before we listen; the flags still assert,
+        // so the ISR still fires.
+        let xfer = i2s
+            .send(tx_buf)
+            .map_err(|_| "failed to send buffer")
+            .unwrap();
+        critical_section::with(|cs| TRANSFER.replace(cs, Some(xfer)));
+        critical_section::with(|cs| {
+            if let Some(xfer) = TRANSFER.borrow_ref(cs).as_ref() {
+                xfer.listen(I2sParallelInterrupt::TotalEof | I2sParallelInterrupt::Done);
+            }
+        });
+
+        // Wait for the transfer to complete and the ISR to fire.
+        poll_until(
+            || {
+                critical_section::with(|cs| {
+                    TRANSFER
+                        .borrow_ref(cs)
+                        .as_ref()
+                        .is_some_and(|xfer| xfer.is_done())
+                }) && ISR_COUNT.load(Ordering::Relaxed) > 0
+            },
+            "transfer did not complete or ISR did not fire",
+        );
+        assert!(
+            ISR_COUNT.load(Ordering::Relaxed) > 0,
+            "ISR should have fired at least once"
+        );
+
+        let xfer = critical_section::with(|cs| TRANSFER.take(cs)).unwrap();
+        let (_i2s, _tx_buf) = xfer.wait();
+    }
+
+    #[test]
+    #[cfg(soc_has_i2s0)]
+    fn i2s_parallel_interrupt_i2s0() {
+        let peripherals = esp_hal::init(
+            esp_hal::Config::default().with_cpu_clock(esp_hal::clock::CpuClock::max()),
+        );
+        let i2s = peripherals.I2S0.into();
+        let dma_channel: I2sDmaChannel<'static> = peripherals.DMA_I2S0.into();
+        run_i2s_parallel_interrupt(i2s, dma_channel);
+    }
+
+    #[test]
+    #[cfg(soc_has_i2s1)]
+    fn i2s_parallel_interrupt_i2s1() {
+        let peripherals = esp_hal::init(
+            esp_hal::Config::default().with_cpu_clock(esp_hal::clock::CpuClock::max()),
+        );
+        let i2s = peripherals.I2S1.into();
+        let dma_channel: I2sDmaChannel<'static> = peripherals.DMA_I2S1.into();
+        run_i2s_parallel_interrupt(i2s, dma_channel);
+    }
 
     async fn run_driver_does_not_hang_when_async(
         i2s: AnyI2s<'static>,


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` or `manual-changelog` label as appropriate.
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

The I2S parallel driver has no public interrupt API. The `Instance` trait is sealed, and the driver only clears `out_done` and `out_total_eof` internally. Downstream drivers that run from the I2S DMA end-of-transfer interrupts must therefore bind the handler with `esp_hal::interrupt::bind_handler` and steal the peripheral to flip `int_ena`/`int_clr` bits.

This PR adds the interrupt API that `parl_io` and `i2s::master` already have:

- `I2sParallelInterrupt` with the four TX interrupt sources of the ESP32 I2S DMA: `Done` (OUT_DONE), `Eof` (OUT_EOF), `DescriptorError` (OUT_DSCR_ERR), and `TotalEof` (OUT_TOTAL_EOF).
- `set_interrupt_handler`, `listen`, `unlisten`, `interrupts`, and `clear_interrupts` on `I2sParallel<'_, Blocking>`, plus an `InterruptConfigurable` implementation. The contract matches `parl_io`: the handler is bound and CPU-enabled, and the peripheral-level sources are controlled with `listen`/`unlisten`.
- `I2sParallelTransfer::clear_interrupts`, so an ISR can clear flags through the in-flight transfer. Circular mode needs this, because `send` has consumed the driver at that point.

The per-descriptor `Eof` source matters for circular DMA chains: the chain never ends, so `out_total_eof` never fires, while `out_eof` fires for every descriptor flagged `suc_eof=1`.

The driver itself never enables peripheral interrupts, so there is no behavior change for existing users. Async mode relies on the DMA channel interrupt (`DmaTxFuture`) and is unaffected. All new items are marked `#[instability::unstable]`, matching the rest of the `i2s` module.

This removes the last register-level poking that external drivers like esp-hub75 need for the I2S path, in both normal and circular DMA modes.

#### Testing

Tested with  [esp-hub75](https://github.com/liebman/esp-hub75) on branch `esp-hal-i2s-parallel-refactor` 

---

# Changelog

## esp-hal

- Added: `I2sParallel::set_interrupt_handler`, `listen`, `unlisten`, `interrupts`, and `clear_interrupts`, `I2sParallelTransfer::clear_interrupts`, and `I2sParallelInterrupt`
