### PR TITLE
Fix breaking GPIO change

### DIFF
--- a/esp-hal/src/gpio/interconnect.rs
+++ b/esp-hal/src/gpio/interconnect.rs
@@ -129,6 +129,9 @@ pub trait PeripheralSignal<'d>: Sealed {
 ///
 /// Peripheral drivers are encouraged to accept types that implement this and
 /// [`PeripheralOutput`] as arguments instead of pin types.
+///
+/// To allow writing functions that are generic over GPIOs, this trait is
+/// blanket-implemented for [`InputPin`][gpio::InputPin] types.
 #[allow(
     private_bounds,
     reason = "InputSignal is unstable, but the trait needs to be public"
@@ -139,6 +142,9 @@ pub trait PeripheralInput<'d>: Into<InputSignal<'d>> + PeripheralSignal<'d> {}
 ///
 /// Peripheral drivers are encouraged to accept types that implement this and
 /// [`PeripheralInput`] as arguments instead of pin types.
+///
+/// To allow writing functions that are generic over GPIOs, this trait is
+/// blanket-implemented for [`OutputPin`] types.
 #[allow(
     private_bounds,
     reason = "OutputSignal is unstable, but the trait needs to be public"

--- a/esp-hal/src/gpio/mod.rs
+++ b/esp-hal/src/gpio/mod.rs
@@ -2301,8 +2301,9 @@ for_each_gpio! {
 
 define_io_mux_reg!();
 
-// Implement the signal traits outside of interconnect, so that the impls
-// don't inherit the module-level instability.
+// documentation only - renders nicer than the blanket implementation, but
+// doesn't prevent generic code from working.
+#[cfg(docsrs)]
 mod io_matrix_impls {
     use crate::gpio::{
         self,
@@ -2322,6 +2323,7 @@ mod io_matrix_impls {
             InputSignal::new(pin).connect_input_to_peripheral(signal);
         }
     }
+
     impl<'d> PeripheralInput<'d> for AnyPin<'d> {}
 
     impl<'d> PeripheralOutput<'d> for AnyPin<'d> {
@@ -2343,6 +2345,7 @@ mod io_matrix_impls {
                     pin.connect_input_to_peripheral(signal);
                 }
             }
+
             impl<'d> PeripheralInput<'d> for crate::peripherals::$gpio<'d> {}
         };
     }
@@ -2361,5 +2364,49 @@ mod io_matrix_impls {
                 }
             }
         };
+    }
+}
+
+#[cfg(not(docsrs))]
+mod io_matrix_impls {
+    use crate::gpio::{
+        self,
+        AnyPin,
+        InputPin,
+        OutputPin,
+        Pin,
+        interconnect::{
+            InputSignal,
+            OutputSignal,
+            PeripheralInput,
+            PeripheralOutput,
+            PeripheralSignal,
+        },
+    };
+
+    // Pins
+    impl<'d, P> PeripheralSignal<'d> for P
+    where
+        P: Pin + 'd,
+    {
+        fn connect_input_to_peripheral(&self, signal: gpio::InputSignal) {
+            let pin = unsafe { AnyPin::steal(self.number()) };
+            InputSignal::new(pin).connect_input_to_peripheral(signal);
+        }
+    }
+    impl<'d, P> PeripheralInput<'d> for P where P: InputPin + 'd {}
+
+    impl<'d, P> PeripheralOutput<'d> for P
+    where
+        P: OutputPin + 'd,
+    {
+        fn connect_peripheral_to_output(&self, signal: gpio::OutputSignal) {
+            let pin = unsafe { AnyPin::steal(self.number()) };
+            OutputSignal::new(pin).connect_peripheral_to_output(signal);
+        }
+        fn disconnect_from_peripheral_output(&self) {
+            let pin = unsafe { AnyPin::steal(self.number()) };
+            OutputSignal::new(pin).disconnect_from_peripheral_output();
+        }
     }
 }

--- a/hil-test/src/bin/gpio.rs
+++ b/hil-test/src/bin/gpio.rs
@@ -919,3 +919,25 @@ mod tests {
         }
     }
 }
+
+#[allow(unused, reason = "Compile tests")]
+#[cfg(spi_master_driver_supported)] // unimportant, one device is enough to check the API
+mod compile_regression_tests {
+    use esp_hal::{
+        Blocking,
+        gpio::{InputPin, OutputPin},
+        spi::master::Spi,
+    };
+
+    fn pin_traits_imply_peripheral_signals() {
+        // The interconnect module is not stable, meaning users can't name `PeripheralInput`.
+        // `InputPin` must therefore imply `PeripheralInput` to allow generic code. This is done by
+        // a blanket implementation, which must be preserved despite the subpar documentation.
+        fn input_pin_generic_user_function(spi: Spi<'_, Blocking>, p: impl InputPin) {
+            spi.with_miso(p);
+        }
+        fn output_pin_generic_user_function(spi: Spi<'_, Blocking>, p: impl OutputPin) {
+            spi.with_mosi(p);
+        }
+    }
+}


### PR DESCRIPTION
This PR undoed the change done by #6105, and instead only changes how we render the documentation. The documentation includes a new note, and the PR adds a regression test for the pattern that was broken by the original change.

<img width="1020" height="1112" alt="image" src="https://github.com/user-attachments/assets/60ce38c9-5065-4590-96bc-f4eea73dad7e" />


# Changelog

## esp-hal/GPIO

- Fixed: Fixed a breaking change introduced in 1.2.0-rc.0, which prevented writing generic functions for GPIOs.