### PR TITLE
Fix esp-storage dep version

### DIFF
--- a/esp-storage/Cargo.toml
+++ b/esp-storage/Cargo.toml
@@ -37,7 +37,7 @@ esp-metadata-generated = { version = "0.5.0", path = "../esp-metadata-generated"
 
 # Optional dependencies
 esp-sync         = { version = "0.3.0", path = "../esp-sync", optional = true }
-esp-rom-sys      = { version = "~0.1", path = "../esp-rom-sys", optional = true }
+esp-rom-sys      = { version = "0.1.5", path = "../esp-rom-sys", optional = true }
 defmt  = { version = "1.1", optional = true }
 
 esp32   = { version = "0.41", features = ["critical-section"], optional = true }


### PR DESCRIPTION
esp-storage is using a feature that was introduced in esp-rom-sys 0.1.5, so it can't just depend on any `0.1.x` version.

Closes #6241