### PR TITLE
Add dram2_uninit.bss

### DIFF
--- a/esp-hal-procmacros/src/ram.rs
+++ b/esp-hal-procmacros/src/ram.rs
@@ -159,6 +159,7 @@ pub fn ram(args: TokenStream, input: TokenStream) -> TokenStream {
 
         (false, false, false, false, false, false, false) => Ok(".data"),
         (false, false, false, true, false, false, false) => Ok(".dram2_uninit"),
+        (false, false, false, true, false, false, true) => Ok(".dram2_uninit.bss"),
         (false, false, false, false, true, false, false) => Ok(".dcache_reclaimed_uninit"),
 
         (false, true, false, false, false, false, false) => Ok(".rtc_fast.data"),

--- a/esp-hal/Cargo.toml
+++ b/esp-hal/Cargo.toml
@@ -50,7 +50,7 @@ bench = false
 test  = false
 
 [dependencies]
-bytemuck                 = "1.24"
+bytemuck                 = { version = "1.24", features = ["zeroable_maybe_uninit"] }
 critical-section         = { version = "1", features = ["restore-state-u32"], optional = true }
 embedded-hal             = "1.0.0"
 embedded-hal-async       = "1.0.0"

--- a/esp-hal/ld/sections/dram2.x
+++ b/esp-hal/ld/sections/dram2.x
@@ -1,5 +1,11 @@
 /* an uninitialized section of RAM otherwise not useable */
 SECTIONS {
+    .dram2_uninit.bss (NOLOAD) : ALIGN(4) {
+        _dram2_uninit_bss_start = ABSOLUTE(.);
+        *(.dram2_uninit.bss)
+        _dram2_uninit_bss_end = ABSOLUTE(.);
+    } > dram2_seg
+
     .dram2_uninit (NOLOAD) : ALIGN(4) {
         *(.dram2_uninit)
     } > dram2_seg

--- a/esp-hal/src/soc/mod.rs
+++ b/esp-hal/src/soc/mod.rs
@@ -111,6 +111,8 @@ mod xtensa {
     }
 
     unsafe extern "C" {
+        static _dram2_uninit_bss_start: u32;
+        static _dram2_uninit_bss_end: u32;
         static _rtc_fast_bss_start: u32;
         static _rtc_fast_bss_end: u32;
         static _rtc_fast_persistent_end: u32;
@@ -131,6 +133,9 @@ mod xtensa {
         .literal sym_init_persistent, {__init_persistent}
         .literal sym_xtensa_lx_rt_zero_fill, {_xtensa_lx_rt_zero_fill}
 
+        .literal sym_dram2_uninit_bss_start, {_dram2_uninit_bss_start}
+        .literal sym_dram2_uninit_bss_end, {_dram2_uninit_bss_end}
+
         .literal sym_rtc_fast_bss_start, {_rtc_fast_bss_start}
         .literal sym_rtc_fast_bss_end, {_rtc_fast_bss_end}
         .literal sym_rtc_fast_persistent_end, {_rtc_fast_persistent_end}
@@ -143,6 +148,9 @@ mod xtensa {
         ",
         __init_persistent = sym __init_persistent,
         _xtensa_lx_rt_zero_fill = sym _xtensa_lx_rt_zero_fill,
+
+        _dram2_uninit_bss_end = sym _dram2_uninit_bss_end,
+        _dram2_uninit_bss_start = sym _dram2_uninit_bss_start,
 
         _rtc_fast_bss_end = sym _rtc_fast_bss_end,
         _rtc_fast_bss_start = sym _rtc_fast_bss_start,
@@ -164,6 +172,10 @@ mod xtensa {
             entry  a1, 0x10                            // 4 words for callx4 spill area
 
             l32r   a2, sym_xtensa_lx_rt_zero_fill      // Pre-load address of zero-fill function
+
+            l32r   a6, sym_dram2_uninit_bss_start      // Set input range to .dram2_uninit.bss
+            l32r   a7, sym_dram2_uninit_bss_end        //
+            callx4 a2                                  // Zero-fill
 
             l32r   a6, sym_rtc_fast_bss_start          // Set input range to .rtc_fast.bss
             l32r   a7, sym_rtc_fast_bss_end            //

--- a/esp-riscv-rt/src/lib.rs
+++ b/esp-riscv-rt/src/lib.rs
@@ -86,6 +86,18 @@ __pre_init:"#,
     blt a0, a1, 1b
     2:
 "#,
+    // Zero .dram2_uninit.bss
+    r#"
+    la a0, _dram2_uninit_bss_start
+    la a1, _dram2_uninit_bss_end
+    bge a0, a1, 2f
+    mv a3, x0
+    1:
+    sw a3, 0(a0)
+    addi a0, a0, 4
+    blt a0, a1, 1b
+    2:
+"#,
 r#"
     ret
 


### PR DESCRIPTION
We have the option to initialize memory in `dram2_uninit`, so let's allow `#[ram(reclaimed, unstable(zeroed))]`.

# Changelog

## esp-hal-procmacros

- Added: `#[ram(reclaimed, unstable(zeroed))]`.

## esp-hal

- Added: `reclaimed` memory now allows zero-initialization via `unstable(zeroed)` as `#[ram(reclaimed, unstable(zeroed))]`.

## esp-riscv-rt

- Added: Zero-initialize `.dram2_uninit.bss`