### PR TITLE
esp-alloc: Make the heap region limit configurable via esp-config

### DIFF
--- a/esp-alloc/Cargo.toml
+++ b/esp-alloc/Cargo.toml
@@ -37,6 +37,7 @@ test = false
 allocator-api2        = { version = "0.3.0", default-features = false }
 defmt                 = { version = "1.1", optional = true }
 enumset               = "1"
+esp-config            = { version = "0.8.0", path = "../esp-config" }
 esp-sync              = { version = "0.3.0", path = "../esp-sync" }
 document-features     = "0.2"
 

--- a/esp-alloc/esp_config.yml
+++ b/esp-alloc/esp_config.yml
@@ -1,6 +1,17 @@
 crate: esp-alloc
 
 options:
+  - name: max_regions
+    description: "Maximum number of memory regions that can be added to a
+      heap allocator. Each region slot is a small constant cost in the
+      allocator itself; only increase this if you need to register more
+      regions than the default allows."
+    default:
+      - value: 3
+    constraints:
+      - type:
+          validator: positive_integer
+
   - name: heap_algorithm
     description: "The heap algorithm to use. TLSF offers higher performance
       and bounded allocation time, but uses more memory."

--- a/esp-alloc/src/lib.rs
+++ b/esp-alloc/src/lib.rs
@@ -161,9 +161,14 @@ pub mod export {
 
 pub use allocators::*;
 use enumset::{EnumSet, EnumSetType};
+use esp_config::esp_config_int;
 use esp_sync::NonReentrantMutex;
 
 use crate::heap::Heap;
+
+/// Maximum number of memory regions that can be added to a heap allocator,
+/// configurable via `ESP_ALLOC_CONFIG_MAX_REGIONS`.
+const MAX_REGIONS: usize = esp_config_int!(usize, "ESP_ALLOC_CONFIG_MAX_REGIONS");
 
 /// The global allocator instance
 #[cfg_attr(feature = "global-allocator", global_allocator)]
@@ -333,7 +338,7 @@ impl HeapRegion {
 #[derive(Debug)]
 pub struct HeapStats {
     /// Granular stats for all the configured memory regions.
-    pub region_stats: [Option<RegionStats>; 3],
+    pub region_stats: [Option<RegionStats>; MAX_REGIONS],
 
     /// Total size of all combined heap regions in bytes.
     pub size: usize,
@@ -406,7 +411,7 @@ struct InternalHeapStats {
 }
 
 struct EspHeapInner {
-    heap: [Option<HeapRegion>; 3],
+    heap: [Option<HeapRegion>; MAX_REGIONS],
     #[cfg(feature = "internal-heap-stats")]
     internal_heap_stats: InternalHeapStats,
 }
@@ -415,7 +420,7 @@ impl EspHeapInner {
     /// Crate a new UNINITIALIZED heap allocator
     pub const fn empty() -> Self {
         EspHeapInner {
-            heap: [const { None }; 3],
+            heap: [const { None }; MAX_REGIONS],
             #[cfg(feature = "internal-heap-stats")]
             internal_heap_stats: InternalHeapStats {
                 max_usage: 0,
@@ -461,7 +466,7 @@ impl EspHeapInner {
     /// called from within `println!()` to pretty-print the usage of the
     /// heap.
     pub fn stats(&self) -> HeapStats {
-        let mut region_stats: [Option<RegionStats>; 3] = [const { None }; 3];
+        let mut region_stats: [Option<RegionStats>; MAX_REGIONS] = [const { None }; MAX_REGIONS];
 
         let mut used = 0;
         let mut free = 0;
@@ -588,7 +593,8 @@ impl EspHeap {
     ///
     /// `size` is the size of the heap in bytes.
     ///
-    /// You can add up to three regions per allocator.
+    /// You can add up to three regions per allocator by default. The limit is
+    /// configurable via `ESP_ALLOC_CONFIG_MAX_REGIONS`.
     ///
     /// Note that:
     ///


### PR DESCRIPTION
### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt-packages` command to ensure that all changed code is formatted correctly.
- [x] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` or `manual-changelog` label as appropriate.
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

`esp-alloc` hard-codes the maximum number of heap regions to 3. Some memory layouts need more: our concrete case is a plain ESP32 (no PSRAM) firmware that registers 4 regions — the main DRAM region, `dram2`, the region freed by shrinking the main stack, and the ROM-stack area that becomes available after boot. With the hard-coded limit, `add_region` for the 4th region panics with `MaxRegionCountExceeded`.

This PR makes the limit configurable through the existing esp-config mechanism, as a new `ESP_ALLOC_CONFIG_MAX_REGIONS` option (validated as a positive integer):

- The default stays 3, so existing users are completely unaffected — the types and behaviour are identical to today's unless the option is set.
- The four `3` literals (`EspHeapInner::heap`, `HeapStats::region_stats`, `EspHeap::stats`) are replaced by a `MAX_REGIONS` constant read via `esp_config_int!`.
- Each additional slot only costs one `Option<HeapRegion>` in the allocator plus one `Option<RegionStats>` in `HeapStats`.

#### Testing

- `cargo check --features esp32c5 --target riscv32imac-unknown-none-elf` with the default, and with `ESP_ALLOC_CONFIG_MAX_REGIONS=4`.
- `ESP_ALLOC_CONFIG_MAX_REGIONS=0` fails the build with the expected `positive_integer` validation error.
- A firmware carrying an equivalent patch (limit raised to 4 on top of the released 0.10.0) has been running in production on ESP32, with all 4 regions registered and exercised.

---

# Changelog

## esp-alloc

- Added: `ESP_ALLOC_CONFIG_MAX_REGIONS` esp-config option to configure the maximum number of heap regions (the default remains 3).
