### PR TITLE
esp-radio: Allow `disconnect_async` to abort an in-progress connection attempt

### DIFF
--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -3228,6 +3228,8 @@ ignored."
     #[procmacros::doc_replace]
     /// Disconnect Wi-Fi station from the AP.
     ///
+    /// If a connection attempt is currently in progress, it is aborted.
+    ///
     /// This function will wait for the connection to be closed before returning.
     ///
     /// ## Example
@@ -3248,9 +3250,14 @@ ignored."
     /// }
     /// # {after_snippet}
     pub async fn disconnect_async(&mut self) -> Result<sta::DisconnectedInfo, WifiError> {
-        // If not connected it would wait forever for a `StationDisconnected` event that will never
-        // happen. Return early instead of hanging.
-        if !self.is_connected() {
+        // If neither connected nor connecting it would wait forever for a `StationDisconnected`
+        // event that will never happen. Return early instead of hanging. Disconnecting while
+        // `Connecting` is allowed: `esp_wifi_disconnect` cancels an in-progress connection
+        // attempt and posts a `StationDisconnected` event.
+        if !matches!(
+            station_state(),
+            WifiStationState::Connected | WifiStationState::Connecting
+        ) {
             return Err(WifiError::NotConnected);
         }
 


### PR DESCRIPTION
### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` or `manual-changelog` label as appropriate.
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

`WifiController::disconnect_async` currently returns `WifiError::NotConnected` when the station is in the `Connecting` state, because the early-return guard only checks `is_connected()`. This leaves no way to abort an in-progress connection attempt: the caller can only wait for the attempt to either succeed or fail on its own (which can take a while, e.g. while the driver retries against an AP that is not responding).

Calling `esp_wifi_disconnect()` while a connection attempt is in progress is valid — it cancels the attempt and posts a `WIFI_EVENT_STA_DISCONNECTED` event, so the event loop inside `disconnect_async` terminates normally.

This PR changes the guard to allow the call in both `Connected` and `Connecting` states. All other states still return `NotConnected` early, preserving the original protection against waiting forever for a `StationDisconnected` event that will never arrive.

#### Testing

- `cargo check --features esp32c5,wifi,unstable,esp-hal/unstable --target riscv32imac-unknown-none-elf`
- An equivalent patch (applied on top of the released 1.0.0-beta.0) has been running in a production ESP32-C5 firmware, where it is used to abort stuck connection attempts before re-configuring the station.

---

# Changelog

## esp-radio

- Fixed: `WifiController::disconnect_async` can now abort an in-progress connection attempt instead of returning `NotConnected`.
