### PR TITLE
esp-radio: WPA3-Personal (SAE) for the station

### DIFF
--- a/esp-radio/src/wifi/ap.rs
+++ b/esp-radio/src/wifi/ap.rs
@@ -69,6 +69,17 @@ impl AccessPointConfig {
             return Err(WifiError::Unsupported);
         }
 
+        // The supplicant is built with SAE for the station; a WPA3 soft-AP has not
+        // been verified, so refuse it rather than let it fail silently.
+        if matches!(
+            self.authentication,
+            AuthenticationMethodConfig::Wpa3Personal(_)
+                | AuthenticationMethodConfig::Wpa2Wpa3Personal(_)
+        ) {
+            warn!("WPA3 is not supported in access point mode yet.");
+            return Err(WifiError::Unsupported);
+        }
+
         if let Some(password) = self.authentication.password()
             && password.is_empty()
         {

--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -7,8 +7,8 @@
 #![doc = concat!("- Station mode (aka STA mode or Wi-Fi client mode). ", chip_pretty!(), " connects to an access point.")]
 #![doc = concat!("- AP mode (aka Soft-AP mode or Access Point mode). Stations connect to the ", chip_pretty!(),".")]
 #![doc = concat!("- Station/AP-coexistence mode (", chip_pretty!(), " is concurrently an access point and a station connected to another access point).")]
-//! - Various security modes for the above (WPA, WPA2, ... Please note that WPA3 is currently not
-//!   supported)
+//! - Various security modes for the above (WPA, WPA2, WPA3-Personal, ...). WPA3-Personal (SAE) is
+//!   available for the station; the supplicant is built with SAE on mbedTLS crypto.
 //! - Scanning for access points (active & passive scanning).
 //! - Promiscuous mode for monitoring of IEEE802.11 Wi-Fi packets.
 //!
@@ -474,8 +474,8 @@ impl AuthenticationMethod {
             // return anything else.
             //
             // In fact from observation the drivers will return
-            // `wifi_auth_mode_t_WIFI_AUTH_OPEN` if the method is unsupported (e.g. any WPA3 in our
-            // case, since the supplicant isn't compiled to support it)
+            // `wifi_auth_mode_t_WIFI_AUTH_OPEN` if the method is unsupported by the supplicant
+            // build (that was the case for WPA3 before the supplicant was built with SAE).
             _ => AuthenticationMethod::None,
         }
     }
@@ -872,6 +872,19 @@ pub enum AuthenticationMethodConfig {
 
     /// WPA/WPA2 Personal authentication and password (supports both).
     WpaWpa2Personal(Password),
+
+    /// WPA3 Personal (SAE) authentication and password.
+    ///
+    /// As a station: joins WPA3-only access points (SAE with hunt-and-peck and
+    /// hash-to-element, PMF capable). Access point mode is not verified yet and is
+    /// rejected by [`AccessPointConfig`].
+    Wpa3Personal(Password),
+
+    /// WPA2/WPA3 Personal authentication and password (supports both).
+    ///
+    /// As a station: the weakest method accepted; a WPA2/WPA3 transition or a
+    /// WPA3-only access point is joined with SAE, a WPA2-only one with PSK.
+    Wpa2Wpa3Personal(Password),
 }
 
 impl AuthenticationMethodConfig {
@@ -882,6 +895,10 @@ impl AuthenticationMethodConfig {
             AuthenticationMethodConfig::Wpa(_) => AuthenticationMethod::Wpa,
             AuthenticationMethodConfig::Wpa2Personal(_) => AuthenticationMethod::Wpa2Personal,
             AuthenticationMethodConfig::WpaWpa2Personal(_) => AuthenticationMethod::WpaWpa2Personal,
+            AuthenticationMethodConfig::Wpa3Personal(_) => AuthenticationMethod::Wpa3Personal,
+            AuthenticationMethodConfig::Wpa2Wpa3Personal(_) => {
+                AuthenticationMethod::Wpa2Wpa3Personal
+            }
         }
     }
 
@@ -891,7 +908,9 @@ impl AuthenticationMethodConfig {
             AuthenticationMethodConfig::Wep(password)
             | AuthenticationMethodConfig::Wpa(password)
             | AuthenticationMethodConfig::Wpa2Personal(password)
-            | AuthenticationMethodConfig::WpaWpa2Personal(password) => Some(password.as_bytes()),
+            | AuthenticationMethodConfig::WpaWpa2Personal(password)
+            | AuthenticationMethodConfig::Wpa3Personal(password)
+            | AuthenticationMethodConfig::Wpa2Wpa3Personal(password) => Some(password.as_bytes()),
         }
     }
 }


### PR DESCRIPTION
## Thank you for your contribution!

### Submission Checklist 📝
- [x] I have updated existing examples or added new ones (if applicable). — not applicable, the examples keep using WPA2.
- [x] I have used `cargo xtask fmt` command to ensure that all changed code is formatted correctly.
- [x] I have added changelog entries and/or migration guide notes in the sections below, or I will ask a maintainer to add the `skip-changelog` or `manual-changelog` label as appropriate.
- [x] My changes are in accordance to the [esp-rs developer guidelines](https://github.com/esp-rs/esp-hal/blob/main/documentation/DEVELOPER-GUIDELINES.md)

#### Extra:
- [x] I have read the [CONTRIBUTING.md guide](https://github.com/esp-rs/esp-hal/blob/main/documentation/CONTRIBUTING.md) and followed its instructions.

### Pull Request Details 📖

#### Description

WPA3-Personal (SAE) for the **station**, closing #1600.

The missing piece was never in esp-radio: the `libwpa_supplicant.a` in esp-wifi-sys is built with `CONFIG_ESP_WIFI_ENABLE_WPA3_SAE=n` / `CONFIG_ESP_WIFI_MBEDTLS_CRYPTO=n`, so the open-source supplicant has no SAE client, and the closed blobs (which reach SAE only through the `wpa_funcs` table the supplicant registers) report a WPA3-only AP as `WIFI_AUTH_OPEN` → `NoAccessPointFound`. Two companion PRs rebuild the esp32 supplicant with SAE on mbedTLS crypto and ship the `libmbedcrypto.a` it needs:

* esp-rs/esp-wireless-drivers-3rdparty#11 — sdkconfig defaults + helper project + xtask, rebuilt archives, provenance
* esp-rs/esp-wifi-sys#511 — the archives and `build.rs` linking `mbedcrypto`

This PR is the esp-radio side, kept to what is needed:

* `AuthenticationMethodConfig` gets `Wpa3Personal(Password)` and `Wpa2Wpa3Personal(Password)` back (removed in #6146 as unsupported), mapped to the existing `AuthenticationMethod::{Wpa3Personal, Wpa2Wpa3Personal}`. The station config already sets PMF capable and `sae_pwe_h2e = 3` (hunt-and-peck + hash-to-element) — that is exactly the configuration the hardware test used, so nothing else in `apply_sta_config` changes.
* `AccessPointConfig::validate` refuses both with `WifiError::Unsupported` + a warning: the supplicant is also built with `CONFIG_ESP_WIFI_SOFTAP_SAE_SUPPORT` (IDF default once SAE is on), but I have not verified a WPA3 soft-AP and would rather not expose a silently failing option — the very complaint in #1600. Easy to lift once someone tests it.
* Module docs / the `from_raw` comment no longer say WPA3 is unsupported.

No compat shim is needed: the mbedTLS build in the companion PRs uses libc `calloc`/`free`, no threading, no PSA key storage, so `libmbedcrypto.a` references nothing esp-radio does not already provide (`cargo xtask build embassy_dhcp esp32` links against the new archives with no other change).

**Depends on** esp-rs/esp-wifi-sys#511: `esp-radio/Cargo.toml` must bump the esp-wifi-sys `rev` to a commit containing it (not done here — the rev does not exist upstream yet). Only esp32 archives are rebuilt in the companion PRs; on other chips these two variants will behave as before (driver reports the AP as open) until their libraries are rebuilt — see the "all chips?" question in the 3rdparty PR. Draft for that reason.

#### Testing

* **Hardware (ESP32-D0WD-V3, 240 MHz):** the same supplicant/mbedcrypto recipe applied to ESP-IDF v5.5.3 (the IDF behind crates.io `esp-wifi-sys-esp32 0.2.0`; its supplicant is byte-identical to 3rdparty `bf1e59a2`) with esp-radio **1.0.0-beta.0**, against a WPA3-only AP (SSID/BSSID withheld). Before: scan classifies the AP as `None`, every threshold incl. BSSID/channel pinning ends in `NoAccessPointFound`, a WPA2 AP on the same radio joins. After: scan reports `Wpa3Personal`; `connect_async()` with the weakest threshold succeeds — SAE commit/confirm + 4-way in **0.95 / 1.35 / 2.9 s** over three boots (software P-256 on the LX6); heap peak **+7 KiB** during SAE (89.4 KiB used vs 82.4 KiB after); image **+63.9 KiB** flash; IRAM (`.rwtext.wifi` 51 800 B) unchanged; DHCP and TCP normal afterwards.
* **This branch (esp-hal `main` + the v6.1 archives from esp-wifi-sys#511 via `[patch]`):** `cargo xtask build embassy_dhcp esp32` links, `cargo xtask lint esp-radio esp32` clean, `cargo +nightly fmt` clean. The ELF contains `sae_prepare_commit`, `sae_process_commit`, `esp_wifi_register_wpa3_cb`, `mbedtls_ecp_mul`, `psa_import_key`. Versus `main` with the current archives: `.text` +69 767 B, `.rodata` +10 896 B, `.bss` +420 B, IRAM unchanged (≈ +81 KiB flash; IDF 6.1's mbedTLS 4 / TF-PSA-Crypto costs more than 5.5's). Not run on hardware with the v6.1 archives — my board is on esp-hal 1.1 / IDF 5.5 libraries.

---

# Changelog

## esp-radio

- Added: `AuthenticationMethodConfig::Wpa3Personal` and `AuthenticationMethodConfig::Wpa2Wpa3Personal` — WPA3-Personal (SAE) for the station, with the SAE-enabled supplicant from esp-wifi-sys.
- Changed: `AccessPointConfig` rejects WPA3 authentication methods with `WifiError::Unsupported` until a WPA3 soft-AP is verified.
