### PR TITLE
Release esp-hal: 1.2.0 → 1.2.1

### DIFF
--- a/esp-hal/CHANGELOG.md
+++ b/esp-hal/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 
+## [v1.2.1] - 2026-09-08
+
+### Fixed
+
+- Reverted the unintentionally stable `DirectBindableCpuInterrupt` to `unstable`. (#6270)
+
 ## [v1.2.0] - 2026-09-01
 
 ### Fixed
@@ -1890,4 +1896,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [v1.1.0]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.0.0...esp-hal-v1.1.0
 [v1.2.0-rc.0]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.1.0...esp-hal-v1.2.0-rc.0
 [v1.2.0]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.2.0-rc.0...esp-hal-v1.2.0
-[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.2.0...HEAD
+[v1.2.1]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.2.0...esp-hal-v1.2.1
+[Unreleased]: https://github.com/esp-rs/esp-hal/compare/esp-hal-v1.2.1...HEAD

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "esp-hal"
-version       = "1.2.0"
+version       = "1.2.1"
 edition       = "2024"
 rust-version  = "1.95.0"
 description   = "Bare-metal HAL for Espressif devices"


### PR DESCRIPTION
⚠️ This pull request was branched off from `esp-hal-1.2.x`. ⚠️

This pull request prepares the following packages for release:

- esp-hal: 1.2.0 → 1.2.1

<details>

<summary>Release plan (click to expand)</summary>

```jsonc
{
  "base": "esp-hal-1.2.x",
  "slug": "0hyxo6",
  "backport": {
    "package": "esp-hal",
    "major": 1,
    "minor": 2
  },
  "packages": [
    {
      "package": "esp-hal",
      "semver_checked": true,
      "current_version": "1.2.0",
      "new_version": "1.2.1",
      "tag_name": "esp-hal-v1.2.1",
      "bump": {
        "base": "Patch",
        "pre": null
      }
    }
  ]
}
```

</details>

Please review the changes and merge them into the `esp-hal-1.2.x` branch.

After merging, please make sure you have this release plan in the repo root,
then run the following command on the `esp-hal-1.2.x` branch to tag and publish the packages:

```
cargo xrelease publish-plan --no-dry-run
```
