### PR TITLE
Fix ESP32-S3 USB JTAG register address

### DIFF
--- a/esp-println/src/lib.rs
+++ b/esp-println/src/lib.rs
@@ -182,7 +182,7 @@ mod auto_printer {
             ))]
             const USB_DEVICE_INT_RAW: *const u32 = 0x6000f008 as *const u32;
             #[cfg(feature = "esp32s3")]
-            const USB_DEVICE_INT_RAW: *const u32 = 0x60038000 as *const u32;
+            const USB_DEVICE_INT_RAW: *const u32 = 0x60038008 as *const u32;
             #[cfg(feature = "esp32p4")]
             const USB_DEVICE_INT_RAW: *const u32 = 0x500D2008 as *const u32;
             #[cfg(feature = "esp32s31")]


### PR DESCRIPTION
#6272 could have been a trivial PR 💀🤦‍♂️

# Changelog

## esp-println

- Fixed: Fixed `auto` detection on ESP32-S3