### PR TITLE
esp-println cleanup

### DIFF
--- a/esp-println/src/lib.rs
+++ b/esp-println/src/lib.rs
@@ -360,33 +360,11 @@ mod serial_jtag_printer {
     }
 }
 
-#[cfg(all(any(feature = "uart", feature = "auto"), feature = "esp32"))]
-mod uart_printer {
-    use super::LockToken;
-    const UART_TX_ONE_CHAR: usize = 0x4000_9200;
-
-    pub struct Printer;
-    impl Printer {
-        pub fn write_bytes_in_cs(bytes: &[u8], _token: LockToken<'_>) {
-            for &b in bytes {
-                unsafe {
-                    let uart_tx_one_char: unsafe extern "C" fn(u8) -> i32 =
-                        core::mem::transmute(UART_TX_ONE_CHAR);
-                    uart_tx_one_char(b)
-                };
-            }
-        }
-
-        pub fn flush(_token: LockToken<'_>) {}
-    }
-}
-
-#[cfg(all(any(feature = "uart", feature = "auto"), not(feature = "esp32")))]
+#[cfg(any(feature = "uart", feature = "auto"))]
 mod uart_printer {
     use super::LockToken;
     trait Functions {
         const TX_ONE_CHAR: usize;
-        const CHUNK_SIZE: usize = 32;
 
         fn tx_byte(b: u8) {
             unsafe {
@@ -396,15 +374,13 @@ mod uart_printer {
             }
         }
 
-        fn flush();
+        fn flush() {}
     }
 
     struct Device;
 
-    // ESP32-P4: resolve through the linker-provided ROM symbol
-    // (`esp_rom_uart_tx_one_char` -> `uart_tx_one_char2 = 0x4fc0_0058`,
-    // see esp-rom-sys/ld/esp32p4/rom/esp32p4.rom.api.ld) instead of
-    // hardcoding the address. Matches the c5/c6/c61/h2 channel-aware path.
+    // ESP32-P4: resolve through the linker-provided ROM symbol instead of
+    // hardcoding the address.
     #[cfg(any(feature = "esp32p4", feature = "esp32s31"))]
     impl Functions for Device {
         // Unused -- tx_byte() below resolves through the linker.
@@ -418,79 +394,31 @@ mod uart_printer {
                 esp_rom_uart_tx_one_char(b);
             }
         }
+    }
 
-        fn flush() {
-            // tx_one_char waits for TX FIFO space
-        }
+    #[cfg(feature = "esp32")]
+    impl Functions for Device {
+        const TX_ONE_CHAR: usize = 0x4000_9200;
     }
 
     #[cfg(feature = "esp32s2")]
     impl Functions for Device {
         const TX_ONE_CHAR: usize = 0x4001_2B10;
-
-        fn flush() {
-            // tx_one_char waits for FIFO space. The ESP32-S2 has no USB Serial/JTAG
-            // peripheral, so there is no buffer that needs an explicit flush.
-        }
     }
 
     #[cfg(feature = "esp32c2")]
     impl Functions for Device {
         const TX_ONE_CHAR: usize = 0x4000_005C;
-
-        fn flush() {
-            // tx_one_char waits for empty
-        }
     }
 
     #[cfg(feature = "esp32c3")]
     impl Functions for Device {
         const TX_ONE_CHAR: usize = 0x4000_0068;
-
-        fn flush() {
-            unsafe {
-                const TX_FLUSH: usize = 0x4000_0080;
-                const GET_CHANNEL: usize = 0x4000_058C;
-                let tx_flush: unsafe extern "C" fn(u8) = core::mem::transmute(TX_FLUSH);
-                let get_channel: unsafe extern "C" fn() -> u8 = core::mem::transmute(GET_CHANNEL);
-
-                const G_USB_PRINT_ADDR: usize = 0x3FCD_FFD0;
-                let g_usb_print = G_USB_PRINT_ADDR as *mut bool;
-
-                let channel = if *g_usb_print {
-                    // Flush USB-JTAG
-                    3
-                } else {
-                    get_channel()
-                };
-                tx_flush(channel);
-            }
-        }
     }
 
     #[cfg(feature = "esp32s3")]
     impl Functions for Device {
         const TX_ONE_CHAR: usize = 0x4000_0648;
-
-        fn flush() {
-            unsafe {
-                const TX_FLUSH: usize = 0x4000_0690;
-                const GET_CHANNEL: usize = 0x4000_1A58;
-                let tx_flush: unsafe extern "C" fn(u8) = core::mem::transmute(TX_FLUSH);
-                let get_channel: unsafe extern "C" fn() -> u8 = core::mem::transmute(GET_CHANNEL);
-
-                const G_USB_PRINT_ADDR: usize = 0x3FCE_FFB8;
-                let g_usb_print = G_USB_PRINT_ADDR as *mut bool;
-
-                let channel = if *g_usb_print {
-                    // Flush USB-JTAG
-                    4
-                } else {
-                    get_channel()
-                };
-                tx_flush(channel);
-            }
-        }
     }
 
     #[cfg(any(
@@ -503,15 +431,15 @@ mod uart_printer {
         const TX_ONE_CHAR: usize = 0x4000_0058;
 
         fn flush() {
+            const TX_FLUSH: usize = 0x4000_0074;
+
+            const GET_CHANNEL: usize = if cfg!(any(feature = "esp32c5", feature = "esp32c61")) {
+                0x4000_0038
+            } else {
+                0x4000_003C
+            };
+
             unsafe {
-                const TX_FLUSH: usize = 0x4000_0074;
-
-                #[cfg(not(any(feature = "esp32c5", feature = "esp32c61")))]
-                const GET_CHANNEL: usize = 0x4000_003C;
-
-                #[cfg(any(feature = "esp32c5", feature = "esp32c61"))]
-                const GET_CHANNEL: usize = 0x4000_0038;
-
                 let tx_flush: unsafe extern "C" fn(u8) = core::mem::transmute(TX_FLUSH);
                 let get_channel: unsafe extern "C" fn() -> u8 = core::mem::transmute(GET_CHANNEL);
 
@@ -523,16 +451,14 @@ mod uart_printer {
     pub struct Printer;
     impl Printer {
         pub fn write_bytes_in_cs(bytes: &[u8], _token: LockToken<'_>) {
-            for chunk in bytes.chunks(Device::CHUNK_SIZE) {
-                for &b in chunk {
-                    Device::tx_byte(b);
-                }
-
-                Device::flush();
+            for &b in bytes {
+                Device::tx_byte(b);
             }
         }
 
-        pub fn flush(_token: LockToken<'_>) {}
+        pub fn flush(_token: LockToken<'_>) {
+            Device::flush();
+        }
     }
 }
 

--- a/esp-println/src/lib.rs
+++ b/esp-println/src/lib.rs
@@ -381,38 +381,7 @@ mod uart_printer {
     }
 }
 
-#[cfg(all(any(feature = "uart", feature = "auto"), feature = "esp32s2"))]
-mod uart_printer {
-    use super::LockToken;
-    pub struct Printer;
-    impl Printer {
-        pub fn write_bytes_in_cs(bytes: &[u8], _token: LockToken<'_>) {
-            // On ESP32-S2 the UART_TX_ONE_CHAR ROM-function seems to have some issues.
-            for chunk in bytes.chunks(64) {
-                for &b in chunk {
-                    unsafe {
-                        // write FIFO
-                        (0x3f400000 as *mut u32).write_volatile(b as u32);
-                    };
-                }
-
-                // wait for TX_DONE
-                while unsafe { (0x3f400004 as *const u32).read_volatile() } & (1 << 14) == 0 {}
-                unsafe {
-                    // reset TX_DONE
-                    (0x3f400010 as *mut u32).write_volatile(1 << 14);
-                }
-            }
-        }
-
-        pub fn flush(_token: LockToken<'_>) {}
-    }
-}
-
-#[cfg(all(
-    any(feature = "uart", feature = "auto"),
-    not(any(feature = "esp32", feature = "esp32s2"))
-))]
+#[cfg(all(any(feature = "uart", feature = "auto"), not(feature = "esp32")))]
 mod uart_printer {
     use super::LockToken;
     trait Functions {
@@ -452,6 +421,16 @@ mod uart_printer {
 
         fn flush() {
             // tx_one_char waits for TX FIFO space
+        }
+    }
+
+    #[cfg(feature = "esp32s2")]
+    impl Functions for Device {
+        const TX_ONE_CHAR: usize = 0x4001_2B10;
+
+        fn flush() {
+            // tx_one_char waits for FIFO space. The ESP32-S2 has no USB Serial/JTAG
+            // peripheral, so there is no buffer that needs an explicit flush.
         }
     }
 


### PR DESCRIPTION
Reference: https://github.com/esp-rs/esp-println/issues/2
Reverts https://github.com/esp-rs/esp-println/pull/7
Reverts https://github.com/esp-rs/esp-println/pull/57

I don't see any problems calling the ROM code, on the other hand our own implementation flushed way too much and was very slow for that reason.

# Changelog

## esp-println

- Fixed: ESP32-S2 UART output no longer waits for the transmit FIFO to drain after every 64 byte.