### PR TITLE
BLE: copy less, refactor HCI

### DIFF
--- a/esp-radio/src/ble/btdm.rs
+++ b/esp-radio/src/ble/btdm.rs
@@ -7,6 +7,7 @@ use portable_atomic::{AtomicBool, Ordering};
 
 use super::{Config, ReceivedPacket};
 use crate::{
+    asynch::AtomicWaker,
     ble::{
         HCI_OUT_COLLECTOR,
         HciOutCollector,
@@ -23,6 +24,7 @@ use crate::{
 pub(crate) mod ble_os_adapter_chip_specific;
 
 static PACKET_IN_FLIGHT: AtomicBool = AtomicBool::new(false);
+static PACKET_SENT_WAKER: AtomicWaker = AtomicWaker::new();
 
 #[repr(C)]
 struct VhciHostCallbacks {
@@ -66,7 +68,8 @@ static VHCI_HOST_CALLBACK: VhciHostCallbacks = VhciHostCallbacks {
 extern "C" fn notify_host_send_available() {
     trace!("notify_host_send_available");
 
-    PACKET_IN_FLIGHT.store(false, Ordering::Relaxed);
+    PACKET_IN_FLIGHT.store(false, Ordering::Release);
+    PACKET_SENT_WAKER.wake();
 }
 
 extern "C" fn notify_host_recv(data: *mut u8, len: u16) -> i32 {
@@ -393,38 +396,56 @@ pub(crate) fn ble_deinit() {
     }
     // Disabling the PHY happens automatically, when the BLEController gets dropped.
 }
+
 /// Sends HCI data to the BLE controller.
 ///
 /// Returns the number of bytes taken from `data`. At most one packet is sent per call, so the
 /// caller must offer the remaining bytes again.
-#[instability::unstable]
-pub fn send_hci(data: &[u8]) -> usize {
+pub(crate) fn send_hci(data: &[u8]) -> usize {
     // make sure the packet buffer doesn't get touched until sent
-    while PACKET_IN_FLIGHT.load(Ordering::Relaxed) {}
+    while PACKET_IN_FLIGHT.load(Ordering::Acquire) {}
+    while unsafe { !API_vhci_host_check_send_available() } {
+        trace!("can_send is false");
+    }
 
-    super::collect_and_send(data, |packet| {
-        unsafe {
-            while !API_vhci_host_check_send_available() {
-                trace!("can_send is false");
-            }
+    super::collect_and_send(data, send_packet)
+}
 
-            PACKET_IN_FLIGHT.store(true, Ordering::Relaxed);
-
-            #[cfg(all(esp32, feature = "coex"))]
-            ble_os_adapter_chip_specific::async_wakeup_request(
-                ble_os_adapter_chip_specific::BTDM_ASYNC_WAKEUP_REQ_HCI,
-            );
-
-            API_vhci_host_send_packet(packet.as_ptr(), packet.len() as u16);
-
-            #[cfg(all(esp32, feature = "coex"))]
-            ble_os_adapter_chip_specific::async_wakeup_request_end(
-                ble_os_adapter_chip_specific::BTDM_ASYNC_WAKEUP_REQ_HCI,
-            );
+pub(crate) async fn send_hci_async(data: &[u8]) -> usize {
+    // make sure the packet buffer doesn't get touched until sent
+    core::future::poll_fn(|cx| {
+        PACKET_SENT_WAKER.register(cx.waker());
+        if PACKET_IN_FLIGHT.load(Ordering::Acquire)
+            || unsafe { !API_vhci_host_check_send_available() }
+        {
+            core::task::Poll::Pending
+        } else {
+            core::task::Poll::Ready(())
         }
-
-        trace!("sent vhci host packet");
-
-        super::dump_packet_info(packet);
     })
+    .await;
+
+    super::collect_and_send(data, send_packet)
+}
+
+fn send_packet(packet: &[u8]) {
+    unsafe {
+        PACKET_IN_FLIGHT.store(true, Ordering::Relaxed);
+
+        #[cfg(all(esp32, feature = "coex"))]
+        ble_os_adapter_chip_specific::async_wakeup_request(
+            ble_os_adapter_chip_specific::BTDM_ASYNC_WAKEUP_REQ_HCI,
+        );
+
+        API_vhci_host_send_packet(packet.as_ptr(), packet.len() as u16);
+
+        #[cfg(all(esp32, feature = "coex"))]
+        ble_os_adapter_chip_specific::async_wakeup_request_end(
+            ble_os_adapter_chip_specific::BTDM_ASYNC_WAKEUP_REQ_HCI,
+        );
+    }
+
+    trace!("sent vhci host packet");
+
+    super::dump_packet_info(packet);
 }

--- a/esp-radio/src/ble/btdm.rs
+++ b/esp-radio/src/ble/btdm.rs
@@ -22,7 +22,7 @@ use crate::{
 #[cfg_attr(esp32, path = "os_adapter_esp32.rs")]
 pub(crate) mod ble_os_adapter_chip_specific;
 
-static PACKET_SENT: AtomicBool = AtomicBool::new(true);
+static PACKET_IN_FLIGHT: AtomicBool = AtomicBool::new(false);
 
 #[repr(C)]
 struct VhciHostCallbacks {
@@ -66,7 +66,7 @@ static VHCI_HOST_CALLBACK: VhciHostCallbacks = VhciHostCallbacks {
 extern "C" fn notify_host_send_available() {
     trace!("notify_host_send_available");
 
-    PACKET_SENT.store(true, Ordering::Relaxed);
+    PACKET_IN_FLIGHT.store(false, Ordering::Relaxed);
 }
 
 extern "C" fn notify_host_recv(data: *mut u8, len: u16) -> i32 {
@@ -405,7 +405,7 @@ pub fn send_hci(data: &[u8]) -> usize {
                 trace!("can_send is false");
             }
 
-            PACKET_SENT.store(false, Ordering::Relaxed);
+            PACKET_IN_FLIGHT.store(true, Ordering::Relaxed);
 
             #[cfg(all(esp32, feature = "coex"))]
             ble_os_adapter_chip_specific::async_wakeup_request(
@@ -425,6 +425,6 @@ pub fn send_hci(data: &[u8]) -> usize {
         super::dump_packet_info(packet);
 
         // make sure the packet buffer doesn't get touched until sent
-        while !PACKET_SENT.load(Ordering::Relaxed) {}
+        while PACKET_IN_FLIGHT.load(Ordering::Relaxed) {}
     })
 }

--- a/esp-radio/src/ble/btdm.rs
+++ b/esp-radio/src/ble/btdm.rs
@@ -399,6 +399,9 @@ pub(crate) fn ble_deinit() {
 /// caller must offer the remaining bytes again.
 #[instability::unstable]
 pub fn send_hci(data: &[u8]) -> usize {
+    // make sure the packet buffer doesn't get touched until sent
+    while PACKET_IN_FLIGHT.load(Ordering::Relaxed) {}
+
     super::collect_and_send(data, |packet| {
         unsafe {
             while !API_vhci_host_check_send_available() {
@@ -423,8 +426,5 @@ pub fn send_hci(data: &[u8]) -> usize {
         trace!("sent vhci host packet");
 
         super::dump_packet_info(packet);
-
-        // make sure the packet buffer doesn't get touched until sent
-        while PACKET_IN_FLIGHT.load(Ordering::Relaxed) {}
     })
 }

--- a/esp-radio/src/ble/btdm.rs
+++ b/esp-radio/src/ble/btdm.rs
@@ -394,48 +394,37 @@ pub(crate) fn ble_deinit() {
     // Disabling the PHY happens automatically, when the BLEController gets dropped.
 }
 /// Sends HCI data to the BLE controller.
+///
+/// Returns the number of bytes taken from `data`. At most one packet is sent per call, so the
+/// caller must offer the remaining bytes again.
 #[instability::unstable]
-pub fn send_hci(data: &[u8]) {
-    let hci_out = unsafe { (*addr_of_mut!(HCI_OUT_COLLECTOR)).assume_init_mut() };
-    hci_out.push(data);
-
-    if hci_out.is_ready() {
-        let packet = hci_out.packet();
-
+pub fn send_hci(data: &[u8]) -> usize {
+    super::collect_and_send(data, |packet| {
         unsafe {
-            loop {
-                let can_send = API_vhci_host_check_send_available();
-
-                if !can_send {
-                    trace!("can_send is false");
-                    continue;
-                }
-
-                PACKET_SENT.store(false, Ordering::Relaxed);
-
-                #[cfg(all(esp32, feature = "coex"))]
-                ble_os_adapter_chip_specific::async_wakeup_request(
-                    ble_os_adapter_chip_specific::BTDM_ASYNC_WAKEUP_REQ_HCI,
-                );
-
-                API_vhci_host_send_packet(packet.as_ptr(), packet.len() as u16);
-
-                #[cfg(all(esp32, feature = "coex"))]
-                ble_os_adapter_chip_specific::async_wakeup_request_end(
-                    ble_os_adapter_chip_specific::BTDM_ASYNC_WAKEUP_REQ_HCI,
-                );
-
-                trace!("sent vhci host packet");
-
-                super::dump_packet_info(packet);
-
-                break;
+            while !API_vhci_host_check_send_available() {
+                trace!("can_send is false");
             }
 
-            // make sure the packet buffer doesn't get touched until sent
-            while !PACKET_SENT.load(Ordering::Relaxed) {}
+            PACKET_SENT.store(false, Ordering::Relaxed);
+
+            #[cfg(all(esp32, feature = "coex"))]
+            ble_os_adapter_chip_specific::async_wakeup_request(
+                ble_os_adapter_chip_specific::BTDM_ASYNC_WAKEUP_REQ_HCI,
+            );
+
+            API_vhci_host_send_packet(packet.as_ptr(), packet.len() as u16);
+
+            #[cfg(all(esp32, feature = "coex"))]
+            ble_os_adapter_chip_specific::async_wakeup_request_end(
+                ble_os_adapter_chip_specific::BTDM_ASYNC_WAKEUP_REQ_HCI,
+            );
         }
 
-        hci_out.reset();
-    }
+        trace!("sent vhci host packet");
+
+        super::dump_packet_info(packet);
+
+        // make sure the packet buffer doesn't get touched until sent
+        while !PACKET_SENT.load(Ordering::Relaxed) {}
+    })
 }

--- a/esp-radio/src/ble/controller/mod.rs
+++ b/esp-radio/src/ble/controller/mod.rs
@@ -24,6 +24,7 @@ use crate::{
         read_hci,
         read_next,
         send_hci,
+        send_hci_async,
         take_next,
     },
 };
@@ -118,6 +119,14 @@ impl<'d> BleConnector<'d> {
     pub fn write(&mut self, buf: &[u8]) -> Result<usize, BleConnectorError> {
         Ok(send_hci(buf))
     }
+
+    /// Write to HCI asynchronously.
+    ///
+    /// Returns the number of bytes written, which is at most one packet.
+    #[instability::unstable]
+    pub async fn write_async(&mut self, buf: &[u8]) -> Result<usize, BleConnectorError> {
+        Ok(send_hci_async(buf).await)
+    }
 }
 
 #[derive(Display, Debug, Copy, Clone, Eq, PartialEq, Hash)]
@@ -199,7 +208,7 @@ impl embedded_io_async_06::Read for BleConnector<'_> {
 
 impl embedded_io_async_06::Write for BleConnector<'_> {
     async fn write(&mut self, buf: &[u8]) -> Result<usize, BleConnectorError> {
-        Ok(send_hci(buf))
+        self.write_async(buf).await
     }
 
     async fn flush(&mut self) -> Result<(), BleConnectorError> {
@@ -216,7 +225,7 @@ impl embedded_io_async_07::Read for BleConnector<'_> {
 
 impl embedded_io_async_07::Write for BleConnector<'_> {
     async fn write(&mut self, buf: &[u8]) -> Result<usize, BleConnectorError> {
-        Ok(send_hci(buf))
+        self.write_async(buf).await
     }
 
     async fn flush(&mut self) -> Result<(), BleConnectorError> {
@@ -283,7 +292,7 @@ impl embedded_io_07::ErrorType for HciWriter {
 
 impl embedded_io_async_07::Write for HciWriter {
     async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
-        Ok(send_hci(buf))
+        Ok(send_hci_async(buf).await)
     }
 
     async fn flush(&mut self) -> Result<(), Self::Error> {

--- a/esp-radio/src/ble/controller/mod.rs
+++ b/esp-radio/src/ble/controller/mod.rs
@@ -112,10 +112,11 @@ impl<'d> BleConnector<'d> {
     }
 
     /// Write to HCI.
+    ///
+    /// Returns the number of bytes written, which is at most one packet.
     #[instability::unstable]
     pub fn write(&mut self, buf: &[u8]) -> Result<usize, BleConnectorError> {
-        send_hci(buf);
-        Ok(buf.len())
+        Ok(send_hci(buf))
     }
 }
 
@@ -198,8 +199,7 @@ impl embedded_io_async_06::Read for BleConnector<'_> {
 
 impl embedded_io_async_06::Write for BleConnector<'_> {
     async fn write(&mut self, buf: &[u8]) -> Result<usize, BleConnectorError> {
-        send_hci(buf);
-        Ok(buf.len())
+        Ok(send_hci(buf))
     }
 
     async fn flush(&mut self) -> Result<(), BleConnectorError> {
@@ -216,8 +216,7 @@ impl embedded_io_async_07::Read for BleConnector<'_> {
 
 impl embedded_io_async_07::Write for BleConnector<'_> {
     async fn write(&mut self, buf: &[u8]) -> Result<usize, BleConnectorError> {
-        send_hci(buf);
-        Ok(buf.len())
+        Ok(send_hci(buf))
     }
 
     async fn flush(&mut self) -> Result<(), BleConnectorError> {
@@ -284,8 +283,7 @@ impl embedded_io_07::ErrorType for HciWriter {
 
 impl embedded_io_async_07::Write for HciWriter {
     async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
-        send_hci(buf);
-        Ok(buf.len())
+        Ok(send_hci(buf))
     }
 
     async fn flush(&mut self) -> Result<(), Self::Error> {

--- a/esp-radio/src/ble/controller/mod.rs
+++ b/esp-radio/src/ble/controller/mod.rs
@@ -1,4 +1,5 @@
 //! BLE controller
+use alloc::boxed::Box;
 use core::{future::Future, task::Poll};
 
 use bt_hci::{
@@ -15,7 +16,16 @@ use esp_phy::PhyInitGuard;
 use crate::{
     RadioRefGuard,
     asynch::AtomicWaker,
-    ble::{Config, InvalidConfigError, have_hci_read_data, read_hci, read_next, send_hci},
+    ble::{
+        Config,
+        InvalidConfigError,
+        have_hci_packet,
+        have_hci_read_data,
+        read_hci,
+        read_next,
+        send_hci,
+        take_next,
+    },
 };
 
 #[derive(Display, Debug, Copy, Clone, Eq, PartialEq, Hash)]
@@ -96,9 +106,7 @@ impl<'d> BleConnector<'d> {
             return Ok(0);
         }
 
-        if !have_hci_read_data() {
-            HciReadyEventFuture.await;
-        }
+        HciAnyDataReadyEventFuture.await;
 
         self.read(buf)
     }
@@ -106,9 +114,7 @@ impl<'d> BleConnector<'d> {
     /// Write to HCI.
     #[instability::unstable]
     pub fn write(&mut self, buf: &[u8]) -> Result<usize, BleConnectorError> {
-        for b in buf {
-            send_hci(&[*b]);
-        }
+        send_hci(buf);
         Ok(buf.len())
     }
 }
@@ -226,10 +232,10 @@ impl From<FromHciBytesError> for BleConnectorError {
     }
 }
 
-#[must_use = "futures do nothing unless you `.await` or poll them"]
-pub(crate) struct HciReadyEventFuture;
+/// Completes once any HCI data is available, including a part-read packet.
+pub(crate) struct HciAnyDataReadyEventFuture;
 
-impl core::future::Future for HciReadyEventFuture {
+impl core::future::Future for HciAnyDataReadyEventFuture {
     type Output = ();
 
     fn poll(
@@ -246,8 +252,25 @@ impl core::future::Future for HciReadyEventFuture {
     }
 }
 
-/// The largest HCI packet, including the packet type indicator byte.
-const MAX_HCI_PACKET_LEN: usize = 259;
+/// Completes once the receive queue holds a complete packet.
+pub(crate) struct HciPacketReadyEventFuture;
+
+impl core::future::Future for HciPacketReadyEventFuture {
+    type Output = ();
+
+    fn poll(
+        self: core::pin::Pin<&mut Self>,
+        cx: &mut core::task::Context<'_>,
+    ) -> Poll<Self::Output> {
+        HCI_WAKER.register(cx.waker());
+
+        if have_hci_packet() {
+            Poll::Ready(())
+        } else {
+            Poll::Pending
+        }
+    }
+}
 
 /// The HCI output of the BLE controller.
 ///
@@ -287,15 +310,15 @@ fn parse_hci(data: &[u8]) -> Result<ControllerToHostPacket<'_>, BleConnectorErro
     }
 }
 
-/// Waits for a packet from the controller, then reads it into `rx`.
-///
-/// Returns the length of the packet.
-async fn next_packet(rx: &mut [u8]) -> usize {
-    if !have_hci_read_data() {
-        HciReadyEventFuture.await;
-    }
+/// Waits for a packet from the controller, then removes it from the receive queue.
+async fn next_packet() -> Box<[u8]> {
+    loop {
+        HciPacketReadyEventFuture.await;
 
-    read_next(rx)
+        if let Some(packet) = take_next() {
+            return packet;
+        }
+    }
 }
 
 impl bt_hci::transport::Transport for BleConnector<'_> {
@@ -305,7 +328,9 @@ impl bt_hci::transport::Transport for BleConnector<'_> {
         // Safety: we only return a reference to x once, if parsing is successful.
         let rx = unsafe { &mut *core::ptr::slice_from_raw_parts_mut(rx.as_mut_ptr(), rx.len()) };
 
-        let len = next_packet(rx).await;
+        // `ControllerToHostPacket` borrows `rx`, so the packet has to be copied there.
+        HciPacketReadyEventFuture.await;
+        let len = read_next(rx);
         parse_hci(&rx[..len])
     }
 
@@ -320,12 +345,11 @@ impl bt_hci::transport::Transport for BleConnector<'_> {
 impl bt_hci_transport::Transport for BleConnector<'_> {
     /// Read a complete HCI packet into the rx buffer
     async fn read<'a, P: PacketToHost<'a>>(&self, rx: &'a mut [u8]) -> Result<P, Self::Error> {
-        // `P::read_hci` deserializes from a reader into `rx`, so the packet must be read into a
-        // buffer other than `rx`.
-        let mut packet = [0; MAX_HCI_PACKET_LEN];
-        let len = next_packet(&mut packet).await;
+        // `P::read_hci` deserializes from a reader into `rx`, so the packet must be read from a
+        // buffer other than `rx`. The queued packet itself is that buffer.
+        let packet = next_packet().await;
 
-        let mut reader = &packet[..len];
+        let mut reader = &packet[..];
         let kind = PacketKind::read(&mut reader)?;
         Ok(P::read_hci(kind, &mut reader, rx)?)
     }

--- a/esp-radio/src/ble/mod.rs
+++ b/esp-radio/src/ble/mod.rs
@@ -6,7 +6,7 @@ pub(crate) mod btdm;
 #[cfg(bt_controller = "npl")]
 pub(crate) mod npl;
 
-use alloc::{boxed::Box, collections::vec_deque::VecDeque, vec::Vec};
+use alloc::{boxed::Box, collections::vec_deque::VecDeque};
 use core::mem::MaybeUninit;
 
 pub(crate) use ble::{ble_deinit, ble_init, send_hci};
@@ -48,12 +48,14 @@ pub(crate) unsafe extern "C" fn free(ptr: *mut crate::sys::c_types::c_void) {
 
 struct BleState {
     pub rx_queue: VecDeque<ReceivedPacket>,
-    pub hci_read_data: Vec<u8>,
+    /// The packet that the byte-stream reader is part-way through, and the number of bytes the
+    /// host already took from it.
+    pub partial_read: Option<(Box<[u8]>, usize)>,
 }
 
 static BT_STATE: NonReentrantMutex<BleState> = NonReentrantMutex::new(BleState {
     rx_queue: VecDeque::new(),
-    hci_read_data: Vec::new(),
+    partial_read: None,
 });
 
 static mut HCI_OUT_COLLECTOR: MaybeUninit<HciOutCollector> = MaybeUninit::uninit();
@@ -142,20 +144,30 @@ impl defmt::Format for ReceivedPacket {
 pub(crate) fn clear_bt_state() {
     BT_STATE.with(|state| {
         state.rx_queue.clear();
-        state.hci_read_data.clear();
+        state.partial_read = None;
     });
 }
 
 /// Checks if there is any HCI data available to read.
 #[instability::unstable]
 pub fn have_hci_read_data() -> bool {
-    BT_STATE.with(|state| !state.rx_queue.is_empty() || !state.hci_read_data.is_empty())
+    BT_STATE.with(|state| !state.rx_queue.is_empty() || state.partial_read.is_some())
+}
+
+/// Checks if the receive queue holds a complete packet.
+pub(crate) fn have_hci_packet() -> bool {
+    BT_STATE.with(|state| !state.rx_queue.is_empty())
+}
+
+/// Removes the next packet from the receive queue, without copying it.
+pub(crate) fn take_next() -> Option<Box<[u8]>> {
+    BT_STATE.with(|state| state.rx_queue.pop_front().map(|packet| packet.data))
 }
 
 pub(crate) fn read_next(data: &mut [u8]) -> usize {
-    if let Some(packet) = BT_STATE.with(|state| state.rx_queue.pop_front()) {
-        data[..packet.data.len()].copy_from_slice(&packet.data[..packet.data.len()]);
-        packet.data.len()
+    if let Some(packet) = take_next() {
+        data[..packet.len()].copy_from_slice(&packet);
+        packet.len()
     } else {
         0
     }
@@ -165,15 +177,26 @@ pub(crate) fn read_next(data: &mut [u8]) -> usize {
 #[instability::unstable]
 pub fn read_hci(data: &mut [u8]) -> usize {
     BT_STATE.with(|state| {
-        if state.hci_read_data.is_empty()
+        if state.partial_read.is_none()
             && let Some(packet) = state.rx_queue.pop_front()
         {
-            state.hci_read_data.extend_from_slice(&packet.data);
+            state.partial_read = Some((packet.data, 0));
         }
 
-        let l = usize::min(state.hci_read_data.len(), data.len());
-        data[..l].copy_from_slice(&state.hci_read_data[..l]);
-        state.hci_read_data.drain(..l);
+        let Some((packet, read)) = state.partial_read.as_mut() else {
+            return 0;
+        };
+
+        let remaining = &packet[*read..];
+        let l = usize::min(remaining.len(), data.len());
+        data[..l].copy_from_slice(&remaining[..l]);
+        *read += l;
+
+        let drained = *read == packet.len();
+        if drained {
+            state.partial_read = None;
+        }
+
         l
     })
 }

--- a/esp-radio/src/ble/mod.rs
+++ b/esp-radio/src/ble/mod.rs
@@ -67,8 +67,16 @@ enum HciOutType {
     Command,
 }
 
+/// The largest HCI packet, including the packet type indicator byte.
+const MAX_HCI_PACKET_LEN: usize = 259;
+
+/// Reassembles whole HCI packets out of the byte stream that the host writes.
+///
+/// The byte-stream write APIs put no constraint on where the caller splits a packet, and one
+/// write can hold several packets. The collector takes only the bytes that the packet in progress
+/// still needs, so that it never runs past a packet boundary.
 struct HciOutCollector {
-    data: [u8; 256],
+    data: [u8; MAX_HCI_PACKET_LEN],
     index: usize,
     ready: bool,
     kind: HciOutType,
@@ -77,7 +85,7 @@ struct HciOutCollector {
 impl HciOutCollector {
     fn new() -> HciOutCollector {
         HciOutCollector {
-            data: [0u8; 256],
+            data: [0u8; MAX_HCI_PACKET_LEN],
             index: 0,
             ready: false,
             kind: HciOutType::Unknown,
@@ -88,30 +96,83 @@ impl HciOutCollector {
         self.ready
     }
 
-    fn push(&mut self, data: &[u8]) {
-        self.data[self.index..(self.index + data.len())].copy_from_slice(data);
-        self.index += data.len();
+    /// The length of the header, including the packet type indicator byte.
+    ///
+    /// The kind is unknown until the indicator byte arrives, so ask for that byte on its own
+    /// first.
+    fn header_len(&self) -> usize {
+        match self.kind {
+            HciOutType::Unknown => 1,
+            HciOutType::Command => 4,
+            HciOutType::Acl => 5,
+        }
+    }
 
-        if self.kind == HciOutType::Unknown {
-            self.kind = match self.data[0] {
+    /// The length of the packet in progress, or `None` while its header is incomplete.
+    fn packet_len(&self) -> Option<usize> {
+        if self.index < self.header_len() {
+            return None;
+        }
+
+        match self.kind {
+            HciOutType::Unknown => None,
+            HciOutType::Command => Some(self.data[3] as usize + 4),
+            HciOutType::Acl => Some(u16::from_le_bytes([self.data[3], self.data[4]]) as usize + 5),
+        }
+    }
+
+    /// Copies bytes from `data` until the packet buffer holds `upto` bytes.
+    ///
+    /// Returns the number of bytes copied.
+    fn fill_to(&mut self, data: &[u8], upto: usize) -> usize {
+        let take = usize::min(data.len(), upto - self.index);
+        self.data[self.index..][..take].copy_from_slice(&data[..take]);
+        self.index += take;
+        take
+    }
+
+    /// Copies as much of `data` as the packet in progress needs, and returns how much it took.
+    ///
+    /// Bytes that belong to the next packet stay in `data`. The caller must send and reset the
+    /// collector once [`Self::is_ready`] holds, before it offers those bytes again.
+    fn push(&mut self, data: &[u8]) -> usize {
+        if data.is_empty() {
+            return 0;
+        }
+
+        if self.index == 0 {
+            self.kind = match data[0] {
                 1 => HciOutType::Command,
                 2 => HciOutType::Acl,
-                _ => HciOutType::Unknown,
+                indicator => {
+                    warn!(
+                        "Dropping HCI byte with unknown packet type indicator {}",
+                        indicator
+                    );
+                    return 1;
+                }
             };
         }
 
-        if !self.ready {
-            if self.kind == HciOutType::Command && self.index >= 4 {
-                if self.index == self.data[3] as usize + 4 {
-                    self.ready = true;
-                }
-            } else if self.kind == HciOutType::Acl
-                && self.index >= 5
-                && self.index == (self.data[3] as usize) + ((self.data[4] as usize) << 8) + 5
-            {
-                self.ready = true;
-            }
+        // The packet length lives in the header, so complete the header before asking for the
+        // rest of the packet.
+        let mut taken = 0;
+        if self.packet_len().is_none() {
+            taken += self.fill_to(data, self.header_len());
         }
+
+        if let Some(total) = self.packet_len() {
+            if total > self.data.len() {
+                warn!("Dropping HCI packet of {} bytes, which is too long", total);
+                self.reset();
+                return taken;
+            }
+
+            taken += self.fill_to(&data[taken..], total);
+            self.ready = self.index == total;
+        }
+
+        taken
     }
 
     fn reset(&mut self) {
@@ -123,6 +184,24 @@ impl HciOutCollector {
     fn packet(&self) -> &[u8] {
         &self.data[0..self.index]
     }
+}
+
+/// Collects bytes of the host's stream, and passes the packet to `send` once it is complete.
+///
+/// This behaves like a byte-stream write: it handles at most one packet, and returns the number
+/// of bytes it took from `data`. Bytes that belong to the next packet stay in `data`, so the
+/// caller offers the rest in a later call. A non-empty `data` always yields a non-zero count.
+pub(crate) fn collect_and_send(data: &[u8], send: impl FnOnce(&[u8])) -> usize {
+    let hci_out = unsafe { (*core::ptr::addr_of_mut!(HCI_OUT_COLLECTOR)).assume_init_mut() };
+
+    let taken = hci_out.push(data);
+
+    if hci_out.is_ready() {
+        send(hci_out.packet());
+        hci_out.reset();
+    }
+
+    taken
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/esp-radio/src/ble/mod.rs
+++ b/esp-radio/src/ble/mod.rs
@@ -9,7 +9,7 @@ pub(crate) mod npl;
 use alloc::{boxed::Box, collections::vec_deque::VecDeque};
 use core::mem::MaybeUninit;
 
-pub(crate) use ble::{ble_deinit, ble_init, send_hci};
+pub(crate) use ble::{ble_deinit, ble_init, send_hci, send_hci_async};
 use docsplay::Display;
 use esp_sync::NonReentrantMutex;
 

--- a/esp-radio/src/ble/npl.rs
+++ b/esp-radio/src/ble/npl.rs
@@ -1,4 +1,4 @@
-use alloc::boxed::Box;
+use alloc::vec::Vec;
 use core::{
     mem::transmute,
     ptr::{NonNull, addr_of, addr_of_mut},
@@ -1458,19 +1458,18 @@ unsafe extern "C" fn ble_hs_hci_rx_evt(cmd: *const u8, arg: *const c_void) -> i3
     let payload = unsafe { core::slice::from_raw_parts(cmd.offset(2), len) };
     trace!("$ pld = {:?}", payload);
 
+    let mut data = Vec::with_capacity(len + 3);
+    data.push(0x04); // this is an event
+    data.push(event);
+    data.push(len as u8);
+    data.extend_from_slice(payload);
+
+    dump_packet_info(&data);
+
     super::BT_STATE.with(|state| {
-        let mut data = [0u8; 256];
-
-        data[0] = 0x04; // this is an event
-        data[1] = event;
-        data[2] = len as u8;
-        data[3..][..len].copy_from_slice(payload);
-
         state.rx_queue.push_back(ReceivedPacket {
-            data: Box::from(&data[..len + 3]),
+            data: data.into_boxed_slice(),
         });
-
-        dump_packet_info(&data[..(len + 3)]);
     });
 
     unsafe {
@@ -1489,17 +1488,16 @@ unsafe extern "C" fn ble_hs_rx_data(om: *const OsMbuf, arg: *const c_void) -> i3
     let len = unsafe { (*om).om_len };
     let data_slice = unsafe { core::slice::from_raw_parts(data_ptr, len as usize) };
 
+    let mut data = Vec::with_capacity(data_slice.len() + 1);
+    data.push(0x02); // ACL
+    data.extend_from_slice(data_slice);
+
+    super::dump_packet_info(&data);
+
     super::BT_STATE.with(|state| {
-        let mut data = [0u8; 256];
-
-        data[0] = 0x02; // ACL
-        data[1..][..data_slice.len()].copy_from_slice(data_slice);
-
         state.rx_queue.push_back(ReceivedPacket {
-            data: Box::from(&data[..data_slice.len() + 1]),
+            data: data.into_boxed_slice(),
         });
-
-        super::dump_packet_info(&data[..(len + 1) as usize]);
     });
 
     unsafe {

--- a/esp-radio/src/ble/npl.rs
+++ b/esp-radio/src/ble/npl.rs
@@ -1513,48 +1513,57 @@ unsafe extern "C" fn ble_hs_rx_data(om: *const OsMbuf, arg: *const c_void) -> i3
 ///
 /// Returns the number of bytes taken from `data`. At most one packet is sent per call, so the
 /// caller must offer the remaining bytes again.
-#[instability::unstable]
-pub fn send_hci(data: &[u8]) -> usize {
-    super::collect_and_send(data, |packet| {
-        const DATA_TYPE_COMMAND: u8 = 1;
-        const DATA_TYPE_ACL: u8 = 2;
+pub(crate) fn send_hci(data: &[u8]) -> usize {
+    super::collect_and_send(data, send_packet)
+}
 
-        dump_packet_info(packet);
+/// Sends HCI data to the Bluetooth controller.
+///
+/// Returns the number of bytes taken from `data`. At most one packet is sent per call, so the
+/// caller must offer the remaining bytes again.
+pub(crate) async fn send_hci_async(data: &[u8]) -> usize {
+    super::collect_and_send(data, send_packet)
+}
 
-        super::BT_STATE.with(|_state| unsafe {
-            if packet[0] == DATA_TYPE_COMMAND {
-                let cmd = r_ble_hci_trans_buf_alloc(BLE_HCI_TRANS_BUF_CMD);
-                core::ptr::copy_nonoverlapping(
-                    &packet[1] as *const _ as *mut u8, // don't send the TYPE
-                    cmd as *mut u8,
-                    packet.len() - 1,
-                );
+fn send_packet(packet: &[u8]) {
+    const DATA_TYPE_COMMAND: u8 = 1;
+    const DATA_TYPE_ACL: u8 = 2;
 
-                let res = r_ble_hci_trans_hs_cmd_tx(cmd);
+    dump_packet_info(packet);
 
-                if res != 0 {
-                    warn!("ble_hci_trans_hs_cmd_tx res == {}", res);
-                }
-            } else if packet[0] == DATA_TYPE_ACL {
-                let om =
-                    r_os_msys_get_pkthdr(packet.len() as u16, ACL_DATA_MBUF_LEADINGSPACE as u16);
+    super::BT_STATE.with(|_state| unsafe {
+        if packet[0] == DATA_TYPE_COMMAND {
+            let cmd = r_ble_hci_trans_buf_alloc(BLE_HCI_TRANS_BUF_CMD);
+            core::ptr::copy_nonoverlapping(
+                &raw const packet[1], // don't send the TYPE
+                cmd as *mut u8,
+                packet.len() - 1,
+            );
 
-                let res =
-                    r_os_mbuf_append(om, packet.as_ptr().offset(1), (packet.len() - 1) as u16);
-                if res != 0 {
-                    panic!("r_os_mbuf_append returned {}", res);
-                }
+            let res = r_ble_hci_trans_hs_cmd_tx(cmd);
 
-                // this modification of the ACL data packet makes it getting sent and
-                // received by the other side
-                *((*om).om_data as *mut u8).offset(1) = 0;
-
-                let res = r_ble_hci_trans_hs_acl_tx(om);
-                if res != 0 {
-                    panic!("ble_hci_trans_hs_acl_tx returned {}", res);
-                }
-                trace!("ACL tx done");
+            if res != 0 {
+                warn!("ble_hci_trans_hs_cmd_tx res == {}", res);
             }
-        });
-    })
+        } else if packet[0] == DATA_TYPE_ACL {
+            let om = r_os_msys_get_pkthdr(packet.len() as u16, ACL_DATA_MBUF_LEADINGSPACE as u16);
+
+            let res = r_os_mbuf_append(om, packet.as_ptr().offset(1), (packet.len() - 1) as u16);
+            if res != 0 {
+                panic!("r_os_mbuf_append returned {}", res);
+            }
+
+            // this modification of the ACL data packet makes it getting sent and
+            // received by the other side
+            *((*om).om_data as *mut u8).offset(1) = 0;
+
+            let res = r_ble_hci_trans_hs_acl_tx(om);
+            if res != 0 {
+                panic!("ble_hci_trans_hs_acl_tx returned {}", res);
+            }
+            trace!("ACL tx done");
+        } else {
+            warn!("Unknown packet kind {} dropped", packet[0]);
+        }
+    });
 }

--- a/esp-radio/src/ble/npl.rs
+++ b/esp-radio/src/ble/npl.rs
@@ -1510,59 +1510,51 @@ unsafe extern "C" fn ble_hs_rx_data(om: *const OsMbuf, arg: *const c_void) -> i3
 }
 
 /// Sends HCI data to the Bluetooth controller.
+///
+/// Returns the number of bytes taken from `data`. At most one packet is sent per call, so the
+/// caller must offer the remaining bytes again.
 #[instability::unstable]
-pub fn send_hci(data: &[u8]) {
-    let hci_out = unsafe { (*addr_of_mut!(HCI_OUT_COLLECTOR)).assume_init_mut() };
-    hci_out.push(data);
+pub fn send_hci(data: &[u8]) -> usize {
+    super::collect_and_send(data, |packet| {
+        const DATA_TYPE_COMMAND: u8 = 1;
+        const DATA_TYPE_ACL: u8 = 2;
 
-    if hci_out.is_ready() {
-        let packet = hci_out.packet();
+        dump_packet_info(packet);
 
-        unsafe {
-            const DATA_TYPE_COMMAND: u8 = 1;
-            const DATA_TYPE_ACL: u8 = 2;
+        super::BT_STATE.with(|_state| unsafe {
+            if packet[0] == DATA_TYPE_COMMAND {
+                let cmd = r_ble_hci_trans_buf_alloc(BLE_HCI_TRANS_BUF_CMD);
+                core::ptr::copy_nonoverlapping(
+                    &packet[1] as *const _ as *mut u8, // don't send the TYPE
+                    cmd as *mut u8,
+                    packet.len() - 1,
+                );
 
-            dump_packet_info(packet);
+                let res = r_ble_hci_trans_hs_cmd_tx(cmd);
 
-            super::BT_STATE.with(|_state| {
-                if packet[0] == DATA_TYPE_COMMAND {
-                    let cmd = r_ble_hci_trans_buf_alloc(BLE_HCI_TRANS_BUF_CMD);
-                    core::ptr::copy_nonoverlapping(
-                        &packet[1] as *const _ as *mut u8, // don't send the TYPE
-                        cmd as *mut u8,
-                        packet.len() - 1,
-                    );
-
-                    let res = r_ble_hci_trans_hs_cmd_tx(cmd);
-
-                    if res != 0 {
-                        warn!("ble_hci_trans_hs_cmd_tx res == {}", res);
-                    }
-                } else if packet[0] == DATA_TYPE_ACL {
-                    let om = r_os_msys_get_pkthdr(
-                        packet.len() as u16,
-                        ACL_DATA_MBUF_LEADINGSPACE as u16,
-                    );
-
-                    let res =
-                        r_os_mbuf_append(om, packet.as_ptr().offset(1), (packet.len() - 1) as u16);
-                    if res != 0 {
-                        panic!("r_os_mbuf_append returned {}", res);
-                    }
-
-                    // this modification of the ACL data packet makes it getting sent and
-                    // received by the other side
-                    *((*om).om_data as *mut u8).offset(1) = 0;
-
-                    let res = r_ble_hci_trans_hs_acl_tx(om);
-                    if res != 0 {
-                        panic!("ble_hci_trans_hs_acl_tx returned {}", res);
-                    }
-                    trace!("ACL tx done");
+                if res != 0 {
+                    warn!("ble_hci_trans_hs_cmd_tx res == {}", res);
                 }
-            });
-        }
+            } else if packet[0] == DATA_TYPE_ACL {
+                let om =
+                    r_os_msys_get_pkthdr(packet.len() as u16, ACL_DATA_MBUF_LEADINGSPACE as u16);
 
-        hci_out.reset();
-    }
+                let res =
+                    r_os_mbuf_append(om, packet.as_ptr().offset(1), (packet.len() - 1) as u16);
+                if res != 0 {
+                    panic!("r_os_mbuf_append returned {}", res);
+                }
+
+                // this modification of the ACL data packet makes it getting sent and
+                // received by the other side
+                *((*om).om_data as *mut u8).offset(1) = 0;
+
+                let res = r_ble_hci_trans_hs_acl_tx(om);
+                if res != 0 {
+                    panic!("ble_hci_trans_hs_acl_tx returned {}", res);
+                }
+                trace!("ACL tx done");
+            }
+        });
+    })
 }


### PR DESCRIPTION
# Changelog

## esp-radio/BLE

- Changed: the BLE HCI implementation is now less wasteful about copying data.
- Fixed: BTDM devices no longer block when sending BLE packets through HCI