### PR TITLE
Fix P4 memory layout

### DIFF
--- a/esp-hal/ld/esp32p4/esp32p4.x
+++ b/esp-hal/ld/esp32p4/esp32p4.x
@@ -36,6 +36,7 @@ INCLUDE "rodata.x"
 INCLUDE "text.x"
 INCLUDE "rtc_fast.x"
 INCLUDE "stack.x"
+INCLUDE "dram2.x"
 INCLUDE "metadata.x"
 INCLUDE "eh_frame.x"
 /* End of Shared sections */

--- a/esp-hal/ld/esp32p4/memory.x
+++ b/esp-hal/ld/esp32p4/memory.x
@@ -26,7 +26,13 @@ RESERVED_L2_CACHE = 0;
 
 MEMORY
 {
-    RAM : ORIGIN = 0x4FF00000 + RESERVED_L2_CACHE, LENGTH = 0x4FFAE000 - RESERVED_L2_CACHE - 0x4FF00000
+    RAM : ORIGIN = 0x4FF00000 + RESERVED_L2_CACHE, LENGTH = 0xADFC0 - RESERVED_L2_CACHE
+
+    /* Memory available after the 2nd stage bootloader finishes.
+       Upper bound is __stack_app = 0x4ffbefc0.
+       Source: esp-idf C:\_Espressif\esp-idf\components\bootloader\subproject\main\ld\esp32p4\bootloader.memory.ld.in
+    */
+    dram2_seg ( RW ): ORIGIN = ORIGIN(RAM) + LENGTH(RAM), len = 0x4ffbefc0 - (ORIGIN(RAM) + LENGTH(RAM))
 
     /* External flash (XIP via cache); +0x20 skips the IDF app image header. */
     ROM : ORIGIN = 0x40000000 + 0x20, LENGTH = 0x400000 - 0x20

--- a/esp-metadata-generated/src/_build_script_utils.rs
+++ b/esp-metadata-generated/src/_build_script_utils.rs
@@ -6082,13 +6082,13 @@ impl Chip {
                         (
                             "dram",
                             MemoryRegion {
-                                address_range: 0x4FF40000..0x4FFC0000,
+                                address_range: 0x4FF40000..0x4FFADFC0,
                             },
                         ),
                         (
                             "dram2_uninit",
                             MemoryRegion {
-                                address_range: 0x4FF00000..0x4FF40000,
+                                address_range: 0x4FFADFC0..0x4FFBEFC0,
                             },
                         ),
                         (

--- a/esp-metadata-generated/src/_generated_esp32p4.rs
+++ b/esp-metadata-generated/src/_generated_esp32p4.rs
@@ -6037,16 +6037,16 @@ macro_rules! implement_peripheral_clocks {
 #[cfg_attr(docsrs, doc(cfg(feature = "_device-selected")))]
 macro_rules! memory_range {
     ("DRAM") => {
-        0x4FF40000..0x4FFC0000
+        0x4FF40000..0x4FFADFC0
     };
     (size as str, "DRAM") => {
-        "524288"
+        "450496"
     };
     ("DRAM2_UNINIT") => {
-        0x4FF00000..0x4FF40000
+        0x4FFADFC0..0x4FFBEFC0
     };
     (size as str, "DRAM2_UNINIT") => {
-        "262144"
+        "69632"
     };
     ("IROM") => {
         0x40000000..0x44000000

--- a/esp-metadata/devices/esp32p4/soc.toml
+++ b/esp-metadata/devices/esp32p4/soc.toml
@@ -41,13 +41,9 @@ internal_memory_cached = true
 
 has_swd_watchdog = true
 
-# HP L2MEM: 0x4FF0_0000 - 0x4FFC_0000 (768 KB)
-# ROM bootloader reserves 0x4FF0_0000 - 0x4FF4_0000 (256 KB)
-# dram: usable application RAM (after ROM reserved region)
-# dram2_uninit: ROM reserved area, reclaimable after 2nd-stage bootloader
 memory_map = { ranges = [
-    { name = "dram", start = 0x4FF4_0000, end = 0x4FFC_0000 },
-    { name = "dram2_uninit", start = 0x4FF0_0000, end = 0x4FF4_0000 },
+    { name = "dram", start = 0x4FF4_0000, end = 0x4FFA_DFC0 },
+    { name = "dram2_uninit", start = 0x4FFA_DFC0, end = 0x4FFB_EFC0 },
     { name = "irom", start = 0x4000_0000, end = 0x4400_0000 },
     { name = "drom", start = 0x4000_0000, end = 0x4400_0000 },
 ] }

--- a/examples/qa/src/bin/sleep_timer_oversleeping.rs
+++ b/examples/qa/src/bin/sleep_timer_oversleeping.rs
@@ -42,7 +42,8 @@ async fn main(_spawner: Spawner) {
     let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
     let peripherals = esp_hal::init(config);
 
-    esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: 65536);
+    esp_alloc::heap_allocator!(size: 32768);
+    esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: 32768);
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     esp_rtos::start(timg0.timer0, peripherals.FROM_CPU_INTR0);


### PR DESCRIPTION
https://github.com/espressif/esp-idf/blob/master/components/bootloader/subproject/main/ld/esp32p4/bootloader.memory.ld.in is a bit hard to follow because of the revision split, but `BOOTLOADER_IRAM_LOADER_SEG_START_EXPECTED 0x4FFADFC0` gives us the DRAM upper bound and the second address in `0x4ff3efc0 / 0x4ffbefc0 ------------------> __stack_app (app cpu)` the dram2_uninit upper bound. Presumably, because esp-idf seems to just assign the entire region above 0x4ffbafc0 to heap.

# Changelog

## esp-hal

- Fixed: ESP32-P4 memory layout now avoids bootloader-reserved memory and defines `ram(reclaimed)`.