### PR TITLE
esp-radio: make Ssid::as_bytes public

### DIFF
--- a/esp-radio/src/wifi/mod.rs
+++ b/esp-radio/src/wifi/mod.rs
@@ -782,7 +782,13 @@ impl Ssid {
         })
     }
 
-    pub(crate) fn as_bytes(&self) -> &[u8] {
+    /// The SSID as raw bytes.
+    ///
+    /// An SSID is at most 32 bytes and is not required to be valid UTF-8
+    /// (the Wi-Fi standard allows arbitrary bytes). Use this to round-trip
+    /// an SSID that [`as_str`][Self::as_str] would otherwise lossily
+    /// truncate at the first invalid byte.
+    pub fn as_bytes(&self) -> &[u8] {
         &self.ssid[..self.len as usize]
     }
 


### PR DESCRIPTION
`Ssid::as_str` truncates at the first invalid UTF-8 byte, and the Wi-Fi standard allows an SSID to be any 32 bytes, not necessarily valid UTF-8. A scanned network name that isn't UTF-8 has no public way to be read back out as bytes for storage.

`Ssid` already implements `TryFrom<&[u8]>` publicly ([esp-radio/src/wifi/mod.rs:843-854](https://github.com/esp-rs/esp-hal/blob/c99cf581f7aed9078abea8f984c06b16cbc2e69f/esp-radio/src/wifi/mod.rs#L843-L854)), which covers rebuilding an `Ssid` from stored bytes. The only missing half is the accessor to get the bytes back out, so this PR makes `as_bytes` public ([esp-radio/src/wifi/mod.rs:785-793](https://github.com/esp-rs/esp-hal/blob/c99cf581f7aed9078abea8f984c06b16cbc2e69f/esp-radio/src/wifi/mod.rs#L785-L793)), matching the visibility of `as_str`, `len`, and `is_empty` on the same type, with a doc comment.

This is a visibility widening on a pre-1.0 crate, so it's additive only; nothing existing changes behavior.

I used AI assistance (Claude) to prepare this branch; I reviewed, tested, and understand the change before opening this PR, per the project's AI tool use policy.

### Testing

`cargo xtask fmt`, `cargo xtask lint esp-radio esp32s3`, and `cargo xtask documentation --packages esp-radio` pass clean. No test added: `esp-radio` has no host-test path and this file's doctests are `no_run`, and the change only widens the visibility of an existing method.

### Changelog

```markdown
# Changelog

## esp-radio

- Changed: `Ssid::as_bytes` is now public, so a scanned SSID that is not valid UTF-8 can be read as raw bytes for storage and later rebuilt with `Ssid::try_from(&[u8])`.
```

Validated with `echo "<body>" | cargo xtask check-pr-changelog` against this exact body (including the prose around it): "PR description changelog format is valid."