### PR TITLE
esp-radio: expose esp-now v1/v2 length and make it more obvious

### DIFF
--- a/esp-radio/src/esp_now/mod.rs
+++ b/esp-radio/src/esp_now/mod.rs
@@ -32,8 +32,11 @@ use crate::{
 
 const RECEIVE_QUEUE_SIZE: usize = 10;
 
-/// Maximum payload length
-pub const ESP_NOW_MAX_DATA_LEN: usize = 250;
+/// Maximum ESP-NOW v1.0 payload length.
+pub const ESP_NOW_MAX_DATA_LEN_V1: usize = crate::sys::include::ESP_NOW_MAX_DATA_LEN as _;
+
+/// Maximum ESP-NOW v2.0 payload length.
+pub const ESP_NOW_MAX_DATA_LEN_V2: usize = crate::sys::include::ESP_NOW_MAX_DATA_LEN_V2 as _;
 
 /// Broadcast address
 pub const BROADCAST_ADDRESS: [u8; 6] = [0xffu8, 0xffu8, 0xffu8, 0xffu8, 0xffu8, 0xffu8];
@@ -417,6 +420,16 @@ impl EspNowManager<'_> {
     }
 
     /// Get the version of ESP-NOW.
+    ///
+    /// Currently, ESP-NOW supports two versions: v1.0 and v2.0. The maximum packet length supported
+    /// by v2.0 devices is 1470 (ESP_NOW_MAX_DATA_LEN_V2) bytes, while the maximum packet length
+    /// supported by v1.0 devices is 250 (ESP_NOW_MAX_DATA_LEN_V1) bytes. The v2.0 devices are
+    /// capable of receiving packets from both v2.0 and v1.0 devices. In contrast, v1.0 devices
+    /// can only receive packets from other v1.0 devices.
+    ///
+    /// However, v1.0 devices can receive v2.0 packets if the packet length is less than or equal to
+    /// 250. For packets exceeding this length, the v1.0 devices will either truncate the data to the
+    /// first 250 bytes or discard the packet entirely.
     #[instability::unstable]
     pub fn version(&self) -> Result<u32, EspNowError> {
         let mut version = 0u32;

--- a/esp-radio/src/esp_now/mod.rs
+++ b/esp-radio/src/esp_now/mod.rs
@@ -421,15 +421,9 @@ impl EspNowManager<'_> {
 
     /// Get the version of ESP-NOW.
     ///
-    /// Currently, ESP-NOW supports two versions: v1.0 and v2.0. The maximum packet length supported
-    /// by v2.0 devices is 1470 (ESP_NOW_MAX_DATA_LEN_V2) bytes, while the maximum packet length
-    /// supported by v1.0 devices is 250 (ESP_NOW_MAX_DATA_LEN_V1) bytes. The v2.0 devices are
-    /// capable of receiving packets from both v2.0 and v1.0 devices. In contrast, v1.0 devices
-    /// can only receive packets from other v1.0 devices.
-    ///
-    /// However, v1.0 devices can receive v2.0 packets if the packet length is less than or equal to
-    /// 250. For packets exceeding this length, the v1.0 devices will either truncate the data to the
-    /// first 250 bytes or discard the packet entirely.
+    /// ESP-NOW supports two versions: v1.0 and v2.0. v1.0 and v2.0 are capable of talking to each
+    /// other, but v1.0 devices may truncate or discard v2.0 messages that exceed the v1.0 maximum
+    /// data length ([`ESP_NOW_MAX_DATA_LEN_V1`]).
     #[instability::unstable]
     pub fn version(&self) -> Result<u32, EspNowError> {
         let mut version = 0u32;


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable).
- [x] I have used `cargo xtask fmt` command to ensure that all changed code is formatted correctly.
- [x] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` or `manual-changelog` label as appropriate.
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

The existing const somewhat implied that only v1 payload lengths were supported. This exposes both and adds a doc comment explaining it.

#### Testing

Ensured xtask tasks were passing.

---

<!-- ============================================================
  Changelog and migration guide entries live here in the PR body.
  They will be collected automatically at release time.
  Delete any section that doesn't apply to your PR.
  ============================================================ -->

# Changelog

## esp-radio

- Changed: `ESP_NOW_MAX_DATA_LEN` is now `ESP_NOW_MAX_DATA_LEN_V1` and `ESP_NOW_MAX_DATA_LEN_V2`

# Migration guide

## esp-radio/ESP-NOW

### `ESP_NOW_MAX_DATA_LEN` has been split into `ESP_NOW_MAX_DATA_LEN_V1` and `ESP_NOW_MAX_DATA_LEN_V2`

Replace occurrences of `ESP_NOW_MAX_DATA_LEN` with the `V1` or `V2` const as needed. Note that v1.0 is only used on devices running firmware prior to ESP-IDF v5.4
