### PR TITLE
Safe threading API with optional `alloc`

### DIFF
--- a/esp-rtos/Cargo.toml
+++ b/esp-rtos/Cargo.toml
@@ -12,9 +12,10 @@ license       = "MIT OR Apache-2.0"
 
 [package.metadata.espressif]
 chip-features-matter = true
-doc-config = { features = ["esp-hal/unstable", "embassy", "esp-radio"] }
+doc-config = { features = ["esp-hal/unstable", "embassy", "esp-radio", "defmt"] }
 check-configs = [
     { features = ["esp-hal/unstable"] },
+    { features = ["esp-hal/unstable", "alloc"] },
     { features = ["esp-hal/unstable", "esp-alloc"] },
     { features = ["esp-hal/unstable", "esp-radio"] },
     { features = ["esp-hal/unstable", "esp-radio", "embassy"] },
@@ -87,18 +88,18 @@ embassy = ["dep:embassy-time-driver", "dep:embassy-executor", "dep:embassy-time-
 ## Enable esp-radio support.
 esp-radio = ["alloc", "dep:esp-radio-rtos-driver"]
 
-# Not documented because we don't currently expose anything that requires alloc, but isn't related to esp-radio.
-# TODO: make this public once we actually have alloc-based APIs.
-alloc = ["dep:allocator-api2", "dep:esp-radio-rtos-driver", "defmt?/alloc"]
-
-## Enable the use of the `esp-alloc` crate for dynamic memory allocation.
+## Enable APIs that dynamically allocate memory, such as spawning a thread on a heap-allocated stack.
 ##
-## Memory allocation is required by `esp-radio`. If you choose to not enable
-## this feature, you need to provide implementations for the following functions:
+## Memory allocation is required by `esp-radio`.
+##
+## Without `esp-alloc` you must provide the following functions:
 ## - `pub extern "C" fn malloc_internal(size: usize) -> *mut u8`
 ## - `pub extern "C" fn free_internal(ptr: *mut u8)`
-## 
+##
 ## Note that the untyped nature of the allocator functions means that esp-alloc is likely the more memory efficient option.
+alloc = ["dep:allocator-api2", "defmt?/alloc"]
+
+## Enable the use of the `esp-alloc` crate for dynamic memory allocation. Also enables `alloc`.
 esp-alloc = ["alloc", "dep:esp-alloc"]
 
 ## Enable [`rtos-trace`](https://crates.io/crates/rtos-trace) support.

--- a/esp-rtos/src/esp_radio/mod.rs
+++ b/esp-rtos/src/esp_radio/mod.rs
@@ -20,9 +20,11 @@ use esp_radio_rtos_driver::{
 };
 
 use crate::{
+    SCHEDULER,
     run_queue::{MaxPriority, Priority},
     scheduler::Scheduler,
     task::{self, Task, TaskExt as _},
+    thread::ThreadSpawner,
     wait_queue::WaitQueue,
 };
 
@@ -68,23 +70,32 @@ impl esp_radio_rtos_driver::SchedulerImplementation for Scheduler {
         pin_to_core: Option<u32>,
         task_stack_size: usize,
     ) -> ThreadPtr {
-        self.create_task(
-            name,
-            task,
-            param,
-            task_stack_size,
-            priority.min(self.max_task_priority()),
-            pin_to_core.and_then(|core| match core {
-                0 => Some(Cpu::ProCpu),
-                #[cfg(multi_core)]
-                1 => Some(Cpu::AppCpu),
-                _ => {
-                    warn!("Invalid core number: {}", core);
-                    None
-                }
-            }),
-        )
-        .cast()
+        debug!(
+            "task_create {} {:?}({:?}) stack_size = {} priority = {}",
+            name, task, param, task_stack_size, priority
+        );
+
+        // Debug builds use a lot more stack than release builds do.
+        #[cfg(debug_build)]
+        let task_stack_size = task_stack_size + 6 * 1024;
+
+        let mut spawner = ThreadSpawner::new(task_stack_size)
+            .with_priority(priority.min(self.max_task_priority()) as usize);
+
+        let pin_to_core = pin_to_core.and_then(|core| match core {
+            0 => Some(Cpu::ProCpu),
+            #[cfg(multi_core)]
+            1 => Some(Cpu::AppCpu),
+            _ => {
+                warn!("Invalid core number: {}", core);
+                None
+            }
+        });
+        if let Some(cpu) = pin_to_core {
+            spawner = spawner.with_pinned_to(cpu);
+        }
+
+        spawner.spawn_extern(task, param).cast()
     }
 
     fn current_task(&self) -> ThreadPtr {
@@ -147,20 +158,22 @@ impl WaitQueueImplementation for WaitQueue {
     }
 
     unsafe fn wait_until(queue: WaitQueuePtr, deadline_instant: Option<u64>) {
-        let wait_queue = unsafe { Self::from_ptr(queue) };
+        let deadline = Instant::EPOCH
+            + deadline_instant
+                .map(Duration::from_micros)
+                .unwrap_or(Duration::MAX);
 
-        wait_queue.wait_with_deadline(
-            Instant::EPOCH
-                + deadline_instant
-                    .map(Duration::from_micros)
-                    .unwrap_or(Duration::MAX),
-        )
+        SCHEDULER.with(|scheduler| {
+            let wait_queue = unsafe { Self::from_ptr(queue) };
+            wait_queue.wait_with_deadline(scheduler, deadline)
+        })
     }
 
     unsafe fn notify(queue: WaitQueuePtr) {
-        let wait_queue = unsafe { Self::from_ptr(queue) };
-
-        wait_queue.notify()
+        SCHEDULER.with(|scheduler| {
+            let wait_queue = unsafe { Self::from_ptr(queue) };
+            wait_queue.notify(scheduler)
+        })
     }
 
     unsafe fn notify_from_isr(queue: WaitQueuePtr, _higher_prio_task_waken: Option<&mut bool>) {

--- a/esp-rtos/src/lib.rs
+++ b/esp-rtos/src/lib.rs
@@ -51,6 +51,11 @@ esp_rtos::start_second_core(
 #![doc = esp_hal::after_snippet!()]
 //! ```
 //! 
+//! ## Threads
+//!
+//! Use the [`thread`] module to run code on a separate stack. See its documentation for the
+//! details.
+//!
 //! To write `async` code, enable the `embassy` feature, and make the main function `async`.
 //! This will create a thread-mode executor on the main thread. Note that, to create async tasks, you will need
 //! the `task` macro from the `embassy-executor` crate. Do NOT enable any of the `arch-*` features on `embassy-executor`.
@@ -157,9 +162,8 @@ mod scheduler;
 pub mod sleep;
 mod syscall;
 mod task;
+pub mod thread;
 mod timer;
-// TODO: these esp-radio gates will need to be cleaned up once we re-introduce IPC objects.
-#[cfg(feature = "esp-radio")]
 mod wait_queue;
 
 #[cfg(feature = "embassy")]

--- a/esp-rtos/src/run_queue.rs
+++ b/esp-rtos/src/run_queue.rs
@@ -167,7 +167,6 @@ impl RunQueue {
         let priority_n = priority.get();
 
         ready_task.set_state(TaskState::Ready);
-        #[cfg(feature = "esp-radio")]
         {
             let mut ready_task = ready_task;
             if let Some(mut containing_queue) =

--- a/esp-rtos/src/scheduler.rs
+++ b/esp-rtos/src/scheduler.rs
@@ -5,21 +5,17 @@ use core::{
     ptr::NonNull,
 };
 
-#[cfg(feature = "alloc")]
-use allocator_api2::boxed::Box;
 use embassy_sync::blocking_mutex::Mutex;
 use esp_hal::{system::Cpu, time::Instant};
 use esp_sync::RawMutex;
 use macros::ram;
 
-#[cfg(feature = "alloc")]
-use crate::InternalMemory;
 #[cfg(feature = "rtos-trace")]
 use crate::TraceEvents;
 #[cfg(feature = "embassy")]
 use crate::timer::embassy::TimerQueue;
 use crate::{
-    run_queue::{Priority, RunQueue},
+    run_queue::{Priority, RunQueue, RunSchedulerOn},
     task::{
         self,
         ContextExt,
@@ -129,13 +125,13 @@ impl CpuState {
             main_task: Task {
                 cpu_context: CpuContext::new(),
                 thread_local: ThreadLocalData::new(),
+                name: None,
                 state: TaskState::Ready,
                 stack: core::ptr::slice_from_raw_parts_mut(core::ptr::null_mut(), 0),
                 #[cfg(any(hw_task_overflow_detection, sw_task_overflow_detection))]
                 stack_guard: core::ptr::null_mut(),
                 #[cfg(sw_task_overflow_detection)]
                 stack_guard_value: 0,
-                #[cfg(feature = "esp-radio")]
                 current_wait_queue: None,
                 priority: Priority::ZERO,
                 #[cfg(multi_core)]
@@ -150,8 +146,7 @@ impl CpuState {
                 timer_queue_item: TaskListItem::None,
                 delete_list_item: TaskListItem::None,
 
-                #[cfg(feature = "alloc")]
-                heap_allocated: false,
+                thread: None,
             },
         }
     }
@@ -199,30 +194,19 @@ impl SchedulerState {
         }
     }
 
-    #[cfg(feature = "esp-radio")]
-    pub(crate) fn create_task(
-        &mut self,
-        name: &str,
-        task: extern "C" fn(*mut c_void),
-        param: *mut c_void,
-        task_stack_size: usize,
-        priority: usize,
-        pinned_to: Option<Cpu>,
-    ) -> TaskPtr {
-        if let Some(cpu) = pinned_to {
+    /// Adds a task to the scheduler.
+    ///
+    /// The caller must have initialized the `Task` object, and must keep it alive until the task
+    /// is deleted.
+    pub(crate) fn register_task(&mut self, mut task_ptr: TaskPtr) {
+        #[cfg(multi_core)]
+        if let Some(cpu) = unsafe { task_ptr.as_ref().pinned_to } {
             assert!(
                 self.active_cores.contains(cpu),
                 "Cannot create a task on {:?}, because the scheduler does not run on it",
                 cpu
             );
         }
-
-        let mut task = Box::new_in(
-            Task::new(name, task, param, task_stack_size, priority, pinned_to),
-            InternalMemory,
-        );
-        task.heap_allocated = true;
-        let mut task_ptr = NonNull::from(Box::leak(task));
 
         unsafe {
             task_ptr
@@ -240,17 +224,17 @@ impl SchedulerState {
                 .mark_task_ready(&self.per_cpu, self.active_cores, task_ptr);
         task::trigger_scheduler(run_scheduler);
 
-        debug!("Task '{}' created: {:?}", name, task_ptr);
-
-        task_ptr
+        debug!("Task created: {:?}", task_ptr);
     }
 
     /// Deletes the tasks marked for deletion on `cpu`, except the one that owns `current_sp`.
     ///
     /// A task that deletes itself keeps running on its own stack until the scheduler switches away
     /// from it. Freeing that stack here would hand it back to the allocator while this CPU still
-    /// writes to it, and the other core could hand it out again. Such a task stays in the list, and
-    /// a later scheduler run deletes it, once this CPU runs on a different stack.
+    /// writes to it, and the other core could hand it out again. Such a task stays in the list,
+    /// and this function requests another scheduler run, which deletes the task once this CPU runs
+    /// on a different stack. Without that request the task could stay in the list forever, because
+    /// a CPU that has nothing else to run goes idle.
     ///
     /// Only the task the CPU currently runs on can be deferred, so the list holds at most one task
     /// after this function returns.
@@ -274,6 +258,7 @@ impl SchedulerState {
 
         if let Some(task_ptr) = in_use {
             self.per_cpu[cpu as usize].to_delete.push(task_ptr);
+            task::trigger_scheduler(RunSchedulerOn::RunOnCore(cpu));
         }
     }
 
@@ -441,7 +426,6 @@ impl SchedulerState {
     }
 
     /// Returns whether `task` is the main task of any CPU.
-    #[cfg(feature = "esp-radio")]
     fn is_main_task(&self, task: TaskPtr) -> bool {
         self.per_cpu
             .iter()
@@ -449,7 +433,7 @@ impl SchedulerState {
     }
 
     /// Returns the CPU that runs `task`, if that CPU is not the current one.
-    #[cfg(all(multi_core, feature = "esp-radio"))]
+    #[cfg(multi_core)]
     fn other_cpu_running(&self, task: TaskPtr) -> Option<Cpu> {
         let current_cpu = Cpu::current();
         Cpu::all().find(|cpu| {
@@ -458,7 +442,6 @@ impl SchedulerState {
         })
     }
 
-    #[cfg(feature = "esp-radio")]
     pub(crate) fn schedule_task_deletion(&mut self, task_to_delete: Option<TaskPtr>) -> bool {
         let current_task = SCHEDULER.current_task();
         let task_to_delete = task_to_delete.unwrap_or(current_task);
@@ -505,7 +488,6 @@ impl SchedulerState {
     }
 
     /// Marks `task` deleted, and queues it to be deleted by a scheduler run on `cpu`.
-    #[cfg(feature = "esp-radio")]
     fn mark_for_deletion(&mut self, cpu: Cpu, task: TaskPtr) {
         if task.state() != TaskState::Deleted {
             self.per_cpu[cpu as usize].to_delete.push(task);
@@ -529,33 +511,26 @@ impl SchedulerState {
         task::trigger_scheduler(run_scheduler);
     }
 
-    fn delete_task(&mut self, mut to_delete: TaskPtr) {
+    fn delete_task(&mut self, to_delete: TaskPtr) {
         unsafe {
-            cfg_select! {
-                xtensa => {
-                    let saved_sp = to_delete.as_ref().cpu_context.A1 as usize;
-                }
-                _ => {
-                    let saved_sp = to_delete.as_ref().cpu_context.sp;
-                }
-            }
+            let saved_sp = cfg_select! {
+                xtensa => to_delete.as_ref().cpu_context.A1 as usize,
+                _ => to_delete.as_ref().cpu_context.sp,
+            };
             to_delete.as_ref().ensure_no_stack_overflow(saved_sp)
         };
 
         debug!("Dropping task: {:x}", to_delete.as_ptr() as usize);
-        unsafe {
-            #[cfg(feature = "alloc")]
-            if to_delete.as_ref().heap_allocated {
-                let task = Box::from_raw_in(to_delete.as_ptr(), InternalMemory);
-                core::mem::drop(task);
-                return;
-            }
 
-            core::ptr::drop_in_place(to_delete.as_mut());
-        }
+        // The task locates the memory block of the thread, so the owner of the block destroys the
+        // task when it releases the memory.
+        let thread = unwrap!(
+            unsafe { to_delete.as_ref().thread },
+            "The main task cannot be deleted"
+        );
+        unsafe { crate::thread::release(thread, self) };
     }
 
-    #[cfg(feature = "esp-radio")]
     fn remove_from_all_queues(&mut self, mut task: TaskPtr) {
         self.all_tasks.remove(task);
         unwrap!(self.time_driver.as_mut()).timer_queue.remove(task);
@@ -573,12 +548,7 @@ impl SchedulerState {
             let task = unsafe { task.as_ref() };
             let in_queue = task.in_run_or_wait_queue;
 
-            let in_waitqueue = cfg_select! {
-                feature = "esp-radio" => task.current_wait_queue.is_some(),
-                _ => false,
-            };
-
-            in_queue && !in_waitqueue
+            in_queue && task.current_wait_queue.is_none()
         };
 
         if task_in_run_queue {
@@ -661,28 +631,6 @@ impl Scheduler {
             TaskPtr::new(tp),
             "The scheduler has not been started. Make sure to call `esp_rtos::init()` before trying to access the current task."
         )
-    }
-
-    #[cfg(feature = "esp-radio")]
-    pub(crate) fn create_task(
-        &self,
-        name: &str,
-        task: extern "C" fn(*mut c_void),
-        param: *mut c_void,
-        task_stack_size: usize,
-        priority: u32,
-        pinned_to: Option<Cpu>,
-    ) -> TaskPtr {
-        self.with(|state| {
-            state.create_task(
-                name,
-                task,
-                param,
-                task_stack_size,
-                priority as usize,
-                pinned_to,
-            )
-        })
     }
 
     pub(crate) fn sleep_until(&self, wake_at: Instant) -> bool {

--- a/esp-rtos/src/task/mod.rs
+++ b/esp-rtos/src/task/mod.rs
@@ -2,15 +2,10 @@
 #[cfg_attr(xtensa, path = "xtensa.rs")]
 pub(crate) mod arch_specific;
 
-#[cfg(feature = "esp-radio")]
-use core::ffi::c_void;
-use core::{marker::PhantomData, mem::MaybeUninit, ptr::NonNull};
+use core::{ffi::c_void, marker::PhantomData, mem::MaybeUninit, ptr::NonNull};
 
 #[cfg(feature = "alloc")]
-use allocator_api2::{
-    alloc::{Allocator, Layout},
-    boxed::Box,
-};
+use allocator_api2::boxed::Box;
 pub(crate) use arch_specific::*;
 use esp_hal::{
     system::Cpu,
@@ -21,14 +16,12 @@ use esp_radio_rtos_driver::semaphore::{SemaphoreHandle, SemaphorePtr};
 #[cfg(feature = "rtos-trace")]
 use rtos_trace::TaskInfo;
 
-#[cfg(feature = "alloc")]
-use crate::InternalMemory;
-#[cfg(feature = "esp-radio")]
-use crate::wait_queue::WaitQueue;
 use crate::{
     SCHEDULER,
     run_queue::{Priority, RunQueue, RunSchedulerOn},
     scheduler::SchedulerState,
+    thread::{ThreadOptions, ThreadPtr},
+    wait_queue::WaitQueue,
 };
 
 pub type IdleFn = extern "C" fn() -> !;
@@ -130,7 +123,7 @@ impl TaskExt for TaskPtr {
     #[cfg(feature = "rtos-trace")]
     fn rtos_trace_info(self, run_queue: &mut RunQueue) -> TaskInfo {
         TaskInfo {
-            name: "<todo>",
+            name: unsafe { self.as_ref().name.unwrap_or("<unnamed>") },
             priority: self.priority(run_queue).get() as u32,
             stack_base: unsafe { self.as_ref().stack.addr() },
             stack_size: unsafe { self.as_ref().stack.len() },
@@ -201,7 +194,6 @@ impl<E: TaskListElement> TaskList<E> {
         popped
     }
 
-    #[cfg(feature = "esp-radio")]
     pub fn remove(&mut self, task: TaskPtr) {
         if E::is_in_queue(task) == Some(false) {
             return;
@@ -349,6 +341,8 @@ pub(crate) struct Task {
 
     pub thread_local: ThreadLocalData,
 
+    pub name: Option<&'static str>,
+
     pub state: TaskState,
     pub stack: *mut [MaybeUninit<u32>],
 
@@ -369,7 +363,6 @@ pub(crate) struct Task {
     pub timer_queued: bool,
 
     /// The current wait queue this task is in.
-    #[cfg(feature = "esp-radio")]
     pub(crate) current_wait_queue: Option<NonNull<WaitQueue>>,
 
     // Lists a task can be in:
@@ -385,9 +378,9 @@ pub(crate) struct Task {
     /// The list of tasks scheduled for deletion
     pub delete_list_item: TaskListItem,
 
-    /// Whether the task was allocated on the heap.
-    #[cfg(feature = "alloc")]
-    pub(crate) heap_allocated: bool,
+    /// The memory block this task lives in, for tasks that were not statically allocated by the
+    /// scheduler. The main tasks have no such block.
+    pub(crate) thread: Option<ThreadPtr>,
 }
 
 pub(crate) trait ContextExt {
@@ -430,75 +423,48 @@ impl ContextExt for CpuContext {
     }
 }
 
-#[cfg(feature = "esp-radio")]
 extern "C" fn task_wrapper(task_fn: extern "C" fn(*mut c_void), param: *mut c_void) {
     task_fn(param);
     schedule_task_deletion(None);
 }
 
 impl Task {
-    #[cfg(feature = "esp-radio")]
+    /// Creates a task that runs `entry(param)` on a caller-provided stack.
+    ///
+    /// The stack guard is placed at the low end of `stack`, so the region must be larger than the
+    /// stack guard offset. `thread` is the memory block the task lives in.
     pub(crate) fn new(
-        name: &str,
-        task_fn: extern "C" fn(*mut c_void),
+        options: &ThreadOptions,
+        entry: extern "C" fn(*mut c_void),
         param: *mut c_void,
-        task_stack_size: usize,
-        priority: usize,
-        pinned_to: Option<Cpu>,
+        stack: *mut [MaybeUninit<u32>],
+        thread: ThreadPtr,
     ) -> Self {
         debug!(
-            "task_create {} {:?}({:?}) stack_size = {} priority = {} pinned_to = {:?}",
-            name, task_fn, param, task_stack_size, priority, pinned_to
+            "task_create {:?} {:?}({:?}) stack = {:?} priority = {} pinned_to = {:?}",
+            options.name, entry, param, stack, options.priority, options.pinned_to
         );
-
-        // Make sure the stack guard doesn't eat into the stack size.
-        let extra_stack = if cfg!(any(hw_task_overflow_detection, sw_task_overflow_detection)) {
-            4 + esp_config::esp_config_int!(usize, "ESP_HAL_CONFIG_STACK_GUARD_OFFSET")
-        } else {
-            0
-        };
-
-        #[cfg(debug_build)]
-        // This is a lot, but debug builds fail in different ways without.
-        let extra_stack = extra_stack.max(6 * 1024);
-
-        let task_stack_size = task_stack_size + extra_stack;
-
-        // Make sure stack size is also aligned to 16 bytes.
-        const MIN_STACK_ALIGNMENT: usize = 16;
-        let task_stack_size = (task_stack_size & !(MIN_STACK_ALIGNMENT - 1)) + MIN_STACK_ALIGNMENT;
-
-        let stack = unwrap!(
-            Layout::from_size_align(task_stack_size, MIN_STACK_ALIGNMENT)
-                .ok()
-                .and_then(|layout| InternalMemory.allocate(layout).ok()),
-            "Failed to allocate stack",
-        )
-        .as_ptr();
-
-        let stack_bottom = stack.cast::<MaybeUninit<u32>>();
-        let stack_len_bytes = stack.len();
 
         let stack_guard_offset =
             esp_config::esp_config_int!(usize, "ESP_HAL_CONFIG_STACK_GUARD_OFFSET");
 
-        let stack_words = core::ptr::slice_from_raw_parts_mut(stack_bottom, stack_len_bytes / 4);
-        let stack_top = unsafe { stack_bottom.add(stack_words.len()).cast() };
+        let stack_bottom = stack.cast::<MaybeUninit<u32>>();
+        let stack_top = unsafe { stack_bottom.add(stack.len()).cast() };
 
         let mut task = Task {
-            cpu_context: new_task_context(task_fn, param, stack_top),
+            cpu_context: new_task_context(entry, param, stack_top),
             thread_local: ThreadLocalData::new(),
+            name: options.name,
             state: TaskState::Ready,
-            stack: stack_words,
+            stack,
             #[cfg(any(hw_task_overflow_detection, sw_task_overflow_detection))]
-            stack_guard: stack_words.cast(),
+            stack_guard: stack.cast(),
             #[cfg(sw_task_overflow_detection)]
             stack_guard_value: 0,
-            #[cfg(feature = "esp-radio")]
             current_wait_queue: None,
-            priority: Priority::new(priority),
+            priority: Priority::new(options.priority),
             #[cfg(multi_core)]
-            pinned_to,
+            pinned_to: options.pinned_to,
 
             wakeup_at: 0,
             timer_queued: false,
@@ -509,8 +475,7 @@ impl Task {
             timer_queue_item: TaskListItem::None,
             delete_list_item: TaskListItem::None,
 
-            #[cfg(feature = "alloc")]
-            heap_allocated: false,
+            thread: Some(thread),
         };
 
         task.set_up_stack_guard(stack_guard_offset, 0xDEED_BAAD);
@@ -578,21 +543,6 @@ impl Task {
         #[cfg(hw_task_overflow_detection)]
         unsafe {
             esp_hal::debugger::set_stack_watchpoint(self.stack_guard as usize);
-        }
-    }
-}
-
-impl Drop for Task {
-    fn drop(&mut self) {
-        debug!("Dropping task: {:?}", self as *mut Task);
-
-        #[cfg(feature = "alloc")]
-        if self.heap_allocated {
-            let layout = unwrap!(
-                Layout::from_size_align(self.stack.len() * 4, 16).ok(),
-                "Cannot compute Layout for stack"
-            );
-            unsafe { InternalMemory.deallocate(unwrap!(NonNull::new(self.stack.cast())), layout) };
         }
     }
 }
@@ -668,6 +618,13 @@ impl CurrentThreadHandle {
         }
     }
 
+    /// Returns the name of the current thread.
+    ///
+    /// The main threads and the threads created by `esp-radio` have no name.
+    pub fn name(self) -> Option<&'static str> {
+        unsafe { self.task.as_ref().name }
+    }
+
     /// Delays the current task for the specified duration.
     pub fn delay(self, duration: Duration) {
         self.delay_until(Instant::now() + duration);
@@ -694,7 +651,6 @@ impl CurrentThreadHandle {
     }
 }
 
-#[cfg(feature = "esp-radio")]
 pub(super) fn schedule_task_deletion(task: Option<NonNull<Task>>) {
     trace!("schedule_task_deletion {:?}", task);
     if SCHEDULER.with(|scheduler| scheduler.schedule_task_deletion(task)) {

--- a/esp-rtos/src/task/riscv.rs
+++ b/esp-rtos/src/task/riscv.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "esp-radio")]
 use core::ffi::c_void;
 
 #[cfg(multi_core)]
@@ -128,7 +127,6 @@ pub(crate) fn write_thread_pointer(task: *mut Task) {
     unsafe { core::arch::asm!("c.mv tp, {0}", in(reg) task, options(nostack)) };
 }
 
-#[cfg(feature = "esp-radio")]
 pub(crate) fn new_task_context(
     task: extern "C" fn(*mut c_void),
     param: *mut c_void,

--- a/esp-rtos/src/task/xtensa.rs
+++ b/esp-rtos/src/task/xtensa.rs
@@ -12,9 +12,7 @@
 //! switching does not interfere with other interrupts, so we don't leave an interrupt handler only
 //! partially executed.
 
-#[cfg(feature = "esp-radio")]
-use core::ffi::c_void;
-use core::sync::atomic::Ordering;
+use core::{ffi::c_void, sync::atomic::Ordering};
 
 pub(crate) use esp_hal::trapframe::TrapFrame as CpuContext;
 #[cfg(not(esp32))]
@@ -57,7 +55,6 @@ const PS_UM: u32 = 1 << 5;
 // Windowed mode.
 const PS_WOE: u32 = 1 << 18;
 // CALLINC field value for call4 instruction.
-#[cfg(feature = "esp-radio")]
 const PS_CALLINC_CALL4: u32 = 1 << 16;
 
 pub(crate) fn set_idle_hook_entry(idle_context: &mut CpuContext, hook_fn: IdleFn) {
@@ -86,7 +83,6 @@ pub(crate) fn write_thread_pointer(task: *mut Task) {
     unsafe { core::arch::asm!("wur.threadptr {0}", in(reg) task, options(nostack)) };
 }
 
-#[cfg(feature = "esp-radio")]
 pub(crate) fn new_task_context(
     task_fn: extern "C" fn(*mut c_void),
     param: *mut c_void,

--- a/esp-rtos/src/thread.rs
+++ b/esp-rtos/src/thread.rs
@@ -1,0 +1,698 @@
+//! Threads.
+//!
+//! A thread runs a function or a closure on its own stack. Threads are scheduled by priority, and
+//! threads of the same priority share the CPU in a round-robin fashion.
+//!
+//! A thread is created by a [`ThreadSpawner`], which owns the memory the thread runs on. The
+//! memory is either allocated on the heap by [`ThreadSpawner::new`], or provided by the caller as
+//! a [`Stack`] via [`ThreadSpawner::from_static`].
+//!
+//! [`ThreadSpawner::spawn`] starts the thread and returns a [`JoinHandle`]. Use the handle to wait
+//! for the thread and to read the value the thread returns. If you drop the handle, the thread is
+//! detached, and it continues to run until it exits.
+//!
+//! A thread can not be deleted. It exits when its function returns.
+//!
+//! ## Example
+//!
+//! ```rust, no_run
+#![doc = esp_hal::before_snippet!()]
+//! # struct FakeHeap;
+//! # unsafe impl core::alloc::GlobalAlloc for FakeHeap {
+//! #     unsafe fn alloc(&self, _: core::alloc::Layout) -> *mut u8 {
+//! #         unimplemented!()
+//! #     }
+//! #     unsafe fn dealloc(&self, _: *mut u8, _: core::alloc::Layout) {
+//! #         unimplemented!()
+//! #     }
+//! # }
+//! # #[global_allocator]
+//! # static ALLOCATOR: FakeHeap = FakeHeap;
+//! use esp_hal::timer::timg::TimerGroup;
+//! use esp_rtos::thread::{Stack, ThreadSpawner};
+//! use static_cell::ConstStaticCell;
+//!
+//! static STACK: ConstStaticCell<Stack<4096>> = ConstStaticCell::new(Stack::new());
+//!
+//! let timg0 = TimerGroup::new(peripherals.TIMG0);
+//! esp_rtos::start(timg0.timer0, peripherals.FROM_CPU_INTR0);
+//!
+//! let offset = 10;
+//! let handle = ThreadSpawner::from_static(STACK.take())
+//!     .with_name("worker")
+//!     .with_priority(2)
+//!     .spawn(move || 32 + offset);
+//!
+//! let (result, spawner) = handle.join();
+//! assert_eq!(result, 42);
+//!
+//! // `spawner` owns the stack again, and can start another thread on it.
+#![doc = esp_hal::after_snippet!()]
+//! ```
+
+use core::{
+    alloc::Layout,
+    ffi::c_void,
+    marker::PhantomData,
+    mem::{ManuallyDrop, MaybeUninit},
+    ptr::NonNull,
+};
+
+#[cfg(feature = "alloc")]
+use allocator_api2::alloc::Allocator;
+use esp_hal::{
+    system::Cpu,
+    time::{Duration, Instant},
+};
+
+#[doc(no_inline)]
+pub use crate::CurrentThreadHandle;
+#[cfg(feature = "alloc")]
+use crate::InternalMemory;
+use crate::{
+    SCHEDULER,
+    run_queue::MaxPriority,
+    scheduler::SchedulerState,
+    task::{Task, TaskPtr},
+    wait_queue::WaitQueue,
+};
+
+/// The alignment of a stack, and the granularity of stack sizes.
+const STACK_ALIGN: usize = 16;
+
+/// The number of bytes reserved below the usable stack, for the stack guard.
+const GUARD_RESERVE: usize = if cfg!(any(hw_task_overflow_detection, sw_task_overflow_detection)) {
+    (esp_config::esp_config_int!(usize, "ESP_HAL_CONFIG_STACK_GUARD_OFFSET") + 4)
+        .next_multiple_of(STACK_ALIGN)
+} else {
+    0
+};
+
+/// The smallest stack a thread can run on, after the payload is placed on it.
+const MIN_STACK: usize = 512;
+
+/// The memory a thread runs on.
+///
+/// `SIZE` is the number of stack bytes available to the thread. The stack guard and the
+/// bookkeeping of the scheduler are stored outside of it, so `Stack<4096>` occupies more than 4096
+/// bytes. The closure and the return value of the thread, however, are placed on the stack, and so
+/// they reduce the number of bytes the thread can use.
+///
+/// Pass the stack to [`ThreadSpawner::from_static`] to run a thread on it.
+#[repr(C, align(16))]
+pub struct Stack<const SIZE: usize> {
+    // The stack grows down, so the guard must come first. The scheduler's bookkeeping comes last,
+    // where an overflow cannot reach it.
+    guard: MaybeUninit<[u8; GUARD_RESERVE]>,
+    stack: MaybeUninit<[u8; SIZE]>,
+    resources: MaybeUninit<Resources>,
+}
+
+// The stack contains uninitialized memory only, until a thread is started on it. The thread's data
+// is not reachable through the `Stack`, and only the thread that owns the memory can access it.
+unsafe impl<const SIZE: usize> Send for Stack<SIZE> {}
+unsafe impl<const SIZE: usize> Sync for Stack<SIZE> {}
+
+impl<const SIZE: usize> Default for Stack<SIZE> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<const SIZE: usize> Stack<SIZE> {
+    /// Creates a new stack, uninitialized.
+    pub const fn new() -> Self {
+        const {
+            ::core::assert!(
+                SIZE.is_multiple_of(STACK_ALIGN),
+                "The stack size must be a multiple of 16 bytes"
+            );
+            ::core::assert!(SIZE > MIN_STACK, "The stack is too small");
+        }
+
+        Self {
+            resources: MaybeUninit::uninit(),
+            guard: MaybeUninit::uninit(),
+            stack: MaybeUninit::uninit(),
+        }
+    }
+}
+
+/// The scheduler's per-thread bookkeeping, at the end of the thread's memory.
+#[repr(C, align(16))]
+struct Resources {
+    task: Task,
+    inner: ThreadInner,
+}
+
+/// The state a thread shares with its [`JoinHandle`]. It is destroyed when both the scheduler and
+/// the `JoinHandle` are done with the thread.
+///
+/// The scheduler lock protects the flags. Both the thread and its `JoinHandle` change them, and
+/// the two can run on different CPUs.
+struct ThreadInner {
+    /// The thread wrote its return value into the payload.
+    has_result: bool,
+    /// The `JoinHandle` was dropped, so nobody will read the return value.
+    detached: bool,
+    /// The scheduler no longer uses the thread's memory.
+    released: bool,
+    /// Whether the memory block must be returned to the allocator.
+    heap: bool,
+    wait_queue: WaitQueue,
+    /// The closure of the thread, replaced by its return value when the thread exits.
+    payload: *mut u8,
+}
+
+/// A pointer to the bookkeeping of a thread, which holds a [`Task`] and a [`ThreadInner`], and
+/// which sits at the end of the thread's memory block.
+#[derive(Clone, Copy)]
+pub(crate) struct ThreadPtr(NonNull<Resources>);
+
+impl ThreadPtr {
+    pub(crate) fn task(self) -> TaskPtr {
+        unsafe { NonNull::new_unchecked(&raw mut (*self.0.as_ptr()).task) }
+    }
+
+    fn inner_ptr(self) -> *mut ThreadInner {
+        unsafe { &raw mut (*self.0.as_ptr()).inner }
+    }
+
+    /// # Safety
+    ///
+    /// The thread must be prepared, and the caller must not create a second reference to the same
+    /// `ThreadInner`.
+    unsafe fn inner<'a>(self) -> &'a mut ThreadInner {
+        unsafe { &mut *self.inner_ptr() }
+    }
+
+    fn as_param(self) -> *mut c_void {
+        self.0.as_ptr().cast()
+    }
+
+    /// # Safety
+    ///
+    /// `param` must come from [`ThreadPtr::as_param`].
+    unsafe fn from_param(param: *mut c_void) -> Self {
+        Self(unwrap!(NonNull::new(param.cast::<Resources>())))
+    }
+
+    /// The start of the memory block, which is the low end of the task's stack.
+    ///
+    /// # Safety
+    ///
+    /// The task must be in place.
+    unsafe fn base(self) -> NonNull<u8> {
+        unsafe { NonNull::new_unchecked(self.task().as_ref().stack.cast::<u8>()) }
+    }
+
+    /// Places the payload between the stack and the bookkeeping, so that a stack overflow hits the
+    /// stack guard first.
+    fn reserve_payload(self, base: NonNull<u8>, payload: Layout) -> *mut u8 {
+        let stack_bottom = base.as_ptr() as usize;
+        let payload_end = self.0.as_ptr() as usize;
+
+        let payload_addr = align_down(payload_end - payload.size(), payload.align().max(4));
+
+        assert!(
+            align_down(payload_addr, STACK_ALIGN) >= stack_bottom + GUARD_RESERVE + MIN_STACK,
+            "The thread does not fit its stack: it needs {} bytes for the closure and the return \
+            value, and at least {} bytes of stack, but the stack is {} bytes",
+            payload.size(),
+            MIN_STACK,
+            payload_end - stack_bottom - GUARD_RESERVE
+        );
+
+        payload_addr as *mut u8
+    }
+
+    /// Creates the task of a prepared thread, which runs `entry(param)`, and hands it to the
+    /// scheduler.
+    ///
+    /// The stack spans from the stack guard to the payload.
+    ///
+    /// # Safety
+    ///
+    /// The closure the thread runs, if any, must already be in place.
+    unsafe fn launch(
+        self,
+        base: NonNull<u8>,
+        options: &ThreadOptions,
+        entry: extern "C" fn(*mut c_void),
+        param: *mut c_void,
+    ) {
+        let stack_bottom = base.as_ptr();
+        let stack_top = align_down(unsafe { self.inner().payload } as usize, STACK_ALIGN);
+        let stack = core::ptr::slice_from_raw_parts_mut(
+            stack_bottom.cast::<MaybeUninit<u32>>(),
+            (stack_top - stack_bottom as usize) / 4,
+        );
+
+        let task = self.task();
+        unsafe {
+            task.as_ptr()
+                .write(Task::new(options, entry, param, stack, self))
+        };
+
+        SCHEDULER.with(|scheduler| scheduler.register_task(task));
+    }
+
+    /// Destroys the bookkeeping of the thread. The scheduler leaves the [`Task`] in place when it
+    /// deletes the thread, because the task locates the memory block.
+    ///
+    /// # Safety
+    ///
+    /// The thread must be prepared, and nothing may use the bookkeeping afterwards.
+    unsafe fn destroy(self) {
+        unsafe { core::ptr::drop_in_place(self.task().as_ptr()) };
+        unsafe { core::ptr::drop_in_place(self.inner_ptr()) };
+    }
+
+    /// Returns the memory block to the allocator, if it came from there.
+    ///
+    /// # Safety
+    ///
+    /// Nothing may use the block afterwards.
+    unsafe fn deallocate(self, base: NonNull<u8>, heap: bool) {
+        if heap {
+            cfg_select! {
+                feature = "alloc" => unsafe {
+                    let block = self.0.as_ptr().add(1) as usize - base.as_ptr() as usize;
+                    let size = block - GUARD_RESERVE - size_of::<Resources>();
+                    InternalMemory.deallocate(base, block_layout(size))
+                },
+                _ => {
+                    _ = base;
+                }
+            }
+        }
+    }
+}
+
+/// The layout of a memory block that offers `size` bytes of stack.
+#[cfg(feature = "alloc")]
+fn block_layout(size: usize) -> Layout {
+    unwrap!(
+        Layout::from_size_align(GUARD_RESERVE + size + size_of::<Resources>(), STACK_ALIGN).ok(),
+        "The stack size is too large"
+    )
+}
+
+/// The properties of a thread, which a `join` returns so that the next thread can reuse them.
+#[derive(Clone, Copy)]
+pub(crate) struct ThreadOptions {
+    pub name: Option<&'static str>,
+    pub priority: usize,
+    pub pinned_to: Option<Cpu>,
+}
+
+impl ThreadOptions {
+    const fn new() -> Self {
+        Self {
+            name: None,
+            priority: 0,
+            pinned_to: None,
+        }
+    }
+}
+
+const fn align_down(addr: usize, align: usize) -> usize {
+    addr & !(align - 1)
+}
+
+/// The error returned when a thread stack cannot be allocated.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct OutOfMemory(usize);
+
+impl core::fmt::Display for OutOfMemory {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "Failed to allocate {} bytes of memory for the thread",
+            self.0
+        )
+    }
+}
+
+impl core::error::Error for OutOfMemory {}
+
+/// Owns the memory of a thread, and starts the thread on it.
+///
+/// The spawner is consumed by [`ThreadSpawner::spawn`], and [`JoinHandle::join`] returns it, so
+/// that the next thread can run on the same memory.
+pub struct ThreadSpawner {
+    /// The start of the memory block, which holds no thread yet.
+    base: NonNull<u8>,
+    /// The bookkeeping at the end of the block.
+    thread: ThreadPtr,
+    /// Whether the block must be returned to the allocator.
+    heap: bool,
+    options: ThreadOptions,
+}
+
+unsafe impl Send for ThreadSpawner {}
+
+impl ThreadSpawner {
+    /// Allocates a stack of `stack_size` bytes in internal memory.
+    ///
+    /// The closure and the return value of the thread are placed on this stack, so they reduce the
+    /// number of bytes the thread can use.
+    ///
+    /// This function panics if the allocation fails. Use [`ThreadSpawner::try_new`] to handle the
+    /// failure.
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    pub fn new(stack_size: usize) -> Self {
+        unwrap!(
+            Self::try_new(stack_size).ok(),
+            "Failed to allocate a thread stack"
+        )
+    }
+
+    /// Allocates a stack of `stack_size` bytes in internal memory.
+    ///
+    /// This function returns an error if the allocation fails.
+    #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
+    pub fn try_new(stack_size: usize) -> Result<Self, OutOfMemory> {
+        let size = stack_size.next_multiple_of(STACK_ALIGN);
+        let base = InternalMemory
+            .allocate(block_layout(size))
+            .map_err(|_| OutOfMemory(stack_size))?
+            .cast::<u8>();
+
+        Ok(Self {
+            base,
+            thread: ThreadPtr(unsafe { base.add(GUARD_RESERVE + size) }.cast()),
+            heap: true,
+            options: ThreadOptions::new(),
+        })
+    }
+
+    /// Runs the thread on a statically allocated stack.
+    pub fn from_static<const SIZE: usize>(stack: &'static mut Stack<SIZE>) -> Self {
+        Self {
+            base: NonNull::from(&mut *stack).cast(),
+            thread: ThreadPtr(NonNull::from(&mut stack.resources).cast()),
+            heap: false,
+            options: ThreadOptions::new(),
+        }
+    }
+
+    /// Sets the name of the thread.
+    ///
+    /// The name is used by the logs and by `rtos-trace`. Threads have no name by default.
+    #[must_use]
+    pub fn with_name(mut self, name: &'static str) -> Self {
+        self.options.name = Some(name);
+        self
+    }
+
+    /// Sets the priority of the thread.
+    ///
+    /// Higher numbers mean higher priority. The default priority is 0, which is the lowest.
+    ///
+    /// This function panics if `priority` is greater than the highest supported priority.
+    #[must_use]
+    pub fn with_priority(mut self, priority: usize) -> Self {
+        assert!(
+            priority <= MaxPriority::MAX_PRIORITY,
+            "The priority must not be greater than {}",
+            MaxPriority::MAX_PRIORITY
+        );
+        self.options.priority = priority;
+        self
+    }
+
+    /// Runs the thread on a single CPU.
+    ///
+    /// By default a thread can run on any CPU the scheduler runs on.
+    #[must_use]
+    pub fn with_pinned_to(mut self, cpu: Cpu) -> Self {
+        self.options.pinned_to = Some(cpu);
+        self
+    }
+
+    /// Starts the thread.
+    ///
+    /// The thread runs `f`, and exits when `f` returns. Drop the returned handle to detach the
+    /// thread, or use [`JoinHandle::join`] to wait for it and to read its return value.
+    ///
+    /// This function panics if `f` and its return value do not fit the thread's stack, if the
+    /// scheduler is not running, if it is called from an interrupt handler, or if the thread is
+    /// pinned to a CPU that does not run the scheduler.
+    pub fn spawn<F, T>(self, f: F) -> JoinHandle<T>
+    where
+        F: FnOnce() -> T + Send + 'static,
+        T: Send + 'static,
+    {
+        crate::assert_thread_mode("ThreadSpawner::spawn");
+
+        let payload = unwrap!(
+            Layout::from_size_align(
+                size_of::<F>().max(size_of::<T>()),
+                align_of::<F>().max(align_of::<T>()),
+            )
+            .ok()
+        );
+
+        let (base, options) = (self.base, self.options);
+        let thread = self.prepare(payload);
+
+        unsafe { thread.inner().payload.cast::<F>().write(f) };
+        unsafe { thread.launch(base, &options, thread_entry::<F, T>, thread.as_param()) };
+
+        JoinHandle {
+            thread,
+            options,
+            _result: PhantomData,
+        }
+    }
+
+    /// Starts a thread that runs a C-compatible function.
+    #[cfg(feature = "esp-radio")]
+    pub(crate) fn spawn_extern(
+        self,
+        entry: extern "C" fn(*mut c_void),
+        param: *mut c_void,
+    ) -> TaskPtr {
+        let (base, options) = (self.base, self.options);
+        let thread = self.prepare(Layout::new::<()>());
+
+        // These threads have no `JoinHandle`, so the scheduler releases their memory when they
+        // exit.
+        unsafe { thread.inner().detached = true };
+        unsafe { thread.launch(base, &options, entry, param) };
+
+        thread.task()
+    }
+
+    /// Reserves the payload, and initializes the state the thread shares with its `JoinHandle`.
+    ///
+    /// The caller must move the closure, if any, into `ThreadInner::payload`, and must then call
+    /// [`ThreadPtr::launch`] to start the thread.
+    fn prepare(self, payload: Layout) -> ThreadPtr {
+        assert!(
+            SCHEDULER.with(|scheduler| scheduler.time_driver.is_some()),
+            "The scheduler is not running. Call esp_rtos::start before spawning a thread."
+        );
+
+        // The thread owns its memory from here on. `JoinHandle` or the scheduler releases it.
+        let this = ManuallyDrop::new(self);
+
+        let thread = this.thread;
+        unsafe {
+            thread.inner_ptr().write(ThreadInner {
+                has_result: false,
+                detached: false,
+                released: false,
+                heap: this.heap,
+                wait_queue: WaitQueue::new(),
+                payload: thread.reserve_payload(this.base, payload),
+            })
+        };
+
+        thread
+    }
+}
+
+impl Drop for ThreadSpawner {
+    fn drop(&mut self) {
+        unsafe { self.thread.deallocate(self.base, self.heap) };
+    }
+}
+
+extern "C" fn thread_entry<F, T>(param: *mut c_void)
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    let thread = unsafe { ThreadPtr::from_param(param) };
+
+    let payload = unsafe { thread.inner().payload };
+    let f = unsafe { payload.cast::<F>().read() };
+
+    let result = f();
+
+    unsafe { publish(thread, result) };
+}
+
+/// Hands the return value of the thread to the `JoinHandle`, or drops it if the thread is
+/// detached.
+unsafe fn publish<T>(thread: ThreadPtr, result: T) {
+    // The thread is still running, so nobody can release its memory while we write.
+    let payload = unsafe { thread.inner().payload.cast::<T>() };
+    unsafe { payload.write(result) };
+
+    let detached = SCHEDULER.with(|_scheduler| {
+        let inner = unsafe { thread.inner() };
+        inner.has_result = !inner.detached;
+        inner.detached
+    });
+
+    if detached {
+        unsafe { payload.drop_in_place() };
+    }
+}
+
+/// Releases the memory of an exited thread. The scheduler calls this after it switched off the
+/// thread's stack for the last time, so the memory can be reused from this point on.
+///
+/// # Safety
+///
+/// The scheduler must no longer use the `Task` of the thread.
+pub(crate) unsafe fn release(thread: ThreadPtr, scheduler: &mut SchedulerState) {
+    let inner = unsafe { thread.inner() };
+    inner.released = true;
+
+    if inner.detached {
+        unsafe { free(thread) };
+    } else {
+        inner.wait_queue.notify(scheduler);
+    }
+}
+
+/// Destroys the thread's bookkeeping, and returns heap-allocated memory to the allocator.
+unsafe fn free(thread: ThreadPtr) {
+    let base = unsafe { thread.base() };
+    let heap = unsafe { thread.inner().heap };
+
+    unsafe { thread.destroy() };
+    unsafe { thread.deallocate(base, heap) };
+}
+
+/// A handle to a running thread.
+///
+/// Dropping the handle detaches the thread. The thread keeps running, but its return value is
+/// dropped, and the memory of a thread that runs on a heap-allocated stack is returned to the
+/// allocator when the thread exits. The memory of a thread that runs on a [`Stack`] is not
+/// recovered.
+pub struct JoinHandle<T> {
+    thread: ThreadPtr,
+    /// The properties of the thread, which outlive it, so that [`JoinHandle::join`] can return a
+    /// spawner that starts an identical thread.
+    options: ThreadOptions,
+    _result: PhantomData<T>,
+}
+
+unsafe impl<T: Send> Send for JoinHandle<T> {}
+
+impl<T> JoinHandle<T> {
+    /// Returns the name of the thread.
+    pub fn name(&self) -> Option<&'static str> {
+        self.options.name
+    }
+
+    /// Returns whether the thread has finished running its closure.
+    pub fn is_finished(&self) -> bool {
+        SCHEDULER.with(|_scheduler| unsafe { self.thread.inner().has_result })
+    }
+
+    /// Detaches the thread.
+    ///
+    /// The thread keeps running until it exits, but its return value is dropped, and its memory
+    /// cannot be reused.
+    pub fn detach(self) {}
+
+    /// Waits for the thread to exit, and returns its return value together with a spawner that
+    /// owns the memory the thread ran on. The spawner has the properties of the thread that
+    /// exited.
+    ///
+    /// The current thread sleeps until the thread exits. This function does not change the
+    /// priority of the thread it waits for, so a thread of a middle priority can delay a
+    /// high-priority thread that waits for a low-priority one.
+    ///
+    /// This function panics if a thread tries to join itself.
+    pub fn join(self) -> (T, ThreadSpawner) {
+        let this = ManuallyDrop::new(self);
+        let thread = this.thread;
+
+        assert!(
+            thread.task() != SCHEDULER.current_task(),
+            "A thread cannot join itself"
+        );
+
+        // The memory is safe to reuse once the scheduler marks the thread released.
+        loop {
+            let released = SCHEDULER.with(|scheduler| {
+                let inner = unsafe { thread.inner() };
+                if inner.released {
+                    true
+                } else {
+                    inner
+                        .wait_queue
+                        .wait_with_deadline(scheduler, Instant::EPOCH + Duration::MAX);
+                    false
+                }
+            });
+
+            if released {
+                break;
+            }
+        }
+
+        let inner = unsafe { thread.inner() };
+
+        debug_assert!(
+            inner.has_result,
+            "The thread exited without publishing its return value"
+        );
+
+        let result = unsafe { inner.payload.cast::<T>().read() };
+        let base = unsafe { thread.base() };
+        let heap = inner.heap;
+
+        unsafe { thread.destroy() };
+
+        (
+            result,
+            ThreadSpawner {
+                base,
+                thread,
+                heap,
+                options: this.options,
+            },
+        )
+    }
+}
+
+impl<T> Drop for JoinHandle<T> {
+    fn drop(&mut self) {
+        // The scheduler releases the thread's memory while it holds its lock, and it may do so as
+        // soon as we mark the thread detached. Working under the same lock makes sure that exactly
+        // one of the two frees the memory, and that the other one stops using it.
+        SCHEDULER.with(|_scheduler| {
+            let inner = unsafe { self.thread.inner() };
+            inner.detached = true;
+
+            if inner.has_result {
+                unsafe { inner.payload.cast::<T>().drop_in_place() };
+            }
+
+            if inner.released {
+                unsafe { free(self.thread) };
+            }
+        });
+    }
+}

--- a/esp-rtos/src/wait_queue.rs
+++ b/esp-rtos/src/wait_queue.rs
@@ -4,9 +4,14 @@ use esp_hal::time::Instant;
 
 use crate::{
     SCHEDULER,
+    scheduler::SchedulerState,
     task::{TaskList, TaskPtr, TaskReadyQueueElement},
 };
 
+/// A list of tasks that wait for an event.
+///
+/// The methods take the locked scheduler, because the caller usually needs to inspect the state
+/// the queue protects, in the same critical section.
 pub(crate) struct WaitQueue {
     // A task is either blocked, or ready. Since it can't be both, we can reuse the ready queue
     // element. Note however, that a task can simultaneously be in the timer queue and a wait
@@ -21,26 +26,24 @@ impl WaitQueue {
         }
     }
 
-    pub(crate) fn notify(&mut self) {
-        SCHEDULER.with(|scheduler| {
-            // Expergiscere eos. Novit enim Ordinator qui sunt eius.
-            while let Some(waken_task) = self.waiting_tasks.pop() {
-                scheduler.resume_task(waken_task);
-            }
-        });
+    /// Wakes up every waiting task.
+    pub(crate) fn notify(&mut self, scheduler: &mut SchedulerState) {
+        // Expergiscere eos. Novit enim Ordinator qui sunt eius.
+        while let Some(waken_task) = self.waiting_tasks.pop() {
+            scheduler.resume_task(waken_task);
+        }
     }
 
-    pub(crate) fn wait_with_deadline(&mut self, deadline: Instant) {
-        SCHEDULER.with(|scheduler| {
-            let mut task = SCHEDULER.current_task();
-            if scheduler.sleep_task_until(task, deadline) {
-                self.waiting_tasks.push(task);
-                unsafe {
-                    task.as_mut().current_wait_queue = Some(NonNull::from(self));
-                }
-                crate::task::yield_task();
+    /// Puts the current task to sleep until the queue is notified, or the deadline passes.
+    pub(crate) fn wait_with_deadline(&mut self, scheduler: &mut SchedulerState, deadline: Instant) {
+        let mut task = SCHEDULER.current_task();
+        if scheduler.sleep_task_until(task, deadline) {
+            self.waiting_tasks.push(task);
+            unsafe {
+                task.as_mut().current_wait_queue = Some(NonNull::from(self));
             }
-        });
+            crate::task::yield_task();
+        }
     }
 
     pub(crate) fn remove(&mut self, task: TaskPtr) {

--- a/hil-test/src/bin/radio_basic/esp_rtos.rs
+++ b/hil-test/src/bin/radio_basic/esp_rtos.rs
@@ -21,9 +21,13 @@ mod tests {
         queue::QueueHandle,
         semaphore::{SemaphoreHandle, SemaphoreKind},
     };
-    use esp_rtos::{CurrentThreadHandle, embassy::InterruptExecutor};
+    use esp_rtos::{
+        CurrentThreadHandle,
+        embassy::InterruptExecutor,
+        thread::{Stack as ThreadStack, ThreadSpawner},
+    };
     use portable_atomic::{AtomicBool, AtomicPtr, AtomicUsize, Ordering};
-    use static_cell::StaticCell;
+    use static_cell::{ConstStaticCell, StaticCell};
 
     struct Context {
         #[cfg(multi_core)]
@@ -92,6 +96,111 @@ mod tests {
         CurrentThreadHandle::get().delay(Duration::from_millis(10));
 
         hil_test::assert!(now.elapsed() >= Duration::from_millis(10));
+    }
+
+    #[test]
+    fn thread_runs_a_function_and_returns_its_value() {
+        fn worker() -> u32 {
+            42
+        }
+
+        let handle = ThreadSpawner::new(4096).with_name("worker").spawn(worker);
+
+        hil_test::assert_eq!(handle.name(), Some("worker"));
+
+        let (value, _spawner) = handle.join();
+        hil_test::assert_eq!(value, 42);
+    }
+
+    #[test]
+    fn thread_returns_a_value_that_is_not_copy() {
+        let captured = Box::new(3_u32);
+
+        let handle = ThreadSpawner::new(4096).spawn(move || {
+            let mut items = alloc::vec::Vec::new();
+            items.push(*captured);
+            items.push(*captured);
+            items
+        });
+
+        let (value, _spawner) = handle.join();
+        hil_test::assert_eq!(value.len(), 2);
+        hil_test::assert_eq!(value[0], 3);
+        hil_test::assert_eq!(value[1], 3);
+    }
+
+    #[test]
+    fn a_static_stack_can_be_reused_after_a_join() {
+        static STACK: ConstStaticCell<ThreadStack<4096>> = ConstStaticCell::new(ThreadStack::new());
+
+        let spawner = ThreadSpawner::from_static(STACK.take()).with_priority(2);
+
+        let (first, spawner) = spawner.spawn(|| 1_u32).join();
+        let (second, _spawner) = spawner.spawn(|| 2_u32).join();
+
+        hil_test::assert_eq!(first, 1);
+        hil_test::assert_eq!(second, 2);
+    }
+
+    #[test]
+    fn a_detached_thread_keeps_running() {
+        static FINISHED: AtomicBool = AtomicBool::new(false);
+
+        ThreadSpawner::new(4096)
+            .spawn(|| {
+                CurrentThreadHandle::get().delay(Duration::from_millis(10));
+                FINISHED.store(true, Ordering::SeqCst);
+            })
+            .detach();
+
+        while !FINISHED.load(Ordering::SeqCst) {
+            CurrentThreadHandle::get().delay(Duration::from_millis(1));
+        }
+    }
+
+    #[test]
+    fn a_detached_thread_drops_its_return_value() {
+        static DROPPED: AtomicBool = AtomicBool::new(false);
+
+        struct Observed;
+        impl Drop for Observed {
+            fn drop(&mut self) {
+                DROPPED.store(true, Ordering::SeqCst);
+            }
+        }
+
+        ThreadSpawner::new(4096).spawn(|| Observed).detach();
+
+        while !DROPPED.load(Ordering::SeqCst) {
+            CurrentThreadHandle::get().delay(Duration::from_millis(1));
+        }
+    }
+
+    #[test]
+    #[cfg(multi_core)]
+    fn a_thread_can_be_pinned_to_the_second_core(ctx: Context) {
+        esp_rtos::start_second_core(
+            unsafe { ctx.cpu_cntl.clone_unchecked() },
+            ctx.sw_int1,
+            #[allow(static_mut_refs)]
+            unsafe {
+                &mut crate::APP_CORE_STACK
+            },
+            || {},
+        );
+
+        let (cpu, _spawner) = ThreadSpawner::new(4096)
+            .with_pinned_to(Cpu::AppCpu)
+            .with_priority(2)
+            .spawn(Cpu::current)
+            .join();
+
+        hil_test::assert!(cpu == Cpu::AppCpu);
+
+        unsafe {
+            // Park the second core, we don't need it anymore
+            esp_hal::system::CpuControl::new(ctx.cpu_cntl).park_core(Cpu::AppCpu);
+        }
     }
 
     #[test]


### PR DESCRIPTION
# Changelog

## esp-rtos

- Added: A safe threading API in the `thread` module. `ThreadSpawner` runs a function or a closure on a heap-allocated or a statically allocated `Stack`, and returns a `JoinHandle` that reads the thread's return value and hands the memory back.
- Added: `CurrentThreadHandle::name`.
- Changed: The `alloc` feature no longer enables `esp-radio-rtos-driver`.
