### PR TITLE
Prevent test firmware from looping

### DIFF
--- a/hil-test/src/lib.rs
+++ b/hil-test/src/lib.rs
@@ -169,3 +169,23 @@ mod executor {
 pub use esp_rtos::embassy::Executor;
 #[cfg(not(feature = "embassy"))]
 pub use executor::Executor;
+
+#[embedded_test::setup]
+fn disable_watchdogs_before_semihosting() {
+    use esp_hal::peripherals;
+
+    // This prevents the firmware reset loop if no debugger is attached.
+    let mut rtc = esp_hal::rtc_cntl::Rtc::new(unsafe { peripherals::RTC_TIMER::steal() });
+
+    // Disable watchdog timers
+    #[cfg(soc_has_swd_watchdog)]
+    rtc.swd.disable();
+
+    rtc.rwdt.disable();
+
+    #[cfg(timergroup_timg0)]
+    esp_hal::timer::timg::Wdt::<peripherals::TIMG0<'static>>::new().disable();
+
+    #[cfg(timergroup_timg1)]
+    esp_hal::timer::timg::Wdt::<peripherals::TIMG1<'static>>::new().disable();
+}


### PR DESCRIPTION
The semihosting call `embedded-test` makes comes before the watchdogs are disabled. This means that after connecting the MCU to power, if probe-rs is not connecting fast enough, the firmware is reset. This reset is mostly annoying, but it may cause problems as well, since the probe-rs connection process takes time and the device resetting in the middle of it might cause problems.

This PR disables the WDTs before the first semihosting call. This is almost the same as probe-rs would do on connection, except the TIMG WDT code also configures a clock source to its default.