### PR TITLE
Remove the S31 15.4 "workaround"

### DIFF
--- a/esp-phy/Cargo.toml
+++ b/esp-phy/Cargo.toml
@@ -36,16 +36,16 @@ esp-metadata-generated = { version = "0.5.1", path = "../esp-metadata-generated"
 esp-sync = { version = "0.3.0", path = "../esp-sync" }
 
 # Make sure these are aligned with esp-radio's dependencies, too!
-esp-wifi-sys-esp32 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "88abcf2" }
-esp-wifi-sys-esp32c2 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "88abcf2" }
-esp-wifi-sys-esp32c3 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "88abcf2" }
-esp-wifi-sys-esp32c5 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "88abcf2" }
-esp-wifi-sys-esp32c6 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "88abcf2" }
-esp-wifi-sys-esp32c61 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "88abcf2" }
-esp-wifi-sys-esp32h2 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "88abcf2" }
-esp-wifi-sys-esp32s2 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "88abcf2" }
-esp-wifi-sys-esp32s3 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "88abcf2" }
-esp-wifi-sys-esp32s31 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "88abcf2" }
+esp-wifi-sys-esp32 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "b1ab831" }
+esp-wifi-sys-esp32c2 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "b1ab831" }
+esp-wifi-sys-esp32c3 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "b1ab831" }
+esp-wifi-sys-esp32c5 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "b1ab831" }
+esp-wifi-sys-esp32c6 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "b1ab831" }
+esp-wifi-sys-esp32c61 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "b1ab831" }
+esp-wifi-sys-esp32h2 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "b1ab831" }
+esp-wifi-sys-esp32s2 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "b1ab831" }
+esp-wifi-sys-esp32s3 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "b1ab831" }
+esp-wifi-sys-esp32s31 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "b1ab831" }
 
 esp32   = { version = "0.41", features = ["critical-section"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "de5316b" }
 esp32c2 = { version = "0.30", features = ["critical-section"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "de5316b" }

--- a/esp-radio/Cargo.toml
+++ b/esp-radio/Cargo.toml
@@ -83,16 +83,16 @@ ieee802154 = { version = "0.6.1", optional = true }
 heapless = "0.9"
 embassy-sync = "0.8"
 # Make sure these are aligned with esp-phy's dependencies, too!
-esp-wifi-sys-esp32 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "88abcf2" }
-esp-wifi-sys-esp32c2 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "88abcf2" }
-esp-wifi-sys-esp32c3 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "88abcf2" }
-esp-wifi-sys-esp32c5 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "88abcf2" }
-esp-wifi-sys-esp32c6 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "88abcf2" }
-esp-wifi-sys-esp32c61 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "88abcf2" }
-esp-wifi-sys-esp32h2 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "88abcf2" }
-esp-wifi-sys-esp32s2 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "88abcf2" }
-esp-wifi-sys-esp32s3 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "88abcf2" }
-esp-wifi-sys-esp32s31 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "88abcf2" }
+esp-wifi-sys-esp32 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "b1ab831" }
+esp-wifi-sys-esp32c2 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "b1ab831" }
+esp-wifi-sys-esp32c3 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "b1ab831" }
+esp-wifi-sys-esp32c5 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "b1ab831" }
+esp-wifi-sys-esp32c6 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "b1ab831" }
+esp-wifi-sys-esp32c61 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "b1ab831" }
+esp-wifi-sys-esp32h2 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "b1ab831" }
+esp-wifi-sys-esp32s2 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "b1ab831" }
+esp-wifi-sys-esp32s3 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "b1ab831" }
+esp-wifi-sys-esp32s31 = { version = "0.2.0", optional = true, git = "https://github.com/esp-rs/esp-wifi-sys.git", rev = "b1ab831" }
 
 esp32   = { version = "0.41", features = ["critical-section"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "de5316b" }
 esp32c2 = { version = "0.30", features = ["critical-section"], optional = true, git = "https://github.com/esp-rs/esp-pacs", rev = "de5316b" }

--- a/esp-radio/src/ieee802154/raw.rs
+++ b/esp-radio/src/ieee802154/raw.rs
@@ -1,7 +1,5 @@
 use alloc::collections::VecDeque as Queue;
 
-#[cfg(esp32s31)]
-use coex_i154::*;
 use esp_hal::{handler, interrupt::Priority, peripherals::IEEE802154};
 use esp_phy::{PhyClockGuard, PhyInitGuard};
 use esp_sync::NonReentrantMutex;
@@ -17,28 +15,15 @@ use super::{
     hal::*,
     pib::*,
 };
-use crate::radio_clocks::{clocks_ll::enable_ieee802154, deinit_radio_clocks, init_radio_clocks};
-#[cfg(not(esp32s31))]
-use crate::sys::include::{
-    ieee802154_coex_event_t,
-    ieee802154_coex_event_t_IEEE802154_IDLE,
-    ieee802154_coex_event_t_IEEE802154_LOW,
-    ieee802154_coex_event_t_IEEE802154_MIDDLE,
+use crate::{
+    radio_clocks::{clocks_ll::enable_ieee802154, deinit_radio_clocks, init_radio_clocks},
+    sys::include::{
+        ieee802154_coex_event_t,
+        ieee802154_coex_event_t_IEEE802154_IDLE,
+        ieee802154_coex_event_t_IEEE802154_LOW,
+        ieee802154_coex_event_t_IEEE802154_MIDDLE,
+    },
 };
-
-/// Stand-in for the `esp_coex_i154.h` bindings, which esp-wifi-sys does not
-/// generate for S31. `ieee802154_coex_event_t` is `HIGH = 1, MIDDLE, LOW,
-/// IDLE`; the driver only uses the last three.
-// TODO: drop once esp-wifi-sys covers the header on S31.
-#[cfg(esp32s31)]
-#[allow(non_camel_case_types, non_upper_case_globals)]
-mod coex_i154 {
-    pub type ieee802154_coex_event_t = crate::sys::c_types::c_uint;
-
-    pub const ieee802154_coex_event_t_IEEE802154_MIDDLE: ieee802154_coex_event_t = 2;
-    pub const ieee802154_coex_event_t_IEEE802154_LOW: ieee802154_coex_event_t = 3;
-    pub const ieee802154_coex_event_t_IEEE802154_IDLE: ieee802154_coex_event_t = 4;
-}
 
 const PHY_ENABLE_VERSION_PRINT: u8 = 1;
 


### PR DESCRIPTION
This is just cosmetics .... initially we didn't include the 15.4 headers for S31.

This won't change a single byte in the final executable.
