### PR TITLE
Fi `latest` redirect

### DIFF
--- a/resources/latest_redirect.html.somni
+++ b/resources/latest_redirect.html.somni
@@ -6,10 +6,16 @@
 <script>
 /*
   nginx sends users here as …/latest/?path=<decoded remainder>. We merge `path` onto `base`
-  (../<semver>/…) only when it looks like a rustdoc-relative path.
+  (../<semver>/, the version root) only when it looks like a rustdoc-relative path;
+  otherwise we open `base` + `fallback`, the version's landing page.
+
+  Fragments (#method.foo) never reach nginx, but browsers re-attach the original
+  fragment to the 301 Location, so it is available here as location.hash. Carry it
+  over explicitly: location.replace() with a fragment-less URL would drop it.
 */
 (function () {
   var base = "{{ base }}";
+  var fallback = "{{ fallback }}";
   var pathFromQuery = new URLSearchParams(location.search).get("path");
 
   /* Reject junk `?path=` values, otherwise we only open `base`. */
@@ -25,15 +31,16 @@
     return /^[0-9A-Za-z./_-]+$/.test(path);
   }
 
-  /* Deep page under `base`, or semver root only if `path` is missing / invalid. */
+  /* Deep page under `base`, or the version's landing page if `path` is missing / invalid. */
+  var hash = location.hash; /* "" or "#fragment"; safe to append, fragments are client-side only. */
   if (pathFromQuery && isAllowedDocPath(pathFromQuery)) {
-    location.replace(base + pathFromQuery);
+    location.replace(base + pathFromQuery + hash);
   } else {
-    location.replace(base);
+    location.replace(base + fallback + hash);
   }
 })();
 </script>
-<noscript><meta http-equiv="refresh" content="0; url={{ base }}" /></noscript>
+<noscript><meta http-equiv="refresh" content="0; url={{ base }}{{ fallback }}" /></noscript>
 </head>
 <body></body>
 </html>

--- a/xtask/src/documentation.rs
+++ b/xtask/src/documentation.rs
@@ -289,11 +289,26 @@ fn highest_eligible_version(manifest: &Manifest) -> Option<semver::Version> {
 }
 
 /// Relative URL from `latest/index.html` to this package's versioned docs root.
-fn latest_redirect_base(package: &Package, version: &semver::Version) -> String {
+///
+/// nginx rewrites `/latest/<rest>` deep links to `/latest/?path=<rest>`, and the
+/// redirect page merges that `path` onto this base, so the base must always be the
+/// version root: `<rest>` already starts with the chip directory for packages with
+/// device-specific docs, or with the crate directory otherwise.
+fn latest_redirect_base(version: &semver::Version) -> String {
+    format!("../{}/", version)
+}
+
+/// Path (relative to the versioned docs root) used when `/latest/` is requested
+/// without a deep-link remainder.
+///
+/// Packages with device-specific docs generate an index page at their version
+/// root, so no fallback path is needed. Other packages have no such index (the
+/// version root 404s/403s), so point at the crate's rustdoc index instead.
+fn latest_redirect_fallback(package: &Package) -> String {
     if package.chip_features_matter() {
-        format!("../{}/", version)
+        String::new()
     } else {
-        format!("../{}/{}/", version, package.to_string().replace('-', "_"))
+        format!("{}/index.html", package.to_string().replace('-', "_"))
     }
 }
 
@@ -303,12 +318,14 @@ fn latest_redirect_html(
     package: &Package,
     version: &semver::Version,
 ) -> Result<String> {
-    let base = latest_redirect_base(package, version);
+    let base = latest_redirect_base(version);
+    let fallback = latest_redirect_fallback(package);
     let resources_path = workspace.join("resources");
 
     render_template(&resources_path, "latest_redirect.html.somni", {
         let mut env = Env::new();
-        env.value("base", base.as_str());
+        env.value("base", base.as_str())
+            .value("fallback", fallback.as_str());
         env
     })
 }
@@ -1014,6 +1031,7 @@ mod tests {
         highest_eligible_version,
         is_eligible_docs_version,
         latest_redirect_base,
+        latest_redirect_fallback,
         latest_redirect_html,
         render_template,
         should_write_latest_redirect,
@@ -1144,28 +1162,46 @@ mod tests {
     #[test]
     fn latest_redirect_base_paths() {
         let v = semver::Version::parse("2.1.0").unwrap();
+        // The base is always the version root; deep-link remainders appended by
+        // the redirect page already include the chip or crate directory.
+        assert_eq!(latest_redirect_base(&v), "../2.1.0/");
+    }
+
+    #[test]
+    fn latest_redirect_fallback_paths() {
+        // Packages with device-specific docs generate an index at the version root.
+        assert_eq!(latest_redirect_fallback(&crate::Package::EspHal), "");
+        // Other packages have no version-root index; land on the crate's index.
         assert_eq!(
-            latest_redirect_base(&crate::Package::EspHal, &v),
-            "../2.1.0/"
-        );
-        assert_eq!(
-            latest_redirect_base(&crate::Package::EspAlloc, &v),
-            "../2.1.0/esp_alloc/"
+            latest_redirect_fallback(&crate::Package::EspAlloc),
+            "esp_alloc/index.html"
         );
     }
 
     /// Small integration check for the redirect template.
     #[test]
-    fn latest_redirect_html_matches_latest_redirect_base() {
+    fn latest_redirect_html_matches_base_and_fallback() {
         let ws = workspace();
         let ver = semver::Version::parse("1.0.0").unwrap();
-        let pkg = crate::Package::EspHal;
 
-        let html = latest_redirect_html(ws, &pkg, &ver).unwrap();
-        let base = latest_redirect_base(&pkg, &ver);
+        for (pkg, fallback) in [
+            (crate::Package::EspHal, ""),
+            (crate::Package::EspAlloc, "esp_alloc/index.html"),
+        ] {
+            let html = latest_redirect_html(ws, &pkg, &ver).unwrap();
+            let base = latest_redirect_base(&ver);
 
-        assert!(html.contains(&format!("var base = \"{base}\"")));
-        assert!(html.contains(&format!("content=\"0; url={base}\"")));
+            assert!(html.contains(&format!("var base = \"{base}\"")));
+            assert!(html.contains(&format!("var fallback = \"{fallback}\"")));
+            assert!(html.contains(&format!("content=\"0; url={base}{fallback}\"")));
+
+            // URL fragments (`#method.foo`) never reach nginx, but browsers
+            // re-attach them to the 301 target, so the redirect page must carry
+            // `location.hash` over to the final destination explicitly.
+            assert!(html.contains("var hash = location.hash;"));
+            assert!(html.contains("location.replace(base + pathFromQuery + hash)"));
+            assert!(html.contains("location.replace(base + fallback + hash)"));
+        }
     }
 
     /// The version select box is embedded in a page full of braces, so make sure the


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝
- [ ] I have updated existing examples or added new ones (if applicable).
- [ ] I have used `cargo xtask fmt` command to ensure that all changed code is formatted correctly.
- [ ] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` or `manual-changelog` label as appropriate.
- [ ] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [ ] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description
While working on the no_std training, I noticed that https://docs.espressif.com/projects/rust/esp-alloc/latest/esp_alloc/index.html fails as it adds an extra `/esp-alloc/` and  https://docs.espressif.com/projects/rust/esp-hal/latest/esp32c3/esp_hal/i2c/master/struct.I2c.html#method.with_sda doesnt take you to the `with_sda` method. So this PR fixes: 
- Non-chip packages such as `esp-alloc` included the crate directory in the redirect base. Deep links then appended it again, producing paths like `esp_alloc/esp_alloc/index.html.`
- URL fragments such as `#method.with_sda` were lost during the JavaScript redirect. The redirect now preserves `location.hash` for both deep-link and fallback targets.

#### Testing
```
cargo test --package esp-devtool latest_redirect
cargo xtask documentation esp-alloc esp-hal esp32c3
cd docs
python3 -m http.server 8000
```

---


# Changelog

## esp-hal
  - No changelog necessary.

