### PR TITLE
Ensure probe-rs stops unwinding the second core stack

### DIFF
--- a/esp-hal/src/soc/esp32p4/cpu_control.rs
+++ b/esp-hal/src/soc/esp32p4/cpu_control.rs
@@ -113,6 +113,7 @@ where
         ".option push",
         ".option norelax",
         "la gp, __global_pointer$",
+        "li ra, 0", // ensure probe-rs stops unwinding
         ".option pop",
         // Initialize the FPU (riscv32imafc has F).
         "li t0, 0x6000",

--- a/esp-hal/src/soc/esp32s31/cpu_control.rs
+++ b/esp-hal/src/soc/esp32s31/cpu_control.rs
@@ -109,6 +109,7 @@ where
         ".option push",
         ".option norelax",
         "la gp, __global_pointer$",
+        "li ra, 0", // ensure probe-rs stops unwinding
         ".option pop",
         // Follow IDF's FPU initialization, enable it in Initial state, touch
         // fcsr (which makes the state Dirty), then clear the dirty bit to


### PR DESCRIPTION
Technically, we should use `.cfi_undefined ra` but probe-rs ignores the directive for reasons lost to time.

# Changelog

## esp-hal

- Fixed: RISC-V chips now set up `ra = 0` when starting the second core. This instructs probe-rs to stop unwinding the stack cleanly.