### PR TITLE
Add interrupt handling support for I8080 driver and update DMA integr…

### DIFF
--- a/esp-hal/src/dma/mod.rs
+++ b/esp-hal/src/dma/mod.rs
@@ -1238,7 +1238,7 @@ where
         }
     }
 
-    fn set_interrupt_handler(&mut self, handler: InterruptHandler) {
+    pub(crate) fn set_interrupt_handler(&mut self, handler: InterruptHandler) {
         self.unlisten_out(EnumSet::all());
         self.clear_out(EnumSet::all());
 

--- a/esp-hal/src/lcd_cam/lcd/i8080.rs
+++ b/esp-hal/src/lcd_cam/lcd/i8080.rs
@@ -58,12 +58,68 @@
 //! transfer.wait();
 //! # {after_snippet}
 //! ```
+//!
+//! ## Interrupts
+//!
+//! The I8080 driver owns two interrupt domains: the LCD half of the LCD_CAM
+//! peripheral, and the DMA TX channel it was created with. The LCD sources
+//! fire on the `LCD_CAM` interrupt, while the DMA sources fire on the DMA
+//! channel's own interrupt, so each domain binds its own handler and controls
+//! its sources separately. Handlers are registered with
+//! [`I8080::set_interrupt_handler`] and [`I8080::set_dma_interrupt_handler`],
+//! and sources are enabled with [`I8080::listen`] and [`I8080::listen_dma`].
+//!
+//! ### Notifying on descriptor completion
+//!
+//! In continuous output mode the transfer does not finish, but every
+//! descriptor with the `suc_eof` bit set raises the DMA channel's
+//! [`DmaTxInterrupt::Eof`](crate::dma::DmaTxInterrupt::Eof) source once its
+//! data has been sent:
+//!
+//! ```rust, no_run
+//! # {before_snippet}
+//! # use esp_hal::dma::{DmaTxBuf, DmaTxInterrupt};
+//! # use esp_hal::dma_tx_buffer;
+//! # use esp_hal::handler;
+//! # use esp_hal::lcd_cam::{LcdCam, lcd::i8080::{Config, I8080}};
+//! # use esp_hal::time::Rate;
+//! #
+//! # static EOF_COUNT: core::sync::atomic::AtomicUsize =
+//! #     core::sync::atomic::AtomicUsize::new(0);
+//! # let mut dma_buf = dma_tx_buffer!(32678)?;
+//! # let lcd_cam = LcdCam::new(peripherals.LCD_CAM);
+//! # let config = Config::default().with_frequency(Rate::from_mhz(20));
+//! # let mut i8080 = I8080::new(lcd_cam.lcd, peripherals.DMA_CH0, config)?
+//! #     .with_dc(peripherals.GPIO0)
+//! #     .with_wrx(peripherals.GPIO47);
+//! # dma_buf.fill(&[0x55]);
+//!
+//! #[handler]
+//! fn dma_handler() {
+//!     EOF_COUNT.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+//!     // The source is cleared through the transfer, see below.
+//! }
+//!
+//! // Binding the handler must happen before listening for DMA sources, and
+//! // before `send` consumes the driver.
+//! i8080.set_dma_interrupt_handler(dma_handler);
+//! i8080.listen_dma(DmaTxInterrupt::Eof);
+//!
+//! let transfer = i8080.send(0x3Au8, 0, dma_buf)?; // RGB565
+//!
+//! // In `dma_handler`, clear the source through the transfer:
+//! // transfer.clear_interrupts_dma(DmaTxInterrupt::Eof);
+//! transfer.wait();
+//! # {after_snippet}
+//! ```
 
 use core::{
     fmt::Formatter,
     mem::{ManuallyDrop, size_of},
     ops::{Deref, DerefMut},
 };
+
+use enumset::EnumSetType;
 
 use crate::{
     Blocking,
@@ -92,6 +148,24 @@ use crate::{
 pub enum ConfigError {
     /// Clock configuration error.
     Clock(ClockError),
+}
+
+/// Interrupt sources of the LCD half of the LCD_CAM peripheral, as exposed by
+/// the [`I8080`] driver.
+///
+/// These sources fire on the `LCD_CAM` interrupt, which is bound via
+/// [`I8080::set_interrupt_handler`]. The DMA TX channel's sources fire on the
+/// channel's own interrupt instead; see [`I8080::set_dma_interrupt_handler`]
+/// and [`DmaTxInterrupt`](crate::dma::DmaTxInterrupt).
+#[derive(Debug, EnumSetType)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[instability::unstable]
+pub enum I8080Interrupt {
+    /// The LCD has started outputting a new frame.
+    LcdVsync,
+
+    /// A DMA transfer to the LCD has finished.
+    LcdTransDone,
 }
 
 /// Represents the I8080 LCD interface.
@@ -443,6 +517,149 @@ where
     }
 }
 
+#[instability::unstable]
+impl I8080<'_, Blocking> {
+    /// Maps the LCD sources of the given set onto the peripheral's interrupt
+    /// sources.
+    fn map_i8080_to_lcdcam(
+        interrupts: enumset::EnumSet<I8080Interrupt>,
+    ) -> enumset::EnumSet<crate::lcd_cam::LcdCamInterrupt> {
+        use crate::lcd_cam::LcdCamInterrupt;
+
+        let mut sources = enumset::EnumSet::new();
+        for interrupt in interrupts {
+            sources.insert(LcdCamInterrupt::from(interrupt));
+        }
+        sources
+    }
+
+    /// Maps the peripheral's asserted LCD interrupt sources back to
+    /// [`I8080Interrupt`].
+    ///
+    /// The mapping is lossy by design: Camera-only [`LcdCamInterrupt`]
+    /// variants have no `I8080Interrupt` counterpart and are dropped. In
+    /// practice they cannot occur here, since the peripheral interrupt
+    /// helpers only read the `lcd_*` raw bits.
+    fn map_lcdcam_to_i8080(
+        sources: enumset::EnumSet<crate::lcd_cam::LcdCamInterrupt>,
+    ) -> enumset::EnumSet<I8080Interrupt> {
+        let mut interrupts = enumset::EnumSet::new();
+        for source in sources {
+            if let Ok(interrupt) = I8080Interrupt::try_from(source) {
+                interrupts.insert(interrupt);
+            }
+        }
+        interrupts
+    }
+
+    /// Registers an interrupt handler for the `LCD_CAM` interrupt.
+    ///
+    /// The handler services the sources enabled via [`Self::listen`].
+    ///
+    /// Note that this replaces any previously registered handler for the
+    /// `LCD_CAM` interrupt, including the one the async driver binds.
+    pub fn set_interrupt_handler(&mut self, handler: crate::interrupt::InterruptHandler) {
+        for core in crate::system::Cpu::other() {
+            crate::interrupt::disable(core, crate::peripherals::Interrupt::LCD_CAM);
+        }
+        crate::interrupt::bind_handler(crate::peripherals::Interrupt::LCD_CAM, handler);
+    }
+
+    /// Registers an interrupt handler for the DMA TX channel used by this
+    /// driver.
+    ///
+    /// The handler services the sources enabled via [`Self::listen_dma`]. It
+    /// fires on the channel's own interrupt, which is separate from the
+    /// `LCD_CAM` interrupt used by [`Self::set_interrupt_handler`].
+    ///
+    /// Binding the handler unlistens from and clears all DMA TX interrupt
+    /// sources, so this function must be called before
+    /// [`Self::listen_dma`]. It must also be called before [`Self::send`],
+    /// which consumes the driver.
+    pub fn set_dma_interrupt_handler(&mut self, handler: crate::interrupt::InterruptHandler) {
+        self.tx_channel.set_interrupt_handler(handler);
+    }
+
+    /// Listens for the given LCD interrupt sources.
+    pub fn listen(&mut self, interrupts: impl Into<enumset::EnumSet<I8080Interrupt>>) {
+        Instance::listen(Self::map_i8080_to_lcdcam(interrupts.into()));
+    }
+
+    /// Stops listening for the given LCD interrupt sources.
+    pub fn unlisten(&mut self, interrupts: impl Into<enumset::EnumSet<I8080Interrupt>>) {
+        Instance::unlisten(Self::map_i8080_to_lcdcam(interrupts.into()));
+    }
+
+    /// Returns the asserted LCD interrupt sources.
+    pub fn interrupts(&mut self) -> enumset::EnumSet<I8080Interrupt> {
+        Self::map_lcdcam_to_i8080(Instance::interrupts())
+    }
+
+    /// Clears the given asserted LCD interrupt sources.
+    pub fn clear_interrupts(&mut self, interrupts: impl Into<enumset::EnumSet<I8080Interrupt>>) {
+        Instance::clear_interrupts(Self::map_i8080_to_lcdcam(interrupts.into()));
+    }
+
+    /// Listens for the given DMA TX interrupt sources.
+    ///
+    /// A handler must have been registered via
+    /// [`Self::set_dma_interrupt_handler`] first.
+    pub fn listen_dma(
+        &mut self,
+        interrupts: impl Into<enumset::EnumSet<crate::dma::DmaTxInterrupt>>,
+    ) {
+        self.tx_channel.listen_out(interrupts.into());
+    }
+
+    /// Stops listening for the given DMA TX interrupt sources.
+    pub fn unlisten_dma(
+        &mut self,
+        interrupts: impl Into<enumset::EnumSet<crate::dma::DmaTxInterrupt>>,
+    ) {
+        self.tx_channel.unlisten_out(interrupts.into());
+    }
+
+    /// Returns the asserted DMA TX interrupt sources.
+    pub fn interrupts_dma(&mut self) -> enumset::EnumSet<crate::dma::DmaTxInterrupt> {
+        self.tx_channel.pending_out_interrupts()
+    }
+
+    /// Clears the given asserted DMA TX interrupt sources.
+    pub fn clear_interrupts_dma(
+        &mut self,
+        interrupts: impl Into<enumset::EnumSet<crate::dma::DmaTxInterrupt>>,
+    ) {
+        self.tx_channel.clear_out(interrupts.into());
+    }
+}
+
+/// Variant-for-variant mapping onto the peripheral's interrupt sources.
+///
+/// This is total: every [`I8080Interrupt`] source has an
+/// [`LcdCamInterrupt`] counterpart. Future Camera-only `LcdCamInterrupt`
+/// variants are simply not reachable from [`I8080Interrupt`].
+impl From<I8080Interrupt> for crate::lcd_cam::LcdCamInterrupt {
+    fn from(value: I8080Interrupt) -> Self {
+        match value {
+            I8080Interrupt::LcdVsync => crate::lcd_cam::LcdCamInterrupt::LcdVsync,
+            I8080Interrupt::LcdTransDone => crate::lcd_cam::LcdCamInterrupt::LcdTransDone,
+        }
+    }
+}
+
+/// Lossy reverse mapping: Camera-only [`LcdCamInterrupt`] variants have no
+/// [`I8080Interrupt`] counterpart and are dropped.
+impl TryFrom<crate::lcd_cam::LcdCamInterrupt> for I8080Interrupt {
+    type Error = ();
+
+    fn try_from(value: crate::lcd_cam::LcdCamInterrupt) -> Result<Self, ()> {
+        match value {
+            crate::lcd_cam::LcdCamInterrupt::LcdVsync => Ok(I8080Interrupt::LcdVsync),
+            crate::lcd_cam::LcdCamInterrupt::LcdTransDone => Ok(I8080Interrupt::LcdTransDone),
+        }
+    }
+}
+
 impl<Dm: DriverMode> core::fmt::Debug for I8080<'_, Dm> {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("I8080").finish()
@@ -568,6 +785,60 @@ impl<BUF: DmaTxBuffer> I8080Transfer<'_, BUF, crate::Async> {
         }
 
         LcdDoneFuture {}.await
+    }
+}
+
+/// Interrupt management for an ongoing transfer.
+///
+/// The driver itself has been consumed by [`I8080::send`], so these methods
+/// take `&self` and allow an interrupt handler to manage the interrupt
+/// sources through the transfer object.
+#[instability::unstable]
+impl<BUF: DmaTxBuffer> I8080Transfer<'_, BUF, Blocking> {
+    /// Listens for the given LCD interrupt sources.
+    pub fn listen(&self, interrupts: impl Into<enumset::EnumSet<I8080Interrupt>>) {
+        Instance::listen(I8080::map_i8080_to_lcdcam(interrupts.into()));
+    }
+
+    /// Stops listening for the given LCD interrupt sources.
+    pub fn unlisten(&self, interrupts: impl Into<enumset::EnumSet<I8080Interrupt>>) {
+        Instance::unlisten(I8080::map_i8080_to_lcdcam(interrupts.into()));
+    }
+
+    /// Returns the asserted LCD interrupt sources.
+    pub fn interrupts(&self) -> enumset::EnumSet<I8080Interrupt> {
+        I8080::map_lcdcam_to_i8080(Instance::interrupts())
+    }
+
+    /// Clears the given asserted LCD interrupt sources.
+    pub fn clear_interrupts(&self, interrupts: impl Into<enumset::EnumSet<I8080Interrupt>>) {
+        Instance::clear_interrupts(I8080::map_i8080_to_lcdcam(interrupts.into()));
+    }
+
+    /// Listens for the given DMA TX interrupt sources.
+    pub fn listen_dma(&self, interrupts: impl Into<enumset::EnumSet<crate::dma::DmaTxInterrupt>>) {
+        self.i8080.tx_channel.listen_out(interrupts.into());
+    }
+
+    /// Stops listening for the given DMA TX interrupt sources.
+    pub fn unlisten_dma(
+        &self,
+        interrupts: impl Into<enumset::EnumSet<crate::dma::DmaTxInterrupt>>,
+    ) {
+        self.i8080.tx_channel.unlisten_out(interrupts.into());
+    }
+
+    /// Returns the asserted DMA TX interrupt sources.
+    pub fn interrupts_dma(&self) -> enumset::EnumSet<crate::dma::DmaTxInterrupt> {
+        self.i8080.tx_channel.pending_out_interrupts()
+    }
+
+    /// Clears the given asserted DMA TX interrupt sources.
+    pub fn clear_interrupts_dma(
+        &self,
+        interrupts: impl Into<enumset::EnumSet<crate::dma::DmaTxInterrupt>>,
+    ) {
+        self.i8080.tx_channel.clear_out(interrupts.into());
     }
 }
 

--- a/esp-hal/src/lcd_cam/lcd/i8080.rs
+++ b/esp-hal/src/lcd_cam/lcd/i8080.rs
@@ -162,10 +162,10 @@ pub enum ConfigError {
 #[instability::unstable]
 pub enum I8080Interrupt {
     /// The LCD has started outputting a new frame.
-    LcdVsync,
+    Vsync,
 
     /// A DMA transfer to the LCD has finished.
-    LcdTransDone,
+    TransDone,
 }
 
 /// Represents the I8080 LCD interface.
@@ -537,9 +537,7 @@ impl I8080<'_, Blocking> {
     /// [`I8080Interrupt`].
     ///
     /// The mapping is lossy by design: Camera-only [`LcdCamInterrupt`]
-    /// variants have no `I8080Interrupt` counterpart and are dropped. In
-    /// practice they cannot occur here, since the peripheral interrupt
-    /// helpers only read the `lcd_*` raw bits.
+    /// variants have no `I8080Interrupt` counterpart and are dropped.
     fn map_lcdcam_to_i8080(
         sources: enumset::EnumSet<crate::lcd_cam::LcdCamInterrupt>,
     ) -> enumset::EnumSet<I8080Interrupt> {
@@ -636,13 +634,13 @@ impl I8080<'_, Blocking> {
 /// Variant-for-variant mapping onto the peripheral's interrupt sources.
 ///
 /// This is total: every [`I8080Interrupt`] source has an
-/// [`LcdCamInterrupt`] counterpart. Future Camera-only `LcdCamInterrupt`
+/// [`LcdCamInterrupt`] counterpart. Camera-only [`LcdCamInterrupt`]
 /// variants are simply not reachable from [`I8080Interrupt`].
 impl From<I8080Interrupt> for crate::lcd_cam::LcdCamInterrupt {
     fn from(value: I8080Interrupt) -> Self {
         match value {
-            I8080Interrupt::LcdVsync => crate::lcd_cam::LcdCamInterrupt::LcdVsync,
-            I8080Interrupt::LcdTransDone => crate::lcd_cam::LcdCamInterrupt::LcdTransDone,
+            I8080Interrupt::Vsync => crate::lcd_cam::LcdCamInterrupt::LcdVsync,
+            I8080Interrupt::TransDone => crate::lcd_cam::LcdCamInterrupt::LcdTransDone,
         }
     }
 }
@@ -654,8 +652,10 @@ impl TryFrom<crate::lcd_cam::LcdCamInterrupt> for I8080Interrupt {
 
     fn try_from(value: crate::lcd_cam::LcdCamInterrupt) -> Result<Self, ()> {
         match value {
-            crate::lcd_cam::LcdCamInterrupt::LcdVsync => Ok(I8080Interrupt::LcdVsync),
-            crate::lcd_cam::LcdCamInterrupt::LcdTransDone => Ok(I8080Interrupt::LcdTransDone),
+            crate::lcd_cam::LcdCamInterrupt::LcdVsync => Ok(I8080Interrupt::Vsync),
+            crate::lcd_cam::LcdCamInterrupt::LcdTransDone => Ok(I8080Interrupt::TransDone),
+            crate::lcd_cam::LcdCamInterrupt::CamVsync => Err(()),
+            crate::lcd_cam::LcdCamInterrupt::CamHs => Err(()),
         }
     }
 }

--- a/esp-hal/src/lcd_cam/lcd/i8080.rs
+++ b/esp-hal/src/lcd_cam/lcd/i8080.rs
@@ -73,7 +73,7 @@
 //!
 //! In continuous output mode the transfer does not finish, but every
 //! descriptor with the `suc_eof` bit set raises the DMA channel's
-//! [`DmaTxInterrupt::Eof`](crate::dma::DmaTxInterrupt::Eof) source once its
+//! [`DmaTxInterrupt::Eof`] source once its
 //! data has been sent:
 //!
 //! ```rust, no_run
@@ -89,9 +89,9 @@
 //! # let mut dma_buf = dma_tx_buffer!(32678)?;
 //! # let lcd_cam = LcdCam::new(peripherals.LCD_CAM);
 //! # let config = Config::default().with_frequency(Rate::from_mhz(20));
-//! # let mut i8080 = I8080::new(lcd_cam.lcd, peripherals.DMA_CH0, config)?
-//! #     .with_dc(peripherals.GPIO0)
-//! #     .with_wrx(peripherals.GPIO47);
+//! # let mut i8080 = I8080::new(lcd_cam.lcd, peripherals.__dma_channel__, config)?
+//! #     .with_dc(peripherals.__dc_pin__)
+//! #     .with_wrx(peripherals.__wrx_pin__);
 //! # dma_buf.fill(&[0x55]);
 //!
 //! #[handler]
@@ -119,12 +119,12 @@ use core::{
     ops::{Deref, DerefMut},
 };
 
-use enumset::EnumSetType;
+use enumset::{EnumSet, EnumSetType};
 
 use crate::{
     Blocking,
     DriverMode,
-    dma::{ChannelTx, DmaError, DmaPeripheral, DmaTxBuffer},
+    dma::{ChannelTx, DmaError, DmaPeripheral, DmaTxBuffer, DmaTxInterrupt},
     gpio::{OutputConfig, OutputSignal, interconnect::PeripheralOutput},
     lcd_cam::{
         BitOrder,
@@ -156,7 +156,7 @@ pub enum ConfigError {
 /// These sources fire on the `LCD_CAM` interrupt, which is bound via
 /// [`I8080::set_interrupt_handler`]. The DMA TX channel's sources fire on the
 /// channel's own interrupt instead; see [`I8080::set_dma_interrupt_handler`]
-/// and [`DmaTxInterrupt`](crate::dma::DmaTxInterrupt).
+/// and [`DmaTxInterrupt`].
 #[derive(Debug, EnumSetType)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[instability::unstable]
@@ -522,7 +522,7 @@ impl I8080<'_, Blocking> {
     /// Maps the LCD sources of the given set onto the peripheral's interrupt
     /// sources.
     fn map_i8080_to_lcdcam(
-        interrupts: enumset::EnumSet<I8080Interrupt>,
+        interrupts: EnumSet<I8080Interrupt>,
     ) -> enumset::EnumSet<crate::lcd_cam::LcdCamInterrupt> {
         use crate::lcd_cam::LcdCamInterrupt;
 
@@ -540,7 +540,7 @@ impl I8080<'_, Blocking> {
     /// variants have no `I8080Interrupt` counterpart and are dropped.
     fn map_lcdcam_to_i8080(
         sources: enumset::EnumSet<crate::lcd_cam::LcdCamInterrupt>,
-    ) -> enumset::EnumSet<I8080Interrupt> {
+    ) -> EnumSet<I8080Interrupt> {
         let mut interrupts = enumset::EnumSet::new();
         for source in sources {
             if let Ok(interrupt) = I8080Interrupt::try_from(source) {
@@ -579,22 +579,22 @@ impl I8080<'_, Blocking> {
     }
 
     /// Listens for the given LCD interrupt sources.
-    pub fn listen(&mut self, interrupts: impl Into<enumset::EnumSet<I8080Interrupt>>) {
+    pub fn listen(&mut self, interrupts: impl Into<EnumSet<I8080Interrupt>>) {
         Instance::listen(Self::map_i8080_to_lcdcam(interrupts.into()));
     }
 
     /// Stops listening for the given LCD interrupt sources.
-    pub fn unlisten(&mut self, interrupts: impl Into<enumset::EnumSet<I8080Interrupt>>) {
+    pub fn unlisten(&mut self, interrupts: impl Into<EnumSet<I8080Interrupt>>) {
         Instance::unlisten(Self::map_i8080_to_lcdcam(interrupts.into()));
     }
 
     /// Returns the asserted LCD interrupt sources.
-    pub fn interrupts(&mut self) -> enumset::EnumSet<I8080Interrupt> {
+    pub fn interrupts(&mut self) -> EnumSet<I8080Interrupt> {
         Self::map_lcdcam_to_i8080(Instance::interrupts())
     }
 
     /// Clears the given asserted LCD interrupt sources.
-    pub fn clear_interrupts(&mut self, interrupts: impl Into<enumset::EnumSet<I8080Interrupt>>) {
+    pub fn clear_interrupts(&mut self, interrupts: impl Into<EnumSet<I8080Interrupt>>) {
         Instance::clear_interrupts(Self::map_i8080_to_lcdcam(interrupts.into()));
     }
 
@@ -602,31 +602,22 @@ impl I8080<'_, Blocking> {
     ///
     /// A handler must have been registered via
     /// [`Self::set_dma_interrupt_handler`] first.
-    pub fn listen_dma(
-        &mut self,
-        interrupts: impl Into<enumset::EnumSet<crate::dma::DmaTxInterrupt>>,
-    ) {
+    pub fn listen_dma(&mut self, interrupts: impl Into<EnumSet<DmaTxInterrupt>>) {
         self.tx_channel.listen_out(interrupts.into());
     }
 
     /// Stops listening for the given DMA TX interrupt sources.
-    pub fn unlisten_dma(
-        &mut self,
-        interrupts: impl Into<enumset::EnumSet<crate::dma::DmaTxInterrupt>>,
-    ) {
+    pub fn unlisten_dma(&mut self, interrupts: impl Into<EnumSet<DmaTxInterrupt>>) {
         self.tx_channel.unlisten_out(interrupts.into());
     }
 
     /// Returns the asserted DMA TX interrupt sources.
-    pub fn interrupts_dma(&mut self) -> enumset::EnumSet<crate::dma::DmaTxInterrupt> {
+    pub fn interrupts_dma(&mut self) -> EnumSet<DmaTxInterrupt> {
         self.tx_channel.pending_out_interrupts()
     }
 
     /// Clears the given asserted DMA TX interrupt sources.
-    pub fn clear_interrupts_dma(
-        &mut self,
-        interrupts: impl Into<enumset::EnumSet<crate::dma::DmaTxInterrupt>>,
-    ) {
+    pub fn clear_interrupts_dma(&mut self, interrupts: impl Into<EnumSet<DmaTxInterrupt>>) {
         self.tx_channel.clear_out(interrupts.into());
     }
 }
@@ -796,48 +787,42 @@ impl<BUF: DmaTxBuffer> I8080Transfer<'_, BUF, crate::Async> {
 #[instability::unstable]
 impl<BUF: DmaTxBuffer> I8080Transfer<'_, BUF, Blocking> {
     /// Listens for the given LCD interrupt sources.
-    pub fn listen(&self, interrupts: impl Into<enumset::EnumSet<I8080Interrupt>>) {
+    pub fn listen(&self, interrupts: impl Into<EnumSet<I8080Interrupt>>) {
         Instance::listen(I8080::map_i8080_to_lcdcam(interrupts.into()));
     }
 
     /// Stops listening for the given LCD interrupt sources.
-    pub fn unlisten(&self, interrupts: impl Into<enumset::EnumSet<I8080Interrupt>>) {
+    pub fn unlisten(&self, interrupts: impl Into<EnumSet<I8080Interrupt>>) {
         Instance::unlisten(I8080::map_i8080_to_lcdcam(interrupts.into()));
     }
 
     /// Returns the asserted LCD interrupt sources.
-    pub fn interrupts(&self) -> enumset::EnumSet<I8080Interrupt> {
+    pub fn interrupts(&self) -> EnumSet<I8080Interrupt> {
         I8080::map_lcdcam_to_i8080(Instance::interrupts())
     }
 
     /// Clears the given asserted LCD interrupt sources.
-    pub fn clear_interrupts(&self, interrupts: impl Into<enumset::EnumSet<I8080Interrupt>>) {
+    pub fn clear_interrupts(&self, interrupts: impl Into<EnumSet<I8080Interrupt>>) {
         Instance::clear_interrupts(I8080::map_i8080_to_lcdcam(interrupts.into()));
     }
 
     /// Listens for the given DMA TX interrupt sources.
-    pub fn listen_dma(&self, interrupts: impl Into<enumset::EnumSet<crate::dma::DmaTxInterrupt>>) {
+    pub fn listen_dma(&self, interrupts: impl Into<EnumSet<DmaTxInterrupt>>) {
         self.i8080.tx_channel.listen_out(interrupts.into());
     }
 
     /// Stops listening for the given DMA TX interrupt sources.
-    pub fn unlisten_dma(
-        &self,
-        interrupts: impl Into<enumset::EnumSet<crate::dma::DmaTxInterrupt>>,
-    ) {
+    pub fn unlisten_dma(&self, interrupts: impl Into<EnumSet<DmaTxInterrupt>>) {
         self.i8080.tx_channel.unlisten_out(interrupts.into());
     }
 
     /// Returns the asserted DMA TX interrupt sources.
-    pub fn interrupts_dma(&self) -> enumset::EnumSet<crate::dma::DmaTxInterrupt> {
+    pub fn interrupts_dma(&self) -> EnumSet<DmaTxInterrupt> {
         self.i8080.tx_channel.pending_out_interrupts()
     }
 
     /// Clears the given asserted DMA TX interrupt sources.
-    pub fn clear_interrupts_dma(
-        &self,
-        interrupts: impl Into<enumset::EnumSet<crate::dma::DmaTxInterrupt>>,
-    ) {
+    pub fn clear_interrupts_dma(&self, interrupts: impl Into<EnumSet<DmaTxInterrupt>>) {
         self.i8080.tx_channel.clear_out(interrupts.into());
     }
 }

--- a/esp-hal/src/lcd_cam/mod.rs
+++ b/esp-hal/src/lcd_cam/mod.rs
@@ -7,6 +7,8 @@
 
 use core::marker::PhantomData;
 
+use enumset::{EnumSet, EnumSetType};
+
 use crate::{
     Async,
     Blocking,
@@ -170,30 +172,90 @@ fn interrupt_handler() {
 
 pub(crate) struct Instance;
 
+/// The interrupt sources of the LCD_CAM DMA interrupt registers that belong to
+/// the LCD half of the peripheral.
+///
+/// This type is `pub(crate)` today. If the Camera driver ever needs its own
+/// listen API, it can be promoted to a public `LcdCamInterrupt` without
+/// renaming.
+#[derive(Debug, EnumSetType)]
+pub(crate) enum LcdCamInterrupt {
+    /// The LCD has started outputting a new frame.
+    LcdVsync,
+
+    /// A DMA transfer to the LCD has finished.
+    LcdTransDone,
+}
+
 // NOTE: the LCD_CAM interrupt registers are shared between LCD and Camera and
 // this is only implemented for the LCD side, when the Camera is implemented a
 // CriticalSection will be needed to protect these shared registers.
 impl Instance {
-    fn enable_listenlcd_done(en: bool) {
-        LCD_CAM::regs()
-            .lc_dma_int_ena()
-            .modify(|_, w| w.lcd_trans_done_int_ena().bit(en));
+    fn enable_listen(sources: EnumSet<LcdCamInterrupt>, en: bool) {
+        LCD_CAM::regs().lc_dma_int_ena().modify(|_, w| {
+            for source in sources {
+                match source {
+                    LcdCamInterrupt::LcdVsync => {
+                        w.lcd_vsync_int_ena().bit(en);
+                    }
+                    LcdCamInterrupt::LcdTransDone => {
+                        w.lcd_trans_done_int_ena().bit(en);
+                    }
+                }
+            }
+            w
+        });
+    }
+
+    pub(crate) fn listen(sources: EnumSet<LcdCamInterrupt>) {
+        Self::enable_listen(sources, true);
+    }
+
+    pub(crate) fn unlisten(sources: EnumSet<LcdCamInterrupt>) {
+        Self::enable_listen(sources, false);
+    }
+
+    pub(crate) fn interrupts() -> EnumSet<LcdCamInterrupt> {
+        let raw = LCD_CAM::regs().lc_dma_int_raw().read();
+        let mut sources = EnumSet::new();
+        if raw.lcd_vsync_int_raw().bit() {
+            sources.insert(LcdCamInterrupt::LcdVsync);
+        }
+        if raw.lcd_trans_done_int_raw().bit() {
+            sources.insert(LcdCamInterrupt::LcdTransDone);
+        }
+        sources
+    }
+
+    /// Only reachable through the unstable `I8080` interrupt API, hence the
+    /// `dead_code` allowance when the `unstable` feature is disabled.
+    #[cfg_attr(not(feature = "unstable"), allow(dead_code))]
+    pub(crate) fn clear_interrupts(sources: EnumSet<LcdCamInterrupt>) {
+        LCD_CAM::regs().lc_dma_int_clr().write(|w| {
+            for source in sources {
+                match source {
+                    LcdCamInterrupt::LcdVsync => {
+                        w.lcd_vsync_int_clr().set_bit();
+                    }
+                    LcdCamInterrupt::LcdTransDone => {
+                        w.lcd_trans_done_int_clr().set_bit();
+                    }
+                }
+            }
+            w
+        });
     }
 
     pub(crate) fn listen_lcd_done() {
-        Self::enable_listenlcd_done(true);
+        Self::listen(LcdCamInterrupt::LcdTransDone.into());
     }
 
     pub(crate) fn unlisten_lcd_done() {
-        Self::enable_listenlcd_done(false);
+        Self::unlisten(LcdCamInterrupt::LcdTransDone.into());
     }
 
     pub(crate) fn is_lcd_done_set() -> bool {
-        LCD_CAM::regs()
-            .lc_dma_int_raw()
-            .read()
-            .lcd_trans_done_int_raw()
-            .bit()
+        Self::interrupts().contains(LcdCamInterrupt::LcdTransDone)
     }
 }
 pub(crate) struct ClockDivider {

--- a/esp-hal/src/lcd_cam/mod.rs
+++ b/esp-hal/src/lcd_cam/mod.rs
@@ -172,8 +172,7 @@ fn interrupt_handler() {
 
 pub(crate) struct Instance;
 
-/// The interrupt sources of the LCD_CAM DMA interrupt registers that belong to
-/// the LCD half of the peripheral.
+/// The interrupt sources of the LCD_CAM DMA interrupt registers.
 ///
 /// This type is `pub(crate)` today. If the Camera driver ever needs its own
 /// listen API, it can be promoted to a public `LcdCamInterrupt` without
@@ -185,11 +184,17 @@ pub(crate) enum LcdCamInterrupt {
 
     /// A DMA transfer to the LCD has finished.
     LcdTransDone,
+
+    /// The camera has received a VSYNC pulse.
+    CamVsync,
+
+    /// The camera has received an HSYNC pulse.
+    CamHs,
 }
 
-// NOTE: the LCD_CAM interrupt registers are shared between LCD and Camera and
-// this is only implemented for the LCD side, when the Camera is implemented a
-// CriticalSection will be needed to protect these shared registers.
+// NOTE: the LCD_CAM interrupt registers are shared between LCD and Camera, so
+// concurrent use of both halves needs a CriticalSection to protect these
+// shared registers.
 impl Instance {
     fn enable_listen(sources: EnumSet<LcdCamInterrupt>, en: bool) {
         LCD_CAM::regs().lc_dma_int_ena().modify(|_, w| {
@@ -200,6 +205,12 @@ impl Instance {
                     }
                     LcdCamInterrupt::LcdTransDone => {
                         w.lcd_trans_done_int_ena().bit(en);
+                    }
+                    LcdCamInterrupt::CamVsync => {
+                        w.cam_vsync_int_ena().bit(en);
+                    }
+                    LcdCamInterrupt::CamHs => {
+                        w.cam_hs_int_ena().bit(en);
                     }
                 }
             }
@@ -224,6 +235,12 @@ impl Instance {
         if raw.lcd_trans_done_int_raw().bit() {
             sources.insert(LcdCamInterrupt::LcdTransDone);
         }
+        if raw.cam_vsync_int_raw().bit() {
+            sources.insert(LcdCamInterrupt::CamVsync);
+        }
+        if raw.cam_hs_int_raw().bit() {
+            sources.insert(LcdCamInterrupt::CamHs);
+        }
         sources
     }
 
@@ -239,6 +256,12 @@ impl Instance {
                     }
                     LcdCamInterrupt::LcdTransDone => {
                         w.lcd_trans_done_int_clr().set_bit();
+                    }
+                    LcdCamInterrupt::CamVsync => {
+                        w.cam_vsync_int_clr().set_bit();
+                    }
+                    LcdCamInterrupt::CamHs => {
+                        w.cam_hs_int_clr().set_bit();
                     }
                 }
             }


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` or `manual-changelog` label as appropriate.
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

The `I8080` driver owns two interrupt domains — the LCD_CAM peripheral and the
DMA TX channel it was created with — but exposes neither. The `ChannelTx` half
is stored type-erased in a private field with no accessor, and all of its
interrupt methods are crate-private (handler binding is fully private), while
the public DMA interrupt API lives on the combined `Channel` struct that the
driver never holds. On the LCD_CAM side, only `set_interrupt_handler` is
public; the peripheral-level source enables are `pub(crate)` helpers reserved
for the async `LcdTransDone` wakeup path. A downstream driver that runs from
either interrupt — e.g. esp-hub75's ESP32-S3 backend, which runs its BCM
refresh loop from `lcd_trans_done` and counts frames from the channel's
per-descriptor `out_eof` source in circular mode — therefore had to capture
the channel number itself and steal `LCD_CAM`/`DMA` to access the
`lc_dma_int_ena` and `out_int` registers.

This PR adds, on `I8080<'_, Blocking>`:

- `I8080Interrupt`, covering the two LCD sources of the (ESP32-S3)
  `lc_dma_int_*` registers: `LcdVsync` and `LcdTransDone`. There are no camera
  or RX variants: `I8080` is TX-only and does not own the camera half of the
  peripheral.
- `set_interrupt_handler`, binding the `LCD_CAM` interrupt, and
  `set_dma_interrupt_handler`, binding the channel's own `DMA_OUT_CHn`
  interrupt. Binding cannot be folded into `listen` because the two domains
  fire on different interrupt lines and `bind_handler` allows one handler per
  line. Note that binding the DMA handler unlistens from and clears all DMA TX
  sources, so it must be called before `listen_dma` enables any of them
  (documented on the method).
- `listen`, `unlisten`, `interrupts`, and `clear_interrupts` for the LCD
  sources, and `listen_dma`, `unlisten_dma`, `interrupts_dma`, and
  `clear_interrupts_dma` for the DMA TX sources (reusing the existing public
  `DmaTxInterrupt` enum). The LCD sources map onto the shared register-level
  helpers, the DMA sources onto the existing crate-internal `ChannelTx`
  out-interrupt helpers.

`I8080Transfer` gains `&self` versions of all of the above (inherent methods,
since the transfer's `Deref` is taken by the buffer view), so an interrupt
handler can clear the sources it handled through the transfer that is kept
alive for the duration of the transfer.

#### Testing

Tested with [esp-hub75](https://github.com/liebman/esp-hub75) branch `lcd_cam-interrupts`, the ESP32-S3 lcd_cam
backend drives its BCM refresh loop from the `lcd_trans_done` interrupt. Its
circular-refresh mode counts frames from the DMA TX channel's per-descriptor
`out_eof` interrupt, which now uses `I8080::set_dma_interrupt_handler` and
`I8080::listen_dma` to bind and enable the source, and
`I8080Transfer::clear_interrupts_dma` from the ISR, instead of stealing `DMA`
and poking the `out_int` registers directly. The blocking path binds its
handler with `I8080::set_interrupt_handler` and enables it with
`I8080::listen(I8080Interrupt::LcdTransDone)`.

---

# Changelog

## esp-hal

- Added: `I8080Interrupt` and `I8080::set_interrupt_handler`, `set_dma_interrupt_handler`, `listen`, `unlisten`, `interrupts`, and `clear_interrupts`
- Added: `I8080::listen_dma`, `unlisten_dma`, `interrupts_dma`, and `clear_interrupts_dma` for `DmaTxInterrupt` sources
- Added: `I8080Transfer::listen`, `unlisten`, `interrupts`, `clear_interrupts`, `listen_dma`, `unlisten_dma`, `interrupts_dma`, and `clear_interrupts_dma`

