### PR TITLE
Disable WDTs by raw register manipulation

### DIFF
--- a/hil-test/src/lib.rs
+++ b/hil-test/src/lib.rs
@@ -170,22 +170,83 @@ pub use esp_rtos::embassy::Executor;
 #[cfg(not(feature = "embassy"))]
 pub use executor::Executor;
 
+/// Disables every watchdog timer with raw register writes.
+///
+/// This prevents the firmware reset loop if no debugger is attached. The function must not depend
+/// on esp-hal drivers, because a driver that is broken or half-initialized must not stop the tests
+/// from running.
 #[embedded_test::setup]
 fn disable_watchdogs_before_semihosting() {
-    use esp_hal::peripherals;
+    cfg_select! {
+        soc_has_lp_wdt => {
+            use esp_hal::peripherals::LP_WDT;
+        }
+        _ => {
+            use esp_hal::peripherals::LPWR as LP_WDT;
+        }
+    }
 
-    // This prevents the firmware reset loop if no debugger is attached.
-    let mut rtc = esp_hal::rtc_cntl::Rtc::new(unsafe { peripherals::RTC_TIMER::steal() });
+    // RWDT
+    let lp_wdt = LP_WDT::regs();
+    cfg_select! {
+        esp32p4 => {
+            lp_wdt.wprotect().write(|w| unsafe { w.bits(0x50D8_3AA1) });
+            lp_wdt.config0().write(|w| unsafe { w.bits(0) });
+            lp_wdt.wprotect().write(|w| unsafe { w.bits(0) });
+        }
+        _ => {
+            lp_wdt
+                .wdtwprotect()
+                .write(|w| unsafe { w.bits(0x50D8_3AA1) });
+            lp_wdt.wdtconfig0().write(|w| unsafe { w.bits(0) });
+            lp_wdt.wdtwprotect().write(|w| unsafe { w.bits(0) });
+        }
+    }
 
-    // Disable watchdog timers
+    // SWD
     #[cfg(soc_has_swd_watchdog)]
-    rtc.swd.disable();
+    {
+        const SWD_WKEY: u32 = cfg_select! {
+            any(esp32c2, esp32c3, esp32s2, esp32s3) => 0x8F1D_312A,
+            _ => 0x50D8_3AA1,
+        };
 
-    rtc.rwdt.disable();
+        lp_wdt
+            .swd_wprotect()
+            .write(|w| unsafe { w.swd_wkey().bits(SWD_WKEY) });
+        cfg_select! {
+            esp32p4 => lp_wdt
+                .swd_config()
+                .write(|w| w.swd_auto_feed_en().set_bit()),
+            _ => lp_wdt.swd_conf().write(|w| w.swd_auto_feed_en().set_bit()),
+        };
+        lp_wdt
+            .swd_wprotect()
+            .write(|w| unsafe { w.swd_wkey().bits(0) });
+    }
 
+    // MWDT
     #[cfg(timergroup_timg0)]
-    esp_hal::timer::timg::Wdt::<peripherals::TIMG0<'static>>::new().disable();
+    {
+        let timg0 = esp_hal::peripherals::TIMG0::regs();
+        timg0
+            .wdtwprotect()
+            .write(|w| unsafe { w.wdt_wkey().bits(0x50D8_3AA1) });
+        timg0.wdtconfig0().modify(|_, w| w.wdt_en().clear_bit());
+        timg0
+            .wdtwprotect()
+            .write(|w| unsafe { w.wdt_wkey().bits(0) });
+    }
 
     #[cfg(timergroup_timg1)]
-    esp_hal::timer::timg::Wdt::<peripherals::TIMG1<'static>>::new().disable();
+    {
+        let timg1 = esp_hal::peripherals::TIMG1::regs();
+        timg1
+            .wdtwprotect()
+            .write(|w| unsafe { w.wdt_wkey().bits(0x50D8_3AA1) });
+        timg1.wdtconfig0().modify(|_, w| w.wdt_en().clear_bit());
+        timg1
+            .wdtwprotect()
+            .write(|w| unsafe { w.wdt_wkey().bits(0) });
+    }
 }


### PR DESCRIPTION
C3 touched its clock tree because for some reason we default TIMG WDT to APB, and the tests ended up crashing before they began. This PR makes sure only the WDT registers are written.