### PR TITLE
Add message when calling async fn before rtos init

### DIFF
--- a/esp-rtos/src/fmt.rs
+++ b/esp-rtos/src/fmt.rs
@@ -252,6 +252,7 @@ macro_rules! unwrap {
 
 #[cold]
 #[inline(never)]
+#[track_caller]
 #[cfg(not(feature = "defmt"))]
 pub(crate) fn __unwrap_failed(arg: &str, e: impl ::core::fmt::Debug) -> ! {
     ::core::panic!("unwrap of `{}` failed: {:?}", arg, e);
@@ -259,6 +260,7 @@ pub(crate) fn __unwrap_failed(arg: &str, e: impl ::core::fmt::Debug) -> ! {
 
 #[cold]
 #[inline(never)]
+#[track_caller]
 #[cfg(not(feature = "defmt"))]
 pub(crate) fn __unwrap_failed_with_message(
     arg: &str,

--- a/esp-rtos/src/scheduler.rs
+++ b/esp-rtos/src/scheduler.rs
@@ -629,7 +629,7 @@ impl Scheduler {
 
         unwrap!(
             TaskPtr::new(tp),
-            "The scheduler has not been started. Make sure to call `esp_rtos::init()` before trying to access the current task."
+            "The scheduler has not been started. Make sure to call `esp_rtos::start()` before trying to access the current task."
         )
     }
 

--- a/esp-rtos/src/timer/embassy.rs
+++ b/esp-rtos/src/timer/embassy.rs
@@ -56,7 +56,10 @@ impl embassy_time_driver::Driver for EmbassyTimeDriver {
             if embassy_timer_queue.schedule_wake(at, waker) {
                 // Next wakeup time became shorter, re-arm the timer.
                 let mut scheduler = global_state.scheduler();
-                let time_driver = unwrap!(scheduler.time_driver.as_mut());
+                let time_driver = unwrap!(
+                    scheduler.time_driver.as_mut(),
+                    "The scheduler has not been started. Make sure to call `esp_rtos::start()` before using async features",
+                );
 
                 time_driver
                     .timer_queue


### PR DESCRIPTION
Fixes #6299

# Changelog

## esp-rtos

- Added: added a more helpful error message to a common usage error pattern.
- Fixed: fixed the start function name in an error message.
- Fixed: panic messages now point to the right location.