### PR TITLE
Add flash encryption support

### DIFF
--- a/esp-hal/build.rs
+++ b/esp-hal/build.rs
@@ -43,6 +43,8 @@ fn try_main() -> Result<(), Box<dyn Error>> {
     // by metadata for single-I2C chips (e.g. ESP32-C3). Register it here to avoid unexpected_cfgs
     // warnings on those targets.
     println!("cargo:rustc-check-cfg=cfg(i2c_slave_i2c1)");
+    // HIL rustflags for encrypted-write tests that run without burned eFuses.
+    println!("cargo:rustc-check-cfg=cfg(__test_flash)");
     if let Ok(level) = std::env::var("OPT_LEVEL")
         && (level == "0" || level == "1")
     {

--- a/esp-hal/src/flash/cache.rs
+++ b/esp-hal/src/flash/cache.rs
@@ -1,4 +1,7 @@
-//! Cache suspend/resume and MMU-backed invalidation for flash operations.
+//! Cache suspend and resume around ROM flash operations.
+//!
+//! Dropping cache lines for a flash range needs the MMU table and lives in
+//! [`super::mmu`] instead.
 
 use procmacros::ram;
 
@@ -68,20 +71,6 @@ impl CacheGuard {
     }
 }
 
-/// Drop cache lines that map `start..start+len` after the caches are back on.
-///
-/// IDF invalidates in this order (`spi_flash_check_and_flush_cache` after the
-/// operation’s cache-restore path). ESP32 cannot invalidate by address and
-/// flushes while still off instead.
-#[cfg(not(esp32))]
-#[ram]
-pub(super) fn invalidate_mapped(start: u32, len: u32) {
-    if len == 0 {
-        return;
-    }
-    invalidate_mapped_range(start, len);
-}
-
 impl Drop for CacheGuard {
     #[ram]
     fn drop(&mut self) {
@@ -93,7 +82,7 @@ impl Drop for CacheGuard {
 }
 
 #[cfg(soc_cpu_has_branch_predictor)]
-#[ram]
+#[inline(always)]
 fn disable_branch_predictor() {
     // MHCR (0x7c1): RS, BFE, BTB. Same bits as `soc::enable_branch_predictor`.
     const MHCR_RS: u32 = 1 << 4;
@@ -105,7 +94,7 @@ fn disable_branch_predictor() {
 }
 
 #[cfg(soc_cpu_has_branch_predictor)]
-#[ram]
+#[inline(always)]
 fn enable_branch_predictor() {
     const MHCR_RS: u32 = 1 << 4;
     const MHCR_BFE: u32 = 1 << 5;
@@ -125,12 +114,10 @@ unsafe extern "C" {
             fn Cache_Suspend_DCache() -> u32;
             fn Cache_Resume_ICache(autoload: u32);
             fn Cache_Resume_DCache(autoload: u32);
-            fn Cache_Invalidate_Addr(addr: u32, size: u32);
         }
         esp32p4 => {
             fn Cache_Suspend_L2_Cache() -> u32;
             fn Cache_Resume_L2_Cache(autoload: u32);
-            fn Cache_Invalidate_Addr(map: u32, addr: u32, size: u32);
         }
         esp32s31 => {
             fn Cache_Suspend_L1_CORE0_ICache() -> u32;
@@ -139,17 +126,14 @@ unsafe extern "C" {
             fn Cache_Resume_L1_CORE0_ICache(autoload: u32);
             fn Cache_Resume_L1_CORE1_ICache(autoload: u32);
             fn Cache_Resume_L1_DCache(autoload: u32);
-            fn Cache_Invalidate_Addr(map: u32, addr: u32, size: u32);
         }
         any(esp32c5, esp32c61) => {
             fn Cache_Suspend_Cache() -> u32;
             fn Cache_Resume_Cache(autoload: u32);
-            fn Cache_Invalidate_Addr(addr: u32, size: u32);
         }
         any(esp32c2, esp32c3, esp32c6, esp32h2) => {
             fn Cache_Suspend_ICache() -> u32;
             fn Cache_Resume_ICache(autoload: u32);
-            fn Cache_Invalidate_Addr(addr: u32, size: u32);
         }
         _ => {
             compile_error!("missing flash cache ROM bindings for this chip");
@@ -165,6 +149,7 @@ fn suspend_caches() -> Inner {
             let dport = DPORT::regs();
             let pro = dport.pro_cache_ctrl().read().pro_cache_enable().bit();
             let app = dport.app_cache_ctrl().read().app_cache_enable().bit();
+            // A cache must be idle before it is turned off, see `cache_ll_l1_disable_cache()`.
             if pro {
                 while dport.pro_dcache_dbug0().read().pro_cache_state().bits() != 1 {}
                 dport
@@ -177,6 +162,7 @@ fn suspend_caches() -> Inner {
                     .app_cache_ctrl()
                     .modify(|_, w| w.app_cache_enable().clear_bit());
             }
+            // Complete the writes above before the flash MMU is written.
             let _ = dport.pro_cache_ctrl().read();
             Inner { pro, app }
         }
@@ -236,6 +222,9 @@ fn resume_caches(inner: &Inner) {
                     .app_cache_ctrl()
                     .modify(|_, w| w.app_cache_enable().set_bit());
             }
+            // The caller returns to flash right away, so make sure that the cache is on again
+            // before the next instruction is fetched: reading the register back completes the
+            // write.
             let _ = dport.pro_cache_ctrl().read();
         }
         any(esp32s2, esp32s3) => unsafe {
@@ -250,319 +239,5 @@ fn resume_caches(inner: &Inner) {
         },
         any(esp32c5, esp32c61) => unsafe { Cache_Resume_Cache(inner.autoload) },
         _ => unsafe { Cache_Resume_ICache(inner.autoload) },
-    }
-}
-
-#[cfg(not(esp32))]
-#[ram]
-fn invalidate_mapped_range(start: u32, len: u32) {
-    let page_size = mmu_page_size();
-    let page_start = start & !(page_size - 1);
-    let end = start.saturating_add(len);
-    let mut addr = page_start;
-
-    while addr < end {
-        invalidate_mapped_page(addr, page_size);
-        addr = addr.saturating_add(page_size);
-    }
-}
-
-/// Drop cache lines for every MMU entry that maps `page_paddr`.
-///
-/// One physical page can appear more than once. On C2, C3, and S3 the same
-/// entry is also visible through a separate I-bus window, so both vaddrs are
-/// invalidated.
-#[cfg(not(esp32))]
-#[ram]
-fn invalidate_mapped_page(page_paddr: u32, page_size: u32) {
-    let page = flash_page_number(page_paddr);
-    let (start, end) = mmu_entry_scan_range();
-
-    for entry_id in start..end {
-        if entry_is_valid(entry_id)
-            && entry_is_flash_mapping(entry_id)
-            && entry_flash_page(entry_id) == page
-        {
-            invalidate_entry_caches(entry_id, page_size);
-        }
-    }
-}
-
-#[cfg(not(esp32))]
-#[ram]
-fn invalidate_entry_caches(entry_id: u32, page_size: u32) {
-    cfg_select! {
-        esp32s2 => {
-            let vaddr = s2::entry_id_to_vaddr(entry_id);
-            if !vaddr.is_null() {
-                invalidate_cache_addr(vaddr as u32, page_size);
-            }
-        }
-        _ => {
-            let offset = entry_id * page_size;
-            let drom = memory_range!("DROM").start as u32 + offset;
-            invalidate_cache_addr(drom, page_size);
-            let irom = memory_range!("IROM").start as u32 + offset;
-            if irom != drom {
-                invalidate_cache_addr(irom, page_size);
-            }
-        }
-    }
-}
-
-#[cfg(not(esp32))]
-#[ram]
-fn invalidate_cache_addr(vaddr: u32, size: u32) {
-    cfg_select! {
-        esp32s31 => {
-            const CACHE_MAP_L1_ICACHE_0: u32 = 1 << 0;
-            const CACHE_MAP_L1_ICACHE_1: u32 = 1 << 1;
-            const CACHE_MAP_L1_DCACHE: u32 = 1 << 4;
-            unsafe {
-                Cache_Invalidate_Addr(
-                    CACHE_MAP_L1_ICACHE_0 | CACHE_MAP_L1_ICACHE_1 | CACHE_MAP_L1_DCACHE,
-                    vaddr,
-                    size,
-                )
-            }
-        }
-        esp32p4 => {
-            const CACHE_MAP_L1_ICACHE_0: u32 = 1 << 0;
-            const CACHE_MAP_L1_ICACHE_1: u32 = 1 << 1;
-            const CACHE_MAP_L1_DCACHE: u32 = 1 << 4;
-            const CACHE_MAP_L2_CACHE: u32 = 1 << 5;
-            // IROM and DROM share the same window; invalidate I, D, and L2.
-            unsafe {
-                Cache_Invalidate_Addr(
-                    CACHE_MAP_L1_ICACHE_0
-                        | CACHE_MAP_L1_ICACHE_1
-                        | CACHE_MAP_L1_DCACHE
-                        | CACHE_MAP_L2_CACHE,
-                    vaddr,
-                    size,
-                )
-            }
-        }
-        _ => unsafe { Cache_Invalidate_Addr(vaddr, size) },
-    }
-}
-
-#[cfg(not(esp32))]
-#[ram]
-fn mmu_page_size() -> u32 {
-    cfg_select! {
-        not(soc_has_mmu_table) => indexed::mmu_page_size(),
-        // C2 page size is configurable (IDF `mmu_ll_get_page_size`).
-        esp32c2 => c2::mmu_page_size(),
-        _ => property!("mmu.page_size"),
-    }
-}
-
-#[cfg(not(esp32))]
-#[ram]
-fn mmu_entry_scan_range() -> (u32, u32) {
-    cfg_select! {
-        not(soc_has_mmu_table) => (0, property!("mmu.entry_num")),
-        // Include I-bus slots (0..0x80). Skip DBUS2/DPORT (0x140..).
-        esp32s2 => (0, s2::DATA_ENTRY_END),
-        _ => (0, property!("mmu.entry_num")),
-    }
-}
-
-#[cfg(not(esp32))]
-#[ram]
-fn flash_page_number(page_paddr: u32) -> u32 {
-    cfg_select! {
-        not(soc_has_mmu_table) => indexed::flash_page_number(page_paddr),
-        esp32c2 => page_paddr >> c2::mmu_page_size().trailing_zeros(),
-        _ => page_paddr >> 16,
-    }
-}
-
-#[cfg(not(esp32))]
-#[ram]
-fn entry_is_valid(entry_id: u32) -> bool {
-    cfg_select! {
-        not(soc_has_mmu_table) => indexed::entry_is_valid(entry_id),
-        _ => table::entry_is_valid(entry_id),
-    }
-}
-
-#[cfg(not(esp32))]
-#[ram]
-fn entry_is_flash_mapping(entry_id: u32) -> bool {
-    cfg_select! {
-        not(soc_has_mmu_table) => indexed::entry_is_flash_mapping(entry_id),
-        _ => table::entry_is_flash_mapping(entry_id),
-    }
-}
-
-#[cfg(not(esp32))]
-#[ram]
-fn entry_flash_page(entry_id: u32) -> u32 {
-    cfg_select! {
-        not(soc_has_mmu_table) => indexed::entry_flash_page(entry_id),
-        _ => table::entry_flash_page(entry_id),
-    }
-}
-
-#[cfg(all(not(esp32), not(soc_has_mmu_table)))]
-mod indexed {
-    use procmacros::ram;
-
-    use crate::peripherals::SPI0;
-
-    #[ram]
-    pub(super) fn mmu_page_size() -> u32 {
-        let code = mmu_page_size_code();
-        cfg_select! {
-            esp32s31 => 0x40000 >> code,
-            _ => 0x10000 >> code,
-        }
-    }
-
-    #[ram]
-    fn mmu_page_size_code() -> u32 {
-        let ctrl = SPI0::regs().mmu_power_ctrl().read();
-        cfg_select! {
-            any(esp32c5, esp32c61, esp32s31) => ctrl.mmu_page_size().bits() as u32,
-            _ => ctrl.spi_mmu_page_size().bits() as u32,
-        }
-    }
-
-    #[ram]
-    fn page_size_shift(page_size: u32) -> u32 {
-        match page_size {
-            0x40000 => 18,
-            0x20000 => 17,
-            0x10000 => 16,
-            0x8000 => 15,
-            0x4000 => 14,
-            0x2000 => 13,
-            _ => 16,
-        }
-    }
-
-    #[ram]
-    pub(super) fn flash_page_number(page_paddr: u32) -> u32 {
-        page_paddr >> page_size_shift(mmu_page_size())
-    }
-
-    #[ram]
-    fn with_entry<R>(entry_id: u32, f: impl FnOnce() -> R) -> R {
-        SPI0::regs()
-            .mmu_item_index()
-            .write(|w| unsafe { w.mmu_item_index().bits(entry_id) });
-        f()
-    }
-
-    #[ram]
-    pub(super) fn entry_is_valid(entry_id: u32) -> bool {
-        with_entry(entry_id, || {
-            SPI0::regs().mmu_item_content().read().valid().bit()
-        })
-    }
-
-    #[ram]
-    pub(super) fn entry_is_flash_mapping(entry_id: u32) -> bool {
-        cfg_select! {
-            any(esp32c5, esp32c61) => with_entry(entry_id, || {
-                !SPI0::regs().mmu_item_content().read().access_spiram().bit()
-            }),
-            _ => {
-                let _ = entry_id;
-                true
-            }
-        }
-    }
-
-    #[ram]
-    pub(super) fn entry_flash_page(entry_id: u32) -> u32 {
-        with_entry(entry_id, || {
-            SPI0::regs().mmu_item_content().read().paddr().bits() as u32
-        })
-    }
-}
-
-#[cfg(all(not(esp32), soc_has_mmu_table))]
-mod table {
-    use procmacros::ram;
-
-    use crate::peripherals::MMU_TABLE;
-
-    #[ram]
-    pub(super) fn entry_is_valid(entry_id: u32) -> bool {
-        !MMU_TABLE::regs()
-            .entry(entry_id as usize)
-            .read()
-            .invalid()
-            .bit()
-    }
-
-    #[ram]
-    pub(super) fn entry_is_flash_mapping(entry_id: u32) -> bool {
-        let e = MMU_TABLE::regs().entry(entry_id as usize).read();
-        cfg_select! {
-            esp32s2 => e.access_flash().bit(),
-            esp32s3 => !e.access_spiram().bit(),
-            _ => {
-                let _ = e;
-                true
-            }
-        }
-    }
-
-    #[ram]
-    pub(super) fn entry_flash_page(entry_id: u32) -> u32 {
-        MMU_TABLE::regs()
-            .entry(entry_id as usize)
-            .read()
-            .paddr()
-            .bits() as u32
-    }
-}
-
-#[cfg(esp32c2)]
-mod c2 {
-    use procmacros::ram;
-
-    use crate::peripherals::EXTMEM;
-
-    /// 0 = 16 KiB, 1 = 32 KiB, 2 = 64 KiB (`EXTMEM_CACHE_MMU_PAGE_SIZE`).
-    #[ram]
-    pub(super) fn mmu_page_size() -> u32 {
-        match EXTMEM::regs()
-            .cache_conf_misc()
-            .read()
-            .cache_mmu_page_size()
-            .bits()
-        {
-            0 => 0x4000,
-            1 => 0x8000,
-            _ => 0x10000,
-        }
-    }
-}
-
-#[cfg(esp32s2)]
-mod s2 {
-    use procmacros::ram;
-
-    pub(super) const DATA_ENTRY_END: u32 = 0x500 / 4;
-
-    #[ram]
-    pub(super) fn entry_id_to_vaddr(entry_id: u32) -> *const u8 {
-        let page_size = super::mmu_page_size();
-        // Matches `mmu_ll_entry_id_to_vaddr_base()`: IBUS0/1 at 0x4000_0000,
-        // DROM/DBUS at 0x3F00_0000. Skip DBUS2/DPORT (0x140..).
-        let (base, relative) = match entry_id {
-            0x00..0x40 => (0x4000_0000u32, entry_id),
-            0x40..0x80 => (0x4000_0000u32, entry_id - 0x40),
-            0x80..0xC0 => (0x3F00_0000u32, entry_id - 0x80),
-            0xC0..0x100 => (0x3F00_0000u32, entry_id - 0xC0),
-            0x100..0x140 => (0x3F00_0000u32, entry_id - 0x100),
-            _ => return core::ptr::null(),
-        };
-        (base + relative * page_size) as *const u8
     }
 }

--- a/esp-hal/src/flash/mmu.rs
+++ b/esp-hal/src/flash/mmu.rs
@@ -1,0 +1,658 @@
+//! Flash MMU access.
+//!
+//! Everything that has to know which flash is mapped where: dropping the cache
+//! lines of a written flash range ([`invalidate_mapped`]), and the temporary
+//! mappings that let [`read_flash_encrypted`] read decrypted flash through the
+//! cache. Suspending the caches themselves is [`super::cache`]'s job.
+//!
+//! Nothing here runs with the cache suspended, so these helpers live in flash.
+//! The two ESP32 exceptions "writing the MMU table and flushing the cache"
+//! are confined to [`esp32_cache`].
+
+use core::{ops::Range, ptr};
+
+use super::Error;
+
+/// Guard for a temporarily mapped flash MMU page.
+struct FlashMmapGuard {
+    entry_id: u32,
+    vaddr: *const u8,
+    #[cfg_attr(
+        esp32,
+        expect(dead_code, reason = "the ESP32 can only flush the whole cache")
+    )]
+    page_size: u32,
+    /// When `false` the entry was already mapped and must not be invalidated.
+    owned: bool,
+}
+
+impl FlashMmapGuard {
+    /// A slot this driver mapped itself, and has to unmap again.
+    fn new_owned(entry_id: u32, vaddr: *const u8, page_size: u32) -> Self {
+        Self {
+            entry_id,
+            vaddr,
+            page_size,
+            owned: true,
+        }
+    }
+}
+
+/// Map a flash physical address to a virtual address for encrypted reading.
+///
+/// The returned mapping is ready to be read through: a temporary slot can
+/// retain cache lines from its previous mapping, so the complete mapping is
+/// invalidated before this function returns.
+fn map_flash_page(paddr: u32) -> Result<FlashMmapGuard, Error> {
+    let page_size = mmu_page_size();
+    let page_paddr = paddr & !(page_size - 1);
+
+    if let Some(entry_id) = find_existing_entry(page_paddr) {
+        let vaddr = entry_id_to_vaddr(entry_id).ok_or(Error::NotSupported)?;
+        invalidate_cache(vaddr as u32, page_size);
+        return Ok(FlashMmapGuard {
+            entry_id,
+            vaddr,
+            page_size,
+            owned: false,
+        });
+    }
+
+    // The virtual address is resolved before the entry is written, so a slot
+    // without one is never left behind mapped.
+    cfg_select! {
+        esp32s2 => {
+            let entry_id = s2::alloc_entry().ok_or(Error::NotSupported)?;
+            let vaddr = s2::map_entry(entry_id, page_paddr)?;
+            Ok(FlashMmapGuard::new_owned(entry_id, vaddr, page_size))
+        }
+        esp32 => {
+            let entry_id = find_free_entry().ok_or(Error::NotSupported)?;
+            let vaddr = entry_id_to_vaddr(entry_id).ok_or(Error::NotSupported)?;
+            // Writing the entry and making it visible to the cache must happen
+            // in one cache-off window. The register is looked up before that
+            // window: the bounds check of the lookup can call into flash.
+            esp32_cache::map_entry(table::entry(entry_id), page_paddr);
+            Ok(FlashMmapGuard::new_owned(entry_id, vaddr, page_size))
+        }
+        _ => {
+            let entry_id = find_free_entry().ok_or(Error::NotSupported)?;
+            let vaddr = entry_id_to_vaddr(entry_id).ok_or(Error::NotSupported)?;
+            write_flash_entry(entry_id, page_paddr);
+            invalidate_cache(vaddr as u32, page_size);
+            Ok(FlashMmapGuard::new_owned(entry_id, vaddr, page_size))
+        }
+    }
+}
+
+/// Unmap a temporarily mapped flash page and invalidate the cache.
+fn unmap_flash_page(guard: FlashMmapGuard) {
+    cfg_select! {
+        esp32 => {
+            esp32_cache::unmap_entry(guard.owned.then(|| table::entry(guard.entry_id)));
+        }
+        _ => {
+            invalidate_cache(guard.vaddr as u32, guard.page_size);
+            if guard.owned {
+                set_entry_invalid(guard.entry_id);
+            }
+        }
+    }
+}
+
+/// Read decrypted flash bytes via temporary MMU mappings.
+///
+/// The cache must stay on. Callers park the other core and disable interrupts.
+pub(super) fn read_flash_encrypted(offset: u32, data: &mut [u32]) -> Result<(), Error> {
+    if data.is_empty() {
+        return Ok(());
+    }
+
+    let bytes = unsafe {
+        core::slice::from_raw_parts_mut(
+            data.as_mut_ptr().cast::<u8>(),
+            data.len() * super::WORD_SIZE as usize,
+        )
+    };
+
+    let page_size = mmu_page_size();
+    let mut remaining = bytes;
+    let mut current_offset = offset;
+
+    while !remaining.is_empty() {
+        let page_base = current_offset & !(page_size - 1);
+        let in_page = (current_offset - page_base) as usize;
+        let chunk = remaining.len().min(page_size as usize - in_page);
+
+        let guard = map_flash_page(page_base)?;
+        let src = unsafe { guard.vaddr.add(in_page) };
+        unsafe {
+            ptr::copy_nonoverlapping(src, remaining.as_mut_ptr(), chunk);
+        }
+        unmap_flash_page(guard);
+
+        current_offset += chunk as u32;
+        remaining = &mut remaining[chunk..];
+    }
+
+    Ok(())
+}
+
+/// Drop the cache lines covering `vaddr..vaddr + size`.
+///
+/// Both users invalidate flash that may be mapped as code as well as data, so
+/// every cache that can hold the line is included.
+#[cfg(not(any(esp32, esp32p4, esp32s31)))]
+fn invalidate_cache(vaddr: u32, size: u32) {
+    unsafe extern "C" {
+        fn Cache_Invalidate_Addr(addr: u32, size: u32);
+    }
+    unsafe {
+        Cache_Invalidate_Addr(vaddr, size);
+    }
+}
+
+#[cfg(any(esp32p4, esp32s31))]
+fn invalidate_cache(vaddr: u32, size: u32) {
+    const CACHE_MAP_L1_ICACHE_0: u32 = 1 << 0;
+    const CACHE_MAP_L1_ICACHE_1: u32 = 1 << 1;
+    const CACHE_MAP_L1_DCACHE: u32 = 1 << 4;
+    #[cfg(esp32p4)]
+    const CACHE_MAP_L2_CACHE: u32 = 1 << 5;
+
+    // IROM and DROM share the same window on the P4, which also needs L2.
+    let map = CACHE_MAP_L1_ICACHE_0 | CACHE_MAP_L1_ICACHE_1 | CACHE_MAP_L1_DCACHE;
+    #[cfg(esp32p4)]
+    let map = map | CACHE_MAP_L2_CACHE;
+
+    unsafe extern "C" {
+        fn Cache_Invalidate_Addr(map: u32, addr: u32, size: u32);
+    }
+    unsafe {
+        Cache_Invalidate_Addr(map, vaddr, size);
+    }
+}
+
+#[cfg(esp32)]
+fn invalidate_cache(_vaddr: u32, _size: u32) {
+    // The ESP32 cache cannot invalidate a single address range, so the whole cache is flushed.
+    esp32_cache::flush_caches();
+}
+
+/// Drop cache lines that map `start..start+len` after the caches are back on.
+///
+/// IDF invalidates in this order (`spi_flash_check_and_flush_cache` after the
+/// operation's cache-restore path). ESP32 cannot invalidate by address and
+/// flushes while still off instead.
+#[cfg(not(esp32))]
+pub(super) fn invalidate_mapped(start: u32, len: u32) {
+    if len == 0 {
+        return;
+    }
+
+    let page_size = mmu_page_size();
+    let end = start.saturating_add(len);
+    let mut addr = start & !(page_size - 1);
+
+    while addr < end {
+        invalidate_mapped_page(addr, page_size);
+        addr = addr.saturating_add(page_size);
+    }
+}
+
+/// Drop cache lines for every MMU entry that maps `page_paddr`.
+///
+/// One physical page can appear more than once. On C2, C3, and S3 the same
+/// entry is also visible through a separate I-bus window, so both vaddrs are
+/// invalidated.
+#[cfg(not(esp32))]
+fn invalidate_mapped_page(page_paddr: u32, page_size: u32) {
+    let page = flash_page_number(page_paddr);
+
+    for entry_id in all_entries() {
+        if entry_is_valid(entry_id)
+            && entry_is_flash_mapping(entry_id)
+            && entry_flash_page(entry_id) == page
+        {
+            invalidate_entry_caches(entry_id, page_size);
+        }
+    }
+}
+
+#[cfg(not(esp32))]
+fn invalidate_entry_caches(entry_id: u32, page_size: u32) {
+    cfg_select! {
+        esp32s2 => {
+            if let Some(vaddr) = entry_id_to_vaddr(entry_id) {
+                invalidate_cache(vaddr as u32, page_size);
+            }
+        }
+        _ => {
+            let offset = entry_id * page_size;
+            let drom = memory_range!("DROM").start as u32 + offset;
+            let irom = memory_range!("IROM").start as u32 + offset;
+            invalidate_cache(drom, page_size);
+            if irom != drom {
+                invalidate_cache(irom, page_size);
+            }
+        }
+    }
+}
+
+/// Virtual address an MMU entry maps to, if it is reachable through a data bus.
+fn entry_id_to_vaddr(entry_id: u32) -> Option<*const u8> {
+    cfg_select! {
+        esp32s2 => s2::entry_id_to_vaddr(entry_id),
+        _ => {
+            let base = memory_range!("DROM").start as u32;
+            Some((base + entry_id * mmu_page_size()) as *const u8)
+        }
+    }
+}
+
+fn find_existing_entry(page_paddr: u32) -> Option<u32> {
+    let page = flash_page_number(page_paddr);
+
+    data_entries().find(|&entry_id| {
+        entry_is_valid(entry_id)
+            && entry_is_flash_mapping(entry_id)
+            && entry_flash_page(entry_id) == page
+    })
+}
+
+fn find_free_entry() -> Option<u32> {
+    let entries = data_entries();
+    // Skip the last entry reserved for bootloader internal flash access.
+    (entries.start..entries.end.saturating_sub(1))
+        .rev()
+        .find(|&entry_id| !entry_is_valid(entry_id))
+}
+
+/// Entries that can back a temporary mapping and be read through as data.
+fn data_entries() -> Range<u32> {
+    cfg_select! {
+        not(soc_has_mmu_table) => 0..property!("mmu.entry_num"),
+        esp32s2 => s2::DATA_ENTRY_START..s2::DATA_ENTRY_END,
+        // The table peripheral bounds the usable entry ids: `mmu.entry_num`
+        // counts logical entries across every bus and indexes out of range on
+        // the ESP32, whose table exposes its 64 DROM0 slots only.
+        _ => 0..table::entry_count(),
+    }
+}
+
+/// Every entry that can map flash, including windows that only serve code.
+#[cfg(not(esp32))]
+fn all_entries() -> Range<u32> {
+    cfg_select! {
+        // Include the S2 I-bus slots (0..0x80). Skip DBUS2/DPORT (0x140..).
+        esp32s2 => 0..s2::DATA_ENTRY_END,
+        _ => data_entries(),
+    }
+}
+
+fn mmu_page_size() -> u32 {
+    cfg_select! {
+        not(soc_has_mmu_table) => indexed::mmu_page_size(),
+        // The C2 page size is configurable (IDF `mmu_ll_get_page_size`).
+        esp32c2 => c2::mmu_page_size(),
+        _ => property!("mmu.page_size"),
+    }
+}
+
+/// Inlined so that the ESP32 can call it from its cache-off window.
+#[inline(always)]
+fn flash_page_number(page_paddr: u32) -> u32 {
+    cfg_select! {
+        not(soc_has_mmu_table) => indexed::flash_page_number(page_paddr),
+        esp32c2 => page_paddr >> c2::mmu_page_size().trailing_zeros(),
+        _ => page_paddr >> 16,
+    }
+}
+
+fn entry_is_valid(entry_id: u32) -> bool {
+    cfg_select! {
+        not(soc_has_mmu_table) => indexed::entry_is_valid(entry_id),
+        _ => table::entry_is_valid(entry_id),
+    }
+}
+
+fn entry_is_flash_mapping(entry_id: u32) -> bool {
+    cfg_select! {
+        not(soc_has_mmu_table) => indexed::entry_is_flash_mapping(entry_id),
+        _ => table::entry_is_flash_mapping(entry_id),
+    }
+}
+
+fn entry_flash_page(entry_id: u32) -> u32 {
+    cfg_select! {
+        not(soc_has_mmu_table) => indexed::entry_flash_page(entry_id),
+        _ => table::entry_flash_page(entry_id),
+    }
+}
+
+/// The ESP32 writes its entries inside a cache-off window instead.
+#[cfg(not(any(esp32, esp32s2)))]
+fn write_flash_entry(entry_id: u32, page_paddr: u32) {
+    cfg_select! {
+        not(soc_has_mmu_table) => indexed::write_flash_entry(entry_id, page_paddr),
+        _ => table::write_flash_entry(entry_id, page_paddr),
+    }
+}
+
+/// The ESP32 invalidates its entries inside a cache-off window instead.
+#[cfg(not(esp32))]
+fn set_entry_invalid(entry_id: u32) {
+    cfg_select! {
+        not(soc_has_mmu_table) => indexed::set_entry_invalid(entry_id),
+        _ => table::set_entry_invalid(entry_id),
+    }
+}
+
+#[cfg(not(soc_has_mmu_table))]
+mod indexed {
+    use crate::peripherals::SPI0;
+
+    pub(super) fn mmu_page_size() -> u32 {
+        let code = mmu_page_size_code();
+        cfg_select! {
+            // The S31 flash MMU's maximum page size is 256 KiB.
+            esp32s31 => 0x40000 >> code,
+            _ => 0x10000 >> code,
+        }
+    }
+
+    fn mmu_page_size_code() -> u32 {
+        let ctrl = SPI0::regs().mmu_power_ctrl().read();
+        cfg_select! {
+            any(esp32c5, esp32c61, esp32s31) => ctrl.mmu_page_size().bits() as u32,
+            _ => ctrl.spi_mmu_page_size().bits() as u32,
+        }
+    }
+
+    pub(super) fn flash_page_number(page_paddr: u32) -> u32 {
+        page_paddr >> mmu_page_size().trailing_zeros()
+    }
+
+    fn with_entry<R>(entry_id: u32, f: impl FnOnce() -> R) -> R {
+        SPI0::regs()
+            .mmu_item_index()
+            .write(|w| unsafe { w.mmu_item_index().bits(entry_id) });
+        f()
+    }
+
+    pub(super) fn entry_is_valid(entry_id: u32) -> bool {
+        with_entry(entry_id, || {
+            SPI0::regs().mmu_item_content().read().valid().bit()
+        })
+    }
+
+    pub(super) fn entry_is_flash_mapping(entry_id: u32) -> bool {
+        cfg_select! {
+            any(esp32c5, esp32c61) => with_entry(entry_id, || {
+                !SPI0::regs().mmu_item_content().read().access_spiram().bit()
+            }),
+            _ => {
+                let _ = entry_id;
+                true
+            }
+        }
+    }
+
+    pub(super) fn entry_flash_page(entry_id: u32) -> u32 {
+        with_entry(entry_id, || {
+            SPI0::regs().mmu_item_content().read().paddr().bits() as u32
+        })
+    }
+
+    pub(super) fn write_flash_entry(entry_id: u32, page_paddr: u32) {
+        let page = super::flash_page_number(page_paddr) as u16;
+        let encrypted = crate::efuse::flash_encryption();
+        with_entry(entry_id, || {
+            SPI0::regs().mmu_item_content().write(|w| {
+                unsafe { w.paddr().bits(page) };
+                #[cfg(any(esp32c5, esp32c61))]
+                w.access_spiram().clear_bit();
+                w.valid().set_bit();
+                if encrypted {
+                    w.sensitive().set_bit();
+                }
+                w
+            });
+        });
+    }
+
+    pub(super) fn set_entry_invalid(entry_id: u32) {
+        with_entry(entry_id, || {
+            // Match `mmu_ll_set_entry_invalid`: the PAC reset value is not zero on every chip.
+            SPI0::regs()
+                .mmu_item_content()
+                .write(|w| unsafe { w.bits(0) });
+        });
+    }
+}
+
+#[cfg(soc_has_mmu_table)]
+mod table {
+    use crate::{pac::mmu_table::ENTRY, peripherals::MMU_TABLE};
+
+    /// Look up one MMU entry.
+    ///
+    /// The ESP32 looks the entry up before it turns the cache off: the bounds
+    /// check of the lookup can call into flash, which is unreachable then.
+    #[inline(always)]
+    pub(super) fn entry(entry_id: u32) -> &'static ENTRY {
+        MMU_TABLE::regs().entry(entry_id as usize)
+    }
+
+    pub(super) fn entry_is_valid(entry_id: u32) -> bool {
+        !entry(entry_id).read().invalid().bit()
+    }
+
+    pub(super) fn entry_is_flash_mapping(entry_id: u32) -> bool {
+        let e = entry(entry_id).read();
+        cfg_select! {
+            esp32s2 => e.access_flash().bit(),
+            esp32s3 => !e.access_spiram().bit(),
+            _ => {
+                let _ = e;
+                true
+            }
+        }
+    }
+
+    pub(super) fn entry_flash_page(entry_id: u32) -> u32 {
+        entry(entry_id).read().paddr().bits() as u32
+    }
+
+    // The ESP32 calls the two functions below with the cache off, where a call into flash would
+    // hang. Inlining them into the caller in RAM keeps them reachable.
+    #[cfg(not(esp32s2))]
+    #[inline(always)]
+    pub(super) fn write_entry(entry: &ENTRY, page_paddr: u32) {
+        let page = super::flash_page_number(page_paddr) as u16;
+        entry.write(|w| {
+            cfg_select! {
+                any(esp32, esp32c2, esp32c3) => unsafe { w.paddr().bits(page as u8) },
+                _ => unsafe { w.paddr().bits(page) },
+            };
+            w.invalid().clear_bit();
+            #[cfg(all(soc_has_psram, not(any(esp32, esp32s2))))]
+            w.access_spiram().clear_bit();
+            w
+        });
+    }
+
+    #[inline(always)]
+    pub(super) fn invalidate_entry(entry: &ENTRY) {
+        entry.write(|w| w.invalid().set_bit());
+    }
+
+    #[cfg(not(any(esp32, esp32s2)))]
+    pub(super) fn write_flash_entry(entry_id: u32, page_paddr: u32) {
+        write_entry(entry(entry_id), page_paddr);
+    }
+
+    #[cfg(not(esp32))]
+    pub(super) fn set_entry_invalid(entry_id: u32) {
+        invalidate_entry(entry(entry_id));
+    }
+
+    /// The S2 derives its range from the bus layout instead.
+    #[cfg(not(esp32s2))]
+    pub(super) fn entry_count() -> u32 {
+        MMU_TABLE::regs().entry_iter().count() as u32
+    }
+}
+
+/// Flash MMU and cache maintenance for the ESP32.
+///
+/// The ESP32 cache must be off while the flash MMU is written or the cache is
+/// flushed. Both operations disturb a cache fill that runs at the same time,
+/// and the core that waits for the fill then hangs. ESP-IDF turns the cache
+/// off around both operations, see `s_do_mapping()` in
+/// `components/esp_mm/esp_mmu_map.c`.
+///
+/// Everything that runs inside the cache-off window must be reachable without
+/// flash: the `#[ram]` entry points below only call `#[ram]` guard methods and
+/// helpers that are inlined into them.
+#[cfg(esp32)]
+mod esp32_cache {
+    use procmacros::ram;
+
+    use super::table;
+    use crate::{flash::cache::CacheGuard, pac::mmu_table::ENTRY};
+
+    /// Map `page_paddr` into `entry` and make the new mapping visible.
+    #[ram]
+    pub(super) fn map_entry(entry: &ENTRY, page_paddr: u32) {
+        let cache = CacheGuard::suspend();
+        table::write_entry(entry, page_paddr);
+        cache.flush_while_off();
+    }
+
+    /// Drop the lines of a temporary mapping and invalidate its entry, if we own it.
+    #[ram]
+    pub(super) fn unmap_entry(owned_entry: Option<&ENTRY>) {
+        let cache = CacheGuard::suspend();
+        if let Some(entry) = owned_entry {
+            table::invalidate_entry(entry);
+        }
+        cache.flush_while_off();
+    }
+
+    /// Drop every cached line.
+    #[ram]
+    pub(super) fn flush_caches() {
+        let cache = CacheGuard::suspend();
+        cache.flush_while_off();
+    }
+}
+
+#[cfg(esp32c2)]
+mod c2 {
+    use crate::peripherals::EXTMEM;
+
+    /// 0 = 16 KiB, 1 = 32 KiB, 2 = 64 KiB (`EXTMEM_CACHE_MMU_PAGE_SIZE`).
+    pub(super) fn mmu_page_size() -> u32 {
+        match EXTMEM::regs()
+            .cache_conf_misc()
+            .read()
+            .cache_mmu_page_size()
+            .bits()
+        {
+            0 => 0x4000,
+            1 => 0x8000,
+            _ => 0x10000,
+        }
+    }
+}
+
+#[cfg(esp32s2)]
+mod s2 {
+    use procmacros::ram;
+
+    use super::*;
+
+    pub(super) const DATA_ENTRY_START: u32 = 0x200 / 4;
+    pub(super) const DATA_ENTRY_END: u32 = 0x500 / 4;
+    const IBUS_ENTRY_END: u32 = 0x300 / 4;
+
+    /// Virtual address for an S2 MMU entry.
+    ///
+    /// Matches `mmu_ll_entry_id_to_vaddr_base()`: IBUS0/1 at 0x4000_0000,
+    /// DROM/DBUS at 0x3F00_0000. DBUS2/DPORT (0x140..) is 32-bit access only
+    /// and has no usable base here.
+    pub(super) fn entry_id_to_vaddr(entry_id: u32) -> Option<*const u8> {
+        let page_size = mmu_page_size();
+        let (base, relative) = match entry_id {
+            0x00..0x40 => (0x4000_0000u32, entry_id),
+            0x40..0x80 => (0x4000_0000u32, entry_id - 0x40),
+            0x80..0xC0 => (0x3F00_0000u32, entry_id - 0x80),
+            0xC0..0x100 => (0x3F00_0000u32, entry_id - 0xC0),
+            0x100..0x140 => (0x3F00_0000u32, entry_id - 0x100),
+            _ => return None,
+        };
+        Some((base + relative * page_size) as *const u8)
+    }
+
+    /// Pick a free MMU slot, preferring IBUS2/DROM entries first.
+    ///
+    /// Only data-bus entries are considered: on ESP32-S2, DROM (entries
+    /// 128..192) is backed by the I-cache bus (`drom0_in_icache = 1` in
+    /// ESP-IDF) but is addressed through 0x3F00_0000, while IBUS0/1 is not
+    /// reachable with 8-bit loads.
+    pub(super) fn alloc_entry() -> Option<u32> {
+        (DATA_ENTRY_START..IBUS_ENTRY_END - 1)
+            .rev()
+            .find(|&entry_id| !entry_is_valid(entry_id))
+            .or_else(find_free_entry)
+    }
+
+    fn entry_uses_ibus(entry_id: u32) -> bool {
+        (DATA_ENTRY_START..IBUS_ENTRY_END).contains(&entry_id)
+    }
+
+    #[ram]
+    fn mmu_rom_set(entry_id: u32, access: u32, vaddr: u32, paddr: u32) -> i32 {
+        unsafe extern "C" {
+            fn Cache_Ibus_MMU_Set(
+                ext_ram: u32,
+                vaddr: u32,
+                paddr: u32,
+                psize: u32,
+                num: u32,
+                fixed: u32,
+            ) -> i32;
+            fn Cache_Dbus_MMU_Set(
+                ext_ram: u32,
+                vaddr: u32,
+                paddr: u32,
+                psize: u32,
+                num: u32,
+                fixed: u32,
+            ) -> i32;
+        }
+
+        unsafe {
+            if entry_uses_ibus(entry_id) {
+                Cache_Ibus_MMU_Set(access, vaddr, paddr, 64, 1, 0)
+            } else {
+                Cache_Dbus_MMU_Set(access, vaddr, paddr, 64, 1, 0)
+            }
+        }
+    }
+
+    /// Map an MMU entry to a flash page via ROM (must run from IRAM on ESP32-S2).
+    #[ram]
+    pub(super) fn map_entry(entry_id: u32, page_paddr: u32) -> Result<*const u8, Error> {
+        let vaddr = entry_id_to_vaddr(entry_id).ok_or(Error::NotSupported)?;
+        let page_size = mmu_page_size();
+        let vaddr_u32 = vaddr as u32;
+        invalidate_cache(vaddr_u32, page_size);
+        if mmu_rom_set(entry_id, 1 << 15, vaddr_u32, page_paddr) != 0 {
+            return Err(Error::NotSupported);
+        }
+        invalidate_cache(vaddr_u32, page_size);
+        Ok(vaddr)
+    }
+}

--- a/esp-hal/src/flash/mod.rs
+++ b/esp-hal/src/flash/mod.rs
@@ -527,7 +527,10 @@ impl<'d> Flash<'d, Blocking> {
     /// 32-byte aligned, the driver preserves the adjacent 16-byte block by
     /// re-encrypting its existing plaintext to the same ciphertext. The neighbor
     /// block therefore does not require prior erasing.
-    ///
+    #[cfg_attr(
+        esp32c5,
+        doc = " Encrypted writes may fail at higher CPU frequencies (240 MHz)."
+    )]
     /// An empty `data` slice only checks that `offset` is within [`Self::capacity`].
     ///
     /// # Errors

--- a/esp-hal/src/flash/mod.rs
+++ b/esp-hal/src/flash/mod.rs
@@ -1,27 +1,36 @@
 #![cfg_attr(docsrs, procmacros::doc_replace)]
-//! # Internal SPI flash (FLASH)
+//! # Internal SPI Flash (FLASH)
 //!
 //! ## Overview
 //!
-//! Blocking access to the chip's attached SPI flash. The driver owns the
-//! virtual [`FLASH`] peripheral.
+//! Provides blocking access to the attached SPI flash memory. The driver owns
+//! the virtual [`FLASH`] peripheral.
 //!
-//! Write and erase are NOR-flash operations: bits can only change from 1 to 0
-//! without an erase. There is no read-modify-write. [`Flash::read`] and
-//! [`Flash::write`] take word slices (`&[u32]`) and a 4-byte-aligned **byte**
-//! offset; the buffer must be in DRAM. [`Flash::erase`] requires
-//! 4096-byte alignment.
+//! Write and erase are NOR flash operations: bits change only from 1 to 0
+//! without an erase. The driver does not perform read-modify-write.
+//! [`Flash::read`] and [`Flash::write`] take word slices (`&[u32]`) and a
+//! 4-byte-aligned byte offset. The buffer must reside in DRAM.
+//! [`Flash::erase`] operates on 4096-byte sectors.
 //!
+//! [`Flash::read_encrypted`] and [`Flash::write_encrypted`] provide transparent
+//! flash encryption. Encrypted writes require a 16-byte-aligned address and a
+//! length that is a multiple of 16 bytes (4 words). The destination must already
+//! be erased, and bytes outside the requested range are not programmed.
+//! Encrypted reads return plaintext if flash encryption is disabled.
+//!
+//! For more information, see the
+#![doc = concat!("[ESP-IDF documentation](https://docs.espressif.com/projects/esp-idf/en/latest/", chip!(), "/api-reference/peripherals/spi_flash/index.html)")]
 //! ## Configuration
 //!
-//! [`Config`] currently only selects the multi-core strategy on dual-core
-//! chips (default: automatically park the other core).
+//! On dual-core chips, [`Config`] selects the multi-core strategy (default:
+//! automatically park the other core).
 //!
 //! ## Usage
 //!
 //! Construct [`Flash`] from the virtual [`FLASH`] peripheral. `offset` is a
-//! flash byte address, not a word index. There is no `embedded-storage` impl
-//! on this type; higher layers own partitioning and trait wrappers.
+//! flash byte address, not a word index. The driver does not implement traits
+//! from `embedded-storage`; higher layers provide partition management and
+//! storage trait implementations.
 //!
 //! ## Examples
 //!
@@ -37,25 +46,24 @@
 //! # {after_snippet}
 //! ```
 //!
-//! ## Limitations
+//! ## Implementation State
 #![cfg_attr(
     esp32,
     doc = "- On ESP32, a second-stage bootloader must identify the flash chip; the ROM does not.
   [`Flash::new`] fails with [`ConfigError::UnknownFlashChip`] if identification is missing
-  (including the ROM placeholder id `0x001540EF`, a valid W25Q16 id on other chips)."
+  (including the ROM placeholder ID `0x001540EF`, a valid W25Q16 ID on other chips)."
 )]
-//! - Driver bounds use the JEDEC density from the ROM-cached device id. ROM operations also check
-//!   the ROM's cached chip size, which a bootloader may set from the image header. A range that
-//!   passes [`Flash`] can still fail in the ROM, and the reverse if the header claims a larger
-//!   chip.
-//! - [`Flash::write`] and [`Flash::erase`] do not refuse currently mapped flash.
-//! - Programming a mapped `.text` or `.rodata` page can destroy the running image or change memory
-//!   the compiler treats as immutable.
-//! - A single [`Flash::read`] / [`Flash::write`] is one ROM call. The flash-backed cache stays off
-//!   (and the other core may stay parked) for the whole transfer. Split large operations in a
-//!   higher layer if that latency matters.
-//! - On dual-core chips, the default strategy stalls the other CPU around every operation,
-//!   including reads. The other core may be frozen while holding a lock or inside an interrupt
+//! - Driver bounds checks use the JEDEC density from the ROM-cached device ID. ROM operations also
+//!   check the ROM-cached chip size, which a bootloader can set from the application image header.
+//!   An operation within [`Flash`] capacity can still fail in the ROM if the ROM-cached size is
+//!   smaller.
+//! - Operations do not check whether the target flash range is mapped. Writing or erasing a mapped
+//!   section (such as `.text` or `.rodata`) can corrupt running code or immutable data.
+//! - Each [`Flash::read`] or [`Flash::write`] call executes a single ROM operation. The flash cache
+//!   remains disabled (and the other core remains parked) for the entire transfer. Split large
+//!   operations in higher-level code if latency is critical.
+//! - On dual-core chips, the default strategy stalls the other core around every operation,
+//!   including reads. The other core can freeze while holding a lock or executing an interrupt
 //!   handler.
 
 use core::marker::PhantomData;
@@ -69,6 +77,7 @@ use crate::interrupt::free;
 use crate::{Blocking, DriverMode, peripherals::FLASH, soc::is_slice_in_dram};
 
 mod cache;
+mod mmu;
 mod rom;
 
 /// Word size required by the read and write paths, in bytes.
@@ -79,6 +88,11 @@ const PAGE_SIZE: u32 = 256;
 const SECTOR_SIZE: u32 = 4096;
 /// Erase block size in bytes.
 const BLOCK_SIZE: u32 = 65536;
+/// Flash-encryption AES block size, and the public encrypted-write alignment.
+const ENCRYPT_BLOCK_SIZE: u32 = 16;
+/// ESP32 ROM encrypted-write row (two AES blocks that share a tweak).
+#[cfg(esp32)]
+const ESP32_ENCRYPT_ROW: u32 = 32;
 
 /// Flash driver configuration.
 #[instability::unstable]
@@ -86,35 +100,35 @@ const BLOCK_SIZE: u32 = 65536;
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub struct Config {
-    /// How to treat the other CPU during a flash operation.
+    /// Strategy for the other core during flash operations.
     ///
     /// Default: [`MultiCoreStrategy::AutoPark`].
     ///
-    /// [`MultiCoreStrategy::ignore`] is only safe when the other core cannot
-    /// fetch from flash for the duration of the operation.
+    /// [`MultiCoreStrategy::ignore`] is safe only when the other core cannot
+    /// fetch from flash during the operation.
     #[cfg(multi_core)]
     #[builder_lite(unstable)]
     multi_core_strategy: MultiCoreStrategy,
 }
 
-/// Strategy for the other CPU during flash operations.
+/// Strategy for the other core during flash operations.
 #[cfg(multi_core)]
 #[instability::unstable]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub enum MultiCoreStrategy {
-    /// Fail with [`Error::OtherCoreRunning`] if the other core is running.
+    /// Returns [`Error::OtherCoreRunning`] if the other core is running.
     Error,
-    /// Park the other core for the operation and unpark it afterwards.
+    /// Parks the other core for the operation and unparks it afterward.
     ///
-    /// The stall can freeze the other core at any instruction. It may hold a
-    /// lock or be inside an interrupt handler. Parking uses the CPU-control
+    /// The stall can freeze the other core at any instruction. The other core can hold a
+    /// lock or execute an interrupt handler. Parking uses CPU-control
     /// registers even if the application already owns
     /// [`crate::peripherals::CPU_CTRL`].
     #[default]
     AutoPark,
-    /// Do not check or park the other core.
+    /// Does not check or park the other core.
     ///
     /// Construct with [`Self::ignore`].
     Ignore(IgnoreMarker),
@@ -133,13 +147,13 @@ pub struct IgnoreMarker {
 
 #[cfg(multi_core)]
 impl MultiCoreStrategy {
-    /// Do not check or park the other core.
+    /// Creates a strategy that does not check or park the other core.
     ///
     /// # Safety
     ///
-    /// The other core must not fetch instructions or data from flash for the
-    /// duration of every operation, including reads. Flash-backed caches are
-    /// unavailable while an operation runs.
+    /// The other core must not fetch instructions or data from flash during any
+    /// operation, including reads. Flash-backed caches are unavailable while
+    /// an operation runs.
     #[instability::unstable]
     pub const unsafe fn ignore() -> Self {
         Self::Ignore(IgnoreMarker { _private: () })
@@ -152,12 +166,12 @@ impl MultiCoreStrategy {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub enum ConfigError {
-    /// The attached flash chip could not be identified, or its size is not
+    /// The attached flash chip cannot be identified, or its size is not
     /// recognized.
     ///
     /// This includes no-response JEDEC sentinels, an unrecognized density
-    /// byte, and on ESP32 the ROM placeholder `0x001540EF` (the ROM does not
-    /// run `RDID`; that word is a valid W25Q16 id on other chips).
+    /// byte, and the ESP32 ROM placeholder ID `0x001540EF` (the ROM does not
+    /// execute `RDID`; this value is a valid W25Q16 ID on other chips).
     UnknownFlashChip,
 }
 
@@ -188,27 +202,30 @@ pub enum Error {
     /// Includes a ROM-side size check against its cached chip size when that
     /// is smaller than [`Flash::capacity`].
     IoError,
-    /// The operation timed out.
+    /// Operation timed out.
     IoTimeout,
     /// Address or length is not aligned for this operation.
     ///
-    /// [`Flash::read`] and [`Flash::write`] require a 4-byte-aligned flash
-    /// offset. [`Flash::erase`] requires a 4096-byte range.
+    /// [`Flash::read`], [`Flash::read_encrypted`], and [`Flash::write`] require a
+    /// 4-byte-aligned flash offset. [`Flash::write_encrypted`] requires a
+    /// 16-byte address and a word count that is a multiple of 4 (16 bytes).
+    /// [`Flash::erase`] requires a 4096-byte range.
     NotAligned,
-    /// The range exceeds [`Flash::capacity`], or `from` > `to`.
+    /// Address range exceeds [`Flash::capacity`], or `from > to`.
     ///
-    /// Capacity is the JEDEC density, not the ROM's cached chip size. A range
-    /// inside this limit can still fail in the ROM if that cached size is
+    /// Capacity is the JEDEC density, not the ROM cached chip size. An address
+    /// range within this limit can still fail in the ROM if the cached size is
     /// smaller (often the image-header size on ESP32).
     OutOfBounds,
     /// Not supported in the current environment.
     ///
-    /// Returned when the buffer is not in DRAM.
+    /// Returned when the buffer is not in DRAM, when
+    /// [`Flash::write_encrypted`] is called while flash encryption is disabled,
+    /// or when [`Flash::read_encrypted`] cannot allocate an MMU entry.
     NotSupported,
     /// The other core is running and the configured strategy is
     /// [`MultiCoreStrategy::Error`].
-    #[cfg(all(multi_core, feature = "unstable"))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
+    #[cfg(multi_core)]
     OtherCoreRunning,
     /// Unexpected ROM status code (logged).
     Unknown,
@@ -224,23 +241,24 @@ impl core::fmt::Display for Error {
             Self::NotAligned => write!(f, "Flash address or length is not aligned"),
             Self::OutOfBounds => write!(f, "Flash range is out of bounds"),
             Self::NotSupported => write!(f, "Flash operation is not supported"),
-            #[cfg(all(multi_core, feature = "unstable"))]
-            Self::OtherCoreRunning => write!(f, "The other CPU core is running"),
+            #[cfg(multi_core)]
+            Self::OtherCoreRunning => write!(f, "The other core is running"),
             Self::Unknown => write!(f, "Unknown flash error"),
         }
     }
 }
 
-/// Identification of the attached flash chip.
+/// Flash chip identification and geometry.
 ///
-/// `chip_id` is manufacturer-first (manufacturer in bits 23:16). Geometry is
-/// fixed: 256-byte pages, 4 KiB sectors and 64 KiB blocks.
+/// `chip_id` contains the manufacturer ID in bits 23:16. Geometry is fixed at
+/// 256-byte pages, 4096-byte sectors, and 64 KiB blocks; it is not probed from
+/// the chip.
 #[instability::unstable]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub struct ChipInfo {
-    /// JEDEC id, manufacturer in bits 23:16.
+    /// JEDEC ID with manufacturer ID in bits 23:16.
     pub chip_id: u32,
     /// JEDEC-decoded physical capacity in bytes.
     ///
@@ -256,7 +274,7 @@ pub struct ChipInfo {
 
 /// Internal SPI flash driver.
 ///
-/// Only [`Blocking`] mode is constructible.
+/// Constructible only in [`Blocking`] mode.
 #[instability::unstable]
 #[derive(Debug)]
 pub struct Flash<'d, Dm: DriverMode> {
@@ -280,19 +298,17 @@ impl<'d> Flash<'d, Blocking> {
     #[instability::unstable]
     pub const BLOCK_SIZE: u32 = 65536;
 
-    /// Creates a new flash driver from the `FLASH` peripheral.
+    /// Creates a new flash driver from the [`FLASH`] peripheral.
     ///
-    /// Capacity is the JEDEC density from the ROM-cached device id, not the
-    /// image-header size and not the ROM's cached chip size used by
-    /// read/write/erase.
-    #[cfg_attr(esp32, doc = "# Limitations")]
-    #[cfg_attr(
-        esp32,
-        doc = "On ESP32, a second-stage bootloader must identify the flash chip; the
-ROM does not. Without that, this method returns
-[`ConfigError::UnknownFlashChip`] (including the ROM placeholder
-`0x001540EF`)."
-    )]
+    /// Capacity is determined from the JEDEC density in the ROM-cached device
+    /// ID, not the image-header size or the ROM cached chip size used by
+    /// read, write, and erase operations.
+    ///
+    /// # Errors
+    ///
+    /// - [`ConfigError::UnknownFlashChip`] if the attached flash chip cannot be identified or its
+    ///   size is not recognized. On ESP32, this error also occurs when a second-stage bootloader
+    ///   has not identified the chip (including the ROM placeholder ID `0x001540EF`).
     #[instability::unstable]
     pub fn new(flash: FLASH<'d>, config: Config) -> Result<Self, ConfigError> {
         let raw_id = rom::cached_device_id();
@@ -314,8 +330,9 @@ ROM does not. Without that, this method returns
 
     /// Applies a new configuration.
     ///
-    /// On dual-core chips this updates the multi-core strategy. On single-core
-    /// chips it is a no-op.
+    /// Updates the multi-core strategy on dual-core chips. On single-core
+    /// chips, this is a no-op. The return type is reserved for future
+    /// configuration options.
     #[instability::unstable]
     pub fn apply_config(&mut self, config: &Config) -> Result<(), ConfigError> {
         #[cfg(multi_core)]
@@ -328,18 +345,19 @@ ROM does not. Without that, this method returns
 
     /// Returns the JEDEC-decoded flash capacity in bytes.
     ///
-    /// Driver bounds use this value. ROM read/write/erase also check the ROM's
-    /// cached chip size, which a bootloader may set from the image header.
+    /// Driver bounds checks use this value. ROM read, write, and erase operations
+    /// also check the ROM-cached chip size, which a bootloader can set from the
+    /// application image header.
     #[instability::unstable]
     pub fn capacity(&self) -> usize {
         self.capacity
     }
 
-    /// Returns chip identification and fixed geometry.
+    /// Returns chip identification and geometry.
     ///
-    /// `chip_id` is manufacturer-first. `capacity` is the JEDEC density; see
-    /// [`Self::capacity`]. Geometry is always 256-byte pages, 4096-byte
-    /// sectors and 64 KiB blocks; it is not probed from the chip.
+    /// `chip_id` contains the manufacturer ID in bits 23:16. `capacity` is the
+    /// JEDEC density; see [`Self::capacity`]. Geometry is fixed, not probed
+    /// from the chip.
     #[instability::unstable]
     pub fn chip_info(&self) -> ChipInfo {
         ChipInfo {
@@ -351,24 +369,23 @@ ROM does not. Without that, this method returns
         }
     }
 
-    /// Reads `data.len()` words starting at byte address `offset`.
+    /// Reads words into `data` starting at byte address `offset`.
     ///
-    /// `offset` is a flash byte address and, when `data` is non-empty, must be
-    /// a multiple of 4. `data` must be in DRAM (not flash, IRAM, RTC memory,
-    /// or PSRAM). An empty `data` slice only checks that `offset` is within
-    /// [`Self::capacity`].
+    /// `offset` is a flash byte address and must be a multiple of 4. `data`
+    /// must reside in DRAM, not in flash, IRAM, RTC memory, or PSRAM. An empty
+    /// `data` slice only checks that `offset` is within [`Self::capacity`].
     ///
     /// # Errors
     ///
-    /// Returns [`Error::NotAligned`] if `data` is non-empty and `offset` is
-    /// not a multiple of 4, [`Error::OutOfBounds`] if the range exceeds
-    /// [`Self::capacity`], [`Error::NotSupported`] if `data` is not in
-    /// DRAM, or a ROM I/O error ([`Error::IoError`],
-    /// [`Error::IoTimeout`], [`Error::Unknown`]).
+    /// - [`Error::NotAligned`] if `data` is non-empty and `offset` is not a multiple of 4.
+    /// - [`Error::OutOfBounds`] if the range exceeds [`Self::capacity`].
+    /// - [`Error::NotSupported`] if `data` is not in DRAM.
     #[cfg_attr(
-        all(multi_core, feature = "unstable"),
-        doc = " On dual-core chips with [`MultiCoreStrategy::Error`], also [`Error::OtherCoreRunning`]."
+        multi_core,
+        doc = "- [`Error::OtherCoreRunning`] on dual-core chips with [`MultiCoreStrategy::Error`]."
     )]
+    /// - [`Error::IoError`], [`Error::IoTimeout`], or [`Error::Unknown`] if the ROM reports an I/O
+    ///   error.
     #[instability::unstable]
     #[ram]
     pub fn read(&mut self, offset: u32, data: &mut [u32]) -> Result<(), Error> {
@@ -385,31 +402,30 @@ ROM does not. Without that, this method returns
         self.with_guard(None, |_| rom::read(offset, data))
     }
 
-    /// Writes `data` starting at byte address `offset` using NOR flash
-    /// semantics.
+    /// Writes `data` starting at byte address `offset`.
     ///
-    /// The target must already be erased. `offset` is a flash byte address and,
-    /// when `data` is non-empty, must be a multiple of 4. `data` must be in
-    /// DRAM (not flash, IRAM, RTC memory, or PSRAM). An empty `data` slice
-    /// only checks that `offset` is within [`Self::capacity`].
+    /// The target flash range must already be erased. `offset` is a flash byte
+    /// address and must be a multiple of 4. `data` must reside in DRAM, not in
+    /// flash, IRAM, RTC memory, or PSRAM. An empty `data` slice only checks
+    /// that `offset` is within [`Self::capacity`].
     ///
     /// # Errors
     ///
-    /// Returns [`Error::NotAligned`] if `data` is non-empty and `offset` is
-    /// not a multiple of 4, [`Error::OutOfBounds`] if the range exceeds
-    /// [`Self::capacity`], [`Error::NotSupported`] if `data` is not in
-    /// DRAM, or a ROM I/O error ([`Error::IoError`],
-    /// [`Error::IoTimeout`], [`Error::Unknown`]).
+    /// - [`Error::NotAligned`] if `data` is non-empty and `offset` is not a multiple of 4.
+    /// - [`Error::OutOfBounds`] if the range exceeds [`Self::capacity`].
+    /// - [`Error::NotSupported`] if `data` is not in DRAM.
     #[cfg_attr(
-        all(multi_core, feature = "unstable"),
-        doc = " On dual-core chips with [`MultiCoreStrategy::Error`], also [`Error::OtherCoreRunning`]."
+        multi_core,
+        doc = "- [`Error::OtherCoreRunning`] on dual-core chips with [`MultiCoreStrategy::Error`]."
     )]
+    /// - [`Error::IoError`], [`Error::IoTimeout`], or [`Error::Unknown`] if the ROM reports an I/O
+    ///   error.
+    ///
     /// # Safety
     ///
     /// The programmed range must not be mapped for instruction fetch or as
     /// immutable data. Writing a mapped `.text` or `.rodata` page overwrites
-    /// the running image, or mutates `static` / `.rodata` the compiler treats
-    /// as immutable.
+    /// the running image or mutates data the compiler treats as immutable.
     #[instability::unstable]
     #[ram]
     pub unsafe fn write(&mut self, offset: u32, data: &[u32]) -> Result<(), Error> {
@@ -427,28 +443,29 @@ ROM does not. Without that, this method returns
         self.with_guard(Some((offset, len as u32)), |_| rom::write(offset, data))
     }
 
-    /// Erases flash in `[from, to)`.
+    /// Erases flash sectors in the range `[from, to)`.
     ///
-    /// `from` and `to` must be multiples of [`Self::SECTOR_SIZE`] (4096 bytes).
-    /// `to == capacity` is allowed. There is no byte-granular erase.
-    /// `from == to` only checks that `from` is within [`Self::capacity`].
+    /// `from` and `to` must be multiples of [`Self::SECTOR_SIZE`] (4096 bytes);
+    /// there is no byte-granular erase. `to == capacity` is allowed. When
+    /// `from == to`, this function only checks that `from` is within
+    /// [`Self::capacity`].
     ///
     /// # Errors
     ///
-    /// Returns [`Error::NotAligned`] if `from != to` and `from` or `to` is not
-    /// a multiple of 4096, [`Error::OutOfBounds`] if `from > to` or the range
-    /// exceeds [`Self::capacity`], or a ROM I/O error ([`Error::IoError`],
-    /// [`Error::IoTimeout`], [`Error::Unknown`]).
+    /// - [`Error::NotAligned`] if `from != to` and `from` or `to` is not a multiple of 4096.
+    /// - [`Error::OutOfBounds`] if `from > to` or the range exceeds [`Self::capacity`].
     #[cfg_attr(
-        all(multi_core, feature = "unstable"),
-        doc = " On dual-core chips with [`MultiCoreStrategy::Error`], also [`Error::OtherCoreRunning`]."
+        multi_core,
+        doc = "- [`Error::OtherCoreRunning`] on dual-core chips with [`MultiCoreStrategy::Error`]."
     )]
+    /// - [`Error::IoError`], [`Error::IoTimeout`], or [`Error::Unknown`] if the ROM reports an I/O
+    ///   error.
+    ///
     /// # Safety
     ///
     /// The erased range must not be mapped for instruction fetch or as
     /// immutable data. Erasing a mapped `.text` or `.rodata` page destroys the
-    /// running image, or mutates `static` / `.rodata` the compiler treats as
-    /// immutable.
+    /// running image or mutates data the compiler treats as immutable.
     #[instability::unstable]
     #[ram]
     pub unsafe fn erase(&mut self, from: u32, to: u32) -> Result<(), Error> {
@@ -465,14 +482,124 @@ ROM does not. Without that, this method returns
         self.ensure_unlocked()?;
         self.erase_range(from, to)
     }
+
+    /// Reads decrypted words into `data` starting at byte address `offset`.
+    ///
+    /// Uses a temporary MMU mapping to read decrypted data through the cache.
+    /// If flash encryption is not enabled, this returns plaintext.
+    ///
+    /// `offset` is a flash byte address and must be a multiple of 4. `data`
+    /// must reside in DRAM, not in flash, IRAM, RTC memory, or PSRAM. An empty
+    /// `data` slice only checks that `offset` is within [`Self::capacity`].
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::NotAligned`] if `data` is non-empty and `offset` is not a multiple of 4.
+    /// - [`Error::OutOfBounds`] if the range exceeds [`Self::capacity`].
+    /// - [`Error::NotSupported`] if `data` is not in DRAM or no MMU entry is available.
+    #[cfg_attr(
+        multi_core,
+        doc = "- [`Error::OtherCoreRunning`] on dual-core chips with [`MultiCoreStrategy::Error`]."
+    )]
+    #[instability::unstable]
+    pub fn read_encrypted(&mut self, offset: u32, data: &mut [u32]) -> Result<(), Error> {
+        let Some(len) = byte_len(data) else {
+            return Err(Error::OutOfBounds);
+        };
+        if data.is_empty() {
+            return self.check_bounds(offset, 0);
+        }
+
+        self.check_word_offset(offset)?;
+        self.check_bounds(offset, len)?;
+        check_buffer(data)?;
+        self.with_mmu_guard(|_| mmu::read_flash_encrypted(offset, data))
+    }
+
+    /// Writes `data` with transparent flash encryption.
+    ///
+    /// `offset` must be a multiple of 16, and `data.len()` must be a multiple
+    /// of 4 words (16 bytes). The destination must already be erased, and bytes
+    /// outside the requested range are not programmed. `data` must reside in
+    /// DRAM, not in flash, IRAM, RTC memory, or PSRAM.
+    ///
+    /// On ESP32, encrypted writes operate in 32-byte rows. If a boundary is not
+    /// 32-byte aligned, the driver preserves the adjacent 16-byte block by
+    /// re-encrypting its existing plaintext to the same ciphertext. The neighbor
+    /// block therefore does not require prior erasing.
+    ///
+    /// An empty `data` slice only checks that `offset` is within [`Self::capacity`].
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::NotSupported`] if flash encryption is disabled. The eFuse gate is checked before
+    ///   the arguments are.
+    /// - [`Error::NotAligned`] if `data` is non-empty and `offset` is not a multiple of 16, or
+    ///   `data.len()` is not a multiple of 4 words (16 bytes).
+    /// - [`Error::OutOfBounds`] if the range exceeds [`Self::capacity`].
+    /// - [`Error::NotSupported`] if `data` is not in DRAM, or on ESP32 if reading a row neighbor
+    ///   fails because no MMU entry is available.
+    #[cfg_attr(
+        multi_core,
+        doc = "- [`Error::OtherCoreRunning`] on dual-core chips with [`MultiCoreStrategy::Error`]."
+    )]
+    /// - [`Error::IoError`], [`Error::IoTimeout`], or [`Error::Unknown`] if the ROM reports an I/O
+    ///   error.
+    ///
+    /// # Safety
+    ///
+    /// The programmed range must not be mapped for instruction fetch or as
+    /// immutable data. Writing a mapped `.text` or `.rodata` page overwrites
+    /// the running image, or mutates `static` or `.rodata` data the compiler
+    /// treats as immutable.
+    #[instability::unstable]
+    #[ram]
+    pub unsafe fn write_encrypted(&mut self, offset: u32, data: &[u32]) -> Result<(), Error> {
+        #[cfg(not(__test_flash))]
+        if !crate::efuse::flash_encryption() {
+            return Err(Error::NotSupported);
+        }
+
+        let Some(len) = byte_len(data) else {
+            return Err(Error::OutOfBounds);
+        };
+        if data.is_empty() {
+            return self.check_bounds(offset, 0);
+        }
+
+        self.check_alignment(ENCRYPT_BLOCK_SIZE, offset, len)?;
+        self.check_bounds(offset, len)?;
+        check_buffer(data)?;
+        self.ensure_unlocked()?;
+
+        #[cfg(esp32)]
+        let neighbors = self.esp32_row_neighbors(offset, len)?;
+        // On ESP32 the programmed range can extend one 16-byte block past each
+        // end; `with_guard` flushes the whole cache there, so the range only
+        // needs to cover the request.
+        self.with_guard(Some((offset, len as u32)), |_| {
+            write_encrypted_rows(
+                offset,
+                words_as_bytes(data),
+                #[cfg(esp32)]
+                &neighbors,
+            )
+        })
+    }
 }
 
-#[ram]
+#[inline(always)]
 fn byte_len(data: &[u32]) -> Option<usize> {
     data.len().checked_mul(WORD_SIZE as usize)
 }
 
-#[ram]
+#[inline(always)]
+fn words_as_bytes(data: &[u32]) -> &[u8] {
+    // SAFETY: inspecting the in-memory bytes of `u32` words.
+    unsafe { core::slice::from_raw_parts(data.as_ptr().cast(), size_of_val(data)) }
+}
+
+#[inline(always)]
 fn check_buffer(buf: &[u32]) -> Result<(), Error> {
     if !is_slice_in_dram(buf) {
         return Err(Error::NotSupported);
@@ -480,8 +607,96 @@ fn check_buffer(buf: &[u32]) -> Result<(), Error> {
     Ok(())
 }
 
+/// Word-aligned staging buffer. The ROM encrypts in place.
+#[repr(C, align(4))]
+struct EncryptRow([u8; XTS_AES_BLOCK_MAX]);
+
+#[ram]
+fn write_encrypted_rows(
+    offset: u32,
+    data: &[u8],
+    #[cfg(esp32)] neighbors: &Esp32Neighbors,
+) -> Result<(), Error> {
+    let mut row = EncryptRow([0; XTS_AES_BLOCK_MAX]);
+    let mut i = 0;
+    while i < data.len() {
+        let row_addr = offset + i as u32;
+        let (program_addr, program_len, consumed) =
+            cfg_select! {
+                esp32 => prepare_esp32_row(&mut row.0, row_addr, &data[i..], neighbors),
+                _ => prepare_xts_row(&mut row.0, row_addr, &data[i..]),
+            };
+        rom::write_encrypted(program_addr, row.0.as_mut_ptr().cast(), program_len)?;
+        i += consumed;
+    }
+    Ok(())
+}
+
+#[cfg(esp32)]
+struct Esp32Neighbors {
+    pre: [u32; 4],
+    post: [u32; 4],
+}
+
+/// Fill a 32-byte ESP32 ROM row. Returns `(program_addr, program_len, consumed)`.
+///
+/// Mirrors the ESP32 arm of ESP-IDF `esp_flash_write_encrypted`: a row is two
+/// AES blocks sharing an address-derived tweak, so a 16-byte write must carry
+/// the decrypted neighbor block along and re-encrypt it to the same ciphertext.
+#[cfg(esp32)]
+#[ram]
+fn prepare_esp32_row(
+    buf: &mut [u8; XTS_AES_BLOCK_MAX],
+    row_addr: u32,
+    remaining: &[u8],
+    neighbors: &Esp32Neighbors,
+) -> (u32, u32, usize) {
+    const BLOCK: usize = ENCRYPT_BLOCK_SIZE as usize;
+    const ROW: usize = ESP32_ENCRYPT_ROW as usize;
+
+    if !row_addr.is_multiple_of(ESP32_ENCRYPT_ROW) {
+        buf[..BLOCK].copy_from_slice(words_as_bytes(&neighbors.pre));
+        buf[BLOCK..ROW].copy_from_slice(&remaining[..BLOCK]);
+        (row_addr - ENCRYPT_BLOCK_SIZE, ESP32_ENCRYPT_ROW, BLOCK)
+    } else if remaining.len() == BLOCK {
+        buf[..BLOCK].copy_from_slice(&remaining[..BLOCK]);
+        buf[BLOCK..ROW].copy_from_slice(words_as_bytes(&neighbors.post));
+        (row_addr, ESP32_ENCRYPT_ROW, BLOCK)
+    } else {
+        buf[..ROW].copy_from_slice(&remaining[..ROW]);
+        (row_addr, ESP32_ENCRYPT_ROW, ROW)
+    }
+}
+
+/// Largest row the flash-encryption hardware accepts, matching IDF's
+/// `SOC_FLASH_ENCRYPTED_XTS_AES_BLOCK_MAX`.
+#[cfg(any(esp32, esp32c2, esp32c3))]
+const XTS_AES_BLOCK_MAX: usize = 32;
+#[cfg(not(any(esp32, esp32c2, esp32c3)))]
+const XTS_AES_BLOCK_MAX: usize = 64;
+
+/// Pick the largest aligned row, as ESP-IDF does for ESP32-S2 and later.
+#[cfg(not(esp32))]
+#[ram]
+fn prepare_xts_row(
+    buf: &mut [u8; XTS_AES_BLOCK_MAX],
+    row_addr: u32,
+    remaining: &[u8],
+) -> (u32, u32, usize) {
+    let row_size =
+        if XTS_AES_BLOCK_MAX >= 64 && row_addr.is_multiple_of(64) && remaining.len() >= 64 {
+            64
+        } else if row_addr.is_multiple_of(32) && remaining.len() >= 32 {
+            32
+        } else {
+            16
+        };
+    buf[..row_size].copy_from_slice(&remaining[..row_size]);
+    (row_addr, row_size as u32, row_size)
+}
+
 impl Flash<'_, Blocking> {
-    #[ram]
+    #[inline(always)]
     fn check_word_offset(&self, offset: u32) -> Result<(), Error> {
         if !offset.is_multiple_of(WORD_SIZE) {
             return Err(Error::NotAligned);
@@ -489,7 +704,7 @@ impl Flash<'_, Blocking> {
         Ok(())
     }
 
-    #[ram]
+    #[inline(always)]
     fn check_alignment(&self, align: u32, offset: u32, length: usize) -> Result<(), Error> {
         if !offset.is_multiple_of(align) || !length.is_multiple_of(align as usize) {
             return Err(Error::NotAligned);
@@ -497,13 +712,48 @@ impl Flash<'_, Blocking> {
         Ok(())
     }
 
-    #[ram]
+    #[inline(always)]
     fn check_bounds(&self, offset: u32, length: usize) -> Result<(), Error> {
         let offset = offset as usize;
         if length > self.capacity || offset > self.capacity - length {
             return Err(Error::OutOfBounds);
         }
         Ok(())
+    }
+
+    /// Park and disable interrupts without suspending the cache.
+    ///
+    /// Encrypted reads map flash through the MMU and copy with the cache on, so
+    /// neither this guard nor anything it calls has to live in RAM.
+    fn with_mmu_guard<R>(
+        &mut self,
+        f: impl FnOnce(&mut Self) -> Result<R, Error>,
+    ) -> Result<R, Error> {
+        free(|| {
+            let _park = ParkGuard::enter(self)?;
+            f(self)
+        })
+    }
+
+    /// Plaintext of row halves the write will touch but not replace.
+    ///
+    /// Read before the cache-off write path: [`Self::read_encrypted`] needs the
+    /// cache on. Re-encrypting this plaintext in [`prepare_esp32_row`] reproduces
+    /// the ciphertext already in flash, so those neighbors need no separate erase.
+    #[cfg(esp32)]
+    fn esp32_row_neighbors(&mut self, offset: u32, len: usize) -> Result<Esp32Neighbors, Error> {
+        let mut neighbors = Esp32Neighbors {
+            pre: [0; 4],
+            post: [0; 4],
+        };
+        if !offset.is_multiple_of(ESP32_ENCRYPT_ROW) {
+            self.read_encrypted(offset - ENCRYPT_BLOCK_SIZE, &mut neighbors.pre)?;
+        }
+        let end = offset + len as u32;
+        if !end.is_multiple_of(ESP32_ENCRYPT_ROW) {
+            self.read_encrypted(end, &mut neighbors.post)?;
+        }
+        Ok(neighbors)
     }
 
     #[ram]
@@ -527,7 +777,7 @@ impl Flash<'_, Blocking> {
                 _ => {
                     drop(cache);
                     if let Some((start, len)) = invalidate {
-                        cache::invalidate_mapped(start, len);
+                        mmu::invalidate_mapped(start, len);
                     }
                 }
             }
@@ -540,17 +790,11 @@ impl Flash<'_, Blocking> {
         if self.unlocked {
             return Ok(());
         }
-        self.with_guard(None, |this| this.unlock_once())
-    }
-
-    #[ram]
-    fn unlock_once(&mut self) -> Result<(), Error> {
-        if self.unlocked {
-            return Ok(());
-        }
-        rom::unlock()?;
-        self.unlocked = true;
-        Ok(())
+        self.with_guard(None, |this| {
+            rom::unlock()?;
+            this.unlocked = true;
+            Ok(())
+        })
     }
 
     #[ram]

--- a/esp-hal/src/flash/rom.rs
+++ b/esp-hal/src/flash/rom.rs
@@ -164,6 +164,18 @@ pub(super) fn write(dest_addr: u32, data: &[u32]) -> Result<(), Error> {
     })
 }
 
+/// Write `len` bytes at `dest_addr` with transparent encryption.
+///
+/// `data` must be word-aligned. On ESP32, `dest_addr` and `len` must be
+/// 32-byte aligned. On later chips, 16/32/64-byte rows are accepted. The
+/// ROM may encrypt in place.
+#[inline(always)]
+pub(super) fn write_encrypted(dest_addr: u32, data: *mut u32, len: u32) -> Result<(), Error> {
+    check_rc(unsafe {
+        esp_rom_sys::rom::spiflash::esp_rom_spiflash_write_encrypted(dest_addr, data, len)
+    })
+}
+
 #[inline(always)]
 pub(super) fn unlock() -> Result<(), Error> {
     check_rc(unsafe { esp_rom_sys::rom::spiflash::esp_rom_spiflash_unlock() })

--- a/esp-rom-sys/src/rom/spiflash.rs
+++ b/esp-rom-sys/src/rom/spiflash.rs
@@ -33,8 +33,10 @@ unsafe extern "C" {
 
     /// Write data to flash with transparent encryption.
     ///
-    /// `flash_addr` and `len` must be 32-byte aligned. The sector must already be
-    /// erased.
+    /// The sector must already be erased. `data` may be encrypted in place.
+    ///
+    /// On ESP32, `flash_addr` and `len` must be 32-byte aligned. On later
+    /// chips the ROM accepts 16-, 32-, or 64-byte rows (chip-dependent max).
     pub fn esp_rom_spiflash_write_encrypted(flash_addr: u32, data: *mut u32, len: u32) -> i32;
 
     /// Enable SPI flash encryption mode.

--- a/examples/qa/src/bin/flash_encrypted.rs
+++ b/examples/qa/src/bin/flash_encrypted.rs
@@ -1,0 +1,120 @@
+//! Encrypted flash access on a device with flash encryption enabled.
+//!
+//! ATTENTION!
+//!
+//! Requires burned flash-encryption eFuses, an encryption-enabled second-stage
+//! bootloader, and a matching partition table. Do not run this via xtask /
+//! devtool.
+//!
+//! An encryption-enabled bootloader is larger than the default one and does not
+//! fit below the usual 0x8000 partition table, so that table has to be moved.
+//! This binary assumes the application image starts at 0x20000. 0xf000 is an
+//! unused sector in the gap that layout leaves; it is erased as scratch.
+//!
+//! IF YOU HAVE NO IDEA WHAT ALL THIS MEANS, STOP HERE!!!
+//!
+//! `Flash::write_encrypted` can only be validated on hardware whose flash
+//! encryption eFuses are burned: the ROM encrypts on write either way, but
+//! `Flash::read_encrypted` only returns plaintext when the hardware decrypts.
+//! HIL runners do not use encrypted boards, so this is a manual test.
+//!
+//! On ESP32 the ROM programs a 32-byte row of two AES blocks that share an
+//! address-derived tweak. A 16-byte write at a 16- but not 32-byte aligned
+//! boundary therefore has to decrypt the adjacent block and re-encrypt it to
+//! the same ciphertext. Every row size and both boundary alignments are
+//! covered below so that bridge is exercised.
+
+//% CHIP_FILTER: flash_driver_supported
+//% FEATURES: unstable
+
+#![no_std]
+#![no_main]
+
+use esp_backtrace as _;
+use esp_hal::{
+    Blocking,
+    flash::{Config, Error, Flash},
+    main,
+};
+use esp_println::println;
+
+esp_bootloader_esp_idf::esp_app_desc!();
+
+/// Unused sector below the application image (see the crate-level docs).
+const SCRATCH: u32 = 0xf000;
+
+/// `(offset into the sector, word count)` for every row size the driver
+/// selects, at both a 32- and a 16-byte aligned offset.
+const CASES: &[(u32, usize)] = &[(0, 4), (0, 8), (0, 12), (16, 4), (16, 8), (16, 12)];
+
+#[main]
+fn main() -> ! {
+    esp_println::logger::init_logger_from_env();
+    let peripherals = esp_hal::init(esp_hal::Config::default());
+
+    assert!(
+        esp_hal::efuse::flash_encryption(),
+        "this device has no flash encryption key burned"
+    );
+
+    let mut flash = Flash::new(peripherals.FLASH, Config::default()).unwrap();
+    let sector = flash.chip_info().sector_size;
+
+    let mut plaintext = [0u32; 12];
+    for (i, word) in plaintext.iter_mut().enumerate() {
+        *word = 0x0102_0304u32.wrapping_mul(i as u32 + 1);
+    }
+
+    for &(offset, words) in CASES {
+        let data = &plaintext[..words];
+        let len = (words * 4) as u32;
+
+        // SAFETY: scratch is below the application image at 0x20000.
+        unsafe { flash.erase(SCRATCH, SCRATCH + sector).unwrap() };
+        unsafe { flash.write_encrypted(SCRATCH + offset, data).unwrap() };
+
+        let mut plain = [0u32; 12];
+        flash
+            .read_encrypted(SCRATCH + offset, &mut plain[..words])
+            .unwrap();
+        assert_eq!(data, &plain[..words], "{len} bytes at {offset} lost data");
+
+        let mut raw = [0u32; 12];
+        flash.read(SCRATCH + offset, &mut raw[..words]).unwrap();
+        assert_ne!(data, &raw[..words], "{len} bytes at {offset} not encrypted");
+
+        // Re-encrypting a bridged neighbor must reproduce erased flash.
+        if offset > 0 {
+            assert_erased(&mut flash, SCRATCH, offset);
+        }
+        assert_erased(&mut flash, SCRATCH + offset + len, 16);
+
+        println!("ok: {len} bytes at offset {offset}");
+    }
+
+    assert_eq!(
+        unsafe { flash.write_encrypted(SCRATCH + 4, &plaintext[..4]) },
+        Err(Error::NotAligned)
+    );
+    assert_eq!(
+        unsafe { flash.write_encrypted(SCRATCH, &plaintext[..3]) },
+        Err(Error::NotAligned)
+    );
+
+    unsafe { flash.erase(SCRATCH, SCRATCH + sector).unwrap() };
+
+    println!("Test passed");
+
+    loop {}
+}
+
+/// Assert that up to 16 bytes of flash read back as erased.
+fn assert_erased(flash: &mut Flash<'static, Blocking>, offset: u32, len: u32) {
+    let mut buf = [0u32; 4];
+    let words = (len / 4) as usize;
+    flash.read(offset, &mut buf[..words]).unwrap();
+    assert!(
+        buf[..words].iter().all(|&word| word == 0xFFFF_FFFF),
+        "{offset:#x} is not erased"
+    );
+}

--- a/hil-test/src/bin/flash.rs
+++ b/hil-test/src/bin/flash.rs
@@ -3,6 +3,8 @@
 //! Assumes a certain (i.e. default) partition table layout.
 //% CHIP_FILTER: flash_driver_supported
 //% FEATURES: unstable
+//% CARGO-CONFIG: target.'cfg(target_arch = "riscv32")'.rustflags = [ "--cfg=__test_flash" ]
+//% CARGO-CONFIG: target.'cfg(target_arch = "xtensa")'.rustflags = [ "--cfg=__test_flash" ]
 
 #![no_std]
 #![no_main]
@@ -367,5 +369,179 @@ mod tests {
             flash.read(APP_DESC_OFFSET, &mut buf),
             Err(Error::OtherCoreRunning)
         );
+    }
+
+    /// HIL boards have no encryption key burned, so `read_encrypted` returns
+    /// the raw image and must agree with a plain read.
+    #[test]
+    fn test_read_encrypted_same_as_unencrypted_wo_encryption_enabled() {
+        let peripherals = esp_hal::init(esp_hal::Config::default());
+        let mut flash = flash_from_peripherals(peripherals);
+
+        let mut words = [0u32; 32];
+        let mut encrypted = [0u32; 32];
+        for offset in (0x10_000..0x20_000).step_by(128) {
+            flash.read(offset, &mut words).unwrap();
+            flash.read_encrypted(offset, &mut encrypted).unwrap();
+            assert_eq!(words, encrypted);
+        }
+    }
+
+    /// The read loop remaps once per MMU page. This range straddles a 64 KiB
+    /// boundary, which is a page boundary on every chip whose MMU page is
+    /// 64 KiB or smaller.
+    #[test]
+    fn test_read_encrypted_across_mmu_page() {
+        let peripherals = esp_hal::init(esp_hal::Config::default());
+        let mut flash = flash_from_peripherals(peripherals);
+
+        let mut words = [0u32; 64];
+        let mut encrypted = [0u32; 64];
+        flash.read(0x1_FF80, &mut words).unwrap();
+        flash.read_encrypted(0x1_FF80, &mut encrypted).unwrap();
+        assert_eq!(words, encrypted);
+    }
+
+    #[test]
+    fn test_write_encrypted_will_encrypt() {
+        let peripherals = esp_hal::init(esp_hal::Config::default());
+        let mut flash = flash_from_peripherals(peripherals);
+
+        let sector = flash.chip_info().sector_size;
+        // SAFETY: NVS is not mapped firmware.
+        unsafe { flash.erase(NVS, NVS + sector).unwrap() };
+
+        let zeros = [0u32; 64];
+        unsafe { flash.write_encrypted(NVS, &zeros).unwrap() };
+
+        // A plain read sees ciphertext, so the stored bytes differ from the
+        // plaintext that was written.
+        let mut words = [0u32; 64];
+        flash.read(NVS, &mut words).unwrap();
+        assert_ne!(words, zeros);
+
+        unsafe { flash.erase(NVS, NVS + sector).unwrap() };
+    }
+
+    #[test]
+    fn test_write_encrypted_alignment_and_bounds() {
+        let peripherals = esp_hal::init(esp_hal::Config::default());
+        let mut flash = flash_from_peripherals(peripherals);
+
+        let cap = flash.capacity() as u32;
+        let buf16 = [0u32; 4];
+        let mut read1 = [0u32; 1];
+
+        assert_eq!(
+            unsafe { flash.write_encrypted(NVS + 1, &buf16) },
+            Err(Error::NotAligned)
+        );
+        assert_eq!(
+            unsafe { flash.write_encrypted(NVS, &[0u32; 3]) },
+            Err(Error::NotAligned)
+        );
+        assert_eq!(flash.read_encrypted(1, &mut read1), Err(Error::NotAligned));
+        assert_eq!(
+            flash.read_encrypted(cap, &mut read1),
+            Err(Error::OutOfBounds)
+        );
+        assert_eq!(
+            unsafe { flash.write_encrypted(cap, &buf16) },
+            Err(Error::OutOfBounds)
+        );
+
+        // Flash-resident source is rejected; the caller must stage through RAM.
+        assert_eq!(
+            unsafe { flash.write_encrypted(NVS, &FLASH_PATTERN) },
+            Err(Error::NotSupported)
+        );
+
+        flash.read_encrypted(NVS, &mut []).unwrap();
+        unsafe { flash.write_encrypted(NVS, &[]).unwrap() };
+    }
+
+    /// True when writing up to `addr` needs the ESP32 neighbor bridge.
+    ///
+    /// On ESP32 a 16- but not 32-byte aligned boundary shares an AES row with
+    /// the neighboring block, so the driver decrypts and re-encrypts that
+    /// neighbor. That only reproduces the original ciphertext once the
+    /// encryption eFuses are burned — without them the ROM encrypts on write
+    /// but `read_encrypted` cannot decrypt, so the neighbor does change. HIL
+    /// boards are never encrypted; `qa-test/flash_encrypted` covers the bridge.
+    fn needs_row_bridge(addr: u32) -> bool {
+        cfg!(esp32) && !addr.is_multiple_of(32)
+    }
+
+    /// ROM headers copy-paste ESP32's 32-byte alignment onto every chip.
+    /// On later chips `esp_rom_spiflash_write_encrypted` accepts 16-byte rows
+    /// (and 64-byte rows when the XTS block allows). Each case below is a
+    /// single ROM call: a 32-byte-only ROM would return an error, or program
+    /// past the request.
+    #[cfg(not(esp32))]
+    #[test]
+    fn test_rom_write_encrypted_accepts_non_32_byte_rows() {
+        let peripherals = esp_hal::init(esp_hal::Config::default());
+        let mut flash = flash_from_peripherals(peripherals);
+
+        let sector = flash.chip_info().sector_size;
+        let row16 = [0x5A5A_5A5Au32; 4];
+
+        // 16 bytes at a 32-byte aligned address.
+        // SAFETY: NVS is not mapped firmware.
+        unsafe { flash.erase(NVS, NVS + sector).unwrap() };
+        unsafe { flash.write_encrypted(NVS, &row16).unwrap() };
+        let mut written = [0u32; 4];
+        flash.read(NVS, &mut written).unwrap();
+        assert_ne!(written, row16);
+        assert_range_erased(&mut flash, NVS + 16, 16);
+
+        // 16 bytes at a 16- but not 32-byte aligned address.
+        unsafe { flash.erase(NVS, NVS + sector).unwrap() };
+        unsafe { flash.write_encrypted(NVS + 16, &row16).unwrap() };
+        flash.read(NVS + 16, &mut written).unwrap();
+        assert_ne!(written, row16);
+        assert_range_erased(&mut flash, NVS, 16);
+        assert_range_erased(&mut flash, NVS + 32, 16);
+
+        #[cfg(not(any(esp32c2, esp32c3)))]
+        {
+            let row64 = [0x5A5A_5A5Au32; 16];
+            unsafe { flash.erase(NVS, NVS + sector).unwrap() };
+            unsafe { flash.write_encrypted(NVS, &row64).unwrap() };
+            let mut written64 = [0u32; 16];
+            flash.read(NVS, &mut written64).unwrap();
+            assert_ne!(written64, row64);
+            assert_range_erased(&mut flash, NVS + 64, 16);
+        }
+
+        unsafe { flash.erase(NVS, NVS + sector).unwrap() };
+    }
+
+    /// 16-, 32-, and 48-byte writes (48 is 32+16) at both 32- and 16-byte
+    /// aligned offsets. Bytes outside the requested range must keep their
+    /// erased value.
+    #[test]
+    fn test_write_encrypted_does_not_touch_neighbors() {
+        let peripherals = esp_hal::init(esp_hal::Config::default());
+        let mut flash = flash_from_peripherals(peripherals);
+
+        let sector = flash.chip_info().sector_size;
+        let data = [0x5A5A_5A5Au32; 12];
+
+        for (offset, words) in [(0u32, 4usize), (0, 8), (0, 12), (16, 4), (16, 8), (16, 12)] {
+            // SAFETY: NVS is not mapped firmware.
+            unsafe { flash.erase(NVS, NVS + sector).unwrap() };
+            unsafe { flash.write_encrypted(NVS + offset, &data[..words]).unwrap() };
+
+            let end = offset + (words * 4) as u32;
+            if offset > 0 && !needs_row_bridge(offset) {
+                assert_range_erased(&mut flash, NVS, offset as usize);
+            }
+            if !needs_row_bridge(end) {
+                assert_range_erased(&mut flash, NVS + end, 16);
+            }
+        }
+
+        unsafe { flash.erase(NVS, NVS + sector).unwrap() };
     }
 }


### PR DESCRIPTION
Adds encryption support to `esp_hal::flash`

Closes #6204

Also tested the `encrypted_flash` qa test on ESP32-C3 hardware and ESP32 QEMU successfully.

---

# Changelog

## esp-hal

- Added: Flash encryption support

## esp-rom-sys

- No changelog necessary.

