### PR TITLE
Implement xarxa-driver

### DIFF
--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -83,6 +83,7 @@ digest-011               = { package = "digest", version = "0.11",   default-fea
 embassy-usb-driver       = { version = "0.2", optional = true }
 embassy-usb-synopsys-otg = { version = "0.4.0", optional = true, features = ["host"] }
 embassy-net-driver-02    = { package = "embassy-net-driver", version = "0.2", optional = true }
+xarxa-driver             = { version = "0.1.0", features = ["async"], optional = true }
 embedded-can             = { version = "0.4.1", optional = true }
 nb                       = { version = "1.1", optional = true }
 sdio                     = { version = "0.5", optional = true }
@@ -205,6 +206,7 @@ esp32   = [
     "dep:sha1",
     "dep:sha2",
     "dep:embassy-net-driver-02",
+    "dep:xarxa-driver",
 ]
 ##
 esp32c2 = [
@@ -260,6 +262,7 @@ esp32p4 = [
     "esp-sync/esp32p4",
     "esp-metadata-generated/esp32p4",
     "dep:embassy-net-driver-02",
+    "dep:xarxa-driver",
 ]
 ##
 esp32c61 = [
@@ -342,7 +345,8 @@ defmt = [
     "fugit/defmt",
     "esp-riscv-rt?/defmt",
     "xtensa-lx-rt?/defmt",
-    "esp-sync/defmt"
+    "esp-sync/defmt",
+    "xarxa-driver?/defmt"
 ]
 
 #! ### Unstable APIs

--- a/esp-hal/src/ethernet/mod.rs
+++ b/esp-hal/src/ethernet/mod.rs
@@ -105,6 +105,7 @@ pub(crate) mod dma;
 pub(crate) mod embassy_net;
 pub mod mac;
 pub mod phy;
+pub(crate) mod xarxa;
 
 use core::task::Poll;
 

--- a/esp-hal/src/ethernet/xarxa.rs
+++ b/esp-hal/src/ethernet/xarxa.rs
@@ -1,0 +1,136 @@
+//! `xarxa` driver integration for the EMAC Ethernet peripheral.
+//!
+//! This module provides a [`xarxa_driver::Driver`] implementation for
+//! [`Ethernet`] operating in async mode, enabling the Ethernet peripheral to be
+//! used as a network interface with [`xarxa`](https://crates.io/crates/xarxa).
+//!
+//! ## Usage
+//!
+//! After obtaining an `Ethernet<'_, Async, P>` instance, pass it directly to the
+//! stack — the [`Driver`] impl is inherent on the type.
+//!
+//! Unlike the `embassy-net` driver, this one copies each frame between the DMA
+//! ring and a pool buffer, because `xarxa` passes ownership of packet buffers
+//! instead of lending the driver's own memory.
+
+use core::{
+    any::TypeId,
+    task::{Context, Waker},
+};
+
+use xarxa_driver::{
+    Capabilities,
+    ChecksumOffload,
+    Driver,
+    HardwareAddress,
+    LinkState,
+    NotSupported,
+    PacketBuf,
+    config::PACKET_BUF_SIZE,
+};
+
+use super::{Ethernet, RX_WAKER, TX_WAKER, mac::EmacRegs};
+use crate::{Async, DriverMode, ethernet::phy::Phy};
+
+/// Maximum Ethernet frame size (header + payload, no FCS).
+///
+/// The packet pool has a fixed buffer size, which caps the frames this driver
+/// can pass on to the stack.
+const MTU: usize = if 1514 < PACKET_BUF_SIZE {
+    1514
+} else {
+    PACKET_BUF_SIZE
+};
+
+impl<'d, Dm: DriverMode + 'static, P: Phy> Driver for Ethernet<'d, Dm, P> {
+    fn capabilities(&self) -> Capabilities {
+        let mut caps = Capabilities::default();
+        caps.max_transmission_unit = MTU;
+        // Checksums are offloaded to hardware in both directions (RX COE + TX
+        // insertion via the descriptor CIC bits), so the stack does neither.
+        caps.checksum.ipv4 = ChecksumOffload::BOTH;
+        caps.checksum.tcp = ChecksumOffload::BOTH;
+        caps.checksum.udp = ChecksumOffload::BOTH;
+        caps.checksum.icmpv4 = ChecksumOffload::BOTH;
+        caps.checksum.icmpv6 = ChecksumOffload::BOTH;
+        caps
+    }
+
+    fn hardware_address(&self) -> HardwareAddress {
+        HardwareAddress::Ethernet(self.mac_addr())
+    }
+
+    fn link_state(&mut self) -> LinkState {
+        let state = self.poll_link(None);
+        if state.up {
+            self.set_speed(state.speed);
+            self.set_duplex(state.duplex);
+            LinkState::Up
+        } else {
+            LinkState::Down
+        }
+    }
+
+    fn register_waker(&mut self, waker: &Waker) -> Result<(), NotSupported> {
+        if TypeId::of::<Dm>() == TypeId::of::<Async>() {
+            // The driver has one waker per event, the stack has one waker for all of them.
+            RX_WAKER.register(waker);
+            TX_WAKER.register(waker);
+            // The PHY keeps the waker to report a link change. A PHY that cannot do so wakes the
+            // stack at once, which makes it poll the link state instead.
+            self.poll_link(Some(&mut Context::from_waker(waker)));
+            Ok(())
+        } else {
+            Err(NotSupported)
+        }
+    }
+
+    fn receive(&mut self) -> Option<PacketBuf> {
+        let Some(frame) = self.rx.receive() else {
+            // receive() may have recycled error frames back to DMA ownership without a
+            // poll-demand write, which would leave the GMAC RX channel suspended.
+            EmacRegs.demand_rx_poll();
+            return None;
+        };
+
+        let buffer = if frame.len() > PACKET_BUF_SIZE {
+            warn!(
+                "Dropping a {} byte frame, the packet buffer holds {} bytes",
+                frame.len(),
+                PACKET_BUF_SIZE
+            );
+            None
+        } else if let Some(mut buffer) = PacketBuf::try_new() {
+            buffer.set_len(frame.len());
+            buffer.copy_from_slice(frame);
+            Some(buffer)
+        } else {
+            // The pool is shared with the rest of the stack and can be empty. Dropping the
+            // frame is the only option, the descriptor must go back to the DMA.
+            None
+        };
+
+        self.rx.pop();
+        EmacRegs.demand_rx_poll();
+
+        buffer
+    }
+
+    fn can_transmit(&mut self) -> bool {
+        self.tx.available_buf().is_some()
+    }
+
+    fn transmit(&mut self, buffer: PacketBuf) -> Result<(), PacketBuf> {
+        let Some(slot) = self.tx.available_buf() else {
+            return Err(buffer);
+        };
+
+        let len = buffer.len().min(MTU);
+        slot[..len].copy_from_slice(&buffer[..len]);
+
+        self.tx.commit(len);
+        EmacRegs.demand_tx_poll();
+
+        Ok(())
+    }
+}

--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -107,6 +107,7 @@ embedded-io-async-06 = { package = "embedded-io-async", version = "0.6", default
 embedded-io-07 = { package = "embedded-io", version = "0.7", default-features = false, optional = true }
 embedded-io-async-07 = { package = "embedded-io-async", version = "0.7", default-features = false, optional = true }
 embassy-net-driver-02 = { package = "embassy-net-driver", version = "0.2.0", optional = true }
+xarxa-driver = { version = "0.1.0", features = ["async"], optional = true }
 bt-hci = { version = "0.9.0", optional = true }
 bt-hci-transport = { version = "0.1.0", optional = true }
 
@@ -269,7 +270,7 @@ esp32s3 = [
 
 #DOC_IF has("wifi_driver_supported")
 ## Enable Wi-Fi support.
-wifi = ["dep:enumset", "dep:embassy-net-driver-02"]
+wifi = ["dep:enumset", "dep:embassy-net-driver-02", "dep:xarxa-driver"]
 
 ## Enable Wi-Fi Enterprise Authentication Protocol (EAP) support.
 ##
@@ -353,6 +354,7 @@ defmt = [
     "esp-sync/defmt",
     "esp-phy/defmt",
     "ieee802154?/defmt",
+    "xarxa-driver?/defmt",
 ]
 
 #! ### Unstable APIs

--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -1458,18 +1458,18 @@ impl InterfaceType {
         }
     }
 
-    fn register_transmit_waker(&self, cx: &mut core::task::Context<'_>) {
-        TRANSMIT_WAKER.register(cx.waker())
+    fn register_transmit_waker(&self, waker: &core::task::Waker) {
+        TRANSMIT_WAKER.register(waker)
     }
 
-    fn register_receive_waker(&self, cx: &mut core::task::Context<'_>) {
-        self.data_queue_rx().with(|q| q.register_waker(cx.waker()));
+    fn register_receive_waker(&self, waker: &core::task::Waker) {
+        self.data_queue_rx().with(|q| q.register_waker(waker));
     }
 
-    fn register_link_state_waker(&self, cx: &mut core::task::Context<'_>) {
+    fn register_link_state_waker(&self, waker: &core::task::Waker) {
         match self {
-            InterfaceType::Station => STA_LINK_STATE_WAKER.register(cx.waker()),
-            InterfaceType::AccessPoint => AP_LINK_STATE_WAKER.register(cx.waker()),
+            InterfaceType::Station => STA_LINK_STATE_WAKER.register(waker),
+            InterfaceType::AccessPoint => AP_LINK_STATE_WAKER.register(waker),
         }
     }
 
@@ -1508,8 +1508,9 @@ pub(super) fn release(bit: u8) {
 
 /// Wi-Fi interface.
 ///
-/// This implements the `embassy-net-driver` trait for up to three latest versions of that crate.
-/// While that crate isn't stable we make an exception here from the [API Guidelines](https://rust-lang.github.io/api-guidelines/necessities.html#c-stable)
+/// This implements the `embassy-net-driver` trait for up to three latest versions of that crate,
+/// and the `xarxa-driver` trait.
+/// While those crates aren't stable we make an exception here from the [API Guidelines](https://rust-lang.github.io/api-guidelines/necessities.html#c-stable)
 /// in exposing unstable dependencies.
 ///
 /// Each interface mode (station, access point) is a singleton — only one
@@ -2111,18 +2112,18 @@ pub(crate) mod embassy_02 {
             &mut self,
             cx: &mut core::task::Context<'_>,
         ) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
-            self.mode.register_receive_waker(cx);
-            self.mode.register_transmit_waker(cx);
+            self.mode.register_receive_waker(cx.waker());
+            self.mode.register_transmit_waker(cx.waker());
             self.mode.rx_token()
         }
 
         fn transmit(&mut self, cx: &mut core::task::Context<'_>) -> Option<Self::TxToken<'_>> {
-            self.mode.register_transmit_waker(cx);
+            self.mode.register_transmit_waker(cx.waker());
             self.mode.tx_token()
         }
 
         fn link_state(&mut self, cx: &mut core::task::Context<'_>) -> LinkState {
-            self.mode.register_link_state_waker(cx);
+            self.mode.register_link_state_waker(cx.waker());
             match self.mode.link_state() {
                 super::LinkState::Down => LinkState::Down,
                 super::LinkState::Up => LinkState::Up,
@@ -2146,6 +2147,100 @@ pub(crate) mod embassy_02 {
 
         fn hardware_address(&self) -> HardwareAddress {
             HardwareAddress::Ethernet(self.mac_address())
+        }
+    }
+}
+
+pub(crate) mod xarxa {
+    use xarxa_driver::{
+        Capabilities,
+        Driver,
+        HardwareAddress,
+        LinkState,
+        NotSupported,
+        PacketBuf,
+        config::PACKET_BUF_SIZE,
+    };
+
+    use super::*;
+
+    /// The largest frame this driver can pass on to the stack.
+    ///
+    /// The packet pool has a fixed buffer size, so a larger configured MTU cannot be used.
+    const XARXA_MTU: usize = if MTU < PACKET_BUF_SIZE {
+        MTU
+    } else {
+        PACKET_BUF_SIZE
+    };
+
+    impl Driver for Interface {
+        fn capabilities(&self) -> Capabilities {
+            let mut caps = Capabilities::default();
+            caps.max_transmission_unit = XARXA_MTU;
+            caps
+        }
+
+        fn hardware_address(&self) -> HardwareAddress {
+            HardwareAddress::Ethernet(self.mac_address())
+        }
+
+        fn link_state(&mut self) -> LinkState {
+            match self.mode.link_state() {
+                super::LinkState::Down => LinkState::Down,
+                super::LinkState::Up => LinkState::Up,
+            }
+        }
+
+        fn register_waker(&mut self, waker: &core::task::Waker) -> Result<(), NotSupported> {
+            // The driver has one waker per event, the stack has one waker for all of them.
+            self.mode.register_receive_waker(waker);
+            self.mode.register_transmit_waker(waker);
+            self.mode.register_link_state_waker(waker);
+            Ok(())
+        }
+
+        fn receive(&mut self) -> Option<PacketBuf> {
+            // We handle the received data outside of the lock because PacketBuffer::drop must
+            // not be called in a critical section. Dropping a PacketBuffer calls
+            // `esp_wifi_internal_free_rx_buffer` which will try to lock an internal mutex. If
+            // the mutex is already taken, the function will try to trigger a context switch,
+            // which will fail if we are in an interrupt-free context.
+            let mut packet = self.mode.data_queue_rx().with(|queue| queue.pop_front())?;
+
+            let data = packet.as_slice_mut();
+            dump_packet_info(data);
+
+            if data.len() > PACKET_BUF_SIZE {
+                warn!(
+                    "Dropping a {} byte frame, the packet buffer holds {} bytes",
+                    data.len(),
+                    PACKET_BUF_SIZE
+                );
+                return None;
+            }
+
+            // The pool is shared with the rest of the stack and can be empty. Dropping the
+            // packet is the only option, the hardware does not hold it for us.
+            let mut buffer = PacketBuf::try_new()?;
+            buffer.set_len(data.len());
+            buffer.copy_from_slice(data);
+
+            Some(buffer)
+        }
+
+        fn can_transmit(&mut self) -> bool {
+            self.mode.can_send() && self.mode.link_state() == super::LinkState::Up
+        }
+
+        fn transmit(&mut self, mut buffer: PacketBuf) -> Result<(), PacketBuf> {
+            if !self.can_transmit() {
+                return Err(buffer);
+            }
+
+            self.mode.increase_in_flight_counter();
+            esp_wifi_send_data(self.mode.interface(), &mut buffer);
+
+            Ok(())
         }
     }
 }


### PR DESCRIPTION
# Changelog

## esp-hal/Ethernet

- Added: Implemented `xarxa-driver` for Ethernet.

## esp-radio/Wi-Fi

- Added: Implemented `xarxa-driver` for the Wi-Fi `Interface`.