### PR TITLE
Revert accidental stabilization of DirectBindableCpuInterrupt

### DIFF
--- a/esp-hal/src/interrupt/riscv.rs
+++ b/esp-hal/src/interrupt/riscv.rs
@@ -73,6 +73,7 @@ for_each_classified_interrupt!(
             /// Enumeration of CPU interrupts available for direct binding.
             #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
             #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+            #[instability::unstable]
             pub enum DirectBindableCpuInterrupt {
                 $(
                     #[doc = concat!(" Direct bindable CPU interrupt number ", stringify!($idx_in_class), ".")]


### PR DESCRIPTION
The only consumer is `enable_direct`, which makes this enum pointless on stable, and we also have to reserve at least interrupt 0 for IPC. This PR marks `DirectBindableCpuInterrupt` as unstable, as it should have been.

# Changelog

## esp-hal

- Fixed: Reverted the unintentionally stable `DirectBindableCpuInterrupt` to `unstable`.