### PR TITLE
Refcount Wi-Fi

### DIFF
--- a/esp-radio/src/esp_now/mod.rs
+++ b/esp-radio/src/esp_now/mod.rs
@@ -27,7 +27,7 @@ use crate::wifi::csi::CsiConfig;
 use crate::{
     asynch::AtomicWaker,
     sys::include::*,
-    wifi::{RxControlInfo, WifiError},
+    wifi::{RxControlInfo, WifiError, WifiRefGuard},
 };
 
 const RECEIVE_QUEUE_SIZE: usize = 10;
@@ -402,11 +402,11 @@ pub struct RateConfig {
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[instability::unstable]
-pub struct EspNowManager<'d> {
-    _rc: EspNowRc<'d>,
+pub struct EspNowManager {
+    _rc: EspNowRc,
 }
 
-impl EspNowManager<'_> {
+impl EspNowManager {
     /// Set primary Wi-Fi channel.
     /// When using ESP-NOW with an access point or station,
     /// the device cannot switch channels after connecting to Wi-Fi.
@@ -610,11 +610,11 @@ impl EspNowManager<'_> {
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[instability::unstable]
-pub struct EspNowSender<'d> {
-    _rc: EspNowRc<'d>,
+pub struct EspNowSender {
+    _rc: EspNowRc,
 }
 
-impl EspNowSender<'_> {
+impl EspNowSender {
     /// Send data to peer
     ///
     /// The peer needs to be added to the peer list first.
@@ -644,7 +644,7 @@ impl EspNowSender<'_> {
 /// invoked.
 #[must_use]
 #[instability::unstable]
-pub struct SendWaiter<'s>(PhantomData<&'s mut EspNowSender<'s>>);
+pub struct SendWaiter<'s>(PhantomData<&'s mut EspNowSender>);
 
 impl SendWaiter<'_> {
     /// Wait for the previous sending to complete, i.e. the send callback is
@@ -677,11 +677,11 @@ impl Drop for SendWaiter<'_> {
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[instability::unstable]
-pub struct EspNowReceiver<'d> {
-    _rc: EspNowRc<'d>,
+pub struct EspNowReceiver {
+    _rc: EspNowRc,
 }
 
-impl EspNowReceiver<'_> {
+impl EspNowReceiver {
     /// Receives data from the ESP-NOW queue.
     #[instability::unstable]
     pub fn receive(&self) -> Option<ReceivedData> {
@@ -692,24 +692,24 @@ impl EspNowReceiver<'_> {
 /// The reference counter for properly deinit espnow after all parts are
 /// dropped.
 #[derive(Debug)]
-struct EspNowRc<'d> {
+struct EspNowRc {
     rc: &'static AtomicU8,
-    inner: PhantomData<EspNow<'d>>,
+    _wifi_guard: WifiRefGuard,
 }
 
 #[cfg(feature = "defmt")]
-impl defmt::Format for EspNowRc<'_> {
+impl defmt::Format for EspNowRc {
     fn format(&self, f: defmt::Formatter<'_>) {
         defmt::write!(
             f,
-            "EspNowRc {{ rc: {}, inner: ... }}",
+            "EspNowRc {{ rc: {}, _wifi_guard: ... }}",
             self.rc.load(Ordering::Relaxed)
         );
     }
 }
 
-impl EspNowRc<'_> {
-    fn new() -> Self {
+impl EspNowRc {
+    fn new(wifi_guard: WifiRefGuard) -> Self {
         static ESP_NOW_RC: AtomicU8 = AtomicU8::new(0);
         assert!(
             ESP_NOW_RC.fetch_add(1, Ordering::AcqRel) == 0,
@@ -718,22 +718,22 @@ impl EspNowRc<'_> {
 
         Self {
             rc: &ESP_NOW_RC,
-            inner: PhantomData,
+            _wifi_guard: wifi_guard,
         }
     }
 }
 
-impl Clone for EspNowRc<'_> {
+impl Clone for EspNowRc {
     fn clone(&self) -> Self {
         self.rc.fetch_add(1, Ordering::Release);
         Self {
             rc: self.rc,
-            inner: PhantomData,
+            _wifi_guard: self._wifi_guard.clone(),
         }
     }
 }
 
-impl Drop for EspNowRc<'_> {
+impl Drop for EspNowRc {
     fn drop(&mut self) {
         if self.rc.fetch_sub(1, Ordering::AcqRel) == 1 {
             unsafe {
@@ -758,16 +758,15 @@ impl Drop for EspNowRc<'_> {
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[instability::unstable]
-pub struct EspNow<'d> {
-    manager: EspNowManager<'d>,
-    sender: EspNowSender<'d>,
-    receiver: EspNowReceiver<'d>,
-    _phantom: PhantomData<&'d ()>,
+pub struct EspNow {
+    manager: EspNowManager,
+    sender: EspNowSender,
+    receiver: EspNowReceiver,
 }
 
-impl<'d> EspNow<'d> {
-    pub(crate) fn new_internal() -> EspNow<'d> {
-        let espnow_rc = EspNowRc::new();
+impl EspNow {
+    pub(crate) fn new_internal(guard: WifiRefGuard) -> EspNow {
+        let espnow_rc = EspNowRc::new(guard);
         let esp_now = EspNow {
             manager: EspNowManager {
                 _rc: espnow_rc.clone(),
@@ -776,7 +775,6 @@ impl<'d> EspNow<'d> {
                 _rc: espnow_rc.clone(),
             },
             receiver: EspNowReceiver { _rc: espnow_rc },
-            _phantom: PhantomData,
         };
 
         check_error_expect!({ esp_now_init() }, "esp-now-init failed");
@@ -805,7 +803,7 @@ impl<'d> EspNow<'d> {
     /// Splits the `EspNow` instance into its manager, sender, and receiver
     /// components.
     #[instability::unstable]
-    pub fn split(self) -> (EspNowManager<'d>, EspNowSender<'d>, EspNowReceiver<'d>) {
+    pub fn split(self) -> (EspNowManager, EspNowSender, EspNowReceiver) {
         (self.manager, self.sender, self.receiver)
     }
 
@@ -971,7 +969,7 @@ unsafe extern "C" fn rcv_cb(
     });
 }
 
-impl EspNowReceiver<'_> {
+impl EspNowReceiver {
     /// This function takes mutable reference to self because the
     /// implementation of `ReceiveFuture` is not logically thread
     /// safe.
@@ -981,7 +979,7 @@ impl EspNowReceiver<'_> {
     }
 }
 
-impl EspNowSender<'_> {
+impl EspNowSender {
     /// Sends data asynchronously to a peer (using its MAC) using ESP-NOW.
     #[instability::unstable]
     pub fn send_async<'s, 'r>(
@@ -998,7 +996,7 @@ impl EspNowSender<'_> {
     }
 }
 
-impl EspNow<'_> {
+impl EspNow {
     /// This function takes mutable reference to self because the
     /// implementation of `ReceiveFuture` is not logically thread
     /// safe.
@@ -1024,7 +1022,7 @@ impl EspNow<'_> {
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 #[instability::unstable]
 pub struct SendFuture<'s, 'r> {
-    _sender: PhantomData<&'s mut EspNowSender<'s>>,
+    _sender: PhantomData<&'s mut EspNowSender>,
     addr: &'r [u8; 6],
     data: &'r [u8],
     sent: bool,
@@ -1062,7 +1060,7 @@ impl core::future::Future for SendFuture<'_, '_> {
 /// the rest of them unwakable.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
 #[instability::unstable]
-pub struct ReceiveFuture<'r>(PhantomData<&'r mut EspNowReceiver<'r>>);
+pub struct ReceiveFuture<'r>(PhantomData<&'r mut EspNowReceiver>);
 
 impl core::future::Future for ReceiveFuture<'_> {
     type Output = ReceivedData;

--- a/esp-radio/src/lib.rs
+++ b/esp-radio/src/lib.rs
@@ -399,7 +399,7 @@ static RADIO_REFCOUNT: Refcount = Refcount::new();
 impl RadioRefGuard {
     /// Increments the refcount. If the old count was 0, it performs hardware init.
     /// If hardware init fails, it rolls back the refcount only once.
-    fn new() -> Self {
+    pub(crate) fn new() -> Self {
         debug!("Creating RadioRefGuard");
 
         RADIO_REFCOUNT.increment(init);

--- a/esp-radio/src/refcount.rs
+++ b/esp-radio/src/refcount.rs
@@ -33,6 +33,34 @@ impl Refcount {
         }
     }
 
+    #[cfg(feature = "wifi")]
+    pub fn try_increment<E>(&self, on_first: impl FnOnce() -> Result<(), E>) -> Result<bool, E> {
+        loop {
+            let op = self
+                .0
+                .fetch_update(Ordering::Release, Ordering::Acquire, |old| {
+                    if old == 1 { None } else { Some(old + 1) }
+                });
+
+            match op {
+                Ok(0) => {
+                    return match on_first() {
+                        Ok(()) => {
+                            self.0.store(2, Ordering::Release);
+                            Ok(true)
+                        }
+                        Err(e) => {
+                            self.0.store(0, Ordering::Release);
+                            Err(e)
+                        }
+                    };
+                }
+                Ok(_) => return Ok(false),
+                Err(_) => {}
+            }
+        }
+    }
+
     pub fn decrement(&self, on_last: impl FnOnce()) {
         loop {
             let op = self

--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -85,6 +85,7 @@ use crate::{
     RadioRefGuard,
     asynch::AtomicWaker,
     hal::ram,
+    refcount::Refcount,
     sys::{
         c_types,
         include::{self, *},
@@ -94,7 +95,7 @@ use crate::{
 pub mod ap;
 
 unstable_module!(
-    #[cfg(all(feature = "csi", wifi_csi_supported))]
+    #[cfg(feature = "csi")]
     #[cfg_attr(docsrs, doc(cfg(feature = "csi")))]
     pub mod csi;
     pub mod event;
@@ -2565,35 +2566,55 @@ impl ControllerConfig {
     }
 }
 
+static WIFI_REFCOUNT: Refcount = Refcount::new();
+
+/// Keeps Wi-Fi initialized until the last guard is dropped.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub(crate) struct WifiRefGuard {
+    _radio_guard: RadioRefGuard,
+}
+
+impl Clone for WifiRefGuard {
+    fn clone(&self) -> Self {
+        let _radio_guard = RadioRefGuard::new();
+        WIFI_REFCOUNT.increment(|| {});
+        Self { _radio_guard }
+    }
+}
+
+impl Drop for WifiRefGuard {
+    fn drop(&mut self) {
+        WIFI_REFCOUNT.decrement(|| {
+            state::locked(|| {
+                set_access_point_state(WifiAccessPointState::Uninitialized);
+                set_station_state(WifiStationState::Uninitialized);
+
+                if let Err(e) = crate::wifi::wifi_deinit() {
+                    warn!("Failed to cleanly deinit wifi: {:?}", e);
+                }
+
+                #[cfg(rng_trng_supported)]
+                esp_hal::if_unstable_hal! {
+                    esp_hal::rng::TrngSource::decrease_entropy_source_counter(unsafe {
+                        esp_hal::Internal::conjure()
+                    });
+                }
+            })
+        });
+    }
+}
+
 /// Wi-Fi controller.
 ///
-/// When the controller is dropped, the Wi-Fi driver is
-/// deinitialized and Wi-Fi is stopped.
+/// When the controller is dropped, the Wi-Fi driver is deinitialized and Wi-Fi
+/// is stopped unless an ESP-NOW or sniffer instance created from it is still
+/// alive. In that case, Wi-Fi keeps running until that instance is dropped too.
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct WifiController<'d> {
-    _guard: RadioRefGuard,
+    _guard: WifiRefGuard,
     _phantom: PhantomData<&'d ()>,
-}
-
-impl Drop for WifiController<'_> {
-    fn drop(&mut self) {
-        state::locked(|| {
-            set_access_point_state(WifiAccessPointState::Uninitialized);
-            set_station_state(WifiStationState::Uninitialized);
-
-            if let Err(e) = crate::wifi::wifi_deinit() {
-                warn!("Failed to cleanly deinit wifi: {:?}", e);
-            }
-
-            #[cfg(rng_trng_supported)]
-            esp_hal::if_unstable_hal! {
-                esp_hal::rng::TrngSource::decrease_entropy_source_counter(unsafe {
-                    esp_hal::Internal::conjure()
-                });
-            }
-        })
-    }
 }
 
 impl<'d> WifiController<'d> {
@@ -2610,7 +2631,8 @@ impl<'d> WifiController<'d> {
     /// Create a Wi-Fi controller. The default initial configuration is
     /// [`Config::Station`]`(`[`StationConfig::default()`]`)`.
     ///
-    /// Dropping the controller will deinitialize / stop Wi-Fi.
+    /// Dropping the controller deinitializes Wi-Fi unless an ESP-NOW or sniffer
+    /// instance created from it is still alive.
     ///
     /// Create [`Interface`]s separately via [`Interface::station()`] /
     /// [`Interface::access_point()`].
@@ -2632,8 +2654,6 @@ impl<'d> WifiController<'d> {
         device: crate::hal::peripherals::WIFI<'d>,
         config: ControllerConfig,
     ) -> Result<Self, WifiError> {
-        let _guard = RadioRefGuard::new();
-
         config.validate();
 
         event::enable_wifi_events(
@@ -2648,60 +2668,75 @@ impl<'d> WifiController<'d> {
                 | WifiEvent::ScanDone,
         );
 
-        unsafe {
-            internal::G_CONFIG = wifi_init_config_t {
-                osi_funcs: (&raw const internal::__ESP_RADIO_G_WIFI_OSI_FUNCS).cast_mut(),
+        let radio_guard = RadioRefGuard::new();
 
-                wpa_crypto_funcs: g_wifi_default_wpa_crypto_funcs,
-                static_rx_buf_num: config.static_rx_buf_num as _,
-                dynamic_rx_buf_num: config.dynamic_rx_buf_num as _,
-                tx_buf_type: crate::sys::include::CONFIG_ESP_WIFI_TX_BUFFER_TYPE as i32,
-                static_tx_buf_num: config.static_tx_buf_num as _,
-                dynamic_tx_buf_num: config.dynamic_tx_buf_num as _,
-                rx_mgmt_buf_type: crate::sys::include::CONFIG_ESP_WIFI_DYNAMIC_RX_MGMT_BUF as i32,
-                rx_mgmt_buf_num: crate::sys::include::CONFIG_ESP_WIFI_RX_MGMT_BUF_NUM_DEF as i32,
-                cache_tx_buf_num: crate::sys::include::WIFI_CACHE_TX_BUFFER_NUM as i32,
-                csi_enable: cfg!(feature = "csi") as i32,
-                ampdu_rx_enable: config.ampdu_rx_enable as _,
-                ampdu_tx_enable: config.ampdu_tx_enable as _,
-                amsdu_tx_enable: config.amsdu_tx_enable as _,
-                nvs_enable: 0,
-                nano_enable: 0,
-                rx_ba_win: config.rx_ba_win as _,
-                wifi_task_core_id: Cpu::current() as _,
-                beacon_max_len: crate::sys::include::WIFI_SOFTAP_BEACON_MAX_LEN as i32,
-                mgmt_sbuf_num: crate::sys::include::WIFI_MGMT_SBUF_NUM as i32,
-                feature_caps: internal::__ESP_RADIO_G_WIFI_FEATURE_CAPS,
-                sta_disconnected_pm: config.sta_disconnected_pm as _,
-                espnow_max_encrypt_num: config.espnow_max_encrypt_num as _,
-
-                tx_hetb_queue_num: 3,
-                dump_hesigb_enable: false,
-
-                magic: WIFI_INIT_CONFIG_MAGIC as i32,
-            };
-        }
-
-        DATA_QUEUE_RX_AP.with(|queue| queue.change_capacity(config.rx_queue_size))?;
-        DATA_QUEUE_RX_STA.with(|queue| queue.change_capacity(config.rx_queue_size))?;
-
-        TX_QUEUE_SIZE.store(config.tx_queue_size, Ordering::Relaxed);
-
-        crate::wifi::wifi_init(device)?;
-
-        // At some point the "High-speed ADC" entropy source became available.
-        #[cfg(rng_trng_supported)]
-        esp_hal::if_unstable_hal! {
+        let first = WIFI_REFCOUNT.try_increment(|| -> Result<(), WifiError> {
             unsafe {
-                esp_hal::rng::TrngSource::increase_entropy_source_counter()
-            };
+                internal::G_CONFIG = wifi_init_config_t {
+                    osi_funcs: (&raw const internal::__ESP_RADIO_G_WIFI_OSI_FUNCS).cast_mut(),
+
+                    wpa_crypto_funcs: g_wifi_default_wpa_crypto_funcs,
+                    static_rx_buf_num: config.static_rx_buf_num as _,
+                    dynamic_rx_buf_num: config.dynamic_rx_buf_num as _,
+                    tx_buf_type: crate::sys::include::CONFIG_ESP_WIFI_TX_BUFFER_TYPE as i32,
+                    static_tx_buf_num: config.static_tx_buf_num as _,
+                    dynamic_tx_buf_num: config.dynamic_tx_buf_num as _,
+                    rx_mgmt_buf_type: crate::sys::include::CONFIG_ESP_WIFI_DYNAMIC_RX_MGMT_BUF
+                        as i32,
+                    rx_mgmt_buf_num: crate::sys::include::CONFIG_ESP_WIFI_RX_MGMT_BUF_NUM_DEF
+                        as i32,
+                    cache_tx_buf_num: crate::sys::include::WIFI_CACHE_TX_BUFFER_NUM as i32,
+                    csi_enable: cfg!(feature = "csi") as i32,
+                    ampdu_rx_enable: config.ampdu_rx_enable as _,
+                    ampdu_tx_enable: config.ampdu_tx_enable as _,
+                    amsdu_tx_enable: config.amsdu_tx_enable as _,
+                    nvs_enable: 0,
+                    nano_enable: 0,
+                    rx_ba_win: config.rx_ba_win as _,
+                    wifi_task_core_id: Cpu::current() as _,
+                    beacon_max_len: crate::sys::include::WIFI_SOFTAP_BEACON_MAX_LEN as i32,
+                    mgmt_sbuf_num: crate::sys::include::WIFI_MGMT_SBUF_NUM as i32,
+                    feature_caps: internal::__ESP_RADIO_G_WIFI_FEATURE_CAPS,
+                    sta_disconnected_pm: config.sta_disconnected_pm as _,
+                    espnow_max_encrypt_num: config.espnow_max_encrypt_num as _,
+
+                    tx_hetb_queue_num: 3,
+                    dump_hesigb_enable: false,
+
+                    magic: WIFI_INIT_CONFIG_MAGIC as i32,
+                };
+            }
+
+            DATA_QUEUE_RX_AP.with(|queue| queue.change_capacity(config.rx_queue_size))?;
+            DATA_QUEUE_RX_STA.with(|queue| queue.change_capacity(config.rx_queue_size))?;
+
+            TX_QUEUE_SIZE.store(config.tx_queue_size, Ordering::Relaxed);
+
+            crate::wifi::wifi_init(device)?;
+
+            #[cfg(rng_trng_supported)]
+            esp_hal::if_unstable_hal! {
+                unsafe {
+                    esp_hal::rng::TrngSource::increase_entropy_source_counter()
+                };
+            }
+
+            Ok(())
+        })?;
+
+        if !first {
+            warn!(
+                "Wi-Fi is already initialized; init-only ControllerConfig settings were ignored: \
+                 static_rx_buf_num, dynamic_rx_buf_num, static_tx_buf_num, dynamic_tx_buf_num, \
+                 rx_queue_size, tx_queue_size, rx_ba_win, espnow_max_encrypt_num, \
+                 ampdu_rx_enable, ampdu_tx_enable, amsdu_tx_enable"
+            );
         }
 
-        // Only create WifiController after we've enabled TRNG - otherwise returning an
-        // error from this function will cause panic because WifiController::drop tries
-        // to disable the TRNG.
         let mut controller = WifiController {
-            _guard,
+            _guard: WifiRefGuard {
+                _radio_guard: radio_guard,
+            },
             _phantom: Default::default(),
         };
 
@@ -2719,30 +2754,36 @@ impl<'d> WifiController<'d> {
 }
 
 impl WifiController<'_> {
-    /// Returns an ESP-NOW instance tied to this controller's lifetime.
+    /// Returns an ESP-NOW instance independent of this controller.
+    ///
+    /// Wi-Fi stays initialized, configured, and running until the instance is
+    /// dropped.
     ///
     /// # Panics
     ///
     /// Panics if an ESP-NOW instance already exists.
-    #[cfg(all(feature = "esp-now", feature = "unstable"))]
+    #[cfg(feature = "esp-now")]
     #[instability::unstable]
-    pub fn esp_now(&self) -> crate::esp_now::EspNow<'_> {
-        crate::esp_now::EspNow::new_internal()
+    pub fn esp_now(&self) -> crate::esp_now::EspNow {
+        crate::esp_now::EspNow::new_internal(self._guard.clone())
     }
 
-    /// Returns a sniffer instance tied to this controller's lifetime.
+    /// Returns a sniffer instance independent of this controller.
+    ///
+    /// Wi-Fi stays initialized, configured, and running until the instance is
+    /// dropped.
     ///
     /// # Panics
     ///
     /// Panics if a sniffer instance already exists.
-    #[cfg(all(feature = "sniffer", feature = "unstable"))]
+    #[cfg(feature = "sniffer")]
     #[instability::unstable]
-    pub fn sniffer(&self) -> Sniffer<'_> {
-        Sniffer::new()
+    pub fn sniffer(&self) -> Sniffer {
+        Sniffer::new(self._guard.clone())
     }
 
     /// Set CSI configuration and register the receiving callback.
-    #[cfg(all(feature = "csi", feature = "unstable"))]
+    #[cfg(feature = "csi")]
     #[instability::unstable]
     pub fn set_csi(
         &mut self,

--- a/esp-radio/src/wifi/sniffer.rs
+++ b/esp-radio/src/wifi/sniffer.rs
@@ -1,10 +1,8 @@
 //! Wi-Fi sniffer.
 
-use core::marker::PhantomData;
-
 use esp_sync::NonReentrantMutex;
 
-use super::{RxControlInfo, SNIFFER_BIT, release, try_acquire};
+use super::{RxControlInfo, SNIFFER_BIT, WifiRefGuard, release, try_acquire};
 use crate::{
     WifiError,
     sys::include::{
@@ -78,12 +76,12 @@ unsafe extern "C" fn promiscuous_rx_cb(buf: *mut core::ffi::c_void, frame_type: 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[instability::unstable]
 #[non_exhaustive]
-pub struct Sniffer<'d> {
-    _phantom: PhantomData<&'d ()>,
+pub struct Sniffer {
+    _wifi_guard: WifiRefGuard,
 }
 
-impl Sniffer<'_> {
-    pub(crate) fn new() -> Self {
+impl Sniffer {
+    pub(crate) fn new(guard: WifiRefGuard) -> Self {
         assert!(try_acquire(SNIFFER_BIT), "sniffer already in use");
 
         // If registering the callback fails we panic, so release the singleton
@@ -95,9 +93,7 @@ impl Sniffer<'_> {
             unwrap!(res);
         }
 
-        Self {
-            _phantom: PhantomData,
-        }
+        Self { _wifi_guard: guard }
     }
 
     /// Set promiscuous mode enabled or disabled.
@@ -136,7 +132,7 @@ impl Sniffer<'_> {
     }
 }
 
-impl Drop for Sniffer<'_> {
+impl Drop for Sniffer {
     fn drop(&mut self) {
         // Clear the user callback first so the C trampoline becomes a no-op even
         // if it fires during the teardown window below.

--- a/examples/esp-now/embassy_esp_now_duplex/src/main.rs
+++ b/examples/esp-now/embassy_esp_now_duplex/src/main.rs
@@ -47,20 +47,19 @@ async fn main(spawner: Spawner) -> ! {
     esp_rtos::start(timg0.timer0, peripherals.FROM_CPU_INTR0);
 
     let wifi = peripherals.WIFI;
-    let controller = mk_static!(
-        esp_radio::wifi::WifiController<'static>,
-        esp_radio::wifi::WifiController::new(wifi, Default::default()).unwrap()
-    );
+    let controller = esp_radio::wifi::WifiController::new(wifi, Default::default()).unwrap();
 
     let esp_now = controller.esp_now();
+    // For demonstration purposes - you _may_ drop the controller, you don't _have to_.
+    drop(controller);
     esp_now.set_channel(11).unwrap();
 
     println!("esp-now version {}", esp_now.version().unwrap());
 
     let (manager, sender, receiver) = esp_now.split();
-    let manager = mk_static!(EspNowManager<'static>, manager);
+    let manager = mk_static!(EspNowManager, manager);
     let sender = mk_static!(
-        Mutex::<NoopRawMutex, EspNowSender<'static>>,
+        Mutex::<NoopRawMutex, EspNowSender>,
         Mutex::<NoopRawMutex, _>::new(sender)
     );
 
@@ -89,7 +88,7 @@ async fn main(spawner: Spawner) -> ! {
 }
 
 #[embassy_executor::task]
-async fn broadcaster(sender: &'static Mutex<NoopRawMutex, EspNowSender<'static>>) {
+async fn broadcaster(sender: &'static Mutex<NoopRawMutex, EspNowSender>) {
     let mut ticker = Ticker::every(Duration::from_secs(1));
     loop {
         ticker.next().await;
@@ -102,7 +101,7 @@ async fn broadcaster(sender: &'static Mutex<NoopRawMutex, EspNowSender<'static>>
 }
 
 #[embassy_executor::task]
-async fn listener(manager: &'static EspNowManager<'static>, mut receiver: EspNowReceiver<'static>) {
+async fn listener(manager: &'static EspNowManager, mut receiver: EspNowReceiver) {
     loop {
         let r = receiver.receive_async().await;
         println!("Received {:?}", r.data());

--- a/examples/wifi/80211_tx/src/main.rs
+++ b/examples/wifi/80211_tx/src/main.rs
@@ -42,8 +42,8 @@ async fn main(_spawner: embassy_executor::Spawner) -> ! {
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     esp_rtos::start(timg0.timer0, peripherals.FROM_CPU_INTR0);
 
-    // The sniffer borrows the controller, so we only need the controller here —
-    // no station/AP `Interface` is required for raw 802.11 transmit.
+    // Wi-Fi stays initialized while the sniffer is alive — no station/AP
+    // `Interface` is required for raw 802.11 transmit.
     let controller =
         esp_radio::wifi::WifiController::new(peripherals.WIFI, Default::default()).unwrap();
 

--- a/examples/wifi/sniffer/src/main.rs
+++ b/examples/wifi/sniffer/src/main.rs
@@ -36,8 +36,8 @@ async fn main(_spawner: embassy_executor::Spawner) -> ! {
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     esp_rtos::start(timg0.timer0, peripherals.FROM_CPU_INTR0);
 
-    // The sniffer borrows the controller, so we only need the controller here —
-    // no station/AP `Interface` is required for promiscuous capture.
+    // Wi-Fi stays initialized while the sniffer is alive — no station/AP
+    // `Interface` is required for promiscuous capture.
     let controller =
         esp_radio::wifi::WifiController::new(peripherals.WIFI, Default::default()).unwrap();
 

--- a/hil-test/src/bin/radio_basic/esp_now_config.rs
+++ b/hil-test/src/bin/radio_basic/esp_now_config.rs
@@ -2,7 +2,7 @@
 mod tests {
     use esp_hal::{clock::CpuClock, peripherals::Peripherals, timer::timg::TimerGroup};
     use esp_radio::{
-        esp_now::{Error, EspNowError, EspNowWifiInterface, PeerInfo},
+        esp_now::{BROADCAST_ADDRESS, Error, EspNowError, EspNowWifiInterface, PeerInfo},
         wifi::{ControllerConfig, WifiController},
     };
 
@@ -74,6 +74,28 @@ mod tests {
         }
 
         assert_eq!(esp_now.peer_count().unwrap().encrypted_count, 4);
+    }
+
+    #[test]
+    fn esp_now_survives_controller_drop(p: Peripherals) {
+        let timg0 = TimerGroup::new(p.TIMG0);
+        esp_rtos::start(timg0.timer0, p.FROM_CPU_INTR0);
+
+        let mut wifi = p.WIFI;
+        let controller = WifiController::new(wifi.reborrow(), Default::default()).unwrap();
+        let mut esp_now = controller.esp_now();
+        drop(controller);
+
+        esp_now.set_channel(1).unwrap();
+        esp_now
+            .send(&BROADCAST_ADDRESS, b"hello")
+            .unwrap()
+            .wait()
+            .unwrap();
+
+        drop(esp_now);
+
+        let _controller = WifiController::new(wifi, Default::default()).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
My approach to close #6220 - now you can do whatever you want with WifiController. As long as any Wi-Fi users exist, Wi-Fi is not deinitialized. The interfaces don't need the lifetime, they just have to come from WifiController so that Wi-Fi is already configured and running.

I don't know how much sense this makes in the long run, since I think you can break EspNow by reconfiguring Wi-Fi in an inappropriate way, but this is meant for a short-term solution so that we don't release an accidentally unusable implementatin.

# Changelog

## esp-radio

- Changed: `WifiController::esp_now()` and `WifiController::sniffer()` return instances that no longer borrow the controller. Wi-Fi stays initialized until the instance is dropped.
- Changed: `EspNow`, `EspNowManager`, `EspNowSender`, `EspNowReceiver`, and `Sniffer` no longer carry a lifetime parameter.
- Added: HIL test `esp_now_survives_controller_drop` to verify Wi-Fi reference counting across controller drop and ESP-NOW teardown.

# Migration guide

## esp-radio/Wi-Fi

### ESP-NOW and sniffer no longer borrow `WifiController`

`WifiController::esp_now()` and `WifiController::sniffer()` now return `EspNow` and `Sniffer` without a lifetime parameter. Each instance keeps Wi-Fi initialized until the instance is dropped.

Remove lifetime arguments from ESP-NOW and sniffer types:

```rust
// before
let esp_now = controller.esp_now();
fn task(manager: &'static EspNowManager<'static>) { ... }

// after
let esp_now = controller.esp_now();
fn task(manager: &'static EspNowManager) { ... }
```

You no longer need `mk_static!` on the controller solely to obtain `'static` ESP-NOW or sniffer handles. Drop the controller when you only need the ESP-NOW or sniffer instance:

```rust
let controller = WifiController::new(peripherals.WIFI, Default::default())?;
let esp_now = controller.esp_now();
drop(controller);
// Wi-Fi stays running until `esp_now` is dropped
```

Because the instance no longer borrows the controller, `&mut self` controller methods remain callable while an ESP-NOW or sniffer instance is live. `set_config` can change the mode and restart Wi-Fi, and `set_channel` can move the channel.

### Init-only `ControllerConfig` settings apply only on first Wi-Fi init

When Wi-Fi is already initialized because an ESP-NOW or sniffer guard from a previously dropped controller is still alive, creating a new `WifiController` skips init-only settings: static/dynamic RX and TX buffer counts, `rx_queue_size`, `tx_queue_size`, `rx_ba_win`, `espnow_max_encrypt_num`, and AMPDU/AMSDU settings. Runtime configuration (`set_country_info`, `set_power_saving`, `set_config`, default TX power) is still applied.
