### PR TITLE
Fix GPIO wakeup from deep sleep

### DIFF
--- a/esp-hal/src/gpio/interrupt.rs
+++ b/esp-hal/src/gpio/interrupt.rs
@@ -54,16 +54,17 @@
 use portable_atomic::{AtomicPtr, Ordering};
 use strum::EnumCount;
 
-use crate::{
-    gpio::{AnyPin, GPIO_LOCK, GpioBank, InputPin, low_level::set_int_enable},
-    ram,
-};
 #[cfg(feature = "rt")]
 use crate::{
+    gpio::low_level::disable_cpu_interrupt,
     handler,
     interrupt::{self, DEFAULT_INTERRUPT_HANDLER},
     peripherals::Interrupt,
     system::Cpu,
+};
+use crate::{
+    gpio::{AnyPin, GPIO_LOCK, GpioBank, InputPin, low_level::set_int_enable},
+    ram,
 };
 
 /// Convenience constant for `Option::None` pin
@@ -148,7 +149,7 @@ fn default_gpio_interrupt_handler() {
                 let pin_nr = pin_pos as u8 + bank.offset();
 
                 // The remaining interrupts are not async, we treat them as single-shot.
-                set_int_enable(pin_nr, Some(0), 0, false);
+                disable_cpu_interrupt(pin_nr);
             }
         }
     });

--- a/esp-hal/src/gpio/low_level/mod.rs
+++ b/esp-hal/src/gpio/low_level/mod.rs
@@ -81,7 +81,7 @@ impl GpioBank {
     ///
     /// The same bits also give the pins that can end a light sleep, because one write sets the
     /// interrupt enable and the wakeup enable of a pad. Sleep entry reads these bits, and thus
-    /// needs no register read for each pin.
+    /// needs no register read for each pin. The default interrupt handler clears only `int_ena`.
     pub(crate) fn listening(self) -> &'static AtomicU32 {
         static FLAGS: PadMask = PadMask::new();
 
@@ -227,6 +227,14 @@ pub(crate) fn set_int_enable(
     } else {
         bank.listening().fetch_and(!pin, Ordering::Relaxed);
     }
+}
+
+/// Clears the CPU interrupt enable of a pad, and keeps its wake condition.
+#[cfg(feature = "rt")]
+pub(crate) fn disable_cpu_interrupt(gpio_num: u8) {
+    GPIO::regs()
+        .pin(gpio_num as usize)
+        .modify(|_, w| unsafe { w.int_ena().bits(0) });
 }
 
 pub(crate) fn is_int_enabled(gpio_num: u8) -> bool {

--- a/esp-hal/src/gpio/lp_io/low_level/v4.rs
+++ b/esp-hal/src/gpio/lp_io/low_level/v4.rs
@@ -66,6 +66,7 @@ pub(crate) fn set_config(lp: u8, input_enable: bool, mux: bool, func: LpFunction
     LP_IO_MUX::regs().gpio(lp as usize).modify(|_, w| unsafe {
         w.slp_sel().bit(false);
         w.fun_ie().bit(input_enable);
+        w.mcu_ie().bit(input_enable);
         w.mcu_sel().bits(func as u8)
     });
 }
@@ -95,9 +96,10 @@ pub(crate) fn output_enable(lp: u8, enable: bool) {
 
 #[cfg(any(ulp_riscv_driver_supported, lp_io_has_gpio_matrix))]
 pub(crate) fn input_enable(lp: u8, enable: bool) {
-    LP_IO_MUX::regs()
-        .gpio(lp as usize)
-        .modify(|_, w| w.fun_ie().bit(enable));
+    LP_IO_MUX::regs().gpio(lp as usize).modify(|_, w| {
+        w.fun_ie().bit(enable);
+        w.mcu_ie().bit(enable)
+    });
 }
 
 pub(crate) fn pullup_enable(lp: u8, enable: bool) {


### PR DESCRIPTION
# Changelog

## esp-hal

- Fixed: A pad that is already at its wake level no longer loses its wake configuration. This fixes a regression in 1.2.0-rc.0.